### PR TITLE
fix(migrations): harden no-transaction execution

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -290,9 +290,16 @@ jobs:
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+          CLICKHOUSE_URL: "clickhouse://ptah_user:ptah_password@localhost:9000/ptah_test"
         run: |
-          go test -v ./migration/migrator -run 'TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration' -timeout 3m
-          go test -v ./migration/generator -run 'TestGenerateMigrationShadowVerificationWithRealDB|TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB' -timeout 5m
+          go test ./migration/migrator -list '^TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration$' | grep -q '^TestNoTransactionDirective_PostgresEnumValueCanBeUsedInSameMigration$'
+          go test ./migration/migrator -list '^TestNoTransactionCheckpoint_ClickHouse(Ptah|Atlas)RevisionIsVisibleToObserver$' | grep -q '^TestNoTransactionCheckpoint_ClickHousePtahRevisionIsVisibleToObserver$'
+          go test ./migration/migrator -list '^TestNoTransactionCheckpoint_ClickHouse(Ptah|Atlas)RevisionIsVisibleToObserver$' | grep -q '^TestNoTransactionCheckpoint_ClickHouseAtlasRevisionIsVisibleToObserver$'
+          go test ./migration/migrator -list '^TestNoTransactionRepair_ClickHouseAtlasRevisionAfterManualReconciliation$' | grep -q '^TestNoTransactionRepair_ClickHouseAtlasRevisionAfterManualReconciliation$'
+          go test ./migration/generator -list '^TestGenerateMigrationShadowVerificationWithRealDB$' | grep -q '^TestGenerateMigrationShadowVerificationWithRealDB$'
+          go test ./migration/generator -list '^TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB$' | grep -q '^TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB$'
+          go test -v -count=1 ./migration/migrator -run '^TestNoTransaction(Directive_PostgresEnumValueCanBeUsedInSameMigration|Checkpoint_ClickHouse(Ptah|Atlas)RevisionIsVisibleToObserver|Repair_ClickHouseAtlasRevisionAfterManualReconciliation)$' -timeout 3m
+          go test -v -count=1 ./migration/generator -run '^TestGenerateMigration(ShadowVerificationWithRealDB|ConcurrentIndexOnPopulatedPostgresTableWithRealDB)$' -timeout 5m
           go test ./cmd/migrateup -list '^TestMigrateUp_LintConfigSeverityOverrideControlsPostgresMigration$' | grep -q '^TestMigrateUp_LintConfigSeverityOverrideControlsPostgresMigration$'
           go test ./cmd/migrateup -list '^TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable$' | grep -q '^TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable$'
           go test -v -count=1 ./cmd/migrateup -run '^TestMigrateUp_LintConfig(SeverityOverrideControlsPostgresMigration|WarningStillBlocksPostgresDropTable)$' -timeout 3m

