### PR TITLE
feat(fs): bind rooted publication to staged identity

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -51,8 +51,11 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Run Windows durable filesystem tests
-        run: go test -v -count=1 ./internal/fsdurable ./internal/pathguard ./internal/migratesum ./internal/devlock -timeout 5m
+      - name: Run Windows rooted publication primitive tests
+        run: go test -v -count=1 ./internal/fsdurable ./internal/pathguard -timeout 5m
+
+      - name: Run Windows publication consumer tests
+        run: go test -v -count=1 ./internal/migratesum ./internal/devlock -timeout 5m
 
       - name: Run Windows migration publication tests
         run: go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m

--- a/internal/fsdurable/errors.go
+++ b/internal/fsdurable/errors.go
@@ -1,9 +1,22 @@
 package fsdurable
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
 	// ErrReplacementCommitted reports that the rooted rename succeeded but a
 	// subsequent identity verification or durability operation failed.
 	ErrReplacementCommitted = errors.New("file replacement committed with uncertain durability")
+	// ErrStagedFileChanged reports that a rooted staged entry no longer
+	// identifies the file captured by its caller.
+	ErrStagedFileChanged = errors.New("staged file identity or metadata changed")
 )
+
+func replacementCommittedError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%w: %w", ErrReplacementCommitted, err)
+}

