### PR TITLE
fix(lint): harden analyzer safety contracts

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -293,7 +293,9 @@ jobs:
         run: |
           go test -v ./migration/migrator -run 'TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration' -timeout 3m
           go test -v ./migration/generator -run 'TestGenerateMigrationShadowVerificationWithRealDB|TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB' -timeout 5m
-          go test -v ./cmd/migrateup -run 'TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres' -timeout 3m
+          go test ./cmd/migrateup -list '^TestMigrateUp_LintConfigSeverityOverrideControlsPostgresMigration$' | grep -q '^TestMigrateUp_LintConfigSeverityOverrideControlsPostgresMigration$'
+          go test ./cmd/migrateup -list '^TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable$' | grep -q '^TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable$'
+          go test -v -count=1 ./cmd/migrateup -run '^TestMigrateUp_LintConfig(SeverityOverrideControlsPostgresMigration|WarningStillBlocksPostgresDropTable)$' -timeout 3m
 
       - name: Run migrate-baseline integration tests
         env:

--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -775,13 +775,13 @@
       "count": 2
     },
     {
-      "path": "migration/generator/shadow_test.go",
+      "path": "migration/generator/shadow_internal_test.go",
       "function": "TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB",
       "kind": "if",
       "count": 3
     },
     {
-      "path": "migration/generator/shadow_test.go",
+      "path": "migration/generator/shadow_internal_test.go",
       "function": "TestGenerateMigrationShadowVerificationWithRealDB",
       "kind": "if",
       "count": 3
@@ -807,12 +807,6 @@
     {
       "path": "migration/lint/lint_test.go",
       "function": "TestLintFS_SameFileCreatedTablesAreExempt",
-      "kind": "if",
-      "count": 1
-    },
-    {
-      "path": "migration/lint/register_external_test.go",
-      "function": "TestRegisterCustomRuleFromExternalPackage",
       "kind": "if",
       "count": 1
     },
@@ -1218,11 +1212,6 @@
     },
     {
       "path": "migration/generator/safety_test.go",
-      "package": "generator",
-      "reason": "same-package test file is not named *_internal_test.go"
-    },
-    {
-      "path": "migration/generator/shadow_test.go",
       "package": "generator",
       "reason": "same-package test file is not named *_internal_test.go"
     },

--- a/cmd/migrate/generate_test.go
+++ b/cmd/migrate/generate_test.go
@@ -3,6 +3,7 @@ package migrate_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -14,6 +15,8 @@ import (
 	"github.com/stokaro/ptah/config/projectconfig"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+	"github.com/stokaro/ptah/migration/safety"
 )
 
 func TestMigrateGenerateCommandExposesShadowDBFlag(t *testing.T) {
@@ -86,6 +89,43 @@ func TestMigratePlanCommandRejectsAtlasApplyAtRoot(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `unexpected positional arguments \["apply"\]`)
 }
 
+func TestMigrateGenerateJSONReportWritesSiblingSafetyArtifact(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaFile := filepath.Join(dir, "schema.sql")
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.WriteFile(schemaFile, []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+	var stdout, stderr bytes.Buffer
+	cmd := migrate.NewMigrateGenerateCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--schema-file", schemaFile,
+		"--db-url", "sqlite:///" + filepath.Join(dir, "ptah.db"),
+		"--migrations-dir", migrationsDir,
+		"--name", "init",
+		"--report", "json",
+	})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+
+	reportFiles, err := filepath.Glob(filepath.Join(migrationsDir, "*_init.safety.json"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(reportFiles, qt.HasLen, 1)
+	c.Assert(stdout.String(), qt.Contains, "REPORT: ")
+	c.Assert(stdout.String(), qt.Contains, filepath.Base(reportFiles[0]))
+
+	rawReport, err := os.ReadFile(reportFiles[0])
+	c.Assert(err, qt.IsNil)
+	var report safety.Report
+	c.Assert(json.Unmarshal(rawReport, &report), qt.IsNil)
+	c.Assert(report.Highest, qt.Equals, safety.Safe)
+	c.Assert(report.Destructive, qt.IsFalse)
+	c.Assert(report.Assessments, qt.HasLen, 1)
+}
+
 func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 	c := qt.New(t)
 	ctx := t.Context()
@@ -120,6 +160,12 @@ func TestMigrateGenerateShadowVerificationWithRealDB(t *testing.T) {
 		err := cmd.Execute()
 
 		c.Assert(err, qt.ErrorMatches, `shadow check failed: missing column users\.name`)
+		var shadowErr *generator.ShadowVerificationError
+		c.Assert(err, qt.ErrorAs, &shadowErr)
+		c.Assert(shadowErr.Result.Stage, qt.Equals, "replay")
+		c.Assert(shadowErr.Result.Mismatches, qt.HasLen, 1)
+		c.Assert(shadowErr.Result.Mismatches[0].Kind, qt.Equals, "replay_error")
+		c.Assert(shadowErr.Err, qt.IsNotNil)
 		matches, globErr := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
 		c.Assert(globErr, qt.IsNil)
 		c.Assert(matches, qt.HasLen, 2)

--- a/cmd/migrate/migrate_test.go
+++ b/cmd/migrate/migrate_test.go
@@ -2,6 +2,7 @@ package migrate_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -9,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/cmd/migrate"
+	"github.com/stokaro/ptah/migration/safety"
 )
 
 func TestMigratePlanTextOutputContainsSQLNotASTPointers(t *testing.T) {
@@ -41,6 +43,33 @@ type User struct {
 	c.Assert(out.String(), qt.Contains, `CREATE TABLE "users"`)
 	c.Assert(out.String(), qt.Not(qt.Contains), "[0x")
 	c.Assert(out.String(), qt.Not(qt.Contains), "&{")
+}
+
+func TestMigratePlanJSONReportEmitsStructuredSafetyOnStdout(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaFile := filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(schemaFile, []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+	var stdout, stderr bytes.Buffer
+	cmd := migrate.NewMigrateCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--schema-file", schemaFile,
+		"--db-url", "sqlite:///" + filepath.Join(dir, "ptah.db"),
+		"--report", "json",
+	})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+
+	var report safety.Report
+	c.Assert(json.Unmarshal(stdout.Bytes(), &report), qt.IsNil)
+	c.Assert(report.Highest, qt.Equals, safety.Safe)
+	c.Assert(report.Destructive, qt.IsFalse)
+	c.Assert(report.Assessments, qt.HasLen, 1)
+	c.Assert(report.Assessments[0].Statement, qt.Contains, `CREATE TABLE "users"`)
 }
 
 func TestMigratePlan_OCIFlags(t *testing.T) {

--- a/cmd/migrateup/lint_config_acceptance_test.go
+++ b/cmd/migrateup/lint_config_acceptance_test.go
@@ -1,0 +1,272 @@
+package migrateup_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	lintcmd "github.com/stokaro/ptah/cmd/lint"
+	"github.com/stokaro/ptah/cmd/migrateup"
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/lint"
+)
+
+func TestMigrateUp_LintConfigSeverityOverrideControlsPostgresMigration(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	dbURL := requireLintGatePostgresURL(t)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	tableName := "ptah_lint_warning_" + suffix
+	revisionTable := "ptah_lint_warning_revisions_" + suffix
+	defer dropLintGatePostgresTables(c, conn, tableName, revisionTable)
+
+	dir := t.TempDir()
+	writeLintGateMigration(c, dir, lint.ConfigFileName, `rules:
+  DS103:
+    severity: error
+`)
+	writeLintGateMigration(c, dir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", tableName))
+	writeLintGateMigration(c, dir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", tableName))
+	writeLintGateMigration(c, dir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", tableName))
+	writeLintGateMigration(c, dir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", tableName))
+
+	var stdout, stderr bytes.Buffer
+	cmd := migrateup.NewMigrateUpCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--migrations-table", revisionTable,
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, "(?s).*pending migrations contain destructive statements.*DS103.*error.*")
+
+	writeLintGateMigration(c, dir, lint.ConfigFileName, `rules:
+  DS103:
+    severity: warning
+`)
+	stdout.Reset()
+	stderr.Reset()
+	cmd = migrateup.NewMigrateUpCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--migrations-table", revisionTable,
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
+
+	var maxLength int
+	err = conn.QueryRowContext(ctx, `
+		SELECT character_maximum_length
+		FROM information_schema.columns
+		WHERE table_schema = 'public' AND table_name = $1 AND column_name = 'email'
+	`, tableName).Scan(&maxLength)
+	c.Assert(err, qt.IsNil)
+	c.Assert(maxLength, qt.Equals, 512)
+}
+
+func TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	dbURL := requireLintGatePostgresURL(t)
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
+	tableName := "ptah_lint_drop_" + suffix
+	revisionTable := "ptah_lint_drop_revisions_" + suffix
+	defer dropLintGatePostgresTables(c, conn, tableName, revisionTable)
+
+	dir := t.TempDir()
+	writeLintGateMigration(c, dir, lint.ConfigFileName, `rules:
+  DS103:
+    severity: warning
+`)
+	writeLintGateMigration(c, dir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", tableName))
+	writeLintGateMigration(c, dir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", tableName))
+	writeLintGateMigration(c, dir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", tableName))
+	writeLintGateMigration(c, dir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", tableName))
+	writeLintGateMigration(c, dir, "0000000003_drop_table.up.sql", fmt.Sprintf("DROP TABLE %s;\n", tableName))
+	writeLintGateMigration(c, dir, "0000000003_drop_table.down.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(512));\n", tableName))
+
+	var stdout, stderr bytes.Buffer
+	cmd := migrateup.NewMigrateUpCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+		"--migrations-table", revisionTable,
+	})
+
+	err = cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, "(?s).*pending migrations contain destructive statements.*DS101.*")
+
+	var tableExists bool
+	err = conn.QueryRowContext(ctx, "SELECT to_regclass($1) IS NOT NULL", "public."+tableName).Scan(&tableExists)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableExists, qt.IsFalse)
+}
+
+func TestMigrateUp_InvalidLintConfigFailsBeforeSQLiteMigrationExecution(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbURL := "sqlite://" + filepath.Join(dir, "ptah.db")
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	writeLintGateMigration(c, migrationsDir, lint.ConfigFileName, "rules:\n  DS101:\n    severty: warning\n")
+	writeLintGateMigration(c, migrationsDir, "0000000001_create.up.sql", "CREATE TABLE users (id INTEGER);\n")
+	writeLintGateMigration(c, migrationsDir, "0000000001_create.down.sql", "DROP TABLE users;\n")
+
+	var stdout, stderr bytes.Buffer
+	cmd := migrateup.NewMigrateUpCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", migrationsDir,
+	})
+
+	err := cmd.Execute()
+	c.Assert(err, qt.ErrorMatches, `(?s).*failed to parse lint config .*field severty not found in type lint.RuleConfig.*`)
+
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var usersTableCount int
+	err = conn.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'users'",
+	).Scan(&usersTableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(usersTableCount, qt.Equals, 0)
+}
+
+func TestMigrateUp_RelativeDirectoryPrefixedExclusionMatchesLintCommand(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	migrationsDir := filepath.Join(root, "migrations")
+	t.Chdir(root)
+
+	assertLintAndMigrateExclusionParity(c, t, root, migrationsDir, "migrations", "migrations/legacy/**")
+}
+
+func TestMigrateUp_NestedDirectoryPrefixedExclusionMatchesLintCommand(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	migrationsDir := filepath.Join(root, "db", "migrations")
+	t.Chdir(root)
+
+	assertLintAndMigrateExclusionParity(c, t, root, migrationsDir, "db/migrations", "db/migrations/legacy/**")
+}
+
+func TestMigrateUp_AbsoluteDirectoryPrefixedExclusionMatchesLintCommand(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	migrationsDir := filepath.Join(root, "migrations")
+	pattern := filepath.ToSlash(filepath.Join(migrationsDir, "legacy", "**"))
+
+	assertLintAndMigrateExclusionParity(c, t, root, migrationsDir, migrationsDir, pattern)
+}
+
+func assertLintAndMigrateExclusionParity(
+	c *qt.C,
+	t *testing.T,
+	root string,
+	migrationsDir string,
+	migrationsArg string,
+	pattern string,
+) {
+	c.Helper()
+	legacyDir := filepath.Join(migrationsDir, "legacy")
+	c.Assert(os.MkdirAll(legacyDir, 0o755), qt.IsNil)
+	writeLintGateMigration(c, migrationsDir, lint.ConfigFileName, fmt.Sprintf("rules:\n  DS101:\n    exclude:\n      - %q\n", pattern))
+	writeLintGateMigration(c, legacyDir, "0000000001_create.up.sql", "CREATE TABLE users (id INTEGER);\n")
+	writeLintGateMigration(c, legacyDir, "0000000001_create.down.sql", "DROP TABLE users;\n")
+	writeLintGateMigration(c, legacyDir, "0000000002_drop.up.sql", "DROP TABLE users;\n")
+	writeLintGateMigration(c, legacyDir, "0000000002_drop.down.sql", "CREATE TABLE users (id INTEGER);\n")
+
+	var lintStdout, lintStderr bytes.Buffer
+	lintCommand := lintcmd.NewLintCommand()
+	lintCommand.SetOut(&lintStdout)
+	lintCommand.SetErr(&lintStderr)
+	lintCommand.SetArgs([]string{"--dir", migrationsArg})
+
+	err := lintCommand.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", lintStderr.String()))
+	c.Assert(lintStdout.String(), qt.Contains, "No lint findings")
+
+	dbURL := "sqlite://" + filepath.Join(root, "ptah.db")
+	var upStdout, upStderr bytes.Buffer
+	upCommand := migrateup.NewMigrateUpCommand()
+	upCommand.SetOut(&upStdout)
+	upCommand.SetErr(&upStderr)
+	upCommand.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", migrationsArg,
+	})
+
+	err = upCommand.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", upStderr.String()))
+
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var usersTableCount int
+	err = conn.QueryRowContext(
+		t.Context(),
+		"SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'users'",
+	).Scan(&usersTableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(usersTableCount, qt.Equals, 0)
+	var currentVersion int64
+	err = conn.QueryRowContext(t.Context(), "SELECT MAX(version) FROM schema_migrations").Scan(&currentVersion)
+	c.Assert(err, qt.IsNil)
+	c.Assert(currentVersion, qt.Equals, int64(2))
+}
+
+func requireLintGatePostgresURL(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	return ""
+}
+
+func writeLintGateMigration(c *qt.C, dir, name, contents string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(contents), 0o600), qt.IsNil)
+}
+
+func dropLintGatePostgresTables(c *qt.C, conn *dbschema.DatabaseConnection, names ...string) {
+	c.Helper()
+	for _, name := range names {
+		statement, err := renderer.RenderSQL(platform.Postgres, ast.NewDropTable(name).SetIfExists().SetCascade())
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(context.Background(), statement)
+		c.Check(err, qt.IsNil)
+	}
+}

