### PR TITLE
Add an evidence-backed Atlas and Ptah feature matrix

### DIFF
--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -277,6 +277,7 @@ in this guide is a review responsibility.
 | Table cells under 350 characters | 8 | `check:style` |
 | Table rows match the header's column count | 8 | `check:style` |
 | Two rows never state different verdicts for one capability | 8 | `check:style` |
+| No bare `--flag` outside a code span on site pages | 4, 6 | `check:style` |
 | Paragraphs under 900 rendered characters | 4 | `check:style` |
 | In-page and cross-page anchors resolve | 9 | `check:links` |
 | No page scrolls sideways at 390px or 1280px | 10 | `check:responsive` |

--- a/docs/STYLE_GUIDE.md
+++ b/docs/STYLE_GUIDE.md
@@ -276,6 +276,7 @@ in this guide is a review responsibility.
 | Exit-code tables stay in lockstep | 9 | `check:exit-codes` |
 | Table cells under 350 characters | 8 | `check:style` |
 | Table rows match the header's column count | 8 | `check:style` |
+| Two rows never state different verdicts for one capability | 8 | `check:style` |
 | Paragraphs under 900 rendered characters | 4 | `check:style` |
 | In-page and cross-page anchors resolve | 9 | `check:links` |
 | No page scrolls sideways at 390px or 1280px | 10 | `check:responsive` |

