### PR TITLE
Support the Atlas HCL data external_schema project data source

### DIFF
--- a/cmd/atlas/external_schema_source_test.go
+++ b/cmd/atlas/external_schema_source_test.go
@@ -1,0 +1,278 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/dbschema"
+)
+
+// seedSQLiteDBAt creates a SQLite database with the given DDL at path.
+func seedSQLiteDBAt(t *testing.T, path, ddl string) {
+	t.Helper()
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+path)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(context.Background(), ddl)
+	c.Assert(err, qt.IsNil)
+}
+
+// externalSchemaHelperModes maps a mode name to the behavior the re-executed
+// test binary performs when it stands in for an atlas.hcl data.external_schema
+// program.
+var externalSchemaHelperModes = map[string]func(){
+	"sql": func() {
+		fmt.Fprint(os.Stdout, "CREATE TABLE ext_users (\n  id INTEGER PRIMARY KEY,\n  email TEXT NOT NULL\n);\n")
+		os.Exit(0)
+	},
+	"fail": func() {
+		fmt.Fprintln(os.Stderr, "external loader blew up")
+		os.Exit(3)
+	},
+	"empty": func() {
+		os.Exit(0)
+	},
+}
+
+// TestExternalSchemaHelperProcess is not a real test; the tests below
+// re-execute this binary with -test.run=TestExternalSchemaHelperProcess to act
+// as the atlas.hcl-declared external schema program.
+func TestExternalSchemaHelperProcess(t *testing.T) {
+	runExternalSchemaHelperProcess()
+}
+
+func runExternalSchemaHelperProcess() {
+	if os.Getenv("GO_WANT_ATLAS_EXTERNAL_HELPER") != "1" {
+		return
+	}
+	emit, ok := externalSchemaHelperModes[os.Getenv("ATLAS_EXTERNAL_HELPER_MODE")]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "unknown helper mode")
+		os.Exit(1)
+	}
+	emit()
+}
+
+// writeExternalSchemaAtlasHCL writes an atlas.hcl declaring a
+// data.external_schema source backed by this test binary and returns the
+// config path.
+func writeExternalSchemaAtlasHCL(t *testing.T, mode string) string {
+	t.Helper()
+	c := qt.New(t)
+	baseDir := t.TempDir()
+	configPath := filepath.Join(baseDir, "atlas.hcl")
+	config := fmt.Sprintf(`data "external_schema" "app" {
+  program = [%s, "-test.run=TestExternalSchemaHelperProcess"]
+  env     = ["GO_WANT_ATLAS_EXTERNAL_HELPER=1", "ATLAS_EXTERNAL_HELPER_MODE=%s", "GORACE=atexit_sleep_ms=0"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`, strconv.Quote(os.Args[0]), mode)
+	c.Assert(os.WriteFile(configPath, []byte(config), 0o600), qt.IsNil) //nolint:gosec // controlled test-only path
+	return configPath
+}
+
+func runCompatCommand(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+func TestSchemaDiffExternalSchemaSource(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+	seedSQLiteDBAt(t, targetPath, "CREATE TABLE existing (id INTEGER PRIMARY KEY)")
+
+	out, err := runCompatCommand(t,
+		"schema", "diff",
+		"--from", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "CREATE TABLE")
+	c.Assert(out, qt.Contains, "ext_users")
+}
+
+func TestSchemaDiffExternalSchemaGate_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+	seedSQLiteDBAt(t, targetPath, "CREATE TABLE existing (id INTEGER PRIMARY KEY)")
+
+	_, err := runCompatCommand(t,
+		"schema", "diff",
+		"--from", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "atlas.hcl data.external_schema executes a repository-controlled program and is disabled by default")
+	c.Assert(err.Error(), qt.Contains, "PTAH_ALLOW_EXTERNAL_SCHEMA=1")
+}
+
+func TestSchemaApplyExternalSchemaSourceDryRun(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+
+	out, err := runCompatCommand(t,
+		"schema", "apply",
+		"--url", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+		"--dry-run",
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "CREATE TABLE")
+	c.Assert(out, qt.Contains, "ext_users")
+	c.Assert(sqliteHasTable(t, targetPath, "ext_users"), qt.IsFalse)
+}
+
+func TestSchemaApplyExternalSchemaSourceApplies(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+
+	out, err := runCompatCommand(t,
+		"schema", "apply",
+		"--url", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(sqliteHasTable(t, targetPath, "ext_users"), qt.IsTrue)
+}
+
+func TestSchemaInspectExternalSchemaSource(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	devPath := filepath.Join(t.TempDir(), "dev.db")
+
+	out, err := runCompatCommand(t,
+		"schema", "inspect",
+		"--url", "env://src",
+		"--dev-url", "sqlite://"+devPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "ext_users")
+}
+
+func TestMigrateDiffExternalSchemaSource(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+	devPath := filepath.Join(t.TempDir(), "dev.db")
+	migrationsDir := filepath.Join(t.TempDir(), "migrations")
+
+	out, err := runCompatCommand(t,
+		"migrate", "diff", "add_ext_users",
+		"--config", "file://"+configPath,
+		"--env", "dev",
+		"--dev-url", "sqlite://"+devPath,
+		"--dir", "file://"+migrationsDir,
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "CREATE TABLE")
+	c.Assert(out, qt.Contains, "ext_users")
+}
+
+func TestSchemaPlanExternalSchemaSource_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+
+	_, err := runCompatCommand(t,
+		"schema", "plan",
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "atlas schema plan does not support atlas.hcl data.external_schema desired state yet; pass --to explicitly")
+}
+
+func TestSchemaTestExternalSchemaSource_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "sql")
+
+	_, err := runCompatCommand(t,
+		"schema", "test",
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "atlas schema test does not support atlas.hcl data.external_schema desired state yet; pass --url explicitly")
+}
+
+func TestSchemaDiffExternalSchemaProgramFailure(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "fail")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+	seedSQLiteDBAt(t, targetPath, "CREATE TABLE existing (id INTEGER PRIMARY KEY)")
+
+	_, err := runCompatCommand(t,
+		"schema", "diff",
+		"--from", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "external loader blew up")
+}
+
+func TestSchemaDiffExternalSchemaEmptyOutput(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "1")
+	configPath := writeExternalSchemaAtlasHCL(t, "empty")
+	targetPath := filepath.Join(t.TempDir(), "target.db")
+	seedSQLiteDBAt(t, targetPath, "CREATE TABLE existing (id INTEGER PRIMARY KEY)")
+
+	_, err := runCompatCommand(t,
+		"schema", "diff",
+		"--from", "sqlite://"+targetPath,
+		"--config", "file://"+configPath,
+		"--env", "dev",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "produced empty output")
+}

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -132,7 +132,8 @@ func runAtlasMigrateDiff(
 			return cmdutil.Fail(cmd, err)
 		}
 	}
-	if loaded && !cmd.Flags().Changed("to") && len(projectCfg.SchemaSources) > 0 {
+	if loaded && !cmd.Flags().Changed("to") &&
+		(len(projectCfg.SchemaSources) > 0 || atlasExternalSchemaConfigured(projectCfg)) {
 		opts.toURLs = []string{"env://src"}
 	}
 	desired, err := prepareAtlasMigrateDiffSource(opts, projectEnv)

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -709,6 +709,13 @@ func applyAtlasSchemaTestProjectConfig(
 	if atlasFlagValueSet(flags, args, "url") {
 		return args, nil
 	}
+	// The schema test verb consumes a single local schema file as --url; an
+	// external schema program has no file spelling to map onto it.
+	if atlasExternalSchemaConfigured(cfg) {
+		return nil, fmt.Errorf(
+			"atlas schema test does not support atlas.hcl data.external_schema desired state yet; pass --url explicitly",
+		)
+	}
 	sources := cfg.SchemaSourcesValue()
 	if !sources.Present {
 		return args, nil
@@ -724,6 +731,15 @@ func applyAtlasSchemaTestProjectConfig(
 		return nil, fmt.Errorf("atlas.hcl schema.src: %w", err)
 	}
 	return append(args, "--url", urls[0]), nil
+}
+
+// atlasExternalSchemaConfigured reports whether the loaded atlas.hcl env's
+// desired state is a data.external_schema program. The parser consumed the
+// data source marker into ExternalSchema and cleared the schema sources, so
+// commands spell the desired state as env://src and let the source resolver
+// expand (and gate) the program.
+func atlasExternalSchemaConfigured(cfg projectconfig.Config) bool {
+	return len(cfg.ExternalSchema.Program) > 0
 }
 
 func atlasProjectLatest(cfg projectconfig.Config) projectconfig.Value[string] {

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -153,6 +153,10 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
 		}
 	}
+	if loaded && !cmd.Flags().Changed("to") && !cmd.Flags().Changed(atlasFileFlagName) &&
+		atlasExternalSchemaConfigured(projectCfg) {
+		opts.toURLs = []string{"env://src"}
+	}
 	if cmd.Flags().Changed(atlasFileFlagName) {
 		opts.toURLs = opts.filePaths
 	}

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -100,6 +100,9 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
 		}
 	}
+	if loaded && !cmd.Flags().Changed("to") && atlasExternalSchemaConfigured(projectCfg) {
+		opts.toURLs = []string{"env://src"}
+	}
 	if formatConfigured && strings.TrimSpace(opts.format) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
 	}

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -123,6 +123,13 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 			return cmdutil.Fail(cmd, fmt.Errorf("atlas.hcl schema.src: %w", err))
 		}
 	}