--- a/internal/fsdurable/publication_nonwindows.go
+++ b/internal/fsdurable/publication_nonwindows.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package fsdurable
+
+import (
+	"io/fs"
+	"os"
+)
+
+func openPublicationFile(root *os.Root, name string) (*os.File, error) {
+	return root.OpenFile(name, os.O_RDWR, 0)
+}
+
+func renamePublicationFile(
+	root *os.Root,
+	_ *os.File,
+	stagedName, targetName string,
+) (bool, error) {
+	if err := root.Rename(stagedName, targetName); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
+func modesEqual(actual, expected fs.FileMode) bool {
+	return actual == expected
+}

--- a/internal/fsdurable/publication_windows.go
+++ b/internal/fsdurable/publication_windows.go
@@ -1,0 +1,131 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+const fileRenameInformationExClass = 65
+
+type fileRenameInformationEx struct {
+	flags          uint32
+	rootDirectory  windows.Handle
+	fileNameLength uint32
+	fileName       [1]uint16
+}
+
+func openPublicationFile(root *os.Root, name string) (*os.File, error) {
+	rootDir, err := root.Open(".")
+	if err != nil {
+		return nil, err
+	}
+	objectName, err := windows.NewNTUnicodeString(name)
+	if err != nil {
+		return nil, errors.Join(err, rootDir.Close())
+	}
+	attributes := &windows.OBJECT_ATTRIBUTES{
+		Length:        uint32(unsafe.Sizeof(windows.OBJECT_ATTRIBUTES{})),
+		RootDirectory: windows.Handle(rootDir.Fd()),
+		ObjectName:    objectName,
+		Attributes:    windows.OBJ_CASE_INSENSITIVE,
+	}
+	var (
+		handle         windows.Handle
+		ioStatus       windows.IO_STATUS_BLOCK
+		allocationSize int64
+	)
+	openErr := windows.NtCreateFile(
+		&handle,
+		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.DELETE,
+		attributes,
+		&ioStatus,
+		&allocationSize,
+		0,
+		windows.FILE_SHARE_READ|windows.FILE_SHARE_WRITE|windows.FILE_SHARE_DELETE,
+		windows.FILE_OPEN,
+		windows.FILE_NON_DIRECTORY_FILE|windows.FILE_SYNCHRONOUS_IO_NONALERT,
+		0,
+		0,
+	)
+	closeRootErr := rootDir.Close()
+	if openErr != nil {
+		return nil, errors.Join(
+			&fs.PathError{Op: "openat", Path: name, Err: openErr},
+			closeRootErr,
+		)
+	}
+	file := os.NewFile(uintptr(handle), name)
+	if file == nil {
+		return nil, errors.Join(
+			fmt.Errorf("create os file for rooted publication %s", name),
+			windows.CloseHandle(handle),
+			closeRootErr,
+		)
+	}
+	if closeRootErr != nil {
+		return nil, errors.Join(closeRootErr, file.Close())
+	}
+	return file, nil
+}
+
+func renamePublicationFile(
+	root *os.Root,
+	staged *os.File,
+	stagedName string,
+	targetName string,
+) (bool, error) {
+	rootDir, err := root.Open(".")
+	if err != nil {
+		return false, err
+	}
+	targetUTF16, err := windows.UTF16FromString(targetName)
+	if err != nil {
+		return false, errors.Join(
+			&os.LinkError{Op: "renameat", Old: stagedName, New: targetName, Err: err},
+			rootDir.Close(),
+		)
+	}
+	nameLength := (len(targetUTF16) - 1) * 2
+	var layout fileRenameInformationEx
+	bufferSize := int(unsafe.Offsetof(layout.fileName)) + nameLength
+	buffer := make([]byte, bufferSize)
+	info := (*fileRenameInformationEx)(unsafe.Pointer(&buffer[0]))
+	info.flags = windows.FILE_RENAME_REPLACE_IF_EXISTS |
+		windows.FILE_RENAME_POSIX_SEMANTICS |
+		windows.FILE_RENAME_IGNORE_READONLY_ATTRIBUTE
+	info.rootDirectory = windows.Handle(rootDir.Fd())
+	info.fileNameLength = uint32(nameLength)
+	copy(
+		unsafe.Slice(&info.fileName[0], nameLength/2),
+		targetUTF16[:len(targetUTF16)-1],
+	)
+	var ioStatus windows.IO_STATUS_BLOCK
+	renameErr := windows.NtSetInformationFile(
+		windows.Handle(staged.Fd()),
+		&ioStatus,
+		&buffer[0],
+		uint32(bufferSize),
+		fileRenameInformationExClass,
+	)
+	if renameErr != nil {
+		return false, errors.Join(
+			&os.LinkError{
+				Op:  "renameat",
+				Old: stagedName,
+				New: targetName,
+				Err: renameErr,
+			},
+			rootDir.Close(),
+		)
+	}
+	return true, rootDir.Close()
+}
+
+func modesEqual(actual, expected fs.FileMode) bool {
+	return actual&0o200 == expected&0o200
+}

--- a/internal/fsdurable/publish_root.go
+++ b/internal/fsdurable/publish_root.go
@@ -1,0 +1,186 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+)
+
+// PublishFileAt durably replaces targetName with the staged regular file
+// identified by stagedInfo from an os stat operation. It applies finalMode and
+// syncs the staged file before rename, then verifies the same filesystem object
+// at targetName and syncs both the published file and its parent. Names must
+// identify direct children of root. Errors after rename wrap
+// ErrReplacementCommitted. FinalMode follows os.Chmod semantics; on Windows,
+// its owner-write bit controls the read-only attribute.
+func PublishFileAt(
+	root *os.Root,
+	stagedName, targetName string,
+	stagedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+) error {
+	return publishFileAt(
+		root,
+		stagedName,
+		targetName,
+		stagedInfo,
+		finalMode,
+		func() {},
+	)
+}
+
+func publishFileAt(
+	root *os.Root,
+	stagedName, targetName string,
+	stagedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+	afterRename func(),
+) error {
+	if err := validateDirectChildName("publishat", stagedName); err != nil {
+		return err
+	}
+	if err := validateDirectChildName("publishat", targetName); err != nil {
+		return err
+	}
+	staged, err := openExpectedWritableFile(root, stagedName, stagedInfo)
+	if err != nil {
+		return err
+	}
+	if err := prepareOpenedFile(root, staged, stagedName, stagedInfo, finalMode); err != nil {
+		return errors.Join(err, staged.Close())
+	}
+	renamed, renameErr := renamePublicationFile(root, staged, stagedName, targetName)
+	if !renamed {
+		return errors.Join(renameErr, staged.Close())
+	}
+	afterRename()
+
+	publishedInfo, verifyErr := root.Lstat(targetName)
+	if verifyErr != nil {
+		verifyErr = fmt.Errorf("lstat published file after rooted publication %s: %w", targetName, verifyErr)
+	} else {
+		verifyErr = validateExpectedFile(publishedInfo, stagedInfo, finalMode)
+	}
+	syncFileErr := staged.Sync()
+	syncRootErr := SyncRoot(root)
+	closeErr := staged.Close()
+	return replacementCommittedError(errors.Join(
+		renameErr,
+		verifyErr,
+		syncFileErr,
+		syncRootErr,
+		closeErr,
+	))
+}
+
+// FinalizeFileAt applies finalMode to a staged regular file whose identity was
+// captured by the caller through an os.Stat or os.File.Stat operation. It syncs
+// the file and its parent directory. Name must identify a direct child of root.
+// Unlike PublishFileAt, it does not rename the entry. FinalMode follows
+// os.Chmod semantics.
+func FinalizeFileAt(
+	root *os.Root,
+	name string,
+	expectedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+) error {
+	if err := validateDirectChildName("finalizeat", name); err != nil {
+		return err
+	}
+	file, err := openExpectedWritableFile(root, name, expectedInfo)
+	if err != nil {
+		return err
+	}
+	prepareErr := prepareOpenedFile(root, file, name, expectedInfo, finalMode)
+	syncRootErr := error(nil)
+	if prepareErr == nil {
+		syncRootErr = SyncRoot(root)
+	}
+	return errors.Join(prepareErr, syncRootErr, file.Close())
+}
+
+func openExpectedWritableFile(
+	root *os.Root,
+	name string,
+	expectedInfo fs.FileInfo,
+) (*os.File, error) {
+	if expectedInfo == nil {
+		return nil, fmt.Errorf("%w: expected identity is nil", ErrStagedFileChanged)
+	}
+	entryInfo, err := root.Lstat(name)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateExpectedFile(entryInfo, expectedInfo, expectedInfo.Mode()); err != nil {
+		return nil, fmt.Errorf("validate staged file %s: %w", name, err)
+	}
+	file, err := openPublicationFile(root, name)
+	if err != nil {
+		return nil, err
+	}
+	openedInfo, statErr := file.Stat()
+	restatedInfo, restatErr := root.Lstat(name)
+	validationErr := errors.Join(statErr, restatErr)
+	if validationErr == nil {
+		validationErr = validateExpectedFile(openedInfo, expectedInfo, expectedInfo.Mode())
+	}
+	if validationErr == nil && !os.SameFile(openedInfo, restatedInfo) {
+		validationErr = fmt.Errorf("%w: %s", ErrStagedFileChanged, name)
+	}
+	if validationErr != nil {
+		return nil, errors.Join(validationErr, file.Close())
+	}
+	return file, nil
+}
+
+func prepareOpenedFile(
+	root *os.Root,
+	file *os.File,
+	name string,
+	expectedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+) error {
+	if err := file.Chmod(finalMode); err != nil {
+		return err
+	}
+	if err := file.Sync(); err != nil {
+		return err
+	}
+	openedInfo, statErr := file.Stat()
+	entryInfo, entryErr := root.Lstat(name)
+	validationErr := errors.Join(statErr, entryErr)
+	if validationErr == nil {
+		validationErr = validateExpectedFile(openedInfo, expectedInfo, finalMode)
+	}
+	if validationErr == nil {
+		validationErr = validateExpectedFile(entryInfo, expectedInfo, finalMode)
+	}
+	if validationErr == nil && !os.SameFile(openedInfo, entryInfo) {
+		validationErr = fmt.Errorf("%w: %s", ErrStagedFileChanged, name)
+	}
+	return validationErr
+}
+
+func validateExpectedFile(
+	actual, expected fs.FileInfo,
+	expectedMode fs.FileMode,
+) error {
+	if actual == nil ||
+		!actual.Mode().IsRegular() ||
+		!os.SameFile(actual, expected) ||
+		!modesEqual(actual.Mode(), expectedMode) ||
+		actual.Size() != expected.Size() ||
+		!actual.ModTime().Equal(expected.ModTime()) {
+		return ErrStagedFileChanged
+	}
+	return nil
+}
+
+func validateDirectChildName(op, name string) error {
+	if name == "" || name == "." || name == ".." || filepath.Base(name) != name {
+		return &fs.PathError{Op: op, Path: name, Err: fs.ErrInvalid}
+	}
+	return nil
+}

