### PR TITLE
fix(schema): stop cleanup leaking credentials and destroying source bytes

### DIFF
--- a/cmd/schema/export_cleanup_safety_test.go
+++ b/cmd/schema/export_cleanup_safety_test.go
@@ -1,0 +1,113 @@
+package schema_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/schema"
+)
+
+// cliSecret is the credential planted in the compiled-command tests. Assertions
+// against it are boolean so a regression never prints it into CI output.
+const cliSecret = `s3cr3t "quoted" \pass`
+
+// decomposedAccentCLI is "e" followed by U+0301, written as an escape so a
+// normalizing editor cannot silently compose it and make the test vacuous.
+const decomposedAccentCLI = "e\u0301"
+
+// secretLeaked keeps the credential out of failure output: quicktest prints
+// matcher arguments, so qt.Not(qt.Contains) with the password would leak it.
+func secretLeaked(text, password string) bool {
+	return strings.Contains(text, password)
+}
+
+func writeRoleModel(c *qt.C, dir, password string) string {
+	c.Helper()
+	path := filepath.Join(dir, "model.go")
+	source := `package models
+
+//ptah:schema:role name="app_user" login="true" password="` + password + `"
+const _ = 0
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+	return path
+}
+
+func runSchemaExportCleanup(c *qt.C, args ...string) (stdout, stderr string, err error) {
+	c.Helper()
+	cmd := schema.NewSchemaCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(append([]string{"export"}, args...))
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func TestSchemaExportCleanupDiffRedactsRolePassword(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeRoleModel(c, dir, cliSecret)
+	outPath := filepath.Join(dir, "schema.hcl")
+
+	stdout, stderr, err := runSchemaExportCleanup(c,
+		"--root-dir", dir,
+		"--out", outPath,
+		"--cleanup-go-annotations",
+		"--cleanup-diff",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(secretLeaked(stdout, cliSecret), qt.IsFalse)
+	c.Assert(secretLeaked(stderr, cliSecret), qt.IsFalse)
+	c.Assert(stdout, qt.Contains, "password=***")
+	// The rest of the annotation stays readable.
+	c.Assert(stdout, qt.Contains, `name="app_user"`)
+}
+
+func TestSchemaExportRefusesCleanupOnNonNFCValue(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	modelPath := filepath.Join(dir, "model.go")
+	source := `package models
+
+//ptah:schema:function name="greet" params="" returns="text" language="sql" body="SELECT 'Caf` +
+		decomposedAccentCLI + `'"
+const _ = 0
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`
+	c.Assert(os.WriteFile(modelPath, []byte(source), 0o600), qt.IsNil)
+	outPath := filepath.Join(dir, "schema.hcl")
+
+	_, stderr, err := runSchemaExportCleanup(c,
+		"--root-dir", dir,
+		"--out", outPath,
+		"--cleanup-go-annotations",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(stderr, qt.Contains, "is not Unicode NFC")
+
+	// The source keeps the only copy of the exact bytes and no HCL was published.
+	content, readErr := os.ReadFile(modelPath)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(content), qt.Equals, source)
+	_, statErr := os.Stat(outPath)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}

--- a/cmd/schema/export_cleanup_safety_test.go
+++ b/cmd/schema/export_cleanup_safety_test.go
@@ -71,9 +71,10 @@ func TestSchemaExportCleanupDiffRedactsRolePassword(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(secretLeaked(stdout, cliSecret), qt.IsFalse)
 	c.Assert(secretLeaked(stderr, cliSecret), qt.IsFalse)
-	c.Assert(stdout, qt.Contains, "password=***")
-	// The rest of the annotation stays readable.
-	c.Assert(stdout, qt.Contains, `name="app_user"`)
+	// cliSecret carries a raw quote, so the delimiters are ambiguous and the
+	// mask correctly runs to end of line. Asserting the exact line means a
+	// partial mask cannot pass, and the expectation holds no fixture bytes.
+	c.Assert(stdout, qt.Contains, `-//ptah:schema:role name="app_user" login="true" password=***`)
 }
 
 func TestSchemaExportRefusesCleanupOnNonNFCValue(t *testing.T) {

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -24,6 +24,10 @@ type Attribute struct {
 	Required    bool   `json:"required,omitempty"`
 	Boolean     bool   `json:"boolean,omitempty"`
 	AliasFor    string `json:"alias_for,omitempty"`
+	// Sensitive marks an attribute whose VALUE is a credential. Display
+	// surfaces must redact it; planning and destructive writes keep using the
+	// original bytes.
+	Sensitive bool `json:"sensitive,omitempty"`
 }
 
 // Directive describes one //ptah annotation directive.
@@ -155,6 +159,32 @@ func AttributeNames(directive string) []string {
 	}
 	sort.Strings(names)
 	return names
+}
+
+// SensitiveAttributes returns the attribute names of directive whose values are
+// credentials, including alias spellings. Display surfaces use this to redact a
+// value without re-deriving which attributes are secret.
+func SensitiveAttributes(directive string) map[string]bool {
+	found, ok := Lookup(directive)
+	if !ok {
+		return nil
+	}
+	sensitive := make(map[string]bool)
+	for _, attribute := range found.Attributes {
+		if attribute.Sensitive {
+			sensitive[attribute.Name] = true
+		}
+	}
+	// An alias of a sensitive attribute is just as sensitive.
+	for _, attribute := range found.Attributes {
+		if attribute.AliasFor != "" && sensitive[attribute.AliasFor] {
+			sensitive[attribute.Name] = true
+		}
+	}
+	if len(sensitive) == 0 {
+		return nil
+	}
+	return sensitive
 }
 
 // BooleanAttributes returns the attributes accepted as bare booleans.
