### PR TITLE
Implement `schema inspect --include` on the compat and native surfaces (#951)

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -198,10 +198,13 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 		forbidden []string
 	}{
 		{
-			name:      "schema_inspect",
-			path:      []string{"schema", "inspect"},
-			flags:     []string{"--url", "--dev-url", "--env", "--schema", "--exclude", "--format"},
-			forbidden: []string{"--include"},
+			name: "schema_inspect",
+			path: []string{"schema", "inspect"},
+			// --include is a Pro-surface flag the pinned Atlas CE binary does
+			// not register on inspect; compat implements it so Pro pipelines
+			// port. --output, --web, and --export stay unregistered.
+			flags:     []string{"--url", "--dev-url", "--env", "--schema", "--exclude", "--format", "--include"},
+			forbidden: []string{"--output", "--web", "--export"},
 		},
 		{
 			name:  "schema_apply",
@@ -1275,17 +1278,26 @@ func TestCompatCommand_SchemaInspectUsesAtlasProjectFormatAndSchemaMode(t *testi
 	c.Assert(out.String(), qt.Equals, "{}")
 }
 
-func TestCompatCommand_SchemaInspectRejectsIncludeAsUnknownFlag(t *testing.T) {
+// TestCompatCommand_SchemaInspectRejectsProOnlyOutputFlags pins the inspect
+// flags the licensed Atlas build registers that compat deliberately does not:
+// --output, --web, and --export are separate items of stokaro/ptah#951.
+// --include is registered and covered by schema_inspect_include_test.go.
+func TestCompatCommand_SchemaInspectRejectsProOnlyOutputFlags(t *testing.T) {
 	c := qt.New(t)
-	cmd := NewCompatCommand("atlas")
-	var out bytes.Buffer
-	cmd.SetOut(&out)
-	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"schema", "inspect", "--url", "sqlite://inspect.db", "--include", "users"})
 
-	err := cmd.Execute()
+	for _, flag := range []string{"--output", "--web", "--export"} {
+		c.Run(flag, func(c *qt.C) {
+			cmd := NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"schema", "inspect", "--url", "sqlite://inspect.db", flag, "x"})
 
-	c.Assert(err, qt.ErrorMatches, "unknown flag: --include")
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, "unknown flag: "+flag)
+		})
+	}
 }
 
 func TestCompatCommand_ForwardsParentedNativeCommand(t *testing.T) {

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -17,6 +17,7 @@ type atlasSchemaInspectOptions struct {
 	url     string
 	devURL  string
 	schemas []string
+	include []string
 	exclude []string
 	format  string
 }
@@ -45,7 +46,18 @@ and ` + "`split \"type\"`" + ` with an optional file extension — through
 ` + "`{{ sql . | split | write \"dir\" }}`" + `. The OSS --exclude filter
 supports resource selectors plus the documented ` + "`[type=extension].version`" + `
 field selector; unsupported selector forms fail before any database is
-contacted.`,
+contacted.
+
+--include positively selects which top-level resources the inspected output
+keeps, using the same selectors as ` + "`schema apply`" + ` and
+` + "`schema diff`" + `: --schema names the schema universe, --include picks
+resources inside it, and --exclude subtracts from the result. Child resources
+(columns, indexes, constraints, triggers, policies, grants) ride along with
+their parent and cannot be selected on their own, in either the
+` + "`[type=column]`" + ` or the ` + "`table.column`" + ` spelling. A selection
+that keeps an object whose dependency it dropped is refused rather than
+rendered, so inspected output never references an object it omitted. The flag
+is absent from Atlas CE, which rejects it as an unknown flag on this command.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaInspect(cmd, opts)
 		},
@@ -54,6 +66,7 @@ contacted.`,
 	flags.StringVarP(&opts.url, "url", "u", "", "Database URL, schema file, migration directory, or env:// reference to inspect")
 	flags.StringVar(&opts.devURL, "dev-url", "", "Dev database URL used to evaluate non-database inspection sources")
 	registerAtlasSchemaFlag(flags, &opts.schemas, "Schema to inspect")
+	flags.StringArrayVar(&opts.include, "include", nil, "Schema objects to include in inspection")
 	flags.StringArrayVar(&opts.exclude, "exclude", nil, "Schema objects to exclude from inspection")
 	flags.StringVar(&opts.format, "format", "", "Output format or Go template: hcl, sql, json, or custom template")
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
@@ -106,6 +119,7 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 		URL:            opts.url,
 		DevURL:         opts.devURL,
 		Schemas:        opts.schemas,
+		Include:        opts.include,
 		Exclude:        opts.exclude,
 		Format:         opts.format,
 		Diagnostics:    cmd.ErrOrStderr(),

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -55,10 +55,12 @@ resources inside it, and --exclude subtracts from the result. Child resources
 (columns, indexes, constraints, triggers, policies, grants) ride along with
 their parent and cannot be selected on their own, in either the
 ` + "`[type=column]`" + ` or the literal-dot ` + "`table.column`" + ` spelling;
-glob metacharacters match a dot too, so ` + "`table*column`" + ` is not caught
-and selects nothing instead. Selector depth counts separators outside quotes,
-so a quoted identifier holding a dot (` + "`main.\"my.table\"`" + `) stays a
-valid depth-one selector. A selection that keeps an object whose dependency it
+glob metacharacters (*, ?, and character classes) match a dot too, so
+` + "`table*column`" + ` and ` + "`table[.]column`" + ` are not caught and
+select nothing instead. Selector depth counts separators outside quotes, so an
+identifier holding a dot is selected as ` + "`main.\"my.table\"`" + ` or
+` + "`a\\.b\\.c`" + `; the bare ` + "`a.b.c`" + ` spelling is refused as
+ambiguous with schema.table.column. A selection that keeps an object whose dependency it
 dropped is refused rather than rendered, so inspected output never references
 an object it omitted. The flag is absent from Atlas CE, which rejects it as an
 unknown flag on this command.`,

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -54,10 +54,14 @@ keeps, using the same selectors as ` + "`schema apply`" + ` and
 resources inside it, and --exclude subtracts from the result. Child resources
 (columns, indexes, constraints, triggers, policies, grants) ride along with
 their parent and cannot be selected on their own, in either the
