### PR TITLE
Fix migration dry-run revision state

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -230,7 +230,7 @@ jobs:
           go test -v ./integration -tags=integration -timeout 15m
           go test -v ./integration/gonative -tags=integration -timeout 15m
           go test -v ./dbschema -run 'TestSQLServerLive(ReadSchema|DropAllTablesDropsForeignKeys|ComputedColumnZeroDiff|DropAllTablesRejectsExternalForeignKeys|IdentifierSemantics_)' -timeout 3m
-          go test -v ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration' -timeout 3m
+          go test -v ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration|TestDryRunRevisionState_SQLServerIntegration' -timeout 3m
           go test -v ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m
 
       - name: Run database-realm cleanup and replay tests
@@ -284,7 +284,7 @@ jobs:
           COCKROACHDB_TEST_DSN: "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_TEST_DSN: "postgresql://yugabyte@localhost:5433/yugabyte?sslmode=disable"
         run: |
-          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_|TestAtlasRevisionMetadata_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouseRejectsSet)Integration|TestAtlasRevisionTable_(Postgres|CockroachDB|YugabyteDB)UsesTimestamptzIntegration|TestAtlasSetSerializable_PostgresConcurrentInsertIntegration' -timeout 3m
+          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_|TestAtlasRevisionMetadata_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouseRejectsSet)Integration|TestAtlasRevisionTable_(Postgres|CockroachDB|YugabyteDB)UsesTimestamptzIntegration|TestAtlasSetSerializable_PostgresConcurrentInsertIntegration|TestDryRunRevisionState_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouse)Integration' -timeout 3m
 
       - name: Run no-transaction and shadow generator integration tests
         env:

--- a/cmd/atlas/migrate_apply_revision_state_test.go
+++ b/cmd/atlas/migrate_apply_revision_state_test.go
@@ -1,0 +1,45 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+)
+
+func TestMigrateApplyDryRunTxModeAllDiagnosticDoesNotSuggestUnsupportedFlag(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "1_users.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "2_checked.sql"),
+		[]byte("-- +ptah check name=\"users_empty\" assert=\"SELECT count(*) = 0 FROM users\" on_fail=abort\nDROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var output bytes.Buffer
+	cmd.SetOut(&output)
+	cmd.SetErr(&output)
+	cmd.SetArgs([]string{
+		"migrate", "apply",
+		"--url", "sqlite://" + filepath.Join(dir, "tx-mode.db"),
+		"--dir", "file://" + migrationsDir,
+		"--dry-run",
+		"--tx-mode", "all",
+	})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, `error applying migrations: migration 2 declares pre-migration checks, which cannot run with tx-mode all; use the default per-file transaction mode`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "--skip-checks")
+}

--- a/cmd/atlas/migrate_down_format_test.go
+++ b/cmd/atlas/migrate_down_format_test.go
@@ -2,6 +2,7 @@ package atlas_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"os"
 	"path/filepath"
@@ -12,6 +13,7 @@ import (
 
 	"github.com/stokaro/ptah/cmd/atlas"
 	"github.com/stokaro/ptah/cmd/migratedown"
+	"github.com/stokaro/ptah/dbschema"
 )
 
 // writeMigrateDownFixture fills migrationsDir with two Atlas-format
@@ -52,6 +54,10 @@ type migrateDownJSONReport struct {
 		Name    string   `json:"Name"`
 		Version string   `json:"Version"`
 		Applied []string `json:"Applied"`
+		Error   *struct {
+			Stmt string `json:"Stmt"`
+			Text string `json:"Text"`
+		} `json:"Error"`
 	} `json:"Reverted"`
 	Current string `json:"Current"`
 	Target  string `json:"Target"`
