### PR TITLE
ci: bump ClickHouse and freeze the legacy integration pin

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
           - 3307:3306
 
       clickhouse:
-        image: clickhouse/clickhouse-server:24.12
+        image: clickhouse/clickhouse-server:26.7
         env:
           CLICKHOUSE_DB: ptah_test
           CLICKHOUSE_USER: ptah_user
@@ -79,6 +79,11 @@ jobs:
           - 9000:9000
 
       clickhouse-legacy:
+        # Pinned below 24.11 on purpose. CHECK GRANT catalog visibility arrived
+        # in 24.11, and TestWriterDropDatabaseRealm_RejectsLegacyServerLive
+        # proves the realm-drop guard fails closed without it. Bumping this tag
+        # deletes that coverage silently, so renovate.json disables updates for
+        # this pin.
         image: clickhouse/clickhouse-server:24.10
         env:
           CLICKHOUSE_DB: ptah_test

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -50,7 +50,7 @@ services:
       retries: 5
 
   clickhouse:
-    image: clickhouse/clickhouse-server:24
+    image: clickhouse/clickhouse-server:26
     environment:
       CLICKHOUSE_DB: ptah_test
       CLICKHOUSE_USER: ptah_user

--- a/renovate.json
+++ b/renovate.json
@@ -41,6 +41,17 @@
         "/^golang$/",
         "/^go$/"
       ]
+    },
+    {
+      "description": "The clickhouse-legacy integration service is pinned below 24.11 deliberately: CHECK GRANT catalog visibility arrived in 24.11, and TestWriterDropDatabaseRealm_RejectsLegacyServerLive proves the realm-drop guard fails closed without it. Matching on the current value freezes only that pin and leaves the current clickhouse service free to update.",
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "clickhouse/clickhouse-server"
+      ],
+      "matchCurrentValue": "24.10",
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
Replaces #883 and #886, both of which were CI-red regressions.

## The pin is deliberate

`go-integration-tests.yml` runs two ClickHouse services:

| Service | Tag | Env var | Purpose |
| --- | --- | --- | --- |
| `clickhouse` | 24.12 → **26.7** | `PTAH_CLICKHOUSE_REALM_TEST_URL` | supported behavior |
| `clickhouse-legacy` | **24.10**, frozen | `PTAH_CLICKHOUSE_LEGACY_REALM_TEST_URL` | proves the guard fails closed |

`TestWriterDropDatabaseRealm_RejectsLegacyServerLive` asserts that on a pre-24.11 server, `DropDatabaseRealm` refuses with:

> `ClickHouse 24.11 or newer is required to prove complete catalog visibility with CHECK GRANT`

So 24.10 is not a stale tag — it is the fixture. Any bump past 24.11 makes the guard stop tripping and the assertion fail.

## What renovate did

`renovate.json` had no `packageRules` for these images, so both services looked like one out-of-date dependency:

- #883 moved `clickhouse-legacy` 24.10 → 24.12
- #886 moved **both** services to 26.7

Both failed `integration-tests` in exactly `internal/dbschema/clickhouse`.

## This change

- Bumps only the current service, 24.12 → 26.7 (the part of #886 that was actually wanted), and the local compose service 24 → 26 so local and CI do not drift.
- Annotates the legacy pin in the workflow with why it exists.
- Freezes it in `renovate.json` with `matchCurrentValue: "24.10"`, so the legacy pin stops being proposed while the current service stays free to update.

## Follow-up

This is a symptom of something broader: a vendor can support several engine versions at once, and Ptah gates that behavior with an ad-hoc runtime version check rather than through the capability system. Tracked separately.