-` + "`[type=column]`" + ` or the ` + "`table.column`" + ` spelling. A selection
-that keeps an object whose dependency it dropped is refused rather than
-rendered, so inspected output never references an object it omitted. The flag
-is absent from Atlas CE, which rejects it as an unknown flag on this command.`,
+` + "`[type=column]`" + ` or the literal-dot ` + "`table.column`" + ` spelling;
+glob metacharacters match a dot too, so ` + "`table*column`" + ` is not caught
+and selects nothing instead. Selector depth counts separators outside quotes,
+so a quoted identifier holding a dot (` + "`main.\"my.table\"`" + `) stays a
+valid depth-one selector. A selection that keeps an object whose dependency it
+dropped is refused rather than rendered, so inspected output never references
+an object it omitted. The flag is absent from Atlas CE, which rejects it as an
+unknown flag on this command.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaInspect(cmd, opts)
 		},

--- a/cmd/atlas/schema_inspect_include_test.go
+++ b/cmd/atlas/schema_inspect_include_test.go
@@ -124,6 +124,38 @@ func TestSchemaInspectIncludeAcceptsQualifiedNames(t *testing.T) {
 	}
 }
 
+func TestSchemaInspectIncludeSelectsQuotedDottedIdentifier(t *testing.T) {
+	c := qt.New(t)
+
+	// The qualified candidate for a dotted identifier quotes the dotted part
+	// (`main."dotted.table"`), so the selector matching it holds two dot
+	// characters and one separator. Depth is measured on separators outside
+	// quotes for exactly this reason.
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "schema qualified", pattern: `main."dotted.table"`},
+		{name: "wildcard schema", pattern: `*."dotted.table"`},
+		{name: "bare name", pattern: `dotted.table`},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbPath := seedSQLiteDB(t,
+				"CREATE TABLE \"dotted.table\" (id INTEGER PRIMARY KEY, email TEXT);\n"+
+					"CREATE TABLE inspect_archive (id INTEGER PRIMARY KEY);")
+
+			stdout, stderr, err := runCompatInspect("--url", "sqlite://"+dbPath, "--include", test.pattern)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+			c.Assert(stdout, qt.Contains, `table "dotted.table"`)
+			c.Assert(stdout, qt.Contains, `column "email"`)
+			c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+		})
+	}
+}
+
 func TestSchemaInspectIncludeComposesWithExclude(t *testing.T) {
 	c := qt.New(t)
 	dbPath := seedSQLiteDB(t, inspectIncludeDDL)

--- a/cmd/atlas/schema_inspect_include_test.go
+++ b/cmd/atlas/schema_inspect_include_test.go
@@ -1,0 +1,408 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/cmd/atlas"
+)
+
+// inspectIncludeDDL mirrors the shape of the fixture the licensed Atlas
+// v1.2.4 `schema inspect --include` transcripts were recorded against: two
+// tables joined by a foreign key plus one independent table, so selection,
+// dependency refusal, and non-selection are all observable.
+const inspectIncludeDDL = `
+CREATE TABLE inspect_users (
+  id INTEGER PRIMARY KEY,
+  email TEXT
+);
+CREATE TABLE inspect_posts (
+  id INTEGER PRIMARY KEY,
+  author_id INTEGER REFERENCES inspect_users(id)
+);
+CREATE TABLE inspect_archive (
+  id INTEGER PRIMARY KEY
+);
+`
+
+// runCompatInspect executes `atlas schema inspect` with args and returns
+// stdout and stderr separately, so a test can assert that a refusal left
+// stdout empty.
+func runCompatInspect(args ...string) (stdout, stderr string, err error) {
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	var errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(append([]string{"schema", "inspect"}, args...))
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+// TestSchemaInspectAdvertisesIncludeInItsFlagList asserts on the rendered
+// flag entry rather than on the help text as a whole: the command's long
+// description explains --include in prose, so a bare substring check against
+// the full help would pass even with the flag unregistered.
+func TestSchemaInspectAdvertisesIncludeInItsFlagList(t *testing.T) {
+	c := qt.New(t)
+
+	stdout, _, err := runCompatInspect("--help")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "--include stringArray   Schema objects to include in inspection")
+}
+
+func TestSchemaInspectIncludeSelectsTopLevelResources(t *testing.T) {
+	c := qt.New(t)
+	dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+	stdout, stderr, err := runCompatInspect("--url", "sqlite://"+dbPath, "--include", "inspect_users")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+	// The selected table is rendered whole, not as an empty shell.
+	c.Assert(stdout, qt.Contains, `column "email"`)
+	c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_posts"`)
+	c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+}
+
+func TestSchemaInspectIncludeUnionsValues(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "repeated flag", args: []string{"--include", "inspect_users", "--include", "inspect_archive"}},
+		{name: "comma separated", args: []string{"--include", "inspect_users,inspect_archive"}},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+			stdout, stderr, err := runCompatInspect(append([]string{"--url", "sqlite://" + dbPath}, test.args...)...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+			c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+			c.Assert(stdout, qt.Contains, `table "inspect_archive"`)
+			c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_posts"`)
+		})
+	}
+}
+
+func TestSchemaInspectIncludeAcceptsQualifiedNames(t *testing.T) {
+	c := qt.New(t)
+
+	// Both spellings name one top-level table. Licensed Atlas v1.2.4 treats
+	// the wildcard form as a child-level pattern instead and renders the
+	// tables as empty shells; Ptah keeps the selected table whole.
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "schema qualified", pattern: "main.inspect_users"},
+		{name: "wildcard schema", pattern: "*.inspect_users"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+			stdout, stderr, err := runCompatInspect("--url", "sqlite://"+dbPath, "--include", test.pattern)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+			c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+			c.Assert(stdout, qt.Contains, `column "email"`)
+			c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+		})
+	}
+}
+
+func TestSchemaInspectIncludeComposesWithExclude(t *testing.T) {
+	c := qt.New(t)
+	dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+	stdout, stderr, err := runCompatInspect(
+		"--url", "sqlite://"+dbPath,
+		"--include", "inspect_users,inspect_archive",
+		"--exclude", "inspect_archive",
+	)
+
+	// The positive selection defines the universe first; --exclude subtracts
+	// from it afterward.
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+	c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+	c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+	c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_posts"`)
+}
+
+func TestSchemaInspectIncludeComposesWithSchemaScope(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("selected schema keeps the selection", func(c *qt.C) {
+		dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+		stdout, stderr, err := runCompatInspect(
+			"--url", "sqlite://"+dbPath,
+			"--schema", "main",
+			"--include", "inspect_users",
+		)
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+	})
+
+	c.Run("unknown schema does not narrow SQLite inspection", func(c *qt.C) {
+		dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+		stdout, stderr, err := runCompatInspect(
+			"--url", "sqlite://"+dbPath,
+			"--schema", "other",
+			"--include", "inspect_users",
+		)
+
+		// Measured against the pinned Atlas CE v1.2.0 binary: SQLite has one
+		// schema, and `schema inspect --schema other` narrows nothing there —
+		// it renders the whole database. Ptah matches that, so on SQLite the
+		// include selection alone governs what survives.
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+	})
+}
+
+func TestSchemaInspectIncludeDegenerateValues(t *testing.T) {
+	c := qt.New(t)
+
+	allTables := []string{"inspect_users", "inspect_posts", "inspect_archive"}
+
+	tests := []struct {
+		name string
+		args []string
+		// wantTables are the table blocks the rendered output must contain,
+		// wantAbsent the ones it must not.
+		wantTables []string
+		wantAbsent []string
+	}{
+		{
+			// A selection that matches nothing renders no objects rather than
+			// failing, mirroring the empty-selection behavior of apply and diff.
+			name:       "matches nothing",
+			args:       []string{"--include", "no_such_table"},
+			wantAbsent: allTables,
+		},
+		{
+			name:       "matches everything",
+			args:       []string{"--include", "*"},
+			wantTables: allTables,
+		},
+		{
+			// An empty value carries no selection, so inspection stays unfiltered.
+			name:       "empty value",
+			args:       []string{"--include", ""},
+			wantTables: allTables,
+		},
+		{
+			// Control: with the flag absent the established unfiltered
+			// behavior must be unchanged.
+			name:       "flag absent",
+			args:       nil,
+			wantTables: allTables,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+			stdout, stderr, err := runCompatInspect(append([]string{"--url", "sqlite://" + dbPath}, test.args...)...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+			for _, table := range test.wantTables {
+				c.Assert(stdout, qt.Contains, `table "`+table+`"`)
+			}
+			for _, table := range test.wantAbsent {
+				c.Assert(stdout, qt.Not(qt.Contains), `table "`+table+`"`)
+			}
+		})
+	}
+}
+
+func TestSchemaInspectIncludeCrossScopeDependencyFails(t *testing.T) {
+	c := qt.New(t)
+	dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+	stdout, _, err := runCompatInspect("--url", "sqlite://"+dbPath, "--include", "inspect_posts")
+
+	// Rendering the selected table alone would emit a foreign key pointing at
+	// a table the same output omits, so the projection is refused instead.
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains,
+		`table "main.inspect_posts" depends on table "main.inspect_users" via a foreign key, but "main.inspect_users" is not selected`)
+	c.Assert(stdout, qt.Equals, "")
+}
+
+func TestSchemaInspectIncludeRejectsChildSelectorsBeforeConnecting(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr string
+	}{
+		{
+			name:    "type selector spelling",
+			pattern: "*[type=column]",
+			wantErr: `unsupported Atlas include selector "\*\[type=column\]": column resources ride along with their parent and cannot be included on their own`,
+		},
+		{
+			name:    "positional spelling",
+			pattern: "main.inspect_users.email",
+			wantErr: `unsupported Atlas include selector "main\.inspect_users\.email": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "unknown resource type",
+			pattern: "*[type=widget]",
+			wantErr: `unsupported Atlas include resource type "widget" in selector "\*\[type=widget\]"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			// The URL points at a closed port: reaching it would fail with a
+			// connection error instead of the selector error asserted below.
+			_, _, err := runCompatInspect(
+				"--url", "postgres://127.0.0.1:1/unreachable",
+				"--include", test.pattern,
+			)
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestSchemaInspectIncludeValidationRunsBeforeDevDatabaseReset(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "schema.sql")
+	devPath := filepath.Join(dir, "dev.db")
+	c.Assert(os.WriteFile(schemaPath, []byte(inspectIncludeDDL), 0o600), qt.IsNil)
+
+	_, _, err := runCompatInspect(
+		"--url", "file://"+schemaPath,
+		"--dev-url", "sqlite://"+devPath,
+		"--include", "*[type=column]",
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	// Validation runs before the dev database is touched, so its destructive
+	// reset never happened and the file was never created.
+	_, statErr := os.Stat(devPath)
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue)
+}
+
+func TestSchemaInspectIncludeAppliesToEverySourceKind(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("local schema file", func(c *qt.C) {
+		dir := t.TempDir()
+		schemaPath := filepath.Join(dir, "schema.sql")
+		c.Assert(os.WriteFile(schemaPath, []byte(inspectIncludeDDL), 0o600), qt.IsNil)
+
+		stdout, stderr, err := runCompatInspect(
+			"--url", "file://"+schemaPath,
+			"--dev-url", "sqlite://"+filepath.Join(dir, "dev.db"),
+			"--include", "inspect_users",
+		)
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+	})
+
+	c.Run("migration directory", func(c *qt.C) {
+		migrationsDir := writeAtlasFormatMigrations(t, inspectIncludeDDL)
+
+		stdout, stderr, err := runCompatInspect(
+			"--url", "file://"+migrationsDir,
+			"--dev-url", "sqlite://"+filepath.Join(t.TempDir(), "dev.db"),
+			"--include", "inspect_users",
+		)
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "inspect_users"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "inspect_archive"`)
+	})
+}
+
+func TestSchemaInspectIncludeAppliesToEveryOutputFormat(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		format string
+		want   string
+	}{
+		{name: "hcl", format: "hcl", want: `table "inspect_users"`},
+		{name: "sql", format: "sql", want: `CREATE TABLE "inspect_users"`},
+		{name: "json", format: "json", want: `"name":"inspect_users"`},
+		{name: "template", format: `{{ range (index .Schema.Schemas 0).Tables }}{{ .Name }};{{ end }}`, want: "inspect_users;"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+
+			stdout, stderr, err := runCompatInspect(
+				"--url", "sqlite://"+dbPath,
+				"--include", "inspect_users",
+				"--format", test.format,
+			)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+			c.Assert(stdout, qt.Contains, test.want)
+			c.Assert(stdout, qt.Not(qt.Contains), "inspect_archive")
+		})
+	}
+}
+
+func TestSchemaInspectIncludeAppliesToSplitWriteExport(t *testing.T) {
+	c := qt.New(t)
+	dbPath := seedSQLiteDB(t, inspectIncludeDDL)
+	outDir := filepath.Join(t.TempDir(), "export")
+
+	_, stderr, err := runCompatInspect(
+		"--url", "sqlite://"+dbPath,
+		"--include", "inspect_users",
+		"--format", `{{ hcl . | split | write "`+outDir+`" }}`,
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+	written := exportedFileNames(c, outDir)
+	c.Assert(written, qt.DeepEquals, []string{"inspect_users.hcl"})
+}
+
+// exportedFileNames returns the base names of every file below root, sorted by
+// walk order, so a split/write export can be asserted on exactly.
+func exportedFileNames(c *qt.C, root string) []string {
+	c.Helper()
+	var names []string
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			names = append(names, filepath.Base(path))
+		}
+		return nil
+	})
+	c.Assert(err, qt.IsNil)
+	return names
+}

--- a/cmd/atlas/schema_scope_live_test.go
+++ b/cmd/atlas/schema_scope_live_test.go
@@ -175,3 +175,80 @@ func TestSchemaDiffSchemaScopeLivePostgres(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "email")
 	c.Assert(out.String(), qt.Not(qt.Contains), auditSchema)
 }
+
+// createScopeInspectSchema provisions one uniquely named schema holding the
+// PostgreSQL-only object kinds the include projection has to reason about: an
+// enum used by a kept column, a SERIAL-owned sequence, an independent table,
+// and a dependent table joined by a foreign key.
+func createScopeInspectSchema(t *testing.T, dbURL string) string {
+	t.Helper()
+	c := qt.New(t)
+	name := fmt.Sprintf("ptah_inspect_inc_%d_%d", os.Getpid(), time.Now().UnixNano()%1_000_000)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "DROP SCHEMA IF EXISTS "+name+" CASCADE")
+		dbschema.CloseAndWarn(conn)
+	})
+	for _, statement := range []string{
+		"CREATE SCHEMA " + name,
+		"CREATE TYPE " + name + ".user_state AS ENUM ('on', 'off')",
+		"CREATE TABLE " + name + ".users (id SERIAL PRIMARY KEY, state " + name + ".user_state)",
+		"CREATE TABLE " + name + ".posts (id SERIAL PRIMARY KEY, author_id INTEGER REFERENCES " + name + ".users(id))",
+		"CREATE TABLE " + name + ".archive (id SERIAL PRIMARY KEY)",
+	} {
+		_, err := conn.ExecContext(context.Background(), statement)
+		c.Assert(err, qt.IsNil)
+	}
+	return name
+}
+
+func TestSchemaInspectIncludeLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	dbURL := livePostgresURLForScope(t)
+	schemaName := createScopeInspectSchema(t, dbURL)
+
+	c.Run("qualified selection keeps the table and the type it uses", func(c *qt.C) {
+		stdout, stderr, err := runCompatInspect(
+			"--url", dbURL, "--schema", schemaName, "--include", schemaName+".users")
+
+		// The enum the kept column uses rides along; the unrelated table and
+		// the dependent table do not.
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "users"`)
+		c.Assert(stdout, qt.Contains, "user_state")
+		c.Assert(stdout, qt.Not(qt.Contains), `table "archive"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "posts"`)
+	})
+
+	c.Run("bare name matches inside the schema universe", func(c *qt.C) {
+		stdout, stderr, err := runCompatInspect(
+			"--url", dbURL, "--schema", schemaName, "--include", "users")
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "users"`)
+		c.Assert(stdout, qt.Not(qt.Contains), `table "archive"`)
+	})
+
+	c.Run("selection dropping a foreign key target is refused", func(c *qt.C) {
+		stdout, _, err := runCompatInspect(
+			"--url", dbURL, "--schema", schemaName, "--include", "posts")
+
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, "via a foreign key")
+		c.Assert(err.Error(), qt.Contains, schemaName+".users")
+		// The refusal replaces the render: no schema output was produced.
+		c.Assert(stdout, qt.Equals, "")
+	})
+
+	c.Run("matching everything keeps every table in the schema universe", func(c *qt.C) {
+		stdout, stderr, err := runCompatInspect(
+			"--url", dbURL, "--schema", schemaName, "--include", "*")
+
+		c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
+		c.Assert(stdout, qt.Contains, `table "users"`)
+		c.Assert(stdout, qt.Contains, `table "posts"`)
+		c.Assert(stdout, qt.Contains, `table "archive"`)
+		c.Assert(stdout, qt.Contains, "user_state")
+	})
+}

--- a/cmd/atlas/schema_scope_test.go
+++ b/cmd/atlas/schema_scope_test.go
@@ -135,6 +135,54 @@ func TestSchemaDiffIncludeCrossScopeDependencyFails(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "add the missing objects to the selection or exclude the dependent objects")
 }
 
+// TestSchemaDiffIncludeSelectsQuotedDottedIdentifier guards the qualified
+// spelling of an identifier that itself contains a dot. Ptah quotes such a
+// part when it builds the schema-qualified candidate, so the selector that
+// matches `main."dotted.table"` carries two dot characters but only one
+// separator. A depth check that counted characters made this selector — and
+// therefore the qualified spelling of every dotted identifier — inexpressible.
+func TestSchemaDiffIncludeSelectsQuotedDottedIdentifier(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "schema qualified", pattern: `main."dotted.table"`},
+		{name: "wildcard schema", pattern: `*."dotted.table"`},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := t.TempDir()
+			fromPath := filepath.Join(dir, "from.sql")
+			toPath := filepath.Join(dir, "to.sql")
+			devPath := filepath.Join(dir, "dev.db")
+			c.Assert(os.WriteFile(fromPath, []byte(""), 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(toPath, []byte(
+				"CREATE TABLE \"dotted.table\" (id INTEGER PRIMARY KEY);\nCREATE TABLE scope_archive (id INTEGER PRIMARY KEY);\n",
+			), 0o600), qt.IsNil)
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"schema", "diff",
+				"--from", "file://" + fromPath,
+				"--to", "file://" + toPath,
+				"--dev-url", "sqlite://" + devPath,
+				"--include", test.pattern,
+			})
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+			c.Assert(out.String(), qt.Contains, `"dotted.table"`)
+			c.Assert(out.String(), qt.Not(qt.Contains), "scope_archive")
+		})
+	}
+}
+
 func TestSchemaDiffIncludeMalformedSelectorFailsBeforeDevDatabase(t *testing.T) {
 	c := qt.New(t)
 	fromPath, toPath, devPath := writeScopeSchemaFiles(t)

--- a/cmd/schema/inspect.go
+++ b/cmd/schema/inspect.go
@@ -65,9 +65,11 @@ object by default, or grouped with --split schema|type.
 --schemas names the schema universe, --include picks top-level resources
 inside it with Atlas-style selectors, and --exclude subtracts from the result.
 Child resources ride along with their parent and cannot be selected on their
-own. A selection that keeps an object whose dependency it dropped is refused
-rather than rendered, so inspected output never references an object it
-omitted.`,
+own: the [type=column] and literal-dot table.column spellings both fail before
+the database is contacted, while glob metacharacters match a dot and escape
+that check. A selection that keeps an object whose dependency it dropped is
+refused rather than rendered, so inspected output never references an object
+it omitted.`,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSchemaInspect(cmd, opts)

--- a/cmd/schema/inspect.go
+++ b/cmd/schema/inspect.go
@@ -19,6 +19,7 @@ const (
 	inspectSchemaFileFlag    = "schema-file"
 	inspectMigrationsDirFlag = "migrations-dir"
 	inspectDevURLFlag        = "dev-url"
+	inspectIncludeFlag       = "include"
 	inspectExcludeFlag       = "exclude"
 	inspectFormatFlag        = "format"
 	inspectOutDirFlag        = "out-dir"
@@ -31,6 +32,7 @@ type schemaInspectOptions struct {
 	migrationsDir  string
 	devURL         string
 	schemas        string
+	include        []string
 	exclude        []string
 	format         string
 	outDir         string
@@ -57,9 +59,15 @@ the output is normalized by a real database of the target dialect.
 
 The default output is HCL; --format selects hcl, sql, or json. With --out-dir
 the inspected schema is exported as files instead of one stream: one file per
-object by default, or grouped with --split schema|type. --schemas restricts
-inspection to the named schema scopes and --exclude filters resources with
-Atlas-style selectors.`,
+object by default, or grouped with --split schema|type.
+
+--schemas, --include, and --exclude select what is inspected, in that order:
+--schemas names the schema universe, --include picks top-level resources
+inside it with Atlas-style selectors, and --exclude subtracts from the result.
+Child resources ride along with their parent and cannot be selected on their
+own. A selection that keeps an object whose dependency it dropped is refused
+rather than rendered, so inspected output never references an object it
+omitted.`,
 		SilenceErrors: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runSchemaInspect(cmd, opts)
@@ -71,6 +79,7 @@ Atlas-style selectors.`,
 	flags.StringVar(&opts.migrationsDir, inspectMigrationsDirFlag, "", "Atlas-format migration directory to inspect; requires --dev-url")
 	flags.StringVar(&opts.devURL, inspectDevURLFlag, "", "Dev database URL used to evaluate non-database inspection sources; it is reset destructively")
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
+	flags.StringArrayVar(&opts.include, inspectIncludeFlag, nil, "Schema objects to include in inspection (Atlas-style selectors)")
 	flags.StringArrayVar(&opts.exclude, inspectExcludeFlag, nil, "Schema objects to exclude from inspection (Atlas-style selectors)")
 	flags.StringVar(&opts.format, inspectFormatFlag, "hcl", "Output format: hcl, sql, or json")
 	flags.StringVar(&opts.outDir, inspectOutDirFlag, "", "Directory the inspected schema is exported into as files (hcl and sql formats only)")
@@ -126,6 +135,7 @@ func runSchemaInspect(cmd *cobra.Command, opts schemaInspectOptions) error {
 		URL:            sourceURL,
 		DevURL:         opts.devURL,
 		Schemas:        dbcli.ParseSchemas(opts.schemas),
+		Include:        opts.include,
 		Exclude:        opts.exclude,
 		Format:         format,
 		Diagnostics:    cmd.ErrOrStderr(),

--- a/cmd/schema/inspect.go
+++ b/cmd/schema/inspect.go
@@ -66,8 +66,10 @@ object by default, or grouped with --split schema|type.
 inside it with Atlas-style selectors, and --exclude subtracts from the result.
 Child resources ride along with their parent and cannot be selected on their
 own: the [type=column] and literal-dot table.column spellings both fail before
-the database is contacted, while glob metacharacters match a dot and escape
-that check. A selection that keeps an object whose dependency it dropped is
+the database is contacted, while glob metacharacters (*, ?, and character
+classes) match a dot and escape that check. An identifier holding a dot is
+selected as main."my.table" or a\.b\.c; the bare a.b.c spelling is refused as
+ambiguous. A selection that keeps an object whose dependency it dropped is
 refused rather than rendered, so inspected output never references an object
 it omitted.`,
 		SilenceErrors: true,

--- a/cmd/schema/inspect_test.go
+++ b/cmd/schema/inspect_test.go
@@ -109,6 +109,63 @@ func TestSchemaInspectRejectsNonMigrationDirectory(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `--migrations-dir .* is not recognized as a migration directory .*`, qt.Commentf("%s", out))
 }
 
+// nativeInspectIncludeDDL gives the include tests a selectable table, a
+// dependent table, and an unrelated table.
+const nativeInspectIncludeDDL = `CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);
+CREATE TABLE posts (id INTEGER PRIMARY KEY, author_id INTEGER REFERENCES users(id));
+CREATE TABLE archive (id INTEGER PRIMARY KEY);`
+
+func TestSchemaInspectIncludeSelectsResources(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "live.db")
+	seedSQLite(c, dbPath, nativeInspectIncludeDDL)
+
+	out, err := runSchema("", "inspect",
+		"--db-url", "sqlite://"+dbPath,
+		"--include", "users",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, `table "users"`)
+	c.Assert(out, qt.Contains, `column "email"`)
+	c.Assert(out, qt.Not(qt.Contains), `table "archive"`)
+}
+
+func TestSchemaInspectIncludeRejectsChildSelectors(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr string
+	}{
+		{
+			name:    "type selector spelling",
+			pattern: "*[type=column]",
+			wantErr: `unsupported Atlas include selector .*column resources ride along with their parent.*`,
+		},
+		{
+			name:    "positional spelling",
+			pattern: "main.users.email",
+			wantErr: `unsupported Atlas include selector .*a deeper pattern names a child resource.*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			// The URL points at a closed port: reaching it would fail with a
+			// connection error instead of the selector error asserted below.
+			out, err := runSchema("", "inspect",
+				"--db-url", "postgres://127.0.0.1:1/unreachable",
+				"--include", test.pattern,
+			)
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr, qt.Commentf("%s", out))
+		})
+	}
+}
+
 // TestSchemaInspectMatchesAtlasSchemaInspect proves the native verb and its
 // Atlas twin produce identical machine output from the same live database:
 // both wrap atlasschema.InspectSource.