@@ -127,6 +133,85 @@ func TestCompatCommand_MigrateDownFormatDryRunPlansWithoutReverting(t *testing.T
 	c.Assert(out.String(), qt.Equals, "2|0|2|")
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_users"), qt.Equals, 1)
+}
+
+func TestCompatCommand_MigrateDownFormatDirtyPreflightHasNoRevertedFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	dbPath := filepath.Join(dir, "down-dirty.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(context.Background(), `UPDATE atlas_schema_revisions
+SET applied = 0, total = 1, error = 'broken'
+WHERE version = '2'`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(conn.Close(), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--url", "sqlite://" + dbPath,
+		"--dir", "file://" + migrationsDir,
+		"--dry-run",
+		"--format", "{{ json . }}",
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, `error rolling back migrations: migration 2 is dirty:.*`)
+	var report migrateDownJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil, qt.Commentf("stdout=%s stderr=%s", out.String(), errOut.String()))
+	c.Assert(report.Planned, qt.HasLen, 1)
+	c.Assert(report.Planned[0].Version, qt.Equals, "1")
+	c.Assert(report.Reverted, qt.HasLen, 0)
+	c.Assert(report.Error, qt.Contains, "migration 2 is dirty")
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_users"), qt.Equals, 1)
+}
+
+func TestCompatCommand_MigrateDownFormatReportsFirstRollbackFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	dbPath := filepath.Join(dir, "down-first-failure.db")
+	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	c.Assert(
+		os.WriteFile(
+			filepath.Join(migrationsDir, "2_add_audit.down.sql"),
+			[]byte("DROP TABLE no_such_table;\n"),
+			0o600,
+		),
+		qt.IsNil,
+	)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out, errOut bytes.Buffer
+	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs([]string{
+		"migrate", "down",
+		"--url", "sqlite://" + dbPath,
+		"--dir", "file://" + migrationsDir,
+		"--to-version", "1",
+		"--format", "{{ json . }}",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*no_such_table.*`)
+	var report migrateDownJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil, qt.Commentf("stdout=%s stderr=%s", out.String(), errOut.String()))
+	c.Assert(report.Reverted, qt.HasLen, 1)
+	c.Assert(report.Reverted[0].Version, qt.Equals, "2")
+	c.Assert(report.Reverted[0].Applied, qt.HasLen, 0)
+	c.Assert(report.Reverted[0].Error, qt.IsNotNil)
+	c.Assert(report.Reverted[0].Error.Stmt, qt.Equals, "DROP TABLE no_such_table")
+	c.Assert(report.Reverted[0].Error.Text, qt.Contains, "no such table")
 }
 
 func TestCompatCommand_MigrateDownFormatFromEnvValue(t *testing.T) {

--- a/cmd/migrateup/limit_allow_dirty_test.go
+++ b/cmd/migrateup/limit_allow_dirty_test.go
@@ -88,6 +88,23 @@ func TestMigrateUpLimitDryRunReportsLimitedCount(t *testing.T) {
 	c.Assert(count, qt.Equals, 0)
 }
 
+func TestMigrateUpDryRunUsesStoredRevisionState(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir := writeUpMigrations(t)
+	dbPath := filepath.Join(t.TempDir(), "stored-state.db")
+
+	out, err := runUp("--db-url", "sqlite://"+dbPath, "--migrations-dir", migrationsDir, "--limit", "1")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(queryCurrentVersion(c, dbPath), qt.Equals, int64(1))
+
+	out, err = runUp("--db-url", "sqlite://"+dbPath, "--migrations-dir", migrationsDir, "--dry-run")
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Current version: 1")
+	c.Assert(out, qt.Contains, "Pending migrations: 1")
+	c.Assert(out, qt.Contains, "Would have applied 1 migrations")
+	c.Assert(queryCurrentVersion(c, dbPath), qt.Equals, int64(1))
+}
+
 // insertOrphanDirtyRevision records a failed revision row for a version that
 // no migration file provides, modeling a crashed migration whose file was
 // later rebased or removed: the dirty guard trips on it, but no pending work

--- a/docs/pre-migration-checks.md
+++ b/docs/pre-migration-checks.md
@@ -59,7 +59,7 @@ exactly the pre-migration state the migration is about to change.
   rejected before anything is applied. Under one shared transaction a check
   reading committed state cannot see earlier batched migrations' uncommitted
   changes, so it would silently evaluate a precondition against stale state. Run
-  such migrations with the default per-file mode, or pass `--skip-checks`.
+  such migrations with the default per-file mode.
 
 Checks are evaluated for the **up** direction only (they guard forward,
 typically destructive, migrations); a `-- +ptah check` in a down migration is

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -527,8 +527,8 @@
   "ptah": "partial",
   "atlas_oss": "yes",
   "atlas_pro": "yes",
-  "note": "Also runs goose/flyway/liquibase/dbmate dirs via ?format=; `--dry-run` ignores the revision table and re-plans already-applied files.",
-  "evidence": "Executed: after a full apply, `ptah-compat migrate status` reports \"Pending Migrations: 0\" while `ptah-compat migrate apply --dry-run` reports \"Migrating to version 20240102000000 from 2 pending migrations. Would have applied 2 migrations.\" Same on native `ptah migrations up --dry-run`. Code: migration/migrator/migrator.go:660 (GetCurrentVersion returns 0 under dry-run) and :719 (queryMigrationRows returns empty). External formats verified: `migrate apply --dir \"file://src2?format=goose\"` applied to version 2."
+  "note": "Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format table creation remains #950; Ptah-format is covered.",
+  "evidence": "Dry-run tests cover native and compat CLIs, dirty/checksum/tx-mode validation, exact legacy and rejected partial SQLite layouts, seven live database targets, PostgreSQL multi-schema search_path and explicit schemas, plus deterministic Spanner SQL. External directory formats remain verified by apply fixtures."
  },
  {
   "area": "Versioned migrations — execution",
@@ -536,8 +536,8 @@
   "ptah": "partial",
   "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "Ptah reverts via pre-planned down files; `--to-tag`/`--skip-checks`/`--plan` fail loudly as waivers. In pinned CE, `migrate down` is a registered community-abort stub, not a working verb.",
-  "evidence": "cli-surface.md CE inventory (37 commands, no `migrate down`); atlas/conformance.md workflow parity: 'migrate down does not exist in the community binary; the CE notice lists down migrations among excluded features'; /tmp/v1-compat migrate down waiver errors reproduced. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): bare `atlas migrate down` -> exit 1 \"Abort: 'atlas migrate down' is not supported by the community version.\"; with --url/--dir it fails earlier on unknown flag because the stub registers no flags. Measured 2026-08-01, Atlas v1.2.4-e282f76-canary licensed trial build, logged in: `migrate down` works locally, deletes reverted revision rows (incl. Ptah-written), and inserts a `.atlas_cloud_identifier` metadata row that aborts Ptah reads - stokaro/ptah#957 (trial-study observations, scenario, migrate-down-revisions)"
+  "note": "Ptah validates all selected down bodies before changing state. Dry-run reports distinguish preflight rejection from attempted rollback. Registry flags remain waivers.",
+  "evidence": "internal/atlasmigrate/down_test.go covers missing-down preservation, dry-run validation, and dirty preflight; cmd/atlas/migrate_down_format_test.go proves preflight failures render no reverted files. CE v1.2.0 logged out aborts as unsupported. Measured 2026-08-01, Atlas v1.2.4-e282f76-canary licensed trial build, logged in: `migrate down` works locally, deletes reverted revision rows (including Ptah-written rows), and inserts `.atlas_cloud_identifier`, which Ptah cannot yet read (#957; trial-study scenario migrate-down-revisions)."
  },
  {
   "area": "Versioned migrations — execution",
@@ -653,8 +653,8 @@
   "ptah": "partial",
   "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "Only the `-- +ptah check` spelling; `--tx-mode` all refuses checked files, and that error names `--skip-checks`, which compat apply lacks. CE applies a failing checks.sql unenforced.",
-  "evidence": "Executed: a migration carrying `-- +ptah check name=\"users_empty\" assert=\"SELECT count(*) = 0 FROM users\" on_fail=abort` aborts with \"pre-migration check users_empty ... was not satisfied\" and nothing applied; with `--tx-mode all` it fails \"...cannot run with tx-mode all; use the default per-file transaction mode or --skip-checks\", but `ptah-compat migrate apply --skip-checks` -> \"unknown flag: --skip-checks\" (the flag exists only on native `ptah migrations up`, cmd/migrateup/migrateup.go:150). Measured 2026-08-01, CE v1.2.0 logged out (scratch env): an `-- atlas:txtar` migration whose checks.sql held a failing assertion applied anyway, exit 0 - CE executes the section as plain SQL without assertion semantics. Atlas pricing page (atlasgo.io/pricing, retrieved 2026-08-01) lists 'Pre-migration safety checks' under Pro, not Starter. Measured 2026-08-01, Atlas v1.2.4-e282f76-canary licensed trial build, logged in: the licensed build ENFORCES txtar checks.sql (failing assertion aborts before any body statement, exit 1) and registers no `migrate apply --skip-checks` - the flag lives on `migrate down` (trial-study observations, scenario, txtar-checks-enforcement, verbs-and-flags)"
+  "note": "Only the `-- +ptah check` spelling. `--tx-mode` all directs users to per-file mode; native `--skip-checks` remains an emergency bypass. CE leaves checks unenforced.",
+  "evidence": "TestMigrateApplyDryRunTxModeAllDiagnosticDoesNotSuggestUnsupportedFlag proves compat dry-run rejects checked files without suggesting its unsupported `--skip-checks`; cmd/migrateup registers that flag only on native `ptah migrations up`. Measured 2026-08-01: CE v1.2.0 applies failing checks.sql unenforced; Atlas v1.2.4-e282f76-canary licensed trial enforces it before the body and exposes `--skip-checks` on down, not apply (trial-study scenarios txtar-checks-enforcement and verbs-and-flags)."
  },
  {
   "area": "Versioned migrations — runtime policy",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -154,7 +154,7 @@ as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Also runs goose/flyway/liquibase/dbmate dirs via ?format=; `--dry-run` ignores the revision table and re-plans already-applied files. |
+| Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format table creation remains #950; Ptah-format is covered. |
 | Atlas SQL template migrations (`--atlas-env`) | ✅ | ❔ | ❔ | Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs. |
 | Atlas txtar migration sections (-- atlas:txtar) | ✅ | ❔ | ✅ | Atlas-format .sql files with `-- atlas:txtar` execute migration.sql and down.sql sections; checks.sql is discarded, not enforced (stokaro/ptah#956); other embedded files are ignored. |
 | Atlas-format checkpoint output | ❌ | ❌ | ✅ | migrate checkpoint `--dir-format`=atlas is a recorded waiver; Ptah writes only the ptah two-file checkpoint convention. |
@@ -179,7 +179,7 @@ as open capabilities regardless.
 | Prometheus metrics endpoint (`--metrics-addr`) | ✅ | ❌ | ❌ | migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run. |
 | Repair dirty or partial revision state | ✅ | ❌ | ❌ | `ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence. |
 | Revision table format and placement | ✅ | ✅ | ✅ | `--revision-format` ptah\|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows. |
-| Roll back applied migrations (down) | 🟡 | ❌ | ✅ | Ptah reverts via pre-planned down files; `--to-tag`/`--skip-checks`/`--plan` fail loudly as waivers. In pinned CE, `migrate down` is a registered community-abort stub, not a working verb. |
+| Roll back applied migrations (down) | 🟡 | ❌ | ✅ | Ptah validates all selected down bodies before changing state. Dry-run reports distinguish preflight rejection from attempted rollback. Registry flags remain waivers. |
 | Set revision state to a version | ✅ | ✅ | ✅ | Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set. |
 | Structured JSON log output (`--log-format`) | ✅ | ❌ | ❌ | migrations up, down, and status take `--log-format` text\|json and `--log-level` debug\|info\|warn\|error for machine-readable run logs. |
 | Transaction modes (`--tx-mode` file/all/none) | ✅ | ✅ | ✅ | all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks. |
@@ -200,7 +200,7 @@ as open capabilities regardless.
 | Inline nolint suppression | 🟡 | ✅ | ✅ | Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored. |
 | Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
 | Per-rule severity policy | 🟡 | ❔ | 🟡 | Severity vocabulary is warning\|error only (info errors out). Measured licensed build is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist. |
-| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Only the `-- +ptah check` spelling; `--tx-mode` all refuses checked files, and that error names `--skip-checks`, which compat apply lacks. CE applies a failing checks.sql unenforced. |
+| Pre-migration assertion checks | 🟡 | ❌ | ✅ | Only the `-- +ptah check` spelling. `--tx-mode` all directs users to per-file mode; native `--skip-checks` remains an emergency bypass. CE leaves checks unenforced. |
 | SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
 | Standalone SQL file linting (`ptah sql lint`) | ✅ | ❌ | ❔ | Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not. |
 | Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -124,6 +124,11 @@ Expected output ends with:
 Database is now at version: 0
 ```
 
+Ptah validates every selected down body before rollback starts. If one is
+missing, the command leaves both the schema and Atlas revision rows unchanged.
+Dry runs use the same dirty-state, checksum, checkpoint, and down-body
+validation path as real rollbacks, while suppressing schema and revision writes.
+
 Add `--dev-url` to reset a disposable dev database, replay the migration
 directory to the target's current version, and verify the rollback there before
 the target is touched:
@@ -169,6 +174,9 @@ mirrors Atlas's public apply-template fields: `Pending`, `Applied`, `Current`,
 `Target`, `Start`, `End`, `Driver`, `URL`, and `Dir`; `{{ json . }}` emits the
 same result as JSON with database credentials redacted. With `--env`, Ptah can
 read `env.url`, `migration`, and `format.migrate.apply` from `atlas.hcl`.
+Dry-run plans read the stored Atlas revision rows and include only migrations
+that a real apply would select. They also run the same dirty-state, checksum,
+execution-order, and transaction-mode validations as a real apply.
 
 The apply path executes every Atlas OSS migration directory format selected by
 `migration.format` or the directory URL `?format=` parameter: `atlas`,

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -37,9 +37,11 @@ Would have applied 1 migrations
 ```
 
 :::note
-The dry run simulates an uninitialized revision table: it walks every
-migration in the directory, not only the ones pending on this target. Use
-`ptah migrations status` to see what a real run would apply.
+The dry run reads an existing revision table and walks only migrations pending
+on this target. On a fresh target, it treats the absent revision table as empty
+without creating it. A legacy three-column Ptah revision table is read without
+upgrading its layout. A partially upgraded table is rejected with a missing
+column diagnostic and is not modified.
 :::
 
 ## Apply with integrity verification

--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -57,6 +57,14 @@ Applied Migrations: 1
 Pending Migrations: 1
 ```
 
+Before rollback starts, Ptah verifies that every selected migration has a down
+body. A missing down body aborts before Ptah changes either the schema or the
+revision table.
+
+Dry run follows the same dirty-state, checksum, checkpoint, and down-body
+validation path as execution. It reports no migration as reverted when a
+preflight check fails before rollback starts.
+
 ## Verify the plan on a shadow database first
 
 Add `--shadow-db` to replay and verify the rollback plan on a disposable

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -40,8 +40,9 @@ type ApplyPlan struct {
 	DryRun           bool
 	StartedAt        time.Time
 
-	mig  *migrator.Migrator
-	opts ApplyOptions
+	mig                    *migrator.Migrator
+	opts                   ApplyOptions
+	assumedAppliedVersions []int64
 }
 
 // ApplyResult contains execution metadata needed by CLI output and Atlas
@@ -102,14 +103,15 @@ func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts A
 	}
 
 	return ApplyPlan{
-		Status:           status,
-		Migrations:       mig.MigrationProvider().Migrations(),
-		SelectedVersions: selectedApplyVersions(pending, opts.Amount),
-		CurrentVersion:   plannedCurrentVersion,
-		DryRun:           opts.DryRun,
-		StartedAt:        startedAt,
-		mig:              mig,
-		opts:             opts,
+		Status:                 status,
+		Migrations:             mig.MigrationProvider().Migrations(),
+		SelectedVersions:       selectedApplyVersions(pending, opts.Amount),
+		CurrentVersion:         plannedCurrentVersion,
+		DryRun:                 opts.DryRun,
+		StartedAt:              startedAt,
+		mig:                    mig,
+		opts:                   opts,
+		assumedAppliedVersions: assumedAppliedVersions,
 	}, nil
 }
 