--- a/cmd/migrateup/lint_internal_test.go
+++ b/cmd/migrateup/lint_internal_test.go
@@ -13,7 +13,9 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/cmd/internal/migrationsource"
 	"github.com/stokaro/ptah/internal/migrationsnapshot"
+	"github.com/stokaro/ptah/migration/lint"
 	"github.com/stokaro/ptah/migration/migrator"
 )
 
@@ -28,11 +30,52 @@ func TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression(t *testing.T) {
 		},
 	}
 
-	findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite")
+	findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite", "")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 1)
 	c.Assert(findings[0].Rule, qt.Equals, "DS101")
+}
+
+func TestLintPendingDestructive_HonorsDirectoryPrefixedExclusion(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("rules:\n  DS101:\n    exclude:\n      - migrations/legacy/**\n"),
+		},
+		"legacy/0000000001_drop.up.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"legacy/0000000001_drop.down.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+	}
+
+	findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite", "migrations")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0)
+}
+
+func TestLintPathPrefixForSource_PreservesLocalSpelling(t *testing.T) {
+	c := qt.New(t)
+
+	got := lintPathPrefixForSource("db/migrations", migrationsource.Source{
+		Display: "/absolute/db/migrations",
+	})
+
+	c.Assert(got, qt.Equals, "db/migrations")
+}
+
+func TestLintPathPrefixForSource_UsesCanonicalOCIDisplay(t *testing.T) {
+	c := qt.New(t)
+
+	got := lintPathPrefixForSource("oci://REGISTRY.EXAMPLE/acme/migrations:latest", migrationsource.Source{
+		Display: "oci://registry.example/acme/migrations:latest",
+		OCI:     &migrationsource.OCI{},
+	})
+
+	c.Assert(got, qt.Equals, "oci://registry.example/acme/migrations:latest")
 }
 
 func TestCapturedMigrationsFeedProviderAndDestructiveGateFromSameBytes(t *testing.T) {
@@ -56,7 +99,7 @@ func TestCapturedMigrationsFeedProviderAndDestructiveGateFromSameBytes(t *testin
 		migrator.WithMigrationDirFormat(migrator.MigrationDirFormatPtah),
 	)
 	c.Assert(err, qt.IsNil)
-	findings, err := lintPendingDestructive(snapshot, []int64{1}, "sqlite")
+	findings, err := lintPendingDestructive(snapshot, []int64{1}, "sqlite", "")
 	c.Assert(err, qt.IsNil)
 
 	migrations := provider.Migrations()
@@ -86,7 +129,7 @@ func TestLockedDestructiveLintHookUsesLockedPlanVersions(t *testing.T) {
 			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
 		},
 	}
