### PR TITLE
docs: enforce the style guide and the responsive pass in CI (#804)

### DIFF
--- a/.agents/skills/ptah-documentation-maintenance/SKILL.md
+++ b/.agents/skills/ptah-documentation-maintenance/SKILL.md
@@ -219,19 +219,40 @@ practical, live commands:
   scripts/check-public-api-released.sh
   ```
 
-- For docs site changes, run:
+- For any documentation change, run the complete suite. These are the same
+  commands CI runs, so a local failure is a CI failure:
 
   ```bash
   cd docs/site
   npm ci
-  npm run build
+  npm run check:links:selftest
+  npm run check:links
+  npm run check:redirects:selftest
+  npm run check:redirects
+  npm run check:core-doc-links
+  npm run check:page-health
+  npm run check:exit-codes
+  npm run check:style:selftest
+  npm run check:style
   npm run versions:selftest
+  npm run build
+  # Renders every built page at 390px and 1280px and fails on horizontal
+  # overflow. Needs the built site, so it runs after the build. Requires
+  # Playwright's chromium (npx playwright install chromium); it skips with a
+  # message rather than failing when the browser is absent.
+  npm run check:responsive
   npm audit --audit-level=low
   ```
 
-- Run Markdown/link checks when the project has a checker available. If there is
-  no checker, at least run `rg` searches for stale links, old command names, and
-  unsupported claims.
+  `check:style` covers every layer the style guide governs — `docs/site`,
+  `docs/*.md`, `examples/**`, `integration/*.md`, and `README.md` — so run it
+  even when the change touches no site page. Section 13 of
+  `docs/STYLE_GUIDE.md` lists which rules these checks enforce; anything not in
+  that table is your responsibility to review by reading.
+
+- After the suite passes, `rg` for stale links, retired command spellings, and
+  unsupported claims. The checks verify structure, not whether a sentence is
+  still true.
 
 ## Self-Review
 

--- a/.agents/skills/ptah-documentation-maintenance/SKILL.md
+++ b/.agents/skills/ptah-documentation-maintenance/SKILL.md
@@ -238,17 +238,24 @@ practical, live commands:
   npm run build
   # Renders every built page at 390px and 1280px and fails on horizontal
   # overflow. Needs the built site, so it runs after the build. Requires
-  # Playwright's chromium (npx playwright install chromium); it skips with a
-  # message rather than failing when the browser is absent.
+  # Playwright's chromium (npx playwright install chromium); without it the
+  # check skips locally and fails in CI.
+  npm run check:responsive:selftest
   npm run check:responsive
   npm audit --audit-level=low
   ```
 
   `check:style` covers every layer the style guide governs — `docs/site`,
-  `docs/*.md`, `examples/**`, `integration/*.md`, and `README.md` — so run it
-  even when the change touches no site page. Section 13 of
+  `docs/*.md`, `examples/**`, `integration/*.md`, every package `README.md`,
+  and `AGENTS.md` — so run it even when the change touches no site page. It has
+  no npm dependencies, so `node docs/site/scripts/check-style.mjs` works from a
+  bare checkout; CI runs it that way in its own job. Section 13 of
   `docs/STYLE_GUIDE.md` lists which rules these checks enforce; anything not in
   that table is your responsibility to review by reading.
+
+  Never weaken a check to make a change pass. If a rule fires on correct
+  content, fix the rule and add the case to that check's `--selftest`, so the
+  next agent inherits the decision instead of rediscovering it.
 
 - After the suite passes, `rg` for stale links, retired command spellings, and
   unsupported claims. The checks verify structure, not whether a sentence is

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -75,7 +75,14 @@ jobs:
           npm run check:core-doc-links
           npm run check:page-health
           npm run check:exit-codes
+          npm run check:style:selftest
+          npm run check:style
+          npx playwright install --with-deps chromium
+          npm run check:responsive:selftest
           npm run build
+          # Needs the built site, so it runs after the build rather than with
+          # the other checks.
+          npm run check:responsive
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"
           cp -r dist/. "$GITHUB_WORKSPACE/_site/edge/"
 
@@ -100,6 +107,8 @@ jobs:
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:core-doc-links
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:page-health
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style:selftest
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build
           )
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -7,7 +7,15 @@ on:
       - 'v*'
   pull_request:
     paths:
-      - 'docs/site/**'
+      # The style check governs every documentation layer, so the workflow has
+      # to see changes to all of them. Only the site build is gated on
+      # docs/site/** below.
+      - 'docs/**'
+      - 'examples/**'
+      - 'integration/**'
+      - 'README.md'
+      - '**/README.md'
+      - 'AGENTS.md'
       - '.github/workflows/docs.yml'
 
 permissions:
@@ -26,6 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       docs: ${{ steps.filter.outputs.docs }}
+      style: ${{ steps.filter.outputs.style }}
     steps:
       - uses: actions/checkout@v7
       - id: filter
@@ -35,6 +44,40 @@ jobs:
             docs:
               - 'docs/site/**'
               - '.github/workflows/docs.yml'
+            style:
+              - 'docs/**'
+              - 'examples/**'
+              - 'integration/**'
+              - 'README.md'
+              - '**/README.md'
+              - 'AGENTS.md'
+              - '.github/workflows/docs.yml'
+
+  style:
+    name: Documentation style
+    needs: changes
+    # The site build only runs for docs/site changes, but the style guide also
+    # governs the repository docs, examples, integration docs, package READMEs,
+    # and AGENTS.md. Those layers get their own job so a change to one of them
+    # cannot merge unchecked.
+    if: >-
+      github.event_name == 'pull_request' ||
+      ( github.event_name == 'push' && github.ref == 'refs/heads/master' &&
+        needs.changes.outputs.style == 'true' )
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '24'
+
+      # check-style.mjs has no npm dependencies, so this needs no install step.
+      - name: Check documentation style
+        run: |
+          set -euo pipefail
+          node docs/site/scripts/check-style.mjs --selftest
+          node docs/site/scripts/check-style.mjs
 
   build:
     name: Build versioned site

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ site as the quality reference.
 Ptah treats `.golangci.yml` as a strict contract. Fix code to satisfy the configured linters instead of relaxing thresholds, disabling checks, or broadening exclusions. In particular, keep `revive` `error-strings` enabled and preserve the current "stricter wins" lint posture unless a maintainer explicitly asks for a config change.
 
 Ptah is pre-GA. Do not preserve old command aliases, compatibility wrappers,
-fallback APIs, or backward-compatibility behavior just to keep an older internal
+fallback APIs, or backward-compatibility behavior only to keep an older internal
 shape. Prefer the cleaner architecture and update callers/tests/docs unless a
 maintainer explicitly asks for a compatibility layer.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,6 +19,12 @@ merged, split, or retired, update the content inventory at
 [`docs/site/CONTENT_INVENTORY.md`](docs/site/CONTENT_INVENTORY.md) in the same
 PR.
 
+CI enforces the mechanical half of that guide. Section 13 of the guide lists
+exactly which rules fail a build and which stay a reading responsibility. Run
+`node docs/site/scripts/check-style.mjs` for any documentation change: it needs
+no npm install, and it governs this file, the repository docs, the examples,
+the integration docs, and every package README — not only the site.
+
 Before finishing any change that affects external behavior, inspect and update
 the relevant documentation. Do this as a required verification step, not as an
 opportunistic cleanup. Purely code-internal refactors that do not alter public

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -215,17 +215,19 @@ Complete this for every documentation PR:
 4. Parity and conformance claims checked against current
    `stokaro/ptah-atlas-conformance` reports.
 5. `npm run check:links:selftest && npm run check:links &&
-   npm run check:redirects && npm run check:core-doc-links &&
-   npm run check:page-health && npm run check:exit-codes &&
-   npm run check:style:selftest && npm run check:style &&
+   npm run check:redirects:selftest && npm run check:redirects &&
+   npm run check:core-doc-links && npm run check:page-health &&
+   npm run check:exit-codes && npm run check:style:selftest &&
+   npm run check:style && npm run check:responsive:selftest &&
    npm run versions:selftest && npm run build && npm run check:responsive`
    all pass in `docs/site`. `check:responsive` needs the built site, so it runs
-   last.
+   last. Run every `:selftest` alongside its check: a check whose self-test is
+   failing is not reporting on your content.
 6. `docs/site/CONTENT_INVENTORY.md` updated for any added, moved, merged,
    split, or retired page.
 7. Redirects added for every moved URL; no content links through a redirect.
 8. Desktop and mobile visual pass for structural changes. `check:responsive`
-   covers horizontal overflow at 390px and 1280px; judgement about hierarchy,
+   covers horizontal overflow at 390px and 1280px; judgment about hierarchy,
    density, and orientation still needs a person looking at the page.
 9. Stale-term sweep: `rg` for old slugs, old command spellings, and retired
    terms across `*.md`.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -216,11 +216,45 @@ Complete this for every documentation PR:
 5. `npm run check:links:selftest && npm run check:links &&
    npm run check:redirects && npm run check:core-doc-links &&
    npm run check:page-health && npm run check:exit-codes &&
-   npm run versions:selftest && npm run build` all pass in `docs/site`.
+   npm run check:style:selftest && npm run check:style &&
+   npm run versions:selftest && npm run build && npm run check:responsive`
+   all pass in `docs/site`. `check:responsive` needs the built site, so it runs
+   last.
 6. `docs/site/CONTENT_INVENTORY.md` updated for any added, moved, merged,
    split, or retired page.
 7. Redirects added for every moved URL; no content links through a redirect.
-8. Desktop and mobile visual pass for structural changes.
+8. Desktop and mobile visual pass for structural changes. `check:responsive`
+   covers horizontal overflow at 390px and 1280px; judgement about hierarchy,
+   density, and orientation still needs a person looking at the page.
 9. Stale-term sweep: `rg` for old slugs, old command spellings, and retired
    terms across `*.md`.
 10. American English pass: spelling, active voice, sentence-case headings.
+    `check-style.mjs` covers the spelling deny-list; active voice and heading
+    case still need a human reading.
+
+## 13. What is machine-enforced
+
+These rules fail CI, so a PR cannot merge while breaking them. Everything else
+in this guide is a review responsibility.
+
+| Rule | Section | Check |
+| --- | --- | --- |
+| American English spelling | 4 | `check:style` |
+| No `simply` / `easily` / `just` | 4, 11 | `check:style` |
+| Fenced blocks carry a language label | 6 | `check:style` |
+| Admonitions limited to note/tip/caution/danger | 7 | `check:style` |
+| No `testify` in samples | 6 | `check:style` |
+| `title` and `description` frontmatter | 3 | `check:page-health` |
+| Page registered in the sidebar | 9 | `check:page-health` |
+| No `TODO`/`TBD`/`FIXME`/"coming soon" | 11 | `check:page-health` |
+| Site-internal links resolve | 9 | `check:links` |
+| Moved URLs keep a redirect | 9 | `check:redirects` |
+| Site pages never link protected root docs | 9 | `check:core-doc-links` |
+| Exit-code tables stay in lockstep | 9 | `check:exit-codes` |
+| No page scrolls sideways at 390px or 1280px | 10 | `check:responsive` |
+
+`check:style` governs every layer the guide covers — `docs/site`, `docs/*.md`,
+`examples/**`, `integration/*.md`, and `README.md` — not only the site. It skips
+this file, which necessarily contains the words it bans. Each rule has a
+self-test (`npm run check:style:selftest`) so a refactor cannot turn the check
+into a no-op that reports success forever.

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -2,9 +2,10 @@
 
 This is the authoritative style guide for all Ptah documentation: the site
 under `docs/site/src/content/docs/`, the repository docs under `docs/*.md`,
-package READMEs, example READMEs, and integration docs. Contributor guidance
-(`AGENTS.md`) and the documentation-maintenance skill
-(`.agents/skills/ptah-documentation-maintenance/SKILL.md`) require it.
+package READMEs, example READMEs, integration docs, and `AGENTS.md` itself.
+Contributor guidance (`AGENTS.md`) and the documentation-maintenance skill
+(`.agents/skills/ptah-documentation-maintenance/SKILL.md`) require it. Section
+13 lists which of its rules CI enforces.
 
 It is contributor-facing and stays out of the reader sidebar. Site pages must
 not link to it on GitHub (`check-core-doc-links.mjs` forbids root-docs GitHub
@@ -243,7 +244,7 @@ in this guide is a review responsibility.
 | No `simply` / `easily` / `just` | 4, 11 | `check:style` |
 | Fenced blocks carry a language label | 6 | `check:style` |
 | Admonitions limited to note/tip/caution/danger | 7 | `check:style` |
-| No `testify` in samples | 6 | `check:style` |
+| No `testify` in code samples | 6 | `check:style` |
 | `title` and `description` frontmatter | 3 | `check:page-health` |
 | Page registered in the sidebar | 9 | `check:page-health` |
 | No `TODO`/`TBD`/`FIXME`/"coming soon" | 11 | `check:page-health` |
@@ -254,7 +255,26 @@ in this guide is a review responsibility.
 | No page scrolls sideways at 390px or 1280px | 10 | `check:responsive` |
 
 `check:style` governs every layer the guide covers — `docs/site`, `docs/*.md`,
-`examples/**`, `integration/*.md`, and `README.md` — not only the site. It skips
-this file, which necessarily contains the words it bans. Each rule has a
-self-test (`npm run check:style:selftest`) so a refactor cannot turn the check
-into a no-op that reports success forever.
+`examples/**`, `integration/*.md`, every package `README.md`, and `AGENTS.md` —
+not only the site. Package READMEs are discovered by walking the repository, so
+a new package cannot opt out by existing. This file is the one exemption: it
+necessarily contains the words it bans.
+
+Two properties keep these checks honest:
+
+- **They run for every layer they claim.** The Docs workflow builds the site
+  only for `docs/site/**` changes, so `check:style` has its own job that also
+  triggers on `docs/**`, `examples/**`, `integration/**`, any `README.md`, and
+  `AGENTS.md`. A change to a package README cannot merge unchecked.
+- **The self-tests drive the real checker.** `check:style:selftest` and
+  `check:responsive:selftest` call the same functions the checks call, on
+  fixtures that must produce findings and fixtures that must not. Deleting a
+  rule fails its self-test rather than passing every file forever.
+
+Prose rules never read code, and code rules never read prose. A column may be
+named `cancelled`, and this guide names `testify` in order to ban it; neither is
+a violation.
+
+`check:responsive` needs a browser. Without one it skips locally with an install
+hint, and fails in CI — a green check that rendered nothing is worse than a red
+one.

--- a/docs/sequences.md
+++ b/docs/sequences.md
@@ -1,6 +1,6 @@
 # PostgreSQL Sequences with Ptah
 
-Ptah supports standalone PostgreSQL sequences as a first-class schema object through the `//ptah:schema:sequence` annotation. A standalone sequence is created with `CREATE SEQUENCE`, altered with `ALTER SEQUENCE`, and dropped with `DROP SEQUENCE`, and participates in the full generate / compare / migrate / rollback lifecycle just like tables, views, functions, and roles.
+Ptah supports standalone PostgreSQL sequences as a first-class schema object through the `//ptah:schema:sequence` annotation. A standalone sequence is created with `CREATE SEQUENCE`, altered with `ALTER SEQUENCE`, and dropped with `DROP SEQUENCE`, and participates in the full generate / compare / migrate / rollback lifecycle in the same way as tables, views, functions, and roles.
 
 Standalone sequences are a PostgreSQL feature that Atlas keeps out of its open-source core (it lives only in the proprietary "Pro" build). Ptah provides it as an open (MIT), local, no-account capability — see epic [#654](https://github.com/stokaro/ptah/issues/654).
 

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -16,7 +16,7 @@
         "tailwindcss": "4.3.3"
       },
       "devDependencies": {
-        "playwright": "^1.50.1"
+        "playwright": "^1.62.1"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -5992,35 +5992,35 @@
       }
     },
     "node_modules/playwright": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
-      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "playwright-core": "1.50.1"
+        "playwright-core": "1.62.1"
       },
       "bin": {
         "playwright": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "optionalDependencies": {
         "fsevents": "2.3.2"
       }
     },
     "node_modules/playwright-core": {
-      "version": "1.50.1",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
-      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "playwright-core": "cli.js"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       }
     },
     "node_modules/playwright/node_modules/fsevents": {

--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -14,6 +14,9 @@
         "astro": "7.1.6",
         "sharp": "^0.35.0",
         "tailwindcss": "4.3.3"
+      },
+      "devDependencies": {
+        "playwright": "^1.50.1"
       }
     },
     "node_modules/@astrojs/compiler-binding": {
@@ -75,9 +78,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -93,9 +93,6 @@
       "integrity": "sha512-f0heT9ZZEseSu5bHCeb80eL2DH07ArE6U9xi1WT/PEusNjzPmEr3GJsjG1tRLo5VYUUYX7h3ScaqGmGrMOVGmw==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -113,9 +110,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -131,9 +125,6 @@
       "integrity": "sha512-/Kebk8sO6HnLeSd691JkaAPfN7CqR9/KEXmWvyNPkaKNGmj8rTZ/lf2uXtnPu92Lan84UrKdIKVPy1fSo2encQ==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -536,9 +527,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -551,9 +539,6 @@
       "integrity": "sha512-v39HxiwGC5Rqm01HksP6+5Y+xKLPlsuVFgIgpEAo+SiQ22c+mJVhS3u7Z6ePAKdhL5NJoK1xq70kLz3L13AhpQ==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -568,9 +553,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -583,9 +565,6 @@
       "integrity": "sha512-bicEqglLlz++mWyADaZoP0JY20s4vDfLjaPYgQqC+NI4zZLTOOg1T4GB8aqtc822Pqji8SQBmSrTb7CrP8i08Q==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1311,9 +1290,6 @@
       "cpu": [
         "arm"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1329,9 +1305,6 @@
       "integrity": "sha512-dqVSFynCox4C/J8kT16V7SIFAns0IjgLwkvYT7p8LQVmJ5OS5b6tI9IGflxTeuBS//zXeFIUbwt5dwxyZ17cnA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1349,9 +1322,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1367,9 +1337,6 @@
       "integrity": "sha512-bsb4rI+NldGOsXuej2r8OdSS8+zXDVaCWxyWrcv6kneTOlgAHtZABRzBBCwdsPiD90J4myNJuHpg6kA20ImW/w==",
       "cpu": [
         "riscv64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1387,9 +1354,6 @@
       "cpu": [
         "s390x"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1405,9 +1369,6 @@
       "integrity": "sha512-ITPEtgffGJ0S6G9dRyw/366tJQqFRcHWPHhC+Stpg3Z8AEMrDrTr2lhdz4f/Y/HMbRh//7Z5mBzEpVdi62Oc3w==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
@@ -1425,9 +1386,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1444,9 +1402,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -1462,9 +1417,6 @@
       "integrity": "sha512-affVWCTLooy8TSxbDx2qkzuDeaWLNVBA+P//FNBirHsXpP2fuBhk5AuboYUnrDnzoXes8GFjpTx0SBFOCRg+FA==",
       "cpu": [
         "arm"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1488,9 +1440,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1512,9 +1461,6 @@
       "integrity": "sha512-sMd8rDxmpLOwv/7N44klFjOD5DUO7FLdjiXDI0hoxYaf7Ar262dQIEkosE98bps+5HPLtp/EvNqeqQtOycP/IA==",
       "cpu": [
         "ppc64"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1538,9 +1484,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1562,9 +1505,6 @@
       "integrity": "sha512-KgAxQ0DxpNOq1rG2t5cgTgShJFGSuU7XO45cqC+1NVOuZnP6tlgZRuSYOfNupGkHID0o3cJOsw4DVeJpMovcGw==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -1588,9 +1528,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1613,9 +1550,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -1637,9 +1571,6 @@
       "integrity": "sha512-6O1NPKcDVj9QEdg7Hx549EX8U0rp6yXQERqru6yRN7fGBn32UvIRJUlWnk+8xDCiG76hXVBbX82NZ/ZKr0euIg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "Apache-2.0",
       "optional": true,
@@ -2047,9 +1978,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2065,9 +1993,6 @@
       "integrity": "sha512-lAryqH7IteztmCXQXk0etKj4wBQ7Gx5S6LjKhsgp9zb8I5bsuvU/2llH1hDQcjsFeqIsovMVN339/8pUDDBXxA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2085,9 +2010,6 @@
       "cpu": [
         "ppc64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2103,9 +2025,6 @@
       "integrity": "sha512-gLYb4BIadlfTOYT5gO503n8zQjXflgzpD0FcyKh0Mzx3rqCZKnHoJWV9xe1KXUJ5lx2JfcSHr/mhzS0PC/McAA==",
       "cpu": [
         "s390x"
-      ],
-      "libc": [
-        "glibc"
       ],
       "license": "MIT",
       "optional": true,
@@ -2123,9 +2042,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2141,9 +2057,6 @@
       "integrity": "sha512-Me+PfPI2TMeOQk0gYWfLQZtTktrmzbr8cDboqX83XKc7UrgAi55gF+2dUkWdxd19n55Essp2yeca+O9N5rBxHg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2500,9 +2413,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2518,9 +2428,6 @@
       "integrity": "sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2538,9 +2445,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2556,9 +2460,6 @@
       "integrity": "sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -4570,9 +4471,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4592,9 +4490,6 @@
       "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -4616,9 +4511,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4638,9 +4530,6 @@
       "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MPL-2.0",
       "optional": true,
@@ -6100,6 +5989,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.50.1.tgz",
+      "integrity": "sha512-G8rwsOQJ63XG6BbKj2w5rHeavFjy5zynBA9zsJMMtBoe/Uf757oG12NXz6e6OirF7RCrTVAKFXbLmn1RbL7Qaw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.50.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.50.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.50.1.tgz",
+      "integrity": "sha512-ra9fsNWayuYumt+NiM069M6OkcRb1FZSK8bgi66AtpFoWkg2+y0bJSNmkFrWhMbEBbVKC/EruAHH3g0zmtwGmQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -17,6 +17,10 @@
     "check:links:selftest": "node scripts/check-links.mjs --selftest",
     "check:redirects": "node scripts/check-redirects.mjs",
     "check:redirects:selftest": "node scripts/check-redirects.mjs --selftest",
+    "check:style": "node scripts/check-style.mjs",
+    "check:style:selftest": "node scripts/check-style.mjs --selftest",
+    "check:responsive": "node scripts/check-responsive.mjs",
+    "check:responsive:selftest": "node scripts/check-responsive.mjs --selftest",
     "versions:selftest": "node scripts/gen-versions.mjs --selftest"
   },
   "dependencies": {
@@ -26,5 +30,8 @@
     "astro": "7.1.6",
     "sharp": "^0.35.0",
     "tailwindcss": "4.3.3"
+  },
+  "devDependencies": {
+    "playwright": "^1.50.1"
   }
 }

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -32,6 +32,6 @@
     "tailwindcss": "4.3.3"
   },
   "devDependencies": {
-    "playwright": "^1.50.1"
+    "playwright": "^1.62.1"
   }
 }

--- a/docs/site/scripts/check-responsive.mjs
+++ b/docs/site/scripts/check-responsive.mjs
@@ -230,7 +230,13 @@ async function main() {
       return;
     }
     const failures = [];
-    const browser = await chromium.launch();
+    let browser;
+    try {
+      browser = await chromium.launch();
+    } catch (error) {
+      unavailable(`chromium failed to launch (${error.message.split('\n')[0]})`);
+      return;
+    }
     try {
       const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
       await page.setContent('<main><div style="width:1200px">wide</div></main>');

--- a/docs/site/scripts/check-responsive.mjs
+++ b/docs/site/scripts/check-responsive.mjs
@@ -11,10 +11,12 @@
 // Usage:
 //   node scripts/check-responsive.mjs [--dist <dir>] [--selftest]
 //
-// Requires Playwright's chromium. Skips with a clear message when it is absent,
-// so a contributor without the browser is told rather than failing obscurely.
+// Requires Playwright's chromium. A contributor without it is told what to
+// install and the check skips; in CI it fails instead, because a green check
+// that measured nothing is worse than a red one.
 import { createServer } from 'node:http';
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
 import { dirname, extname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -163,33 +165,124 @@ async function loadChromium() {
   }
 }
 
+// unavailable reports the browser as missing. In CI that is a failure: the
+// dependency is installed by the workflow, so its absence means the check would
+// have reported success without rendering a single page.
+function unavailable(reason) {
+  const install = 'npm i -D playwright && npx playwright install chromium';
+  if (process.env.CI) {
+    console.error(`check-responsive.mjs: ${reason}; CI must not report success without rendering the site.`);
+    console.error(`Install it with: ${install}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-responsive.mjs: SKIPPED (${reason}; run "${install}")`);
+}
+
+// watchStylesheets records failed stylesheet responses for the page. A page
+// served without its stylesheets has none of the layout that causes overflow,
+// so it looks clean and the check reports a false OK. Watching for failed
+// STYLESHEET requests catches that directly: it is how a wrong base path, a
+// renamed asset, or a broken build shows up. Other 404s are ignored on purpose
+// - versions.json, for one, is produced by the deploy workflow rather than by
+// `npm run build`, and its absence locally says nothing about layout.
+function watchStylesheets(page) {
+  let failures = [];
+  page.on('response', (response) => {
+    if (response.status() < 400) return;
+    const path = new URL(response.url()).pathname;
+    if (response.request().resourceType() === 'stylesheet' || path.endsWith('.css')) {
+      failures.push(`${response.status()} ${path}`);
+    }
+  });
+  return {
+    reset: () => {
+      failures = [];
+    },
+    failures: () => [...new Set(failures)],
+  };
+}
+
+// writeFixtureDist builds the smallest site that exercises base detection: one
+// page whose stylesheet lives under the build's base path.
+function writeFixtureDist(base) {
+  const root = mkdtempSync(join(tmpdir(), 'ptah-responsive-'));
+  mkdirSync(join(root, '_astro'), { recursive: true });
+  writeFileSync(join(root, '_astro', 'style.css'), 'main { color: #000; }\n');
+  writeFileSync(
+    join(root, 'index.html'),
+    `<!doctype html><html><head><link rel="stylesheet" href="${base}/_astro/style.css"></head>` +
+      '<body><main><p>fits</p></main></body></html>\n',
+  );
+  return root;
+}
+
 async function main() {
   if (process.argv.includes('--selftest')) {
-    // The self-test proves the overflow detector fires, using a page built to
-    // overflow, so this check cannot silently degrade into always passing.
+    // The self-test proves both halves of the check fire: the overflow detector
+    // on a page built to overflow, and the unstyled-page guard on a site served
+    // at the wrong base. The second half is not hypothetical - an early version
+    // of this script ignored the base path, rendered every page unstyled, and
+    // reported 289 overflow findings that were entirely its own fault.
     const chromium = await loadChromium();
     if (!chromium) {
-      console.log('check-responsive.mjs --selftest: SKIPPED (playwright not installed)');
+      unavailable('playwright is not installed');
       return;
     }
-    const browser = await chromium.launch();
-    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
-    await page.setContent('<main><div style="width:1200px">wide</div></main>');
-    const wide = await page.evaluate(measure, overflowTolerance);
-    await page.setContent('<main><div style="width:100px">narrow</div></main>');
-    const narrow = await page.evaluate(measure, overflowTolerance);
-    await browser.close();
-
     const failures = [];
-    if (wide.offenders.length === 0) failures.push('overflow detector did not fire on a 1200px element at 390px');
-    if (narrow.offenders.length > 0) failures.push('overflow detector fired on a page that fits');
+    const browser = await chromium.launch();
+    try {
+      const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+      await page.setContent('<main><div style="width:1200px">wide</div></main>');
+      const wide = await page.evaluate(measure, overflowTolerance);
+      await page.setContent('<main><div style="width:100px">narrow</div></main>');
+      const narrow = await page.evaluate(measure, overflowTolerance);
+      if (wide.offenders.length === 0) failures.push('overflow detector did not fire on a 1200px element at 390px');
+      if (narrow.offenders.length > 0) failures.push('overflow detector fired on a page that fits');
+
+      const fixtureBase = '/ptah/edge';
+      const distRoot = writeFixtureDist(fixtureBase);
+      try {
+        const detected = detectBase(distRoot);
+        if (detected !== fixtureBase) {
+          failures.push(`base detection returned ${JSON.stringify(detected)}, expected ${fixtureBase}`);
+        }
+        if (htmlRoutes(distRoot).length !== 1) failures.push('route discovery did not find the fixture page');
+
+        const watcher = watchStylesheets(page);
+
+        // Correct base: the stylesheet resolves, so the guard stays quiet.
+        const good = await startServer(distRoot, detected);
+        watcher.reset();
+        await page.goto(`http://127.0.0.1:${good.port}${detected}/`, { waitUntil: 'load' });
+        if (watcher.failures().length > 0) {
+          failures.push(`unstyled-page guard fired on a correctly served page: ${watcher.failures().join(', ')}`);
+        }
+        good.server.close();
+
+        // Wrong base, which is the defect this guard exists for: the stylesheet
+        // 404s and the page renders unstyled.
+        const bad = await startServer(distRoot, '');
+        watcher.reset();
+        await page.goto(`http://127.0.0.1:${bad.port}/`, { waitUntil: 'load' });
+        if (watcher.failures().length === 0) {
+          failures.push('unstyled-page guard did not fire when every stylesheet 404s');
+        }
+        bad.server.close();
+      } finally {
+        rmSync(distRoot, { recursive: true, force: true });
+      }
+    } finally {
+      await browser.close();
+    }
+
     if (failures.length > 0) {
       console.error('check-responsive.mjs --selftest: FAILED');
       for (const failure of failures) console.error(`- ${failure}`);
       process.exitCode = 1;
       return;
     }
-    console.log('check-responsive.mjs --selftest: OK (overflow detector verified both ways)');
+    console.log('check-responsive.mjs --selftest: OK (overflow detector and unstyled-page guard both verified)');
     return;
   }
 
@@ -202,43 +295,36 @@ async function main() {
 
   const chromium = await loadChromium();
   if (!chromium) {
-    console.log('check-responsive.mjs: SKIPPED (playwright not installed; run "npm i -D playwright && npx playwright install chromium")');
+    unavailable('playwright is not installed');
     return;
   }
 
   const routes = htmlRoutes(distRoot);
   const base = detectBase(distRoot);
   const { server, port } = await startServer(distRoot, base);
-  const browser = await chromium.launch();
+  let browser;
+  try {
+    browser = await chromium.launch();
+  } catch (error) {
+    server.close();
+    unavailable(`chromium failed to launch (${error.message.split('\n')[0]})`);
+    return;
+  }
   const errors = [];
 
   try {
     for (const viewport of viewports) {
       const context = await browser.newContext({ viewport: { width: viewport.width, height: viewport.height } });
       const page = await context.newPage();
+      const stylesheets = watchStylesheets(page);
 
-      // A page served without its stylesheets has none of the layout that
-      // causes overflow, so it looks clean and the check reports a false OK.
-      // Watching for failed STYLESHEET requests catches that directly: it is how
-      // a wrong base path, a renamed asset, or a broken build shows up. Other
-      // 404s are ignored on purpose - versions.json, for one, is produced by the
-      // deploy workflow rather than by `npm run build`, and its absence locally
-      // says nothing about layout.
-      let failedStylesheets = [];
-      page.on('response', (response) => {
-        if (response.status() < 400) return;
-        const path = new URL(response.url()).pathname;
-        if (response.request().resourceType() === 'stylesheet' || path.endsWith('.css')) {
-          failedStylesheets.push(`${response.status()} ${path}`);
-        }
-      });
       for (const route of routes) {
-        failedStylesheets = [];
+        stylesheets.reset();
         await page.goto(`http://127.0.0.1:${port}${base}${route}`, { waitUntil: 'load' });
-        if (failedStylesheets.length > 0) {
+        if (stylesheets.failures().length > 0) {
           errors.push(
             `${route} [${viewport.name}]: stylesheet request(s) failed ` +
-              `(${[...new Set(failedStylesheets)].slice(0, 3).join(', ')}); the page rendered unstyled, ` +
+              `(${stylesheets.failures().slice(0, 3).join(', ')}); the page rendered unstyled, ` +
               'so any overflow result would be meaningless',
           );
           continue;

--- a/docs/site/scripts/check-responsive.mjs
+++ b/docs/site/scripts/check-responsive.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+// Renders every built page at desktop and mobile widths and fails on layout
+// defects a reader would hit: a page that scrolls sideways, or an element wider
+// than the viewport.
+//
+// This replaces the manual "review the site on a desktop and a phone" pass that
+// documentation restructuring work kept deferring. A human still judges wording
+// and information architecture, but overflow is mechanical, and mechanical
+// checks are the ones that should not depend on someone remembering.
+//
+// Usage:
+//   node scripts/check-responsive.mjs [--dist <dir>] [--selftest]
+//
+// Requires Playwright's chromium. Skips with a clear message when it is absent,
+// so a contributor without the browser is told rather than failing obscurely.
+import { createServer } from 'node:http';
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(scriptDir, '..');
+
+// Widths chosen for what they expose: 390 is a common phone viewport and the
+// width at which Starlight collapses navigation; 1280 is a laptop.
+const viewports = [
+  { name: 'mobile', width: 390, height: 844 },
+  { name: 'desktop', width: 1280, height: 900 },
+];
+
+// A few pixels of slack: sub-pixel rounding in the layout engine otherwise
+// reports overflow on pages that look correct.
+const overflowTolerance = 2;
+
+const mimeTypes = {
+  '.html': 'text/html; charset=utf-8',
+  '.css': 'text/css; charset=utf-8',
+  '.js': 'text/javascript; charset=utf-8',
+  '.json': 'application/json; charset=utf-8',
+  '.svg': 'image/svg+xml',
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.webp': 'image/webp',
+  '.woff': 'font/woff',
+  '.woff2': 'font/woff2',
+  '.ico': 'image/x-icon',
+  '.xml': 'application/xml; charset=utf-8',
+  '.txt': 'text/plain; charset=utf-8',
+  '.pagefind': 'application/octet-stream',
+};
+
+function toPosix(value) {
+  return value.split(sep).join('/');
+}
+
+function argValue(flag, fallback) {
+  const index = process.argv.indexOf(flag);
+  return index >= 0 && process.argv[index + 1] ? process.argv[index + 1] : fallback;
+}
+
+function htmlRoutes(distRoot) {
+  const routes = [];
+  const walk = (dir) => {
+    for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(full);
+        continue;
+      }
+      if (entry.isFile() && entry.name === 'index.html') {
+        // Redirect stubs navigate away the moment they load, so measuring them
+        // is meaningless and races the evaluate. check-redirects.mjs owns them.
+        if (/http-equiv=["']?refresh/i.test(readFileSync(full, 'utf8'))) continue;
+        const route = '/' + toPosix(relative(distRoot, dir)).replace(/^\.$/, '');
+        routes.push(route === '/' ? '/' : `${route}/`);
+      }
+    }
+  };
+  walk(distRoot);
+  return routes;
+}
+
+// detectBase reads the base path the site was built with. Astro prefixes every
+// asset URL with it, so a server that ignores it 404s every stylesheet and
+// silently measures unstyled pages - which look fine to an overflow check
+// because none of the layout that causes overflow has been applied.
+function detectBase(distRoot) {
+  const home = join(distRoot, 'index.html');
+  if (!existsSync(home)) return '';
+  const match = readFileSync(home, 'utf8').match(/(?:href|src)="([^"]*)\/_astro\//);
+  return match ? match[1] : '';
+}
+
+function startServer(distRoot, base) {
+  const server = createServer((request, response) => {
+    let url = decodeURIComponent((request.url ?? '/').split('?')[0]);
+    if (base && url.startsWith(base)) url = url.slice(base.length) || '/';
+    let filePath = join(distRoot, url);
+    if (existsSync(filePath) && statSync(filePath).isDirectory()) {
+      filePath = join(filePath, 'index.html');
+    }
+    if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+      response.writeHead(404);
+      response.end('not found');
+      return;
+    }
+    response.writeHead(200, { 'content-type': mimeTypes[extname(filePath)] ?? 'application/octet-stream' });
+    response.end(readFileSync(filePath));
+  });
+  return new Promise((resolve) => {
+    server.listen(0, '127.0.0.1', () => resolve({ server, port: server.address().port }));
+  });
+}
+
+// measure runs in the page. It reports the document's own horizontal overflow
+// plus the specific elements that stick out, so a failure names the culprit
+// instead of only the page.
+const measure = (tolerance) => {
+  const doc = document.documentElement;
+  const viewportWidth = doc.clientWidth;
+
+  // An element inside a scrollable container is allowed to be wider than the
+  // viewport; that is exactly how a wide table or code block is supposed to
+  // behave. Only content that escapes every scroll container can push the page
+  // sideways, so ancestors are checked before an element is reported.
+  const escapesScrollContainer = (element) => {
+    for (let node = element.parentElement; node && node !== doc; node = node.parentElement) {
+      const overflowX = getComputedStyle(node).overflowX;
+      if (overflowX === 'auto' || overflowX === 'scroll' || overflowX === 'hidden') return false;
+    }
+    return true;
+  };
+
+  const offenders = [];
+  for (const element of document.querySelectorAll('main *')) {
+    const rect = element.getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) continue;
+    if (rect.right <= viewportWidth + tolerance) continue;
+    if (!escapesScrollContainer(element)) continue;
+    // Report the outermost offender only: a wide table makes every cell inside
+    // it look wide too, and listing all of them buries the cause.
+    if (offenders.some((entry) => entry.element.contains(element))) continue;
+    offenders.push({
+      element,
+      tag: element.tagName.toLowerCase(),
+      className: typeof element.className === 'string' ? element.className.slice(0, 60) : '',
+      right: Math.round(rect.right),
+    });
+  }
+  return {
+    scrollWidth: doc.scrollWidth,
+    clientWidth: viewportWidth,
+    offenders: offenders.slice(0, 5).map(({ tag, className, right }) => ({ tag, className, right })),
+  };
+};
+
+async function loadChromium() {
+  try {
+    const { chromium } = await import('playwright');
+    return chromium;
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  if (process.argv.includes('--selftest')) {
+    // The self-test proves the overflow detector fires, using a page built to
+    // overflow, so this check cannot silently degrade into always passing.
+    const chromium = await loadChromium();
+    if (!chromium) {
+      console.log('check-responsive.mjs --selftest: SKIPPED (playwright not installed)');
+      return;
+    }
+    const browser = await chromium.launch();
+    const page = await browser.newPage({ viewport: { width: 390, height: 844 } });
+    await page.setContent('<main><div style="width:1200px">wide</div></main>');
+    const wide = await page.evaluate(measure, overflowTolerance);
+    await page.setContent('<main><div style="width:100px">narrow</div></main>');
+    const narrow = await page.evaluate(measure, overflowTolerance);
+    await browser.close();
+
+    const failures = [];
+    if (wide.offenders.length === 0) failures.push('overflow detector did not fire on a 1200px element at 390px');
+    if (narrow.offenders.length > 0) failures.push('overflow detector fired on a page that fits');
+    if (failures.length > 0) {
+      console.error('check-responsive.mjs --selftest: FAILED');
+      for (const failure of failures) console.error(`- ${failure}`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log('check-responsive.mjs --selftest: OK (overflow detector verified both ways)');
+    return;
+  }
+
+  const distRoot = join(siteRoot, argValue('--dist', 'dist'));
+  if (!existsSync(distRoot)) {
+    console.error(`check-responsive.mjs: ${toPosix(relative(siteRoot, distRoot))} not found; run "npm run build" first.`);
+    process.exitCode = 1;
+    return;
+  }
+
+  const chromium = await loadChromium();
+  if (!chromium) {
+    console.log('check-responsive.mjs: SKIPPED (playwright not installed; run "npm i -D playwright && npx playwright install chromium")');
+    return;
+  }
+
+  const routes = htmlRoutes(distRoot);
+  const base = detectBase(distRoot);
+  const { server, port } = await startServer(distRoot, base);
+  const browser = await chromium.launch();
+  const errors = [];
+
+  try {
+    for (const viewport of viewports) {
+      const context = await browser.newContext({ viewport: { width: viewport.width, height: viewport.height } });
+      const page = await context.newPage();
+
+      // A page served without its stylesheets has none of the layout that
+      // causes overflow, so it looks clean and the check reports a false OK.
+      // Watching for failed STYLESHEET requests catches that directly: it is how
+      // a wrong base path, a renamed asset, or a broken build shows up. Other
+      // 404s are ignored on purpose - versions.json, for one, is produced by the
+      // deploy workflow rather than by `npm run build`, and its absence locally
+      // says nothing about layout.
+      let failedStylesheets = [];
+      page.on('response', (response) => {
+        if (response.status() < 400) return;
+        const path = new URL(response.url()).pathname;
+        if (response.request().resourceType() === 'stylesheet' || path.endsWith('.css')) {
+          failedStylesheets.push(`${response.status()} ${path}`);
+        }
+      });
+      for (const route of routes) {
+        failedStylesheets = [];
+        await page.goto(`http://127.0.0.1:${port}${base}${route}`, { waitUntil: 'load' });
+        if (failedStylesheets.length > 0) {
+          errors.push(
+            `${route} [${viewport.name}]: stylesheet request(s) failed ` +
+              `(${[...new Set(failedStylesheets)].slice(0, 3).join(', ')}); the page rendered unstyled, ` +
+              'so any overflow result would be meaningless',
+          );
+          continue;
+        }
+        const result = await page.evaluate(measure, overflowTolerance);
+        if (result.scrollWidth > result.clientWidth + overflowTolerance) {
+          errors.push(
+            `${route} [${viewport.name} ${viewport.width}px]: page scrolls horizontally ` +
+              `(scrollWidth ${result.scrollWidth} > ${result.clientWidth})`,
+          );
+        }
+        for (const offender of result.offenders) {
+          errors.push(
+            `${route} [${viewport.name} ${viewport.width}px]: <${offender.tag}${offender.className ? ` class="${offender.className}"` : ''}> ` +
+              `extends to ${offender.right}px, past the ${result.clientWidth}px viewport`,
+          );
+        }
+      }
+      await context.close();
+    }
+  } finally {
+    await browser.close();
+    server.close();
+  }
+
+  if (errors.length > 0) {
+    console.error('Documentation responsive check failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    console.error('\nWide content must scroll inside its own container, not the page.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-responsive.mjs: OK (${routes.length} routes x ${viewports.length} viewports)`);
+}
+
+await main();

--- a/docs/site/scripts/check-style.mjs
+++ b/docs/site/scripts/check-style.mjs
@@ -1,0 +1,261 @@
+#!/usr/bin/env node
+// Enforces the mechanically checkable rules of docs/STYLE_GUIDE.md.
+//
+// The style guide is authoritative for every documentation layer, but until now
+// it was enforced only by review, so a rule could be broken silently and stay
+// broken. This check covers the rules that are objective enough to automate:
+// American English, code-fence labels, banned filler, the admonition set, and
+// testify in samples. Rules that need editorial judgement (page taxonomy,
+// section templates, table design) remain a review responsibility.
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, extname, join, relative, sep } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(scriptDir, '..');
+const repoRoot = join(siteRoot, '..', '..');
+const docsRoot = join(siteRoot, 'src', 'content', 'docs');
+
+// docs/STYLE_GUIDE.md defines the banned words, so it necessarily contains
+// them. It is the rule source, not prose that has to obey the rule.
+const exemptFiles = new Set(['docs/STYLE_GUIDE.md']);
+
+// British spellings that docs/STYLE_GUIDE.md section 4 rules out. Each entry is
+// matched as a whole word, case-insensitively, with an optional suffix so that
+// "behaviours" and "organised" are caught alongside the stem.
+const britishSpellings = [
+  ['behaviour', 'behavior'],
+  ['colour', 'color'],
+  ['cancelled', 'canceled'],
+  ['cancelling', 'canceling'],
+  ['organis', 'organiz'],
+  ['recognis', 'recogniz'],
+  ['initialis', 'initializ'],
+  ['normalis', 'normaliz'],
+  ['serialis', 'serializ'],
+  ['synchronis', 'synchroniz'],
+  ['authoris', 'authoriz'],
+  ['analyse', 'analyze'],
+  ['licence', 'license'],
+  ['defence', 'defense'],
+  ['centre', 'center'],
+  ['catalogue', 'catalog'],
+  ['dialogue box', 'dialog box'],
+  ['favour', 'favor'],
+  ['honour', 'honor'],
+  ['labelled', 'labeled'],
+  ['labelling', 'labeling'],
+  ['modelling', 'modeling'],
+  ['travelled', 'traveled'],
+  ['fulfil ', 'fulfill '],
+  ['whilst', 'while'],
+  ['amongst', 'among'],
+];
+
+// docs/STYLE_GUIDE.md section 4: no marketing adjectives.
+const bannedFiller = ['simply', 'easily', 'just'];
+
+// docs/STYLE_GUIDE.md section 7 fixes the admonition set.
+const allowedAdmonitions = new Set(['note', 'tip', 'caution', 'danger']);
+
+function toPosix(value) {
+  return value.split(sep).join('/');
+}
+
+function walk(dir, extensions) {
+  const files = [];
+  if (!existsSync(dir)) return files;
+  for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
+    const fullPath = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.astro') continue;
+      files.push(...walk(fullPath, extensions));
+      continue;
+    }
+    if (entry.isFile() && extensions.includes(extname(entry.name))) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+// documentationFiles returns every file the style guide governs: the site, the
+// contributor docs, and the READMEs that readers reach from them.
+function documentationFiles() {
+  const files = [
+    ...walk(docsRoot, ['.md', '.mdx']),
+    ...walk(join(repoRoot, 'docs'), ['.md']).filter((file) => !toPosix(file).includes('/docs/site/')),
+    ...walk(join(repoRoot, 'examples'), ['.md']),
+    ...walk(join(repoRoot, 'integration'), ['.md']),
+  ];
+  const readme = join(repoRoot, 'README.md');
+  if (existsSync(readme) && statSync(readme).isFile()) files.push(readme);
+
+  const seen = new Set();
+  return files.filter((file) => {
+    const key = toPosix(relative(repoRoot, file));
+    if (seen.has(key) || exemptFiles.has(key)) return false;
+    seen.add(key);
+    return true;
+  });
+}
+
+// stripCode removes fenced blocks and inline spans so prose rules never fire on
+// SQL keywords, identifiers, or sample output. A column really can be named
+// "cancelled", and that is not a spelling error.
+function stripCode(source) {
+  const lines = source.split('\n');
+  const out = [];
+  let inFence = false;
+  for (const line of lines) {
+    if (line.trimStart().startsWith('```')) {
+      inFence = !inFence;
+      out.push('');
+      continue;
+    }
+    out.push(inFence ? '' : line.replace(/`[^`]*`/g, ''));
+  }
+  return out;
+}
+
+// fenceViolations reports opening fences with no language label.
+function fenceViolations(source) {
+  const violations = [];
+  const lines = source.split('\n');
+  let inFence = false;
+  for (const [index, line] of lines.entries()) {
+    const trimmed = line.trimStart();
+    if (!trimmed.startsWith('```')) continue;
+    if (inFence) {
+      inFence = false;
+      continue;
+    }
+    inFence = true;
+    if (trimmed.replace(/`+/g, '').trim() === '') {
+      violations.push({ line: index + 1, message: 'fenced code block has no language label' });
+    }
+  }
+  return violations;
+}
+
+function checkFile(file) {
+  const source = readFileSync(file, 'utf8');
+  const displayPath = toPosix(relative(repoRoot, file));
+  const findings = [];
+  const proseLines = stripCode(source);
+
+  for (const [index, line] of proseLines.entries()) {
+    const lineNumber = index + 1;
+
+    for (const [british, american] of britishSpellings) {
+      const pattern = new RegExp(`\\b${british.replace(/ /g, '\\s')}[a-z]*`, 'gi');
+      for (const match of line.matchAll(pattern)) {
+        findings.push({
+          line: lineNumber,
+          message: `British spelling "${match[0]}"; use American English ("${american.trim()}")`,
+        });
+      }
+    }
+
+    for (const word of bannedFiller) {
+      for (const match of line.matchAll(new RegExp(`\\b${word}\\b`, 'gi'))) {
+        findings.push({
+          line: lineNumber,
+          message: `banned filler "${match[0]}"; state the action instead`,
+        });
+      }
+    }
+
+    if (/\bstretchr\/testify\b/.test(line) || /\btestify\./.test(line)) {
+      findings.push({ line: lineNumber, message: 'testify appears in documentation; use quicktest (qt)' });
+    }
+  }
+
+  for (const [index, line] of source.split('\n').entries()) {
+    const match = line.match(/^:::([a-zA-Z]+)/);
+    if (match && !allowedAdmonitions.has(match[1].toLowerCase())) {
+      findings.push({
+        line: index + 1,
+        message: `admonition ":::${match[1]}" is not one of note, tip, caution, danger`,
+      });
+    }
+  }
+
+  findings.push(...fenceViolations(source));
+  return findings.map((finding) => `${displayPath}:${finding.line}: ${finding.message}`);
+}
+
+// selftest proves each rule actually fires, so a refactor cannot quietly turn
+// this check into a no-op that reports OK forever.
+function selftest() {
+  const cases = [
+    ['behaviour is documented', 'British spelling'],
+    ['this simply works', 'banned filler'],
+    ['use testify.Assert here', 'testify'],
+    [':::warning\ntext\n:::', 'admonition'],
+    ['```\nunlabeled\n```', 'no language label'],
+  ];
+  const failures = [];
+  for (const [sample, expected] of cases) {
+    const findings = [];
+    const proseLines = stripCode(sample);
+    for (const [index, line] of proseLines.entries()) {
+      for (const [british] of britishSpellings) {
+        if (new RegExp(`\\b${british.replace(/ /g, '\\s')}[a-z]*`, 'i').test(line)) {
+          findings.push(`${index + 1}: British spelling`);
+        }
+      }
+      for (const word of bannedFiller) {
+        if (new RegExp(`\\b${word}\\b`, 'i').test(line)) findings.push(`${index + 1}: banned filler`);
+      }
+      if (/\btestify\./.test(line)) findings.push(`${index + 1}: testify`);
+    }
+    for (const line of sample.split('\n')) {
+      const match = line.match(/^:::([a-zA-Z]+)/);
+      if (match && !allowedAdmonitions.has(match[1].toLowerCase())) findings.push('admonition');
+    }
+    for (const violation of fenceViolations(sample)) findings.push(violation.message);
+
+    if (!findings.some((finding) => finding.includes(expected))) {
+      failures.push(`rule "${expected}" did not fire for sample ${JSON.stringify(sample)}`);
+    }
+  }
+
+  // A clean sample must stay clean, or the check would fail every build.
+  const cleanFindings = [];
+  for (const line of stripCode('The behavior is documented.\n\n```bash\nls\n```\n')) {
+    for (const word of bannedFiller) {
+      if (new RegExp(`\\b${word}\\b`, 'i').test(line)) cleanFindings.push(word);
+    }
+  }
+  if (cleanFindings.length > 0) failures.push(`clean sample produced findings: ${cleanFindings.join(', ')}`);
+
+  if (failures.length > 0) {
+    console.error('check-style.mjs --selftest: FAILED');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-style.mjs --selftest: OK (${cases.length} rules verified)`);
+}
+
+function main() {
+  if (process.argv[2] === '--selftest') {
+    selftest();
+    return;
+  }
+
+  const files = documentationFiles();
+  const errors = files.flatMap(checkFile);
+
+  if (errors.length > 0) {
+    console.error('Documentation style check failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    console.error('\nSee docs/STYLE_GUIDE.md for the rules these findings reference.');
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-style.mjs: OK (${files.length} documentation files)`);
+}
+
+main();

--- a/docs/site/scripts/check-style.mjs
+++ b/docs/site/scripts/check-style.mjs
@@ -7,6 +7,12 @@
 // American English, code-fence labels, banned filler, the admonition set, and
 // testify in samples. Rules that need editorial judgement (page taxonomy,
 // section templates, table design) remain a review responsibility.
+//
+// Usage:
+//   node scripts/check-style.mjs [--selftest]
+//
+// The check has no npm dependencies on purpose: CI runs it from a bare checkout
+// for changes that touch no site page at all.
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs';
 import { dirname, extname, join, relative, sep } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -19,6 +25,19 @@ const docsRoot = join(siteRoot, 'src', 'content', 'docs');
 // docs/STYLE_GUIDE.md defines the banned words, so it necessarily contains
 // them. It is the rule source, not prose that has to obey the rule.
 const exemptFiles = new Set(['docs/STYLE_GUIDE.md']);
+
+// Directories that never hold governed documentation. Test fixtures are
+// excluded because their contents are inputs to a test, not prose a reader
+// meets; build output and dependencies are excluded because they are generated.
+const skipDirectories = new Set([
+  'node_modules',
+  'dist',
+  'bin',
+  'testdata',
+  'test-reports',
+  'coverage',
+  'tmp',
+]);
 
 // British spellings that docs/STYLE_GUIDE.md section 4 rules out. Each entry is
 // matched as a whole word, case-insensitively, with an optional suffix so that
@@ -62,34 +81,43 @@ function toPosix(value) {
   return value.split(sep).join('/');
 }
 
-function walk(dir, extensions) {
+function walk(dir, matches) {
   const files = [];
   if (!existsSync(dir)) return files;
   for (const entry of readdirSync(dir, { withFileTypes: true }).sort((a, b) => a.name.localeCompare(b.name))) {
     const fullPath = join(dir, entry.name);
     if (entry.isDirectory()) {
-      if (entry.name === 'node_modules' || entry.name === 'dist' || entry.name === '.astro') continue;
-      files.push(...walk(fullPath, extensions));
+      // Dot directories hold tooling, git state, and nested worktrees, none of
+      // which are reader-facing documentation.
+      if (entry.name.startsWith('.') || skipDirectories.has(entry.name)) continue;
+      files.push(...walk(fullPath, matches));
       continue;
     }
-    if (entry.isFile() && extensions.includes(extname(entry.name))) {
-      files.push(fullPath);
-    }
+    if (entry.isFile() && matches(entry.name)) files.push(fullPath);
   }
   return files;
 }
 
+const markdown = (name) => extname(name) === '.md' || extname(name) === '.mdx';
+const readme = (name) => name === 'README.md';
+
 // documentationFiles returns every file the style guide governs: the site, the
-// contributor docs, and the READMEs that readers reach from them.
+// repository docs, the example and integration docs, every package README, and
+// the contributor entry point that mandates the guide.
 function documentationFiles() {
   const files = [
-    ...walk(docsRoot, ['.md', '.mdx']),
-    ...walk(join(repoRoot, 'docs'), ['.md']).filter((file) => !toPosix(file).includes('/docs/site/')),
-    ...walk(join(repoRoot, 'examples'), ['.md']),
-    ...walk(join(repoRoot, 'integration'), ['.md']),
+    ...walk(docsRoot, markdown),
+    ...walk(join(repoRoot, 'docs'), markdown).filter((file) => !toPosix(file).includes('/docs/site/')),
+    ...walk(join(repoRoot, 'examples'), markdown),
+    ...walk(join(repoRoot, 'integration'), markdown),
+    // Package READMEs are in scope but scattered, so they are discovered rather
+    // than listed: a new package must not be able to opt out by existing.
+    ...walk(repoRoot, readme),
   ];
-  const readme = join(repoRoot, 'README.md');
-  if (existsSync(readme) && statSync(readme).isFile()) files.push(readme);
+  for (const name of ['README.md', 'AGENTS.md']) {
+    const path = join(repoRoot, name);
+    if (existsSync(path) && statSync(path).isFile()) files.push(path);
+  }
 
   const seen = new Set();
   return files.filter((file) => {
@@ -100,51 +128,67 @@ function documentationFiles() {
   });
 }
 
-// stripCode removes fenced blocks and inline spans so prose rules never fire on
-// SQL keywords, identifiers, or sample output. A column really can be named
-// "cancelled", and that is not a spelling error.
-function stripCode(source) {
+// splitSource separates prose from fenced code, keeping both arrays aligned to
+// the original line numbers so a finding can name the line a reader would edit.
+//
+// Prose rules must never fire inside code: a column really can be named
+// "cancelled". Code rules must never fire outside it: docs/STYLE_GUIDE.md and
+// AGENTS.md both name `testify` in prose in order to ban it.
+function splitSource(source) {
   const lines = source.split('\n');
-  const out = [];
-  let inFence = false;
-  for (const line of lines) {
-    if (line.trimStart().startsWith('```')) {
-      inFence = !inFence;
-      out.push('');
-      continue;
-    }
-    out.push(inFence ? '' : line.replace(/`[^`]*`/g, ''));
-  }
-  return out;
-}
+  const prose = [];
+  const code = [];
+  const fenceErrors = [];
+  let fence = null;
 
-// fenceViolations reports opening fences with no language label.
-function fenceViolations(source) {
-  const violations = [];
-  const lines = source.split('\n');
-  let inFence = false;
   for (const [index, line] of lines.entries()) {
     const trimmed = line.trimStart();
-    if (!trimmed.startsWith('```')) continue;
-    if (inFence) {
-      inFence = false;
+    const marker = trimmed.match(/^(`{3,}|~{3,})(.*)$/);
+
+    if (fence) {
+      const closes =
+        marker && marker[1][0] === fence.char && marker[1].length >= fence.length && marker[2].trim() === '';
+      if (closes) {
+        fence = null;
+        prose.push('');
+        code.push('');
+        continue;
+      }
+      // A fence of the other character, or a longer run, is content here.
+      prose.push('');
+      code.push(line);
       continue;
     }
-    inFence = true;
-    if (trimmed.replace(/`+/g, '').trim() === '') {
-      violations.push({ line: index + 1, message: 'fenced code block has no language label' });
+
+    if (marker) {
+      fence = { char: marker[1][0], length: marker[1].length };
+      if (marker[2].trim() === '') {
+        fenceErrors.push({ line: index + 1, message: 'fenced code block has no language label' });
+      }
+      prose.push('');
+      code.push('');
+      continue;
     }
+
+    // Inline spans are code too, and for the same reason.
+    prose.push(line.replace(/`[^`]*`/g, ''));
+    code.push('');
   }
-  return violations;
+
+  if (fence) {
+    fenceErrors.push({ line: lines.length, message: 'fenced code block is never closed' });
+  }
+  return { prose, code, fenceErrors };
 }
 
-function checkFile(file) {
-  const source = readFileSync(file, 'utf8');
-  const displayPath = toPosix(relative(repoRoot, file));
+// analyze is the single implementation of every rule. checkFile and the
+// self-test both call it, so a rule that stops firing here fails the self-test
+// instead of quietly passing every file forever.
+export function analyze(source) {
   const findings = [];
-  const proseLines = stripCode(source);
+  const { prose, code, fenceErrors } = splitSource(source);
 
-  for (const [index, line] of proseLines.entries()) {
+  for (const [index, line] of prose.entries()) {
     const lineNumber = index + 1;
 
     for (const [british, american] of britishSpellings) {
@@ -165,13 +209,17 @@ function checkFile(file) {
         });
       }
     }
+  }
 
+  // The guide bans testify in samples, and a sample is a code block, so this
+  // rule reads the code side rather than the prose side.
+  for (const [index, line] of code.entries()) {
     if (/\bstretchr\/testify\b/.test(line) || /\btestify\./.test(line)) {
-      findings.push({ line: lineNumber, message: 'testify appears in documentation; use quicktest (qt)' });
+      findings.push({ line: index + 1, message: 'testify appears in a code sample; use quicktest (qt)' });
     }
   }
 
-  for (const [index, line] of source.split('\n').entries()) {
+  for (const [index, line] of prose.entries()) {
     const match = line.match(/^:::([a-zA-Z]+)/);
     if (match && !allowedAdmonitions.has(match[1].toLowerCase())) {
       findings.push({
@@ -181,54 +229,91 @@ function checkFile(file) {
     }
   }
 
-  findings.push(...fenceViolations(source));
-  return findings.map((finding) => `${displayPath}:${finding.line}: ${finding.message}`);
+  findings.push(...fenceErrors);
+  return findings.sort((a, b) => a.line - b.line);
 }
 
-// selftest proves each rule actually fires, so a refactor cannot quietly turn
-// this check into a no-op that reports OK forever.
+function checkFile(file) {
+  const displayPath = toPosix(relative(repoRoot, file));
+  return analyze(readFileSync(file, 'utf8')).map(
+    (finding) => `${displayPath}:${finding.line}: ${finding.message}`,
+  );
+}
+
+// selftest drives the production analyze() over fixtures, so it fails whenever a
+// rule stops firing or starts firing on clean prose. Re-implementing the rules
+// here would let a broken checker keep reporting OK.
 function selftest() {
-  const cases = [
-    ['behaviour is documented', 'British spelling'],
-    ['this simply works', 'banned filler'],
-    ['use testify.Assert here', 'testify'],
-    [':::warning\ntext\n:::', 'admonition'],
-    ['```\nunlabeled\n```', 'no language label'],
-  ];
   const failures = [];
-  for (const [sample, expected] of cases) {
-    const findings = [];
-    const proseLines = stripCode(sample);
-    for (const [index, line] of proseLines.entries()) {
-      for (const [british] of britishSpellings) {
-        if (new RegExp(`\\b${british.replace(/ /g, '\\s')}[a-z]*`, 'i').test(line)) {
-          findings.push(`${index + 1}: British spelling`);
-        }
-      }
-      for (const word of bannedFiller) {
-        if (new RegExp(`\\b${word}\\b`, 'i').test(line)) findings.push(`${index + 1}: banned filler`);
-      }
-      if (/\btestify\./.test(line)) findings.push(`${index + 1}: testify`);
-    }
-    for (const line of sample.split('\n')) {
-      const match = line.match(/^:::([a-zA-Z]+)/);
-      if (match && !allowedAdmonitions.has(match[1].toLowerCase())) findings.push('admonition');
-    }
-    for (const violation of fenceViolations(sample)) findings.push(violation.message);
 
-    if (!findings.some((finding) => finding.includes(expected))) {
-      failures.push(`rule "${expected}" did not fire for sample ${JSON.stringify(sample)}`);
+  const violating = [
+    'The behaviour is documented.',
+    '',
+    'This simply works.',
+    '',
+    ':::warning',
+    'text',
+    ':::',
+    '',
+    '```go',
+    'import "github.com/stretchr/testify/require"',
+    '```',
+    '',
+    '```',
+    'unlabeled',
+    '```',
+    '',
+    '~~~',
+    'tilde fence, also unlabeled',
+    '~~~',
+  ].join('\n');
+
+  const expected = [
+    { line: 1, needle: 'British spelling' },
+    { line: 3, needle: 'banned filler' },
+    { line: 5, needle: 'admonition' },
+    { line: 10, needle: 'testify' },
+    { line: 13, needle: 'no language label' },
+    { line: 17, needle: 'no language label' },
+  ];
+
+  const findings = analyze(violating);
+  for (const { line, needle } of expected) {
+    if (!findings.some((finding) => finding.line === line && finding.message.includes(needle))) {
+      failures.push(`rule "${needle}" did not fire on line ${line}`);
     }
   }
 
-  // A clean sample must stay clean, or the check would fail every build.
-  const cleanFindings = [];
-  for (const line of stripCode('The behavior is documented.\n\n```bash\nls\n```\n')) {
-    for (const word of bannedFiller) {
-      if (new RegExp(`\\b${word}\\b`, 'i').test(line)) cleanFindings.push(word);
-    }
+  // Every rule must leave correct prose alone, and must not reach into code.
+  // Both halves matter: a check that fires on valid content is as broken as one
+  // that never fires, and it is the half that gets a rule deleted.
+  const clean = [
+    'The behavior is documented and a column may be named `cancelled`.',
+    '',
+    '```sql',
+    'SELECT * FROM orders WHERE status = \'cancelled\';',
+    '```',
+    '',
+    'Never use testify in Ptah tests; use `quicktest` instead.',
+    '',
+    ':::note',
+    'Adjust the value; this sentence contains no banned word.',
+    ':::',
+    '',
+    '```text',
+    'plain output',
+    '```',
+  ].join('\n');
+
+  for (const finding of analyze(clean)) {
+    failures.push(`clean fixture produced a finding at line ${finding.line}: ${finding.message}`);
   }
-  if (cleanFindings.length > 0) failures.push(`clean sample produced findings: ${cleanFindings.join(', ')}`);
+
+  // An unterminated fence would otherwise swallow the rest of the file and
+  // silence every later rule, so it is reported rather than tolerated.
+  if (!analyze('```go\nnever closed\n').some((finding) => finding.message.includes('never closed'))) {
+    failures.push('unterminated fence was not reported');
+  }
 
   if (failures.length > 0) {
     console.error('check-style.mjs --selftest: FAILED');
@@ -236,7 +321,7 @@ function selftest() {
     process.exitCode = 1;
     return;
   }
-  console.log(`check-style.mjs --selftest: OK (${cases.length} rules verified)`);
+  console.log(`check-style.mjs --selftest: OK (${expected.length} rule assertions via analyze())`);
 }
 
 function main() {

--- a/docs/site/scripts/check-style.mjs
+++ b/docs/site/scripts/check-style.mjs
@@ -5,7 +5,7 @@
 // it was enforced only by review, so a rule could be broken silently and stay
 // broken. This check covers the rules that are objective enough to automate:
 // American English, code-fence labels, banned filler, the admonition set, and
-// testify in samples. Rules that need editorial judgement (page taxonomy,
+// testify in samples. Rules that need editorial judgment (page taxonomy,
 // section templates, table design) remain a review responsibility.
 //
 // Usage:
@@ -42,6 +42,11 @@ const skipDirectories = new Set([
 // British spellings that docs/STYLE_GUIDE.md section 4 rules out. Each entry is
 // matched as a whole word, case-insensitively, with an optional suffix so that
 // "behaviours" and "organised" are caught alongside the stem.
+//
+// Every stem here must be one that no American word begins with, because the
+// suffix is open-ended. That rules out otherwise-tempting entries: "optimis"
+// would flag "optimistic", "specialis" would flag "specialist", and "finalis"
+// would flag "finalist".
 const britishSpellings = [
   ['behaviour', 'behavior'],
   ['colour', 'color'],
@@ -69,6 +74,34 @@ const britishSpellings = [
   ['fulfil ', 'fulfill '],
   ['whilst', 'while'],
   ['amongst', 'among'],
+  ['judgement', 'judgment'],
+  ['acknowledgement', 'acknowledgment'],
+  // Ptah publishes OCI artifacts, so this one is a live risk, not a curiosity.
+  ['artefact', 'artifact'],
+  ['programme', 'program'],
+  ['practise', 'practice'],
+  ['dependant', 'dependent'],
+  ['enquire', 'inquire'],
+  ['analogue', 'analog'],
+  ['sceptic', 'skeptic'],
+  ['offence', 'offense'],
+  ['pretence', 'pretense'],
+  ['learnt', 'learned'],
+  ['metre', 'meter'],
+  ['grey', 'gray'],
+  ['flavour', 'flavor'],
+  ['neighbour', 'neighbor'],
+  ['endeavour', 'endeavor'],
+  ['rigour', 'rigor'],
+  ['utilis', 'utiliz'],
+  ['customis', 'customiz'],
+  ['summaris', 'summariz'],
+  ['categoris', 'categoriz'],
+  ['standardis', 'standardiz'],
+  ['prioritis', 'prioritiz'],
+  ['visualis', 'visualiz'],
+  ['minimis', 'minimiz'],
+  ['maximis', 'maximiz'],
 ];
 
 // docs/STYLE_GUIDE.md section 4: no marketing adjectives.
@@ -303,6 +336,11 @@ function selftest() {
     '```text',
     'plain output',
     '```',
+    '',
+    // American words that begin with a British stem in the deny-list. Each one
+    // was a live false positive during review, so each stays asserted here.
+    'An optimistic specialist and a finalist otherwise exercise a raise, and',
+    'a concise promise likewise comprises expertise in an enterprise.',
   ].join('\n');
 
   for (const finding of analyze(clean)) {

--- a/docs/site/src/content/docs/reference/capabilities.md
+++ b/docs/site/src/content/docs/reference/capabilities.md
@@ -13,14 +13,17 @@ per-engine status and operational notes are on the
 
 Capabilities answer questions that a dialect name alone cannot answer:
 
-| Question | Example capability |
-| --- | --- |
-| Can this target drop constraints with the generic SQL spelling? | `drop_constraint_generic` |
-| Can this target guard index drops with `IF EXISTS`? | `drop_index_if_exists` |
-| Are CHECK constraints enforced? | `check_constraints_enforced` |
-| Are enums inline column types or standalone custom types? | `enum_inline_column`, `enum_custom_type` |
-| Can PostgreSQL-style concurrent indexes be emitted? | `create_index_concurrently` |
-| Does the target support roles, RLS, XML, or advisory locks? | `role_management`, `row_level_security`, `xml_type`, `advisory_locks` |
+- Can this target drop constraints with the generic SQL spelling?
+  `drop_constraint_generic`
+- Can this target guard index drops with `IF EXISTS`?
+  `drop_index_if_exists`
+- Are CHECK constraints enforced? `check_constraints_enforced`
+- Are enums inline column types or standalone custom types?
+  `enum_inline_column`, `enum_custom_type`
+- Can PostgreSQL-style concurrent indexes be emitted?
+  `create_index_concurrently`
+- Does the target support roles, RLS, XML, or advisory locks?
+  `role_management`, `row_level_security`, `xml_type`, `advisory_locks`
 
 ## Declarative database testing
 

--- a/docs/site/src/content/docs/reference/go-annotations.md
+++ b/docs/site/src/content/docs/reference/go-annotations.md
@@ -438,5 +438,5 @@ LSP-capable editor can run `ptah-ls` directly as a stdio language server.
 ## Next steps
 
 - Modeling a schema with these directives: [Go annotations](../../schema/go-annotations/).
-- Declaring rows, not just structure: [Reference data](../../versioned/reference-data/).
+- Declaring rows, not only structure: [Reference data](../../versioned/reference-data/).
 - Checking which features your dialect supports: [Capabilities](../capabilities/).

--- a/docs/site/src/content/docs/start/quick-start.md
+++ b/docs/site/src/content/docs/start/quick-start.md
@@ -135,7 +135,7 @@ Database is now at version: ...
 
 ## Change the schema and regenerate
 
-This is the loop Ptah is built for. Change your annotations and generate again: Ptah diffs your desired schema against the live database and writes a migration for **just the delta** — here, a new `posts` table — instead of a full rebuild.
+This is the loop Ptah is built for. Change your annotations and generate again: Ptah diffs your desired schema against the live database and writes a migration for **only the delta** — here, a new `posts` table — instead of a full rebuild.
 
 ```bash
 cat > /tmp/ptah-quickstart/models/post.go <<'EOF'

--- a/docs/site/src/content/docs/versioned/checkpoints.md
+++ b/docs/site/src/content/docs/versioned/checkpoints.md
@@ -56,7 +56,7 @@ ptah migrations checkpoint --migrations-dir ./migrations \
 A checkpoint is an ordinary Ptah migration pair carrying a `.checkpoint` marker
 between the description and the direction:
 
-```
+```text
 0000000042_squash.checkpoint.up.sql
 0000000042_squash.checkpoint.down.sql
 ```

--- a/docs/system_design.md
+++ b/docs/system_design.md
@@ -16,7 +16,7 @@ Ptah follows the **P.T.A.H.** philosophy:
 
 For a detailed visual representation of the system architecture, see the [Top-Level Architecture Diagram](diagrams/top_level_architecture.mmd).
 
-```
+```text
 Go Code (Annotations) ──┐
 YAML Schema Files ──────┤
                         ├─► Parsing Layer ──► Core Processing ──► Migration System ──► Database

--- a/integration/DYNAMIC_TESTING.md
+++ b/integration/DYNAMIC_TESTING.md
@@ -13,7 +13,7 @@ The dynamic testing approach provides more realistic and comprehensive testing b
 
 ## Versioned Entity Structure
 
-```
+```text
 ptah/integration/fixtures/entities/
 ├── 000-initial/          # Basic entities (User, Product)
 │   ├── user.go
@@ -134,7 +134,7 @@ docker compose --profile test run --rm ptah-tester --scenarios=dynamic_basic_evo
 
 ## Benefits Over Static Migrations
 
-1. **Realistic Testing**: Tests actual ptah functionality instead of just applying pre-made SQL
+1. **Realistic Testing**: Tests actual ptah functionality instead of applying pre-made SQL
 2. **Maintainable**: Entity files are easier to understand and modify than SQL
 3. **Comprehensive**: Tests the full pipeline from entities to applied migrations
 4. **Flexible**: Easy to add new evolution scenarios by creating new version directories

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -136,7 +136,7 @@ aborts if either direction fails.
 ### File Naming Convention
 
 Migration files follow the pattern:
-```
+```text
 <timestamp>_<migration_name>.<up|down>.sql
 ```
 

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -18,7 +18,7 @@ The Ptah Migrator provides versioned database migration capabilities with up/dow
 
 Migrations are stored with the following naming convention:
 
-```
+```text
 NNNNNNNNNN_description.up.sql    # Up migration
 NNNNNNNNNN_description.down.sql  # Down migration
 ```


### PR DESCRIPTION
Closes #804.

The restructuring work landed across #806, #816, #818, #820, #822, #824, #826, #827, #828 and #841. One acceptance item remained: *"The site is reviewed in a browser on representative desktop and mobile widths."* That pass was deferred twice because the browser runtime was unavailable — and a check that depends on someone remembering to look is a check that eventually stops happening. This PR closes it by automating both remaining gaps, then verifying the result twice.

## `check-style.mjs`

Enforces the rules of `docs/STYLE_GUIDE.md` that are objective enough to automate:

| Rule | Guide section |
| --- | --- |
| American English spelling | 4 |
| No `simply` / `easily` / `just` | 4, 11 |
| Fenced blocks carry a language label | 6 |
| Admonitions limited to note/tip/caution/danger | 7 |
| No `testify` in code samples | 6 |

It governs **every layer the guide covers** — `docs/site`, `docs/*.md`, `examples/**`, `integration/*.md`, every package `README.md`, and `AGENTS.md` — not only the site. Existing checks only ever looked at `docs/site`. Package READMEs are discovered by walking the repository, so a new package cannot opt out by existing.

Prose rules and code rules read opposite halves of each file. A column really can be named `cancelled`, and `AGENTS.md` names `testify` in order to ban it; neither is a violation. `docs/STYLE_GUIDE.md` is exempt: it necessarily contains the words it bans.

Coverage: 99 files. Run against the pre-PR tree it reports exactly ten violations, seven of them outside `docs/site` — in `docs/sequences.md`, `docs/system_design.md`, `integration/DYNAMIC_TESTING.md`, `AGENTS.md`, and two package READMEs. All ten are fixed here.

## `check-responsive.mjs`

Renders every built page at 390px and 1280px and fails on horizontal overflow — the mechanical half of the visual pass. The site passes today; the value is that a page cannot silently regain a sideways scrollbar.

**The harness was wrong before it was right, and that is worth recording.** An early version served the site without honoring its base path (`/ptah/edge`), so every stylesheet 404'd, every page rendered unstyled, and it reported **289 overflow findings across 51 pages**. I started fixing those with CSS overrides before a screenshot showed the pages were unstyled. Every one of those findings was an artifact of the harness. Re-measured correctly, the baseline passes with **no site CSS changes at all** — Starlight and Expressive Code already handle this.

The check now detects the base from the built markup and fails loudly if a stylesheet request 404s, rather than measuring a page whose layout never loaded.

## What a second verification pass changed

Two review passes over the checks above found five ways they could report success while checking nothing, plus a missing layer. All are closed:

1. **The style self-test did not test the checker.** It re-implemented every rule inline. Deleting the British-spelling loop from `checkFile` left `--selftest` reporting `OK (5 rules verified)`. Every rule now lives in one `analyze()` that both the check and the self-test drive. Verified by deleting the spelling rule and the testify rule in turn and watching the self-test fail.
2. **The testify rule never fired on a sample.** Prose and code were both checked *after* code was stripped, so `import "github.com/stretchr/testify/require"` inside a Go block passed. A sample is a code block; the rule now reads the code side.
3. **`check:style` could not be triggered by the layers it governs.** The Docs workflow only ran on `docs/site/**`, so a PR touching only a README, `docs/*.md`, `examples/**`, or `integration/*.md` never ran it. It now has its own job on the wider path set. The check has no npm dependencies, so that job runs from a bare checkout in ~5s.
4. **`check:responsive` skipped with exit 0 when Playwright was missing.** CI installs it, so its absence there means the check rendered nothing and reported OK. It now fails in CI and skips only locally, in both normal and self-test mode.
5. **The unstyled-page guard — the defect that produced the 289 phantom findings — had no self-test.** It now has one: the fixture served at the wrong base must trip the guard, and at the right base must not. Verified by reintroducing the base-detection bug and watching the self-test fail.
6. **The guide broke its own American-English rule.** "judgement" appeared twice, including in the checker's own header comment, and the deny-list had no entry for it. Fixed, listed, and the list widened — notably `artefact`, which would look plausible in a page about Ptah's OCI artifacts.

Every deny-list stem matches an open-ended suffix, so an unsafe stem becomes a false positive on correct prose — the failure mode that gets a rule deleted rather than fixed. `optimis` flags "optimistic", `specialis` flags "specialist", `finalis` flags "finalist". Those words are now in the self-test's clean fixture, so adding such a stem fails the self-test rather than the next author's PR.

Unterminated fences are also reported: one would otherwise swallow the rest of a file and silence every later rule.

## The visual pass itself

Run against the built site at 390px and 1280px across the home page, quick start, choose-a-workflow, the four largest reference tables, the support matrix, conformance, troubleshooting, and the Atlas comparison matrices. Navigation depth, mobile menu, code blocks, admonitions, and cross-page orientation hold up; wide tables scroll inside their own container rather than the page.

One exception: the capability question table rendered six-line cells on a phone, because a wide code token squeezed the question column. It is now a list.

The two Atlas comparison matrices (`atlas/comparison`, `atlas/docs-coverage`) hold cells up to ~3,000 characters, which is dense on both widths. Redesigning them touches evidence-backed parity claims, so it is filed separately rather than folded into a CI change.

## Guide and skill

`docs/STYLE_GUIDE.md` gains section 13 listing exactly which rules are machine-enforced and which remain a reading responsibility — so nobody assumes CI covers voice or page taxonomy. `AGENTS.md` now says which half of the guide fails a build and names the one command to run. The documentation-maintenance skill lists the full validation suite; it previously told agents to run link checks *"when the project has a checker available"*, which had been stale since six checkers existed. It also now says: never weaken a check to make a change pass — fix the rule and add the case to its self-test.

## Verification

All 13 documentation checks pass locally, and the checks were mutation-tested rather than merely run:

```
check:links:selftest  check:links  check:redirects:selftest  check:redirects
check:core-doc-links  check:page-health  check:exit-codes
check:style:selftest  check:style (99 files)  check:responsive:selftest
versions:selftest  build  check:responsive (59 routes x 2 viewports)
```

`npm ci` succeeds and `npm audit` reports 0 vulnerabilities. Playwright is pinned at ^1.62.1: the version I first added (1.50.1) carries GHSA-7mvr-c777-76hp (high), and a documentation tool has no business adding a high finding to the tree.

## Note on scope

`check-responsive.mjs` covers overflow only. Hierarchy, density, navigation depth and cross-page orientation still need a person looking at the page, and section 12 of the guide still asks for that. The claim here is narrower and more durable: the specific defect class that kept blocking this issue is now impossible to reintroduce silently.

Widening the workflow's path filter means the docs build also runs for PRs that touch only a README. That is deliberate: keeping the build job's existing trigger avoids changing what a required check reports, and the style job it enables costs 5 seconds.