@@ -130,21 +132,25 @@ func (p ApplyPlan) Execute(ctx context.Context) (ApplyResult, error) {
 		DryRun:           p.DryRun,
 		StartedAt:        p.StartedAt,
 	}
-	if p.Noop() || p.opts.DryRun {
-		result.EndedAt = time.Now()
-		return result, nil
-	}
-
+	executionStarted := false
 	err := p.mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
-		Amount:     p.opts.Amount,
-		AllowDirty: p.opts.AllowDirty,
+		Amount:                 p.opts.Amount,
+		AllowDirty:             p.opts.AllowDirty,
+		AssumedAppliedVersions: p.assumedAppliedVersions,
+		Preflight: func(_ context.Context, plan migrator.MigrationPlan) error {
+			executionStarted = len(plan.Versions) > 0
+			return nil
+		},
 	})
 	result.EndedAt = time.Now()
 	if err != nil {
-		result.Applied = true
+		result.Applied = executionStarted && !p.DryRun
 		result.ApplyError = err
 		result.ErrorText = err.Error()
 		return result, fmt.Errorf("error applying migrations: %w", err)
+	}
+	if p.DryRun || !executionStarted {
+		return result, nil
 	}
 
 	finalStatus, err := p.mig.GetMigrationStatus(ctx)

--- a/internal/atlasmigrate/apply_test.go
+++ b/internal/atlasmigrate/apply_test.go
@@ -176,6 +176,166 @@ func TestPrepareApplyExecute_DryRunBaselinePlansRemaining(t *testing.T) {
 	c.Assert(sqliteTableExists(c, conn, "dry_baseline_three"), qt.IsFalse)
 }
 
