### PR TITLE
feat(fs): add rooted durable publication primitives

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Run Windows filesystem publication tests
-        run: |
-          go test -v -count=1 ./internal/fsdurable ./internal/migratesum ./internal/devlock -timeout 5m
-          go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
-          go test -v -count=1 ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m
+      - name: Run Windows durable filesystem tests
+        run: go test -v -count=1 ./internal/fsdurable ./internal/pathguard ./internal/migratesum ./internal/devlock -timeout 5m
+
+      - name: Run Windows migration publication tests
+        run: go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
+
+      - name: Run Windows migration generator tests
+        run: go test -v -count=1 ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m

--- a/internal/fsdurable/errors.go
+++ b/internal/fsdurable/errors.go
@@ -1,0 +1,9 @@
+package fsdurable
+
+import "errors"
+
+var (
+	// ErrReplacementCommitted reports that a file replacement completed but a
+	// subsequent durability or verification operation failed.
+	ErrReplacementCommitted = errors.New("file replacement committed with uncertain durability")
+)

--- a/internal/fsdurable/errors.go
+++ b/internal/fsdurable/errors.go
@@ -3,7 +3,7 @@ package fsdurable
 import "errors"
 
 var (
-	// ErrReplacementCommitted reports that a file replacement completed but a
-	// subsequent durability or verification operation failed.
+	// ErrReplacementCommitted reports that the rooted rename succeeded but a
+	// subsequent identity verification or durability operation failed.
 	ErrReplacementCommitted = errors.New("file replacement committed with uncertain durability")
 )

--- a/internal/fsdurable/replace_root_nonwindows.go
+++ b/internal/fsdurable/replace_root_nonwindows.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package fsdurable
+
+import "os"
+
+// ReplaceFileAt atomically replaces newName with oldName through root.
+func ReplaceFileAt(root *os.Root, oldName, newName string) error {
+	return root.Rename(oldName, newName)
+}

--- a/internal/fsdurable/replace_root_windows.go
+++ b/internal/fsdurable/replace_root_windows.go
@@ -1,0 +1,45 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// ReplaceFileAt replaces newName with oldName through root and flushes the
+// published file before returning.
+func ReplaceFileAt(root *os.Root, oldName, newName string) (err error) {
+	staged, err := root.OpenFile(oldName, os.O_RDWR, 0)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		err = errors.Join(err, staged.Close())
+	}()
+
+	stagedInfo, err := staged.Stat()
+	if err != nil {
+		return fmt.Errorf("stat staged file before rooted replacement %s: %w", oldName, err)
+	}
+	if err := root.Rename(oldName, newName); err != nil {
+		return err
+	}
+	published, err := root.Open(newName)
+	if err != nil {
+		return err
+	}
+	publishedInfo, statErr := published.Stat()
+	if statErr != nil {
+		return errors.Join(
+			fmt.Errorf("stat published file after rooted replacement %s: %w", newName, statErr),
+			published.Close(),
+		)
+	}
+	if closeErr := published.Close(); closeErr != nil {
+		return closeErr
+	}
+	if !os.SameFile(stagedInfo, publishedInfo) {
+		return fmt.Errorf("published file changed during rooted replacement: %s", newName)
+	}
+	return staged.Sync()
+}

--- a/internal/fsdurable/replace_root_windows.go
+++ b/internal/fsdurable/replace_root_windows.go
@@ -7,39 +7,52 @@ import (
 )
 
 // ReplaceFileAt replaces newName with oldName through root and flushes the