--- a/internal/fsdurable/publish_root_internal_test.go
+++ b/internal/fsdurable/publish_root_internal_test.go
@@ -1,0 +1,51 @@
+package fsdurable
+
+// White-box testing required: this file exercises the deterministic
+// post-rename verification boundary, which is not exposed by the public API.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func Test_publishFileAt_FailurePath_ReportsPostCommitIdentityChange(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	displacedPath := filepath.Join(dir, "displaced")
+	c.Assert(os.WriteFile(stagedPath, []byte("staged"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = publishFileAt(root, "staged", "published", stagedInfo, 0o600, func() {
+		c.Assert(root.Rename("published", "displaced"), qt.IsNil)
+		replacement, openErr := root.OpenFile(
+			"published",
+			os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+			0o600,
+		)
+		c.Assert(openErr, qt.IsNil)
+		_, writeErr := replacement.WriteString("replacement")
+		c.Assert(writeErr, qt.IsNil)
+		c.Assert(replacement.Close(), qt.IsNil)
+	})
+
+	c.Assert(err, qt.ErrorIs, ErrReplacementCommitted)
+	c.Assert(err, qt.ErrorIs, ErrStagedFileChanged)
+	contents, err := os.ReadFile(displacedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "staged")
+	contents, err = os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "replacement")
+}

--- a/internal/fsdurable/publish_root_test.go
+++ b/internal/fsdurable/publish_root_test.go
@@ -1,0 +1,316 @@
+package fsdurable_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestPublishFileAt_HappyPath_AppliesReadOnlyMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	c.Assert(os.Chmod(publishedPath, 0o400), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(publishedPath, 0o600), qt.IsNil)
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o400)
+
+	c.Assert(err, qt.IsNil)
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	publishedInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(stagedInfo, publishedInfo), qt.IsTrue)
+	c.Assert(publishedInfo.Mode().Perm()&0o200, qt.Equals, os.FileMode(0))
+	_, err = os.Stat(stagedPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestFinalizeFileAt_HappyPath_AppliesReadOnlyMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	c.Assert(os.WriteFile(stagedPath, []byte("backup"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(stagedPath, 0o600), qt.IsNil)
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.FinalizeFileAt(root, "staged", stagedInfo, 0o400)
+
+	c.Assert(err, qt.IsNil)
+	contents, err := os.ReadFile(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "backup")
+	finalInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsTrue)
+	c.Assert(finalInfo.Mode().Perm()&0o200, qt.Equals, os.FileMode(0))
+}
+
+func TestPublishFileAt_HappyPath_CreatesMissingDestination(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o600)
+
+	c.Assert(err, qt.IsNil)
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	_, err = os.Stat(stagedPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}
+
+func TestPublishFileAt_FailurePath_RejectsReplacedStagedEntry(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Remove(stagedPath), qt.IsNil)
+	c.Assert(os.WriteFile(stagedPath, []byte("replacement"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o640)
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	contents, err := os.ReadFile(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "replacement")
+	contents, err = os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "old")
+}
+
+func TestPublishFileAt_FailurePath_RejectsModifiedStagedFile(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(stagedPath, []byte("modified staged contents"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o640)
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	contents, err := os.ReadFile(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "modified staged contents")
+	contents, err = os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "old")
+}
+
+func TestPublishFileAt_FailurePath_RejectsMissingStagedEntry(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	expectedPath := filepath.Join(dir, "expected")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(expectedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(expectedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "missing", "published", expectedInfo, 0o600)
+
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "old")
+}
+
+func TestPublishFileAt_FailurePath_RejectsChangedStagedMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chmod(stagedPath, 0o400), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(stagedPath, 0o600), qt.IsNil)
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o600)
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "old")
+}
+
+func TestPublishFileAt_FailurePath_RejectsChangedStagedModTime(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	changedTime := expectedInfo.ModTime().Add(time.Hour)
+	c.Assert(os.Chtimes(stagedPath, changedTime, changedTime), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o600)
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "old")
+}
+
+func TestPublishFileAt_FailurePath_RejectsPathComponents(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+	tests := []struct {
+		name       string
+		stagedName string
+		targetName string
+	}{
+		{name: "empty staged name", stagedName: "", targetName: "published"},
+		{name: "current staged directory", stagedName: ".", targetName: "published"},
+		{name: "parent staged directory", stagedName: "..", targetName: "published"},
+		{name: "nested staged path", stagedName: filepath.Join("nested", "staged"), targetName: "published"},
+		{name: "nested target path", stagedName: "staged", targetName: filepath.Join("nested", "published")},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := fsdurable.PublishFileAt(
+				root,
+				test.stagedName,
+				test.targetName,
+				expectedInfo,
+				0o600,
+			)
+			c.Assert(err, qt.ErrorIs, fs.ErrInvalid)
+		})
+	}
+}
+
+func TestFinalizeFileAt_FailurePath_RejectsReplacedStagedEntry(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Remove(stagedPath), qt.IsNil)
+	c.Assert(os.WriteFile(stagedPath, []byte("replacement"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.FinalizeFileAt(root, "staged", expectedInfo, 0o400)
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	contents, err := os.ReadFile(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "replacement")
+	info, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().Perm()&0o200, qt.Equals, os.FileMode(0o200))
+}
+
+func TestFinalizeFileAt_FailurePath_RejectsPathComponents(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	c.Assert(os.WriteFile(stagedPath, []byte("expected"), 0o600), qt.IsNil)
+	expectedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+	tests := []struct {
+		name       string
+		stagedName string
+	}{
+		{name: "empty name", stagedName: ""},
+		{name: "current directory", stagedName: "."},
+		{name: "parent directory", stagedName: ".."},
+		{name: "nested path", stagedName: filepath.Join("nested", "staged")},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := fsdurable.FinalizeFileAt(root, test.stagedName, expectedInfo, 0o600)
+			c.Assert(err, qt.ErrorIs, fs.ErrInvalid)
+		})
+	}
+}