--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -775,18 +775,6 @@
       "count": 2
     },
     {
-      "path": "migration/generator/shadow_internal_test.go",
-      "function": "TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB",
-      "kind": "if",
-      "count": 3
-    },
-    {
-      "path": "migration/generator/shadow_internal_test.go",
-      "function": "TestGenerateMigrationShadowVerificationWithRealDB",
-      "kind": "if",
-      "count": 3
-    },
-    {
       "path": "migration/lint/lint_test.go",
       "function": "TestLintFS_CommentsAndLiteralsDoNotHideOrFakeHazards",
       "kind": "if",

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -76,7 +76,11 @@ Ptah behavior is the zero-value default.
 audit successful filesystem-migration execution without replacing the
 interceptor, splitter, directive, or transaction path. Observers receive
 structured source and statement metadata after execution but no connection
-handle, so they cannot alter the migrator execution path.
+handle, so they cannot alter the migrator execution path. For SQL-backed
+`no_transaction` migrations, Ptah durably checkpoints the statement before
+calling the observer. Atlas-format down execution is excluded because it
+preserves Atlas's unchanged-row bookkeeping. A custom `MigrationFunc` remains
+opaque and has no statement-level checkpointing.
 
 `migration/migrator.WithStatementValidator` installs a pre-execution safety
 gate on a filesystem provider. Ptah splits and validates every statement in one

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5990,7 +5990,8 @@ type GenerateMigrationOptions struct {
     // ReportFormat optionally writes a safety report next to generated files.
     // Supported values: "", "html", "json".
     ReportFormat string
-    // ShadowDatabaseURL enables pre-write verification on an ephemeral database.
+    // ShadowDatabaseURL enables pre-write verification on an ephemeral database
+    // whose live database realm must be distinct from the target connection.
     // The generator drops all objects in this database, replays existing
     // migrations from OutputDir, applies the candidate migration, re-introspects
     // the result, and aborts if it differs from the Go schema.
@@ -6966,9 +6967,6 @@ type Migration struct {
     UpNoTransaction bool
     // DownNoTransaction is the down-direction counterpart to UpNoTransaction.
     DownNoTransaction bool
-    // NoTransaction reports whether either direction opts out of the normal
-    // per-migration transaction. Execution uses the direction-specific fields.
-    NoTransaction bool
 
     // IsCheckpoint marks a checkpoint migration whose up body is the full
     // cumulative schema at its version. On a fresh database the migrator
@@ -7423,9 +7421,12 @@ package migrator // import "github.com/stokaro/ptah/migration/migrator"
 type StatementObserver interface {
     ObserveStatement(ctx context.Context, event StatementEvent) error
 }
-    StatementObserver receives successfully executed migration statements. It is
-    called after either an interceptor or the normal migrator path executes the
-    statement. Returning an error aborts the migration.
+    StatementObserver receives successfully executed migration statements.
+    It is called after either an interceptor or the normal migrator path
+    executes the statement. When a Migrator executes SQL in no-transaction mode,
+    the observer normally runs after Ptah durably checkpoints that statement's
+    progress. Atlas-format down execution preserves Atlas bookkeeping and is not
+    checkpointed. Returning an error aborts the migration.
 
 
 ### github.com/stokaro/ptah/migration/migrator.StatementObserverFunc

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -51,6 +51,10 @@ keeping any files, and `ptah migrations checkpoint` and
 expected schema before anything is recorded. `ptah migrations down` uses it to
 verify the rollback plan before changing the target.
 
+The shadow database must identify a different live database realm from the
+target. Ptah compares both connections before cleanup and fails before changing
+either database when they resolve to the same realm.
+
 **A throwaway test database** is what `ptah migrations test` and
 `ptah schema test` run cases against: by default a fresh ephemeral SQLite
 database per case, or the database passed with `--db-url` when tests must

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -72,6 +72,13 @@ migration and returns a `migrator.StatementObservationError` with source and
 statement context; dirty progress includes the statement that completed before
 the callback failed.
 
+For SQL-backed `no_transaction` migrations, Ptah writes a durable progress
+checkpoint before invoking the observer. Before each statement, it first marks
+that statement's outcome as unknown; after success, it advances the completed
+count and clears the marker. Atlas-format down execution is excluded because it
+preserves Atlas's unchanged-row bookkeeping. A custom `MigrationFunc` is opaque
+to the migrator and does not receive statement-level checkpointing.
+
 The observer composes with `StatementInterceptor`: a statement handled by an
 external executor is observed once after that executor reports success.
 

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -168,7 +168,11 @@ people and pipelines share a directory:
   versions as out-of-order.
 - **Timeouts and locks**: `--statement-timeout`, `--lock-timeout`, and
   `--migration-lock-timeout` bound long DDL and the session-level advisory
-  lock that keeps two migrators from racing.
+  lock that keeps two migrators from racing. A `no_transaction` migration
+  cannot use statement or lock timeouts. Ptah rejects the combination before
+  executing SQL or changing the revision row. SQL-backed migrations record a
+  durable progress marker before and after each autocommit statement. A custom
+  Go `MigrationFunc` remains opaque and is recorded only when it returns.
 - **Run logging** (`--log-level`, `--log-format`): `--log-level`
   debug\|info\|warn\|error selects how much of the run is narrated —
   `warn` silences the per-statement dry-run narration — and `--log-format`
@@ -243,6 +247,12 @@ every later run refuses to continue until it is repaired — see
 that state on the native surface only; `ptah-compat migrate down` reproduces
 Atlas's bookkeeping and leaves the row untouched, which
 [Roll back migrations](../rollback/) states in full.
+
+**The process stopped during a non-transactional statement.** The revision row
+records the last known completed statement and marks the interrupted
+statement's outcome as unknown. Inspect the database before repair. Ptah
+rejects `repair --resume-from` while this marker is present because the SQL may
+already have committed.
 
 **A pre-migration check blocked the migration.** Nothing is applied and no
 revision row is written, so the run is recorded as never started. Fix the data

--- a/docs/site/src/content/docs/versioned/generate.md
+++ b/docs/site/src/content/docs/versioned/generate.md
@@ -193,7 +193,8 @@ Generated migration files for ...
 ```
 
 The shadow database must be an ephemeral database of the same engine as the
-target — never a real environment.
+target and must identify a different live database realm. Never point it at a
+real environment.
 
 ## Generate without the target database (replay)
 

--- a/docs/site/src/content/docs/versioned/maintain-history.md
+++ b/docs/site/src/content/docs/versioned/maintain-history.md
@@ -142,6 +142,17 @@ Error Statement: INSERT INTO missing_table (id) VALUES (1)
 Run 'ptah migrations repair --version <version>' after fixing the database state.
 ```
 
+An abrupt process exit during a `no_transaction` statement is more ambiguous.
+Before each SQL-backed statement, Ptah durably records the last known completed
+statement and marks the next statement's outcome as unknown. After success, it
+advances the progress count and clears the marker.
+
+If the process exits between those writes, the statement may or may not have
+committed. Inspect the database before changing the revision row. Ptah rejects
+`--resume-from` while the unknown-outcome marker is present because automatic
+replay could duplicate committed SQL. Repair without `--resume-from` only after
+you have reconciled the schema by hand.
+
 Fix the migration file (it is unapplied, so `edit` applies), re-hash, and
 repair. `--resume-from` executes the remaining up statements — here starting
 at the second — before marking the migration applied:

--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -175,7 +175,8 @@ On the default per-file transaction mode the down body is rolled back with it,
 so the schema is untouched. A down marked `-- atlas:txmode none` runs outside a
 transaction, so statements that already completed stay applied: the schema is
 left half-reverted behind a revision row that still reads as fully applied,
-with no dirty state and no repair hook. That is Atlas's behavior too.
+with no dirty state and no repair hook. Ptah deliberately does not write
+statement checkpoints on this path. That is Atlas's behavior too.
 
 That fidelity is the point of the compat surface: a database it touched must
 read the same way to Atlas. It also means the failure is not visible in the

--- a/integration/framework.go
+++ b/integration/framework.go
@@ -556,7 +556,7 @@ func (vem *VersionedEntityManager) ApplyMigrationFromEntities(ctx context.Contex
 	downSQL := "-- Auto-generated down migration\n-- Manual review required\n"
 
 	migration := migrator.CreateMigrationFromSQL(int64(vem.version), description, upSQL.String(), downSQL)
-	migration.NoTransaction = noTransaction
+	migration.UpNoTransaction = noTransaction
 
 	p := migrator.NewRegisteredMigrationProvider(migration)
 	m := migrator.NewMigrator(conn, p)

--- a/integration/shadow_generate_e2e_test.go
+++ b/integration/shadow_generate_e2e_test.go
@@ -37,11 +37,16 @@ func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	defer adminDB.Close()
 
-	testDBName := fmt.Sprintf("ptah_shadow_e2e_%d", time.Now().UnixNano())
-	createE2EDatabase(c, ctx, adminDB, testDBName)
-	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+	testID := time.Now().UnixNano()
+	targetDBName := fmt.Sprintf("ptah_shadow_target_e2e_%d", testID)
+	shadowDBName := fmt.Sprintf("ptah_shadow_replay_e2e_%d", testID)
+	createE2EDatabase(c, ctx, adminDB, targetDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, targetDBName)
+	createE2EDatabase(c, ctx, adminDB, shadowDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, shadowDBName)
 
-	testDBURL := replaceDatabaseName(c, dbURL, testDBName)
+	targetDBURL := replaceDatabaseName(c, dbURL, targetDBName)
+	shadowDBURL := replaceDatabaseName(c, dbURL, shadowDBName)
 
 	t.Run("broken hand-edited migration aborts before writing candidate files", func(t *testing.T) {
 		c := qt.New(t)
@@ -50,7 +55,7 @@ func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
 		migrationsDir := filepath.Join(dir, "migrations")
 		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
 		writeShadowE2EPriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY);\n")
-		prepareShadowE2ETargetDB(c, ctx, testDBURL)
+		prepareShadowE2ETargetDB(c, ctx, targetDBURL)
 
 		output, err := runPtah(
 			ctx,
@@ -58,10 +63,10 @@ func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
 			binaryPath,
 			"migrations", "generate",
 			"--root-dir", entitiesDir,
-			"--db-url", testDBURL,
+			"--db-url", targetDBURL,
 			"--migrations-dir", migrationsDir,
 			"--name", "add_email",
-			"--shadow-db", testDBURL,
+			"--shadow-db", shadowDBURL,
 		)
 
 		c.Assert(err, qt.Not(qt.IsNil))
@@ -78,7 +83,7 @@ func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
 		migrationsDir := filepath.Join(dir, "migrations")
 		c.Assert(os.MkdirAll(migrationsDir, 0755), qt.IsNil)
 		writeShadowE2EPriorMigration(c, migrationsDir, "CREATE TABLE users (id SERIAL PRIMARY KEY, name TEXT NOT NULL);\n")
-		prepareShadowE2ETargetDB(c, ctx, testDBURL)
+		prepareShadowE2ETargetDB(c, ctx, targetDBURL)
 
 		output, err := runPtah(
 			ctx,
@@ -86,10 +91,10 @@ func TestMigrateGenerateShadowDatabaseE2E(t *testing.T) {
 			binaryPath,
 			"migrations", "generate",
 			"--root-dir", entitiesDir,
-			"--db-url", testDBURL,
+			"--db-url", targetDBURL,
 			"--migrations-dir", migrationsDir,
 			"--name", "add_email",
-			"--shadow-db", testDBURL,
+			"--shadow-db", shadowDBURL,
 		)
 
 		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", output))

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -126,8 +126,10 @@ opts := generator.GenerateMigrationOptions{
 }
 ```
 
-The shadow database is treated as disposable. The generator drops all objects in
-it, applies every existing migration from `OutputDir`, applies the candidate
+The shadow database is treated as disposable and must identify a different
+live database realm from the target. Ptah verifies that separation before any
+destructive work. The generator drops all objects in the shadow database,
+applies every existing migration from `OutputDir`, applies the candidate
 migration, re-introspects the database, and compares the result against the Go
 schema. If the replayed schema differs, generation aborts before writing files:
 
@@ -284,7 +286,7 @@ type GenerateMigrationOptions struct {
 - `OutputDir`: Directory where migration files will be saved (required)
 - `CompareOptions`: Schema comparison options (optional)
 - `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
-- `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks (optional)
+- `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks; it must identify a different live database realm from the target (optional)
 
 ### PostgreSQL Concurrent Indexes
 

--- a/migration/generator/baseline_shadow.go
+++ b/migration/generator/baseline_shadow.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stokaro/ptah/dbschema"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/internal/convert/dbschematogo"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
 )
@@ -45,15 +46,8 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 	}
 	defer dbschema.CloseAndWarn(shadowConn)
 
-	if !sameDialect(opts.Dialect, shadowConn.Info().Dialect) {
-		return fmt.Errorf(
-			"baseline shadow check failed: shadow database dialect %q does not match target dialect %q",
-			shadowConn.Info().Dialect,
-			opts.Dialect,
-		)
-	}
-	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, shadowConn.Info().Capabilities) {
-		return fmt.Errorf("baseline shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
+	if err := validateBaselineShadowConnection(ctx, opts, shadowConn); err != nil {
+		return err
 	}
 
 	targetSchema, err := validateBaselineTargetIdentifierSemantics(
@@ -127,6 +121,31 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 		return nil
 	}
 	return fmt.Errorf("baseline shadow check failed: %s", describeShadowDiff(diff))
+}
+
+func validateBaselineShadowConnection(
+	ctx context.Context,
+	opts BaselineShadowVerifyOptions,
+	shadowConn *dbschema.DatabaseConnection,
+) error {
+	if !sameDialect(opts.Dialect, shadowConn.Info().Dialect) {
+		return fmt.Errorf(
+			"baseline shadow check failed: shadow database dialect %q does not match target dialect %q",
+			shadowConn.Info().Dialect,
+			opts.Dialect,
+		)
+	}
+	sameRealm, err := devlock.SameRealm(ctx, opts.TargetConn, shadowConn)
+	if err != nil {
+		return fmt.Errorf("baseline shadow check failed: compare target and shadow database realms: %w", err)
+	}
+	if sameRealm {
+		return fmt.Errorf("baseline shadow check failed: shadow database must be distinct from target database")
+	}
+	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, shadowConn.Info().Capabilities) {
+		return fmt.Errorf("baseline shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
+	}
+	return nil
 }
 
 func validateBaselineTargetIdentifierSemantics(

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -86,7 +86,8 @@ type GenerateMigrationOptions struct {
 	// ReportFormat optionally writes a safety report next to generated files.
 	// Supported values: "", "html", "json".
 	ReportFormat string
-	// ShadowDatabaseURL enables pre-write verification on an ephemeral database.
+	// ShadowDatabaseURL enables pre-write verification on an ephemeral database
+	// whose live database realm must be distinct from the target connection.
 	// The generator drops all objects in this database, replays existing
 	// migrations from OutputDir, applies the candidate migration, re-introspects
 	// the result, and aborts if it differs from the Go schema.
@@ -437,10 +438,11 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 
 	if opts.ShadowDatabaseURL != "" {
 		if err := verifyShadowMigration(ctx, shadowMigrationOptions{
-			DatabaseURL:   opts.ShadowDatabaseURL,
-			MigrationsDir: opts.OutputDir,
-			Dialect:       info.Dialect,
-			Capabilities:  info.Capabilities,
+			DatabaseURL:      opts.ShadowDatabaseURL,
+			TargetConnection: conn,
+			MigrationsDir:    opts.OutputDir,
+			Dialect:          info.Dialect,
+			Capabilities:     info.Capabilities,
 			IdentifierSemantics: cloneIdentifierSemanticsValue(
 				diff.IdentifierSemantics,
 			),

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stokaro/ptah/core/platform/capability"
 	"github.com/stokaro/ptah/core/platform/identifier"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/devlock"
 	"github.com/stokaro/ptah/migration/internal/shadowdb"
 	"github.com/stokaro/ptah/migration/migrator"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -79,6 +80,7 @@ func newShadowVerificationError(stage, kind, message string, err error) *ShadowV
 
 type shadowMigrationOptions struct {
 	DatabaseURL         string
+	TargetConnection    *dbschema.DatabaseConnection
 	MigrationsDir       string
 	Dialect             string
 	Capabilities        capability.Capabilities
@@ -109,6 +111,31 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 			"dialect-check",
 			"dialect_mismatch",
 			fmt.Sprintf("shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect),
+			nil,
+		)
+	}
+	if opts.TargetConnection == nil {
+		return newShadowVerificationError(
+			"realm-check",
+			"target_connection_required",
+			"compare target and shadow database realms: target connection is required",
+			nil,
+		)
+	}
+	sameRealm, err := devlock.SameRealm(ctx, opts.TargetConnection, conn)
+	if err != nil {
+		return newShadowVerificationError(
+			"realm-check",
+			"realm_comparison_error",
+			"compare target and shadow database realms",
+			err,
+		)
+	}
+	if sameRealm {
+		return newShadowVerificationError(
+			"realm-check",
+			"target_shadow_same_realm",
+			"shadow database must be distinct from target database",
 			nil,
 		)
 	}
@@ -146,8 +173,6 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 	if err := conn.SchemaWriter().DropAllTables(ctx); err != nil {
 		return newShadowVerificationError("drop-all", "drop_all_error", "drop all objects", err)
 	}
-	replayCtx := context.Background()
-
 	prior, err := loadPriorMigrations(opts.MigrationsDir)
 	if err != nil {
 		return newShadowVerificationError("load-prior", "load_prior_error", "load prior migrations", err)
@@ -162,24 +187,24 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 	}
 
 	mig := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...))
-	if err := mig.MigrateUp(replayCtx); err != nil {
+	if err := mig.MigrateUp(ctx); err != nil {
 		if description := describeReplayError(err); description != "" {
 			return newShadowVerificationError("replay", "replay_error", description, err)
 		}
 		return newShadowVerificationError("replay", "replay_error", "replay migrations", err)
 	}
-	if err := assertShadowSchemaMatches(replayCtx, conn, opts); err != nil {
+	if err := assertShadowSchemaMatches(ctx, conn, opts); err != nil {
 		return err
 	}
 
 	previousVersion := latestMigrationVersion(prior)
-	if err := mig.MigrateDownTo(replayCtx, previousVersion); err != nil {
+	if err := mig.MigrateDownTo(ctx, previousVersion); err != nil {
 		return newShadowVerificationError("round-trip-down", "round_trip_down_error", "round-trip down", err)
 	}
-	if err := mig.MigrateTo(replayCtx, latestMigrationVersion(migrations)); err != nil {
+	if err := mig.MigrateTo(ctx, latestMigrationVersion(migrations)); err != nil {
 		return newShadowVerificationError("round-trip-up", "round_trip_up_error", "round-trip up", err)
 	}
-	return assertShadowSchemaMatches(replayCtx, conn, opts)
+	return assertShadowSchemaMatches(ctx, conn, opts)
 }
 
 func shadowIdentifierSemanticsMatch(

--- a/migration/generator/shadow_external_test.go
+++ b/migration/generator/shadow_external_test.go
@@ -93,3 +93,176 @@ type User struct {
 	c.Assert(err, qt.IsNil)
 	c.Assert(migrationFiles, qt.HasLen, 2)
 }
+
+func TestGenerateMigration_RejectsTargetDatabaseAsShadow(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.db")
+	targetURL := "sqlite://" + targetPath
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+
+	modelsDir, migrationsDir := writeShadowRealmSafetyFixture(c, dir)
+
+	files, err := generator.GenerateMigration(t.Context(), generator.GenerateMigrationOptions{
+		GoEntitiesDir:     modelsDir,
+		DBConn:            target,
+		MigrationName:     "add_email",
+		OutputDir:         migrationsDir,
+		ShadowDatabaseURL: targetURL,
+	})
+
+	assertShadowRealmRejected(c, target, files, err)
+}
+
+func TestGenerateMigration_RejectsEquivalentTargetDatabaseAliasAsShadow(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.db")
+	targetURL := "sqlite://" + targetPath
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	dbschema.CloseAndWarn(target)
+
+	aliasPath := filepath.Join(dir, "target-alias.db")
+	c.Assert(os.Link(targetPath, aliasPath), qt.IsNil)
+	target, err = dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	modelsDir, migrationsDir := writeShadowRealmSafetyFixture(c, dir)
+
+	files, err := generator.GenerateMigration(t.Context(), generator.GenerateMigrationOptions{
+		GoEntitiesDir:     modelsDir,
+		DBConn:            target,
+		MigrationName:     "add_email",
+		OutputDir:         migrationsDir,
+		ShadowDatabaseURL: "sqlite://" + aliasPath,
+	})
+
+	assertShadowRealmRejected(c, target, files, err)
+}
+
+func TestVerifyBaselineShadow_RejectsTargetDatabaseAsShadow(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.db")
+	targetURL := "sqlite://" + targetPath
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	migrationsDir := writeBaselineShadowRealmSafetyFixture(c, dir)
+
+	err = generator.VerifyBaselineShadow(t.Context(), generator.BaselineShadowVerifyOptions{
+		ShadowDatabaseURL: targetURL,
+		TargetConn:        target,
+		MigrationsDir:     migrationsDir,
+		Version:           1,
+		Dialect:           target.Info().Dialect,
+	})
+
+	assertBaselineShadowRealmRejected(c, target, err)
+}
+
+func TestVerifyBaselineShadow_RejectsEquivalentTargetDatabaseAlias(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	targetPath := filepath.Join(dir, "target.db")
+	targetURL := "sqlite://" + targetPath
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	dbschema.CloseAndWarn(target)
+
+	aliasPath := filepath.Join(dir, "target-alias.db")
+	c.Assert(os.Link(targetPath, aliasPath), qt.IsNil)
+	target, err = dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	migrationsDir := writeBaselineShadowRealmSafetyFixture(c, dir)
+
+	err = generator.VerifyBaselineShadow(t.Context(), generator.BaselineShadowVerifyOptions{
+		ShadowDatabaseURL: "sqlite://" + aliasPath,
+		TargetConn:        target,
+		MigrationsDir:     migrationsDir,
+		Version:           1,
+		Dialect:           target.Info().Dialect,
+	})
+
+	assertBaselineShadowRealmRejected(c, target, err)
+}
+
+func writeShadowRealmSafetyFixture(c *qt.C, dir string) (modelsDir, migrationsDir string) {
+	c.Helper()
+	modelsDir = filepath.Join(dir, "models")
+	c.Assert(os.MkdirAll(modelsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "models.go"), []byte(`package models
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int
+	//ptah:schema:field name="email" type="TEXT"
+	Email string
+}
+`), 0o600), qt.IsNil)
+	migrationsDir = filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	return modelsDir, migrationsDir
+}
+
+func assertShadowRealmRejected(
+	c *qt.C,
+	target *dbschema.DatabaseConnection,
+	files *generator.MigrationFiles,
+	err error,
+) {
+	c.Helper()
+	c.Assert(files, qt.IsNil)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "realm-check")
+	c.Assert(shadowErr.Result.Mismatches, qt.DeepEquals, []generator.ShadowMismatch{{
+		Kind:    "target_shadow_same_realm",
+		Message: "shadow database must be distinct from target database",
+	}})
+	var tableCount int64
+	c.Assert(target.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&tableCount), qt.IsNil)
+	c.Assert(tableCount, qt.Equals, int64(1))
+}
+
+func writeBaselineShadowRealmSafetyFixture(c *qt.C, dir string) string {
+	c.Helper()
+	migrationsDir := filepath.Join(dir, "baseline-migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE users;"),
+		0o600,
+	), qt.IsNil)
+	return migrationsDir
+}
+
+func assertBaselineShadowRealmRejected(
+	c *qt.C,
+	target *dbschema.DatabaseConnection,
+	err error,
+) {
+	c.Helper()
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: shadow database must be distinct from target database`)
+	var tableCount int64
+	c.Assert(target.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&tableCount), qt.IsNil)
+	c.Assert(tableCount, qt.Equals, int64(1))
+}

--- a/migration/generator/shadow_internal_test.go
+++ b/migration/generator/shadow_internal_test.go
@@ -7,9 +7,13 @@ package generator
 
 import (
 	"context"
+	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
 	qt "github.com/frankban/quicktest"
 
@@ -245,23 +249,46 @@ func TestVerifyShadowMigrationConnectErrorIsStructured(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `shadow check failed: connect to shadow database: invalid database URL: missing scheme`)
 }
 
-func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
-	dbURL := shadowTestDatabaseURL()
-	if dbURL == "" {
-		t.Skip("PostgreSQL test database URL is not set")
-	}
+func TestVerifyShadowMigration_ReplayHonorsCallerCancellation(t *testing.T) {
+	c := qt.New(t)
+	target, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "target.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	ctx, cancel := context.WithTimeout(t.Context(), 500*time.Millisecond)
+	defer cancel()
 
+	err = verifyShadowMigration(ctx, shadowMigrationOptions{
+		DatabaseURL:      "sqlite://" + filepath.Join(t.TempDir(), "shadow.db"),
+		TargetConnection: target,
+		Dialect:          platform.SQLite,
+		Candidates: []shadowCandidate{{
+			Version: 1,
+			Name:    "long replay",
+			UpSQL: `WITH RECURSIVE counter(value) AS (
+				VALUES (0)
+				UNION ALL
+				SELECT value + 1 FROM counter WHERE value < 100000000
+			) SELECT sum(value) FROM counter;`,
+			DownSQL: "SELECT 1;",
+		}},
+	})
+
+	var shadowErr *ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "replay")
+	c.Assert(err, qt.ErrorIs, context.DeadlineExceeded)
+}
+
+func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 	c := qt.New(t)
 	ctx := t.Context()
-
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	if err != nil {
-		t.Skipf("test database is not available: %v", err)
-	}
+	dbURL, conn := openShadowTestPostgres(c)
 	defer dbschema.CloseAndWarn(conn)
-	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
-		t.Skipf("shadow acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
-	}
+	shadowURL, shadowDatabase := createShadowTestPostgres(c, conn, dbURL)
+	defer dropShadowTestPostgres(c, conn, shadowDatabase)
 	releaseLock := acquireShadowTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
@@ -282,7 +309,7 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 			DatabaseURL:       dbURL,
 			MigrationName:     "add_email",
 			OutputDir:         migrationsDir,
-			ShadowDatabaseURL: dbURL,
+			ShadowDatabaseURL: shadowURL,
 		})
 
 		c.Assert(files, qt.IsNil)
@@ -312,7 +339,7 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 			DatabaseURL:       dbURL,
 			MigrationName:     "add_email",
 			OutputDir:         migrationsDir,
-			ShadowDatabaseURL: dbURL,
+			ShadowDatabaseURL: shadowURL,
 		})
 
 		c.Assert(err, qt.IsNil)
@@ -326,22 +353,10 @@ func TestGenerateMigrationShadowVerificationWithRealDB(t *testing.T) {
 }
 
 func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *testing.T) {
-	dbURL := shadowTestDatabaseURL()
-	if dbURL == "" {
-		t.Skip("PostgreSQL test database URL is not set")
-	}
-
 	c := qt.New(t)
 	ctx := t.Context()
-
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	if err != nil {
-		t.Skipf("test database is not available: %v", err)
-	}
+	dbURL, conn := openShadowTestPostgres(c)
 	defer dbschema.CloseAndWarn(conn)
-	if platform.NormalizeDialect(conn.Info().Dialect) != platform.Postgres {
-		t.Skipf("concurrent index acceptance test requires PostgreSQL, got %s", conn.Info().Dialect)
-	}
 	releaseLock := acquireShadowTestLock(c, ctx, conn)
 	defer releaseLock()
 	defer func() {
@@ -349,7 +364,7 @@ func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *t
 	}()
 
 	c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
-	_, err = conn.ExecContext(ctx, `
+	_, err := conn.ExecContext(ctx, `
 		CREATE TABLE users (
 			id SERIAL PRIMARY KEY,
 			name TEXT NOT NULL,
@@ -386,6 +401,14 @@ func TestGenerateMigrationConcurrentIndexOnPopulatedPostgresTableWithRealDB(t *t
 	c.Assert(err, qt.IsNil)
 	mig := migrator.NewMigrator(conn, provider)
 	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	var valid bool
+	c.Assert(conn.QueryRowContext(ctx, `
+		SELECT index.indisvalid AND index.indisready
+		FROM pg_index AS index
+		JOIN pg_class AS class ON class.oid = index.indexrelid
+		WHERE class.relname = 'idx_users_email'
+	`).Scan(&valid), qt.IsNil)
+	c.Assert(valid, qt.IsTrue)
 }
 
 func shadowTestDatabaseURL() string {
@@ -395,6 +418,52 @@ func shadowTestDatabaseURL() string {
 		}
 	}
 	return ""
+}
+
+func openShadowTestPostgres(c *qt.C) (string, *dbschema.DatabaseConnection) {
+	c.Helper()
+	dbURL := shadowTestDatabaseURL()
+	if dbURL == "" {
+		c.Skip("PostgreSQL test database URL is not set")
+	}
+	conn, err := dbschema.ConnectToDatabase(c.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(platform.NormalizeDialect(conn.Info().Dialect), qt.Equals, platform.Postgres)
+	return dbURL, conn
+}
+
+func createShadowTestPostgres(
+	c *qt.C,
+	admin *dbschema.DatabaseConnection,
+	baseURL string,
+) (shadowURL, database string) {
+	c.Helper()
+	database = fmt.Sprintf("ptah_generator_shadow_%d", time.Now().UnixNano())
+	_, err := admin.ExecContext(c.Context(), "CREATE DATABASE "+quoteShadowTestPostgresIdentifier(database))
+	c.Assert(err, qt.IsNil)
+	parsed, err := url.Parse(baseURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + database
+	parsed.RawPath = ""
+	return parsed.String(), database
+}
+
+func dropShadowTestPostgres(c *qt.C, admin *dbschema.DatabaseConnection, database string) {
+	c.Helper()
+	_, _ = admin.ExecContext(
+		context.Background(),
+		"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+		database,
+	)
+	_, err := admin.ExecContext(
+		context.Background(),
+		"DROP DATABASE IF EXISTS "+quoteShadowTestPostgresIdentifier(database),
+	)
+	c.Assert(err, qt.IsNil)
+}
+
+func quoteShadowTestPostgresIdentifier(identifier string) string {
+	return `"` + strings.ReplaceAll(identifier, `"`, `""`) + `"`
 }
 
 func writeConcurrentIndexEntities(c *qt.C, dir string) string {

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -641,9 +641,37 @@ ALTER TABLE users ALTER COLUMN status SET DEFAULT 'archived';
 normal per-migration transaction. This is intended for narrow database
 requirements such as PostgreSQL enum value additions that must be used by a
 later statement in the same migration, or PostgreSQL `CREATE INDEX
-CONCURRENTLY` operations. Migration timeouts
-are rejected for `no_transaction` migrations because Ptah cannot safely apply
-writer/session timeouts to raw autocommit statements.
+CONCURRENTLY` operations. Programmatic migrations set `UpNoTransaction` or
+`DownNoTransaction` explicitly; the two directions never share an execution-mode
+flag.
+
+Migration timeouts are rejected for `no_transaction` migrations because Ptah
+cannot safely apply writer/session timeouts to raw autocommit statements. Ptah
+rejects that combination before running the migration body or changing its
+revision row, so fixing the directives and retrying does not require dirty-state
+repair. If execution is canceled after an autocommit statement, Ptah uses a
+bounded cleanup context to record committed progress or finalize the revision
+state before returning.
+
+SQL-backed migrations executed through `Migrator` use a two-phase progress
+record around each autocommit statement. Before execution, Ptah records the
+last known completed statement and marks the next statement's outcome as
+unknown. After success, it advances `applied/total`, clears that marker, and
+then calls the configured `StatementObserver`.
+
+An abrupt process exit therefore leaves either exact completed progress or a
+dirty row that requires database inspection. `RepairMigration` rejects
+`ResumeFrom` while the unknown-outcome marker is present because replaying the
+statement could duplicate committed SQL. A custom `MigrationFunc` is opaque to
+Ptah and can only be recorded at function completion; use SQL-backed migrations
+when statement-level crash progress is required.
+
+Atlas-format down execution is the deliberate exception. It leaves the
+revision row unchanged before and during the down body to reproduce Atlas's
+measured bookkeeping. A non-transactional Atlas-format down can therefore
+partially change the schema without leaving statement progress in the revision
+table. Prefer the native revision format when crash-visible rollback progress
+matters.
 
 ## Safety Features
 

--- a/migration/migrator/atlas_metadata_sql_internal_test.go
+++ b/migration/migrator/atlas_metadata_sql_internal_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/platform"
 )
 
 // atlasMetadataNullGuard restates the expected CASE arm as a literal rather
@@ -121,4 +123,25 @@ func TestPtahRevisionSQL_HasNoMetadataFilter(t *testing.T) {
 		c.Assert(sql, qt.Not(qt.Contains), atlasMetadataNullGuard,
 			qt.Commentf("%s (ptah layout) must not carry the Atlas cast guard", name))
 	}
+}
+
+func TestRevisionUpdateSQL_ClickHouseUsesSynchronousMutation(t *testing.T) {
+	c := qt.New(t)
+
+	got := revisionUpdateSQL(platform.ClickHouse, "`revisions`", "applied = ?, total = ?")
+
+	c.Assert(got, qt.Equals, `ALTER TABLE `+"`revisions`"+`
+UPDATE applied = ?, total = ?
+WHERE version = ?
+SETTINGS mutations_sync = 1`)
+}
+
+func TestRevisionUpdateSQL_TransactionalDialectUsesUpdate(t *testing.T) {
+	c := qt.New(t)
+
+	got := revisionUpdateSQL(platform.Postgres, `"revisions"`, "applied = ?, total = ?")
+
+	c.Assert(got, qt.Equals, `UPDATE "revisions"
+SET applied = ?, total = ?
+WHERE version = ?`)
 }

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -202,8 +202,6 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.atlasCheckFiles = up.checkFiles
 			migration.UpTimeouts = up.timeouts
 			migration.UpNoTransaction = up.noTransaction
-			migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
-			migration.directionalNoTransactionMode = true
 		case "down":
 			down, err := migrationFuncFromSQLFilenameWithMetadata(migrationFile.Path, p.fsys, p.hooks, nil)
 			if err != nil {
@@ -215,8 +213,6 @@ func (p *FSMigrationProvider) loadPtah(files []MigrationFile) error {
 			migration.DownSQL = down.sql
 			migration.DownTimeouts = down.timeouts
 			migration.DownNoTransaction = down.noTransaction
-			migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
-			migration.directionalNoTransactionMode = true
 		default:
 			return fmt.Errorf("invalid migration direction: %s", migrationFile.Direction)
 		}
@@ -370,8 +366,6 @@ func setAtlasUp(parts *atlasParts, up sqlMigrationFile) {
 	migration.atlasCheckFiles = up.checkFiles
 	migration.UpTimeouts = up.timeouts
 	migration.UpNoTransaction = up.noTransaction
-	migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
-	migration.directionalNoTransactionMode = true
 	parts.hasUp = true
 }
 
@@ -383,8 +377,6 @@ func setAtlasDown(parts *atlasParts, down sqlMigrationFile) {
 	migration.DownSQL = down.sql
 	migration.DownTimeouts = down.timeouts
 	migration.DownNoTransaction = down.noTransaction
-	migration.NoTransaction = migration.UpNoTransaction || migration.DownNoTransaction
-	migration.directionalNoTransactionMode = true
 	parts.hasDown = true
 }
 

--- a/migration/migrator/migration_provider_test.go
+++ b/migration/migrator/migration_provider_test.go
@@ -548,7 +548,6 @@ DROP TABLE users;
 
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1)
-	c.Assert(migrations[0].NoTransaction, qt.IsTrue)
 	c.Assert(migrations[0].UpNoTransaction, qt.IsFalse)
 	c.Assert(migrations[0].DownNoTransaction, qt.IsTrue)
 }
@@ -572,7 +571,6 @@ DROP INDEX users_email_idx;
 
 	migrations := provider.Migrations()
 	c.Assert(migrations, qt.HasLen, 1)
-	c.Assert(migrations[0].NoTransaction, qt.IsTrue)
 	c.Assert(migrations[0].UpNoTransaction, qt.IsTrue)
 	c.Assert(migrations[0].DownNoTransaction, qt.IsFalse)
 }

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -110,7 +110,10 @@ type StatementEvent struct {
 
 // StatementObserver receives successfully executed migration statements. It is
 // called after either an interceptor or the normal migrator path executes the
-// statement. Returning an error aborts the migration.
+// statement. When a Migrator executes SQL in no-transaction mode, the observer
+// normally runs after Ptah durably checkpoints that statement's progress.
+// Atlas-format down execution preserves Atlas bookkeeping and is not
+// checkpointed. Returning an error aborts the migration.
 type StatementObserver interface {
 	ObserveStatement(ctx context.Context, event StatementEvent) error
 }
@@ -130,6 +133,73 @@ type statementExecutionHooks struct {
 	interceptor StatementInterceptor
 	validator   StatementValidator
 	observer    StatementObserver
+}
+
+type statementProgressRecorder func(context.Context, StatementEvent) error
+
+type statementProgressHooks struct {
+	before statementProgressRecorder
+	after  statementProgressRecorder
+}
+
+type statementProgressRecorderContextKey struct{}
+
+type statementProgressError struct {
+	err     error
+	event   StatementEvent
+	applied int
+	phase   string
+}
+
+func (e *statementProgressError) Error() string {
+	return fmt.Sprintf("failed to checkpoint migration progress %s statement %d: %v", e.phase, e.event.Index, e.err)
+}
+
+func (e *statementProgressError) Unwrap() error {
+	return e.err
+}
+
+func withStatementProgressRecorder(
+	ctx context.Context,
+	before statementProgressRecorder,
+	after statementProgressRecorder,
+) context.Context {
+	return context.WithValue(ctx, statementProgressRecorderContextKey{}, statementProgressHooks{
+		before: before,
+		after:  after,
+	})
+}
+
+func recordStatementProgressBefore(ctx context.Context, event StatementEvent) error {
+	hooks, _ := ctx.Value(statementProgressRecorderContextKey{}).(statementProgressHooks)
+	if hooks.before == nil {
+		return nil
+	}
+	if err := hooks.before(ctx, event); err != nil {
+		return &statementProgressError{
+			err:     err,
+			event:   event,
+			applied: event.Index - 1,
+			phase:   "before",
+		}
+	}
+	return nil
+}
+
+func recordStatementProgressAfter(ctx context.Context, event StatementEvent) error {
+	hooks, _ := ctx.Value(statementProgressRecorderContextKey{}).(statementProgressHooks)
+	if hooks.after == nil {
+		return nil
+	}
+	if err := hooks.after(ctx, event); err != nil {
+		return &statementProgressError{
+			err:     err,
+			event:   event,
+			applied: event.Index,
+			phase:   "after",
+		}
+	}
+	return nil
 }
 
 type migrationExecutionMode int
@@ -518,10 +588,6 @@ type Migration struct {
 	UpNoTransaction bool
 	// DownNoTransaction is the down-direction counterpart to UpNoTransaction.
 	DownNoTransaction bool
-	// NoTransaction reports whether either direction opts out of the normal
-	// per-migration transaction. Execution uses the direction-specific fields.
-	NoTransaction                bool
-	directionalNoTransactionMode bool
 	// atlasCheckFiles are raw Atlas txtar checks.sql and checks/*.sql sections.
 	// They are parsed with the live connection dialect before `-- +ptah check`
 	// directives in UpSQL, preventing dialect-blind boundary decisions.
@@ -547,14 +613,14 @@ func (m *Migration) atlasFilenameDescription() string {
 }
 
 func (m *Migration) upExecutionMode() migrationExecutionMode {
-	if m.UpNoTransaction || (!m.directionalNoTransactionMode && m.NoTransaction) {
+	if m.UpNoTransaction {
 		return migrationExecutionNoTransaction
 	}
 	return migrationExecutionTransactional
 }
 
 func (m *Migration) downExecutionMode() migrationExecutionMode {
-	if m.DownNoTransaction || (!m.directionalNoTransactionMode && m.NoTransaction) {
+	if m.DownNoTransaction {
 		return migrationExecutionNoTransaction
 	}
 	return migrationExecutionTransactional
@@ -567,14 +633,12 @@ func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *
 	downNoTransaction, downDirectiveErr := parseNoTransactionDirectiveFromSQL(downSQL)
 
 	migration := &Migration{
-		Version:                      version,
-		Description:                  description,
-		UpSQL:                        upSQL,
-		DownSQL:                      downSQL,
-		UpNoTransaction:              upNoTransaction,
-		DownNoTransaction:            downNoTransaction,
-		NoTransaction:                upNoTransaction || downNoTransaction,
-		directionalNoTransactionMode: true,
+		Version:           version,
+		Description:       description,
+		UpSQL:             upSQL,
+		DownSQL:           downSQL,
+		UpNoTransaction:   upNoTransaction,
+		DownNoTransaction: downNoTransaction,
 	}
 
 	upFunc := func(ctx context.Context, conn *dbschema.DatabaseConnection) error {
@@ -606,6 +670,14 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 			continue // Skip empty statements and comments
 		}
 
+		event := StatementEvent{
+			Statement: stmt,
+			Index:     i + 1,
+			Total:     len(statements),
+		}
+		if err := recordStatementProgressBefore(ctx, event); err != nil {
+			return err
+		}
 		if err := executeMigrationStatement(ctx, conn, stmt, mode); err != nil {
 			return &MigrationExecutionError{
 				Err:            fmt.Errorf("failed to execute SQL statement: %w", err),
@@ -613,6 +685,9 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 				StatementIndex: i + 1,
 				Total:          len(statements),
 			}
+		}
+		if err := recordStatementProgressAfter(ctx, event); err != nil {
+			return err
 		}
 	}
 
@@ -651,6 +726,17 @@ func executeMigrationFileSQL(
 			continue
 		}
 
+		event := StatementEvent{
+			SourcePath: filename,
+			Statement:  stmt,
+			Index:      i + 1,
+			Total:      len(statements),
+			Directives: maps.Clone(fileDirectives),
+		}
+		if err := recordStatementProgressBefore(ctx, event); err != nil {
+			return err
+		}
+
 		handled := false
 		if hooks.interceptor != nil {
 			var err error
@@ -675,14 +761,10 @@ func executeMigrationFileSQL(
 				}
 			}
 		}
+		if err := recordStatementProgressAfter(ctx, event); err != nil {
+			return err
+		}
 		if hooks.observer != nil {
-			event := StatementEvent{
-				SourcePath: filename,
-				Statement:  stmt,
-				Index:      i + 1,
-				Total:      len(statements),
-				Directives: maps.Clone(fileDirectives),
-			}
 			if err := hooks.observer.ObserveStatement(ctx, event); err != nil {
 				return &StatementObservationError{
 					Err:   err,

--- a/migration/migrator/migrations_test.go
+++ b/migration/migrator/migrations_test.go
@@ -48,7 +48,6 @@ func TestCreateMigrationFromSQL(t *testing.T) {
 	c.Assert(migration.Description, qt.Equals, "Create test table")
 	c.Assert(migration.Up, qt.IsNotNil)
 	c.Assert(migration.Down, qt.IsNotNil)
-	c.Assert(migration.NoTransaction, qt.IsFalse)
 	c.Assert(migration.UpNoTransaction, qt.IsFalse)
 	c.Assert(migration.DownNoTransaction, qt.IsFalse)
 
@@ -65,7 +64,6 @@ func TestCreateMigrationFromSQL_NoTransactionDirective(t *testing.T) {
 		"-- manual down migration required",
 	)
 
-	c.Assert(migration.NoTransaction, qt.IsTrue)
 	c.Assert(migration.UpNoTransaction, qt.IsTrue)
 	c.Assert(migration.DownNoTransaction, qt.IsFalse)
 }
@@ -78,7 +76,6 @@ func TestCreateMigrationFromSQL_DownNoTransactionDirective(t *testing.T) {
 		"-- +ptah no_transaction\nDROP INDEX CONCURRENTLY users_email_idx;",
 	)
 
-	c.Assert(migration.NoTransaction, qt.IsTrue)
 	c.Assert(migration.UpNoTransaction, qt.IsFalse)
 	c.Assert(migration.DownNoTransaction, qt.IsTrue)
 }
@@ -91,15 +88,14 @@ func TestCreateMigrationFromSQL_AtlasTxModeNoneDirective(t *testing.T) {
 		"DROP INDEX users_email_idx;",
 	)
 
-	c.Assert(migration.NoTransaction, qt.IsTrue)
 	c.Assert(migration.UpNoTransaction, qt.IsTrue)
 	c.Assert(migration.DownNoTransaction, qt.IsFalse)
 }
 
-func TestMigration_ExplicitNoTransactionFieldControlsManualMigrations(t *testing.T) {
+func TestMigration_ExplicitDirectionalNoTransactionFieldsControlManualMigrations(t *testing.T) {
 	c := qt.New(t)
 
-	migration := &Migration{NoTransaction: true}
+	migration := &Migration{UpNoTransaction: true, DownNoTransaction: true}
 
 	c.Assert(migration.upExecutionMode(), qt.Equals, migrationExecutionNoTransaction)
 	c.Assert(migration.downExecutionMode(), qt.Equals, migrationExecutionNoTransaction)

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1571,6 +1571,14 @@ func (m *Migrator) applyUpMigrationObserved(ctx context.Context, migration *Migr
 	}()
 
 	m.logger.Info("Applying migration", "version", migration.Version, "description", migration.Description)
+	if migration.upExecutionMode() == migrationExecutionNoTransaction {
+		if err := ensureNoTransactionHasNoTimeouts(
+			migration.Version,
+			mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts),
+		); err != nil {
+			return err
+		}
+	}
 	if err := m.runPreMigrationChecks(ctx, migration); err != nil {
 		return err
 	}
@@ -1625,6 +1633,12 @@ func (m *Migrator) applyUpMigrationForcedNoTransactionObserved(ctx context.Conte
 }
 
 func (m *Migrator) applyUpMigrationForcedNoTransactionAt(ctx context.Context, migration *Migration, startedAt time.Time) error {
+	if err := ensureNoTransactionHasNoTimeouts(
+		migration.Version,
+		mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts),
+	); err != nil {
+		return err
+	}
 	if err := m.runPreMigrationChecks(ctx, migration); err != nil {
 		return err
 	}
@@ -1744,6 +1758,17 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 		_ = tx.Rollback()
 		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.UpSQL, "")
 	}
+	if err := m.completeMigrationRevisionOn(ctx, txConn, migration, startedAt); err != nil {
+		_ = tx.Rollback()
+		return m.failMigrationWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.UpSQL,
+			fmt.Sprintf("failed to record migration %d", migration.Version),
+		)
+	}
 
 	if err := tx.Commit(); err != nil {
 		return m.failMigrationWithDirtyState(
@@ -1755,21 +1780,23 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 			fmt.Sprintf("failed to commit transaction for migration %d", migration.Version),
 		)
 	}
-	if err := m.completeMigrationRevision(ctx, migration, startedAt); err != nil {
-		return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
-	}
-
 	m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
 	return nil
 }
 
 func (m *Migrator) applyUpMigrationNoTransaction(ctx context.Context, migration *Migration, startedAt time.Time) error {
-	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts)); err != nil {
-		return m.failMigrationWithDirtyStateWithMode(ctx, migration, startedAt, err, migration.UpSQL, "", MigrationTxModeNone)
-	}
 	// Pre-migration checks already ran in runPreMigrationChecks, before this
 	// migration had any revision row.
-	if err := migration.Up(ctx, m.conn); err != nil {
+	executionCtx := withStatementProgressRecorder(
+		ctx,
+		func(ctx context.Context, event StatementEvent) error {
+			return m.markMigrationStatementInFlight(ctx, migration, startedAt, event)
+		},
+		func(ctx context.Context, event StatementEvent) error {
+			return m.checkpointMigrationRevision(ctx, migration, startedAt, event)
+		},
+	)
+	if err := migration.Up(executionCtx, m.conn); err != nil {
 		return m.failMigrationWithDirtyStateWithMode(
 			ctx,
 			migration,
@@ -1780,7 +1807,9 @@ func (m *Migrator) applyUpMigrationNoTransaction(ctx context.Context, migration 
 			MigrationTxModeNone,
 		)
 	}
-	if err := m.completeMigrationRevision(ctx, migration, startedAt); err != nil {
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
+	if err := m.completeMigrationRevision(recordCtx, migration, startedAt); err != nil {
 		return fmt.Errorf("failed to record migration %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Applied non-transactional migration", "version", migration.Version, "description", migration.Description)
@@ -1808,6 +1837,14 @@ func (m *Migrator) rollbackMigrationObserved(ctx context.Context, migration *Mig
 	}()
 
 	m.logger.Info("Rolling back migration", "version", migration.Version, "description", migration.Description)
+	if migration.downExecutionMode() == migrationExecutionNoTransaction {
+		if err := ensureNoTransactionHasNoTimeouts(
+			migration.Version,
+			mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts),
+		); err != nil {
+			return err
+		}
+	}
 	// The Atlas-shaped surface records nothing before the down body: Atlas marks
 	// a reverted migration only by deleting its row on success. See
 	// reproducesAtlasDownBookkeeping.
@@ -1925,10 +1962,19 @@ func (m *Migrator) rollbackMigrationNoTransaction(
 	startedAt time.Time,
 	deleteSQL string,
 ) error {
-	if err := ensureNoTransactionHasNoTimeouts(migration.Version, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts)); err != nil {
-		return m.failRollbackWithDirtyStateWithMode(ctx, migration, startedAt, err, migration.DownSQL, "", MigrationTxModeNone)
+	executionCtx := ctx
+	if !m.reproducesAtlasDownBookkeeping() {
+		executionCtx = withStatementProgressRecorder(
+			ctx,
+			func(ctx context.Context, event StatementEvent) error {
+				return m.markMigrationStatementInFlight(ctx, migration, startedAt, event)
+			},
+			func(ctx context.Context, event StatementEvent) error {
+				return m.checkpointMigrationRevision(ctx, migration, startedAt, event)
+			},
+		)
 	}
-	if err := migration.Down(ctx, m.conn); err != nil {
+	if err := migration.Down(executionCtx, m.conn); err != nil {
 		return m.failRollbackWithDirtyStateWithMode(
 			ctx,
 			migration,
@@ -1939,7 +1985,9 @@ func (m *Migrator) rollbackMigrationNoTransaction(
 			MigrationTxModeNone,
 		)
 	}
-	if err := executeSQLOutsideTransaction(ctx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
+	if err := executeSQLOutsideTransaction(recordCtx, m.conn, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
 		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
 	}
 	m.logger.Info("Rolled back non-transactional migration", "version", migration.Version, "description", migration.Description)

--- a/migration/migrator/migrator_test.go
+++ b/migration/migrator/migrator_test.go
@@ -76,7 +76,6 @@ func TestNewFSMigrator_LoadsNoTransactionDirective(t *testing.T) {
 	m, err := migrator.NewFSMigrator(nil, fsys)
 	c.Assert(err, qt.IsNil)
 	migration := m.MigrationProvider().Migrations()[0]
-	c.Assert(migration.NoTransaction, qt.IsTrue)
 	c.Assert(migration.UpNoTransaction, qt.IsTrue)
 	c.Assert(migration.DownNoTransaction, qt.IsFalse)
 }
@@ -96,7 +95,6 @@ func TestNewFSMigrator_LoadsDirectionalDownNoTransactionDirective(t *testing.T) 
 	m, err := migrator.NewFSMigrator(nil, fsys)
 	c.Assert(err, qt.IsNil)
 	migration := m.MigrationProvider().Migrations()[0]
-	c.Assert(migration.NoTransaction, qt.IsTrue)
 	c.Assert(migration.UpNoTransaction, qt.IsFalse)
 	c.Assert(migration.DownNoTransaction, qt.IsTrue)
 }

--- a/migration/migrator/no_transaction_cancellation_test.go
+++ b/migration/migrator/no_transaction_cancellation_test.go
@@ -1,0 +1,121 @@
+package migrator_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestNoTransactionCancellation_RecordsCommittedProgress(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	conn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "no-transaction-cancellation.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	observer := migrator.StatementObserverFunc(func(context.Context, migrator.StatementEvent) error {
+		cancel()
+		return context.Canceled
+	})
+	provider, err := migrator.NewFSMigrationProvider(
+		fstest.MapFS{
+			"000001_create_users.up.sql": {
+				Data: []byte("-- +ptah no_transaction\nCREATE TABLE users (id INTEGER PRIMARY KEY);\nINSERT INTO users (id) VALUES (1);"),
+			},
+			"000001_create_users.down.sql": {
+				Data: []byte("DROP TABLE users;"),
+			},
+		},
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	mig := migrator.NewMigrator(conn, provider)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorIs, context.Canceled)
+	var state string
+	var applied, total int
+	c.Assert(
+		conn.QueryRow("SELECT state, applied, total FROM schema_migrations WHERE version = 1").Scan(&state, &applied, &total),
+		qt.IsNil,
+	)
+	c.Assert(state, qt.Equals, "failed")
+	c.Assert(applied, qt.Equals, 1)
+	c.Assert(total, qt.Equals, 2)
+}
+
+func TestNoTransactionCancellation_AfterFinalUpStatementCompletesRevision(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithCancel(t.Context())
+	conn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "no-transaction-final-up.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	observer := migrator.StatementObserverFunc(func(context.Context, migrator.StatementEvent) error {
+		cancel()
+		return nil
+	})
+	provider, err := migrator.NewFSMigrationProvider(
+		fstest.MapFS{
+			"000001_create_users.up.sql": {
+				Data: []byte("-- +ptah no_transaction\nCREATE TABLE users (id INTEGER PRIMARY KEY);"),
+			},
+			"000001_create_users.down.sql": {
+				Data: []byte("DROP TABLE users;"),
+			},
+		},
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	mig := migrator.NewMigrator(conn, provider)
+
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+	c.Assert(noTransactionRevisionState(c, conn), qt.Equals, "applied")
+}
+
+func TestNoTransactionCancellation_AfterFinalDownStatementDeletesRevision(t *testing.T) {
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(
+		t.Context(),
+		"sqlite://"+filepath.Join(t.TempDir(), "no-transaction-final-down.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	fsys := fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("-- +ptah no_transaction\nDROP TABLE users;"),
+		},
+	}
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrator.NewMigrator(conn, provider).MigrateUp(t.Context()), qt.IsNil)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	observer := migrator.StatementObserverFunc(func(context.Context, migrator.StatementEvent) error {
+		cancel()
+		return nil
+	})
+	provider, err = migrator.NewFSMigrationProvider(fsys, migrator.WithStatementObserver(observer))
+	c.Assert(err, qt.IsNil)
+	mig := migrator.NewMigrator(conn, provider)
+
+	c.Assert(mig.MigrateDownTo(ctx, 0), qt.IsNil)
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsFalse)
+	c.Assert(noTransactionRevisionCount(c, conn), qt.Equals, int64(0))
+}

--- a/migration/migrator/no_transaction_clickhouse_integration_test.go
+++ b/migration/migrator/no_transaction_clickhouse_integration_test.go
@@ -1,0 +1,147 @@
+package migrator_test
+
+import (
+	"context"
+	"os"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+type clickHouseRevisionProgress struct {
+	State   string
+	Applied int
+	Total   int
+	Failure string
+}
+
+func TestNoTransactionCheckpoint_ClickHousePtahRevisionIsVisibleToObserver(t *testing.T) {
+	c := qt.New(t)
+	conn := openNoTransactionClickHouse(t)
+	defer dbschema.CloseAndWarn(conn)
+	const revisionsTable = "ptah_issue_152_revisions"
+	dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+	defer dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+
+	progress := make([]clickHouseRevisionProgress, 0, 2)
+	observer := migrator.StatementObserverFunc(func(ctx context.Context, _ migrator.StatementEvent) error {
+		var snapshot clickHouseRevisionProgress
+		err := conn.QueryRowContext(
+			ctx,
+			"SELECT state, applied, total, COALESCE(error, '') FROM "+revisionsTable+" WHERE version = 1",
+		).Scan(&snapshot.State, &snapshot.Applied, &snapshot.Total, &snapshot.Failure)
+		progress = append(progress, snapshot)
+		return err
+	})
+	mig := newNoTransactionClickHouseMigrator(c, conn, observer).
+		WithMigrationsTable("", revisionsTable)
+
+	c.Assert(mig.MigrateUp(t.Context()), qt.IsNil)
+	c.Assert(progress, qt.DeepEquals, []clickHouseRevisionProgress{
+		{State: "pending", Applied: 1, Total: 2},
+		{State: "pending", Applied: 2, Total: 2},
+	})
+}
+
+func TestNoTransactionCheckpoint_ClickHouseAtlasRevisionIsVisibleToObserver(t *testing.T) {
+	c := qt.New(t)
+	conn := openNoTransactionClickHouse(t)
+	defer dbschema.CloseAndWarn(conn)
+	const revisionsTable = "ptah_issue_152_atlas_revisions"
+	dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+	defer dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+
+	progress := make([]clickHouseRevisionProgress, 0, 2)
+	observer := migrator.StatementObserverFunc(func(ctx context.Context, _ migrator.StatementEvent) error {
+		var snapshot clickHouseRevisionProgress
+		err := conn.QueryRowContext(
+			ctx,
+			"SELECT applied, total, COALESCE(error, '') FROM "+revisionsTable+" WHERE version = '1'",
+		).Scan(&snapshot.Applied, &snapshot.Total, &snapshot.Failure)
+		progress = append(progress, snapshot)
+		return err
+	})
+	mig := newNoTransactionClickHouseMigrator(c, conn, observer).
+		WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithMigrationsTable("", revisionsTable)
+
+	c.Assert(mig.MigrateUp(t.Context()), qt.IsNil)
+	c.Assert(progress, qt.DeepEquals, []clickHouseRevisionProgress{
+		{Applied: 1, Total: 2},
+		{Applied: 2, Total: 2},
+	})
+}
+
+func TestNoTransactionRepair_ClickHouseAtlasRevisionAfterManualReconciliation(t *testing.T) {
+	c := qt.New(t)
+	conn := openNoTransactionClickHouse(t)
+	defer dbschema.CloseAndWarn(conn)
+	const revisionsTable = "ptah_issue_152_atlas_repair"
+	dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+	defer dropNoTransactionClickHouseTable(c, conn, revisionsTable)
+
+	mig := newNoTransactionClickHouseMigrator(c, conn, nil).
+		WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithMigrationsTable("", revisionsTable)
+	c.Assert(mig.MigrateUp(t.Context()), qt.IsNil)
+	_, err := conn.ExecContext(t.Context(), `ALTER TABLE `+revisionsTable+`
+		UPDATE applied = 0, error = 'statement execution outcome is unknown after process interruption', error_stmt = 'SELECT 1'
+		WHERE version = '1'
+		SETTINGS mutations_sync = 1`)
+	c.Assert(err, qt.IsNil)
+
+	err = mig.RepairMigration(t.Context(), migrator.RepairMigrationOptions{Version: 1})
+	c.Assert(err, qt.IsNil)
+	var applied, total int
+	var failure string
+	c.Assert(conn.QueryRowContext(
+		t.Context(),
+		"SELECT applied, total, COALESCE(error, '') FROM "+revisionsTable+" WHERE version = '1'",
+	).Scan(&applied, &total, &failure), qt.IsNil)
+	c.Assert(applied, qt.Equals, 2)
+	c.Assert(total, qt.Equals, 2)
+	c.Assert(failure, qt.Equals, "")
+}
+
+func openNoTransactionClickHouse(t *testing.T) *dbschema.DatabaseConnection {
+	t.Helper()
+	dbURL := os.Getenv("CLICKHOUSE_URL")
+	if dbURL == "" {
+		t.Skip("CLICKHOUSE_URL not set")
+	}
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	qt.Assert(t, err, qt.IsNil)
+	return conn
+}
+
+func newNoTransactionClickHouseMigrator(
+	c *qt.C,
+	conn *dbschema.DatabaseConnection,
+	observer migrator.StatementObserver,
+) *migrator.Migrator {
+	c.Helper()
+	mig, err := migrator.NewFSMigrator(
+		conn,
+		fstest.MapFS{
+			"000001_probe.up.sql": {
+				Data: []byte("-- +ptah no_transaction\nSELECT 1;\nSELECT 2;\n"),
+			},
+			"000001_probe.down.sql": {
+				Data: []byte("-- +ptah no_transaction\nSELECT 2;\nSELECT 1;\n"),
+			},
+		},
+		migrator.WithStatementObserver(observer),
+	)
+	c.Assert(err, qt.IsNil)
+	return mig
+}
+
+func dropNoTransactionClickHouseTable(c *qt.C, conn *dbschema.DatabaseConnection, table string) {
+	c.Helper()
+	_, err := conn.ExecContext(c.Context(), "DROP TABLE IF EXISTS "+table+" SYNC")
+	c.Assert(err, qt.IsNil)
+}

--- a/migration/migrator/no_transaction_crash_test.go
+++ b/migration/migrator/no_transaction_crash_test.go
@@ -1,0 +1,180 @@
+package migrator_test
+
+import (
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestNoTransactionCrash_PersistsProgressBeforeObserver(t *testing.T) {
+	c := qt.New(t)
+	helperPath := filepath.Join(t.TempDir(), "no-transaction-crash-helper")
+	build := exec.Command("go", "build", "-o", helperPath, "./testdata/no_transaction_crash")
+	build.Dir = "."
+	c.Assert(build.Run(), qt.IsNil)
+
+	c.Run("Ptah revision table", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "ptah-crash.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "ptah", "up", "after-checkpoint")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+
+		var state string
+		var applied, total int
+		c.Assert(
+			conn.QueryRow("SELECT state, applied, total FROM schema_migrations WHERE version = 1").Scan(&state, &applied, &total),
+			qt.IsNil,
+		)
+		c.Assert(state, qt.Equals, "pending")
+		c.Assert(applied, qt.Equals, 1)
+		c.Assert(total, qt.Equals, 2)
+	})
+
+	c.Run("Atlas revision table", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "atlas-crash.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "atlas", "up", "after-checkpoint")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+
+		var applied, total int
+		var failure string
+		c.Assert(
+			conn.QueryRow("SELECT applied, total, COALESCE(error, '') FROM atlas_schema_revisions WHERE version = '1'").Scan(&applied, &total, &failure),
+			qt.IsNil,
+		)
+		c.Assert(applied, qt.Equals, 1)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(failure, qt.Equals, "")
+	})
+
+	c.Run("Ptah down revision", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "ptah-down-crash.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "ptah", "down", "after-checkpoint")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+
+		var state string
+		var applied, total int
+		c.Assert(
+			conn.QueryRow("SELECT state, applied, total FROM schema_migrations WHERE version = 1").Scan(&state, &applied, &total),
+			qt.IsNil,
+		)
+		c.Assert(state, qt.Equals, "pending")
+		c.Assert(applied, qt.Equals, 1)
+		c.Assert(total, qt.Equals, 2)
+	})
+
+	c.Run("Ptah in-flight statement", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "ptah-in-flight.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "ptah", "up", "after-execution")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+
+		var state, failure, failureStatement string
+		var applied, total int
+		c.Assert(conn.QueryRow(`
+			SELECT state, applied, total, COALESCE(error, ''), COALESCE(error_stmt, '')
+			FROM schema_migrations WHERE version = 1
+		`).Scan(&state, &applied, &total, &failure, &failureStatement), qt.IsNil)
+		c.Assert(state, qt.Equals, "pending")
+		c.Assert(applied, qt.Equals, 0)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(failure, qt.Contains, "statement execution outcome is unknown")
+		c.Assert(failureStatement, qt.Contains, "CREATE TABLE users")
+
+		mig := migrator.NewMigrator(conn, noTransactionCrashProvider(c))
+		err := mig.RepairMigration(c.Context(), migrator.RepairMigrationOptions{Version: 1, ResumeFrom: 1})
+		c.Assert(err, qt.ErrorMatches, `migration 1 has an unknown statement outcome.*omit --resume-from.*`)
+	})
+
+	c.Run("Atlas in-flight statement", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "atlas-in-flight.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "atlas", "up", "after-execution")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+
+		var failure, failureStatement string
+		var applied, total int
+		c.Assert(conn.QueryRow(`
+			SELECT applied, total, COALESCE(error, ''), COALESCE(error_stmt, '')
+			FROM atlas_schema_revisions WHERE version = '1'
+		`).Scan(&applied, &total, &failure, &failureStatement), qt.IsNil)
+		c.Assert(applied, qt.Equals, 0)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(failure, qt.Contains, "statement execution outcome is unknown")
+		c.Assert(failureStatement, qt.Contains, "CREATE TABLE users")
+
+		mig := migrator.NewMigrator(conn, noTransactionCrashProvider(c)).
+			WithRevisionTableFormat(migrator.RevisionTableFormatAtlas)
+		err := mig.RepairMigration(c.Context(), migrator.RepairMigrationOptions{Version: 1, ResumeFrom: 1})
+		c.Assert(err, qt.ErrorMatches, `migration 1 has an unknown statement outcome.*omit --resume-from.*`)
+	})
+
+	c.Run("Atlas down preserves compatibility bookkeeping", func(c *qt.C) {
+		databasePath := filepath.Join(c.TempDir(), "atlas-down-crash.db")
+		runNoTransactionCrashHelper(c, helperPath, databasePath, "atlas", "down", "after-checkpoint")
+		conn := openNoTransactionCrashDatabase(c, databasePath)
+		defer dbschema.CloseAndWarn(conn)
+		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
+		c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+
+		var failure string
+		var applied, total int
+		c.Assert(
+			conn.QueryRow("SELECT applied, total, COALESCE(error, '') FROM atlas_schema_revisions WHERE version = '1'").Scan(&applied, &total, &failure),
+			qt.IsNil,
+		)
+		c.Assert(applied, qt.Equals, 2)
+		c.Assert(total, qt.Equals, 2)
+		c.Assert(failure, qt.Equals, "")
+	})
+}
+
+func runNoTransactionCrashHelper(
+	c *qt.C,
+	helperPath, databasePath, revisionFormat, direction, crashPoint string,
+) {
+	c.Helper()
+	run := exec.Command(helperPath, databasePath, revisionFormat, direction, crashPoint)
+	err := run.Run()
+	var exitErr *exec.ExitError
+	c.Assert(err, qt.ErrorAs, &exitErr)
+	c.Assert(exitErr.ExitCode(), qt.Equals, 73)
+}
+
+func noTransactionCrashProvider(c *qt.C) migrator.MigrationProvider {
+	c.Helper()
+	provider, err := migrator.NewFSMigrationProvider(fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("-- +ptah no_transaction\nCREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE posts (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("-- +ptah no_transaction\nDROP TABLE posts;\nDROP TABLE users;"),
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	return provider
+}
+
+func openNoTransactionCrashDatabase(c *qt.C, databasePath string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+databasePath)
+	c.Assert(err, qt.IsNil)
+	return conn
+}

--- a/migration/migrator/no_transaction_validation_test.go
+++ b/migration/migrator/no_transaction_validation_test.go
@@ -1,0 +1,164 @@
+package migrator_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestNoTransactionTimeoutValidation_UpLeavesNoRevision(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	conn := openNoTransactionValidationSQLite(c)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("-- +ptah no_transaction lock_timeout=1s\nCREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("DROP TABLE users;"),
+		},
+	})
+	c.Assert(err, qt.IsNil)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `migration 1 is marked no_transaction, so migration timeouts cannot be applied safely`)
+	c.Assert(noTransactionRevisionCount(c, conn), qt.Equals, int64(0))
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsFalse)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(0))
+	c.Assert(status.DirtyRevision, qt.IsNil)
+}
+
+func TestNoTransactionTimeoutValidation_DownPreservesAppliedRevision(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	conn := openNoTransactionValidationSQLite(c)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("-- +ptah no_transaction statement_timeout=1s\nDROP TABLE users;"),
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+
+	err = mig.MigrateDownTo(ctx, 0)
+	c.Assert(err, qt.ErrorMatches, `migration 1 is marked no_transaction, so migration timeouts cannot be applied safely`)
+	c.Assert(noTransactionRevisionCount(c, conn), qt.Equals, int64(1))
+	c.Assert(noTransactionRevisionState(c, conn), qt.Equals, "applied")
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+	c.Assert(status.DirtyRevision, qt.IsNil)
+}
+
+func TestNoTransactionTimeoutValidation_DefaultTimeoutCanBeFixedAndRetried(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	conn := openNoTransactionValidationSQLite(c)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("-- +ptah no_transaction\nCREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("DROP TABLE users;"),
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	mig = mig.WithDefaultTimeouts(migrator.MigrationTimeouts{
+		LockTimeout:    time.Second,
+		HasLockTimeout: true,
+	})
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `migration 1 is marked no_transaction, so migration timeouts cannot be applied safely`)
+	c.Assert(noTransactionRevisionCount(c, conn), qt.Equals, int64(0))
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsFalse)
+
+	mig = mig.WithDefaultTimeouts(migrator.MigrationTimeouts{})
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	c.Assert(noTransactionRevisionCount(c, conn), qt.Equals, int64(1))
+	c.Assert(noTransactionRevisionState(c, conn), qt.Equals, "applied")
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+}
+
+func TestProgrammaticMigration_UpNoTransactionUsesAutocommit(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	conn := openNoTransactionValidationSQLite(c)
+	defer dbschema.CloseAndWarn(conn)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"create users",
+		"CREATE TABLE users (id INTEGER PRIMARY KEY); INSERT INTO missing_table (id) VALUES (1);",
+		"DROP TABLE users;",
+	)
+	migration.UpNoTransaction = true
+	mig := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migration))
+
+	err := mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `(?s).*failed to execute SQL.*no such table: missing_table.*`)
+	c.Assert(noTransactionTableExists(c, conn, "users"), qt.IsTrue)
+	c.Assert(noTransactionRevisionState(c, conn), qt.Equals, "failed")
+	var applied, total int
+	c.Assert(
+		conn.QueryRow("SELECT applied, total FROM schema_migrations WHERE version = 1").Scan(&applied, &total),
+		qt.IsNil,
+	)
+	c.Assert(applied, qt.Equals, 1)
+	c.Assert(total, qt.Equals, 2)
+}
+
+func openNoTransactionValidationSQLite(c *qt.C) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(
+		context.Background(),
+		"sqlite://"+filepath.Join(c.TempDir(), "no-transaction-validation.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	return conn
+}
+
+func noTransactionRevisionCount(c *qt.C, conn *dbschema.DatabaseConnection) int64 {
+	c.Helper()
+	var count int64
+	c.Assert(conn.QueryRow("SELECT COUNT(*) FROM schema_migrations").Scan(&count), qt.IsNil)
+	return count
+}
+
+func noTransactionRevisionState(c *qt.C, conn *dbschema.DatabaseConnection) string {
+	c.Helper()
+	var state string
+	c.Assert(conn.QueryRow("SELECT state FROM schema_migrations WHERE version = 1").Scan(&state), qt.IsNil)
+	return state
+}
+
+func noTransactionTableExists(c *qt.C, conn *dbschema.DatabaseConnection, table string) bool {
+	c.Helper()
+	var count int64
+	c.Assert(
+		conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?", table).Scan(&count),
+		qt.IsNil,
+	)
+	return count == 1
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -18,12 +18,14 @@ import (
 )
 
 const (
-	migrationStateApplied = "applied"
-	migrationStatePending = "pending"
-	migrationStateFailed  = "failed"
-	ptahOperatorVersion   = "Ptah"
-	atlasNullJSON         = "null"
-	atlasSetMaxAttempts   = 3
+	migrationStateApplied        = "applied"
+	migrationStatePending        = "pending"
+	migrationStateFailed         = "failed"
+	ptahOperatorVersion          = "Ptah"
+	atlasNullJSON                = "null"
+	atlasSetMaxAttempts          = 3
+	revisionWriteTimeout         = 10 * time.Second
+	unknownStatementOutcomeError = "statement execution outcome is unknown after process interruption"
 )
 
 // MigrationRevision records one row from the migration metadata table.
@@ -141,6 +143,12 @@ func (m *Migrator) migrationStatementCount(sqlText string) int {
 }
 
 func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMode) (applied int, total int, stmt string) {
+	var progressErr *statementProgressError
+	if errors.As(err, &progressErr) {
+		event := progressErr.event
+		return progressErr.applied, event.Total, event.Statement
+	}
+
 	var observationErr *StatementObservationError
 	if errors.As(err, &observationErr) {
 		event := observationErr.Event
@@ -306,53 +314,74 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
 
 func (m *Migrator) completeMigrationSQL() string {
 	if m.revisionTableFormat.isAtlas() {
-		return fmt.Sprintf(`UPDATE %s
-SET applied = ?, total = ?, execution_time = ?, error = '', error_stmt = '', partial_hashes = ?, operator_version = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+		return revisionUpdateSQL(
+			m.connectionDialect(),
+			m.qualifiedMigrationsTable(),
+			"applied = ?, total = ?, execution_time = ?, error = '', error_stmt = '', partial_hashes = ?, operator_version = ?",
+		)
 	}
-	if m.isClickHouse() {
-		return fmt.Sprintf(`ALTER TABLE %s
-UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?
-WHERE version = ?
-SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?",
+	)
+}
+
+func (m *Migrator) checkpointMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return revisionUpdateSQL(
+			m.connectionDialect(),
+			m.qualifiedMigrationsTable(),
+			"applied = ?, total = ?, execution_time = ?, error = '', error_stmt = '', operator_version = ?",
+		)
 	}
-	return fmt.Sprintf(`UPDATE %s
-SET state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, applied_at = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?",
+	)
 }
 
 func (m *Migrator) beginRollbackSQL() string {
 	if m.revisionTableFormat.isAtlas() {
-		return fmt.Sprintf(`UPDATE %s
-SET applied = ?, total = ?, executed_at = ?, execution_time = ?, error = '', error_stmt = '', partial_hashes = ?, operator_version = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+		return revisionUpdateSQL(
+			m.connectionDialect(),
+			m.qualifiedMigrationsTable(),
+			"applied = ?, total = ?, executed_at = ?, execution_time = ?, error = '', error_stmt = '', partial_hashes = ?, operator_version = ?",
+		)
 	}
-	if m.isClickHouse() {
-		return fmt.Sprintf(`ALTER TABLE %s
-UPDATE state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?
-WHERE version = ?
-SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
-	}
-	return fmt.Sprintf(`UPDATE %s
-SET state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?",
+	)
 }
 
 func (m *Migrator) failMigrationSQL() string {
 	if m.revisionTableFormat.isAtlas() {
-		return fmt.Sprintf(`UPDATE %s
-SET applied = ?, total = ?, execution_time = ?, error = ?, error_stmt = ?, operator_version = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+		return revisionUpdateSQL(
+			m.connectionDialect(),
+			m.qualifiedMigrationsTable(),
+			"applied = ?, total = ?, execution_time = ?, error = ?, error_stmt = ?, operator_version = ?",
+		)
 	}
-	if m.isClickHouse() {
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?",
+	)
+}
+
+func revisionUpdateSQL(dialect, table, assignments string) string {
+	if platform.NormalizeDialect(dialect) == platform.ClickHouse {
 		return fmt.Sprintf(`ALTER TABLE %s
-UPDATE state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?
+UPDATE %s
 WHERE version = ?
-SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+SETTINGS mutations_sync = 1`, table, assignments)
 	}
 	return fmt.Sprintf(`UPDATE %s
-SET state = ?, applied = ?, total = ?, error = ?, error_stmt = ?, execution_time_ms = ?
-WHERE version = ?`, m.qualifiedMigrationsTable())
+SET %s
+WHERE version = ?`, table, assignments)
 }
 
 func (m *Migrator) forceAppliedMigrationSQL() string {
@@ -371,11 +400,20 @@ func (m *Migrator) insertAtlasRevisionSQL() string {
 VALUES (?, ?, ?, ?, ?, ?, ?, '', '', ?, ?, ?)`, m.qualifiedMigrationsTable())
 }
 
-func (m *Migrator) forceAppliedUpdateSQL() string {
-	return fmt.Sprintf(`ALTER TABLE %s
-UPDATE description = ?, applied_at = ?, state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, checksum = ?
-WHERE version = ?
-SETTINGS mutations_sync = 1`, m.qualifiedMigrationsTable())
+func (m *Migrator) forceAppliedPtahUpdateSQL() string {
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"description = ?, applied_at = ?, state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, checksum = ?",
+	)
+}
+
+func (m *Migrator) forceAppliedAtlasUpdateSQL() string {
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"description = ?, type = ?, applied = ?, total = ?, executed_at = ?, execution_time = ?, error = '', error_stmt = '', hash = ?, partial_hashes = ?, operator_version = ?",
+	)
 }
 
 func (m *Migrator) countRevisionsSQL() string {
@@ -774,7 +812,7 @@ func (m *Migrator) beginAtlasMigrationRevisionOn(
 		query,
 		strconv.FormatInt(migration.Version, 10),
 		migration.atlasFilenameDescription(),
-		AtlasRevisionTypeApplied,
+		int64(AtlasRevisionTypeApplied),
 		0,
 		m.migrationStatementCount(migration.UpSQL),
 		m.atlasRevisionTimestamp(startedAt),
@@ -835,6 +873,82 @@ func (m *Migrator) completeAtlasMigrationRevisionOn(
 		m.atlasNullJSONValue(),
 		ptahOperatorVersion,
 		strconv.FormatInt(migration.Version, 10),
+	)
+}
+
+func (m *Migrator) checkpointMigrationRevision(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	event StatementEvent,
+) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.checkpointMigrationSQL())
+	if m.revisionTableFormat.isAtlas() {
+		return executeSQLOutsideTransaction(
+			recordCtx,
+			m.conn,
+			query,
+			event.Index,
+			event.Total,
+			time.Since(startedAt).Nanoseconds(),
+			ptahOperatorVersion,
+			strconv.FormatInt(migration.Version, 10),
+		)
+	}
+	return executeSQLOutsideTransaction(
+		recordCtx,
+		m.conn,
+		query,
+		migrationStatePending,
+		event.Index,
+		event.Total,
+		time.Since(startedAt).Milliseconds(),
+		migration.Version,
+	)
+}
+
+func (m *Migrator) markMigrationStatementInFlight(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	event StatementEvent,
+) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
+	if m.revisionTableFormat.isAtlas() {
+		return executeSQLOutsideTransaction(
+			recordCtx,
+			m.conn,
+			query,
+			event.Index-1,
+			event.Total,
+			time.Since(startedAt).Nanoseconds(),
+			unknownStatementOutcomeError,
+			event.Statement,
+			ptahOperatorVersion,
+			strconv.FormatInt(migration.Version, 10),
+		)
+	}
+	return executeSQLOutsideTransaction(
+		recordCtx,
+		m.conn,
+		query,
+		migrationStatePending,
+		event.Index-1,
+		event.Total,
+		unknownStatementOutcomeError,
+		event.Statement,
+		time.Since(startedAt).Milliseconds(),
+		migration.Version,
 	)
 }
 
@@ -901,16 +1015,18 @@ func (m *Migrator) failMigrationRevisionWithMode(
 	if m.conn.Writer().IsDryRun() {
 		return nil
 	}
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
 	applied, total, stmt := migrationExecutionProgress(failure, m.conn.Info().Dialect, txMode)
 	if total == 0 {
 		total = m.migrationStatementCount(sqlText)
 	}
 	if m.revisionTableFormat.isAtlas() {
-		return m.failAtlasMigrationRevision(ctx, migration, startedAt, failure, applied, total, stmt)
+		return m.failAtlasMigrationRevision(recordCtx, migration, startedAt, failure, applied, total, stmt)
 	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
 	return executeSQLOutsideTransaction(
-		ctx,
+		recordCtx,
 		m.conn,
 		query,
 		migrationStateFailed,
@@ -921,6 +1037,10 @@ func (m *Migrator) failMigrationRevisionWithMode(
 		time.Since(startedAt).Milliseconds(),
 		migration.Version,
 	)
+}
+
+func durableRevisionWriteContext(ctx context.Context) (context.Context, context.CancelFunc) {
+	return context.WithTimeout(context.WithoutCancel(ctx), revisionWriteTimeout)
 }
 
 func (m *Migrator) failAtlasMigrationRevision(
@@ -1137,7 +1257,7 @@ func (m *Migrator) writeAtlasBaselineMigrationRow(
 		query,
 		strconv.FormatInt(migration.Version, 10),
 		migration.atlasFilenameDescription(),
-		AtlasRevisionTypeBaseline,
+		int64(AtlasRevisionTypeBaseline),
 		0,
 		0,
 		m.atlasRevisionTimestamp(time.Now()),
@@ -1346,7 +1466,7 @@ func (m *Migrator) writeAtlasSetRevisionRows(
 			if _, err := tx.ExecContext(
 				ctx,
 				updateTypeSQL,
-				revisionType,
+				int64(revisionType),
 				strconv.FormatInt(revision.Version, 10),
 			); err != nil {
 				return fmt.Errorf("failed to update dirty Atlas revision %d type: %w", revision.Version, err)
@@ -1450,6 +1570,13 @@ func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOpti
 		return fmt.Errorf("migration %d is not dirty; rerun with --force to rewrite it", opts.Version)
 	}
 	if opts.ResumeFrom > 0 {
+		if revision != nil && revision.Error == unknownStatementOutcomeError {
+			return fmt.Errorf(
+				"migration %d has an unknown statement outcome for %q; inspect the database before repair and omit --resume-from to avoid repeating committed SQL",
+				migration.Version,
+				revision.ErrorStatement,
+			)
+		}
 		if err := m.resumeMigration(ctx, migration, opts.ResumeFrom); err != nil {
 			return err
 		}
@@ -1527,7 +1654,7 @@ func (m *Migrator) forceAppliedAtlasMigration(ctx context.Context, migration *Mi
 		query,
 		strconv.FormatInt(migration.Version, 10),
 		migration.atlasFilenameDescription(),
-		AtlasRevisionTypeApplied,
+		int64(AtlasRevisionTypeApplied),
 		total,
 		total,
 		m.atlasRevisionTimestamp(time.Now()),
@@ -1549,7 +1676,7 @@ func (m *Migrator) writeAtlasManuallySetMigrationRow(
 		query,
 		strconv.FormatInt(migration.Version, 10),
 		migration.atlasFilenameDescription(),
-		AtlasRevisionTypeManuallySet,
+		int64(AtlasRevisionTypeManuallySet),
 		0,
 		0,
 		m.atlasRevisionTimestamp(time.Now()),
@@ -1572,14 +1699,17 @@ func (m *Migrator) atlasRevisionTimestamp(at time.Time) any {
 }
 
 func (m *Migrator) atlasNullJSONValue() any {
-	if m.isSQLServer() {
+	if m.isSQLServer() || m.isClickHouse() {
 		return atlasNullJSON
 	}
 	return []byte(atlasNullJSON)
 }
 
 func (m *Migrator) forceAppliedMigrationClickHouse(ctx context.Context, migration *Migration) error {
-	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedUpdateSQL())
+	if m.revisionTableFormat.isAtlas() {
+		return m.forceAppliedAtlasMigrationClickHouse(ctx, migration)
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedPtahUpdateSQL())
 	return executeSQLOutsideTransaction(
 		ctx,
 		m.conn,
@@ -1592,6 +1722,26 @@ func (m *Migrator) forceAppliedMigrationClickHouse(ctx context.Context, migratio
 		0,
 		migrationRevisionHash(migration),
 		migration.Version,
+	)
+}
+
+func (m *Migrator) forceAppliedAtlasMigrationClickHouse(ctx context.Context, migration *Migration) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.forceAppliedAtlasUpdateSQL())
+	total := m.migrationStatementCount(migration.UpSQL)
+	return executeSQLOutsideTransaction(
+		ctx,
+		m.conn,
+		query,
+		migration.atlasFilenameDescription(),
+		int64(AtlasRevisionTypeApplied),
+		total,
+		total,
+		m.atlasRevisionTimestamp(time.Now()),
+		int64(0),
+		migrationRevisionHash(migration),
+		m.atlasNullJSONValue(),
+		ptahOperatorVersion,
+		strconv.FormatInt(migration.Version, 10),
 	)
 }
 

--- a/migration/migrator/security_test.go
+++ b/migration/migrator/security_test.go
@@ -30,6 +30,7 @@ func TestMigrationMetadataSQL_UsesPlaceholders(t *testing.T) {
 	}{
 		"begin migration":    {sql: (&Migrator{}).beginMigrationSQL(), placeholders: 10},
 		"complete migration": {sql: (&Migrator{}).completeMigrationSQL(), placeholders: 6},
+		"checkpoint":         {sql: (&Migrator{}).checkpointMigrationSQL(), placeholders: 5},
 		"begin rollback":     {sql: (&Migrator{}).beginRollbackSQL(), placeholders: 5},
 		"fail migration":     {sql: (&Migrator{}).failMigrationSQL(), placeholders: 7},
 		"force applied":      {sql: (&Migrator{}).forceAppliedMigrationSQL(), placeholders: 8},

--- a/migration/migrator/testdata/no_transaction_crash/main.go
+++ b/migration/migrator/testdata/no_transaction_crash/main.go
@@ -1,0 +1,113 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing/fstest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+const crashExitCode = 73
+
+func main() {
+	databasePath := os.Args[1]
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+databasePath)
+	must(err)
+	fsys := fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("-- +ptah no_transaction\nCREATE TABLE users (id INTEGER PRIMARY KEY);\nCREATE TABLE posts (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("-- +ptah no_transaction\nDROP TABLE posts;\nDROP TABLE users;"),
+		},
+	}
+	revisionFormat := migrator.RevisionTableFormat(os.Args[2])
+	switch os.Args[3] {
+	case "up":
+		crashDuringUp(conn, fsys, revisionFormat)
+	case "down":
+		crashDuringDown(conn, fsys, revisionFormat)
+	default:
+		panic("unknown crash direction")
+	}
+}
+
+func crashDuringUp(
+	conn *dbschema.DatabaseConnection,
+	fsys fstest.MapFS,
+	revisionFormat migrator.RevisionTableFormat,
+) {
+	provider, err := crashProvider(fsys, os.Args[4])
+	must(err)
+	mig := migrator.NewMigrator(conn, provider).
+		WithRevisionTableFormat(revisionFormat)
+	must(mig.MigrateUp(context.Background()))
+	panic("migration completed without crashing")
+}
+
+func crashDuringDown(
+	conn *dbschema.DatabaseConnection,
+	fsys fstest.MapFS,
+	revisionFormat migrator.RevisionTableFormat,
+) {
+	provider, err := migrator.NewFSMigrationProvider(fsys)
+	must(err)
+	mig := migrator.NewMigrator(conn, provider).WithRevisionTableFormat(revisionFormat)
+	must(mig.MigrateUp(context.Background()))
+
+	provider, err = crashProvider(fsys, os.Args[4])
+	must(err)
+	mig = migrator.NewMigrator(conn, provider).WithRevisionTableFormat(revisionFormat)
+	must(mig.MigrateDownTo(context.Background(), 0))
+	panic("rollback completed without crashing")
+}
+
+func crashProvider(fsys fstest.MapFS, crashPoint string) (*migrator.FSMigrationProvider, error) {
+	switch crashPoint {
+	case "after-checkpoint":
+		return migrator.NewFSMigrationProvider(
+			fsys,
+			migrator.WithStatementObserver(migrator.StatementObserverFunc(crashAfterCheckpoint)),
+		)
+	case "after-execution":
+		return migrator.NewFSMigrationProvider(
+			fsys,
+			migrator.WithStatementInterceptor(crashAfterExecutionInterceptor{}),
+		)
+	default:
+		panic("unknown crash point")
+	}
+}
+
+type crashAfterExecutionInterceptor struct{}
+
+func (crashAfterExecutionInterceptor) ValidateDirectives(map[string]string) error {
+	return nil
+}
+
+func (crashAfterExecutionInterceptor) ExecuteStatement(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	statement string,
+	_ map[string]string,
+) (bool, error) {
+	_, err := conn.ExecContext(ctx, statement)
+	must(err)
+	os.Exit(crashExitCode)
+	return true, nil
+}
+
+func crashAfterCheckpoint(context.Context, migrator.StatementEvent) error {
+	os.Exit(crashExitCode)
+	return nil
+}
+
+func must(err error) {
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/migration/migrator/transactional_revision_atomicity_test.go
+++ b/migration/migrator/transactional_revision_atomicity_test.go
@@ -1,0 +1,52 @@
+package migrator_test
+
+import (
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/migration/migrator"
+)
+
+func TestTransactionalMigration_SQLiteRevisionCompletionFailureRollsBackBody(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	conn, err := dbschema.ConnectToDatabase(
+		ctx,
+		"sqlite://"+filepath.Join(t.TempDir(), "transactional-revision.db"),
+	)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	mig, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"000001_create_users.up.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER PRIMARY KEY);"),
+		},
+		"000001_create_users.down.sql": {
+			Data: []byte("DROP TABLE users;"),
+		},
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.Initialize(ctx), qt.IsNil)
+	_, err = conn.ExecContext(ctx, `
+		CREATE TRIGGER reject_applied_revision
+		BEFORE UPDATE OF state ON schema_migrations
+		WHEN NEW.state = 'applied'
+		BEGIN
+			SELECT RAISE(ABORT, 'reject applied revision');
+		END;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to record migration 1: .*reject applied revision.*`)
+	var tableCount int64
+	c.Assert(conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&tableCount), qt.IsNil)
+	c.Assert(tableCount, qt.Equals, int64(0))
+	var revisionState string
+	c.Assert(conn.QueryRow("SELECT state FROM schema_migrations WHERE version = 1").Scan(&revisionState), qt.IsNil)
+	c.Assert(revisionState, qt.Equals, "failed")
+}


### PR DESCRIPTION
## Summary

Hardens the completed `no_transaction` and PostgreSQL concurrent-index work from #152 across crash consistency, cancellation, metadata dialects, destructive shadow replay, and acceptance coverage.

- records a pre-statement unknown-outcome marker and a post-statement durable checkpoint for SQL-backed autocommit migrations
- finalizes failure/success bookkeeping with bounded contexts detached from caller cancellation
- commits transactional migration SQL and its applied revision atomically where the driver supports DDL transactions
- rejects incompatible migration timeouts before SQL or revision mutation
- removes the ambiguous pre-GA `Migration.NoTransaction` field in favor of directional `UpNoTransaction` / `DownNoTransaction`
- makes ClickHouse Ptah/Atlas revision mutations synchronous and fixes format-aware Atlas repair bindings
- rejects target/shadow connections that resolve to the same live database realm before destructive cleanup
- keeps Atlas-format down bookkeeping byte-compatible and documents its deliberate lack of statement checkpoints

## Validation

- `go test -count=1 ./...`
- `go test -race -count=1 ./migration/migrator ./migration/generator ./integration`
- real PostgreSQL generated `CREATE INDEX CONCURRENTLY` + apply acceptance, including `indisvalid` / `indisready`
- real ClickHouse Ptah and Atlas checkpoint/repair acceptance
- subprocess crash tests for before/after-checkpoint windows on Ptah and Atlas revision formats
- `golangci-lint run --fix ./...` and clean second pass
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- public API snapshot/released guards
- docs style, link, redirect, build, and responsive validation
- coverage threshold and `govulncheck ./...`

## Follow-ups

The remaining architectural work is tracked separately in #995, #996, #997, #998, and #999. Existing #887 remains open for full resumable Atlas no-transaction behavior.

This PR is rebased on current `master` after #994.