+func TestPrepareApplyExecute_DryRunUsesStoredRevisionState(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_one.sql", "CREATE TABLE dry_state_one (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_two.sql", "CREATE TABLE dry_state_two (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "3_three.sql", "CREATE TABLE dry_state_three (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dry-state.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+		Amount:    2,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+
+	dryRunPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		DryRun:    true,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(dryRunPlan.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(dryRunPlan.Status.AppliedMigrations, qt.DeepEquals, []int64{1, 2})
+	c.Assert(dryRunPlan.Status.PendingMigrations, qt.DeepEquals, []int64{3})
+	c.Assert(dryRunPlan.SelectedVersions, qt.DeepEquals, []int64{3})
+
+	result, err := dryRunPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Applied, qt.IsFalse)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2"})
+	c.Assert(sqliteTableExists(c, conn, "dry_state_three"), qt.IsFalse)
+}
+
+func TestPrepareApplyExecute_DryRunRejectsDirtyRevision(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_users.sql", "CREATE TABLE dry_dirty_users (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dry-dirty.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `UPDATE atlas_schema_revisions
+SET applied = 0, total = 1, error = 'broken'
+WHERE version = '1'`)
+	c.Assert(err, qt.IsNil)
+
+	dryRunPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		DryRun:    true,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := dryRunPlan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `error applying migrations: migration 1 is dirty:.*`)
+	c.Assert(result.Applied, qt.IsFalse)
+	c.Assert(result.ApplyError, qt.IsNotNil)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1"})
+	c.Assert(sqliteTableExists(c, conn, "dry_dirty_users"), qt.IsTrue)
+}
+
+func TestPrepareApplyExecute_DirtyPreflightIsNotReportedAsApplyAttempt(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_users.sql", "CREATE TABLE dirty_apply_users (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dirty-apply.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `UPDATE atlas_schema_revisions
+SET applied = 0, total = 1, error = 'broken'
+WHERE version = '1'`)
+	c.Assert(err, qt.IsNil)
+
+	retryPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := retryPlan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `error applying migrations: migration 1 is dirty:.*`)
+	c.Assert(result.Applied, qt.IsFalse)
+	var dirty *migrator.DirtyMigrationError
+	c.Assert(result.ApplyError, qt.ErrorAs, &dirty)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1"})
+	c.Assert(sqliteTableExists(c, conn, "dirty_apply_users"), qt.IsTrue)
+}
+
+func TestPrepareApplyExecute_DryRunRejectsChecksumMismatch(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_users.sql", "CREATE TABLE dry_checksum_users (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dry-checksum.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `UPDATE atlas_schema_revisions SET hash = 'deadbeef' WHERE version = '1'`)
+	c.Assert(err, qt.IsNil)
+
+	dryRunPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		DryRun:    true,
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := dryRunPlan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `error applying migrations: migration 1 checksum mismatch:.*`)
+	c.Assert(result.Applied, qt.IsFalse)
+	c.Assert(result.ApplyError, qt.IsNotNil)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1"})
+	c.Assert(sqliteTableExists(c, conn, "dry_checksum_users"), qt.IsTrue)
+}
+
 func TestPrepareApplyExecute_NoopReturnsResult(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()

--- a/internal/atlasmigrate/down.go
+++ b/internal/atlasmigrate/down.go
@@ -88,11 +88,7 @@ func PrepareDown(ctx context.Context, conn *dbschema.DatabaseConnection, opts Do
 		WithMigrationLockTimeout(opts.MigrationLockTimeout).
 		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
 
-	// Unlike PrepareApply, the writer's dry-run mode is enabled only after the
-	// revision state is read: the migrator short-circuits reads to empty
-	// results under writer dry-run, and a down plan is meaningless without the
-	// real applied set. Execute skips the rollback under DryRun, and the
-	// writer's dry-run mode then guards any residual write path.
+	conn.SchemaWriter().SetDryRun(opts.DryRun)
 	status, err := mig.GetMigrationStatus(ctx)
 	if err != nil {
 		return DownPlan{}, fmt.Errorf("error getting migration status: %w", err)
@@ -101,8 +97,6 @@ func PrepareDown(ctx context.Context, conn *dbschema.DatabaseConnection, opts Do
 	if err != nil {
 		return DownPlan{}, fmt.Errorf("error getting applied migrations: %w", err)
 	}
-	conn.SchemaWriter().SetDryRun(opts.DryRun)
-
 	return DownPlan{
 		Status:          status,
 		Migrations:      mig.MigrationProvider().Migrations(),
@@ -135,20 +129,25 @@ func (p DownPlan) Execute(ctx context.Context) (DownResult, error) {
 		DryRun:          p.DryRun,
 		StartedAt:       p.StartedAt,
 	}
-	if p.Noop() || p.DryRun {
-		result.EndedAt = time.Now()
-		return result, nil
-	}
-
-	err := p.mig.MigrateDownTo(ctx, p.opts.TargetVersion)
+	executionStarted := false
+	err := p.mig.MigrateDownToWithPreflight(ctx, p.opts.TargetVersion, func(_ context.Context, plan migrator.MigrationPlan) error {
+		executionStarted = len(plan.Versions) > 0
+		return nil
+	})
 	result.EndedAt = time.Now()
-	result.Reverted = true
 	if err != nil {
 		result.DownError = err
 		result.ErrorText = err.Error()
-		result.RevertedVersions = p.revertedVersionsAfterError(ctx)
+		result.Reverted = executionStarted && !p.DryRun
+		if result.Reverted {
+			result.RevertedVersions = p.revertedVersionsAfterError(ctx)
+		}
 		return result, fmt.Errorf("error rolling back migrations: %w", err)
 	}
+	if p.DryRun || !executionStarted {
+		return result, nil
+	}
+	result.Reverted = true
 	result.RevertedVersions = p.PlannedVersions
 
 	finalStatus, err := p.mig.GetMigrationStatus(ctx)

--- a/internal/atlasmigrate/down_test.go
+++ b/internal/atlasmigrate/down_test.go
@@ -100,12 +100,124 @@ func TestPrepareDownExecute_DryRunLeavesRevisionsUntouched(t *testing.T) {
 		DryRun:        true,
 	})
 	c.Assert(err, qt.IsNil)
+	c.Assert(plan.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(plan.PlannedVersions, qt.DeepEquals, []int64{2, 1})
 
 	result, err := plan.Execute(ctx)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(result.Reverted, qt.IsFalse)
 	c.Assert(result.RevertedVersions, qt.HasLen, 0)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2"})
+	c.Assert(sqliteTableExists(c, conn, "down_users"), qt.IsTrue)
+}
+
+func TestPrepareDownExecute_MissingDownPreservesRevisionAndSchemaState(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_users.sql", "CREATE TABLE missing_down_users (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_posts.sql", "CREATE TABLE missing_down_posts (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "2_posts.down.sql", "DROP TABLE missing_down_posts;")
+	conn := connectSQLite(c, filepath.Join(dir, "missing-down.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+
+	downPlan, err := atlasmigrate.PrepareDown(ctx, conn, atlasmigrate.DownOptions{
+		Dir:           migrationsDir,
+		FS:            os.DirFS(migrationsDir),
+		TargetVersion: 0,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(downPlan.PlannedVersions, qt.DeepEquals, []int64{2, 1})
+
+	result, err := downPlan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 has no Atlas down migration.*`)
+	c.Assert(result.Reverted, qt.IsFalse)
+	c.Assert(result.RevertedVersions, qt.HasLen, 0)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2"})
+	c.Assert(sqliteTableExists(c, conn, "missing_down_users"), qt.IsTrue)
+	c.Assert(sqliteTableExists(c, conn, "missing_down_posts"), qt.IsTrue)
+
+	status, err := atlasmigrate.Status(ctx, conn, atlasmigrate.StatusOptions{
+		Dir: migrationsDir,
+		FS:  os.DirFS(migrationsDir),
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.Status.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(status.Status.AppliedMigrations, qt.DeepEquals, []int64{1, 2})
+	c.Assert(status.Status.PendingMigrations, qt.HasLen, 0)
+	c.Assert(status.Status.DirtyRevision, qt.IsNil)
+}
+
+func TestPrepareDownExecute_DryRunRejectsMissingDownWithoutMutation(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyMigrationFile(c, migrationsDir, "1_users.sql", "CREATE TABLE dry_missing_down_users (id INTEGER PRIMARY KEY);")
+	conn := connectSQLite(c, filepath.Join(dir, "dry-missing-down.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	applyPlan, err := atlasmigrate.PrepareApply(ctx, conn, atlasmigrate.ApplyOptions{
+		Dir:       migrationsDir,
+		FS:        os.DirFS(migrationsDir),
+		ExecOrder: migrator.ExecOrderLinear,
+		TxMode:    migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	_, err = applyPlan.Execute(ctx)
+	c.Assert(err, qt.IsNil)
+
+	downPlan, err := atlasmigrate.PrepareDown(ctx, conn, atlasmigrate.DownOptions{
+		Dir:           migrationsDir,
+		FS:            os.DirFS(migrationsDir),
+		TargetVersion: 0,
+		DryRun:        true,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := downPlan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `error rolling back migrations: migration 1 has no Atlas down migration.*`)
+	c.Assert(result.Reverted, qt.IsFalse)
+	c.Assert(result.RevertedVersions, qt.HasLen, 0)
+	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1"})
+	c.Assert(sqliteTableExists(c, conn, "dry_missing_down_users"), qt.IsTrue)
+}
+
+func TestPrepareDownExecute_DirtyPreflightIsNotReportedAsRollbackAttempt(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	migrationsDir, conn := prepareDownFixture(c, "ALTER TABLE down_users DROP COLUMN email;")
+	defer dbschema.CloseAndWarn(conn)
+	_, err := conn.ExecContext(ctx, `UPDATE atlas_schema_revisions
+SET applied = 0, total = 1, error = 'broken'
+WHERE version = '2'`)
+	c.Assert(err, qt.IsNil)
+
+	plan, err := atlasmigrate.PrepareDown(ctx, conn, atlasmigrate.DownOptions{
+		Dir:           migrationsDir,
+		FS:            os.DirFS(migrationsDir),
+		TargetVersion: 0,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := plan.Execute(ctx)
+	c.Assert(err, qt.ErrorMatches, `error rolling back migrations: migration 2 is dirty:.*`)
+	c.Assert(result.Reverted, qt.IsFalse)
+	c.Assert(result.RevertedVersions, qt.HasLen, 0)
+	var dirty *migrator.DirtyMigrationError
+	c.Assert(result.DownError, qt.ErrorAs, &dirty)
 	c.Assert(sqliteAtlasRevisionVersions(c, conn), qt.DeepEquals, []string{"1", "2"})
 	c.Assert(sqliteTableExists(c, conn, "down_users"), qt.IsTrue)
 }
@@ -168,6 +280,28 @@ func TestPrepareDownExecute_FailurePathReportsRevertedPrefix(t *testing.T) {
 	c.Assert(result.RevertedVersions, qt.DeepEquals, []int64{2})
 	c.Assert(result.DownError, qt.IsNotNil)
 	c.Assert(result.ErrorText, qt.Contains, "failed to revert migration 1")
+}
+
+func TestPrepareDownExecute_FailurePathReportsFirstRollbackAttempt(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	migrationsDir, conn := prepareDownFixture(c, "DROP TABLE no_such_table;")
+	defer dbschema.CloseAndWarn(conn)
+
+	plan, err := atlasmigrate.PrepareDown(ctx, conn, atlasmigrate.DownOptions{
+		Dir:           migrationsDir,
+		FS:            os.DirFS(migrationsDir),
+		TargetVersion: 1,
+	})
+	c.Assert(err, qt.IsNil)
+
+	result, err := plan.Execute(ctx)
+
+	c.Assert(err, qt.ErrorMatches, `(?s)error rolling back migrations: .*no_such_table.*`)
+	c.Assert(result.Reverted, qt.IsTrue)
+	c.Assert(result.RevertedVersions, qt.HasLen, 0)
+	c.Assert(result.DownError, qt.IsNotNil)
+	c.Assert(result.ErrorText, qt.Contains, "failed to revert migration 2")
 }
 
 func TestPrepareDown_FailurePathValidatesOptions(t *testing.T) {

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -137,9 +137,11 @@ metadata table location.
 
 If an Atlas migration does not provide `down.sql`, `migrations down` returns a typed
 error explaining that Atlas dynamic down-plan synthesis is not implemented yet.
-This is distinct from transaction rollback on a failed migration: transaction
-rollback undoes an in-progress failure, Ptah paired `.down.sql` files and Atlas
-txtar `down.sql` sections revert already-applied migrations, and Atlas dynamic
+The migrator validates the complete rollback selection before execution, so a
+missing down body leaves schema and revision state unchanged. This is distinct
+from transaction rollback on a failed migration: transaction rollback undoes
+an in-progress failure, Ptah paired `.down.sql` files and Atlas txtar
+`down.sql` sections revert already-applied migrations, and Atlas dynamic
 `migrate down` would synthesize a downgrade plan from database/dev state.
 
 `-- +ptah` directives inside `migration.sql` and `down.sql` are parsed per
@@ -159,6 +161,16 @@ With dry run:
 ```bash
 go run ./cmd migrations up --db-url postgres://user:pass@localhost/db --migrations-dir /path/to/migrations --dry-run
 ```
+
+Dry-run reads existing revision metadata and selects only pending migrations.
+When the metadata table is absent, it models an empty revision history without
+creating the table. It reads the legacy three-column Ptah revision layout
+without adding the newer state and checksum columns. A table containing only a
+subset of the current revision columns fails with an explicit layout diagnostic
+and remains unchanged. For the current revision layout, dry-run still enforces
+dirty-state and checksum validation. It enforces execution-order,
+transaction-mode, checkpoint, and down-body validation for both current and
+legacy revision layouts.
 
 Allow applying a migration whose version is below the current high-water mark:
 ```bash

--- a/migration/migrator/atlas_integration_test.go
+++ b/migration/migrator/atlas_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/sha256"
 	"database/sql"
 	"encoding/hex"
+	"net/url"
 	"os"
 	"strconv"
 	"strings"
@@ -112,6 +113,233 @@ func TestAtlasRevisionMetadata_CockroachDBIntegration(t *testing.T) {
 
 func TestAtlasRevisionMetadata_YugabyteDBIntegration(t *testing.T) {
 	runAtlasRevisionMetadataIntegration(t, yugabyteDBAtlasTestURL(t))
+}
+
+func TestDryRunRevisionState_PostgresIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, postgresTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_PostgresIntegration_SearchPath(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	rawURL := postgresTestURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, rawURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	_, _ = admin.ExecContext(ctx, "DROP SCHEMA IF EXISTS ptah_issue_937_search_path CASCADE")
+	_, err = admin.ExecContext(ctx, "CREATE SCHEMA ptah_issue_937_search_path")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, _ = admin.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS ptah_issue_937_search_path CASCADE")
+	}()
+
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	query := parsed.Query()
+	query.Set("search_path", "ptah_issue_937_search_path")
+	parsed.RawQuery = query.Encode()
+	conn, err := dbschema.ConnectToDatabase(ctx, parsed.String())
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	fsys := fstest.MapFS{
+		"1_probe.sql": &fstest.MapFile{Data: []byte("SELECT 1;\n")},
+	}
+	writer, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	writer = writer.WithRevisionTableFormat(migrator.RevisionTableFormatPtah)
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	reader, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	reader = reader.WithRevisionTableFormat(migrator.RevisionTableFormatPtah)
+
+	status, err := reader.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+}
+
+func TestDryRunRevisionState_PostgresIntegration_SearchPathIgnoresFallbackMetadata(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	rawURL := postgresTestURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, rawURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	_, _ = admin.ExecContext(ctx, "DROP SCHEMA IF EXISTS ptah_issue_937_current CASCADE")
+	_, _ = admin.ExecContext(ctx, "DROP SCHEMA IF EXISTS ptah_issue_937_fallback CASCADE")
+	_, err = admin.ExecContext(ctx, "CREATE SCHEMA ptah_issue_937_current")
+	c.Assert(err, qt.IsNil)
+	_, err = admin.ExecContext(ctx, "CREATE SCHEMA ptah_issue_937_fallback")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		_, _ = admin.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS ptah_issue_937_current CASCADE")
+		_, _ = admin.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS ptah_issue_937_fallback CASCADE")
+	}()
+
+	parsedFallback, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	fallbackQuery := parsedFallback.Query()
+	fallbackQuery.Set("search_path", "ptah_issue_937_fallback")
+	parsedFallback.RawQuery = fallbackQuery.Encode()
+	fallbackConn, err := dbschema.ConnectToDatabase(ctx, parsedFallback.String())
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(fallbackConn)
+	fSys := fstest.MapFS{
+		"1_probe.sql": &fstest.MapFile{Data: []byte("SELECT 1;\n")},
+	}
+	fallbackWriter, err := migrator.NewFSMigrator(
+		fallbackConn,
+		fSys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	fallbackWriter = fallbackWriter.WithRevisionTableFormat(migrator.RevisionTableFormatPtah)
+	c.Assert(fallbackWriter.MigrateUp(ctx), qt.IsNil)
+
+	parsedCurrent, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	currentQuery := parsedCurrent.Query()
+	currentQuery.Set("search_path", "ptah_issue_937_current,ptah_issue_937_fallback")
+	parsedCurrent.RawQuery = currentQuery.Encode()
+	currentConn, err := dbschema.ConnectToDatabase(ctx, parsedCurrent.String())
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(currentConn)
+	currentConn.SchemaWriter().SetDryRun(true)
+	reader, err := migrator.NewFSMigrator(
+		currentConn,
+		fSys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	reader = reader.WithRevisionTableFormat(migrator.RevisionTableFormatPtah)
+
+	status, err := reader.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(status.AppliedMigrations, qt.HasLen, 0)
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{1})
+}
+
+func TestDryRunRevisionState_PostgresIntegration_ExplicitSchema(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, postgresTestURL(t))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, _ = conn.ExecContext(ctx, "DROP SCHEMA IF EXISTS ptah_issue_937_explicit CASCADE")
+	_, err = conn.ExecContext(ctx, "CREATE SCHEMA ptah_issue_937_explicit")
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		conn.SchemaWriter().SetDryRun(false)
+		_, _ = conn.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS ptah_issue_937_explicit CASCADE")
+	}()
+	fsys := fstest.MapFS{
+		"1_probe.sql": &fstest.MapFile{Data: []byte("SELECT 1;\n")},
+	}
+	writer, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	writer = writer.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithMigrationsTable("ptah_issue_937_explicit", "atlas_schema_revisions")
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	reader, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	reader = reader.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithMigrationsTable("ptah_issue_937_explicit", "atlas_schema_revisions")
+
+	status, err := reader.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+}
+
+func TestDryRunRevisionState_MySQLIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, mysqlAtlasTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_MariaDBIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, mariaDBAtlasTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_SQLServerIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, sqlServerAtlasTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_CockroachDBIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, cockroachDBAtlasTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_YugabyteDBIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, yugabyteDBAtlasTestURL(t), migrator.RevisionTableFormatAtlas)
+}
+
+func TestDryRunRevisionState_ClickHouseIntegration(t *testing.T) {
+	runDryRunRevisionStateIntegration(t, clickHouseAtlasTestURL(t), migrator.RevisionTableFormatPtah)
+}
+
+func runDryRunRevisionStateIntegration(
+	t *testing.T,
+	dbURL string,
+	revisionFormat migrator.RevisionTableFormat,
+) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := t.Context()
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	cleanupIssue937(t, conn)
+	defer cleanupIssue937(t, conn)
+
+	fsys := fstest.MapFS{
+		"1_probe.sql": &fstest.MapFile{Data: []byte("SELECT 1;\n")},
+	}
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithRevisionTableFormat(revisionFormat).
+		WithMigrationsTable("", "ptah_issue_937_revisions")
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+
+	conn.SchemaWriter().SetDryRun(true)
+	dryRunMigrator, err := migrator.NewFSMigrator(
+		conn,
+		fsys,
+		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatAtlas),
+	)
+	c.Assert(err, qt.IsNil)
+	dryRunMigrator = dryRunMigrator.WithRevisionTableFormat(revisionFormat).
+		WithMigrationsTable("", "ptah_issue_937_revisions")
+	status, err := dryRunMigrator.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+
+	conn.SchemaWriter().SetDryRun(false)
 }
 
 func TestAtlasSetSerializable_PostgresConcurrentInsertIntegration(t *testing.T) {
@@ -868,6 +1096,13 @@ func cleanupIssue819(t *testing.T, conn *dbschema.DatabaseConnection) {
 
 	_, _ = conn.ExecContext(context.Background(), "DROP TABLE IF EXISTS atlas_schema_revisions")
 	_, _ = conn.ExecContext(context.Background(), "DROP FUNCTION IF EXISTS ptah_issue_819_pause_delete()")
+}
+
+func cleanupIssue937(t *testing.T, conn *dbschema.DatabaseConnection) {
+	t.Helper()
+
+	conn.SchemaWriter().SetDryRun(false)
+	_, _ = conn.ExecContext(context.Background(), "DROP TABLE IF EXISTS ptah_issue_937_revisions")
 }
 
 func createLegacyIssue273MetadataTable(t *testing.T, conn *dbschema.DatabaseConnection) {

--- a/migration/migrator/dry_run_revision_state_test.go
+++ b/migration/migrator/dry_run_revision_state_test.go
@@ -1,0 +1,194 @@
+package migrator_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func openDryRunRevisionSQLite(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+	conn, err := dbschema.ConnectToDatabase(
+		context.Background(),
+		"sqlite://"+filepath.Join(t.TempDir(), "revision-state.db"),
+	)
+	qt.Assert(t, err, qt.IsNil)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func revisionStateMigrations() (first, second *migrator.Migration) {
+	return migrator.CreateMigrationFromSQL(
+			1,
+			"create_users",
+			"CREATE TABLE dry_run_users (id INTEGER PRIMARY KEY);",
+			"DROP TABLE dry_run_users;",
+		), migrator.CreateMigrationFromSQL(
+			2,
+			"create_posts",
+			"CREATE TABLE dry_run_posts (id INTEGER PRIMARY KEY);",
+			"DROP TABLE dry_run_posts;",
+		)
+}
+
+func TestDryRunRevisionState_LegacyPtahTableIsReadWithoutUpgrade(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	_, err := conn.ExecContext(ctx, `CREATE TABLE schema_migrations (
+		version BIGINT PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at TIMESTAMP NOT NULL
+	)`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `INSERT INTO schema_migrations (version, description, applied_at)
+		VALUES (1, 'create_users', CURRENT_TIMESTAMP)`)
+	c.Assert(err, qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	one, two := revisionStateMigrations()
+	dryRun := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one, two))
+
+	status, err := dryRun.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{2})
+	c.Assert(dryRun.MigrateUp(ctx), qt.IsNil)
+
+	var columnCount int
+	err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('schema_migrations')").Scan(&columnCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(columnCount, qt.Equals, 3)
+}
+
+func TestDryRunRevisionState_PartialPtahTableFailsWithLayoutDiagnostic(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	_, err := conn.ExecContext(ctx, `CREATE TABLE schema_migrations (
+		version BIGINT PRIMARY KEY,
+		description TEXT NOT NULL,
+		applied_at TIMESTAMP NOT NULL,
+		state VARCHAR(32) NOT NULL DEFAULT 'applied'
+	)`)
+	c.Assert(err, qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	one, _ := revisionStateMigrations()
+	dryRun := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one))
+
+	status, err := dryRun.GetMigrationStatus(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*failed to initialize migrations table: failed to inspect migrations table layout: incomplete migrations metadata layout: missing columns applied, total, error, error_stmt, execution_time_ms, checksum`)
+	c.Assert(status, qt.IsNil)
+
+	var columnCount int
+	err = conn.QueryRowContext(ctx, "SELECT COUNT(*) FROM pragma_table_info('schema_migrations')").Scan(&columnCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(columnCount, qt.Equals, 4)
+}
+
+func TestDryRunRevisionState_SQLiteMetadataLookupMatchesIdentifierCase(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	one, _ := revisionStateMigrations()
+	writer := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one)).
+		WithMigrationsTable("", "Schema_Migrations")
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	reader := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one)).
+		WithMigrationsTable("", "schema_migrations")
+
+	status, err := reader.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+}
+
+func TestDryRunRevisionState_SQLiteAttachedMetadataSchema(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	auxPath := filepath.Join(t.TempDir(), "revision-state-aux.db")
+	_, err := conn.ExecContext(ctx, "ATTACH DATABASE ? AS aux", auxPath)
+	c.Assert(err, qt.IsNil)
+	one, _ := revisionStateMigrations()
+	writer := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one)).
+		WithMigrationsTable("aux", "Schema_Migrations")
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	reader := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one)).
+		WithMigrationsTable("aux", "schema_migrations")
+
+	status, err := reader.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(status.PendingMigrations, qt.HasLen, 0)
+}
+
+func TestDryRunRevisionState_FreshDatabaseRemainsUnmodified(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	conn.SchemaWriter().SetDryRun(true)
+	one, _ := revisionStateMigrations()
+	dryRun := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one))
+
+	status, err := dryRun.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(status.AppliedMigrations, qt.HasLen, 0)
+	c.Assert(status.PendingMigrations, qt.DeepEquals, []int64{1})
+	c.Assert(dryRun.MigrateUp(ctx), qt.IsNil)
+
+	var tableCount int
+	err = conn.QueryRowContext(ctx, `SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'schema_migrations'`).Scan(&tableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 0)
+}
+
+func TestDryRunRevisionState_DirtyRevisionStillBlocksApply(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	one, two := revisionStateMigrations()
+	writer := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one))
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	_, err := conn.ExecContext(ctx, "UPDATE schema_migrations SET state = 'failed' WHERE version = 1")
+	c.Assert(err, qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	dryRun := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one, two))
+
+	err = dryRun.MigrateUp(ctx)
+	var dirty *migrator.DirtyMigrationError
+	c.Assert(err, qt.ErrorAs, &dirty)
+	c.Assert(dirty.Revision.Version, qt.Equals, int64(1))
+}
+
+func TestDryRunRevisionState_ChecksumMismatchStillBlocksApply(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openDryRunRevisionSQLite(t)
+	one, _ := revisionStateMigrations()
+	writer := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(one))
+	c.Assert(writer.MigrateUp(ctx), qt.IsNil)
+	conn.SchemaWriter().SetDryRun(true)
+	changed := migrator.CreateMigrationFromSQL(
+		1,
+		"create_users",
+		"CREATE TABLE dry_run_users (id INTEGER PRIMARY KEY, name TEXT);",
+		"DROP TABLE dry_run_users;",
+	)
+	dryRun := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(changed))
+
+	err := dryRun.MigrateUp(ctx)
+	var mismatch *migrator.ChecksumMismatchError
+	c.Assert(err, qt.ErrorAs, &mismatch)
+	c.Assert(mismatch.Version, qt.Equals, int64(1))
+}

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -1,0 +1,138 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/sqlutil"
+)
+
+func (m *Migrator) migrationsTableExists(ctx context.Context) (bool, error) {
+	table := m.migrationsTableName()
+	query, args, err := migrationTablePresenceQuery(
+		m.connectionDialect(),
+		m.metadataTableSchemaName(),
+		m.connectionSchemaName(),
+		table,
+		m.quoteIdentifier,
+	)
+	if err != nil {
+		return false, err
+	}
+
+	var count int64
+	query = sqlutil.Rebind(m.connectionDialect(), query)
+	if err := m.conn.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return false, err
+	}
+	return count > 0, nil
+}
+
+func (m *Migrator) migrationsTableUsesLegacyRevisionLayout(ctx context.Context) (bool, error) {
+	rows, err := m.conn.QueryContext(
+		ctx,
+		fmt.Sprintf("SELECT * FROM %s WHERE 1 = 0", m.qualifiedMigrationsTable()),
+	)
+	if err != nil {
+		return false, fmt.Errorf("failed to inspect migrations metadata columns: %w", err)
+	}
+	defer rows.Close()
+	columns, err := rows.Columns()
+	if err != nil {
+		return false, fmt.Errorf("failed to read migrations metadata columns: %w", err)
+	}
+	present := make(map[string]struct{}, len(columns))
+	for _, column := range columns {
+		present[strings.ToLower(column)] = struct{}{}
+	}
+	baseColumns := []string{"version", "description", "applied_at"}
+	if missing := missingMetadataColumns(present, baseColumns); len(missing) > 0 {
+		return false, fmt.Errorf("invalid migrations metadata layout: missing base columns %s", strings.Join(missing, ", "))
+	}
+	currentColumns := []string{"state", "applied", "total", "error", "error_stmt", "execution_time_ms", "checksum"}
+	missing := missingMetadataColumns(present, currentColumns)
+	if len(missing) == len(currentColumns) {
+		return true, nil
+	}
+	if len(missing) > 0 {
+		return false, fmt.Errorf("incomplete migrations metadata layout: missing columns %s", strings.Join(missing, ", "))
+	}
+	return false, nil
+}
+
+func missingMetadataColumns(present map[string]struct{}, required []string) []string {
+	missing := make([]string, 0, len(required))
+	for _, column := range required {
+		if _, ok := present[column]; !ok {
+			missing = append(missing, column)
+		}
+	}
+	return missing
+}
+
+func migrationTablePresenceQuery(
+	dialect string,
+	configuredSchema string,
+	connectionSchema string,
+	table string,
+	quoteIdentifier func(string) string,
+) (string, []any, error) {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		if configuredSchema == "" {
+			// Unqualified CREATE TABLE targets current_schema(), even when an older
+			// table with the same name exists later in search_path. Inspect exactly
+			// that schema so dry-run and real initialization resolve the same table.
+			return `SELECT COUNT(*)
+FROM information_schema.tables
+WHERE table_schema = current_schema() AND table_name = ? AND table_type = 'BASE TABLE'`, []any{table}, nil
+		}
+		return informationSchemaTablePresenceQuery(configuredSchema, table)
+	case platform.Spanner, platform.MySQL, platform.MariaDB:
+		return informationSchemaTablePresenceQuery(
+			configuredOrConnectionSchema(configuredSchema, connectionSchema),
+			table,
+		)
+	case platform.ClickHouse:
+		return `SELECT count()
+FROM system.tables
+WHERE database = ? AND name = ? AND is_temporary = 0`, []any{
+				configuredOrConnectionSchema(configuredSchema, connectionSchema),
+				table,
+			}, nil
+	case platform.SQLite:
+		schema := configuredOrConnectionSchema(configuredSchema, connectionSchema)
+		if schema == "" {
+			schema = "main"
+		}
+		return fmt.Sprintf(
+			"SELECT COUNT(*) FROM %s.sqlite_schema WHERE type = 'table' AND name = ? COLLATE NOCASE",
+			quoteIdentifier(schema),
+		), []any{table}, nil
+	case platform.SQLServer:
+		return `SELECT COUNT(*)
+FROM sys.tables AS t
+JOIN sys.schemas AS s ON s.schema_id = t.schema_id
+WHERE s.name = ? AND t.name = ?`, []any{
+				configuredOrConnectionSchema(configuredSchema, connectionSchema),
+				table,
+			}, nil
+	default:
+		return "", nil, fmt.Errorf("unsupported migration metadata dialect %q", dialect)
+	}
+}
+
+func informationSchemaTablePresenceQuery(schema, table string) (string, []any, error) {
+	return `SELECT COUNT(*)
+FROM information_schema.tables
+WHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'`, []any{schema, table}, nil
+}
+
+func configuredOrConnectionSchema(configured, connection string) string {
+	if configured != "" {
+		return configured
+	}
+	return connection
+}

--- a/migration/migrator/metadata_presence_internal_test.go
+++ b/migration/migrator/metadata_presence_internal_test.go
@@ -1,0 +1,92 @@
+package migrator
+
+// White-box testing required: migrationTablePresenceQuery is deliberately
+// internal, and deterministic query inspection covers the Spanner branch that
+// cannot be exercised through the public API without a live Spanner service.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
+)
+
+func Test_migrationTablePresenceQuery_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	quote := func(value string) string { return `"` + value + `"` }
+	tests := []struct {
+		name             string
+		dialect          string
+		configuredSchema string
+		connectionSchema string
+		table            string
+		wantQuery        string
+		wantArgs         []any
+	}{
+		{
+			name:      "postgres search path",
+			dialect:   platform.Postgres,
+			table:     "schema_migrations",
+			wantQuery: "SELECT COUNT(*)\nFROM information_schema.tables\nWHERE table_schema = current_schema() AND table_name = ? AND table_type = 'BASE TABLE'",
+			wantArgs:  []any{"schema_migrations"},
+		},
+		{
+			name:             "postgres configured schema",
+			dialect:          platform.Postgres,
+			configuredSchema: "revisions",
+			table:            "schema_migrations",
+			wantQuery:        "SELECT COUNT(*)\nFROM information_schema.tables\nWHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'",
+			wantArgs:         []any{"revisions", "schema_migrations"},
+		},
+		{
+			name:             "spanner connection schema",
+			dialect:          platform.Spanner,
+			connectionSchema: "public",
+			table:            "schema_migrations",
+			wantQuery:        "SELECT COUNT(*)\nFROM information_schema.tables\nWHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'",
+			wantArgs:         []any{"public", "schema_migrations"},
+		},
+		{
+			name:             "sqlite attached schema",
+			dialect:          platform.SQLite,
+			configuredSchema: "aux",
+			table:            "Schema_Migrations",
+			wantQuery:        `SELECT COUNT(*) FROM "aux".sqlite_schema WHERE type = 'table' AND name = ? COLLATE NOCASE`,
+			wantArgs:         []any{"Schema_Migrations"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			query, args, err := migrationTablePresenceQuery(
+				test.dialect,
+				test.configuredSchema,
+				test.connectionSchema,
+				test.table,
+				quote,
+			)
+			c.Assert(err, qt.IsNil)
+			c.Assert(query, qt.Equals, test.wantQuery)
+			c.Assert(args, qt.DeepEquals, test.wantArgs)
+		})
+	}
+}
+
+func Test_metadataInformationSchemaName_SpannerUsesConnectionSchema(t *testing.T) {
+	c := qt.New(t)
+
+	got := metadataInformationSchemaName(platform.Spanner, "public", "")
+
+	c.Assert(got, qt.Equals, "public")
+}
+
+func Test_migrationTablePresenceQuery_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	query, args, err := migrationTablePresenceQuery("unsupported", "", "", "schema_migrations", func(value string) string {
+		return value
+	})
+	c.Assert(err, qt.ErrorMatches, `unsupported migration metadata dialect "unsupported"`)
+	c.Assert(query, qt.Equals, "")
+	c.Assert(args, qt.IsNil)
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -95,6 +95,8 @@ type Migrator struct {
 	logger               *slog.Logger
 	observer             Observer
 	skipChecks           bool
+	metadataAvailable    bool
+	legacyRevisionTable  bool
 }
 
 // NewFSMigrator creates a new migrator that loads migrations from a filesystem.
@@ -184,7 +186,7 @@ func (m *Migrator) rejectChecksUnderTxModeAll(migration *Migration) error {
 		return fmt.Errorf("migration %d has invalid pre-migration check directives: %w", migration.Version, err)
 	}
 	if len(checks) > 0 {
-		return fmt.Errorf("migration %d declares pre-migration checks, which cannot run with tx-mode all; use the default per-file transaction mode or --skip-checks", migration.Version)
+		return fmt.Errorf("migration %d declares pre-migration checks, which cannot run with tx-mode all; use the default per-file transaction mode", migration.Version)
 	}
 	return nil
 }
@@ -214,6 +216,8 @@ func (m *Migrator) WithMigrationsTable(schema, table string) *Migrator {
 		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
 	tmp.initialized = false
+	tmp.metadataAvailable = false
+	tmp.legacyRevisionTable = false
 	return &tmp
 }
 
@@ -226,6 +230,8 @@ func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator
 		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
 	tmp.initialized = false
+	tmp.metadataAvailable = false
+	tmp.legacyRevisionTable = false
 	return &tmp
 }
 
@@ -353,6 +359,9 @@ func (m *Migrator) getVersionSQL() string {
 			m.qualifiedMigrationsTable(),
 		)
 	}