--- a/internal/fsdurable/publish_root_unix_test.go
+++ b/internal/fsdurable/publish_root_unix_test.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/fsdurable"
+)
+
+func TestPublishFileAt_HappyPath_AppliesExactUnixMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o640)
+
+	c.Assert(err, qt.IsNil)
+	publishedInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(publishedInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+}
+
+func TestFinalizeFileAt_HappyPath_AppliesExactUnixMode(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	c.Assert(os.WriteFile(stagedPath, []byte("backup"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.FinalizeFileAt(root, "staged", stagedInfo, 0o640)
+
+	c.Assert(err, qt.IsNil)
+	finalInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(finalInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+}

--- a/internal/fsdurable/replace_root_windows.go
+++ b/internal/fsdurable/replace_root_windows.go
@@ -39,10 +39,3 @@ func ReplaceFileAt(root *os.Root, oldName, newName string) error {
 	}
 	return replacementCommittedError(errors.Join(verifyErr, staged.Sync(), staged.Close()))
 }
-
-func replacementCommittedError(err error) error {
-	if err == nil {
-		return nil
-	}
-	return fmt.Errorf("%w: %w", ErrReplacementCommitted, err)
-}

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -72,6 +72,45 @@ func (d *OpenedDirectory) ReplaceFile(oldName, newName string) error {
 	return fsdurable.ReplaceFileAt(d.root, oldName, newName)
 }
 
+// PublishFile durably replaces newName with the staged regular file identified
+// by expectedInfo from os.Stat or os.File.Stat. The final mode is applied before
+// rename. Both names must identify direct children. An error wrapping
+// fsdurable.ErrReplacementCommitted means the rename succeeded.
+func (d *OpenedDirectory) PublishFile(
+	oldName, newName string,
+	expectedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+) error {
+	return fsdurable.PublishFileAt(d.root, oldName, newName, expectedInfo, finalMode)
+}
+
+// FinalizeFile applies finalMode to a staged regular file with the supplied
+// identity from os.Stat or os.File.Stat and durably preserves it without
+// renaming it. Name must identify a direct child.
+func (d *OpenedDirectory) FinalizeFile(
+	name string,
+	expectedInfo fs.FileInfo,
+	finalMode fs.FileMode,
+) error {
+	return fsdurable.FinalizeFileAt(d.root, name, expectedInfo, finalMode)
+}
+
+// Revalidate verifies that Path still identifies this opened directory.
+func (d *OpenedDirectory) Revalidate() error {
+	openedInfo, openedErr := d.root.Stat(".")
+	pathInfo, pathErr := os.Stat(d.path)
+	if err := errors.Join(openedErr, pathErr); err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrDirectoryChanged, d.path, err)
+	}
+	if !openedInfo.IsDir() ||
+		!pathInfo.IsDir() ||
+		!os.SameFile(d.info, openedInfo) ||
+		!os.SameFile(openedInfo, pathInfo) {
+		return fmt.Errorf("%w: %s", ErrDirectoryChanged, d.path)
+	}
+	return nil
+}
+
 // Sync flushes rooted directory-entry changes where the platform supports it.
 // Call it after ReplaceFile and Remove before reporting a durable transaction.
 func (d *OpenedDirectory) Sync() error {

--- a/internal/pathguard/opened_directory_ops_test.go
+++ b/internal/pathguard/opened_directory_ops_test.go
@@ -104,6 +104,56 @@ func TestOpenedDirectoryOperations_FailurePath(t *testing.T) {
 	c.Assert(removeErr.Path, qt.Equals, "missing")
 }
 
+func TestOpenedDirectoryPublication_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	opened, err := pathguard.OpenDirectory(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(publishedPath, 0o600), qt.IsNil)
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	staged, stagedName, err := opened.CreateTemp("staged-*")
+	c.Assert(err, qt.IsNil)
+	_, err = staged.WriteString("new")
+	c.Assert(err, qt.IsNil)
+	c.Assert(staged.Sync(), qt.IsNil)
+	stagedInfo, err := staged.Stat()
+	c.Assert(err, qt.IsNil)
+	c.Assert(staged.Close(), qt.IsNil)
+	backup, backupName, err := opened.CreateTemp("backup")
+	c.Assert(err, qt.IsNil)
+	_, err = backup.WriteString("original")
+	c.Assert(err, qt.IsNil)
+	c.Assert(backup.Sync(), qt.IsNil)
+	backupInfo, err := backup.Stat()
+	c.Assert(err, qt.IsNil)
+	c.Assert(backup.Close(), qt.IsNil)
+	backupPath := filepath.Join(dir, backupName)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(backupPath, 0o600), qt.IsNil)
+	})
+
+	c.Assert(opened.PublishFile(stagedName, "published", stagedInfo, 0o400), qt.IsNil)
+	c.Assert(opened.FinalizeFile(backupName, backupInfo, 0o400), qt.IsNil)
+	c.Assert(opened.Revalidate(), qt.IsNil)
+
+	contents, err := os.ReadFile(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "new")
+	publishedInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(publishedInfo.Mode().Perm()&0o200, qt.Equals, os.FileMode(0))
+	contents, err = os.ReadFile(backupPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "original")
+	backupFinalInfo, err := os.Stat(backupPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(backupFinalInfo.Mode().Perm()&0o200, qt.Equals, os.FileMode(0))
+}
+
 func TestOpenedDirectoryCreateTemp_FailurePath(t *testing.T) {
 	c := qt.New(t)
 	opened, err := pathguard.OpenDirectory(c.TempDir())

--- a/internal/pathguard/opened_directory_revalidate_test.go
+++ b/internal/pathguard/opened_directory_revalidate_test.go
@@ -1,0 +1,39 @@
+package pathguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestOpenedDirectoryRevalidate_FailurePath_RejectsDirectoryPathReplacement(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	selected := filepath.Join(root, "selected")
+	captured := filepath.Join(root, "captured")
+	c.Assert(os.Mkdir(captured, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(captured, "inside"), []byte("captured"), 0o600), qt.IsNil)
+	c.Assert(os.Symlink(captured, selected), qt.IsNil)
+	opened, err := pathguard.OpenDirectory(selected)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	c.Assert(os.Remove(selected), qt.IsNil)
+	c.Assert(os.Mkdir(selected, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(selected, "inside"), []byte("replacement"), 0o600), qt.IsNil)
+
+	err = opened.Revalidate()
+
+	c.Assert(err, qt.ErrorIs, pathguard.ErrDirectoryChanged)
+	contents, err := opened.ReadFile("inside")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "captured")
+	replacementContents, err := os.ReadFile(filepath.Join(selected, "inside"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(replacementContents), qt.Equals, "replacement")
+}

--- a/internal/pathguard/opened_directory_revalidate_unix_test.go
+++ b/internal/pathguard/opened_directory_revalidate_unix_test.go
@@ -1,0 +1,41 @@
+//go:build unix
+
+package pathguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestOpenedDirectoryRevalidate_FailurePath_RejectsAncestorReplacement(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	selected := filepath.Join(root, "selected")
+	captured := filepath.Join(root, "captured")
+	outside := c.TempDir()
+	c.Assert(os.Mkdir(selected, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(selected, "inside"), []byte("captured"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(outside, "inside"), []byte("outside"), 0o600), qt.IsNil)
+	opened, err := pathguard.OpenDirectory(selected)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	c.Assert(os.Rename(selected, captured), qt.IsNil)
+	c.Assert(os.Symlink(outside, selected), qt.IsNil)
+
+	err = opened.Revalidate()
+
+	c.Assert(err, qt.ErrorIs, pathguard.ErrDirectoryChanged)
+	contents, err := opened.ReadFile("inside")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "captured")
+	outsideContents, err := os.ReadFile(filepath.Join(selected, "inside"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(outsideContents), qt.Equals, "outside")
+}

--- a/internal/pathguard/pathguard.go
+++ b/internal/pathguard/pathguard.go
@@ -15,6 +15,9 @@ import (
 var (
 	// ErrOutsideRoot reports that a path escapes its configured filesystem root.
 	ErrOutsideRoot = errors.New("outside allowed root")
+	// ErrDirectoryChanged reports that an opened directory's lexical path no
+	// longer identifies the filesystem object selected when it was opened.
+	ErrDirectoryChanged = errors.New("opened directory path changed")
 )
 
 // OpenedDirectory is a directory handle anchored to the filesystem object
@@ -23,6 +26,7 @@ var (
 type OpenedDirectory struct {
 	root *os.Root
 	path string
+	info fs.FileInfo
 }
 
 type rootedPath struct {
@@ -57,7 +61,7 @@ func (d *OpenedDirectory) OpenDirectory(path string) (*OpenedDirectory, error) {
 		}
 		return nil, err
 	}
-	return &OpenedDirectory{root: opened, path: target.display}, nil
+	return newOpenedDirectory(opened, target.display)
 }
 
 // Stat returns information about name through the rooted handle.
@@ -135,7 +139,7 @@ func OpenCurrentDirectory() (*OpenedDirectory, error) {
 			closeErr,
 		)
 	}
-	return &OpenedDirectory{root: root, path: filepath.Clean(cwd)}, nil
+	return newOpenedDirectory(root, filepath.Clean(cwd))
 }
 
 // OpenDirectoryWithinRoot binds allowedRoot first, then opens path only through
@@ -195,7 +199,21 @@ func OpenDirectory(path string) (*OpenedDirectory, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &OpenedDirectory{root: root, path: absolute}, nil
+	return newOpenedDirectory(root, absolute)
+}
+
+func newOpenedDirectory(root *os.Root, path string) (*OpenedDirectory, error) {
+	info, err := root.Stat(".")
+	if err != nil {
+		return nil, errors.Join(err, root.Close())
+	}
+	if !info.IsDir() {
+		return nil, errors.Join(
+			fmt.Errorf("opened path is not a directory: %s", path),
+			root.Close(),
+		)
+	}
+	return &OpenedDirectory{root: root, path: path, info: info}, nil
 }
 
 func rootedRelativePath(path, root string) (rootedPath, error) {


### PR DESCRIPTION
Closes #914.

## Summary

- add identity-bound rooted publication and finalization primitives that apply the final mode before commit and distinguish pre-commit failures from `ErrReplacementCommitted`
- use the retained staged handle for Windows rename, including replacement of read-only targets, and revalidate published identity and durability
- capture and revalidate opened-directory identity so callers can detect lexical path replacement
- isolate the Windows publication primitives in their own runtime CI step

## Test coverage

- regular, read-only, and exact Unix mode publication
- missing, replaced, size-changed, mode-changed, and modtime-changed staged entries
- direct-child path enforcement
- deterministic post-rename identity replacement with both committed and identity sentinels
- directory-path replacement on all platforms plus Unix symlink replacement
- Windows cross-compilation and runtime coverage through GitHub Actions

## Validation

All local checks pass on the branch rebased onto current `master` after #903 and #917 merged:

- `gopls check`
- `go test -race -count=10 ./internal/fsdurable ./internal/pathguard`
- Windows cross-compilation for both changed packages
- `scripts/check-test-style.sh`
- `go tool qtlint ./internal/fsdurable ./internal/pathguard`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go test -race -count=1 ./...`

Two self-review rounds addressed Windows mode normalization, read-only destination replacement, direct-child durability boundaries, deterministic post-commit verification, cross-platform directory replacement, and best-effort finalization after every committed rename.

## Documentation impact

This is an internal filesystem API and CI change. Public CLI behavior and reader-facing documentation do not change; package comments document mode semantics, direct-child constraints, and the post-commit error contract.

Prerequisite for #900.