### PR TITLE
fix(schema): harden Go annotation publication

### DIFF
--- a/.github/workflows/go-unit-tests.yml
+++ b/.github/workflows/go-unit-tests.yml
@@ -57,6 +57,9 @@ jobs:
       - name: Run Windows publication consumer tests
         run: go test -v -count=1 ./internal/migratesum ./internal/devlock -timeout 5m
 
+      - name: Run Windows Go annotation publication tests
+        run: go test -v -count=1 ./internal/goannotationcleanup ./internal/goannotationexport -timeout 5m
+
       - name: Run Windows migration publication tests
         run: go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
 

--- a/docs/site/src/content/docs/schema/go-annotations.md
+++ b/docs/site/src/content/docs/schema/go-annotations.md
@@ -153,7 +153,11 @@ any unexpected diagnostic before cleanup.
 One export captures the complete selected Go source set and uses that immutable
 view for both HCL parsing and cleanup planning. Ptah rechecks source membership,
 file identity, permissions, and contents before publishing the HCL; a concurrent
-source change aborts the export.
+source change aborts the export. The output directory is bound before staging,
+and Ptah also rechecks an existing output's identity, permissions, and contents.
+An output creation, edit, or replacement detected at this commit barrier is
+left untouched and aborts publication. Successful HCL replacement is flushed
+to durable storage before Go annotation cleanup starts.
 
 Preview annotation removal only after the export has no diagnostics:
 
@@ -177,8 +181,15 @@ output uses a `.go` path or aliases a protected source, or no removable
 annotations remain. Ptah revalidates the Go source set before HCL publication
 and again before cleanup. If a source changes between those steps, the HCL file
 remains published but cleanup leaves every Go file unchanged and returns an