-	hook := lockedDestructiveLintHook(fsys, "sqlite")
+	hook := lockedDestructiveLintHook(fsys, "sqlite", "")
 
 	err := hook(context.Background(), migrator.MigrationPlan{
 		Versions: []int64{2},
@@ -111,7 +154,7 @@ func TestLockedDestructiveLintHookAllowsSafeLockedPlan(t *testing.T) {
 			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
 		},
 	}
-	hook := lockedDestructiveLintHook(fsys, "sqlite")
+	hook := lockedDestructiveLintHook(fsys, "sqlite", "")
 
 	err := hook(context.Background(), migrator.MigrationPlan{
 		Versions: []int64{1},

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -303,6 +304,7 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	if migrationsDir == "" {
 		return fmt.Errorf("migrations directory is required")
 	}
+	requestedMigrationsDir := migrationsDir
 	settings, err := parseMigrationSettings(
 		dirFormatValue,
 		revisionFormatValue,
@@ -321,6 +323,7 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	if err != nil {
 		return err
 	}
+	lintPathPrefix := lintPathPrefixForSource(requestedMigrationsDir, source)
 	migrationsFS := source.FileSystem
 	migrationsDir = source.Display
 	settings.dirFormat = source.DirFormat
@@ -452,7 +455,7 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	}, emit, cliobs.NewOutputWriter(cmd.OutOrStdout(), runtime, "pre-flight output"))
 	if !opts.allowDestructive {
 		preflightHook = dbcli.CombineMigrationHooks(
-			lockedDestructiveLintHook(migrationsFS, conn.Info().Dialect),
+			lockedDestructiveLintHook(migrationsFS, conn.Info().Dialect, lintPathPrefix),
 			preflightHook,
 		)
 	}
@@ -512,6 +515,13 @@ func emitMigrateUpSummary(
 	}
 	emit.Println("✅ Migrations completed successfully!")
 	emit.Printf("Database is now at version: %d\n", finalStatus.CurrentVersion)
+}
+
+func lintPathPrefixForSource(requested string, source migrationsource.Source) string {
+	if source.OCI != nil {
+		return filepath.ToSlash(source.Display)
+	}
+	return filepath.ToSlash(requested)
 }
 
 func verifyMigrationIntegrity(
@@ -602,14 +612,20 @@ func shutdownObservability(runtime *cliobs.Runtime) {
 	}
 }
 
-func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint.Finding, error) {
+func lintPendingDestructive(
+	fsys fs.FS,
+	pending []int64,
+	dialect string,
+	pathPrefix string,
+) ([]lint.Finding, error) {
 	cfg, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
 	if err != nil {
 		return nil, err
 	}
 	findings, err := lint.LintFS(fsys, lint.Options{
-		Dialect:  dialect,
-		Disabled: append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
+		Dialect:    dialect,
+		Disabled:   append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
+		PathPrefix: pathPrefix,
 		Selection: lint.VersionSelection{
 			Versions:   pending,
 			Restricted: true,
@@ -628,9 +644,9 @@ func lintPendingDestructive(fsys fs.FS, pending []int64, dialect string) ([]lint
 	return destructive, nil
 }
 
-func lockedDestructiveLintHook(fsys fs.FS, dialect string) migrator.PreMigrationHook {
+func lockedDestructiveLintHook(fsys fs.FS, dialect, pathPrefix string) migrator.PreMigrationHook {
 	return func(_ context.Context, plan migrator.MigrationPlan) error {
-		findings, err := lintPendingDestructive(fsys, plan.Versions, dialect)
+		findings, err := lintPendingDestructive(fsys, plan.Versions, dialect, pathPrefix)
 		if err != nil {
 			return fmt.Errorf("error checking pending migration safety: %w", err)
 		}

--- a/cmd/migrateup/migrateup_test.go
+++ b/cmd/migrateup/migrateup_test.go
@@ -88,7 +88,7 @@ ALTER TABLE accounts DISABLE ROW LEVEL SECURITY;
 		},
 	}
 
-	findings, err := lintPendingDestructive(fsys, []int64{2}, "postgres")
+	findings, err := lintPendingDestructive(fsys, []int64{2}, "postgres", "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 5)
 	c.Assert([]string{findings[0].Rule, findings[1].Rule, findings[2].Rule, findings[3].Rule, findings[4].Rule}, qt.DeepEquals, []string{"DS102", "DS107", "DS107", "DS108", "DS109"})
@@ -119,99 +119,15 @@ rules:
 		"0000000003_drop_table.down.sql": &fstest.MapFile{Data: []byte("-- restore\n")},
 	}
 
-	findings, err := lintPendingDestructive(fsys, []int64{1, 2}, "postgres")
+	findings, err := lintPendingDestructive(fsys, []int64{1, 2}, "postgres", "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 0,
 		qt.Commentf("DS103 is warning-grade and DS102 is disabled by config"))
 
-	findings, err = lintPendingDestructive(fsys, []int64{1, 2, 3}, "postgres")
+	findings, err = lintPendingDestructive(fsys, []int64{1, 2, 3}, "postgres", "")
 	c.Assert(err, qt.IsNil)
 	c.Assert(findings, qt.HasLen, 1)
 	c.Assert(findings[0].Rule, qt.Equals, "DS101")
-}
-
-func TestMigrateUpCommandHonorsLintConfigSeverityWithPostgres(t *testing.T) {
-	c := qt.New(t)
-	ctx := context.Background()
-	dbURL := requiredPostgresTestURL(t)
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	c.Assert(err, qt.IsNil)
-	defer dbschema.CloseAndWarn(conn)
-
-	suffix := fmt.Sprintf("%d", time.Now().UnixNano())
-	widenTable := "ptah_migrateup_widen_" + suffix
-	dropTable := "ptah_migrateup_drop_" + suffix
-	widenRevisions := "ptah_migrateup_widen_revisions_" + suffix
-	dropRevisions := "ptah_migrateup_drop_revisions_" + suffix
-	defer cleanupPostgresObjects(t, conn, widenTable, dropTable, widenRevisions, dropRevisions)
-
-	widenDir := t.TempDir()
-	writeMigrateUpFile(c, widenDir, lint.ConfigFileName, `rules:
-  DS103:
-    severity: warning
-`)
-	writeMigrateUpFile(c, widenDir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", widenTable))
-	writeMigrateUpFile(c, widenDir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", widenTable))
-	writeMigrateUpFile(c, widenDir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", widenTable))
-	writeMigrateUpFile(c, widenDir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", widenTable))
-
-	cmd := NewMigrateUpCommand()
-	resetMigrateUpCommandForTest(c, cmd)
-	t.Cleanup(func() { resetMigrateUpCommandForTest(c, cmd) })
-	var stdout, stderr bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{
-		"--db-url", dbURL,
-		"--migrations-dir", widenDir,
-		"--migrations-table", widenRevisions,
-	})
-
-	err = cmd.Execute()
-	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr.String()))
-
-	var maxLength int
-	err = conn.QueryRowContext(ctx, `
-		SELECT character_maximum_length
-		FROM information_schema.columns
-		WHERE table_schema = 'public' AND table_name = $1 AND column_name = 'email'
-	`, widenTable).Scan(&maxLength)
-	c.Assert(err, qt.IsNil)
-	c.Assert(maxLength, qt.Equals, 512)
-
-	dropDir := t.TempDir()
-	writeMigrateUpFile(c, dropDir, lint.ConfigFileName, `rules:
-  DS103:
-    severity: warning
-`)
-	writeMigrateUpFile(c, dropDir, "0000000001_init.up.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(255));\n", dropTable))
-	writeMigrateUpFile(c, dropDir, "0000000001_init.down.sql", fmt.Sprintf("DROP TABLE %s;\n", dropTable))
-	writeMigrateUpFile(c, dropDir, "0000000002_widen_email.up.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(512);\n", dropTable))
-	writeMigrateUpFile(c, dropDir, "0000000002_widen_email.down.sql", fmt.Sprintf("ALTER TABLE %s ALTER COLUMN email TYPE VARCHAR(255);\n", dropTable))
-	writeMigrateUpFile(c, dropDir, "0000000003_drop_table.up.sql", fmt.Sprintf("DROP TABLE %s;\n", dropTable))
-	writeMigrateUpFile(c, dropDir, "0000000003_drop_table.down.sql", fmt.Sprintf("CREATE TABLE %s (id SERIAL PRIMARY KEY, email VARCHAR(512));\n", dropTable))
-
-	cmd = NewMigrateUpCommand()
-	resetMigrateUpCommandForTest(c, cmd)
-	stdout.Reset()
-	stderr.Reset()
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{
-		"--db-url", dbURL,
-		"--migrations-dir", dropDir,
-		"--migrations-table", dropRevisions,
-	})
-
-	err = cmd.Execute()
-	c.Assert(err, qt.IsNotNil)
-	c.Assert(err.Error(), qt.Contains, "pending migrations contain destructive statements")
-	c.Assert(err.Error(), qt.Contains, "DS101")
-
-	var dropExists bool
-	err = conn.QueryRowContext(ctx, "SELECT to_regclass($1) IS NOT NULL", "public."+dropTable).Scan(&dropExists)
-	c.Assert(err, qt.IsNil)
-	c.Assert(dropExists, qt.IsFalse)
 }
 
 func TestMigrateUpCommandPreflightHookAbortPreventsMigration(t *testing.T) {

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -58,7 +58,8 @@ integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
 prepared files and findings together with a read-only source snapshot. Capture
 does not apply the lint policy automatically: embedders call `LoadConfigFS`
 and pass its `Dialect`, `DisabledRules`, and `Rules` through `lint.Options`.
-Configuration decoding rejects unknown keys and noncanonical rule selectors.
+Configuration decoding rejects unknown keys and noncanonical rule selectors,
+including selectors with leading or trailing whitespace.
 
 Finding contexts identify the exact statement and affected tables or columns;
 column subjects can also carry the parent table and declared data type. Each

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -55,7 +55,10 @@ through that filesystem.
 `migration/lint` provides the compact `LintFS` findings API and the richer
 `AnalyzeFS` API. `AnalyzeFS` captures each migration input once: SQL files,
 integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
-prepared files and findings together with a read-only source snapshot.
+prepared files and findings together with a read-only source snapshot. Capture
+does not apply the lint policy automatically: embedders call `LoadConfigFS`
+and pass its `Dialect`, `DisabledRules`, and `Rules` through `lint.Options`.
+Configuration decoding rejects unknown keys and noncanonical rule selectors.
 
 Finding contexts identify the exact statement and affected tables or columns;
 column subjects can also carry the parent table and declared data type. Each
@@ -137,6 +140,20 @@ cross-process publication lock and rejects concurrent use of one plan with
 `generator.ErrMigrationPlanInUse`. `GenerateMigration` remains the convenience
 composition of planning and publication and propagates its context through
 both phases.
+
+`migration/safety.RenderJSON` writes a `safety.Report` containing the highest
+risk, destructive verdict, and rendered statement assessments. The native
+`ptah migrations plan --report json` command writes that document to standard
+output. `GenerateMigrationOptions.ReportFormat: "json"` instead publishes one
+`.safety.json` file beside each generated migration pair.
+
+Candidate shadow failures preserve a typed
+`*generator.ShadowVerificationError` through `PlanMigration`,
+`GenerateMigration`, and command wrappers. Use `errors.As` to inspect
+`Result.Stage` and the structured `Result.Mismatches`; operational failures
+also expose their underlying error through `Unwrap`. A schema mismatch carries
+the complete, deterministically ordered mismatch list without a wrapped
+execution error.
 
 `migration/generator.VerifyRollbackFromShadow` requires the caller's open
 target `dbschema.DatabaseConnection`. It checks the target and shadow's live

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6117,14 +6117,13 @@ func (e *ShadowVerificationError) Unwrap() error
 package generator // import "github.com/stokaro/ptah/migration/generator"
 
 type ShadowVerificationResult struct {
-    Stage      string           `json:"stage"`
-    Success    bool             `json:"success"`
+    Stage string `json:"stage"`
+    // Mismatches contains every structural mismatch in deterministic category and object order.
     Mismatches []ShadowMismatch `json:"mismatches,omitempty"`
 }
-    ShadowVerificationResult is a structured shadow-database verification
-    outcome. Errors preserve the historical text form through
-    ShadowVerificationError.Error while exposing mismatches to callers that need
-    machine-readable diagnostics.
+    ShadowVerificationResult describes one failed shadow-database verification.
+    Errors preserve the text form through ShadowVerificationError.Error while
+    exposing mismatches to callers that need machine-readable diagnostics.
 
 
 ## github.com/stokaro/ptah/migration/importer
@@ -6440,7 +6439,8 @@ type Options struct {
 package lint // import "github.com/stokaro/ptah/migration/lint"
 
 type Rule struct {
-    // Code is the stable identifier (DS101, PG101, ...).
+    // Code is the stable identifier (DS101, PG101, ...). It starts with an
+    // uppercase ASCII letter and contains only uppercase ASCII letters and digits.
     Code string
     // Title is the short human-readable name of the hazard.
     Title string

--- a/docs/site/CONTENT_INVENTORY.md
+++ b/docs/site/CONTENT_INVENTORY.md
@@ -424,7 +424,7 @@ Versioned migrations
   versioned/apply                     howto
   versioned/rollback                  howto
   versioned/integrity-and-safety      howto (hash/validate/verify-sum, lint, destructive gate,
-                                      pre-migration checks, shadow verification)
+                                      pre-migration checks)
   versioned/maintain-history          howto (edit, rebase, rm, repair)
   versioned/import                    howto (golang-migrate/Goose/Flyway/Liquibase)
   versioned/checkpoints               howto (current workflows/checkpoints)

--- a/docs/site/src/content/docs/extend/components.md
+++ b/docs/site/src/content/docs/extend/components.md
@@ -354,7 +354,20 @@ if err != nil {
 }
 fmt.Printf("directory hash: %s\n", sum.DirHash)
 
-findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+lintConfig, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
+if err != nil {
+	return err
+}
+dialect := lintConfig.Dialect
+if dialect == "" {
+	dialect = "postgres"
+}
+
+findings, err := lint.LintFS(fsys, lint.Options{
+	Dialect:     dialect,
+	Disabled:    lintConfig.DisabledRules,
+	RuleConfigs: lintConfig.Rules,
+})
 if err != nil {
 	return err
 }
@@ -415,8 +428,9 @@ captured snapshot.
 
 A host tool can add its own analyzers to the same run without reimplementing
 the dialect-aware scanner. `Options.ExtraRules` appends per-run rules — the
-preferred shape, with no global state — and `lint.Register` installs a rule
-process-wide. Either way, the rule receives statements Ptah has already
+preferred shape, with no global state. `lint.Register` separately installs a
+rule process-wide and returns an error for invalid or duplicate rules; callers
+must handle that error during initialization. Either way, the rule receives statements Ptah has already
 prepared: `Statement.Words` is the comment-free token-word sequence the
 built-in rules scan, and `Statement.Canonical` is the uppercased display
 form. This example is compile-checked in `examples/reusable_components`:
@@ -435,6 +449,24 @@ findings, err = lint.LintFS(fsys, lint.Options{
 })
 ```
 
+For plugin-style process initialization, register once and propagate the
+validation error:
+
+```go
+err := lint.Register(lint.Rule{
+	Code:     "ORG102",
+	Title:    "organization policy",
+	Severity: lint.SeverityWarning,
+	CheckStatement: func(stmt *lint.Statement) (bool, string) {
+		return slices.Contains(stmt.Words, "UNLOGGED"), "UNLOGGED tables require platform review"
+	},
+})
+if err != nil {
+	return err
+}
+```
+
+Rule codes use uppercase ASCII letters and digits and start with a letter.
 Custom codes flow through reporting, `--disable`, inline `-- ptah:nolint`
 directives, and `.ptah-lint.yaml` per-rule severity and path excludes
 exactly like built-in codes; the configuration surface is documented in

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -143,6 +143,40 @@ Embedders that need cancellation while waiting for that lock use
 checked planning; malformed references, unresolved additions, and target
 index-namespace conflicts fail before SQL is returned.
 
+## Safety reports and shadow errors
+
+`migration/safety.RenderJSON` writes a `safety.Report` with the highest risk,
+the destructive verdict, and every rendered statement assessment. Use this
+API when an embedder needs the same machine-readable contract as
+`ptah migrations plan --report json`. Setting
+`generator.GenerateMigrationOptions.ReportFormat` to `json` instead publishes
+one `.safety.json` artifact beside each generated migration pair.
+
+When candidate shadow verification fails, `generator.PlanMigration` and
+`generator.GenerateMigration` preserve a typed
+`*generator.ShadowVerificationError`. Inspect it with `errors.As` instead of
+parsing `Error()`:
+
+```go
+var shadowErr *generator.ShadowVerificationError
+if errors.As(err, &shadowErr) {
+	stage := shadowErr.Result.Stage
+	mismatches := shadowErr.Result.Mismatches
+	// Report stage and mismatches to the caller.
+}
+```
+
+`Result.Stage` identifies the failed boundary, such as `connect`, `replay`,
+`schema-match`, `round-trip-down`, or `round-trip-up`. A schema-match result
+contains every mismatch in deterministic category and object order, not only
+the first.
+Each `ShadowMismatch` has a stable `Kind`, a human-readable `Message`, and the
+available object, table, column, constraint, or changed-property fields.
+Operational failures also preserve their underlying error through `Unwrap`;
+a structural schema mismatch has no wrapped error. A successful verification
+returns `nil` and continues planning; `ShadowVerificationResult` is only the
+structured failure payload carried by `ShadowVerificationError`.
+
 ## Error contracts
 
 Public failures should use `core/ptaherr` when callers can reasonably branch on
@@ -154,6 +188,8 @@ the error:
   `ptaherr.ErrUnsupportedDialect`;
 - invalid schema diffs rejected during planning should support `errors.Is` with
   `ptaherr.ErrInvalidSchemaDiff`;
+- shadow candidate verification should support `errors.As` with
+  `*generator.ShadowVerificationError`;
 - command wrappers should preserve typed errors instead of replacing them with
   string-only errors.
 

--- a/docs/site/src/content/docs/versioned/generate.md
+++ b/docs/site/src/content/docs/versioned/generate.md
@@ -65,6 +65,24 @@ Generated 1 migration statements.
 Because the database is empty, the difference is the whole schema. On a
 migrated database the plan contains only the delta.
 
+### Send the plan verdict to CI
+
+Use `--report json` when automation needs the safety verdict:
+
+```bash
+ptah migrations plan \
+  --schema-file ./schema.sql \
+  --db-url "sqlite://app.db" \
+  --report json
+```
+
+This form writes one `safety.Report` JSON document to standard output. Its
+`highest` field carries the highest operational risk, `destructive` is the
+blocking destructive verdict, and `assessments` lists every rendered
+statement assessment. It does not print migration SQL or write migration
+files. Run the default text plan separately when reviewers also need the SQL,
+as the [CI](../../testing/ci/) workflow does.
+
 ## Generate the migration files
 
 ```bash
@@ -86,6 +104,13 @@ DOWN: .../migrations/1785255952_init.down.sql
 The version prefix is a timestamp; `--name` becomes the description in the
 file name. Ptah writes both directions — the generated down file reverses the
 up file:
+
+Pass `--report json` to publish a machine-readable safety artifact with each
+generated pair. `generate` writes
+`<version>_<name>.safety.json` beside the up and down files and prints its path
+as `REPORT: ...`; unlike `plan --report json`, it does not write the JSON to
+standard output. HTML reports follow the same rule with a `.safety.html`
+suffix.
 
 ```sql
 -- Migration rollback
@@ -236,11 +261,10 @@ exit `2`:
 error: destructive migration statements require AllowDestructive
 ```
 
-Review the plan, then rerun with `--allow-destructive` to accept it. Use
-`--report json` when CI needs the safety classification as structured data
-instead of text — the GitHub Action's destructive-change check run is driven
-by exactly that report ([CI](../../testing/ci/)). The apply-time gate on
-`ptah migrations up` is separate — see
+Review the plan, then rerun with `--allow-destructive` to accept it. Use the
+[structured plan report](#send-the-plan-verdict-to-ci) for CI decisions, or
+the generated sibling report when an audit artifact must stay with the
+migration pair. The apply-time gate on `ptah migrations up` is separate — see
 [Integrity and safety](../integrity-and-safety/).
 
 **Conflicting sources stop generation.** When two schema sources disagree

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -211,8 +211,9 @@ artifact, and `--attach` stores the canonical report next to it — see
 ### Configure rules with `.ptah-lint.yaml`
 
 Commit a `.ptah-lint.yaml` next to the migration files to make lint policy
-part of the reviewed migration directory. Without an explicit `--config`
-path, Ptah loads `<dir>/.ptah-lint.yaml` when present:
+part of the reviewed migration directory. `ptah migrations lint --config`
+selects an explicit lint policy; without that flag, lint loads
+`<dir>/.ptah-lint.yaml` when present:
 
 ```yaml
 dialect: postgres
@@ -230,7 +231,8 @@ rules:
 
 - `dialect` sets the default lint dialect; `--dialect` overrides it.
 - `disabled-rules` lists rule codes (`DS101`) or family prefixes (`MY`) to
-  skip entirely; entries merge with `--disable` flags.
+  skip entirely; entries merge with `--disable` flags. Selectors and custom
+  rule codes use uppercase ASCII letters and digits and start with a letter.
 - `rules` keys name an exact code or a family prefix; the most specific key
   wins, so a `DS102` entry beats a `DS` entry.
 - `severity` accepts `warning` or `error` and replaces the rule's default
@@ -238,9 +240,16 @@ rules:
   destructive gate below evaluate. Any other value fails config parsing
   (exit `2`).
 - `exclude` lists slash-separated path globs (`**` crosses directory
-  levels) where the rule is skipped, matched against each migration file's
-  path — "DS102 is acceptable under `legacy/`" without disabling the rule
-  everywhere.
+  levels) where the rule is skipped. Prefer paths relative to the migration
+  directory, such as `legacy/**`; these match regardless of how `--dir` was
+  spelled. A directory-prefixed pattern such as `migrations/legacy/**`
+  matches only when the command path has that prefix, for example
+  `--dir migrations`, and need not match an absolute `--dir` path.
+
+Configuration decoding is strict. Unknown keys, misspelled keys such as
+`severty`, lowercase selectors, selectors that match no registered rule,
+unsupported severities, and multiple YAML documents fail before linting or
+migration execution instead of silently weakening policy.
 
 Precedence: a rule listed in `disabled-rules` never runs, regardless of its
 `rules` entry; then `exclude` skips the matching files; then `severity`
@@ -287,9 +296,15 @@ error: error running migrations: pending migrations contain destructive statemen
 Use `--allow-destructive` only after the plan has been reviewed and the
 rollback path is understood.
 
-The apply-time gate loads the same `.ptah-lint.yaml` as
-`ptah migrations lint` and blocks on error-severity `DS` data-safety
-findings. That makes the escape hatch proportional: a rule downgraded with
+The apply-time gate always loads the conventional
+`<migrations-dir>/.ptah-lint.yaml` and blocks on error-severity `DS`
+data-safety findings. The `--config` flag on `ptah migrations up` selects
+`ptah.yaml`; it does not select a lint policy. This distinction prevents a
+project configuration path from silently replacing the policy shipped with
+the migration directory.
+
+The gate otherwise uses the same rule configuration and path matching as
+`ptah migrations lint`. That makes the escape hatch proportional: a rule downgraded with
 `severity: warning`, listed under `disabled-rules`, or excluded for a path
 stops blocking exactly that reviewed pattern — a widening
 `ALTER COLUMN ... TYPE` under `rules: {DS103: {severity: warning}}` applies
@@ -297,6 +312,10 @@ without `--allow-destructive` — while a `DROP TABLE` in another pending
 file of the same batch still aborts the apply. `--allow-destructive`
 remains the all-or-nothing per-run override rather than the only way past
 a single warning-grade finding.
+
+Lint-policy severities are `warning` and `error`. Generated safety reports use
+the operational vocabulary `safe`, `warning`, and `destructive`; an `error`
+lint assessment and a `destructive` safety assessment are both blocking.
 
 Know the limits of this gate: the policy file is not tamper-evident.
 

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -247,7 +247,7 @@ rules:
   `--dir migrations`, and need not match an absolute `--dir` path.
 
 Configuration decoding is strict. Unknown keys, misspelled keys such as
-`severty`, lowercase selectors, selectors that match no registered rule,
+`severty`, lowercase or whitespace-padded selectors, selectors that match no registered rule,
 unsupported severities, and multiple YAML documents fail before linting or
 migration execution instead of silently weakening policy.
 

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -87,8 +87,13 @@ The plan records the migration-directory snapshot used for planning.
 `WriteFiles` acquires the shared cross-process directory lock and rejects the
 plan if migration SQL or integrity metadata changed before publication. It
 never renumbers and publishes a plan derived from stale history.
+
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.
+Set `ReportFormat` to `json` or `html` to publish one
+`<version>_<name>.safety.<format>` file beside each migration pair. The
+resulting `MigrationFilePair.ReportFile` names the published artifact.
+
 Use `WriteFilesContext` when lock acquisition must honor cancellation or an
 operation deadline. Callers can branch on
 `generator.ErrMigrationDirectoryChanged` when another process changed the
@@ -132,6 +137,23 @@ shadow check failed: missing column users.email
 
 Ptah also runs an `up -> down -> up` round-trip on the candidate migration and
 aborts if either direction fails.
+
+Shadow failures preserve structured diagnostics. Use `errors.As` rather than
+parsing the display message:
+
+```go
+var shadowErr *generator.ShadowVerificationError
+if errors.As(err, &shadowErr) {
+    fmt.Printf("shadow stage: %s\n", shadowErr.Result.Stage)
+    for _, mismatch := range shadowErr.Result.Mismatches {
+        fmt.Printf("%s: %s\n", mismatch.Kind, mismatch.Message)
+    }
+}
+```
+
+Operational failures also unwrap to the underlying database or migration
+error. Structural schema mismatches carry the complete, deterministically
+ordered mismatch list without an underlying error.
 
 ### File Naming Convention
 

--- a/migration/generator/index_refs_internal_test.go
+++ b/migration/generator/index_refs_internal_test.go
@@ -326,5 +326,11 @@ func TestCollectShadowMismatches_ReportsQualifiedIndex(t *testing.T) {
 			Object:  "orders.idx_shared",
 			Message: "missing index orders.idx_shared",
 		},
+		{
+			Kind:    "missing_index",
+			Table:   "users",
+			Object:  "users.idx_shared",
+			Message: "missing index users.idx_shared",
+		},
 	})
 }

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -7,7 +7,6 @@ import (
 	"maps"
 	"os"
 	"regexp"
-	"sort"
 	"strings"
 
 	"github.com/stokaro/ptah/config"
@@ -19,18 +18,17 @@ import (
 	"github.com/stokaro/ptah/migration/internal/shadowdb"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
-	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
 
 var missingColumnErrorRe = regexp.MustCompile(`column "([^"]+)" of relation "([^"]+)" does not exist`)
 
-// ShadowVerificationResult is a structured shadow-database verification
-// outcome. Errors preserve the historical text form through
+// ShadowVerificationResult describes one failed shadow-database verification.
+// Errors preserve the text form through
 // ShadowVerificationError.Error while exposing mismatches to callers that need
 // machine-readable diagnostics.
 type ShadowVerificationResult struct {
-	Stage      string           `json:"stage"`
-	Success    bool             `json:"success"`
+	Stage string `json:"stage"`
+	// Mismatches contains every structural mismatch in deterministic category and object order.
 	Mismatches []ShadowMismatch `json:"mismatches,omitempty"`
 }
 
@@ -69,8 +67,7 @@ func newShadowVerificationError(stage, kind, message string, err error) *ShadowV
 	}
 	return &ShadowVerificationError{
 		Result: ShadowVerificationResult{
-			Stage:   stage,
-			Success: false,
+			Stage: stage,
 			Mismatches: []ShadowMismatch{{
 				Kind:    kind,
 				Message: message,
@@ -279,167 +276,6 @@ func assertShadowSchemaMatches(
 	}
 	return &ShadowVerificationError{Result: ShadowVerificationResult{
 		Stage:      "schema-match",
-		Success:    false,
 		Mismatches: collectShadowMismatches(diff),
 	}}
-}
-
-func describeShadowDiff(diff *types.SchemaDiff) string {
-	mismatches := collectShadowMismatches(diff)
-	if len(mismatches) > 0 {
-		return mismatches[0].Message
-	}
-	return "schema differs"
-}
-
-// collectModifiedTableMismatch returns the first structural mismatch for a
-// modified table (a missing/extra column or constraint, or a column change), or
-// nil when the table matches. It is split out of collectShadowMismatches to
-// keep that dispatcher's cyclomatic complexity manageable.
-func collectModifiedTableMismatch(table types.TableDiff) []ShadowMismatch {
-	for _, columnName := range sortedStrings(table.ColumnsAdded) {
-		message := fmt.Sprintf("missing column %s.%s", table.TableName, columnName)
-		return []ShadowMismatch{{Kind: "missing_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message}}
-	}
-	for _, constraintName := range sortedStrings(table.ConstraintsAdded) {
-		message := fmt.Sprintf("missing constraint %s.%s", table.TableName, constraintName)
-		return []ShadowMismatch{{Kind: "missing_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message}}
-	}
-	for _, column := range sortedColumnDiffs(table.ColumnsModified) {
-		message := fmt.Sprintf("column mismatch %s.%s: %s", table.TableName, column.ColumnName, describeChanges(column.Changes))
-		return []ShadowMismatch{{Kind: "column_mismatch", Table: table.TableName, Column: column.ColumnName, Object: table.TableName + "." + column.ColumnName, Changes: column.Changes, Message: message}}
-	}
-	for _, columnName := range sortedStrings(table.ColumnsRemoved) {
-		message := fmt.Sprintf("extra column %s.%s", table.TableName, columnName)
-		return []ShadowMismatch{{Kind: "extra_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message}}
-	}
-	for _, constraintName := range sortedStrings(table.ConstraintsRemoved) {
-		message := fmt.Sprintf("extra constraint %s.%s", table.TableName, constraintName)
-		return []ShadowMismatch{{Kind: "extra_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message}}
-	}
-	return nil
-}
-
-func collectShadowMismatches(diff *types.SchemaDiff) []ShadowMismatch {
-	if diff == nil {
-		return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
-	}
-
-	for _, tableName := range sortedStrings(diff.TablesAdded) {
-		return []ShadowMismatch{{Kind: "missing_table", Table: tableName, Object: tableName, Message: "missing table " + tableName}}
-	}
-	for _, table := range sortedTableDiffs(diff.TablesModified) {
-		if mismatch := collectModifiedTableMismatch(table); mismatch != nil {
-			return mismatch
-		}
-	}
-	for _, enumName := range sortedStrings(diff.EnumsAdded) {
-		return []ShadowMismatch{{Kind: "missing_enum", Object: enumName, Message: "missing enum " + enumName}}
-	}
-	for _, enum := range sortedEnumDiffs(diff.EnumsModified) {
-		for _, value := range sortedStrings(enum.ValuesAdded) {
-			message := fmt.Sprintf("missing enum value %s.%s", enum.EnumName, value)
-			return []ShadowMismatch{{Kind: "missing_enum_value", Object: enum.EnumName + "." + value, Message: message}}
-		}
-		for _, value := range sortedStrings(enum.ValuesRemoved) {
-			message := fmt.Sprintf("extra enum value %s.%s", enum.EnumName, value)
-			return []ShadowMismatch{{Kind: "extra_enum_value", Object: enum.EnumName + "." + value, Message: message}}
-		}
-	}
-	indexAdditions := sortedIndexRefs(diff.IndexAdditions())
-	if len(indexAdditions) > 0 {
-		ref := indexAdditions[0]
-		object := ref.Name
-		if ref.TableName != "" {
-			object = ref.TableName + "." + ref.Name
-		}
-		return []ShadowMismatch{{
-			Kind:    "missing_index",
-			Table:   ref.TableName,
-			Object:  object,
-			Message: "missing index " + object,
-		}}
-	}
-	for _, extensionName := range sortedStrings(diff.ExtensionsAdded) {
-		return []ShadowMismatch{{Kind: "missing_extension", Object: extensionName, Message: "missing extension " + extensionName}}
-	}
-	for _, functionName := range sortedStrings(diff.FunctionsAdded) {
-		return []ShadowMismatch{{Kind: "missing_function", Object: functionName, Message: "missing function " + functionName}}
-	}
-	for _, sequenceName := range sortedStrings(diff.SequencesAdded) {
-		return []ShadowMismatch{{Kind: "missing_sequence", Object: sequenceName, Message: "missing sequence " + sequenceName}}
-	}
-	for _, policyName := range sortedStrings(diff.RLSPoliciesAdded) {
-		return []ShadowMismatch{{Kind: "missing_rls_policy", Object: policyName, Message: "missing RLS policy " + policyName}}
-	}
-	for _, tableName := range sortedStrings(diff.RLSEnabledTablesAdded) {
-		return []ShadowMismatch{{Kind: "missing_rls_enablement", Table: tableName, Object: tableName, Message: "missing RLS enablement " + tableName}}
-	}
-	for _, roleName := range sortedStrings(diff.RolesAdded) {
-		return []ShadowMismatch{{Kind: "missing_role", Object: roleName, Message: "missing role " + roleName}}
-	}
-	for _, constraintName := range sortedStrings(diff.ConstraintsAdded) {
-		return []ShadowMismatch{{Kind: "missing_constraint", Constraint: constraintName, Object: constraintName, Message: "missing constraint " + constraintName}}
-	}
-
-	return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
-}
-
-func sortedIndexRefs(refs []types.IndexRef) []types.IndexRef {
-	sorted := append([]types.IndexRef(nil), refs...)
-	sort.Slice(sorted, func(i, j int) bool {
-		if sorted[i].TableName != sorted[j].TableName {
-			return sorted[i].TableName < sorted[j].TableName
-		}
-		return sorted[i].Name < sorted[j].Name
-	})
-	return sorted
-}
-
-func sortedStrings(values []string) []string {
-	out := append([]string(nil), values...)
-	sort.Strings(out)
-	return out
-}
-
-func sortedTableDiffs(values []types.TableDiff) []types.TableDiff {
-	out := append([]types.TableDiff(nil), values...)
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].TableName < out[j].TableName
-	})
-	return out
-}
-
-func sortedColumnDiffs(values []types.ColumnDiff) []types.ColumnDiff {
-	out := append([]types.ColumnDiff(nil), values...)
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].ColumnName < out[j].ColumnName
-	})
-	return out
-}
-
-func sortedEnumDiffs(values []types.EnumDiff) []types.EnumDiff {
-	out := append([]types.EnumDiff(nil), values...)
-	sort.Slice(out, func(i, j int) bool {
-		return out[i].EnumName < out[j].EnumName
-	})
-	return out
-}
-
-func describeChanges(changes map[string]string) string {
-	if len(changes) == 0 {
-		return "unknown change"
-	}
-
-	keys := make([]string, 0, len(changes))
-	for key := range changes {
-		keys = append(keys, key)
-	}
-	sort.Strings(keys)
-
-	parts := make([]string, 0, len(keys))
-	for _, key := range keys {
-		parts = append(parts, key+" "+changes[key])
-	}
-	return strings.Join(parts, ", ")
 }

--- a/migration/generator/shadow_external_test.go
+++ b/migration/generator/shadow_external_test.go
@@ -1,0 +1,95 @@
+package generator_test
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/generator"
+)
+
+func TestGenerateMigration_ShadowSchemaMismatchReturnsStructuredError(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetURL := "sqlite://" + filepath.Join(dir, "target.db")
+	shadowURL := "sqlite://" + filepath.Join(dir, "shadow.db")
+
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	c.Assert(err, qt.IsNil)
+	dbschema.CloseAndWarn(target)
+
+	modelsDir := filepath.Join(dir, "models")
+	c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "models.go"), []byte(`package models
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int
+	//ptah:schema:field name="name" type="TEXT"
+	Name string
+	//ptah:schema:field name="email" type="TEXT"
+	Email string
+}
+`), 0o600), qt.IsNil)
+
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY, legacy TEXT);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	files, err := generator.GenerateMigration(t.Context(), generator.GenerateMigrationOptions{
+		GoEntitiesDir:     modelsDir,
+		DatabaseURL:       targetURL,
+		MigrationName:     "add_email",
+		OutputDir:         migrationsDir,
+		ShadowDatabaseURL: shadowURL,
+	})
+
+	c.Assert(files, qt.IsNil)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Error(), qt.Equals, "shadow check failed: missing column users.name")
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "schema-match")
+	c.Assert(shadowErr.Result.Mismatches, qt.DeepEquals, []generator.ShadowMismatch{
+		{
+			Kind:    "missing_column",
+			Object:  "users.name",
+			Table:   "users",
+			Column:  "name",
+			Message: "missing column users.name",
+		},
+		{
+			Kind:    "extra_column",
+			Object:  "users.legacy",
+			Table:   "users",
+			Column:  "legacy",
+			Message: "extra column users.legacy",
+		},
+	})
+	c.Assert(shadowErr.Err, qt.IsNil)
+	c.Assert(errors.Unwrap(shadowErr), qt.IsNil)
+
+	rawResult, err := json.Marshal(shadowErr.Result)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(rawResult), qt.Equals, `{"stage":"schema-match","mismatches":[{"kind":"missing_column","object":"users.name","table":"users","column":"name","message":"missing column users.name"},{"kind":"extra_column","object":"users.legacy","table":"users","column":"legacy","message":"extra column users.legacy"}]}`)
+
+	migrationFiles, err := filepath.Glob(filepath.Join(migrationsDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrationFiles, qt.HasLen, 2)
+}

--- a/migration/generator/shadow_internal_test.go
+++ b/migration/generator/shadow_internal_test.go
@@ -1,5 +1,10 @@
 package generator
 
+// White-box testing required: these tests exercise shadow replay stages,
+// deterministic mismatch collection, and migration-version helpers that are
+// not observable independently through the exported generation API. Public
+// propagation is covered separately in shadow_external_test.go.
+
 import (
 	"context"
 	"os"
@@ -28,13 +33,24 @@ func TestDescribeShadowDiffMissingColumn(t *testing.T) {
 
 	c.Assert(describeShadowDiff(diff), qt.Equals, "missing column users.email")
 	mismatches := collectShadowMismatches(diff)
-	c.Assert(mismatches, qt.HasLen, 1)
-	c.Assert(mismatches[0].Kind, qt.Equals, "missing_column")
-	c.Assert(mismatches[0].Table, qt.Equals, "users")
-	c.Assert(mismatches[0].Column, qt.Equals, "email")
+	c.Assert(mismatches, qt.DeepEquals, []ShadowMismatch{
+		{
+			Kind:    "missing_column",
+			Object:  "users.email",
+			Table:   "users",
+			Column:  "email",
+			Message: "missing column users.email",
+		},
+		{
+			Kind:    "missing_column",
+			Object:  "users.name",
+			Table:   "users",
+			Column:  "name",
+			Message: "missing column users.name",
+		},
+	})
 	c.Assert((&ShadowVerificationError{Result: ShadowVerificationResult{
 		Stage:      "schema-match",
-		Success:    false,
 		Mismatches: mismatches,
 	}}).Error(), qt.Equals, "shadow check failed: missing column users.email")
 }
@@ -48,6 +64,147 @@ func TestDescribeChangesIsDeterministic(t *testing.T) {
 	})
 
 	c.Assert(got, qt.Equals, "nullable true -> false, type text -> varchar")
+}
+
+func TestCollectShadowMismatchesCoversEverySchemaDiffCategory(t *testing.T) {
+	c := qt.New(t)
+	changes := map[string]string{"definition": "old -> new"}
+	diff := &types.SchemaDiff{
+		TablesAdded:   []string{"missing_table"},
+		TablesRemoved: []string{"extra_table"},
+		TablesModified: []types.TableDiff{{
+			TableName:          "changed_table",
+			ColumnsAdded:       []string{"missing_column"},
+			ColumnsRemoved:     []string{"extra_column"},
+			ColumnsModified:    []types.ColumnDiff{{ColumnName: "changed_column", Changes: changes}},
+			ConstraintsAdded:   []string{"missing_table_constraint"},
+			ConstraintsRemoved: []string{"extra_table_constraint"},
+		}},
+		EnumsAdded:   []string{"missing_enum"},
+		EnumsRemoved: []string{"extra_enum"},
+		EnumsModified: []types.EnumDiff{{
+			EnumName:      "changed_enum",
+			ValuesAdded:   []string{"missing_value"},
+			ValuesRemoved: []string{"extra_value"},
+		}},
+		IndexesAdded:              []types.IndexRef{{TableName: "users", Name: "missing_index"}},
+		IndexesRemoved:            []types.IndexRef{{TableName: "users", Name: "extra_index"}},
+		ExtensionsAdded:           []string{"missing_extension"},
+		ExtensionsRemoved:         []string{"extra_extension"},
+		FunctionsAdded:            []string{"missing_function"},
+		FunctionsRemoved:          []string{"extra_function"},
+		FunctionsModified:         []types.FunctionDiff{{FunctionName: "changed_function", Changes: changes}},
+		SequencesAdded:            []string{"missing_sequence"},
+		SequencesRemoved:          []string{"extra_sequence"},
+		SequencesModified:         []types.SequenceDiff{{SequenceName: "changed_sequence", Changes: changes}},
+		DomainsAdded:              []string{"missing_domain"},
+		DomainsRemoved:            []string{"extra_domain"},
+		DomainsModified:           []types.DomainDiff{{DomainName: "changed_domain", Changes: changes}},
+		CompositeTypesAdded:       []string{"missing_composite"},
+		CompositeTypesRemoved:     []string{"extra_composite"},
+		CompositeTypesModified:    []types.CompositeTypeDiff{{TypeName: "changed_composite", Changes: changes}},
+		RangesAdded:               []string{"missing_range"},
+		RangesRemoved:             []string{"extra_range"},
+		ViewsAdded:                []string{"missing_view"},
+		ViewsRemoved:              []string{"extra_view"},
+		ViewsModified:             []types.ViewDiff{{ViewName: "changed_view", Changes: changes}},
+		MaterializedViewsAdded:    []string{"missing_materialized_view"},
+		MaterializedViewsRemoved:  []string{"extra_materialized_view"},
+		MaterializedViewsModified: []types.MaterializedViewDiff{{ViewName: "changed_materialized_view", Changes: changes}},
+		TriggersAdded:             []types.TriggerRef{{TableName: "users", TriggerName: "missing_trigger"}},
+		TriggersRemoved:           []types.TriggerRef{{TableName: "users", TriggerName: "extra_trigger"}},
+		TriggersModified:          []types.TriggerDiff{{TableName: "users", TriggerName: "changed_trigger", Changes: changes}},
+		RLSPoliciesAdded:          []string{"missing_policy"},
+		RLSPoliciesRemoved:        []types.RLSPolicyRef{{TableName: "users", PolicyName: "extra_policy"}},
+		RLSPoliciesModified:       []types.RLSPolicyDiff{{TableName: "users", PolicyName: "changed_policy", Changes: changes}},
+		RLSEnabledTablesAdded:     []string{"missing_rls_table"},
+		RLSEnabledTablesRemoved:   []string{"extra_rls_table"},
+		RolesAdded:                []string{"missing_role"},
+		RolesRemoved:              []string{"extra_role"},
+		RolesModified:             []types.RoleDiff{{RoleName: "changed_role", Changes: changes}},
+		GrantsAdded:               []types.GrantRef{{Role: "app", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"}},
+		GrantsRemoved:             []types.GrantRef{{Role: "app", Privilege: "INSERT", ObjectType: "TABLE", ObjectName: "users"}},
+		GrantOptionsAdded:         []types.GrantRef{{Role: "app", Privilege: "UPDATE", ObjectType: "TABLE", ObjectName: "users"}},
+		GrantOptionsRevoked:       []types.GrantRef{{Role: "app", Privilege: "DELETE", ObjectType: "TABLE", ObjectName: "users"}},
+		ConstraintsAdded:          []string{"missing_global_constraint"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+			Name:      "missing_global_constraint",
+			TableName: "accounts",
+		}},
+		ConstraintsRemoved: []string{"extra_global_constraint"},
+		ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+			Name:      "extra_global_constraint",
+			TableName: "accounts",
+		}},
+	}
+
+	mismatches := collectShadowMismatches(diff)
+	c.Assert(mismatchKinds(mismatches), qt.DeepEquals, []string{
+		"missing_table",
+		"extra_table",
+		"missing_column",
+		"missing_constraint",
+		"column_mismatch",
+		"extra_column",
+		"extra_constraint",
+		"missing_enum",
+		"extra_enum",
+		"missing_enum_value",
+		"extra_enum_value",
+		"missing_index",
+		"extra_index",
+		"missing_extension",
+		"extra_extension",
+		"missing_function",
+		"extra_function",
+		"function_mismatch",
+		"missing_sequence",
+		"extra_sequence",
+		"sequence_mismatch",
+		"missing_domain",
+		"extra_domain",
+		"domain_mismatch",
+		"missing_composite_type",
+		"extra_composite_type",
+		"composite_type_mismatch",
+		"missing_range",
+		"extra_range",
+		"missing_view",
+		"extra_view",
+		"view_mismatch",
+		"missing_materialized_view",
+		"extra_materialized_view",
+		"materialized_view_mismatch",
+		"missing_trigger",
+		"extra_trigger",
+		"trigger_mismatch",
+		"missing_rls_policy",
+		"extra_rls_policy",
+		"rls_policy_mismatch",
+		"missing_rls_enablement",
+		"extra_rls_enablement",
+		"missing_role",
+		"extra_role",
+		"role_mismatch",
+		"missing_grant",
+		"extra_grant",
+		"missing_grant_option",
+		"extra_grant_option",
+		"missing_constraint",
+		"extra_constraint",
+	})
+	c.Assert(mismatches[len(mismatches)-2].Object, qt.Equals, "accounts.missing_global_constraint")
+	c.Assert(mismatches[len(mismatches)-2].Table, qt.Equals, "accounts")
+	c.Assert(mismatches[len(mismatches)-1].Object, qt.Equals, "accounts.extra_global_constraint")
+	c.Assert(mismatches[len(mismatches)-1].Table, qt.Equals, "accounts")
+}
+
+func mismatchKinds(mismatches []ShadowMismatch) []string {
+	kinds := make([]string, len(mismatches))
+	for index, mismatch := range mismatches {
+		kinds[index] = mismatch.Kind
+	}
+	return kinds
 }
 
 func TestNextAvailableMigrationVersionChecksUpAndDownFiles(t *testing.T) {
@@ -82,7 +239,6 @@ func TestVerifyShadowMigrationConnectErrorIsStructured(t *testing.T) {
 	var shadowErr *ShadowVerificationError
 	c.Assert(err, qt.ErrorAs, &shadowErr)
 	c.Assert(shadowErr.Result.Stage, qt.Equals, "connect")
-	c.Assert(shadowErr.Result.Success, qt.IsFalse)
 	c.Assert(shadowErr.Result.Mismatches, qt.HasLen, 1)
 	c.Assert(shadowErr.Result.Mismatches[0].Kind, qt.Equals, "connect_error")
 	c.Assert(shadowErr.Err, qt.IsNotNil)

--- a/migration/generator/shadow_mismatch.go
+++ b/migration/generator/shadow_mismatch.go
@@ -1,0 +1,460 @@
+package generator
+
+import (
+	"fmt"
+	"maps"
+	"sort"
+	"strings"
+
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func describeShadowDiff(diff *types.SchemaDiff) string {
+	mismatches := collectShadowMismatches(diff)
+	if len(mismatches) > 0 {
+		return mismatches[0].Message
+	}
+	return "schema differs"
+}
+
+func collectModifiedTableMismatches(table types.TableDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, columnName := range sortedStrings(table.ColumnsAdded) {
+		message := fmt.Sprintf("missing column %s.%s", table.TableName, columnName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "missing_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message})
+	}
+	for _, constraintName := range sortedStrings(table.ConstraintsAdded) {
+		message := fmt.Sprintf("missing constraint %s.%s", table.TableName, constraintName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "missing_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message})
+	}
+	for _, column := range sortedColumnDiffs(table.ColumnsModified) {
+		message := fmt.Sprintf("column mismatch %s.%s: %s", table.TableName, column.ColumnName, describeChanges(column.Changes))
+		mismatches = append(mismatches, ShadowMismatch{Kind: "column_mismatch", Table: table.TableName, Column: column.ColumnName, Object: table.TableName + "." + column.ColumnName, Changes: maps.Clone(column.Changes), Message: message})
+	}
+	for _, columnName := range sortedStrings(table.ColumnsRemoved) {
+		message := fmt.Sprintf("extra column %s.%s", table.TableName, columnName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_column", Table: table.TableName, Column: columnName, Object: table.TableName + "." + columnName, Message: message})
+	}
+	for _, constraintName := range sortedStrings(table.ConstraintsRemoved) {
+		message := fmt.Sprintf("extra constraint %s.%s", table.TableName, constraintName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_constraint", Table: table.TableName, Constraint: constraintName, Object: table.TableName + "." + constraintName, Message: message})
+	}
+	return mismatches
+}
+
+func collectShadowMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	if diff == nil {
+		return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
+	}
+
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, collectTableMismatches(diff)...)
+	mismatches = append(mismatches, collectEnumAndIndexMismatches(diff)...)
+	mismatches = append(mismatches, collectSchemaObjectMismatches(diff)...)
+	mismatches = append(mismatches, collectAccessControlMismatches(diff)...)
+	mismatches = append(mismatches, collectTopLevelConstraintMismatches(diff)...)
+	if len(mismatches) == 0 {
+		return []ShadowMismatch{{Kind: "schema", Message: "schema differs"}}
+	}
+	return mismatches
+}
+
+func collectTableMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, tableMismatches(diff.TablesAdded, "missing_table", "missing table")...)
+	mismatches = append(mismatches, tableMismatches(diff.TablesRemoved, "extra_table", "extra table")...)
+	for _, table := range sortedTableDiffs(diff.TablesModified) {
+		mismatches = append(mismatches, collectModifiedTableMismatches(table)...)
+	}
+	return mismatches
+}
+
+func collectSchemaObjectMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, namedMismatches(diff.ExtensionsAdded, "missing_extension", "missing extension")...)
+	mismatches = append(mismatches, namedMismatches(diff.ExtensionsRemoved, "extra_extension", "extra extension")...)
+	mismatches = append(mismatches, namedMismatches(diff.FunctionsAdded, "missing_function", "missing function")...)
+	mismatches = append(mismatches, namedMismatches(diff.FunctionsRemoved, "extra_function", "extra function")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.FunctionsModified,
+		"function_mismatch",
+		"function",
+		func(value types.FunctionDiff) string { return value.FunctionName },
+		func(value types.FunctionDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, namedMismatches(diff.SequencesAdded, "missing_sequence", "missing sequence")...)
+	mismatches = append(mismatches, namedMismatches(diff.SequencesRemoved, "extra_sequence", "extra sequence")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.SequencesModified,
+		"sequence_mismatch",
+		"sequence",
+		func(value types.SequenceDiff) string { return value.SequenceName },
+		func(value types.SequenceDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, collectUserTypeMismatches(diff)...)
+	mismatches = append(mismatches, collectViewMismatches(diff)...)
+	mismatches = append(mismatches, collectTriggerMismatches(diff)...)
+	return mismatches
+}
+
+func collectUserTypeMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, namedMismatches(diff.DomainsAdded, "missing_domain", "missing domain")...)
+	mismatches = append(mismatches, namedMismatches(diff.DomainsRemoved, "extra_domain", "extra domain")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.DomainsModified,
+		"domain_mismatch",
+		"domain",
+		func(value types.DomainDiff) string { return value.DomainName },
+		func(value types.DomainDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, namedMismatches(diff.CompositeTypesAdded, "missing_composite_type", "missing composite type")...)
+	mismatches = append(mismatches, namedMismatches(diff.CompositeTypesRemoved, "extra_composite_type", "extra composite type")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.CompositeTypesModified,
+		"composite_type_mismatch",
+		"composite type",
+		func(value types.CompositeTypeDiff) string { return value.TypeName },
+		func(value types.CompositeTypeDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, namedMismatches(diff.RangesAdded, "missing_range", "missing range")...)
+	mismatches = append(mismatches, namedMismatches(diff.RangesRemoved, "extra_range", "extra range")...)
+	return mismatches
+}
+
+func collectViewMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, namedMismatches(diff.ViewsAdded, "missing_view", "missing view")...)
+	mismatches = append(mismatches, namedMismatches(diff.ViewsRemoved, "extra_view", "extra view")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.ViewsModified,
+		"view_mismatch",
+		"view",
+		func(value types.ViewDiff) string { return value.ViewName },
+		func(value types.ViewDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, namedMismatches(diff.MaterializedViewsAdded, "missing_materialized_view", "missing materialized view")...)
+	mismatches = append(mismatches, namedMismatches(diff.MaterializedViewsRemoved, "extra_materialized_view", "extra materialized view")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.MaterializedViewsModified,
+		"materialized_view_mismatch",
+		"materialized view",
+		func(value types.MaterializedViewDiff) string { return value.ViewName },
+		func(value types.MaterializedViewDiff) map[string]string { return value.Changes },
+	)...)
+	return mismatches
+}
+
+func collectTriggerMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, ref := range sortedTriggerRefs(diff.TriggersAdded) {
+		object := qualifiedObject(ref.TableName, ref.TriggerName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "missing_trigger", Table: ref.TableName, Object: object, Message: "missing trigger " + object})
+	}
+	for _, ref := range sortedTriggerRefs(diff.TriggersRemoved) {
+		object := qualifiedObject(ref.TableName, ref.TriggerName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_trigger", Table: ref.TableName, Object: object, Message: "extra trigger " + object})
+	}
+	for _, trigger := range sortedTriggerDiffs(diff.TriggersModified) {
+		object := qualifiedObject(trigger.TableName, trigger.TriggerName)
+		message := fmt.Sprintf("trigger mismatch %s: %s", object, describeChanges(trigger.Changes))
+		mismatches = append(mismatches, ShadowMismatch{Kind: "trigger_mismatch", Table: trigger.TableName, Object: object, Changes: maps.Clone(trigger.Changes), Message: message})
+	}
+	return mismatches
+}
+
+func collectAccessControlMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, namedMismatches(diff.RLSPoliciesAdded, "missing_rls_policy", "missing RLS policy")...)
+	for _, ref := range sortedRLSPolicyRefs(diff.RLSPoliciesRemoved) {
+		object := qualifiedObject(ref.TableName, ref.PolicyName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_rls_policy", Table: ref.TableName, Object: object, Message: "extra RLS policy " + object})
+	}
+	for _, policy := range sortedRLSPolicyDiffs(diff.RLSPoliciesModified) {
+		object := qualifiedObject(policy.TableName, policy.PolicyName)
+		message := fmt.Sprintf("RLS policy mismatch %s: %s", object, describeChanges(policy.Changes))
+		mismatches = append(mismatches, ShadowMismatch{Kind: "rls_policy_mismatch", Table: policy.TableName, Object: object, Changes: maps.Clone(policy.Changes), Message: message})
+	}
+	mismatches = append(mismatches, tableMismatches(diff.RLSEnabledTablesAdded, "missing_rls_enablement", "missing RLS enablement")...)
+	mismatches = append(mismatches, tableMismatches(diff.RLSEnabledTablesRemoved, "extra_rls_enablement", "extra RLS enablement")...)
+	mismatches = append(mismatches, namedMismatches(diff.RolesAdded, "missing_role", "missing role")...)
+	mismatches = append(mismatches, namedMismatches(diff.RolesRemoved, "extra_role", "extra role")...)
+	mismatches = append(mismatches, changedObjectMismatches(
+		diff.RolesModified,
+		"role_mismatch",
+		"role",
+		func(value types.RoleDiff) string { return value.RoleName },
+		func(value types.RoleDiff) map[string]string { return value.Changes },
+	)...)
+	mismatches = append(mismatches, grantMismatches(diff.GrantsAdded, "missing_grant", "missing grant")...)
+	mismatches = append(mismatches, grantMismatches(diff.GrantsRemoved, "extra_grant", "extra grant")...)
+	mismatches = append(mismatches, grantMismatches(diff.GrantOptionsAdded, "missing_grant_option", "missing grant option")...)
+	mismatches = append(mismatches, grantMismatches(diff.GrantOptionsRevoked, "extra_grant_option", "extra grant option")...)
+	return mismatches
+}
+
+func collectTopLevelConstraintMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, constraintAdditionMismatches(diff)...)
+	mismatches = append(mismatches, constraintRemovalMismatches(diff)...)
+	return mismatches
+}
+
+func constraintAdditionMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	represented := make(map[string]struct{}, len(diff.ConstraintsAddedWithTables))
+	var mismatches []ShadowMismatch
+	for _, info := range sortedConstraintAdditions(diff.ConstraintsAddedWithTables) {
+		object := qualifiedObject(info.TableName, info.Name)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "missing_constraint", Table: info.TableName, Constraint: info.Name, Object: object, Message: "missing constraint " + object})
+		represented[info.Name] = struct{}{}
+	}
+	for _, name := range sortedStrings(diff.ConstraintsAdded) {
+		if _, ok := represented[name]; !ok {
+			mismatches = append(mismatches, ShadowMismatch{Kind: "missing_constraint", Constraint: name, Object: name, Message: "missing constraint " + name})
+		}
+	}
+	return mismatches
+}
+
+func constraintRemovalMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	represented := make(map[string]struct{}, len(diff.ConstraintsRemovedWithTables))
+	var mismatches []ShadowMismatch
+	for _, info := range sortedConstraintRemovals(diff.ConstraintsRemovedWithTables) {
+		object := qualifiedObject(info.TableName, info.Name)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_constraint", Table: info.TableName, Constraint: info.Name, Object: object, Message: "extra constraint " + object})
+		represented[info.Name] = struct{}{}
+	}
+	for _, name := range sortedStrings(diff.ConstraintsRemoved) {
+		if _, ok := represented[name]; !ok {
+			mismatches = append(mismatches, ShadowMismatch{Kind: "extra_constraint", Constraint: name, Object: name, Message: "extra constraint " + name})
+		}
+	}
+	return mismatches
+}
+
+func tableMismatches(names []string, kind, label string) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, name := range sortedStrings(names) {
+		mismatches = append(mismatches, ShadowMismatch{Kind: kind, Table: name, Object: name, Message: label + " " + name})
+	}
+	return mismatches
+}
+
+func namedMismatches(names []string, kind, label string) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, name := range sortedStrings(names) {
+		mismatches = append(mismatches, ShadowMismatch{Kind: kind, Object: name, Message: label + " " + name})
+	}
+	return mismatches
+}
+
+func indexMismatches(refs []types.IndexRef, kind, label string) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, ref := range sortedIndexRefs(refs) {
+		object := qualifiedObject(ref.TableName, ref.Name)
+		mismatches = append(mismatches, ShadowMismatch{Kind: kind, Table: ref.TableName, Object: object, Message: label + " " + object})
+	}
+	return mismatches
+}
+
+func changedObjectMismatches[T any](
+	values []T,
+	kind string,
+	label string,
+	object func(T) string,
+	changes func(T) map[string]string,
+) []ShadowMismatch {
+	sorted := append([]T(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return object(sorted[i]) < object(sorted[j]) })
+	mismatches := make([]ShadowMismatch, 0, len(sorted))
+	for _, value := range sorted {
+		name := object(value)
+		objectChanges := changes(value)
+		message := fmt.Sprintf("%s mismatch %s: %s", label, name, describeChanges(objectChanges))
+		mismatches = append(mismatches, ShadowMismatch{Kind: kind, Object: name, Changes: maps.Clone(objectChanges), Message: message})
+	}
+	return mismatches
+}
+
+func grantMismatches(refs []types.GrantRef, kind, label string) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	for _, ref := range sortedGrantRefs(refs) {
+		object := fmt.Sprintf("%s %s ON %s %s", ref.Role, ref.Privilege, ref.ObjectType, ref.ObjectName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: kind, Object: object, Message: label + " " + object})
+	}
+	return mismatches
+}
+
+func qualifiedObject(namespace, name string) string {
+	if namespace == "" {
+		return name
+	}
+	return namespace + "." + name
+}
+
+func collectEnumAndIndexMismatches(diff *types.SchemaDiff) []ShadowMismatch {
+	var mismatches []ShadowMismatch
+	mismatches = append(mismatches, namedMismatches(diff.EnumsAdded, "missing_enum", "missing enum")...)
+	mismatches = append(mismatches, namedMismatches(diff.EnumsRemoved, "extra_enum", "extra enum")...)
+	for _, enum := range sortedEnumDiffs(diff.EnumsModified) {
+		for _, value := range sortedStrings(enum.ValuesAdded) {
+			message := fmt.Sprintf("missing enum value %s.%s", enum.EnumName, value)
+			mismatches = append(mismatches, ShadowMismatch{Kind: "missing_enum_value", Object: enum.EnumName + "." + value, Message: message})
+		}
+		for _, value := range sortedStrings(enum.ValuesRemoved) {
+			message := fmt.Sprintf("extra enum value %s.%s", enum.EnumName, value)
+			mismatches = append(mismatches, ShadowMismatch{Kind: "extra_enum_value", Object: enum.EnumName + "." + value, Message: message})
+		}
+	}
+	mismatches = append(mismatches, indexMismatches(diff.IndexAdditions(), "missing_index", "missing index")...)
+	mismatches = append(mismatches, indexMismatches(diff.IndexRemovals(), "extra_index", "extra index")...)
+	return mismatches
+}
+
+func sortedIndexRefs(refs []types.IndexRef) []types.IndexRef {
+	sorted := append([]types.IndexRef(nil), refs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].TableName != sorted[j].TableName {
+			return sorted[i].TableName < sorted[j].TableName
+		}
+		return sorted[i].Name < sorted[j].Name
+	})
+	return sorted
+}
+
+func sortedTriggerRefs(refs []types.TriggerRef) []types.TriggerRef {
+	sorted := append([]types.TriggerRef(nil), refs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(
+			sorted[i].TableName, sorted[i].TriggerName,
+			sorted[j].TableName, sorted[j].TriggerName,
+		) < 0
+	})
+	return sorted
+}
+
+func sortedTriggerDiffs(values []types.TriggerDiff) []types.TriggerDiff {
+	sorted := append([]types.TriggerDiff(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(
+			sorted[i].TableName, sorted[i].TriggerName,
+			sorted[j].TableName, sorted[j].TriggerName,
+		) < 0
+	})
+	return sorted
+}
+
+func sortedRLSPolicyRefs(refs []types.RLSPolicyRef) []types.RLSPolicyRef {
+	sorted := append([]types.RLSPolicyRef(nil), refs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(
+			sorted[i].TableName, sorted[i].PolicyName,
+			sorted[j].TableName, sorted[j].PolicyName,
+		) < 0
+	})
+	return sorted
+}
+
+func sortedRLSPolicyDiffs(values []types.RLSPolicyDiff) []types.RLSPolicyDiff {
+	sorted := append([]types.RLSPolicyDiff(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(
+			sorted[i].TableName, sorted[i].PolicyName,
+			sorted[j].TableName, sorted[j].PolicyName,
+		) < 0
+	})
+	return sorted
+}
+
+func sortedGrantRefs(refs []types.GrantRef) []types.GrantRef {
+	sorted := append([]types.GrantRef(nil), refs...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareGrantRefs(sorted[i], sorted[j]) < 0
+	})
+	return sorted
+}
+
+func compareGrantRefs(left, right types.GrantRef) int {
+	for _, values := range [][2]string{
+		{left.Role, right.Role},
+		{left.Privilege, right.Privilege},
+		{left.ObjectType, right.ObjectType},
+		{left.ObjectName, right.ObjectName},
+	} {
+		if compared := strings.Compare(values[0], values[1]); compared != 0 {
+			return compared
+		}
+	}
+	return 0
+}
+
+func sortedConstraintAdditions(values []types.ConstraintAdditionInfo) []types.ConstraintAdditionInfo {
+	sorted := append([]types.ConstraintAdditionInfo(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(sorted[i].TableName, sorted[i].Name, sorted[j].TableName, sorted[j].Name) < 0
+	})
+	return sorted
+}
+
+func sortedConstraintRemovals(values []types.ConstraintRemovalInfo) []types.ConstraintRemovalInfo {
+	sorted := append([]types.ConstraintRemovalInfo(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool {
+		return compareQualified(sorted[i].TableName, sorted[i].Name, sorted[j].TableName, sorted[j].Name) < 0
+	})
+	return sorted
+}
+
+func compareQualified(leftNamespace, leftName, rightNamespace, rightName string) int {
+	if compared := strings.Compare(leftNamespace, rightNamespace); compared != 0 {
+		return compared
+	}
+	return strings.Compare(leftName, rightName)
+}
+
+func sortedStrings(values []string) []string {
+	out := append([]string(nil), values...)
+	sort.Strings(out)
+	return out
+}
+
+func sortedTableDiffs(values []types.TableDiff) []types.TableDiff {
+	out := append([]types.TableDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].TableName < out[j].TableName
+	})
+	return out
+}
+
+func sortedColumnDiffs(values []types.ColumnDiff) []types.ColumnDiff {
+	out := append([]types.ColumnDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ColumnName < out[j].ColumnName
+	})
+	return out
+}
+
+func sortedEnumDiffs(values []types.EnumDiff) []types.EnumDiff {
+	out := append([]types.EnumDiff(nil), values...)
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].EnumName < out[j].EnumName
+	})
+	return out
+}
+
+func describeChanges(changes map[string]string) string {
+	if len(changes) == 0 {
+		return "unknown change"
+	}
+
+	keys := make([]string, 0, len(changes))
+	for key := range changes {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, key+" "+changes[key])
+	}
+	return strings.Join(parts, ", ")
+}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -249,7 +249,17 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 	if err := validateCompatibilityProfile(opts.Compatibility); err != nil {
 		return Analysis{}, err
 	}
-	if err := validateRules(rulesForOptions(opts)); err != nil {
+	rules := rulesForOptions(opts)
+	if err := validateRules(rules); err != nil {
+		return Analysis{}, err
+	}
+	if err := validateRuleConfigs(opts.RuleConfigs); err != nil {
+		return Analysis{}, err
+	}
+	if err := validateRuleSelectors(opts.Disabled); err != nil {
+		return Analysis{}, err
+	}
+	if err := validateConfiguredRuleSelectors(rules, opts); err != nil {
 		return Analysis{}, err
 	}
 	dirFormat, err := migrator.ParseMigrationDirFormat(string(opts.DirFormat))
@@ -316,7 +326,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			continue
 		}
 		file := cloneFile(files[i])
-		findings = append(findings, runRules(&file, opts)...)
+		findings = append(findings, runRules(&file, opts, rules)...)
 	}
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].File != findings[j].File {

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -119,8 +119,7 @@ func validateRuleConfigs(configs map[string]RuleConfig) error {
 func validateConfiguredRuleSelectors(rules []Rule, opts Options) error {
 	selectors := append(slices.Sorted(maps.Keys(opts.RuleConfigs)), opts.Disabled...)
 	for _, selector := range selectors {
-		trimmed := strings.TrimSpace(selector)
-		if trimmed != "" && !selectorMatchesRule(trimmed, rules) {
+		if selector != "" && !selectorMatchesRule(selector, rules) {
 			return fmt.Errorf("rule selector %q does not match any registered rule", selector)
 		}
 	}
@@ -138,8 +137,7 @@ func selectorMatchesRule(selector string, rules []Rule) bool {
 
 func validateRuleSelectors(selectors []string) error {
 	for _, selector := range selectors {
-		trimmed := strings.TrimSpace(selector)
-		if trimmed != "" && !isCanonicalRuleCode(trimmed) {
+		if selector != "" && !isCanonicalRuleCode(selector) {
 			return invalidRuleSelectorError(selector)
 		}
 	}

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -1,10 +1,15 @@
 package lint
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
+	"maps"
 	"os"
+	"slices"
+	"strings"
 
 	yaml "go.yaml.in/yaml/v3"
 )
@@ -39,7 +44,7 @@ type Config struct {
 }
 
 // LoadConfig reads an explicit lint configuration file. Missing, unreadable,
-// and malformed files are errors.
+// malformed, and unknown configuration fields are errors.
 func LoadConfig(path string) (*Config, error) {
 	raw, err := os.ReadFile(path)
 	if err != nil {
@@ -53,7 +58,7 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 // LoadConfigFS reads a conventional lint configuration from fsys. A missing
-// file is not an error.
+// file is not an error; malformed and unknown configuration fields are errors.
 func LoadConfigFS(fsys fs.FS, name string) (*Config, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -67,8 +72,21 @@ func LoadConfigFS(fsys fs.FS, name string) (*Config, error) {
 
 func parseConfig(raw []byte, name string) (*Config, error) {
 	var cfg Config
-	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+	decoder := yaml.NewDecoder(bytes.NewReader(raw))
+	decoder.KnownFields(true)
+	err := decoder.Decode(&cfg)
+	if err != nil && !errors.Is(err, io.EOF) {
 		return nil, fmt.Errorf("failed to parse lint config %s: %w", name, err)
+	}
+	if err == nil {
+		var trailing any
+		err = decoder.Decode(&trailing)
+		if err != nil && !errors.Is(err, io.EOF) {
+			return nil, fmt.Errorf("failed to parse lint config %s: %w", name, err)
+		}
+		if err == nil {
+			return nil, fmt.Errorf("failed to parse lint config %s: multiple YAML documents are not supported", name)
+		}
 	}
 	if err := validateConfig(cfg); err != nil {
 		return nil, fmt.Errorf("failed to parse lint config %s: %w", name, err)
@@ -77,7 +95,18 @@ func parseConfig(raw []byte, name string) (*Config, error) {
 }
 
 func validateConfig(cfg Config) error {
-	for code, rule := range cfg.Rules {
+	if err := validateRuleSelectors(cfg.DisabledRules); err != nil {
+		return err
+	}
+	return validateRuleConfigs(cfg.Rules)
+}
+
+func validateRuleConfigs(configs map[string]RuleConfig) error {
+	for _, code := range slices.Sorted(maps.Keys(configs)) {
+		rule := configs[code]
+		if !isCanonicalRuleCode(code) {
+			return invalidRuleSelectorError(code)
+		}
 		switch rule.Severity {
 		case "", SeverityWarning, SeverityError:
 		default:
@@ -85,4 +114,38 @@ func validateConfig(cfg Config) error {
 		}
 	}
 	return nil
+}
+
+func validateConfiguredRuleSelectors(rules []Rule, opts Options) error {
+	selectors := append(slices.Sorted(maps.Keys(opts.RuleConfigs)), opts.Disabled...)
+	for _, selector := range selectors {
+		trimmed := strings.TrimSpace(selector)
+		if trimmed != "" && !selectorMatchesRule(trimmed, rules) {
+			return fmt.Errorf("rule selector %q does not match any registered rule", selector)
+		}
+	}
+	return nil
+}
+
+func selectorMatchesRule(selector string, rules []Rule) bool {
+	for _, rule := range rules {
+		if strings.HasPrefix(rule.Code, selector) {
+			return true
+		}
+	}
+	return false
+}
+
+func validateRuleSelectors(selectors []string) error {
+	for _, selector := range selectors {
+		trimmed := strings.TrimSpace(selector)
+		if trimmed != "" && !isCanonicalRuleCode(trimmed) {
+			return invalidRuleSelectorError(selector)
+		}
+	}
+	return nil
+}
+
+func invalidRuleSelectorError(selector string) error {
+	return fmt.Errorf("rule selector %q must start with an uppercase ASCII letter and contain only uppercase ASCII letters and digits", selector)
 }

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -54,7 +54,8 @@ const (
 
 // Rule is one lint check. Exactly one of CheckStatement / CheckFile is set.
 type Rule struct {
-	// Code is the stable identifier (DS101, PG101, ...).
+	// Code is the stable identifier (DS101, PG101, ...). It starts with an
+	// uppercase ASCII letter and contains only uppercase ASCII letters and digits.
 	Code string
 	// Title is the short human-readable name of the hazard.
 	Title string
@@ -172,9 +173,9 @@ func commentStartsLine(sql string, pos int) bool {
 }
 
 // runRules applies every enabled rule to one prepared file.
-func runRules(file *File, opts Options) []Finding {
+func runRules(file *File, opts Options, rules []Rule) []Finding {
 	var findings []Finding
-	for _, rule := range rulesForOptions(opts) {
+	for _, rule := range rules {
 		if ruleDisabled(rule.Code, opts.Disabled) ||
 			fileSuppressesRule(file, rule.Code) ||
 			!ruleAppliesToDialect(rule, opts.Dialect) ||
@@ -222,7 +223,7 @@ func runRules(file *File, opts Options) []Finding {
 
 func rulesForOptions(opts Options) []Rule {
 	rules := Rules()
-	return append(rules, opts.ExtraRules...)
+	return append(rules, cloneRules(opts.ExtraRules)...)
 }
 
 func ruleSeverity(rule Rule, configs map[string]RuleConfig) Severity {

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -101,6 +101,17 @@ func TestLintFS_InvalidProgrammaticRuleSelectorFailsFast(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `rule selector "ds101" must start with an uppercase ASCII letter.*`)
 }
 
+func TestLintFS_WhitespacePaddedProgrammaticRuleSelectorFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_init.up.sql":   "DROP TABLE users;\n",
+		"0000000001_init.down.sql": "CREATE TABLE users (id INTEGER);\n",
+	}), lint.Options{Disabled: []string{" DS101 "}})
+
+	c.Assert(err, qt.ErrorMatches, `rule selector " DS101 " must start with an uppercase ASCII letter.*`)
+}
+
 func TestLintFS_UnknownProgrammaticRuleSelectorFailsFast(t *testing.T) {
 	c := qt.New(t)
 
@@ -1091,6 +1102,12 @@ func TestLoadConfig_FailurePath(t *testing.T) {
 	c.Run("lowercase rule selector", func(c *qt.C) {
 		_, err := lint.LoadConfig(dir + "/lowercase-selector.yaml")
 		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule selector "ds103" must start with an uppercase ASCII letter.*`)
+	})
+
+	c.Assert(writeFile(dir+"/whitespace-selector.yaml", "disabled-rules:\n  - ' DS103 '\n"), qt.IsNil)
+	c.Run("whitespace-padded rule selector", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/whitespace-selector.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule selector " DS103 " must start with an uppercase ASCII letter.*`)
 	})
 
 	c.Assert(writeFile(dir+"/multiple-documents.yaml", "dialect: postgres\n---\ndialect: sqlite\n"), qt.IsNil)

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -71,6 +71,51 @@ ALTER TYPE mood ADD VALUE 'ambivalent';
 	c.Assert(byRule["PG101"].Severity, qt.Equals, lint.SeverityWarning)
 }
 
+func TestLintFS_InvalidProgrammaticRuleSeverityFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_init.up.sql":   "CREATE TABLE users (id INTEGER);\n",
+		"0000000001_init.down.sql": "DROP TABLE users;\n",
+	}), lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{
+			"DS101": {Severity: lint.Severity("fatal")},
+		},
+	})
+
+	c.Assert(err, qt.ErrorMatches, `rule DS101 has unsupported severity "fatal"`)
+}
+
+func TestLintFS_InvalidProgrammaticRuleSelectorFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_init.up.sql":   "DROP TABLE users;\n",
+		"0000000001_init.down.sql": "CREATE TABLE users (id INTEGER);\n",
+	}), lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{
+			"ds101": {Severity: lint.SeverityError},
+		},
+	})
+
+	c.Assert(err, qt.ErrorMatches, `rule selector "ds101" must start with an uppercase ASCII letter.*`)
+}
+
+func TestLintFS_UnknownProgrammaticRuleSelectorFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_init.up.sql":   "DROP TABLE users;\n",
+		"0000000001_init.down.sql": "CREATE TABLE users (id INTEGER);\n",
+	}), lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{
+			"ZZ404": {Severity: lint.SeverityError},
+		},
+	})
+
+	c.Assert(err, qt.ErrorMatches, `rule selector "ZZ404" does not match any registered rule`)
+}
+
 func TestLintFS_VersionsRestrictsFindings(t *testing.T) {
 	c := qt.New(t)
 
@@ -767,9 +812,15 @@ func TestAnalyzeFS_CustomRuleUsesPublicScanner(t *testing.T) {
 		Severity:       lint.SeverityWarning,
 		CheckStatement: checkCustomCreateTable,
 	}
-	findings, err := lint.LintFS(fsys, lint.Options{ExtraRules: []lint.Rule{customRule}})
+	findings, err := lint.LintFS(fsys, lint.Options{
+		ExtraRules: []lint.Rule{customRule},
+		RuleConfigs: map[string]lint.RuleConfig{
+			"XX001": {Severity: lint.SeverityError},
+		},
+	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"XX001"})
+	c.Assert(findings[0].Severity, qt.Equals, lint.SeverityError)
 	c.Assert(findings[0].Message, qt.Contains, "Ptah's scanner")
 }
 
@@ -789,6 +840,24 @@ func TestLintFS_InvalidCustomRuleFailsFast(t *testing.T) {
 	}), lint.Options{ExtraRules: []lint.Rule{{Code: "XX001", Title: "broken"}}})
 
 	c.Assert(err, qt.ErrorMatches, "rule XX001 has unsupported severity.*")
+}
+
+func TestLintFS_LowercaseCustomRuleCodeFailsFast(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := lint.LintFS(fixture(map[string]string{
+		"0000000001_x.up.sql":   "SELECT 1;\n",
+		"0000000001_x.down.sql": "-- restore\n",
+	}), lint.Options{ExtraRules: []lint.Rule{{
+		Code:     "ext001",
+		Title:    "lowercase code",
+		Severity: lint.SeverityWarning,
+		CheckStatement: func(*lint.Statement) (bool, string) {
+			return false, ""
+		},
+	}}})
+
+	c.Assert(err, qt.ErrorMatches, `rule code "ext001" must start with an uppercase ASCII letter.*`)
 }
 
 func TestLintFS_RuleConfigsOverrideSeverityAndExcludePaths(t *testing.T) {
@@ -1004,6 +1073,30 @@ func TestLoadConfig_FailurePath(t *testing.T) {
 	c.Run("invalid rule severity", func(c *qt.C) {
 		_, err := lint.LoadConfig(dir + "/bad-severity.yaml")
 		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported severity "fatal".*`)
+	})
+
+	c.Assert(writeFile(dir+"/unknown-top-level.yaml", "severty: error\n"), qt.IsNil)
+	c.Run("unknown top-level key", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/unknown-top-level.yaml")
+		c.Assert(err, qt.ErrorMatches, `(?s)failed to parse lint config .*field severty not found in type lint.Config.*`)
+	})
+
+	c.Assert(writeFile(dir+"/unknown-rule-key.yaml", "rules:\n  DS103:\n    severty: error\n"), qt.IsNil)
+	c.Run("unknown nested rule key", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/unknown-rule-key.yaml")
+		c.Assert(err, qt.ErrorMatches, `(?s)failed to parse lint config .*field severty not found in type lint.RuleConfig.*`)
+	})
+
+	c.Assert(writeFile(dir+"/lowercase-selector.yaml", "rules:\n  ds103:\n    severity: error\n"), qt.IsNil)
+	c.Run("lowercase rule selector", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/lowercase-selector.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule selector "ds103" must start with an uppercase ASCII letter.*`)
+	})
+
+	c.Assert(writeFile(dir+"/multiple-documents.yaml", "dialect: postgres\n---\ndialect: sqlite\n"), qt.IsNil)
+	c.Run("multiple YAML documents", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/multiple-documents.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*multiple YAML documents are not supported`)
 	})
 }
 

--- a/migration/lint/register_external_test.go
+++ b/migration/lint/register_external_test.go
@@ -1,6 +1,9 @@
 package lint_test
 
 import (
+	"fmt"
+	"slices"
+	"sync/atomic"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -8,18 +11,22 @@ import (
 	"github.com/stokaro/ptah/migration/lint"
 )
 
+var externalRuleSequence atomic.Uint64
+
+func nextExternalRuleCode() string {
+	return fmt.Sprintf("ZZ%06d", externalRuleSequence.Add(1))
+}
+
 func TestRegisterCustomRuleFromExternalPackage(t *testing.T) {
 	c := qt.New(t)
+	ruleCode := nextExternalRuleCode()
 
 	err := lint.Register(lint.Rule{
-		Code:     "ZZ999",
+		Code:     ruleCode,
 		Title:    "external analyzer sentinel",
 		Severity: lint.SeverityWarning,
 		CheckStatement: func(stmt *lint.Statement) (bool, string) {
-			if stmt.Canonical == "SELECT 424242" {
-				return true, "external analyzer used Ptah's prepared statement"
-			}
-			return false, ""
+			return stmt.Canonical == "SELECT 424242", "external analyzer used Ptah's prepared statement"
 		},
 	})
 	c.Assert(err, qt.IsNil)
@@ -30,7 +37,42 @@ func TestRegisterCustomRuleFromExternalPackage(t *testing.T) {
 	}), lint.Options{})
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(findings, qt.HasLen, 1)
-	c.Assert(findings[0].Rule, qt.Equals, "ZZ999")
-	c.Assert(findings[0].Message, qt.Contains, "Ptah's prepared statement")
+	registeredIndex := slices.IndexFunc(findings, func(finding lint.Finding) bool {
+		return finding.Rule == ruleCode
+	})
+	c.Assert(registeredIndex, qt.Not(qt.Equals), -1)
+	c.Assert(findings[registeredIndex].Message, qt.Contains, "Ptah's prepared statement")
+}
+
+func TestRegisterCustomRuleClonesMutableDialectState(t *testing.T) {
+	c := qt.New(t)
+	ruleCode := nextExternalRuleCode()
+	dialects := []string{"postgres"}
+
+	err := lint.Register(lint.Rule{
+		Code:     ruleCode,
+		Title:    "registry copy isolation",
+		Severity: lint.SeverityWarning,
+		Dialects: dialects,
+		CheckStatement: func(*lint.Statement) (bool, string) {
+			return false, ""
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	dialects[0] = "mysql"
+
+	rules := lint.Rules()
+	registeredIndex := slices.IndexFunc(rules, func(rule lint.Rule) bool {
+		return rule.Code == ruleCode
+	})
+	c.Assert(registeredIndex, qt.Not(qt.Equals), -1)
+	c.Assert(rules[registeredIndex].Dialects, qt.DeepEquals, []string{"postgres"})
+	rules[registeredIndex].Dialects[0] = "sqlite"
+
+	freshRules := lint.Rules()
+	freshIndex := slices.IndexFunc(freshRules, func(rule lint.Rule) bool {
+		return rule.Code == ruleCode
+	})
+	c.Assert(freshIndex, qt.Not(qt.Equals), -1)
+	c.Assert(freshRules[freshIndex].Dialects, qt.DeepEquals, []string{"postgres"})
 }

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -28,7 +28,7 @@ func Register(rule Rule) error {
 			return fmt.Errorf("duplicate rule code %s", rule.Code)
 		}
 	}
-	registeredRules.rules = append(registeredRules.rules, rule)
+	registeredRules.rules = append(registeredRules.rules, cloneRule(rule))
 	return nil
 }
 
@@ -38,7 +38,20 @@ func Rules() []Rule {
 	rules := builtinRules()
 	registeredRules.RLock()
 	defer registeredRules.RUnlock()
-	return append(rules, registeredRules.rules...)
+	return append(rules, cloneRules(registeredRules.rules)...)
+}
+
+func cloneRule(rule Rule) Rule {
+	rule.Dialects = slices.Clone(rule.Dialects)
+	return rule
+}
+
+func cloneRules(rules []Rule) []Rule {
+	cloned := make([]Rule, len(rules))
+	for i, rule := range rules {
+		cloned[i] = cloneRule(rule)
+	}
+	return cloned
 }
 
 func builtinRules() []Rule {
@@ -56,8 +69,8 @@ func builtinRules() []Rule {
 }
 
 func validateRule(rule Rule) error {
-	if strings.TrimSpace(rule.Code) == "" {
-		return fmt.Errorf("rule code is required")
+	if !isCanonicalRuleCode(rule.Code) {
+		return fmt.Errorf("rule code %q must start with an uppercase ASCII letter and contain only uppercase ASCII letters and digits", rule.Code)
 	}
 	if strings.TrimSpace(rule.Title) == "" {
 		return fmt.Errorf("rule %s title is required", rule.Code)
@@ -71,6 +84,19 @@ func validateRule(rule Rule) error {
 		return fmt.Errorf("rule %s must set exactly one checker", rule.Code)
 	}
 	return nil
+}
+
+func isCanonicalRuleCode(code string) bool {
+	for index, value := range code {
+		if value >= 'A' && value <= 'Z' {
+			continue
+		}
+		if index > 0 && value >= '0' && value <= '9' {
+			continue
+		}
+		return false
+	}
+	return code != ""
 }
 
 func validateRules(rules []Rule) error {

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -110,7 +110,7 @@ func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding {
 func Highest(findings []Finding) Severity {
 	highest := Safe
 	for _, finding := range findings {
-		if severityRank(finding.Severity) > severityRank(highest) {
+		if severityOutranks(finding.Severity, highest) {
 			highest = finding.Severity
 		}
 	}
@@ -119,7 +119,12 @@ func Highest(findings []Finding) Severity {
 
 // HasDestructive returns true when any finding is destructive.
 func HasDestructive(findings []Finding) bool {
-	return Highest(findings) == Destructive
+	for _, finding := range findings {
+		if finding.Severity == Destructive {
+			return true
+		}
+	}
+	return false
 }
 
 // Classify returns the highest operational risk for a migration AST node.
@@ -195,7 +200,7 @@ func AssessSQL(statement string) StatementAssessment {
 func HighestAssessment(assessments []StatementAssessment) Severity {
 	highest := Safe
 	for _, assessment := range assessments {
-		if severityRank(assessment.Severity) > severityRank(highest) {
+		if severityOutranks(assessment.Severity, highest) {
 			highest = assessment.Severity
 		}
 	}
@@ -204,15 +209,19 @@ func HighestAssessment(assessments []StatementAssessment) Severity {
 
 // HasDestructiveAssessment returns true when any statement is destructive.
 func HasDestructiveAssessment(assessments []StatementAssessment) bool {
-	return HighestAssessment(assessments) == Destructive
+	for _, assessment := range assessments {
+		if assessment.Severity == Destructive {
+			return true
+		}
+	}
+	return false
 }
 
 // NewReport returns a machine-readable safety report envelope.
 func NewReport(assessments []StatementAssessment) Report {
-	highest := HighestAssessment(assessments)
 	return Report{
-		Highest:     highest,
-		Destructive: highest == Destructive,
+		Highest:     HighestAssessment(assessments),
+		Destructive: HasDestructiveAssessment(assessments),
 		Assessments: assessments,
 	}
 }
@@ -542,6 +551,13 @@ func aggregate(findings []Finding) []Finding {
 
 func severityRank(severity Severity) int {
 	return risk.Rank(severity)
+}
+
+func severityOutranks(candidate, current Severity) bool {
+	candidateRank := severityRank(candidate)
+	currentRank := severityRank(current)
+	return candidateRank > currentRank ||
+		(candidateRank == currentRank && candidate == Destructive && current != Destructive)
 }
 
 // IsTypeNarrowing reports whether changing from oldType to newType can lose

--- a/migration/safety/safety_test.go
+++ b/migration/safety/safety_test.go
@@ -9,6 +9,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/migration/risk"
 	"github.com/stokaro/ptah/migration/safety"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
 )
@@ -171,6 +172,38 @@ func TestRenderJSON(t *testing.T) {
 	c.Assert(report.Highest, qt.Equals, safety.Destructive)
 	c.Assert(report.Destructive, qt.IsTrue)
 	c.Assert(report.Assessments, qt.DeepEquals, assessments)
+}
+
+func TestNewReportDestructiveVerdictDoesNotDependOnAssessmentOrder(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name        string
+		assessments []safety.StatementAssessment
+	}{
+		{
+			name: "lint error before destructive assessment",
+			assessments: []safety.StatementAssessment{
+				{Severity: risk.Error},
+				{Severity: safety.Destructive},
+			},
+		},
+		{
+			name: "destructive assessment before lint error",
+			assessments: []safety.StatementAssessment{
+				{Severity: safety.Destructive},
+				{Severity: risk.Error},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			report := safety.NewReport(test.assessments)
+			c.Assert(report.Highest, qt.Equals, safety.Destructive)
+			c.Assert(report.Destructive, qt.IsTrue)
+			c.Assert(safety.HasDestructiveAssessment(test.assessments), qt.IsTrue)
+		})
+	}
 }
 
 func TestAssessRenderedSplitsPostgresModifyColumnStatements(t *testing.T) {


### PR DESCRIPTION
## Summary

- make lint configuration fail closed for unknown YAML fields, invalid severities, noncanonical selectors, and selectors that match no registered rule
- snapshot and isolate custom rule state, preserve lint path semantics in the migration apply gate, and make destructive safety verdicts order-independent
- expose complete deterministic shadow mismatch diagnostics, remove the unreachable pre-v1 `Success` field, and document the public contracts
- add black-box CLI, SQLite, PostgreSQL, public API, race, and deterministic mismatch coverage; keep both PostgreSQL apply-gate acceptance tests selected in CI

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./migration/lint ./migration/generator`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `scripts/check-public-api.sh`
- documentation style, link, redirect, page-health, exit-code, and version checks
- `npm run build`
- `npm run check:responsive` (60 routes x 2 viewports)
- `npm audit --audit-level=high`

Hardens the acceptance and public contracts delivered for #270.