--- a/docs/site/astro.config.mjs
+++ b/docs/site/astro.config.mjs
@@ -145,6 +145,7 @@ export default defineConfig({
           label: 'Atlas compatibility',
           items: [
             { slug: 'atlas/overview' },
+            { slug: 'atlas/feature-matrix' },
             { slug: 'atlas/migrate-commands' },
             { slug: 'atlas/schema-commands' },
             { slug: 'atlas/project-config' },

--- a/docs/site/scripts/build-feature-matrix.mjs
+++ b/docs/site/scripts/build-feature-matrix.mjs
@@ -1,0 +1,196 @@
+#!/usr/bin/env node
+// Regenerates docs/site/src/content/docs/atlas/feature-matrix.md from its
+// committed parts: the per-row evidence data, a head, and a tail.
+//
+// The page is generated so that its summary counts can never drift from its
+// body, and so that every row edit happens in the evidence file - which
+// records, for each cell, the command that was run or the source cited. The
+// first version of this tooling lived outside the repository and was lost to a
+// scratch-directory cleanup; that is why it lives here now.
+//
+// Usage:
+//   node scripts/build-feature-matrix.mjs          # rewrite the page
+//   node scripts/build-feature-matrix.mjs --check  # fail if the page is stale
+import { readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const dataDir = join(scriptDir, 'data');
+const pagePath = join(scriptDir, '..', 'src', 'content', 'docs', 'atlas', 'feature-matrix.md');
+
+const SYMBOL = { yes: '✅', partial: '🟡', no: '❌', na: '➖', unknown: '❔' };
+const BANNED = /\b(simply|easily|just|seamless|powerful|blazing|effortless|cutting-edge)\b/i;
+
+// Reader-facing section order, folding the audit's fine-grained area labels.
+const AREA_MAP = [
+  ['Schema sources', ['schema sources', 'go-first modeling']],
+  ['Declarative and direct schema changes', ['declarative', 'schema inspection filters']],
+  ['Versioned migrations', ['versioned migrations', 'migration directory formats', 'migration import']],
+  ['Linting and safety', ['lint', 'migration linting', 'safety gates']],
+  ['Testing', ['test frameworks', 'testing framework', 'verification and contracts', 'testing']],
+  ['Configuration and dev databases', ['project config', 'atlas project config', 'dev databases', 'configuration and dev databases']],
+  ['Databases and schema objects', ['database engines', 'schema object kinds', 'databases and schema objects']],
+  ['Go embedding and developer tooling', ['go embedding', 'editor tooling', 'schema visualization', 'api schema export']],
+  ['Data and distribution', ['data management', 'oci artifacts', 'data and distribution']],
+  ['Atlas Registry and Cloud', ['atlas registry', 'approval and policy']],
+];
+
+// A section whose lead row needs more than a cell can carry gets an intro:
+// what the verdicts mean for the reader, stated as checkable facts.
+const SECTION_INTROS = {
+  'Data and distribution': `Ptah's registry story differs from Atlas's in storage, not in function.
+Everything artifact distribution needs — publish a migration directory or a
+desired schema, pull it elsewhere, pin an exact version, run migrations
+straight from the registry — works against any OCI-compliant registry: GHCR,
+ECR, GAR, Harbor, Docker Hub, or a self-hosted \`registry:2\`.
+
+For a team this means the registry and credentials already used for container
+images also serve schema artifacts; there is no separate account, login verb,
+or hosted service to depend on; and a digest pin makes a deployment
+reproducible byte for byte. The artifacts are ordinary OCI 1.1 manifests, so
+registry-side controls — replication, retention, immutable-tag policy, access
+control — come from the registry, not from Ptah. The full workflow is on
+[OCI registry artifacts](../../operate/oci-registry/).`,
+  'Atlas Registry and Cloud': `These rows are the services Atlas hosts on top of its registry — approvals,
+reporting, monitoring, the \`atlas://\` scheme itself. They concern the hosted
+service, not artifact storage; the storage function is covered under
+[Data and distribution](#data-and-distribution).`,
+};
+
+function bucket(area) {
+  const text = area.toLowerCase();
+  for (const [index, [title, prefixes]] of AREA_MAP.entries()) {
+    if (text === title.toLowerCase() || prefixes.some((p) => text.startsWith(p))) {
+      return { index, title };
+    }
+  }
+  throw new Error(`unmapped area ${JSON.stringify(area)}: add it to AREA_MAP`);
+}
+
+function normalize(feature) {
+  return feature
+    .toLowerCase()
+    .replace(/[`'"()]/g, '')
+    .replace(/\b(the|a|an|and|or|for|to|with|as)\b/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+function validate(rows) {
+  const problems = [];
+  const seen = new Map();
+  for (const row of rows) {
+    if (row.note.length > 200) problems.push(`${row.feature}: note is ${row.note.length} chars`);
+    if (BANNED.test(row.note) || BANNED.test(row.feature)) problems.push(`${row.feature}: banned word`);
+    for (const key of ['ptah', 'atlas_oss', 'atlas_pro']) {
+      if (!(row[key] in SYMBOL)) problems.push(`${row.feature}: bad status ${row[key]}`);
+    }
+    const key = normalize(row.feature);
+    const first = seen.get(key);
+    if (first) {
+      const clash = ['ptah', 'atlas_oss', 'atlas_pro'].filter((c) => first[c] !== row[c]);
+      problems.push(
+        clash.length
+          ? `${row.feature}: duplicates ${first.feature} and disagrees on ${clash.join(', ')}`
+          : `${row.feature}: duplicates ${first.feature}`,
+      );
+    } else {
+      seen.set(key, row);
+    }
+  }
+  if (problems.length > 0) {
+    console.error('REFUSING TO BUILD:');
+    for (const p of problems) console.error('  ' + p);
+    process.exit(1);
+  }
+}
+
+function summary(rows) {
+  const count = (fn) => rows.filter(fn).length;
+  const readings = [
+    ['Ptah supports it fully', count((r) => r.ptah === 'yes')],
+    ['Ptah supports it with a stated limitation', count((r) => r.ptah === 'partial')],
+    ['Ptah does not implement it', count((r) => r.ptah === 'no')],
+    ['Ptah and Atlas CE both support it', count((r) => r.ptah === 'yes' && r.atlas_oss === 'yes')],
+    [
+      'Ptah implements it openly where Atlas gates it behind Pro or Cloud',
+      count((r) => ['yes', 'partial'].includes(r.ptah) && r.atlas_oss === 'no' && r.atlas_pro === 'yes'),
+    ],
+    ['Ptah has it and neither Atlas edition does', count((r) => r.ptah === 'yes' && r.atlas_oss === 'no' && r.atlas_pro === 'no')],
+    ['Atlas CE has it and Ptah does not, or only in part', count((r) => ['no', 'partial'].includes(r.ptah) && r.atlas_oss === 'yes')],
+    [
+      'An Atlas column is ❔ — not established by this page\'s evidence',
+      count((r) => r.atlas_oss === 'unknown' || r.atlas_pro === 'unknown'),
+    ],
+  ];
+  return [
+    '## At a glance',
+    '',
+    `Across the ${rows.length} capabilities below:`,
+    '',
+    '| Reading | Count |',
+    '| --- | --- |',
+    ...readings.map(([label, n]) => `| ${label} | ${n} |`),
+    '',
+    'Every 🟡 in the Ptah column names its specific limitation, reproduced against a',
+    'binary built from this repository; Atlas-column verdicts rest on the cited',
+    'Atlas-side sources only. Confirmed gaps are tracked in',
+    '[#926 to #942](https://github.com/stokaro/ptah/issues/926) and [#944](https://github.com/stokaro/ptah/issues/944).',
+    '',
+    'The command surface is counted separately, because it is measured rather than',
+    'assessed. The conformance harness inventories every command in the pinned Atlas',
+    'CE binary and compares it with the `ptah-compat` surface: 19 of the 37',
+    'inventoried commands are open parity targets, and every one of them matches on',
+    'help usage and flags — 107 observations, no gap. The remaining 18 are registry,',
+    'Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them',
+    'as open capabilities regardless.',
+    '',
+  ].join('\n');
+}
+
+function body(rows) {
+  const grouped = new Map();
+  const sorted = [...rows].sort((a, b) => {
+    const ba = bucket(a.area);
+    const bb = bucket(b.area);
+    if (ba.index !== bb.index) return ba.index - bb.index;
+    return a.feature.toLowerCase().localeCompare(b.feature.toLowerCase());
+  });
+  for (const row of sorted) {
+    const { title } = bucket(row.area);
+    if (!grouped.has(title)) grouped.set(title, []);
+    grouped.get(title).push(row);
+  }
+  const out = [];
+  const cell = (text) => text.replace(/\|/g, '\\|').trim();
+  for (const [title, items] of grouped) {
+    out.push(`## ${title}`, '');
+    if (SECTION_INTROS[title]) out.push(SECTION_INTROS[title], '');
+    out.push('| Capability | Ptah | CE | Pro | Difference |');
+    out.push('| --- | :-: | :-: | :-: | --- |');
+    for (const row of items) {
+      out.push(`| ${cell(row.feature)} | ${SYMBOL[row.ptah]} | ${SYMBOL[row.atlas_oss]} | ${SYMBOL[row.atlas_pro]} | ${cell(row.note)} |`);
+    }
+    out.push('');
+  }
+  return out.join('\n');
+}
+
+const rows = JSON.parse(readFileSync(join(dataDir, 'feature-matrix-rows.json'), 'utf8'));
+validate(rows);
+const head = readFileSync(join(dataDir, 'feature-matrix.head.md'), 'utf8');
+const tail = readFileSync(join(dataDir, 'feature-matrix.tail.md'), 'utf8');
+const page = head + '\n' + summary(rows) + '\n' + body(rows) + '\n' + tail;
+
+if (process.argv.includes('--check')) {
+  const current = readFileSync(pagePath, 'utf8');
+  if (current !== page) {
+    console.error('feature-matrix.md is stale: edit scripts/data/feature-matrix-rows.json and run node scripts/build-feature-matrix.mjs');
+    process.exit(1);
+  }
+  console.log(`build-feature-matrix.mjs --check: OK (${rows.length} rows)`);
+} else {
+  writeFileSync(pagePath, page);
+  console.log(`wrote feature-matrix.md (${rows.length} rows)`);
+}

--- a/docs/site/scripts/check-style.mjs
+++ b/docs/site/scripts/check-style.mjs
@@ -363,6 +363,65 @@ function paragraphViolations(lines) {
   return findings;
 }
 
+// The symbols a status matrix uses. A contradiction is only meaningful between
+// cells drawn from a fixed vocabulary; prose cells legitimately differ.
+const STATUS_SYMBOLS = new Set(['✅', '🟡', '❌', '➖', '❔']);
+
+const NAME_STOPWORDS = new Set(
+  'a an the and or of to in on for with is are it its as by from not no only that this all each per via'.split(' '),
+);
+
+function nameTokens(cell) {
+  const text = cell.replace(/`([^`]*)`/g, '$1').toLowerCase();
+  return new Set(
+    (text.match(/[a-z0-9][a-z0-9_.-]*/g) ?? []).filter((w) => w.length > 2 && !NAME_STOPWORDS.has(w)),
+  );
+}
+
+function overlap(a, b) {
+  if (a.size === 0 || b.size === 0) return 0;
+  let shared = 0;
+  for (const token of a) if (b.has(token)) shared += 1;
+  return shared / (a.size + b.size - shared);
+}
+
+// contradictionViolations reports two rows that name the same capability and
+// then disagree about it.
+//
+// A comparison page is assembled from many rows, and a merge can leave the row
+// it was meant to supersede in place. When that happens the page states two
+// different verdicts for one capability, which is worse than redundancy: a
+// reader cannot tell which is current. Requiring BOTH a high name overlap and a
+// differing status keeps this off legitimately-similar rows - `migrations test`
+// and `schema test` are different commands that share most of their words.
+function contradictionViolations(lines) {
+  const rows = [];
+  for (const [index, line] of lines.entries()) {
+    if (!line.trimStart().startsWith('|')) continue;
+    const cells = splitCells(line);
+    if (isDelimiterRow(cells) || cells.length < 3) continue;
+    const statuses = cells.slice(1).filter((cell) => STATUS_SYMBOLS.has(cell));
+    if (statuses.length < 2) continue;
+    rows.push({ line: index + 1, name: cells[0], tokens: nameTokens(cells[0]), statuses });
+  }
+
+  const findings = [];
+  for (let i = 0; i < rows.length; i += 1) {
+    for (let j = i + 1; j < rows.length; j += 1) {
+      if (overlap(rows[i].tokens, rows[j].tokens) < 0.6) continue;
+      if (rows[i].statuses.join('') === rows[j].statuses.join('')) continue;
+      findings.push({
+        line: rows[j].line,
+        message:
+          `row "${rows[j].name}" states ${rows[j].statuses.join('')} while ` +
+          `"${rows[i].name}" on line ${rows[i].line} states ${rows[i].statuses.join('')}; ` +
+          'the two name the same capability and disagree — supersede one of them',
+      });
+    }
+  }
+  return findings;
+}
+
 // analyze is the single implementation of every rule. checkFile and the
 // self-test both call it, so a rule that stops firing here fails the self-test
 // instead of quietly passing every file forever.
@@ -413,6 +472,7 @@ export function analyze(source) {
 
   findings.push(...tableViolations(text));
   findings.push(...paragraphViolations(text));
+  findings.push(...contradictionViolations(text));
   findings.push(...fenceErrors);
   return findings.sort((a, b) => a.line - b.line);
 }
@@ -461,6 +521,13 @@ function selftest() {
     '| --- | --- | --- |',
     '| Exports | HCL/SQL `split | write` file exports | #510 |',
     '',
+    // Two rows naming one capability and disagreeing about it. A merge that
+    // fails to supersede the old row leaves exactly this shape.
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| OCI desired-schema artifacts | ✅ | ❌ |',
+    '| Desired-schema artifacts over OCI | ✅ | 🟡 |',
+    '',
     `A wall of prose. ${'Every flag is described inline rather than in a list. '.repeat(20)}`,
   ].join('\n');
 
@@ -473,7 +540,8 @@ function selftest() {
     { line: 17, needle: 'no language label' },
     { line: 23, needle: 'over the 350 limit' },
     { line: 27, needle: 'cells but the header has 3' },
-    { line: 29, needle: 'over the 900 limit' },
+    { line: 34, needle: 'over the 900 limit' },
+    { line: 32, needle: 'name the same capability and disagree' },
   ];
 
   const findings = analyze(violating);
@@ -502,6 +570,14 @@ function selftest() {
     '```text',
     'plain output',
     '```',
+    '',
+    // Near-identical names carrying the SAME verdict. The rule targets
+    // contradictions, so this pair must stay silent; without it, deleting the
+    // same-status guard would go unnoticed.
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| OCI migration artifacts | ✅ | ❌ |',
+    '| OCI migration artifacts and tags | ✅ | ❌ |',
     '',
     // A numbered list and an indented list continuation. Both were measured as
     // one giant paragraph by the first version of the length rule, which would

--- a/docs/site/scripts/check-style.mjs
+++ b/docs/site/scripts/check-style.mjs
@@ -322,7 +322,7 @@ function tableViolations(lines) {
 // indented continuations matter most: a numbered list reads as a list, and
 // joining its items would invent a paragraph nobody wrote.
 const blockStart =
-  /^\s*(?:[-*+]\s|\d+[.)]\s|>|\||#{1,6}\s|:::|<|\[\^[^\]]+\]:|\!\[|\s{2,}\S)/;
+  /^\s*(?:[-*+]\s|\d+[.)]\s|>|\||#{1,6}\s|:::|<|\[\^[^\]]+\]:|\[[^\]]+\]:\s|\!\[|\s{2,}\S)/;
 
 // paragraphViolations reports prose blocks that have grown into walls. Blank
 // lines, headings, tables, lists, list continuations, admonition markers, HTML,
@@ -378,6 +378,14 @@ function nameTokens(cell) {
   );
 }
 
+// The code spans in a capability name are its identity: rows named
+// "Upstream verb \`migrate ls\`" and "Upstream verb \`migrate show\`" share
+// every prose word and are different capabilities. When both names carry code
+// and the code differs, the rows are not comparable.
+function codeIdentity(cell) {
+  return (cell.match(/`[^`]+`/g) ?? []).sort().join('|');
+}
+
 function overlap(a, b) {
   if (a.size === 0 || b.size === 0) return 0;
   let shared = 0;
@@ -408,6 +416,12 @@ function contradictionViolations(lines) {
   const findings = [];
   for (let i = 0; i < rows.length; i += 1) {
     for (let j = i + 1; j < rows.length; j += 1) {
+      // Short names carry too little signal for overlap to mean identity:
+      // "Dry run" under two different command sections is two capabilities.
+      if (rows[i].tokens.size < 3 || rows[j].tokens.size < 3) continue;
+      const idA = codeIdentity(rows[i].name);
+      const idB = codeIdentity(rows[j].name);
+      if (idA && idB && idA !== idB) continue;
       if (overlap(rows[i].tokens, rows[j].tokens) < 0.6) continue;
       if (rows[i].statuses.join('') === rows[j].statuses.join('')) continue;
       findings.push({
@@ -422,10 +436,47 @@ function contradictionViolations(lines) {
   return findings;
 }
 
+// bareFlagViolations reports a --flag written outside a code span. Astro's
+// smartypants pass renders a bare double hyphen as an en dash, so the reader
+// sees a typographic dash where a flag was meant and copies a broken token.
+// Inside backticks nothing is transformed. Applies to site content only:
+// root docs render on GitHub, which leaves hyphens alone.
+function bareFlagViolations(lines) {
+  const findings = [];
+  // Inline code spans may wrap across lines inside one paragraph, so backtick
+  // parity carries from line to line and resets on a blank line. A per-line
+  // strip mispairs the ticks on such lines and reports flags that are inside
+  // a span.
+  let inSpan = false;
+  for (const [index, line] of lines.entries()) {
+    if (line.trim() === '') {
+      inSpan = false;
+      continue;
+    }
+    const segments = line.split('`');
+    let outside = '';
+    for (const [si, segment] of segments.entries()) {
+      const open = inSpan ? si % 2 === 1 : si % 2 === 0;
+      outside += open ? segment : ' '.repeat(segment.length);
+      outside += si < segments.length - 1 ? ' ' : '';
+    }
+    if (segments.length % 2 === 0) inSpan = !inSpan;
+    for (const match of outside.matchAll(/(?<![`\w-])--[a-z][a-z0-9-]*/g)) {
+      findings.push({
+        line: index + 1,
+        message:
+          `bare flag "${match[0]}" outside a code span renders with an en dash; wrap it in backticks`,
+      });
+    }
+  }
+  return findings;
+}
+
 // analyze is the single implementation of every rule. checkFile and the
 // self-test both call it, so a rule that stops firing here fails the self-test
 // instead of quietly passing every file forever.
-export function analyze(source) {
+export function analyze(source, options = {}) {
+  const { siteContent = true } = options;
   const findings = [];
   const { prose, code, text, fenceErrors } = splitSource(source);
 
@@ -473,13 +524,15 @@ export function analyze(source) {
   findings.push(...tableViolations(text));
   findings.push(...paragraphViolations(text));
   findings.push(...contradictionViolations(text));
+  if (siteContent) findings.push(...bareFlagViolations(text));
   findings.push(...fenceErrors);
   return findings.sort((a, b) => a.line - b.line);
 }
 
 function checkFile(file) {
   const displayPath = toPosix(relative(repoRoot, file));
-  return analyze(readFileSync(file, 'utf8')).map(
+  const siteContent = toPosix(file).includes('/docs/site/src/content/docs/');
+  return analyze(readFileSync(file, 'utf8'), { siteContent }).map(
     (finding) => `${displayPath}:${finding.line}: ${finding.message}`,
   );
 }
@@ -529,6 +582,30 @@ function selftest() {
     '| Desired-schema artifacts over OCI | ✅ | 🟡 |',
     '',
     `A wall of prose. ${'Every flag is described inline rather than in a list. '.repeat(20)}`,
+    '',
+    // A contradiction expressed through non-boolean symbols, and an overlap
+    // just above the threshold: pins the vocabulary and the 0.6 cut from below.
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| Spanner live coverage probes | ➖ | ❔ |',
+    '| Spanner nightly coverage probes | ❌ | ❔ |',
+    '',
+    // A row with FEWER cells than its header exercises the missing-cell branch.
+    '| A | B | C |',
+    '| --- | --- | --- |',
+    '| only | two |',
+    '',
+    // An empty middle cell must not make the row a delimiter: the long third
+    // cell must still be measured.
+    '| H1 | H2 | H3 |',
+    '| --- | --- | --- |',
+    `| left |  | ${'y'.repeat(360)} |`,
+    '',
+    // A hard-wrapped wall: each source line is short, the joined block is not.
+    ...Array.from({ length: 16 }, () => 'This wall is wrapped at ordinary width like real documentation prose.'),
+    '',
+    // A bare flag outside any code span.
+    'Pass --dry-run to preview the plan.',
   ].join('\n');
 
   const expected = [
@@ -540,8 +617,13 @@ function selftest() {
     { line: 17, needle: 'no language label' },
     { line: 23, needle: 'over the 350 limit' },
     { line: 27, needle: 'cells but the header has 3' },
-    { line: 34, needle: 'over the 900 limit' },
     { line: 32, needle: 'name the same capability and disagree' },
+    { line: 34, needle: 'over the 900 limit' },
+    { line: 39, needle: 'name the same capability and disagree' },
+    { line: 43, needle: 'missing cells render empty' },
+    { line: 47, needle: 'over the 350 limit' },
+    { line: 49, needle: 'over the 900 limit' },
+    { line: 66, needle: 'bare flag "--dry-run"' },
   ];
 
   const findings = analyze(violating);
@@ -596,6 +678,41 @@ function selftest() {
     '5. Review the generated diff whenever the database model changes, treating',
     '   every added, removed, or retyped field as a deliberate contract change',
     '   that a reviewer has to approve rather than as incidental churn.',
+    '',
+    // A code span that wraps across two lines carries a flag inside it; the
+    // backtick parity must carry over so this never reports.
+    'Integrity checks such as `ptah migrations',
+    'validate` and `up --verify-sum` still pass on a clean directory.',
+    '',
+    // Same prose words, different code spans: different capabilities, and the
+    // differing verdicts are legitimate.
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| Upstream verb `migrate ls` | 🟡 | ❌ |',
+    '| Upstream verb `migrate show` | ❌ | ❌ |',
+    '',
+    // Names too short to compare: two-token labels under different sections.
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| Dry run | ✅ | ✅ |',
+    '',
+    '| Capability | Ptah | CE |',
+    '| --- | --- | --- |',
+    '| Dry run | ✅ | ❌ |',
+    '',
+    // A reference-link definition block is not a paragraph wall.
+    '[cli-surface]: https://github.com/stokaro/ptah-atlas-conformance/blob/main/cli-surface.md',
+    '[gaps]: https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md',
+    '[gaps-live]: https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md',
+    '[gaps-diff]: https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md',
+    '[parity]: https://github.com/stokaro/ptah-atlas-conformance/blob/main/PARITY.md',
+    '[features]: https://atlasgo.io/features',
+    '[cli-ref]: https://atlasgo.io/cli-reference',
+    '[declarative]: https://atlasgo.io/declarative/plan',
+    '[versioned-apply]: https://atlasgo.io/versioned/apply',
+    '[versioned-down]: https://atlasgo.io/versioned/down',
+    '[versioned-import]: https://atlasgo.io/versioned/import',
+    '[cloud-deploy]: https://atlasgo.io/cloud/deployment',
     '',
     // Under the limit as a reader sees it, over it as raw markdown. Only the
     // rendered measurement keeps this from being reported.

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1,0 +1,1343 @@
+[
+ {
+  "area": "Schema sources",
+  "feature": "Go struct annotations",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program.",
+  "evidence": "ptah schema render --help (--root-dir); docs/site/src/content/docs/schema/go-annotations.md; docs/site/src/content/docs/schema/orm-and-external.md:65 (atlas-provider-gorm)"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "YAML schema files",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs.",
+  "evidence": "ptah schema render --help (--schema-file accepts YAML); docs/site/src/content/docs/reference/yaml-schema.md; docs/site/src/content/docs/atlas/comparison.md:411"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "SQL DDL schema files",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped.",
+  "evidence": "ptah schema render --help; ptah-compat schema diff --help (.sql accepted on --from/--to); docs/site/src/content/docs/atlas/docs-coverage.md:202 (Atlas: 'Open sources include SQL, HCL, and external schema')"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Live database as desired state",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively.",
+  "evidence": "ptah-compat schema apply/diff --help; ptah-compat migrate diff --help; ptah db read --help; docs/site/src/content/docs/atlas/docs-coverage.md:148-190 (declarative apply and diff: 'Open')"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Migration directory as a source",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff.",
+  "evidence": "ptah schema inspect --help (--migrations-dir, requires --dev-url); ptah-compat schema apply --help; ptah-compat schema diff --help; ptah-compat migrate diff --help"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "External program / ORM loaders",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "`--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML.",
+  "evidence": "ptah schema render --help (--schema-cmd, --schema-format, --allow-external-schema); docs/site/src/content/docs/schema/orm-and-external.md; examples/orm-loaders/gorm; examples/orm-loaders/sqlalchemy; orm-and-external.md records this as the open counterpart of Atlas's external_schema source and its ORM providers"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Atlas HCL data \"external_schema\"",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Ptah's `data` block is an unlabeled seed-row declaration; every labeled Atlas data source fails with `data block does not accept labels`.",
+  "evidence": "internal/atlashcl/objects.go:376-379; external_schema, composite_schema and remote_dir all produce that one error; comparison.md:415 lists Atlas OSS external schema as Open"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Composite multi-source desired schema",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source.",
+  "evidence": "ptah schema render --help ('repeatable; multiple sources merge into one composite schema'); docs/site/src/content/docs/schema/composite.md:58; docs/site/src/content/docs/atlas/comparison.md:407,413"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Live database to Go annotation source",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "`ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow.",
+  "evidence": "ptah introspect --help (--db-url, --out, --package); docs/site/src/content/docs/atlas/comparison.md:536-540 ('Native Go annotations'); conformance cli-surface.md (Atlas CE inventory)"
+ },
+ {
+  "area": "Project config",
+  "feature": "Atlas project config (atlas.hcl)",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema.",
+  "evidence": "config/projectconfig/atlas.go:214 (collectAtlasTopBlock default -> unsupportedBlock), :402 (parseEnvAttr default), :475 (parseMigration default); each rejection reproduced with /tmp/pc-audit at exit 1; Atlas-side block inventory from https://atlasgo.io/atlas-schema/projects (top-level variable, locals, atlas, env, script, lint, diff, exporter, deployment)"
+ },
+ {
+  "area": "Project config",
+  "feature": "Native project config (ptah.yaml)",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail.",
+  "evidence": "config/projectconfig/yaml.go:17-92 (typed key set; the desired-source key is `schemas`, not `src`). Repro: `src: [\"s.sql\"]` in ptah.yaml -> `error: failed to parse ptah config ptah.yaml: yaml: unmarshal errors: line 2: field src not found in type projectconfig.yamlDocument`"
+ },
+ {
+  "area": "Project config",
+  "feature": "Variables, locals, and HCL functions",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Only file, fileset, format, getenv, jsonencode evaluate; variable type, sensitive, validation and env for_each are rejected.",
+  "evidence": "config/projectconfig/atlas.go:126-133 (five-function eval context), :930 and :953 (variable attribute allowlist default/description), :402 (for_each hits the env attribute default). Repro: `dev = urlsetpath(\"sqlite://file.db\",\"x\")` -> `error: unsupported atlas.hcl construct \"dev\" at atlas.hcl:2`; upper, lower, join, split, concat, trimspace, coalesce, toupper, abspath, urlescape, urlqueryset, print all fail the same way, while file, fileset, format, getenv, jsonencode evaluate"
+ },
+ {
+  "area": "Project config",
+  "feature": "data \"hcl_schema\" reference",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected.",
+  "evidence": "config/projectconfig/atlas.go:1034-1080 (hclSchemaDataSource accepts only path/paths), :1416-1431 (validateAtlasLocalPathValue, atlasLocalFileURL). Atlas documents path, paths, vars in and url out (https://atlasgo.io/atlas-schema/projects). Repro: vars -> `error: unsupported atlas.hcl construct \"vars\" at atlas.hcl:3`"
+ },
+ {
+  "area": "Project config",
+  "feature": "env:// desired-state references",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently.",
+  "evidence": "internal/atlassource/atlassource.go:266-282 expandEnv attribute allowlist; env:// classification is reached only from --to/--from ClassifySet. Reproduced: `--exclude env://exclude` with env.exclude=[\"users\"] still emitted the users table"
+ },
+ {
+  "area": "Project config",
+  "feature": "Remote and template directory sources",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path.",
+  "evidence": "ptah-compat migrate status --env prod with migration.dir set to atlas:// or oci:// -> exit 1 'atlas migrate status --dir: only local file:// migration directories are supported'"
+ },
+ {
+  "area": "Go embedding",
+  "feature": "Reusable Go packages (embedder API)",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs.",
+  "evidence": "docs/site/src/content/docs/extend/public-api.md (stable package table); docs/site/src/content/docs/extend/components.md (component map)"
+ },
+ {
+  "area": "Go embedding",
+  "feature": "Public API compatibility gate",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line.",
+  "evidence": "scripts/check-public-api.sh; scripts/check-public-api-released.sh; docs/public_api_approvals.txt"
+ },
+ {
+  "area": "Go embedding",
+  "feature": "Query builder for parameterized SQL",
+  "ptah": "partial",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error.",
+  "evidence": "core/query/query.go (InnerJoin/LeftJoin/RightJoin/FullJoin, Distinct, GroupBy, Having) and core/query/write.go (InsertInto/Update/DeleteFrom, Returning); core/ast/select.go:17-18 records arithmetic, LIKE, subqueries and window functions as follow-ups; core/ast/write.go:13-16 records upsert, INSERT..SELECT, CTEs and multi-table UPDATE/DELETE as out of scope; core/renderer/select.go:84-89 maps placeholders for postgres/cockroachdb/yugabytedb/mysql/mariadb/sqlite only; executed probe over renderer.RenderInsert confirms sqlserver, mssql, clickhouse and spanner return \"renderer: INSERT rendering is not supported for dialect ...\""
+ },
+ {
+  "area": "Schema visualization",
+  "feature": "Schema visualization (ERD diagrams)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas features page lists visualization as Pro.",
+  "evidence": "ptah viz --help; docs/site/src/content/docs/schema/visualize.md; docs/site/src/content/docs/atlas/comparison.md (cites atlasgo.io/features: visualization is Pro); conformance cli-surface.md CE inventory"
+ },
+ {
+  "area": "API schema export",
+  "feature": "API schema export: OpenAPI 3.0 and GraphQL",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list.",
+  "evidence": "ptah schema export --help (--to openapi-v3|graphql); docs/site/src/content/docs/schema/export.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+ },
+ {
+  "area": "API schema export",
+  "feature": "Protobuf schema export with pinned field numbers",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory.",
+  "evidence": "ptah schema export --help (--proto-type-removal, --proto-on-name-reuse, --proto-on-incompatible-change); internal/protobufrender/render.go; docs/site/src/content/docs/schema/protobuf.md; conformance cli-surface.md CE inventory"
+ },
+ {
+  "area": "API schema export",
+  "feature": "Annotation metadata as JSON Schema",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to.",
+  "evidence": "ptah schema annotations --help; docs/site/src/content/docs/reference/native-commands.md (line 17)"
+ },
+ {
+  "area": "Data management",
+  "feature": "Declarative reference data",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "//ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature.",
+  "evidence": "ptah migrations data --help; docs/site/src/content/docs/versioned/reference-data.md (Reversibility section); docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features: declarative data management is Pro); conformance PARITY.md managed-data-workflow"
+ },
+ {
+  "area": "Data management",
+  "feature": "Environment-scoped SQL seed runner",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list.",
+  "evidence": "ptah seed --help (--env, --protected-env, --allow-prod); docs/site/src/content/docs/operate/seed-data.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+ },
+ {
+  "area": "Editor tooling",
+  "feature": "ptah-ls annotation language server",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax.",
+  "evidence": "cmd/ptah-ls/main.go (builds via go build ./cmd/ptah-ls); editors/vscode/package.json and extension.js; docs/site/src/content/docs/reference/go-annotations.md (Editor support)"
+ },
+ {
+  "area": "Go-first modeling",
+  "feature": "Annotated Go models from a live database",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list.",
+  "evidence": "ptah introspect --help (--add-db-tags, --add-json-tags, --per-table); docs/site/src/content/docs/reference/native-commands.md (line 74); conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "`atlas://` vendor protocol",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "The scheme is Cloud-bound and rejected with a named error; every function behind it is available natively over `oci://`. The compat binary mirrors the Atlas surface, which has no `oci://`.",
+  "evidence": "ptah-compat schema apply --to atlas://myorg/myrepo -> exit 1 'atlas:// registry URLs are not supported: Ptah has no Atlas Cloud registry'; atlas.hcl migration.dir = atlas:// -> exit 1 'only local file:// migration directories are supported'; ptah-compat schema apply --to oci://localhost:5555/demo/schema:v1 -> exit 1 'unsupported desired-state URL scheme \"oci\"'; atlas.hcl migration.dir = oci:// -> exit 1 'only local file:// migration directories are supported'"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "`migrate push` and `schema push`",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "ptah-compat boundary stubs printing the CE abort text, exit 1. The native equivalents are `ptah schema push` and `ptah migrations push`.",
+  "evidence": "ptah-compat schema push -> exit 1 \"Abort: 'atlas schema push' is not supported by the community version.\"; cli-surface.md lines 35 and 58 mark both absent from CE v1.2.0"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "`schema plan` registry sub-verbs",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "approve, lint, list, new, pull, push, rm, test and validate all stay CE boundary stubs; only local plan files are implemented.",
+  "evidence": "ptah-compat schema plan approve; conformance cli-surface.md classifies every `atlas schema plan` sub-verb as absent from the pinned CE binary"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "`schema plan` registry and output flags",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`--push`/`--pending`/`--repo` are recorded waivers; `--format`/`--name-format`/`--directive`/`--edit`/`--skip-lint` fail as unimplemented.",
+  "evidence": "ptah-compat schema plan --push --from sqlite://x.db --to file://s.sql; conformance cli-surface.md classifies `atlas schema plan` as absent from the pinned CE binary"
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Dynamic down planning (`migrate down --plan`)",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files.",
+  "evidence": "ptah-compat migrate down --plan --url sqlite://x.db --dir file://m; conformance cli-surface.md CE inventory"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "Atlas Cloud deployment reporting",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "No Atlas account model or deployment API. Ptah attaches a deployment-report referrer to its own OCI artifact after an oci:// migrations up.",
+  "evidence": "migrations up over oci:// then oci referrers -> application/vnd.stokaro.ptah.deployment.v1, sha256:cffc640a; --skip-report opts out; docs-coverage.md:499-505 records Atlas Cloud reporting as Cloud and out of scope"
+ },
+ {
+  "area": "Atlas Registry and Cloud",
+  "feature": "Schema monitoring, hosted UI, login",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check.",
+  "evidence": "docs/site/src/content/docs/atlas/docs-coverage.md"
+ },
+ {
+  "area": "Approval and policy workflows",
+  "feature": "Reviewer approval and policy workflows",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope.",
+  "evidence": "docs/site/src/content/docs/atlas/comparison.md"
+ },
+ {
+  "area": "Dev databases",
+  "feature": "Docker dev databases (`docker://` `--dev-url`)",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL.",
+  "evidence": "ptah-compat migrate diff --dev-url docker://postgres/16/dev --dir file://m --to file://s.sql; conformance cli-surface.md lists `--dev-url` in the CE `atlas migrate diff` flag set"
+ },
+ {
+  "area": "Migration linting",
+  "feature": "Atlas web reports (`--web`)",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either.",
+  "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web`, `ptah-compat schema diff --web`, `ptah migrations lint --web` each print `error: unknown flag: --web`. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
+ },
+ {
+  "area": "Testing framework",
+  "feature": "Atlas `.test.hcl` ingestion",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "No .test.hcl parser; a directory of them reports 'no test cases found' (`ptah-compat` exit 1, native exit 2).",
+  "evidence": "Built ptah-compat: `migrate test --dir file://migrations --dev-url sqlite://dev2.db hcltests` where hcltests holds one basic.test.hcl exits 1 with \"error: no test cases found in hcltests\"; migration/dbtest/parse.go reads YAML cases only; conformance cli-surface.md line 40 classifies `atlas migrate test` out-of-scope for CE"
+ },
+ {
+  "area": "Schema inspection filters",
+  "feature": "`schema inspect --include` filtering",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Flag absent from the pinned Atlas CE v1.2.0 inspect flags; Ptah rejects it as unknown. No cited source settles the licensed builds.",
+  "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; built ptah-compat `schema inspect -u sqlite://t.db --include users` exits 1 with \"error: unknown flag: --include\". Pro cell corrected to unknown because the Atlas feature availability page is not cited for inspect-side --include"
+ },
+ {
+  "area": "Migration directory formats",
+  "feature": "Flyway repeatable (`R__`) migration import",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Compat import aborts the entire directory on any R__ file; native import rewrites R__ as a one-time migration, losing re-run-on-change.",
+  "evidence": "Executed: `ptah-compat migrate import --dir-format flyway --from file://src --to file://out` -> \"error: Flyway repeatable migration R__active_users.sql cannot be imported yet...\" exit 1, no output dir written; `ptah migrations import --from flyway` wrote 0000000002_repeatable_active_users.up.sql. Atlas side: the vendored Atlas corpus carries import/flyway/R__views.sql and its golden output import/flyway_gold/3R_views.sql (conformance gaps.md:571,577)."
+ },
+ {
+  "area": "Migration directory formats",
+  "feature": "External `--dir-format` outside `migrate import`",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "hash, lint, new, set, status and validate accept only `--dir-format`=atlas; other tool formats must first go through migrate import.",
+  "evidence": "ptah-compat migrate hash --dir-format goose --dir file://m"
+ },
+ {
+  "area": "Migration directory formats",
+  "feature": "Atlas-format checkpoint output",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention.",
+  "evidence": "ptah-compat migrate checkpoint --dir-format atlas --dir file://m --dev-url sqlite://d.db"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "schema inspect to HCL, SQL, or JSON",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Default HCL; `--format` sql|json|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export.",
+  "evidence": "`ptah-compat schema inspect --help`; conformance cli-surface.md row `atlas schema inspect`"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Inspect non-database sources via `--dev-url`",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails.",
+  "evidence": "conformance gaps.md probe `inspect-source-workflow`; /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/docs/site/src/content/docs/atlas/schema-commands.md"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Inspect split/write file exports",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`{{ hcl . | split | write \"dir\" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community.",
+  "evidence": "Verified: `ptah-compat schema inspect --format '{{ hcl . | split | write \"exp\" }}'` wrote exp/tables/{posts,users}.hcl; comparison.md:139"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "schema apply against a live database",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite.",
+  "evidence": "Verified: `ptah-compat schema apply --url sqlite://target.db --to file://new.sql --auto-approve`; conformance cli-surface.md `atlas schema apply`"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "`--dry-run`, `--auto-approve`, and `--edit`",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied.",
+  "evidence": "Verified: a scripted $EDITOR replaced the plan and `schema apply --edit --auto-approve` applied the edited SQL; `ptah-compat schema apply --help`; conformance cli-surface.md lists all three in the CE `atlas schema apply` flag set"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Dev-database rehearsal before apply",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row.",
+  "evidence": "Reproduced: `pc schema apply --url sqlite://t4.db --to file://b.sql --auto-approve --dev-url sqlite://dv4.db` -> `Schema apply completed successfully.` (exit 0); `--dev-url sqlite://r1.db` equal to --url -> `error: --dev-url must not point at the target database: the dev database is reset destructively before the plan is rehearsed on it` (exit 1). Conformance gaps.md lines 25-27 record the reset, failed-rehearsal, and dev!=target observations. The only refused form is docker://, covered by the existing ❌ 'Docker dev databases' row"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Apply advisory lock and `--lock-timeout`",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note.",
+  "evidence": "internal/dblock/dblock.go:54-64 returns true for Postgres, YugabyteDB, MySQL, MariaDB, SQLServer — the previous note wrongly listed YugabyteDB as unlocked. cmd/atlas/schema_apply.go:578 emits the stderr note. Reproduced: `pc schema apply --url sqlite://t1.db --to file://b.sql --auto-approve --lock-timeout 10s` -> `note: schema apply locking is not supported for dialect \"sqlite\"; --lock-timeout is ignored and the apply proceeds without a database lock` then a successful apply (exit 0). CE registers --lock-timeout on schema apply per cli-surface.md:43"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Desired-state sources for `--to` and `--from`",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early.",
+  "evidence": "internal/atlassource/atlassource.go:245-264 classifyLocal only promotes a directory to a source when atlas.sum is present; :123-124 atlas:// rejection. Reproduced: `ptah-compat schema diff --to file://sqldir` -> \"schema file is a directory\""
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Local pre-approved plan files",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale.",
+  "evidence": "Verified: `schema plan --from sqlite://x.db --to file://new.sql --save --output p.plan.json`, then `schema apply --plan file://p.plan.json`; cli-surface.md `atlas schema plan`"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "schema diff between two schema states",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply.",
+  "evidence": "internal/planner/dialects/sqlite/sqlite.go:87-105 and :489 return unsupportedFeaturef for these cases. Reproduced: TEXT->INTEGER and NOT NULL->nullable both give `error: generate schema diff SQL: sqlite: modifying columns on table users requires a table rebuild plan` (exit 1); adding a column with UNIQUE gives `sqlite: adding column email to table users requires a table rebuild plan`. Plain adds and table drops still plan cleanly. CE registers schema diff per cli-surface.md:45"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "`--schema` / -s scoping of both sides",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically.",
+  "evidence": "conformance gaps.md `atlas schema apply -s` and `atlas schema diff -s` shorthand rows; docs/site/src/content/docs/atlas/schema-commands.md"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "`--include` resource selectors",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "CE registers `--include` on apply/diff but aborts it as non-community; pinned CE inspect has no `--include`. Ptah selects with union semantics and cross-scope dependency diagnostics.",
+  "evidence": "cli-surface.md lines 43,45 (--include registered on CE apply/diff); atlas/comparison.md: 'Atlas CE aborts --include as a non-community feature'; schema-scope-workflow probe in gaps.md"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "`--exclude` glob and type selectors",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums.",
+  "evidence": "internal/atlasfilter/filter.go:341-346 (filterFunctions matches function.Name only) and :298-302 (filterEnums matches value.Name only); dbschema/types/types.go:358-367 DBFunction and :106-109 DBEnum carry no Schema field; internal/tableref/tableref.go:14-21 Canonical returns the bare name when schema is empty; live PostgreSQL 16 repro with the built ptah-compat binary; Atlas CE side from conformance cli-surface.md line 43/45/47 (--exclude registered on schema apply, diff, inspect)"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "schema fmt (HCL canonical layout)",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate.",
+  "evidence": "`ptah-compat schema fmt --help`; conformance cli-surface.md flags and usage rows for `atlas schema fmt`"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "schema clean",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables.",
+  "evidence": "internal/schemaclean/clean.go:109-147 enumerates only foreign keys, tables and enums; :75-81 executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty — the unreported view v_const was dropped as well. CE registers schema clean per cli-surface.md:44"
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Drift detection against desired schema",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope.",
+  "evidence": "`ptah schema drift --help`; docs/site/src/content/docs/atlas/docs-coverage.md section \"Drift detection\""
+ },
+ {
+  "area": "Declarative / direct schema workflow",
+  "feature": "Go-template `--format` output",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only.",
+  "evidence": "internal/atlasreport/schema_apply.go:45-47 and schema_diff.go:66 register only \"sql\"; schema_inspect.go:161-173 registers base64url/hcl/json/mermaid/sql/split/write. Reproduced: `pc schema diff ... --format '{{ json . }}'` -> `error: parse --format template: template: atlas-schema-diff-format:1: function \"json\" not defined` (exit 1); same on schema apply; `{{ .Realm }}` on diff -> `can't evaluate field Realm in type atlasreport.SchemaDiff`. `{{ json . }}` works on schema inspect, schema clean, and migrate status"
+ },
+ {
+  "area": "Versioned migrations — execution",
+  "feature": "Apply pending migrations (apply/up)",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Also runs goose/flyway/liquibase/dbmate dirs via ?format=; `--dry-run` ignores the revision table and re-plans already-applied files.",
+  "evidence": "Executed: after a full apply, `ptah-compat migrate status` reports \"Pending Migrations: 0\" while `ptah-compat migrate apply --dry-run` reports \"Migrating to version 20240102000000 from 2 pending migrations. Would have applied 2 migrations.\" Same on native `ptah migrations up --dry-run`. Code: migration/migrator/migrator.go:660 (GetCurrentVersion returns 0 under dry-run) and :719 (queryMigrationRows returns empty). External formats verified: `migrate apply --dir \"file://src2?format=goose\"` applied to version 2."
+ },
+ {
+  "area": "Versioned migrations — execution",
+  "feature": "Roll back applied migrations (down)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Ptah reverts via pre-planned down files; `--to-tag`/`--skip-checks`/`--plan` fail loudly as waivers. `migrate down` is absent from the pinned CE binary.",
+  "evidence": "cli-surface.md CE inventory (37 commands, no `migrate down`); atlas/conformance.md workflow parity: 'migrate down does not exist in the community binary; the CE notice lists down migrations among excluded features'; /tmp/v1-compat migrate down waiver errors reproduced"
+ },
+ {
+  "area": "Versioned migrations — execution",
+  "feature": "Migration status report",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next.",
+  "evidence": "/tmp/ptah-compat migrate status --format '{{ .Env }}|{{ len .Available }}|{{ len .Applied }}|{{ len .Pending }}|{{ .Current }}|{{ .Next }}' against SQLite; conformance cli-surface.md row `atlas migrate status` (oss)"
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Directory integrity file: hash and validate",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "hash writes `ptah.sum`, or `atlas.sum` for atlas-format directories; validate checks it and with `--dev-url` cleans and replays the dir.",
+  "evidence": "/tmp/ptah migrations hash/validate --help; verified create→hash→validate (exit 0) then tampered file→validate exit 1; ptah migrations hash --dir-format atlas wrote atlas.sum"
+ },
+ {
+  "area": "Versioned migrations — safety",
+  "feature": "Migration linting",
+  "ptah": "yes",
+  "atlas_oss": "partial",
+  "atlas_pro": "yes",
+  "note": "CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time.",
+  "evidence": "Executed: `ptah-compat migrate lint --dir file://migrations --latest 1` reports \"destructive changes detected -- L1: DROP COLUMN ... #DS103\" and exits 1; `--format '{{ range .Files }}{{ .Name }}{{ end }}'` renders the Atlas template. No rule-loading flag in `ptah migrations lint --help`; custom rules come from migration/lint/rules.go:20 (Register) and lint.Options.ExtraRules (migration/lint/lint.go:107). Atlas CE registers migrate lint (conformance cli-surface.md:33)."
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Create an empty migration file",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR.",
+  "evidence": "verified `ptah-compat migrate new init_users --dir file://atlasdir` wrote one .sql plus atlas.sum, and `ptah migrations create` wrote an up/down pair; ptah migrations create --help (--editor defaults to $VISUAL then $EDITOR)"
+ },
+ {
+  "area": "Versioned migrations — revision state",
+  "feature": "Set revision state to a version",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set.",
+  "evidence": "docs/site/src/content/docs/atlas/comparison.md#versioned-migrations (`ptah-compat migrate set` paragraph); /tmp/ptah-compat migrate set --help; conformance gaps-migrate-runtime.md fixture `sqlite/set-repair-state`"
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Generate migrations from a schema diff",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry.",
+  "evidence": "Executed: `ptah-compat migrate diff --dir file://migrations --dev-url sqlite://... --to file://desired.sql first` into an empty dir wrote 1785514646_first.sql; into a dir whose latest was 20240101000000 it wrote 20240101000001_add_posts.sql; `ptah-compat migrate new ... hello` wrote 20260731161705_hello.sql. Code: migration/generator/generator.go:414 seeds from migrator.GetNextMigrationVersion (migration/migrator/util.go:302, time.Now().Unix()) while generator.go:228 uses \"20060102150405\". Atlas fixture versions are 14-digit (20220318104614_initial.sql, gaps.md)."
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Migration import from other tools",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed.",
+  "evidence": "Executed: `ptah-compat migrate import --from https://example.com/m` and `--from atlas://myrepo` both fail \"only local file:// migration directories are supported\"; `--dir-format liquibase` on a changelog.xml fails \"liquibase XML/YAML/JSON changelogs are not yet supported\". golang-migrate, goose and dbmate dirs import to single up-only Atlas files (down bodies dropped). Conformance PARITY.md:147 records Liquibase XML/YAML/JSON as a follow-up.; ptah migrations import --help (--from golang-migrate, goose, flyway, liquibase, dbmate); conformance cli-surface.md (atlas migrate import, class oss); do"
+ },
+ {
+  "area": "Versioned migrations — revision state",
+  "feature": "Baseline an existing database",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`.",
+  "evidence": "/tmp/ptah migrations baseline --help (--shadow-db, --dry-run, --version); conformance cli-surface.md `atlas migrate apply` flag list (--baseline)"
+ },
+ {
+  "area": "Versioned migrations — revision state",
+  "feature": "Repair dirty or partial revision state",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "no",
+  "note": "`ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence.",
+  "evidence": "/tmp/ptah migrations repair --help (--resume-from executes remaining up statements before marking applied); conformance cli-surface.md Atlas CE inventory (no `atlas migrate repair` row)"
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Migration checkpoints (squash history)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Replays the directory on `--shadow-db` into a cumulative checkpoint pair; CE has no checkpoint verb and Atlas lists it as Pro.",
+  "evidence": "/tmp/ptah migrations checkpoint --help (--shadow-db required); conformance cli-surface.md `atlas migrate checkpoint` (out-of-scope: Pro, absent from CE); PARITY.md `checkpoint-workflow`"
+ },
+ {
+  "area": "Versioned migrations — directory",
+  "feature": "Directory maintenance: edit, rebase, rm",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Each rewrites `ptah.sum`/`atlas.sum` and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs.",
+  "evidence": "/tmp/ptah migrations edit|rebase|rm --help (\"refusing already-applied migrations\", --force, --db-url); conformance cli-surface.md rows `atlas migrate edit|rebase|rm` (out-of-scope: Pro); PARITY.md `pro-maint-workflow`"
+ },
+ {
+  "area": "Versioned migrations — revision state",
+  "feature": "Revision table format and placement",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "`--revision-format` ptah|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows.",
+  "evidence": "/tmp/ptah migrations up --help (--revision-format default ptah, --migrations-table, --migrations-schema); conformance gaps-migrate-runtime.md `sqlite/project-config-apply-oracle` and `postgres/custom-revisions-schema`"
+ },
+ {
+  "area": "Safety gates",
+  "feature": "Pre-migration assertion checks",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Only the `-- +ptah check` spelling; `--tx-mode` all refuses checked files, and that error names `--skip-checks`, which compat apply lacks.",
+  "evidence": "Executed: a migration carrying `-- +ptah check name=\"users_empty\" assert=\"SELECT count(*) = 0 FROM users\" on_fail=abort` aborts with \"pre-migration check users_empty ... was not satisfied\" and nothing applied; with `--tx-mode all` it fails \"...cannot run with tx-mode all; use the default per-file transaction mode or --skip-checks\", but `ptah-compat migrate apply --skip-checks` -> \"unknown flag: --skip-checks\" (the flag exists only on native `ptah migrations up`, cmd/migrateup/migrateup.go:150)."
+ },
+ {
+  "area": "Versioned migrations — runtime policy",
+  "feature": "Transaction modes (`--tx-mode` file/all/none)",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks.",
+  "evidence": "migration/migrator/migrator.go validateTxModeAllDialect and rejectChecksUnderTxModeAll (also rejects no_transaction and per-migration timeouts); conformance gaps-migrate-runtime.md `sqlite/tx-mode-all|file|none`; /tmp/ptah migrations up --help"
+ },
+ {
+  "area": "Versioned migrations — runtime policy",
+  "feature": "Execution order (`--exec-order`)",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it.",
+  "evidence": "/tmp/ptah migrations up --help (--exec-order linear|linear-skip|non-linear); docs/site/src/content/docs/versioned/apply.md lines 138-141; conformance cli-surface.md `atlas migrate apply --exec-order`"
+ },
+ {
+  "area": "Versioned migrations — runtime policy",
+  "feature": "Migration lock and lock timeout",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`.",
+  "evidence": "/tmp/ptah migrations up --help (--lock-timeout per-migration, --migration-lock-timeout advisory); docs/site/src/content/docs/atlas/migrate-commands.md line 356; conformance cli-surface.md `atlas migrate apply --lock-timeout`"
+ },
+ {
+  "area": "Test frameworks",
+  "feature": "Migration test framework (`ptah migrations test`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set.",
+  "evidence": "`ptah migrations test --help`; docs/site/src/content/docs/reference/test-cases.md (Isolation); conformance cli-surface.md classifies `atlas migrate test` as absent from the pinned CE binary"
+ },
+ {
+  "area": "Test frameworks",
+  "feature": "Schema test framework (`ptah schema test`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb.",
+  "evidence": "ptah-atlas-conformance cli-surface.md (`atlas schema test` = out-of-scope); `ptah schema test --help`"
+ },
+ {
+  "area": "Test frameworks",
+  "feature": "Atlas-shaped migrate test / schema test verbs",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`.",
+  "evidence": "Built ptah-compat `schema test --help` (flags: --dev-url, --run, -u only) and `migrate test --help` (--dev-url, --dir, --dir-format, --run only); `schema test -u file:///path/schema.sql` exits 1 with \"parse desired schema from ...: stat .: not a directory\"; `-u sqlite://target.db` and `-u env://src` exit 1 with \"only local file:// migration directories are supported\"; `migrate test --report json` is parsed as a positional path. Passing baseline: `migrate test --dir file://migrations --dev-url sqlite://dev.db tests` exits 0. Atlas side from cli-surface.md lines 40/59 (out-of-scope in CE) and lines 138-140/168-170"
+ },
+ {
+  "area": "Test frameworks",
+  "feature": "Embeddable test runner (Go package)",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package.",
+  "evidence": "migration/dbtest/engine.go:247 RunMigrationTest and migration/dbtest/schema.go:53 RunSchemaTest; conformance cli-surface.md measures CLI commands only, and gaps.md lines 167-172 show the corpus imports atlasexec fixtures, so Atlas does have an observable Go package surface — the previous ❌/❌ cells asserted an Atlas distribution fact no cited source establishes"
+ },
+ {
+  "area": "Lint analyzers",
+  "feature": "Native migration lint rule set",
+  "ptah": "yes",
+  "atlas_oss": "partial",
+  "atlas_pro": "yes",
+  "note": "42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro.",
+  "evidence": "`ptah migrations lint --help` registers `--dialect` gating postgres/mysql/mariadb/sqlite/clickhouse/cockroachdb/yugabytedb/spanner; migration/lint/rules.go carries the DS/CD/DD/MF/BC/PG/MY/LT/TX families. Atlas feature availability page: \"Migration Linting\" = Pro, with \"Destructive changes\" and \"Backward incompatible changes\" listed Open and \"Concurrent index changes\" listed Pro."
+ },
+ {
+  "area": "Lint analyzers",
+  "feature": "Atlas Pro analyzer code coverage",
+  "ptah": "partial",
+  "atlas_oss": "na",
+  "atlas_pro": "yes",
+  "note": "OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones.",
+  "evidence": "Reproduced on postgres: `ALTER TABLE t ALTER COLUMN c TYPE bigint` -> DS103 (PG301); `ALTER TABLE t2 ADD PRIMARY KEY (c)` -> PG104 (PG304). On mysql: `ALTER TABLE t CONVERT TO CHARACTER SET utf8mb4` -> MY101 (MY136); migration/lint/rules.go:1095 scanConvertCharset. gaps.md lint-analyzer-catalog records all five as `covered (mapped)`. comparison.md:488 records OW101/OW102 as account-bound waivers."
+ },
+ {
+  "area": "Lint analyzers",
+  "feature": "Default-firing Atlas analyzer concern mapping",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus.",
+  "evidence": "gaps.md lint-analyzer-catalog rows (lines 395-436) are all `ok` across the DS, MF, BC, CD, PG1, PG3, PG110, MY, LT and TX families. PARITY.md:178-203 states every default-firing concern is covered and that an uncovered concern added later fails closed to a red `missing` gap."
+ },
+ {
+  "area": "Lint analyzers",
+  "feature": "Custom lint rules and check-level policy",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail.",
+  "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} — no rule definition. config/projectconfig/atlas.go:536 parseLintPolicyBlocks accepts only concurrent_index, data_depend, destructive, git, nestedtx, incompatible; atlas.go:613 rejects `force`. Atlas features page classifies \"Custom linting rules\" as Pro."
+ },
+ {
+  "area": "Lint policy and suppression",
+  "feature": "Inline nolint suppression",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored.",
+  "evidence": "internal/atlaslint/rules.go:41 NativeSuppressionTargets maps 5 analyzer names + ds102/ds103/mf103 only, default returns nil. Reproduced: `ptah-compat migrate lint` prints `https://atlasgo.io/lint/analyzers#PG101` yet `-- atlas:nolint PG101` leaves the diagnostic. CE side: PARITY.md:420 records the imported Atlas fixtures asserting `-- atlas:nolint` suppression for `atlas migrate lint`; gaps.md:814 runs cli-migrate-lint-ignore.txtar with 57 assertions."
+ },
+ {
+  "area": "Lint policy and suppression",
+  "feature": "Per-rule severity policy",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "yes",
+  "note": "Severity vocabulary is warning|error only (info errors out); atlas.hcl exposes 5 analyzer blocks mapped to an error bool and rejects force.",
+  "evidence": "migration/lint/config.go:78 validateConfig admits only SeverityWarning/SeverityError. Reproduced: `severity: info` -> `error: failed to parse lint config .ptah-lint.yaml: rule DS101 has unsupported severity \"info\"` (exit 2); `severity: warning` demotes DS101 from error. config/projectconfig/atlas.go:594 parseLintAnalyzer takes only `error` bool. No cited Atlas source establishes CE severity-policy behavior; the Atlas features page classifies the linting CLI as Pro."
+ },
+ {
+  "area": "Lint output and CI",
+  "feature": "SARIF 2.1.0 lint report",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "na",
+  "note": "Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint.",
+  "evidence": "Reproduced: `ptah migrations lint --format sarif` emits version 2.1.0 with driver \"ptah migrations lint\", a rules array, and a result carrying ruleId DS101, level warning, artifactLocation and region.startLine. gaps-migrate-runtime.md:34 `fidelity: sarif output shape` records the same. cli-surface.md:33 shows CE `--format` is the Atlas Go template only."
+ },
+ {
+  "area": "Lint output and CI",
+  "feature": "CI integration (GitHub Action, annotations)",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations.",
+  "evidence": "`ptah migrations lint --help` registers `--format ... github-actions`. Atlas side: docs/site/src/content/docs/atlas/docs-coverage.md:533 \"Atlas integration parity is unmeasured\"; the Atlas feature availability page does not address GitHub Actions integration, and cli-surface.md inventories no action. Nothing cited settles either Atlas column."
+ },
+ {
+  "area": "Safety gates",
+  "feature": "Apply-time destructive-change gate",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "na",
+  "note": "migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file.",
+  "evidence": "Reproduced: `ptah migrations up` aborts with `pending migrations contain destructive statements; rerun with --allow-destructive after review: - 0000000002_drop.up.sql:1 DS101 error`. Adding `.ptah-lint.yaml` with `disabled-rules: [DS101]` let the same up succeed; ptah.sum was byte-identical and `ptah migrations validate` still printed `OK: migrations directory matches ptah.sum`. Atlas side: cli-surface.md:27 lists no destructive-gate flag on `atlas migrate apply`."
+ },
+ {
+  "area": "Safety gates",
+  "feature": "Statement safety classification report",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "plan `--report` text|html|json and generate `--report` html|json emit highest severity, a destructive flag, and per-statement assessments.",
+  "evidence": "`ptah migrations plan --help` registers `--report string  Safety report format: text, html, or json (default \"text\")`; `ptah migrations generate --help` registers `--report string  Safety report format next to the migration files: \"\", html, or json`."
+ },
+ {
+  "area": "Verification and contracts",
+  "feature": "Dev / shadow database verification",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "`--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely.",
+  "evidence": "Built ptah binary --help: --shadow-db on `migrations generate`, `migrations checkpoint`, `migrations baseline`, `migrations down`; `migrations validate --dev-url docker://postgres/16/dev` exits 2 with \"docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for migration SQL replay\"; ptah-compat `schema apply --dev-url sqlite:///nonexistent-dir-xyz/dev.db --dry-run` exits 0 and prints a plan, while the same dev URL with --auto-approve exits 1 with \"connect to --dev-url: failed to ping database: unable to open database file (14)\"; conformance PARITY.md line 48 (dbtest-workflow) for the working replay path"
+ },
+ {
+  "area": "Verification and contracts",
+  "feature": "Exit-code contract for CI gates",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "na",
+  "note": "Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2.",
+  "evidence": "docs/site/src/content/docs/reference/exit-codes.md; docs/site/src/content/docs/reference/test-cases.md (Exit contract)"
+ },
+ {
+  "area": "Database engines",
+  "feature": "PostgreSQL 12+ (postgres, postgresql)",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner.",
+  "evidence": "/tmp/ptah-mx schema render --dialect postgres (built from /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/cmd/ptah); core/platform/capability/capability.go Postgres13/Postgres16/Postgres17 + ForServerVersion; docs/site/src/content/docs/databases/postgresql.md (Version-dependent behavior); comparison.md#supported-databases cites the Atlas Open driver list"
+ },
+ {
+  "area": "Database engines",
+  "feature": "MySQL and MariaDB",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback.",
+  "evidence": "Live MySQL 9.7 `ptah schema apply --dry-run` fails with \"materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target\"; with the matview removed the plan contains only tables, a view, a trigger and the FK — the extension, function, sequence, domain, role, grant and RLS objects produce no statement and no warning. capability.go:358 MariaDB1011 sets Sequences=true, yet `schema render --dialect mariadb` emits no CREATE SEQUENCE. Atlas side: comparison.md:398 lists MySQL and MariaDB as Open drivers."
+ },
+ {
+  "area": "Database engines",
+  "feature": "SQLite (sqlite, sqlite3)",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with \"modifying columns ... requires a table rebuild plan\". PG-only objects error one at a time.",
+  "evidence": "`ptah schema diff --from a.sql --to b.sql --dev-url sqlite://dev.db` (TEXT->INTEGER) errors \"sqlite: modifying columns on table t requires a table rebuild plan\"; same error for NOT NULL removal, DEFAULT add and column UNIQUE add. Dropping a column instead emits the full \"__ptah_rebuild_t\" CREATE/INSERT/DROP/RENAME sequence. internal/planner/dialects/sqlite/sqlite.go:91 and :96. Live SQLite apply rejects matview, extension, function, sequence and user-defined types with one error each. Atlas side: comparison.md:398 lists SQLite as an Open driver."
+ },
+ {
+  "area": "Database engines",
+  "feature": "SQL Server and Azure SQL (sqlserver, mssql, tsql)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews.",
+  "evidence": "`ptah schema render --dialect sqlserver` emits 6 statements including CREATE VIEW and CREATE TRIGGER; `--dialect mssql` and `--dialect tsql` emit 4 with both missing, reproducible across 3 runs. Root cause fromschema.go:1747 supportsStandaloneViewsAndTriggers compares the raw string. cmd/generate/generate.go:113 default list omits sqlserver; :69 help text omits it. capability.go:481 SQLServer2022 sets Sequences/RLS/RoleManagement=false. Atlas side: comparison.md:400 lists SQL Server as Pro."
+ },
+ {
+  "area": "Database engines",
+  "feature": "ClickHouse (clickhouse, ch)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic.",
+  "evidence": "Live ClickHouse 24.12: `ptah schema apply --root-dir <fixture> --db-url clickhouse://... --dry-run` planned only the two CREATE TABLE statements from a 13-object fixture. Offline `schema render` emits skip comments for extension/enum/FK but nothing for views or triggers. capability.go:430 ClickHouse24 sets ForeignKeys=false, CheckConstraintsEnforced=false. Atlas side: comparison.md:400 lists ClickHouse as a Pro driver."
+ },
+ {
+  "area": "Database engines",
+  "feature": "CockroachDB (cockroachdb, crdb)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers.",
+  "evidence": "capability.go:507 CockroachDB23. `ptah schema render --dialect cockroachdb` errors: \"cockroachdb does not support sequence-backed type SERIAL; use a platform-specific type override\"; on a non-SERIAL fixture it emits 5 statements against postgres's 15, dropping view/matview/function/trigger/role/grant/RLS/domain/sequence. Root cause fromschema.go:110 isPostgreSQLPlatform matches only \"postgres\"/\"postgresql\". Atlas side: comparison.md:400 lists CockroachDB as Pro."
+ },
+ {
+  "area": "Database engines",
+  "feature": "YugabyteDB (yugabytedb, ysql)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them.",
+  "evidence": "Live YugabyteDB 2026.1.0.0: `ptah schema apply --db-url yugabytedb://... --dry-run` planned CREATE ROLE, CREATE SEQUENCE, CREATE DOMAIN, CREATE VIEW, CREATE MATERIALIZED VIEW, CREATE FUNCTION, CREATE TRIGGER and GRANT, and no RLS statement. `ptah schema render --dialect yugabytedb` on the same fixture emits 5 statements with all of those absent. capability.go:521 YugabyteDB25 sets RowLevelSecurity=false, RoleManagement=true. Atlas side: comparison.md:400 lists YugabyteDB as Pro."
+ },
+ {
+  "area": "Database engines",
+  "feature": "Spanner PostgreSQL interface (spanner)",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists.",
+  "evidence": "`ptah schema render --dialect spanner` emits \"-- SPANNER: enum type user_status is not supported by this target; skipped.\" and \"-- SPANNER: constraint \\\"fk_orders_user_id\\\" is not supported by this target; skipped.\"; with SERIAL it errors \"spanner does not support sequence-backed type SERIAL\". capability.go:532 SpannerPostgres. docker-compose.yaml has no spanner service (cockroachdb:71 and sqlserver:101 do); internal/dbschema/ has no spanner package. Atlas side: comparison.md:400 lists Spanner as Pro."
+ },
+ {
+  "area": "Database engines",
+  "feature": "TiDB and LibSQL",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Both names fail dialect normalization: \"unsupported database dialect: tidb\" / \"...: libsql\". No renderer, planner or driver entry.",
+  "evidence": "`ptah schema render --dialect tidb` -> \"error: error rendering tidb schema: unsupported database dialect: tidb\"; same for libsql. platform/constants.go:19 NormalizeDialect has no tidb or libsql case. Atlas side: comparison.md:398 lists TiDB and LibSQL as Open drivers."
+ },
+ {
+  "area": "Database engines",
+  "feature": "Oracle, Snowflake, Redshift, Databricks",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers.",
+  "evidence": "`ptah schema render --dialect oracle` -> \"error: error rendering oracle schema: unsupported database dialect: oracle\". platform/constants.go:19. Atlas side: comparison.md:400 lists Oracle, Snowflake, Redshift and Databricks as Pro drivers."
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Enum types",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim.",
+  "evidence": "internal/convert/fromschema/fromschema.go:268 `if !strings.HasPrefix(field.Type, \"enum_\") { return field }`; reproduced with /tmp/pt-audit schema render. Atlas CE column from stokaro/ptah-atlas-conformance gaps-diff.md rows `mysql/02-enum`, `postgres/02-enum`, `sqlite/02-enum` (compare against Atlas CE inspect, ok)"
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Views and materialized views",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1758-1764 appends only Views (never MaterializedViews) for the non-PostgreSQL path; `ptah schema render --dialect mysql` emitted no matview statement, while `ptah schema apply` against live MySQL 9.7 failed with \"materialized views are not supported by MySQL or MariaDB\""
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Functions",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1632-1634 appends functions only when isPostgreSQLPlatform; live MySQL 9.7 `ptah schema apply --dry-run` planned no function and printed no diagnostic. Atlas columns from stokaro/ptah-atlas-conformance PARITY.md: \"Atlas CE silently omits Pro-gated objects (views, triggers, functions, sequences) from inspection — no error, exit 0\""
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Triggers",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1747-1756 matches platform.SQLServer (\"sqlserver\") without normalizing; core/renderer/internal/dialects/mysqllike/mysqllike.go:643 hard-codes FOR EACH ROW; core/renderer/internal/dialects/mssql/mssql.go:626-628 maps BEFORE to AFTER; core/renderer/internal/dialects/sqlite/sqlite.go:313 errors on FOR EACH STATEMENT"
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Standalone sequences",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1593 gates CREATE SEQUENCE on isPostgreSQLPlatform; live YugabyteDB apply planned CREATE SEQUENCE \"yb_seq\" START WITH 1; SQL source: \"unsupported CREATE target: SEQUENCE\". Atlas columns from PARITY.md Pro-gated-object sentence"
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Extensions",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment.",
+  "evidence": "core/renderer/internal/dialects/mysql/mysql.go:26-30 copies the bufwriter by value so VisitExtension (line 132) writes to a buffer Output() never reads; verified live: `ptah schema compare` against PostgreSQL 18 proposed DROP EXTENSION for pg_trgm and left plpgsql alone"
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Roles, grants, and row-level security",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY and ENABLE RLS.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1710-1745 (roles/grants/RLS behind isPostgreSQLPlatform); live YugabyteDB apply planned CREATE ROLE \"yb_role\"; `ptah schema render --schema-file` rejects CREATE ROLE / GRANT / CREATE POLICY / ALTER TABLE ... ENABLE ROW LEVEL SECURITY"
+ },
+ {
+  "area": "Schema object kinds",
+  "feature": "Domains, composite types, and range types",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all.",
+  "evidence": "internal/convert/fromschema/fromschema.go:1616 gates domain/range/composite emission on isPostgreSQLPlatform (postgres|postgresql only); migration/schemadiff/internal/compare/usertypes.go:158-174 compares ranges by name only; live YugabyteDB 2026.1.0.0 `ptah schema apply --dry-run` planned CREATE DOMAIN \"yb_domain\" AS TEXT"
+ },
+ {
+  "area": "Data and distribution",
+  "feature": "Registry-backed distribution: `oci://` vs `atlas://`",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`atlas://` functions — publish, pull, digest-pin, run migrations directly, schemas via `--schema-file` — over any OCI registry, no account. See [OCI registry artifacts](../../operate/oci-registry/).",
+  "evidence": "ptah schema push oci://localhost:5555/demo/schema:v1 --root-dir ./models --plain-http -> exit 0; cli-surface.md lines 35 and 58 classify `atlas migrate push` and `atlas schema push` as not present in the pinned CE binary; ptah migrations up --db-url sqlite://app.db --migrations-dir oci://localhost:5555/demo/mg:c1 --plain-http -> applied version 1785514698, exit 0; ptah migrations down --target 0 over the same reference rolled back, exit 0; internal/ociartifact/client.go:46 credentials.NewStoreFromDocker; htpasswd-protected registry: push without creds -> exit 2 'basic credential not found', sa"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Desired-schema artifacts in an OCI registry",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "`ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2.",
+  "evidence": "push -> Digest sha256:2ebd84f93717f397e89cb5862913f6e7679064d624a9f1e22b7092504bd1de92; ptah schema pull --out pulled.hcl returned the same digest and a valid table block"
+ },
+ {
+  "area": "Data and distribution",
+  "feature": "oci:// as a `--schema-file` desired-state source",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "yes",
+  "note": "Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose `--plain-http`.",
+  "evidence": "ptah schema drift/compare --schema-file oci://... --plain-http -> works; ptah schema inspect --schema-file oci://... -> 'unsupported desired-state URL scheme \"oci\"'; ptah schema render/plan/apply and migrations generate -> 'unknown flag: --plain-http'"
+ },
+ {
+  "area": "Data and distribution",
+  "feature": "Digest pinning and write-once version tags",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "unknown",
+  "note": "Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move.",
+  "evidence": "push to @sha256:2ebd84f9... -> exit 2 'cannot push to a digest reference'; re-push --version rel1 with changed content -> exit 2 'OCI write-once tag already exists'; tag v1 moved from sha256:869dd082 to sha256:70575f30 across pushes while rel1 stayed pinned"
+ },
+ {
+  "area": "Data and distribution",
+  "feature": "Artifact integrity check (`--verify-sum`)",
+  "ptah": "partial",
+  "atlas_oss": "na",
+  "atlas_pro": "unknown",
+  "note": "On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes.",
+  "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'"
+ },
+ {
+  "area": "OCI artifacts",
+  "feature": "Referrer attachments: lint, plan, deployment reports",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "lint `--attach`, migrations plan `--attach` and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload.",
+  "evidence": "oci referrers --format json returns digest/artifact_type/media_type/size/annotations only; flags are --format, --type, --plain-http; the manifest's deployment.json layer (362 bytes) is reachable only through the raw registry API; cmd/oci/oci.go:69 calls ocireferrers.List"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Atlas CE inspect HCL parses back into Ptah",
+  "ptah": "yes",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "30 atlas-differential observations parse Atlas CE 1.2.0 `schema inspect` HCL on Postgres/MySQL/SQLite with zero schema-fact mismatches.",
+  "evidence": "conformance gaps-diff.md (30 ok / 0 gap, probe atlas-differential, Atlas pinned a5e0aec); PARITY.md: \"Atlas's view comes from `schema inspect` in its native HCL, parsed by Ptah's own core/atlashcl\""
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL top-level blocks Ptah parses",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data.",
+  "evidence": "internal/atlashcl/atlashcl.go:73-113; a fixture exercising all 16 renders 17 PostgreSQL statements via `ptah schema render --schema-file all.hcl --dialect postgres`"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL table and column child blocks",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform.",
+  "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL variable blocks and var.* references",
+  "ptah": "no",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "`variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error.",
+  "evidence": "internal/atlashcl/atlashcl.go:107-110 and 1478-1484; conformance gaps.md atlas-hcl-parse row `schemahcl/testdata/variables.hcl` — \"only non-schema top-level blocks: variable\""
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL function calls in schema files",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally.",
+  "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496; render emits column type `sql(\"geometry(Point,4326)\")`"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL locals, lock, atlas, dynamic/for_each",
+  "ptah": "no",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\".",
+  "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "HCL foreign_key deferrable",
+  "ptah": "no",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too.",
+  "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Ptah-only HCL schema extensions",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block.",
+  "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData"
+ },
+ {
+  "area": "Schema sources",
+  "feature": "Directory of .hcl files as one schema source",
+  "ptah": "no",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "`--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file.",
+  "evidence": "cmd/internal/schemaload/schemaload.go:257-259; `ptah-compat schema diff --to file://dir` prints \"load --to schema: schema file is a directory\""
+ },
+ {
+  "area": "Schema inspection filters",
+  "feature": "Schema-qualified exclude globs for enums and functions",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only.",
+  "evidence": "internal/atlasfilter/filter.go:299-303 (filterEnums matches value.Name) and :342-346 (filterFunctions matches function.Name) versus :348-356 and :327-340 which build qualifiedNameCandidates for views and extensions. docs/site/src/content/docs/atlas/schema-commands.md:96-98 records the same limitation. Nothing in cli-surface.md, gaps.md, gaps-live.md, or gaps-diff.md establishes Atlas CE's qualification semantics for enum and function exclude globs, so both Atlas columns are ❔"
+ },
+ {
+  "area": "Project config",
+  "feature": "atlas.hcl from the native ptah binary",
+  "ptah": "partial",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved.",
+  "evidence": "cmd/internal/dbcli/project_config.go:66-80 (the atlas.hcl path and --var forwarding flags are hidden adapter-only), config/projectconfig/load.go:20-24 (AtlasPath defaults to AtlasFileName in the working directory). Repro: `ptah schema compare --env local --schema-file s.sql --var dburl=sqlite://file.db` -> `error: unknown flag: --var`; `ptah schema compare --config atlas.hcl --env local` -> `error: failed to parse ptah config atlas.hcl: yaml: unmarshal errors`"
+ },
+ {
+  "area": "Schema inspection filters",
+  "feature": "Inspect `--exclude` field selectors",
+  "ptah": "partial",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted.",
+  "evidence": "internal/atlasfilter/filter.go:188-200 parseFieldSelector accepts only field==\"version\" with hasOnlyType(types,\"extension\"), and :132-135 rejects a second [type= segment; built ptah-compat on live PostgreSQL: `--exclude '*[type=extension].version'` blanks the version, `--exclude '*[type=table].comment'` exits 1 \"unsupported Atlas exclude field selector \\\".comment\\\"\", `--exclude '*[type=table]*'` exits 1 \"unsupported Atlas exclude field selector suffix \\\"*\\\"\". Atlas columns downgraded to unknown: conformance cli-surface.md line 47 establishes that --exclude exists on Atlas CE schema inspect but nothing cited establishes which field-selector forms Atlas honors, and no cited source defines an \"exporter block\" at all"
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Pre-migration webhook and shell hook gates",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "`--webhook` POSTs migration metadata and requires HTTP 200; `--pre-up-hook`/`--pre-down-hook` run a shell command that must exit 0, else the run aborts. Also ptah.yaml migration.webhook/pre_up_hook.",
+  "evidence": "/tmp/c-ptah migrations up --help shows --webhook and --pre-up-hook; down shows --pre-down-hook. Atlas-side: cli-surface.md line 27 lists every atlas migrate apply flag; no webhook or hook flag. docs/site/src/content/docs/versioned/apply.md:154-158."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Pre-migration database backups (`--pg-dump-to`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "`--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to.",
+  "evidence": "/tmp/c-ptah migrations up --help and down --help show --pg-dump-to/--mysqldump-to. Atlas-side: cli-surface.md line 27 migrate apply flag list has no backup flag. docs/site/src/content/docs/reference/configuration.md:87."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Prometheus metrics endpoint (`--metrics-addr`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run.",
+  "evidence": "/tmp/c-ptah migrations up/down/status --help all show \"--metrics-addr Address for the Prometheus /metrics endpoint, such as :9090\". Atlas-side: cli-surface.md lines 27/39 list migrate apply and status flags; none exposes a metrics endpoint."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Structured JSON log output (`--log-format`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "migrations up, down, and status take `--log-format` text|json and `--log-level` debug|info|warn|error for machine-readable run logs.",
+  "evidence": "/tmp/c-ptah migrations up --help shows --log-format and --log-level. Atlas-side: cli-surface.md line 27 migrate apply flag list has no log flags (only output --format)."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Online DDL routing via gh-ost or pt-osc",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "ptah.yaml online_ddl.tool (ghost|pt-osc), threshold_rows, args, and fallback (error|plain) route large-table ALTERs through an online-DDL tool during migrations up/down.",
+  "evidence": "config/projectconfig/config.go:22-35,407-447 defines the config; cmd/migrateup/migrateup.go:374 consumes it; config/projectconfig/online_ddl_test.go. docs/site/src/content/docs/reference/configuration.md:89 documents the four keys. Matrix mentions online_ddl only as a ptah.yaml key name."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Atlas txtar migration sections (-- atlas:txtar)",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Atlas-format .sql files with the -- atlas:txtar directive execute their migration.sql and down.sql sections (giving Atlas dirs a down path); unrelated embedded files are ignored.",
+  "evidence": "migration/migrator/migrations.go:164,351-377 parses the directive and sections; docs/site/src/content/docs/atlas/migrate-commands.md:40-47 documents it. The down row's \"Atlas single-file dirs have no down body\" note does not cover this exception."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Atlas SQL template migrations (`--atlas-env`)",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs.",
+  "evidence": "migration/migrator/atlas_template.go:15-45 (AtlasTemplateData{Env}, RenderAtlasTemplateSQL); /tmp/c-ptah migrations up --help shows \"--atlas-env Value exposed as .Env when rendering Atlas SQL template migrations\"."
+ },
+ {
+  "area": "Linting and safety",
+  "feature": "Generation-time destructive-change gate",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row.",
+  "evidence": "/tmp/c-ptah migrations generate --help and plan --help show --check-destructive/--allow-destructive. Atlas-side: cli-surface.md line 29 migrate diff flag list has no destructive gate flag."
+ },
+ {
+  "area": "Linting and safety",
+  "feature": "Standalone SQL file linting (`ptah sql lint`)",
+  "ptah": "yes",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not.",
+  "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based."
+ },
+ {
+  "area": "Declarative and direct schema changes",
+  "feature": "JSON output for native schema diff",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated.",
+  "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0."
+ },
+ {
+  "area": "Go embedding and developer tooling",
+  "feature": "Go annotations to HCL export with cleanup",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "schema export `--to` hcl writes an HCL schema from Go annotations; `--cleanup-go-annotations` removes the annotations after a lossless export, with `--cleanup-dry-run`/`--cleanup-diff` previews.",
+  "evidence": "/tmp/c-ptah schema export --to hcl --root-dir . --out schema.hcl produced a table \"products\" HCL file, exit 0; export --help shows the three cleanup flags. Atlas has no //ptah annotation set for the concept to apply to (matrix's own ➖ rationale)."
+ },
+ {
+  "area": "Configuration and dev databases",
+  "feature": "PTAH_* environment-variable flag equivalents",
+  "ptah": "yes",
+  "atlas_oss": "unknown",
+  "atlas_pro": "unknown",
+  "note": "Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag.",
+  "evidence": "All 49 --help screens annotate each flag with [env: PTAH_*]; verified live: PTAH_FORMAT=dot /tmp/c-ptah viz --root-dir . emitted Graphviz DOT instead of the mermaid default, exit 0. No Atlas-side env-var inventory is cited by the page."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "migrate apply `--allow-dirty` semantics",
+  "ptah": "partial",
+  "atlas_oss": "yes",
+  "atlas_pro": "yes",
+  "note": "Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite).",
+  "evidence": "/tmp/c-compat migrate apply onto SQLite with a pre-existing table succeeded with no flag ('Migration complete'); after a failed migration, apply refuses ('is dirty'), and --allow-dirty errors 'UNIQUE constraint failed: atlas_schema_revisions.version'. Flag in CE inventory, cli-surface.md line 27; help: 'Allow applying migrations when the revision table is dirty'."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Upstream verb `migrate ls`",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Beyond the CE pin: ptah-compat rejects it as unknown command; native ptah migrations status lists every migration with version and state, per the gap register triage.",
+  "evidence": "Verified: /tmp/c-compat migrate ls -> 'unknown command'; /tmp/c-ptah migrations status --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin' records it absent from pinned CE v1.2.0 (unknown command, not an abort stub) while present in current Atlas docs."
+ },
+ {
+  "area": "Versioned migrations",
+  "feature": "Upstream verb `migrate show`",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Beyond the CE pin: prints a migration's SQL upstream; no compat or native Ptah verb exists, and the gap register triages it as future work.",
+  "evidence": "Verified: /tmp/c-compat migrate show -> 'unknown command'; comparison.md:699-701 triage 'migrate show (print a migration's SQL) is future work with no native verb today'; absent from cli-surface.md inventory."
+ },
+ {
+  "area": "Declarative and direct schema changes",
+  "feature": "Upstream verb `schema validate`",
+  "ptah": "partial",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Beyond the CE pin: no validate verb; the gap register triage covers it with native schema render parse/load validation plus schema test and schema apply `--dry-run`.",
+  "evidence": "Verified: /tmp/c-compat schema validate -> 'unknown command'; /tmp/c-ptah schema render --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin'; absent from cli-surface.md inventory."
+ },
+ {
+  "area": "Declarative and direct schema changes",
+  "feature": "Upstream verb `schema stats`",
+  "ptah": "no",
+  "atlas_oss": "no",
+  "atlas_pro": "unknown",
+  "note": "Beyond the CE pin: upstream OpenMetrics database-statistics verb; the gap register triages it out of scope as an observability surface rather than schema management.",
+  "evidence": "Verified: /tmp/c-compat schema stats -> 'unknown command'; comparison.md:699-701 triage 'schema stats (OpenMetrics database statistics) is out of scope'; absent from cli-surface.md inventory."
+ },
+ {
+  "area": "Go embedding and developer tooling",
+  "feature": "Statement observer and validator hooks (Go API)",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "migrator.WithStatementObserver runs a read-only callback per executed statement; WithStatementValidator gates all statements pre-execution; both compose with StatementInterceptor.",
+  "evidence": "migration/migrator/migration_provider.go:98 (WithStatementValidator), :106 (WithStatementObserver); StatementObservationError in migration/migrator/revisions.go:144. Documented at docs/site/src/content/docs/extend/public-api.md:59-99. Atlas cells na per the matrix's own convention for Go-API rows: CE conformance measures CLI commands, not Go APIs."
+ },
+ {
+  "area": "Go embedding and developer tooling",
+  "feature": "Pinned database sessions (WithSession)",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "`WithSession` on `DatabaseConnection` pins one physical session for a callback, rebinding reader/writer/SQL runner, and discards the connection so session state cannot leak.",
+  "evidence": "dbschema/connection.go:262; docs/site/src/content/docs/extend/public-api.md:78-87. Atlas cells na per the matrix's convention for Go-API rows (CE conformance measures CLI commands, not Go APIs)."
+ },
+ {
+  "area": "Go embedding and developer tooling",
+  "feature": "Concurrency-guarded migration plan publication",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "generator.PlanMigration binds a plan to a directory snapshot; WriteFiles rejects changed history (ErrMigrationDirectoryChanged) under a cross-process lock; concurrent reuse fails (ErrMigrationPlanInUs",
+  "evidence": "migration/generator/plan_test.go:84 (qt.ErrorIs generator.ErrMigrationDirectoryChanged), :91 (TestMigrationPlanWriteFilesContext_RejectsConcurrentUse); docs/site/src/content/docs/extend/public-api.md:115-126. Atlas cells na per the matrix's Go-API row convention."
+ },
+ {
+  "area": "Go embedding and developer tooling",
+  "feature": "testkit companion module for database tests",
+  "ptah": "yes",
+  "atlas_oss": "na",
+  "atlas_pro": "na",
+  "note": "Separate module github.com/stokaro/ptah/testkit wraps testcontainers-go for tests needing real databases; versions independently and stays out of the main module graph.",
+  "evidence": "testkit/go.mod line 1: module github.com/stokaro/ptah/testkit; testkit/testkit.go, containers_test.go present. Documented at docs/site/src/content/docs/extend/public-api.md:54-57. Distinct from the existing \"Embeddable test runner (Go package)\" row, which is migration/dbtest. Atlas cells na per the matrix's Go-API row convention."
+ }
+]

--- a/docs/site/scripts/data/feature-matrix.head.md
+++ b/docs/site/scripts/data/feature-matrix.head.md
@@ -1,0 +1,49 @@
+---
+title: Feature matrix
+description: Ptah and Atlas capabilities side by side, with the evidence behind every row.
+---
+
+This page answers one question: for a given capability, what does Ptah do, what
+does the open Atlas community binary do, and what does Atlas keep in its
+licensed builds. Every row cites the evidence it rests on.
+
+It is a status index, not an argument. The per-area detail behind these rows is
+on [Comparison](../comparison/), the measured evidence is on
+[Conformance](../conformance/), and the Atlas-documentation crosswalk is on
+[Atlas docs coverage](../docs-coverage/).
+
+## How to read the tables
+
+| Symbol | Meaning |
+| --- | --- |
+| ✅ | Supported today |
+| 🟡 | Partial. The difference column states what is missing |
+| ❌ | Not implemented |
+| ➖ | Does not apply to that product |
+| ❔ | Not established by the evidence this page uses |
+
+Each table has the same columns. **Ptah**, **CE**, and **Pro** carry one symbol
+each:
+
+- **Ptah** — the native `ptah` binary plus the separate `ptah-compat` drop-in.
+- **CE** — the pinned Atlas community binary, version 1.2.0, which the
+  conformance harness runs against.
+- **Pro** — capabilities Atlas documents as licensed on the
+  [Atlas feature availability](https://atlasgo.io/features) page, covering both
+  Atlas Pro and Atlas Cloud.
+
+Every Atlas cell has to come from an Atlas-side source: the command, usage, and
+flag inventory the conformance harness reads out of the pinned community
+binary, or a classification Atlas publishes. Where neither settles a question,
+the cell is ❔ rather than a guess. That is why the schema-object rows carry ❔
+in the Atlas columns: this page can show what Ptah emits for a domain or a
+trigger, but nothing it cites establishes what Atlas CE emits for the same
+object.
+
+:::caution
+A ✅ in the Ptah column means the capability works, not that it is
+byte-identical to Atlas. Ptah is an independent pre-GA implementation, and the
+conformance repository states plainly that no number it produces is a
+full feature-set parity test. Read the difference column before relying on a
+row for a migration decision.
+:::

--- a/docs/site/scripts/data/feature-matrix.tail.md
+++ b/docs/site/scripts/data/feature-matrix.tail.md
@@ -1,0 +1,48 @@
+## How these rows were established
+
+The Ptah column is derived from the built binaries. `ptah --help` and
+`ptah-compat --help` are the strongest available proof that a capability
+exists, and a row that could not be demonstrated that way is marked 🟡 with the
+limitation named, or ❌.
+
+The Atlas columns are narrower on purpose. Ptah is a clean-room implementation
+that studies observable behavior only, so the Atlas CE column is derived from
+the command, usage, and flag inventory the conformance harness reads out of the
+pinned Atlas community binary, and the Pro/Cloud column from the classification
+Atlas publishes on its feature availability page. Where neither source settles
+a question, the row says so rather than guessing.
+
+The full per-row evidence — the command that was run or the source cited for
+every cell — is version-controlled at
+`docs/site/scripts/data/feature-matrix-rows.json`, so a row can be re-verified
+or disputed without archaeology.
+
+Two sources carry most of the weight:
+
+- [`cli-surface.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/cli-surface.md)
+  inventories every command in Atlas CE v1.2.0 and classifies it as an OSS
+  parity target or out of scope, with the reason recorded per command.
+- [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md),
+  [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md),
+  and [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md)
+  record measured outcomes over Atlas fixtures, live databases, and Atlas CE
+  differential checks.
+
+## What this page does not claim
+
+A green conformance run is a floor on the distance to Atlas, never a ceiling.
+The conformance repository states it directly: no number it produces is a
+full feature-set parity test, and several runtime dimensions stay unmeasured.
+
+Specifically, this page does not claim that Ptah reproduces Atlas byte for
+byte, that a ✅ row behaves identically under every flag combination, or that
+the Atlas columns are exhaustive for capabilities Atlas ships outside its
+documented CLI surface.
+
+## Next steps
+
+- Per-area detail behind these rows: [Comparison](../comparison/).
+- The measured evidence and how to re-run it: [Conformance](../conformance/).
+- Which Atlas documentation area maps where: [Atlas docs coverage](../docs-coverage/).
+- Why Ptah can be Atlas-compatible without Atlas code:
+  [License boundary](../license-boundary/).

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -3,6 +3,10 @@ title: Comparison
 description: Ptah native commands, Atlas-compatible commands, feature parity evidence, Pro analyzer coverage, and the tracked gap register.
 ---
 
+This page carries the per-area detail. For a one-line status per capability,
+start at the [Feature matrix](../feature-matrix/) and come back here for the
+area that matters to you.
+
 ## Product positioning
 
 Ptah is an independent MIT-licensed implementation. It does not use Atlas source

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -21,13 +21,15 @@ on [Comparison](../comparison/), the measured evidence is on
 | ❌ | Not implemented |
 | ➖ | Does not apply to that product |
 
-The columns are:
+Each table has the same columns. **Ptah**, **CE**, and **Pro** carry one symbol
+each:
 
 - **Ptah** — the native `ptah` binary plus the separate `ptah-compat` drop-in.
-- **Atlas CE** — the pinned Atlas community binary, version 1.2.0, which the
+- **CE** — the pinned Atlas community binary, version 1.2.0, which the
   conformance harness runs against.
-- **Pro/Cloud** — capabilities Atlas documents as licensed, on the
-  [Atlas feature availability](https://atlasgo.io/features) page.
+- **Pro** — capabilities Atlas documents as licensed on the
+  [Atlas feature availability](https://atlasgo.io/features) page, covering both
+  Atlas Pro and Atlas Cloud.
 
 :::caution
 A ✅ in the Ptah column means the capability works, not that it is
@@ -59,24 +61,24 @@ Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them
 as open capabilities regardless.
 ## Schema sources
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Annotated Go models from a live database | ✅ | ❌ | ❌ | Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list. |
-| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | The ptah.yaml external_schema block fills the same desired-schema role but does not evaluate the Atlas HCL data source. |
+| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | The `ptah.yaml` external_schema block fills the same desired-schema role but does not evaluate the Atlas HCL data source. |
 | Composite multi-source desired schema | ✅ | ❌ | ✅ | Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source. |
-| External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or ptah.yaml external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
+| External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
 | HCL schema files | 🟡 | ✅ | ✅ | Ptah parses a strict subset and fails explicitly on unsupported constructs; complete Atlas HCL coverage is not claimed. |
-| Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; ptah db read introspects natively. |
-| Live database to Go annotation source | ✅ | ❌ | ❌ | ptah introspect writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
-| Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with atlas.sum, replayed on a required `--dev-url`. Works on ptah schema inspect and compat apply/diff/migrate diff. |
-| Registry-backed schema source | 🟡 | ❌ | ✅ | ptah schema pull fetches a canonical HCL artifact over oci://; it is then passed as `--schema-file`. atlas:// registry URLs are rejected. |
-| SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by ptah-compat schema apply/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
+| Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
+| Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
+| Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |
+| Registry-backed schema source | 🟡 | ❌ | ✅ | `ptah schema pull` fetches a canonical HCL artifact over oci://; it is then passed as `--schema-file`. atlas:// registry URLs are rejected. |
+| SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
 | YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
 
 ## Declarative and direct schema changes
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | --dry-run, --auto-approve, and --edit | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
 | --exclude glob and type selectors | 🟡 | ✅ | ✅ | Resource selectors plus the [type=extension].version field selector; other field selectors and non-final type selectors fail explicitly. |
@@ -84,12 +86,12 @@ as open capabilities regardless.
 | --schema / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
 | `schema inspect --include` filtering | ❌ | ❌ | ❌ | Flag absent from the pinned Atlas CE v1.2.0 inspect surface; Ptah rejects it as unknown and scopes inspect with `--schema`/`--exclude`. |
 | Apply advisory lock and --lock-timeout | 🟡 | ✅ | ✅ | Real locks on PostgreSQL, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, YugabyteDB and Spanner run unlocked with a note. |
-| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Schema files, one DB URL, one atlas.sum migration dir, or env://. atlas:// registry URLs fail before the target is contacted. |
+| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Schema files, one DB URL, one `atlas.sum` migration dir, or env://. atlas:// registry URLs fail before the target is contacted. |
 | Dev-database rehearsal before apply | 🟡 | ✅ | ✅ | Dev DB is reset, target schema recreated, exact plan run; failure aborts the apply. Needs a connectable dev URL — docker:// is a gap. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
 | Go-template --format output | 🟡 | ✅ | ✅ | sql/hcl/json/mermaid/split/write helpers over .Changes, .Realm, .MarshalSQL. Atlas web and Cloud report output remains a gap. |
 | Inspect exclude field selectors and exporters | 🟡 | ✅ | ✅ | Only the `*[type=extension].version` field selector works; other field selectors, non-final type selectors and exporters fail. |
-| Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, atlas.sum migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
+| Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
 | Plan registry sub-verbs and schema push | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test, validate and `schema push` are boundary stubs printing the CE abort text. |
@@ -101,19 +103,19 @@ as open capabilities regardless.
 
 ## Versioned migrations
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Apply pending migrations (apply/up) | ✅ | ✅ | ✅ | Compat apply matches the CE flag set and also runs goose, flyway, liquibase, dbmate and golang-migrate directories up-only. |
 | Atlas-format checkpoint output | ❌ | ❌ | ✅ | migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention. |
 | Baseline an existing database | ✅ | ✅ | ✅ | Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`. |
-| Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes atlas.sum, `--edit` opens $VISUAL or $EDITOR. |
-| Directory integrity file: hash and validate | ✅ | ✅ | ✅ | hash writes ptah.sum, or atlas.sum for atlas-format directories; validate checks it and with `--dev-url` cleans and replays the dir. |
-| Directory maintenance: edit, rebase, rm | ✅ | ❌ | ✅ | Each rewrites ptah.sum/atlas.sum and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs. |
+| Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR. |
+| Directory integrity file: hash and validate | ✅ | ✅ | ✅ | hash writes `ptah.sum`, or `atlas.sum` for atlas-format directories; validate checks it and with `--dev-url` cleans and replays the dir. |
+| Directory maintenance: edit, rebase, rm | ✅ | ❌ | ✅ | Each rewrites `ptah.sum`/`atlas.sum` and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs. |
 | Dynamic down planning (`migrate down --plan`) | ❌ | ❌ | ✅ | `--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files. |
 | Execution order (--exec-order) | ✅ | ✅ | ✅ | linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it. |
 | External `--dir-format` outside `migrate import` | ❌ | ✅ | ✅ | hash, lint, new, set, status and validate accept only `--dir-format`=atlas; other tool formats must first go through migrate import. |
 | Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Native `ptah migrations import` converts R__ into a one-time migration; Atlas-shaped `ptah-compat migrate import` rejects R__ files. |
-| Generate migrations from a schema diff | 🟡 | ✅ | ✅ | Replays the directory on `--dev-url` and writes files before atlas.sum; `--qualifier`, `--edit`, `--format` work. Docker dev databases are a gap. |
+| Generate migrations from a schema diff | 🟡 | ✅ | ✅ | Replays the directory on `--dev-url` and writes files before `atlas.sum`; `--qualifier`, `--edit`, `--format` work. Docker dev databases are a gap. |
 | Import from other migration tools | 🟡 | ✅ | ✅ | Compat import takes local file:// dirs only and rejects Flyway R__ repeatable files; native import converts them to one-time migrations. |
 | Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint pair; CE has no checkpoint verb and Atlas lists it as Pro. |
 | Migration linting | 🟡 | 🟡 | ✅ | CE registers migrate lint; Atlas's features page marks the lint CLI Pro with a basic Open rule set. Ptah lacks custom rules, web reports. |
@@ -121,7 +123,7 @@ as open capabilities regardless.
 | Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
 | Native migration import | ✅ | ✅ | ✅ | Both convert golang-migrate, Goose, Flyway and Liquibase dirs; ptah adds dbmate. Liquibase XML/YAML/JSON changelogs are rejected. |
 | Pre-migration assertion checks | 🟡 | ❌ | ✅ | Local -- +ptah check assert=... aborts before the body; rejected under `--tx-mode` all. The reviewer-approval half is not implemented. |
-| Repair dirty or partial revision state | ✅ | ❌ | ❌ | ptah migrations repair `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
+| Repair dirty or partial revision state | ✅ | ❌ | ❌ | `ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
 | Revision table format and placement | ✅ | ✅ | ✅ | `--revision-format` ptah\|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows. |
 | Roll back applied migrations (down) | 🟡 | ✅ | ✅ | Ptah reverts via pre-planned down files; `--to-tag`, `--skip-checks` and `--plan` fail loudly as waivers. Atlas Pro adds plan approval. |
 | Set revision state to a version | ✅ | ✅ | ✅ | Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set. |
@@ -129,9 +131,9 @@ as open capabilities regardless.
 
 ## Linting and safety
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files without `--allow-destructive`; .ptah-lint.yaml tunes it, but ptah.sum does not hash it. |
+| Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files without `--allow-destructive`; .ptah-lint.yaml tunes it, but `ptah.sum` does not hash it. |
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | 23 of 30 Pro-marked codes covered, 5 partial (PG301, PG304, MY130, MY133, MY136), 2 waived (OW101, OW102) as account-bound policy. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
 | Check-level policy and custom lint rules | ❌ | ❌ | ✅ | Only analyzer severity policy for the five mapped families is read; check-level policy, custom rules and force/allow-lists are gaps. |
@@ -140,38 +142,38 @@ as open capabilities regardless.
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
 | Inline nolint suppression | ✅ | 🟡 | ✅ | Native ptah:nolint is statement-scoped; atlas:nolint selectors and whole-file headers apply only under the ptah-compat lint profile. |
 | Native migration lint rule set | ✅ | 🟡 | ✅ | 42 built-in codes in DS, CD, DD, MF, BC, PG, MY, LT, TX families; `--dialect` gates dialect-specific rules. Atlas has a basic Open rule set. |
-| Per-rule severity policy | 🟡 | 🟡 | ✅ | .ptah-lint.yaml sets per-rule severity and path excludes; atlas.hcl maps only 5 analyzer blocks to severity and rejects force. |
+| Per-rule severity policy | 🟡 | 🟡 | ✅ | .ptah-lint.yaml sets per-rule severity and path excludes; `atlas.hcl` maps only 5 analyzer blocks to severity and rejects force. |
 | SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
 | Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |
 
 ## Testing
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | ptah-compat migrate test and schema test run Ptah-native YAML/Go cases only; .test.hcl files are not parsed. |
+| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | `ptah-compat migrate test` and schema test run Ptah-native YAML/Go cases only; .test.hcl files are not parsed. |
 | Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | ptah-compat forwards to native runners (`--dir`, -u, `--dev-url`, `--run`); Atlas .test.hcl is not ingested — Ptah YAML is the payload. |
 | Dev / shadow database verification | 🟡 | ✅ | ✅ | Replay on `--dev-url`, `--shadow-db` for generate and checkpoint, apply rehearsal. Docker dev-database URLs unsupported. |
 | Embeddable test runner (Go package) | ✅ | ❌ | ❌ | Runner exported as migration/dbtest (RunMigrationTest, RunSchemaTest); Atlas ships its test framework only in a closed-source binary. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
-| Registry plan testing (`schema plan test`) | ❌ | ❌ | ✅ | ptah-compat schema plan test stays an Atlas CE unsupported boundary stub: `--help` exits 0, direct execution aborts and exits 1. |
+| Registry plan testing (`schema plan test`) | ❌ | ❌ | ✅ | `ptah-compat schema plan` test stays an Atlas CE unsupported boundary stub: `--help` exits 0, direct execution aborts and exits 1. |
 | Schema test framework (`ptah schema test`) | ✅ | ❌ | ✅ | Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb. |
 
 ## Configuration and dev databases
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Documented local subset: variable, locals, data hcl_schema, env, schema, migration, format, diff, lint. Cloud and registry blocks fail. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Only data.hcl_schema.<name>.url for local schema files resolves; any other data block label fails explicitly. |
 | Docker dev databases (`docker://` --dev-url) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
 | env:// desired-state references | 🟡 | ✅ | ✅ | ptah-compat only; attributes src, schema.src, url, dev, migration, migration.dir. Nested env:// fails; native ptah has no equivalent. |
-| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Ptah-owned file for url, src, dev, external_schema, migration, lint, diff, online_ddl. Unknown keys fail. Ranks below atlas.hcl. |
-| Remote and template directory sources | ❌ | ✅ | ✅ | Rejected while parsing atlas.hcl. The native substitute is the bring-your-own oci:// artifact workflow, not an Atlas data source. |
+| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Ptah-owned file for url, src, dev, external_schema, migration, lint, diff, online_ddl. Unknown keys fail. Ranks below `atlas.hcl`. |
+| Remote and template directory sources | ❌ | ✅ | ✅ | Rejected while parsing `atlas.hcl`. The native substitute is the bring-your-own oci:// artifact workflow, not an Atlas data source. |
 | Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | variable defaults, repeated `--var` strings/lists, locals, getenv, file, fileset, format, jsonencode. Typed and sensitive variables fail. |
 
 ## Databases and schema objects
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | No foreign keys, enforced CHECKs, views, matviews, functions or triggers; standalone enum types are rejected. Atlas lists it as Pro. |
 | CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS; views, functions and triggers are not emitted at all. |
@@ -194,7 +196,7 @@ as open capabilities regardless.
 
 ## Go embedding and developer tooling
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Annotation metadata as JSON Schema | ✅ | ➖ | ➖ | Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to. |
 | API schema export: OpenAPI 3.0 and GraphQL | ✅ | ❌ | ❌ | Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list. |
@@ -207,17 +209,17 @@ as open capabilities regardless.
 
 ## Data and distribution
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
 | OCI deployment, lint and plan report referrers | 🟡 | ❌ | 🟡 | Lists referrer descriptors only; payload download is absent. Atlas Cloud deployment reporting is a hosted service, not registry referrers. |
-| OCI desired-schema artifacts | ✅ | ❌ | 🟡 | Canonical schema.hcl push/pull; compare, drift and plan read `--schema-file` oci://. atlas schema push is a CE unsupported boundary stub. |
+| OCI desired-schema artifacts | ✅ | ❌ | 🟡 | Canonical schema.hcl push/pull; compare, drift and plan read `--schema-file` oci://. `atlas schema push` is a CE unsupported boundary stub. |
 | OCI migration artifacts | ✅ | ❌ | 🟡 | push/pull plus direct up, status, down and lint over oci://. Atlas's registry equivalent is hosted and account-bound, not bring-your-own. |
 
 ## Atlas Registry and Cloud
 
-| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | `migrate push` and `schema push` | ❌ | ❌ | ✅ | Registered as Atlas CE boundary stubs: help prints the community-version notice, direct execution prints the CE abort text. |
 | `schema plan` registry and output flags | ❌ | ❌ | ✅ | `--push`/`--pending`/`--repo` are recorded waivers; `--format`/`--name-format`/`--directive`/`--edit`/`--skip-lint` fail as unimplemented. |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -20,6 +20,7 @@ on [Comparison](../comparison/), the measured evidence is on
 | 🟡 | Partial. The difference column states what is missing |
 | ❌ | Not implemented |
 | ➖ | Does not apply to that product |
+| ❔ | Not established by the evidence this page uses |
 
 Each table has the same columns. **Ptah**, **CE**, and **Pro** carry one symbol
 each:
@@ -30,6 +31,14 @@ each:
 - **Pro** — capabilities Atlas documents as licensed on the
   [Atlas feature availability](https://atlasgo.io/features) page, covering both
   Atlas Pro and Atlas Cloud.
+
+Every Atlas cell has to come from an Atlas-side source: the command, usage, and
+flag inventory the conformance harness reads out of the pinned community
+binary, or a classification Atlas publishes. Where neither settles a question,
+the cell is ❔ rather than a guess. That is why the schema-object rows carry ❔
+in the Atlas columns: this page can show what Ptah emits for a domain or a
+trigger, but nothing it cites establishes what Atlas CE emits for the same
+object.
 
 :::caution
 A ✅ in the Ptah column means the capability works, not that it is
@@ -48,9 +57,10 @@ Across the 120 capabilities below:
 | Ptah supports it with a stated limitation | 43 |
 | Ptah does not implement it | 21 |
 | Ptah and Atlas CE both support it | 23 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 22 |
 | Ptah has it and neither Atlas edition does | 9 |
 | Atlas CE has it and Ptah does not, or only in part | 26 |
+| Atlas side not established by this page's evidence | 5 |
 
 The command surface is counted separately, because it is measured rather than
 assessed. The conformance harness inventories every command in the pinned Atlas
@@ -177,18 +187,18 @@ as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | No foreign keys, enforced CHECKs, views, matviews, functions or triggers; standalone enum types are rejected. Atlas lists it as Pro. |
 | CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS; views, functions and triggers are not emitted at all. |
-| Domains, composite types, and range types | 🟡 | ❌ | ✅ | PostgreSQL only - not CockroachDB, YugabyteDB or Spanner. Domain check/default are create-only; base-type changes drop and recreate. |
+| Domains, composite types, and range types | 🟡 | ❔ | ❔ | PostgreSQL only - not CockroachDB, YugabyteDB or Spanner. Domain check/default are create-only; base-type changes drop and recreate. |
 | Enum types | 🟡 | ✅ | ✅ | Postgres CREATE TYPE; MySQL inline ENUM; SQLite TEXT+CHECK; SQL Server NVARCHAR+CHECK; ClickHouse passthrough; Spanner skips enums. |
-| Extensions | 🟡 | ❌ | ✅ | PostgreSQL family only, with a default ignore list (plpgsql). SQLite, SQL Server and ClickHouse comment it out; MySQL/MariaDB emit nothing. |
-| Functions | 🟡 | ❌ | ✅ | Renders on PostgreSQL only; MySQL/MariaDB emit a not-supported comment and error on DROP; CockroachDB, YugabyteDB, Spanner omit silently. |
+| Extensions | 🟡 | ❔ | ❔ | PostgreSQL family only, with a default ignore list (plpgsql). SQLite, SQL Server and ClickHouse comment it out; MySQL/MariaDB emit nothing. |
+| Functions | 🟡 | ❔ | ❔ | Renders on PostgreSQL only; MySQL/MariaDB emit a not-supported comment and error on DROP; CockroachDB, YugabyteDB, Spanner omit silently. |
 | MySQL and MariaDB | 🟡 | ✅ | ✅ | Separate dialects with different capability sets; no PostgreSQL-only objects; implicit DDL commit blocks transactional rollback. |
 | Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | Listed as Atlas Pro drivers. Ptah has no dialect, renderer or driver for any of them. |
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
-| Roles, grants, and row-level security | 🟡 | ❌ | ✅ | Emitted on PostgreSQL only; CockroachDB, YugabyteDB and Spanner get none despite PostgreSQL-family capability flags for roles. |
+| Roles, grants, and row-level security | 🟡 | ❔ | ❔ | Emitted on PostgreSQL only; CockroachDB, YugabyteDB and Spanner get none despite PostgreSQL-family capability flags for roles. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Most conservative preset: no enums, foreign keys, sequences, RLS, XML or advisory locks. Coverage is offline; no live container. |
 | SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | Portable T-SQL subset: no sequences, RLS, roles/grants or matviews, and automatic column removal is refused. Atlas lists it as Pro. |
 | SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Constraint changes and most column modifications report rebuild-required instead of generating a rebuild; PG-only objects rejected. |
-| Standalone sequences | 🟡 | ❌ | ✅ | Standalone CREATE SEQUENCE renders on PostgreSQL only; YugabyteDB carries the capability flag but the generator emits none. |
+| Standalone sequences | 🟡 | ❔ | ❔ | Standalone CREATE SEQUENCE renders on PostgreSQL only; YugabyteDB carries the capability flag but the generator emits none. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Atlas docs list both as Open drivers; Ptah's dialect normalizer has no TiDB or LibSQL entry, so the names do not resolve. |
 | Triggers | 🟡 | ❌ | ✅ | Render on PostgreSQL, MySQL/MariaDB, SQLite (row-level only) and SQL Server; ClickHouse, CockroachDB, YugabyteDB and Spanner do not. |
 | Views and materialized views | 🟡 | ❌ | ✅ | Views: PostgreSQL, MySQL/MariaDB, SQLite, SQL Server. Matviews: PostgreSQL only. CockroachDB, YugabyteDB, Spanner, ClickHouse: neither. |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -49,15 +49,15 @@ row for a migration decision.
 :::
 ## At a glance
 
-Across the 132 capabilities below:
+Across the 129 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 65 |
+| Ptah supports it fully | 63 |
 | Ptah supports it with a stated limitation | 44 |
-| Ptah does not implement it | 23 |
+| Ptah does not implement it | 22 |
 | Ptah and Atlas CE both support it | 25 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 26 |
 | Ptah has it and neither Atlas edition does | 8 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
 | Atlas side not established by this page's evidence | 15 |
@@ -231,28 +231,44 @@ as open capabilities regardless.
 
 ## Data and distribution
 
+Ptah's registry story differs from Atlas's in storage, not in function.
+Everything artifact distribution needs — publish a migration directory or a
+desired schema, pull it elsewhere, pin an exact version, run migrations
+straight from the registry — works against any OCI-compliant registry: GHCR,
+ECR, GAR, Harbor, Docker Hub, or a self-hosted `registry:2`.
+
+For a team this means the registry and credentials already used for container
+images also serve schema artifacts; there is no separate account, login verb,
+or hosted service to depend on; and a digest pin makes a deployment
+reproducible byte for byte. The artifacts are ordinary OCI 1.1 manifests, so
+registry-side controls — replication, retention, immutable-tag policy, access
+control — come from the registry, not from Ptah. The full workflow is on
+[OCI registry artifacts](../../operate/oci-registry/).
+
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Artifact integrity check (--verify-sum) | 🟡 | ➖ | ❔ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
 | Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
 | Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; --version is write-once and a conflict exits 2. The reference tag, --tag values and latest all move. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
-| Migration directories in an OCI registry | ✅ | ❌ | ✅ | `migrations push/pull`, plus `up`, `status`, `down` and `lint` reading `oci://` directly as the directory flag. No local checkout needed. |
 | oci:// as a --schema-file desired-state source | 🟡 | ❌ | ✅ | Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose --plain-http. |
-| oci:// in the Atlas-compatible ptah-compat binary | ❌ | ❌ | ➖ | By design: compat mirrors the Atlas surface, which has no oci:// scheme. migration.dir takes file:// only; the OCI workflow lives in the native ptah binary. |
 | Referrer attachments: lint, plan, deployment reports | 🟡 | ❌ | ❔ | lint --attach, migrations plan --attach and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload. |
-| Registry-backed artifact distribution | ✅ | ❌ | ✅ | Ptah pushes/pulls schema and migration artifacts to any OCI registry. Atlas Registry is a hosted Cloud service; CE v1.2.0 has no push verb. |
-| Self-hosted registry with no vendor account | ✅ | ➖ | ❌ | Any OCI registry; auth reads the Docker credential store. Ptah registers no login verb. Atlas Registry is documented as an Atlas Cloud service. |
+| Registry-backed distribution: `oci://` vs `atlas://` | ✅ | ❌ | ✅ | Same functions as `atlas://` — publish, pull, digest-pin, consume directly — over any OCI registry with no vendor account. Full workflow: [OCI registry artifacts](../../operate/oci-registry/). |
 
 ## Atlas Registry and Cloud
 
+These rows are the services Atlas hosts on top of its registry — approvals,
+reporting, monitoring, the `atlas://` scheme itself. They concern the hosted
+service, not artifact storage; the storage function is covered under
+[Data and distribution](#data-and-distribution).
+
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
+| `atlas://` vendor protocol | ❌ | ❌ | ✅ | The scheme is Cloud-bound and rejected with a named error; every function behind it is available natively over `oci://`. The compat binary mirrors the Atlas surface, which has no `oci://`. |
 | `migrate push` and `schema push` | ❌ | ❌ | ✅ | ptah-compat boundary stubs printing the CE abort text, exit 1. The native equivalents are `ptah schema push` and `ptah migrations push`. |
 | `schema plan` registry and output flags | ❌ | ❌ | ✅ | `--push`/`--pending`/`--repo` are recorded waivers; `--format`/`--name-format`/`--directive`/`--edit`/`--skip-lint` fail as unimplemented. |
 | `schema plan` registry sub-verbs | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test and validate all stay CE boundary stubs; only local plan files are implemented. |
 | Atlas Cloud deployment reporting | ❌ | ❌ | ✅ | No Atlas account model or deployment API. Ptah attaches a deployment-report referrer to its own OCI artifact after an oci:// migrations up. |
-| Atlas Registry `atlas://` source URLs | ❌ | ❌ | ✅ | ptah-compat rejects atlas:// in --to/--from and atlas.hcl migration.dir with named errors. Ptah's scheme is oci://, not an atlas:// resolver. |
 | Reviewer approval and policy workflows | ❌ | ❌ | ✅ | Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope. |
 | Schema monitoring, hosted UI, login | ❌ | ❌ | ✅ | Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check. |
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -47,24 +47,25 @@ conformance repository states plainly that no number it produces is a
 full feature-set parity test. Read the difference column before relying on a
 row for a migration decision.
 :::
+
 ## At a glance
 
-Across the 129 capabilities below:
+Across the 149 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 63 |
-| Ptah supports it with a stated limitation | 44 |
-| Ptah does not implement it | 22 |
-| Ptah and Atlas CE both support it | 25 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 26 |
+| Ptah supports it fully | 78 |
+| Ptah supports it with a stated limitation | 47 |
+| Ptah does not implement it | 24 |
+| Ptah and Atlas CE both support it | 24 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
 | Ptah has it and neither Atlas edition does | 8 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
-| Atlas side not established by this page's evidence | 15 |
+| An Atlas column is ❔ — not established by this page's evidence | 34 |
 
-Every 🟡 on this page names the specific limitation, and each one was
-reproduced against a binary built from this repository. Where the limitation is
-work that has not been done, it is tracked in
+Every 🟡 in the Ptah column names its specific limitation, reproduced against a
+binary built from this repository; Atlas-column verdicts rest on the cited
+Atlas-side sources only. Confirmed gaps are tracked in
 [#926 to #942](https://github.com/stokaro/ptah/issues/926) and [#944](https://github.com/stokaro/ptah/issues/944).
 
 The command surface is counted separately, because it is measured rather than
@@ -74,6 +75,7 @@ inventoried commands are open parity targets, and every one of them matches on
 help usage and flags — 107 observations, no gap. The remaining 18 are registry,
 Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them
 as open capabilities regardless.
+
 ## Schema sources
 
 | Capability | Ptah | CE | Pro | Difference |
@@ -88,7 +90,7 @@ as open capabilities regardless.
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
 | HCL foreign_key deferrable | ❌ | ❔ | ❔ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. |
 | HCL function calls in schema files | 🟡 | ❔ | ❔ | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally. |
-| HCL locals, lock, atlas, dynamic/for_each | ❌ | ❔ | ❔ | Named rejections, exit 1: unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". |
+| HCL locals, lock, atlas, dynamic/for_each | ❌ | ❔ | ❔ | Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". |
 | HCL table and column child blocks | ✅ | ❔ | ❔ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. |
 | HCL top-level blocks Ptah parses | ✅ | ❔ | ❔ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. |
 | HCL variable blocks and var.* references | ❌ | ✅ | ✅ | `variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error. |
@@ -103,53 +105,65 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| --dry-run, --auto-approve, and --edit | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
-| --exclude glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
-| --include resource selectors | ✅ | ❌ | ✅ | Top-level globs and [type=...] on apply/diff, repeated values union; child types refused by design, schemas selected with --schema. |
-| --schema / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
+| `--dry-run`, `--auto-approve`, and `--edit` | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
+| `--exclude` glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
+| `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community; pinned CE inspect has no `--include`. Ptah selects with union semantics and cross-scope dependency diagnostics. |
+| `--schema` / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
 | `schema inspect --include` filtering | ❌ | ❌ | ❔ | Flag absent from the pinned Atlas CE v1.2.0 inspect flags; Ptah rejects it as unknown. No cited source settles the licensed builds. |
-| Apply advisory lock and --lock-timeout | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
-| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
+| Apply advisory lock and `--lock-timeout` | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
+| Desired-state sources for `--to` and `--from` | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
-| Go-template --format output | 🟡 | ✅ | ✅ | schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only. |
-| Inspect --exclude field selectors | 🟡 | ❔ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. |
-| Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
+| Go-template `--format` output | 🟡 | ✅ | ✅ | schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only. |
+| Inspect `--exclude` field selectors | 🟡 | ❔ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. |
+| Inspect non-database sources via `--dev-url` | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
+| JSON output for native schema diff | ✅ | ❔ | ❔ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
-| schema clean | 🟡 | ✅ | ✅ | Plan and --dry-run list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
+| schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
 | Schema-qualified exclude globs for enums and functions | 🟡 | ❔ | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. |
+| Upstream verb `schema stats` | ❌ | ❌ | ❔ | Beyond the CE pin: upstream OpenMetrics database-statistics verb; the gap register triages it out of scope as an observability surface rather than schema management. |
+| Upstream verb `schema validate` | 🟡 | ❌ | ❔ | Beyond the CE pin: no validate verb; the gap register triage covers it with native schema render parse/load validation plus schema test and schema apply `--dry-run`. |
 
 ## Versioned migrations
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Also runs goose/flyway/liquibase/dbmate dirs via ?format=; --dry-run ignores the revision table and re-plans already-applied files. |
+| Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Also runs goose/flyway/liquibase/dbmate dirs via ?format=; `--dry-run` ignores the revision table and re-plans already-applied files. |
+| Atlas SQL template migrations (`--atlas-env`) | ✅ | ❔ | ❔ | Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs. |
+| Atlas txtar migration sections (-- atlas:txtar) | ✅ | ❔ | ❔ | Atlas-format .sql files with the -- atlas:txtar directive execute their migration.sql and down.sql sections (giving Atlas dirs a down path); unrelated embedded files are ignored. |
 | Atlas-format checkpoint output | ❌ | ❌ | ✅ | migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention. |
 | Baseline an existing database | ✅ | ✅ | ✅ | Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`. |
 | Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR. |
 | Directory integrity file: hash and validate | ✅ | ✅ | ✅ | hash writes `ptah.sum`, or `atlas.sum` for atlas-format directories; validate checks it and with `--dev-url` cleans and replays the dir. |
 | Directory maintenance: edit, rebase, rm | ✅ | ❌ | ✅ | Each rewrites `ptah.sum`/`atlas.sum` and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs. |
 | Dynamic down planning (`migrate down --plan`) | ❌ | ❌ | ✅ | `--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files. |
-| Execution order (--exec-order) | ✅ | ✅ | ✅ | linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it. |
+| Execution order (`--exec-order`) | ✅ | ✅ | ✅ | linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it. |
 | External `--dir-format` outside `migrate import` | ❌ | ✅ | ✅ | hash, lint, new, set, status and validate accept only `--dir-format`=atlas; other tool formats must first go through migrate import. |
 | Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Compat import aborts the entire directory on any R__ file; native import rewrites R__ as a one-time migration, losing re-run-on-change. |
 | Generate migrations from a schema diff | 🟡 | ✅ | ✅ | New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry. |
-| Import from other migration tools | 🟡 | ✅ | ✅ | --from must be a local file:// dir; Liquibase XML/YAML/JSON changelogs are refused - only formatted-SQL changelogs import. |
+| migrate apply `--allow-dirty` semantics | 🟡 | ✅ | ✅ | Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite). |
 | Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint pair; CE has no checkpoint verb and Atlas lists it as Pro. |
-| Migration linting | ✅ | 🟡 | ✅ | Runs with Atlas's flag set and 42 codes; custom rules load only through the Go API at compile time, not from a CLI flag or config file. |
+| Migration import from other tools | 🟡 | ✅ | ✅ | Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed. |
+| Migration linting | ✅ | 🟡 | ✅ | CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time. |
 | Migration lock and lock timeout | ✅ | ✅ | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`. |
 | Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
-| Native migration import | ✅ | ✅ | ✅ | Both convert golang-migrate, Goose, Flyway and Liquibase dirs; ptah adds dbmate. Liquibase XML/YAML/JSON changelogs are rejected. |
+| Online DDL routing via gh-ost or pt-osc | ✅ | ❔ | ❔ | ptah.yaml online_ddl.tool (ghost\|pt-osc), threshold_rows, args, and fallback (error\|plain) route large-table ALTERs through an online-DDL tool during migrations up/down. |
+| Pre-migration database backups (`--pg-dump-to`) | ✅ | ❌ | ❔ | `--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to. |
+| Pre-migration webhook and shell hook gates | ✅ | ❌ | ❔ | `--webhook` POSTs migration metadata and requires HTTP 200; `--pre-up-hook`/`--pre-down-hook` run a shell command that must exit 0, else the run aborts. Also ptah.yaml migration.webhook/pre_up_hook. |
+| Prometheus metrics endpoint (`--metrics-addr`) | ✅ | ❌ | ❔ | migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run. |
 | Repair dirty or partial revision state | ✅ | ❌ | ❌ | `ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
 | Revision table format and placement | ✅ | ✅ | ✅ | `--revision-format` ptah\|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows. |
-| Roll back applied migrations (down) | 🟡 | ✅ | ✅ | Atlas single-file dirs have no down body: down dirties the revision row before it discovers that, so apply then aborts on a dirty revision. |
+| Roll back applied migrations (down) | 🟡 | ❌ | ✅ | Ptah reverts via pre-planned down files; `--to-tag`/`--skip-checks`/`--plan` fail loudly as waivers. `migrate down` is absent from the pinned CE binary. |
 | Set revision state to a version | ✅ | ✅ | ✅ | Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set. |
-| Transaction modes (--tx-mode file/all/none) | ✅ | ✅ | ✅ | all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks. |
+| Structured JSON log output (`--log-format`) | ✅ | ❌ | ❔ | migrations up, down, and status take `--log-format` text\|json and `--log-level` debug\|info\|warn\|error for machine-readable run logs. |
+| Transaction modes (`--tx-mode` file/all/none) | ✅ | ✅ | ✅ | all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks. |
+| Upstream verb `migrate ls` | 🟡 | ❌ | ❔ | Beyond the CE pin: ptah-compat rejects it as unknown command; native ptah migrations status lists every migration with version and state, per the gap register triage. |
+| Upstream verb `migrate show` | ❌ | ❌ | ❔ | Beyond the CE pin: prints a migration's SQL upstream; no compat or native Ptah verb exists, and the gap register triages it as future work. |
 
 ## Linting and safety
 
@@ -158,23 +172,25 @@ as open capabilities regardless.
 | Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file. |
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
-| CI integration (GitHub Action, annotations) | ✅ | ❔ | ❔ | stokaro/ptah-action@v1 posts a sticky PR comment; --format github-actions emits annotations. Atlas features page omits CI integrations. |
+| CI integration (GitHub Action, annotations) | ✅ | ❔ | ❔ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations. |
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
+| Generation-time destructive-change gate | ✅ | ❌ | ❔ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
 | Inline nolint suppression | 🟡 | ✅ | ✅ | Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored. |
-| Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by --dialect. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
+| Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
 | Per-rule severity policy | 🟡 | ❔ | ✅ | Severity vocabulary is warning\|error only (info errors out); atlas.hcl exposes 5 analyzer blocks mapped to an error bool and rejects force. |
-| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Only the -- +ptah check spelling; --tx-mode all refuses checked files, and that error names --skip-checks, which compat apply lacks. |
-| SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native --format sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template --format output for migrate lint. |
-| Statement safety classification report | ✅ | ➖ | ➖ | plan --report text\|html\|json and generate --report html\|json emit highest severity, a destructive flag, and per-statement assessments. |
+| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Only the `-- +ptah check` spelling; `--tx-mode` all refuses checked files, and that error names `--skip-checks`, which compat apply lacks. |
+| SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
+| Standalone SQL file linting (`ptah sql lint`) | ✅ | ❌ | ❔ | Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not. |
+| Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |
 
 ## Testing
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | No .test.hcl parser; a directory of them exits 1 with "no test cases found" instead of naming the unsupported file format. |
-| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes --report or --seed-dir. |
-| Dev / shadow database verification | 🟡 | ✅ | ✅ | --shadow-db on generate, checkpoint, baseline and down; docker:// is refused, and schema apply --dry-run skips the rehearsal entirely. |
+| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | No .test.hcl parser; a directory of them reports 'no test cases found' (`ptah-compat` exit 1, native exit 2). |
+| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`. |
+| Dev / shadow database verification | 🟡 | ✅ | ✅ | `--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely. |
 | Embeddable test runner (Go package) | ✅ | ❔ | ❔ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
@@ -185,11 +201,12 @@ as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema. |
-| atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah --env reads ./atlas.hcl only: no --var flag, and --config takes ptah.yaml, so a variable without a default cannot be resolved. |
+| atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected. |
-| Docker dev databases (`docker://` --dev-url) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
-| env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on --to/--from and only src, schema.src, url, dev, migration.dir; elsewhere (--exclude) the literal string is used silently. |
+| Docker dev databases (`docker://` `--dev-url`) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
+| env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently. |
 | Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail. |
+| PTAH_* environment-variable flag equivalents | ✅ | ❔ | ❔ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
 | Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | Only file, fileset, format, getenv, jsonencode evaluate; variable type, sensitive, validation and env for_each are rejected. |
 
@@ -208,12 +225,12 @@ as open capabilities regardless.
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
 | Roles, grants, and row-level security | 🟡 | ❔ | ❔ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY and ENABLE RLS. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
-| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and --dialect help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
+| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
 | SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
 | Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
 | Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
-| Views and materialized views | 🟡 | ❌ | ✅ | `mssql`/`tsql` aliases drop views. Matviews are PostgreSQL-only: `schema render` silently drops them elsewhere, `schema apply` errors. |
+| Views and materialized views | 🟡 | ❌ | ✅ | Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently. |
 | YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them. |
 
 ## Go embedding and developer tooling
@@ -222,12 +239,17 @@ as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | Annotation metadata as JSON Schema | ✅ | ➖ | ➖ | Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to. |
 | API schema export: OpenAPI 3.0 and GraphQL | ✅ | ❌ | ❌ | Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list. |
+| Concurrency-guarded migration plan publication | ✅ | ➖ | ➖ | generator.PlanMigration binds a plan to a directory snapshot; WriteFiles rejects changed history (ErrMigrationDirectoryChanged) under a cross-process lock; concurrent reuse fails (ErrMigrationPlanInUs |
+| Go annotations to HCL export with cleanup | ✅ | ➖ | ➖ | schema export `--to` hcl writes an HCL schema from Go annotations; `--cleanup-go-annotations` removes the annotations after a lossless export, with `--cleanup-dry-run`/`--cleanup-diff` previews. |
+| Pinned database sessions (WithSession) | ✅ | ➖ | ➖ | `WithSession` on `DatabaseConnection` pins one physical session for a callback, rebinding reader/writer/SQL runner, and discards the connection so session state cannot leak. |
 | Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
 | ptah-ls annotation language server | ✅ | ➖ | ➖ | stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax. |
 | Public API compatibility gate | ✅ | ➖ | ➖ | check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line. |
 | Query builder for parameterized SQL | 🟡 | ➖ | ➖ | Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error. |
 | Reusable Go packages (embedder API) | ✅ | ➖ | ➖ | Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs. |
 | Schema visualization (ERD diagrams) | ✅ | ❌ | ✅ | Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas features page lists visualization as Pro. |
+| Statement observer and validator hooks (Go API) | ✅ | ➖ | ➖ | migrator.WithStatementObserver runs a read-only callback per executed statement; WithStatementValidator gates all statements pre-execution; both compose with StatementInterceptor. |
+| testkit companion module for database tests | ✅ | ➖ | ➖ | Separate module github.com/stokaro/ptah/testkit wraps testcontainers-go for tests needing real databases; versions independently and stays out of the main module graph. |
 
 ## Data and distribution
 
@@ -247,13 +269,13 @@ control — come from the registry, not from Ptah. The full workflow is on
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Artifact integrity check (--verify-sum) | 🟡 | ➖ | ❔ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
+| Artifact integrity check (`--verify-sum`) | 🟡 | ➖ | ❔ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
 | Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
-| Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; --version is write-once and a conflict exits 2. The reference tag, --tag values and latest all move. |
+| Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
-| oci:// as a --schema-file desired-state source | 🟡 | ❌ | ✅ | Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose --plain-http. |
-| Referrer attachments: lint, plan, deployment reports | 🟡 | ❌ | ❔ | lint --attach, migrations plan --attach and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload. |
-| Registry-backed distribution: `oci://` vs `atlas://` | ✅ | ❌ | ✅ | Same functions as `atlas://` — publish, pull, digest-pin, consume directly — over any OCI registry with no vendor account. Full workflow: [OCI registry artifacts](../../operate/oci-registry/). |
+| oci:// as a `--schema-file` desired-state source | 🟡 | ❌ | ✅ | Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose `--plain-http`. |
+| Referrer attachments: lint, plan, deployment reports | 🟡 | ❌ | ❔ | lint `--attach`, migrations plan `--attach` and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload. |
+| Registry-backed distribution: `oci://` vs `atlas://` | ✅ | ❌ | ✅ | `atlas://` functions — publish, pull, digest-pin, run migrations directly, schemas via `--schema-file` — over any OCI registry, no account. See [OCI registry artifacts](../../operate/oci-registry/). |
 
 ## Atlas Registry and Cloud
 
@@ -285,6 +307,11 @@ the command, usage, and flag inventory the conformance harness reads out of the
 pinned Atlas community binary, and the Pro/Cloud column from the classification
 Atlas publishes on its feature availability page. Where neither source settles
 a question, the row says so rather than guessing.
+
+The full per-row evidence — the command that was run or the source cited for
+every cell — is version-controlled at
+`docs/site/scripts/data/feature-matrix-rows.json`, so a row can be re-verified
+or disputed without archaeology.
 
 Two sources carry most of the weight:
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -49,18 +49,23 @@ row for a migration decision.
 :::
 ## At a glance
 
-Across the 120 capabilities below:
+Across the 135 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 56 |
-| Ptah supports it with a stated limitation | 43 |
-| Ptah does not implement it | 21 |
-| Ptah and Atlas CE both support it | 23 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 22 |
-| Ptah has it and neither Atlas edition does | 9 |
-| Atlas CE has it and Ptah does not, or only in part | 26 |
-| Atlas side not established by this page's evidence | 5 |
+| Ptah supports it fully | 66 |
+| Ptah supports it with a stated limitation | 44 |
+| Ptah does not implement it | 25 |
+| Ptah and Atlas CE both support it | 25 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
+| Ptah has it and neither Atlas edition does | 8 |
+| Atlas CE has it and Ptah does not, or only in part | 25 |
+| Atlas side not established by this page's evidence | 15 |
+
+Every 🟡 on this page names the specific limitation, and each one was
+reproduced against a binary built from this repository. Where the limitation is
+work that has not been done, it is tracked: see
+[issues #926 to #942](https://github.com/stokaro/ptah/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement%2Cbug+created%3A%3E2026-07-30).
 
 The command surface is counted separately, because it is measured rather than
 assessed. The conformance harness inventories every command in the pinned Atlas
@@ -74,15 +79,23 @@ as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Annotated Go models from a live database | ✅ | ❌ | ❌ | Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list. |
-| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | The `ptah.yaml` external_schema block fills the same desired-schema role but does not evaluate the Atlas HCL data source. |
+| Atlas CE inspect HCL parses back into Ptah | ✅ | ✅ | ✅ | 30 atlas-differential observations parse Atlas CE 1.2.0 `schema inspect` HCL on Postgres/MySQL/SQLite with zero schema-fact mismatches. |
+| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | Ptah's `data` block is an unlabeled seed-row declaration; every labeled Atlas data source fails with `data block does not accept labels`. |
 | Composite multi-source desired schema | ✅ | ❌ | ✅ | Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source. |
+| Desired-schema artifacts in an OCI registry | ✅ | ❌ | ✅ | `ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2. |
+| Directory of .hcl files as one schema source | ❌ | ❔ | ❔ | `--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. |
 | External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
-| HCL schema files | 🟡 | ✅ | ✅ | Ptah parses a strict subset and fails explicitly on unsupported constructs; complete Atlas HCL coverage is not claimed. |
+| HCL foreign_key deferrable | ❌ | ❔ | ❔ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. |
+| HCL function calls in schema files | 🟡 | ❔ | ❔ | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally. |
+| HCL locals, lock, atlas, dynamic/for_each | ❌ | ❔ | ❔ | Named rejections, exit 1: unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". |
+| HCL table and column child blocks | ✅ | ❔ | ❔ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. |
+| HCL top-level blocks Ptah parses | ✅ | ❔ | ❔ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. |
+| HCL variable blocks and var.* references | ❌ | ✅ | ✅ | `variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error. |
 | Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
 | Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |
-| Registry-backed schema source | 🟡 | ❌ | ✅ | `ptah schema pull` fetches a canonical HCL artifact over oci://; it is then passed as `--schema-file`. atlas:// registry URLs are rejected. |
+| Ptah-only HCL schema extensions | ✅ | ❔ | ❔ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
 | SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
 | YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
 
@@ -91,31 +104,32 @@ as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | --dry-run, --auto-approve, and --edit | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
-| --exclude glob and type selectors | 🟡 | ✅ | ✅ | Resource selectors plus the [type=extension].version field selector; other field selectors and non-final type selectors fail explicitly. |
-| --include resource selectors | 🟡 | ❌ | ✅ | Ptah: top-level [type=...] selectors on apply/diff; child and field selectors rejected, none on inspect. Atlas CE aborts the flag. |
+| --exclude glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
+| --include resource selectors | ✅ | ❌ | ✅ | Top-level globs and [type=...] on apply/diff, repeated values union; child types refused by design, schemas selected with --schema. |
 | --schema / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
-| `schema inspect --include` filtering | ❌ | ❌ | ❌ | Flag absent from the pinned Atlas CE v1.2.0 inspect surface; Ptah rejects it as unknown and scopes inspect with `--schema`/`--exclude`. |
-| Apply advisory lock and --lock-timeout | 🟡 | ✅ | ✅ | Real locks on PostgreSQL, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, YugabyteDB and Spanner run unlocked with a note. |
-| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Schema files, one DB URL, one `atlas.sum` migration dir, or env://. atlas:// registry URLs fail before the target is contacted. |
-| Dev-database rehearsal before apply | 🟡 | ✅ | ✅ | Dev DB is reset, target schema recreated, exact plan run; failure aborts the apply. Needs a connectable dev URL — docker:// is a gap. |
+| `schema inspect --include` filtering | ❌ | ❌ | ❔ | Flag absent from the pinned Atlas CE v1.2.0 inspect flags; Ptah rejects it as unknown. No cited source settles the licensed builds. |
+| Apply advisory lock and --lock-timeout | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
+| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
+| Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
-| Go-template --format output | 🟡 | ✅ | ✅ | sql/hcl/json/mermaid/split/write helpers over .Changes, .Realm, .MarshalSQL. Atlas web and Cloud report output remains a gap. |
-| Inspect exclude field selectors and exporters | 🟡 | ✅ | ✅ | Only the `*[type=extension].version` field selector works; other field selectors, non-final type selectors and exporters fail. |
+| Go-template --format output | 🟡 | ✅ | ✅ | schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only. |
+| Inspect --exclude field selectors | 🟡 | ❔ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. |
 | Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
 | Plan registry sub-verbs and schema push | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test, validate and `schema push` are boundary stubs printing the CE abort text. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
-| schema clean | 🟡 | ✅ | ✅ | Drops user tables on supported dialects, PostgreSQL enums and sequences, SQL Server FKs; other object kinds are not modeled yet. |
-| schema diff between two schema states | 🟡 | ✅ | ✅ | Files, DB URLs, migration dirs, env:// per side; `--dev-url` pins the dialect. SQLite column type changes fail: rebuild plan not emitted. |
+| schema clean | 🟡 | ✅ | ✅ | Plan and --dry-run list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
+| schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
+| Schema-qualified exclude globs for enums and functions | 🟡 | ❔ | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. |
 
 ## Versioned migrations
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Apply pending migrations (apply/up) | ✅ | ✅ | ✅ | Compat apply matches the CE flag set and also runs goose, flyway, liquibase, dbmate and golang-migrate directories up-only. |
+| Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Also runs goose/flyway/liquibase/dbmate dirs via ?format=; --dry-run ignores the revision table and re-plans already-applied files. |
 | Atlas-format checkpoint output | ❌ | ❌ | ✅ | migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention. |
 | Baseline an existing database | ✅ | ✅ | ✅ | Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`. |
 | Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR. |
@@ -124,18 +138,17 @@ as open capabilities regardless.
 | Dynamic down planning (`migrate down --plan`) | ❌ | ❌ | ✅ | `--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files. |
 | Execution order (--exec-order) | ✅ | ✅ | ✅ | linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it. |
 | External `--dir-format` outside `migrate import` | ❌ | ✅ | ✅ | hash, lint, new, set, status and validate accept only `--dir-format`=atlas; other tool formats must first go through migrate import. |
-| Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Native `ptah migrations import` converts R__ into a one-time migration; Atlas-shaped `ptah-compat migrate import` rejects R__ files. |
-| Generate migrations from a schema diff | 🟡 | ✅ | ✅ | Replays the directory on `--dev-url` and writes files before `atlas.sum`; `--qualifier`, `--edit`, `--format` work. Docker dev databases are a gap. |
-| Import from other migration tools | 🟡 | ✅ | ✅ | Compat import takes local file:// dirs only and rejects Flyway R__ repeatable files; native import converts them to one-time migrations. |
+| Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Compat import aborts the entire directory on any R__ file; native import rewrites R__ as a one-time migration, losing re-run-on-change. |
+| Generate migrations from a schema diff | 🟡 | ✅ | ✅ | New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry. |
+| Import from other migration tools | 🟡 | ✅ | ✅ | --from must be a local file:// dir; Liquibase XML/YAML/JSON changelogs are refused - only formatted-SQL changelogs import. |
 | Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint pair; CE has no checkpoint verb and Atlas lists it as Pro. |
-| Migration linting | 🟡 | 🟡 | ✅ | CE registers migrate lint; Atlas's features page marks the lint CLI Pro with a basic Open rule set. Ptah lacks custom rules, web reports. |
+| Migration linting | ✅ | 🟡 | ✅ | Runs with Atlas's flag set and 42 codes; custom rules load only through the Go API at compile time, not from a CLI flag or config file. |
 | Migration lock and lock timeout | ✅ | ✅ | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`. |
 | Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
 | Native migration import | ✅ | ✅ | ✅ | Both convert golang-migrate, Goose, Flyway and Liquibase dirs; ptah adds dbmate. Liquibase XML/YAML/JSON changelogs are rejected. |
-| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Local -- +ptah check assert=... aborts before the body; rejected under `--tx-mode` all. The reviewer-approval half is not implemented. |
 | Repair dirty or partial revision state | ✅ | ❌ | ❌ | `ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
 | Revision table format and placement | ✅ | ✅ | ✅ | `--revision-format` ptah\|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows. |
-| Roll back applied migrations (down) | 🟡 | ✅ | ✅ | Ptah reverts via pre-planned down files; `--to-tag`, `--skip-checks` and `--plan` fail loudly as waivers. Atlas Pro adds plan approval. |
+| Roll back applied migrations (down) | 🟡 | ✅ | ✅ | Atlas single-file dirs have no down body: down dirties the revision row before it discovers that, so apply then aborts on a dirty revision. |
 | Set revision state to a version | ✅ | ✅ | ✅ | Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set. |
 | Transaction modes (--tx-mode file/all/none) | ✅ | ✅ | ✅ | all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks. |
 
@@ -143,27 +156,27 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files without `--allow-destructive`; .ptah-lint.yaml tunes it, but `ptah.sum` does not hash it. |
-| Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | 23 of 30 Pro-marked codes covered, 5 partial (PG301, PG304, MY130, MY133, MY136), 2 waived (OW101, OW102) as account-bound policy. |
+| Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file. |
+| Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
-| Check-level policy and custom lint rules | ❌ | ❌ | ✅ | Only analyzer severity policy for the five mapped families is read; check-level policy, custom rules and force/allow-lists are gaps. |
-| CI integration (GitHub Action, annotations) | ✅ | 🟡 | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment and destructive-change check run; `--format` github-actions emits inline annotations. |
-| Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules register from Go (lint.Register, Options.ExtraRules); Atlas check-level policy and analyzer force/allow options are absent. |
+| CI integration (GitHub Action, annotations) | ✅ | ❔ | ❔ | stokaro/ptah-action@v1 posts a sticky PR comment; --format github-actions emits annotations. Atlas features page omits CI integrations. |
+| Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
-| Inline nolint suppression | ✅ | 🟡 | ✅ | Native ptah:nolint is statement-scoped; atlas:nolint selectors and whole-file headers apply only under the ptah-compat lint profile. |
-| Native migration lint rule set | ✅ | 🟡 | ✅ | 42 built-in codes in DS, CD, DD, MF, BC, PG, MY, LT, TX families; `--dialect` gates dialect-specific rules. Atlas has a basic Open rule set. |
-| Per-rule severity policy | 🟡 | 🟡 | ✅ | .ptah-lint.yaml sets per-rule severity and path excludes; `atlas.hcl` maps only 5 analyzer blocks to severity and rejects force. |
-| SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
-| Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |
+| Inline nolint suppression | 🟡 | ✅ | ✅ | Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored. |
+| Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by --dialect. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
+| Per-rule severity policy | 🟡 | ❔ | ✅ | Severity vocabulary is warning\|error only (info errors out); atlas.hcl exposes 5 analyzer blocks mapped to an error bool and rejects force. |
+| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Only the -- +ptah check spelling; --tx-mode all refuses checked files, and that error names --skip-checks, which compat apply lacks. |
+| SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native --format sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template --format output for migrate lint. |
+| Statement safety classification report | ✅ | ➖ | ➖ | plan --report text\|html\|json and generate --report html\|json emit highest severity, a destructive flag, and per-statement assessments. |
 
 ## Testing
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | `ptah-compat migrate test` and schema test run Ptah-native YAML/Go cases only; .test.hcl files are not parsed. |
-| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | ptah-compat forwards to native runners (`--dir`, -u, `--dev-url`, `--run`); Atlas .test.hcl is not ingested — Ptah YAML is the payload. |
-| Dev / shadow database verification | 🟡 | ✅ | ✅ | Replay on `--dev-url`, `--shadow-db` for generate and checkpoint, apply rehearsal. Docker dev-database URLs unsupported. |
-| Embeddable test runner (Go package) | ✅ | ❌ | ❌ | Runner exported as migration/dbtest (RunMigrationTest, RunSchemaTest); Atlas ships its test framework only in a closed-source binary. |
+| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | No .test.hcl parser; a directory of them exits 1 with "no test cases found" instead of naming the unsupported file format. |
+| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes --report or --seed-dir. |
+| Dev / shadow database verification | 🟡 | ✅ | ✅ | --shadow-db on generate, checkpoint, baseline and down; docker:// is refused, and schema apply --dry-run skips the rehearsal entirely. |
+| Embeddable test runner (Go package) | ✅ | ❔ | ❔ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
 | Registry plan testing (`schema plan test`) | ❌ | ❌ | ✅ | `ptah-compat schema plan` test stays an Atlas CE unsupported boundary stub: `--help` exits 0, direct execution aborts and exits 1. |
@@ -173,36 +186,37 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Documented local subset: variable, locals, data hcl_schema, env, schema, migration, format, diff, lint. Cloud and registry blocks fail. |
-| data "hcl_schema" reference | 🟡 | ✅ | ✅ | Only data.hcl_schema.<name>.url for local schema files resolves; any other data block label fails explicitly. |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema. |
+| atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah --env reads ./atlas.hcl only: no --var flag, and --config takes ptah.yaml, so a variable without a default cannot be resolved. |
+| data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected. |
 | Docker dev databases (`docker://` --dev-url) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
-| env:// desired-state references | 🟡 | ✅ | ✅ | ptah-compat only; attributes src, schema.src, url, dev, migration, migration.dir. Nested env:// fails; native ptah has no equivalent. |
-| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Ptah-owned file for url, src, dev, external_schema, migration, lint, diff, online_ddl. Unknown keys fail. Ranks below `atlas.hcl`. |
-| Remote and template directory sources | ❌ | ✅ | ✅ | Rejected while parsing `atlas.hcl`. The native substitute is the bring-your-own oci:// artifact workflow, not an Atlas data source. |
-| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | variable defaults, repeated `--var` strings/lists, locals, getenv, file, fileset, format, jsonencode. Typed and sensitive variables fail. |
+| env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on --to/--from and only src, schema.src, url, dev, migration.dir; elsewhere (--exclude) the literal string is used silently. |
+| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail. |
+| Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
+| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | Only file, fileset, format, getenv, jsonencode evaluate; variable type, sensitive, validation and env for_each are rejected. |
 
 ## Databases and schema objects
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | No foreign keys, enforced CHECKs, views, matviews, functions or triggers; standalone enum types are rejected. Atlas lists it as Pro. |
-| CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS; views, functions and triggers are not emitted at all. |
-| Domains, composite types, and range types | 🟡 | ❔ | ❔ | PostgreSQL only - not CockroachDB, YugabyteDB or Spanner. Domain check/default are create-only; base-type changes drop and recreate. |
-| Enum types | 🟡 | ✅ | ✅ | Postgres CREATE TYPE; MySQL inline ENUM; SQLite TEXT+CHECK; SQL Server NVARCHAR+CHECK; ClickHouse passthrough; Spanner skips enums. |
-| Extensions | 🟡 | ❔ | ❔ | PostgreSQL family only, with a default ignore list (plpgsql). SQLite, SQL Server and ClickHouse comment it out; MySQL/MariaDB emit nothing. |
-| Functions | 🟡 | ❔ | ❔ | Renders on PostgreSQL only; MySQL/MariaDB emit a not-supported comment and error on DROP; CockroachDB, YugabyteDB, Spanner omit silently. |
-| MySQL and MariaDB | 🟡 | ✅ | ✅ | Separate dialects with different capability sets; no PostgreSQL-only objects; implicit DDL commit blocks transactional rollback. |
-| Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | Listed as Atlas Pro drivers. Ptah has no dialect, renderer or driver for any of them. |
+| ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic. |
+| CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers. |
+| Domains, composite types, and range types | 🟡 | ❔ | ❔ | PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all. |
+| Enum types | 🟡 | ✅ | ✅ | MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim. |
+| Extensions | 🟡 | ❔ | ❔ | PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. |
+| Functions | 🟡 | ❌ | ✅ | `schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently. |
+| MySQL and MariaDB | 🟡 | ✅ | ✅ | Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback. |
+| Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers. |
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
-| Roles, grants, and row-level security | 🟡 | ❔ | ❔ | Emitted on PostgreSQL only; CockroachDB, YugabyteDB and Spanner get none despite PostgreSQL-family capability flags for roles. |
-| Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Most conservative preset: no enums, foreign keys, sequences, RLS, XML or advisory locks. Coverage is offline; no live container. |
-| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | Portable T-SQL subset: no sequences, RLS, roles/grants or matviews, and automatic column removal is refused. Atlas lists it as Pro. |
-| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Constraint changes and most column modifications report rebuild-required instead of generating a rebuild; PG-only objects rejected. |
-| Standalone sequences | 🟡 | ❔ | ❔ | Standalone CREATE SEQUENCE renders on PostgreSQL only; YugabyteDB carries the capability flag but the generator emits none. |
-| TiDB and LibSQL | ❌ | ✅ | ✅ | Atlas docs list both as Open drivers; Ptah's dialect normalizer has no TiDB or LibSQL entry, so the names do not resolve. |
-| Triggers | 🟡 | ❌ | ✅ | Render on PostgreSQL, MySQL/MariaDB, SQLite (row-level only) and SQL Server; ClickHouse, CockroachDB, YugabyteDB and Spanner do not. |
-| Views and materialized views | 🟡 | ❌ | ✅ | Views: PostgreSQL, MySQL/MariaDB, SQLite, SQL Server. Matviews: PostgreSQL only. CockroachDB, YugabyteDB, Spanner, ClickHouse: neither. |
-| YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, advisory locks, RLS; roles and sequences stay, but views, functions, triggers are never emitted. |
+| Roles, grants, and row-level security | 🟡 | ❔ | ❔ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY and ENABLE RLS. |
+| Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
+| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and --dialect help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
+| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
+| Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported. |
+| TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
+| Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
+| Views and materialized views | 🟡 | ❌ | ✅ | `mssql`/`tsql` aliases drop views. Matviews are PostgreSQL-only: `schema render` silently drops them elsewhere, `schema apply` errors. |
+| YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them. |
 
 ## Go embedding and developer tooling
 
@@ -213,7 +227,7 @@ as open capabilities regardless.
 | Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
 | ptah-ls annotation language server | ✅ | ➖ | ➖ | stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax. |
 | Public API compatibility gate | ✅ | ➖ | ➖ | check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line. |
-| Query builder for parameterized SQL | 🟡 | ➖ | ➖ | SELECT/INSERT/UPDATE/DELETE with bound values and quoted identifiers. No subqueries, LIKE, arithmetic, window functions, CTEs or upsert. |
+| Query builder for parameterized SQL | 🟡 | ➖ | ➖ | Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error. |
 | Reusable Go packages (embedder API) | ✅ | ➖ | ➖ | Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs. |
 | Schema visualization (ERD diagrams) | ✅ | ❌ | ✅ | Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas features page lists visualization as Pro. |
 
@@ -221,21 +235,27 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
+| Artifact integrity check (--verify-sum) | 🟡 | ➖ | ❔ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
 | Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
+| Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; --version is write-once and a conflict exits 2. The reference tag, --tag values and latest all move. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
-| OCI deployment, lint and plan report referrers | 🟡 | ❌ | 🟡 | Lists referrer descriptors only; payload download is absent. Atlas Cloud deployment reporting is a hosted service, not registry referrers. |
+| Migration directories in an OCI registry | ✅ | ❌ | ✅ | `migrations push/pull`, plus `up`, `status`, `down` and `lint` reading `oci://` directly as the directory flag. No local checkout needed. |
 | OCI desired-schema artifacts | ✅ | ❌ | 🟡 | Canonical schema.hcl push/pull; compare, drift and plan read `--schema-file` oci://. `atlas schema push` is a CE unsupported boundary stub. |
-| OCI migration artifacts | ✅ | ❌ | 🟡 | push/pull plus direct up, status, down and lint over oci://. Atlas's registry equivalent is hosted and account-bound, not bring-your-own. |
+| oci:// as a --schema-file desired-state source | 🟡 | ❌ | ✅ | Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose --plain-http. |
+| oci:// in the Atlas-compatible ptah-compat binary | ❌ | ❌ | ➖ | By design: compat mirrors the Atlas surface, which has no oci:// scheme. migration.dir takes file:// only; the OCI workflow lives in the native ptah binary. |
+| Referrer attachments: lint, plan, deployment reports | 🟡 | ❌ | ❔ | lint --attach, migrations plan --attach and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload. |
+| Registry-backed artifact distribution | ✅ | ❌ | ✅ | Ptah pushes/pulls schema and migration artifacts to any OCI registry. Atlas Registry is a hosted Cloud service; CE v1.2.0 has no push verb. |
+| Self-hosted registry with no vendor account | ✅ | ➖ | ❌ | Any OCI registry; auth reads the Docker credential store. Ptah registers no login verb. Atlas Registry is documented as an Atlas Cloud service. |
 
 ## Atlas Registry and Cloud
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| `migrate push` and `schema push` | ❌ | ❌ | ✅ | Registered as Atlas CE boundary stubs: help prints the community-version notice, direct execution prints the CE abort text. |
+| `migrate push` and `schema push` | ❌ | ❌ | ✅ | ptah-compat boundary stubs printing the CE abort text, exit 1. The native equivalents are `ptah schema push` and `ptah migrations push`. |
 | `schema plan` registry and output flags | ❌ | ❌ | ✅ | `--push`/`--pending`/`--repo` are recorded waivers; `--format`/`--name-format`/`--directive`/`--edit`/`--skip-lint` fail as unimplemented. |
 | `schema plan` registry sub-verbs | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test and validate all stay CE boundary stubs; only local plan files are implemented. |
-| Atlas Cloud deployment reporting | ❌ | ❌ | ✅ | No Atlas account model or deployment API. Ptah attaches best-effort deployment reports to its own OCI registry instead. |
-| Atlas Registry `atlas://` source URLs | ❌ | ❌ | ✅ | Rejected in `--from`/`--to`/`--plan` and migration.dir; Ptah offers a bring-your-own oci:// registry instead, not an atlas:// resolver. |
+| Atlas Cloud deployment reporting | ❌ | ❌ | ✅ | No Atlas account model or deployment API. Ptah attaches a deployment-report referrer to its own OCI artifact after an oci:// migrations up. |
+| Atlas Registry `atlas://` source URLs | ❌ | ❌ | ✅ | ptah-compat rejects atlas:// in --to/--from and atlas.hcl migration.dir with named errors. Ptah's scheme is oci://, not an atlas:// resolver. |
 | Reviewer approval and policy workflows | ❌ | ❌ | ✅ | Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope. |
 | Schema monitoring, hosted UI, login | ❌ | ❌ | ✅ | Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check. |
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -49,13 +49,13 @@ row for a migration decision.
 :::
 ## At a glance
 
-Across the 135 capabilities below:
+Across the 132 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 66 |
+| Ptah supports it fully | 65 |
 | Ptah supports it with a stated limitation | 44 |
-| Ptah does not implement it | 25 |
+| Ptah does not implement it | 23 |
 | Ptah and Atlas CE both support it | 25 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
 | Ptah has it and neither Atlas edition does | 8 |
@@ -64,8 +64,8 @@ Across the 135 capabilities below:
 
 Every 🟡 on this page names the specific limitation, and each one was
 reproduced against a binary built from this repository. Where the limitation is
-work that has not been done, it is tracked: see
-[issues #926 to #942](https://github.com/stokaro/ptah/issues?q=is%3Aissue+is%3Aopen+label%3Aenhancement%2Cbug+created%3A%3E2026-07-30).
+work that has not been done, it is tracked in
+[#926 to #942](https://github.com/stokaro/ptah/issues/926) and [#944](https://github.com/stokaro/ptah/issues/944).
 
 The command surface is counted separately, because it is measured rather than
 assessed. The conformance harness inventories every command in the pinned Atlas
@@ -117,7 +117,6 @@ as open capabilities regardless.
 | Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
-| Plan registry sub-verbs and schema push | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test, validate and `schema push` are boundary stubs printing the CE abort text. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | Plan and --dry-run list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
@@ -179,7 +178,6 @@ as open capabilities regardless.
 | Embeddable test runner (Go package) | ✅ | ❔ | ❔ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
-| Registry plan testing (`schema plan test`) | ❌ | ❌ | ✅ | `ptah-compat schema plan` test stays an Atlas CE unsupported boundary stub: `--help` exits 0, direct execution aborts and exits 1. |
 | Schema test framework (`ptah schema test`) | ✅ | ❌ | ✅ | Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb. |
 
 ## Configuration and dev databases
@@ -240,7 +238,6 @@ as open capabilities regardless.
 | Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; --version is write-once and a conflict exits 2. The reference tag, --tag values and latest all move. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
 | Migration directories in an OCI registry | ✅ | ❌ | ✅ | `migrations push/pull`, plus `up`, `status`, `down` and `lint` reading `oci://` directly as the directory flag. No local checkout needed. |
-| OCI desired-schema artifacts | ✅ | ❌ | 🟡 | Canonical schema.hcl push/pull; compare, drift and plan read `--schema-file` oci://. `atlas schema push` is a CE unsupported boundary stub. |
 | oci:// as a --schema-file desired-state source | 🟡 | ❌ | ✅ | Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose --plain-http. |
 | oci:// in the Atlas-compatible ptah-compat binary | ❌ | ❌ | ➖ | By design: compat mirrors the Atlas surface, which has no oci:// scheme. migration.dir takes file:// only; the OCI workflow lives in the native ptah binary. |
 | Referrer attachments: lint, plan, deployment reports | 🟡 | ❌ | ❔ | lint --attach, migrations plan --attach and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload. |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -1,0 +1,272 @@
+---
+title: Feature matrix
+description: Ptah and Atlas capabilities side by side, with the evidence behind every row.
+---
+
+This page answers one question: for a given capability, what does Ptah do, what
+does the open Atlas community binary do, and what does Atlas keep in its
+licensed builds. Every row cites the evidence it rests on.
+
+It is a status index, not an argument. The per-area detail behind these rows is
+on [Comparison](../comparison/), the measured evidence is on
+[Conformance](../conformance/), and the Atlas-documentation crosswalk is on
+[Atlas docs coverage](../docs-coverage/).
+
+## How to read the tables
+
+| Symbol | Meaning |
+| --- | --- |
+| ✅ | Supported today |
+| 🟡 | Partial. The difference column states what is missing |
+| ❌ | Not implemented |
+| ➖ | Does not apply to that product |
+
+The columns are:
+
+- **Ptah** — the native `ptah` binary plus the separate `ptah-compat` drop-in.
+- **Atlas CE** — the pinned Atlas community binary, version 1.2.0, which the
+  conformance harness runs against.
+- **Pro/Cloud** — capabilities Atlas documents as licensed, on the
+  [Atlas feature availability](https://atlasgo.io/features) page.
+
+:::caution
+A ✅ in the Ptah column means the capability works, not that it is
+byte-identical to Atlas. Ptah is an independent pre-GA implementation, and the
+conformance repository states plainly that no number it produces is a
+full feature-set parity test. Read the difference column before relying on a
+row for a migration decision.
+:::
+## At a glance
+
+Across the 120 capabilities below:
+
+| Reading | Count |
+| --- | --- |
+| Ptah supports it fully | 56 |
+| Ptah supports it with a stated limitation | 43 |
+| Ptah does not implement it | 21 |
+| Ptah and Atlas CE both support it | 23 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
+| Ptah has it and neither Atlas edition does | 9 |
+| Atlas CE has it and Ptah does not, or only in part | 26 |
+
+The command surface is counted separately, because it is measured rather than
+assessed. The conformance harness inventories every command in the pinned Atlas
+CE binary and compares it with the `ptah-compat` surface: 19 of the 37
+inventoried commands are open parity targets, and every one of them matches on
+help usage and flags — 107 observations, no gap. The remaining 18 are registry,
+Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them
+as open capabilities regardless.
+## Schema sources
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Annotated Go models from a live database | ✅ | ❌ | ❌ | Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list. |
+| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | The ptah.yaml external_schema block fills the same desired-schema role but does not evaluate the Atlas HCL data source. |
+| Composite multi-source desired schema | ✅ | ❌ | ✅ | Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source. |
+| External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or ptah.yaml external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
+| Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
+| HCL schema files | 🟡 | ✅ | ✅ | Ptah parses a strict subset and fails explicitly on unsupported constructs; complete Atlas HCL coverage is not claimed. |
+| Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; ptah db read introspects natively. |
+| Live database to Go annotation source | ✅ | ❌ | ❌ | ptah introspect writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
+| Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with atlas.sum, replayed on a required `--dev-url`. Works on ptah schema inspect and compat apply/diff/migrate diff. |
+| Registry-backed schema source | 🟡 | ❌ | ✅ | ptah schema pull fetches a canonical HCL artifact over oci://; it is then passed as `--schema-file`. atlas:// registry URLs are rejected. |
+| SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by ptah-compat schema apply/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
+| YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
+
+## Declarative and direct schema changes
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| --dry-run, --auto-approve, and --edit | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
+| --exclude glob and type selectors | 🟡 | ✅ | ✅ | Resource selectors plus the [type=extension].version field selector; other field selectors and non-final type selectors fail explicitly. |
+| --include resource selectors | 🟡 | ❌ | ✅ | Ptah: top-level [type=...] selectors on apply/diff; child and field selectors rejected, none on inspect. Atlas CE aborts the flag. |
+| --schema / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
+| `schema inspect --include` filtering | ❌ | ❌ | ❌ | Flag absent from the pinned Atlas CE v1.2.0 inspect surface; Ptah rejects it as unknown and scopes inspect with `--schema`/`--exclude`. |
+| Apply advisory lock and --lock-timeout | 🟡 | ✅ | ✅ | Real locks on PostgreSQL, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, YugabyteDB and Spanner run unlocked with a note. |
+| Desired-state sources for --to and --from | 🟡 | ✅ | ✅ | Schema files, one DB URL, one atlas.sum migration dir, or env://. atlas:// registry URLs fail before the target is contacted. |
+| Dev-database rehearsal before apply | 🟡 | ✅ | ✅ | Dev DB is reset, target schema recreated, exact plan run; failure aborts the apply. Needs a connectable dev URL — docker:// is a gap. |
+| Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
+| Go-template --format output | 🟡 | ✅ | ✅ | sql/hcl/json/mermaid/split/write helpers over .Changes, .Realm, .MarshalSQL. Atlas web and Cloud report output remains a gap. |
+| Inspect exclude field selectors and exporters | 🟡 | ✅ | ✅ | Only the `*[type=extension].version` field selector works; other field selectors, non-final type selectors and exporters fail. |
+| Inspect non-database sources via --dev-url | ✅ | ✅ | ✅ | Schema file, atlas.sum migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
+| Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
+| Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
+| Plan registry sub-verbs and schema push | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test, validate and `schema push` are boundary stubs printing the CE abort text. |
+| schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
+| schema clean | 🟡 | ✅ | ✅ | Drops user tables on supported dialects, PostgreSQL enums and sequences, SQL Server FKs; other object kinds are not modeled yet. |
+| schema diff between two schema states | 🟡 | ✅ | ✅ | Files, DB URLs, migration dirs, env:// per side; `--dev-url` pins the dialect. SQLite column type changes fail: rebuild plan not emitted. |
+| schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
+| schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
+
+## Versioned migrations
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Apply pending migrations (apply/up) | ✅ | ✅ | ✅ | Compat apply matches the CE flag set and also runs goose, flyway, liquibase, dbmate and golang-migrate directories up-only. |
+| Atlas-format checkpoint output | ❌ | ❌ | ✅ | migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention. |
+| Baseline an existing database | ✅ | ✅ | ✅ | Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`. |
+| Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes atlas.sum, `--edit` opens $VISUAL or $EDITOR. |
+| Directory integrity file: hash and validate | ✅ | ✅ | ✅ | hash writes ptah.sum, or atlas.sum for atlas-format directories; validate checks it and with `--dev-url` cleans and replays the dir. |
+| Directory maintenance: edit, rebase, rm | ✅ | ❌ | ✅ | Each rewrites ptah.sum/atlas.sum and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs. |
+| Dynamic down planning (`migrate down --plan`) | ❌ | ❌ | ✅ | `--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files. |
+| Execution order (--exec-order) | ✅ | ✅ | ✅ | linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it. |
+| External `--dir-format` outside `migrate import` | ❌ | ✅ | ✅ | hash, lint, new, set, status and validate accept only `--dir-format`=atlas; other tool formats must first go through migrate import. |
+| Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Native `ptah migrations import` converts R__ into a one-time migration; Atlas-shaped `ptah-compat migrate import` rejects R__ files. |
+| Generate migrations from a schema diff | 🟡 | ✅ | ✅ | Replays the directory on `--dev-url` and writes files before atlas.sum; `--qualifier`, `--edit`, `--format` work. Docker dev databases are a gap. |
+| Import from other migration tools | 🟡 | ✅ | ✅ | Compat import takes local file:// dirs only and rejects Flyway R__ repeatable files; native import converts them to one-time migrations. |
+| Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint pair; CE has no checkpoint verb and Atlas lists it as Pro. |
+| Migration linting | 🟡 | 🟡 | ✅ | CE registers migrate lint; Atlas's features page marks the lint CLI Pro with a basic Open rule set. Ptah lacks custom rules, web reports. |
+| Migration lock and lock timeout | ✅ | ✅ | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`. |
+| Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
+| Native migration import | ✅ | ✅ | ✅ | Both convert golang-migrate, Goose, Flyway and Liquibase dirs; ptah adds dbmate. Liquibase XML/YAML/JSON changelogs are rejected. |
+| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Local -- +ptah check assert=... aborts before the body; rejected under `--tx-mode` all. The reviewer-approval half is not implemented. |
+| Repair dirty or partial revision state | ✅ | ❌ | ❌ | ptah migrations repair `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
+| Revision table format and placement | ✅ | ✅ | ✅ | `--revision-format` ptah\|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows. |
+| Roll back applied migrations (down) | 🟡 | ✅ | ✅ | Ptah reverts via pre-planned down files; `--to-tag`, `--skip-checks` and `--plan` fail loudly as waivers. Atlas Pro adds plan approval. |
+| Set revision state to a version | ✅ | ✅ | ✅ | Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set. |
+| Transaction modes (--tx-mode file/all/none) | ✅ | ✅ | ✅ | all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks. |
+
+## Linting and safety
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files without `--allow-destructive`; .ptah-lint.yaml tunes it, but ptah.sum does not hash it. |
+| Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | 23 of 30 Pro-marked codes covered, 5 partial (PG301, PG304, MY130, MY133, MY136), 2 waived (OW101, OW102) as account-bound policy. |
+| Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
+| Check-level policy and custom lint rules | ❌ | ❌ | ✅ | Only analyzer severity policy for the five mapped families is read; check-level policy, custom rules and force/allow-lists are gaps. |
+| CI integration (GitHub Action, annotations) | ✅ | 🟡 | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment and destructive-change check run; `--format` github-actions emits inline annotations. |
+| Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules register from Go (lint.Register, Options.ExtraRules); Atlas check-level policy and analyzer force/allow options are absent. |
+| Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
+| Inline nolint suppression | ✅ | 🟡 | ✅ | Native ptah:nolint is statement-scoped; atlas:nolint selectors and whole-file headers apply only under the ptah-compat lint profile. |
+| Native migration lint rule set | ✅ | 🟡 | ✅ | 42 built-in codes in DS, CD, DD, MF, BC, PG, MY, LT, TX families; `--dialect` gates dialect-specific rules. Atlas has a basic Open rule set. |
+| Per-rule severity policy | 🟡 | 🟡 | ✅ | .ptah-lint.yaml sets per-rule severity and path excludes; atlas.hcl maps only 5 analyzer blocks to severity and rejects force. |
+| SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
+| Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |
+
+## Testing
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | ptah-compat migrate test and schema test run Ptah-native YAML/Go cases only; .test.hcl files are not parsed. |
+| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | ptah-compat forwards to native runners (`--dir`, -u, `--dev-url`, `--run`); Atlas .test.hcl is not ingested — Ptah YAML is the payload. |
+| Dev / shadow database verification | 🟡 | ✅ | ✅ | Replay on `--dev-url`, `--shadow-db` for generate and checkpoint, apply rehearsal. Docker dev-database URLs unsupported. |
+| Embeddable test runner (Go package) | ✅ | ❌ | ❌ | Runner exported as migration/dbtest (RunMigrationTest, RunSchemaTest); Atlas ships its test framework only in a closed-source binary. |
+| Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
+| Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
+| Registry plan testing (`schema plan test`) | ❌ | ❌ | ✅ | ptah-compat schema plan test stays an Atlas CE unsupported boundary stub: `--help` exits 0, direct execution aborts and exits 1. |
+| Schema test framework (`ptah schema test`) | ✅ | ❌ | ✅ | Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb. |
+
+## Configuration and dev databases
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Documented local subset: variable, locals, data hcl_schema, env, schema, migration, format, diff, lint. Cloud and registry blocks fail. |
+| data "hcl_schema" reference | 🟡 | ✅ | ✅ | Only data.hcl_schema.<name>.url for local schema files resolves; any other data block label fails explicitly. |
+| Docker dev databases (`docker://` --dev-url) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
+| env:// desired-state references | 🟡 | ✅ | ✅ | ptah-compat only; attributes src, schema.src, url, dev, migration, migration.dir. Nested env:// fails; native ptah has no equivalent. |
+| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Ptah-owned file for url, src, dev, external_schema, migration, lint, diff, online_ddl. Unknown keys fail. Ranks below atlas.hcl. |
+| Remote and template directory sources | ❌ | ✅ | ✅ | Rejected while parsing atlas.hcl. The native substitute is the bring-your-own oci:// artifact workflow, not an Atlas data source. |
+| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | variable defaults, repeated `--var` strings/lists, locals, getenv, file, fileset, format, jsonencode. Typed and sensitive variables fail. |
+
+## Databases and schema objects
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | No foreign keys, enforced CHECKs, views, matviews, functions or triggers; standalone enum types are rejected. Atlas lists it as Pro. |
+| CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS; views, functions and triggers are not emitted at all. |
+| Domains, composite types, and range types | 🟡 | ❌ | ✅ | PostgreSQL only - not CockroachDB, YugabyteDB or Spanner. Domain check/default are create-only; base-type changes drop and recreate. |
+| Enum types | 🟡 | ✅ | ✅ | Postgres CREATE TYPE; MySQL inline ENUM; SQLite TEXT+CHECK; SQL Server NVARCHAR+CHECK; ClickHouse passthrough; Spanner skips enums. |
+| Extensions | 🟡 | ❌ | ✅ | PostgreSQL family only, with a default ignore list (plpgsql). SQLite, SQL Server and ClickHouse comment it out; MySQL/MariaDB emit nothing. |
+| Functions | 🟡 | ❌ | ✅ | Renders on PostgreSQL only; MySQL/MariaDB emit a not-supported comment and error on DROP; CockroachDB, YugabyteDB, Spanner omit silently. |
+| MySQL and MariaDB | 🟡 | ✅ | ✅ | Separate dialects with different capability sets; no PostgreSQL-only objects; implicit DDL commit blocks transactional rollback. |
+| Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | Listed as Atlas Pro drivers. Ptah has no dialect, renderer or driver for any of them. |
+| PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
+| Roles, grants, and row-level security | 🟡 | ❌ | ✅ | Emitted on PostgreSQL only; CockroachDB, YugabyteDB and Spanner get none despite PostgreSQL-family capability flags for roles. |
+| Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Most conservative preset: no enums, foreign keys, sequences, RLS, XML or advisory locks. Coverage is offline; no live container. |
+| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | Portable T-SQL subset: no sequences, RLS, roles/grants or matviews, and automatic column removal is refused. Atlas lists it as Pro. |
+| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Constraint changes and most column modifications report rebuild-required instead of generating a rebuild; PG-only objects rejected. |
+| Standalone sequences | 🟡 | ❌ | ✅ | Standalone CREATE SEQUENCE renders on PostgreSQL only; YugabyteDB carries the capability flag but the generator emits none. |
+| TiDB and LibSQL | ❌ | ✅ | ✅ | Atlas docs list both as Open drivers; Ptah's dialect normalizer has no TiDB or LibSQL entry, so the names do not resolve. |
+| Triggers | 🟡 | ❌ | ✅ | Render on PostgreSQL, MySQL/MariaDB, SQLite (row-level only) and SQL Server; ClickHouse, CockroachDB, YugabyteDB and Spanner do not. |
+| Views and materialized views | 🟡 | ❌ | ✅ | Views: PostgreSQL, MySQL/MariaDB, SQLite, SQL Server. Matviews: PostgreSQL only. CockroachDB, YugabyteDB, Spanner, ClickHouse: neither. |
+| YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, advisory locks, RLS; roles and sequences stay, but views, functions, triggers are never emitted. |
+
+## Go embedding and developer tooling
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Annotation metadata as JSON Schema | ✅ | ➖ | ➖ | Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to. |
+| API schema export: OpenAPI 3.0 and GraphQL | ✅ | ❌ | ❌ | Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list. |
+| Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
+| ptah-ls annotation language server | ✅ | ➖ | ➖ | stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax. |
+| Public API compatibility gate | ✅ | ➖ | ➖ | check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line. |
+| Query builder for parameterized SQL | 🟡 | ➖ | ➖ | SELECT/INSERT/UPDATE/DELETE with bound values and quoted identifiers. No subqueries, LIKE, arithmetic, window functions, CTEs or upsert. |
+| Reusable Go packages (embedder API) | ✅ | ➖ | ➖ | Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs. |
+| Schema visualization (ERD diagrams) | ✅ | ❌ | ✅ | Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas features page lists visualization as Pro. |
+
+## Data and distribution
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
+| Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |
+| OCI deployment, lint and plan report referrers | 🟡 | ❌ | 🟡 | Lists referrer descriptors only; payload download is absent. Atlas Cloud deployment reporting is a hosted service, not registry referrers. |
+| OCI desired-schema artifacts | ✅ | ❌ | 🟡 | Canonical schema.hcl push/pull; compare, drift and plan read `--schema-file` oci://. atlas schema push is a CE unsupported boundary stub. |
+| OCI migration artifacts | ✅ | ❌ | 🟡 | push/pull plus direct up, status, down and lint over oci://. Atlas's registry equivalent is hosted and account-bound, not bring-your-own. |
+
+## Atlas Registry and Cloud
+
+| Capability | Ptah | Atlas CE | Pro/Cloud | Difference |
+| --- | :-: | :-: | :-: | --- |
+| `migrate push` and `schema push` | ❌ | ❌ | ✅ | Registered as Atlas CE boundary stubs: help prints the community-version notice, direct execution prints the CE abort text. |
+| `schema plan` registry and output flags | ❌ | ❌ | ✅ | `--push`/`--pending`/`--repo` are recorded waivers; `--format`/`--name-format`/`--directive`/`--edit`/`--skip-lint` fail as unimplemented. |
+| `schema plan` registry sub-verbs | ❌ | ❌ | ✅ | approve, lint, list, new, pull, push, rm, test and validate all stay CE boundary stubs; only local plan files are implemented. |
+| Atlas Cloud deployment reporting | ❌ | ❌ | ✅ | No Atlas account model or deployment API. Ptah attaches best-effort deployment reports to its own OCI registry instead. |
+| Atlas Registry `atlas://` source URLs | ❌ | ❌ | ✅ | Rejected in `--from`/`--to`/`--plan` and migration.dir; Ptah offers a bring-your-own oci:// registry instead, not an atlas:// resolver. |
+| Reviewer approval and policy workflows | ❌ | ❌ | ✅ | Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope. |
+| Schema monitoring, hosted UI, login | ❌ | ❌ | ✅ | Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check. |
+
+## How these rows were established
+
+The Ptah column is derived from the built binaries. `ptah --help` and
+`ptah-compat --help` are the strongest available proof that a capability
+exists, and a row that could not be demonstrated that way is marked 🟡 with the
+limitation named, or ❌.
+
+The Atlas columns are narrower on purpose. Ptah is a clean-room implementation
+that studies observable behavior only, so the Atlas CE column is derived from
+the command, usage, and flag inventory the conformance harness reads out of the
+pinned Atlas community binary, and the Pro/Cloud column from the classification
+Atlas publishes on its feature availability page. Where neither source settles
+a question, the row says so rather than guessing.
+
+Two sources carry most of the weight:
+
+- [`cli-surface.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/cli-surface.md)
+  inventories every command in Atlas CE v1.2.0 and classifies it as an OSS
+  parity target or out of scope, with the reason recorded per command.
+- [`gaps.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps.md),
+  [`gaps-live.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-live.md),
+  and [`gaps-diff.md`](https://github.com/stokaro/ptah-atlas-conformance/blob/main/gaps-diff.md)
+  record measured outcomes over Atlas fixtures, live databases, and Atlas CE
+  differential checks.
+
+## What this page does not claim
+
+A green conformance run is a floor on the distance to Atlas, never a ceiling.
+The conformance repository states it directly: no number it produces is a
+full feature-set parity test, and several runtime dimensions stay unmeasured.
+
+Specifically, this page does not claim that Ptah reproduces Atlas byte for
+byte, that a ✅ row behaves identically under every flag combination, or that
+the Atlas columns are exhaustive for capabilities Atlas ships outside its
+documented CLI surface.
+
+## Next steps
+
+- Per-area detail behind these rows: [Comparison](../comparison/).
+- The measured evidence and how to re-run it: [Conformance](../conformance/).
+- Which Atlas documentation area maps where: [Atlas docs coverage](../docs-coverage/).
+- Why Ptah can be Atlas-compatible without Atlas code:
+  [License boundary](../license-boundary/).


### PR DESCRIPTION
A single page answering, per capability: what does Ptah do, what does the open Atlas community binary do, and what does Atlas keep outside its community build. Every row cites its evidence, every 🟡 names its specific limitation, and the Atlas columns only assert what Atlas-side evidence establishes.

## The page

**149 capabilities, ten sections.**

| Symbol | Meaning |
| --- | --- |
| ✅ | Supported today |
| 🟡 | Partial — the difference column states what is missing |
| ❌ | Not implemented |
| ➖ | Does not apply to that product |
| ❔ | Not established by the evidence this page uses |

| Reading | Count |
| --- | --- |
| Ptah supports it fully | 78 |
| Ptah supports it with a stated limitation | 47 |
| Ptah does not implement it | 24 |
| Ptah and Atlas CE both support it | 24 |
| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 27 |
| Ptah has it and neither Atlas edition does | 8 |
| Atlas CE has it and Ptah does not, or only in part | 25 |
| An Atlas column is ❔ — not established by this page's evidence | 34 |

Command surface is counted separately because it is *measured*: 19 of the 37 commands in the pinned Atlas CE binary are open parity targets, all matching on help usage and flags — 107 observations, no gap.

## The page is generated

`scripts/build-feature-matrix.mjs` renders it from `scripts/data/feature-matrix-rows.json` — the per-row evidence, version-controlled — plus committed head/tail parts. The summary counts are computed from the body, so they cannot drift, and `--check` fails when the page is stale. The first version of this tooling lived in a scratch directory and was lost to cleanup mid-review, which settled where it belongs.

## How the rows were established

Five successive passes, each adversarial to the previous:

1. **Gather + refute** — 7 dimensions gathered, 7 verifiers attacked; 57/122 rows corrected, mostly Atlas columns backed by Ptah-side evidence.
2. **Evidence audit** — 39 rows asserted an Atlas status citing nothing Atlas-side; 17 got real citations, 5 schema-object claims became ❔.
3. **Deep audit of every 🟡** — 10 agents, what exactly is missing; 65 confirmed gaps now tracked in #926–#942 and #944, 19 candidates dismissed as design choices; two correctness bugs reproduced by hand (`--dry-run` ignores the revision table; `migrate down` dirties the revision row before checking for a down body).
4. **Independent verification** — 6 fresh verifiers: 6 must-fix, 17 should-fix. Both verdict corrections again hit Atlas columns ('down' claimed CE support against the inventory; `--include` claimed CE absence against an inventory that registers it — the note now states both facts with citations). Nine self-test blind spots became mutation-tested fixtures. A new lint rejects bare `--flags` that smartypants renders as en dashes; its first implementation mispaired backticks on line-wrapped code spans, and that false-positive shape is now a fixture too.
5. **Completeness sweep** — 3 agents walked the full CLI/docs/embedder surface; 21 verified rows added. The page had been underselling: webhooks and shell hooks, pg_dump/mysqldump pre-apply backups, Prometheus metrics, JSON logs, online DDL via gh-ost/pt-osc, txtar down sections, template migrations, a generation-time destructive gate, standalone SQL linting, HCL export with annotation cleanup, PTAH_* env equivalents, five Go-embedder capabilities. Plus honest gaps: `--allow-dirty` semantics and the four upstream verbs beyond the CE pin.

## The registry story

One capability verdict instead of protocol fragmentation: **Registry-backed distribution: `oci://` vs `atlas://` — Ptah ✅ / CE ❌ / Pro ✅**, with a section intro stating what it means in practice (the registry and credentials a team already uses for images serve schema artifacts; no separate account or hosted dependency; digest pins make deployments byte-reproducible; registry-side controls come from the registry because the artifacts are ordinary OCI 1.1 manifests). `atlas://` is one protocol row under Atlas Registry and Cloud, whose intro draws the service-vs-storage line. All verified against a local `registry:2` including auth failures and digest-push refusals.

## Known limits and follow-ups

- **#946** — at 390px the matrix wraps instead of scrolling and 275 cells exceed the desktop 8-line cap; that needs a layout decision, not a lint tweak.
- Commit `ec0f058`'s message overstates its diff (it claims 17 rows gained citations; those edits landed in the data that this PR later committed as `feature-matrix-rows.json`, not in that commit's page diff).
- Issue cross-links: #938↔#846 (Flyway R__), #939↔#844 (docker:// diagnostics), #934↔#843 (env for_each) — partial overlaps with pre-existing issues, linked with the canonical owner named.

## Verification

All 13 documentation checks pass, the build is green, `npm audit` is clean, the built page contains zero en-dash flag tokens, and `build-feature-matrix.mjs --check` passes. Mutation testing covers 24 self-test assertions across the style rules.