@@ -132,4 +189,37 @@ func TestSchemaInspectMatchesAtlasSchemaInspect(t *testing.T) {
 	c.Assert(atlasCmd.Execute(), qt.IsNil, qt.Commentf("%s", atlasOut.String()))
 
 	c.Assert(nativeOut, qt.Equals, atlasOut.String())
+}
+
+// TestSchemaInspectIncludeMatchesAtlasSchemaInspect pins that the two surfaces
+// resolve the same include selection to the same bytes, so the compat spelling
+// is not a second implementation of the selector engine.
+func TestSchemaInspectIncludeMatchesAtlasSchemaInspect(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "live.db")
+	seedSQLite(c, dbPath, nativeInspectIncludeDDL)
+
+	nativeOut, err := runSchema("", "inspect",
+		"--db-url", "sqlite://"+dbPath,
+		"--include", "users",
+		"--format", "hcl",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", nativeOut))
+
+	atlasCmd := atlas.NewCompatCommand("atlas")
+	var atlasOut bytes.Buffer
+	atlasCmd.SetOut(&atlasOut)
+	atlasCmd.SetErr(&atlasOut)
+	atlasCmd.SetArgs([]string{
+		"schema", "inspect",
+		"--url", "sqlite://" + dbPath,
+		"--include", "users",
+		"--format", "hcl",
+	})
+	c.Assert(atlasCmd.Execute(), qt.IsNil, qt.Commentf("%s", atlasOut.String()))
+
+	c.Assert(nativeOut, qt.Equals, atlasOut.String())
+	c.Assert(nativeOut, qt.Contains, `table "users"`)
+	c.Assert(nativeOut, qt.Not(qt.Contains), `table "archive"`)
 }