+	// Schema plan resolves local schema files only (LocalFilesOnly), so an env
+	// whose desired state is an external schema program cannot feed it yet.
+	if loaded && !cmd.Flags().Changed("to") && atlasExternalSchemaConfigured(projectCfg) {
+		return cmdutil.Fail(cmd, fmt.Errorf(
+			"atlas schema plan does not support atlas.hcl data.external_schema desired state yet; pass --to explicitly",
+		))
+	}
 	if err := validateAtlasSchemaPlanOptions(cmd, opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -49,7 +49,8 @@ func NewGenerateCommand() *cobra.Command {
 By default, this command scans the directory recursively for Go files with migrator directives.
 When --schema-file is set, it reads a language-agnostic YAML schema, HCL
 schema, or SQL schema file instead. An external program configured with
---schema-cmd or ptah.yaml external_schema can provide the desired schema too.`,
+--schema-cmd, ptah.yaml external_schema, or an atlas.hcl data.external_schema
+source can provide the desired schema too.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return generateCommand(cmd, &opts)
 		},

--- a/cmd/generate/generate_atlas_external_test.go
+++ b/cmd/generate/generate_atlas_external_test.go
@@ -1,0 +1,66 @@
+package generate_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/generate"
+)
+
+// writeExternalSchemaAtlasConfig writes an atlas.hcl declaring a
+// data.external_schema source backed by this test binary into dir.
+func writeExternalSchemaAtlasConfig(t *testing.T, dir string) {
+	t.Helper()
+	c := qt.New(t)
+	config := fmt.Sprintf(`data "external_schema" "app" {
+  program = [%s, "-test.run=TestGenerateHelperProcess"]
+  format  = "yaml"
+  env     = ["GO_WANT_GENERATE_HELPER_PROCESS=1"]
+}
+
+env "verified" {
+  src = data.external_schema.app.url
+}
+`, strconv.Quote(os.Args[0]))
+	// The config path is rooted in t.TempDir and not influenced by production input.
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(config), 0o600), qt.IsNil) //nolint:gosec // controlled test-only path
+}
+
+func TestGenerateCommand_UsesExternalSchemaFromAtlasConfigEnv(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeExternalSchemaAtlasConfig(t, dir)
+	t.Chdir(dir)
+
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{
+		"--env", "verified",
+		"--allow-external-schema",
+		"--dialect", "postgres",
+	})
+
+	output, err := captureGenerateStdout(c, cmd.Execute)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(output, qt.Contains, "Found 1 tables")
+	c.Assert(output, qt.Contains, `CREATE TABLE "configured_widgets"`)
+}
+
+func TestGenerateCommand_RejectsImplicitExternalSchemaFromAtlasConfig(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeExternalSchemaAtlasConfig(t, dir)
+	t.Chdir(dir)
+
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--env", "verified", "--dialect", "postgres"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, "atlas.hcl data.external_schema is disabled by default; pass --allow-external-schema to execute it")
+}

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -18,7 +18,8 @@ const (
 	// EnvFlagName selects an env block from project config.
 	EnvFlagName = "env"
 	// AllowExternalSchemaFlagName explicitly permits executing the
-	// external_schema program loaded from ptah.yaml.
+	// external_schema program loaded from ptah.yaml or from an atlas.hcl
+	// data.external_schema source.
 	AllowExternalSchemaFlagName = "allow-external-schema"
 	// AtlasProjectConfigFlagName passes an Atlas project config path through
 	// internal command adapters without exposing Atlas flags on native commands.
@@ -52,13 +53,14 @@ func RegisterEnvFlag(flags *pflag.FlagSet, target *string) {
 }
 
 // RegisterExternalSchemaOptInFlag registers the safety gate for executing an
-// external_schema program loaded from ptah.yaml. An explicit --schema-cmd does
-// not require this flag because supplying the command is already an opt-in.
+// external_schema program loaded from ptah.yaml or atlas.hcl. An explicit
+// --schema-cmd does not require this flag because supplying the command is
+// already an opt-in.
 func RegisterExternalSchemaOptInFlag(flags *pflag.FlagSet) {
 	flags.Bool(
 		AllowExternalSchemaFlagName,
 		false,
-		"Allow executing the external_schema program configured in ptah.yaml",
+		"Allow executing the external_schema program configured in ptah.yaml or atlas.hcl",
 	)
 }
 
@@ -144,8 +146,9 @@ func JoinSchemasValue(value projectconfig.Value[[]string]) projectconfig.Value[s
 
 // ResolveExternalSchemaCommands resolves the external-command schema source for
 // a command, preferring an explicit --schema-cmd. A ptah.yaml external_schema
-// block requires --allow-external-schema because the conventional config file
-// is auto-discovered and executing repository-controlled code must be explicit.
+// block or an atlas.hcl data.external_schema source requires
+// --allow-external-schema because the conventional config files are
+// auto-discovered and executing repository-controlled code must be explicit.
 func ResolveExternalSchemaCommands(
 	cmd *cobra.Command,
 	schemaCmd string,
@@ -167,7 +170,8 @@ func ResolveExternalSchemaCommands(
 	}
 	if !allowed {
 		return nil, fmt.Errorf(
-			"ptah.yaml external_schema is disabled by default; pass --%s to execute it",
+			"%s is disabled by default; pass --%s to execute it",
+			externalSchemaSourceLabel(cfg.ExternalSchema.Origin),
 			AllowExternalSchemaFlagName,
 		)
 	}
@@ -177,6 +181,16 @@ func ResolveExternalSchemaCommands(
 		cfg.ExternalSchema.WorkingDir,
 		cfg.ExternalSchema.Env,
 	)
+}
+
+// externalSchemaSourceLabel names the config construct that supplied the
+// external schema program, so the safety-gate error points the user at the
+// file they need to review before opting in.
+func externalSchemaSourceLabel(origin string) string {
+	if origin == projectconfig.AtlasFileName {
+		return "atlas.hcl data.external_schema"
+	}
+	return "ptah.yaml external_schema"
 }
 
 func externalSchemaCommandsFromCLI(commandLine, format string) []schemasource.Command {

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -350,6 +350,44 @@ func TestExternalSchemaCommandsRejectsImplicitConfigExecution(t *testing.T) {
 	c.Assert(commands, qt.IsNil)
 }
 
+func TestExternalSchemaCommandsRejectsImplicitAtlasConfigExecution(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	dbcli.RegisterExternalSchemaOptInFlag(cmd.Flags())
+	cfg := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program: []string{"config-loader"},
+			Origin:  projectconfig.AtlasFileName,
+		},
+	}
+
+	commands, err := dbcli.ResolveExternalSchemaCommands(cmd, "", "sql", cfg)
+
+	c.Assert(err, qt.ErrorMatches, "atlas.hcl data.external_schema is disabled by default; pass --allow-external-schema to execute it")
+	c.Assert(commands, qt.IsNil)
+}
+
+func TestExternalSchemaCommandsAllowsAtlasConfigWithOptIn(t *testing.T) {
+	c := qt.New(t)
+	cmd := &cobra.Command{Use: "test"}
+	dbcli.RegisterExternalSchemaOptInFlag(cmd.Flags())
+	c.Assert(cmd.Flags().Set(dbcli.AllowExternalSchemaFlagName, "true"), qt.IsNil)
+	cfg := projectconfig.Config{
+		ExternalSchema: projectconfig.ExternalSchemaConfig{
+			Program: []string{"config-loader", "--dialect", "sqlite"},
+			Format:  "sql",
+			Origin:  projectconfig.AtlasFileName,
+		},
+	}
+
+	commands, err := dbcli.ResolveExternalSchemaCommands(cmd, "", "sql", cfg)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(commands, qt.HasLen, 1)
+	c.Assert(commands[0].Args, qt.DeepEquals, []string{"config-loader", "--dialect", "sqlite"})
+	c.Assert(commands[0].Format, qt.Equals, "sql")
+}
+
 func TestExternalSchemaCommandsNilWhenNeitherSet(t *testing.T) {
 	c := qt.New(t)
 	cmd := &cobra.Command{Use: "test"}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -105,7 +105,7 @@ func ParseAtlasFSWithOptions(
 		return Config{}, fmt.Errorf("parse atlas project config: unsupported body type %T", file.Body)
 	}
 
-	p, err := newAtlasParser(fsys, opts.Vars)
+	p, err := newAtlasParser(fsys, opts.Vars, filename)
 	if err != nil {
 		return Config{}, err
 	}
@@ -115,9 +115,16 @@ func ParseAtlasFSWithOptions(
 type atlasParser struct {
 	ctx         *hcl.EvalContext
 	varOverride map[string]cty.Value
+	// baseDir is the directory that contains the parsed atlas.hcl file, as
+	// spelled by the caller. Relative data.external_schema working_dir values
+	// resolve against it so the configured program runs where the config file
+	// lives, matching how other atlas.hcl relative paths behave.
+	baseDir string
+	// externalSchemas holds the declared data.external_schema sources by name.
+	externalSchemas map[string]externalSchemaDataSource
 }
 
-func newAtlasParser(fsys fs.FS, rawVars []string) (atlasParser, error) {
+func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser, error) {
 	overrides, err := parseAtlasVarOverrides(rawVars)
 	if err != nil {
 		return atlasParser{}, err
@@ -133,7 +140,9 @@ func newAtlasParser(fsys fs.FS, rawVars []string) (atlasParser, error) {
 				"jsonencode": stdlib.JSONEncodeFunc,
 			},
 		},
-		varOverride: overrides,
+		varOverride:     overrides,
+		baseDir:         filepath.Dir(filename),
+		externalSchemas: map[string]externalSchemaDataSource{},
 	}, nil
 }
 
@@ -171,7 +180,11 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 	if err != nil {
 		return Config{}, err
 	}
-	return Merge(base, cfg), nil
+	merged := Merge(base, cfg)
+	if err := p.resolveExternalSchemaMarkers(&merged); err != nil {
+		return Config{}, err
+	}
+	return merged, nil
 }
 
 type atlasTopBlocks struct {
@@ -1007,29 +1020,281 @@ func (p atlasParser) evaluateLocals(locals map[string]cty.Value, pending hclsynt
 
 func (p atlasParser) configureDataSources(blocks []*hclsyntax.Block) error {
 	hclSchemas := map[string]cty.Value{}
+	externalSchemas := map[string]cty.Value{}
 	for _, block := range blocks {
 		if len(block.Labels) != 2 {
 			return unsupportedBlock(block)
 		}
-		if block.Labels[0] != "hcl_schema" {
+		switch block.Labels[0] {
+		case "hcl_schema":
+			if err := p.configureHCLSchemaDataSource(block, hclSchemas); err != nil {
+				return err
+			}
+		case "external_schema":
+			if err := p.configureExternalSchemaDataSource(block, externalSchemas); err != nil {
+				return err
+			}
+		default:
 			return unsupported(block.Type+"."+block.Labels[0], block.TypeRange)
 		}
-		name := block.Labels[1]
-		if _, ok := hclSchemas[name]; ok {
-			return fmt.Errorf("duplicate atlas.hcl data.hcl_schema %q at %s:%d", name, block.TypeRange.Filename, block.TypeRange.Start.Line)
+	}
+	data := map[string]cty.Value{}
+	if len(hclSchemas) > 0 {
+		data["hcl_schema"] = cty.ObjectVal(hclSchemas)
+	}
+	if len(externalSchemas) > 0 {
+		data["external_schema"] = cty.ObjectVal(externalSchemas)
+	}
+	if len(data) > 0 {
+		p.ctx.Variables["data"] = cty.ObjectVal(data)
+	}
+	return nil
+}
+
+func (p atlasParser) configureHCLSchemaDataSource(
+	block *hclsyntax.Block,
+	values map[string]cty.Value,
+) error {
+	name := block.Labels[1]
+	if _, ok := values[name]; ok {
+		return fmt.Errorf("duplicate atlas.hcl data.hcl_schema %q at %s:%d", name, block.TypeRange.Filename, block.TypeRange.Start.Line)
+	}
+	value, err := p.hclSchemaDataSource(block)
+	if err != nil {
+		return err
+	}
+	values[name] = value
+	return nil
+}
+
+// externalSchemaMarkerScheme prefixes the opaque data.external_schema.<name>.url
+// value. It is a Ptah-internal marker, never a runnable location: the scheme is
+// reserved (Classify and the schema-file loaders reject it), so a
+// user-provided URL cannot collide with a declared data source.
+const externalSchemaMarkerScheme = "ptah-external-schema://"
+
+// externalSchemaMarkerName reports whether value is a data.external_schema
+// marker URL and returns the declared data source name it references.
+func externalSchemaMarkerName(value string) (string, bool) {
+	return strings.CutPrefix(value, externalSchemaMarkerScheme)
+}
+
+// externalSchemaDataSource is one declared data.external_schema source. It
+// mirrors ExternalSchemaConfig: program is an explicit argv list run without a
+// shell, format is the stdout format, working_dir is the program's working
+// directory, and env holds extra KEY=VALUE entries.
+type externalSchemaDataSource struct {
+	program    []string
+	format     string
+	workingDir string
+	env        []string
+}
+
+func (p atlasParser) configureExternalSchemaDataSource(
+	block *hclsyntax.Block,
+	values map[string]cty.Value,
+) error {
+	name := block.Labels[1]
+	if _, ok := p.externalSchemas[name]; ok {
+		return fmt.Errorf("duplicate atlas.hcl data.external_schema %q at %s:%d", name, block.TypeRange.Filename, block.TypeRange.Start.Line)
+	}
+	source, err := p.externalSchemaDataSource(block)
+	if err != nil {
+		return err
+	}
+	p.externalSchemas[name] = source
+	values[name] = cty.ObjectVal(map[string]cty.Value{
+		"url": cty.StringVal(externalSchemaMarkerScheme + name),
+	})
+	return nil
+}
+
+func (p atlasParser) externalSchemaDataSource(block *hclsyntax.Block) (externalSchemaDataSource, error) {
+	if len(block.Body.Blocks) > 0 {
+		return externalSchemaDataSource{}, unsupportedBlock(block.Body.Blocks[0])
+	}
+	name := block.Labels[1]
+	source := externalSchemaDataSource{format: "sql"}
+	for attrName, attr := range block.Body.Attributes {
+		if err := p.parseExternalSchemaAttr(name, attrName, attr, &source); err != nil {
+			return externalSchemaDataSource{}, err
 		}
-		value, err := p.hclSchemaDataSource(block)
+	}
+	if len(source.program) == 0 {
+		return externalSchemaDataSource{}, fmt.Errorf(
+			"atlas.hcl data.external_schema %q requires a non-empty program list at %s:%d",
+			name, block.TypeRange.Filename, block.TypeRange.Start.Line,
+		)
+	}
+	return source, nil
+}
+
+func (p atlasParser) parseExternalSchemaAttr(
+	name string,
+	attrName string,
+	attr *hclsyntax.Attribute,
+	source *externalSchemaDataSource,
+) error {
+	switch attrName {
+	case "program":
+		values, err := p.stringListAttr(attrName, attr)
 		if err != nil {
 			return err
 		}
-		hclSchemas[name] = value
+		if len(values) == 0 || strings.TrimSpace(values[0]) == "" {
+			return fmt.Errorf(
+				"atlas.hcl data.external_schema %q requires a non-empty program list at %s:%d",
+				name, attr.NameRange.Filename, attr.NameRange.Start.Line,
+			)
+		}
+		source.program = values
+		return nil
+	case "format":
+		value, err := p.stringAttr(attrName, attr)
+		if err != nil {
+			return err
+		}
+		return applyExternalSchemaFormat(name, value, attr, source)
+	case "working_dir":
+		value, err := p.stringAttr(attrName, attr)
+		if err != nil {
+			return err
+		}
+		source.workingDir = value
+		return nil
+	case "env":
+		values, err := p.stringListAttr(attrName, attr)
+		if err != nil {
+			return err
+		}
+		return applyExternalSchemaEnv(name, values, attr, source)
+	default:
+		return unsupportedAttr(attrName, attr)
 	}
-	if len(hclSchemas) > 0 {
-		p.ctx.Variables["data"] = cty.ObjectVal(map[string]cty.Value{
-			"hcl_schema": cty.ObjectVal(hclSchemas),
-		})
+}
+
+func applyExternalSchemaFormat(
+	name string,
+	value string,
+	attr *hclsyntax.Attribute,
+	source *externalSchemaDataSource,
+) error {
+	switch normalized := strings.ToLower(strings.TrimSpace(value)); normalized {
+	case "sql", "hcl", "yaml":
+		source.format = normalized
+		return nil
+	case "yml":
+		source.format = "yaml"
+		return nil
+	default:
+		return fmt.Errorf(
+			"atlas.hcl data.external_schema %q format must be sql, hcl, or yaml, got %q at %s:%d",
+			name, value, attr.NameRange.Filename, attr.NameRange.Start.Line,
+		)
+	}
+}
+
+func applyExternalSchemaEnv(
+	name string,
+	values []string,
+	attr *hclsyntax.Attribute,
+	source *externalSchemaDataSource,
+) error {
+	for _, entry := range values {
+		key, _, ok := strings.Cut(entry, "=")
+		if !ok || strings.TrimSpace(key) == "" {
+			return fmt.Errorf(
+				"atlas.hcl data.external_schema %q env entries must be KEY=VALUE, got %q at %s:%d",
+				name, entry, attr.NameRange.Filename, attr.NameRange.Start.Line,
+			)
+		}
+	}
+	source.env = values
+	return nil
+}
+
+// resolveExternalSchemaMarkers translates a data.external_schema marker
+// referenced by the selected env into the merged config's ExternalSchema
+// block. The marker is only valid as the env desired-state source (env src or
+// schema.src); any other reference is rejected. Declared-but-unreferenced data
+// sources are ignored and never executed.
+func (p atlasParser) resolveExternalSchemaMarkers(cfg *Config) error {
+	if err := rejectExternalSchemaMarker(cfg.DatabaseURL, "env url"); err != nil {
+		return err
+	}
+	if err := rejectExternalSchemaMarker(cfg.DevURL, "env dev"); err != nil {
+		return err
+	}
+	if err := rejectExternalSchemaMarker(cfg.Migration.Dir, "env migration.dir"); err != nil {
+		return err
+	}
+	for _, value := range cfg.Exclude {
+		if err := rejectExternalSchemaMarker(value, "env exclude"); err != nil {
+			return err
+		}
+	}
+	return p.consumeExternalSchemaMarker(cfg)
+}
+
+func rejectExternalSchemaMarker(value, location string) error {
+	name, ok := externalSchemaMarkerName(value)
+	if !ok {
+		return nil
+	}
+	return fmt.Errorf(
+		"atlas.hcl data.external_schema.%s.url can only be the env desired-state source (env src or schema.src), not %s",
+		name, location,
+	)
+}
+
+func (p atlasParser) consumeExternalSchemaMarker(cfg *Config) error {
+	for _, value := range cfg.SchemaSources {
+		name, ok := externalSchemaMarkerName(value)
+		if !ok {
+			continue
+		}
+		if len(cfg.SchemaSources) > 1 {
+			return fmt.Errorf("atlas.hcl data.external_schema.%s.url must be the only env src value", name)
+		}
+		source, declared := p.externalSchemas[name]
+		if !declared {
+			return fmt.Errorf("atlas.hcl env src references undeclared data.external_schema %q", name)
+		}
+		p.applyExternalSchemaSource(cfg, source)
+		return nil
 	}
 	return nil
+}
+
+// applyExternalSchemaSource replaces the config's external schema wholesale
+// with the referenced data source and drops the marker from the schema
+// sources, so downstream consumers see the ordinary "external schema
+// configured" state. Every field is marked present, defaults included, so an
+// atlas.hcl data source never mixes with a ptah.yaml external_schema block.
+func (p atlasParser) applyExternalSchemaSource(cfg *Config, source externalSchemaDataSource) {
+	cfg.ExternalSchema = ExternalSchemaConfig{
+		Program:    slices.Clone(source.program),
+		Format:     source.format,
+		WorkingDir: p.resolveExternalSchemaWorkingDir(source.workingDir),
+		Env:        slices.Clone(source.env),
+		Origin:     AtlasFileName,
+	}
+	cfg.presence.mark(fieldExternalSchemaProgram)
+	cfg.presence.mark(fieldExternalSchemaFormat)
+	cfg.presence.mark(fieldExternalSchemaWorkingDir)
+	cfg.presence.mark(fieldExternalSchemaEnv)
+	cfg.SchemaSources = nil
+	cfg.presence.unmark(fieldSchemaSources)
+}
+
+// resolveExternalSchemaWorkingDir resolves a relative working_dir against the
+// atlas.hcl directory, so the program runs where the config file lives no
+// matter which directory the CLI was invoked from.
+func (p atlasParser) resolveExternalSchemaWorkingDir(dir string) string {
+	if dir == "" || filepath.IsAbs(dir) {
+		return dir
+	}
+	return filepath.Join(p.baseDir, dir)
 }
 
 func (p atlasParser) hclSchemaDataSource(block *hclsyntax.Block) (cty.Value, error) {

--- a/config/projectconfig/atlas_external_schema_test.go
+++ b/config/projectconfig/atlas_external_schema_test.go
@@ -1,0 +1,480 @@
+package projectconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+)
+
+func TestParseAtlasExternalSchemaDataSource_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("program only defaults format to sql", func(c *qt.C) {
+		raw := []byte(`data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`)
+
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "dev")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"./gen.sh"})
+		c.Assert(cfg.ExternalSchema.Format, qt.Equals, "sql")
+		c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "")
+		c.Assert(cfg.ExternalSchema.Env, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Origin, qt.Equals, projectconfig.AtlasFileName)
+		c.Assert(cfg.SchemaSources, qt.IsNil)
+		c.Assert(cfg.SchemaSourcesValue().Present, qt.IsFalse)
+	})
+
+	c.Run("all attributes", func(c *qt.C) {
+		raw := []byte(`data "external_schema" "app" {
+  program     = ["python3", "export.py", "--dialect", "postgres"]
+  format      = "yaml"
+  working_dir = "loaders"
+  env         = ["APP_ENV=ci", "EMPTY="]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`)
+
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "dev")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"python3", "export.py", "--dialect", "postgres"})
+		c.Assert(cfg.ExternalSchema.Format, qt.Equals, "yaml")
+		c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "loaders")
+		c.Assert(cfg.ExternalSchema.Env, qt.DeepEquals, []string{"APP_ENV=ci", "EMPTY="})
+		c.Assert(cfg.ExternalSchema.Origin, qt.Equals, projectconfig.AtlasFileName)
+	})
+
+	c.Run("yml format normalizes to yaml", func(c *qt.C) {
+		raw := []byte(`data "external_schema" "app" {
+  program = ["./gen.sh"]
+  format  = "yml"
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`)
+
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "dev")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Format, qt.Equals, "yaml")
+	})
+
+	c.Run("schema block src spelling", func(c *qt.C) {
+		raw := []byte(`data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  schema {
+    src = data.external_schema.app.url
+  }
+}
+`)
+
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "dev")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"./gen.sh"})
+		c.Assert(cfg.SchemaSources, qt.IsNil)
+	})
+}
+
+func TestParseAtlasExternalSchemaDataSource_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name: "missing program",
+			raw: `data "external_schema" "app" {
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" requires a non-empty program list at atlas\.hcl:1`,
+		},
+		{
+			name: "empty program list",
+			raw: `data "external_schema" "app" {
+  program = []
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" requires a non-empty program list at atlas\.hcl:2`,
+		},
+		{
+			name: "blank program executable",
+			raw: `data "external_schema" "app" {
+  program = [" "]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" requires a non-empty program list at atlas\.hcl:2`,
+		},
+		{
+			name: "invalid format",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+  format  = "toml"
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" format must be sql, hcl, or yaml, got "toml" at atlas\.hcl:3`,
+		},
+		{
+			name: "malformed env entry",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+  env     = ["MISSING_EQUALS"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" env entries must be KEY=VALUE, got "MISSING_EQUALS" at atlas\.hcl:3`,
+		},
+		{
+			name: "env entry with empty key",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+  env     = ["=value"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema "app" env entries must be KEY=VALUE, got "=value" at atlas\.hcl:3`,
+		},
+		{
+			name: "unknown attribute",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+  command = "./gen.sh"
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "command" at atlas\.hcl:3`,
+		},
+		{
+			name: "child block",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+  retry {
+  }
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "retry" at atlas\.hcl:3`,
+		},
+		{
+			name: "duplicate data source name",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+data "external_schema" "app" {
+  program = ["./other.sh"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`,
+			wantErr: `duplicate atlas\.hcl data\.external_schema "app" at atlas\.hcl:5`,
+		},
+		{
+			name: "marker as env url",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  url = data.external_schema.app.url
+  src = "schema.sql"
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema\.app\.url can only be the env desired-state source \(env src or schema\.src\), not env url`,
+		},
+		{
+			name: "marker as env dev",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  dev = data.external_schema.app.url
+  src = "schema.sql"
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema\.app\.url can only be the env desired-state source \(env src or schema\.src\), not env dev`,
+		},
+		{
+			name: "marker as migration dir",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  src = "schema.sql"
+  migration {
+    dir = data.external_schema.app.url
+  }
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema\.app\.url can only be the env desired-state source \(env src or schema\.src\), not env migration\.dir`,
+		},
+		{
+			name: "marker in exclude list",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  src     = "schema.sql"
+  exclude = [data.external_schema.app.url]
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema\.app\.url can only be the env desired-state source \(env src or schema\.src\), not env exclude`,
+		},
+		{
+			name: "marker mixed with other schema sources",
+			raw: `data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+
+env "dev" {
+  src = [data.external_schema.app.url, "schema.sql"]
+}
+`,
+			wantErr: `atlas\.hcl data\.external_schema\.app\.url must be the only env src value`,
+		},
+		{
+			name: "undeclared marker",
+			raw: `env "dev" {
+  src = "ptah-external-schema://ghost"
+}
+`,
+			wantErr: `atlas\.hcl env src references undeclared data\.external_schema "ghost"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := projectconfig.ParseAtlas([]byte(test.raw), "atlas.hcl", "dev")
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestParseAtlasExternalSchemaCoexistsWithHCLSchema(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`data "hcl_schema" "declared" {
+  path = "schema.hcl"
+}
+
+data "external_schema" "generated" {
+  program = ["./gen.sh"]
+}
+
+env "files" {
+  src = data.hcl_schema.declared.url
+}
+
+env "program" {
+  src = data.external_schema.generated.url
+}
+`)
+
+	c.Run("env selecting the hcl_schema source", func(c *qt.C) {
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "files")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.SchemaSources, qt.DeepEquals, []string{"file://schema.hcl"})
+		c.Assert(cfg.ExternalSchema.Program, qt.IsNil)
+	})
+
+	c.Run("env selecting the external_schema source", func(c *qt.C) {
+		cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "program")
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.SchemaSources, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"./gen.sh"})
+	})
+}
+
+func TestLoadAtlasExternalSchemaWorkingDirResolvesAgainstConfigDir(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	atlasPath := filepath.Join(dir, "atlas.hcl")
+	c.Assert(os.WriteFile(atlasPath, []byte(`data "external_schema" "app" {
+  program     = ["./gen.sh"]
+  working_dir = "loaders"
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`), 0o600), qt.IsNil)
+
+	cfg, err := projectconfig.LoadAtlasFile(atlasPath, "dev")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, filepath.Join(dir, "loaders"))
+}
+
+func TestLoadAtlasExternalSchemaAbsoluteWorkingDirIsKept(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	absolute := filepath.Join(dir, "elsewhere")
+	atlasPath := filepath.Join(dir, "atlas.hcl")
+	c.Assert(os.WriteFile(atlasPath, []byte(`data "external_schema" "app" {
+  program     = ["./gen.sh"]
+  working_dir = `+strconvQuoteForHCL(absolute)+`
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`), 0o600), qt.IsNil)
+
+	cfg, err := projectconfig.LoadAtlasFile(atlasPath, "dev")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, absolute)
+}
+
+func TestLoadAtlasExternalSchemaUnreferencedSourceIsNotExecuted(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "executed.sentinel")
+	script := filepath.Join(dir, "gen.sh")
+	// The script would create the sentinel file if anything ran it.
+	c.Assert(os.WriteFile(script, []byte("#!/bin/sh\ntouch "+sentinel+"\n"), 0o700), qt.IsNil) //nolint:gosec // executable test fixture in a private temp dir
+	atlasPath := filepath.Join(dir, "atlas.hcl")
+	c.Assert(os.WriteFile(atlasPath, []byte(`data "external_schema" "unused" {
+  program = [`+strconvQuoteForHCL(script)+`]
+}
+
+env "dev" {
+  src = "schema.sql"
+}
+`), 0o600), qt.IsNil)
+
+	cfg, err := projectconfig.LoadAtlasFile(atlasPath, "dev")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.ExternalSchema.Program, qt.IsNil)
+	c.Assert(cfg.SchemaSources, qt.DeepEquals, []string{"schema.sql"})
+	_, statErr := os.Stat(sentinel)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}
+
+func TestLoadExternalSchemaPrecedence_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("atlas.hcl data source replaces ptah.yaml external_schema wholesale", func(c *qt.C) {
+		dir := t.TempDir()
+		ptahPath := filepath.Join(dir, "ptah.yaml")
+		c.Assert(os.WriteFile(ptahPath, []byte(`external_schema:
+  program: ["./from-ptah.sh"]
+  format: yaml
+  working_dir: "ptah-dir"
+  env: ["FROM=ptah"]
+`), 0o600), qt.IsNil)
+		atlasPath := filepath.Join(dir, "atlas.hcl")
+		c.Assert(os.WriteFile(atlasPath, []byte(`data "external_schema" "app" {
+  program = ["./from-atlas.sh"]
+}
+
+env "dev" {
+  src = data.external_schema.app.url
+}
+`), 0o600), qt.IsNil)
+
+		cfg, err := projectconfig.Load(projectconfig.LoadOptions{
+			PtahPath:  ptahPath,
+			AtlasPath: atlasPath,
+			EnvName:   "dev",
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"./from-atlas.sh"})
+		// The whole block is replaced: the atlas.hcl defaults win over the
+		// ptah.yaml values so the two files never mix into a hybrid program.
+		c.Assert(cfg.ExternalSchema.Format, qt.Equals, "sql")
+		c.Assert(cfg.ExternalSchema.WorkingDir, qt.Equals, "")
+		c.Assert(cfg.ExternalSchema.Env, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Origin, qt.Equals, projectconfig.AtlasFileName)
+	})
+
+	c.Run("ptah.yaml external_schema survives when atlas.hcl declares none", func(c *qt.C) {
+		dir := t.TempDir()
+		ptahPath := filepath.Join(dir, "ptah.yaml")
+		c.Assert(os.WriteFile(ptahPath, []byte(`external_schema:
+  program: ["./from-ptah.sh"]
+  format: yaml
+`), 0o600), qt.IsNil)
+		atlasPath := filepath.Join(dir, "atlas.hcl")
+		c.Assert(os.WriteFile(atlasPath, []byte(`env "dev" {
+  url = "sqlite://app.db"
+}
+`), 0o600), qt.IsNil)
+
+		cfg, err := projectconfig.Load(projectconfig.LoadOptions{
+			PtahPath:  ptahPath,
+			AtlasPath: atlasPath,
+			EnvName:   "dev",
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(cfg.ExternalSchema.Program, qt.DeepEquals, []string{"./from-ptah.sh"})
+		c.Assert(cfg.ExternalSchema.Format, qt.Equals, "yaml")
+		c.Assert(cfg.ExternalSchema.Origin, qt.Equals, projectconfig.PtahFileName)
+	})
+}
+
+// strconvQuoteForHCL quotes a filesystem path for embedding in an HCL string
+// literal; Go string quoting and HCL string escapes agree for the characters
+// that appear in test paths (notably Windows backslashes).
+func strconvQuoteForHCL(value string) string {
+	return strconv.Quote(value)
+}

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -474,6 +474,11 @@ type ExternalSchemaConfig struct {
 	WorkingDir string
 	// Env holds extra "KEY=VALUE" entries passed to the program.
 	Env []string
+	// Origin names the config file that supplied Program: PtahFileName for a
+	// ptah.yaml external_schema block or AtlasFileName for an atlas.hcl
+	// data.external_schema source. Safety-gate errors use it to point the user
+	// at the file that configured the program.
+	Origin string
 }
 
 // ConfigBool preserves whether a boolean project config value was set
@@ -811,6 +816,11 @@ func mergeExternalSchema(
 		overridePresence,
 		resultPresence,
 	)
+	// Origin follows Program: whichever source supplied the program names the
+	// file the safety gate should point at.
+	if overridePresence.has(fieldExternalSchemaProgram) || len(override.Program) > 0 {
+		result.Origin = override.Origin
+	}
 	result.Format = mergeStringValue(
 		base.Format,
 		override.Format,

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -288,6 +288,7 @@ func (c yamlSettings) projectConfig() (Config, error) {
 	c.OnlineDDL.applyTo(&cfg)
 	if c.ExternalSchema.Program != nil {
 		cfg.ExternalSchema.Program = slices.Clone(*c.ExternalSchema.Program)
+		cfg.ExternalSchema.Origin = PtahFileName
 		cfg.presence.mark(fieldExternalSchemaProgram)
 	}
 	if c.ExternalSchema.Env != nil {

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -8,8 +8,8 @@ invocations in this document run the separate `ptah-compat` drop-in binary.
 
 ## Supported subset
 
-Ptah accepts top-level `variable`, `locals`, `data "hcl_schema"`, `env`,
-`lint`, and `diff` blocks. `env` blocks may have either one label or no label:
+Ptah accepts top-level `variable`, `locals`, `data "hcl_schema"`,
+`data "external_schema"`, `env`, `lint`, and `diff` blocks. `env` blocks may have either one label or no label:
 
 ```hcl
 lint {
@@ -149,9 +149,12 @@ surface. It supplies an explicit external-program argument list and SQL, HCL,
 or YAML stdout to `ptah schema render`, `ptah schema compare`,
 `ptah schema drift`, `ptah migrations plan`, and
 `ptah migrations generate`; executing that config-sourced program requires
-`--allow-external-schema`. Atlas HCL `data.external_schema` evaluation remains
-outside the supported `atlas.hcl` subset and must not be inferred from the
-native Ptah feature.
+`--allow-external-schema`. Atlas HCL `data "external_schema"` is part of the
+supported subset: a block declares `program` (argv, no shell) plus the Ptah
+extensions `format`, `working_dir`, and `env`, and its `.url` value is
+consumed when an env `src` selects it. Execution stays gated: native commands
+require `--allow-external-schema`, and `ptah-compat` requires
+`PTAH_ALLOW_EXTERNAL_SCHEMA=1` because the compat flag surface mirrors Atlas.
 
 Ptah parses Atlas's `atlas`, `golang-migrate`, `goose`, `flyway`, `liquibase`,
 and `dbmate` migration format values so the project file can be evaluated
@@ -307,8 +310,8 @@ Atlas-compatible commands under `ptah-compat schema ...` and
 Variable overrides are strings. A `variable` block without a `default` is valid
 when the invocation provides a matching `--var name=value`. Variable `type` and
 `sensitive` attributes are not accepted until Ptah implements their semantics.
-Unsupported dynamic data sources such as external schemas, SQL data sources,
-registry-backed sources, and Cloud-specific sources still fail explicitly.
+Unsupported dynamic data sources such as SQL data sources, registry-backed
+sources, and Cloud-specific sources still fail explicitly.
 
 ## Env selection
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -305,6 +305,11 @@ type ExternalSchemaConfig struct {
     WorkingDir string
     // Env holds extra "KEY=VALUE" entries passed to the program.
     Env []string
+    // Origin names the config file that supplied Program: PtahFileName for a
+    // ptah.yaml external_schema block or AtlasFileName for an atlas.hcl
+    // data.external_schema source. Safety-gate errors use it to point the user
+    // at the file that configured the program.
+    Origin string
 }
     ExternalSchemaConfig configures an external program whose standard output is
     the desired schema. It is Ptah's open equivalent of Atlas's external_schema

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -56,11 +56,11 @@
  {
   "area": "Schema sources",
   "feature": "Atlas HCL data \"external_schema\"",
-  "ptah": "no",
-  "atlas_oss": "yes",
+  "ptah": "yes",
+  "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "Ptah's `data` block is an unlabeled seed-row declaration; every labeled Atlas data source fails with `data block does not accept labels`.",
-  "evidence": "internal/atlashcl/objects.go:376-379; external_schema, composite_schema and remote_dir all produce that one error; comparison.md:415 lists Atlas OSS external schema as Open"
+  "note": "Ptah evaluates the data source and runs the program, gated behind `--allow-external-schema`/`PTAH_ALLOW_EXTERNAL_SCHEMA`. Community Atlas rejects `data.external_schema`.",
+  "evidence": "config/projectconfig/atlas.go (configureDataSources external_schema branch); repro: PTAH_ALLOW_EXTERNAL_SCHEMA=1 ptah-compat schema apply --url sqlite://app.db --env dev --dry-run --auto-approve emits the program's CREATE TABLE; ptah schema render --env dev --allow-external-schema renders it natively; go test ./cmd/atlas -run TestSchemaDiffExternalSchemaSource. Measured 2026-08-01, Atlas CE v1.2.0 logged out: atlas.hcl data \"external_schema\" -> exit 1 'Error: data.external_schema is not supported by the community version of Atlas.'"
  },
  {
   "area": "Schema sources",
@@ -86,7 +86,7 @@
   "ptah": "partial",
   "atlas_oss": "yes",
   "atlas_pro": "yes",
-  "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema.",
+  "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema.",
   "evidence": "config/projectconfig/atlas.go:214 (collectAtlasTopBlock default -> unsupportedBlock), :402 (parseEnvAttr default), :475 (parseMigration default); each rejection reproduced with /tmp/pc-audit at exit 1; Atlas-side block inventory from https://atlasgo.io/atlas-schema/projects (top-level variable, locals, atlas, env, script, lint, diff, exporter, deployment)"
  },
  {

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -406,13 +406,13 @@ Native lint and plan commands can attach canonical reports to exact migration or
 
 **Ptah.** Ptah parses strict HCL schema and Atlas project config subsets.
 
-Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff` policy, and supported lint analyzer severity policy feed Atlas-compatible commands, including local variable defaults, repeated string/list `--var name=value` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, and `lint.latest` / `lint.git` changeset defaults for migration linting.
+Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff` policy, and supported lint analyzer severity policy feed Atlas-compatible commands, including local variable defaults, repeated string/list `--var name=value` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, `data.external_schema.<name>.url` (gated behind `--allow-external-schema` / `PTAH_ALLOW_EXTERNAL_SCHEMA`), and `lint.latest` / `lint.git` changeset defaults for migration linting.
 
 Ptah also composes a desired-schema schema from multiple sources — several Go roots, or a mix of Go annotations, YAML, HCL, and SQL — via repeatable `--root-dir` and `--schema-file` flags on `ptah schema render`, `ptah schema compare`, `ptah migrations plan`, and `ptah migrations generate`, an open, local, no-account counterpart to Atlas's Pro `composite_schema` data source.
 
 Unsupported constructs fail explicitly rather than being silently ignored.
 
-**Atlas OSS.** Atlas OSS supports SQL, HCL schema, external schema, remote/template directories, and related data sources listed as Open.
+**Atlas OSS.** Atlas OSS supports SQL and HCL schema sources. The community binary rejects the `data "external_schema"` project data source (measured 2026-08-01, Atlas CE v1.2.0 logged out: exit 1, `Error: data.external_schema is not supported by the community version of Atlas.`); Ptah evaluates it in the open build behind the external-schema opt-in.
 
 **Atlas Commercial / Cloud.** Pro data sources and policy features include composite schema, blob directory, custom lint rules, and review workflows.
 

--- a/docs/site/src/content/docs/atlas/docs-coverage.md
+++ b/docs/site/src/content/docs/atlas/docs-coverage.md
@@ -199,13 +199,13 @@ Before a non-dry-run apply, `--dev-url` rehearses the exact ordered plan on the 
 
 ### Desired-state sources
 
-**Atlas availability.** Open sources include SQL, HCL, and external schema integrations; some data sources are Pro
+**Atlas availability.** The Atlas docs describe SQL, HCL, and external schema integrations, with some data sources Pro. Measured 2026-08-01: the pinned Atlas CE v1.2.0 binary rejects `data "external_schema"` with "not supported by the community version", so the external-schema data source is not an Open capability
 
 **Ptah documentation.** [Composite desired schema](../../schema/composite/), [ORM and external loaders](../../schema/orm-and-external/), [OCI registry artifacts](../../operate/oci-registry/), [HCL schema](../../schema/hcl/)
 
 **Implementation status.** Partial. Native Ptah supports YAML, Go annotations, supported HCL schema files, SQL schema files, live DB introspection, external programs that emit SQL, HCL, or YAML, and canonical desired-schema artifacts in a bring-your-own OCI registry. The same `ptah.yaml external_schema` block supplies native render, compare, drift, and migration planning.
 
-The native OCI source is available to `schema compare` and `drift` through `--schema-file`; it is not Atlas Registry parity or an `atlas://` source for Atlas-compatible commands. Atlas HCL `data.external_schema`, registry-backed sources, and full Atlas data-source evaluation remain outside the supported compatibility subset.
+The native OCI source is available to `schema compare` and `drift` through `--schema-file`; it is not Atlas Registry parity or an `atlas://` source for Atlas-compatible commands. Atlas HCL `data "external_schema"` is implemented for both binaries, gated behind `--allow-external-schema` (native) or `PTAH_ALLOW_EXTERNAL_SCHEMA=1` (`ptah-compat`); registry-backed sources and the remaining Atlas data sources stay outside the supported compatibility subset.
 
 **Conformance status.** Native external programs are measured by a deterministic 20-observation SQL/HCL/YAML workflow through render, compare, drift, plan, generate, apply, live SQLite facts, and convergence. A separate zero-gap tier exercises pinned GORM and SQLAlchemy providers. The native OCI round trip remains covered by Ptah's own command and integration tests rather than Atlas conformance.
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -73,13 +73,13 @@ Across the 152 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 78 |
+| Ptah supports it fully | 79 |
 | Ptah supports it with a stated limitation | 47 |
-| Ptah does not implement it | 27 |
+| Ptah does not implement it | 26 |
 | Ptah and Atlas CE both support it | 24 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 28 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 29 |
 | Ptah has it and neither Atlas edition does | 8 |
-| Atlas CE has it and Ptah does not, or only in part | 25 |
+| Atlas CE has it and Ptah does not, or only in part | 24 |
 | An Atlas column is ❔ — not established by this page's evidence | 33 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
@@ -101,7 +101,7 @@ as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | Annotated Go models from a live database | ✅ | ❌ | ❌ | Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list. |
 | Atlas CE inspect HCL parses back into Ptah | ✅ | ✅ | ✅ | 30 atlas-differential observations parse Atlas CE 1.2.0 `schema inspect` HCL on Postgres/MySQL/SQLite with zero schema-fact mismatches. |
-| Atlas HCL data "external_schema" | ❌ | ✅ | ✅ | Ptah's `data` block is an unlabeled seed-row declaration; every labeled Atlas data source fails with `data block does not accept labels`. |
+| Atlas HCL data "external_schema" | ✅ | ❌ | ✅ | Ptah evaluates the data source and runs the program, gated behind `--allow-external-schema`/`PTAH_ALLOW_EXTERNAL_SCHEMA`. Community Atlas rejects `data.external_schema`. |
 | Composite multi-source desired schema | ✅ | ❌ | ✅ | Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source. |
 | Desired-schema artifacts in an OCI registry | ✅ | ❌ | ✅ | `ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2. |
 | Directory of .hcl files as one schema source | ❌ | ❔ | ❔ | `--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. |
@@ -219,7 +219,7 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema. |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema. |
 | atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected. |
 | Docker dev databases (`docker://` `--dev-url`) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -17,6 +17,7 @@ Ptah accepts these local configuration blocks:
 - top-level `variable`
 - top-level `locals`
 - `data "hcl_schema"` for local schema file data
+- `data "external_schema"` for program-generated desired state
 - `env` blocks, with either one label or no label
 - top-level and env-local `lint`
 - env-local `schema`, `migration`, `format`, and `diff`
@@ -181,10 +182,75 @@ to the process working directory unless they are absolute.
 The Atlas-compatible schema commands and `migrate diff` also accept explicit
 `env://` references. `env://src` and `env://schema.src` expand the selected
 environment's schema sources through the typed desired-schema resolver, so the
-expanded value can be a supported local file or database URL. `env://url` and
-`env://dev` resolve the corresponding database URL; `env://migration.dir`
-resolves the configured local migration directory. Nested `env://` references
-fail explicitly.
+expanded value can be a supported local file, database URL, or declared
+external schema program. `env://url` and `env://dev` resolve the corresponding
+database URL; `env://migration.dir` resolves the configured local migration
+directory. Nested `env://` references fail explicitly.
+
+## External schema data source
+
+`data "external_schema"` declares a program whose standard output is the
+desired schema. Selecting its `.url` as an env's desired-state source makes
+that program the source of truth for the environment:
+
+```hcl
+data "external_schema" "app" {
+  program = ["python3", "export.py"]
+  format  = "sql"
+}
+
+env "dev" {
+  url = "sqlite://app.db"
+  src = data.external_schema.app.url
+}
+```
+
+The program runs directly with an explicit argument vector — never through a
+shell — and must print the complete desired schema to standard output. This is
+the `atlas.hcl` spelling of the native `ptah.yaml` `external_schema` block and
+the `--schema-cmd` flag; all three share one execution path. See
+[External and ORM schema sources](../../schema/orm-and-external/).
+
+| Attribute | Meaning |
+| --- | --- |
+| `program` | Required argv list. `program[0]` is the executable; no shell runs. |
+| `format` | Stdout format: `sql` (default), `hcl`, or `yaml`. Ptah extension. |
+| `working_dir` | Program working directory. Relative values resolve against the `atlas.hcl` directory. Ptah extension. |
+| `env` | Extra `KEY=VALUE` entries for the program. `PATH` and `PWD` cannot be overridden. Ptah extension. |
+
+The data source follows strict placement rules:
+
+- Its `.url` value is only valid as the selected env's desired-state source
+  (`env.src` or `env.schema.src`) and must be that source's only value.
+  Referencing it from `url`, `dev`, `migration.dir`, or `exclude` fails
+  explicitly.
+- A declared-but-unreferenced data source is ignored and never executed.
+- When the selected env's desired state is an external schema source, it
+  replaces a `ptah.yaml` `external_schema` block wholesale, so the two config
+  files never mix into one hybrid program configuration.
+
+Executing repository-controlled code from an auto-discovered config file
+requires an explicit opt-in, in both binaries:
+
+- Native `ptah` commands that consume project config (for example
+  `ptah schema render --env dev`) require `--allow-external-schema` or its
+  `PTAH_ALLOW_EXTERNAL_SCHEMA` environment twin. Without it, the command fails
+  with `atlas.hcl data.external_schema is disabled by default; pass
+  --allow-external-schema to execute it`.
+- `ptah-compat` keeps the Atlas-identical flag surface, so the opt-in is the
+  `PTAH_ALLOW_EXTERNAL_SCHEMA=1` environment variable. Without it, commands
+  fail during source classification, before the program could run.
+
+`ptah-compat schema diff`, `schema apply`, `schema inspect` (spelled
+`--url env://src`), and `migrate diff` consume the source. `schema plan` and
+`schema test` do not support it yet and fail explicitly.
+
+Community Atlas rejects this data source entirely: measured 2026-08-01 with a
+logged-out Atlas CE v1.2.0 binary, an `atlas.hcl` declaring
+`data "external_schema"` fails with exit 1 and
+`Error: data.external_schema is not supported by the community version of
+Atlas.` Ptah evaluates it in the open build, behind the opt-in described
+above.
 
 When an `atlas.hcl` `migration` block is present, Ptah defaults
 `revision-format` to `atlas`, so migration commands use

--- a/docs/site/src/content/docs/schema/orm-and-external.md
+++ b/docs/site/src/content/docs/schema/orm-and-external.md
@@ -94,7 +94,12 @@ Constraints on the block:
   directory after symlink resolution. Use an explicit absolute path for a
   deliberately external loader.
 - The block mirrors the desired-schema role of Atlas's
-  `data "external_schema"` but does not evaluate that Atlas HCL data source.
+  `data "external_schema"`. The same loader can also be declared directly in
+  `atlas.hcl` as a `data "external_schema"` source and selected as an env's
+  desired state; see
+  [Atlas project config](../../atlas/project-config/#external-schema-data-source).
+  All three spellings — `--schema-cmd`, `ptah.yaml` `external_schema`, and the
+  `atlas.hcl` data source — share one execution path and one opt-in gate.
 
 ## GORM (verified)
 

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -375,7 +375,7 @@ func (p *parser) parsePermission(block *hclsyntax.Block) error {
 
 func (p *parser) parseManagedData(block *hclsyntax.Block) error {
 	if len(block.Labels) != 0 {
-		return p.blockError(block, "data block does not accept labels")
+		return p.labeledDataBlockError(block)
 	}
 	if len(block.Body.Blocks) > 0 {
 		return p.blockError(block.Body.Blocks[0], "unsupported data block %q", block.Body.Blocks[0].Type)
@@ -387,6 +387,29 @@ func (p *parser) parseManagedData(block *hclsyntax.Block) error {
 	}, "data"); err != nil {
 		return err
 	}
+	return p.parseManagedDataBody(block)
+}
+
+// labeledDataBlockError explains a labeled data block. In a schema file, data
+// declares managed seed rows and takes no labels; the labeled data sources
+// users paste here by accident are atlas.hcl project-config constructs, so the
+// known Atlas labels get an error that points at the right file.
+func (p *parser) labeledDataBlockError(block *hclsyntax.Block) error {
+	switch label := block.Labels[0]; label {
+	case "external_schema":
+		return p.blockError(block,
+			"data %q is an atlas.hcl project-config data source, not a schema declaration; declare it in atlas.hcl, where Ptah supports it",
+			label)
+	case "composite_schema", "remote_dir", "hcl_schema":
+		return p.blockError(block,
+			"data %q is an atlas.hcl project-config data source, not a schema declaration",
+			label)
+	default:
+		return p.blockError(block, "data block does not accept labels")
+	}
+}
+
+func (p *parser) parseManagedDataBody(block *hclsyntax.Block) error {
 	tableName, ok := traversalObjectRefName(p.optionalRawExpr(block.Body.Attributes["table"]), "table")
 	if !ok {
 		return p.blockError(block, "data requires table reference")

--- a/internal/atlashcl/parity_extensions_test.go
+++ b/internal/atlashcl/parity_extensions_test.go
@@ -193,6 +193,42 @@ data "users" {
 			match: `.*data block does not accept labels.*`,
 		},
 		{
+			name: "external_schema data source in a schema file",
+			hcl: `
+data "external_schema" "app" {
+  program = ["./gen.sh"]
+}
+`,
+			match: `.*data "external_schema" is an atlas\.hcl project-config data source, not a schema declaration; declare it in atlas\.hcl, where Ptah supports it.*`,
+		},
+		{
+			name: "composite_schema data source in a schema file",
+			hcl: `
+data "composite_schema" "app" {
+  schema "public" {}
+}
+`,
+			match: `.*data "composite_schema" is an atlas\.hcl project-config data source, not a schema declaration.*`,
+		},
+		{
+			name: "remote_dir data source in a schema file",
+			hcl: `
+data "remote_dir" "migrations" {
+  name = "app"
+}
+`,
+			match: `.*data "remote_dir" is an atlas\.hcl project-config data source, not a schema declaration.*`,
+		},
+		{
+			name: "hcl_schema data source in a schema file",
+			hcl: `
+data "hcl_schema" "app" {
+  path = "schema.hcl"
+}
+`,
+			match: `.*data "hcl_schema" is an atlas\.hcl project-config data source, not a schema declaration.*`,
+		},
+		{
 			name: "managed data keys type",
 			hcl: `
 data {

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -116,6 +116,15 @@ func inspectOnDev(
 		if err != nil {
 			return "", err
 		}
+	case atlassource.KindExternalSchema:
+		state, err := set.Resolve(ctx, atlassource.ResolveOptions{
+			Dialect:     dialect,
+			DialectFlag: "--dev-url",
+		})
+		if err != nil {
+			return "", err
+		}
+		desired = state.Schema
 	case atlassource.KindMigrationDir:
 		if err := atlassource.VerifyMigrationDir(set.Sources[0].Path); err != nil {
 			return "", err
@@ -156,7 +165,7 @@ func inspectOnDev(
 			return "", fmt.Errorf("--url %q: %w", set.Sources[0].Raw, err)
 		}
 		return rendered, nil
-	case atlassource.KindLocalFile:
+	case atlassource.KindLocalFile, atlassource.KindExternalSchema:
 		var rendered string
 		err := withMaterializedDevSchema(
 			ctx,

--- a/internal/atlassource/atlassource.go
+++ b/internal/atlassource/atlassource.go
@@ -11,8 +11,11 @@
 //   - An env:// reference must be the flag's only value; it expands to the
 //     selected env's configured sources, which are then re-classified under
 //     the same rules.
-//   - Database-URL and migration-directory sources accept exactly one URL per
-//     flag; local schema files accept many.
+//   - Database-URL, migration-directory, and external-schema sources accept
+//     exactly one URL per flag; local schema files accept many.
+//   - An env whose desired state is a declared atlas.hcl data.external_schema
+//     source expands to an external-schema program source, gated on the
+//     PTAH_ALLOW_EXTERNAL_SCHEMA environment variable.
 //   - A local file:// or plain-path directory that contains an atlas.sum file
 //     is a migration directory; any other directory keeps the pre-resolver
 //     local-file behavior.
@@ -25,10 +28,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
+	"strconv"
 	"strings"
 
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/schemasource"
 	"github.com/stokaro/ptah/internal/atlasprojectpath"
 	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/migratesum"
@@ -53,7 +59,19 @@ const (
 	// KindEnv is an env://<attribute> reference into the evaluated atlas.hcl
 	// environment. ClassifySet expands it, so resolved sets never carry it.
 	KindEnv Kind = "env reference"
+	// KindExternalSchema is an atlas.hcl data.external_schema program whose
+	// standard output is the desired state. It only ever appears through env
+	// expansion of a selected env whose desired-state source is a declared
+	// external schema data source.
+	KindExternalSchema Kind = "external schema program"
 )
+
+// AllowExternalSchemaEnvVar gates executing an atlas.hcl
+// data.external_schema program resolved through env expansion. The
+// Atlas-identical `ptah-compat` flag surface cannot grow a new flag, so the
+// opt-in is this environment variable — the same variable that drives the
+// native --allow-external-schema flag through Ptah's env twin machinery.
+const AllowExternalSchemaEnvVar = "PTAH_ALLOW_EXTERNAL_SCHEMA"
 
 // Source is one classified desired-state URL.
 type Source struct {
@@ -66,6 +84,10 @@ type Source struct {
 	Path string
 	// EnvAttr is the referenced attribute for env:// sources.
 	EnvAttr string
+	// Command is the resolved external schema program for external-schema
+	// sources; zero for every other kind. Its dialect hint is filled during
+	// resolution.
+	Command schemasource.Command
 }
 
 // ProjectEnv carries the evaluated atlas.hcl environment used to expand env://
@@ -167,7 +189,7 @@ func (s *Set) validate() error {
 				s.Flag, first.Raw, first.Kind, source.Raw, source.Kind)
 		}
 	}
-	if (s.Kind == KindDatabase || s.Kind == KindMigrationDir) && len(s.Sources) > 1 {
+	if s.Kind != KindLocalFile && len(s.Sources) > 1 {
 		return fmt.Errorf("%s accepts one %s desired-state source, got %d", s.Flag, s.Kind, len(s.Sources))
 	}
 	return nil
@@ -269,7 +291,7 @@ func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 	}
 	switch source.EnvAttr {
 	case "src", "schema.src":
-		return expandEnvSchemaSources(env)
+		return expandEnvSchemaSources(source, env)
 	case "url":
 		return expandEnvDatabaseURL(source.EnvAttr, env.Config.DatabaseURL)
 	case "dev":
@@ -281,8 +303,11 @@ func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 	}
 }
 
-func expandEnvSchemaSources(env ProjectEnv) ([]Source, error) {
+func expandEnvSchemaSources(source Source, env ProjectEnv) ([]Source, error) {
 	if len(env.Config.SchemaSources) == 0 {
+		if len(env.Config.ExternalSchema.Program) > 0 {
+			return expandEnvExternalSchema(source, env)
+		}
 		return nil, errors.New("the selected atlas.hcl env does not define schema sources (env.src or env.schema.src)")
 	}
 	sources := make([]Source, 0, len(env.Config.SchemaSources))
@@ -294,6 +319,40 @@ func expandEnvSchemaSources(env ProjectEnv) ([]Source, error) {
 		sources = append(sources, source)
 	}
 	return sources, nil
+}
+
+// expandEnvExternalSchema turns the selected env's external schema program
+// into a desired-state source. The program is repository-controlled code
+// reached through an auto-discovered config file, so expansion is gated on an
+// explicit environment opt-in; the gate fails during classification, before
+// any database is contacted and before the program could run.
+func expandEnvExternalSchema(source Source, env ProjectEnv) ([]Source, error) {
+	if !externalSchemaAllowed() {
+		return nil, fmt.Errorf(
+			"atlas.hcl data.external_schema executes a repository-controlled program and is disabled by default; set %s=1 to allow it",
+			AllowExternalSchemaEnvVar,
+		)
+	}
+	external := env.Config.ExternalSchema
+	return []Source{{
+		Raw:  source.Raw,
+		Kind: KindExternalSchema,
+		Command: schemasource.Command{
+			Args:   slices.Clone(external.Program),
+			Format: external.Format,
+			Dir:    external.WorkingDir,
+			Env:    slices.Clone(external.Env),
+		},
+	}}, nil
+}
+
+// externalSchemaAllowed reports whether the external schema opt-in variable is
+// set to a true boolean value. Unset, empty, false, and unparsable values all
+// deny, mirroring how the native env twin feeds the --allow-external-schema
+// bool flag.
+func externalSchemaAllowed() bool {
+	allowed, err := strconv.ParseBool(os.Getenv(AllowExternalSchemaEnvVar))
+	return err == nil && allowed
 }
 
 // classifyEnvValue classifies one env-provided source value. Relative local

--- a/internal/atlassource/atlassource.go
+++ b/internal/atlassource/atlassource.go
@@ -144,6 +144,12 @@ func Classify(rawURL string) (Source, error) {
 		return Source{}, errors.New("docker:// URLs provision Atlas dev databases and cannot be used as a desired-state source; pass a directly connectable database URL")
 	case scheme == "atlas":
 		return Source{}, errors.New("atlas:// registry URLs are not supported: Ptah has no Atlas Cloud registry; use a local schema file, a migration directory, a database URL, or an env:// reference")
+	case scheme == "ptah-external-schema":
+		// The marker is minted internally when an atlas.hcl env src selects a
+		// data "external_schema" source; spelled directly it must never reach
+		// classification, so reject it here rather than relying on the
+		// generic unknown-scheme default below staying strict.
+		return Source{}, errors.New("ptah-external-schema:// is a reserved internal marker scheme; reference data.external_schema.<name>.url from an atlas.hcl env src instead")
 	default:
 		return Source{}, fmt.Errorf("unsupported desired-state URL scheme %q: supported sources are local schema files, migration directories, database URLs, and env:// references", scheme)
 	}

--- a/internal/atlassource/atlassource_test.go
+++ b/internal/atlassource/atlassource_test.go
@@ -119,6 +119,11 @@ func TestClassify_Errors(t *testing.T) {
 			want: `docker:// URLs provision Atlas dev databases and cannot be used as a desired-state source; pass a directly connectable database URL`,
 		},
 		{
+			name: "reserved external-schema marker scheme",
+			url:  "ptah-external-schema://app",
+			want: `ptah-external-schema:// is a reserved internal marker scheme; reference data\.external_schema\.<name>\.url from an atlas\.hcl env src instead`,
+		},
+		{
 			name: "atlas registry",
 			url:  "atlas://remote/app",
 			want: `atlas:// registry URLs are not supported: Ptah has no Atlas Cloud registry; use a local schema file, a migration directory, a database URL, or an env:// reference`,

--- a/internal/atlassource/external_schema_test.go
+++ b/internal/atlassource/external_schema_test.go
@@ -1,0 +1,209 @@
+package atlassource_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/config/projectconfig"
+	"github.com/stokaro/ptah/core/schemasource"
+	"github.com/stokaro/ptah/internal/atlassource"
+)
+
+// externalHelperModes maps a mode name to the behavior the re-executed test
+// binary performs when it stands in for an atlas.hcl external schema program.
+var externalHelperModes = map[string]func(){
+	"sql": func() {
+		fmt.Fprint(os.Stdout, "CREATE TABLE ext_users (\n  id INTEGER PRIMARY KEY,\n  email TEXT NOT NULL\n);\n")
+		os.Exit(0) //nolint:revive // subprocess fixture must terminate before the test runner writes to stdout
+	},
+	"fail": func() {
+		fmt.Fprintln(os.Stderr, "external loader blew up")
+		os.Exit(3) //nolint:revive // subprocess fixture must terminate with the tested failure code
+	},
+	"empty": func() {
+		os.Exit(0) //nolint:revive // subprocess fixture must terminate before the test runner writes to stdout
+	},
+}
+
+// TestExternalSchemaHelperProcess is not a real test; the tests below
+// re-execute this binary with -test.run=TestExternalSchemaHelperProcess to act
+// as the configured external schema program.
+func TestExternalSchemaHelperProcess(t *testing.T) {
+	runExternalSchemaHelperProcess()
+}
+
+func runExternalSchemaHelperProcess() {
+	if os.Getenv("GO_WANT_ATLASSOURCE_HELPER") != "1" {
+		return
+	}
+	emit, ok := externalHelperModes[os.Getenv("ATLASSOURCE_HELPER_MODE")]
+	if !ok {
+		fmt.Fprintln(os.Stderr, "unknown helper mode")
+		os.Exit(1) //nolint:revive // subprocess fixture must terminate on bad wiring
+	}
+	emit()
+}
+
+func externalSchemaProjectEnv(mode string) atlassource.ProjectEnv {
+	return atlassource.ProjectEnv{
+		Loaded: true,
+		Config: projectconfig.Config{
+			ExternalSchema: projectconfig.ExternalSchemaConfig{
+				Program: []string{os.Args[0], "-test.run=TestExternalSchemaHelperProcess"},
+				Format:  "sql",
+				Env: []string{
+					"GO_WANT_ATLASSOURCE_HELPER=1",
+					"ATLASSOURCE_HELPER_MODE=" + mode,
+					"GORACE=atexit_sleep_ms=0",
+				},
+				Origin: projectconfig.AtlasFileName,
+			},
+		},
+	}
+}
+
+func TestClassifySetExternalSchema_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "1")
+
+	tests := []struct {
+		name   string
+		rawURL string
+	}{
+		{name: "env src reference", rawURL: "env://src"},
+		{name: "env schema.src reference", rawURL: "env://schema.src"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			env := externalSchemaProjectEnv("sql")
+
+			set, err := atlassource.ClassifySet("--to", []string{test.rawURL}, env)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(set.Kind, qt.Equals, atlassource.KindExternalSchema)
+			c.Assert(set.Sources, qt.HasLen, 1)
+			c.Assert(set.Sources[0].Raw, qt.Equals, test.rawURL)
+			c.Assert(set.Sources[0].Command.Args, qt.DeepEquals, env.Config.ExternalSchema.Program)
+			c.Assert(set.Sources[0].Command.Format, qt.Equals, "sql")
+			c.Assert(set.Sources[0].Command.Env, qt.DeepEquals, env.Config.ExternalSchema.Env)
+		})
+	}
+}
+
+func TestClassifySetExternalSchema_GateFailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "zero", value: "0"},
+		{name: "false", value: "false"},
+		{name: "garbage", value: "yes-please"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			t.Setenv(atlassource.AllowExternalSchemaEnvVar, test.value)
+
+			_, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("sql"))
+
+			c.Assert(err, qt.ErrorMatches, `--to "env://src": atlas\.hcl data\.external_schema executes a repository-controlled program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`)
+		})
+	}
+}
+
+func TestClassifySetExternalSchemaGateDoesNotExecuteProgram(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "")
+	dir := t.TempDir()
+	sentinel := filepath.Join(dir, "executed.sentinel")
+	script := filepath.Join(dir, "gen.sh")
+	// The script would create the sentinel file if anything ran it.
+	c.Assert(os.WriteFile(script, []byte("#!/bin/sh\ntouch "+sentinel+"\n"), 0o700), qt.IsNil) //nolint:gosec // executable test fixture in a private temp dir
+	env := atlassource.ProjectEnv{
+		Loaded: true,
+		Config: projectconfig.Config{
+			ExternalSchema: projectconfig.ExternalSchemaConfig{
+				Program: []string{script},
+				Origin:  projectconfig.AtlasFileName,
+			},
+		},
+	}
+
+	_, err := atlassource.ClassifySet("--to", []string{"env://src"}, env)
+
+	c.Assert(err, qt.IsNotNil)
+	_, statErr := os.Stat(sentinel)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}
+
+func TestResolveExternalSchema_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "1")
+	set, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("sql"))
+	c.Assert(err, qt.IsNil)
+
+	state, err := set.Resolve(t.Context(), atlassource.ResolveOptions{
+		Dialect:     "sqlite",
+		DialectFlag: "--dev-url",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(state.Kind, qt.Equals, atlassource.KindExternalSchema)
+	c.Assert(state.Schema.Tables, qt.HasLen, 1)
+	c.Assert(state.Schema.Tables[0].Name, qt.Equals, "ext_users")
+	c.Assert(state.DB, qt.IsNil)
+}
+
+func TestResolveExternalSchema_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "1")
+
+	c.Run("program exiting non-zero surfaces stderr", func(c *qt.C) {
+		set, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("fail"))
+		c.Assert(err, qt.IsNil)
+
+		_, err = set.Resolve(t.Context(), atlassource.ResolveOptions{Dialect: "sqlite"})
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, `--to "env://src"`)
+		c.Assert(err.Error(), qt.Contains, "external loader blew up")
+	})
+
+	c.Run("empty stdout is rejected", func(c *qt.C) {
+		set, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("empty"))
+		c.Assert(err, qt.IsNil)
+
+		_, err = set.Resolve(t.Context(), atlassource.ResolveOptions{Dialect: "sqlite"})
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "produced empty output")
+	})
+}
+
+// TestResolveExternalSchemaCommandIsIsolatedPerResolve guards against the
+// resolver mutating the classified source: the dialect hint is applied to a
+// copy of the command, so one classified set can be resolved repeatedly.
+func TestResolveExternalSchemaCommandIsIsolatedPerResolve(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "1")
+	set, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("sql"))
+	c.Assert(err, qt.IsNil)
+
+	_, err = set.Resolve(t.Context(), atlassource.ResolveOptions{Dialect: "sqlite"})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(set.Sources[0].Command, qt.DeepEquals, schemasource.Command{
+		Args:   set.Sources[0].Command.Args,
+		Format: "sql",
+		Env:    set.Sources[0].Command.Env,
+	})
+	c.Assert(set.Sources[0].Command.Dialect, qt.Equals, "")
+}

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/schemasource"
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlasurl"
@@ -71,7 +72,8 @@ type State struct {
 // Resolve materializes the set's desired state. Local schema files load
 // exactly as before this resolver existed; database URLs are introspected
 // live; migration directories are replayed on the dev database and the result
-// is introspected.
+// is introspected; external schema programs run without a shell and their
+// standard output is parsed as the desired schema.
 func (s Set) Resolve(ctx context.Context, opts ResolveOptions) (State, error) {
 	switch s.Kind {
 	case KindLocalFile:
@@ -84,9 +86,26 @@ func (s Set) Resolve(ctx context.Context, opts ResolveOptions) (State, error) {
 		return s.resolveDatabase(ctx, opts)
 	case KindMigrationDir:
 		return s.resolveMigrationDir(ctx, opts)
+	case KindExternalSchema:
+		return s.resolveExternalSchema(ctx, opts)
 	default:
 		return State{}, fmt.Errorf("%s: unresolved %s desired-state source", s.Flag, s.Kind)
 	}
+}
+
+// resolveExternalSchema runs the classified external schema program and parses
+// its standard output into the desired schema IR. The classification gate has
+// already been passed; execution itself delegates to the same schemasource
+// runner the native external_schema path uses (no shell, bounded output,
+// stderr surfaced on failure).
+func (s Set) resolveExternalSchema(ctx context.Context, opts ResolveOptions) (State, error) {
+	command := s.Sources[0].Command
+	command.Dialect = opts.Dialect
+	schema, err := schemasource.Run(ctx, command)
+	if err != nil {
+		return State{}, fmt.Errorf("%s %q: %w", s.Flag, s.Sources[0].Raw, err)
+	}
+	return State{Kind: s.Kind, Schema: schema}, nil
 }
 
 func (s Set) rawURLs() []string {


### PR DESCRIPTION
Partially addresses #843 and #934; part of the #951 drop-in-for-Pro umbrella. Does not close any of them.

## What

`atlas.hcl` can now declare `data "external_schema"` sources and select one as an env's desired state:

```hcl
data "external_schema" "app" {
  program = ["./gen.sh"]
}

env "dev" {
  url = "sqlite://app.db"
  src = data.external_schema.app.url
}
```

Attributes mirror the `ptah.yaml` `external_schema` shape: `program` (required argv list, `program[0]` is the executable, no shell), plus the Ptah extensions `format` (`sql` default, `hcl`, `yaml`), `working_dir` (relative values resolve against the `atlas.hcl` directory), and `env` (`KEY=VALUE` entries). Unknown attributes, child blocks, duplicate names, empty programs, bad formats, and malformed env entries are all named errors.

## Design: marker + reuse of ExternalSchemaConfig

`data.external_schema.<name>.url` evaluates to an opaque internal marker, `ptah-external-schema://<name>` — a reserved scheme that cannot collide with user URLs and is never a runnable location. After env evaluation, a marker selected as the env's desired-state source (`src` / `schema.src`) is consumed into `Config.ExternalSchema` (replacing a `ptah.yaml` `external_schema` block wholesale — the files never mix into a hybrid program) and the src is cleared, so every downstream consumer sees the ordinary "external schema configured" state. Execution reuses the existing `schemasource` runner — no shell, explicit argv, bounded stdout, process-tree cleanup, secret-redacted stderr on failure. There is no second execution path.

Placement rules: the marker must be the only src value; referencing it from `url`, `dev`, `migration.dir`, or `exclude` is a named error; a declared-but-unreferenced data source is ignored and never executed (covered by a sentinel-file test).

For `ptah-compat`, the desired-state resolver gained a `KindExternalSchema` source kind: env expansion turns the configured program into a classified source, and `Set.Resolve` runs it. Consumers: `schema diff`, `schema apply`, `schema inspect` (spelled `--url env://src`), and `migrate diff`. `schema plan` (LocalFilesOnly resolver) and `schema test` (single file URL mapping) reject it with explicit errors instead of misbehaving.

## Gate posture

Executing repository-controlled code from an auto-discovered config file stays opt-in in both binaries:

- **Native `ptah`**: the existing `--allow-external-schema` flag (and its standard `PTAH_ALLOW_EXTERNAL_SCHEMA` env twin). The gate error now names the file that declared the program: `atlas.hcl data.external_schema is disabled by default; pass --allow-external-schema to execute it`.
- **`ptah-compat`**: the conformance cli-surface tier asserts flag-set parity with Atlas CE, so compat gains no new flag. The gate is the `PTAH_ALLOW_EXTERNAL_SCHEMA` environment variable — the same variable that drives the native flag — checked during source classification, before any database is contacted and before the program could run: `atlas.hcl data.external_schema executes a repository-controlled program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`.

## Measured CE rejection

Measured 2026-08-01 on the pinned Atlas CE v1.2.0 binary, logged out: an `atlas.hcl` with `data "external_schema" "app" { program = ["./gen.sh"] }` and an env src referencing it fails with exit 1: `Error: data.external_schema is not supported by the community version of Atlas.` Atlas gates this data source behind paid builds; Ptah implements it openly behind the opt-in above, consistent with checkpoint/edit/rebase.

## Matrix corrections

- `Atlas HCL data "external_schema"`: Ptah ❌→✅; Atlas CE ✅→❌ (the previous CE claim was wrong — corrected by the measurement above); Atlas Pro stays ✅. Claim scope is external_schema only; `composite_schema` and `remote_dir` remain unsupported in Ptah's atlas.hcl.
- `Atlas project config (atlas.hcl)`: the note's data-block fragment now reads "data blocks but hcl_schema and external_schema".

The schema-file parser also stops answering `data "external_schema"` (and composite_schema/remote_dir/hcl_schema) with the bare `data block does not accept labels`: it now explains these are atlas.hcl project-config constructs, and for external_schema points at the newly supported location.

## Docs

- `atlas/project-config.md`: new "External schema data source" section (attribute table, placement rules, gate behavior for both binaries, measured CE fact).
- `schema/orm-and-external.md`: the atlas.hcl spelling now cross-references alongside `ptah.yaml` and `--schema-cmd`.
- `atlas/comparison.md`: the HCL-and-config register now lists `data.external_schema.<name>.url` for Ptah and records the measured CE rejection.
- `feature-matrix.md` regenerated via `build-feature-matrix.mjs`; `check-style.mjs` passes.

## Verification

- `go vet ./...`, `golangci-lint run ./...` (only pre-existing findings in stale `.codex` worktree leftovers outside this change), `scripts/check-test-style.sh`, and the full unit suite `go test ./...` — all green.
- Unit tests: parse happy paths (program only, all attributes, yml alias, schema.src spelling), every named error, marker placement rules, unreferenced-source-never-executed (sentinel file), hcl_schema/external_schema coexistence, ptah.yaml-vs-atlas.hcl precedence in both directions, classification gate on/off/garbage values, resolver happy path plus non-zero-exit (stderr surfaced) and empty-stdout errors.
- Command tests (in-process, sqlite, re-exec helper as the external program): native `schema render` gated and allowed; compat `schema diff`, `schema apply` (dry-run and real apply asserting the table exists), `schema inspect`, `migrate diff`, plus the `schema plan`/`schema test` exclusions and both failure modes.
- Real-binary e2e (sqlite, `./gen.sh` emitting `CREATE TABLE ext_users`): native `ptah schema render --env dev` fails closed without the flag, renders with it, and the env twin works; `ptah-compat schema diff` / `schema apply --dry-run --auto-approve` / real apply all produce `ext_users`, fail closed without `PTAH_ALLOW_EXTERNAL_SCHEMA`, and surface program stderr / empty-output errors.