-// published file before returning.
-func ReplaceFileAt(root *os.Root, oldName, newName string) (err error) {
+// published file before returning. Errors after the rename wrap
+// ErrReplacementCommitted so callers can avoid treating them as pre-commit
+// failures.
+func ReplaceFileAt(root *os.Root, oldName, newName string) error {
 	staged, err := root.OpenFile(oldName, os.O_RDWR, 0)
 	if err != nil {
 		return err
 	}
-	defer func() {
-		err = errors.Join(err, staged.Close())
-	}()
 
 	stagedInfo, err := staged.Stat()
 	if err != nil {
-		return fmt.Errorf("stat staged file before rooted replacement %s: %w", oldName, err)
+		return errors.Join(
+			fmt.Errorf("stat staged file before rooted replacement %s: %w", oldName, err),
+			staged.Close(),
+		)
 	}
 	if err := root.Rename(oldName, newName); err != nil {
-		return err
+		return errors.Join(err, staged.Close())
 	}
 	published, err := root.Open(newName)
 	if err != nil {
-		return err
+		return replacementCommittedError(errors.Join(err, staged.Close()))
 	}
 	publishedInfo, statErr := published.Stat()
 	if statErr != nil {
-		return errors.Join(
+		return replacementCommittedError(errors.Join(
 			fmt.Errorf("stat published file after rooted replacement %s: %w", newName, statErr),
 			published.Close(),
-		)
+			staged.Close(),
+		))
 	}
 	if closeErr := published.Close(); closeErr != nil {
-		return closeErr
+		return replacementCommittedError(errors.Join(closeErr, staged.Close()))
 	}
 	if !os.SameFile(stagedInfo, publishedInfo) {
-		return fmt.Errorf("published file changed during rooted replacement: %s", newName)
+		return replacementCommittedError(errors.Join(
+			fmt.Errorf("published file changed during rooted replacement: %s", newName),
+			staged.Close(),
+		))
 	}
-	return staged.Sync()
+	return replacementCommittedError(errors.Join(staged.Sync(), staged.Close()))
+}
+
+func replacementCommittedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrReplacementCommitted, err)
 }

