### PR TITLE
Keep dry-run output quiet on the Atlas-compatible surface

### DIFF
--- a/DRY_RUN.md
+++ b/DRY_RUN.md
@@ -127,7 +127,10 @@ go run . seed --db-dsn postgres://user:pass@localhost/db --dry-run
 
 ### Dry Run Output Format
 
-When dry run mode is enabled, all operations are prefixed with `[DRY RUN]`:
+When dry run mode is enabled, all operations are prefixed with `[DRY RUN]`. The
+example below shows both output streams interleaved, as a terminal would render
+them; see [Where Dry Run Output Goes](#where-dry-run-output-goes) for which line
+lands on which stream.
 
 ```
 [DRY RUN] Would write schema from ./models to database postgres://user:***@localhost/db
@@ -152,6 +155,34 @@ Creating table 2/2...
 [DRY RUN] Would commit transaction
 ✅ [DRY RUN] Schema operations completed successfully!
 ```
+
+### Where Dry Run Output Goes
+
+Dry run produces two different kinds of output, on two different streams:
+
+1. **The command report** — the `=== DRY RUN MODE ===` banner, the summary
+   counts, and the closing `Would have applied N migrations` line — is written
+   to **stdout** by the command itself.
+2. **The per-statement narration** — the `[DRY RUN] Would begin transaction`,
+   `[DRY RUN] Would execute SQL`, and `[DRY RUN] Would commit transaction`
+   records emitted by the dialect writers — is a **log record**, not report
+   output. It goes to the command's log stream, which is stderr by default.
+
+Because the narration is a log record, the native commands' existing
+observability flags control it:
+
+- `--log-level warn` (or `error`) drops it, leaving only the stdout report.
+- `--log-format json` moves the whole run log — report lines included — onto
+  stdout as one JSON object per line, so `ptah migrations up --dry-run
+  --log-format json | jq` is parseable.
+
+The Atlas-compatible binary (`ptah-compat`) deliberately differs: it writes
+**nothing** to stderr for a successful dry run, because the Atlas CE binary it
+mirrors writes nothing either, and because `--format` consumers routinely fold
+stderr into stdout (`2>&1 | jq`), where one stray log line stops the output from
+being a single JSON document. Failures are still reported there — the command's
+`Error: …` diagnostic goes to stderr and the process exits `1`. See
+[stokaro/ptah#967](https://github.com/stokaro/ptah/issues/967).
 
 ### Safety Features
 

--- a/DRY_RUN.md
+++ b/DRY_RUN.md
@@ -176,12 +176,25 @@ observability flags control it:
   stdout as one JSON object per line, so `ptah migrations up --dry-run
   --log-format json | jq` is parseable.
 
-The Atlas-compatible binary (`ptah-compat`) deliberately differs: it writes
-**nothing** to stderr for a successful dry run, because the Atlas CE binary it
-mirrors writes nothing either, and because `--format` consumers routinely fold
+The Atlas-compatible binary (`ptah-compat`) deliberately differs: it drops the
+narration entirely rather than exposing a flag for it, because the Atlas CE
+binary it mirrors prints none, and because `--format` consumers routinely fold
 stderr into stdout (`2>&1 | jq`), where one stray log line stops the output from
-being a single JSON document. Failures are still reported there — the command's
-`Error: …` diagnostic goes to stderr and the process exits `1`. See
+being a single JSON document.
+
+Quiet is not silent. Two things still reach `ptah-compat`'s stderr, neither of
+which appears on a clean run:
+
+- **Command failures** — the `Error: …` diagnostic, with exit status `1`.
+- **Warn-level diagnostics that exist on no other channel** — a circular
+  foreign-key or function ordering, a dev or shadow database that would not
+  close, an unrecognized embedding mode. None of these are returned as errors,
+  so dropping them would let a real apply report success while quietly
+  degrading.
+
+One exception: `ptah-compat migrate down` without `--format` forwards to the
+native rollback command and inherits its run log on stderr. See
+[stokaro/ptah#969](https://github.com/stokaro/ptah/issues/969) and
 [stokaro/ptah#967](https://github.com/stokaro/ptah/issues/967).
 
 ### Safety Features

--- a/cmd/internal/cliobs/cliobs.go
+++ b/cmd/internal/cliobs/cliobs.go
@@ -48,27 +48,41 @@ type Runtime struct {
 	once     sync.Once
 }
 
-// SilenceDefaultLogger installs a discarding default slog logger.
+// QuietDefaultLogger installs a default slog logger that drops narration and
+// keeps diagnostics.
 //
-// Library code narrates through the package-level slog functions — the dialect
-// writers' dry-run statement narration, connection-close warnings, annotation
-// diagnostics — which resolve to slog.Default() and therefore reach stderr even
-// when the caller never wired observability. The Atlas-compatible binary must
-// not write those records: the pinned Atlas CE binary emits nothing on stderr
-// for the same commands, and `--format` consumers redirect stderr into stdout
-// (`2>&1 | jq`), where a single extra line breaks JSON parsing. See
-// stokaro/ptah#967.
+// Library code logs through the package-level slog functions, which resolve to
+// slog.Default() and therefore reach stderr even when the caller never wired
+// observability. Those calls split cleanly by level, and the threshold sits on
+// the seam:
 //
-// Failures are unaffected: the Atlas-compatible commands report them through
-// the command's own error stream, never through slog.
+//   - Info and below is narration — the dialect writers' "[DRY RUN] Would ..."
+//     statement records, the Postgres enum-creation notices. Atlas CE never
+//     prints any of it, and `--format` consumers redirect stderr into stdout
+//     (`2>&1 | jq`), where one extra line stops the output from being a single
+//     JSON document. This is what broke stokaro/ptah#967, and it is dropped.
+//   - Warn and above is a diagnostic that exists nowhere else: circular
+//     foreign-key and function ordering, a dev or shadow database that would
+//     not close, an unrecognized embedding mode that silently inlines. None of
+//     them are returned as errors, so dropping them would let a real apply
+//     report success while quietly degrading. These are kept.
+//
+// Atlas parity survives the split because a clean run emits nothing at either
+// level: the diagnostics only appear when something is genuinely wrong, and a
+// user who sees one is better served than by byte-parity with CE.
+//
+// Command failures are unaffected either way: the Atlas-compatible commands
+// report them through the command's own error stream, never through slog.
 //
 // Call this once, before any command runs. It deliberately does not take
 // globalStateMu: Start holds that lock for the duration of a command and
 // restores whatever default was installed beforehand, so a command that starts
-// its own observability runtime still nests correctly on top of the silenced
+// its own observability runtime still nests correctly on top of the quiet
 // default.
-func SilenceDefaultLogger() {
-	slog.SetDefault(slog.New(slog.DiscardHandler))
+func QuietDefaultLogger() {
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
 }
 
 // Start initializes command logging, tracing, and metrics.

--- a/cmd/internal/cliobs/cliobs.go
+++ b/cmd/internal/cliobs/cliobs.go
@@ -48,6 +48,29 @@ type Runtime struct {
 	once     sync.Once
 }
 
+// SilenceDefaultLogger installs a discarding default slog logger.
+//
+// Library code narrates through the package-level slog functions — the dialect
+// writers' dry-run statement narration, connection-close warnings, annotation
+// diagnostics — which resolve to slog.Default() and therefore reach stderr even
+// when the caller never wired observability. The Atlas-compatible binary must
+// not write those records: the pinned Atlas CE binary emits nothing on stderr
+// for the same commands, and `--format` consumers redirect stderr into stdout
+// (`2>&1 | jq`), where a single extra line breaks JSON parsing. See
+// stokaro/ptah#967.
+//
+// Failures are unaffected: the Atlas-compatible commands report them through
+// the command's own error stream, never through slog.
+//
+// Call this once, before any command runs. It deliberately does not take
+// globalStateMu: Start holds that lock for the duration of a command and
+// restores whatever default was installed beforehand, so a command that starts
+// its own observability runtime still nests correctly on top of the silenced
+// default.
+func SilenceDefaultLogger() {
+	slog.SetDefault(slog.New(slog.DiscardHandler))
+}
+
 // Start initializes command logging, tracing, and metrics.
 func Start(ctx context.Context, opts Options) (*Runtime, error) {
 	logLevel, err := parseLogLevel(opts.LogLevel)

--- a/cmd/internal/cliobs/silence_test.go
+++ b/cmd/internal/cliobs/silence_test.go
@@ -11,33 +11,46 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/cliobs"
 )
 
-// SilenceDefaultLogger is what keeps library code that narrates through the
-// package-level slog functions off the Atlas-compatible binary's streams
-// (stokaro/ptah#967).
-func TestSilenceDefaultLoggerDropsEveryLevel(t *testing.T) {
+// QuietDefaultLogger keeps library narration off the Atlas-compatible binary's
+// streams (stokaro/ptah#967) without dropping the diagnostics that have no
+// other channel. The process-level contract is pinned by the subprocess tests
+// in cmd/ptah-compat; this holds the level split those rest on.
+func TestQuietDefaultLoggerDropsNarrationAndKeepsDiagnostics(t *testing.T) {
 	c := qt.New(t)
 	previous := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	cliobs.SilenceDefaultLogger()
+	cliobs.QuietDefaultLogger()
 
 	ctx := context.Background()
-	levels := []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError}
-	for _, level := range levels {
-		c.Assert(slog.Default().Enabled(ctx, level), qt.IsFalse, qt.Commentf("level %s", level))
+	tests := []struct {
+		name    string
+		level   slog.Level
+		escapes bool
+	}{
+		{name: "debug narration is dropped", level: slog.LevelDebug, escapes: false},
+		{name: "info narration is dropped", level: slog.LevelInfo, escapes: false},
+		{name: "warn diagnostics are kept", level: slog.LevelWarn, escapes: true},
+		{name: "error diagnostics are kept", level: slog.LevelError, escapes: true},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(slog.Default().Enabled(ctx, tt.level), qt.Equals, tt.escapes)
+		})
 	}
 }
 
-// A command that starts its own observability runtime must still log: Start
-// installs its logger over the silenced default and restores the silence on
-// shutdown, so the two nest instead of fighting.
-func TestSilenceDefaultLoggerNestsUnderStart(t *testing.T) {
+// A command that starts its own observability runtime must still log at the
+// level it asked for: Start installs its logger over the quiet default and
+// restores the quiet default on shutdown, so the two nest instead of fighting.
+func TestQuietDefaultLoggerNestsUnderStart(t *testing.T) {
 	c := qt.New(t)
 	previous := slog.Default()
 	t.Cleanup(func() { slog.SetDefault(previous) })
 
-	cliobs.SilenceDefaultLogger()
-	silenced := slog.Default()
+	cliobs.QuietDefaultLogger()
+	quiet := slog.Default()
 
 	var out bytes.Buffer
 	runtime, err := cliobs.Start(context.Background(), cliobs.Options{
@@ -52,5 +65,5 @@ func TestSilenceDefaultLoggerNestsUnderStart(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "visible while the runtime owns the default logger")
 
 	c.Assert(runtime.Shutdown(context.Background()), qt.IsNil)
-	c.Assert(slog.Default(), qt.Equals, silenced)
+	c.Assert(slog.Default(), qt.Equals, quiet)
 }

--- a/cmd/internal/cliobs/silence_test.go
+++ b/cmd/internal/cliobs/silence_test.go
@@ -1,0 +1,56 @@
+package cliobs_test
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/internal/cliobs"
+)
+
+// SilenceDefaultLogger is what keeps library code that narrates through the
+// package-level slog functions off the Atlas-compatible binary's streams
+// (stokaro/ptah#967).
+func TestSilenceDefaultLoggerDropsEveryLevel(t *testing.T) {
+	c := qt.New(t)
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	cliobs.SilenceDefaultLogger()
+
+	ctx := context.Background()
+	levels := []slog.Level{slog.LevelDebug, slog.LevelInfo, slog.LevelWarn, slog.LevelError}
+	for _, level := range levels {
+		c.Assert(slog.Default().Enabled(ctx, level), qt.IsFalse, qt.Commentf("level %s", level))
+	}
+}
+
+// A command that starts its own observability runtime must still log: Start
+// installs its logger over the silenced default and restores the silence on
+// shutdown, so the two nest instead of fighting.
+func TestSilenceDefaultLoggerNestsUnderStart(t *testing.T) {
+	c := qt.New(t)
+	previous := slog.Default()
+	t.Cleanup(func() { slog.SetDefault(previous) })
+
+	cliobs.SilenceDefaultLogger()
+	silenced := slog.Default()
+
+	var out bytes.Buffer
+	runtime, err := cliobs.Start(context.Background(), cliobs.Options{
+		Command:   "test",
+		LogFormat: "text",
+		LogLevel:  "info",
+		LogWriter: &out,
+	})
+	c.Assert(err, qt.IsNil)
+
+	slog.Info("visible while the runtime owns the default logger")
+	c.Assert(out.String(), qt.Contains, "visible while the runtime owns the default logger")
+
+	c.Assert(runtime.Shutdown(context.Background()), qt.IsNil)
+	c.Assert(slog.Default(), qt.Equals, silenced)
+}

--- a/cmd/migrateup/dry_run_log_controls_test.go
+++ b/cmd/migrateup/dry_run_log_controls_test.go
@@ -1,0 +1,106 @@
+package migrateup_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/migrateup"
+)
+
+// The native surface keeps the dry-run statement narration the Atlas-compatible
+// surface deliberately drops (stokaro/ptah#967): it is genuinely useful when
+// reviewing a plan, and it is already routed through the command's observability
+// runtime, so `--log-level` selects whether it appears and `--log-format`
+// selects the stream and encoding. These pins hold that wiring, and hold the
+// narration down to one "[DRY RUN] Would initialize migrations metadata" record
+// per run — the dry-run revision-state fix (stokaro/ptah#963) repeated it once
+// per metadata read.
+
+// runUpStreams runs `ptah migrations up` with stdout and the log stream kept
+// apart, which is what the log-format contract is about.
+func runUpStreams(args ...string) (stdout, stderr string, err error) {
+	cmd := migrateup.NewMigrateUpCommand()
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func dryRunUpArgs(t *testing.T, extra ...string) []string {
+	t.Helper()
+	args := []string{
+		"--db-url", "sqlite://" + t.TempDir() + "/dry-run-logs.db",
+		"--migrations-dir", writeUpMigrations(t),
+		"--dry-run",
+	}
+	return append(args, extra...)
+}
+
+func TestMigrateUpDryRunNarratesThroughTheLogStream(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := runUpStreams(dryRunUpArgs(t)...)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", stdout, stderr))
+	// The human report stays on stdout.
+	c.Assert(stdout, qt.Contains, "=== DRY RUN MODE ===")
+	c.Assert(stdout, qt.Contains, "Would have applied 2 migrations")
+	c.Assert(stdout, qt.Not(qt.Contains), "[DRY RUN] Would execute SQL")
+	// The per-statement narration is a log record, not report output.
+	c.Assert(stderr, qt.Contains, "[DRY RUN] Would begin transaction")
+	c.Assert(stderr, qt.Contains, "[DRY RUN] Would execute SQL")
+	c.Assert(stderr, qt.Contains, "[DRY RUN] Would commit transaction")
+	// Regression pin for stokaro/ptah#963: one metadata record, not one per read.
+	c.Assert(strings.Count(stderr, "[DRY RUN] Would initialize migrations metadata"), qt.Equals, 1)
+}
+
+func TestMigrateUpDryRunNarrationHonorsLogLevel(t *testing.T) {
+	tests := []struct {
+		name          string
+		logLevel      string
+		wantNarration bool
+	}{
+		{name: "default info level narrates", logLevel: "info", wantNarration: true},
+		{name: "debug level narrates", logLevel: "debug", wantNarration: true},
+		{name: "warn level is quiet", logLevel: "warn", wantNarration: false},
+		{name: "error level is quiet", logLevel: "error", wantNarration: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			stdout, stderr, err := runUpStreams(dryRunUpArgs(t, "--log-level", tt.logLevel)...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", stdout, stderr))
+			// The stdout report is unaffected by the log level either way.
+			c.Assert(stdout, qt.Contains, "Would have applied 2 migrations")
+			c.Assert(strings.Contains(stderr, "[DRY RUN] Would execute SQL"), qt.Equals, tt.wantNarration,
+				qt.Commentf("stderr=%s", stderr))
+		})
+	}
+}
+
+func TestMigrateUpDryRunJSONLogFormatKeepsStdoutParseable(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, stderr, err := runUpStreams(dryRunUpArgs(t, "--log-format", "json")...)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", stdout, stderr))
+	// JSON mode folds the human report into the log stream, so stdout carries
+	// one JSON record per line and the error stream stays clean.
+	c.Assert(stderr, qt.Equals, "")
+	lines := strings.Split(strings.TrimSpace(stdout), "\n")
+	c.Assert(len(lines) > 0, qt.IsTrue)
+	for _, line := range lines {
+		var record map[string]any
+		c.Assert(json.Unmarshal([]byte(line), &record), qt.IsNil, qt.Commentf("line: %s", line))
+	}
+	c.Assert(stdout, qt.Contains, `"[DRY RUN] Would execute SQL"`)
+}

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -183,40 +183,52 @@ func TestCompatBinaryDryRunPinNoWriterNarration(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
 	migrationsDir := dryRunQuietDir(c)
-	dbPath := filepath.Join(c.TempDir(), "pin.db")
-	applyForReal(c, binPath, dbPath, migrationsDir)
+
+	// The apply cases need a target with pending work and the down case needs
+	// one with a revision to roll back. Sharing a database between them would
+	// leave the apply dry runs with nothing pending, so the writers would never
+	// be entered and the pin would hold vacuously.
+	applyDB := filepath.Join(c.TempDir(), "pin-apply.db")
+	downDB := filepath.Join(c.TempDir(), "pin-down.db")
+	applyForReal(c, binPath, downDB, migrationsDir)
 
 	tests := []struct {
 		name string
 		args []string
+		// wantPlanned proves the run actually reached the writers, so the
+		// narration assertions below can never pass on an empty plan.
+		wantPlanned string
 	}{
 		{
 			name: "apply default format",
 			args: []string{
 				"migrate", "apply",
-				"--url", "sqlite://" + dbPath,
+				"--url", "sqlite://" + applyDB,
 				"--dir", "file://" + migrationsDir,
 				"--dry-run",
 			},
+			wantPlanned: "Would have applied 1 migrations.",
 		},
 		{
 			name: "apply go template",
 			args: []string{
 				"migrate", "apply",
-				"--url", "sqlite://" + dbPath,
+				"--url", "sqlite://" + applyDB,
 				"--dir", "file://" + migrationsDir,
 				"--dry-run", "--format", "{{ json . }}",
 			},
+			wantPlanned: `"Target":"1"`,
 		},
 		{
 			name: "down go template",
 			args: []string{
 				"migrate", "down",
-				"--url", "sqlite://" + dbPath,
+				"--url", "sqlite://" + downDB,
 				"--dir", "file://" + migrationsDir,
 				"--to-version", "0",
 				"--dry-run", "--format", "{{ json . }}",
 			},
+			wantPlanned: `"Planned":[{"Name":"1_init.sql"`,
 		},
 	}
 
@@ -227,8 +239,61 @@ func TestCompatBinaryDryRunPinNoWriterNarration(t *testing.T) {
 			combined, err := run.CombinedOutput()
 
 			c.Assert(err, qt.IsNil, qt.Commentf("%s", combined))
+			c.Assert(string(combined), qt.Contains, tt.wantPlanned)
 			c.Assert(string(combined), qt.Not(qt.Contains), "[DRY RUN]")
 			c.Assert(string(combined), qt.Not(qt.Contains), "level=INFO")
+		})
+	}
+}
+
+// TestCompatBinaryKeepsLogOnlyDiagnostics is the other half of the quiet
+// contract: narration is dropped, but a Warn-level diagnostic that exists on no
+// other channel still gets through. A circular foreign-key graph is reordered
+// and reported only through this record — it is never returned as an error — so
+// dropping it would let an apply report success while quietly emitting DDL that
+// depends on creation order.
+func TestCompatBinaryKeepsLogOnlyDiagnostics(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	dir := c.TempDir()
+	schemaPath := filepath.Join(dir, "circular.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		"CREATE TABLE authors (\n"+
+			"  id INTEGER PRIMARY KEY,\n"+
+			"  favorite_book_id INTEGER REFERENCES books(id)\n"+
+			");\n"+
+			"CREATE TABLE books (\n"+
+			"  id INTEGER PRIMARY KEY,\n"+
+			"  author_id INTEGER REFERENCES authors(id)\n"+
+			");\n"), 0o600), qt.IsNil)
+
+	tests := []struct {
+		name string
+		mode string
+	}{
+		{name: "dry run", mode: "--dry-run"},
+		{name: "real apply", mode: "--auto-approve"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			runDir := c.TempDir()
+			run := newCompatProcess(binPath,
+				"schema", "apply",
+				"--url", "sqlite://"+filepath.Join(runDir, "target.db"),
+				"--to", "file://"+schemaPath,
+				"--dev-url", "sqlite://"+filepath.Join(runDir, "dev.db"),
+				tt.mode,
+			)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
+			c.Assert(stderr.String(), qt.Contains, "level=WARN")
+			c.Assert(stderr.String(), qt.Contains, "Circular dependency detected in foreign key relationships")
 		})
 	}
 }

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -1,0 +1,289 @@
+package main_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/internal/migratesum"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// The Atlas-compatible binary is quiet: the pinned Atlas CE v1.2.0 binary
+// writes nothing to stderr for a dry run, and `--format` consumers redirect
+// stderr into stdout (`2>&1 | jq`), which the conformance harness's
+// atlas-cli-report-format probe does. The dry-run revision-state fix
+// (stokaro/ptah#963) started routing dry runs through the dialect writers,
+// whose per-statement narration goes to the package-level slog logger and
+// therefore to stderr, so the probe stopped seeing a single JSON document
+// (stokaro/ptah#967).
+//
+// These pins hold both halves of the contract: nothing extra on the combined
+// stream, and failures still reported — quiet must not mean silent.
+
+// dryRunQuietDir writes an Atlas-format migration directory with a matching
+// down migration and seals it with atlas.sum.
+func dryRunQuietDir(c *qt.C) string {
+	c.Helper()
+	dir := c.TempDir()
+	files := map[string]string{
+		"1_init.sql":      "CREATE TABLE quiet_users (id INTEGER PRIMARY KEY);\n",
+		"1_init.down.sql": "DROP TABLE quiet_users;\n",
+	}
+	for name, content := range files {
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+// applyForReal runs a real apply so the revision table exists for a later
+// dry-run rollback.
+func applyForReal(c *qt.C, binPath, dbPath, migrationsDir string) {
+	c.Helper()
+	run := newCompatProcess(binPath,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	out, err := run.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+}
+
+// assertSingleJSONDocument asserts that combined holds exactly one JSON
+// document and nothing else — the shape `... 2>&1 | jq` requires.
+func assertSingleJSONDocument(c *qt.C, combined []byte) map[string]any {
+	c.Helper()
+	decoder := json.NewDecoder(bytes.NewReader(combined))
+	var document map[string]any
+	c.Assert(decoder.Decode(&document), qt.IsNil, qt.Commentf("combined output:\n%s", combined))
+
+	var trailing any
+	c.Assert(decoder.Decode(&trailing), qt.Equals, io.EOF,
+		qt.Commentf("combined output carries more than one document:\n%s", combined))
+	return document
+}
+
+func TestCompatBinaryDryRunFormatCombinedOutputIsOneJSONDocument(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+
+	c.Run("migrate apply", func(c *qt.C) {
+		dbPath := filepath.Join(c.TempDir(), "apply.db")
+		run := newCompatProcess(binPath,
+			"migrate", "apply",
+			"--url", "sqlite://"+dbPath,
+			"--dir", "file://"+migrationsDir,
+			"--dry-run",
+			"--format", "{{ json . }}",
+		)
+		combined, err := run.CombinedOutput()
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", combined))
+		document := assertSingleJSONDocument(c, combined)
+		c.Assert(document["Target"], qt.Equals, "1")
+	})
+
+	c.Run("migrate down", func(c *qt.C) {
+		dbPath := filepath.Join(c.TempDir(), "down.db")
+		applyForReal(c, binPath, dbPath, migrationsDir)
+
+		run := newCompatProcess(binPath,
+			"migrate", "down",
+			"--url", "sqlite://"+dbPath,
+			"--dir", "file://"+migrationsDir,
+			"--to-version", "0",
+			"--dry-run",
+			"--format", "{{ json . }}",
+		)
+		run.Stdin = strings.NewReader("YES\n")
+		combined, err := run.CombinedOutput()
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", combined))
+		document := assertSingleJSONDocument(c, combined)
+		c.Assert(document["Current"], qt.Equals, "1")
+	})
+}
+
+func TestCompatBinaryDryRunDefaultFormatKeepsStderrEmpty(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+
+	tests := []struct {
+		name       string
+		args       func(c *qt.C, dbPath string) []string
+		wantStdout string
+	}{
+		{
+			name: "migrate apply",
+			args: func(_ *qt.C, dbPath string) []string {
+				return []string{
+					"migrate", "apply",
+					"--url", "sqlite://" + dbPath,
+					"--dir", "file://" + migrationsDir,
+					"--dry-run",
+				}
+			},
+			wantStdout: "Dry run mode: no changes will be made.\n" +
+				"Migrating to version 1 from 1 pending migrations.\n" +
+				"Would have applied 1 migrations.\n",
+		},
+		{
+			name: "schema apply",
+			args: func(c *qt.C, dbPath string) []string {
+				c.Helper()
+				schemaPath := filepath.Join(filepath.Dir(dbPath), "schema.sql")
+				c.Assert(os.WriteFile(schemaPath,
+					[]byte("CREATE TABLE quiet_schema (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+				return []string{
+					"schema", "apply",
+					"--url", "sqlite://" + dbPath,
+					"--to", "file://" + schemaPath,
+					"--dev-url", "sqlite://" + filepath.Join(filepath.Dir(dbPath), "dev.db"),
+					"--dry-run",
+				}
+			},
+			wantStdout: "Planned schema changes:\n" +
+				"CREATE TABLE \"quiet_schema\" (\n  \"id\" INTEGER PRIMARY KEY\n);\n",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dbPath := filepath.Join(c.TempDir(), "quiet.db")
+			run := newCompatProcess(binPath, tt.args(c, dbPath)...)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
+			c.Assert(stderr.String(), qt.Equals, "")
+			c.Assert(stdout.String(), qt.Equals, tt.wantStdout)
+		})
+	}
+}
+
+// TestCompatBinaryDryRunPinNoWriterNarration is the direct pin for
+// stokaro/ptah#963: the dialect writers' "[DRY RUN] Would ..." narration must
+// never reach the Atlas-compatible binary's streams, whatever mechanism keeps
+// it away.
+func TestCompatBinaryDryRunPinNoWriterNarration(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+	dbPath := filepath.Join(c.TempDir(), "pin.db")
+	applyForReal(c, binPath, dbPath, migrationsDir)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{
+			name: "apply default format",
+			args: []string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+				"--dry-run",
+			},
+		},
+		{
+			name: "apply go template",
+			args: []string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+				"--dry-run", "--format", "{{ json . }}",
+			},
+		},
+		{
+			name: "down go template",
+			args: []string{
+				"migrate", "down",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+				"--to-version", "0",
+				"--dry-run", "--format", "{{ json . }}",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			run := newCompatProcess(binPath, tt.args...)
+			run.Stdin = strings.NewReader("YES\n")
+			combined, err := run.CombinedOutput()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", combined))
+			c.Assert(string(combined), qt.Not(qt.Contains), "[DRY RUN]")
+			c.Assert(string(combined), qt.Not(qt.Contains), "level=INFO")
+		})
+	}
+}
+
+// TestCompatBinaryDryRunFailuresStillReportOnStderr keeps the quiet default
+// from turning into silence: a dry run that fails still explains itself.
+func TestCompatBinaryDryRunFailuresStillReportOnStderr(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+
+	tests := []struct {
+		name       string
+		args       func(c *qt.C) []string
+		wantStderr string
+	}{
+		{
+			name: "missing migration directory",
+			args: func(c *qt.C) []string {
+				return []string{
+					"migrate", "apply",
+					"--url", "sqlite://" + filepath.Join(c.TempDir(), "missing.db"),
+					"--dir", "file://" + filepath.Join(c.TempDir(), "absent"),
+					"--dry-run",
+					"--format", "{{ json . }}",
+				}
+			},
+			wantStderr: "no such file or directory",
+		},
+		{
+			name: "checksum mismatch",
+			args: func(c *qt.C) []string {
+				return []string{
+					"migrate", "apply",
+					"--url", "sqlite://" + filepath.Join(c.TempDir(), "tampered.db"),
+					"--dir", "file://" + malformedAtlasDir(c),
+					"--dry-run",
+				}
+			},
+			wantStderr: "Error: checksum mismatch\n",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			run := newCompatProcess(binPath, tt.args(c)...)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
+			var exitErr *exec.ExitError
+
+			c.Assert(err, qt.ErrorAs, &exitErr)
+			c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+			c.Assert(stderr.String(), qt.Contains, tt.wantStderr)
+		})
+	}
+}

--- a/cmd/ptah-compat/main.go
+++ b/cmd/ptah-compat/main.go
@@ -5,9 +5,16 @@ import (
 	"path/filepath"
 
 	"github.com/stokaro/ptah/cmd/atlas"
+	"github.com/stokaro/ptah/cmd/internal/cliobs"
 	"github.com/stokaro/ptah/cmd/root"
 )
 
 func main() {
+	// The Atlas-compatible surface is quiet by construction: Atlas CE writes
+	// nothing to stderr for the commands this binary mirrors, so no library
+	// logging may reach this process's streams either. Without this, a
+	// `--format` report piped through `2>&1 | jq` stops being a single JSON
+	// document (stokaro/ptah#967).
+	cliobs.SilenceDefaultLogger()
 	root.ExecuteCommand(atlas.NewCompatCommand(filepath.Base(os.Args[0])))
 }

--- a/cmd/ptah-compat/main.go
+++ b/cmd/ptah-compat/main.go
@@ -11,10 +11,11 @@ import (
 
 func main() {
 	// The Atlas-compatible surface is quiet by construction: Atlas CE writes
-	// nothing to stderr for the commands this binary mirrors, so no library
-	// logging may reach this process's streams either. Without this, a
-	// `--format` report piped through `2>&1 | jq` stops being a single JSON
-	// document (stokaro/ptah#967).
-	cliobs.SilenceDefaultLogger()
+	// nothing to stderr for a clean run of the commands this binary mirrors,
+	// so library narration must not reach this process's streams either.
+	// Without this, a `--format` report piped through `2>&1 | jq` stops being a
+	// single JSON document (stokaro/ptah#967). Quiet is not silent — log-only
+	// Warn and Error diagnostics still get through.
+	cliobs.QuietDefaultLogger()
 	root.ExecuteCommand(atlas.NewCompatCommand(filepath.Base(os.Args[0])))
 }

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -186,6 +186,23 @@ Dry-run plans read the stored Atlas revision rows and include only migrations
 that a real apply would select. They also run the same dirty-state, checksum,
 execution-order, and transaction-mode validations as a real apply.
 
+A successful `ptah-compat` run writes nothing to stderr, matching Atlas CE:
+there is no progress narration on the Atlas-compatible surface, in a dry run or
+otherwise, so `--format` output survives the usual CI idiom of folding both
+streams together.
+
+```bash
+ptah-compat migrate apply --url "$DATABASE_URL" --dir file://migrations \
+  --dry-run --format '{{ json . }}' 2>&1 | jq
+```
+
+Failures are still reported: a dry run that cannot proceed prints its
+`Error: …` diagnostic to stderr and exits `1`. The equivalent native command,
+`ptah migrations up --dry-run`, does narrate each statement it would execute
+through its run log; that narration is selected by the native `--log-level` and
+`--log-format` flags, which the Atlas surface does not expose. See
+[Apply migrations](../../versioned/apply/).
+
 The apply path executes every Atlas OSS migration directory format selected by
 `migration.format` or the directory URL `?format=` parameter: `atlas`,
 `golang-migrate`, `goose`, `flyway`, `liquibase`, and `dbmate`. The native

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -186,22 +186,35 @@ Dry-run plans read the stored Atlas revision rows and include only migrations
 that a real apply would select. They also run the same dirty-state, checksum,
 execution-order, and transaction-mode validations as a real apply.
 
-A successful `ptah-compat` run writes nothing to stderr, matching Atlas CE:
-there is no progress narration on the Atlas-compatible surface, in a dry run or
-otherwise, so `--format` output survives the usual CI idiom of folding both
-streams together.
+A successful `ptah-compat migrate apply` writes nothing to stderr, matching
+Atlas CE: there is no progress narration, in a dry run or otherwise, so
+`--format` output survives the usual CI idiom of folding both streams together.
 
 ```bash
 ptah-compat migrate apply --url "$DATABASE_URL" --dir file://migrations \
   --dry-run --format '{{ json . }}' 2>&1 | jq
 ```
 
-Failures are still reported: a dry run that cannot proceed prints its
-`Error: …` diagnostic to stderr and exits `1`. The equivalent native command,
-`ptah migrations up --dry-run`, does narrate each statement it would execute
-through its run log; that narration is selected by the native `--log-level` and
-`--log-format` flags, which the Atlas surface does not expose. See
-[Apply migrations](../../versioned/apply/).
+Two things still reach stderr, by design. A command that fails prints its
+`Error: …` diagnostic there and exits `1`. And a Warn-level diagnostic that
+exists on no other channel — a circular foreign-key or function ordering, a dev
+database that would not close — is still reported, because dropping it would let
+an apply claim success while quietly degrading. Neither appears on a clean run.
+
+:::caution
+`ptah-compat migrate down` is the exception. Without `--format` it forwards to
+the native `ptah migrations down`, which starts its own run log and writes it to
+stderr — eight lines on a successful dry run, four on a successful rollback.
+The Atlas surface exposes no `--log-level` to quiet it. Use `--format` when you
+need a clean stderr from `migrate down`; that path renders the report directly
+and stays quiet. Tracked in
+[`stokaro/ptah#969`](https://github.com/stokaro/ptah/issues/969).
+:::
+
+The equivalent native command, `ptah migrations up --dry-run`, does narrate each
+statement it would execute through its run log; that narration is selected by
+the native `--log-level` and `--log-format` flags, which the Atlas surface does
+not expose. See [Apply migrations](../../versioned/apply/).
 
 The apply path executes every Atlas OSS migration directory format selected by
 `migration.format` or the directory URL `?format=` parameter: `atlas`,

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -24,17 +24,30 @@ ptah migrations up \
   --dry-run
 ```
 
-Expected output includes:
+Expected output on stdout:
 
 ```text
 === DRY RUN MODE ===
 No actual changes will be made to the database
 
-[DRY RUN] Would execute SQL ... sql="CREATE TABLE \"users\" ..."
-
 ✅ Dry run completed successfully!
 Would have applied 1 migrations
 ```
+
+The statement-by-statement narration is a log record, not report output, so it
+goes to the log stream — stderr by default:
+
+```text
+level=INFO msg="[DRY RUN] Would begin transaction"
+level=INFO msg="[DRY RUN] Would execute SQL" sql="CREATE TABLE \"users\" ..."
+level=INFO msg="[DRY RUN] Would commit transaction"
+```
+
+Both `--log-level` and `--log-format` apply to it: `--log-level warn` drops the
+narration and leaves only the stdout report, and `--log-format json` moves every
+record — report lines included — onto stdout as one JSON object per line, which
+keeps `ptah migrations up ... | jq` parseable. See
+[Execution controls](#execution-controls).
 
 :::note
 The dry run reads an existing revision table and walks only migrations pending
@@ -42,6 +55,13 @@ on this target. On a fresh target, it treats the absent revision table as empty
 without creating it. A legacy three-column Ptah revision table is read without
 upgrading its layout. A partially upgraded table is rejected with a missing
 column diagnostic and is not modified.
+:::
+
+:::caution
+This narration is native-only. `ptah-compat migrate apply --dry-run` stays quiet
+on stderr to match Atlas CE, so `ptah-compat ... --format '{{ json . }}' 2>&1 | jq`
+always sees exactly one JSON document. See
+[Atlas migrate commands](../../atlas/migrate-commands/).
 :::
 
 ## Apply with integrity verification
@@ -147,6 +167,11 @@ people and pipelines share a directory:
 - **Timeouts and locks**: `--statement-timeout`, `--lock-timeout`, and
   `--migration-lock-timeout` bound long DDL and the session-level advisory
   lock that keeps two migrators from racing.
+- **Run logging** (`--log-level`, `--log-format`): `--log-level`
+  debug\|info\|warn\|error selects how much of the run is narrated —
+  `warn` silences the per-statement dry-run narration — and `--log-format`
+  text\|json selects the encoding. `json` moves every record, the stdout
+  report included, onto stdout as one JSON object per line.
 
 See [Configuration](../../reference/configuration/) for the `ptah.yaml`
 equivalents of every control.

--- a/migration/migrator/dry_run_initialize_once_test.go
+++ b/migration/migrator/dry_run_initialize_once_test.go
@@ -1,0 +1,117 @@
+package migrator_test
+
+import (
+	"context"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+// Every migrator read entry point calls Initialize, so a dry run that skipped
+// memoizing its metadata inspection re-inspected the table — and repeated the
+// "[DRY RUN] Would initialize migrations metadata" narration — once per read.
+// The regression was introduced with the dry-run revision-state fix
+// (stokaro/ptah#963) and reported on stokaro/ptah#967.
+
+func openInitializeOnceSQLite(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+	conn, err := dbschema.ConnectToDatabase(
+		context.Background(),
+		"sqlite://"+filepath.Join(t.TempDir(), "initialize-once.db"),
+	)
+	qt.Assert(t, err, qt.IsNil)
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+// countingHandler records the messages of every log record it receives.
+type countingHandler struct {
+	messages *[]string
+}
+
+func (countingHandler) Enabled(context.Context, slog.Level) bool { return true }
+
+func (h countingHandler) Handle(_ context.Context, record slog.Record) error {
+	*h.messages = append(*h.messages, record.Message)
+	return nil
+}
+
+func (h countingHandler) WithAttrs([]slog.Attr) slog.Handler { return h }
+
+func (h countingHandler) WithGroup(string) slog.Handler { return h }
+
+func countMessages(messages []string, want string) int {
+	count := 0
+	for _, message := range messages {
+		count += strings.Count(message, want)
+	}
+	return count
+}
+
+func TestDryRunInitializeNarratesMetadataOnce(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openInitializeOnceSQLite(t)
+	conn.SchemaWriter().SetDryRun(true)
+
+	var messages []string
+	mig := migrator.NewMigrator(
+		conn,
+		migrator.NewRegisteredMigrationProvider(
+			migrator.CreateMigrationFromSQL(
+				1,
+				"create_users",
+				"CREATE TABLE initialize_once_users (id INTEGER PRIMARY KEY);",
+				"DROP TABLE initialize_once_users;",
+			),
+		),
+	).WithLogger(slog.New(countingHandler{messages: &messages}))
+
+	// GetMigrationStatus alone reads the version, the applied set, and the
+	// revision rows; MigrateUp reads again after executing.
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+
+	c.Assert(countMessages(messages, "[DRY RUN] Would initialize migrations metadata"), qt.Equals, 1)
+}
+
+func TestDryRunInitializeDoesNotSuppressRealInitialize(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+	conn := openInitializeOnceSQLite(t)
+	conn.SchemaWriter().SetDryRun(true)
+
+	mig := migrator.NewMigrator(
+		conn,
+		migrator.NewRegisteredMigrationProvider(
+			migrator.CreateMigrationFromSQL(
+				1,
+				"create_users",
+				"CREATE TABLE initialize_once_users (id INTEGER PRIMARY KEY);",
+				"DROP TABLE initialize_once_users;",
+			),
+		),
+	)
+
+	c.Assert(mig.Initialize(ctx), qt.IsNil)
+
+	// The memoized dry-run inspection must not be reused once the writer leaves
+	// dry-run mode: the metadata table still has to be created for real.
+	conn.SchemaWriter().SetDryRun(false)
+	c.Assert(mig.Initialize(ctx), qt.IsNil)
+
+	var tableCount int
+	err := conn.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'",
+	).Scan(&tableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 1)
+}

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -220,6 +220,7 @@ func (m *Migrator) WithMigrationsTable(schema, table string) *Migrator {
 		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
 	tmp.initialized = false
+	tmp.initializedDryRun = false
 	tmp.metadataAvailable = false
 	tmp.legacyRevisionTable = false
 	return &tmp
@@ -234,6 +235,7 @@ func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator
 		tmp.migrationsTable = tmp.defaultMigrationsTable()
 	}
 	tmp.initialized = false
+	tmp.initializedDryRun = false
 	tmp.metadataAvailable = false
 	tmp.legacyRevisionTable = false
 	return &tmp

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -92,11 +92,15 @@ type Migrator struct {
 	migrationLockName    string
 	migrationLockTimeout time.Duration
 	initialized          bool
-	logger               *slog.Logger
-	observer             Observer
-	skipChecks           bool
-	metadataAvailable    bool
-	legacyRevisionTable  bool
+	// initializedDryRun records the writer's dry-run mode at the time
+	// initialized was set, so the memoized state is never reused across a
+	// mode change.
+	initializedDryRun   bool
+	logger              *slog.Logger
+	observer            Observer
+	skipChecks          bool
+	metadataAvailable   bool
+	legacyRevisionTable bool
 }
 
 // NewFSMigrator creates a new migrator that loads migrations from a filesystem.
@@ -385,12 +389,18 @@ func (m *Migrator) deleteMigrationSQL() string {
 
 // Initialize creates the migrations table if it doesn't exist
 func (m *Migrator) Initialize(ctx context.Context) error {
-	// Skip if already initialized
-	if m.initialized {
+	dryRun := m.conn.Writer().IsDryRun()
+
+	// Skip if already initialized. The memoized result is only valid for the
+	// dry-run mode it was computed under: a real Initialize records that the
+	// metadata now exists, while a dry-run Initialize only records what the
+	// metadata looks like, so a writer that later leaves dry-run mode must
+	// still get its table created.
+	if m.initialized && m.initializedDryRun == dryRun {
 		return nil
 	}
 
-	if m.conn.Writer().IsDryRun() {
+	if dryRun {
 		return m.initializeDryRun(ctx)
 	}
 
@@ -419,33 +429,52 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 
 	// Mark as initialized
 	m.initialized = true
+	m.initializedDryRun = false
 	m.metadataAvailable = true
 	m.legacyRevisionTable = false
 	return nil
 }
 
+// initializeDryRun records what a real Initialize would find without writing
+// anything. Like the real path it memoizes its result: every read entry point
+// calls Initialize, so without memoization a single dry run re-inspects the
+// metadata table — and repeats the "[DRY RUN] Would initialize" narration —
+// once per read (stokaro/ptah#967).
 func (m *Migrator) initializeDryRun(ctx context.Context) error {
-	exists, err := m.migrationsTableExists(ctx)
+	available, legacy, err := m.inspectDryRunMetadata(ctx)
 	if err != nil {
-		return fmt.Errorf("failed to inspect migrations table: %w", err)
+		return err
 	}
-	if !exists {
-		m.metadataAvailable = false
-		m.legacyRevisionTable = false
+	if !available {
 		m.logger.Info("[DRY RUN] Would initialize migrations metadata", "table", m.qualifiedMigrationsTable())
-		return nil
 	}
 
-	m.metadataAvailable = true
-	if m.revisionTableFormat.isAtlas() {
-		return nil
-	}
-	legacy, err := m.migrationsTableUsesLegacyRevisionLayout(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to inspect migrations table layout: %w", err)
-	}
+	m.metadataAvailable = available
 	m.legacyRevisionTable = legacy
+	m.initialized = true
+	m.initializedDryRun = true
 	return nil
+}
+
+// inspectDryRunMetadata reports whether the revision metadata a dry run would
+// read is present, and whether it still uses the legacy Ptah layout.
+func (m *Migrator) inspectDryRunMetadata(ctx context.Context) (available, legacy bool, err error) {
+	exists, err := m.migrationsTableExists(ctx)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to inspect migrations table: %w", err)
+	}
+	if !exists {
+		return false, false, nil
+	}
+	if m.revisionTableFormat.isAtlas() {
+		return true, false, nil
+	}
+
+	legacy, err = m.migrationsTableUsesLegacyRevisionLayout(ctx)
+	if err != nil {
+		return false, false, fmt.Errorf("failed to inspect migrations table layout: %w", err)
+	}
+	return true, legacy, nil
 }
 
 func (m *Migrator) ensureMigrationsRevisionColumns(ctx context.Context) error {


### PR DESCRIPTION
Closes #967. Refs #963, #951. Follow-up filed as #969.

## What broke

#963 made `ApplyPlan.Execute` / `DownPlan.Execute` stop short-circuiting on `DryRun` and run the plan through the migrator with the writer in dry-run mode. The dialect writers narrate each simulated statement with the **package-level** `slog` functions:

```go
// internal/dbschema/sqlite/writer.go
if w.dryRun {
    slog.Info("[DRY RUN] Would execute SQL", "sql", sqlExpr, "args", args)
    return nil
}
```

`internal/atlasmigrate` already injects a discard logger into the *migrator* (`WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))`), but the writers bypass any injected logger and resolve `slog.Default()` at call time. The Atlas-compatible surface wires no logger at all, so those records went straight to the process's stderr.

Measured on the probe shape:

```console
$ ptah-compat migrate apply --url sqlite://apply.db --dir file://migrations \
    --dry-run --format '{{ json . }}' 2>&1
2026/08/01 15:35:43 INFO [DRY RUN] Would begin transaction
2026/08/01 15:35:43 INFO [DRY RUN] Would execute SQL sql="CREATE TABLE users (id INTEGER PRIMARY KEY)" args=[]
2026/08/01 15:35:43 INFO [DRY RUN] Would commit transaction
{"Driver":"sqlite","URL":{...},"Dir":"file://migrations","Pending":[...],"Target":"1",...}
```

After:

```console
$ ptah-compat migrate apply --url sqlite://apply.db --dir file://migrations \
    --dry-run --format '{{ json . }}' 2>&1 | jq -c '{Target, Pending: (.Pending|length)}'
{"Target":"1","Pending":1}
```

Default format, before → after: three `[DRY RUN]` lines on stderr → stderr empty, stdout unchanged.

## The fix

`cmd/ptah-compat/main.go` installs a quiet default `slog` logger before any command runs (`cliobs.QuietDefaultLogger`) — a text handler at `LevelWarn`.

This makes the contract a **process property** instead of a per-call-site convention. It is not only the writers that log through the package-level `slog` functions — `dbschema.CloseAndWarn`, the `goschema` annotation diagnostics, and the enum-creation notices do too. Suppressing at the call sites, or gating on "a machine-readable `--format` was requested", would leave that class open and need re-litigating every time a library package gains a log line.

The threshold sits on a real seam, not at zero:

- **Info and below is narration** — all 22 `[DRY RUN] Would ...` sites and the two Postgres enum notices. Atlas CE prints none of it. This is what broke #967, and it is dropped.
- **Warn and above is a diagnostic with no other channel** — `core/goschema/utils.go:78` (circular FK ordering), `utils.go:962` (circular function ordering), `dbschema/connection.go:394` `CloseAndWarn` (49 call sites, including `atlasschema/simulate.go` and `migrationreplay/replay.go` — a dev/shadow database that would not close), and `convert/fromschema/fromschema.go:2225` (unrecognized embedding mode silently inlines). None are returned as errors, so dropping them would let a real apply report success while quietly degrading. These are kept.

Atlas parity survives the split because a clean run emits nothing at either level. Verified on the built binary: a circular-FK schema emits `level=WARN msg="Circular dependency detected in foreign key relationships..."` on both `schema apply --dry-run` and `schema apply --auto-approve`, while the JSON probe under `2>&1` still pipes to `jq` and the default-format dry run still leaves stderr byte-empty.

Quiet is not silent in the other direction either: command failures are reported through the command's own error stream, so a dry run that cannot proceed still prints `Error: …` and exits `1`.

Deliberately **not** an exported public API change: `dbschema/types.SchemaWriter` is covered by the released-API baseline and the `docs/public_api.snapshot` guard, so plumbing a logger through the writer interface would have been a breaking change for a regression fix.

## Native surface: keeps the narration, unchanged

Investigating the actual mechanism turned up that the native surface was never the problem. `cliobs.Start` calls `slog.SetDefault(logger)`, so the writers' package-level `slog.Info` already resolves to the command's own handler — the records carry `correlation_id` and `command` attributes, honor `--log-level`, and follow `--log-format` onto stdout as JSON.

```console
$ ptah migrations up ... --dry-run 2>&1 >/dev/null | head -1
time=… level=INFO msg="[DRY RUN] Would execute SQL" correlation_id=… command=migrations.up sql="CREATE TABLE …"

$ ptah migrations up ... --dry-run --log-level warn 2>&1 >/dev/null
(nothing)
```

So the decision is to keep it as-is: the narration is useful when reviewing a plan, it is already behind the documented `--log-level` / `--log-format` controls, and changing its default would be a gratuitous native regression in a compat fix. What was missing was tests and docs pinning that, both of which are added.

## Also fixed: the repeated `Initialize` narration

The #964 reviewer's observation — `[DRY RUN] Would initialize migrations metadata` logged four times per dry run — is a **different root cause in the same PR**, not the same one. It goes through the migrator's *injected* logger, which the compat surface already discards, so it never contributed to #967; it is only visible on the native surface.

The cause is that #963 added `metadataAvailable` / `legacyRevisionTable` caches to `initializeDryRun` but never set `initialized`, so every read entry point (`GetCurrentVersion`, `GetAppliedMigrations`, `GetRevisions`, …) re-ran the whole inspection. It now memoizes like the real path — one narration line, and three fewer `information_schema` round-trips per dry run. The memo is keyed on the writer's dry-run mode so a writer that later leaves dry-run mode still gets its table created (pinned by a test).

`initializeDryRun` is also split so the inspection is a pure query and the state mutation happens in one place.

## Other compat verbs

| Verb | Affected by #963? | Status |
| --- | --- | --- |
| `migrate apply --dry-run` (default + `--format`) | yes | fixed, pinned |
| `migrate down --dry-run --format` | yes — same `internal/atlasmigrate` path | fixed, pinned |
| `schema apply --dry-run` | no — `ApplyRuntimePlan.Execute` returns before the writer ever enters dry-run mode | verified clean, pinned anyway |
| `migrate down --dry-run` *without* `--format` | **no** — pre-existing | filed as #969 |

`migrate down` without `--format` forwards to the native `ptah migrations down`, which starts its own `cliobs` runtime and logs to stderr — measured at 8 lines on a successful dry run and 4 on a successful rollback, both exit `0`. `cmd/migratedown/migratedown.go` is byte-identical at `fec2303` (pre-#963) and at `master`, so this is an older divergence from the forward design. Split out as **#969** (suggested fix there: the compat wrapper passes a quiet log level into the forwarded native command). The compat docs now name the exception explicitly instead of implying a guarantee.

## Tests

- `cmd/ptah-compat/dry_run_quiet_test.go` — subprocess-level, the real contract:
  - combined stdout+stderr of `migrate apply --dry-run --format '{{ json . }}'` decodes as exactly one JSON document and then `io.EOF` (the exact probe shape);
  - same for `migrate down --dry-run --format`;
  - default format: stderr byte-equal to `""` for `migrate apply` and `schema apply`, stdout pinned;
  - regression pin naming #963: no `[DRY RUN]` and no `level=INFO` anywhere in the combined output of three dry-run invocations, each with a planned-work marker asserted so the pin cannot pass on an empty plan;
  - **log-only diagnostics survive**: a circular-FK schema still emits its `level=WARN` record on both a dry run and a real `--auto-approve` apply;
  - failures still report on stderr and exit `1` (missing directory, checksum mismatch).
- `cmd/migrateup/dry_run_log_controls_test.go` — native: report on stdout, narration on the log stream, `--log-level` table (`info`/`debug` narrate, `warn`/`error` quiet), `--log-format json` keeps stdout parseable line-by-line and stderr empty, and exactly one metadata record.
- `migration/migrator/dry_run_initialize_once_test.go` — one `Would initialize migrations metadata` record across a status read plus a `MigrateUp`; and a dry-run `Initialize` does not suppress a later real one.
- `cmd/internal/cliobs/silence_test.go` — the level split as a contract (Info dropped, Warn kept, both directions); `Start` nests on top and restores the quiet default on shutdown.

Mutation-verified in both directions:

| Mutation | Result |
| --- | --- |
| revert `QuietDefaultLogger()` from `main` | all three `PinNoWriterNarration` subtests fail (previously only `down_go_template` did) |
| revert `QuietDefaultLogger()` from `main` | `DefaultFormatKeepsStderrEmpty/migrate_apply` fails, `FormatCombinedOutputIsOneJSONDocument` fails on `Decode` |
| swap `LevelWarn` back to `slog.DiscardHandler` | both `KeepsLogOnlyDiagnostics` subtests fail; `warn`/`error` subtests of the cliobs split fail |

## Open question for the conformance repo

On a **failing** apply, `--format` writes the JSON report to stdout and the `Error: …` diagnostic to stderr, so `2>&1 | jq` breaks on the failure path. That is probably correct Atlas parity — Atlas also writes its diagnostic to stderr — but the `atlas-cli-report-format` probe only covers the success path, so the failure path is currently unpinned either way. Worth a probe on the conformance side to lock in whichever behavior is intended.

## Verification

`go vet ./...` clean · full `go test ./...` green · `go test -race` on the four touched packages green · `golangci-lint run` on the four touched packages: 0 issues · `scripts/check-test-style.sh`: OK · `scripts/check-public-api-snapshot.sh`: no drift · docs site `check-links.mjs`, `check-style.mjs`, `check-page-health.mjs`, `check-core-doc-links.mjs`: OK.

## Docs

- `docs/site/src/content/docs/versioned/apply.md` — the dry-run section showed the stdout report and the `[DRY RUN] Would execute SQL` narration as one block; they are separate streams. Now split, with the `--log-level` / `--log-format` behavior spelled out, a new logging bullet under Execution controls, and a cross-reference to the compat surface.
- `docs/site/src/content/docs/atlas/migrate-commands.md` — scoped to `ptah-compat migrate apply` and to `--format`, shows the `2>&1 | jq` idiom, states that failures *and* Warn-level diagnostics still reach stderr, and calls out the `migrate down` exception with a pointer to #969.
- `DRY_RUN.md` — new "Where Dry Run Output Goes" section covering both streams and both surfaces, including what quiet does and does not drop; the pre-existing interleaved example is now labeled as such.