-error. Do not repeat the cleanup command after a successful migration; use
-`schema.hcl` as the new source.
+error.
+
+If a later source fails during a multi-file cleanup, Ptah rolls back earlier
+replacements only while they still match the exact cleaned file it committed.
+If that check detects a concurrent edit, Ptah leaves the edit in place,
+preserves the original source in a `.ptah-backup-*` file, and reports its
+location. These checks are optimistic; exclude uncooperative writers that can
+mutate the same paths after the final commit barrier. Do not repeat cleanup
+after a successful migration; use `schema.hcl` as the new source.
 :::
 
 ## Next steps

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -8,6 +8,7 @@ import (
 	"go/parser"
 	"go/token"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -16,7 +17,15 @@ import (
 
 	"github.com/stokaro/ptah/internal/annotationmeta"
 	"github.com/stokaro/ptah/internal/annotationparse"
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/internal/goannotationsource"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+var (
+	// ErrRollbackConflict reports that cleanup could not safely restore an
+	// original source because its committed file or parent directory changed.
+	ErrRollbackConflict = errors.New("Go annotation cleanup rollback conflict")
 )
 
 // Result describes cleanup changes for one file.
@@ -48,10 +57,27 @@ type filePlan struct {
 	removed []removedLine
 }
 
+type applyHooks struct {
+	revalidate  func() error
+	afterCommit func()
+}
+
+type openedPlan struct {
+	plan       filePlan
+	parent     *pathguard.OpenedDirectory
+	targetName string
+}
+
+type stagedFile struct {
+	name string
+	info fs.FileInfo
+}
+
 type stagedPlan struct {
-	plan           filePlan
-	cleanedPath    string
-	backupPath     string
+	opened         *openedPlan
+	cleaned        stagedFile
+	backup         stagedFile
+	committed      bool
 	preserveBackup bool
 }
 
@@ -116,7 +142,10 @@ func (p *Plan) Apply() error {
 	if err := p.snapshot.Revalidate(); err != nil {
 		return fmt.Errorf("revalidate Go annotation sources before cleanup: %w", err)
 	}
-	return applyPlans(p.changes, p.snapshot.Revalidate)
+	return applyPlans(p.changes, applyHooks{
+		revalidate:  p.snapshot.Revalidate,
+		afterCommit: func() {},
+	})
 }
 
 func planFile(source goannotationsource.File) (filePlan, error) {
@@ -147,105 +176,190 @@ func planFile(source goannotationsource.File) (filePlan, error) {
 	}, nil
 }
 
-func applyPlans(plans []filePlan, revalidate func() error) error {
-	files := make([]*os.File, 0, len(plans))
-	for _, plan := range plans {
-		file, err := openValidatedPlan(plan)
-		if err != nil {
-			return errors.Join(err, closeFiles(files))
-		}
-		files = append(files, file)
-	}
-
-	staged, err := stagePlans(plans)
+func applyPlans(plans []filePlan, hooks applyHooks) error {
+	opened, err := openPlans(plans)
 	if err != nil {
-		return errors.Join(err, closeFiles(files))
+		return err
 	}
-	for i, file := range files {
-		if err := validateOpenPlan(file, plans[i]); err != nil {
-			return errors.Join(err, closeFiles(files), cleanupStagedPlans(staged))
-		}
+	staged, err := stagePlans(opened)
+	if err != nil {
+		return errors.Join(err, closeOpenedPlans(opened))
 	}
-	if err := closeFiles(files); err != nil {
-		return errors.Join(err, cleanupStagedPlans(staged))
-	}
-	if err := revalidate(); err != nil {
-		return errors.Join(
+	if err := hooks.revalidate(); err != nil {
+		return finishApply(
+			opened,
+			staged,
 			fmt.Errorf("revalidate Go annotation sources before cleanup commit: %w", err),
-			cleanupStagedPlans(staged),
 		)
 	}
-	if err := commitStagedPlans(staged); err != nil {
-		return errors.Join(err, cleanupStagedPlans(staged))
+	if err := commitStagedPlans(staged, hooks.afterCommit); err != nil {
+		return finishApply(opened, staged, err)
 	}
-	return cleanupStagedPlans(staged)
+	return finishApply(opened, staged, nil)
 }
 
-func openValidatedPlan(plan filePlan) (*os.File, error) {
-	if err := validatePlanPath(plan); err != nil {
+func finishApply(opened []openedPlan, staged []stagedPlan, applyErr error) error {
+	finishErr := errors.Join(applyErr, cleanupStagedPlans(staged), closeOpenedPlans(opened))
+	if finishErr == nil || !hasCommittedPlan(staged) || errors.Is(finishErr, fsdurable.ErrReplacementCommitted) {
+		return finishErr
+	}
+	return fmt.Errorf("%w: %w", fsdurable.ErrReplacementCommitted, finishErr)
+}
+
+func hasCommittedPlan(staged []stagedPlan) bool {
+	return slices.ContainsFunc(staged, func(plan stagedPlan) bool {
+		return plan.committed
+	})
+}
+
+func openPlans(plans []filePlan) ([]openedPlan, error) {
+	opened := make([]openedPlan, 0, len(plans))
+	parents := make(map[string]*pathguard.OpenedDirectory)
+	for _, plan := range plans {
+		parentPath := filepath.Clean(filepath.Dir(plan.result.Path))
+		parent := parents[parentPath]
+		openedParent := false
+		if parent == nil {
+			var err error
+			parent, err = pathguard.OpenDirectory(parentPath)
+			if err != nil {
+				return nil, errors.Join(
+					fmt.Errorf("open Go source parent for cleanup %s: %w", plan.result.Path, err),
+					closeOpenedPlans(opened),
+				)
+			}
+			parents[parentPath] = parent
+			openedParent = true
+		}
+		current, err := openPlan(plan, parent)
+		if err != nil {
+			if openedParent {
+				err = errors.Join(err, parent.Close())
+			}
+			return nil, errors.Join(err, closeOpenedPlans(opened))
+		}
+		opened = append(opened, current)
+	}
+	return opened, nil
+}
+
+func openPlan(plan filePlan, parent *pathguard.OpenedDirectory) (openedPlan, error) {
+	targetName := filepath.Base(plan.result.Path)
+	source, err := openValidatedPlan(parent, targetName, plan)
+	if err != nil {
+		return openedPlan{}, err
+	}
+	if err := source.Close(); err != nil {
+		return openedPlan{}, fmt.Errorf("close validated Go source %s: %w", plan.result.Path, err)
+	}
+	return openedPlan{
+		plan:       plan,
+		parent:     parent,
+		targetName: targetName,
+	}, nil
+}
+
+func openValidatedPlan(
+	parent *pathguard.OpenedDirectory,
+	targetName string,
+	plan filePlan,
+) (*os.File, error) {
+	entryInfo, err := parent.Lstat(targetName)
+	if err != nil {
+		return nil, fmt.Errorf("stat Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 {
+		return nil, fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
+	}
+	if err := validatePlanInfo(entryInfo, plan); err != nil {
 		return nil, err
 	}
-	file, err := os.Open(plan.result.Path)
+	file, err := parent.Open(targetName)
 	if err != nil {
 		return nil, fmt.Errorf("open Go source for cleanup %s: %w", plan.result.Path, err)
 	}
-	if err := validateOpenPlan(file, plan); err != nil {
-		_ = file.Close()
-		return nil, err
+	if err := validateOpenPlanEntry(parent, targetName, file, plan); err != nil {
+		return nil, errors.Join(err, file.Close())
 	}
 	return file, nil
 }
 
-func validatePlanPath(plan filePlan) error {
-	info, err := os.Lstat(plan.result.Path)
-	if err != nil {
-		return fmt.Errorf("stat Go source before cleanup %s: %w", plan.result.Path, err)
-	}
-	if info.Mode()&os.ModeSymlink != 0 {
-		return fmt.Errorf("refuse to clean symlinked Go source %s", plan.result.Path)
-	}
-	if !info.Mode().IsRegular() || !plan.source.SameFile(info) {
-		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
-	}
-	current, err := os.ReadFile(plan.result.Path)
-	if err != nil {
-		return fmt.Errorf("read Go source before cleanup %s: %w", plan.result.Path, err)
-	}
-	if !bytes.Equal(current, plan.before) {
+func validatePlanInfo(info fs.FileInfo, plan filePlan) error {
+	if !info.Mode().IsRegular() ||
+		!plan.source.SameFile(info) ||
+		info.Mode() != plan.source.Mode() {
 		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
 	}
 	return nil
 }
 
-func validateOpenPlan(file *os.File, plan filePlan) error {
+func validateOpenPlanEntry(
+	parent *pathguard.OpenedDirectory,
+	targetName string,
+	file *os.File,
+	plan filePlan,
+) error {
 	currentInfo, err := file.Stat()
 	if err != nil {
 		return fmt.Errorf("stat opened Go source %s: %w", plan.result.Path, err)
 	}
-	if !plan.source.SameFile(currentInfo) {
+	if err := validatePlanInfo(currentInfo, plan); err != nil {
+		return err
+	}
+	entryInfo, err := parent.Lstat(targetName)
+	if err != nil {
+		return fmt.Errorf("restat Go source before cleanup %s: %w", plan.result.Path, err)
+	}
+	if entryInfo.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(currentInfo, entryInfo) {
 		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
 	}
-	return validatePlanContent(file, plan)
-}
-
-func validatePlanContent(file *os.File, plan filePlan) error {
-	if _, err := file.Seek(0, io.SeekStart); err != nil {
-		return fmt.Errorf("seek Go source before cleanup %s: %w", plan.result.Path, err)
+	if err := validatePlanContent(file, plan.before, plan.result.Path); err != nil {
+		return err
 	}
-	current, err := io.ReadAll(file)
-	if err != nil {
-		return fmt.Errorf("read Go source before cleanup %s: %w", plan.result.Path, err)
+	finalInfo, statErr := file.Stat()
+	finalEntryInfo, restatErr := parent.Lstat(targetName)
+	if err := errors.Join(statErr, restatErr); err != nil {
+		return fmt.Errorf("restat Go source after cleanup validation %s: %w", plan.result.Path, err)
 	}
-	if !bytes.Equal(current, plan.before) {
+	if err := validatePlanInfo(finalInfo, plan); err != nil {
+		return err
+	}
+	if finalEntryInfo.Mode()&os.ModeSymlink != 0 ||
+		!os.SameFile(currentInfo, finalInfo) ||
+		!os.SameFile(finalInfo, finalEntryInfo) ||
+		finalEntryInfo.Mode() != plan.source.Mode() {
 		return fmt.Errorf("go source changed before cleanup: %s", plan.result.Path)
 	}
 	return nil
 }
 
-func stagePlans(plans []filePlan) ([]stagedPlan, error) {
-	staged := make([]stagedPlan, 0, len(plans))
-	for _, plan := range plans {
-		stagedFile, err := stagePlan(plan)
+func validatePlanPath(opened *openedPlan) error {
+	file, err := openValidatedPlan(opened.parent, opened.targetName, opened.plan)
+	if err != nil {
+		return err
+	}
+	return file.Close()
+}
+
+func validatePlanContent(file *os.File, expected []byte, displayPath string) error {
+	if _, err := file.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek Go source before cleanup %s: %w", displayPath, err)
+	}
+	current, err := io.ReadAll(file)
+	if err != nil {
+		return fmt.Errorf("read Go source before cleanup %s: %w", displayPath, err)
+	}
+	if !bytes.Equal(current, expected) {
+		return fmt.Errorf("go source changed before cleanup: %s", displayPath)
+	}
+	return nil
+}
+
+func stagePlans(opened []openedPlan) ([]stagedPlan, error) {
+	staged := make([]stagedPlan, 0, len(opened))
+	for i := range opened {
+		stagedFile, err := stagePlan(&opened[i])
 		if err != nil {
 			return nil, errors.Join(err, cleanupStagedPlans(staged))
 		}
@@ -254,123 +368,327 @@ func stagePlans(plans []filePlan) ([]stagedPlan, error) {
 	return staged, nil
 }
 
-func stagePlan(plan filePlan) (stagedPlan, error) {
-	backupPath, err := stageFile(plan, "backup", plan.before)
+func stagePlan(opened *openedPlan) (stagedPlan, error) {
+	backup, err := stageFile(opened, "backup", opened.plan.before)
 	if err != nil {
 		return stagedPlan{}, err
 	}
-	cleanedPath, err := stageFile(plan, "cleaned", plan.after)
+	cleaned, err := stageFile(opened, "cleaned", opened.plan.after)
 	if err != nil {
-		return stagedPlan{}, errors.Join(err, removeStagedFile(backupPath))
+		return stagedPlan{}, errors.Join(err, removeStagedFile(opened.parent, &backup))
 	}
-	return stagedPlan{
-		plan:        plan,
-		cleanedPath: cleanedPath,
-		backupPath:  backupPath,
-	}, nil
-}
-
-func stageFile(plan filePlan, kind string, data []byte) (string, error) {
-	dir := filepath.Dir(plan.result.Path)
-	pattern := "." + filepath.Base(plan.result.Path) + ".ptah-" + kind + "-*"
-	file, err := os.CreateTemp(dir, pattern)
-	if err != nil {
-		return "", fmt.Errorf("create staged %s for %s: %w", kind, plan.result.Path, err)
+	staged := stagedPlan{
+		opened:  opened,
+		cleaned: cleaned,
+		backup:  backup,
 	}
-	path := file.Name()
-	if err := file.Chmod(plan.source.Mode()); err != nil {
-		_ = file.Close()
-		return "", errors.Join(
-			fmt.Errorf("set staged %s mode for %s: %w", kind, plan.result.Path, err),
-			removeStagedFile(path),
+	if err := opened.parent.Sync(); err != nil {
+		return stagedPlan{}, errors.Join(
+			fmt.Errorf("sync staged cleanup files for %s: %w", opened.plan.result.Path, err),
+			cleanupStagedPlans([]stagedPlan{staged}),
 		)
 	}
+	return staged, nil
+}
+
+func stageFile(opened *openedPlan, kind string, data []byte) (stagedFile, error) {
+	pattern := "." + opened.targetName + ".ptah-" + kind + "-*"
+	file, name, err := opened.parent.CreateTemp(pattern)
+	if err != nil {
+		return stagedFile{}, fmt.Errorf(
+			"create staged %s for %s: %w",
+			kind,
+			opened.plan.result.Path,
+			err,
+		)
+	}
+	staged := stagedFile{name: name}
 	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
-		return "", errors.Join(
-			fmt.Errorf("write staged %s for %s: %w", kind, plan.result.Path, err),
-			removeStagedFile(path),
+		return stagedFile{}, errors.Join(
+			fmt.Errorf("write staged %s for %s: %w", kind, opened.plan.result.Path, err),
+			file.Close(),
+			removeStagedFile(opened.parent, &staged),
 		)
 	}
 	if err := file.Sync(); err != nil {
-		_ = file.Close()
-		return "", errors.Join(
-			fmt.Errorf("sync staged %s for %s: %w", kind, plan.result.Path, err),
-			removeStagedFile(path),
+		return stagedFile{}, errors.Join(
+			fmt.Errorf("sync staged %s for %s: %w", kind, opened.plan.result.Path, err),
+			file.Close(),
+			removeStagedFile(opened.parent, &staged),
+		)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return stagedFile{}, errors.Join(
+			fmt.Errorf("stat staged %s for %s: %w", kind, opened.plan.result.Path, err),
+			file.Close(),
+			removeStagedFile(opened.parent, &staged),
 		)
 	}
 	if err := file.Close(); err != nil {
-		return "", errors.Join(
-			fmt.Errorf("close staged %s for %s: %w", kind, plan.result.Path, err),
-			removeStagedFile(path),
+		return stagedFile{}, errors.Join(
+			fmt.Errorf("close staged %s for %s: %w", kind, opened.plan.result.Path, err),
+			removeStagedFile(opened.parent, &staged),
 		)
 	}
-	return path, nil
+	staged.info = info
+	return staged, nil
 }
 
-func commitStagedPlans(staged []stagedPlan) error {
+func commitStagedPlans(staged []stagedPlan, afterCommit func()) error {
 	for i := range staged {
-		if err := validatePlanPath(staged[i].plan); err != nil {
-			return errors.Join(err, rollbackStagedPlans(staged[:i]))
-		}
-		if err := replaceFile(staged[i].cleanedPath, staged[i].plan.result.Path); err != nil {
+		if err := staged[i].opened.parent.Revalidate(); err != nil {
 			return errors.Join(
-				fmt.Errorf("commit cleaned Go source %s: %w", staged[i].plan.result.Path, err),
+				fmt.Errorf("revalidate Go source parent before cleanup %s: %w", staged[i].opened.plan.result.Path, err),
 				rollbackStagedPlans(staged[:i]),
 			)
 		}
-		staged[i].cleanedPath = ""
+		if err := validatePlanPath(staged[i].opened); err != nil {
+			return errors.Join(err, rollbackStagedPlans(staged[:i]))
+		}
+		committed, err := commitStagedFile(&staged[i], &staged[i].cleaned)
+		staged[i].committed = committed
+		if committed {
+			afterCommit()
+		}
+		if err != nil {
+			rollbackEnd := i
+			if committed {
+				rollbackEnd++
+			}
+			return errors.Join(
+				fmt.Errorf("commit cleaned Go source %s: %w", staged[i].opened.plan.result.Path, err),
+				rollbackStagedPlans(staged[:rollbackEnd]),
+			)
+		}
 	}
 	return nil
+}
+
+func commitStagedFile(plan *stagedPlan, staged *stagedFile) (bool, error) {
+	if err := plan.opened.parent.Revalidate(); err != nil {
+		return false, err
+	}
+	replaceErr := plan.opened.parent.PublishFile(
+		staged.name,
+		plan.opened.targetName,
+		staged.info,
+		plan.opened.plan.source.Mode(),
+	)
+	committed := replaceErr == nil || errors.Is(replaceErr, fsdurable.ErrReplacementCommitted)
+	if !committed {
+		return false, replaceErr
+	}
+	staged.name = ""
+	revalidateErr := plan.opened.parent.Revalidate()
+	return true, replacementCommittedError(errors.Join(replaceErr, revalidateErr))
+}
+
+func replacementCommittedError(err error) error {
+	if err == nil || errors.Is(err, fsdurable.ErrReplacementCommitted) {
+		return err
+	}
+	return fmt.Errorf("%w: %w", fsdurable.ErrReplacementCommitted, err)
 }
 
 func rollbackStagedPlans(staged []stagedPlan) error {
 	var rollbackErr error
 	for i := range slices.Backward(staged) {
-		if err := replaceFile(staged[i].backupPath, staged[i].plan.result.Path); err != nil {
+		if !staged[i].committed {
+			continue
+		}
+		if err := staged[i].opened.parent.Revalidate(); err != nil {
 			staged[i].preserveBackup = true
 			rollbackErr = errors.Join(
 				rollbackErr,
-				fmt.Errorf(
-					"restore Go source %s from %s: %w",
-					staged[i].plan.result.Path,
-					staged[i].backupPath,
-					err,
-				),
+				rollbackConflictError(&staged[i], err),
 			)
 			continue
 		}
-		staged[i].backupPath = ""
+		if err := validateCommittedPlan(&staged[i]); err != nil {
+			staged[i].preserveBackup = true
+			rollbackErr = errors.Join(
+				rollbackErr,
+				rollbackConflictError(&staged[i], err),
+			)
+			continue
+		}
+		committed, err := commitStagedFile(&staged[i], &staged[i].backup)
+		if committed {
+			staged[i].committed = false
+		}
+		if err == nil {
+			continue
+		}
+		if !committed {
+			staged[i].preserveBackup = true
+		}
+		rollbackErr = errors.Join(
+			rollbackErr,
+			fmt.Errorf(
+				"restore Go source %s from %s: %w",
+				staged[i].opened.plan.result.Path,
+				stagedFilePath(staged[i].opened.parent, &staged[i].backup),
+				err,
+			),
+		)
 	}
 	return rollbackErr
 }
 
+func validateCommittedPlan(staged *stagedPlan) error {
+	entryInfo, err := staged.opened.parent.Lstat(staged.opened.targetName)
+	if err != nil {
+		return err
+	}
+	if !entryInfo.Mode().IsRegular() ||
+		!os.SameFile(staged.cleaned.info, entryInfo) ||
+		entryInfo.Mode() != staged.opened.plan.source.Mode() {
+		return errors.New("committed cleaned source identity or mode changed")
+	}
+	file, err := staged.opened.parent.Open(staged.opened.targetName)
+	if err != nil {
+		return err
+	}
+	currentInfo, statErr := file.Stat()
+	openedEntryInfo, restatErr := staged.opened.parent.Lstat(staged.opened.targetName)
+	validationErr := errors.Join(statErr, restatErr)
+	if validationErr == nil &&
+		(!os.SameFile(staged.cleaned.info, currentInfo) ||
+			!os.SameFile(currentInfo, openedEntryInfo)) {
+		validationErr = errors.New("committed cleaned source identity changed")
+	}
+	if validationErr == nil {
+		validationErr = validatePlanContent(
+			file,
+			staged.opened.plan.after,
+			staged.opened.plan.result.Path,
+		)
+	}
+	finalInfo, finalStatErr := file.Stat()
+	finalEntryInfo, finalRestatErr := staged.opened.parent.Lstat(staged.opened.targetName)
+	validationErr = errors.Join(validationErr, finalStatErr, finalRestatErr)
+	if validationErr == nil &&
+		(!finalInfo.Mode().IsRegular() ||
+			finalInfo.Mode() != staged.opened.plan.source.Mode() ||
+			finalEntryInfo.Mode() != staged.opened.plan.source.Mode() ||
+			currentInfo.Size() != finalInfo.Size() ||
+			!currentInfo.ModTime().Equal(finalInfo.ModTime()) ||
+			!os.SameFile(currentInfo, finalInfo) ||
+			!os.SameFile(finalInfo, finalEntryInfo)) {
+		validationErr = errors.New("committed cleaned source changed during rollback validation")
+	}
+	return errors.Join(validationErr, file.Close())
+}
+
+func rollbackConflictError(staged *stagedPlan, cause error) error {
+	return fmt.Errorf(
+		"%w: refuse to restore %s because the committed cleaned source cannot be safely validated; preserved backup %s: %w",
+		ErrRollbackConflict,
+		staged.opened.plan.result.Path,
+		stagedFilePath(staged.opened.parent, &staged.backup),
+		cause,
+	)
+}
+
 func cleanupStagedPlans(staged []stagedPlan) error {
 	var cleanupErr error
-	for _, stagedFile := range staged {
-		cleanupErr = errors.Join(cleanupErr, removeStagedFile(stagedFile.cleanedPath))
-		if !stagedFile.preserveBackup {
-			cleanupErr = errors.Join(cleanupErr, removeStagedFile(stagedFile.backupPath))
+	for i := range staged {
+		cleanupErr = errors.Join(
+			cleanupErr,
+			removeStagedFile(staged[i].opened.parent, &staged[i].cleaned),
+		)
+		if staged[i].preserveBackup {
+			preserveErr := finalizePreservedBackup(&staged[i])
+			cleanupErr = errors.Join(cleanupErr, preserveErr)
+			continue
 		}
+		cleanupErr = errors.Join(
+			cleanupErr,
+			removeStagedFile(staged[i].opened.parent, &staged[i].backup),
+		)
 	}
 	return cleanupErr
 }
 
-func removeStagedFile(path string) error {
-	if path == "" {
-		return nil
-	}
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return fmt.Errorf("remove staged cleanup file %s: %w", path, err)
-	}
-	return nil
+func finalizePreservedBackup(staged *stagedPlan) error {
+	return wrapStagedFileError(
+		"finalize preserved cleanup backup",
+		staged.opened.parent,
+		&staged.backup,
+		staged.opened.parent.FinalizeFile(
+			staged.backup.name,
+			staged.backup.info,
+			staged.opened.plan.source.Mode(),
+		),
+	)
 }
 
-func closeFiles(files []*os.File) error {
+func removeStagedFile(parent *pathguard.OpenedDirectory, staged *stagedFile) error {
+	if staged.name == "" {
+		return nil
+	}
+	removeErr := parent.Remove(staged.name)
+	if errors.Is(removeErr, os.ErrNotExist) {
+		removeErr = nil
+	}
+	if removeErr == nil {
+		staged.name = ""
+	}
+	syncErr := error(nil)
+	if removeErr == nil {
+		syncErr = parent.Sync()
+	}
+	return errors.Join(
+		wrapStagedFileError("remove staged cleanup file", parent, staged, removeErr),
+		syncErr,
+	)
+}
+
+func wrapStagedFileError(
+	action string,
+	parent *pathguard.OpenedDirectory,
+	staged *stagedFile,
+	err error,
+) error {
+	if err == nil {
+		return nil
+	}
+	return fmt.Errorf("%s %s: %w", action, stagedFilePath(parent, staged), err)
+}
+
+func stagedFilePath(parent *pathguard.OpenedDirectory, staged *stagedFile) string {
+	if staged.name == "" {
+		return filepath.Join(parent.Path(), "<committed>")
+	}
+	if err := parent.Revalidate(); err != nil {
+		return fmt.Sprintf(
+			"entry %q in the originally opened directory %q (the current path no longer identifies that directory)",
+			staged.name,
+			parent.Path(),
+		)
+	}
+	return filepath.Join(parent.Path(), staged.name)
+}
+
+func closeOpenedPlans(opened []openedPlan) error {
 	var closeErr error
-	for _, file := range files {
-		if err := file.Close(); err != nil {
-			closeErr = errors.Join(closeErr, fmt.Errorf("close Go source %s: %w", file.Name(), err))
+	closed := make(map[*pathguard.OpenedDirectory]struct{})
+	for i := range opened {
+		if opened[i].parent == nil {
+			continue
+		}
+		parent := opened[i].parent
+		opened[i].parent = nil
+		if _, ok := closed[parent]; ok {
+			continue
+		}
+		closed[parent] = struct{}{}
+		if err := parent.Close(); err != nil {
+			closeErr = errors.Join(
+				closeErr,
+				fmt.Errorf("close Go source parent %s: %w", parent.Path(), err),
+			)
 		}
 	}
 	return closeErr

--- a/internal/goannotationcleanup/cleanup_ancestor_unix_internal_test.go
+++ b/internal/goannotationcleanup/cleanup_ancestor_unix_internal_test.go
@@ -1,0 +1,56 @@
+//go:build unix
+
+package goannotationcleanup
+
+// White-box testing required: this file replaces a source ancestor after the
+// unexported post-staging revalidation barrier to verify that cleanup aborts
+// without mutating either the selected or replacement directory.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/goannotationsource"
+	"github.com/stokaro/ptah/internal/pathguard"
+)
+
+func TestApplyPlans_FailurePath_AncestorSwapAbortsCleanup(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	sourceDir := filepath.Join(root, "models")
+	capturedDir := filepath.Join(root, "captured-models")
+	outsideDir := c.TempDir()
+	c.Assert(os.MkdirAll(sourceDir, 0o700), qt.IsNil)
+	sourcePath := filepath.Join(sourceDir, "model.go")
+	outsidePath := filepath.Join(outsideDir, "model.go")
+	sourceData := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	outsideData := []byte("package outside\n\ntype Outside struct{}\n")
+	c.Assert(os.WriteFile(sourcePath, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(outsidePath, outsideData, 0o600), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	plan, err := NewPlan(snapshot)
+	c.Assert(err, qt.IsNil)
+
+	err = applyPlans(plan.changes, applyHooks{
+		revalidate: func() error {
+			c.Assert(snapshot.Revalidate(), qt.IsNil)
+			c.Assert(os.Rename(sourceDir, capturedDir), qt.IsNil)
+			c.Assert(os.Symlink(outsideDir, sourceDir), qt.IsNil)
+			return nil
+		},
+		afterCommit: func() {},
+	})
+
+	c.Assert(err, qt.ErrorIs, pathguard.ErrDirectoryChanged)
+	assertInternalFileBytes(c, filepath.Join(capturedDir, "model.go"), sourceData)
+	assertInternalFileBytes(c, outsidePath, outsideData)
+	entries, err := os.ReadDir(capturedDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(internalEntryNames(entries), qt.DeepEquals, []string{"model.go"})
+}

--- a/internal/goannotationcleanup/cleanup_internal_test.go
+++ b/internal/goannotationcleanup/cleanup_internal_test.go
@@ -11,6 +11,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
@@ -63,9 +64,12 @@ func TestApplyPlans_FailurePath_RevalidatesCompleteSourceSetAfterStaging(t *test
 			plan, err := NewPlan(snapshot)
 			c.Assert(err, qt.IsNil)
 
-			err = applyPlans(plan.changes, func() error {
-				test.mutate(c, root, plainPath)
-				return snapshot.Revalidate()
+			err = applyPlans(plan.changes, applyHooks{
+				revalidate: func() error {
+					test.mutate(c, root, plainPath)
+					return snapshot.Revalidate()
+				},
+				afterCommit: func() {},
 			})
 
 			c.Assert(err, qt.ErrorIs, goannotationsource.ErrChanged)
@@ -76,6 +80,125 @@ func TestApplyPlans_FailurePath_RevalidatesCompleteSourceSetAfterStaging(t *test
 			c.Assert(internalEntryNames(entries), qt.DeepEquals, test.wantEntryNames)
 		})
 	}
+}
+
+func TestApplyPlans_FailurePath_PreservesConcurrentEditAndRecoveryBackup(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	firstPath := filepath.Join(root, "a.go")
+	secondPath := filepath.Join(root, "z.go")
+	firstOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"first\"\ntype First struct{}\n",
+	)
+	secondOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"second\"\ntype Second struct{}\n",
+	)
+	firstConcurrent := []byte("package models\n\ntype First struct{ Concurrent bool }\n")
+	secondConcurrent := []byte("package models\n\ntype Second struct{ Concurrent bool }\n")
+	c.Assert(os.WriteFile(firstPath, firstOriginal, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(secondPath, secondOriginal, 0o600), qt.IsNil)
+	c.Assert(os.Chmod(firstPath, 0o640), qt.IsNil)
+	c.Assert(os.Chmod(secondPath, 0o640), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	plan, err := NewPlan(snapshot)
+	c.Assert(err, qt.IsNil)
+
+	applyErr := applyPlans(plan.changes, applyHooks{
+		revalidate: snapshot.Revalidate,
+		afterCommit: func() {
+			c.Assert(os.WriteFile(firstPath, firstConcurrent, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(secondPath, secondConcurrent, 0o600), qt.IsNil)
+		},
+	})
+
+	c.Assert(applyErr, qt.ErrorIs, ErrRollbackConflict)
+	c.Assert(applyErr.Error(), qt.Contains, "preserved backup")
+	assertInternalFileBytes(c, firstPath, firstConcurrent)
+	assertInternalFileBytes(c, secondPath, secondConcurrent)
+	backups, err := filepath.Glob(filepath.Join(root, ".a.go.ptah-backup-*"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(backups, qt.HasLen, 1)
+	assertInternalFileBytes(c, backups[0], firstOriginal)
+	backupInfo, err := os.Stat(backups[0])
+	c.Assert(err, qt.IsNil)
+	c.Assert(backupInfo.Mode().Perm(), qt.Equals, plan.changes[0].source.Mode().Perm())
+	c.Assert(applyErr.Error(), qt.Contains, backups[0])
+	cleanedFiles, err := filepath.Glob(filepath.Join(root, ".*.ptah-cleaned-*"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(cleanedFiles, qt.HasLen, 0)
+}
+
+func TestApplyPlans_FailurePath_RollbackRestoresBytesAndMode(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	firstPath := filepath.Join(root, "a.go")
+	secondPath := filepath.Join(root, "z.go")
+	firstOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"first\"\ntype First struct{}\n",
+	)
+	secondOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"second\"\ntype Second struct{}\n",
+	)
+	secondConcurrent := []byte("package models\n\ntype Second struct{ Concurrent bool }\n")
+	c.Assert(os.WriteFile(firstPath, firstOriginal, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(secondPath, secondOriginal, 0o600), qt.IsNil)
+	c.Assert(os.Chmod(firstPath, 0o640), qt.IsNil)
+	c.Assert(os.Chmod(secondPath, 0o640), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	plan, err := NewPlan(snapshot)
+	c.Assert(err, qt.IsNil)
+
+	applyErr := applyPlans(plan.changes, applyHooks{
+		revalidate: snapshot.Revalidate,
+		afterCommit: func() {
+			c.Assert(os.WriteFile(secondPath, secondConcurrent, 0o600), qt.IsNil)
+		},
+	})
+
+	c.Assert(applyErr, qt.IsNotNil)
+	c.Assert(applyErr, qt.Not(qt.ErrorIs), ErrRollbackConflict)
+	assertInternalFileBytes(c, firstPath, firstOriginal)
+	assertInternalFileBytes(c, secondPath, secondConcurrent)
+	firstInfo, err := os.Stat(firstPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(firstInfo.Mode().Perm(), qt.Equals, plan.changes[0].source.Mode().Perm())
+	entries, err := os.ReadDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(internalEntryNames(entries), qt.DeepEquals, []string{"a.go", "z.go"})
+}
+
+func TestApplyPlans_FailurePath_RejectsReplacedStagedFile(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	sourcePath := filepath.Join(root, "model.go")
+	original := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	c.Assert(os.WriteFile(sourcePath, original, 0o600), qt.IsNil)
+	snapshot, err := goannotationsource.Capture(root)
+	c.Assert(err, qt.IsNil)
+	plan, err := NewPlan(snapshot)
+	c.Assert(err, qt.IsNil)
+
+	applyErr := applyPlans(plan.changes, applyHooks{
+		revalidate: func() error {
+			staged, err := filepath.Glob(filepath.Join(root, ".model.go.ptah-cleaned-*"))
+			c.Assert(err, qt.IsNil)
+			c.Assert(staged, qt.HasLen, 1)
+			c.Assert(os.Remove(staged[0]), qt.IsNil)
+			c.Assert(os.WriteFile(staged[0], []byte("attacker-controlled\n"), 0o600), qt.IsNil)
+			return snapshot.Revalidate()
+		},
+		afterCommit: func() {},
+	})
+
+	c.Assert(applyErr, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	assertInternalFileBytes(c, sourcePath, original)
+	entries, err := os.ReadDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(internalEntryNames(entries), qt.DeepEquals, []string{"model.go"})
 }
 
 func assertInternalFileBytes(c *qt.C, path string, want []byte) {

--- a/internal/goannotationcleanup/cleanup_test.go
+++ b/internal/goannotationcleanup/cleanup_test.go
@@ -57,7 +57,7 @@ type User struct {
 	c.Assert(string(content), qt.Not(qt.Contains), "ptah:embedded")
 	info, err := os.Stat(path)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o644))
+	assertFileMode(c, info.Mode(), 0o644)
 
 	plan, err = planDir(dir)
 	c.Assert(err, qt.IsNil)
@@ -83,6 +83,33 @@ func TestCleanDirPreservesUnrelatedFormattingByteForByte(t *testing.T) {
 	content, err := os.ReadFile(path)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Equals, expected)
+}
+
+func TestCleanDir_HappyPath_PreservesReadOnlyMode(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "model.go")
+	original := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	expected := []byte("package models\n\ntype User struct{}\n")
+	c.Assert(os.WriteFile(path, original, 0o600), qt.IsNil)
+	c.Assert(os.Chmod(path, 0o400), qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.Chmod(path, 0o600), qt.IsNil)
+	})
+	plan, err := planDir(dir)
+	c.Assert(err, qt.IsNil)
+
+	err = plan.Apply()
+
+	c.Assert(err, qt.IsNil)
+	content, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(content, qt.DeepEquals, expected)
+	info, err := os.Stat(path)
+	c.Assert(err, qt.IsNil)
+	assertFileMode(c, info.Mode(), 0o400)
 }
 
 func TestCleanDirDiffReportsDuplicateRemovedLinesByPosition(t *testing.T) {
@@ -230,10 +257,10 @@ func TestCleanDir_FailurePath_InvalidGoSourceIsNotModified(t *testing.T) {
 	c.Assert(string(invalidContent), qt.Equals, invalidOriginal)
 	validInfo, err := os.Stat(validPath)
 	c.Assert(err, qt.IsNil)
-	c.Assert(validInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, validInfo.Mode(), 0o640)
 	invalidInfo, err := os.Stat(invalidPath)
 	c.Assert(err, qt.IsNil)
-	c.Assert(invalidInfo.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, invalidInfo.Mode(), 0o640)
 }
 
 func TestPlanApply_FailurePath_PrevalidatesEverySourceBeforeWriting(t *testing.T) {
@@ -297,7 +324,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(string(content), qt.Equals, original)
 	info, err := os.Stat(path)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, info.Mode(), 0o640)
 
 	diffPlan, err := planDir(dir)
 
@@ -314,7 +341,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(string(content), qt.Equals, original)
 	info, err = os.Stat(path)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, info.Mode(), 0o640)
 
 	writePlan, err := planDir(dir)
 
@@ -331,7 +358,7 @@ func TestCleanDir_HappyPath_DryRunDiffAndWriteAreConsistentAndIdempotent(t *test
 	c.Assert(string(content), qt.Equals, expected)
 	info, err = os.Stat(path)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, info.Mode(), 0o640)
 
 	idempotentDryRunPlan, err := planDir(dir)
 	c.Assert(err, qt.IsNil)

--- a/internal/goannotationcleanup/mode_assert_unix_test.go
+++ b/internal/goannotationcleanup/mode_assert_unix_test.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package goannotationcleanup_test
+
+import (
+	"io/fs"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func assertFileMode(c *qt.C, got, want fs.FileMode) {
+	c.Helper()
+	c.Assert(got.Perm(), qt.Equals, want.Perm())
+}

--- a/internal/goannotationcleanup/mode_assert_windows_test.go
+++ b/internal/goannotationcleanup/mode_assert_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package goannotationcleanup_test
+
+import (
+	"io/fs"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func assertFileMode(c *qt.C, got, want fs.FileMode) {
+	c.Helper()
+	c.Assert(got.Perm()&0o200, qt.Equals, want.Perm()&0o200)
+}

--- a/internal/goannotationcleanup/replacefile_nonwindows.go
+++ b/internal/goannotationcleanup/replacefile_nonwindows.go
@@ -1,9 +1,0 @@
-//go:build !windows
-
-package goannotationcleanup
-
-import "os"
-
-func replaceFile(source, target string) error {
-	return os.Rename(source, target)
-}

--- a/internal/goannotationcleanup/replacefile_windows.go
+++ b/internal/goannotationcleanup/replacefile_windows.go
@@ -1,9 +1,0 @@
-//go:build windows
-
-package goannotationcleanup
-
-import "golang.org/x/sys/windows"
-
-func replaceFile(source, target string) error {
-	return windows.Rename(source, target)
-}

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -5,6 +5,8 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"slices"
@@ -14,6 +16,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/internal/atlashcl"
 	"github.com/stokaro/ptah/internal/atlashclrender"
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/internal/goannotationcleanup"
 	"github.com/stokaro/ptah/internal/goannotationsource"
 	"github.com/stokaro/ptah/internal/pathguard"
@@ -35,6 +38,9 @@ var (
 	// ErrOutputAliasesManagedData reports that the output aliases a managed-data
 	// source and would overwrite the referenced row data.
 	ErrOutputAliasesManagedData = errors.New("HCL output aliases a managed data file")
+	// ErrOutputChanged reports that another writer changed the HCL destination
+	// after Ptah staged its replacement.
+	ErrOutputChanged = errors.New("HCL output changed after staging")
 )
 
 // Options controls one Go-annotation-to-HCL export.
@@ -71,9 +77,20 @@ type renderedExport struct {
 	diagnostics []atlashclrender.Diagnostic
 }
 
+type outputState struct {
+	exists bool
+	info   fs.FileInfo
+	data   []byte
+}
+
 type stagedOutput struct {
 	outputPath string
-	tempPath   string
+	parent     *pathguard.OpenedDirectory
+	targetName string
+	tempName   string
+	tempInfo   fs.FileInfo
+	mode       os.FileMode
+	original   outputState
 }
 
 // Export renders Go annotations to HCL and optionally applies one validated
@@ -91,11 +108,7 @@ func export(opts Options, afterOutputStage func()) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	mode, err := outputMode(plan.outputPath, rendered.database.Roles)
-	if err != nil {
-		return Result{}, err
-	}
-	staged, err := stageOutput(plan.outputPath, rendered.hcl, mode)
+	staged, err := stageOutput(plan.outputPath, rendered.hcl, rendered.database.Roles)
 	if err != nil {
 		return Result{}, err
 	}
@@ -103,8 +116,18 @@ func export(opts Options, afterOutputStage func()) (Result, error) {
 	if err := plan.validatePublication(rendered.database.ManagedData); err != nil {
 		return Result{}, errors.Join(err, staged.cleanup())
 	}
+	if err := staged.validateDestination(); err != nil {
+		return Result{}, errors.Join(err, staged.cleanup())
+	}
 	if err := staged.commit(); err != nil {
 		return Result{}, errors.Join(err, staged.cleanup())
+	}
+	if err := staged.close(); err != nil {
+		return Result{}, fmt.Errorf(
+			"%w: close HCL output directory after commit: %w",
+			fsdurable.ErrReplacementCommitted,
+			err,
+		)
 	}
 	if err := plan.applyCleanup(); err != nil {
 		return Result{}, err
@@ -396,37 +419,54 @@ func hasRolePasswords(roles []goschema.Role) bool {
 	})
 }
 
-func stageOutput(path string, data []byte, mode os.FileMode) (stagedOutput, error) {
-	parent := filepath.Dir(path)
-	if err := os.MkdirAll(parent, 0o755); err != nil {
+func stageOutput(path string, data []byte, roles []goschema.Role) (stagedOutput, error) {
+	parentPath := filepath.Dir(path)
+	if err := os.MkdirAll(parentPath, 0o755); err != nil {
 		return stagedOutput{}, fmt.Errorf("create HCL output directory: %w", err)
 	}
-
-	file, err := os.CreateTemp(parent, "."+filepath.Base(path)+".tmp-*")
+	parent, err := pathguard.OpenDirectory(parentPath)
 	if err != nil {
-		return stagedOutput{}, fmt.Errorf("create temporary HCL output: %w", err)
+		return stagedOutput{}, fmt.Errorf("open HCL output directory: %w", err)
 	}
-	tempPath := file.Name()
-	staged := stagedOutput{outputPath: path, tempPath: tempPath}
-
-	if err := file.Chmod(mode); err != nil {
-		_ = file.Close()
+	targetName := filepath.Base(path)
+	original, mode, err := captureOutputState(parent, targetName, path, roles)
+	if err != nil {
+		return stagedOutput{}, errors.Join(err, parent.Close())
+	}
+	file, tempName, err := parent.CreateTemp("." + targetName + ".tmp-*")
+	if err != nil {
 		return stagedOutput{}, errors.Join(
-			fmt.Errorf("set temporary HCL output mode: %w", err),
-			staged.cleanup(),
+			fmt.Errorf("create temporary HCL output: %w", err),
+			parent.Close(),
 		)
 	}
+	staged := stagedOutput{
+		outputPath: path,
+		parent:     parent,
+		targetName: targetName,
+		tempName:   tempName,
+		mode:       mode,
+		original:   original,
+	}
 	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
 		return stagedOutput{}, errors.Join(
 			fmt.Errorf("write temporary HCL output: %w", err),
+			file.Close(),
 			staged.cleanup(),
 		)
 	}
 	if err := file.Sync(); err != nil {
-		_ = file.Close()
 		return stagedOutput{}, errors.Join(
 			fmt.Errorf("sync temporary HCL output: %w", err),
+			file.Close(),
+			staged.cleanup(),
+		)
+	}
+	info, err := file.Stat()
+	if err != nil {
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("stat temporary HCL output: %w", err),
+			file.Close(),
 			staged.cleanup(),
 		)
 	}
@@ -436,45 +476,193 @@ func stageOutput(path string, data []byte, mode os.FileMode) (stagedOutput, erro
 			staged.cleanup(),
 		)
 	}
+	staged.tempInfo = info
+	if err := parent.Sync(); err != nil {
+		return stagedOutput{}, errors.Join(
+			fmt.Errorf("sync temporary HCL output directory: %w", err),
+			staged.cleanup(),
+		)
+	}
 	return staged, nil
 }
 
-func (s *stagedOutput) commit() error {
-	if err := os.Rename(s.tempPath, s.outputPath); err != nil {
-		return fmt.Errorf("commit HCL output: %w", err)
+func captureOutputState(
+	parent *pathguard.OpenedDirectory,
+	targetName, outputPath string,
+	roles []goschema.Role,
+) (outputState, os.FileMode, error) {
+	info, data, err := readOutputFile(parent, targetName, outputPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return outputState{}, 0o600, nil
 	}
-	s.tempPath = ""
+	if err != nil {
+		return outputState{}, 0, err
+	}
+	mode := info.Mode().Perm()
+	if hasRolePasswords(roles) {
+		mode = 0o600
+	}
+	return outputState{exists: true, info: info, data: data}, mode, nil
+}
+
+func readOutputFile(
+	parent *pathguard.OpenedDirectory,
+	targetName, outputPath string,
+) (fs.FileInfo, []byte, error) {
+	entryInfo, err := parent.Lstat(targetName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("stat HCL output %s: %w", outputPath, err)
+	}
+	if !entryInfo.Mode().IsRegular() {
+		return nil, nil, fmt.Errorf("HCL output is not a regular file: %s", outputPath)
+	}
+	file, err := parent.Open(targetName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("open HCL output %s: %w", outputPath, err)
+	}
+	info, statErr := file.Stat()
+	openedEntryInfo, restatErr := parent.Lstat(targetName)
+	validationErr := errors.Join(statErr, restatErr)
+	if validationErr == nil {
+		validationErr = validateOpenedOutputFile(outputPath, entryInfo, info, openedEntryInfo)
+	}
+	var data []byte
+	readErr := error(nil)
+	if validationErr == nil {
+		data, readErr = io.ReadAll(file)
+	}
+	finalInfo, finalStatErr := file.Stat()
+	finalEntryInfo, finalRestatErr := parent.Lstat(targetName)
+	finalValidationErr := errors.Join(finalStatErr, finalRestatErr)
+	if finalValidationErr == nil && validationErr == nil {
+		finalValidationErr = validateReadOutputFile(outputPath, info, finalInfo, finalEntryInfo)
+	}
+	closeErr := file.Close()
+	if err := errors.Join(
+		validationErr,
+		readErr,
+		finalValidationErr,
+		closeErr,
+	); err != nil {
+		return nil, nil, err
+	}
+	return finalInfo, data, nil
+}
+
+func validateOpenedOutputFile(
+	outputPath string,
+	entryInfo, info, openedEntryInfo fs.FileInfo,
+) error {
+	if !info.Mode().IsRegular() ||
+		!openedEntryInfo.Mode().IsRegular() ||
+		!os.SameFile(entryInfo, info) ||
+		!os.SameFile(info, openedEntryInfo) {
+		return fmt.Errorf("%w: %s", ErrOutputChanged, outputPath)
+	}
 	return nil
+}
+
+func validateReadOutputFile(
+	outputPath string,
+	info, finalInfo, finalEntryInfo fs.FileInfo,
+) error {
+	if !finalInfo.Mode().IsRegular() ||
+		!finalEntryInfo.Mode().IsRegular() ||
+		info.Mode() != finalInfo.Mode() ||
+		finalInfo.Mode() != finalEntryInfo.Mode() ||
+		info.Size() != finalInfo.Size() ||
+		!info.ModTime().Equal(finalInfo.ModTime()) ||
+		!os.SameFile(info, finalInfo) ||
+		!os.SameFile(finalInfo, finalEntryInfo) {
+		return fmt.Errorf("%w: %s", ErrOutputChanged, outputPath)
+	}
+	return nil
+}
+
+func (s *stagedOutput) validateDestination() error {
+	if err := s.parent.Revalidate(); err != nil {
+		return fmt.Errorf("%w: revalidate output parent %s: %w", ErrOutputChanged, s.outputPath, err)
+	}
+	info, data, err := readOutputFile(s.parent, s.targetName, s.outputPath)
+	if !s.original.exists && errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", ErrOutputChanged, s.outputPath, err)
+	}
+	if !s.original.exists ||
+		!os.SameFile(s.original.info, info) ||
+		s.original.info.Mode() != info.Mode() ||
+		!bytes.Equal(s.original.data, data) {
+		return fmt.Errorf("%w: %s", ErrOutputChanged, s.outputPath)
+	}
+	return nil
+}
+
+func (s *stagedOutput) commit() error {
+	if err := s.validateDestination(); err != nil {
+		return err
+	}
+	if err := s.parent.Revalidate(); err != nil {
+		return fmt.Errorf(
+			"%w: revalidate output parent before commit: %w",
+			ErrOutputChanged,
+			err,
+		)
+	}
+	replaceErr := s.parent.PublishFile(s.tempName, s.targetName, s.tempInfo, s.mode)
+	committed := replaceErr == nil || errors.Is(replaceErr, fsdurable.ErrReplacementCommitted)
+	if !committed {
+		return fmt.Errorf("commit HCL output: %w", replaceErr)
+	}
+	s.tempName = ""
+	commitErr := errors.Join(replaceErr, s.parent.Revalidate())
+	if commitErr == nil {
+		return nil
+	}
+	if !errors.Is(commitErr, fsdurable.ErrReplacementCommitted) {
+		commitErr = fmt.Errorf("%w: %w", fsdurable.ErrReplacementCommitted, commitErr)
+	}
+	return fmt.Errorf("commit HCL output: %w", commitErr)
 }
 
 func (s *stagedOutput) cleanup() error {
-	if s.tempPath == "" {
-		return nil
+	removeErr := error(nil)
+	syncErr := error(nil)
+	if s.tempName != "" {
+		removeErr = s.parent.Remove(s.tempName)
+		if errors.Is(removeErr, os.ErrNotExist) {
+			removeErr = nil
+		}
+		if removeErr == nil {
+			s.tempName = ""
+			syncErr = s.parent.Sync()
+		}
 	}
-	err := os.Remove(s.tempPath)
-	if errors.Is(err, os.ErrNotExist) {
-		err = nil
-	}
-	if err != nil {
-		return fmt.Errorf("remove temporary HCL output: %w", err)
-	}
-	s.tempPath = ""
-	return nil
+	closeParentErr := s.closeParent()
+	return errors.Join(
+		wrapOutputError("remove temporary HCL output", removeErr),
+		wrapOutputError("sync HCL output directory", syncErr),
+		wrapOutputError("close HCL output directory", closeParentErr),
+	)
 }
 
-func outputMode(path string, roles []goschema.Role) (os.FileMode, error) {
-	info, err := os.Stat(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return 0o600, nil
+func (s *stagedOutput) close() error {
+	return wrapOutputError("close HCL output directory", s.closeParent())
+}
+
+func (s *stagedOutput) closeParent() error {
+	if s.parent == nil {
+		return nil
 	}
-	if err != nil {
-		return 0, fmt.Errorf("stat HCL output: %w", err)
+	err := s.parent.Close()
+	s.parent = nil
+	return err
+}
+
+func wrapOutputError(action string, err error) error {
+	if err == nil {
+		return nil
 	}
-	if !info.Mode().IsRegular() {
-		return 0, fmt.Errorf("HCL output is not a regular file: %s", path)
-	}
-	if hasRolePasswords(roles) {
-		return 0o600, nil
-	}
-	return info.Mode().Perm(), nil
+	return fmt.Errorf("%s: %w", action, err)
 }

--- a/internal/goannotationexport/export_ancestor_unix_internal_test.go
+++ b/internal/goannotationexport/export_ancestor_unix_internal_test.go
@@ -1,0 +1,51 @@
+//go:build unix
+
+package goannotationexport
+
+// White-box testing required: this file replaces the HCL output ancestor after
+// staging to verify that publication aborts without reporting a stale output
+// path or mutating either the selected or replacement directory.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestExport_FailurePath_AncestorSwapAbortsHCLPublication(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	source := filepath.Join(root, "model.go")
+	outputDir := filepath.Join(root, "output")
+	capturedDir := filepath.Join(root, "captured-output")
+	outsideDir := c.TempDir()
+	output := filepath.Join(outputDir, "schema.hcl")
+	outsideOutput := filepath.Join(outsideDir, "schema.hcl")
+	sourceData := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	previousOutput := []byte("previous schema\n")
+	outsideData := []byte("outside schema\n")
+	c.Assert(os.MkdirAll(outputDir, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, previousOutput, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(outsideOutput, outsideData, 0o600), qt.IsNil)
+	result, err := export(Options{
+		RootDir:    root,
+		OutputPath: output,
+	}, func() {
+		c.Assert(os.Rename(outputDir, capturedDir), qt.IsNil)
+		c.Assert(os.Symlink(outsideDir, outputDir), qt.IsNil)
+	})
+
+	c.Assert(err, qt.ErrorIs, ErrOutputChanged)
+	c.Assert(result, qt.DeepEquals, Result{})
+	assertExportInternalFileBytes(c, filepath.Join(capturedDir, "schema.hcl"), previousOutput)
+	assertExportInternalFileBytes(c, outsideOutput, outsideData)
+	assertExportInternalFileBytes(c, source, sourceData)
+	entries, err := os.ReadDir(capturedDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, []string{"schema.hcl"})
+}

--- a/internal/goannotationexport/export_internal_test.go
+++ b/internal/goannotationexport/export_internal_test.go
@@ -11,6 +11,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/internal/fsdurable"
 	"github.com/stokaro/ptah/internal/goannotationsource"
 )
 
@@ -93,6 +94,93 @@ func TestExport_FailurePath_RevalidatesSourcesAfterOutputStaging(t *testing.T) {
 			c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, test.wantEntryNames)
 		})
 	}
+}
+
+func TestExport_FailurePath_PreservesConcurrentOutputChangeAfterStaging(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		prepare func(c *qt.C, output string)
+	}{
+		{
+			name: "existing output edited",
+			prepare: func(c *qt.C, output string) {
+				c.Assert(os.WriteFile(output, []byte("previous schema\n"), 0o600), qt.IsNil)
+			},
+		},
+		{
+			name:    "missing output created",
+			prepare: func(*qt.C, string) {},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			sourceData := []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			)
+			concurrentOutput := []byte("concurrent schema\n")
+			c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+			test.prepare(c, output)
+
+			result, err := export(Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			}, func() {
+				c.Assert(os.WriteFile(output, concurrentOutput, 0o600), qt.IsNil)
+			})
+
+			c.Assert(err, qt.ErrorIs, ErrOutputChanged)
+			c.Assert(result, qt.DeepEquals, Result{})
+			assertExportInternalFileBytes(c, source, sourceData)
+			assertExportInternalFileBytes(c, output, concurrentOutput)
+			entries, err := os.ReadDir(root)
+			c.Assert(err, qt.IsNil)
+			c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, []string{
+				"model.go",
+				"schema.hcl",
+			})
+		})
+	}
+}
+
+func TestExport_FailurePath_RejectsReplacedStagedOutput(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	source := filepath.Join(root, "model.go")
+	output := filepath.Join(root, "schema.hcl")
+	sourceData := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	previousOutput := []byte("previous schema\n")
+	c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(output, previousOutput, 0o600), qt.IsNil)
+
+	result, err := export(Options{
+		RootDir:    root,
+		OutputPath: output,
+		Cleanup:    true,
+	}, func() {
+		staged, err := filepath.Glob(filepath.Join(root, ".schema.hcl.tmp-*"))
+		c.Assert(err, qt.IsNil)
+		c.Assert(staged, qt.HasLen, 1)
+		c.Assert(os.Remove(staged[0]), qt.IsNil)
+		c.Assert(os.WriteFile(staged[0], []byte("attacker-controlled\n"), 0o600), qt.IsNil)
+	})
+
+	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
+	c.Assert(result, qt.DeepEquals, Result{})
+	assertExportInternalFileBytes(c, source, sourceData)
+	assertExportInternalFileBytes(c, output, previousOutput)
+	entries, err := os.ReadDir(root)
+	c.Assert(err, qt.IsNil)
+	c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, []string{
+		"model.go",
+		"schema.hcl",
+	})
 }
 
 func assertExportInternalFileBytes(c *qt.C, path string, want []byte) {

--- a/internal/goannotationexport/export_test.go
+++ b/internal/goannotationexport/export_test.go
@@ -47,7 +47,7 @@ func TestExport_HappyPath_WritesValidatedHCLAndCleansAnnotations(t *testing.T) {
 	c.Assert(parsed.Fields, qt.HasLen, 1)
 	info, err := os.Stat(output)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o640))
+	assertFileMode(c, info.Mode(), 0o640)
 }
 
 func TestExport_HappyPath_UsesOneSourcePolicyForParsingAndCleanup(t *testing.T) {
@@ -116,7 +116,7 @@ func TestExport_HappyPath_TightensPermissionsForRolePasswords(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	info, err := os.Stat(output)
 	c.Assert(err, qt.IsNil)
-	c.Assert(info.Mode().Perm(), qt.Equals, os.FileMode(0o600))
+	assertFileMode(c, info.Mode(), 0o600)
 	content, err := os.ReadFile(output)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(content), qt.Contains, `password = "SCRAM-SHA-256$fixture"`)

--- a/internal/goannotationexport/mode_assert_unix_test.go
+++ b/internal/goannotationexport/mode_assert_unix_test.go
@@ -1,0 +1,14 @@
+//go:build unix
+
+package goannotationexport_test
+
+import (
+	"io/fs"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func assertFileMode(c *qt.C, got, want fs.FileMode) {
+	c.Helper()
+	c.Assert(got.Perm(), qt.Equals, want.Perm())
+}

--- a/internal/goannotationexport/mode_assert_windows_test.go
+++ b/internal/goannotationexport/mode_assert_windows_test.go
@@ -1,0 +1,14 @@
+//go:build windows
+
+package goannotationexport_test
+
+import (
+	"io/fs"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func assertFileMode(c *qt.C, got, want fs.FileMode) {
+	c.Helper()
+	c.Assert(got.Perm()&0o200, qt.Equals, want.Perm()&0o200)
+}

--- a/internal/goannotationexport/parity_test.go
+++ b/internal/goannotationexport/parity_test.go
@@ -16,7 +16,12 @@ import (
 func TestExport_HappyPath_PreservesGoAnnotationSemantics(t *testing.T) {
 	c := qt.New(t)
 	root := filepath.Join("testdata", "parity")
-	output := filepath.Join(t.TempDir(), "schema.hcl")
+	outputDir, err := os.MkdirTemp(filepath.Dir(root), ".parity-export-*")
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(os.RemoveAll(outputDir), qt.IsNil)
+	})
+	output := filepath.Join(outputDir, "schema.hcl")
 	before, err := goschema.ParseDir(root)
 	c.Assert(err, qt.IsNil)
 


### PR DESCRIPTION
## Summary

- publish HCL output and cleanup replacements through rooted, identity-bound durable primitives
- revalidate output/source parents and complete file snapshots at commit and rollback barriers
- preserve recovery backups instead of overwriting a changed cleaned source
- close staged/source descriptors before commit and deduplicate rooted parent handles
- expose post-commit state through fsdurable.ErrReplacementCommitted
- run the annotation publication consumers on the native Windows CI runner

## Transaction behavior

HCL publication records the existing destination state, rejects changes observed at the final commit barrier, applies the final mode before publication, and completes durable file and parent synchronization before source cleanup starts.

Cleanup stages both cleaned and original bytes. Rollback restores an original only when the committed target still has the staged cleaned identity, mode, metadata, and bytes. Otherwise it leaves the target untouched, finalizes the backup, and reports ErrRollbackConflict with its recovery location.

Portable validate-then-replace cannot provide an atomic compare-and-swap against an uncooperative writer acting after the final barrier. The documentation now states that boundary explicitly; #948 owns a platform-aware conditional publication primitive.

## Tests

- go test -race -count=10 ./internal/goannotationcleanup ./internal/goannotationexport
- go test -race ./...
- go tool qtlint ./...
- scripts/check-test-style.sh
- golangci-lint run ./...
- Windows cross-compilation for both changed packages
- scripts/check-hcl-export-acceptance.sh with a freshly built ptah
- complete docs link, redirect, page-health, exit-code, style, versions, build, responsive, and npm audit suite

## Documentation impact

Checked README.md, docs/README.md, docs/*.md, the schema-source site pages, examples, integration docs, and package READMEs. The canonical Go-annotations how-to is the only reader-facing page that describes this one-time cleanup transaction, so it is the only page changed. No page was added, moved, split, merged, or retired; CONTENT_INVENTORY.md is unchanged.

Closes #900.