+	if m.legacyRevisionTable {
+		return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s", m.qualifiedMigrationsTable())
+	}
 	return fmt.Sprintf("SELECT COALESCE(MAX(version), 0) FROM %s WHERE state = 'applied'", m.qualifiedMigrationsTable())
 }
 
@@ -363,6 +372,9 @@ func (m *Migrator) getAppliedMigrationsSQL() string {
 			m.qualifiedMigrationsTable(),
 			m.atlasVersionNumberExpression(),
 		)
+	}
+	if m.legacyRevisionTable {
+		return fmt.Sprintf("SELECT version FROM %s ORDER BY version", m.qualifiedMigrationsTable())
 	}
 	return fmt.Sprintf("SELECT version FROM %s WHERE state = 'applied' ORDER BY version", m.qualifiedMigrationsTable())
 }
@@ -379,8 +391,7 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 	}
 
 	if m.conn.Writer().IsDryRun() {
-		m.logger.Info("[DRY RUN] Would initialize migrations metadata", "table", m.qualifiedMigrationsTable())
-		return nil
+		return m.initializeDryRun(ctx)
 	}
 
 	if schemaSQL := m.migrationsSchemaStatement(); schemaSQL != "" {
@@ -408,6 +419,32 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 
 	// Mark as initialized
 	m.initialized = true
+	m.metadataAvailable = true
+	m.legacyRevisionTable = false
+	return nil
+}
+
+func (m *Migrator) initializeDryRun(ctx context.Context) error {
+	exists, err := m.migrationsTableExists(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to inspect migrations table: %w", err)
+	}
+	if !exists {
+		m.metadataAvailable = false
+		m.legacyRevisionTable = false
+		m.logger.Info("[DRY RUN] Would initialize migrations metadata", "table", m.qualifiedMigrationsTable())
+		return nil
+	}
+
+	m.metadataAvailable = true
+	if m.revisionTableFormat.isAtlas() {
+		return nil
+	}
+	legacy, err := m.migrationsTableUsesLegacyRevisionLayout(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to inspect migrations table layout: %w", err)
+	}
+	m.legacyRevisionTable = legacy
 	return nil
 }
 