@@ -513,7 +543,7 @@ var directives = []Directive{
 		Attributes: []Attribute{
 			attr("name", "Role name.", valueString, false, false),
 			attr("login", "Creates the role with LOGIN.", valueBoolean, false, false),
-			attr("password", "Role password.", valueString, false, false),
+			sensitiveAttr("password", "Role password.", valueString, false, false),
 			attr("superuser", "Creates the role as SUPERUSER.", valueBoolean, false, false),
 			attr("createdb", "Allows database creation.", valueBoolean, false, false),
 			alias("create_db", "createdb", "Alias for createdb.", valueBoolean, false),
@@ -561,6 +591,13 @@ func attr(name, description, value string, required, boolean bool) Attribute {
 		Required:    required,
 		Boolean:     boolean,
 	}
+}
+
+// sensitiveAttr is attr for an attribute carrying a credential.
+func sensitiveAttr(name, description, value string, required, boolean bool) Attribute {
+	a := attr(name, description, value, required, boolean)
+	a.Sensitive = true
+	return a
 }
 
 func alias(name, aliasFor, description, value string, boolean bool) Attribute {

--- a/internal/annotationmeta/meta.go
+++ b/internal/annotationmeta/meta.go
@@ -187,6 +187,32 @@ func SensitiveAttributes(directive string) map[string]bool {
 	return sensitive
 }
 
+// AllSensitiveAttributes returns every attribute name marked Sensitive on any
+// directive, including alias spellings.
+//
+// Redaction uses this rather than SensitiveAttributes because a redactor must be
+// the WIDEST matcher in the system, not the narrowest. Directive resolution here
+// is stricter than the prefix match core/goschema uses to build a live role, so
+// gating on it would let a spelling Ptah still exports print its credential.
+func AllSensitiveAttributes() map[string]bool {
+	sensitive := make(map[string]bool)
+	for _, directive := range directives {
+		for _, attribute := range directive.Attributes {
+			if attribute.Sensitive {
+				sensitive[strings.ToLower(attribute.Name)] = true
+			}
+		}
+	}
+	for _, directive := range directives {
+		for _, attribute := range directive.Attributes {
+			if attribute.AliasFor != "" && sensitive[strings.ToLower(attribute.AliasFor)] {
+				sensitive[strings.ToLower(attribute.Name)] = true
+			}
+		}
+	}
+	return sensitive
+}
+
 // BooleanAttributes returns the attributes accepted as bare booleans.
 func BooleanAttributes() map[string]bool {
 	out := make(map[string]bool)

--- a/internal/annotationparse/parse.go
+++ b/internal/annotationparse/parse.go
@@ -112,6 +112,14 @@ func readDirective(body string) (string, int) {
 	return body[:end], end
 }
 
+// ScanAttributes returns every key="value" attribute on a single line, with
+// source ranges, without requiring the line to resolve to a known directive.
+// Redaction needs this: it must mask a credential even on a spelling the
+// directive recognizer rejects.
+func ScanAttributes(line string) []Attribute {
+	return scanAttributes(0, line)
+}
+
 func scanAttributes(lineNo int, line string) []Attribute {
 	matches := attrRe.FindAllStringSubmatchIndex(line, -1)
 	attrs := make([]Attribute, 0, len(matches))

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -516,34 +516,39 @@ const redactionMarker = "***"
 // source line, leaving the rest of the line byte-identical so the diff still
 // shows the file, directive, and the other attributes.
 //
-// The line is rescanned rather than reusing the ranges collected during
-// planning: those were computed against the comment text, whose offsets differ
-// from the raw source line by the leading indentation. Masking is done by
-// ValueRange offsets, not by matching the value, because a value may itself
-// contain a quote.
+// Matching is deliberately directive-INDEPENDENT. core/goschema builds a live
+// role from a bare "//ptah:schema:role" prefix, which accepts spellings the
+// directive recognizer rejects (a suffix, text before the "//", an exotic space
+// after it). Gating redaction on recognition would print the credential for
+// exactly those lines while Ptah still exported the role. A redactor has to be
+// the widest matcher in the system, so this masks any sensitive attribute name
+// on any line mentioning "ptah:". Over-masking is safe: the surface is
+// display-only, and planning and destructive writes use the original bytes.
+//
+// The line is rescanned rather than reusing ranges collected during planning:
+// those were computed against the comment text, whose offsets differ from the
+// raw source line by the leading indentation. Masking is done by ValueRange
+// offsets, not by matching the value, because a value may contain a quote.
 func redactSensitiveValues(line string) string {
-	annotations := annotationparse.Scan(line)
-	if len(annotations) == 0 {
+	if !strings.Contains(line, "ptah:") {
+		return line
+	}
+	sensitive := annotationmeta.AllSensitiveAttributes()
+	if len(sensitive) == 0 {
 		return line
 	}
 
 	type span struct{ start, end int }
 	var spans []span
-	for _, annotation := range annotations {
-		sensitive := annotationmeta.SensitiveAttributes(annotation.Directive)
-		if len(sensitive) == 0 {
+	for _, attribute := range annotationparse.ScanAttributes(line) {
+		if !sensitive[strings.ToLower(attribute.Name)] {
 			continue
 		}
-		for _, attribute := range annotation.Attributes {
-			if !sensitive[strings.ToLower(attribute.Name)] {
-				continue
-			}
-			start, end := attribute.ValueRange.Start.Character, attribute.ValueRange.End.Character
-			if start < 0 || end > len(line) || start >= end {
-				continue
-			}
-			spans = append(spans, span{start: start, end: end})
+		start, end := attribute.ValueRange.Start.Character, attribute.ValueRange.End.Character
+		if start < 0 || end > len(line) || start >= end {
+			continue
 		}
+		spans = append(spans, span{start: start, end: widenAmbiguousValue(line, start, end)})
 	}
 	if len(spans) == 0 {
 		return line
@@ -562,6 +567,24 @@ func redactSensitiveValues(line string) string {
 	}
 	builder.WriteString(line[cursor:])
 	return builder.String()
+}
+
+// widenAmbiguousValue extends a masked span to the end of the line when the
+// recognized value does not end at a token boundary.
+//
+// A password containing an unescaped quote, such as password="a"b", makes the
+// attribute regex stop at the inner quote, so masking only the recognized span
+// would print the remainder. The delimiters are ambiguous, so the safe reading
+// is that everything after it may still be the secret.
+func widenAmbiguousValue(line string, start, end int) int {
+	if end >= len(line) {
+		return end
+	}
+	switch line[end] {
+	case ' ', '\t', '\r', '\n':
+		return end
+	}
+	return end + len(strings.TrimRight(line[end:], "\r\n"))
 }
 
 func writeDiffLine(builder *strings.Builder, prefix byte, line string) {

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/internal/annotationmeta"
@@ -507,7 +508,64 @@ func diffRange(start, count int) string {
 	return fmt.Sprintf("%d,%d", start, count)
 }
 
+// redactionMarker replaces a credential in display-only output. It matches the
+// convention already used for connection strings in dbschema.
+const redactionMarker = "***"
+
+// redactSensitiveValues masks the value of every sensitive attribute in a
+// source line, leaving the rest of the line byte-identical so the diff still
+// shows the file, directive, and the other attributes.
+//
+// The line is rescanned rather than reusing the ranges collected during
+// planning: those were computed against the comment text, whose offsets differ
+// from the raw source line by the leading indentation. Masking is done by
+// ValueRange offsets, not by matching the value, because a value may itself
+// contain a quote.
+func redactSensitiveValues(line string) string {
+	annotations := annotationparse.Scan(line)
+	if len(annotations) == 0 {
+		return line
+	}
+
+	type span struct{ start, end int }
+	var spans []span
+	for _, annotation := range annotations {
+		sensitive := annotationmeta.SensitiveAttributes(annotation.Directive)
+		if len(sensitive) == 0 {
+			continue
+		}
+		for _, attribute := range annotation.Attributes {
+			if !sensitive[strings.ToLower(attribute.Name)] {
+				continue
+			}
+			start, end := attribute.ValueRange.Start.Character, attribute.ValueRange.End.Character
+			if start < 0 || end > len(line) || start >= end {
+				continue
+			}
+			spans = append(spans, span{start: start, end: end})
+		}
+	}
+	if len(spans) == 0 {
+		return line
+	}
+	sort.Slice(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+
+	var builder strings.Builder
+	cursor := 0
+	for _, s := range spans {
+		if s.start < cursor {
+			continue
+		}
+		builder.WriteString(line[cursor:s.start])
+		builder.WriteString(redactionMarker)
+		cursor = s.end
+	}
+	builder.WriteString(line[cursor:])
+	return builder.String()
+}
+
 func writeDiffLine(builder *strings.Builder, prefix byte, line string) {
+	line = redactSensitiveValues(line)
 	builder.WriteByte(prefix)
 	builder.WriteString(line)
 	if !strings.HasSuffix(line, "\n") {

--- a/internal/goannotationcleanup/redaction_test.go
+++ b/internal/goannotationcleanup/redaction_test.go
@@ -25,6 +25,15 @@ func leaks(text, password string) bool {
 	return strings.Contains(text, password)
 }
 
+// redactedRoleLine is the removed line a well-formed fixture produces: only the
+// value is masked and the remaining attributes stay readable.
+const redactedRoleLine = `-//ptah:schema:role name="app_user" login="true" password=*** superuser="false"`
+
+// redactedToEndOfLine is what an ambiguously delimited value produces. A raw
+// quote inside the value makes the attribute end where the value does not, so
+// everything after it may still be the secret and the mask runs to end of line.
+const redactedToEndOfLine = `-//ptah:schema:role name="app_user" login="true" password=***`
+
 func roleModelSource(password string) string {
 	return `package models
 
@@ -57,11 +66,18 @@ func TestCleanupDiffRedactsRolePassword(t *testing.T) {
 	tests := []struct {
 		name     string
 		password string
+		want     string
 	}{
-		{name: "plain", password: "SUPERSECRET"},
-		{name: "escaped", password: `p@ss w"rd`},
-		{name: "unicode", password: "pass-é-é"},
-		{name: "mixed", password: secretValue},
+		{name: "plain", password: "SUPERSECRET", want: redactedRoleLine},
+		// A properly escaped quote keeps the attribute well-formed, so the
+		// trailing attributes survive the mask.
+		{name: "escaped", password: `p@ss w\"rd`, want: redactedRoleLine},
+		{name: "unicode", password: "pass-é-é", want: redactedRoleLine},
+		{name: "backslash", password: `trailing\\`, want: redactedRoleLine},
+		// A raw quote makes the delimiters ambiguous, so masking must not stop
+		// at the fragment the attribute regex happened to recognize.
+		{name: "unescaped quote", password: `p@ss w"rd`, want: redactedToEndOfLine},
+		{name: "mixed", password: secretValue, want: redactedToEndOfLine},
 	}
 
 	for _, tt := range tests {
@@ -73,7 +89,46 @@ func TestCleanupDiffRedactsRolePassword(t *testing.T) {
 			// leaks() rather than qt.Not(qt.Contains): that matcher prints its
 			// argument on failure, which would put the credential in CI output.
 			c.Assert(leaks(diff, tt.password), qt.IsFalse)
-			c.Assert(diff, qt.Contains, "password=***")
+			// Exact line, not just "contains ***": a partially masked value
+			// leaves a residue that a containment check happily accepts. The
+			// expected text carries no fixture-derived bytes, so a regression
+			// cannot print the secret.
+			c.Assert(diff, qt.Contains, tt.want)
+		})
+	}
+}
+
+// TestCleanupDiffRedactsUnrecognizedDirectiveSpellings pins the rule that
+// redaction is directive-INDEPENDENT. core/goschema builds a live role from a
+// bare "//ptah:schema:role" prefix, so these spellings still export a role with
+// its password; gating the mask on directive recognition printed them in clear.
+func TestCleanupDiffRedactsUnrecognizedDirectiveSpellings(t *testing.T) {
+	tests := []struct {
+		name string
+		line string
+	}{
+		{name: "suffixed", line: `//ptah:schema:roles name="a" password="%s"`},
+		{name: "colon suffixed", line: `//ptah:schema:role:app name="a" password="%s"`},
+		{name: "text before slashes", line: `/* ops */ //ptah:schema:role name="a" password="%s"`},
+		{name: "non-ascii space", line: "//\u00a0ptah:schema:role name=\"a\" password=\"%s\""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			source := "package models\n\n" +
+				strings.Replace(tt.line, "%s", "hunter2", 1) + "\ntype AppRoles struct{}\n\n" +
+				`//ptah:schema:table name="users"` + "\ntype User struct {\n" +
+				"\t" + `//ptah:schema:field name="id" type="SERIAL" primary="true"` + "\n\tID int64\n}\n"
+			c.Assert(os.WriteFile(filepath.Join(dir, "model.go"), []byte(source), 0o600), qt.IsNil)
+
+			plan, err := planDir(dir)
+			c.Assert(err, qt.IsNil)
+
+			for _, result := range plan.DiffResults() {
+				c.Assert(leaks(result.Diff, "hunter2"), qt.IsFalse)
+			}
 		})
 	}
 }
@@ -94,22 +149,28 @@ func TestCleanupWritesOriginalBytesDespiteRedactedDiff(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
 	path := filepath.Join(dir, "model.go")
-	original := roleModelSource("SUPERSECRET")
+
+	// A role annotation inside a raw string literal is not schema intent, so
+	// cleanup leaves it alone. That makes the assertion load-bearing: the
+	// credential must survive in the file byte-for-byte even though the diff
+	// masked it. Asserting only on a removed line would be tautological, since
+	// removed text is absent whatever redaction does.
+	original := "package models\n\nconst doc = `\n" +
+		`//ptah:schema:role name="app_user" login="true" password="` + secretValue + `" superuser="false"` +
+		"\n`\n\n" +
+		`//ptah:schema:table name="users"` + "\ntype User struct {\n" +
+		"\t" + `//ptah:schema:field name="id" type="SERIAL" primary="true"` + "\n\tID int64\n}\n"
 	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
 
 	plan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)
-
-	// Planning is display-only: the source keeps the exact bytes, and the
-	// redaction never reaches the file that cleanup rewrites.
-	before, err := os.ReadFile(path)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(before), qt.Equals, original)
-
 	c.Assert(plan.Apply(), qt.IsNil)
 
 	after, err := os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
+	// The untouched literal keeps the exact original bytes, credential included.
+	c.Assert(leaks(string(after), secretValue), qt.IsTrue)
 	c.Assert(string(after), qt.Not(qt.Contains), "***")
-	c.Assert(string(after), qt.Not(qt.Contains), "ptah:schema:role")
+	// The real annotations were still removed.
+	c.Assert(string(after), qt.Not(qt.Contains), `//ptah:schema:table`)
 }

--- a/internal/goannotationcleanup/redaction_test.go
+++ b/internal/goannotationcleanup/redaction_test.go
@@ -1,0 +1,115 @@
+package goannotationcleanup_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// secretValue is the credential these tests plant. Assertions never compare
+// against it with a matcher that would echo it into failure output; they assert
+// a boolean instead, so a regression reports "value is not false" rather than
+// printing the password into CI logs.
+//
+//nolint:gosec // G101: fixture password, deliberately fake.
+const secretValue = `p@ss w"rd\ń`
+
+// leaks reports whether text still contains the credential. It exists so the
+// assertion can be boolean: quicktest prints matcher arguments on failure, so
+// asserting qt.Not(qt.Contains) with the password would defeat the very
+// property under test.
+func leaks(text, password string) bool {
+	return strings.Contains(text, password)
+}
+
+func roleModelSource(password string) string {
+	return `package models
+
+//ptah:schema:role name="app_user" login="true" password="` + password + `" superuser="false"
+const _ = 0
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`
+}
+
+func planRoleModel(c *qt.C, password string) string {
+	c.Helper()
+	dir := c.TempDir()
+	path := filepath.Join(dir, "model.go")
+	c.Assert(os.WriteFile(path, []byte(roleModelSource(password)), 0o600), qt.IsNil)
+
+	plan, err := planDir(dir)
+	c.Assert(err, qt.IsNil)
+	results := plan.DiffResults()
+	c.Assert(results, qt.HasLen, 1)
+	return results[0].Diff
+}
+
+func TestCleanupDiffRedactsRolePassword(t *testing.T) {
+	//nolint:gosec // G101: fixture passwords, deliberately fake, never real credentials.
+	tests := []struct {
+		name     string
+		password string
+	}{
+		{name: "plain", password: "SUPERSECRET"},
+		{name: "escaped", password: `p@ss w"rd`},
+		{name: "unicode", password: "pass-é-é"},
+		{name: "mixed", password: secretValue},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := planRoleModel(c, tt.password)
+
+			// leaks() rather than qt.Not(qt.Contains): that matcher prints its
+			// argument on failure, which would put the credential in CI output.
+			c.Assert(leaks(diff, tt.password), qt.IsFalse)
+			c.Assert(diff, qt.Contains, "password=***")
+		})
+	}
+}
+
+func TestCleanupDiffKeepsNonSensitiveAttributesReadable(t *testing.T) {
+	c := qt.New(t)
+
+	diff := planRoleModel(c, "SUPERSECRET")
+
+	// The diff must still identify the file, directive and the other
+	// attributes; only the credential is masked.
+	c.Assert(diff, qt.Contains, "model.go")
+	c.Assert(diff, qt.Contains, `-//ptah:schema:role name="app_user" login="true" password=*** superuser="false"`)
+	c.Assert(diff, qt.Contains, `-//ptah:schema:table name="users"`)
+}
+
+func TestCleanupWritesOriginalBytesDespiteRedactedDiff(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := roleModelSource("SUPERSECRET")
+	c.Assert(os.WriteFile(path, []byte(original), 0o600), qt.IsNil)
+
+	plan, err := planDir(dir)
+	c.Assert(err, qt.IsNil)
+
+	// Planning is display-only: the source keeps the exact bytes, and the
+	// redaction never reaches the file that cleanup rewrites.
+	before, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(before), qt.Equals, original)
+
+	c.Assert(plan.Apply(), qt.IsNil)
+
+	after, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(after), qt.Not(qt.Contains), "***")
+	c.Assert(string(after), qt.Not(qt.Contains), "ptah:schema:role")
+}

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -188,6 +188,14 @@ func renderExport(plan exportPlan) (renderedExport, error) {
 		return renderedExport{}, fmt.Errorf("render HCL schema: %w", err)
 	}
 	diagnostics := append([]atlashclrender.Diagnostic(nil), rendered.Diagnostics...)
+	// Normalization loss is detected against the SOURCE, not the rendered HCL:
+	// once cty has composed a value, the original code points are gone and the
+	// round-trip below can only prove the composed form is self-stable.
+	normalization, err := normalizationDiagnostics(plan.snapshot.FS())
+	if err != nil {
+		return renderedExport{}, fmt.Errorf("scan annotations for normalization loss: %w", err)
+	}
+	diagnostics = append(diagnostics, normalization...)
 	sortDiagnostics(diagnostics)
 	canonicalHCL, err := canonicalRoundTrip(rendered.Data)
 	if err != nil {

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -191,7 +191,7 @@ func renderExport(plan exportPlan) (renderedExport, error) {
 	// Normalization loss is detected against the SOURCE, not the rendered HCL:
 	// once cty has composed a value, the original code points are gone and the
 	// round-trip below can only prove the composed form is self-stable.
-	normalization, err := normalizationDiagnostics(plan.snapshot.FS())
+	normalization, err := normalizationDiagnostics(plan.snapshot.FS(), rendered.Data)
 	if err != nil {
 		return renderedExport{}, fmt.Errorf("scan annotations for normalization loss: %w", err)
 	}

--- a/internal/goannotationexport/normalization.go
+++ b/internal/goannotationexport/normalization.go
@@ -1,0 +1,111 @@
+package goannotationexport
+
+import (
+	"io/fs"
+	"path"
+	"sort"
+	"strconv"
+	"strings"
+
+	"golang.org/x/text/unicode/norm"
+
+	"github.com/stokaro/ptah/internal/annotationparse"
+	"github.com/stokaro/ptah/internal/atlashclrender"
+)
+
+// normalizationDiagnostics reports annotation attribute values that are not in
+// Unicode NFC.
+//
+// HCL rendering routes every string through cty.StringVal, which NFC-composes
+// it, while Go annotation parsing preserves the source code points. A
+// decomposed value therefore reaches the HCL with different bytes than it had
+// in the Go source. On its own that is only a fidelity loss, but destructive
+// cleanup then deletes the Go source, and with it the only copy of the original
+// bytes. Reporting the value as lossy lets the existing ErrLossyCleanup gate
+// refuse the cleanup before anything is written.
+//
+// Diagnostics identify the file, line, directive and attribute, and never carry
+// the value itself: an attribute may hold a credential.
+func normalizationDiagnostics(fsys fs.FS) ([]atlashclrender.Diagnostic, error) {
+	var diagnostics []atlashclrender.Diagnostic
+
+	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() || path.Ext(name) != ".go" {
+			return nil
+		}
+		data, err := fs.ReadFile(fsys, name)
+		if err != nil {
+			return err
+		}
+		diagnostics = append(diagnostics, fileNormalizationDiagnostics(name, string(data))...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	sort.Slice(diagnostics, func(i, j int) bool {
+		if diagnostics[i].Path != diagnostics[j].Path {
+			return diagnostics[i].Path < diagnostics[j].Path
+		}
+		return diagnostics[i].Message < diagnostics[j].Message
+	})
+	return diagnostics, nil
+}
+
+func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnostic {
+	var diagnostics []atlashclrender.Diagnostic
+	lines := strings.Split(source, "\n")
+
+	for _, annotation := range annotationparse.Scan(source) {
+		if !annotation.Known {
+			// Unknown directives are never rendered, so they cannot lose bytes
+			// through the HCL.
+			continue
+		}
+		if annotation.Line < 1 || annotation.Line > len(lines) {
+			continue
+		}
+		line := lines[annotation.Line-1]
+
+		for _, attribute := range annotation.Attributes {
+			value, ok := decodeAttributeValue(line, attribute)
+			if !ok || norm.NFC.IsNormalString(value) {
+				continue
+			}
+			diagnostics = append(diagnostics, atlashclrender.Diagnostic{
+				Severity: atlashclrender.SeverityWarning,
+				Path:     name,
+				Message: "line " + strconv.Itoa(annotation.Line) + ": " + annotation.Directive +
+					" attribute " + attribute.Name +
+					" is not Unicode NFC; HCL rendering composes it, so exporting changes its bytes",
+			})
+		}
+	}
+	return diagnostics
+}
+
+// decodeAttributeValue returns the attribute's value as the renderer will see
+// it. annotationparse keeps the raw span, quotes included, and its Value field
+// only trims quotes, so an escaped code point such as ́ would still look
+// like plain ASCII. Unquoting first is what core/goschema does when it builds
+// the schema, so this matches what actually reaches the renderer.
+func decodeAttributeValue(line string, attribute annotationparse.Attribute) (string, bool) {
+	start := attribute.ValueRange.Start.Character
+	end := attribute.ValueRange.End.Character
+	if start < 0 || end > len(line) || start >= end {
+		return attribute.Value, attribute.Value != ""
+	}
+	raw := line[start:end]
+	if !strings.HasPrefix(raw, `"`) {
+		return raw, raw != ""
+	}
+	unquoted, err := strconv.Unquote(raw)
+	if err != nil {
+		return strings.Trim(raw, `"`), true
+	}
+	return unquoted, true
+}

--- a/internal/goannotationexport/normalization.go
+++ b/internal/goannotationexport/normalization.go
@@ -1,6 +1,9 @@
 package goannotationexport
 
 import (
+	"bytes"
+	"go/parser"
+	"go/token"
 	"io/fs"
 	"path"
 	"sort"
@@ -26,7 +29,7 @@ import (
 //
 // Diagnostics identify the file, line, directive and attribute, and never carry
 // the value itself: an attribute may hold a credential.
-func normalizationDiagnostics(fsys fs.FS) ([]atlashclrender.Diagnostic, error) {
+func normalizationDiagnostics(fsys fs.FS, rendered []byte) ([]atlashclrender.Diagnostic, error) {
 	var diagnostics []atlashclrender.Diagnostic
 
 	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, err error) error {
@@ -40,7 +43,7 @@ func normalizationDiagnostics(fsys fs.FS) ([]atlashclrender.Diagnostic, error) {
 		if err != nil {
 			return err
 		}
-		diagnostics = append(diagnostics, fileNormalizationDiagnostics(name, string(data))...)
+		diagnostics = append(diagnostics, fileNormalizationDiagnostics(name, string(data), rendered)...)
 		return nil
 	})
 	if err != nil {
@@ -56,11 +59,25 @@ func normalizationDiagnostics(fsys fs.FS) ([]atlashclrender.Diagnostic, error) {
 	return diagnostics, nil
 }
 
-func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnostic {
+func fileNormalizationDiagnostics(name, source string, rendered []byte) []atlashclrender.Diagnostic {
 	var diagnostics []atlashclrender.Diagnostic
 	lines := strings.Split(source, "\n")
 
+	// Only real Go comments can become schema intent. Scanning raw text would
+	// also match a "//ptah:" line inside a string literal, which goschema never
+	// parses and cleanup never removes - reporting one would refuse a cleanup
+	// that loses nothing. Mirrors annotationLineNumbers in goannotationcleanup.
+	commentLines, ok := annotationCommentLines(name, source)
+	if !ok {
+		// Unparseable Go: goschema could not have built a schema from it, so
+		// there is nothing this check could be protecting.
+		return nil
+	}
+
 	for _, annotation := range annotationparse.Scan(source) {
+		if !commentLines[annotation.Line+1] {
+			continue
+		}
 		if !annotation.Known {
 			// Unknown directives are never rendered, so they cannot lose bytes
 			// through the HCL.
@@ -80,6 +97,13 @@ func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnost
 			if !ok || norm.NFC.IsNormalString(value) {
 				continue
 			}
+			// Being non-NFC is only a candidate signal. If the exact bytes
+			// survive into the output, nothing was lost and refusing cleanup
+			// would be a false positive: not every attribute is routed through
+			// cty as a string.
+			if bytes.Contains(rendered, []byte(value)) {
+				continue
+			}
 			diagnostics = append(diagnostics, atlashclrender.Diagnostic{
 				Severity: atlashclrender.SeverityWarning,
 				Path:     name,
@@ -90,6 +114,23 @@ func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnost
 		}
 	}
 	return diagnostics
+}
+
+// annotationCommentLines returns the 1-based lines of source that are genuine
+// Go comments. The second result is false when the file does not parse.
+func annotationCommentLines(name, source string) (map[int]bool, bool) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, name, source, parser.ParseComments|parser.SkipObjectResolution)
+	if err != nil {
+		return nil, false
+	}
+	lines := make(map[int]bool)
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			lines[fileSet.PositionFor(comment.Pos(), false).Line] = true
+		}
+	}
+	return lines, true
 }
 
 // decodeAttributeValue returns the attribute's value as the renderer will see

--- a/internal/goannotationexport/normalization.go
+++ b/internal/goannotationexport/normalization.go
@@ -66,10 +66,14 @@ func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnost
 			// through the HCL.
 			continue
 		}
-		if annotation.Line < 1 || annotation.Line > len(lines) {
+		// annotationparse.Scan numbers lines from zero, so the slice index is
+		// the line number itself. Reading lines[Line-1] would decode the
+		// PREVIOUS line, whose ranges never match, silently falling back to the
+		// quote-trimmed value and missing escaped code points entirely.
+		if annotation.Line < 0 || annotation.Line >= len(lines) {
 			continue
 		}
-		line := lines[annotation.Line-1]
+		line := lines[annotation.Line]
 
 		for _, attribute := range annotation.Attributes {
 			value, ok := decodeAttributeValue(line, attribute)
@@ -79,7 +83,7 @@ func fileNormalizationDiagnostics(name, source string) []atlashclrender.Diagnost
 			diagnostics = append(diagnostics, atlashclrender.Diagnostic{
 				Severity: atlashclrender.SeverityWarning,
 				Path:     name,
-				Message: "line " + strconv.Itoa(annotation.Line) + ": " + annotation.Directive +
+				Message: "line " + strconv.Itoa(annotation.Line+1) + ": " + annotation.Directive +
 					" attribute " + attribute.Name +
 					" is not Unicode NFC; HCL rendering composes it, so exporting changes its bytes",
 			})

--- a/internal/goannotationexport/normalization_test.go
+++ b/internal/goannotationexport/normalization_test.go
@@ -1,0 +1,159 @@
+package goannotationexport_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationexport"
+)
+
+// decomposedAccent is "e" followed by U+0301 COMBINING ACUTE ACCENT. Written as
+// an escape on purpose: an editor or filesystem that normalizes source files
+// would silently compose a literal and make these tests vacuous.
+const decomposedAccent = "e\u0301"
+
+// composedAccent is the same grapheme as the single code point U+00E9.
+const composedAccent = "\u00e9"
+
+// modelWithFunctionBody writes a minimal annotated package whose function body
+// carries the given text, and returns the directory holding it.
+func modelWithFunctionBody(c *qt.C, body string) string {
+	c.Helper()
+	dir := c.TempDir()
+	source := `package models
+
+//ptah:schema:function name="greet" params="" returns="text" language="sql" body="SELECT '` + body + `'"
+const _ = 0
+
+//ptah:schema:table name="items"
+type Item struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "models.go"), []byte(source), 0o600), qt.IsNil)
+	return dir
+}
+
+func exportOptions(dir, out string, cleanup bool) goannotationexport.Options {
+	return goannotationexport.Options{RootDir: dir, OutputPath: out, Cleanup: cleanup}
+}
+
+func TestExportReportsNonNFCAttributeValue(t *testing.T) {
+	c := qt.New(t)
+
+	dir := modelWithFunctionBody(c, "Caf"+decomposedAccent)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	result, err := goannotationexport.Export(exportOptions(dir, out, false))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.Not(qt.HasLen), 0)
+	c.Assert(diagnosticMessages(result), qt.Any(qt.Contains), "attribute body is not Unicode NFC")
+	c.Assert(diagnosticMessages(result), qt.Any(qt.Contains), "models.go")
+}
+
+func TestExportNonNFCDiagnosticNeverCarriesTheValue(t *testing.T) {
+	c := qt.New(t)
+
+	// A password is the case that matters: the diagnostic must name the
+	// attribute without ever echoing what it holds.
+	dir := c.TempDir()
+	source := `package models
+
+//ptah:schema:role name="app" login="true" password="Caf` + decomposedAccent + `-secret"
+const _ = 0
+
+//ptah:schema:table name="items"
+type Item struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "models.go"), []byte(source), 0o600), qt.IsNil)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	result, err := goannotationexport.Export(exportOptions(dir, out, false))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diagnosticMessages(result), qt.Any(qt.Contains), "attribute password is not Unicode NFC")
+	for _, message := range diagnosticMessages(result) {
+		c.Assert(message, qt.Not(qt.Contains), "secret")
+	}
+}
+
+func TestExportRefusesDestructiveCleanupOnNonNFCValue(t *testing.T) {
+	c := qt.New(t)
+
+	dir := modelWithFunctionBody(c, "Caf"+decomposedAccent)
+	source := filepath.Join(dir, "models.go")
+	before, err := os.ReadFile(source)
+	c.Assert(err, qt.IsNil)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	_, err = goannotationexport.Export(exportOptions(dir, out, true))
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorIs, goannotationexport.ErrLossyCleanup)
+
+	// The source still holds the only copy of the exact bytes, and nothing was
+	// published over the output path.
+	after, readErr := os.ReadFile(source)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(after, qt.DeepEquals, before)
+	_, statErr := os.Stat(out)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}
+
+func TestExportAcceptsComposedAndASCIIValues(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "composed", body: "Caf" + composedAccent},
+		{name: "ascii", body: "Cafe"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			dir := modelWithFunctionBody(c, tt.body)
+			out := filepath.Join(c.TempDir(), "schema.hcl")
+
+			result, err := goannotationexport.Export(exportOptions(dir, out, true))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(normalizationMessages(result), qt.HasLen, 0)
+		})
+	}
+}
+
+func diagnosticMessages(result goannotationexport.Result) []string {
+	messages := make([]string, 0, len(result.Diagnostics))
+	for _, diagnostic := range result.Diagnostics {
+		messages = append(messages, diagnostic.Path+": "+diagnostic.Message)
+	}
+	return messages
+}
+
+func normalizationMessages(result goannotationexport.Result) []string {
+	var messages []string
+	for _, diagnostic := range result.Diagnostics {
+		messages = appendIfNormalization(messages, diagnostic.Message)
+	}
+	return messages
+}
+
+// appendIfNormalization keeps the branch out of the test body, which teststyle
+// forbids.
+func appendIfNormalization(messages []string, message string) []string {
+	if strings.Contains(message, "is not Unicode NFC") {
+		return append(messages, message)
+	}
+	return messages
+}

--- a/internal/goannotationexport/normalization_test.go
+++ b/internal/goannotationexport/normalization_test.go
@@ -57,6 +57,37 @@ func TestExportReportsNonNFCAttributeValue(t *testing.T) {
 	c.Assert(diagnosticMessages(result), qt.Any(qt.Contains), "models.go")
 }
 
+func TestExportDetectsEscapedNonNFCCodePoint(t *testing.T) {
+	c := qt.New(t)
+
+	// The combining mark is written as a literal backslash escape, so the file
+	// holds only ASCII. Decoding has to unquote before checking, exactly as
+	// core/goschema does when it builds the schema; comparing the raw span
+	// would see plain ASCII and miss the loss.
+	dir := modelWithFunctionBody(c, `Cafe\u0301`)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	result, err := goannotationexport.Export(exportOptions(dir, out, false))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(normalizationMessages(result), qt.Not(qt.HasLen), 0)
+}
+
+func TestExportNonNFCDiagnosticReportsTheSourceLine(t *testing.T) {
+	c := qt.New(t)
+
+	// modelWithFunctionBody puts the function annotation on line 3: line 1 is
+	// the package clause and line 2 is blank. annotationparse numbers lines from
+	// zero, so a diagnostic that forwards that number unchanged is off by one.
+	dir := modelWithFunctionBody(c, "Caf"+decomposedAccent)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	result, err := goannotationexport.Export(exportOptions(dir, out, false))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(normalizationMessages(result), qt.Any(qt.Contains), "line 3:")
+}
+
 func TestExportNonNFCDiagnosticNeverCarriesTheValue(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/goannotationexport/normalization_test.go
+++ b/internal/goannotationexport/normalization_test.go
@@ -140,6 +140,34 @@ func TestExportRefusesDestructiveCleanupOnNonNFCValue(t *testing.T) {
 	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
 }
 
+// TestExportRenderedHCLLosesDecomposedBytes proves the loss the diagnostic
+// warns about is real, on an attribute that actually reaches the output: the
+// source bytes are decomposed and the rendered HCL holds the composed form.
+func TestExportRenderedHCLLosesDecomposedBytes(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	source := `package models
+
+//ptah:schema:table name="caf` + decomposedAccent + `_users"
+type User struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(dir, "models.go"), []byte(source), 0o600), qt.IsNil)
+	out := filepath.Join(c.TempDir(), "schema.hcl")
+
+	result, err := goannotationexport.Export(exportOptions(dir, out, false))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(normalizationMessages(result), qt.Not(qt.HasLen), 0)
+
+	rendered, err := os.ReadFile(out)
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Contains(string(rendered), decomposedAccent), qt.IsFalse)
+	c.Assert(strings.Contains(string(rendered), composedAccent), qt.IsTrue)
+}
+
 func TestExportAcceptsComposedAndASCIIValues(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/goannotationexport/normalization_test.go
+++ b/internal/goannotationexport/normalization_test.go
@@ -164,8 +164,10 @@ type User struct {
 
 	rendered, err := os.ReadFile(out)
 	c.Assert(err, qt.IsNil)
-	c.Assert(strings.Contains(string(rendered), decomposedAccent), qt.IsFalse)
-	c.Assert(strings.Contains(string(rendered), composedAccent), qt.IsTrue)
+	// No credential here, so the idiomatic matchers are right; the boolean
+	// helpers elsewhere exist only to keep passwords out of failure output.
+	c.Assert(string(rendered), qt.Not(qt.Contains), decomposedAccent)
+	c.Assert(string(rendered), qt.Contains, composedAccent)
 }
 
 func TestExportAcceptsComposedAndASCIIValues(t *testing.T) {


### PR DESCRIPTION
Fixes #901 and #902. Both were reproduced against a binary built from `master` before any change.

## #901 — credential leak in cleanup diffs

`ptah schema export --cleanup-go-annotations --cleanup-diff` printed whole removed annotation lines:

```
-//ptah:schema:role name="app_user" login="true" password="SUPERSECRET-123"
```

…to stdout and CI logs, while the HCL output carrying the same secret was correctly `0600`. Now:

```
-//ptah:schema:role name="app_user" login="true" password=***
```

`annotationmeta.Attribute` gains a `Sensitive` marker (set on the role `password`, and inherited by aliases via `SensitiveAttributes`), and the diff writer masks those values.

Two traps the implementation avoids, both called out by the issue's "must not rely on brittle substring replacement":

- **Masking is by `ValueRange` offsets, rescanned from the raw source line.** The ranges collected during planning are offsets into the *comment text*, which differs from the raw line by the leading indentation — reusing them would mask the wrong span.
- **Not by matching the value**, since a password may itself contain a quote.

Planning and destructive writes keep operating on the original bytes.

## #902 — silent destruction of source bytes

HCL rendering routes strings through `cty.StringVal`, which NFC-composes them, while annotation parsing preserves the source code points. Verified end to end: a function body containing `Cafe` + U+0301 was published as the composed form —

```
source : 43616665cc81   ("Cafe" + combining acute)
hcl    : 436166c3a9     (composed "é")
```

— with exit 0 and zero diagnostics, after which cleanup deleted the Go source holding the only copy of the original bytes.

Non-NFC attribute values are now detected **against the source**, before publication — once cty has composed a value the originals are gone, and the existing canonical round-trip can only prove the composed form is self-stable. The existing `ErrLossyCleanup` gate then refuses destructive cleanup before anything is written; it already ran before `stageOutput`, so no new ordering was introduced.

Detection decodes with `strconv.Unquote` first, matching what `core/goschema` does — otherwise an escaped code point looks like plain ASCII and slips through. Diagnostics name the file, line, directive and attribute, and never the value, since an attribute may hold a credential.

## Verification

- Non-destructive export reports `models.go: line 78: ptah:schema:function attribute body is not Unicode NFC; ...`
- Destructive cleanup exits non-zero with `refuse to clean Go annotations after a lossy HCL export`, leaving the Go source byte-identical (decomposed bytes intact) and the previous HCL untouched.
- **No false positives**: the repo's own parity fixture, an NFC-composed value, and plain ASCII all still clean successfully.
- `scripts/check-hcl-export-acceptance.sh` (added by #903) passes.

## Notes on the tests

- Credential absence is asserted through a named boolean helper rather than `qt.Not(qt.Contains)`. That matcher prints its argument on failure, which would put the password into CI output — the exact thing #901 exists to prevent. `qtlint` prefers the matcher, so the helper also keeps the lint honest without a blanket suppression.
- Unicode fixtures use `\u` escapes, not literals. A normalizing editor or filesystem would otherwise compose them silently and make the tests vacuous — I hit exactly that while building the reproduction.
- The composed-value case was mutation-checked: feeding it the decomposed form makes it fail, confirming the assertion is real.

Full gate green locally: `go test -race ./...`, `golangci-lint` 0 issues, `qtlint`, `teststyle` baseline unchanged (179 groups, 46 files).