--- a/internal/fsdurable/replace_root_windows.go
+++ b/internal/fsdurable/replace_root_windows.go
@@ -26,28 +26,18 @@ func ReplaceFileAt(root *os.Root, oldName, newName string) error {
 	if err := root.Rename(oldName, newName); err != nil {
 		return errors.Join(err, staged.Close())
 	}
-	published, err := root.Open(newName)
-	if err != nil {
-		return replacementCommittedError(errors.Join(err, staged.Close()))
+
+	publishedInfo, verifyErr := root.Lstat(newName)
+	if verifyErr != nil {
+		verifyErr = fmt.Errorf("stat published file after rooted replacement %s: %w", newName, verifyErr)
 	}
-	publishedInfo, statErr := published.Stat()
-	if statErr != nil {
-		return replacementCommittedError(errors.Join(
-			fmt.Errorf("stat published file after rooted replacement %s: %w", newName, statErr),
-			published.Close(),
-			staged.Close(),
-		))
+	if verifyErr == nil && !publishedInfo.Mode().IsRegular() {
+		verifyErr = fmt.Errorf("published file is not regular after rooted replacement: %s", newName)
 	}
-	if closeErr := published.Close(); closeErr != nil {
-		return replacementCommittedError(errors.Join(closeErr, staged.Close()))
+	if verifyErr == nil && !os.SameFile(stagedInfo, publishedInfo) {
+		verifyErr = fmt.Errorf("published file changed during rooted replacement: %s", newName)
 	}
-	if !os.SameFile(stagedInfo, publishedInfo) {
-		return replacementCommittedError(errors.Join(
-			fmt.Errorf("published file changed during rooted replacement: %s", newName),
-			staged.Close(),
-		))
-	}
-	return replacementCommittedError(errors.Join(staged.Sync(), staged.Close()))
+	return replacementCommittedError(errors.Join(verifyErr, staged.Sync(), staged.Close()))
 }
 
 func replacementCommittedError(err error) error {

--- a/internal/fsdurable/root_replace_nonwindows_test.go
+++ b/internal/fsdurable/root_replace_nonwindows_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package fsdurable_test
+
+import (
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestReplaceFileAt_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	root, err := os.OpenRoot(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.ReplaceFileAt(root, "missing", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var linkErr *os.LinkError
+	c.Assert(err, qt.ErrorAs, &linkErr)
+	c.Assert(linkErr.Op, qt.Equals, "renameat")
+	c.Assert(linkErr.Old, qt.Equals, "missing")
+	c.Assert(linkErr.New, qt.Equals, "published")
+}

--- a/internal/fsdurable/root_replace_windows_test.go
+++ b/internal/fsdurable/root_replace_windows_test.go
@@ -1,0 +1,30 @@
+package fsdurable_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestReplaceFileAt_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	root, err := os.OpenRoot(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.ReplaceFileAt(root, "missing", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	c.Assert(errors.Is(err, fsdurable.ErrReplacementCommitted), qt.IsFalse)
+	var pathErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &pathErr)
+	c.Assert(pathErr.Op, qt.Equals, "openat")
+	c.Assert(pathErr.Path, qt.Equals, "missing")
+}

--- a/internal/fsdurable/root_test.go
+++ b/internal/fsdurable/root_test.go
@@ -30,24 +30,6 @@ func TestReplaceFileAt_HappyPath(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
-func TestReplaceFileAt_FailurePath(t *testing.T) {
-	c := qt.New(t)
-	root, err := os.OpenRoot(c.TempDir())
-	c.Assert(err, qt.IsNil)
-	t.Cleanup(func() {
-		c.Assert(root.Close(), qt.IsNil)
-	})
-
-	err = fsdurable.ReplaceFileAt(root, "missing", "published")
-
-	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	var linkErr *os.LinkError
-	c.Assert(err, qt.ErrorAs, &linkErr)
-	c.Assert(linkErr.Op, qt.Equals, "renameat")
-	c.Assert(linkErr.Old, qt.Equals, "missing")
-	c.Assert(linkErr.New, qt.Equals, "published")
-}
-
 func TestSyncRoot_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()

--- a/internal/fsdurable/root_test.go
+++ b/internal/fsdurable/root_test.go
@@ -1,0 +1,62 @@
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestReplaceFileAt_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("new"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "published"), []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(root.Close(), qt.IsNil)
+	})
+
+	c.Assert(fsdurable.ReplaceFileAt(root, "staged", "published"), qt.IsNil)
+
+	contents, err := os.ReadFile(filepath.Join(dir, "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	_, err = os.Stat(filepath.Join(dir, "staged"))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestReplaceFileAt_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	root, err := os.OpenRoot(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.ReplaceFileAt(root, "missing", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var linkErr *os.LinkError
+	c.Assert(err, qt.ErrorAs, &linkErr)
+	c.Assert(linkErr.Op, qt.Equals, "renameat")
+	c.Assert(linkErr.Old, qt.Equals, "missing")
+	c.Assert(linkErr.New, qt.Equals, "published")
+}
+
+func TestSyncRoot_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "entry"), []byte("value"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(root.Close(), qt.IsNil)
+	})
+
+	c.Assert(fsdurable.SyncRoot(root), qt.IsNil)
+}

--- a/internal/fsdurable/sync_nonwindows_test.go
+++ b/internal/fsdurable/sync_nonwindows_test.go
@@ -20,3 +20,15 @@ func TestSyncDir_FailurePath(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `open directory for sync: .*`)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
+
+func TestSyncRoot_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	root, err := os.OpenRoot(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	c.Assert(root.Close(), qt.IsNil)
+
+	err = fsdurable.SyncRoot(root)
+
+	c.Assert(err, qt.ErrorMatches, `open rooted directory for sync: .*`)
+	c.Assert(err, qt.ErrorIs, os.ErrClosed)
+}

--- a/internal/fsdurable/sync_nonwindows_test.go
+++ b/internal/fsdurable/sync_nonwindows_test.go
@@ -3,6 +3,7 @@
 package fsdurable_test
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"testing"
@@ -31,4 +32,8 @@ func TestSyncRoot_FailurePath(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, `open rooted directory for sync: .*`)
 	c.Assert(err, qt.ErrorIs, os.ErrClosed)
+	var pathErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &pathErr)
+	c.Assert(pathErr.Op, qt.Equals, "openat")
+	c.Assert(pathErr.Path, qt.Equals, ".")
 }

--- a/internal/fsdurable/sync_root_nonwindows.go
+++ b/internal/fsdurable/sync_root_nonwindows.go
@@ -1,0 +1,18 @@
+//go:build !windows
+
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// SyncRoot flushes root directory-entry changes to stable storage.
+func SyncRoot(root *os.Root) error {
+	handle, err := root.Open(".")
+	if err != nil {
+		return fmt.Errorf("open rooted directory for sync: %w", err)
+	}
+	return errors.Join(handle.Sync(), handle.Close())
+}

--- a/internal/fsdurable/sync_root_windows.go
+++ b/internal/fsdurable/sync_root_windows.go
@@ -1,0 +1,9 @@
+package fsdurable
+
+import "os"
+
+// SyncRoot is a no-op on Windows because FlushFileBuffers does not support
+// directory handles. ReplaceFileAt flushes the published file instead.
+func SyncRoot(*os.Root) error {
+	return nil
+}

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -65,6 +65,9 @@ func (d *OpenedDirectory) CreateTemp(pattern string) (*os.File, string, error) {
 // ReplaceFile atomically replaces newName with oldName through the rooted
 // directory handle. On Unix, callers must follow successful replacement with
 // Sync. On Windows, replacement flushes the published file and Sync is a no-op.
+// Windows requires oldName to identify a writable regular file. An error
+// wrapping fsdurable.ErrReplacementCommitted means the rooted rename succeeded,
+// so callers must not treat it as a pre-commit failure.
 func (d *OpenedDirectory) ReplaceFile(oldName, newName string) error {
 	return fsdurable.ReplaceFileAt(d.root, oldName, newName)
 }

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -1,0 +1,91 @@
+package pathguard
+
+import (
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+const createTempAttempts = 10_000
+
+// Open opens name through the rooted directory handle.
+func (d *OpenedDirectory) Open(name string) (*os.File, error) {
+	return d.root.Open(name)
+}
+
+// Lstat returns information about name without following its final symlink.
+func (d *OpenedDirectory) Lstat(name string) (fs.FileInfo, error) {
+	return d.root.Lstat(name)
+}
+
+// ReadFile reads name through the rooted directory handle.
+func (d *OpenedDirectory) ReadFile(name string) ([]byte, error) {
+	return d.root.ReadFile(name)
+}
+
+// Remove removes name through the rooted directory handle.
+func (d *OpenedDirectory) Remove(name string) error {
+	return d.root.Remove(name)
+}
+
+// CreateTemp creates a new exclusively owned file directly in the opened
+// directory. Pattern may contain one or more asterisks; the last is replaced
+// with random text. A pattern without an asterisk receives a random suffix.
+// The caller owns the returned file and must close it. If the file is not
+// published, the caller must also remove the returned relative name.
+func (d *OpenedDirectory) CreateTemp(pattern string) (*os.File, string, error) {
+	prefix, suffix, err := splitTempPattern(pattern)
+	if err != nil {
+		return nil, "", err
+	}
+	for range createTempAttempts {
+		name := prefix + rand.Text() + suffix
+		file, openErr := d.root.OpenFile(name, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o600)
+		if errors.Is(openErr, fs.ErrExist) {
+			continue
+		}
+		if openErr != nil {
+			return nil, "", fmt.Errorf("create rooted temporary file %s: %w", name, openErr)
+		}
+		return file, name, nil
+	}
+	return nil, "", &fs.PathError{
+		Op:   "createtemp",
+		Path: pattern,
+		Err:  fs.ErrExist,
+	}
+}
+
+// ReplaceFile atomically replaces newName with oldName through the rooted
+// directory handle. On Unix, callers must follow successful replacement with
+// Sync. On Windows, replacement flushes the published file and Sync is a no-op.
+func (d *OpenedDirectory) ReplaceFile(oldName, newName string) error {
+	return fsdurable.ReplaceFileAt(d.root, oldName, newName)
+}
+
+// Sync flushes rooted directory-entry changes where the platform supports it.
+// Call it after ReplaceFile and Remove before reporting a durable transaction.
+func (d *OpenedDirectory) Sync() error {
+	return fsdurable.SyncRoot(d.root)
+}
+
+func splitTempPattern(pattern string) (prefix, suffix string, err error) {
+	if pattern != "" && (filepath.Base(pattern) != pattern || pattern == "." || pattern == "..") {
+		return "", "", &fs.PathError{
+			Op:   "createtemp",
+			Path: pattern,
+			Err:  fs.ErrInvalid,
+		}
+	}
+	index := strings.LastIndexByte(pattern, '*')
+	if index < 0 {
+		return pattern, "", nil
+	}
+	return pattern[:index], pattern[index+1:], nil
+}

--- a/internal/pathguard/opened_directory_ops_test.go
+++ b/internal/pathguard/opened_directory_ops_test.go
@@ -102,13 +102,6 @@ func TestOpenedDirectoryOperations_FailurePath(t *testing.T) {
 	c.Assert(err, qt.ErrorAs, &removeErr)
 	c.Assert(removeErr.Op, qt.Equals, "removeat")
 	c.Assert(removeErr.Path, qt.Equals, "missing")
-	err = opened.ReplaceFile("missing", "published")
-	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	var replaceErr *os.LinkError
-	c.Assert(err, qt.ErrorAs, &replaceErr)
-	c.Assert(replaceErr.Op, qt.Equals, "renameat")
-	c.Assert(replaceErr.Old, qt.Equals, "missing")
-	c.Assert(replaceErr.New, qt.Equals, "published")
 }
 
 func TestOpenedDirectoryCreateTemp_FailurePath(t *testing.T) {

--- a/internal/pathguard/opened_directory_ops_test.go
+++ b/internal/pathguard/opened_directory_ops_test.go
@@ -120,6 +120,11 @@ func TestOpenedDirectoryCreateTemp_FailurePath(t *testing.T) {
 	file, name, err := opened.CreateTemp("staged-*")
 
 	c.Assert(err, qt.ErrorMatches, `create rooted temporary file staged-.*: .*`)
+	c.Assert(err, qt.ErrorIs, os.ErrClosed)
+	var pathErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &pathErr)
+	c.Assert(pathErr.Op, qt.Equals, "openat")
+	c.Assert(pathErr.Path, qt.Matches, `staged-.*`)
 	c.Assert(file, qt.IsNil)
 	c.Assert(name, qt.Equals, "")
 }

--- a/internal/pathguard/opened_directory_ops_test.go
+++ b/internal/pathguard/opened_directory_ops_test.go
@@ -1,0 +1,159 @@
+package pathguard_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestOpenedDirectoryOperations_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "published"), []byte("old"), 0o600), qt.IsNil)
+	opened, err := pathguard.OpenDirectory(dir)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	staged, stagedName, err := opened.CreateTemp("staged-*.tmp")
+	c.Assert(err, qt.IsNil)
+	c.Assert(filepath.Base(stagedName), qt.Equals, stagedName)
+	c.Assert(strings.HasPrefix(stagedName, "staged-"), qt.IsTrue)
+	c.Assert(strings.HasSuffix(stagedName, ".tmp"), qt.IsTrue)
+	_, err = staged.WriteString("new")
+	c.Assert(err, qt.IsNil)
+	c.Assert(staged.Sync(), qt.IsNil)
+	c.Assert(staged.Close(), qt.IsNil)
+
+	info, err := opened.Lstat(stagedName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().IsRegular(), qt.IsTrue)
+	contents, err := opened.ReadFile(stagedName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	handle, err := opened.Open(stagedName)
+	c.Assert(err, qt.IsNil)
+	c.Assert(handle.Close(), qt.IsNil)
+
+	other, otherName, err := opened.CreateTemp("other-")
+	c.Assert(err, qt.IsNil)
+	c.Assert(stagedName, qt.Not(qt.Equals), otherName)
+	c.Assert(other.Close(), qt.IsNil)
+	c.Assert(opened.Remove(otherName), qt.IsNil)
+	random, randomName, err := opened.CreateTemp("")
+	c.Assert(err, qt.IsNil)
+	c.Assert(randomName, qt.Not(qt.Equals), "")
+	c.Assert(filepath.Base(randomName), qt.Equals, randomName)
+	c.Assert(random.Close(), qt.IsNil)
+	c.Assert(opened.Remove(randomName), qt.IsNil)
+
+	c.Assert(opened.ReplaceFile(stagedName, "published"), qt.IsNil)
+	c.Assert(opened.Sync(), qt.IsNil)
+	contents, err = os.ReadFile(filepath.Join(dir, "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	_, err = os.Stat(filepath.Join(dir, stagedName))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+
+	c.Assert(opened.Remove("published"), qt.IsNil)
+	_, err = os.Stat(filepath.Join(dir, "published"))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestOpenedDirectoryOperations_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	opened, err := pathguard.OpenDirectory(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	handle, err := opened.Open("missing")
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var openErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &openErr)
+	c.Assert(openErr.Op, qt.Equals, "openat")
+	c.Assert(openErr.Path, qt.Equals, "missing")
+	c.Assert(handle, qt.IsNil)
+	contents, err := opened.ReadFile("missing")
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var readErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &readErr)
+	c.Assert(readErr.Op, qt.Equals, "openat")
+	c.Assert(readErr.Path, qt.Equals, "missing")
+	c.Assert(contents, qt.IsNil)
+	info, err := opened.Lstat("missing")
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var statErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &statErr)
+	c.Assert(statErr.Op, qt.Equals, "statat")
+	c.Assert(statErr.Path, qt.Equals, "missing")
+	c.Assert(info, qt.IsNil)
+	err = opened.Remove("missing")
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var removeErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &removeErr)
+	c.Assert(removeErr.Op, qt.Equals, "removeat")
+	c.Assert(removeErr.Path, qt.Equals, "missing")
+	err = opened.ReplaceFile("missing", "published")
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var replaceErr *os.LinkError
+	c.Assert(err, qt.ErrorAs, &replaceErr)
+	c.Assert(replaceErr.Op, qt.Equals, "renameat")
+	c.Assert(replaceErr.Old, qt.Equals, "missing")
+	c.Assert(replaceErr.New, qt.Equals, "published")
+}
+
+func TestOpenedDirectoryCreateTemp_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	opened, err := pathguard.OpenDirectory(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	c.Assert(opened.Close(), qt.IsNil)
+
+	file, name, err := opened.CreateTemp("staged-*")
+
+	c.Assert(err, qt.ErrorMatches, `create rooted temporary file staged-.*: .*`)
+	c.Assert(file, qt.IsNil)
+	c.Assert(name, qt.Equals, "")
+}
+
+func TestOpenedDirectoryCreateTempRejectsPathComponents(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	opened, err := pathguard.OpenDirectory(dir)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "current directory", pattern: "."},
+		{name: "parent directory", pattern: ".."},
+		{name: "parent traversal", pattern: filepath.Join("..", "escape-*")},
+		{name: "nested path", pattern: filepath.Join("nested", "file-*")},
+		{name: "absolute path", pattern: filepath.Join(dir, "absolute-*")},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			file, name, err := opened.CreateTemp(test.pattern)
+			c.Assert(err, qt.ErrorIs, fs.ErrInvalid)
+			var pathErr *fs.PathError
+			c.Assert(err, qt.ErrorAs, &pathErr)
+			c.Assert(pathErr.Op, qt.Equals, "createtemp")
+			c.Assert(pathErr.Path, qt.Equals, test.pattern)
+			c.Assert(file, qt.IsNil)
+			c.Assert(name, qt.Equals, "")
+		})
+	}
+}