@@ -475,12 +512,22 @@ func (m *Migrator) migrationsColumnExists(ctx context.Context, name string) (boo
 	case platform.SQLite:
 		return m.sqliteMigrationsColumnExists(ctx, name)
 	}
-	query := sqlutil.Rebind(m.conn.Info().Dialect, `
+	query := `
 SELECT COUNT(*)
 FROM information_schema.columns
-WHERE table_schema = ? AND table_name = ? AND column_name = ?`)
+WHERE table_schema = ? AND table_name = ? AND column_name = ?`
+	schema := m.metadataSchemaName()
+	if m.isPostgresFamily() {
+		query = `
+SELECT COUNT(*)
+FROM information_schema.columns
+WHERE table_schema = COALESCE(NULLIF(?, ''), current_schema())
+  AND table_name = ? AND column_name = ?`
+		schema = m.metadataTableSchemaName()
+	}
+	query = sqlutil.Rebind(m.conn.Info().Dialect, query)
 	var count int
-	if err := m.conn.QueryRowContext(ctx, query, m.metadataSchemaName(), m.migrationsTableName(), name).Scan(&count); err != nil {
+	if err := m.conn.QueryRowContext(ctx, query, schema, m.migrationsTableName(), name).Scan(&count); err != nil {
 		return false, fmt.Errorf("failed to inspect migrations metadata column %s: %w", name, err)
 	}
 	return count > 0, nil
@@ -551,7 +598,10 @@ func (m *Migrator) ensurePostgresMigrationsVersionColumn(ctx context.Context) er
 		sqlutil.Rebind(m.conn.Info().Dialect, `
 SELECT data_type
 FROM information_schema.columns
-WHERE table_schema = ? AND table_name = ? AND column_name = 'version'`),
+WHERE table_schema = COALESCE(NULLIF(?, ''), current_schema())
+  AND table_name = ? AND column_name = 'version'`),
+		m.metadataTableSchemaName(),
+		m.migrationsTableName(),
 	)
 	if err != nil {
 		return err
@@ -576,6 +626,8 @@ func (m *Migrator) ensureMySQLMigrationsVersionColumn(ctx context.Context) error
 		`SELECT data_type
 FROM information_schema.columns
 WHERE table_schema = ? AND table_name = ? AND column_name = 'version'`,
+		m.metadataSchemaName(),
+		m.migrationsTableName(),
 	)
 	if err != nil {
 		return err
@@ -594,13 +646,22 @@ WHERE table_schema = ? AND table_name = ? AND column_name = 'version'`,
 	return nil
 }
 
-func (m *Migrator) migrationsVersionColumnType(ctx context.Context, query string) (string, error) {
+func (m *Migrator) migrationsVersionColumnType(ctx context.Context, query string, args ...any) (string, error) {
 	var dataType string
-	err := m.conn.QueryRowContext(ctx, query, m.metadataSchemaName(), m.migrationsTableName()).Scan(&dataType)
+	err := m.conn.QueryRowContext(ctx, query, args...).Scan(&dataType)
 	if err != nil {
 		return "", fmt.Errorf("failed to inspect migrations version column: %w", err)
 	}
 	return strings.ToLower(dataType), nil
+}
+
+func (m *Migrator) isPostgresFamily() bool {
+	switch platform.NormalizeDialect(m.connectionDialect()) {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		return true
+	default:
+		return false
+	}
 }
 
 func (m *Migrator) metadataSchemaName() string {
@@ -614,7 +675,7 @@ func metadataInformationSchemaName(dialect, connectionSchema, configuredSchema s
 	switch platform.NormalizeDialect(dialect) {
 	case platform.Postgres:
 		return "public"
-	case platform.MySQL, platform.MariaDB:
+	case platform.Spanner, platform.MySQL, platform.MariaDB:
 		return strings.TrimSpace(connectionSchema)
 	}
 	return ""
@@ -657,7 +718,7 @@ func (m *Migrator) GetCurrentVersion(ctx context.Context) (int64, error) {
 	if err := m.Initialize(ctx); err != nil {
 		return 0, fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
-	if m.conn.Writer().IsDryRun() {
+	if !m.metadataAvailable {
 		return 0, nil
 	}
 
@@ -670,7 +731,7 @@ func (m *Migrator) GetAppliedMigrations(ctx context.Context) ([]int64, error) {
 	return queryMigrationRows(
 		ctx,
 		m,
-		m.getAppliedMigrationsSQL(),
+		m.getAppliedMigrationsSQL,
 		m.scanAppliedVersion,
 		"failed to query applied migrations",
 		"failed to scan migration version",
@@ -683,7 +744,7 @@ func (m *Migrator) GetAppliedRevisions(ctx context.Context) ([]MigrationRevision
 	return queryMigrationRows(
 		ctx,
 		m,
-		m.getAppliedRevisionsSQL(),
+		m.getAppliedRevisionsSQL,
 		m.scanRevisionRow,
 		"failed to query applied migration revisions",
 		"failed to scan migration revision",
@@ -696,7 +757,7 @@ func (m *Migrator) GetRevisions(ctx context.Context) ([]MigrationRevision, error
 	return queryMigrationRows(
 		ctx,
 		m,
-		m.getRevisionsSQL(),
+		m.getRevisionsSQL,
 		m.scanRevisionRow,
 		"failed to query migration revisions",
 		"failed to scan migration revision",
@@ -707,7 +768,7 @@ func (m *Migrator) GetRevisions(ctx context.Context) ([]MigrationRevision, error
 func queryMigrationRows[T any](
 	ctx context.Context,
 	m *Migrator,
-	query string,
+	query func() string,
 	scan func(rowScanner) (T, error),
 	queryErr string,
 	scanErr string,
@@ -716,11 +777,11 @@ func queryMigrationRows[T any](
 	if err := m.Initialize(ctx); err != nil {
 		return nil, fmt.Errorf("failed to initialize migrations table: %w", err)
 	}
-	if m.conn.Writer().IsDryRun() {
+	if !m.metadataAvailable {
 		return []T{}, nil
 	}
 
-	return queryMigrationRowsFrom(ctx, m.conn, query, scan, queryErr, scanErr, iterErr)
+	return queryMigrationRowsFrom(ctx, m.conn, query(), scan, queryErr, scanErr, iterErr)
 }
 
 type migrationRowsQueryer interface {
@@ -1158,6 +1219,9 @@ func (m *Migrator) migrateDownToLocked(ctx context.Context, targetVersion int64,
 	}
 	migrationsToRollback, err := migrationsToRollback(migrationMap, appliedMigrations, targetVersion)
 	if err != nil {
+		return err
+	}
+	if err := validateDownMigrations(migrationsToRollback); err != nil {
 		return err
 	}
 	if err := runPreMigrationHook(ctx, hook, MigrationPlan{
@@ -1674,9 +1738,6 @@ func (m *Migrator) rollbackMigrationObserved(ctx context.Context, migration *Mig
 	if err := m.beginRollbackRevision(ctx, migration, startedAt); err != nil {
 		return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
 	}
-	if migration.downUnavailable {
-		return m.rollbackMigrationWithoutRegisteredDown(ctx, migration, startedAt, deleteSQL)
-	}
 	if migration.downExecutionMode() == migrationExecutionNoTransaction {
 		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
 	}
@@ -1708,29 +1769,6 @@ func (m *Migrator) migrationMetricAttributes(direction MigrationDirection, migra
 		attr("migration.direction", string(direction)),
 		attr("migration.version", migration.Version),
 	}
-}
-
-func (m *Migrator) rollbackMigrationWithoutRegisteredDown(
-	ctx context.Context,
-	migration *Migration,
-	startedAt time.Time,
-	deleteSQL string,
-) error {
-	if err := migration.Down(ctx, m.conn); err != nil {
-		return m.failMigrationWithDirtyState(
-			ctx,
-			migration,
-			startedAt,
-			err,
-			migration.DownSQL,
-			fmt.Sprintf("failed to revert migration %d", migration.Version),
-		)
-	}
-	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
-		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
-	}
-	m.logger.Info("Rolled back migration", "version", migration.Version, "description", migration.Description)
-	return nil
 }
 
 func (m *Migrator) rollbackMigrationTransactional(
@@ -2052,4 +2090,16 @@ func migrationsToRollback(migrationsByVersion map[int64]*Migration, applied []in
 		rollbackMigrations = append(rollbackMigrations, migration)
 	}
 	return rollbackMigrations, nil
+}
+
+func validateDownMigrations(migrations []*Migration) error {
+	for _, migration := range migrations {
+		if migration.downUnavailable {
+			return &AtlasDownNotImplementedError{
+				Version:     migration.Version,
+				Description: migration.Description,
+			}
+		}
+	}
+	return nil
 }

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -218,9 +218,9 @@ func (m *Migrator) getRevisionSQL() string {
 FROM %s
 WHERE version = ?`, m.qualifiedMigrationsTable())
 	}
-	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+	return fmt.Sprintf(`SELECT %s
 FROM %s
-WHERE version = ?`, m.qualifiedMigrationsTable())
+WHERE version = ?`, m.ptahRevisionProjection(), m.qualifiedMigrationsTable())
 }
 
 func (m *Migrator) getAppliedRevisionsSQL() string {
@@ -234,10 +234,13 @@ ORDER BY %s`,
 			m.atlasVersionNumberExpression(),
 		)
 	}
-	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+	where := "WHERE state = 'applied'\n"
+	if m.legacyRevisionTable {
+		where = ""
+	}
+	return fmt.Sprintf(`SELECT %s
 FROM %s
-WHERE state = 'applied'
-ORDER BY version`, m.qualifiedMigrationsTable())
+%sORDER BY version`, m.ptahRevisionProjection(), m.qualifiedMigrationsTable(), where)
 }
 
 func (m *Migrator) getRevisionsSQL() string {
@@ -250,9 +253,16 @@ ORDER BY %s`,
 			m.atlasVersionNumberExpression(),
 		)
 	}
-	return fmt.Sprintf(`SELECT version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at
+	return fmt.Sprintf(`SELECT %s
 FROM %s
-ORDER BY version`, m.qualifiedMigrationsTable())
+ORDER BY version`, m.ptahRevisionProjection(), m.qualifiedMigrationsTable())
+}
+
+func (m *Migrator) ptahRevisionProjection() string {
+	if m.legacyRevisionTable {
+		return "version, description, 'applied', 1, 1, '', '', 0, '', applied_at"
+	}
+	return "version, description, state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, ''), execution_time_ms, checksum, applied_at"
 }
 
 func (m *Migrator) getRevisionsForUpdateSQL() string {
@@ -650,7 +660,7 @@ func parseRevisionAppliedAtString(value string) (time.Time, error) {
 }
 
 func (m *Migrator) failIfDirty(ctx context.Context) error {
-	if m.conn.Writer().IsDryRun() {
+	if !m.metadataAvailable || m.legacyRevisionTable {
 		return nil
 	}
 	revision, err := m.dirtyRevision(ctx)
@@ -880,7 +890,7 @@ func (m *Migrator) failAtlasMigrationRevision(
 }
 
 func (m *Migrator) verifyAppliedMigrationChecksums(ctx context.Context, migrations []*Migration) error {
-	if m.conn.Writer().IsDryRun() {
+	if !m.metadataAvailable || m.legacyRevisionTable {
 		return nil
 	}
 	for _, migration := range migrations {


### PR DESCRIPTION
## Summary

- make migration dry-run read the real revision state without creating or upgrading metadata
- validate dirty state, checksums, checkpoints, transaction mode, and complete down availability before mutation
- report apply and rollback attempts accurately when preflight or first-statement execution fails
- detect revision metadata correctly across supported dialects, including PostgreSQL search paths and explicit schemas
- document the corrected revision-state and dry-run semantics

## Compatibility and scope

Exact legacy three-column Ptah revision tables remain readable during dry-run. Partially upgraded metadata layouts now fail explicitly instead of being treated as legacy. The feature matrix remains `partial` because ClickHouse Atlas-format DDL is an independent gap tracked in #950.

## Validation

- `GOWORK=off go test ./...`
- `GOWORK=off go test -race ./...`
- `GOWORK=off go vet ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...` (0 issues)
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- real `gopls check` across all modified Go files
- live PostgreSQL, CockroachDB, YugabyteDB, MySQL, MariaDB, ClickHouse, and SQL Server integration tests
- deterministic Spanner metadata-query coverage
- documentation generators, structural checks, link checks, and production site build
- all public API guards
- `go tool govulncheck ./...` (0 reachable vulnerabilities)
- `npm audit --audit-level=high` (0 vulnerabilities)

The optional responsive docs check skipped because Playwright is not installed in this repository; documentation changes are text-only.

Two independent review passes were completed and all findings were fixed before opening this PR.

Closes #937