--- a/docs/site/scripts/build-feature-matrix.mjs
+++ b/docs/site/scripts/build-feature-matrix.mjs
@@ -141,10 +141,12 @@ function summary(rows) {
     'The command surface is counted separately, because it is measured rather than',
     'assessed. The conformance harness inventories every command in the pinned Atlas',
     'CE binary and compares it with the `ptah-compat` surface: 19 of the 37',
-    'inventoried commands are open parity targets, and every one of them matches on',
-    'help usage and flags — 107 observations, no gap. The remaining 18 are registry,',
-    'Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them',
-    'as open capabilities regardless.',
+    'inventoried commands are open parity targets, and they match on help usage and',
+    'flags across 107 observations with one gap — `schema inspect --include`, a',
+    'Pro-surface flag the pinned CE binary does not register and Ptah implements',
+    'openly ([#951](https://github.com/stokaro/ptah/issues/951)). The remaining 18',
+    'are registry, Cloud, or Pro verbs that are not drop-in targets. Ptah implements',
+    'seven of them as open capabilities regardless.',
     '',
   ].join('\n');
 }

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -335,11 +335,11 @@
  {
   "area": "Schema inspection filters",
   "feature": "`schema inspect --include` filtering",
-  "ptah": "no",
+  "ptah": "yes",
   "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "Flag absent from the pinned Atlas CE v1.2.0 inspect flags; Ptah rejects it as unknown. The licensed build registers it and it filters on SQLite.",
-  "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; built ptah-compat `schema inspect -u sqlite://t.db --include users` exits 1 with \"error: unknown flag: --include\". Measured 2026-08-01, Atlas v1.2.4-e282f76-canary licensed trial build, logged in: `atlas schema inspect --include` registered and functional on sqlite (trial-study observations, scenario, verbs-and-flags)"
+  "note": "Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects.",
+  "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; pinned Atlas CE v1.2.0 `schema inspect -u sqlite://app.db --include users` exits 1 with \"Error: unknown flag: --include\". Built ptah-compat after this change: `schema inspect -u sqlite://app.db --include t1` renders t1 with its columns and drops t2; `--include main.t1.*` exits 1 before connecting; `--include t2` refuses the projection because t2's foreign key targets unselected t1. Measured 2026-08-01, Atlas v1.2.4-e282f76-canary licensed trial build, logged in: `--include t1` matches Ptah, `--include '*.t1'` is read at child depth and renders t1 without columns plus an empty t2 shell, `--include 'main.t1.*'` exits 1 with \"too many parts in pattern\" (trial-study observations, scenario, verbs-and-flags)"
  },
  {
   "area": "Migration directory formats",
@@ -473,8 +473,8 @@
   "ptah": "yes",
   "atlas_oss": "no",
   "atlas_pro": "yes",
-  "note": "CE registers `--include` on apply/diff but aborts it as non-community; pinned CE inspect has no `--include`. Ptah selects with union semantics and cross-scope dependency diagnostics.",
-  "evidence": "cli-surface.md lines 43,45 (--include registered on CE apply/diff); atlas/comparison.md: 'Atlas CE aborts --include as a non-community feature'; schema-scope-workflow probe in gaps.md"
+  "note": "CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics.",
+  "evidence": "cli-surface.md lines 43,45 (--include registered on CE apply/diff); atlas/comparison.md: 'Atlas CE aborts --include as a non-community feature'; schema-scope-workflow probe in gaps.md; pinned CE v1.2.0 `schema diff --include users` exits 1 with \"Abort: 'atlas schema diff --include' is not supported by the community version\", and `schema inspect --include users` exits 1 with \"Error: unknown flag: --include\""
  },
  {
   "area": "Declarative / direct schema workflow",

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -135,9 +135,41 @@ existing-directory destinations.
 
 Non-database sources require `--dev-url` and are evaluated Atlas-style on the dev database (reset, materialize, introspect); a missing dev database fails with Atlas's `--dev-url cannot be empty` message.
 
-The OSS `--exclude` flag filters inspected resources with Atlas-style globs and type selectors, including the Atlas-documented `*[type=extension].version` field selector with schema-qualified globs. Other field-level exclude selectors and type selectors on non-final pattern segments fail explicitly; include filtering and exporter blocks remain gaps.
+The OSS `--exclude` flag filters inspected resources with Atlas-style globs and type selectors, including the Atlas-documented `*[type=extension].version` field selector with schema-qualified globs. Other field-level exclude selectors and type selectors on non-final pattern segments fail explicitly; exporter blocks remain a gap.
 
 The pinned Atlas CE binary rejects `split`, `write`, and `hcl` template functions as non-community features, so Ptah's split-write exports are an open extension beyond the pinned CE binary.
+
+#### `schema inspect --include`
+
+`ptah-compat schema inspect --include` positively selects the top-level
+resources inspection keeps, through the same engine as `schema apply` and
+`schema diff`: schema universe, then include selection, then exclusion.
+
+Atlas CE v1.2.0 does not register the flag at all — `atlas schema inspect -u
+sqlite://app.db --include users` exits 1 with `Error: unknown flag:
+--include`. The licensed Atlas v1.2.4 build registers it, and Ptah's behavior
+diverges from it in two measured ways, both deliberate:
+
+| Input | Licensed Atlas v1.2.4 | Ptah |
+| --- | --- | --- |
+| `--include 't1'` | `t1` with its columns, plus `schema "main"` | same selection |
+| `--include '*.t1'` | pattern is read at child depth: `t1` rendered without its columns and `t2` rendered as an empty shell, exit 0 | `*.t1` is the wildcard spelling of the qualified name `main.t1`, so `t1` is rendered whole and `t2` is dropped |
+| `--include 'main.t1.*'` | `Error: too many parts in pattern: ["main" "main" "t1" "*"]`, exit 1 | rejected before any database is contacted: child resources ride along with their parent and cannot be selected on their own |
+
+Ptah has no child-level include selection in either spelling, so it keeps
+whole objects instead of emitting partial ones. It also refuses a selection
+that drops a dependency of a selected object, where the licensed build renders
+the reference anyway — its `*.t1` output keeps `primary_key { columns =
+[column.id] }` on a table whose `id` column the same output omits. The
+Atlas-side rows are the recorded trial transcripts; the trial account has since
+been suspended, so behavior beyond those inputs is not established here.
+
+There is no `atlas.hcl` spelling of this selector. Atlas documents `exclude`
+but no `include` attribute on the `env` block; CE accepts `include = [...]`
+there only because it accepts any unknown env attribute — a run with
+`not_a_real = [...]` is likewise accepted and prints the full schema. Ptah
+rejects unknown `atlas.hcl` constructs instead of ignoring them, so
+`env.include` fails explicitly.
 
 **Atlas OSS.** `atlas schema inspect` is documented as an open CLI feature for inspecting a database schema with HCL, SQL, JSON, template output forms, split/write file exports, and resource exclusion filters. The pinned Atlas CE flag surface does not register `schema inspect --include`.
 
@@ -638,7 +670,9 @@ The registry-bound `--push`, `--pending`, `--repo`, and `--auto-approve` plan fl
 
 `ptah-compat schema inspect --exclude` now filters inspection output with Atlas-style resource globs and type selectors, including the documented `*[type=extension].version` field selector with schema-qualified globs; other field selectors and type selectors on non-final pattern segments fail explicitly.
 
-The pinned Atlas CE flag surface does not register `schema inspect --include`, `schema diff --web`, `migrate apply --to-version`, or `migrate apply --lock-name`, so Ptah rejects those flags as unknown.
+`ptah-compat schema inspect --include` positively selects which top-level resources inspection keeps, through the same engine as `schema apply` and `schema diff`. The pinned Atlas CE binary rejects the flag with `unknown flag: --include`, so this is a Pro-surface spelling Ptah implements openly; the two measured divergences from the licensed build are tabulated under [Schema inspection](#schema-inspect---include).
+
+The pinned Atlas CE flag surface does not register `schema diff --web`, `migrate apply --to-version`, or `migrate apply --lock-name`, so Ptah rejects those flags as unknown.
 
 `ptah-compat schema apply --to` and `ptah-compat schema diff --from/--to` accept local schema files, one database URL, one migration directory replayed on the required `--dev-url` dev database, or one `env://` reference resolved through the evaluated `atlas.hcl` env; source kinds cannot be mixed within a flag, and unsupported schemes such as `atlas://` fail before the target database is contacted.
 

--- a/docs/site/src/content/docs/atlas/docs-coverage.md
+++ b/docs/site/src/content/docs/atlas/docs-coverage.md
@@ -138,7 +138,9 @@ the index; the sections carry the detail.
 
 `ptah-compat schema inspect` now emits Atlas-shaped output without Ptah status banners: HCL by default, SQL with `--format sql` or `--format '{{ sql . }}'`, JSON with `--format json` or `--format '{{ json . }}'`, custom templates using the supported inspect helpers, HCL/SQL split-write file exports with the documented Atlas split strategies (per object by default, `split "schema"`, `split "type"`, optional file-extension argument), and OSS `--exclude` resource filters including the Atlas-documented `*[type=extension].version` field selector with schema-qualified globs.
 
-Local schema files, migration directories, and `env://` references are inspected through required `--dev-url` dev-database evaluation (reset, materialize, introspect). Other field-level exclude selectors fail explicitly; exporter blocks remain tracked gaps. The pinned Atlas CE flag surface does not register `schema inspect --include`, so Ptah rejects it as unknown.
+Local schema files, migration directories, and `env://` references are inspected through required `--dev-url` dev-database evaluation (reset, materialize, introspect). Other field-level exclude selectors fail explicitly; exporter blocks remain tracked gaps.
+
+`ptah-compat schema inspect --include` positively selects which top-level resources the output keeps, through the same selector engine as `schema apply` and `schema diff`: `--schema` names the schema universe, `--include` picks resources inside it, `--exclude` subtracts. The pinned Atlas CE binary does not register the flag on this command and rejects it as an unknown flag, so this is a Pro-surface spelling Ptah implements openly rather than a CE parity target.
 
 **Conformance status.** Partially measured by live SQLite HCL/SQL/JSON/custom-template/split-write/exclude/compat probes and CLI flag probes.
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -75,11 +75,11 @@ Across the 153 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 80 |
+| Ptah supports it fully | 81 |
 | Ptah supports it with a stated limitation | 47 |
-| Ptah does not implement it | 26 |
+| Ptah does not implement it | 25 |
 | Ptah and Atlas CE both support it | 24 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 31 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 32 |
 | Ptah has it and neither Atlas edition does | 14 |
 | Atlas CE has it and Ptah does not, or only in part | 24 |
 | An Atlas column is ❔ — not established by this page's evidence | 23 |
@@ -128,9 +128,9 @@ as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | `--dry-run`, `--auto-approve`, and `--edit` | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
 | `--exclude` glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
-| `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community; pinned CE inspect has no `--include`. Ptah selects with union semantics and cross-scope dependency diagnostics. |
+| `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics. |
 | `--schema` / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
-| `schema inspect --include` filtering | ❌ | ❌ | ✅ | Flag absent from the pinned Atlas CE v1.2.0 inspect flags; Ptah rejects it as unknown. The licensed build registers it and it filters on SQLite. |
+| `schema inspect --include` filtering | ✅ | ❌ | ✅ | Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects. |
 | Apply advisory lock and `--lock-timeout` | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
 | Desired-state sources for `--to` and `--from` | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -92,10 +92,12 @@ Atlas-side sources only. Confirmed gaps are tracked in
 The command surface is counted separately, because it is measured rather than
 assessed. The conformance harness inventories every command in the pinned Atlas
 CE binary and compares it with the `ptah-compat` surface: 19 of the 37
-inventoried commands are open parity targets, and every one of them matches on
-help usage and flags — 107 observations, no gap. The remaining 18 are registry,
-Cloud, or Pro verbs that are not drop-in targets. Ptah implements seven of them
-as open capabilities regardless.
+inventoried commands are open parity targets, and they match on help usage and
+flags across 107 observations with one gap — `schema inspect --include`, a
+Pro-surface flag the pinned CE binary does not register and Ptah implements
+openly ([#951](https://github.com/stokaro/ptah/issues/951)). The remaining 18
+are registry, Cloud, or Pro verbs that are not drop-in targets. Ptah implements
+seven of them as open capabilities regardless.
 
 ## Schema sources
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -117,9 +117,12 @@ ptah-compat schema inspect --url "postgres://localhost/app" \
 Child resources — columns, indexes, constraints, triggers, policies, grants —
 ride along with their parent and cannot be selected on their own, in either
 the `[type=column]` or the literal-dot `table.column` spelling; both fail
-before any database is contacted. Glob metacharacters still match a dot, so
-`table*column` is not caught by that check and selects nothing instead
-([`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979)). A selection
+before any database is contacted. Glob metacharacters — `*`, `?`, and
+character classes — still match a dot, so `table*column` and `table[.]column`
+are not caught by that check and select nothing instead
+([`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979)). An
+identifier that itself contains a dot is selected as `main."my.table"` or
+`a\.b\.c`; the bare `a.b.c` spelling is refused as ambiguous. A selection
 that keeps an object whose dependency it dropped is refused rather than
 rendered, so inspected output never references an object it omits:
 
@@ -284,16 +287,57 @@ see, on `schema apply` and `schema diff` alike:
   cannot project a partial parent faithfully. The literal-dot spelling of the
   same thing is rejected too: a selector names a resource as `name` or
   `schema.name`, so a pattern with a deeper path such as `main.users.email`
-  or `main.users.*` fails instead of silently selecting nothing. Depth counts
-  separators outside quotes, so a quoted identifier that contains a dot —
-  `main."my.table"` — stays a valid depth-one selector.
+  or `main.users.*` fails instead of silently selecting nothing.
 
-  That rejection covers the literal-dot spelling only. Glob metacharacters
-  match a dot like any other character, so `main.users*email` and
-  `main.users?email` still reach past a top-level resource and still report a
-  synced schema rather than failing. Closing the whole class needs a check on
-  the selection's outcome instead of its shape, tracked in
-  [`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979).
+#### Selecting an identifier that contains a dot
+
+Selector depth counts separators **outside quotes**, so a quoted identifier
+holding a dot stays a valid depth-one selector:
+
+```bash
+ptah-compat schema diff … --include 'main."my.table"'   # qualified
+ptah-compat schema diff … --include '*."my.table"'      # any schema
+```
+
+The **bare** spelling of a dotted name is refused, because `a.b.c` cannot be
+told apart from the `schema.table.column` form the depth rule exists to
+reject:
+
+```text
+$ ptah-compat schema diff … --include 'a.b.c'
+error: unsupported Atlas include selector "a.b.c": selectors name top-level
+resources as "name" or "schema.name", and a deeper pattern names a child
+resource that rides along with its parent
+```
+
+Spell it one of two unambiguous ways instead — escape the dots, or quote the
+identifier:
+
+```bash
+ptah-compat schema diff … --include 'a\.b\.c'
+ptah-compat schema diff … --include 'main."a.b.c"'
+```
+
+This is a deliberate trade of one ambiguous spelling for two exact ones.
+Removing the need for it requires checking the selection's outcome rather than
+its shape, tracked in
+[`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979).
+
+#### What the depth check does not catch
+
+It covers the literal-dot spelling only. Every glob metacharacter that can
+stand for a dot escapes it — `*`, `?`, and a character class — so all three of
+these reach past a top-level resource and report a synced schema instead of
+failing:
+
+```bash
+ptah-compat schema diff … --include 'main.users*email'
+ptah-compat schema diff … --include 'main.users?email'
+ptah-compat schema diff … --include 'main.users[.]email'
+```
+
+Closing the whole class needs the outcome-based check in
+[`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979).
 - `--exclude` and disabled `schema.mode` values subtract from the positive
   selection afterward. The composition order is fixed: schema universe first,
   include selection inside it, exclusion last.

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -95,9 +95,43 @@ schema-qualified globs such as `public.*[type=extension].version`.
 Other field-level selectors, and type selectors on non-final pattern segments,
 fail explicitly before any database is contacted. Schema-qualified function
 and enum filters remain limited by Ptah's current introspection model, which
-does not retain schema names for those resource types yet. `--include` is not
-part of the pinned Atlas CE inspect flag surface. Exporter blocks remain an
-explicit gap.
+does not retain schema names for those resource types yet. Exporter blocks
+remain an explicit gap.
+
+### Select what is inspected with `--include`
+
+`--include` positively selects which top-level resources survive inspection,
+with the same selector engine as [`schema apply` and `schema
+diff`](#scope-the-comparison-with---schema-and---include): `--schema` names
+the schema universe, `--include` picks resources inside it, and `--exclude`
+subtracts from the result. Repeated and comma-separated values union.
+Selectors that match nothing render no objects; an empty value carries no
+selection, so inspection stays unfiltered.
+
+```bash
+ptah-compat schema inspect --url "sqlite://app.db" --include users
+ptah-compat schema inspect --url "postgres://localhost/app" \
+  --schema public --include 'app_*' --exclude app_scratch
+```
+
+Child resources — columns, indexes, constraints, triggers, policies, grants —
+ride along with their parent and cannot be selected on their own, in either
+the `[type=column]` or the `table.column` spelling; both fail before any
+database is contacted. A selection that keeps an object whose dependency it
+dropped is refused rather than rendered, so inspected output never references
+an object it omits:
+
+```text
+error: the --schema/--include selection drops objects that selected objects depend on:
+  - table "main.posts" depends on table "main.users" via a foreign key, but "main.users" is not selected
+add the missing objects to the selection or exclude the dependent objects
+```
+
+The flag is not part of the pinned Atlas CE inspect surface: CE v1.2.0 rejects
+`schema inspect --include` with `Error: unknown flag: --include`. It is
+registered on the licensed Atlas build, where its behavior differs from
+Ptah's in two measured ways, both documented in
+[the comparison](../comparison/#schema-inspect---include).
 
 ## Apply a desired schema
 
@@ -245,7 +279,10 @@ see, on `schema apply` and `schema diff` alike:
   tables, roles named by kept grants, owning schemas) are retained.
   Child-resource selectors such as `[type=column]` or `[type=index]`, field
   selectors, and unknown resource types are rejected loudly because Ptah
-  cannot project a partial parent faithfully.
+  cannot project a partial parent faithfully. The positional spelling of the
+  same thing is rejected too: a selector names a resource as `name` or
+  `schema.name`, so a pattern with a deeper path such as `main.users.email`
+  or `main.users.*` fails instead of silently selecting nothing.
 - `--exclude` and disabled `schema.mode` values subtract from the positive
   selection afterward. The composition order is fixed: schema universe first,
   include selection inside it, exclusion last.

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -116,10 +116,12 @@ ptah-compat schema inspect --url "postgres://localhost/app" \
 
 Child resources — columns, indexes, constraints, triggers, policies, grants —
 ride along with their parent and cannot be selected on their own, in either
-the `[type=column]` or the `table.column` spelling; both fail before any
-database is contacted. A selection that keeps an object whose dependency it
-dropped is refused rather than rendered, so inspected output never references
-an object it omits:
+the `[type=column]` or the literal-dot `table.column` spelling; both fail
+before any database is contacted. Glob metacharacters still match a dot, so
+`table*column` is not caught by that check and selects nothing instead
+([`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979)). A selection
+that keeps an object whose dependency it dropped is refused rather than
+rendered, so inspected output never references an object it omits:
 
 ```text
 error: the --schema/--include selection drops objects that selected objects depend on:
@@ -279,10 +281,19 @@ see, on `schema apply` and `schema diff` alike:
   tables, roles named by kept grants, owning schemas) are retained.
   Child-resource selectors such as `[type=column]` or `[type=index]`, field
   selectors, and unknown resource types are rejected loudly because Ptah
-  cannot project a partial parent faithfully. The positional spelling of the
+  cannot project a partial parent faithfully. The literal-dot spelling of the
   same thing is rejected too: a selector names a resource as `name` or
   `schema.name`, so a pattern with a deeper path such as `main.users.email`
-  or `main.users.*` fails instead of silently selecting nothing.
+  or `main.users.*` fails instead of silently selecting nothing. Depth counts
+  separators outside quotes, so a quoted identifier that contains a dot —
+  `main."my.table"` — stays a valid depth-one selector.
+
+  That rejection covers the literal-dot spelling only. Glob metacharacters
+  match a dot like any other character, so `main.users*email` and
+  `main.users?email` still reach past a top-level resource and still report a
+  synced schema rather than failing. Closing the whole class needs a check on
+  the selection's outcome instead of its shape, tracked in
+  [`stokaro/ptah#979`](https://github.com/stokaro/ptah/issues/979).
 - `--exclude` and disabled `schema.mode` values subtract from the positive
   selection afterward. The composition order is fixed: schema universe first,
   include selection inside it, exclusion last.

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -119,11 +119,18 @@ ptah schema inspect --db-url "sqlite://$PWD/app.db" --include users
 Child resources — columns, indexes, constraints, triggers, policies, grants —
 ride along with their parent and cannot be selected on their own; a selector
 that names one with `[type=column]` or with a literal dot (`users.email`)
-fails before the database is contacted. Glob metacharacters match a dot too,
-so `users*email` escapes that check and selects nothing instead
-([#979](https://github.com/stokaro/ptah/issues/979)). A selection that keeps
-an object whose dependency it dropped is refused rather than rendered, so the
-output never references an object it omits.
+fails before the database is contacted. Glob metacharacters — `*`, `?`, and
+character classes — match a dot too, so `users*email` and `users[.]email`
+escape that check and select nothing instead
+([#979](https://github.com/stokaro/ptah/issues/979)).
+
+To select a table whose own name contains a dot, escape the dots or quote the
+identifier — `--include 'a\.b\.c'` or `--include 'main."a.b.c"'`. The bare
+`a.b.c` spelling is refused, because it cannot be told apart from
+`schema.table.column`.
+
+A selection that keeps an object whose dependency it dropped is refused rather
+than rendered, so the output never references an object it omits.
 
 The source does not have to be a live database: `--schema-file` inspects a
 local `.hcl`, `.yaml`, `.yml`, or `.sql` schema file, and `--migrations-dir`

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -118,7 +118,10 @@ ptah schema inspect --db-url "sqlite://$PWD/app.db" --include users
 
 Child resources — columns, indexes, constraints, triggers, policies, grants —
 ride along with their parent and cannot be selected on their own; a selector
-that names one fails before the database is contacted. A selection that keeps
+that names one with `[type=column]` or with a literal dot (`users.email`)
+fails before the database is contacted. Glob metacharacters match a dot too,
+so `users*email` escapes that check and selects nothing instead
+([#979](https://github.com/stokaro/ptah/issues/979)). A selection that keeps
 an object whose dependency it dropped is refused rather than rendered, so the
 output never references an object it omits.
 

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -106,9 +106,21 @@ table "users" {
 }
 ```
 
-`--format sql` and `--format json` select SQL and JSON output, `--schemas`
-narrows inspection to selected database schemas, and `--exclude` filters
-resources with Atlas-style glob patterns.
+`--format sql` and `--format json` select SQL and JSON output. `--schemas`,
+`--include`, and `--exclude` select what is inspected, in that order:
+`--schemas` names the database schemas, `--include` picks top-level resources
+inside them with Atlas-style glob patterns, and `--exclude` subtracts from the
+result.
+
+```bash
+ptah schema inspect --db-url "sqlite://$PWD/app.db" --include users
+```
+
+Child resources — columns, indexes, constraints, triggers, policies, grants —
+ride along with their parent and cannot be selected on their own; a selector
+that names one fails before the database is contacted. A selection that keeps
+an object whose dependency it dropped is refused rather than rendered, so the
+output never references an object it omits.
 
 The source does not have to be a live database: `--schema-file` inspects a
 local `.hcl`, `.yaml`, `.yml`, or `.sql` schema file, and `--migrations-dir`

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -298,12 +298,26 @@ non-community template functions, so these exports are an open Ptah extension.
 **Filtering**
 
 - `--schema`/`-s` narrows inspection when supported by the database reader.
+- `--include` positively selects the top-level resources that survive, with
+  Atlas-style globs and `[type=...]` selectors. Repeated and comma-separated
+  values union. Composition order is `--schema`, then `--include`, then
+  `--exclude`. A selection that matches nothing renders no objects; an empty
+  value carries no selection and leaves inspection unfiltered.
 - The OSS `--exclude` flag filters inspected resources with Atlas-style globs
   and `[type=...]` selectors, including the Atlas-documented
   `*[type=extension].version` field selector with schema-qualified globs.
+- Child resources (columns, indexes, constraints, triggers, policies, grants)
+  cannot be included on their own, in either the `[type=column]` or the
+  `table.column` spelling; both fail before any database is contacted. A
+  selection that drops a dependency of a selected object is refused rather
+  than rendered.
 - Other field-level exclude selectors and type selectors on non-final pattern
-  segments fail explicitly; include filtering and exporter blocks remain
-  explicit gaps.
+  segments fail explicitly; exporter blocks remain an explicit gap.
+
+The pinned Atlas CE binary rejects `schema inspect --include` with
+`unknown flag: --include`; the licensed build registers it. The measured
+behavioral differences are tabulated in
+[the Atlas comparison](../../atlas/comparison/#schema-inspect---include).
 
 Native twin: [`ptah schema inspect`](../native-commands/).
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -309,11 +309,16 @@ non-community template functions, so these exports are an open Ptah extension.
 - Child resources (columns, indexes, constraints, triggers, policies, grants)
   cannot be included on their own, in either the `[type=column]` or the
   literal-dot `table.column` spelling; both fail before any database is
-  contacted. Depth counts separators outside quotes, so `main."my.table"`
-  remains valid. Glob metacharacters match a dot, so `table*column` is not
-  caught by the depth check and selects nothing
-  ([#979](https://github.com/stokaro/ptah/issues/979)). A selection that drops
-  a dependency of a selected object is refused rather than rendered.
+  contacted.
+- Depth counts separators outside quotes, so an identifier holding a dot is
+  selected as `main."my.table"` or `a\.b\.c`. The bare `a.b.c` spelling is
+  refused, because it cannot be told apart from `schema.table.column`.
+- Glob metacharacters — `*`, `?`, and character classes — match a dot, so
+  `table*column`, `table?column`, and `table[.]column` are not caught by the
+  depth check and select nothing
+  ([#979](https://github.com/stokaro/ptah/issues/979)).
+- A selection that drops a dependency of a selected object is refused rather
+  than rendered.
 - Other field-level exclude selectors and type selectors on non-final pattern
   segments fail explicitly; exporter blocks remain an explicit gap.
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -308,9 +308,12 @@ non-community template functions, so these exports are an open Ptah extension.
   `*[type=extension].version` field selector with schema-qualified globs.
 - Child resources (columns, indexes, constraints, triggers, policies, grants)
   cannot be included on their own, in either the `[type=column]` or the
-  `table.column` spelling; both fail before any database is contacted. A
-  selection that drops a dependency of a selected object is refused rather
-  than rendered.
+  literal-dot `table.column` spelling; both fail before any database is
+  contacted. Depth counts separators outside quotes, so `main."my.table"`
+  remains valid. Glob metacharacters match a dot, so `table*column` is not
+  caught by the depth check and selects nothing
+  ([#979](https://github.com/stokaro/ptah/issues/979)). A selection that drops
+  a dependency of a selected object is refused rather than rendered.
 - Other field-level exclude selectors and type selectors on non-final pattern
   segments fail explicitly; exporter blocks remain an explicit gap.
 

--- a/internal/atlasfilter/scope.go
+++ b/internal/atlasfilter/scope.go
@@ -116,10 +116,11 @@ var includeChildTypes = map[string]struct{}{
 // characters rejected the selector that matches it.
 //
 // The rule closes the literal-separator spelling only. Because path.Match
-// treats "." as an ordinary character, `main.users*email` and
-// `main.users?email` still reach past a top-level resource and still select
-// nothing; see stokaro/ptah#979 for the outcome-based check that would cover
-// the whole class.
+// treats "." as an ordinary character, every metacharacter that can stand for
+// it escapes the check: `main.users*email`, `main.users?email`, and the
+// character class `main.users[.]email` all reach past a top-level resource and
+// still select nothing. See stokaro/ptah#979 for the outcome-based check that
+// would cover the whole class.
 const includeSelectorMaxDots = 1
 
 // ValidateIncludeSelectors parses Atlas-style --include selectors and rejects
@@ -186,9 +187,17 @@ func validateIncludeSelectorDepth(raw, glob string) error {
 // path.Match reads as an escape for the following character, so `a\.b\.c`
 // matches the single bare name "a.b.c" and stays a depth-one selector.
 //
-// An unterminated quote leaves the remainder uncounted. That is the permissive
-// direction on purpose: this check must never reject a selector that could
-// have matched something.
+// An unterminated quote leaves the remainder uncounted, which is the
+// permissive direction for that input.
+//
+// The check is not conservative in general, though. The selection also offers
+// the bare name as a candidate, and a bare name is never quoted, so a table
+// literally named "a.b.c" is matched by the selector `a.b.c` — which this rule
+// refuses, because that spelling is indistinguishable from the
+// schema.table.column form it exists to reject. That ambiguity is why the
+// refusal is deliberate rather than a bug, and why the disambiguated spellings
+// `a\.b\.c` and `main."a.b.c"` are supported and documented. Resolving it
+// without an escape needs the outcome-based check in stokaro/ptah#979.
 func unquotedDots(glob string) int {
 	dots := 0
 	var closeQuote byte

--- a/internal/atlasfilter/scope.go
+++ b/internal/atlasfilter/scope.go
@@ -104,11 +104,22 @@ var includeChildTypes = map[string]struct{}{
 // includeSelectorMaxDots bounds how deep an --include selector may reach. The
 // selection matches top-level resources by their bare name and by their
 // effective-schema-qualified name, so a selector carries at most one "."
-// separator. A literal separator in a glob can only ever be matched by a
-// literal separator in the candidate name, so a deeper selector cannot match
-// anything: it is the positional spelling of the child-resource selection
-// [validateIncludeSelectorTypes] already rejects, and it is rejected the same
-// way instead of silently projecting an empty selection.
+// *separator*. A deeper selector is the positional spelling of the
+// child-resource selection [validateIncludeSelectorTypes] already rejects, and
+// it is rejected the same way instead of silently projecting an empty
+// selection.
+//
+// Depth is measured by [unquotedDots], not by counting "." characters: an
+// identifier may itself contain a dot, and [dbschematypes.QualifyTableName]
+// quotes any such part, so the candidate for table "my.table" in schema "main"
+// is `main."my.table"` — two dot characters, one separator. Counting
+// characters rejected the selector that matches it.
+//
+// The rule closes the literal-separator spelling only. Because path.Match
+// treats "." as an ordinary character, `main.users*email` and
+// `main.users?email` still reach past a top-level resource and still select
+// nothing; see stokaro/ptah#979 for the outcome-based check that would cover
+// the whole class.
 const includeSelectorMaxDots = 1
 
 // ValidateIncludeSelectors parses Atlas-style --include selectors and rejects
@@ -157,12 +168,51 @@ func parseIncludeSelector(value string) (resourcePattern, error) {
 // validateIncludeSelectorDepth rejects include selectors that reach past the
 // "schema.name" qualification of a top-level resource.
 func validateIncludeSelectorDepth(raw, glob string) error {
-	if strings.Count(glob, ".") <= includeSelectorMaxDots {
+	if unquotedDots(glob) <= includeSelectorMaxDots {
 		return nil
 	}
 	return fmt.Errorf(
 		"unsupported Atlas include selector %q: selectors name top-level resources as \"name\" or \"schema.name\", and a deeper pattern names a child resource that rides along with its parent",
 		raw)
+}
+
+// unquotedDots counts the "." separators of a selector glob, skipping dots
+// that belong to an identifier rather than to the path.
+//
+// Dots are skipped inside the quoting forms the tableref parser accepts — SQL
+// standard double quotes, MySQL backticks, and SQL Server brackets — because a
+// qualified candidate quotes any part holding a dot, so `main."my.table"` is
+// one separator, not two. Dots are also skipped after a backslash, which
+// path.Match reads as an escape for the following character, so `a\.b\.c`
+// matches the single bare name "a.b.c" and stays a depth-one selector.
+//
+// An unterminated quote leaves the remainder uncounted. That is the permissive
+// direction on purpose: this check must never reject a selector that could
+// have matched something.
+func unquotedDots(glob string) int {
+	dots := 0
+	var closeQuote byte
+	for index := 0; index < len(glob); index++ {
+		character := glob[index]
+		if closeQuote != 0 {
+			if character == closeQuote {
+				closeQuote = 0
+			}
+			continue
+		}
+		switch character {
+		case '"', '`':
+			closeQuote = character
+		case '[':
+			closeQuote = ']'
+		case '\\':
+			// path.Match escape: the next byte is a literal, never a separator.
+			index++
+		case '.':
+			dots++
+		}
+	}
+	return dots
 }
 
 func validateIncludeSelectorTypes(raw string, types map[string]struct{}) error {

--- a/internal/atlasfilter/scope.go
+++ b/internal/atlasfilter/scope.go
@@ -101,10 +101,20 @@ var includeChildTypes = map[string]struct{}{
 	"grant":       {},
 }
 
+// includeSelectorMaxDots bounds how deep an --include selector may reach. The
+// selection matches top-level resources by their bare name and by their
+// effective-schema-qualified name, so a selector carries at most one "."
+// separator. A literal separator in a glob can only ever be matched by a
+// literal separator in the candidate name, so a deeper selector cannot match
+// anything: it is the positional spelling of the child-resource selection
+// [validateIncludeSelectorTypes] already rejects, and it is rejected the same
+// way instead of silently projecting an empty selection.
+const includeSelectorMaxDots = 1
+
 // ValidateIncludeSelectors parses Atlas-style --include selectors and rejects
 // forms Ptah cannot honor: malformed globs, field selectors, child resource
-// types, and unknown resource types. Commands run it before any database
-// work.
+// types, child-depth patterns, and unknown resource types. Commands run it
+// before any database work.
 func ValidateIncludeSelectors(values []string) error {
 	_, err := parseIncludeSelectors(values)
 	return err
@@ -138,7 +148,21 @@ func parseIncludeSelector(value string) (resourcePattern, error) {
 	if err := validateIncludeSelectorTypes(raw, pattern.types); err != nil {
 		return resourcePattern{}, err
 	}
+	if err := validateIncludeSelectorDepth(raw, pattern.glob); err != nil {
+		return resourcePattern{}, err
+	}
 	return pattern, nil
+}
+
+// validateIncludeSelectorDepth rejects include selectors that reach past the
+// "schema.name" qualification of a top-level resource.
+func validateIncludeSelectorDepth(raw, glob string) error {
+	if strings.Count(glob, ".") <= includeSelectorMaxDots {
+		return nil
+	}
+	return fmt.Errorf(
+		"unsupported Atlas include selector %q: selectors name top-level resources as \"name\" or \"schema.name\", and a deeper pattern names a child resource that rides along with its parent",
+		raw)
 }
 
 func validateIncludeSelectorTypes(raw string, types map[string]struct{}) error {

--- a/internal/atlasfilter/scope_test.go
+++ b/internal/atlasfilter/scope_test.go
@@ -51,16 +51,25 @@ func TestValidateIncludeSelectors_HappyPath(t *testing.T) {
 		// schema-wildcard spelling of a qualified name stays valid.
 		{name: "wildcard schema qualifier", values: []string{"*.users"}},
 		{name: "qualified type selector", values: []string{"public.users[type=table]"}},
-		// A dotted identifier is quoted in the qualified candidate
+		// Capability: a dotted identifier is quoted in the qualified candidate
 		// (`main."my.table"`), so the selector that matches it carries two dot
 		// characters but only one separator. Counting characters rejected it
 		// and made the qualified spelling of a dotted table inexpressible.
+		// These two spellings really do select such a table.
 		{name: "qualified dotted identifier", values: []string{`main."my.table"`}},
 		{name: "wildcard schema dotted identifier", values: []string{`*."my.table"`}},
+		// Permissiveness only: tableref.Canonical emits double quotes and
+		// never these forms, and path.Match reads `[my.table]` as a character
+		// class rather than a quoted identifier, so neither spelling can
+		// actually select a table named "my.table". They are here to pin that
+		// the scanner treats backtick and bracket runs as identifier quoting
+		// and does not count the dot inside them.
 		{name: "backtick dotted identifier", values: []string{"main.`my.table`"}},
 		{name: "bracket dotted identifier", values: []string{"main.[my.table]"}},
 		// path.Match reads "\." as a literal dot, so this selects the single
-		// bare name "a.b.c" rather than reaching child depth.
+		// bare name "a.b.c" rather than reaching child depth. It is also the
+		// documented workaround for the bare `a.b.c` spelling, which stays
+		// refused as ambiguous with schema.table.column.
 		{name: "escaped dots", values: []string{`a\.b\.c`}},
 	}
 
@@ -150,11 +159,24 @@ func TestValidateIncludeSelectors_FailurePath(t *testing.T) {
 			wantErr: `unsupported Atlas include selector "main\.t1\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
 		},
 		// Quoting an identifier does not buy extra depth: the separators
-		// outside the quotes still count.
+		// outside the quotes still count. One case per quoting form, so each
+		// arm of the scanner's close-delimiter mapping is pinned — a bracket
+		// run that never terminates would swallow the trailing separator and
+		// wrongly accept.
 		{
 			name:    "child depth past a quoted identifier",
 			values:  []string{`main."my.table".id`},
 			wantErr: `unsupported Atlas include selector "main\.\\"my\.table\\"\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "child depth past a bracketed identifier",
+			values:  []string{"main.[ab].id"},
+			wantErr: `unsupported Atlas include selector "main\.\[ab\]\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "child depth past a backticked identifier",
+			values:  []string{"main.`ab`.id"},
+			wantErr: "unsupported Atlas include selector \"main\\.`ab`\\.id\": selectors name top-level resources as \"name\" or \"schema\\.name\", and a deeper pattern names a child resource that rides along with its parent",
 		},
 	}
 

--- a/internal/atlasfilter/scope_test.go
+++ b/internal/atlasfilter/scope_test.go
@@ -51,6 +51,17 @@ func TestValidateIncludeSelectors_HappyPath(t *testing.T) {
 		// schema-wildcard spelling of a qualified name stays valid.
 		{name: "wildcard schema qualifier", values: []string{"*.users"}},
 		{name: "qualified type selector", values: []string{"public.users[type=table]"}},
+		// A dotted identifier is quoted in the qualified candidate
+		// (`main."my.table"`), so the selector that matches it carries two dot
+		// characters but only one separator. Counting characters rejected it
+		// and made the qualified spelling of a dotted table inexpressible.
+		{name: "qualified dotted identifier", values: []string{`main."my.table"`}},
+		{name: "wildcard schema dotted identifier", values: []string{`*."my.table"`}},
+		{name: "backtick dotted identifier", values: []string{"main.`my.table`"}},
+		{name: "bracket dotted identifier", values: []string{"main.[my.table]"}},
+		// path.Match reads "\." as a literal dot, so this selects the single
+		// bare name "a.b.c" rather than reaching child depth.
+		{name: "escaped dots", values: []string{`a\.b\.c`}},
 	}
 
 	for _, test := range tests {
@@ -138,6 +149,13 @@ func TestValidateIncludeSelectors_FailurePath(t *testing.T) {
 			values:  []string{"users,main.t1.id"},
 			wantErr: `unsupported Atlas include selector "main\.t1\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
 		},
+		// Quoting an identifier does not buy extra depth: the separators
+		// outside the quotes still count.
+		{
+			name:    "child depth past a quoted identifier",
+			values:  []string{`main."my.table".id`},
+			wantErr: `unsupported Atlas include selector "main\.\\"my\.table\\"\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
 	}
 
 	for _, test := range tests {
@@ -149,8 +167,10 @@ func TestValidateIncludeSelectors_FailurePath(t *testing.T) {
 
 // TestIncludeSelectorDepthRuleIsIncludeOnly pins that the child-depth
 // rejection is scoped to --include. Exclusion legitimately reaches child
-// resources, and its "table.child" and "schema.table.child" spellings must
-// keep parsing.
+// resources, so its "table.child" and "schema.table.child" spellings must keep
+// parsing. This asserts parsing only: whether a given exclude spelling then
+// matches is a separate, pre-existing question — "table.child" matches on the
+// default schema while "schema.table.child" does not.
 func TestIncludeSelectorDepthRuleIsIncludeOnly(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/atlasfilter/scope_test.go
+++ b/internal/atlasfilter/scope_test.go
@@ -47,6 +47,10 @@ func TestValidateIncludeSelectors_HappyPath(t *testing.T) {
 		{name: "type selector", values: []string{"users[type=table]"}},
 		{name: "type union", values: []string{"*[type=view|materialized_view]"}},
 		{name: "blank entries", values: []string{" ", ","}},
+		// One separator is the deepest a top-level selector reaches, so the
+		// schema-wildcard spelling of a qualified name stays valid.
+		{name: "wildcard schema qualifier", values: []string{"*.users"}},
+		{name: "qualified type selector", values: []string{"public.users[type=table]"}},
 	}
 
 	for _, test := range tests {
@@ -109,11 +113,60 @@ func TestValidateIncludeSelectors_FailurePath(t *testing.T) {
 			values:  []string{"*[type=]"},
 			wantErr: `empty Atlas include type selector "type="`,
 		},
+		// Child depth is the positional spelling of the [type=column] form
+		// above: the selection matches "name" and "schema.name" only, so a
+		// deeper pattern can never match and is rejected instead of silently
+		// selecting nothing. Licensed Atlas v1.2.4 also refuses this input
+		// ("too many parts in pattern").
+		{
+			name:    "child depth",
+			values:  []string{"main.t1.id"},
+			wantErr: `unsupported Atlas include selector "main\.t1\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "child depth wildcard",
+			values:  []string{"main.t1.*"},
+			wantErr: `unsupported Atlas include selector "main\.t1\.\*": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "child depth with type selector",
+			values:  []string{"main.t1.*[type=table]"},
+			wantErr: `unsupported Atlas include selector "main\.t1\.\*\[type=table\]": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
+		{
+			name:    "child depth in comma separated list",
+			values:  []string{"users,main.t1.id"},
+			wantErr: `unsupported Atlas include selector "main\.t1\.id": selectors name top-level resources as "name" or "schema\.name", and a deeper pattern names a child resource that rides along with its parent`,
+		},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
 			c.Assert(atlasfilter.ValidateIncludeSelectors(test.values), qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+// TestIncludeSelectorDepthRuleIsIncludeOnly pins that the child-depth
+// rejection is scoped to --include. Exclusion legitimately reaches child
+// resources, and its "table.child" and "schema.table.child" spellings must
+// keep parsing.
+func TestIncludeSelectorDepthRuleIsIncludeOnly(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		values []string
+	}{
+		{name: "table child", values: []string{"users.email"}},
+		{name: "qualified table child", values: []string{"public.users.email"}},
+		{name: "qualified table child wildcard", values: []string{"public.users.*"}},
+		{name: "qualified child with type selector", values: []string{"public.users.*[type=column]"}},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(atlasfilter.ValidateExcludeSelectors(test.values), qt.IsNil)
 		})
 	}
 }

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -17,8 +17,13 @@ import (
 
 // InspectOptions configures Atlas-compatible schema inspection.
 type InspectOptions struct {
-	DevURL      string
-	Schemas     []string
+	DevURL  string
+	Schemas []string
+	// Include positively selects the top-level resources inspection keeps,
+	// with the same Atlas-style selectors [atlasfilter.Scope] applies to
+	// schema apply and diff. Empty keeps every inspected resource, and the
+	// exclusion-only path is then byte-for-byte unchanged.
+	Include     []string
 	Exclude     []string
 	Format      string
 	Diagnostics io.Writer
@@ -70,7 +75,7 @@ func renderInspectSchema(
 	if err != nil {
 		return "", err
 	}
-	schema, err = atlasfilter.ExcludeDatabase(schema, opts.Exclude)
+	schema, err = scopeInspectSchema(schema, info, opts)
 	if err != nil {
 		return "", err
 	}
@@ -88,6 +93,25 @@ func renderInspectSchema(
 		return "", err
 	}
 	return output.Text, nil
+}
+
+// scopeInspectSchema applies the inspection selection to the introspected
+// schema. --schema is honored upstream, when the schema is read, so only
+// --include and --exclude reach the projection here: with --include the full
+// positive projection runs (include selection, exclude subtraction, then
+// cross-scope dependency validation, so inspection never renders a reference
+// to an object it dropped), and without it the established exclusion-only path
+// is kept unchanged.
+func scopeInspectSchema(
+	schema *dbschematypes.DBSchema,
+	info dbschematypes.DBInfo,
+	opts InspectOptions,
+) (*dbschematypes.DBSchema, error) {
+	return atlasfilter.ScopeDatabase(schema, atlasfilter.Scope{
+		Include:       opts.Include,
+		Exclude:       opts.Exclude,
+		DefaultSchema: info.Schema,
+	})
 }
 
 // applyInspectFileExports hands the rendered output plan to the shared

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -34,6 +34,9 @@ type InspectSourceOptions struct {
 	DevURL string
 	// Schemas restricts inspection to the named schema scopes.
 	Schemas []string
+	// Include positively selects the top-level resources inspection keeps,
+	// with Atlas-style selectors. Empty keeps every inspected resource.
+	Include []string
 	// Exclude filters inspected resources with Atlas-style selectors.
 	Exclude []string
 	// Format is the Atlas --format value or Go template.
@@ -62,6 +65,11 @@ func InspectSource(ctx context.Context, opts InspectSourceOptions) (string, erro
 	if err := atlasfilter.ValidateExcludeSelectors(opts.Exclude); err != nil {
 		return "", err
 	}
+	// Malformed or unsupported --include selectors fail before any database is
+	// contacted and before the dev database is reset.
+	if err := atlasfilter.ValidateIncludeSelectors(opts.Include); err != nil {
+		return "", err
+	}
 	set, err := atlassource.ClassifySet("--url", []string{opts.URL}, opts.ProjectEnv)
 	if err != nil {
 		return "", err
@@ -70,6 +78,7 @@ func InspectSource(ctx context.Context, opts InspectSourceOptions) (string, erro
 	inspectOpts := InspectOptions{
 		DevURL:      opts.DevURL,
 		Schemas:     opts.Schemas,
+		Include:     opts.Include,
 		Exclude:     opts.Exclude,
 		Format:      opts.Format,
 		Diagnostics: opts.Diagnostics,

--- a/internal/atlasschema/inspect_source_test.go
+++ b/internal/atlasschema/inspect_source_test.go
@@ -326,6 +326,28 @@ func TestInspectSource_FailurePath(t *testing.T) {
 		c.Assert(err, qt.ErrorMatches, `unsupported Atlas exclude selector .*final pattern segment only`)
 	})
 
+	c.Run("invalid include selector before any connection", func(c *qt.C) {
+		// The unreachable URL proves selector validation runs pre-connect:
+		// reaching the database would produce a connection error instead.
+		_, err := atlasschema.InspectSource(context.Background(), atlasschema.InspectSourceOptions{
+			URL:     "postgres://127.0.0.1:1/unreachable",
+			Include: []string{"*[type=column]"},
+		})
+
+		c.Assert(err, qt.ErrorMatches,
+			`unsupported Atlas include selector "\*\[type=column\]": column resources ride along with their parent and cannot be included on their own`)
+	})
+
+	c.Run("child-depth include selector before any connection", func(c *qt.C) {
+		_, err := atlasschema.InspectSource(context.Background(), atlasschema.InspectSourceOptions{
+			URL:     "postgres://127.0.0.1:1/unreachable",
+			Include: []string{"public.users.email"},
+		})
+
+		c.Assert(err, qt.ErrorMatches,
+			`unsupported Atlas include selector "public\.users\.email": selectors name top-level resources as "name" or "schema\.name".*`)
+	})
+
 	c.Run("invalid format before source resolution", func(c *qt.C) {
 		_, err := atlasschema.InspectSource(context.Background(), atlasschema.InspectSourceOptions{
 			URL:    "sqlite://ignored.db",

--- a/internal/atlasschema/inspect_test.go
+++ b/internal/atlasschema/inspect_test.go
@@ -57,6 +57,64 @@ func TestInspect_ExcludeFilter(t *testing.T) {
 	c.Assert(rendered, qt.Not(qt.Contains), `posts_user_fk`)
 }
 
+func TestInspect_IncludeSelection(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("selects the named table and its children", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "inspect-include.db"))
+		defer dbschema.CloseAndWarn(conn)
+		createInspectSchema(c, conn)
+
+		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+			Format:  "hcl",
+			Include: []string{"users"},
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(rendered, qt.Contains, `table "users"`)
+		c.Assert(rendered, qt.Contains, `column "email"`)
+		c.Assert(rendered, qt.Contains, `users_email_key`)
+		c.Assert(rendered, qt.Not(qt.Contains), `table "posts"`)
+	})
+
+	c.Run("refuses a selection that drops a dependency", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "inspect-include-dep.db"))
+		defer dbschema.CloseAndWarn(conn)
+		createInspectSchema(c, conn)
+
+		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+			Format:  "hcl",
+			Include: []string{"posts"},
+		})
+
+		c.Assert(err, qt.ErrorMatches, `(?s)the --schema/--include selection drops objects.*`)
+		c.Assert(rendered, qt.Equals, "")
+	})
+
+	c.Run("exclusion-only inspection is unchanged", func(c *qt.C) {
+		conn := connectSQLite(c, filepath.Join(c.TempDir(), "inspect-include-none.db"))
+		defer dbschema.CloseAndWarn(conn)
+		createInspectSchema(c, conn)
+
+		withoutInclude, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+			Format:  "hcl",
+			Exclude: []string{"posts"},
+		})
+		c.Assert(err, qt.IsNil)
+
+		withEmptyInclude, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+			Format:  "hcl",
+			Exclude: []string{"posts"},
+			Include: []string{"", " "},
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(withEmptyInclude, qt.Equals, withoutInclude)
+		c.Assert(withoutInclude, qt.Contains, `table "users"`)
+		c.Assert(withoutInclude, qt.Not(qt.Contains), `table "posts"`)
+	})
+}
+
 func TestInspect_FailurePath(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Closes the `schema inspect --include` item of #951.

`ptah-compat schema inspect --include` and `ptah schema inspect --include` positively select which top-level resources inspection keeps, reusing the selector engine already behind `schema apply --include` / `schema diff --include` (#813): schema universe, then include selection, then exclusion, with the cross-scope dependency refusal so inspected output never references an object it omits.

The projection runs in the single shared inspect tail (`renderInspectSchema`), so it covers every source kind and every output form. With the flag absent, the exclusion-only path is byte-for-byte unchanged.

> **Two corrections after review, both of absolute claims I made about my own rule.** I wrote that the depth check "cannot reject a pattern that could have matched" (revision 1) and then that it "can never refuse a selector that could have matched" (revision 2). Both were falsifiable in one command. See [Correction 1](#correction-1-depth-was-measured-on-characters-not-separators) and [Correction 3](#correction-3-the-rule-is-not-conservative-and-that-is-now-documented). No absolute claim of that shape remains in the code, the docs, or this body.

## What was measured, and with which binary

* **Pinned CE oracle** — `~/Work/denis/ptah-atlas-conformance/bin/atlas`, `atlas community version v1.2.0`, always by absolute path. `/usr/local/bin/atlas` is a different build and was never invoked.
* **The non-community build** — not invoked. Read verbatim from `the observation study fixtures, `.

### Does CE accept `schema inspect --include`?

No — it does not register the flag at all:

```text
$ ~/Work/denis/ptah-atlas-conformance/bin/atlas schema inspect -u "sqlite://app.db" --include users
Error: unknown flag: --include
exit=1
```

CE *does* register `--include` on `schema apply`/`schema diff` and aborts at runtime (`Abort: 'atlas schema diff --include' is not supported by the community version`). So this is a **Pro-surface flag, not a CE parity gap**.

### What Atlas does with it

Verbatim from `verbs-and-flags/commands.log`, fixture `t1(id PK, c)`, `t2(id, t1_id REFERENCES t1(id))`:

| Input | Atlas | Ptah |
| --- | --- | --- |
| `--include 't1'` | `t1` with both columns + PK, plus `schema "main" {}`, exit 0 | same selection |
| `--include '*.t1'` | read at child depth — `t1` with `primary_key` but **no columns**, `t2` an empty shell, exit 0 | wildcard spelling of the qualified name: `t1` whole, `t2` dropped |
| `--include 'main.t1.*'` | `Error: too many parts in pattern: […]`, exit 1 | rejected pre-connect (different message) |

Behavior beyond these three inputs is **not established**, and I did not infer it.

### The atlas.hcl / `--env` spelling: measured, deliberately absent

CE appears to accept `env { include = [...] }`, but that is tolerance, not support — it accepts *any* unknown env attribute:

```text
$ CE schema inspect --env local  (env { include    = ["t1"] })  -> exit 0, FULL schema
$ CE schema inspect -c bogus.hcl (env { not_a_real = ["t1"] })  -> exit 0, FULL schema
$ ptah-compat schema inspect --env local  -> error: unsupported atlas.hcl construct "include" (exit 1)
```

Atlas documents no `include` env attribute, so none was added. A case where compat errors and CE succeeds, recorded on purpose.

## Correction 1 — depth was measured on characters, not separators

`tableref.canonicalPart` **quotes any part containing a dot**, so the qualified candidate for table `my.table` in schema `main` is `main."my.table"` — two dot characters, one separator. Counting characters refused the selector that matches it. Measured base vs head:

```text
$ schema diff … --include 'main."my.table"'
  base: exit 0, CREATE TABLE "my.table" ("id" INTEGER PRIMARY KEY, "n" TEXT);
  head (f631bb6): exit 1, unsupported Atlas include selector
```

Same split for `*."my.table"`, on `schema apply --dry-run`, and on `schema inspect`. A real capability loss on two verbs this PR is not about.

**Fixed** by `unquotedDots`, which skips separators inside `"…"`, backticks and `[…]`, and after a `path.Match` backslash escape. Regression tests on `schema diff` (the verb that regressed) and `schema inspect`, plus **five** happy-path and one failure case in `TestValidateIncludeSelectors_*`.

## Correction 2 — the rule closes one spelling, not the class

`path.Match` treats `.` as an ordinary character, so **every** metacharacter that can stand for it escapes the check:

```text
--include 'main.users.email'   -> exit 1, unsupported Atlas include selector
--include 'main.users*email'   -> exit 0, "Schemas are synced, no changes to be made."
--include 'main.users?email'   -> exit 0, "Schemas are synced, no changes to be made."
--include 'main.users[.]email' -> exit 0, "Schemas are synced, no changes to be made."
```

The character class is a **new** escape this delta created: `main.other[.]id` was exit 1 on `f631bb6` (character counting saw two dots) and is exit 0 once bracket runs are skipped as identifier quoting. Enumerated in all three doc pages, both long-help strings and #979 — a reader who tests `*` and `?` would otherwise assume `[.]` is caught.

## Correction 3 — the rule is not conservative, and that is now documented

The selection also offers the **bare** name, which is never quoted. So a table literally named `a.b.c` is matched by `a.b.c` — which the rule refuses. Measured base `6bb495d` vs head `95fd2eb`, fixture `CREATE TABLE "a.b.c" (id INTEGER PRIMARY KEY, n TEXT);`:

```text
$ schema diff … --include 'a.b.c'
  base: exit 0, CREATE TABLE "a.b.c" ("id" INTEGER PRIMARY KEY, "n" TEXT);
  head: exit 1, "a deeper pattern names a child resource that rides along with its parent"
```

**Treated as deliberate**: `a.b.c` is genuinely indistinguishable from `schema.table.column`, and the `\.` escape landed in the same commit as the disambiguated spelling. Both workarounds verified on head:

```text
--include 'a\.b\.c'       -> exit 0, emits the table
--include 'main."a.b.c"'  -> exit 0, emits the table
```

It is still a contract change from base, and the escape spelling appeared in **no** user-facing doc. It is now in `schema-commands.md` (its own subsection next to the `main."my.table"` paragraph), `direct/inspect.md`, `reference/atlas-commands.md`, and both commands' long help. #979 gained the case — it is the opposite condition from the rest of that issue (a selector that *would* have matched, refused), and the outcome-based check proposed there fixes it too.

The godoc no longer claims the check is conservative. It states that a bare candidate is never quoted, that a dotted table must be spelled `a\.b\.c` or `main."a.b.c"`, and points at #979.

## Every branch that reaches the flag

| Branch | Result |
| --- | --- |
| `--url` live database / local file / migration dir | selects |
| `--url` external schema | same `case KindLocalFile, KindExternalSchema:` clause — one code path, covered by the local-file test |
| `--url env://…` | classified into one of the above |
| `--format hcl / sql / json / template` | all four select |
| `{{ hcl . \| split \| write "dir" }}` | only the selected object's file written |
| `--web` / `--output` / `--export` | still unregistered — separate #951 items; pinned by a test |
| `--schema` + `--include` | compose; on SQLite `--schema other` narrows nothing (**same as CE**); on live PostgreSQL both apply |
| repeated / comma-separated | union |
| `--include ""` | no selection; identical to the flag being absent |
| matches nothing / matches everything | exit 0 with no objects / full schema |
| `--include` + `--exclude` | include first, exclude subtracts |
| `--include t1,t2 --exclude t1` | refused: `t2`'s FK target was dropped |
| child selectors (`[type=column]`, `main.t1.*`, `[type=widget]`) | rejected pre-connect |
| quoted dotted identifier (3 spellings) | selected — Correction 1 |
| bare dotted identifier `a.b.c` | refused as ambiguous; `a\.b\.c` and `main."a.b.c"` work — Correction 3 |
| glob-metacharacter child depth (`*`, `?`, `[.]`) | **not** caught — #979 |
| PostgreSQL live (enum + SERIAL sequence + FK) | green against a disposable `postgres:16-alpine` |

## Behavior change outside inspect (intentional)

The depth rule is in the shared validator, so `schema apply/diff --include 'main.users.id'` moved from a silent false-green (exit 0 "Schemas are synced") to a loud rejection. It is include-only — exclusion legitimately reaches child resources and its `table.column` / `schema.table.child` spellings still **parse** (whether a given spelling then *matches* is a separate pre-existing question: `--exclude 't2.t1_id'` drops the column, `--exclude 'main.t2.t1_id'` matches nothing on the default schema).

## Mutation table

| # | Mutation | Tests that failed |
| --- | --- | --- |
| M1 | Drop the `validateIncludeSelectorDepth` call | 4 × `…FailurePath/child_depth*`; `TestInspectSource_FailurePath/child-depth…`; `cmd/atlas …RejectsChildSelectorsBeforeConnecting/positional_spelling`; `cmd/schema …RejectsChildSelectors/positional_spelling` |
| M2 | `includeSelectorMaxDots` 1 → 2 | same set as M1 |
| M3 | Drop `Include` from the inspect projection | `TestInspect_IncludeSelection` (2); 9 `cmd/atlas` inspect-include tests; `cmd/schema` ×2 |
| M4 | Remove pre-connect `ValidateIncludeSelectors` | `TestInspectSource_FailurePath` (2); `…RejectsChildSelectorsBeforeConnecting` (3); `…ValidationRunsBeforeDevDatabaseReset`; `cmd/schema` (2) |
| M5 | Unregister `--include` on compat inspect | `TestSchemaInspectAdvertisesIncludeInItsFlagList` + all compat inspect-include tests |
| M6 | Unregister `--include` on native inspect | `cmd/schema` ×3 |
| M7 | Apply the depth rule in the shared `parsePattern` | `TestIncludeSelectorDepthRuleIsIncludeOnly` (3) + 6 pre-existing exclude tests |
| M8 | `validateDatabaseScope` returns nil | `TestInspect_IncludeSelection/refuses…`; `TestSchemaInspectIncludeCrossScopeDependencyFails` |
| M9 | Drop the quoted-run skip from `unquotedDots` | 4 × `HappyPath/*dotted_identifier`; both `…SelectsQuotedDottedIdentifier` suites (4 subtests) |
| M10 | Drop the backslash-escape skip | `HappyPath/escaped_dots` |
| M11 | Revert `unquotedDots` to `strings.Count` (the shipped bug) | 5 × `HappyPath`; both `…SelectsQuotedDottedIdentifier` suites (4 subtests) |
| **M12** | `case '[': closeQuote = '['` — bracket run never terminates | `FailurePath/child_depth_past_a_bracketed_identifier` |
| **M13** | Drop the backtick arm | `HappyPath/backtick_dotted_identifier` |
| **M14** | `closeQuote = 1` — no quote run ever terminates | `FailurePath/child_depth_past_a_quoted_identifier`, `…past_a_backticked_identifier` |

No mutation survived. M12 was the reviewer's find: before this commit the whole suite stayed green under it, because brackets and backticks had accept-fixtures only. M13 is killed by the happy-path case rather than the new failure case — reported as measured, not as designed.

**Vacuity finding.** M5 initially left `TestCompatCommand_AdvertisesEssentialAtlasFlags/schema_inspect` green — it substring-matches the whole `--help` output, and the long description names its own flags in prose. That row is now vacuous for **three** flags (`--include`, `--schema`, `--exclude`). `TestSchemaInspectAdvertisesIncludeInItsFlagList` asserts the rendered flag entry instead and does go red under M5. General fix: #978.

## Conformance impact — measured, not predicted

Probe run against a binary built from this branch (`PTAH_COMPAT_BIN=…`, reports to a scratch dir; `stokaro/ptah-atlas-conformance` untouched, `git status` clean), re-run after every fix:

```text
37 commands, 107 observations, 1 non-OK observation(s), 1 unwaived
| **RED** | **gap** | atlas-cli-surface-ptah-compat | `atlas schema inspect` | flags | flag mismatch: extra --include | #514 |
```

Routing decided by the coordinator: **a closed per-command allow-list, not a waiver** — a `waivers.txt` line is scoped to command+category, so after it *any* extra flag on `atlas schema inspect` goes invisible, including a genuinely non-Atlas one, eroding the #951 constraint the tier exists to protect. Allow-list data already exists and is exact: the captured help surface, key `"atlas schema inspect"` minus the CE set gives `--export --include --output --web`. Not touched here.

Proposed ce-gating scenario, parallel to the existing `--web` row:

```go
{
    fixture:  "atlas schema inspect --include",
    argv:     []string{"schema", "inspect", "--include", "users"},
    expected: CEGatingUnknownFlag,
},
```

Measured expectation: `class: unknown-flag — Error: unknown flag: --include`.

## Feature matrix

Edited `docs/site/scripts/data/feature-matrix-rows.json` only, then regenerated; `--check` passes.

* `schema inspect --include filtering`: ptah ❌ → ✅.
* `--include resource selectors`: note now states CE registers it on apply/diff and none on inspect.
* Counts: fully 80 → 81, not implemented 26 → 25, open-where-Pro-gated 31 → 32.

**`build-feature-matrix.mjs` fixed here** (was a follow-up): it hard-coded "107 observations, no gap" in the published summary, which this branch makes false. `--check` passes regardless because it only verifies generator-to-page consistency, not truth. The generator now names the gap; re-measured after the fix to confirm the prose is accurate.

## Docs updated

* `atlas/schema-commands.md` — the `--include` section, a "Selecting an identifier that contains a dot" subsection (escape and quoted spellings, and why bare is refused), and a "What the depth check does not catch" subsection.
* `atlas/comparison.md` — `#schema-inspect---include` with the divergence table and the atlas.hcl finding.
* `atlas/docs-coverage.md` — **was asserting the opposite of this PR**; rewritten.
* `reference/atlas-commands.md`, `direct/inspect.md` — filtering lists, dotted-identifier spellings, metacharacter escapes, #979.

## Gates

`go vet ./...`, full `go test ./...`, `-race` on the touched packages, `golangci-lint run ./...` (0 issues), `go tool qtlint ./...`, `scripts/check-test-style.sh`, the three public-API scripts, and every docs checker plus the matrix builder — all green.

* **#975 confirmed.** `check-test-style.sh` printed `rg: command not found` and skipped its testify guard. Ran it manually — no matches.
* A `golangci-lint run` mid-session reported a file outside this worktree from a stale shared cache; `cache clean` then `run ./...` reports 0 issues.

## Follow-ups (not in this PR)

1. **#979** — outcome-based zero-match check; needs a measurement first. Now also covers the bare `a.b.c` case.
2. **#978** — `TestCompatCommand_AdvertisesEssentialAtlasFlags` should assert against the parsed `Flags:` block.
3. `schema inspect --output/--web/--export` remain unregistered (#951); `schema clean --include/--exclude` is the same shape and can reuse this wiring.