--- a/internal/pathguard/opened_directory_replace_nonwindows_test.go
+++ b/internal/pathguard/opened_directory_replace_nonwindows_test.go
@@ -1,0 +1,30 @@
+//go:build !windows
+
+package pathguard_test
+
+import (
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestOpenedDirectoryReplaceFile_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	opened, err := pathguard.OpenDirectory(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	err = opened.ReplaceFile("missing", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	var linkErr *os.LinkError
+	c.Assert(err, qt.ErrorAs, &linkErr)
+	c.Assert(linkErr.Op, qt.Equals, "renameat")
+	c.Assert(linkErr.Old, qt.Equals, "missing")
+	c.Assert(linkErr.New, qt.Equals, "published")
+}

--- a/internal/pathguard/opened_directory_replace_windows_test.go
+++ b/internal/pathguard/opened_directory_replace_windows_test.go
@@ -1,0 +1,31 @@
+package pathguard_test
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestOpenedDirectoryReplaceFile_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	opened, err := pathguard.OpenDirectory(c.TempDir())
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	err = opened.ReplaceFile("missing", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	c.Assert(errors.Is(err, fsdurable.ErrReplacementCommitted), qt.IsFalse)
+	var pathErr *fs.PathError
+	c.Assert(err, qt.ErrorAs, &pathErr)
+	c.Assert(pathErr.Op, qt.Equals, "openat")
+	c.Assert(pathErr.Path, qt.Equals, "missing")
+}

--- a/internal/pathguard/pathguard_root_unix_test.go
+++ b/internal/pathguard/pathguard_root_unix_test.go
@@ -147,3 +147,43 @@ func TestOpenCurrentDirectoryAnchorsBeforePathReplacement(t *testing.T) {
 	c.Assert(string(contents), qt.Equals, "SELECT 'safe';\n")
 	c.Assert(opened.Close(), qt.IsNil)
 }
+
+func TestOpenedDirectoryReplaceFileAnchorsBeforeAncestorReplacement(t *testing.T) {
+	c := qt.New(t)
+	parent := c.TempDir()
+	directory := filepath.Join(parent, "root")
+	c.Assert(os.Mkdir(directory, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "target"), []byte("old"), 0o600), qt.IsNil)
+	opened, err := pathguard.OpenDirectory(directory)
+	c.Assert(err, qt.IsNil)
+	t.Cleanup(func() {
+		c.Assert(opened.Close(), qt.IsNil)
+	})
+
+	staged, stagedName, err := opened.CreateTemp("staged-*")
+	c.Assert(err, qt.IsNil)
+	_, err = staged.WriteString("new")
+	c.Assert(err, qt.IsNil)
+	c.Assert(staged.Sync(), qt.IsNil)
+	c.Assert(staged.Close(), qt.IsNil)
+
+	captured := filepath.Join(parent, "captured")
+	c.Assert(os.Rename(directory, captured), qt.IsNil)
+	outside := filepath.Join(parent, "outside")
+	c.Assert(os.Mkdir(outside, 0o700), qt.IsNil)
+	outsideContents := []byte("outside")
+	c.Assert(os.WriteFile(filepath.Join(outside, "target"), outsideContents, 0o600), qt.IsNil)
+	c.Assert(os.Symlink(outside, directory), qt.IsNil)
+
+	c.Assert(opened.ReplaceFile(stagedName, "target"), qt.IsNil)
+	c.Assert(opened.Sync(), qt.IsNil)
+
+	contents, err := os.ReadFile(filepath.Join(captured, "target"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	contents, err = os.ReadFile(filepath.Join(outside, "target"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(contents, qt.DeepEquals, outsideContents)
+	_, err = os.Stat(filepath.Join(captured, stagedName))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}


### PR DESCRIPTION
## Summary

- add root-relative durable replacement and directory synchronization primitives to `internal/fsdurable`
- expose rooted open, lstat, read, remove, temporary-file creation, replacement, and sync through `pathguard.OpenedDirectory`
- preserve the originally opened directory across ancestor rename/symlink replacement without exposing the underlying `*os.Root`
- verify operation/path error context and direct-child temp-file constraints with declarative black-box tests
- make each Windows publication test command an independent CI step so an earlier native failure cannot be masked by a later success

## Security and durability

- temporary files use cryptographic names and exclusive rooted creation
- Unix replacement uses `os.Root.Rename` followed by rooted directory synchronization
- Windows retains a write-capable staged-file handle across rename, uses rooted `Lstat` to reject symlink/non-regular destination entries, verifies destination identity with `os.SameFile`, and always attempts flush/close after commit
- Windows failures after a successful rename wrap `fsdurable.ErrReplacementCommitted`, so transaction callers can distinguish committed-but-not-finalized state from a pre-commit failure
- deterministic Unix ancestor-swap coverage proves the captured target changes while an outside target remains byte-identical
- platform-specific missing-source tests pin the actual Windows `openat` and Unix `renameat` error contracts without runtime branching

## Review status

The implementation completed two independent multi-agent review rounds:

- round 1 found a Windows read-only flush and rename/open identity gap; fixed in `f997545`
- round 2 found ambiguous post-commit errors, incomplete error context, final-symlink verification, skipped flush-on-verification-error, platform-specific error-contract differences, and a falsely green multi-command PowerShell step; fixed in `3cdbb0a` and `d5e9088`

Both independent reviewers approve exact head `d5e9088` with no remaining findings. Copilot review was requested on the same head but returned only a quota-limit notice and no code comments. Review threads are empty.

## Verification

Completed on exact pushed head `d5e9088`:

- `go test -race -count=10 ./internal/fsdurable ./internal/pathguard`
- `go test -race -count=1 ./...` outside the sandbox
- `go tool qtlint ./internal/fsdurable ./internal/pathguard`
- `scripts/check-test-style.sh`
- `gopls check` on every edited Go file
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- Linux amd64 test cross-compilation for both changed packages
- Windows amd64 test cross-compilation for both changed packages
- Ruby YAML parse for `.github/workflows/go-unit-tests.yml` (`actionlint` is not installed locally)
- all 14 executable GitHub checks succeeded; release was expectedly skipped
- corrected native `windows-publication` ran three independent steps and covered both `internal/fsdurable` and `internal/pathguard`

## Documentation

This PR adds internal reusable primitives and hardens an existing CI gate. It does not change CLI behavior, file formats, public Go APIs, or reader workflows. Package and exported-symbol comments document ownership, committed-state errors, and platform-specific durability sequencing; no reader-facing documentation update is required.

Closes #912.
Prerequisite for #900.