### PR TITLE
Validate every Atlas environment structure

### DIFF
--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -159,6 +159,9 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 	if err != nil {
 		return Config{}, err
 	}
+	if err := validateAtlasEnvStructures(blocks.envs); err != nil {
+		return Config{}, err
+	}
 
 	if err := p.configureEvalContext(blocks.variables, blocks.locals, blocks.data); err != nil {
 		return Config{}, err

--- a/config/projectconfig/atlas_structure.go
+++ b/config/projectconfig/atlas_structure.go
@@ -1,0 +1,122 @@
+package projectconfig
+
+import (
+	"slices"
+
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+type atlasBodyStructure struct {
+	attributes []string
+	blocks     map[string]atlasBlockStructure
+}
+
+type atlasBlockStructure struct {
+	body   atlasBodyStructure
+	labels int
+}
+
+func atlasEnvBodyStructure() atlasBodyStructure {
+	return atlasBodyStructure{
+		attributes: []string{"dev", "exclude", "src", "url"},
+		blocks: map[string]atlasBlockStructure{
+			"diff": {
+				body: atlasBodyStructure{blocks: map[string]atlasBlockStructure{
+					"concurrent_index": {
+						body: atlasBodyStructure{attributes: []string{"create", "drop"}},
+					},
+					"skip": {
+						body: atlasBodyStructure{attributes: []string{"drop_table"}},
+					},
+				}},
+			},
+			"format": {
+				body: atlasBodyStructure{blocks: map[string]atlasBlockStructure{
+					"migrate": {
+						body: atlasBodyStructure{attributes: []string{"apply", "diff", "lint", "status"}},
+					},
+					"schema": {
+						body: atlasBodyStructure{attributes: []string{"apply", "clean", "diff", "inspect"}},
+					},
+				}},
+			},
+			"lint": {
+				body: atlasBodyStructure{
+					attributes: []string{"latest", "log"},
+					blocks: map[string]atlasBlockStructure{
+						"concurrent_index": {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"data_depend":      {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"destructive":      {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"git":              {body: atlasBodyStructure{attributes: []string{"base", "dir"}}},
+						"incompatible":     {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"nestedtx":         {body: atlasBodyStructure{attributes: []string{"error"}}},
+					},
+				},
+			},
+			"migration": {
+				body: atlasBodyStructure{attributes: []string{
+					"dir",
+					"exec_order",
+					"format",
+					"lock_timeout",
+					"revisions_schema",
+					"tx_mode",
+				}},
+			},
+			"schema": {
+				body: atlasBodyStructure{
+					attributes: []string{"src"},
+					blocks: map[string]atlasBlockStructure{
+						"mode": {
+							body: atlasBodyStructure{attributes: []string{
+								"funcs",
+								"objects",
+								"permissions",
+								"roles",
+								"sensitive",
+								"tables",
+								"triggers",
+								"types",
+								"views",
+							}},
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func validateAtlasEnvStructures(envs []atlasEnvBlock) error {
+	structure := atlasEnvBodyStructure()
+	for _, env := range envs {
+		if err := validateAtlasBodyStructure(env.block.Body, structure); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateAtlasBodyStructure(body *hclsyntax.Body, structure atlasBodyStructure) error {
+	for _, name := range sortedAttributeNames(body.Attributes) {
+		if !slices.Contains(structure.attributes, name) {
+			return unsupportedAttr(name, body.Attributes[name])
+		}
+	}
+
+	seen := map[string]struct{}{}
+	for _, block := range body.Blocks {
+		blockStructure, ok := structure.blocks[block.Type]
+		if !ok || len(block.Labels) != blockStructure.labels {
+			return unsupportedBlock(block)
+		}
+		if _, duplicate := seen[block.Type]; duplicate {
+			return unsupportedBlock(block)
+		}
+		seen[block.Type] = struct{}{}
+		if err := validateAtlasBodyStructure(block.Body, blockStructure.body); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1230,6 +1230,94 @@ env "prod" {
 	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "url" at atlas\.hcl:5`)
 }
 
+func TestParseAtlasProjectConfigRejectsUnsupportedConstructsInUnselectedEnv(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
+		{
+			name: "environment attribute",
+			raw: `env "dev" {
+  url = "sqlite://dev.db"
+}
+env "prod" {
+  url     = missing.value
+  project = "production"
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "project" at atlas\.hcl:6`,
+		},
+		{
+			name: "environment block",
+			raw: `env "dev" {
+  url = "sqlite://dev.db"
+}
+env "prod" {
+  url = missing.value
+  cloud {}
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "cloud" at atlas\.hcl:6`,
+		},
+		{
+			name: "nested migration attribute",
+			raw: `env "dev" {
+  url = "sqlite://dev.db"
+}
+env "prod" {
+  url = missing.value
+  migration {
+    dir        = "file://migrations"
+    remote_dir = "atlas://team/project"
+  }
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "remote_dir" at atlas\.hcl:8`,
+		},
+		{
+			name: "labeled nested block",
+			raw: `env "dev" {
+  url = "sqlite://dev.db"
+}
+env "prod" {
+  url = missing.value
+  migration "remote" {
+    dir = "file://migrations"
+  }
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "migration" at atlas\.hcl:6`,
+		},
+		{
+			name: "duplicate nested block",
+			raw: `env "dev" {
+  url = "sqlite://dev.db"
+}
+env "prod" {
+  url = missing.value
+  migration {
+    dir = "file://migrations"
+  }
+  migration {
+    dir = "file://other"
+  }
+}
+`,
+			wantErr: `unsupported atlas\.hcl construct "migration" at atlas\.hcl:9`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := projectconfig.ParseAtlas([]byte(test.raw), "atlas.hcl", "dev")
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
 func TestLoadAtlasProjectConfigEmptyEnvURLOverridesPtahFallback(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -434,6 +434,13 @@ unsupported atlas.hcl construct "src" at atlas.hcl:2
 This hard-fail policy prevents partially interpreted Atlas project configs from
 silently changing migration behavior.
 
+Structural validation covers every `env` block, including environments that
+are not selected for the current command. An unsupported attribute, nested
+block, label, or duplicate therefore fails even when it appears in another
+environment. Expressions are evaluated only in the selected environment, so
+an unselected environment may still refer to variables, files, or environment
+values that are unavailable in the current invocation.
+
 Non-local URI schemes in `migration.dir` and `schema.src` fail explicitly when
 a command needs that configured value. An explicit CLI path flag still wins over
 the matching `atlas.hcl` value before URI validation.

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -437,9 +437,11 @@ silently changing migration behavior.
 Structural validation covers every `env` block, including environments that
 are not selected for the current command. An unsupported attribute, nested
 block, label, or duplicate therefore fails even when it appears in another
-environment. Expressions are evaluated only in the selected environment, so
-an unselected environment may still refer to variables, files, or environment
-values that are unavailable in the current invocation.
+environment. Expressions inside `env` blocks are evaluated only in the selected
+environment, so an unselected environment may still refer to variables, files,
+or environment values that are unavailable in the current invocation. Global
+`variable`, `locals`, and `data` blocks are evaluated separately to build the
+shared context before environment selection.
 
 Non-local URI schemes in `migration.dir` and `schema.src` fail explicitly when
 a command needs that configured value. An explicit CLI path flag still wins over

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -309,3 +309,10 @@ unsupported environment layouts fail instead of guessing.
 Ptah intentionally rejects unsupported project config constructs. This prevents
 a dangerous half-configured state where a user believes an Atlas setting is in
 effect but Ptah silently ignored it.
+
+Structural validation covers every `env` block, including environments that
+are not selected for the current command. An unsupported attribute, nested
+block, label, or duplicate therefore fails even when it appears in another
+environment. Expressions are evaluated only in the selected environment, so
+an unselected environment may still refer to variables, files, or environment
+values that are unavailable in the current invocation.

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -313,6 +313,8 @@ effect but Ptah silently ignored it.
 Structural validation covers every `env` block, including environments that
 are not selected for the current command. An unsupported attribute, nested
 block, label, or duplicate therefore fails even when it appears in another
-environment. Expressions are evaluated only in the selected environment, so
-an unselected environment may still refer to variables, files, or environment
-values that are unavailable in the current invocation.
+environment. Expressions inside `env` blocks are evaluated only in the selected
+environment, so an unselected environment may still refer to variables, files,
+or environment values that are unavailable in the current invocation. Global
+`variable`, `locals`, and `data` blocks are evaluated separately to build the
+shared context before environment selection.


### PR DESCRIPTION
## Summary

- validate the supported Atlas HCL shape in every `env` block before selecting one
- keep expression evaluation scoped to the selected environment
- reject unsupported attributes, nested blocks, labels, and duplicates in unselected environments with location-aware errors
- document the strict whole-config behavior

## Verification

- `go test -count=1 ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- complete docs style, link, redirect, page-health, exit-code, build, and responsive checks
- independent Atlas CE runtime gate: 26 observations, 0 non-OK
- two-pass self-review plus independent code review: no remaining findings

Fixes #276