### PR TITLE
Harden circular foreign key support across render paths

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -227,11 +227,11 @@ jobs:
           PTAH_SQLSERVER_REALM_TEST_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
           PTAH_OCI_TEST_REGISTRY: "127.0.0.1:5000"
         run: |
-          go test -v ./integration -tags=integration -timeout 15m
-          go test -v ./integration/gonative -tags=integration -timeout 15m
-          go test -v ./dbschema -run 'TestSQLServerLive(ReadSchema|DropAllTablesDropsForeignKeys|ComputedColumnZeroDiff|DropAllTablesRejectsExternalForeignKeys|IdentifierSemantics_)' -timeout 3m
-          go test -v ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration|TestAtlasTxtarChecks_SQLServer(SequenceDoesNotAdvance)?Integration|TestDryRunRevisionState_SQLServerIntegration' -timeout 3m
-          go test -v ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m
+          go test -v -count=1 ./integration -tags=integration -timeout 15m
+          go test -v -count=1 ./integration/gonative -tags=integration -timeout 15m
+          go test -v -count=1 ./dbschema -run 'TestSQLServerLive(ReadSchema|DropAllTablesDropsForeignKeys|ComputedColumnZeroDiff|DropAllTablesRejectsExternalForeignKeys|IdentifierSemantics_)' -timeout 3m
+          go test -v -count=1 ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration|TestAtlasTxtarChecks_SQLServer(SequenceDoesNotAdvance)?Integration|TestDryRunRevisionState_SQLServerIntegration' -timeout 3m
+          go test -v -count=1 ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m
 
       - name: Run database-realm cleanup and replay tests
         env:
@@ -284,7 +284,7 @@ jobs:
           COCKROACHDB_TEST_DSN: "postgresql://root@localhost:26257/defaultdb?sslmode=disable"
           YUGABYTEDB_TEST_DSN: "postgresql://yugabyte@localhost:5433/yugabyte?sslmode=disable"
         run: |
-          go test -v ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_|TestAtlasRevisionMetadata_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouseRejectsSet)Integration|TestAtlasDotMetadata_(Postgres|MySQL)Integration|TestAtlasTxtarChecks_((Postgres|MySQL|MariaDB)(SessionLockReleased|CommentSemantics|EscapeString|ExecutableCommentEscape|ShortNumericPrefixRejectsNonSelect)?|ClickHouse|CockroachDB|YugabyteDB)Integration|TestAtlasRevisionTable_(Postgres|CockroachDB|YugabyteDB)UsesTimestamptzIntegration|TestAtlasSetSerializable_PostgresConcurrentInsertIntegration|TestDryRunRevisionState_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouse)Integration' -timeout 3m
+          go test -v -count=1 ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_|TestAtlasRevisionMetadata_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouseRejectsSet)Integration|TestAtlasDotMetadata_(Postgres|MySQL)Integration|TestAtlasTxtarChecks_((Postgres|MySQL|MariaDB)(SessionLockReleased|CommentSemantics|EscapeString|ExecutableCommentEscape|ShortNumericPrefixRejectsNonSelect)?|ClickHouse|CockroachDB|YugabyteDB)Integration|TestAtlasRevisionTable_(Postgres|CockroachDB|YugabyteDB)UsesTimestamptzIntegration|TestAtlasSetSerializable_PostgresConcurrentInsertIntegration|TestDryRunRevisionState_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouse)Integration' -timeout 3m
 
       - name: Run no-transaction and shadow generator integration tests
         env:
@@ -308,7 +308,7 @@ jobs:
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
         run: |
-          go test -v ./cmd/migratebaseline -run 'TestVerifyBaselineShadowPostgres|TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL' -timeout 3m
+          go test -v -count=1 ./cmd/migratebaseline -run 'TestVerifyBaselineShadowPostgres|TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL' -timeout 3m
 
       - name: Run all databases comprehensive test
         env:
@@ -335,7 +335,7 @@ jobs:
         env:
           SQLSERVER_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
         run: |
-          ./integration-test --databases=sqlserver --scenarios=apply_incremental_migrations,rollback_migrations,upgrade_to_specific_version,check_current_version,read_actual_db_schema,dry_run_support,operation_planning,failure_diagnostics,idempotency_reapply,idempotency_up_to_date,parallel_migrate_smoke,cleanup_support,dynamic_sqlserver_identity_schema_bracket_reserved_words --report=stdout,txt,json,html --verbose --output=./reports
+          ./integration-test --databases=sqlserver --scenarios=apply_incremental_migrations,rollback_migrations,upgrade_to_specific_version,check_current_version,read_actual_db_schema,dry_run_support,operation_planning,failure_diagnostics,idempotency_reapply,idempotency_up_to_date,parallel_migrate_smoke,cleanup_support,dynamic_circular_dependencies,dynamic_sqlserver_identity_schema_bracket_reserved_words --report=stdout,txt,json,html --verbose --output=./reports
 
       - name: Upload integration test reports
         uses: actions/upload-artifact@v7
@@ -361,4 +361,4 @@ jobs:
           YUGABYTEDB_URL: "yugabytedb://yugabyte@localhost:5433/yugabyte?sslmode=disable"
           SQLSERVER_URL: "sqlserver://sa:P%40ssw0rd-ptah-2026@localhost:1433?database=master&encrypt=disable"
         run: |
-          go test -v -race ./integration -tags=integration -timeout 30m
+          go test -v -race -count=1 ./integration -tags=integration -timeout 30m

--- a/.teststyle-baseline.json
+++ b/.teststyle-baseline.json
@@ -757,12 +757,6 @@
       "count": 2
     },
     {
-      "path": "migration/generator/multihost_fk_down_test.go",
-      "function": "TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost",
-      "kind": "if",
-      "count": 1
-    },
-    {
       "path": "migration/generator/reverse_diff_test.go",
       "function": "TestGenerateDownMigrationSQL_Issue194_DropsFieldLevelCheckMySQLFamily",
       "kind": "if",

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -4,8 +4,8 @@
 package generate
 
 import (
+	"bytes"
 	"fmt"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,7 +13,6 @@ import (
 	"github.com/stokaro/ptah/cmd/internal/dbcli"
 	"github.com/stokaro/ptah/cmd/internal/schemaload"
 	"github.com/stokaro/ptah/core/goschema"
-	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/renderer"
 )
 
@@ -62,18 +61,25 @@ source can provide the desired schema too.`,
 }
 
 func registerFlags(cmd *cobra.Command, opts *options) {
+	const dialectUsage = "Database dialect (postgres, mysql, mariadb, sqlite, clickhouse, " +
+		"cockroachdb, yugabytedb, sqlserver, spanner). If empty, attempts the built-in " +
+		"review targets and emits output only if every target succeeds"
+
 	flags := cmd.Flags()
 	flags.StringArrayVar(&opts.rootDirs, rootDirFlag, nil, "Root directory to scan for Go entities (repeatable; multiple roots merge into one composite schema; defaults to ./)")
 	flags.StringArrayVar(&opts.schemaFiles, schemaFileFlag, nil, "YAML, HCL, or SQL schema file to generate from instead of, or combined with, Go entities (repeatable; multiple sources merge into one composite schema)")
 	flags.StringVar(&opts.schemaCmd, schemaCmdFlag, "", schemaCmdUsage)
 	flags.StringVar(&opts.schemaFormat, schemaFormatFlag, "sql", "Format of the --schema-cmd output: sql, hcl, or yaml")
-	flags.StringVar(&opts.dialect, dialectFlag, "", "Database dialect (postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, spanner). If empty, generates for all dialects")
+	flags.StringVar(&opts.dialect, dialectFlag, "", dialectUsage)
 	flags.StringVar(&opts.configPath, dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
 	dbcli.RegisterEnvFlag(flags, &opts.envName)
 	dbcli.RegisterExternalSchemaOptInFlag(flags)
 }
 
 func generateCommand(cmd *cobra.Command, opts *options) error {
+	stdout := cmd.OutOrStdout()
+	stderr := cmd.ErrOrStderr()
+
 	projectCfg, err := dbcli.LoadProjectConfig(cmd, opts.configPath)
 	if err != nil {
 		return err
@@ -95,20 +101,17 @@ func generateCommand(cmd *cobra.Command, opts *options) error {
 		SchemaFiles: opts.schemaFiles,
 		Commands:    commands,
 		Dialect:     opts.dialect,
-		Logf:        func(format string, args ...any) { fmt.Printf(format+"\n", args...) },
+		Logf:        func(format string, args ...any) { fmt.Fprintf(stderr, format+"\n", args...) },
 	})
 	if err != nil {
 		return err
 	}
 
-	// Print summary
-	fmt.Printf("Found %d tables, %d fields, %d indexes, %d enums, %d embedded fields\n",
+	fmt.Fprintf(stderr, "Found %d tables, %d fields, %d indexes, %d enums, %d embedded fields\n",
 		len(result.Tables), len(result.Fields), len(result.Indexes), len(result.Enums), len(result.EmbeddedFields))
-	fmt.Println()
-
-	// Print dependency information
-	fmt.Println(goschema.GetDependencyInfo(result))
-	fmt.Println()
+	fmt.Fprintln(stderr)
+	fmt.Fprintln(stderr, goschema.GetDependencyInfo(result))
+	fmt.Fprintln(stderr)
 
 	// Determine which dialects to generate
 	dialects := []string{"postgres", "mysql", "mariadb", "sqlite", "clickhouse", "cockroachdb", "yugabytedb", "spanner"}
@@ -116,45 +119,23 @@ func generateCommand(cmd *cobra.Command, opts *options) error {
 		dialects = []string{opts.dialect}
 	}
 
-	// Generate SQL for each dialect
+	var rendered bytes.Buffer
 	for _, d := range dialects {
-		fmt.Printf("=== %s SCHEMA ===\n", strings.ToUpper(d))
-		fmt.Println()
-
-		// Generate enum statements first (only once per dialect)
-		if len(result.Enums) > 0 {
-			fmt.Println("-- ENUMS --")
-			for _, enum := range result.Enums {
-				switch platform.NormalizeDialect(d) {
-				case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
-					fmt.Printf("CREATE TYPE %s AS ENUM (%s);\n", enum.Name,
-						strings.Join(func() []string {
-							quoted := make([]string, len(enum.Values))
-							for i, v := range enum.Values {
-								quoted[i] = "'" + v + "'"
-							}
-							return quoted
-						}(), ", "))
-				default:
-					fmt.Printf("-- Enum %s: %v (handled in table definitions)\n", enum.Name, enum.Values)
-				}
-			}
-			fmt.Println()
-		}
-
-		// Generate table statements
 		statements, err := renderer.GetOrderedCreateStatements(result, d)
 		if err != nil {
 			return fmt.Errorf("error rendering %s schema: %w", d, err)
 		}
 
-		for i, statement := range statements {
-			fmt.Printf("-- Statement %d/%d\n", i+1, len(statements))
-			fmt.Println(statement)
-			fmt.Println()
+		if len(dialects) > 1 {
+			fmt.Fprintf(&rendered, "-- %s schema\n\n", d)
 		}
+		for i, statement := range statements {
+			fmt.Fprintf(&rendered, "-- Statement %d/%d\n%s\n\n", i+1, len(statements), statement)
+		}
+	}
 
-		fmt.Println()
+	if _, err := rendered.WriteTo(stdout); err != nil {
+		return fmt.Errorf("write rendered schema: %w", err)
 	}
 
 	return nil

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -114,7 +114,10 @@ func generateCommand(cmd *cobra.Command, opts *options) error {
 	fmt.Fprintln(stderr)
 
 	// Determine which dialects to generate
-	dialects := []string{"postgres", "mysql", "mariadb", "sqlite", "clickhouse", "cockroachdb", "yugabytedb", "spanner"}
+	dialects := []string{
+		"postgres", "mysql", "mariadb", "sqlite", "clickhouse",
+		"cockroachdb", "yugabytedb", "sqlserver", "spanner",
+	}
 	if opts.dialect != "" {
 		dialects = []string{opts.dialect}
 	}

--- a/cmd/generate/generate_atlas_external_test.go
+++ b/cmd/generate/generate_atlas_external_test.go
@@ -44,11 +44,12 @@ func TestGenerateCommand_UsesExternalSchemaFromAtlasConfigEnv(t *testing.T) {
 		"--dialect", "postgres",
 	})
 
-	output, err := captureGenerateStdout(c, cmd.Execute)
+	stdout, stderr, err := executeGenerate(c, cmd)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(output, qt.Contains, "Found 1 tables")
-	c.Assert(output, qt.Contains, `CREATE TABLE "configured_widgets"`)
+	c.Assert(stdout, qt.Contains, `CREATE TABLE "configured_widgets"`)
+	c.Assert(stdout, qt.Not(qt.Contains), "Found 1 tables")
+	c.Assert(stderr, qt.Contains, "Found 1 tables")
 }
 
 func TestGenerateCommand_RejectsImplicitExternalSchemaFromAtlasConfig(t *testing.T) {

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -31,25 +30,18 @@ func TestGenerateHelperProcess(t *testing.T) {
 	runGenerateHelperProcess()
 }
 
-func captureGenerateStdout(c *qt.C, run func() error) (string, error) {
+func executeGenerate(c *qt.C, cmd interface {
+	SetOut(io.Writer)
+	SetErr(io.Writer)
+	Execute() error
+}) (stdoutText, stderrText string, executeErr error) {
 	c.Helper()
-
-	oldStdout := os.Stdout
-	outR, outW, err := os.Pipe()
-	c.Assert(err, qt.IsNil)
-	c.Cleanup(func() {
-		os.Stdout = oldStdout
-		c.Assert(outR.Close(), qt.IsNil)
-	})
-
-	os.Stdout = outW
-	runErr := run()
-	c.Assert(outW.Close(), qt.IsNil)
-	os.Stdout = oldStdout
-
-	output, err := io.ReadAll(outR)
-	c.Assert(err, qt.IsNil)
-	return string(output), runErr
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	err := cmd.Execute()
+	return stdout.String(), stderr.String(), err
 }
 
 func outputStatementContaining(output, marker string) string {
@@ -83,11 +75,12 @@ func TestGenerateCommand_UsesExternalSchemaFromPtahConfigEnv(t *testing.T) {
 		"--dialect", "postgres",
 	})
 
-	output, err := captureGenerateStdout(c, cmd.Execute)
+	stdout, stderr, err := executeGenerate(c, cmd)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(output, qt.Contains, "Found 1 tables")
-	c.Assert(output, qt.Contains, `CREATE TABLE "configured_widgets"`)
+	c.Assert(stdout, qt.Contains, `CREATE TABLE "configured_widgets"`)
+	c.Assert(stdout, qt.Not(qt.Contains), "Found 1 tables")
+	c.Assert(stderr, qt.Contains, "Found 1 tables")
 }
 
 func TestGenerateCommand_RejectsImplicitExternalSchemaFromConfig(t *testing.T) {
@@ -136,11 +129,12 @@ func TestGenerateCommand_MutualForeignKeysAreTwoPhase(t *testing.T) {
 	c := qt.New(t)
 
 	fixtureDir := filepath.Join("..", "..", "integration", "fixtures", "entities", "029-roundtrip-mutual-cycle")
-	cmd := exec.Command("go", "run", "../main.go", "schema", "render", "--root-dir", fixtureDir, "--dialect", "postgres")
-	output, err := cmd.CombinedOutput()
-	c.Assert(err, qt.IsNil, qt.Commentf("generate output:\n%s", output))
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--root-dir", fixtureDir, "--dialect", "postgres"})
+	stdout, stderr, err := executeGenerate(c, cmd)
+	c.Assert(err, qt.IsNil, qt.Commentf("generate stderr:\n%s", stderr))
 
-	sql := string(output)
+	sql := stdout
 	leftCreate := outputStatementContaining(sql, `CREATE TABLE "left_nodes"`)
 	rightCreate := outputStatementContaining(sql, `CREATE TABLE "right_nodes"`)
 	c.Assert(leftCreate, qt.Not(qt.Equals), "")
@@ -155,11 +149,52 @@ func TestGenerateCommand_JsonEmbeddedFieldRendersOnce(t *testing.T) {
 	c := qt.New(t)
 
 	fixtureDir := filepath.Join("..", "..", "integration", "fixtures", "entities", "023-go-annotations-objects")
-	cmd := exec.Command("go", "run", "../main.go", "schema", "render", "--root-dir", fixtureDir, "--dialect", "postgres")
-	output, err := cmd.CombinedOutput()
-	c.Assert(err, qt.IsNil, qt.Commentf("generate output:\n%s", output))
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--root-dir", fixtureDir, "--dialect", "postgres"})
+	stdout, stderr, err := executeGenerate(c, cmd)
+	c.Assert(err, qt.IsNil, qt.Commentf("generate stderr:\n%s", stderr))
 
-	usersCreate := outputStatementContaining(string(output), `CREATE TABLE "users"`)
+	usersCreate := outputStatementContaining(stdout, `CREATE TABLE "users"`)
 	c.Assert(usersCreate, qt.Not(qt.Equals), "")
 	c.Assert(strings.Count(usersCreate, `"metadata" JSONB NOT NULL`), qt.Equals, 1)
+}
+
+func TestGenerateCommand_StdoutIsExecutableSQL(t *testing.T) {
+	c := qt.New(t)
+
+	schemaPath := filepath.Join(t.TempDir(), "schema.yaml")
+	c.Assert(os.WriteFile(schemaPath, []byte(`enums:
+  account_status: [active, suspended]
+tables:
+  accounts:
+    columns:
+      id: {type: INTEGER, primary: true}
+      status: {type: account_status, not_null: true}
+`), 0o600), qt.IsNil)
+
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--schema-file", schemaPath, "--dialect", "postgres"})
+	stdout, stderr, err := executeGenerate(c, cmd)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Count(stdout, `CREATE TYPE "account_status"`), qt.Equals, 1)
+	c.Assert(stdout, qt.Contains, `CREATE TABLE "accounts"`)
+	c.Assert(stdout, qt.Not(qt.Contains), "Found 1 tables")
+	c.Assert(stdout, qt.Not(qt.Contains), "Table Dependencies:")
+	c.Assert(stdout, qt.Not(qt.Contains), "=== POSTGRES SCHEMA ===")
+	c.Assert(stderr, qt.Contains, "Found 1 tables")
+	c.Assert(stderr, qt.Contains, "Table Dependencies:")
+}
+
+func TestGenerateCommand_OmittedDialectForeignKeyFailureKeepsStdoutEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	fixtureDir := filepath.Join("..", "..", "integration", "fixtures", "entities", "029-roundtrip-mutual-cycle")
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--root-dir", fixtureDir})
+	stdout, stderr, err := executeGenerate(c, cmd)
+
+	c.Assert(err, qt.ErrorMatches, "error rendering clickhouse schema: clickhouse does not support foreign keys")
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Contains, "Found 2 tables")
 }

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -198,3 +198,22 @@ func TestGenerateCommand_OmittedDialectForeignKeyFailureKeepsStdoutEmpty(t *test
 	c.Assert(stdout, qt.Equals, "")
 	c.Assert(stderr, qt.Contains, "Found 2 tables")
 }
+
+func TestGenerateCommand_OmittedDialectIncludesSQLServerReviewTarget(t *testing.T) {
+	c := qt.New(t)
+
+	schemaPath := filepath.Join(t.TempDir(), "schema.yaml")
+	c.Assert(os.WriteFile(schemaPath, []byte(`tables:
+  accounts:
+    columns:
+      id: {type: INTEGER, primary: true}
+`), 0o600), qt.IsNil)
+
+	cmd := generate.NewGenerateCommand()
+	cmd.SetArgs([]string{"--schema-file", schemaPath})
+	stdout, stderr, err := executeGenerate(c, cmd)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("generate stderr:\n%s", stderr))
+	c.Assert(stdout, qt.Contains, "-- sqlserver schema")
+	c.Assert(stdout, qt.Contains, "-- spanner schema")
+}

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -246,13 +246,9 @@ func TestCompatBinaryDryRunPinNoWriterNarration(t *testing.T) {
 	}
 }
 
-// TestCompatBinaryKeepsLogOnlyDiagnostics is the other half of the quiet
-// contract: narration is dropped, but a Warn-level diagnostic that exists on no
-// other channel still gets through. A circular foreign-key graph is reordered
-// and reported only through this record — it is never returned as an error — so
-// dropping it would let an apply report success while quietly emitting DDL that
-// depends on creation order.
-func TestCompatBinaryKeepsLogOnlyDiagnostics(t *testing.T) {
+// TestCompatBinaryValidCircularForeignKeysDoNotWarn verifies that two-phase
+// foreign-key rendering treats valid cycles as ordinary schema relationships.
+func TestCompatBinaryValidCircularForeignKeysDoNotWarn(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
 	dir := c.TempDir()
@@ -292,8 +288,7 @@ func TestCompatBinaryKeepsLogOnlyDiagnostics(t *testing.T) {
 			err := run.Run()
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
-			c.Assert(stderr.String(), qt.Contains, "level=WARN")
-			c.Assert(stderr.String(), qt.Contains, "Circular dependency detected in foreign key relationships")
+			c.Assert(stderr.String(), qt.Equals, "")
 		})
 	}
 }

--- a/cmd/readdb/readdb.go
+++ b/cmd/readdb/readdb.go
@@ -3,7 +3,6 @@
 package readdb
 
 import (
-	"context"
 	"fmt"
 	"strings"
 
@@ -51,14 +50,13 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 }
 
-func readDBCommand(_ *cobra.Command, opts *options) error {
+func readDBCommand(cmd *cobra.Command, opts *options) error {
 	if opts.dbURL == "" {
 		return fmt.Errorf("database URL is required")
 	}
 
-	fmt.Printf("Reading schema from database: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
-	fmt.Println("=== DATABASE SCHEMA ===")
-	fmt.Println()
+	stderr := cmd.ErrOrStderr()
+	fmt.Fprintf(stderr, "Reading schema from database: %s\n", dbschema.FormatDatabaseURL(opts.dbURL))
 
 	connectTimeout, err := dbcli.ParseConnectTimeout(opts.connectTimeout)
 	if err != nil {
@@ -66,28 +64,26 @@ func readDBCommand(_ *cobra.Command, opts *options) error {
 	}
 
 	// Connect to the database
-	connectCtx, cancelConnect := dbcli.ConnectContext(context.Background(), connectTimeout)
+	connectCtx, cancelConnect := dbcli.ConnectContext(cmd.Context(), connectTimeout)
 	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.dbURL)
 	cancelConnect()
 	if err != nil {
-		fmt.Printf("Error connecting to database: %v\n", err)
-		fmt.Println()
-		fmt.Println("Make sure:")
-		fmt.Println("1. The database URL is correct")
-		fmt.Println("2. The database server is running")
-		fmt.Println("3. You have the correct permissions")
-		fmt.Println("4. The database exists")
+		fmt.Fprintf(stderr, "Error connecting to database: %v\n\n", err)
+		fmt.Fprintln(stderr, "Make sure:")
+		fmt.Fprintln(stderr, "1. The database URL is correct")
+		fmt.Fprintln(stderr, "2. The database server is running")
+		fmt.Fprintln(stderr, "3. You have the correct permissions")
+		fmt.Fprintln(stderr, "4. The database exists")
 		if connectTimeout > 0 {
-			fmt.Printf("5. The connection completes within --connect-timeout (currently %s)\n", connectTimeout)
+			fmt.Fprintf(stderr, "5. The connection completes within --connect-timeout (currently %s)\n", connectTimeout)
 		} else {
-			fmt.Println("5. --connect-timeout is disabled; the call will not time out at the application layer")
+			fmt.Fprintln(stderr, "5. --connect-timeout is disabled; the call will not time out at the application layer")
 		}
 		return err
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	fmt.Printf("Connected to %s database successfully!\n", conn.Info().Dialect)
-	fmt.Println()
+	fmt.Fprintf(stderr, "Connected to %s database successfully!\n", conn.Info().Dialect)
 
 	// Read the schema
 	schemas := dbcli.ParseSchemas(opts.schemas)
@@ -103,8 +99,7 @@ func readDBCommand(_ *cobra.Command, opts *options) error {
 	if err != nil {
 		return fmt.Errorf("error rendering schema: %w", err)
 	}
-	output := strings.Join(statements, ";\n") + ";"
-	fmt.Print(output)
+	fmt.Fprintln(cmd.OutOrStdout(), strings.Join(statements, "\n\n"))
 
 	return nil
 }

--- a/cmd/readdb/readdb_test.go
+++ b/cmd/readdb/readdb_test.go
@@ -1,0 +1,66 @@
+package readdb_test
+
+import (
+	"bytes"
+	"database/sql"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "modernc.org/sqlite"
+
+	"github.com/stokaro/ptah/cmd/readdb"
+)
+
+func TestReadDBCommand_StdoutIsExecutableSQL(t *testing.T) {
+	c := qt.New(t)
+
+	sourcePath := filepath.Join(t.TempDir(), "source.db")
+	source, err := sql.Open("sqlite", sourcePath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(source.Close(), qt.IsNil) })
+	_, err = source.Exec(`
+CREATE TABLE left_nodes (
+    id INTEGER PRIMARY KEY,
+    right_id INTEGER,
+    CONSTRAINT fk_left_right FOREIGN KEY (right_id) REFERENCES right_nodes(id)
+);
+CREATE TABLE right_nodes (
+    id INTEGER PRIMARY KEY,
+    left_id INTEGER,
+    CONSTRAINT fk_right_left FOREIGN KEY (left_id) REFERENCES left_nodes(id)
+);`)
+	c.Assert(err, qt.IsNil)
+
+	cmd := readdb.NewReadDBCommand()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--db-url", "sqlite://" + sourcePath})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout.String(), qt.Contains, `CREATE TABLE "left_nodes"`)
+	c.Assert(stdout.String(), qt.Contains, `CREATE TABLE "right_nodes"`)
+	c.Assert(stdout.String(), qt.Contains, `REFERENCES "right_nodes" ("id")`)
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "Reading schema from database:")
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "Connected to sqlite database successfully!")
+	c.Assert(stdout.String(), qt.Not(qt.Contains), ";;")
+	c.Assert(stderr.String(), qt.Contains, "Reading schema from database:")
+	c.Assert(stderr.String(), qt.Contains, "Connected to sqlite database successfully!")
+
+	target, err := sql.Open("sqlite", filepath.Join(t.TempDir(), "target.db"))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(target.Close(), qt.IsNil) })
+	_, err = target.Exec(stdout.String())
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered SQL:\n%s", stdout.String()))
+
+	var tableCount int
+	err = target.QueryRow(`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name IN ('left_nodes', 'right_nodes')`).Scan(&tableCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 2)
+	c.Assert(strings.Count(stdout.String(), "REFERENCES"), qt.Equals, 2)
+}

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -2620,6 +2620,11 @@ func (n *OpaqueRoutineNode) Accept(visitor Visitor) error {
 // This method visits each statement in the list in order. If any statement
 // fails to be visited, the process stops and returns the error.
 func (sl *StatementList) Accept(visitor Visitor) error {
+	if listVisitor, ok := visitor.(interface {
+		VisitStatementList(*StatementList) error
+	}); ok {
+		return listVisitor.VisitStatementList(sl)
+	}
 	for _, stmt := range sl.Statements {
 		if err := stmt.Accept(visitor); err != nil {
 			return fmt.Errorf("error visiting statement: %w", err)

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -2617,8 +2617,9 @@ func (n *OpaqueRoutineNode) Accept(visitor Visitor) error {
 
 // Accept implements the Node interface for StatementList.
 //
-// This method visits each statement in the list in order. If any statement
-// fails to be visited, the process stops and returns the error.
+// When the visitor implements VisitStatementList, this method delegates the
+// entire list and returns that method's result. Otherwise, it visits each
+// statement in order and stops at the first error.
 func (sl *StatementList) Accept(visitor Visitor) error {
 	if listVisitor, ok := visitor.(interface {
 		VisitStatementList(*StatementList) error

--- a/core/goschema/conflicts.go
+++ b/core/goschema/conflicts.go
@@ -251,7 +251,7 @@ func scopeHelperType(
 	helperTypes map[string]struct{},
 ) string {
 	if _, exists := helperTypes[structName]; exists {
-		return scopedGoTypeIdentity(sourceScope, structName)
+		return scopedGoTypeIdentity(sourceScope, unscopedGoTypeIdentity(structName))
 	}
 	return structName
 }
@@ -369,7 +369,8 @@ func (v compositeDefinitionValidator) constraints() error {
 	return validateNamedDefinitions(
 		v.database.Constraints,
 		func(constraint Constraint) string {
-			return v.resolver.resolve(constraint.StructName, constraint.Table) + "." + constraint.Name
+			scope := v.resolver.resolve(constraint.StructName, constraint.Table)
+			return constraintIdentity(scope, constraint)
 		},
 		canonicalConstraintDefinition,
 		func(constraint Constraint, _ string) error {

--- a/core/goschema/embedded_overrides_test.go
+++ b/core/goschema/embedded_overrides_test.go
@@ -40,7 +40,7 @@ type User struct {
 	//ptah:embedded mode="json" name="metadata" type="JSONB" nullable="true" platform.mysql.type="JSON"
 	Metadata map[string]any
 
-	//ptah:embedded mode="relation" field="manager_id" ref="accounts(id)" platform.mysql.type="BIGINT UNSIGNED"
+	//ptah:embedded mode="relation" field="manager_id" ref="accounts(id)" type="BIGINT" platform.mysql.type="BIGINT UNSIGNED"
 	Manager Account
 }
 `
@@ -62,9 +62,9 @@ type User struct {
 		"mysql": {"type": "JSON"},
 	})
 	c.Assert(fields["User.manager_id"].Foreign, qt.Equals, "accounts(id)")
+	c.Assert(fields["User.manager_id"].Type, qt.Equals, "BIGINT")
 	c.Assert(fields["User.manager_id"].Overrides, qt.DeepEquals, map[string]map[string]string{
-		"mariadb": {"type": "INT"},
-		"mysql":   {"type": "BIGINT UNSIGNED"},
+		"mysql": {"type": "BIGINT UNSIGNED"},
 	})
 }
 

--- a/core/goschema/finalize_test.go
+++ b/core/goschema/finalize_test.go
@@ -1,0 +1,321 @@
+package goschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+func TestFinalize_RebuildsDerivedForeignKeyState(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "User", Name: "parent_id", Type: "INTEGER", Foreign: "users(id)"},
+			{StructName: "Post", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Post", Name: "user_id", Type: "INTEGER", Foreign: "users(id)"},
+		},
+	}
+
+	goschema.Finalize(database)
+	goschema.Finalize(database)
+
+	c.Assert(database.Dependencies["posts"], qt.DeepEquals, []string{"users"})
+	c.Assert(database.SelfReferencingForeignKeys["users"], qt.DeepEquals, []goschema.SelfReferencingFK{{
+		FieldName: "parent_id",
+		Foreign:   "users(id)",
+	}})
+
+	database.Fields = []goschema.Field{
+		{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+		{StructName: "Post", Name: "id", Type: "INTEGER", Primary: true},
+	}
+	goschema.Finalize(database)
+
+	c.Assert(database.Dependencies, qt.DeepEquals, map[string][]string{
+		"posts": {},
+		"users": {},
+	})
+	c.Assert(database.SelfReferencingForeignKeys, qt.DeepEquals, map[string][]goschema.SelfReferencingFK{})
+}
+
+func TestFinalize_ExpandsEmbeddedRelationsIdempotently(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Post", Name: "id", Type: "INTEGER", Primary: true},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{{
+			StructName:       "Post",
+			EmbeddedTypeName: "User",
+			Mode:             "relation",
+			Field:            "user_id",
+			Ref:              "users(id)",
+		}},
+	}
+
+	goschema.Finalize(database)
+	goschema.Finalize(database)
+
+	c.Assert(database.Fields, qt.HasLen, 3)
+	c.Assert(database.Dependencies["posts"], qt.DeepEquals, []string{"users"})
+	c.Assert(database.Fields[2].Name, qt.Equals, "user_id")
+	c.Assert(database.Fields[2].Foreign, qt.Equals, "users(id)")
+}
+
+func TestFinalize_ReplacesGeneratedEmbeddedFieldsAfterMutation(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users"},
+			{StructName: "Account", Name: "accounts"},
+			{StructName: "Post", Name: "posts"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Account", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Post", Name: "id", Type: "INTEGER", Primary: true},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{{
+			StructName:       "Post",
+			EmbeddedTypeName: "User",
+			Mode:             "relation",
+			Field:            "user_id",
+			Ref:              "users(id)",
+		}},
+	}
+
+	goschema.Finalize(database)
+	database.EmbeddedFields = []goschema.EmbeddedField{{
+		StructName:       "Post",
+		EmbeddedTypeName: "Account",
+		Mode:             "relation",
+		Field:            "account_id",
+		Ref:              "accounts(id)",
+	}}
+	goschema.Finalize(database)
+
+	c.Assert(database.Fields, qt.HasLen, 4)
+	c.Assert(database.Fields[3].Name, qt.Equals, "account_id")
+	c.Assert(database.Fields[3].Foreign, qt.Equals, "accounts(id)")
+	c.Assert(database.Dependencies["posts"], qt.DeepEquals, []string{"accounts"})
+}
+
+func TestFinalize_RecordsEmbeddedSelfReferenceOnce(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Node", Name: "nodes"}},
+		Fields: []goschema.Field{{
+			StructName: "Node",
+			Name:       "id",
+			Type:       "INTEGER",
+			Primary:    true,
+		}},
+		EmbeddedFields: []goschema.EmbeddedField{{
+			StructName:       "Node",
+			EmbeddedTypeName: "Parent",
+			Mode:             "relation",
+			Field:            "parent_id",
+			Ref:              "nodes(id)",
+		}},
+	}
+
+	goschema.Finalize(database)
+
+	c.Assert(database.SelfReferencingForeignKeys["nodes"], qt.DeepEquals, []goschema.SelfReferencingFK{{
+		FieldName:      "parent_id",
+		Foreign:        "nodes(id)",
+		ForeignKeyName: "fk_node_parent_id",
+	}})
+}
+
+func TestFinalize_ExpandsNestedEmbeddedModesAndStopsInlineCycles(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Tenant", Name: "tenants"},
+			{StructName: "Order", Name: "orders"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Tenant", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Order", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Ownership", Name: "label", Type: "TEXT"},
+			{StructName: "Cycle", Name: "code", Type: "TEXT"},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{StructName: "Order", EmbeddedTypeName: "Ownership", Mode: "inline", Prefix: "owner_"},
+			{StructName: "Ownership", EmbeddedTypeName: "Tenant", Mode: "relation", Field: "tenant_id", Ref: "tenants(id)"},
+			{StructName: "Ownership", EmbeddedTypeName: "Metadata", Mode: "json", Name: "metadata"},
+			{StructName: "Ownership", EmbeddedTypeName: "Cycle", Mode: "inline"},
+			{StructName: "Cycle", EmbeddedTypeName: "Ownership", Mode: "inline"},
+		},
+	}
+
+	goschema.Finalize(database)
+
+	c.Assert(database.Fields, qt.HasLen, 14)
+	c.Assert(database.Fields[7].StructName, qt.Equals, "Order")
+	c.Assert(database.Fields[7].Name, qt.Equals, "owner_label")
+	c.Assert(database.Fields[8].Name, qt.Equals, "owner_tenant_id")
+	c.Assert(database.Fields[8].Foreign, qt.Equals, "tenants(id)")
+	c.Assert(database.Fields[8].ForeignKeyName, qt.Equals, "fk_order_owner_tenant_id")
+	c.Assert(database.Fields[8].Overrides, qt.DeepEquals, map[string]map[string]string{
+		"mysql":   {"type": "INT"},
+		"mariadb": {"type": "INT"},
+	})
+	c.Assert(database.Fields[9].Name, qt.Equals, "owner_metadata")
+	c.Assert(database.Fields[9].Type, qt.Equals, "JSONB")
+	c.Assert(database.Fields[10].Name, qt.Equals, "owner_code")
+	c.Assert(database.Dependencies["orders"], qt.DeepEquals, []string{"tenants"})
+}
+
+func TestFinalize_PreservesUnnamedTableConstraints(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Node", Name: "nodes"}},
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Node",
+				Type:           "FOREIGN KEY",
+				Columns:        []string{"tenant_id", "parent_id"},
+				ForeignTable:   "nodes",
+				ForeignColumns: []string{"tenant_id", "id"},
+			},
+			{
+				StructName:      "Node",
+				Type:            "CHECK",
+				CheckExpression: "tenant_id > 0",
+			},
+		},
+	}
+
+	goschema.Finalize(database)
+
+	c.Assert(database.Constraints, qt.HasLen, 2)
+	c.Assert(database.SelfReferencingForeignKeys, qt.DeepEquals, map[string][]goschema.SelfReferencingFK{})
+}
+
+func TestFinalize_PreservesDistinctUnnamedForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "FirstParent", Name: "first_parents"},
+			{StructName: "SecondParent", Name: "second_parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "Child", Type: "FOREIGN KEY", Columns: []string{"parent_id"}, ForeignTable: "first_parents", ForeignColumns: []string{"id"}},
+			{StructName: "Child", Type: "FOREIGN KEY", Columns: []string{"parent_id"}, ForeignTable: "second_parents", ForeignColumns: []string{"id"}},
+		},
+	}
+
+	goschema.Finalize(database)
+
+	c.Assert(database.Constraints, qt.HasLen, 2)
+	c.Assert(database.Dependencies["children"], qt.DeepEquals, []string{"first_parents", "second_parents"})
+}
+
+func TestFinalize_DeduplicatesEquivalentNormalizedUnnamedForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Child", Schema: "app", Name: "children"},
+			{StructName: "Parent", Schema: "app", Name: "parents"},
+		},
+		Constraints: []goschema.Constraint{
+			{
+				StructName:     "Child",
+				Type:           "FOREIGN KEY",
+				Columns:        []string{"parent_id"},
+				ForeignTable:   "parents",
+				ForeignColumns: []string{"id"},
+			},
+			{
+				StructName:     "Child",
+				Table:          "app.children",
+				Type:           "FOREIGN KEY",
+				Columns:        []string{"parent_id"},
+				ForeignTable:   "app.parents",
+				ForeignColumns: []string{"id"},
+			},
+		},
+	}
+
+	goschema.Finalize(database)
+
+	c.Assert(database.Constraints, qt.DeepEquals, []goschema.Constraint{{
+		StructName:     "Child",
+		Table:          "app.children",
+		Type:           "FOREIGN KEY",
+		Columns:        []string{"parent_id"},
+		ForeignTable:   "app.parents",
+		ForeignColumns: []string{"id"},
+	}})
+	c.Assert(database.Dependencies["app.children"], qt.DeepEquals, []string{"app.parents"})
+}
+
+func TestFinalize_OrdersStronglyConnectedComponentsDeterministically(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name   string
+		tables []goschema.Table
+	}{
+		{
+			name: "dependent declared before cycle",
+			tables: []goschema.Table{
+				{StructName: "Leaf", Name: "leaf"},
+				{StructName: "CycleB", Name: "cycle_b"},
+				{StructName: "CycleA", Name: "cycle_a"},
+				{StructName: "Root", Name: "root"},
+			},
+		},
+		{
+			name: "cycle members and acyclic nodes permuted",
+			tables: []goschema.Table{
+				{StructName: "CycleA", Name: "cycle_a"},
+				{StructName: "Root", Name: "root"},
+				{StructName: "Leaf", Name: "leaf"},
+				{StructName: "CycleB", Name: "cycle_b"},
+			},
+		},
+	}
+	expected := []goschema.Table{
+		{StructName: "Root", Name: "root"},
+		{StructName: "CycleA", Name: "cycle_a"},
+		{StructName: "CycleB", Name: "cycle_b"},
+		{StructName: "Leaf", Name: "leaf"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := &goschema.Database{
+				Tables: test.tables,
+				Fields: []goschema.Field{
+					{StructName: "Root", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "CycleA", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "CycleA", Name: "root_id", Type: "INTEGER", Foreign: "root(id)"},
+					{StructName: "CycleA", Name: "cycle_b_id", Type: "INTEGER", Foreign: "cycle_b(id)"},
+					{StructName: "CycleB", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "CycleB", Name: "cycle_a_id", Type: "INTEGER", Foreign: "cycle_a(id)"},
+					{StructName: "Leaf", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "Leaf", Name: "cycle_a_id", Type: "INTEGER", Foreign: "cycle_a(id)"},
+				},
+			}
+
+			goschema.Finalize(database)
+
+			c.Assert(database.Tables, qt.DeepEquals, expected)
+		})
+	}
+}

--- a/core/goschema/merge.go
+++ b/core/goschema/merge.go
@@ -4,27 +4,31 @@ package goschema
 // initialized, ready to accumulate schema objects from one or more sources.
 func newDatabase() *Database {
 	return &Database{
-		Schemas:                    []Schema{},
-		Tables:                     []Table{},
-		Fields:                     []Field{},
-		Indexes:                    []Index{},
-		Constraints:                []Constraint{},
-		Enums:                      []Enum{},
-		EmbeddedFields:             []EmbeddedField{},
-		Extensions:                 []Extension{},
-		Functions:                  []Function{},
-		Sequences:                  []Sequence{},
-		Domains:                    []Domain{},
-		CompositeTypes:             []CompositeType{},
-		Ranges:                     []Range{},
-		Views:                      []View{},
-		MaterializedViews:          []MaterializedView{},
-		Triggers:                   []Trigger{},
-		RLSPolicies:                []RLSPolicy{},
-		RLSEnabledTables:           []RLSEnabledTable{},
-		Roles:                      []Role{},
-		Grants:                     []Grant{},
-		ManagedData:                []ManagedData{},
+		Schemas:           []Schema{},
+		Tables:            []Table{},
+		Fields:            []Field{},
+		Indexes:           []Index{},
+		Constraints:       []Constraint{},
+		Enums:             []Enum{},
+		EmbeddedFields:    []EmbeddedField{},
+		Extensions:        []Extension{},
+		Functions:         []Function{},
+		Sequences:         []Sequence{},
+		Domains:           []Domain{},
+		CompositeTypes:    []CompositeType{},
+		Ranges:            []Range{},
+		Views:             []View{},
+		MaterializedViews: []MaterializedView{},
+		Triggers:          []Trigger{},
+		RLSPolicies:       []RLSPolicy{},
+		RLSEnabledTables:  []RLSEnabledTable{},
+		Roles:             []Role{},
+		Grants:            []Grant{},
+		ManagedData:       []ManagedData{},
+		EmbeddedSources: EmbeddedSources{
+			Fields:      []Field{},
+			Definitions: []EmbeddedField{},
+		},
 		Dependencies:               make(map[string][]string),
 		FunctionDependencies:       make(map[string][]string),
 		SelfReferencingForeignKeys: make(map[string][]SelfReferencingFK),
@@ -39,10 +43,12 @@ func appendDatabase(dst, src *Database) {
 	dst.Schemas = append(dst.Schemas, src.Schemas...)
 	dst.Tables = append(dst.Tables, src.Tables...)
 	dst.Fields = append(dst.Fields, src.Fields...)
+	dst.Fields = append(dst.Fields, src.EmbeddedSources.Fields...)
 	dst.Indexes = append(dst.Indexes, src.Indexes...)
 	dst.Constraints = append(dst.Constraints, src.Constraints...)
 	dst.Enums = append(dst.Enums, src.Enums...)
 	dst.EmbeddedFields = append(dst.EmbeddedFields, src.EmbeddedFields...)
+	dst.EmbeddedFields = append(dst.EmbeddedFields, src.EmbeddedSources.Definitions...)
 	dst.Extensions = append(dst.Extensions, src.Extensions...)
 	dst.Functions = append(dst.Functions, src.Functions...)
 	dst.Sequences = append(dst.Sequences, src.Sequences...)
@@ -77,7 +83,7 @@ func finalizeDatabase(result *Database) error {
 		validator.resolver,
 		compositeDeduplicationScope,
 	)
-	removeCompositeHelperDefinitions(result)
+	stashCompositeHelperDefinitions(result)
 
 	// Build dependency graph for foreign key ordering.
 	buildDependencyGraph(result)
@@ -88,30 +94,63 @@ func finalizeDatabase(result *Database) error {
 	return nil
 }
 
-// removeCompositeHelperDefinitions keeps source provenance inside the merge
-// pipeline. Embedded helper types are expansion inputs, not database columns;
-// once their concrete table fields have been generated they must not reach
-// renderers, planners, exporters, or schema comparison.
-func removeCompositeHelperDefinitions(result *Database) {
+// stashCompositeHelperDefinitions removes source-only composite helpers from
+// the public schema surface while retaining them for repeated finalization.
+func stashCompositeHelperDefinitions(result *Database) {
+	helperStructs := embeddedSourceStructNames(result)
+	result.EmbeddedSources.Fields = result.EmbeddedSources.Fields[:0]
 	fields := result.Fields[:0]
 	for _, field := range result.Fields {
-		if isCompositeHelperType(field.StructName) {
-			continue
+		if helperStructs[field.StructName] {
+			result.EmbeddedSources.Fields = append(result.EmbeddedSources.Fields, field)
+			if isCompositeHelperType(field.StructName) {
+				continue
+			}
 		}
 		field.FieldName = unscopedGoTypeIdentity(field.FieldName)
 		fields = append(fields, field)
 	}
 	result.Fields = fields
 
+	result.EmbeddedSources.Definitions = result.EmbeddedSources.Definitions[:0]
 	embeddedFields := result.EmbeddedFields[:0]
 	for _, field := range result.EmbeddedFields {
-		if isCompositeHelperType(field.StructName) {
-			continue
+		if helperStructs[field.StructName] {
+			result.EmbeddedSources.Definitions = append(result.EmbeddedSources.Definitions, field)
+			if isCompositeHelperType(field.StructName) {
+				continue
+			}
 		}
-		field.EmbeddedTypeName = unscopedGoTypeIdentity(field.EmbeddedTypeName)
 		embeddedFields = append(embeddedFields, field)
 	}
 	result.EmbeddedFields = embeddedFields
+}
+
+func embeddedSourceStructNames(result *Database) map[string]bool {
+	tableStructs := make(map[string]bool, len(result.Tables))
+	for _, table := range result.Tables {
+		tableStructs[table.StructName] = true
+	}
+	helperStructs := make(map[string]bool)
+	for _, embedded := range result.EmbeddedFields {
+		if !tableStructs[embedded.StructName] {
+			helperStructs[embedded.StructName] = true
+		}
+		if !tableStructs[embedded.EmbeddedTypeName] {
+			helperStructs[embedded.EmbeddedTypeName] = true
+		}
+	}
+	return helperStructs
+}
+
+func restoreCompositeHelperDefinitions(result *Database) {
+	result.Fields = append(result.Fields, result.EmbeddedSources.Fields...)
+	result.EmbeddedFields = append(
+		result.EmbeddedFields,
+		result.EmbeddedSources.Definitions...,
+	)
+	result.EmbeddedSources.Fields = nil
+	result.EmbeddedSources.Definitions = nil
 }
 
 func finalizeAccumulatedDatabase(result *Database) error {

--- a/core/goschema/merge_conflicts_test.go
+++ b/core/goschema/merge_conflicts_test.go
@@ -357,6 +357,37 @@ func TestMerge_IsolatesSourceLocalNestedEmbeddedHelpers(t *testing.T) {
 	c.Assert(rendered, qt.Not(qt.Contains), "composite-source-")
 }
 
+func TestMerge_PreservesNestedEmbeddedHelpersAcrossRefinalization(t *testing.T) {
+	c := qt.New(t)
+	auth := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Schema: "auth", Name: "users"}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "BIGINT", Primary: true},
+			{StructName: "Metadata", Name: "label", Type: "TEXT"},
+			{StructName: "Audit", Name: "created_at", Type: "TIMESTAMPTZ"},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{StructName: "User", EmbeddedTypeName: "Metadata", Mode: "inline"},
+			{StructName: "Metadata", EmbeddedTypeName: "Audit", Mode: "inline"},
+		},
+	}
+
+	merged, err := goschema.Merge(auth)
+	c.Assert(err, qt.IsNil)
+	goschema.Finalize(merged)
+	refinalizedSQL, err := renderer.GetOrderedCreateStatements(merged, "postgres")
+	c.Assert(err, qt.IsNil)
+
+	remerged, err := goschema.Merge(merged)
+	c.Assert(err, qt.IsNil)
+	remergedSQL, err := renderer.GetOrderedCreateStatements(remerged, "postgres")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(strings.Join(refinalizedSQL, "\n"), qt.Contains, `"label" TEXT`)
+	c.Assert(strings.Join(refinalizedSQL, "\n"), qt.Contains, `"created_at" TIMESTAMPTZ`)
+	c.Assert(remergedSQL, qt.DeepEquals, refinalizedSQL)
+}
+
 func TestMerge_DoesNotAttachSourceLocalHelperToSameNamedTable(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -6,7 +6,9 @@ import (
 	"go/parser"
 	"go/token"
 	"log/slog"
+	"maps"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -1407,13 +1409,9 @@ func ParseFileWithDependencies(filename string) (Database, error) {
 		return Database{}, fmt.Errorf("find related Go files for %q: %w", filename, err)
 	}
 
-	// Collect embedded type names that we need to resolve
-	embeddedTypeNames := make(map[string]bool)
-	for _, embedded := range database.EmbeddedFields {
-		embeddedTypeNames[embedded.EmbeddedTypeName] = true
-	}
-
-	// Parse each related file to collect embedded type definitions
+	// Parse each related file once, then include the transitive closure of helper
+	// fields and embeddings reachable from the main file.
+	relatedDatabases := make([]Database, 0, len(matches))
 	for _, match := range matches {
 		if match == filename {
 			continue // Skip the main file as it's already parsed
@@ -1424,16 +1422,58 @@ func ParseFileWithDependencies(filename string) (Database, error) {
 		if err != nil {
 			return Database{}, fmt.Errorf("parse related Go file %q: %w", match, err)
 		}
-		relatedFields := dbmatch.Fields
-
-		// Only add fields from embedded types that we actually need
-		for _, field := range relatedFields {
-			if embeddedTypeNames[field.StructName] {
-				database.Fields = append(database.Fields, field)
-			}
-		}
+		relatedDatabases = append(relatedDatabases, dbmatch)
 	}
 
-	buildDependencyGraph(&database)
+	includeRelatedEmbeddedDefinitions(&database, relatedDatabases)
+	Finalize(&database)
 	return database, nil
+}
+
+func includeRelatedEmbeddedDefinitions(database *Database, relatedDatabases []Database) {
+	embeddedTypeNames := make(map[string]struct{})
+	for _, embedded := range database.EmbeddedFields {
+		embeddedTypeNames[embedded.EmbeddedTypeName] = struct{}{}
+	}
+
+	included := make(map[string]bool, len(embeddedTypeNames))
+	for _, typeName := range slices.Sorted(maps.Keys(embeddedTypeNames)) {
+		includeRelatedEmbeddedType(database, relatedDatabases, typeName, included)
+	}
+}
+
+func includeRelatedEmbeddedType(database *Database, relatedDatabases []Database, typeName string, included map[string]bool) {
+	if typeName == "" || included[typeName] {
+		return
+	}
+	included[typeName] = true
+
+	for _, relatedDatabase := range relatedDatabases {
+		database.Fields = append(database.Fields, fieldsForStruct(relatedDatabase.Fields, typeName)...)
+		embeddedFields := embeddedFieldsForStruct(relatedDatabase.EmbeddedFields, typeName)
+		database.EmbeddedFields = append(database.EmbeddedFields, embeddedFields...)
+		for _, embedded := range embeddedFields {
+			includeRelatedEmbeddedType(database, relatedDatabases, embedded.EmbeddedTypeName, included)
+		}
+	}
+}
+
+func fieldsForStruct(fields []Field, structName string) []Field {
+	matching := make([]Field, 0)
+	for _, field := range fields {
+		if field.StructName == structName {
+			matching = append(matching, field)
+		}
+	}
+	return matching
+}
+
+func embeddedFieldsForStruct(embeddedFields []EmbeddedField, structName string) []EmbeddedField {
+	matching := make([]EmbeddedField, 0)
+	for _, embedded := range embeddedFields {
+		if embedded.StructName == structName {
+			matching = append(matching, embedded)
+		}
+	}
+	return matching
 }

--- a/core/goschema/parser_dependencies_test.go
+++ b/core/goschema/parser_dependencies_test.go
@@ -1,0 +1,141 @@
+package goschema_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+)
+
+func TestParseFileWithDependencies_RecursivelyIncludesEmbeddedHelpers(t *testing.T) {
+	c := qt.New(t)
+	directory := c.TempDir()
+	mainFile := filepath.Join(directory, "models.go")
+	c.Assert(os.WriteFile(mainFile, []byte(`package models
+
+//ptah:schema:table name="tenants"
+type Tenant struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+
+//ptah:schema:table name="orders"
+type Order struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//ptah:embedded mode="inline"
+	Ownership
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "ownership.go"), []byte(`package models
+
+type Ownership struct {
+	//ptah:embedded mode="inline"
+	TenantKey
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "tenant_key.go"), []byte(`package models
+
+type TenantKey struct {
+	//ptah:schema:field name="tenant_id" type="INTEGER" foreign="tenants(id)"
+	TenantID int64
+}
+`), 0o600), qt.IsNil)
+
+	database, err := goschema.ParseFileWithDependencies(mainFile)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.EmbeddedFields, qt.HasLen, 2)
+	c.Assert(database.Dependencies["orders"], qt.DeepEquals, []string{"tenants"})
+	c.Assert(database.Tables, qt.HasLen, 2)
+	c.Assert(database.Tables[0].QualifiedName(), qt.Equals, "tenants")
+	c.Assert(database.Tables[1].QualifiedName(), qt.Equals, "orders")
+}
+
+func TestParseFileWithDependencies_StopsCyclicInlineHelpers(t *testing.T) {
+	c := qt.New(t)
+	directory := c.TempDir()
+	mainFile := filepath.Join(directory, "models.go")
+	c.Assert(os.WriteFile(mainFile, []byte(`package models
+
+//ptah:schema:table name="records"
+type Record struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//ptah:embedded mode="inline"
+	First
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "first.go"), []byte(`package models
+
+type First struct {
+	//ptah:schema:field name="first_value" type="TEXT"
+	Value string
+
+	//ptah:embedded mode="inline"
+	*Second
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "second.go"), []byte(`package models
+
+type Second struct {
+	//ptah:schema:field name="second_value" type="TEXT"
+	Value string
+
+	//ptah:embedded mode="inline"
+	*First
+}
+`), 0o600), qt.IsNil)
+
+	database, err := goschema.ParseFileWithDependencies(mainFile)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.Fields, qt.HasLen, 7)
+	c.Assert(database.Fields[0].Name, qt.Equals, "id")
+	c.Assert(database.Fields[4].StructName, qt.Equals, "Record")
+	c.Assert(database.Fields[4].Name, qt.Equals, "first_value")
+	c.Assert(database.Fields[5].Name, qt.Equals, "second_value")
+}
+
+func TestParseFileWithDependencies_ExpandsNestedRelationHelper(t *testing.T) {
+	c := qt.New(t)
+	directory := c.TempDir()
+	mainFile := filepath.Join(directory, "models.go")
+	c.Assert(os.WriteFile(mainFile, []byte(`package models
+
+//ptah:schema:table name="tenants"
+type Tenant struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+
+//ptah:schema:table name="orders"
+type Order struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+
+	//ptah:embedded mode="inline" prefix="owner_"
+	Ownership
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(directory, "ownership.go"), []byte(`package models
+
+type Ownership struct {
+	//ptah:embedded mode="relation" field="tenant_id" ref="tenants(id)"
+	Tenant
+}
+`), 0o600), qt.IsNil)
+
+	database, err := goschema.ParseFileWithDependencies(mainFile)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.Dependencies["orders"], qt.DeepEquals, []string{"tenants"})
+	c.Assert(database.Fields, qt.HasLen, 4)
+	c.Assert(database.Fields[2].Name, qt.Equals, "owner_tenant_id")
+	c.Assert(database.Fields[2].Foreign, qt.Equals, "tenants(id)")
+}

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -94,7 +94,7 @@ type EmbeddedField struct {
 	Mode             string                       // inline, json, relation, skip
 	Prefix           string                       // For inline mode - prefix for field names
 	Name             string                       // For json mode - column name
-	Type             string                       // For json mode - column type (JSON/JSONB)
+	Type             string                       // For json/relation mode - generated column type
 	Nullable         bool                         // Whether the field can be null
 	Field            string                       // For relation mode - foreign key field name
 	Ref              string                       // For relation mode - reference table(column)

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -52,6 +52,10 @@ type Database struct {
 	Dependencies               map[string][]string            // table -> list of tables it depends on
 	FunctionDependencies       map[string][]string            // function -> list of functions it depends on
 	SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
+
+	// EmbeddedSources retains source-only helper declarations needed to
+	// materialize embedded columns again after a schema is merged or finalized.
+	EmbeddedSources EmbeddedSources
 }
 
 // Schema represents a database schema/namespace.
@@ -99,6 +103,13 @@ type EmbeddedField struct {
 	Comment          string                       // Comment for the field/column
 	EmbeddedTypeName string                       // The name of the embedded type (e.g., "Timestamps")
 	Overrides        map[string]map[string]string // Platform-specific overrides
+}
+
+// EmbeddedSources preserves helper declarations separately from materialized
+// database columns so Finalize and Merge remain idempotent.
+type EmbeddedSources struct {
+	Fields      []Field
+	Definitions []EmbeddedField
 }
 
 // Field represents a database column/field definition parsed from Go struct field annotations.
@@ -168,6 +179,10 @@ type Field struct {
 	Collate   string
 	Comment   string                       // Column comment
 	Overrides map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
+
+	// GeneratedFromEmbedded distinguishes materialized embedded columns from
+	// source declarations so Finalize can rebuild them after schema mutation.
+	GeneratedFromEmbedded bool
 }
 
 // IndexPart represents one column or expression inside an index definition.
@@ -1087,16 +1102,17 @@ type ManagedData struct {
 	SourceDir string
 }
 
-// SelfReferencingFK represents a self-referencing foreign key that needs to be
-// handled separately from regular foreign keys to avoid circular dependencies.
+// SelfReferencingFK represents a field-level self-referencing foreign key that
+// migration planners emit after creating its table.
 //
 // Self-referencing foreign keys occur when a table has a foreign key that references
 // its own primary key, such as a "parent_id" field in a hierarchical structure.
-// These cannot be created as part of the initial CREATE TABLE statement because
-// the table doesn't exist yet when the constraint is being defined.
-//
-// Instead, these foreign keys are tracked separately and added as ALTER TABLE
-// ADD CONSTRAINT statements after the table has been created.
+// Ptah tracks these references separately because PostgreSQL-family and MySQL-
+// family planners use a table-first, foreign-key-second creation strategy.
+// SQL permits a self reference inside CREATE TABLE, and SQLite renderers use
+// that inline form because SQLite cannot add a foreign key with ALTER TABLE.
+// Table-level foreign keys remain in Database.Constraints so composite column
+// lists are never collapsed into this single-field representation.
 //
 // Example:
 //

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -821,12 +821,15 @@ func processEmbeddedRelationMode(generatedFields []Field, embedded EmbeddedField
 		return generatedFields
 	}
 
-	// Intelligent type inference based on reference pattern
-	refType := "INTEGER" // Default assumption: numeric primary key
-	if strings.Contains(embedded.Ref, "VARCHAR") || strings.Contains(embedded.Ref, "TEXT") ||
-		strings.Contains(strings.ToLower(embedded.Ref), "uuid") {
-		// Reference suggests string-based key (likely UUID)
-		refType = "VARCHAR(36)" // Standard UUID length
+	// An explicit relation type is authoritative. When it is omitted, use the
+	// conservative numeric or string heuristic documented for relation fields.
+	refType := strings.TrimSpace(embedded.Type)
+	if refType == "" {
+		refType = "INTEGER"
+		if strings.Contains(embedded.Ref, "VARCHAR") || strings.Contains(embedded.Ref, "TEXT") ||
+			strings.Contains(strings.ToLower(embedded.Ref), "uuid") {
+			refType = "VARCHAR(36)"
+		}
 	}
 
 	fieldName := embedded.Prefix + embedded.Field

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -43,116 +43,164 @@ func getCachedRegex(functionName string) *regexp.Regexp {
 	return regex
 }
 
-func sortTablesProcessQueue(queue *[]string, sorted *[]Table, dependencies map[string][]string, inDegree map[string]int, tableMap map[string]Table) {
-	for len(*queue) > 0 {
-		// Remove first element from queue
-		current := (*queue)[0]
-		*queue = (*queue)[1:]
-
-		// Add to sorted result if table exists
-		if table, exists := tableMap[current]; exists {
-			*sorted = append(*sorted, table)
-		}
-
-		// Reduce in-degree of tables that depend on the current table
-		for tableName, deps := range dependencies {
-			for _, dep := range deps {
-				if dep != current {
-					continue
-				}
-				inDegree[tableName]--
-				if inDegree[tableName] == 0 {
-					*queue = insertSortedString(*queue, tableName)
-				}
-			}
-		}
-	}
-}
-
-func checkForCircularDependencies(r *Database, sorted *[]Table) {
-	if len(*sorted) == len(r.Tables) {
-		// No circular dependencies
-		return
-	}
-
-	slog.Warn("Circular dependency detected in foreign key relationships; emit foreign keys after table creation to keep DDL executable.")
-	// Add remaining tables to the end
-	for _, table := range r.Tables {
-		found := false
-		for _, sortedTable := range *sorted {
-			if sortedTable.QualifiedName() == table.QualifiedName() {
-				found = true
-				break
-			}
-		}
-		if !found {
-			*sorted = append(*sorted, table)
-		}
-	}
-}
-
 // sortTablesByDependencies performs topological sort to order tables by their dependencies.
 //
-// This method implements Kahn's algorithm for topological sorting to determine the correct
-// order for creating database tables. Tables with no dependencies are created first,
-// followed by tables that depend on them, ensuring that foreign key constraints can be
-// satisfied during migration execution.
-//
-// Algorithm steps:
-//  1. Calculate in-degrees (number of dependencies) for each table
-//  2. Initialize queue with tables that have no dependencies (in-degree 0)
-//  3. Process queue: remove table, add to sorted result, reduce in-degrees of dependent tables
-//  4. Continue until all tables are processed or circular dependency is detected
-//
-// Circular dependency handling:
-//   - If circular dependencies are detected, a warning is logged
-//   - Remaining tables are appended to the end of the sorted list
-//   - Schema rendering emits foreign keys after table creation, so the resulting
-//     DDL remains executable for supported dialects
-//
-// The method modifies the Tables slice in-place, reordering it according to dependency
-// requirements. Renderers that support post-create foreign keys emit those
-// constraints in a separate phase after all tables exist.
+// Strongly connected components are collapsed into a condensation graph before
+// sorting. This keeps every cycle contiguous while still honoring dependencies
+// into and out of the cycle. Component members and ready components are ordered
+// by qualified table name so source declaration order cannot affect the result.
 func sortTablesByDependencies(r *Database) {
-	// Create a map for quick table lookup
-	tableMap := make(map[string]Table)
+	tableMap := make(map[string]Table, len(r.Tables))
 	for _, table := range r.Tables {
 		tableMap[table.QualifiedName()] = table
 	}
+	adjacency := internalTableDependencies(tableMap, r.Dependencies)
+	components := stronglyConnectedTableComponents(adjacency)
+	componentDependencies, componentDependents := tableComponentEdges(components, adjacency)
+	r.Tables = orderTableComponents(tableMap, components, componentDependencies, componentDependents)
+}
 
-	// Perform topological sort using Kahn's algorithm
-	var sorted []Table
-	inDegree := make(map[string]int)
-
-	// Calculate in-degrees from dependencies present in this source. A parsed
-	// source may reference a table supplied by another source and finalized only
-	// after composition; that is an unresolved external edge, not a cycle.
+func internalTableDependencies(tableMap map[string]Table, dependencies map[string][]string) map[string][]string {
+	adjacency := make(map[string][]string, len(tableMap))
 	for tableName := range tableMap {
-		inDegree[tableName] = 0
-		for _, dependency := range r.Dependencies[tableName] {
+		internal := make(map[string]struct{})
+		for _, dependency := range dependencies[tableName] {
 			if _, exists := tableMap[dependency]; exists {
-				inDegree[tableName]++
+				internal[dependency] = struct{}{}
+			}
+		}
+		adjacency[tableName] = slices.Sorted(maps.Keys(internal))
+	}
+	return adjacency
+}
+
+func stronglyConnectedTableComponents(adjacency map[string][]string) [][]string {
+	visited := make(map[string]bool, len(adjacency))
+	postorder := make([]string, 0, len(adjacency))
+	for _, tableName := range slices.Sorted(maps.Keys(adjacency)) {
+		appendTableDependencyPostorder(tableName, adjacency, visited, &postorder)
+	}
+
+	clear(visited)
+	reversed := reverseTableDependencies(adjacency)
+	components := make([][]string, 0, len(adjacency))
+	for _, tableName := range slices.Backward(postorder) {
+		component := collectTableDependencyComponent(tableName, reversed, visited)
+		if len(component) == 0 {
+			continue
+		}
+		sort.Strings(component)
+		components = append(components, component)
+	}
+	return components
+}
+
+func appendTableDependencyPostorder(tableName string, adjacency map[string][]string, visited map[string]bool, postorder *[]string) {
+	if visited[tableName] {
+		return
+	}
+	visited[tableName] = true
+	for _, dependency := range adjacency[tableName] {
+		appendTableDependencyPostorder(dependency, adjacency, visited, postorder)
+	}
+	*postorder = append(*postorder, tableName)
+}
+
+func reverseTableDependencies(adjacency map[string][]string) map[string][]string {
+	reversed := make(map[string][]string, len(adjacency))
+	for tableName := range adjacency {
+		reversed[tableName] = nil
+	}
+	for tableName, dependencies := range adjacency {
+		for _, dependency := range dependencies {
+			reversed[dependency] = append(reversed[dependency], tableName)
+		}
+	}
+	for tableName := range reversed {
+		sort.Strings(reversed[tableName])
+	}
+	return reversed
+}
+
+func collectTableDependencyComponent(tableName string, adjacency map[string][]string, visited map[string]bool) []string {
+	if visited[tableName] {
+		return nil
+	}
+	visited[tableName] = true
+	component := []string{tableName}
+	for _, dependency := range adjacency[tableName] {
+		component = append(component, collectTableDependencyComponent(dependency, adjacency, visited)...)
+	}
+	return component
+}
+
+func tableComponentEdges(
+	components [][]string,
+	adjacency map[string][]string,
+) (componentDependencies, componentDependents []map[int]struct{}) {
+	componentByTable := make(map[string]int, len(adjacency))
+	componentDependencies = make([]map[int]struct{}, len(components))
+	componentDependents = make([]map[int]struct{}, len(components))
+	for componentIndex, component := range components {
+		componentDependencies[componentIndex] = make(map[int]struct{})
+		componentDependents[componentIndex] = make(map[int]struct{})
+		for _, tableName := range component {
+			componentByTable[tableName] = componentIndex
+		}
+	}
+
+	for tableName, dependencies := range adjacency {
+		componentIndex := componentByTable[tableName]
+		for _, dependency := range dependencies {
+			dependencyComponent := componentByTable[dependency]
+			if componentIndex == dependencyComponent {
+				continue
+			}
+			componentDependencies[componentIndex][dependencyComponent] = struct{}{}
+			componentDependents[dependencyComponent][componentIndex] = struct{}{}
+		}
+	}
+	return componentDependencies, componentDependents
+}
+
+func orderTableComponents(
+	tableMap map[string]Table,
+	components [][]string,
+	componentDependencies []map[int]struct{},
+	componentDependents []map[int]struct{},
+) []Table {
+	remainingDependencies := make([]int, len(components))
+	queue := make([]int, 0, len(components))
+	for componentIndex, dependencies := range componentDependencies {
+		remainingDependencies[componentIndex] = len(dependencies)
+		if len(dependencies) == 0 {
+			queue = insertSortedTableComponent(queue, componentIndex, components)
+		}
+	}
+
+	ordered := make([]Table, 0, len(tableMap))
+	for len(queue) > 0 {
+		componentIndex := queue[0]
+		queue = queue[1:]
+		for _, tableName := range components[componentIndex] {
+			ordered = append(ordered, tableMap[tableName])
+		}
+		for dependentComponent := range componentDependents[componentIndex] {
+			remainingDependencies[dependentComponent]--
+			if remainingDependencies[dependentComponent] == 0 {
+				queue = insertSortedTableComponent(queue, dependentComponent, components)
 			}
 		}
 	}
+	return ordered
+}
 
-	// Find tables with no dependencies (in-degree 0)
-	var queue []string
-	for tableName, degree := range inDegree {
-		if degree == 0 {
-			queue = append(queue, tableName)
-		}
-	}
-	sort.Strings(queue)
-
-	// Process queue
-	sortTablesProcessQueue(&queue, &sorted, r.Dependencies, inDegree, tableMap)
-
-	// Check for circular dependencies
-	checkForCircularDependencies(r, &sorted)
-
-	// Update the tables slice with sorted order
-	r.Tables = sorted
+func insertSortedTableComponent(queue []int, componentIndex int, components [][]string) []int {
+	componentName := components[componentIndex][0]
+	position := sort.Search(len(queue), func(i int) bool {
+		return components[queue[i]][0] >= componentName
+	})
+	return slices.Insert(queue, position, componentIndex)
 }
 
 // buildDependencyGraph analyzes foreign key relationships to build a dependency graph.
@@ -177,7 +225,7 @@ func sortTablesByDependencies(r *Database) {
 // The resulting dependency graph is stored in the Dependencies field and used by
 // sortTablesByDependencies() to perform topological sorting.
 func buildDependencyGraph(r *Database) {
-	initializeDependencyMaps(r)
+	resetDependencyMaps(r)
 	analyzeFieldForeignKeys(r)
 	analyzeEmbeddedFieldRelations(r)
 	analyzeConstraintForeignKeys(r)
@@ -190,18 +238,11 @@ func buildDependencyGraph(r *Database) {
 // as Go annotations: deduplicated declarations, dependency maps, self-referencing
 // foreign keys, and dependency-ordered tables/functions.
 func Finalize(r *Database) {
-	if r.Dependencies == nil {
-		r.Dependencies = make(map[string][]string)
-	}
-	if r.FunctionDependencies == nil {
-		r.FunctionDependencies = make(map[string][]string)
-	}
-	if r.SelfReferencingForeignKeys == nil {
-		r.SelfReferencingForeignKeys = make(map[string][]SelfReferencingFK)
-	}
-
-	Deduplicate(r)
+	restoreCompositeHelperDefinitions(r)
+	r.Fields = processEmbeddedFields(r.EmbeddedFields, r.Fields)
 	normalizeTableScopedNames(r)
+	Deduplicate(r)
+	stashCompositeHelperDefinitions(r)
 	buildDependencyGraph(r)
 	sortTablesByDependencies(r)
 	sortFunctionsByDependencies(r)
@@ -408,16 +449,15 @@ func ResolveIndexTableNames(indexes []Index, tables []Table) []string {
 	return owners
 }
 
-// initializeDependencyMaps initializes the dependency tracking maps
-func initializeDependencyMaps(r *Database) {
-	// Initialize dependencies map for all tables
+// resetDependencyMaps discards derived state before rebuilding it from the
+// current schema declarations. Finalization is intentionally idempotent.
+func resetDependencyMaps(r *Database) {
+	r.Dependencies = make(map[string][]string, len(r.Tables))
+	r.FunctionDependencies = make(map[string][]string, len(r.Functions))
+	r.SelfReferencingForeignKeys = make(map[string][]SelfReferencingFK)
+
 	for _, table := range r.Tables {
 		r.Dependencies[table.QualifiedName()] = []string{}
-	}
-
-	// Initialize self-referencing foreign keys tracking
-	if r.SelfReferencingForeignKeys == nil {
-		r.SelfReferencingForeignKeys = make(map[string][]SelfReferencingFK)
 	}
 }
 
@@ -434,7 +474,7 @@ func analyzeFieldForeignKeys(r *Database) {
 			continue
 		}
 
-		processForeignKeyDependency(r, *table, refTable, SelfReferencingFK{
+		processForeignKeyDependency(r, *table, refTable, &SelfReferencingFK{
 			FieldName:      field.Name,
 			Foreign:        field.Foreign,
 			ForeignKeyName: field.ForeignKeyName,
@@ -457,7 +497,7 @@ func analyzeEmbeddedFieldRelations(r *Database) {
 			continue
 		}
 
-		processForeignKeyDependency(r, *table, refTable, SelfReferencingFK{
+		processForeignKeyDependency(r, *table, refTable, &SelfReferencingFK{
 			FieldName:      embedded.Field,
 			Foreign:        embedded.Ref,
 			ForeignKeyName: generateForeignKeyName(table.Name, embedded.Field),
@@ -476,21 +516,11 @@ func analyzeConstraintForeignKeys(r *Database) {
 		if table == nil {
 			continue
 		}
-		processForeignKeyDependency(r, *table, constraint.ForeignTable, SelfReferencingFK{
-			FieldName:      strings.Join(constraint.Columns, ","),
-			Foreign:        foreignKeyReferenceString(constraint.ForeignTable, constraint.ForeignColumnsOrDefault()),
-			ForeignKeyName: constraint.Name,
-			OnDelete:       constraint.OnDelete,
-			OnUpdate:       constraint.OnUpdate,
-		})
+		// Table-level constraints retain their structured local and referenced
+		// column lists. They must not be projected into SelfReferencingFK, whose
+		// field-level shape is intentionally single-column and lossy.
+		processForeignKeyDependency(r, *table, constraint.ForeignTable, nil)
 	}
-}
-
-func foreignKeyReferenceString(table string, columns []string) string {
-	if len(columns) == 0 {
-		return table
-	}
-	return table + "(" + strings.Join(columns, ",") + ")"
 }
 
 // findTableByStructName finds a table by its struct name
@@ -504,16 +534,29 @@ func findTableByStructName(tables []Table, structName string) *Table {
 }
 
 // processForeignKeyDependency processes a foreign key dependency, handling self-references appropriately
-func processForeignKeyDependency(r *Database, table Table, refTable string, selfRefFK SelfReferencingFK) {
+func processForeignKeyDependency(r *Database, table Table, refTable string, selfRefFK *SelfReferencingFK) {
 	tableName := table.QualifiedName()
 	refTable = resolveReferenceTableName(r.Tables, table, refTable)
 	if tableName == refTable {
-		// Track self-referencing foreign key for deferred constraint creation
-		r.SelfReferencingForeignKeys[tableName] = append(r.SelfReferencingForeignKeys[tableName], selfRefFK)
+		if selfRefFK != nil && !containsSelfReferencingForeignKey(r.SelfReferencingForeignKeys[tableName], *selfRefFK) {
+			r.SelfReferencingForeignKeys[tableName] = append(r.SelfReferencingForeignKeys[tableName], *selfRefFK)
+		}
 	} else if !slices.Contains(r.Dependencies[tableName], refTable) {
 		// Add dependency: table depends on refTable (only for non-self-referencing FKs)
 		r.Dependencies[tableName] = append(r.Dependencies[tableName], refTable)
 	}
+}
+
+func containsSelfReferencingForeignKey(foreignKeys []SelfReferencingFK, candidate SelfReferencingFK) bool {
+	for _, foreignKey := range foreignKeys {
+		if foreignKey.FieldName == candidate.FieldName &&
+			foreignKey.Foreign == candidate.Foreign &&
+			foreignKey.OnDelete == candidate.OnDelete &&
+			foreignKey.OnUpdate == candidate.OnUpdate {
+			return true
+		}
+	}
+	return false
 }
 
 func resolveReferenceTableName(tables []Table, current Table, refTable string) string {
@@ -570,19 +613,26 @@ func generateForeignKeyName(tableName, fieldName string) string {
 // Returns:
 //   - Combined slice of Field containing both original fields and generated fields from embedded processing
 func processEmbeddedFields(embeddedFields []EmbeddedField, originalFields []Field) []Field {
+	sourceFields := make([]Field, 0, len(originalFields))
+	for _, field := range originalFields {
+		if !field.GeneratedFromEmbedded {
+			sourceFields = append(sourceFields, field)
+		}
+	}
+
 	// Estimate capacity: original fields + estimated embedded fields
 	// Each embedded field could potentially generate multiple fields
 	estimatedEmbeddedFields := len(embeddedFields) * 2 // Conservative estimate
-	estimatedCapacity := len(originalFields) + estimatedEmbeddedFields
+	estimatedCapacity := len(sourceFields) + estimatedEmbeddedFields
 
 	// Pre-allocate slice with estimated capacity for better performance
-	allFields := make([]Field, len(originalFields), estimatedCapacity)
-	copy(allFields, originalFields)
+	allFields := make([]Field, len(sourceFields), estimatedCapacity)
+	copy(allFields, sourceFields)
 
 	// Process embedded fields for each struct
 	structNames := UniqueStructNames(embeddedFields)
 	for _, structName := range structNames {
-		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, originalFields, structName)
+		generatedFields := processEmbeddedFieldsForStruct(embeddedFields, sourceFields, structName)
 		allFields = append(allFields, generatedFields...)
 	}
 
@@ -649,14 +699,34 @@ func processEmbeddedFieldsForStruct(embeddedFields []EmbeddedField, allFields []
 // This function now supports recursive embedded field processing to handle nested embedded structs.
 func processEmbeddedInlineMode(generatedFields []Field, embedded EmbeddedField, allFields []Field, allEmbeddedFields []EmbeddedField, structName string) []Field {
 	// INLINE MODE: Expand embedded struct fields as individual table columns
-	generatedFields = processEmbeddedInlineModeRecursive(generatedFields, embedded, allFields, allEmbeddedFields, structName)
+	generatedFields = processEmbeddedInlineModeRecursive(
+		generatedFields,
+		embedded,
+		allFields,
+		allEmbeddedFields,
+		structName,
+		make(map[string]bool),
+	)
 
 	return generatedFields
 }
 
 // processEmbeddedInlineModeRecursive recursively processes embedded fields in inline mode.
 // This handles nested embedded structs by recursively expanding embedded fields within embedded types.
-func processEmbeddedInlineModeRecursive(generatedFields []Field, embedded EmbeddedField, allFields []Field, allEmbeddedFields []EmbeddedField, structName string) []Field {
+func processEmbeddedInlineModeRecursive(
+	generatedFields []Field,
+	embedded EmbeddedField,
+	allFields []Field,
+	allEmbeddedFields []EmbeddedField,
+	structName string,
+	activeTypes map[string]bool,
+) []Field {
+	if embedded.EmbeddedTypeName == "" || activeTypes[embedded.EmbeddedTypeName] {
+		return generatedFields
+	}
+	activeTypes[embedded.EmbeddedTypeName] = true
+	defer delete(activeTypes, embedded.EmbeddedTypeName)
+
 	// Step 1: Add direct fields from the embedded type
 	for _, field := range allFields {
 		if field.StructName != embedded.EmbeddedTypeName {
@@ -666,6 +736,7 @@ func processEmbeddedInlineModeRecursive(generatedFields []Field, embedded Embedd
 		newField := field
 		newField.StructName = structName
 		newField.Overrides = mergePlatformOverrides(field.Overrides, embedded.Overrides)
+		newField.GeneratedFromEmbedded = true
 
 		// Apply prefix to column name if specified
 		if embedded.Prefix != "" {
@@ -681,27 +752,30 @@ func processEmbeddedInlineModeRecursive(generatedFields []Field, embedded Embedd
 			continue
 		}
 
-		// Only process inline mode embedded fields recursively
-		if nestedEmbedded.Mode == "inline" {
-			// Create a new embedded field with the target struct name and combined prefix
-			recursiveEmbedded := nestedEmbedded
-			recursiveEmbedded.StructName = structName
-			recursiveEmbedded.Overrides = mergePlatformOverrides(
-				nestedEmbedded.Overrides,
-				embedded.Overrides,
+		recursiveEmbedded := nestedEmbedded
+		recursiveEmbedded.StructName = structName
+		recursiveEmbedded.Overrides = mergePlatformOverrides(
+			nestedEmbedded.Overrides,
+			embedded.Overrides,
+		)
+		recursiveEmbedded.Prefix = embedded.Prefix + nestedEmbedded.Prefix
+
+		switch nestedEmbedded.Mode {
+		case "json":
+			generatedFields = processEmbeddedJSONMode(generatedFields, recursiveEmbedded, structName)
+		case "relation":
+			generatedFields = processEmbeddedRelationMode(generatedFields, recursiveEmbedded, structName)
+		case "skip":
+			continue
+		default:
+			generatedFields = processEmbeddedInlineModeRecursive(
+				generatedFields,
+				recursiveEmbedded,
+				allFields,
+				allEmbeddedFields,
+				structName,
+				activeTypes,
 			)
-
-			// Combine prefixes: if the parent has a prefix, prepend it to the nested prefix
-			if embedded.Prefix != "" {
-				if recursiveEmbedded.Prefix != "" {
-					recursiveEmbedded.Prefix = embedded.Prefix + recursiveEmbedded.Prefix
-				} else {
-					recursiveEmbedded.Prefix = embedded.Prefix
-				}
-			}
-
-			// Recursively process the nested embedded field
-			generatedFields = processEmbeddedInlineModeRecursive(generatedFields, recursiveEmbedded, allFields, allEmbeddedFields, structName)
 		}
 	}
 
@@ -716,6 +790,7 @@ func processEmbeddedJSONMode(generatedFields []Field, embedded EmbeddedField, st
 		// Auto-generate column name: "Meta" -> "meta_data"
 		columnName = strings.ToLower(embedded.EmbeddedTypeName) + "_data"
 	}
+	columnName = embedded.Prefix + columnName
 
 	columnType := embedded.Type
 	if columnType == "" {
@@ -731,6 +806,8 @@ func processEmbeddedJSONMode(generatedFields []Field, embedded EmbeddedField, st
 		Nullable:   embedded.Nullable,
 		Comment:    embedded.Comment,
 		Overrides:  mergePlatformOverrides(nil, embedded.Overrides),
+
+		GeneratedFromEmbedded: true,
 	})
 
 	return generatedFields
@@ -752,8 +829,10 @@ func processEmbeddedRelationMode(generatedFields []Field, embedded EmbeddedField
 		refType = "VARCHAR(36)" // Standard UUID length
 	}
 
+	fieldName := embedded.Prefix + embedded.Field
+
 	// Generate automatic foreign key constraint name following convention
-	foreignKeyName := generateForeignKeyName(structName, embedded.Field)
+	foreignKeyName := generateForeignKeyName(structName, fieldName)
 
 	// Create platform-specific overrides for MySQL/MariaDB compatibility
 	// MySQL/MariaDB use INT for SERIAL types, so foreign keys should also use INT
@@ -768,7 +847,7 @@ func processEmbeddedRelationMode(generatedFields []Field, embedded EmbeddedField
 	generatedFields = append(generatedFields, Field{
 		StructName:     structName,
 		FieldName:      embedded.EmbeddedTypeName,
-		Name:           embedded.Field,    // e.g., "user_id"
+		Name:           fieldName,         // e.g., "user_id"
 		Type:           refType,           // INTEGER or VARCHAR(36)
 		Nullable:       embedded.Nullable, // Can the relationship be optional?
 		Foreign:        embedded.Ref,      // e.g., "users(id)"
@@ -777,6 +856,8 @@ func processEmbeddedRelationMode(generatedFields []Field, embedded EmbeddedField
 		OnUpdate:       embedded.OnUpdate,
 		Comment:        embedded.Comment, // Documentation for the relationship
 		Overrides:      overrides,        // Platform-specific type overrides
+
+		GeneratedFromEmbedded: true,
 	})
 
 	return generatedFields
@@ -1247,7 +1328,34 @@ func constraintDedupKey(c Constraint) string {
 	if strings.TrimSpace(c.Table) != "" {
 		scope = strings.TrimSpace(c.Table)
 	}
-	return scope + "." + c.Name
+	return constraintIdentity(scope, c)
+}
+
+func constraintIdentity(scope string, constraint Constraint) string {
+	if name := strings.TrimSpace(constraint.Name); name != "" {
+		return scope + "\x00named\x00" + name
+	}
+
+	nullsDistinct := "unset"
+	if constraint.NullsDistinct != nil {
+		nullsDistinct = strconv.FormatBool(*constraint.NullsDistinct)
+	}
+	return strings.Join([]string{
+		scope,
+		"unnamed",
+		strings.ToUpper(strings.TrimSpace(constraint.Type)),
+		strings.Join(constraint.Columns, "\x01"),
+		strings.Join(constraint.IncludeColumns, "\x01"),
+		nullsDistinct,
+		constraint.UsingMethod,
+		constraint.ExcludeElements,
+		constraint.WhereCondition,
+		constraint.CheckExpression,
+		constraint.ForeignTable,
+		strings.Join(constraint.ForeignColumnsOrDefault(), "\x01"),
+		constraint.OnDelete,
+		constraint.OnUpdate,
+	}, "\x00")
 }
 
 // deduplicateGrants dedups by role + privileges + target (table, schema, or

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -129,10 +129,29 @@ const (
 	RoleManagement Capability = "role_management"
 
 	// ForeignKeys marks support for declarative FOREIGN KEY constraints.
-	// PostgreSQL, CockroachDB, YugabyteDB, MySQL, and MariaDB support them;
-	// Spanner's PostgreSQL interface has historically not supported the
-	// PostgreSQL FOREIGN KEY surface, so its conservative preset disables it.
+	// PostgreSQL, CockroachDB, YugabyteDB, Spanner's PostgreSQL interface,
+	// MySQL, MariaDB, SQLite, and SQL Server support them.
 	ForeignKeys Capability = "foreign_keys"
+
+	// ForeignKeysRequireUniqueReference marks targets that reject a foreign
+	// key unless its referenced columns already form a declared unique key.
+	// PostgreSQL-family standards-oriented targets, SQLite, and SQL Server use
+	// this policy. MySQL 8.4+ enables it by default through
+	// restrict_fk_on_non_standard_key; MySQL 8.0 and MariaDB instead retain
+	// indexed, nonunique referenced-key support.
+	ForeignKeysRequireUniqueReference Capability = "foreign_keys_require_unique_reference"
+
+	// ForeignKeysRequireIndexedReference marks targets that permit a foreign
+	// key to reference a nonunique key, but require the referenced columns to
+	// be a full leftmost prefix of an existing index. MySQL before 8.4 and
+	// MariaDB use this policy.
+	ForeignKeysRequireIndexedReference Capability = "foreign_keys_require_indexed_reference"
+
+	// ForeignKeysCreateBackingIndex marks targets that create and manage the
+	// referenced-key backing index themselves. Cloud Spanner uses this policy,
+	// so Ptah must not reject an otherwise valid foreign key merely because the
+	// referenced columns are not declared unique or indexed in the input.
+	ForeignKeysCreateBackingIndex Capability = "foreign_keys_create_backing_index"
 
 	// Sequences marks support for database sequence objects used by
 	// PostgreSQL SERIAL/BIGSERIAL or explicit CREATE SEQUENCE support.
@@ -203,6 +222,18 @@ var registry = map[Capability]spec{
 	ForeignKeys: {
 		doc: "declarative FOREIGN KEY constraints",
 	},
+	ForeignKeysRequireUniqueReference: {
+		doc:      "foreign keys require a declared unique referenced key",
+		requires: []Capability{ForeignKeys},
+	},
+	ForeignKeysRequireIndexedReference: {
+		doc:      "foreign keys require the referenced columns as a full leftmost index prefix (MySQL before 8.4 and MariaDB)",
+		requires: []Capability{ForeignKeys},
+	},
+	ForeignKeysCreateBackingIndex: {
+		doc:      "the database creates the referenced-key backing index (Cloud Spanner)",
+		requires: []Capability{ForeignKeys},
+	},
 	Sequences: {
 		doc: "database sequence objects (SERIAL/BIGSERIAL or explicit CREATE SEQUENCE support)",
 	},
@@ -218,6 +249,13 @@ var registry = map[Capability]spec{
 // enabled: they describe mutually exclusive modelings of the same concept.
 var mutexGroups = [][]Capability{
 	{EnumInlineColumn, EnumCustomType},
+	{ForeignKeysRequireUniqueReference, ForeignKeysRequireIndexedReference, ForeignKeysCreateBackingIndex},
+}
+
+var foreignKeyReferencePolicies = []Capability{
+	ForeignKeysRequireUniqueReference,
+	ForeignKeysRequireIndexedReference,
+	ForeignKeysCreateBackingIndex,
 }
 
 // Capabilities is a set of feature flags describing one concrete target, as
@@ -292,6 +330,17 @@ func (c Capabilities) Validate() error {
 			return fmt.Errorf("capabilities %s are mutually exclusive", strings.Join(enabled, " and "))
 		}
 	}
+	if c.Has(ForeignKeys) {
+		enabled := 0
+		for _, key := range foreignKeyReferencePolicies {
+			if c.Has(key) {
+				enabled++
+			}
+		}
+		if enabled != 1 {
+			return fmt.Errorf("capability %q requires exactly one foreign-key reference policy", ForeignKeys)
+		}
+	}
 	return nil
 }
 
@@ -311,36 +360,46 @@ func All() []Capability {
 	return out
 }
 
-// MySQL80 is the preset for the current MySQL line: 8.0.19+ and the 9.x
-// releases, which share these capabilities. Notably NO IF EXISTS on
+// MySQL84 is the preset for MySQL 8.4 and newer. Notably NO IF EXISTS on
 // constraint or index drops — plans must be exactly-once by construction
 // (see the MySQL planner's constraint-drop ownership rules, issue #207).
-func MySQL80() Capabilities {
+func MySQL84() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          true,
-		DropConstraintIfExists:         false,
-		DropIndexIfExists:              false,
-		CheckConstraintsEnforced:       true,
-		DropCheckClause:                true,
-		EnumInlineColumn:               true,
-		EnumCustomType:                 false,
-		CreateIndexConcurrently:        false,
-		CreateOrReplaceTrigger:         false,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               false,
-		RoleManagement:                 false,
-		ForeignKeys:                    true,
-		Sequences:                      false,
-		XMLType:                        false,
-		AdvisoryLocks:                  false,
+		DropConstraintGeneric:              true,
+		DropConstraintIfExists:             false,
+		DropIndexIfExists:                  false,
+		CheckConstraintsEnforced:           true,
+		DropCheckClause:                    true,
+		EnumInlineColumn:                   true,
+		EnumCustomType:                     false,
+		CreateIndexConcurrently:            false,
+		CreateOrReplaceTrigger:             false,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   false,
+		RoleManagement:                     false,
+		ForeignKeys:                        true,
+		ForeignKeysRequireUniqueReference:  true,
+		ForeignKeysRequireIndexedReference: false,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          false,
+		XMLType:                            false,
+		AdvisoryLocks:                      false,
 	}
+}
+
+// MySQL8019 is the preset for MySQL 8.0.19–8.3. It permits foreign keys that
+// reference nonunique indexes, unlike MySQL 8.4 and newer.
+func MySQL8019() Capabilities {
+	return MySQL84().
+		With(ForeignKeysRequireUniqueReference, false).
+		With(ForeignKeysRequireIndexedReference, true)
 }
 
 // MySQL8016 is the preset for MySQL 8.0.16–8.0.18: CHECK constraints are
 // enforced, but the generic DROP CONSTRAINT clause does not exist yet (CHECK
 // drops must use ALTER TABLE ... DROP CHECK).
 func MySQL8016() Capabilities {
-	return MySQL80().With(DropConstraintGeneric, false)
+	return MySQL8019().With(DropConstraintGeneric, false)
 }
 
 // MySQLLegacy is the preset for MySQL before 8.0.16: no generic
@@ -357,22 +416,25 @@ func MySQLLegacy() Capabilities {
 // constraint and index drops.
 func MariaDB1011() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          true,
-		DropConstraintIfExists:         true,
-		DropIndexIfExists:              true,
-		CheckConstraintsEnforced:       true,
-		DropCheckClause:                false,
-		EnumInlineColumn:               true,
-		EnumCustomType:                 false,
-		CreateIndexConcurrently:        false,
-		CreateOrReplaceTrigger:         true,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               false,
-		RoleManagement:                 false,
-		ForeignKeys:                    true,
-		Sequences:                      true,
-		XMLType:                        false,
-		AdvisoryLocks:                  false,
+		DropConstraintGeneric:              true,
+		DropConstraintIfExists:             true,
+		DropIndexIfExists:                  true,
+		CheckConstraintsEnforced:           true,
+		DropCheckClause:                    false,
+		EnumInlineColumn:                   true,
+		EnumCustomType:                     false,
+		CreateIndexConcurrently:            false,
+		CreateOrReplaceTrigger:             true,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   false,
+		RoleManagement:                     false,
+		ForeignKeys:                        true,
+		ForeignKeysRequireUniqueReference:  false,
+		ForeignKeysRequireIndexedReference: true,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          true,
+		XMLType:                            false,
+		AdvisoryLocks:                      false,
 	}
 }
 
@@ -393,22 +455,25 @@ func MariaDBLegacy() Capabilities {
 // Postgres16 is the preset for PostgreSQL 14–16.
 func Postgres16() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          true,
-		DropConstraintIfExists:         true,
-		DropIndexIfExists:              true,
-		CheckConstraintsEnforced:       true,
-		DropCheckClause:                false,
-		EnumInlineColumn:               false,
-		EnumCustomType:                 true,
-		CreateIndexConcurrently:        true,
-		CreateOrReplaceTrigger:         true,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               true,
-		RoleManagement:                 true,
-		ForeignKeys:                    true,
-		Sequences:                      true,
-		XMLType:                        true,
-		AdvisoryLocks:                  true,
+		DropConstraintGeneric:              true,
+		DropConstraintIfExists:             true,
+		DropIndexIfExists:                  true,
+		CheckConstraintsEnforced:           true,
+		DropCheckClause:                    false,
+		EnumInlineColumn:                   false,
+		EnumCustomType:                     true,
+		CreateIndexConcurrently:            true,
+		CreateOrReplaceTrigger:             true,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   true,
+		RoleManagement:                     true,
+		ForeignKeys:                        true,
+		ForeignKeysRequireUniqueReference:  true,
+		ForeignKeysRequireIndexedReference: false,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          true,
+		XMLType:                            true,
+		AdvisoryLocks:                      true,
 	}
 }
 
@@ -429,22 +494,25 @@ func Postgres13() Capabilities {
 // (Enum8/Enum16).
 func ClickHouse24() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          false,
-		DropConstraintIfExists:         false,
-		DropIndexIfExists:              false,
-		CheckConstraintsEnforced:       false,
-		DropCheckClause:                false,
-		EnumInlineColumn:               true,
-		EnumCustomType:                 false,
-		CreateIndexConcurrently:        false,
-		CreateOrReplaceTrigger:         false,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               false,
-		RoleManagement:                 false,
-		ForeignKeys:                    false,
-		Sequences:                      false,
-		XMLType:                        false,
-		AdvisoryLocks:                  false,
+		DropConstraintGeneric:              false,
+		DropConstraintIfExists:             false,
+		DropIndexIfExists:                  false,
+		CheckConstraintsEnforced:           false,
+		DropCheckClause:                    false,
+		EnumInlineColumn:                   true,
+		EnumCustomType:                     false,
+		CreateIndexConcurrently:            false,
+		CreateOrReplaceTrigger:             false,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   false,
+		RoleManagement:                     false,
+		ForeignKeys:                        false,
+		ForeignKeysRequireUniqueReference:  false,
+		ForeignKeysRequireIndexedReference: false,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          false,
+		XMLType:                            false,
+		AdvisoryLocks:                      false,
 	}
 }
 
@@ -454,22 +522,25 @@ func ClickHouse24() Capabilities {
 // advisory-lock surface.
 func SQLite3() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          false,
-		DropConstraintIfExists:         false,
-		DropIndexIfExists:              true,
-		CheckConstraintsEnforced:       true,
-		DropCheckClause:                false,
-		EnumInlineColumn:               false,
-		EnumCustomType:                 false,
-		CreateIndexConcurrently:        false,
-		CreateOrReplaceTrigger:         false,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               false,
-		RoleManagement:                 false,
-		ForeignKeys:                    true,
-		Sequences:                      false,
-		XMLType:                        false,
-		AdvisoryLocks:                  false,
+		DropConstraintGeneric:              false,
+		DropConstraintIfExists:             false,
+		DropIndexIfExists:                  true,
+		CheckConstraintsEnforced:           true,
+		DropCheckClause:                    false,
+		EnumInlineColumn:                   false,
+		EnumCustomType:                     false,
+		CreateIndexConcurrently:            false,
+		CreateOrReplaceTrigger:             false,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   false,
+		RoleManagement:                     false,
+		ForeignKeys:                        true,
+		ForeignKeysRequireUniqueReference:  true,
+		ForeignKeysRequireIndexedReference: false,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          false,
+		XMLType:                            false,
+		AdvisoryLocks:                      false,
 	}
 }
 
@@ -480,22 +551,25 @@ func SQLite3() Capabilities {
 // are not.
 func SQLServer2022() Capabilities {
 	return Capabilities{
-		DropConstraintGeneric:          true,
-		DropConstraintIfExists:         false,
-		DropIndexIfExists:              false,
-		CheckConstraintsEnforced:       true,
-		DropCheckClause:                false,
-		EnumInlineColumn:               false,
-		EnumCustomType:                 false,
-		CreateIndexConcurrently:        false,
-		CreateOrReplaceTrigger:         true,
-		AlterGeneratedColumnExpression: false,
-		RowLevelSecurity:               false,
-		RoleManagement:                 false,
-		ForeignKeys:                    true,
-		Sequences:                      false,
-		XMLType:                        true,
-		AdvisoryLocks:                  false,
+		DropConstraintGeneric:              true,
+		DropConstraintIfExists:             false,
+		DropIndexIfExists:                  false,
+		CheckConstraintsEnforced:           true,
+		DropCheckClause:                    false,
+		EnumInlineColumn:                   false,
+		EnumCustomType:                     false,
+		CreateIndexConcurrently:            false,
+		CreateOrReplaceTrigger:             true,
+		AlterGeneratedColumnExpression:     false,
+		RowLevelSecurity:                   false,
+		RoleManagement:                     false,
+		ForeignKeys:                        true,
+		ForeignKeysRequireUniqueReference:  true,
+		ForeignKeysRequireIndexedReference: false,
+		ForeignKeysCreateBackingIndex:      false,
+		Sequences:                          false,
+		XMLType:                            true,
+		AdvisoryLocks:                      false,
 	}
 }
 
@@ -528,7 +602,8 @@ func YugabyteDB25() Capabilities {
 // SpannerPostgres is the conservative preset for Cloud Spanner's PostgreSQL
 // interface. Spanner's SQL surface is sufficiently different that Ptah only
 // routes the simplest PostgreSQL-family statements through this preset; enums,
-// sequences, RLS, advisory locks, XML, and foreign keys are disabled.
+// sequences, RLS, advisory locks, and XML are disabled. Enforced foreign keys,
+// including circular relationships added with ALTER TABLE, are supported.
 func SpannerPostgres() Capabilities {
 	return Postgres16().
 		With(DropConstraintGeneric, false).
@@ -540,10 +615,11 @@ func SpannerPostgres() Capabilities {
 		With(CreateOrReplaceTrigger, false).
 		With(RowLevelSecurity, false).
 		With(RoleManagement, false).
-		With(ForeignKeys, false).
 		With(Sequences, false).
 		With(XMLType, false).
-		With(AdvisoryLocks, false)
+		With(AdvisoryLocks, false).
+		With(ForeignKeysRequireUniqueReference, false).
+		With(ForeignKeysCreateBackingIndex, true)
 }
 
 // ForDialect returns the default preset for a dialect name (normalized via
@@ -554,7 +630,7 @@ func ForDialect(dialect string) Capabilities {
 	case platform.Postgres:
 		return Postgres17()
 	case platform.MySQL:
-		return MySQL80()
+		return MySQL84()
 	case platform.MariaDB:
 		return MariaDB1011()
 	case platform.ClickHouse:
@@ -616,14 +692,7 @@ func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 
 	switch normalized {
 	case platform.MySQL:
-		switch {
-		case v.major > 8 || (v.major == 8 && (v.minor > 0 || v.patch >= 19)):
-			return MySQL80(), true
-		case v.major == 8 && v.patch >= 16:
-			return MySQL8016(), true
-		default:
-			return MySQLLegacy(), true
-		}
+		return mysqlForVersion(v), true
 	case platform.MariaDB:
 		return mariaDBForVersion(version), parseableMariaDBVersion(version)
 	case platform.Postgres:
@@ -636,6 +705,19 @@ func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 		return Postgres13(), true
 	default:
 		return ForDialect(dialect), false
+	}
+}
+
+func mysqlForVersion(v serverVersion) Capabilities {
+	switch {
+	case v.major > 8 || (v.major == 8 && v.minor >= 4):
+		return MySQL84()
+	case v.major == 8 && (v.minor > 0 || v.patch >= 19):
+		return MySQL8019()
+	case v.major == 8 && v.patch >= 16:
+		return MySQL8016()
+	default:
+		return MySQLLegacy()
 	}
 }
 

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -84,11 +84,33 @@ func TestCapabilities_Validate_MutexGroup(t *testing.T) {
 	c.Assert(capability.Capabilities{}.Validate(), qt.IsNil)
 }
 
+func TestCapabilities_Validate_ForeignKeyReferencePolicy(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(capability.Capabilities{
+		capability.ForeignKeys: true,
+	}.Validate(), qt.ErrorMatches,
+		`capability "foreign_keys" requires exactly one foreign-key reference policy`)
+
+	c.Assert(capability.Capabilities{
+		capability.ForeignKeys:                        true,
+		capability.ForeignKeysRequireUniqueReference:  true,
+		capability.ForeignKeysRequireIndexedReference: true,
+	}.Validate(), qt.ErrorMatches,
+		`capabilities foreign_keys_require_unique_reference and foreign_keys_require_indexed_reference are mutually exclusive`)
+
+	c.Assert(capability.Capabilities{
+		capability.ForeignKeys:                        true,
+		capability.ForeignKeysRequireIndexedReference: true,
+	}.Validate(), qt.IsNil)
+}
+
 func TestPresets_AllValid_AndCoverEveryRegisteredCapability(t *testing.T) {
 	c := qt.New(t)
 
 	presets := map[string]capability.Capabilities{
-		"MySQL80":       capability.MySQL80(),
+		"MySQL84":       capability.MySQL84(),
+		"MySQL8019":     capability.MySQL8019(),
 		"MySQL8016":     capability.MySQL8016(),
 		"MySQLLegacy":   capability.MySQLLegacy(),
 		"MariaDB1011":   capability.MariaDB1011(),
@@ -119,13 +141,18 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c := qt.New(t)
 
 	// The MySQL family never gets IF EXISTS guards; MariaDB does.
-	c.Assert(capability.MySQL80().Has(capability.DropConstraintIfExists), qt.IsFalse)
-	c.Assert(capability.MySQL80().Has(capability.DropIndexIfExists), qt.IsFalse)
+	c.Assert(capability.MySQL84().Has(capability.DropConstraintIfExists), qt.IsFalse)
+	c.Assert(capability.MySQL84().Has(capability.DropIndexIfExists), qt.IsFalse)
+	c.Assert(capability.MySQL84().Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(capability.MySQL8019().Has(capability.ForeignKeysRequireUniqueReference), qt.IsFalse)
+	c.Assert(capability.MySQL8019().Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
 	c.Assert(capability.MariaDB1011().Has(capability.DropConstraintIfExists), qt.IsTrue)
 	c.Assert(capability.MariaDB1011().Has(capability.DropIndexIfExists), qt.IsTrue)
+	c.Assert(capability.MariaDB1011().Has(capability.ForeignKeysRequireUniqueReference), qt.IsFalse)
+	c.Assert(capability.MariaDB1011().Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
 
 	// Version ladder within MySQL.
-	c.Assert(capability.MySQL80().Has(capability.DropConstraintGeneric), qt.IsTrue)
+	c.Assert(capability.MySQL84().Has(capability.DropConstraintGeneric), qt.IsTrue)
 	c.Assert(capability.MySQL8016().Has(capability.DropConstraintGeneric), qt.IsFalse)
 	c.Assert(capability.MySQL8016().Has(capability.CheckConstraintsEnforced), qt.IsTrue)
 	c.Assert(capability.MySQLLegacy().Has(capability.CheckConstraintsEnforced), qt.IsFalse)
@@ -141,15 +168,15 @@ func TestPresets_KeyDifferences(t *testing.T) {
 	c.Assert(capability.Postgres16().Has(capability.RoleManagement), qt.IsTrue)
 
 	// Enum modeling is mutually exclusive and dialect-appropriate.
-	c.Assert(capability.MySQL80().Has(capability.EnumInlineColumn), qt.IsTrue)
-	c.Assert(capability.MySQL80().Has(capability.EnumCustomType), qt.IsFalse)
-	c.Assert(capability.MySQL80().Has(capability.RoleManagement), qt.IsFalse)
+	c.Assert(capability.MySQL84().Has(capability.EnumInlineColumn), qt.IsTrue)
+	c.Assert(capability.MySQL84().Has(capability.EnumCustomType), qt.IsFalse)
+	c.Assert(capability.MySQL84().Has(capability.RoleManagement), qt.IsFalse)
 	c.Assert(capability.Postgres16().Has(capability.EnumCustomType), qt.IsTrue)
 	c.Assert(capability.Postgres16().Has(capability.EnumInlineColumn), qt.IsFalse)
 
 	// DROP CHECK is a MySQL-only spelling (MariaDB rejects it — verified
 	// live), present exactly in the enforcing MySQL windows.
-	c.Assert(capability.MySQL80().Has(capability.DropCheckClause), qt.IsTrue)
+	c.Assert(capability.MySQL84().Has(capability.DropCheckClause), qt.IsTrue)
 	c.Assert(capability.MySQL8016().Has(capability.DropCheckClause), qt.IsTrue)
 	c.Assert(capability.MySQLLegacy().Has(capability.DropCheckClause), qt.IsFalse)
 	c.Assert(capability.MariaDB1011().Has(capability.DropCheckClause), qt.IsFalse)
@@ -183,7 +210,8 @@ func TestPresets_KeyDifferences(t *testing.T) {
 
 	spanner := capability.SpannerPostgres()
 	c.Assert(spanner.Has(capability.EnumCustomType), qt.IsFalse)
-	c.Assert(spanner.Has(capability.ForeignKeys), qt.IsFalse)
+	c.Assert(spanner.Has(capability.ForeignKeys), qt.IsTrue)
+	c.Assert(spanner.Has(capability.ForeignKeysCreateBackingIndex), qt.IsTrue)
 	c.Assert(spanner.Has(capability.Sequences), qt.IsFalse)
 	c.Assert(spanner.Has(capability.XMLType), qt.IsFalse)
 	c.Assert(spanner.Has(capability.RoleManagement), qt.IsFalse)
@@ -222,7 +250,7 @@ func TestCapabilities_Clone(t *testing.T) {
 	var nilSet capability.Capabilities
 	c.Assert(nilSet.Clone(), qt.IsNil)
 
-	orig := capability.MySQL80()
+	orig := capability.MySQL84()
 	cl := orig.Clone()
 	cl[capability.DropIndexIfExists] = true
 	c.Assert(orig.Has(capability.DropIndexIfExists), qt.IsFalse, qt.Commentf("clone must be independent"))
@@ -247,7 +275,7 @@ func TestForDialect(t *testing.T) {
 	c.Assert(capability.ForDialect("yugabyte").Has(capability.CreateIndexConcurrently), qt.IsFalse)
 	c.Assert(capability.ForDialect("mssql").Has(capability.CreateOrReplaceTrigger), qt.IsTrue)
 	c.Assert(capability.ForDialect("sql-server").Has(capability.ForeignKeys), qt.IsTrue)
-	c.Assert(capability.ForDialect("spanner").Has(capability.ForeignKeys), qt.IsFalse)
+	c.Assert(capability.ForDialect("spanner").Has(capability.ForeignKeys), qt.IsTrue)
 	// Unknown dialects get the conservative nil set.
 	c.Assert(capability.ForDialect("oracle"), qt.IsNil)
 }
@@ -263,7 +291,10 @@ func TestForServerVersion(t *testing.T) {
 	}{
 		{"mysql 8.0.19+ line", "mysql", "8.0.42", capability.DropConstraintGeneric, true},
 		{"mysql 8.0.42-log suffix", "mysql", "8.0.42-log", capability.DropConstraintGeneric, true},
+		{"mysql 8.0 permits nonunique referenced keys", "mysql", "8.0.42", capability.ForeignKeysRequireUniqueReference, false},
+		{"mysql 8.4 requires unique referenced keys", "mysql", "8.4.0", capability.ForeignKeysRequireUniqueReference, true},
 		{"mysql 9.x line", "mysql", "9.7.1", capability.DropConstraintGeneric, true},
+		{"mysql 9 requires unique referenced keys", "mysql", "9.7.1", capability.ForeignKeysRequireUniqueReference, true},
 		{"mysql 8.1 minor above zero", "mysql", "8.1.0", capability.DropConstraintGeneric, true},
 		{"mysql 8.0.19 exact boundary", "mysql", "8.0.19", capability.DropConstraintGeneric, true},
 		{"mysql 8.0.18 upper edge of the DROP CHECK window", "mysql", "8.0.18", capability.DropConstraintGeneric, false},
@@ -289,7 +320,7 @@ func TestForServerVersion(t *testing.T) {
 		{"cockroach banner disables concurrent indexes", "postgres", "CockroachDB CCL v23.2.5 (x86_64-pc-linux-gnu)", capability.CreateIndexConcurrently, false},
 		{"cockroach banner disables XML", "postgres", "CockroachDB CCL v23.2.5 (x86_64-pc-linux-gnu)", capability.XMLType, false},
 		{"yugabytedb banner disables concurrent indexes", "postgres", "PostgreSQL 11.2-YB-2.25.1.0-b0 on x86_64-pc-linux-gnu, compiled by clang", capability.CreateIndexConcurrently, false},
-		{"spanner banner disables foreign keys", "postgres", "Cloud Spanner PostgreSQL interface", capability.ForeignKeys, false},
+		{"spanner banner supports foreign keys", "postgres", "Cloud Spanner PostgreSQL interface", capability.ForeignKeys, true},
 		{"unparseable falls back to dialect default", "mysql", "who knows", capability.DropConstraintGeneric, true},
 	}
 	for _, tt := range tests {

--- a/core/renderer/capability_gating_test.go
+++ b/core/renderer/capability_gating_test.go
@@ -95,7 +95,7 @@ func TestMySQLRendererWithCapabilities_UsesPassedCapabilitySet(t *testing.T) {
 
 	node := ast.NewDropIndex("idx_users_email").SetIfExists().SetTable("users")
 
-	sql, err := renderer.RenderSQLWithCapabilities("mysql", capability.MySQL80(), node)
+	sql, err := renderer.RenderSQLWithCapabilities("mysql", capability.MySQL84(), node)
 	c.Assert(err, qt.IsNil)
 	sql = legacyRenderedSQL(sql)
 	c.Assert(sql, qt.Contains, "DROP INDEX idx_users_email ON users;")
@@ -110,7 +110,7 @@ func TestMySQLRendererWithCapabilities_UsesPassedCapabilitySet(t *testing.T) {
 func TestMySQLRendererWithCapabilities_ClonesCapabilitySet(t *testing.T) {
 	c := qt.New(t)
 
-	caps := capability.MySQL80()
+	caps := capability.MySQL84()
 	mysqlRenderer := mysql.NewWithCapabilities(caps)
 	caps[capability.DropIndexIfExists] = true
 

--- a/core/renderer/circular_dependencies_test.go
+++ b/core/renderer/circular_dependencies_test.go
@@ -1,0 +1,1428 @@
+package renderer_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/ast"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/core/renderer"
+)
+
+func TestGetOrderedCreateStatements_MutualForeignKeysUseTwoPhases(t *testing.T) {
+	c := qt.New(t)
+	database := mutualForeignKeyDatabase()
+
+	dialects := []string{"postgres", "cockroachdb", "yugabytedb", "mysql", "mariadb", "sqlserver"}
+	for _, dialect := range dialects {
+		c.Run(dialect, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(database, dialect)
+			c.Assert(err, qt.IsNil)
+
+			sql := strings.Join(statements, "\n")
+			c.Assert(statements, qt.HasLen, 4)
+			c.Assert(strings.Count(sql, "CREATE TABLE"), qt.Equals, 2)
+			c.Assert(strings.Count(sql, "ALTER TABLE"), qt.Equals, 2)
+			c.Assert(strings.Count(sql, "FOREIGN KEY"), qt.Equals, 2)
+			c.Assert(statements[0], qt.Not(qt.Contains), "FOREIGN KEY")
+			c.Assert(statements[1], qt.Not(qt.Contains), "FOREIGN KEY")
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SQLiteKeepsMutualForeignKeysInline(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(mutualForeignKeyDatabase(), "sqlite")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 2)
+	sql := strings.Join(statements, "\n")
+	c.Assert(strings.Count(sql, "CREATE TABLE"), qt.Equals, 2)
+	c.Assert(strings.Count(sql, "REFERENCES"), qt.Equals, 2)
+	c.Assert(sql, qt.Not(qt.Contains), "ALTER TABLE")
+}
+
+func TestGetOrderedCreateStatements_QualifiesSameSchemaForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Schemas: []goschema.Schema{{Name: "app"}},
+		Tables: []goschema.Table{
+			{StructName: "User", Schema: "app", Name: "users"},
+			{StructName: "Order", Schema: "app", Name: "orders"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Order", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Order", Name: "user_id", Type: "INTEGER", Foreign: "users(id)"},
+		},
+	}
+	goschema.Finalize(database)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	sql := strings.Join(statements, "\n")
+	c.Assert(sql, qt.Contains, `ALTER TABLE "app"."orders"`)
+	c.Assert(sql, qt.Contains, `REFERENCES "app"."users"("id")`)
+}
+
+func TestGetOrderedCreateStatements_ValidatesMaterializedEmbeddedForeignKey(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Tenant", Name: "tenants"},
+			{StructName: "Order", Name: "orders"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Tenant", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Order", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Ownership", Name: "tenant_id", Type: "INTEGER", Foreign: "tenants(id)"},
+		},
+		EmbeddedFields: []goschema.EmbeddedField{{
+			StructName:       "Order",
+			EmbeddedTypeName: "Ownership",
+			Mode:             "inline",
+		}},
+	}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, `FOREIGN KEY ("tenant_id") REFERENCES "tenants"("id")`)
+}
+
+func TestGetOrderedCreateStatements_CompositeSelfForeignKeyIsEmittedOnce(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Node", Name: "nodes"}},
+		Fields: []goschema.Field{
+			{StructName: "Node", Name: "tenant_id", Type: "INTEGER", Primary: true},
+			{StructName: "Node", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Node", Name: "parent_id", Type: "INTEGER"},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:     "Node",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "parent_id"},
+			ForeignTable:   "nodes",
+			ForeignColumns: []string{"tenant_id", "id"},
+		}},
+	}
+	goschema.Finalize(database)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	sql := strings.Join(statements, "\n")
+	c.Assert(strings.Count(sql, "FOREIGN KEY"), qt.Equals, 1)
+	c.Assert(sql, qt.Contains, `FOREIGN KEY ("tenant_id", "parent_id") REFERENCES "nodes"("tenant_id", "id")`)
+	c.Assert(sql, qt.Not(qt.Contains), `"tenant_id,parent_id"`)
+}
+
+func TestGetOrderedCreateStatements_ForeignKeysDisabled_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		caps    capability.Capabilities
+	}{
+		{name: "postgres", dialect: "postgres", caps: capability.Postgres17().With(capability.ForeignKeysRequireUniqueReference, false).With(capability.ForeignKeys, false)},
+		{name: "mysql", dialect: "mysql", caps: capability.MySQL84().With(capability.ForeignKeysRequireUniqueReference, false).With(capability.ForeignKeys, false)},
+		{name: "mariadb", dialect: "mariadb", caps: capability.MariaDB1011().With(capability.ForeignKeysRequireIndexedReference, false).With(capability.ForeignKeys, false)},
+		{name: "sqlite", dialect: "sqlite", caps: capability.SQLite3().With(capability.ForeignKeysRequireUniqueReference, false).With(capability.ForeignKeys, false)},
+		{name: "sqlserver", dialect: "sqlserver", caps: capability.SQLServer2022().With(capability.ForeignKeysRequireUniqueReference, false).With(capability.ForeignKeys, false)},
+		{name: "clickhouse", dialect: "clickhouse", caps: capability.ClickHouse24()},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(mutualForeignKeyDatabase(), test.dialect, test.caps)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(err, qt.ErrorMatches, test.dialect+` does not support foreign keys`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_NilDatabase_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(nil, "postgres")
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, "cannot render a nil database schema")
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestValidateSchema_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	err := renderer.ValidateSchema(mutualForeignKeyDatabase(), "postgres")
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestValidateSchemaWithCapabilities_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	err := renderer.ValidateSchemaWithCapabilities(
+		mutualForeignKeyDatabase(),
+		"mysql",
+		capability.MySQL84(),
+	)
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestValidateSchema_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("nil database", func(c *qt.C) {
+		err := renderer.ValidateSchema(nil, "postgres")
+		c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+		c.Assert(err, qt.ErrorMatches, "cannot validate a nil database schema")
+	})
+
+	c.Run("unsupported dialect", func(c *qt.C) {
+		err := renderer.ValidateSchema(mutualForeignKeyDatabase(), "oracle")
+		c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedDialect)
+	})
+
+	c.Run("foreign keys disabled", func(c *qt.C) {
+		err := renderer.ValidateSchemaWithCapabilities(
+			mutualForeignKeyDatabase(),
+			"postgres",
+			capability.Postgres17().
+				With(capability.ForeignKeysRequireUniqueReference, false).
+				With(capability.ForeignKeys, false),
+		)
+		c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	})
+}
+
+func TestGetOrderedCreateStatements_CompositeForeignKeyCardinalityMismatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:     "Child",
+			Name:           "fk_children_parents",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "parent_id"},
+			ForeignTable:   "parents",
+			ForeignColumns: []string{"id"},
+		}},
+	}
+
+	for _, dialect := range []string{"postgres", "cockroachdb", "yugabytedb", "mysql", "mariadb", "sqlite", "sqlserver", "spanner"} {
+		c.Run(dialect, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(database, dialect)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key constraint "fk_children_parents": 2 local columns and 1 referenced columns`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_ReferentialAction_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		dialect  string
+		onDelete string
+		onUpdate string
+		wantErr  string
+	}{
+		{name: "mysql set default", dialect: "mysql", onDelete: "SET DEFAULT", wantErr: "mysql does not support ON DELETE SET DEFAULT"},
+		{name: "mariadb set default", dialect: "mariadb", onUpdate: "SET DEFAULT", wantErr: "mariadb does not support ON UPDATE SET DEFAULT"},
+		{name: "spanner update action", dialect: "spanner", onUpdate: "CASCADE", wantErr: "spanner does not support ON UPDATE CASCADE"},
+		{name: "spanner set null", dialect: "spanner", onDelete: "SET NULL", wantErr: "spanner does not support ON DELETE SET NULL"},
+		{name: "unknown postgres action", dialect: "postgres", onDelete: "ARCHIVE", wantErr: "postgres does not support ON DELETE ARCHIVE"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := foreignKeyActionDatabase(test.onDelete, test.onUpdate)
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SQLServerNormalizesRestrict(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(foreignKeyActionDatabase("RESTRICT", "RESTRICT"), "sqlserver")
+
+	c.Assert(err, qt.IsNil)
+	sql := strings.Join(statements, "\n")
+	c.Assert(sql, qt.Contains, "ON DELETE NO ACTION")
+	c.Assert(sql, qt.Contains, "ON UPDATE NO ACTION")
+	c.Assert(sql, qt.Not(qt.Contains), "RESTRICT")
+}
+
+func TestGetOrderedCreateStatements_NormalizesAtlasActionTokens(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		foreignKeyActionDatabase("NO_ACTION", "SET_NULL"),
+		"postgres",
+	)
+
+	c.Assert(err, qt.IsNil)
+	sql := strings.Join(statements, "\n")
+	c.Assert(sql, qt.Contains, "ON DELETE NO ACTION")
+	c.Assert(sql, qt.Contains, "ON UPDATE SET NULL")
+	c.Assert(sql, qt.Not(qt.Contains), "NO_ACTION")
+	c.Assert(sql, qt.Not(qt.Contains), "SET_NULL")
+}
+
+func TestGetOrderedCreateStatements_SpannerMutualCompositeForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	database := mutualCompositeForeignKeyDatabase()
+	goschema.Finalize(database)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "spanner")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 4)
+	sql := strings.Join(statements, "\n")
+	c.Assert(strings.Count(sql, "CREATE TABLE"), qt.Equals, 2)
+	c.Assert(strings.Count(sql, "ALTER TABLE"), qt.Equals, 2)
+	c.Assert(strings.Count(sql, "FOREIGN KEY"), qt.Equals, 2)
+	c.Assert(sql, qt.Not(qt.Contains), "not supported")
+}
+
+func TestGetOrderedCreateStatements_UnnamedForeignKeyNamesAreUnique(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "FirstParent", Name: "first_parents"},
+			{StructName: "SecondParent", Name: "second_parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "FirstParent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "SecondParent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "INTEGER"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "Child", Type: "FOREIGN KEY", Columns: []string{"parent_id"}, ForeignTable: "first_parents", ForeignColumns: []string{"id"}},
+			{StructName: "Child", Type: "FOREIGN KEY", Columns: []string{"parent_id"}, ForeignTable: "second_parents", ForeignColumns: []string{"id"}},
+		},
+	}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 5)
+	firstName := alterConstraintName(statements[3])
+	secondName := alterConstraintName(statements[4])
+	c.Assert(firstName, qt.Not(qt.Equals), secondName)
+	c.Assert(statements[3], qt.Contains, `REFERENCES "first_parents"`)
+	c.Assert(statements[4], qt.Contains, `REFERENCES "second_parents"`)
+}
+
+func TestGetOrderedCreateStatements_MySQLFamilyIndexesPrecedeForeignKeys(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	tests := []struct {
+		name    string
+		dialect string
+		caps    capability.Capabilities
+	}{
+		{name: "mysql 8.0", dialect: "mysql", caps: capability.MySQL8019()},
+		{name: "mariadb", dialect: "mariadb", caps: capability.MariaDB1011()},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(database, test.dialect, test.caps)
+			c.Assert(err, qt.IsNil)
+
+			sql := strings.Join(statements, "\n")
+			parentIndex := strings.Index(sql, "idx_parents_tenant_code")
+			childIndex := strings.Index(sql, "idx_children_tenant_parent_code")
+			foreignKey := strings.Index(sql, "fk_children_parents")
+			c.Assert(parentIndex, qt.Not(qt.Equals), -1)
+			c.Assert(childIndex, qt.Not(qt.Equals), -1)
+			c.Assert(foreignKey, qt.Not(qt.Equals), -1)
+			c.Assert(parentIndex < foreignKey, qt.IsTrue)
+			c.Assert(childIndex < foreignKey, qt.IsTrue)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_MySQL84RejectsNonuniqueReferencedKey(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(indexedForeignKeyDatabase(), "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `mysql requires referenced columns tenant_id, code on table "parents" to be declared unique`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestRenderSQLWithCapabilities_DirectASTForeignKeysDisabled_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	node := foreignKeyAlterNode("CASCADE", "")
+	tests := []struct {
+		name    string
+		dialect string
+		caps    capability.Capabilities
+	}{
+		{
+			name:    "postgres",
+			dialect: "postgres",
+			caps: capability.Postgres17().
+				With(capability.ForeignKeysRequireUniqueReference, false).
+				With(capability.ForeignKeys, false),
+		},
+		{
+			name:    "mysql",
+			dialect: "mysql",
+			caps: capability.MySQL84().
+				With(capability.ForeignKeysRequireUniqueReference, false).
+				With(capability.ForeignKeys, false),
+		},
+		{
+			name:    "clickhouse",
+			dialect: "clickhouse",
+			caps:    capability.ClickHouse24(),
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			sql, err := renderer.RenderSQLWithCapabilities(test.dialect, test.caps, node)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(err, qt.ErrorMatches, test.dialect+` does not support foreign keys`)
+			c.Assert(sql, qt.Equals, "")
+		})
+	}
+}
+
+func TestRenderSQLWithCapabilities_DirectASTNormalizesCloneOnly(t *testing.T) {
+	c := qt.New(t)
+	node := foreignKeyAlterNode("restrict", "restrict")
+	operation := node.Operations[0].(*ast.AddConstraintOperation)
+
+	sql, err := renderer.RenderSQLWithCapabilities("sqlserver", capability.SQLServer2022(), node)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ON DELETE NO ACTION")
+	c.Assert(sql, qt.Contains, "ON UPDATE NO ACTION")
+	c.Assert(operation.Constraint.Reference.OnDelete, qt.Equals, "restrict")
+	c.Assert(operation.Constraint.Reference.OnUpdate, qt.Equals, "restrict")
+}
+
+func TestRenderSQL_DirectColumnSetNullRequiresNullableColumn_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	column := ast.NewColumn("parent_id", "INTEGER").
+		SetNotNull().
+		SetForeignKey("parents", "id", "fk_children_parent")
+	column.ForeignKey.OnDelete = "set null"
+
+	sql, err := renderer.RenderSQL("postgres", column)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: column "parent_id" uses SET NULL but is NOT NULL`)
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestRenderSQL_DirectTableConstraintSetNullRequiresNullableColumns_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	reference := &ast.ForeignKeyRef{Table: "parents", Column: "id", OnUpdate: "SET NULL"}
+	table := ast.NewCreateTable("children").
+		AddColumn(ast.NewColumn("parent_id", "INTEGER").SetNotNull()).
+		AddConstraint(ast.NewForeignKeyConstraint("fk_children_parent", []string{"parent_id"}, reference))
+
+	sql, err := renderer.RenderSQL("postgres", table)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign key on "children"\."parent_id" uses SET NULL but the local column is NOT NULL`)
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestRenderSQL_DirectTableConstraintSetNullAcceptsNullableColumns(t *testing.T) {
+	c := qt.New(t)
+	reference := &ast.ForeignKeyRef{Table: "parents", Column: "id", OnDelete: "set null"}
+	table := ast.NewCreateTable("children").
+		AddColumn(ast.NewColumn("parent_id", "INTEGER")).
+		AddConstraint(ast.NewForeignKeyConstraint("fk_children_parent", []string{"parent_id"}, reference))
+
+	sql, err := renderer.RenderSQL("postgres", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ON DELETE SET NULL")
+}
+
+func TestRenderSQLWithCapabilities_DirectASTCardinalityMismatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	node := foreignKeyAlterNode("", "")
+	operation := node.Operations[0].(*ast.AddConstraintOperation)
+	operation.Constraint.Columns = []string{"tenant_id", "parent_id"}
+
+	sql, err := renderer.RenderSQLWithCapabilities("postgres", capability.Postgres17(), node)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign key has 2 local columns and 1 referenced columns`)
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestStatementList_DirectAcceptPreflightsNestedNodesAtomically_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer("postgres")
+	c.Assert(err, qt.IsNil)
+	invalid := foreignKeyAlterNode("ARCHIVE", "")
+	list := &ast.StatementList{Statements: []ast.Node{
+		ast.NewCreateTable("parents").AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary()),
+		&ast.StatementList{Statements: []ast.Node{invalid}},
+	}}
+
+	err = list.Accept(r)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, "postgres does not support ON DELETE ARCHIVE")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestStatementList_DirectAcceptHonorsForeignKeyCapabilities_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	caps := capability.Postgres17().
+		With(capability.ForeignKeysRequireUniqueReference, false).
+		With(capability.ForeignKeys, false)
+	r, err := renderer.NewRendererWithCapabilities("postgres", caps)
+	c.Assert(err, qt.IsNil)
+	list := &ast.StatementList{Statements: []ast.Node{foreignKeyAlterNode("CASCADE", "")}}
+
+	err = list.Accept(r)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, "postgres does not support foreign keys")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestStatementList_DirectAcceptNormalizesCloneOnly(t *testing.T) {
+	c := qt.New(t)
+	node := foreignKeyAlterNode("restrict", "restrict")
+	operation := node.Operations[0].(*ast.AddConstraintOperation)
+	r, err := renderer.NewRenderer("sqlserver")
+	c.Assert(err, qt.IsNil)
+	list := &ast.StatementList{Statements: []ast.Node{node}}
+
+	err = list.Accept(r)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(r.Output(), qt.Contains, "ON DELETE NO ACTION")
+	c.Assert(r.Output(), qt.Contains, "ON UPDATE NO ACTION")
+	c.Assert(operation.Constraint.Reference.OnDelete, qt.Equals, "restrict")
+	c.Assert(operation.Constraint.Reference.OnUpdate, qt.Equals, "restrict")
+}
+
+func TestRenderSQL_TypedNilForeignKeyContainers_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	var createTable *ast.CreateTableNode
+	var alterTable *ast.AlterTableNode
+	var column *ast.ColumnNode
+	var constraint *ast.ConstraintNode
+	tests := []struct {
+		name    string
+		node    ast.Node
+		wantErr string
+	}{
+		{name: "create table", node: createTable, wantErr: "invalid foreign key: create-table node is nil"},
+		{name: "alter table", node: alterTable, wantErr: "invalid foreign key: alter-table node is nil"},
+		{name: "column", node: column, wantErr: "invalid foreign key: column node is nil"},
+		{name: "constraint", node: constraint, wantErr: "invalid foreign key: constraint node is nil"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			sql, err := renderer.RenderSQL("postgres", test.node)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(sql, qt.Equals, "")
+		})
+	}
+}
+
+func TestRenderSQL_NilASTNode_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	sql, err := renderer.RenderSQL("postgres", nil)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, "invalid foreign key: AST node is nil")
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestRenderSQL_TypedNilGenericASTNode_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	var index *ast.IndexNode
+
+	sql, err := renderer.RenderSQL("postgres", index)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, "invalid foreign key: AST node is nil")
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestRenderSQL_NilAlterOperation_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	node := &ast.AlterTableNode{Name: "children"}
+	node.Operations = append(node.Operations, nil)
+
+	sql, err := renderer.RenderSQL("postgres", node)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, "invalid foreign key: alter-table operation is nil")
+	c.Assert(sql, qt.Equals, "")
+}
+
+func TestRenderSQL_TypedNilAlterOperations_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	var dropColumn *ast.DropColumnOperation
+	var alterGenerated *ast.AlterGeneratedColumnExpressionOperation
+	var dropConstraint *ast.DropConstraintOperation
+	var renameColumn *ast.RenameColumnOperation
+	var renameTable *ast.RenameTableOperation
+	var addSkippingIndex *ast.AddSkippingIndexOperation
+	var modifyTTL *ast.ModifyTTLOperation
+	tests := []struct {
+		name      string
+		operation ast.AlterOperation
+	}{
+		{name: "drop column", operation: dropColumn},
+		{name: "alter generated expression", operation: alterGenerated},
+		{name: "drop constraint", operation: dropConstraint},
+		{name: "rename column", operation: renameColumn},
+		{name: "rename table", operation: renameTable},
+		{name: "add skipping index", operation: addSkippingIndex},
+		{name: "modify ttl", operation: modifyTTL},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			node := &ast.AlterTableNode{Name: "children", Operations: []ast.AlterOperation{test.operation}}
+			sql, err := renderer.RenderSQL("postgres", node)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, "invalid foreign key: alter-table operation is nil")
+			c.Assert(sql, qt.Equals, "")
+		})
+	}
+}
+
+func TestVisitorRenderSQL_FailedRenderClearsPreviousOutput(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer("postgres")
+	c.Assert(err, qt.IsNil)
+	valid := ast.NewCreateTable("parents").AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary())
+
+	sql, err := renderer.VisitorRenderSQL(r, valid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE TABLE")
+
+	sql, err = renderer.VisitorRenderSQL(r, nil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestRendererRender_FailedValidationClearsPreviousOutput(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer("postgres")
+	c.Assert(err, qt.IsNil)
+	valid := ast.NewCreateTable("parents").AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary())
+
+	sql, err := r.Render(valid)
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "CREATE TABLE")
+
+	sql, err = r.Render(nil)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestVisitorRenderSQL_RendererErrorClearsPartialOutput(t *testing.T) {
+	c := qt.New(t)
+	r, err := renderer.NewRenderer("postgres")
+	c.Assert(err, qt.IsNil)
+	valid := ast.NewCreateTable("parents").AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary())
+	nullsDistinct := true
+	invalid := ast.NewIndex("idx_parents_id", "parents", "id")
+	invalid.NullsDistinct = &nullsDistinct
+
+	sql, err := renderer.VisitorRenderSQL(r, valid, invalid)
+
+	c.Assert(err, qt.ErrorMatches, "postgresql NULLS DISTINCT is only valid for unique indexes")
+	c.Assert(sql, qt.Equals, "")
+	c.Assert(r.Output(), qt.Equals, "")
+}
+
+func TestGetOrderedCreateStatements_UnknownForeignKeyTarget_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Child", Name: "children"}},
+		Fields: []goschema.Field{
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "INTEGER", Foreign: "missing(id)"},
+		},
+	}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: field "parent_id" references unknown table "missing"`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_UnknownForeignKeyColumn_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := mutualForeignKeyDatabase()
+	database.Fields[1].Foreign = "right_nodes(missing_id)"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: referenced table "right_nodes" has no column "missing_id"`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_PartialUniqueIndexIsNotReferencedKey_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	database.Indexes[0].Unique = true
+	database.Indexes[0].Condition = "tenant_id > 0"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `postgres requires referenced columns tenant_id, code on table "parents" to be declared unique`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLPrefixIndexIsNotReferencedKey_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	database.Indexes[0].Fields = nil
+	database.Indexes[0].Parts = []goschema.IndexPart{
+		{Name: "tenant_id"},
+		{Name: "code", Prefix: "4"},
+	}
+
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		database,
+		"mysql",
+		capability.MySQL8019(),
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `mysql requires referenced columns tenant_id, code on table "parents" to be the full leftmost prefix of an index`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MariaDBAllowsIndexedLeftPrefix(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	database.Fields = append(database.Fields, goschema.Field{
+		StructName: "Parent",
+		Name:       "region_id",
+		Type:       "INTEGER",
+	})
+	database.Indexes[0].Fields = []string{"tenant_id", "code", "region_id"}
+
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		database,
+		"mariadb",
+		capability.MariaDB1011(),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, "fk_children_parents")
+}
+
+func TestGetOrderedCreateStatements_DuplicateForeignKeyNamesRespectDialectScope_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql database scope", dialect: "mysql"},
+		{name: "mariadb database scope", dialect: "mariadb"},
+		{name: "sql server schema scope", dialect: "sqlserver"},
+		{name: "spanner schema scope", dialect: "spanner"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(
+				duplicateForeignKeyNameDatabase(),
+				test.dialect,
+			)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign-key name "fk_shared_parent" is duplicated in .* constraint namespace`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_PostgresAllowsForeignKeyNamesRepeatedAcrossTables(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(duplicateForeignKeyNameDatabase(), "postgres")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Count(strings.Join(statements, "\n"), `CONSTRAINT "fk_shared_parent"`), qt.Equals, 2)
+}
+
+func TestGetOrderedCreateStatements_MySQLFamilyRejectsUnsuitableReferencedIndexes_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		dialect   string
+		caps      capability.Capabilities
+		indexType string
+		parser    string
+	}{
+		{name: "mysql fulltext", dialect: "mysql", caps: capability.MySQL8019(), indexType: "FULLTEXT"},
+		{name: "mysql spatial", dialect: "mysql", caps: capability.MySQL8019(), indexType: "SPATIAL"},
+		{name: "mysql hash", dialect: "mysql", caps: capability.MySQL8019(), indexType: "HASH"},
+		{name: "mysql parser", dialect: "mysql", caps: capability.MySQL8019(), parser: "ngram"},
+		{name: "mariadb fulltext", dialect: "mariadb", caps: capability.MariaDB1011(), indexType: "FULLTEXT"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := indexedForeignKeyDatabase()
+			database.Indexes[0].Type = test.indexType
+			database.Indexes[0].Parser = test.parser
+			statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+				database,
+				test.dialect,
+				test.caps,
+			)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+			c.Assert(err, qt.ErrorMatches, test.dialect+` requires referenced columns tenant_id, code on table "parents" to be the full leftmost prefix of an index`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_MySQLBTREEReferencedIndex(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	database.Indexes[0].Type = "BTREE"
+
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		database,
+		"mysql",
+		capability.MySQL8019(),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, "fk_children_parents")
+}
+
+func TestGetOrderedCreateStatements_SQLiteRejectsUnverifiableStandaloneUniqueIndex_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Fields[0].Primary = false
+	database.Indexes = []goschema.Index{{
+		StructName: "Parent",
+		Name:       "uq_parents_id",
+		Fields:     []string{"id"},
+		Unique:     true,
+	}}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "sqlite")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `sqlite requires referenced columns id on table "parents" to be declared unique`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_SQLiteAcceptsInlineUniqueReferencedColumn(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Fields[0].Primary = false
+	database.Fields[0].Unique = true
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "sqlite")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, `REFERENCES "parents" ("id")`)
+}
+
+func TestGetOrderedCreateStatements_IncompatibleForeignKeyTypes_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "postgres", dialect: "postgres"},
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "sql server", dialect: "sqlserver"},
+		{name: "spanner", dialect: "spanner"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(
+				simpleForeignKeyDatabase("INTEGER", "BIGINT"),
+				test.dialect,
+			)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign-key columns "children"\."parent_id" \(BIGINT\) and "parents"\."id" \(INTEGER\) have incompatible types`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SQLiteUsesAffinityForForeignKeyTypes(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		simpleForeignKeyDatabase("TEXT", "INTEGER"),
+		"sqlite",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, `REFERENCES "parents" ("id")`)
+}
+
+func TestGetOrderedCreateStatements_MySQLSignednessMismatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		simpleForeignKeyDatabase("BIGINT UNSIGNED", "BIGINT"),
+		"mysql",
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `.*have incompatible types`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLCollationMismatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("VARCHAR(64)", "VARCHAR(64)")
+	database.Tables[0].Charset = "utf8mb4"
+	database.Tables[0].Collate = "utf8mb4_bin"
+	database.Tables[1].Charset = "utf8mb4"
+	database.Tables[1].Collate = "utf8mb4_unicode_ci"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `.*have incompatible collations "utf8mb4_unicode_ci" and "utf8mb4_bin"`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLIntegerForeignKeyIgnoresTableCharset(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Tables[0].Charset = "latin1"
+	database.Tables[1].Charset = "utf8mb4"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, "FOREIGN KEY")
+}
+
+func TestGetOrderedCreateStatements_MySQLEnumDefinitionsMustMatch_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("ENUM", "ENUM")
+	database.Fields[0].Enum = []string{"open", "closed"}
+	database.Fields[1].Enum = []string{"open", "archived"}
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `.*have incompatible types`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLGeneratedForeignKeyColumn_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Fields[1].GeneratedExpression = "1"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: generated columns cannot participate in portable mysql foreign keys: .*`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLStoredGeneratedForeignKeyColumn(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Fields[1].GeneratedExpression = "1"
+	database.Fields[1].GeneratedKind = "STORED"
+	database.Fields[1].OnDelete = "CASCADE"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, "ON DELETE CASCADE")
+}
+
+func TestGetOrderedCreateStatements_MySQLStoredGeneratedForeignKeyAction_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+	database.Fields[1].GeneratedExpression = "1"
+	database.Fields[1].GeneratedKind = "STORED"
+	database.Fields[1].OnUpdate = "CASCADE"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: stored generated foreign-key columns do not support ON DELETE NO ACTION ON UPDATE CASCADE`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLStringLengthsMayDiffer(t *testing.T) {
+	c := qt.New(t)
+	database := simpleForeignKeyDatabase("VARCHAR(64)", "VARCHAR(128)")
+	database.Tables[0].Charset = "utf8mb4"
+	database.Tables[1].Charset = "utf8mb4"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(statements, "\n"), qt.Contains, "FOREIGN KEY")
+}
+
+func TestGetOrderedCreateStatements_MySQLUnindexableForeignKeyType_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		simpleForeignKeyDatabase("TEXT", "TEXT"),
+		"mysql",
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `.*have incompatible types`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_MySQLFamilyNonInnoDB_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		engine  string
+	}{
+		{name: "mysql MyISAM", dialect: "mysql", engine: "MyISAM"},
+		{name: "mariadb Aria", dialect: "mariadb", engine: "Aria"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+			database.Tables[0].Engine = test.engine
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key: table "parents" uses storage engine ".*"; .* foreign keys require InnoDB`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_MySQLFamilyEmitsExplicitInnoDB(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+			database.Tables[0].Overrides = map[string]map[string]string{
+				test.dialect: {"engine": ""},
+			}
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+			c.Assert(err, qt.IsNil)
+			c.Assert(strings.Count(strings.Join(statements, "\n"), "ENGINE=InnoDB"), qt.Equals, 2)
+		})
+	}
+}
+
+func TestRenderSQL_MySQLFamilyInlineForeignKeyEmitsExplicitInnoDB(t *testing.T) {
+	c := qt.New(t)
+	table := ast.NewCreateTable("children").
+		AddColumn(ast.NewColumn("id", "INTEGER").SetPrimary()).
+		AddColumn(ast.NewColumn("parent_id", "INTEGER").SetForeignKey("parents", "id", "fk_parent"))
+
+	sql, err := renderer.RenderSQL("mysql", table)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "ENGINE=InnoDB")
+	c.Assert(table.Options, qt.DeepEquals, map[string]string{})
+}
+
+func TestRenderSQL_MySQLFamilyInlineForeignKeyNonInnoDB_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		engine  string
+	}{
+		{name: "mysql MyISAM", dialect: "mysql", engine: "MyISAM"},
+		{name: "mariadb Aria", dialect: "mariadb", engine: "Aria"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			table := ast.NewCreateTable("children").
+				AddColumn(ast.NewColumn("parent_id", "INTEGER").SetForeignKey("parents", "id", "fk_parent")).
+				SetOption("engine", test.engine)
+			sql, err := renderer.RenderSQL(test.dialect, table)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key: table "children" uses storage engine ".*"; .* foreign keys require InnoDB`)
+			c.Assert(sql, qt.Equals, "")
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SetNullRequiresNullableLocalColumns_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		dialect  string
+		onDelete string
+		onUpdate string
+	}{
+		{name: "postgres delete", dialect: "postgres", onDelete: "SET NULL"},
+		{name: "mysql update", dialect: "mysql", onUpdate: "SET NULL"},
+		{name: "mariadb delete", dialect: "mariadb", onDelete: "SET NULL"},
+		{name: "sqlite update", dialect: "sqlite", onUpdate: "SET NULL"},
+		{name: "sqlserver delete", dialect: "sqlserver", onDelete: "SET NULL"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := foreignKeyActionDatabase(test.onDelete, test.onUpdate)
+			database.Fields[1].Nullable = false
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign key on "children"\."parent_id" uses SET NULL but the local column is NOT NULL`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_CompositeSetNullRequiresAllLocalColumnsNullable_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := indexedForeignKeyDatabase()
+	database.Fields[2].Nullable = true
+	database.Constraints[0].OnDelete = "SET NULL"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: foreign key on "children"\."parent_code" uses SET NULL but the local column is NOT NULL`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_ExplicitForeignKeyIdentifierLimit_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		fkName  string
+		wantErr string
+	}{
+		{name: "postgres bytes", dialect: "postgres", fkName: strings.Repeat("a", 64), wantErr: ".*63-byte identifier limit"},
+		{name: "postgres multibyte bytes", dialect: "postgres", fkName: strings.Repeat("é", 32), wantErr: ".*63-byte identifier limit"},
+		{name: "mysql characters", dialect: "mysql", fkName: strings.Repeat("a", 65), wantErr: ".*mysql 64-character identifier limit"},
+		{name: "mariadb characters", dialect: "mariadb", fkName: strings.Repeat("é", 65), wantErr: ".*mariadb 64-character identifier limit"},
+		{name: "sqlserver characters", dialect: "sqlserver", fkName: strings.Repeat("a", 129), wantErr: ".*sqlserver 128-character identifier limit"},
+		{name: "sqlserver multibyte characters", dialect: "sqlserver", fkName: strings.Repeat("界", 129), wantErr: ".*sqlserver 128-character identifier limit"},
+		{name: "spanner characters", dialect: "spanner", fkName: strings.Repeat("a", 129), wantErr: ".*spanner 128-character identifier limit"},
+		{name: "spanner multibyte characters", dialect: "spanner", fkName: strings.Repeat("界", 129), wantErr: ".*spanner 128-character identifier limit"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := simpleForeignKeyDatabase("INTEGER", "INTEGER")
+			database.Fields[1].ForeignKeyName = test.fkName
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SchemaScopedForeignKeyNamesTreatDefaultSchemaAsExplicit_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name          string
+		dialect       string
+		defaultSchema string
+	}{
+		{name: "SQL Server", dialect: "sqlserver", defaultSchema: "dbo"},
+		{name: "Spanner", dialect: "spanner", defaultSchema: "public"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := &goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "Parent", Name: "parents"},
+					{StructName: "Child", Name: "children"},
+					{StructName: "Audit", Schema: test.defaultSchema, Name: "audit_entries"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+					{
+						StructName:     "Child",
+						Name:           "parent_id",
+						Type:           "INTEGER",
+						Foreign:        "parents(id)",
+						ForeignKeyName: "shared_fk",
+					},
+					{
+						StructName:     "Audit",
+						Name:           "parent_id",
+						Type:           "INTEGER",
+						Foreign:        "parents(id)",
+						ForeignKeyName: "SHARED_FK",
+					},
+				},
+			}
+
+			statements, err := renderer.GetOrderedCreateStatements(database, test.dialect)
+
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, `.*foreign-key name ".*" is duplicated in schema ".*" constraint namespace`)
+			c.Assert(statements, qt.IsNil)
+		})
+	}
+}
+
+func TestGetOrderedCreateStatements_SpannerArrayForeignKey_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		simpleForeignKeyDatabase("ARRAY<INT64>", "ARRAY<INT64>"),
+		"spanner",
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: Spanner type ARRAY<INT64> cannot participate in foreign keys: .*`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_SpannerFloat4ForeignKey_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		simpleForeignKeyDatabase("FLOAT4", "FLOAT4"),
+		"spanner",
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid foreign key: Spanner type FLOAT4 cannot participate in foreign keys: .*`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_SQLServerCascadeCycle_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := mutualForeignKeyDatabase()
+	database.Fields[1].OnDelete = "CASCADE"
+	database.Fields[3].OnDelete = "CASCADE"
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "sqlserver")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `sqlserver does not allow ON DELETE cycles or multiple cascade paths reaching table .*`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestGetOrderedCreateStatements_SQLServerMultipleCascadePaths_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	database := sqlServerDiamondCascadeDatabase()
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "sqlserver")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `sqlserver does not allow ON DELETE cycles or multiple cascade paths reaching table "leaves"`)
+	c.Assert(statements, qt.IsNil)
+}
+
+func mutualForeignKeyDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Left", Name: "left_nodes"},
+			{StructName: "Right", Name: "right_nodes"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Left", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Left", Name: "right_id", Type: "INTEGER", Foreign: "right_nodes(id)", ForeignKeyName: "fk_left_right"},
+			{StructName: "Right", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Right", Name: "left_id", Type: "INTEGER", Foreign: "left_nodes(id)", ForeignKeyName: "fk_right_left"},
+		},
+	}
+}
+
+func foreignKeyActionDatabase(onDelete, onUpdate string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{
+				StructName:     "Child",
+				Name:           "parent_id",
+				Type:           "INTEGER",
+				Nullable:       true,
+				Foreign:        "parents(id)",
+				ForeignKeyName: "fk_children_parents",
+				OnDelete:       onDelete,
+				OnUpdate:       onUpdate,
+			},
+		},
+	}
+}
+
+func mutualCompositeForeignKeyDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Left", Name: "left_nodes", PrimaryKey: []string{"tenant_id", "id"}},
+			{StructName: "Right", Name: "right_nodes", PrimaryKey: []string{"tenant_id", "id"}},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Left", Name: "tenant_id", Type: "BIGINT"},
+			{StructName: "Left", Name: "id", Type: "BIGINT"},
+			{StructName: "Left", Name: "right_id", Type: "BIGINT"},
+			{StructName: "Right", Name: "tenant_id", Type: "BIGINT"},
+			{StructName: "Right", Name: "id", Type: "BIGINT"},
+			{StructName: "Right", Name: "left_id", Type: "BIGINT"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "Left", Name: "fk_left_right", Type: "FOREIGN KEY", Columns: []string{"tenant_id", "right_id"}, ForeignTable: "right_nodes", ForeignColumns: []string{"tenant_id", "id"}},
+			{StructName: "Right", Name: "fk_right_left", Type: "FOREIGN KEY", Columns: []string{"tenant_id", "left_id"}, ForeignTable: "left_nodes", ForeignColumns: []string{"tenant_id", "id"}},
+		},
+	}
+}
+
+func indexedForeignKeyDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "tenant_id", Type: "INTEGER"},
+			{StructName: "Parent", Name: "code", Type: "INTEGER"},
+			{StructName: "Child", Name: "tenant_id", Type: "INTEGER"},
+			{StructName: "Child", Name: "parent_code", Type: "INTEGER"},
+		},
+		Indexes: []goschema.Index{
+			{StructName: "Parent", Name: "idx_parents_tenant_code", Fields: []string{"tenant_id", "code"}},
+			{StructName: "Child", Name: "idx_children_tenant_parent_code", Fields: []string{"tenant_id", "parent_code"}},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:     "Child",
+			Name:           "fk_children_parents",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "parent_code"},
+			ForeignTable:   "parents",
+			ForeignColumns: []string{"tenant_id", "code"},
+		}},
+	}
+}
+
+func foreignKeyAlterNode(onDelete, onUpdate string) *ast.AlterTableNode {
+	return &ast.AlterTableNode{
+		Name: "children",
+		Operations: []ast.AlterOperation{&ast.AddConstraintOperation{
+			Constraint: ast.NewForeignKeyConstraint(
+				"fk_children_parents",
+				[]string{"parent_id"},
+				&ast.ForeignKeyRef{
+					Table:    "parents",
+					Column:   "id",
+					OnDelete: onDelete,
+					OnUpdate: onUpdate,
+				},
+			),
+		}},
+	}
+}
+
+func sqlServerDiamondCascadeDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Root", Name: "roots"},
+			{StructName: "Left", Name: "left_nodes"},
+			{StructName: "Right", Name: "right_nodes"},
+			{StructName: "Leaf", Name: "leaves"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Root", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Left", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Left", Name: "root_id", Type: "INTEGER", Foreign: "roots(id)", OnDelete: "CASCADE"},
+			{StructName: "Right", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Right", Name: "root_id", Type: "INTEGER", Foreign: "roots(id)", OnDelete: "CASCADE"},
+			{StructName: "Leaf", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Leaf", Name: "left_id", Type: "INTEGER", Foreign: "left_nodes(id)", OnDelete: "CASCADE"},
+			{StructName: "Leaf", Name: "right_id", Type: "INTEGER", Foreign: "right_nodes(id)", OnDelete: "CASCADE"},
+		},
+	}
+}
+
+func duplicateForeignKeyNameDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "FirstChild", Name: "first_children"},
+			{StructName: "SecondChild", Name: "second_children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "FirstChild", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)", ForeignKeyName: "fk_shared_parent"},
+			{StructName: "SecondChild", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)", ForeignKeyName: "fk_shared_parent"},
+		},
+	}
+}
+
+func simpleForeignKeyDatabase(parentType, childType string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: parentType, Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: childType, Foreign: "parents(id)"},
+		},
+	}
+}
+
+func alterConstraintName(statement string) string {
+	_, suffix, _ := strings.Cut(statement, "ADD CONSTRAINT ")
+	name, _, _ := strings.Cut(suffix, " ")
+	return name
+}

--- a/core/renderer/internal/dialects/mysql/mysql.go
+++ b/core/renderer/internal/dialects/mysql/mysql.go
@@ -17,7 +17,7 @@ type Renderer struct {
 
 // New creates a new MySQL renderer
 func New() *Renderer {
-	return NewWithCapabilities(capability.MySQL80())
+	return NewWithCapabilities(capability.MySQL84())
 }
 
 // NewWithCapabilities creates a MySQL renderer for a concrete server

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -1747,11 +1747,6 @@ func (r *Renderer) VisitCreateRole(node *ast.CreateRoleNode) error {
 		return err
 	}
 
-	// Add comment if provided
-	if node.Comment != "" {
-		r.w.WriteLinef("-- %s", node.Comment)
-	}
-
 	// Build CREATE ROLE statement
 	var parts []string
 	parts = append(parts, "CREATE ROLE", r.escapeIdentifier(node.Name))
@@ -1810,6 +1805,13 @@ func (r *Renderer) VisitCreateRole(node *ast.CreateRoleNode) error {
 	}
 
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
+	if node.Comment != "" {
+		r.w.WriteLinef(
+			"COMMENT ON ROLE %s IS %s;",
+			r.escapeIdentifier(node.Name),
+			r.escapeValue(node.Comment),
+		)
+	}
 
 	return nil
 }

--- a/core/renderer/internal/dialects/postgres/postgres_role_test.go
+++ b/core/renderer/internal/dialects/postgres/postgres_role_test.go
@@ -19,7 +19,8 @@ func TestPostgreSQLRenderer_VisitCreateRole(t *testing.T) {
 		sql, err := renderer.Render(role)
 
 		c.Assert(err, qt.IsNil)
-		c.Assert(legacyPostgresSQL(sql), qt.Equals, "CREATE ROLE test_role WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;\n")
+		c.Assert(legacyPostgresSQL(sql), qt.Contains, "CREATE ROLE test_role WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;")
+		c.Assert(sql, qt.Not(qt.Contains), "duplicate_object")
 	})
 
 	t.Run("role with login and password", func(t *testing.T) {
@@ -72,14 +73,25 @@ func TestPostgreSQLRenderer_VisitCreateRole(t *testing.T) {
 		renderer := postgres.New()
 
 		role := ast.NewCreateRole("documented_role").
-			SetComment("This is a test role")
+			SetComment("Owner's test role")
 		sql, err := renderer.Render(role)
 
 		c.Assert(err, qt.IsNil)
-		lines := strings.Split(strings.TrimSpace(legacyPostgresSQL(sql)), "\n")
-		c.Assert(lines[0], qt.Equals, "-- This is a test role")
-		c.Assert(lines[1], qt.Contains, "CREATE ROLE documented_role")
+		c.Assert(legacyPostgresSQL(sql), qt.Contains, "CREATE ROLE documented_role")
+		c.Assert(legacyPostgresSQL(sql), qt.Contains, "COMMENT ON ROLE documented_role IS 'Owner''s test role';")
 	})
+}
+
+func TestPostgreSQLRenderer_VisitCreateRoleKeepsPasswordDollarTagLiteral(t *testing.T) {
+	c := qt.New(t)
+	renderer := postgres.New()
+	role := ast.NewCreateRole("app_user").SetPassword("SCRAM-SHA-256$ptah_role$collision")
+
+	sql, err := renderer.Render(role)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "PASSWORD 'SCRAM-SHA-256$ptah_role$collision'")
+	c.Assert(sql, qt.Not(qt.Contains), "DO $ptah_role$")
 }
 
 func TestPostgreSQLRenderer_VisitDropRole(t *testing.T) {

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -35,11 +35,17 @@ package renderer
 import (
 	"errors"
 	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+	"unicode/utf8"
 
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
 	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/platform/identifier"
 	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/clickhouse"
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/mariadb"
@@ -48,6 +54,7 @@ import (
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/postgres"
 	"github.com/stokaro/ptah/core/renderer/internal/dialects/sqlite"
 	"github.com/stokaro/ptah/internal/convert/fromschema"
+	"github.com/stokaro/ptah/internal/planner/tablelookup"
 )
 
 // RenderVisitor defines the interface for rendering AST nodes to SQL statements.
@@ -96,23 +103,32 @@ func NewRenderer(dialect string) (RenderVisitor, error) {
 // capability set. Use this on live database paths where capabilities were
 // resolved from DBInfo.Version; NewRenderer remains the offline default.
 func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (RenderVisitor, error) {
+	if err := caps.Validate(); err != nil {
+		return nil, &ptaherr.CapabilityError{
+			Dialect: dialect,
+			Feature: "capability set",
+			Err:     err,
+			Message: fmt.Sprintf("invalid capabilities for %s: %s", platform.NormalizeDialect(dialect), err),
+		}
+	}
 	normalizedDialect := platform.NormalizeDialect(dialect)
+	var raw RenderVisitor
 
 	switch normalizedDialect {
 	case platform.Postgres:
-		return postgres.NewWithCapabilities(caps, normalizedDialect), nil
+		raw = postgres.NewWithCapabilities(caps, normalizedDialect)
 	case platform.MySQL:
-		return mysql.NewWithCapabilities(caps), nil
+		raw = mysql.NewWithCapabilities(caps)
 	case platform.MariaDB:
-		return mariadb.NewWithCapabilities(caps), nil
+		raw = mariadb.NewWithCapabilities(caps)
 	case platform.ClickHouse:
-		return clickhouse.New(), nil
+		raw = clickhouse.New()
 	case platform.SQLite:
-		return sqlite.New(), nil
+		raw = sqlite.New()
 	case platform.SQLServer:
-		return mssql.New(), nil
+		raw = mssql.New()
 	case platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
-		return postgres.NewWithCapabilities(caps, normalizedDialect), nil
+		raw = postgres.NewWithCapabilities(caps, normalizedDialect)
 	default:
 		return nil, &ptaherr.RenderError{
 			Dialect: dialect,
@@ -120,6 +136,98 @@ func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (
 			Message: fmt.Sprintf("unsupported database dialect: %s", dialect),
 		}
 	}
+	return &validatingRenderer{
+		RenderVisitor: raw,
+		dialect:       dialect,
+		capabilities:  caps.Clone(),
+	}, nil
+}
+
+type validatingRenderer struct {
+	RenderVisitor
+	dialect      string
+	capabilities capability.Capabilities
+}
+
+func (r *validatingRenderer) Render(node ast.Node) (string, error) {
+	r.Reset()
+	prepared, err := prepareASTNodeForRendering(r.dialect, r.capabilities, node)
+	if err != nil {
+		return "", err
+	}
+	output, err := r.RenderVisitor.Render(prepared)
+	if err != nil {
+		r.Reset()
+		return "", err
+	}
+	return output, nil
+}
+
+func (r *validatingRenderer) VisitStatementList(list *ast.StatementList) error {
+	prepared, err := prepareStatementListNode(r.dialect, r.capabilities, list)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	for _, statement := range prepared.Statements {
+		if err := statement.Accept(r.RenderVisitor); err != nil {
+			r.Reset()
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *validatingRenderer) VisitCreateTable(node *ast.CreateTableNode) error {
+	prepared, err := prepareCreateTableNode(r.dialect, r.capabilities, node)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	if err := r.RenderVisitor.VisitCreateTable(prepared); err != nil {
+		r.Reset()
+		return err
+	}
+	return nil
+}
+
+func (r *validatingRenderer) VisitAlterTable(node *ast.AlterTableNode) error {
+	prepared, err := prepareAlterTableNode(r.dialect, r.capabilities, node)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	if err := r.RenderVisitor.VisitAlterTable(prepared); err != nil {
+		r.Reset()
+		return err
+	}
+	return nil
+}
+
+func (r *validatingRenderer) VisitColumn(node *ast.ColumnNode) error {
+	prepared, err := prepareColumnNode(r.dialect, r.capabilities, node)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	if err := r.RenderVisitor.VisitColumn(prepared); err != nil {
+		r.Reset()
+		return err
+	}
+	return nil
+}
+
+func (r *validatingRenderer) VisitConstraint(node *ast.ConstraintNode) error {
+	prepared, err := prepareConstraintNode(r.dialect, r.capabilities, node)
+	if err != nil {
+		r.Reset()
+		return err
+	}
+	if err := r.RenderVisitor.VisitConstraint(prepared); err != nil {
+		r.Reset()
+		return err
+	}
+	return nil
 }
 
 // RenderSQL is a convenience function that creates a renderer and renders an AST node in one call.
@@ -127,11 +235,7 @@ func NewRendererWithCapabilities(dialect string, caps capability.Capabilities) (
 // This function is useful for one-off SQL generation where you don't need to reuse the renderer.
 // For multiple operations, it's more efficient to create a renderer once and reuse it.
 func RenderSQL(dialect string, nodes ...ast.Node) (string, error) {
-	r, err := NewRenderer(dialect)
-	if err != nil {
-		return "", err
-	}
-	return VisitorRenderSQL(r, nodes...)
+	return RenderSQLWithCapabilities(dialect, capability.ForDialect(dialect), nodes...)
 }
 
 // RenderSQLWithCapabilities renders SQL for a concrete server capability set.
@@ -145,8 +249,20 @@ func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nod
 
 func VisitorRenderSQL(r RenderVisitor, nodes ...ast.Node) (string, error) {
 	r.Reset()
+	if validating, ok := r.(*validatingRenderer); ok {
+		prepared, err := prepareASTNodesForRendering(
+			validating.dialect,
+			validating.capabilities,
+			nodes,
+		)
+		if err != nil {
+			return "", err
+		}
+		nodes = prepared
+	}
 	for _, node := range nodes {
 		if err := node.Accept(r); err != nil {
+			r.Reset()
 			var renderErr *ptaherr.RenderError
 			if errors.As(err, &renderErr) {
 				return "", err
@@ -162,12 +278,459 @@ func VisitorRenderSQL(r RenderVisitor, nodes ...ast.Node) (string, error) {
 	return r.Output(), nil
 }
 
+func prepareASTNodesForRendering(
+	dialect string,
+	caps capability.Capabilities,
+	nodes []ast.Node,
+) ([]ast.Node, error) {
+	prepared := make([]ast.Node, len(nodes))
+	for i, node := range nodes {
+		cloned, err := prepareASTNodeForRendering(dialect, caps, node)
+		if err != nil {
+			return nil, err
+		}
+		prepared[i] = cloned
+	}
+	return prepared, nil
+}
+
+func prepareASTNodeForRendering(
+	dialect string,
+	caps capability.Capabilities,
+	node ast.Node,
+) (ast.Node, error) {
+	if node == nil {
+		return nil, invalidASTForeignKeyError(dialect, "AST node is nil")
+	}
+	switch typed := node.(type) {
+	case *ast.StatementList:
+		return prepareStatementListNode(dialect, caps, typed)
+	case *ast.CreateTableNode:
+		return prepareCreateTableNode(dialect, caps, typed)
+	case *ast.AlterTableNode:
+		return prepareAlterTableNode(dialect, caps, typed)
+	case *ast.ConstraintNode:
+		return prepareConstraintNode(dialect, caps, typed)
+	case *ast.ColumnNode:
+		return prepareColumnNode(dialect, caps, typed)
+	default:
+		if isNilInterface(node) {
+			return nil, invalidASTForeignKeyError(dialect, "AST node is nil")
+		}
+		return node, nil
+	}
+}
+
+func prepareStatementListNode(
+	dialect string,
+	caps capability.Capabilities,
+	list *ast.StatementList,
+) (*ast.StatementList, error) {
+	if list == nil {
+		return nil, invalidASTForeignKeyError(dialect, "statement list is nil")
+	}
+	prepared, err := prepareASTNodesForRendering(dialect, caps, list.Statements)
+	if err != nil {
+		return nil, err
+	}
+	return &ast.StatementList{Statements: prepared}, nil
+}
+
+func prepareCreateTableNode(
+	dialect string,
+	caps capability.Capabilities,
+	node *ast.CreateTableNode,
+) (*ast.CreateTableNode, error) {
+	if node == nil {
+		return nil, invalidASTForeignKeyError(dialect, "create-table node is nil")
+	}
+	cloned := *node
+	cloned.Columns = slices.Clone(node.Columns)
+	cloned.Constraints = slices.Clone(node.Constraints)
+	cloned.Options = maps.Clone(node.Options)
+
+	for i, column := range cloned.Columns {
+		prepared, err := prepareColumnNode(dialect, caps, column)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Columns[i] = prepared
+	}
+	for i, constraint := range cloned.Constraints {
+		prepared, err := prepareConstraintNode(dialect, caps, constraint)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Constraints[i] = prepared
+	}
+	if err := validateCreateTableForeignKeyColumns(dialect, &cloned); err != nil {
+		return nil, err
+	}
+	if err := ensureASTForeignKeyTableEngine(dialect, &cloned); err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func ensureASTForeignKeyTableEngine(dialect string, node *ast.CreateTableNode) error {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	if normalizedDialect != platform.MySQL && normalizedDialect != platform.MariaDB {
+		return nil
+	}
+	if !createTableContainsForeignKey(node) {
+		return nil
+	}
+
+	optionKey, engine := tableOption(node.Options, "ENGINE")
+	if strings.TrimSpace(engine) == "" {
+		if optionKey == "" {
+			optionKey = "ENGINE"
+		}
+		if node.Options == nil {
+			node.Options = make(map[string]string)
+		}
+		node.Options[optionKey] = "InnoDB"
+		return nil
+	}
+	if !strings.EqualFold(strings.TrimSpace(engine), "InnoDB") {
+		return invalidASTForeignKeyError(
+			dialect,
+			fmt.Sprintf(
+				"table %q uses storage engine %q; %s foreign keys require InnoDB",
+				node.Name,
+				strings.TrimSpace(engine),
+				normalizedDialect,
+			),
+		)
+	}
+	return nil
+}
+
+func createTableContainsForeignKey(node *ast.CreateTableNode) bool {
+	for _, column := range node.Columns {
+		if column.ForeignKey != nil {
+			return true
+		}
+	}
+	for _, constraint := range node.Constraints {
+		if constraint.Type == ast.ForeignKeyConstraint {
+			return true
+		}
+	}
+	return false
+}
+
+func tableOption(options map[string]string, target string) (optionKey, optionValue string) {
+	for key, value := range options {
+		if strings.EqualFold(key, target) {
+			return key, value
+		}
+	}
+	return "", ""
+}
+
+func prepareAlterTableNode(
+	dialect string,
+	caps capability.Capabilities,
+	node *ast.AlterTableNode,
+) (*ast.AlterTableNode, error) {
+	if node == nil {
+		return nil, invalidASTForeignKeyError(dialect, "alter-table node is nil")
+	}
+	cloned := *node
+	cloned.Operations = slices.Clone(node.Operations)
+	for i, operation := range cloned.Operations {
+		prepared, err := prepareAlterOperation(dialect, caps, operation)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Operations[i] = prepared
+	}
+	return &cloned, nil
+}
+
+func prepareAlterOperation(
+	dialect string,
+	caps capability.Capabilities,
+	operation ast.AlterOperation,
+) (ast.AlterOperation, error) {
+	if operation == nil {
+		return nil, invalidASTForeignKeyError(dialect, "alter-table operation is nil")
+	}
+	switch typed := operation.(type) {
+	case *ast.AddConstraintOperation:
+		if typed == nil {
+			return nil, invalidASTForeignKeyError(dialect, "add-constraint operation is nil")
+		}
+		cloned := *typed
+		constraint, err := prepareConstraintNode(dialect, caps, typed.Constraint)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Constraint = constraint
+		return &cloned, nil
+	case *ast.AddColumnOperation:
+		if typed == nil {
+			return nil, invalidASTForeignKeyError(dialect, "add-column operation is nil")
+		}
+		cloned := *typed
+		column, err := prepareColumnNode(dialect, caps, typed.Column)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Column = column
+		return &cloned, nil
+	case *ast.ModifyColumnOperation:
+		if typed == nil {
+			return nil, invalidASTForeignKeyError(dialect, "modify-column operation is nil")
+		}
+		cloned := *typed
+		column, err := prepareColumnNode(dialect, caps, typed.Column)
+		if err != nil {
+			return nil, err
+		}
+		cloned.Column = column
+		return &cloned, nil
+	default:
+		if isNilInterface(operation) {
+			return nil, invalidASTForeignKeyError(dialect, "alter-table operation is nil")
+		}
+		return operation, nil
+	}
+}
+
+func isNilInterface(value any) bool {
+	if value == nil {
+		return true
+	}
+	reflected := reflect.ValueOf(value)
+	return reflected.Kind() == reflect.Pointer && reflected.IsNil()
+}
+
+func prepareColumnNode(
+	dialect string,
+	caps capability.Capabilities,
+	node *ast.ColumnNode,
+) (*ast.ColumnNode, error) {
+	if node == nil {
+		return nil, invalidASTForeignKeyError(dialect, "column node is nil")
+	}
+	if node.ForeignKey == nil {
+		return node, nil
+	}
+	if !caps.Has(capability.ForeignKeys) {
+		return nil, foreignKeysUnsupportedError(dialect)
+	}
+
+	cloned := *node
+	cloned.ForeignKey = cloneForeignKeyRef(node.ForeignKey)
+	if err := validateASTForeignKey(dialect, []string{node.Name}, cloned.ForeignKey); err != nil {
+		return nil, err
+	}
+	var err error
+	cloned.ForeignKey.OnDelete, cloned.ForeignKey.OnUpdate, err = normalizeReferentialActions(
+		dialect,
+		cloned.ForeignKey.OnDelete,
+		cloned.ForeignKey.OnUpdate,
+	)
+	if err != nil {
+		return nil, err
+	}
+	if !cloned.Nullable && foreignKeyUsesSetNull(cloned.ForeignKey) {
+		return nil, invalidASTForeignKeyError(
+			dialect,
+			fmt.Sprintf("column %q uses SET NULL but is NOT NULL", cloned.Name),
+		)
+	}
+	return &cloned, nil
+}
+
+func validateCreateTableForeignKeyColumns(dialect string, node *ast.CreateTableNode) error {
+	for _, constraint := range node.Constraints {
+		if constraint.Type != ast.ForeignKeyConstraint {
+			continue
+		}
+		for _, columnName := range constraint.Columns {
+			column := createTableColumn(node.Columns, columnName)
+			if column == nil {
+				return invalidASTForeignKeyError(
+					dialect,
+					fmt.Sprintf("table %q has no local foreign-key column %q", node.Name, columnName),
+				)
+			}
+			if !column.Nullable && foreignKeyUsesSetNull(constraint.Reference) {
+				return invalidASTForeignKeyError(
+					dialect,
+					fmt.Sprintf(
+						"foreign key on %q.%q uses SET NULL but the local column is NOT NULL",
+						node.Name,
+						columnName,
+					),
+				)
+			}
+		}
+	}
+	return nil
+}
+
+func createTableColumn(columns []*ast.ColumnNode, name string) *ast.ColumnNode {
+	for _, column := range columns {
+		if column != nil && column.Name == name {
+			return column
+		}
+	}
+	return nil
+}
+
+func foreignKeyUsesSetNull(reference *ast.ForeignKeyRef) bool {
+	return reference != nil && (reference.OnDelete == "SET NULL" || reference.OnUpdate == "SET NULL")
+}
+
+func prepareConstraintNode(
+	dialect string,
+	caps capability.Capabilities,
+	node *ast.ConstraintNode,
+) (*ast.ConstraintNode, error) {
+	if node == nil {
+		return nil, invalidASTForeignKeyError(dialect, "constraint node is nil")
+	}
+	if node.Type != ast.ForeignKeyConstraint {
+		return node, nil
+	}
+	if !caps.Has(capability.ForeignKeys) {
+		return nil, foreignKeysUnsupportedError(dialect)
+	}
+
+	cloned := *node
+	cloned.Columns = slices.Clone(node.Columns)
+	cloned.Reference = cloneForeignKeyRef(node.Reference)
+	if err := validateASTForeignKey(dialect, cloned.Columns, cloned.Reference); err != nil {
+		return nil, err
+	}
+	var err error
+	cloned.Reference.OnDelete, cloned.Reference.OnUpdate, err = normalizeReferentialActions(
+		dialect,
+		cloned.Reference.OnDelete,
+		cloned.Reference.OnUpdate,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &cloned, nil
+}
+
+func cloneForeignKeyRef(reference *ast.ForeignKeyRef) *ast.ForeignKeyRef {
+	if reference == nil {
+		return nil
+	}
+	cloned := *reference
+	cloned.Columns = slices.Clone(reference.Columns)
+	return &cloned
+}
+
+func validateASTForeignKey(
+	dialect string,
+	localColumns []string,
+	reference *ast.ForeignKeyRef,
+) error {
+	if reference == nil || strings.TrimSpace(reference.Table) == "" {
+		return invalidASTForeignKeyError(dialect, "referenced table is empty")
+	}
+	referencedColumns := reference.ReferencedColumns()
+	if err := validateForeignKeyColumnLists(localColumns, referencedColumns); err != nil {
+		return invalidASTForeignKeyError(dialect, err.Error())
+	}
+	return nil
+}
+
+func validateForeignKeyColumnLists(localColumns, referencedColumns []string) error {
+	if len(localColumns) == 0 || len(referencedColumns) == 0 || len(localColumns) != len(referencedColumns) {
+		return fmt.Errorf(
+			"foreign key has %d local columns and %d referenced columns",
+			len(localColumns),
+			len(referencedColumns),
+		)
+	}
+	if err := validateForeignKeyColumns("local", localColumns); err != nil {
+		return err
+	}
+	return validateForeignKeyColumns("referenced", referencedColumns)
+}
+
+func validateForeignKeyColumns(kind string, columns []string) error {
+	seen := make(map[string]struct{}, len(columns))
+	for _, column := range columns {
+		if strings.TrimSpace(column) == "" {
+			return fmt.Errorf("%s foreign-key column is empty", kind)
+		}
+		if _, duplicate := seen[column]; duplicate {
+			return fmt.Errorf("%s foreign-key column %q is duplicated", kind, column)
+		}
+		seen[column] = struct{}{}
+	}
+	return nil
+}
+
+func invalidASTForeignKeyError(dialect, message string) error {
+	return &ptaherr.RenderError{
+		Dialect: dialect,
+		Err:     ptaherr.ErrInvalidSchemaDiff,
+		Message: "invalid foreign key: " + message,
+	}
+}
+
+func foreignKeysUnsupportedError(dialect string) error {
+	return &ptaherr.CapabilityError{
+		Dialect: dialect,
+		Feature: "foreign keys",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: fmt.Sprintf("%s does not support foreign keys", platform.NormalizeDialect(dialect)),
+	}
+}
+
+// GetOrderedCreateStatements renders a complete schema for the default
+// capability preset of dialect. Non-SQLite targets emit all tables before
+// phase-two foreign key constraints, so mutually dependent tables remain
+// executable. SQLite keeps foreign keys inline because it cannot add them
+// after table creation.
+//
+// The function validates foreign key shape, actions, and target capabilities
+// before rendering. Unsupported or malformed constraints return an error and
+// no partial statement list.
 func GetOrderedCreateStatements(r *goschema.Database, dialect string) ([]string, error) {
 	return GetOrderedCreateStatementsWithCapabilities(r, dialect, capability.ForDialect(dialect))
 }
 
+// ValidateSchema validates a complete schema against the default capability
+// preset for dialect without rendering SQL.
+func ValidateSchema(r *goschema.Database, dialect string) error {
+	return ValidateSchemaWithCapabilities(r, dialect, capability.ForDialect(dialect))
+}
+
+// ValidateSchemaWithCapabilities validates a complete schema against a
+// concrete server capability set without rendering SQL.
+func ValidateSchemaWithCapabilities(
+	r *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) error {
+	if _, err := NewRendererWithCapabilities(dialect, caps); err != nil {
+		return err
+	}
+	if r == nil {
+		return &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: "cannot validate a nil database schema",
+		}
+	}
+	_, err := prepareDatabaseForRendering(r, dialect, caps)
+	return err
+}
+
 // GetOrderedCreateStatementsWithCapabilities renders ordered create statements
-// for a concrete server capability set.
+// for a concrete server capability set. It has the same two-phase and
+// fail-closed guarantees as GetOrderedCreateStatements.
 func GetOrderedCreateStatementsWithCapabilities(
 	r *goschema.Database,
 	dialect string,
@@ -175,7 +738,21 @@ func GetOrderedCreateStatementsWithCapabilities(
 ) ([]string, error) {
 	var statements []string
 
-	astNodes := fromschema.FromDatabase(*r, dialect)
+	if _, err := NewRendererWithCapabilities(dialect, caps); err != nil {
+		return nil, err
+	}
+	if r == nil {
+		return nil, &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: "cannot render a nil database schema",
+		}
+	}
+	database, err := prepareDatabaseForRendering(r, dialect, caps)
+	if err != nil {
+		return nil, err
+	}
+	astNodes := fromschema.FromDatabase(database, dialect)
 	for _, node := range astNodes.Statements {
 		sql, err := RenderSQLWithCapabilities(dialect, caps, node)
 		if err != nil {
@@ -185,4 +762,1186 @@ func GetOrderedCreateStatementsWithCapabilities(
 	}
 
 	return statements, nil
+}
+
+func prepareDatabaseForRendering(
+	database *goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) (goschema.Database, error) {
+	prepared := *database
+	prepared.Tables = slices.Clone(database.Tables)
+	prepared.Fields = slices.Clone(database.Fields)
+	prepared.EmbeddedFields = slices.Clone(database.EmbeddedFields)
+	prepared.Constraints = slices.Clone(database.Constraints)
+
+	hasForeignKeys := false
+	for i := range prepared.Fields {
+		field := &prepared.Fields[i]
+		if field.Foreign == "" {
+			continue
+		}
+		hasForeignKeys = true
+		if err := validateFieldForeignKey(*field, dialect); err != nil {
+			return goschema.Database{}, err
+		}
+		var err error
+		field.OnDelete, field.OnUpdate, err = normalizeReferentialActions(dialect, field.OnDelete, field.OnUpdate)
+		if err != nil {
+			return goschema.Database{}, err
+		}
+	}
+	for i := range prepared.EmbeddedFields {
+		embedded := &prepared.EmbeddedFields[i]
+		if embedded.Mode != "relation" || embedded.Ref == "" {
+			continue
+		}
+		hasForeignKeys = true
+		if err := validateForeignKeyReference(embedded.Ref); err != nil {
+			return goschema.Database{}, &ptaherr.RenderError{
+				Dialect: dialect,
+				Err:     ptaherr.ErrInvalidSchemaDiff,
+				Message: fmt.Sprintf("invalid embedded foreign key on field %q: %s", embedded.Field, err),
+			}
+		}
+		var err error
+		embedded.OnDelete, embedded.OnUpdate, err = normalizeReferentialActions(dialect, embedded.OnDelete, embedded.OnUpdate)
+		if err != nil {
+			return goschema.Database{}, err
+		}
+	}
+	for i := range prepared.Constraints {
+		constraint := &prepared.Constraints[i]
+		if !strings.EqualFold(strings.TrimSpace(constraint.Type), "FOREIGN KEY") {
+			continue
+		}
+		hasForeignKeys = true
+		if err := validateTableForeignKey(*constraint, dialect); err != nil {
+			return goschema.Database{}, err
+		}
+		var err error
+		constraint.OnDelete, constraint.OnUpdate, err = normalizeReferentialActions(dialect, constraint.OnDelete, constraint.OnUpdate)
+		if err != nil {
+			return goschema.Database{}, err
+		}
+	}
+	if hasForeignKeys && !caps.Has(capability.ForeignKeys) {
+		return goschema.Database{}, foreignKeysUnsupportedError(dialect)
+	}
+	if err := validateSchemaForeignKeys(prepared, dialect, caps); err != nil {
+		return goschema.Database{}, err
+	}
+	if hasForeignKeys {
+		makeMySQLForeignKeyTableEnginesExplicit(&prepared, dialect)
+	}
+	return prepared, nil
+}
+
+func makeMySQLForeignKeyTableEnginesExplicit(database *goschema.Database, dialect string) {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	if normalizedDialect != platform.MySQL && normalizedDialect != platform.MariaDB {
+		return
+	}
+
+	participants := mysqlForeignKeyTableParticipants(*database)
+	for i := range database.Tables {
+		table := &database.Tables[i]
+		if _, participates := participants[table.QualifiedName()]; !participates {
+			continue
+		}
+		engine, overridden := configuredTableEngine(*table, normalizedDialect)
+		if strings.TrimSpace(engine) != "" {
+			continue
+		}
+		if overridden {
+			table.Overrides = maps.Clone(table.Overrides)
+			table.Overrides[normalizedDialect] = maps.Clone(table.Overrides[normalizedDialect])
+			table.Overrides[normalizedDialect]["engine"] = "InnoDB"
+			continue
+		}
+		table.Engine = "InnoDB"
+	}
+}
+
+func mysqlForeignKeyTableParticipants(database goschema.Database) map[string]struct{} {
+	participants := make(map[string]struct{})
+	fields := fromschema.ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
+	for _, field := range fields {
+		if field.Foreign == "" {
+			continue
+		}
+		owner := tableByStructName(database.Tables, field.StructName)
+		if owner == nil {
+			continue
+		}
+		target := referencedTable(
+			database.Tables,
+			*owner,
+			fromschema.ParseForeignKeyReference(field.Foreign).Table,
+		)
+		participants[owner.QualifiedName()] = struct{}{}
+		participants[target.QualifiedName()] = struct{}{}
+	}
+	for _, constraint := range database.Constraints {
+		if !strings.EqualFold(strings.TrimSpace(constraint.Type), "FOREIGN KEY") {
+			continue
+		}
+		owner := constraintOwnerTable(database.Tables, constraint)
+		target := referencedTable(database.Tables, *owner, constraint.ForeignTable)
+		participants[owner.QualifiedName()] = struct{}{}
+		participants[target.QualifiedName()] = struct{}{}
+	}
+	return participants
+}
+
+func configuredTableEngine(table goschema.Table, dialect string) (string, bool) {
+	if overrides := table.Overrides[dialect]; overrides != nil {
+		if engine, found := overrides["engine"]; found {
+			return engine, true
+		}
+	}
+	return table.Engine, false
+}
+
+func validateFieldForeignKey(field goschema.Field, dialect string) error {
+	if err := validateForeignKeyReference(field.Foreign); err != nil {
+		return &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: fmt.Sprintf("invalid foreign key on field %q: %s", field.Name, err),
+		}
+	}
+	return nil
+}
+
+func validateForeignKeyReference(reference string) error {
+	parsed := fromschema.ParseForeignKeyReference(reference)
+	if parsed == nil || strings.TrimSpace(parsed.Table) == "" {
+		return fmt.Errorf("malformed reference %q", reference)
+	}
+	columns := parsed.ReferencedColumns()
+	if len(columns) != 1 || strings.TrimSpace(columns[0]) == "" || strings.Contains(columns[0], ",") {
+		return fmt.Errorf("reference %q must name exactly one column", reference)
+	}
+	return nil
+}
+
+func validateTableForeignKey(constraint goschema.Constraint, dialect string) error {
+	localColumns := constraint.Columns
+	foreignColumns := constraint.ForeignColumnsOrDefault()
+	if strings.TrimSpace(constraint.ForeignTable) == "" || len(localColumns) == 0 || len(foreignColumns) == 0 || len(localColumns) != len(foreignColumns) {
+		return &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     ptaherr.ErrInvalidSchemaDiff,
+			Message: fmt.Sprintf(
+				"invalid foreign key constraint %q: %d local columns and %d referenced columns",
+				constraint.Name,
+				len(localColumns),
+				len(foreignColumns),
+			),
+		}
+	}
+	return nil
+}
+
+func normalizeReferentialActions(
+	dialect, onDelete, onUpdate string,
+) (normalizedDelete, normalizedUpdate string, err error) {
+	normalizedDelete, err = normalizeReferentialAction(dialect, "ON DELETE", onDelete)
+	if err != nil {
+		return "", "", err
+	}
+	normalizedUpdate, err = normalizeReferentialAction(dialect, "ON UPDATE", onUpdate)
+	if err != nil {
+		return "", "", err
+	}
+	return normalizedDelete, normalizedUpdate, nil
+}
+
+func normalizeReferentialAction(dialect, clause, action string) (string, error) {
+	action = strings.ReplaceAll(action, "_", " ")
+	action = strings.ToUpper(strings.Join(strings.Fields(action), " "))
+	if action == "" {
+		return "", nil
+	}
+	if !slices.Contains([]string{"NO ACTION", "RESTRICT", "CASCADE", "SET NULL", "SET DEFAULT"}, action) {
+		return "", invalidReferentialActionError(dialect, clause, action)
+	}
+
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	switch normalizedDialect {
+	case platform.MySQL, platform.MariaDB:
+		if action == "SET DEFAULT" {
+			return "", invalidReferentialActionError(dialect, clause, action)
+		}
+	case platform.SQLServer:
+		if action == "RESTRICT" {
+			return "NO ACTION", nil
+		}
+	case platform.Spanner:
+		if clause == "ON UPDATE" || !slices.Contains([]string{"NO ACTION", "CASCADE"}, action) {
+			return "", invalidReferentialActionError(dialect, clause, action)
+		}
+	}
+	return action, nil
+}
+
+func invalidReferentialActionError(dialect, clause, action string) error {
+	return &ptaherr.CapabilityError{
+		Dialect: dialect,
+		Feature: "foreign key referential actions",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: fmt.Sprintf("%s does not support %s %s", platform.NormalizeDialect(dialect), clause, action),
+	}
+}
+
+func validateSchemaForeignKeys(
+	database goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+) error {
+	fields := fromschema.ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
+	bindings := make([]foreignKeyBinding, 0)
+	explicitNames := make(map[string]map[string]struct{})
+	for _, field := range fields {
+		if field.Foreign == "" {
+			continue
+		}
+		owner := tableByStructName(database.Tables, field.StructName)
+		if owner == nil {
+			if isEmbeddedHelperStruct(database.EmbeddedFields, field.StructName) {
+				continue
+			}
+			return invalidSchemaForeignKeyError(
+				dialect,
+				fmt.Sprintf("field %q has no owning table for struct %q", field.Name, field.StructName),
+			)
+		}
+		if err := reserveExplicitForeignKeyName(explicitNames, dialect, *owner, field.ForeignKeyName); err != nil {
+			return invalidSchemaForeignKeyError(dialect, err.Error())
+		}
+		reference := fromschema.ParseForeignKeyReference(field.Foreign)
+		target := referencedTable(database.Tables, *owner, reference.Table)
+		if target == nil {
+			return invalidSchemaForeignKeyError(
+				dialect,
+				fmt.Sprintf("field %q references unknown table %q", field.Name, reference.Table),
+			)
+		}
+		referencedColumns := reference.ReferencedColumns()
+		if err := validateSchemaForeignKeyColumns(
+			fields,
+			dialect,
+			*owner,
+			[]string{field.Name},
+			*target,
+			referencedColumns,
+			field.OnDelete,
+			field.OnUpdate,
+		); err != nil {
+			return err
+		}
+		if err := validateReferencedKeyPolicy(database, dialect, caps, *target, referencedColumns); err != nil {
+			return err
+		}
+		bindings = append(bindings, foreignKeyBinding{
+			owner:    owner.QualifiedName(),
+			target:   target.QualifiedName(),
+			onDelete: field.OnDelete,
+			onUpdate: field.OnUpdate,
+		})
+	}
+	for _, constraint := range database.Constraints {
+		if !strings.EqualFold(strings.TrimSpace(constraint.Type), "FOREIGN KEY") {
+			continue
+		}
+		owner := constraintOwnerTable(database.Tables, constraint)
+		if owner == nil {
+			return invalidSchemaForeignKeyError(
+				dialect,
+				fmt.Sprintf("constraint %q has no owning table", constraint.Name),
+			)
+		}
+		if err := reserveExplicitForeignKeyName(explicitNames, dialect, *owner, constraint.Name); err != nil {
+			return invalidSchemaForeignKeyError(dialect, err.Error())
+		}
+		columns := constraint.ForeignColumnsOrDefault()
+		target := referencedTable(database.Tables, *owner, constraint.ForeignTable)
+		if target == nil {
+			return invalidSchemaForeignKeyError(
+				dialect,
+				fmt.Sprintf("constraint %q references unknown table %q", constraint.Name, constraint.ForeignTable),
+			)
+		}
+		if err := validateSchemaForeignKeyColumns(
+			fields,
+			dialect,
+			*owner,
+			constraint.Columns,
+			*target,
+			columns,
+			constraint.OnDelete,
+			constraint.OnUpdate,
+		); err != nil {
+			return err
+		}
+		if err := validateReferencedKeyPolicy(database, dialect, caps, *target, columns); err != nil {
+			return err
+		}
+		bindings = append(bindings, foreignKeyBinding{
+			owner:    owner.QualifiedName(),
+			target:   target.QualifiedName(),
+			onDelete: constraint.OnDelete,
+			onUpdate: constraint.OnUpdate,
+		})
+	}
+	if platform.NormalizeDialect(dialect) == platform.SQLServer {
+		return validateSQLServerCascadeGraph(dialect, bindings)
+	}
+	return nil
+}
+
+func isEmbeddedHelperStruct(embeddedFields []goschema.EmbeddedField, structName string) bool {
+	for _, embedded := range embeddedFields {
+		if embedded.StructName == structName || embedded.EmbeddedTypeName == structName {
+			return true
+		}
+	}
+	return false
+}
+
+func reserveExplicitForeignKeyName(
+	reserved map[string]map[string]struct{},
+	dialect string,
+	table goschema.Table,
+	name string,
+) error {
+	if name == "" {
+		return nil
+	}
+	if err := validateExplicitForeignKeyName(dialect, name); err != nil {
+		return err
+	}
+	scope, normalizedName := foreignKeyNameScope(dialect, table, name)
+	if reserved[scope] == nil {
+		reserved[scope] = make(map[string]struct{})
+	}
+	if _, duplicate := reserved[scope][normalizedName]; duplicate {
+		return fmt.Errorf("foreign-key name %q is duplicated in %s", name, scope)
+	}
+	reserved[scope][normalizedName] = struct{}{}
+	return nil
+}
+
+func validateExplicitForeignKeyName(dialect, name string) error {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	switch normalizedDialect {
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+		if len(name) > 63 {
+			return fmt.Errorf("foreign-key name %q exceeds the PostgreSQL-family 63-byte identifier limit", name)
+		}
+	case platform.MySQL, platform.MariaDB:
+		if utf8.RuneCountInString(name) > 64 {
+			return fmt.Errorf("foreign-key name %q exceeds the %s 64-character identifier limit", name, normalizedDialect)
+		}
+	case platform.SQLServer, platform.Spanner:
+		if utf8.RuneCountInString(name) > 128 {
+			return fmt.Errorf("foreign-key name %q exceeds the %s 128-character identifier limit", name, normalizedDialect)
+		}
+	}
+	return nil
+}
+
+func foreignKeyNameScope(dialect string, table goschema.Table, name string) (scope, normalizedName string) {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	switch normalizedDialect {
+	case platform.MySQL, platform.MariaDB:
+		return "database constraint namespace", strings.ToLower(name)
+	case platform.SQLServer, platform.Spanner:
+		schema := strings.TrimSpace(table.Schema)
+		if schema == "" {
+			schema = identifier.ForDialect(dialect).DefaultSchema
+		}
+		schema = strings.ToLower(schema)
+		return fmt.Sprintf("schema %q constraint namespace", schema), strings.ToLower(name)
+	default:
+		return fmt.Sprintf("table %q constraint namespace", table.QualifiedName()), name
+	}
+}
+
+type foreignKeyBinding struct {
+	owner    string
+	target   string
+	onDelete string
+	onUpdate string
+}
+
+func validateSchemaForeignKeyColumns(
+	fields []goschema.Field,
+	dialect string,
+	owner goschema.Table,
+	localColumns []string,
+	target goschema.Table,
+	referencedColumns []string,
+	onDelete string,
+	onUpdate string,
+) error {
+	if err := validateForeignKeyColumnLists(localColumns, referencedColumns); err != nil {
+		return invalidSchemaForeignKeyError(dialect, err.Error())
+	}
+	if missing := firstMissingTableColumn(fields, owner, localColumns); missing != "" {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf("table %q has no local foreign-key column %q", owner.QualifiedName(), missing),
+		)
+	}
+	if missing := firstMissingTableColumn(fields, target, referencedColumns); missing != "" {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf("referenced table %q has no column %q", target.QualifiedName(), missing),
+		)
+	}
+	if err := validateForeignKeyTableStorage(dialect, owner, target); err != nil {
+		return err
+	}
+	for i, localColumn := range localColumns {
+		localField := tableColumn(fields, owner, localColumn)
+		referencedField := tableColumn(fields, target, referencedColumns[i])
+		if err := validateForeignKeyColumnCompatibility(
+			dialect,
+			owner,
+			localField,
+			target,
+			referencedField,
+			onDelete,
+			onUpdate,
+		); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateForeignKeyTableStorage(dialect string, owner, target goschema.Table) error {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	if normalizedDialect != platform.MySQL && normalizedDialect != platform.MariaDB {
+		return nil
+	}
+	for _, table := range []goschema.Table{owner, target} {
+		engine := effectiveTableEngine(table, normalizedDialect)
+		if !strings.EqualFold(engine, "InnoDB") {
+			return invalidSchemaForeignKeyError(
+				dialect,
+				fmt.Sprintf(
+					"table %q uses storage engine %q; %s foreign keys require InnoDB",
+					table.QualifiedName(),
+					engine,
+					normalizedDialect,
+				),
+			)
+		}
+	}
+	return nil
+}
+
+func effectiveTableEngine(table goschema.Table, dialect string) string {
+	configured, _ := configuredTableEngine(table, dialect)
+	engine := strings.TrimSpace(configured)
+	if engine == "" {
+		return "InnoDB"
+	}
+	return engine
+}
+
+func validateForeignKeyColumnCompatibility(
+	dialect string,
+	owner goschema.Table,
+	local goschema.Field,
+	target goschema.Table,
+	referenced goschema.Field,
+	onDelete string,
+	onUpdate string,
+) error {
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	local = fromschema.EffectiveFieldForPlatform(local, normalizedDialect)
+	referenced = fromschema.EffectiveFieldForPlatform(referenced, normalizedDialect)
+	if (onDelete == "SET NULL" || onUpdate == "SET NULL") && !local.Nullable {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf(
+				"foreign key on %q.%q uses SET NULL but the local column is NOT NULL",
+				owner.QualifiedName(),
+				local.Name,
+			),
+		)
+	}
+	if normalizedDialect == platform.SQLite {
+		return nil
+	}
+	if normalizedDialect == platform.MySQL || normalizedDialect == platform.MariaDB {
+		if err := validateMySQLFamilyGeneratedForeignKey(
+			dialect,
+			owner,
+			local,
+			target,
+			referenced,
+			onDelete,
+			onUpdate,
+		); err != nil {
+			return err
+		}
+	}
+	localType := normalizeForeignKeyColumnType(local.Type, normalizedDialect)
+	referencedType := normalizeForeignKeyColumnType(referenced.Type, normalizedDialect)
+	if localType == "" || referencedType == "" ||
+		!foreignKeyColumnTypesCompatible(localType, referencedType, normalizedDialect) {
+		return incompatibleForeignKeyColumnTypesError(dialect, owner, local, target, referenced)
+	}
+	if normalizedDialect == platform.MySQL || normalizedDialect == platform.MariaDB {
+		if mysqlForeignKeyTypeUsesCharset(localType) || mysqlForeignKeyTypeUsesCharset(referencedType) {
+			if err := validateMySQLForeignKeyTextMetadata(
+				dialect,
+				owner,
+				local,
+				target,
+				referenced,
+			); err != nil {
+				return err
+			}
+		}
+		if mysqlForeignKeyTypeBase(localType) == "ENUM" && !slices.Equal(local.Enum, referenced.Enum) {
+			return incompatibleForeignKeyColumnTypesError(dialect, owner, local, target, referenced)
+		}
+	}
+	if normalizedDialect == platform.Spanner && isSpannerNonKeyType(localType) {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf(
+				"Spanner type %s cannot participate in foreign keys: %q.%q references %q.%q",
+				local.Type,
+				owner.QualifiedName(),
+				local.Name,
+				target.QualifiedName(),
+				referenced.Name,
+			),
+		)
+	}
+	return nil
+}
+
+func incompatibleForeignKeyColumnTypesError(
+	dialect string,
+	owner goschema.Table,
+	local goschema.Field,
+	target goschema.Table,
+	referenced goschema.Field,
+) error {
+	return invalidSchemaForeignKeyError(
+		dialect,
+		fmt.Sprintf(
+			"foreign-key columns %q.%q (%s) and %q.%q (%s) have incompatible types",
+			owner.QualifiedName(),
+			local.Name,
+			local.Type,
+			target.QualifiedName(),
+			referenced.Name,
+			referenced.Type,
+		),
+	)
+}
+
+func validateMySQLFamilyGeneratedForeignKey(
+	dialect string,
+	owner goschema.Table,
+	local goschema.Field,
+	target goschema.Table,
+	referenced goschema.Field,
+	onDelete string,
+	onUpdate string,
+) error {
+	generated := local.GeneratedExpression != "" || referenced.GeneratedExpression != ""
+	if !generated {
+		return nil
+	}
+	normalizedDialect := platform.NormalizeDialect(dialect)
+	if normalizedDialect == platform.MariaDB ||
+		!generatedForeignKeyColumnsAreStored(local, referenced) {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf(
+				"generated columns cannot participate in portable %s foreign keys: %q.%q references %q.%q",
+				normalizedDialect,
+				owner.QualifiedName(),
+				local.Name,
+				target.QualifiedName(),
+				referenced.Name,
+			),
+		)
+	}
+	if slices.Contains([]string{"CASCADE", "SET NULL", "SET DEFAULT"}, onUpdate) ||
+		slices.Contains([]string{"SET NULL", "SET DEFAULT"}, onDelete) {
+		return invalidSchemaForeignKeyError(
+			dialect,
+			fmt.Sprintf(
+				"stored generated foreign-key columns do not support ON DELETE %s ON UPDATE %s",
+				referentialActionOrDefault(onDelete),
+				referentialActionOrDefault(onUpdate),
+			),
+		)
+	}
+	return nil
+}
+
+func generatedForeignKeyColumnsAreStored(fields ...goschema.Field) bool {
+	for _, field := range fields {
+		if field.GeneratedExpression == "" {
+			continue
+		}
+		kind := strings.ToUpper(strings.TrimSpace(field.GeneratedKind))
+		if kind != "STORED" {
+			return false
+		}
+	}
+	return true
+}
+
+func referentialActionOrDefault(action string) string {
+	if action == "" {
+		return "NO ACTION"
+	}
+	return action
+}
+
+func validateMySQLForeignKeyTextMetadata(
+	dialect string,
+	owner goschema.Table,
+	local goschema.Field,
+	target goschema.Table,
+	referenced goschema.Field,
+) error {
+	localCharset := effectiveColumnMetadata(local.Charset, effectiveTableMetadata(owner, dialect, "charset"))
+	referencedCharset := effectiveColumnMetadata(
+		referenced.Charset,
+		effectiveTableMetadata(target, dialect, "charset"),
+	)
+	if localCharset != referencedCharset {
+		return incompatibleForeignKeyTextMetadataError(
+			dialect,
+			"character sets",
+			owner,
+			local,
+			localCharset,
+			target,
+			referenced,
+			referencedCharset,
+		)
+	}
+	localCollation := effectiveColumnMetadata(local.Collate, effectiveTableMetadata(owner, dialect, "collate"))
+	referencedCollation := effectiveColumnMetadata(
+		referenced.Collate,
+		effectiveTableMetadata(target, dialect, "collate"),
+	)
+	if localCollation != referencedCollation {
+		return incompatibleForeignKeyTextMetadataError(
+			dialect,
+			"collations",
+			owner,
+			local,
+			localCollation,
+			target,
+			referenced,
+			referencedCollation,
+		)
+	}
+	return nil
+}
+
+func effectiveTableMetadata(table goschema.Table, dialect, key string) string {
+	value := table.Charset
+	if key == "collate" {
+		value = table.Collate
+	}
+	if overrides := table.Overrides[platform.NormalizeDialect(dialect)]; overrides != nil {
+		if override, found := overrides[key]; found {
+			value = override
+		}
+	}
+	return value
+}
+
+func effectiveColumnMetadata(columnValue, tableValue string) string {
+	value := strings.TrimSpace(columnValue)
+	if value == "" {
+		value = strings.TrimSpace(tableValue)
+	}
+	return strings.ToLower(value)
+}
+
+func incompatibleForeignKeyTextMetadataError(
+	dialect string,
+	metadata string,
+	owner goschema.Table,
+	local goschema.Field,
+	localValue string,
+	target goschema.Table,
+	referenced goschema.Field,
+	referencedValue string,
+) error {
+	return invalidSchemaForeignKeyError(
+		dialect,
+		fmt.Sprintf(
+			"foreign-key columns %q.%q and %q.%q have incompatible %s %q and %q",
+			owner.QualifiedName(),
+			local.Name,
+			target.QualifiedName(),
+			referenced.Name,
+			metadata,
+			localValue,
+			referencedValue,
+		),
+	)
+}
+
+func normalizeForeignKeyColumnType(fieldType, dialect string) string {
+	normalized := strings.ToUpper(strings.Join(strings.Fields(fieldType), " "))
+	normalized = strings.TrimSpace(strings.ReplaceAll(normalized, " AUTO_INCREMENT", ""))
+	unsigned := strings.Contains(normalized, " UNSIGNED") || strings.Contains(normalized, " ZEROFILL")
+	normalized = strings.TrimSpace(strings.ReplaceAll(normalized, " UNSIGNED", ""))
+	normalized = strings.TrimSpace(strings.ReplaceAll(normalized, " ZEROFILL", ""))
+	normalized = normalizeForeignKeyColumnTypeAlias(normalized, dialect)
+	if unsigned {
+		normalized += " UNSIGNED"
+	}
+	return normalized
+}
+
+func normalizeForeignKeyColumnTypeAlias(fieldType, dialect string) string {
+	if dialect == platform.MySQL || dialect == platform.MariaDB {
+		fieldType = stripMySQLIntegerDisplayWidth(fieldType)
+	}
+	switch {
+	case strings.HasPrefix(fieldType, "CHARACTER VARYING("):
+		return "VARCHAR" + strings.TrimPrefix(fieldType, "CHARACTER VARYING")
+	case strings.HasPrefix(fieldType, "CHARACTER("):
+		return "CHAR" + strings.TrimPrefix(fieldType, "CHARACTER")
+	case strings.HasPrefix(fieldType, "DECIMAL("):
+		return "NUMERIC" + strings.TrimPrefix(fieldType, "DECIMAL")
+	}
+	switch fieldType {
+	case "SMALLSERIAL", "SERIAL2", "INT2":
+		return "SMALLINT"
+	case "SERIAL", "SERIAL4", "INT", "INT4":
+		return "INTEGER"
+	case "BIGSERIAL", "SERIAL8", "INT8":
+		return "BIGINT"
+	case "CHARACTER VARYING":
+		return "VARCHAR"
+	case "CHARACTER":
+		return "CHAR"
+	case "DECIMAL":
+		return "NUMERIC"
+	default:
+		return fieldType
+	}
+}
+
+func foreignKeyColumnTypesCompatible(localType, referencedType, dialect string) bool {
+	if localType == referencedType {
+		return !mysqlFamilyForeignKeyTypeUnsupported(localType, dialect)
+	}
+	if dialect != platform.MySQL && dialect != platform.MariaDB {
+		return false
+	}
+	if mysqlFamilyForeignKeyTypeUnsupported(localType, dialect) ||
+		mysqlFamilyForeignKeyTypeUnsupported(referencedType, dialect) {
+		return false
+	}
+	return mysqlStringTypeFamily(localType) != "" &&
+		mysqlStringTypeFamily(localType) == mysqlStringTypeFamily(referencedType)
+}
+
+func mysqlStringTypeFamily(fieldType string) string {
+	base := mysqlForeignKeyTypeBase(fieldType)
+	if slices.Contains([]string{"CHAR", "VARCHAR", "BINARY", "VARBINARY"}, base) {
+		return base
+	}
+	return ""
+}
+
+func mysqlForeignKeyTypeUsesCharset(fieldType string) bool {
+	return slices.Contains([]string{
+		"CHAR", "VARCHAR", "TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT", "ENUM", "SET",
+	}, mysqlForeignKeyTypeBase(fieldType))
+}
+
+func mysqlForeignKeyTypeBase(fieldType string) string {
+	base, _, _ := strings.Cut(fieldType, "(")
+	return strings.TrimSuffix(base, " UNSIGNED")
+}
+
+func mysqlFamilyForeignKeyTypeUnsupported(fieldType, dialect string) bool {
+	if dialect != platform.MySQL && dialect != platform.MariaDB {
+		return false
+	}
+	base := mysqlForeignKeyTypeBase(fieldType)
+	return slices.Contains([]string{
+		"TINYTEXT", "TEXT", "MEDIUMTEXT", "LONGTEXT",
+		"TINYBLOB", "BLOB", "MEDIUMBLOB", "LONGBLOB", "JSON",
+	}, base)
+}
+
+func stripMySQLIntegerDisplayWidth(fieldType string) string {
+	for _, integerType := range []string{"TINYINT", "SMALLINT", "MEDIUMINT", "INT", "INTEGER", "BIGINT"} {
+		prefix := integerType + "("
+		if strings.HasPrefix(fieldType, prefix) && strings.HasSuffix(fieldType, ")") {
+			return integerType
+		}
+	}
+	return fieldType
+}
+
+func isSpannerNonKeyType(fieldType string) bool {
+	return slices.Contains([]string{"FLOAT32", "FLOAT4", "REAL", "NUMERIC", "JSON", "JSONB", "STRUCT"}, fieldType) ||
+		strings.HasPrefix(fieldType, "ARRAY<") || strings.HasSuffix(fieldType, "[]")
+}
+
+func tableColumn(fields []goschema.Field, table goschema.Table, column string) goschema.Field {
+	for _, field := range fields {
+		if field.StructName == table.StructName && field.Name == column {
+			return field
+		}
+	}
+	return goschema.Field{}
+}
+
+func firstMissingTableColumn(fields []goschema.Field, table goschema.Table, columns []string) string {
+	available := make(map[string]struct{})
+	for _, field := range fields {
+		if field.StructName == table.StructName {
+			available[field.Name] = struct{}{}
+		}
+	}
+	for _, column := range columns {
+		if _, found := available[column]; !found {
+			return column
+		}
+	}
+	return ""
+}
+
+func validateReferencedKeyPolicy(
+	database goschema.Database,
+	dialect string,
+	caps capability.Capabilities,
+	target goschema.Table,
+	columns []string,
+) error {
+	switch {
+	case caps.Has(capability.ForeignKeysRequireUniqueReference):
+		if !tableHasUniqueKey(database, dialect, target, columns) {
+			return uniqueReferenceError(dialect, target, columns)
+		}
+	case caps.Has(capability.ForeignKeysRequireIndexedReference):
+		if !tableHasIndexedKey(database, target, columns) {
+			return indexedReferenceError(dialect, target, columns)
+		}
+	case caps.Has(capability.ForeignKeysCreateBackingIndex):
+		return nil
+	}
+	return nil
+}
+
+func tableByStructName(tables []goschema.Table, structName string) *goschema.Table {
+	for i := range tables {
+		if tables[i].StructName == structName {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func constraintOwnerTable(tables []goschema.Table, constraint goschema.Constraint) *goschema.Table {
+	if constraint.Table != "" {
+		for i := range tables {
+			if tables[i].QualifiedName() == constraint.Table || tables[i].Name == constraint.Table {
+				return &tables[i]
+			}
+		}
+	}
+	return tableByStructName(tables, constraint.StructName)
+}
+
+func referencedTable(tables []goschema.Table, owner goschema.Table, reference string) *goschema.Table {
+	resolved := tablelookup.ResolveReference(tables, owner, reference)
+	for i := range tables {
+		if tables[i].QualifiedName() == resolved {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func tableHasUniqueKey(database goschema.Database, dialect string, table goschema.Table, columns []string) bool {
+	return tablePrimaryKeyEquals(table, columns) ||
+		tableFieldsHaveUniqueKey(allDatabaseFields(database), table, columns) ||
+		tableConstraintsHaveUniqueKey(database, table, columns) ||
+		tableIndexesHaveUniqueKey(database, dialect, table, columns)
+}
+
+func tablePrimaryKeyEquals(table goschema.Table, columns []string) bool {
+	return slices.Equal(table.PrimaryKey, columns) ||
+		(primaryKeyPartsAreFullColumns(table.PrimaryKeyParts) &&
+			slices.Equal(primaryKeyPartNames(table.PrimaryKeyParts), columns))
+}
+
+func tableFieldsHaveUniqueKey(fields []goschema.Field, table goschema.Table, columns []string) bool {
+	var primaryFields []string
+	for _, field := range fields {
+		if field.StructName != table.StructName {
+			continue
+		}
+		if field.Primary {
+			primaryFields = append(primaryFields, field.Name)
+		}
+		if len(columns) == 1 && field.Name == columns[0] && field.Unique {
+			return true
+		}
+	}
+	return slices.Equal(primaryFields, columns)
+}
+
+func tableConstraintsHaveUniqueKey(
+	database goschema.Database,
+	table goschema.Table,
+	columns []string,
+) bool {
+	for _, constraint := range database.Constraints {
+		owner := constraintOwnerTable(database.Tables, constraint)
+		if owner != nil && owner.QualifiedName() == table.QualifiedName() &&
+			(strings.EqualFold(constraint.Type, "PRIMARY KEY") || strings.EqualFold(constraint.Type, "UNIQUE")) &&
+			slices.Equal(constraint.Columns, columns) {
+			return true
+		}
+	}
+	return false
+}
+
+func tableIndexesHaveUniqueKey(
+	database goschema.Database,
+	dialect string,
+	table goschema.Table,
+	columns []string,
+) bool {
+	// SQLite's IR does not preserve per-index-part collation. Accepting a
+	// standalone unique index could therefore produce a deferred
+	// "foreign key mismatch" at DML time. Inline keys remain verifiable.
+	if platform.NormalizeDialect(dialect) == platform.SQLite {
+		return false
+	}
+	indexOwners := goschema.ResolveIndexTableNames(database.Indexes, database.Tables)
+	for i, index := range database.Indexes {
+		indexColumns, valid := fullIndexColumnNames(index)
+		if index.Unique && valid && strings.TrimSpace(index.Condition) == "" &&
+			indexOwners[i] == table.QualifiedName() && slices.Equal(indexColumns, columns) {
+			return true
+		}
+	}
+	return false
+}
+
+func tableHasIndexedKey(database goschema.Database, table goschema.Table, columns []string) bool {
+	if isColumnPrefix(table.PrimaryKey, columns) ||
+		(primaryKeyPartsAreFullColumns(table.PrimaryKeyParts) &&
+			isColumnPrefix(primaryKeyPartNames(table.PrimaryKeyParts), columns)) {
+		return true
+	}
+
+	var primaryFields []string
+	for _, field := range allDatabaseFields(database) {
+		if field.StructName != table.StructName {
+			continue
+		}
+		if field.Primary {
+			primaryFields = append(primaryFields, field.Name)
+		}
+		if len(columns) == 1 && field.Name == columns[0] && field.Unique {
+			return true
+		}
+	}
+	if isColumnPrefix(primaryFields, columns) {
+		return true
+	}
+
+	for _, constraint := range database.Constraints {
+		owner := constraintOwnerTable(database.Tables, constraint)
+		if owner != nil && owner.QualifiedName() == table.QualifiedName() &&
+			(strings.EqualFold(constraint.Type, "PRIMARY KEY") || strings.EqualFold(constraint.Type, "UNIQUE")) &&
+			isColumnPrefix(constraint.Columns, columns) {
+			return true
+		}
+	}
+	indexOwners := goschema.ResolveIndexTableNames(database.Indexes, database.Tables)
+	for i, index := range database.Indexes {
+		if indexOwners[i] == table.QualifiedName() && indexHasFullColumnPrefix(index, columns) {
+			return true
+		}
+	}
+	return false
+}
+
+func allDatabaseFields(database goschema.Database) []goschema.Field {
+	return fromschema.ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
+}
+
+func isColumnPrefix(keyColumns, referencedColumns []string) bool {
+	return len(referencedColumns) > 0 && len(keyColumns) >= len(referencedColumns) &&
+		slices.Equal(keyColumns[:len(referencedColumns)], referencedColumns)
+}
+
+func primaryKeyPartsAreFullColumns(parts []goschema.PrimaryKeyPart) bool {
+	if len(parts) == 0 {
+		return false
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part.Name) == "" || strings.TrimSpace(part.Prefix) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func primaryKeyPartNames(parts []goschema.PrimaryKeyPart) []string {
+	names := make([]string, 0, len(parts))
+	for _, part := range parts {
+		names = append(names, part.Name)
+	}
+	return names
+}
+
+func fullIndexColumnNames(index goschema.Index) ([]string, bool) {
+	if len(index.Parts) == 0 {
+		return index.Fields, len(index.Fields) > 0
+	}
+	names := make([]string, 0, len(index.Parts))
+	for _, part := range index.Parts {
+		if strings.TrimSpace(part.Name) == "" || strings.TrimSpace(part.Expr) != "" ||
+			strings.TrimSpace(part.Prefix) != "" || strings.TrimSpace(part.Operator) != "" {
+			return nil, false
+		}
+		names = append(names, part.Name)
+	}
+	return names, true
+}
+
+func indexHasFullColumnPrefix(index goschema.Index, columns []string) bool {
+	if strings.TrimSpace(index.Condition) != "" || len(columns) == 0 {
+		return false
+	}
+	indexType := strings.ToUpper(strings.TrimSpace(index.Type))
+	if (indexType != "" && indexType != "BTREE") || strings.TrimSpace(index.Parser) != "" {
+		return false
+	}
+	if len(index.Parts) == 0 {
+		return isColumnPrefix(index.Fields, columns)
+	}
+	if len(index.Parts) < len(columns) {
+		return false
+	}
+	for i, column := range columns {
+		part := index.Parts[i]
+		if part.Name != column || strings.TrimSpace(part.Expr) != "" ||
+			strings.TrimSpace(part.Prefix) != "" || strings.TrimSpace(part.Operator) != "" {
+			return false
+		}
+	}
+	return true
+}
+
+func uniqueReferenceError(dialect string, table goschema.Table, columns []string) error {
+	return &ptaherr.CapabilityError{
+		Dialect: dialect,
+		Feature: "foreign key referenced key uniqueness",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: fmt.Sprintf(
+			"%s requires referenced columns %s on table %q to be declared unique",
+			platform.NormalizeDialect(dialect),
+			strings.Join(columns, ", "),
+			table.QualifiedName(),
+		),
+	}
+}
+
+func indexedReferenceError(dialect string, table goschema.Table, columns []string) error {
+	return &ptaherr.CapabilityError{
+		Dialect: dialect,
+		Feature: "foreign key referenced key index",
+		Err:     ptaherr.ErrUnsupportedFeature,
+		Message: fmt.Sprintf(
+			"%s requires referenced columns %s on table %q to be the full leftmost prefix of an index",
+			platform.NormalizeDialect(dialect),
+			strings.Join(columns, ", "),
+			table.QualifiedName(),
+		),
+	}
+}
+
+func invalidSchemaForeignKeyError(dialect, message string) error {
+	return &ptaherr.RenderError{
+		Dialect: dialect,
+		Err:     ptaherr.ErrInvalidSchemaDiff,
+		Message: "invalid foreign key: " + message,
+	}
+}
+
+func validateSQLServerCascadeGraph(dialect string, bindings []foreignKeyBinding) error {
+	deleteGraph := make(map[string][]string)
+	updateGraph := make(map[string][]string)
+	for _, binding := range bindings {
+		if isCascadingReferentialAction(binding.onDelete) {
+			deleteGraph[binding.target] = append(deleteGraph[binding.target], binding.owner)
+		}
+		if isCascadingReferentialAction(binding.onUpdate) {
+			updateGraph[binding.target] = append(updateGraph[binding.target], binding.owner)
+		}
+	}
+	if err := validateSQLServerCascadeActionGraph(dialect, "ON DELETE", deleteGraph); err != nil {
+		return err
+	}
+	return validateSQLServerCascadeActionGraph(dialect, "ON UPDATE", updateGraph)
+}
+
+func isCascadingReferentialAction(action string) bool {
+	return action != "" && action != "NO ACTION"
+}
+
+func validateSQLServerCascadeActionGraph(
+	dialect string,
+	clause string,
+	graph map[string][]string,
+) error {
+	for start := range graph {
+		seen := map[string]struct{}{start: {}}
+		queue := []string{start}
+		for len(queue) > 0 {
+			current := queue[0]
+			queue = queue[1:]
+			for _, next := range graph[current] {
+				if _, duplicatePath := seen[next]; duplicatePath {
+					return &ptaherr.CapabilityError{
+						Dialect: dialect,
+						Feature: "SQL Server cascading referential actions",
+						Err:     ptaherr.ErrUnsupportedFeature,
+						Message: fmt.Sprintf(
+							"sqlserver does not allow %s cycles or multiple cascade paths reaching table %q",
+							clause,
+							next,
+						),
+					}
+				}
+				seen[next] = struct{}{}
+				queue = append(queue, next)
+			}
+		}
+	}
+	return nil
 }

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -83,13 +83,17 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 	}
 
 	// Get database info
-	info, err := getDatabaseInfo(ctx, db, dialect, parsedURL, dbURL)
+	info, versionSpecific, err := getDatabaseInfoWithCapabilities(
+		ctx,
+		db,
+		dialect,
+		parsedURL,
+		dbURL,
+	)
 	if err != nil {
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to get database info: %w", err)
 	}
-	caps, versionSpecific := capability.ForServerVersionResult(info.Dialect, info.Version)
-	info.Capabilities = caps
 	if !versionSpecific {
 		slog.Debug(
 			"falling back to dialect default capabilities",
@@ -165,6 +169,30 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		newWriter:      newWriter,
 		inMemorySQLite: inMemorySQLite,
 	}, nil
+}
+
+func getDatabaseInfoWithCapabilities(
+	ctx context.Context,
+	db *sql.DB,
+	dialect string,
+	parsedURL *url.URL,
+	dbURL string,
+) (types.DBInfo, bool, error) {
+	info, err := getDatabaseInfo(ctx, db, dialect, parsedURL, dbURL)
+	if err != nil {
+		return types.DBInfo{}, false, err
+	}
+	caps, versionSpecific := resolveDatabaseCapabilities(info)
+	info.Capabilities = caps
+	return info, versionSpecific, nil
+}
+
+func resolveDatabaseCapabilities(info types.DBInfo) (capability.Capabilities, bool) {
+	// Root metadata must describe the conservative server-version baseline.
+	// Session variables can differ between pooled physical connections, so
+	// session-specific relaxations are detected only after WithSession pins the
+	// connection that will plan and execute the statements.
+	return capability.ForServerVersionResult(info.Dialect, info.Version)
 }
 
 func databaseDriverConfig(dialect, dbURL string) (driverName, dataSourceName string) {
@@ -375,7 +403,23 @@ func (dc *DatabaseConnection) WithSession(
 	}()
 
 	runner := sqlrunner.NewConn(ctx, session)
+	baselineCapabilities := capability.ForServerVersion(dc.info.Dialect, dc.info.Version)
+	sessionCapabilities, err := refineMySQLForeignKeyCapabilities(
+		dc.info.Dialect,
+		baselineCapabilities,
+		baselineCapabilities,
+		func(destination ...any) error {
+			return session.QueryRowContext(
+				ctx,
+				"SELECT @@SESSION.restrict_fk_on_non_standard_key",
+			).Scan(destination...)
+		},
+	)
+	if err != nil {
+		return fmt.Errorf("detect pinned-session foreign-key reference policy: %w", err)
+	}
 	scoped := *dc
+	scoped.info.Capabilities = sessionCapabilities
 	scoped.runner = runner
 	scoped.reader = dc.newReader(runner)
 	scoped.writer = dc.newWriter(runner, session)
@@ -386,6 +430,32 @@ func (dc *DatabaseConnection) WithSession(
 		scoped.writer.SetDryRun(true)
 	}
 	return use(&scoped)
+}
+
+func refineMySQLForeignKeyCapabilities(
+	dialect string,
+	caps capability.Capabilities,
+	baseline capability.Capabilities,
+	scan func(...any) error,
+) (capability.Capabilities, error) {
+	if platform.NormalizeDialect(dialect) != platform.MySQL ||
+		!baseline.Has(capability.ForeignKeysRequireUniqueReference) {
+		return caps, nil
+	}
+
+	var restrictNonstandardKey int64
+	if err := scan(&restrictNonstandardKey); err != nil {
+		return nil, fmt.Errorf("query restrict_fk_on_non_standard_key: %w", err)
+	}
+	if restrictNonstandardKey != 0 {
+		return caps.
+			With(capability.ForeignKeysRequireIndexedReference, false).
+			With(capability.ForeignKeysRequireUniqueReference, true), nil
+	}
+
+	return caps.
+		With(capability.ForeignKeysRequireUniqueReference, false).
+		With(capability.ForeignKeysRequireIndexedReference, true), nil
 }
 
 func discardSQLConnection(session *sql.Conn, label string) error {

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -165,6 +165,164 @@ func TestDatabaseConnectionWithSession_RebindsAllDatabaseOperations(t *testing.T
 	c.Assert(db.ExecCount(), qt.Equals, 3)
 }
 
+func TestResolveDatabaseCapabilities_MySQLKeepsVersionBaseline(t *testing.T) {
+	c := qt.New(t)
+
+	got, versionSpecific := resolveDatabaseCapabilities(types.DBInfo{
+		Dialect: "mysql",
+		Version: "8.4.0",
+	})
+
+	c.Assert(versionSpecific, qt.IsTrue)
+	c.Assert(got, qt.DeepEquals, capability.MySQL84())
+	c.Assert(got.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(got.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+}
+
+func TestDatabaseConnectionWithSession_MySQLRelaxationIsCallbackScoped(t *testing.T) {
+	c := qt.New(t)
+	db := dbtest.Open(t, func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+		return dbtest.QueryResult{
+			Columns: []string{"restrict_fk_on_non_standard_key"},
+			Rows:    [][]driver.Value{{int64(0)}},
+		}, nil
+	})
+	db.SQL.SetMaxOpenConns(1)
+	newReader := func(runner sqlrunner.Runner) types.SchemaReader {
+		return &connectionSessionReader{runner: runner}
+	}
+	newWriter := func(runner sqlrunner.Runner, _ *sql.Conn) types.SchemaWriter {
+		return &connectionSessionWriter{runner: runner}
+	}
+	baseline := capability.MySQL84()
+	rootRunner := sqlrunner.Runner(db.SQL)
+	conn := &DatabaseConnection{
+		db:     db.SQL,
+		runner: rootRunner,
+		info: types.DBInfo{
+			Dialect:      "mysql",
+			Version:      "8.4.0",
+			Capabilities: baseline,
+		},
+		reader:    newReader(rootRunner),
+		writer:    newWriter(rootRunner, nil),
+		newReader: newReader,
+		newWriter: newWriter,
+	}
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second)
+	t.Cleanup(cancel)
+
+	c.Assert(conn.Info().Capabilities, qt.DeepEquals, baseline)
+	err := conn.WithSession(ctx, func(scoped *DatabaseConnection) error {
+		c.Assert(scoped.Info().Capabilities.Has(capability.ForeignKeysRequireUniqueReference), qt.IsFalse)
+		c.Assert(scoped.Info().Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
+		c.Assert(conn.Info().Capabilities, qt.DeepEquals, baseline)
+		return nil
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.QueryCount(), qt.Equals, 1)
+	c.Assert(conn.Info().Capabilities, qt.DeepEquals, baseline)
+}
+
+func TestRefineMySQLForeignKeyCapabilities_RestrictionEnabled(t *testing.T) {
+	c := qt.New(t)
+	probeCalls := 0
+
+	got, err := refineMySQLForeignKeyCapabilities(
+		"mysql",
+		capability.MySQL84(),
+		capability.MySQL84(),
+		func(destination ...any) error {
+			probeCalls++
+			value := destination[0].(*int64)
+			*value = 1
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(probeCalls, qt.Equals, 1)
+	c.Assert(got.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(got.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+	c.Assert(got.Validate(), qt.IsNil)
+}
+
+func TestRefineMySQLForeignKeyCapabilities_RestrictionDisabled(t *testing.T) {
+	c := qt.New(t)
+
+	got, err := refineMySQLForeignKeyCapabilities(
+		"mysql",
+		capability.MySQL84(),
+		capability.MySQL84(),
+		func(destination ...any) error {
+			value := destination[0].(*int64)
+			*value = 0
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Has(capability.ForeignKeysRequireUniqueReference), qt.IsFalse)
+	c.Assert(got.Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
+	c.Assert(got.Validate(), qt.IsNil)
+}
+
+func TestRefineMySQLForeignKeyCapabilities_LegacyPresetSkipsProbe(t *testing.T) {
+	c := qt.New(t)
+	probeCalls := 0
+
+	got, err := refineMySQLForeignKeyCapabilities(
+		"mysql",
+		capability.MySQL8019(),
+		capability.MySQL8019(),
+		func(...any) error {
+			probeCalls++
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(probeCalls, qt.Equals, 0)
+	c.Assert(got, qt.DeepEquals, capability.MySQL8019())
+}
+
+func TestRefineMySQLForeignKeyCapabilities_RestrictionEnabledRestoresStrictPolicy(t *testing.T) {
+	c := qt.New(t)
+
+	got, err := refineMySQLForeignKeyCapabilities(
+		"mysql",
+		capability.MySQL84().
+			With(capability.ForeignKeysRequireUniqueReference, false).
+			With(capability.ForeignKeysRequireIndexedReference, true),
+		capability.MySQL84(),
+		func(destination ...any) error {
+			value := destination[0].(*int64)
+			*value = 1
+			return nil
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(got.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+	c.Assert(got.Validate(), qt.IsNil)
+}
+
+func TestRefineMySQLForeignKeyCapabilities_ProbeFailure(t *testing.T) {
+	c := qt.New(t)
+
+	got, err := refineMySQLForeignKeyCapabilities(
+		"mysql",
+		capability.MySQL84(),
+		capability.MySQL84(),
+		func(...any) error { return driver.ErrBadConn },
+	)
+
+	c.Assert(err, qt.ErrorMatches, `query restrict_fk_on_non_standard_key: driver: bad connection`)
+	c.Assert(got, qt.IsNil)
+}
+
 func TestConvertClickHouseURL(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/docs/POSTGRESQL_ROLES.md
+++ b/docs/POSTGRESQL_ROLES.md
@@ -115,15 +115,15 @@ Ptah generates appropriate PostgreSQL SQL statements for role management:
 ### CREATE ROLE Statements
 
 ```sql
--- Application user role
 CREATE ROLE app_user WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
-
--- Administrator role with full privileges
-CREATE ROLE admin_user WITH LOGIN SUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
-
--- Service user for automated processes
-CREATE ROLE service_user WITH LOGIN NOSUPERUSER CREATEDB NOCREATEROLE INHERIT NOREPLICATION;
+COMMENT ON ROLE app_user IS 'Application user role';
 ```
+
+PostgreSQL has no `CREATE ROLE IF NOT EXISTS`. Ptah deliberately fails when a
+role already exists instead of suppressing the collision and applying later
+comments or grants to a role whose security attributes Ptah did not create.
+Apply an inspected cluster-role dump to a clean target, or reconcile existing
+roles explicitly before applying it.
 
 ### Role Modifications
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -12,7 +12,7 @@ and restrict or enable individual emissions accordingly (issues #225/#226/#171).
 
 Package: `core/platform/capability`.
 
-## Cross-Cutting Artifact Distribution
+## Cross-cutting artifact distribution
 
 OCI artifact distribution is a cross-cutting Ptah capability, not a database
 dialect capability key in `core/platform/capability`.
@@ -94,6 +94,9 @@ so typos fail fast. Current registry:
 | `row_level_security` | Row-level security policies (PostgreSQL) |
 | `role_management` | PostgreSQL role and object privilege management (`CREATE/ALTER ROLE`, `GRANT`, `REVOKE`) |
 | `foreign_keys` | Declarative `FOREIGN KEY` constraints |
+| `foreign_keys_require_unique_reference` | Foreign keys require a declared primary or unique referenced key (MySQL 8.4+ default). Requires `foreign_keys` |
+| `foreign_keys_require_indexed_reference` | Foreign keys may reference a complete leftmost index prefix (MySQL before 8.4 and MariaDB). Requires `foreign_keys` |
+| `foreign_keys_create_backing_index` | The database creates the foreign key's backing index (Spanner). Requires `foreign_keys` |
 | `sequences` | Database sequence objects: `SERIAL`/`BIGSERIAL` column backing and first-class standalone sequences via `//ptah:schema:sequence` (`CREATE`/`ALTER`/`DROP SEQUENCE`). See [Sequences](./sequences.md). |
 | `xml_type` | PostgreSQL `XML` column type |
 | `advisory_locks` | PostgreSQL advisory lock functions such as `pg_advisory_lock` |
@@ -110,33 +113,40 @@ so typos fail fast. Current registry:
 3. **Mutual exclusion groups** — at most one member of a group may be enabled
    (`enum_inline_column` vs `enum_custom_type`: a dialect models enums one way
    or the other).
+4. **Foreign-key reference policy** — a target with `foreign_keys` enabled has
+   exactly one referenced-key policy: declared unique key, full leftmost index
+   prefix, or engine-managed backing index.
 
 Presets are valid by construction (unit-tested); validate hand-built or
 composed sets yourself.
 
 ## Presets
 
-| Capability | MySQL80 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres17 | Postgres16 | Postgres13 | ClickHouse24 | CockroachDB23 | YugabyteDB25 | SQLite3 | SQLServer2022 | SpannerPG |
-|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
-| `drop_constraint_generic` | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| `drop_index_if_exists` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
-| `check_constraints_enforced` | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `drop_check_clause` | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
-| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
-| `alter_generated_column_expression` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| `role_management` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
-| `sequences` | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
-| `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
-| `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Capability | MySQL84 | MySQL8019 | MySQL8016 | MySQLLegacy | MariaDB1011 | MariaDBLegacy | Postgres17 | Postgres16 | Postgres13 | ClickHouse24 | CockroachDB23 | YugabyteDB25 | SQLite3 | SQLServer2022 | SpannerPG |
+|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|---|
+| `drop_constraint_generic` | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| `drop_constraint_if_exists` | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| `drop_index_if_exists` | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ |
+| `check_constraints_enforced` | ✅ | ✅ | ✅ | ❌ | ✅ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `drop_check_clause` | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
+| `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `create_or_replace_trigger` | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
+| `alter_generated_column_expression` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `role_management` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `foreign_keys` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ |
+| `foreign_keys_require_unique_reference` | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ | ❌ |
+| `foreign_keys_require_indexed_reference` | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `foreign_keys_create_backing_index` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ |
+| `sequences` | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ |
+| `xml_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ✅ | ❌ | ✅ | ❌ |
+| `advisory_locks` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 
-Version lines: `MySQL80()` covers MySQL 8.0.19+ and 9.x; `MySQL8016()` covers
-8.0.16–8.0.18; `MySQLLegacy()` anything older. `MariaDB1011()` covers the
+Version lines: `MySQL84()` covers MySQL 8.4+ and 9.x; `MySQL8019()` covers
+8.0.19–8.3; `MySQL8016()` covers 8.0.16–8.0.18; `MySQLLegacy()` anything
+older. `MariaDB1011()` covers the
 supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
 floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres17()` covers
 PostgreSQL 17+; `Postgres16()` covers 14–16; `Postgres13()` covers 12–13 (no
@@ -177,7 +187,14 @@ planner := mysql.NewWithCapabilities(caps)
   `YugabyteDB`/`Yugabyte`, or `Spanner` resolve to their distributed-SQL
   presets. `dbschema.ConnectToDatabase` stores this resolved set in
   `conn.Info().Capabilities`, and live migration generation passes that same
-  set through planning, rendering, and safety assessment.
+  set through planning, rendering, and safety assessment. Root MySQL 8.4+
+  connections keep the conservative unique-key policy because a session value
+  sampled through a pool may not belong to the session that executes the SQL.
+  `DatabaseConnection.WithSession` reads
+  `restrict_fk_on_non_standard_key` on its pinned physical connection before
+  invoking the callback: `ON` keeps the unique-key policy, while `OFF` selects
+  the indexed-left-prefix policy for planning and execution on that same
+  session.
 
 Offline SQL generation has no server banner to inspect. Factories such as
 `planner.GetPlanner`, `renderer.NewRenderer`, and
@@ -188,6 +205,30 @@ value or wants to pin a specific server version in tests/CI.
 
 ## Current consumers
 
+- **Foreign key rendering.** Schema rendering validates every foreign key
+  before producing statements, including owner/target tables, local and
+  referenced columns, compatible column types, duplicate columns and names,
+  referential actions, and the target's referenced-key policy. Targets other
+  than SQLite create tables first and add foreign keys in a second phase, so
+  circular and composite cycles are executable. SQLite keeps constraints
+  inline and accepts only candidate keys whose collation semantics are present
+  in the schema IR. MySQL before 8.4 and MariaDB accept a full leftmost BTREE
+  index prefix on InnoDB tables; FULLTEXT, SPATIAL, HASH, parser-backed, prefix,
+  and expression indexes do not qualify. The portable MySQL-family path also
+  emits `ENGINE=InnoDB` explicitly for every table participating in a foreign
+  key when no engine was declared, so the session default cannot silently
+  disable referential integrity. It
+  rejects MariaDB generated FK columns, MySQL virtual generated FK columns,
+  invalid actions on MySQL stored generated columns, and mismatched signedness,
+  character sets, or collations. `SET NULL` requires every affected local
+  column to be nullable. Explicit foreign-key names must fit the target's
+  identifier limit: 63 bytes for the PostgreSQL family, 64 characters for the
+  MySQL family, and 128 characters for SQL Server and Spanner. Generated names
+  are shortened deterministically before collision checks. Standards-oriented targets require a declared candidate key;
+  Spanner creates its own backing index. A disabled `foreign_keys` capability
+  or any invalid constraint fails the complete render instead of omitting the
+  constraint or returning partial DDL. SQL Server also rejects cycles and
+  multiple paths for cascading actions before SQL emission.
 - **Constraint drops (MySQL family).** The MariaDB-preset planner requests
   `IF EXISTS` on `DROP CONSTRAINT` / `DROP FOREIGN KEY`; the mariadb renderer
   honors it, the mysql renderer strips it. On MySQL the exactly-once drop
@@ -232,8 +273,10 @@ value or wants to pin a specific server version in tests/CI.
   CockroachDB disables `CREATE INDEX CONCURRENTLY`, sequences, `XML`,
   advisory locks, role management, and RLS; YugabyteDB disables
   `CREATE INDEX CONCURRENTLY` because regular `CREATE INDEX` is already
-  asynchronous in YSQL; Spanner disables enums, foreign keys, sequences, RLS,
-  XML, advisory locks, and concurrent indexes.
+  asynchronous in YSQL; Spanner supports foreign keys, including circular and
+  composite relationships, while disabling enums, sequences, RLS, XML,
+  advisory locks, and concurrent indexes. Spanner accepts only `NO ACTION` and
+  `CASCADE` for `ON DELETE`; any `ON UPDATE` action fails before rendering.
   CockroachDB and YugabyteDB integration coverage uses opt-in common-subset
   scenarios that run against live OSS containers in CI. Spanner currently has
   capability, planning, rendering, URL, and detection coverage only; there is

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -52,6 +52,37 @@ execution without a second configuration-file read.
 already anchored or immutable `fs.FS`; `file()` and `fileset()` resolve only
 through that filesystem.
 
+`core/renderer.GetOrderedCreateStatements` and its capability-aware variant
+render complete schema DDL fail-closed. Non-SQLite targets return all table
+creation statements before phase-two foreign keys; SQLite keeps foreign keys
+inline. Invalid or unsupported foreign keys return typed errors and no partial
+statement list. Foreign-key-capable capability sets select exactly one
+referenced-key policy: `ForeignKeysRequireUniqueReference`,
+`ForeignKeysRequireIndexedReference`, or `ForeignKeysCreateBackingIndex`.
+`ValidateSchema` and `ValidateSchemaWithCapabilities` run the same complete
+schema validation without rendering SQL. Migration planning calls this path
+before producing AST nodes.
+
+`goschema.Finalize` rebuilds materialized inline, JSON, and relation fields on
+every call. `Field.GeneratedFromEmbedded` identifies those derived fields so a
+caller can mutate the source fields or embedded declarations and finalize the
+database again without retaining stale or duplicate columns. Treat the flag as
+derived metadata: source declarations should leave it false.
+
+`Database.EmbeddedSources` retains source-only field and embedding declarations
+that are needed to rebuild nested embedded fields after `Finalize` or `Merge`.
+Callers normally should not modify this bookkeeping directly. A caller that
+copies a finalized `Database` and expects to finalize or merge the copy again
+must preserve `EmbeddedSources`; dropping it can discard the source declarations
+behind materialized `GeneratedFromEmbedded` fields.
+
+`core/platform/capability.MySQL80` was intentionally removed after `v0.1.2`.
+The name implied one capability set for every MySQL 8.0 release even though
+generic `DROP CONSTRAINT` support starts at MySQL 8.0.19, and MySQL 8.4 changes
+the default foreign-key referenced-key policy. Pre-GA callers must select the
+explicit `MySQL8016`, `MySQL8019`, or `MySQL84` preset that matches their server
+instead of relying on an ambiguous compatibility alias.
+
 `migration/lint` provides the compact `LintFS` findings API and the richer
 `AnalyzeFS` API. `AnalyzeFS` captures each migration input once: SQL files,
 integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
@@ -93,7 +124,10 @@ an external executor must take over accepted statements.
 for a callback and rebinds the dialect reader, writer, and SQL runner to it.
 Use it when session-local state must remain consistent across cleanup, replay,
 introspection, and verification. The scoped connection must not escape the
-callback.
+callback. Root MySQL capability metadata remains conservative; on MySQL 8.4+
+the scoped connection refines its referenced-key policy from
+`restrict_fk_on_non_standard_key` on the pinned session before the callback,
+so planning and execution can safely use that same effective policy.
 
 `dbschema.DatabaseConnection.WithUntrustedSQLSession` pins a session that will
 execute SQL the caller does not trust and applies every engine-level

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3617,7 +3617,7 @@ type EmbeddedField struct {
     Mode             string                       // inline, json, relation, skip
     Prefix           string                       // For inline mode - prefix for field names
     Name             string                       // For json mode - column name
-    Type             string                       // For json mode - column type (JSON/JSONB)
+    Type             string                       // For json/relation mode - generated column type
     Nullable         bool                         // Whether the field can be null
     Field            string                       // For relation mode - foreign key field name
     Ref              string                       // For relation mode - reference table(column)

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3396,6 +3396,7 @@ type Database struct{ ... }
     func ParseSource(filename string, source any) (Database, error)
 type Domain struct{ ... }
 type EmbeddedField struct{ ... }
+type EmbeddedSources struct{ ... }
 type Enum struct{ ... }
 type Extension struct{ ... }
 type Field struct{ ... }
@@ -3544,6 +3545,10 @@ type Database struct {
     Dependencies               map[string][]string            // table -> list of tables it depends on
     FunctionDependencies       map[string][]string            // function -> list of functions it depends on
     SelfReferencingForeignKeys map[string][]SelfReferencingFK // table -> list of self-referencing foreign keys
+
+    // EmbeddedSources retains source-only helper declarations needed to
+    // materialize embedded columns again after a schema is merged or finalized.
+    EmbeddedSources EmbeddedSources
 }
     Database represents the complete database schema derived from Go struct
     annotations.
@@ -3647,6 +3652,18 @@ type EmbeddedField struct {
             //ptah:embedded mode="relation" field="company_id" ref="companies(id)"
             Company Company  // Results in: company_id INTEGER + FK constraint
         }
+
+
+### github.com/stokaro/ptah/core/goschema.EmbeddedSources
+
+package goschema // import "github.com/stokaro/ptah/core/goschema"
+
+type EmbeddedSources struct {
+    Fields      []Field
+    Definitions []EmbeddedField
+}
+    EmbeddedSources preserves helper declarations separately from materialized
+    database columns so Finalize and Merge remain idempotent.
 
 
 ### github.com/stokaro/ptah/core/goschema.Enum
@@ -3771,6 +3788,10 @@ type Field struct {
     Collate   string
     Comment   string                       // Column comment
     Overrides map[string]map[string]string // Platform-specific overrides (e.g., platform.mysql.type)
+
+    // GeneratedFromEmbedded distinguishes materialized embedded columns from
+    // source declarations so Finalize can rebuild them after schema mutation.
+    GeneratedFromEmbedded bool
 }
     Field represents a database column/field definition parsed from Go struct
     field annotations. This is the core building block for table schema
@@ -4284,17 +4305,18 @@ type SelfReferencingFK struct {
     OnDelete       string // ON DELETE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
     OnUpdate       string // ON UPDATE action (CASCADE, SET NULL, RESTRICT, NO ACTION)
 }
-    SelfReferencingFK represents a self-referencing foreign key that needs to be
-    handled separately from regular foreign keys to avoid circular dependencies.
+    SelfReferencingFK represents a field-level self-referencing foreign key that
+    migration planners emit after creating its table.
 
     Self-referencing foreign keys occur when a table has a foreign key
-    that references its own primary key, such as a "parent_id" field in a
-    hierarchical structure. These cannot be created as part of the initial
-    CREATE TABLE statement because the table doesn't exist yet when the
-    constraint is being defined.
-
-    Instead, these foreign keys are tracked separately and added as ALTER TABLE
-    ADD CONSTRAINT statements after the table has been created.
+    that references its own primary key, such as a "parent_id" field in
+    a hierarchical structure. Ptah tracks these references separately
+    because PostgreSQL-family and MySQL- family planners use a table-first,
+    foreign-key-second creation strategy. SQL permits a self reference inside
+    CREATE TABLE, and SQLite renderers use that inline form because SQLite
+    cannot add a foreign key with ALTER TABLE. Table-level foreign keys remain
+    in Database.Constraints so composite column lists are never collapsed into
+    this single-field representation.
 
     Example:
 
@@ -4488,8 +4510,9 @@ type Capabilities map[Capability]bool
     func ForServerVersionResult(dialect, version string) (Capabilities, bool)
     func MariaDB1011() Capabilities
     func MariaDBLegacy() Capabilities
-    func MySQL80() Capabilities
     func MySQL8016() Capabilities
+    func MySQL8019() Capabilities
+    func MySQL84() Capabilities
     func MySQLLegacy() Capabilities
     func Postgres13() Capabilities
     func Postgres16() Capabilities
@@ -4519,8 +4542,9 @@ func ForServerVersion(dialect, version string) Capabilities
 func ForServerVersionResult(dialect, version string) (Capabilities, bool)
 func MariaDB1011() Capabilities
 func MariaDBLegacy() Capabilities
-func MySQL80() Capabilities
 func MySQL8016() Capabilities
+func MySQL8019() Capabilities
+func MySQL84() Capabilities
 func MySQLLegacy() Capabilities
 func Postgres13() Capabilities
 func Postgres16() Capabilities
@@ -4879,6 +4903,8 @@ func RenderSQLWithCapabilities(dialect string, caps capability.Capabilities, nod
 func RenderSelect(stmt *ast.SelectStatement, dialect string) (string, []any, error)
 func RenderUpdate(stmt *ast.UpdateStatement, dialect string) (string, []any, error)
 func SupportedDialects() []string
+func ValidateSchema(r *goschema.Database, dialect string) error
+func ValidateSchemaWithCapabilities(r *goschema.Database, dialect string, caps capability.Capabilities) error
 func VisitorRenderSQL(r RenderVisitor, nodes ...ast.Node) (string, error)
 type RenderVisitor interface{ ... }
     func NewRenderer(dialect string) (RenderVisitor, error)

--- a/docs/public_api_approvals.txt
+++ b/docs/public_api_approvals.txt
@@ -7,6 +7,7 @@
 # an incompatible public API change before v1. The PR must explain the
 # compatibility rationale and update docs/public_api.md when the stable package
 # set changes.
+v0.1.2 github.com/stokaro/ptah/core/platform/capability
 v0.1.1 github.com/stokaro/ptah/migration/generator
 v0.1.2 github.com/stokaro/ptah/migration/generator
 v0.1.2 github.com/stokaro/ptah/migration/migrator

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -236,9 +236,11 @@ ptah-compat migrate apply --url "$DATABASE_URL" --dir file://migrations \
 
 Two things still reach stderr, by design. A command that fails prints its
 `Error: …` diagnostic there and exits `1`. And a Warn-level diagnostic that
-exists on no other channel — a circular foreign-key or function ordering, a dev
-database that would not close — is still reported, because dropping it would let
-an apply claim success while quietly degrading. Neither appears on a clean run.
+exists on no other channel — such as function ordering or a dev database that
+would not close — is still reported, because dropping it would let an apply
+claim success while quietly degrading. Valid circular foreign keys are rendered
+in two phases and do not produce a warning. Neither diagnostic appears on a
+clean run.
 
 :::caution
 `ptah-compat migrate down` is the exception. Without `--format` it forwards to

--- a/docs/site/src/content/docs/concepts/dialects-and-capabilities.md
+++ b/docs/site/src/content/docs/concepts/dialects-and-capabilities.md
@@ -46,8 +46,17 @@ rather than shipped.
   implementation serves four engines honestly, because each engine's preset
   removes what it does not support.
 - **Unsupported operations fail loudly.** Where an operation has no valid
-  spelling for the target, Ptah emits an explicit error or a loud `WARNING`
-  comment — never syntactically valid SQL the server would parse and ignore.
+  spelling for the target, Ptah emits an explicit error or, for explicitly
+  documented advisory operations, a loud `WARNING` comment. Schema rendering
+  never replaces a declared foreign key with a comment.
+- **Foreign-key validity is target-specific.** Capability presets distinguish
+  candidate-key targets, MySQL-family indexed-left-prefix targets, and
+  Spanner's engine-managed backing indexes. Root MySQL 8.4+ connections retain
+  the conservative unique-key policy; a pinned `WithSession` callback refines
+  it from `restrict_fk_on_non_standard_key` on the same physical connection
+  used for execution. Ptah also
+  validates column types, name namespaces, and engine-specific index/storage
+  restrictions before emitting SQL.
 - **Version upgrades can change plans.** Moving a server across a preset
   boundary (for example PostgreSQL 13 to 14) legitimately changes generated
   SQL, such as trigger replacement switching to `CREATE OR REPLACE TRIGGER`.

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -56,7 +56,10 @@ privileges next to your entities. Ptah emits `CREATE ROLE` for new roles,
 `ALTER ROLE` for attribute changes, and `GRANT`/`REVOKE` as declared grants
 change. Grants target a table, a schema, or a sequence, and table grants are
 compared per individual privilege, so a `privilege="SELECT,INSERT"` list
-round-trips cleanly through introspection.
+round-trips cleanly through introspection. New-role SQL fails closed when the
+role already exists, so later comments and grants cannot be applied to a role
+with unverified security attributes. Role descriptions are applied with
+`COMMENT ON ROLE` after successful creation.
 
 Ordering is dependency-aware: roles are created before the functions and
 policies that reference them, and grants are emitted after the roles and

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -49,6 +49,17 @@ SQL:
   that guard, so the `mysql` renderer strips it.
 - The `DROP CHECK` spelling exists only on MySQL 8.0.16+; MariaDB uses the
   generic `DROP CONSTRAINT` clause.
+- Portable foreign keys require InnoDB tables and compatible column types,
+  signedness, character sets, and collations. MariaDB generated FK columns and
+  MySQL virtual generated FK columns fail before rendering. MySQL stored
+  generated columns reject referential actions the engine cannot apply. When
+  an FK-participating table has no declared engine, Ptah emits
+  `ENGINE=InnoDB` explicitly instead of trusting the session default.
+- `SET NULL` requires nullable local columns. Explicit foreign-key names are
+  limited to 64 characters; generated names are shortened deterministically.
+- A nonunique referenced key must be a complete leftmost BTREE prefix.
+  FULLTEXT, SPATIAL, HASH, parser-backed, expression, and prefix indexes do not
+  qualify.
 - DDL commits implicitly on both engines, so a failed migration cannot be
   rolled back by the surrounding transaction.
 
@@ -86,6 +97,11 @@ schema changes require a table rebuild, and PostgreSQL-only objects are
 rejected. [SQLite](../sqlite/) covers URL forms, the supported DDL surface,
 and the rebuild rules.
 
+SQLite checks foreign-key candidate keys from primary and inline unique
+declarations. Ptah does not accept a standalone unique index as a referenced
+key when its per-column collation is absent from the schema IR; this avoids SQL
+that creates successfully but fails later with `foreign key mismatch`.
+
 ## SQL Server
 
 SQL Server and Azure SQL are supported as a deliberately conservative portable
@@ -109,9 +125,15 @@ matching preset automatically.
 - **YugabyteDB**: the preset excludes concurrent index creation because
   regular `CREATE INDEX` is already asynchronous in YSQL; role management,
   standalone sequences, and `XML` columns are included.
-- **Spanner**: the most conservative preset — enums, foreign keys, standalone
-  sequences, row-level security, `XML` columns, advisory locks, and concurrent
-  indexes are all excluded.
+- **Spanner**: foreign keys are included, including composite and circular
+  relationships rendered in two phases. Spanner manages the referenced-key
+  backing index, so Ptah does not require an input unique/index declaration.
+  Participating columns must have compatible key-capable types; JSON and array
+  columns fail before rendering.
+  The preset excludes enums, standalone sequences, row-level security, `XML`
+  columns, advisory locks, and concurrent indexes. Foreign key actions are
+  limited to `ON DELETE NO ACTION` or `CASCADE`; `ON UPDATE` fails before
+  rendering.
 
 CockroachDB and YugabyteDB run in integration coverage against live
 open-source containers; Spanner coverage is offline (capability, planning,

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -10,7 +10,7 @@ representation:
 
 | Command | Output | Reach for it when |
 | --- | --- | --- |
-| `ptah db read` | SQL `CREATE` statements with a status banner | You want a readable snapshot in the terminal |
+| `ptah db read` | Executable SQL on stdout; connection status on stderr | You want a SQL snapshot you can review or redirect |
 | `ptah introspect` | Annotated Go model files | You want the live schema to become your desired schema |
 | `ptah schema inspect` | HCL, SQL, or JSON without banners | You want machine-readable output for files and scripts |
 
@@ -32,13 +32,9 @@ SQL:
 ptah db read --db-url "sqlite://$PWD/app.db"
 ```
 
-Expected output includes:
+Standard output contains SQL only:
 
-```text
-=== DATABASE SCHEMA ===
-
-Connected to sqlite database successfully!
-
+```sql
 CREATE TABLE "users" (
   "id" INTEGER PRIMARY KEY AUTOINCREMENT,
   "email" TEXT NOT NULL UNIQUE,
@@ -46,9 +42,22 @@ CREATE TABLE "users" (
 );
 ```
 
+Connection progress and diagnostics go to standard error. You can redirect the
+SQL without filtering the command output:
+
+```bash
+ptah db read --db-url "sqlite://$PWD/app.db" >schema.sql
+sqlite3 restored.db <schema.sql
+```
+
 On PostgreSQL-family databases, `--schemas` accepts a comma-separated list of
 database schemas to read; when empty, Ptah reads the connection's default
-schema.
+schema. Cluster-role creation statements in PostgreSQL output are intended for
+a clean target. If a role already exists, applying the SQL
+fails before its description or grants are changed; this prevents privileges
+from being attached to a role with unverified security attributes. Role
+descriptions are restored with `COMMENT ON ROLE`; schema and table grants are
+still emitted after successful role creation.
 
 ## Turn the schema into Go models
 
@@ -154,8 +163,8 @@ custom Go templates, Mermaid output, and template-driven split exports; see
 ## Failure modes
 
 An unreachable database fails with exit code `2` on every native command. The
-`ptah db read` output ends with a connection checklist and the underlying
-error:
+The `ptah db read` standard error stream ends with a connection checklist and
+the underlying error:
 
 ```text
 Make sure:

--- a/docs/site/src/content/docs/extend/components.md
+++ b/docs/site/src/content/docs/extend/components.md
@@ -167,6 +167,11 @@ if err != nil {
 fmt.Println(statements[0])
 ```
 
+For targets other than SQLite, schema rendering places every `CREATE TABLE`
+before phase-two foreign key statements. SQLite keeps foreign keys inline.
+Malformed or capability-incompatible foreign keys return a typed error and no
+partial statement list.
+
 ### Render SQL from Atlas HCL
 
 Use `atlascompat` when you need Atlas-shaped HCL input through a stable public

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -21,7 +21,7 @@ packages, examples, fixtures, tests, or implementation details.
 | `core/platform/identifier` | Catalog identifier comparison and namespace semantics. |
 | `core/ptaherr` | Typed public errors and sentinel errors. |
 | `core/query` | Fluent builder for parameterized, dialect-aware SELECT statements. |
-| `core/renderer` | Dialect-aware SQL rendering from AST/schema IR. |
+| `core/renderer` | Dialect-aware SQL rendering from AST/schema IR, including fail-closed two-phase foreign key ordering. |
 | `core/sqlutil` | SQL utility helpers used by public paths. |
 | `dbschema` | Live database schema introspection connection layer. |
 | `dbschema/types` | Shared database schema types. |
@@ -50,6 +50,23 @@ its case model and [Database test commands](../../reference/test-cases/) for CLI
 `projectconfig.ParseAtlasFSWithOptions` evaluates `atlas.hcl` against a
 caller-provided `fs.FS`. Use it when project config and its `file()` or
 `fileset()` inputs must come from one anchored or immutable filesystem view.
+
+`renderer.ValidateSchema` and `renderer.ValidateSchemaWithCapabilities` check
+a complete `goschema.Database` without rendering SQL. They use the same
+foreign-key and capability validation as ordered schema rendering and migration
+planning.
+
+`goschema.Finalize` can be called again after mutating schema input. It rebuilds
+materialized embedded fields and marks them with
+`Field.GeneratedFromEmbedded`; source declarations should leave that derived
+metadata false.
+
+`Database.EmbeddedSources` preserves source-only field and embedding
+declarations needed to rebuild nested embedded fields after `Finalize` or
+`Merge`. Embedders normally should not modify this bookkeeping directly. Keep
+it when copying a finalized `Database` that will be finalized or merged again;
+discarding it can also discard the source declarations behind materialized
+`GeneratedFromEmbedded` fields.
 
 The separate [`testkit`](https://github.com/stokaro/ptah/tree/master/testkit)
 module (`github.com/stokaro/ptah/testkit`) is an opt-in helper for tests that
@@ -88,6 +105,11 @@ external executor is observed once after that executor reports success.
 for the duration of a callback and rebinds the dialect reader, writer, and SQL
 runner to that session. Use it for cleanup, replay, and inspection workflows
 that depend on session-local state or SQLite attached-database visibility.
+
+Root MySQL capability metadata remains conservative. On MySQL 8.4+ the scoped
+connection refines its referenced-key policy from
+`restrict_fk_on_non_standard_key` on the pinned physical session before the
+callback, so planning and execution use the same effective policy.
 
 The scoped connection must not escape the callback. Ptah discards the physical
 connection afterward so session-local state cannot leak to a later pool user.

--- a/docs/site/src/content/docs/reference/capabilities.md
+++ b/docs/site/src/content/docs/reference/capabilities.md
@@ -24,6 +24,42 @@ Capabilities answer questions that a dialect name alone cannot answer:
   `create_index_concurrently`
 - Does the target support roles, RLS, XML, or advisory locks?
   `role_management`, `row_level_security`, `xml_type`, `advisory_locks`
+- Does the target support foreign keys, and how is the referenced key backed?
+  `foreign_keys`, `foreign_keys_require_unique_reference`,
+  `foreign_keys_require_indexed_reference`,
+  `foreign_keys_create_backing_index`
+
+Schema rendering validates foreign keys before emitting any SQL. A malformed
+constraint, incompatible column types, an unsupported referential action, or a
+target without `foreign_keys` fails the complete render instead of producing
+partial DDL or a comment that silently omits referential integrity.
+
+Exactly one referenced-key policy is enabled for every foreign-key-capable
+preset. PostgreSQL, CockroachDB, YugabyteDB, SQLite, SQL Server, and MySQL 8.4+
+require a declared candidate key. MySQL before 8.4 and MariaDB accept the
+referenced columns as a full leftmost index prefix. Spanner creates and manages
+the backing index. A root MySQL 8.4+ connection keeps the conservative
+unique-key policy because a pooled session probe cannot describe a later
+execution session. `DatabaseConnection.WithSession` refines the policy from
+`restrict_fk_on_non_standard_key` on the pinned physical connection, so the
+callback plans and executes with one consistent session policy.
+
+The referenced-key policy is only one part of validation. MySQL and MariaDB
+require InnoDB tables in Ptah's portable schema path. Their nonunique-key
+policy accepts a complete leftmost BTREE prefix, not FULLTEXT, SPATIAL, HASH,
+parser-backed, expression, or prefix indexes. The same path rejects generated
+FK columns on MariaDB, virtual generated FK columns on MySQL, invalid actions
+on MySQL stored generated columns, and mismatched signedness, character sets,
+or collations. SQLite accepts standalone candidate keys only when their
+collation semantics are represented in the schema IR; otherwise declare the
+primary or unique key inline.
+
+Ptah emits `ENGINE=InnoDB` for participating tables when the schema leaves the
+engine blank, so a session default cannot silently disable foreign keys.
+`SET NULL` requires nullable local columns. Explicit foreign-key names must fit
+the target identifier limit: 63 bytes for the PostgreSQL family, 64 characters
+for the MySQL family, and 128 characters for SQL Server and Spanner. Generated
+names are shortened deterministically before collision checks.
 
 ## Declarative database testing
 

--- a/docs/site/src/content/docs/reference/go-annotations.md
+++ b/docs/site/src/content/docs/reference/go-annotations.md
@@ -157,9 +157,13 @@ Controls how an embedded Go field contributes schema objects.
 | `on_update` | No | Generated foreign key ON UPDATE action. |
 | `prefix` | No | Column prefix for inline embedded fields. |
 | `ref` | No | Relation target in table(column) form. |
-| `type` | No | Column type for json embedding. |
+| `type` | No | Generated column type for json or relation embedding. |
 
 Platform overrides: yes.
+
+For relation embedding, set `type` to the referenced column's physical type.
+When it is omitted, Ptah uses a conservative numeric or string heuristic,
+which cannot infer every user-defined or dialect-specific key type.
 
 ### `//ptah:schema:index`
 

--- a/docs/site/src/content/docs/reference/native-commands.md
+++ b/docs/site/src/content/docs/reference/native-commands.md
@@ -13,7 +13,7 @@ Use `ptah <command> --help` for the exact flag set in an installed binary.
 
 | Command | Purpose |
 | --- | --- |
-| `ptah schema render` | Render desired schema SQL from Go, YAML, HCL, SQL, or external-command inputs. |
+| `ptah schema render` | Render desired-schema SQL to stdout from Go, YAML, HCL, SQL, or external-command inputs; write progress and dependency diagnostics to stderr. |
 | `ptah schema annotations` | Export Ptah Go annotation metadata as a JSON Schema document. |
 | `ptah schema compare` | Compare desired schema with a live database. |
 | `ptah schema drift` | Check live database drift against desired schema. |
@@ -26,6 +26,12 @@ Use `ptah <command> --help` for the exact flag set in an installed binary.
 | `ptah schema push` | Publish a lossless canonical desired schema to an OCI registry. |
 | `ptah schema pull` | Pull a canonical desired schema from an OCI registry. |
 | `ptah schema test` | Apply a desired schema (from Go annotations) to a throwaway database and run declarative seed/SQL/assert YAML cases against it. |
+
+Pass an explicit `--dialect` when the output must be executable by one target.
+Without it, `schema render` attempts the built-in review targets and emits
+labeled output only if every target can render the schema. An unsupported
+feature fails atomically with empty standard output. The combined output is a
+review artifact, not one executable SQL script.
 
 ## Migration lifecycle: `ptah migrations`
 
@@ -57,7 +63,7 @@ Use `ptah <command> --help` for the exact flag set in an installed binary.
 
 | Command | Purpose |
 | --- | --- |
-| `ptah db read` | Read schema from a live database. |
+| `ptah db read` | Read a live database as executable SQL on stdout; write connection status and failures to stderr. |
 | `ptah db drop-all` | Drop all schema objects in a live database. |
 
 ## Registries and SQL files: `ptah oci`, `ptah sql`

--- a/docs/site/src/content/docs/schema/go-annotations.md
+++ b/docs/site/src/content/docs/schema/go-annotations.md
@@ -69,6 +69,22 @@ ptah schema render --root-dir ./models --dialect sqlite >/tmp/ptah-schema.sql
 sed -n '1,80p' /tmp/ptah-schema.sql
 ```
 
+Standard output contains SQL only. Source-loading progress, schema counts, and
+the dependency summary go to standard error, so the redirected file can be
+executed unchanged. For PostgreSQL-family, MySQL-family, SQL Server, and
+Spanner targets, Ptah creates all tables before adding foreign keys. SQLite
+keeps foreign keys inline because it cannot add them after table creation.
+
+Malformed foreign keys and constraints unsupported by the selected dialect
+fail before Ptah emits any SQL. The output never silently omits a declared
+foreign key. Ptah also checks referenced-key policy, compatible column types,
+constraint-name scope, and dialect-specific index or storage restrictions.
+
+Always pass `--dialect` when redirecting executable SQL. Without it, Ptah
+attempts the built-in review targets and emits separate labeled sections only
+if every target can render the schema. Any unsupported feature fails atomically
+with empty standard output.
+
 ## Compare before changing data
 
 For an existing database, inspect and compare first:

--- a/docs/site/src/content/docs/testing/ci.md
+++ b/docs/site/src/content/docs/testing/ci.md
@@ -103,6 +103,10 @@ ptah migrations lint --dir ./migrations --dialect postgres
 ptah schema render --root-dir ./models --dialect postgres >/tmp/ptah-schema.sql
 ```
 
+`schema render` writes executable SQL to stdout and diagnostics to stderr. A CI
+job can apply `/tmp/ptah-schema.sql` unchanged to a disposable database to test
+the public command path, including cyclic foreign key ordering.
+
 Use a disposable database for `migrations plan`, `migrations generate`, and
 `migrations up` in pull requests.
 
@@ -136,7 +140,7 @@ code-scanning permission model.
 | --- | --- |
 | `migrations validate` | Fails when committed migration files and `ptah.sum` disagree. |
 | `migrations lint` | Catches risky SQL before it reaches a database. |
-| `schema render` | Proves the desired schema source still parses. |
+| `schema render` | Proves the desired schema source parses and produces executable, capability-valid SQL. |
 | `migrations plan` against a disposable DB | Shows the SQL Ptah would apply. |
 | `migrations up --verify-sum --dry-run` | Exercises the apply path without changing the shared target. |
 | `schema drift` | Fails when a long-lived environment diverged from the desired schema. |

--- a/integration/gonative/circular_fk_hardening_integration_test.go
+++ b/integration/gonative/circular_fk_hardening_integration_test.go
@@ -1,0 +1,523 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"maps"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	mysqldriver "github.com/go-sql-driver/mysql"
+	_ "github.com/jackc/pgx/v5/stdlib"
+	_ "github.com/microsoft/go-mssqldb"
+
+	"github.com/stokaro/ptah/cmd/generate"
+	"github.com/stokaro/ptah/cmd/readdb"
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform/capability"
+	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/core/renderer"
+	"github.com/stokaro/ptah/dbschema"
+)
+
+func TestPostgreSQLSchemaRenderCircularForeignKeysApplyIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	cleanupPostgreSQLCycleSchema(c, db)
+	c.Cleanup(func() { cleanupPostgreSQLCycleSchema(c, db) })
+	_, err = db.Exec(`CREATE SCHEMA ptah_cycle_137`)
+	c.Assert(err, qt.IsNil)
+
+	fixtureDir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(fixtureDir, "models.go"), []byte(`package models
+
+//ptah:schema:table schema="ptah_cycle_137" name="left_nodes"
+type Left struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+	//ptah:schema:field name="right_id" type="BIGINT" foreign="right_nodes(id)" foreign_key_name="fk_cycle_left_right"
+	RightID int64
+}
+
+//ptah:schema:table schema="ptah_cycle_137" name="right_nodes"
+type Right struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+	//ptah:schema:field name="left_id" type="BIGINT" foreign="left_nodes(id)" foreign_key_name="fk_cycle_right_left"
+	LeftID int64
+}
+`), 0o600), qt.IsNil)
+
+	cmd := generate.NewGenerateCommand()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--root-dir", fixtureDir, "--dialect", "postgres"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout.String(), qt.Contains, `REFERENCES "ptah_cycle_137"."right_nodes"("id")`)
+	c.Assert(stdout.String(), qt.Contains, `REFERENCES "ptah_cycle_137"."left_nodes"("id")`)
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "Found 2 tables")
+	c.Assert(stderr.String(), qt.Contains, "Found 2 tables")
+	c.Assert(stderr.String(), qt.Not(qt.Contains), "Circular dependency detected")
+	_, err = db.Exec(stdout.String())
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered SQL:\n%s", stdout.String()))
+
+	var foreignKeyCount int
+	err = db.QueryRow(`
+SELECT COUNT(*)
+FROM pg_constraint AS c
+JOIN pg_namespace AS n ON n.oid = c.connamespace
+WHERE c.contype = 'f'
+  AND n.nspname = 'ptah_cycle_137'
+  AND c.conname IN ('fk_cycle_left_right', 'fk_cycle_right_left')`).Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func TestPostgreSQLDBReadCircularForeignKeysRoundTripIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	cleanupPostgreSQLReadCycleSchema(c, db)
+	c.Cleanup(func() { cleanupPostgreSQLReadCycleSchema(c, db) })
+
+	_, err = db.Exec(`
+CREATE SCHEMA ptah_cycle_read_137;
+CREATE TABLE ptah_cycle_read_137.left_nodes (
+    id BIGINT PRIMARY KEY,
+    right_id BIGINT
+);
+CREATE TABLE ptah_cycle_read_137.right_nodes (
+    id BIGINT PRIMARY KEY,
+    left_id BIGINT
+);
+ALTER TABLE ptah_cycle_read_137.left_nodes
+    ADD CONSTRAINT fk_cycle_read_left_right
+    FOREIGN KEY (right_id) REFERENCES ptah_cycle_read_137.right_nodes(id);
+ALTER TABLE ptah_cycle_read_137.right_nodes
+    ADD CONSTRAINT fk_cycle_read_right_left
+    FOREIGN KEY (left_id) REFERENCES ptah_cycle_read_137.left_nodes(id);`)
+	c.Assert(err, qt.IsNil)
+
+	cmd := readdb.NewReadDBCommand()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetContext(t.Context())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--db-url", dsn, "--schemas", "ptah_cycle_read_137"})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout.String(), qt.Contains, `CREATE TABLE "ptah_cycle_read_137"."left_nodes"`)
+	c.Assert(stdout.String(), qt.Contains, "fk_cycle_read_left_right")
+	c.Assert(stdout.String(), qt.Contains, "fk_cycle_read_right_left")
+	c.Assert(stderr.String(), qt.Contains, "Connected to postgres database successfully!")
+
+	cleanupPostgreSQLReadCycleSchema(c, db)
+	_, err = db.Exec(stdout.String())
+	c.Assert(err, qt.IsNil, qt.Commentf("db read SQL:\n%s", stdout.String()))
+
+	var foreignKeyCount int
+	err = db.QueryRow(`
+SELECT COUNT(*)
+FROM pg_constraint AS c
+JOIN pg_namespace AS n ON n.oid = c.connamespace
+WHERE c.contype = 'f'
+  AND n.nspname = 'ptah_cycle_read_137'
+  AND c.conname IN ('fk_cycle_read_left_right', 'fk_cycle_read_right_left')`).Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func TestCockroachDBMutualForeignKeysApplyIntegration(t *testing.T) {
+	dsn := skipIfNoCockroachDB(t)
+	testPostgreSQLFamilyMutualForeignKeys(t, "CockroachDB", "cockroachdb", dsn)
+}
+
+func TestYugabyteDBMutualForeignKeysApplyIntegration(t *testing.T) {
+	dsn := requireReachableTestDSN(t, "YUGABYTEDB_TEST_DSN", "pgx", "YugabyteDB")
+	testPostgreSQLFamilyMutualForeignKeys(t, "YugabyteDB", "yugabytedb", dsn)
+}
+
+func TestMySQLMutualForeignKeysApplyIntegration(t *testing.T) {
+	testMySQLFamilyMutualForeignKeys(t, "MySQL", skipIfNoMySQL(t))
+}
+
+func TestMySQLForeignKeysOverrideMyISAMSessionDefaultIntegration(t *testing.T) {
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "mysql://"+skipIfNoMySQL(t))
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	prefix := "ptah_cycle_137_mysql_engine"
+	cleanupMySQLFamilyCycleTablesWithConnection(c, conn, prefix)
+	c.Cleanup(func() { cleanupMySQLFamilyCycleTablesWithConnection(c, conn, prefix) })
+
+	err = conn.WithSession(t.Context(), func(session *dbschema.DatabaseConnection) error {
+		_, setErr := session.ExecContext(t.Context(), "SET SESSION default_storage_engine = MyISAM")
+		c.Assert(setErr, qt.IsNil)
+		info := session.Info()
+		statements, renderErr := renderer.GetOrderedCreateStatementsWithCapabilities(
+			mutualLiveForeignKeyDatabase(prefix),
+			info.Dialect,
+			info.Capabilities,
+		)
+		c.Assert(renderErr, qt.IsNil)
+		c.Assert(strings.Count(strings.Join(statements, "\n"), "ENGINE=InnoDB"), qt.Equals, 2)
+		execConnectionStatements(c, session, statements)
+
+		var innoDBTableCount int
+		engineErr := session.QueryRow(`
+SELECT COUNT(*)
+FROM information_schema.tables
+WHERE table_schema = DATABASE()
+  AND table_name IN (?, ?)
+  AND engine = 'InnoDB'`, prefix+"_left", prefix+"_right").Scan(&innoDBTableCount)
+		c.Assert(engineErr, qt.IsNil)
+		c.Assert(innoDBTableCount, qt.Equals, 2)
+
+		var foreignKeyCount int
+		foreignKeyErr := session.QueryRow(`
+SELECT COUNT(*)
+FROM information_schema.referential_constraints
+WHERE constraint_schema = DATABASE()
+  AND constraint_name IN (?, ?)`, "fk_"+prefix+"_left_right", "fk_"+prefix+"_right_left").Scan(&foreignKeyCount)
+		c.Assert(foreignKeyErr, qt.IsNil)
+		c.Assert(foreignKeyCount, qt.Equals, 2)
+		return nil
+	})
+
+	c.Assert(err, qt.IsNil)
+}
+
+func TestMariaDBMutualForeignKeysApplyIntegration(t *testing.T) {
+	testMySQLFamilyMutualForeignKeys(t, "MariaDB", skipIfNoMariaDB(t))
+}
+
+func TestMySQLDefaultRejectsNonuniqueReferencedKeyIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoMySQL(t)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "mysql://"+dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	info := conn.Info()
+
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		indexedLiveForeignKeyDatabase("ptah_indexed_137_mysql_default"),
+		info.Dialect,
+		info.Capabilities,
+	)
+
+	c.Assert(info.Capabilities.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(statements, qt.IsNil)
+}
+
+func TestMySQLSessionOverrideAllowsNonuniqueReferencedKeyIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsnConfig, err := mysqldriver.ParseDSN(skipIfNoMySQL(t))
+	c.Assert(err, qt.IsNil)
+	params := make(map[string]string, len(dsnConfig.Params)+1)
+	maps.Copy(params, dsnConfig.Params)
+	params["restrict_fk_on_non_standard_key"] = "OFF"
+	dsnConfig.Params = params
+	dsn := dsnConfig.FormatDSN()
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "mysql://"+dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	prefix := "ptah_indexed_137_mysql_override"
+	cleanupMySQLFamilyIndexedTables(c, conn, prefix)
+	c.Cleanup(func() { cleanupMySQLFamilyIndexedTables(c, conn, prefix) })
+	rootInfo := conn.Info()
+	c.Assert(rootInfo.Capabilities.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(rootInfo.Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+
+	err = conn.WithSession(t.Context(), func(session *dbschema.DatabaseConnection) error {
+		info := session.Info()
+		statements, renderErr := renderer.GetOrderedCreateStatementsWithCapabilities(
+			indexedLiveForeignKeyDatabase(prefix),
+			info.Dialect,
+			info.Capabilities,
+		)
+		c.Assert(renderErr, qt.IsNil)
+		c.Assert(info.Capabilities.Has(capability.ForeignKeysRequireUniqueReference), qt.IsFalse)
+		c.Assert(info.Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
+		execConnectionStatements(c, session, statements)
+
+		var foreignKeyCount int
+		queryErr := session.QueryRow(`SELECT COUNT(*) FROM information_schema.referential_constraints WHERE constraint_schema = DATABASE() AND constraint_name = ?`,
+			"fk_"+prefix+"_child_parent").Scan(&foreignKeyCount)
+		c.Assert(queryErr, qt.IsNil)
+		c.Assert(foreignKeyCount, qt.Equals, 1)
+		return nil
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(conn.Info().Capabilities, qt.DeepEquals, rootInfo.Capabilities)
+}
+
+func TestMariaDBAllowsNonuniqueReferencedKeyIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoMariaDB(t)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), "mariadb://"+dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	prefix := "ptah_indexed_137_mariadb"
+	cleanupMySQLFamilyIndexedTables(c, conn, prefix)
+	c.Cleanup(func() { cleanupMySQLFamilyIndexedTables(c, conn, prefix) })
+	info := conn.Info()
+
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		indexedLiveForeignKeyDatabase(prefix),
+		info.Dialect,
+		info.Capabilities,
+	)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsTrue)
+	execConnectionStatements(c, conn, statements)
+
+	var foreignKeyCount int
+	err = conn.QueryRow(`SELECT COUNT(*) FROM information_schema.referential_constraints WHERE constraint_schema = DATABASE() AND constraint_name = ?`,
+		"fk_"+prefix+"_child_parent").Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 1)
+}
+
+func TestSQLServerMutualForeignKeysApplyIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := requireReachableTestDSN(t, "SQLSERVER_TEST_DSN", "sqlserver", "SQL Server")
+	db, err := sql.Open("sqlserver", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	cleanupSQLServerCycleTables(c, db)
+	c.Cleanup(func() { cleanupSQLServerCycleTables(c, db) })
+
+	statements, err := renderer.GetOrderedCreateStatements(mutualLiveForeignKeyDatabase("ptah_cycle_137_mssql"), "sqlserver")
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 4)
+	execStatements(c, db, statements)
+
+	var foreignKeyCount int
+	err = db.QueryRow(`SELECT COUNT(*) FROM sys.foreign_keys WHERE name IN ('fk_ptah_cycle_137_mssql_left_right', 'fk_ptah_cycle_137_mssql_right_left')`).Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func testPostgreSQLFamilyMutualForeignKeys(t *testing.T, databaseName, dialect, dsn string) {
+	t.Helper()
+	c := qt.New(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	prefix := "ptah_cycle_137_" + strings.ToLower(databaseName)
+	cleanupPostgreSQLFamilyCycleTables(c, db, prefix)
+	c.Cleanup(func() { cleanupPostgreSQLFamilyCycleTables(c, db, prefix) })
+
+	var version string
+	err = db.QueryRow(`SELECT version()`).Scan(&version)
+	c.Assert(err, qt.IsNil)
+	caps := capability.ForServerVersion(dialect, version)
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(mutualLiveForeignKeyDatabase(prefix), dialect, caps)
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 4)
+	execStatements(c, db, statements)
+
+	var foreignKeyCount int
+	err = db.QueryRow(`SELECT COUNT(*) FROM information_schema.table_constraints WHERE constraint_type = 'FOREIGN KEY' AND constraint_name IN ($1, $2)`,
+		"fk_"+prefix+"_left_right", "fk_"+prefix+"_right_left").Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func testMySQLFamilyMutualForeignKeys(t *testing.T, databaseName, dsn string) {
+	t.Helper()
+	c := qt.New(t)
+	db, err := sql.Open("mysql", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	prefix := "ptah_cycle_137_" + strings.ToLower(databaseName)
+	cleanupMySQLFamilyCycleTables(c, db, prefix)
+	c.Cleanup(func() { cleanupMySQLFamilyCycleTables(c, db, prefix) })
+
+	var version string
+	err = db.QueryRow(`SELECT VERSION()`).Scan(&version)
+	c.Assert(err, qt.IsNil)
+	caps := capability.ForServerVersion("mysql", version)
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(mutualLiveForeignKeyDatabase(prefix), strings.ToLower(databaseName), caps)
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 4)
+	execStatements(c, db, statements)
+
+	var foreignKeyCount int
+	err = db.QueryRow(`SELECT COUNT(*) FROM information_schema.referential_constraints WHERE constraint_schema = DATABASE() AND constraint_name IN (?, ?)`,
+		"fk_"+prefix+"_left_right", "fk_"+prefix+"_right_left").Scan(&foreignKeyCount)
+	c.Assert(err, qt.IsNil)
+	c.Assert(foreignKeyCount, qt.Equals, 2)
+}
+
+func mutualLiveForeignKeyDatabase(prefix string) *goschema.Database {
+	leftTable := prefix + "_left"
+	rightTable := prefix + "_right"
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Left", Name: leftTable},
+			{StructName: "Right", Name: rightTable},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Left", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Left", Name: "right_id", Type: "INTEGER", Foreign: rightTable + "(id)", ForeignKeyName: "fk_" + prefix + "_left_right"},
+			{StructName: "Right", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Right", Name: "left_id", Type: "INTEGER", Foreign: leftTable + "(id)", ForeignKeyName: "fk_" + prefix + "_right_left"},
+		},
+	}
+}
+
+func indexedLiveForeignKeyDatabase(prefix string) *goschema.Database {
+	parentTable := prefix + "_parent"
+	childTable := prefix + "_child"
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: parentTable},
+			{StructName: "Child", Name: childTable},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Parent", Name: "code", Type: "INTEGER"},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_code", Type: "INTEGER"},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "Parent",
+			Name:       "idx_" + prefix + "_parent_code",
+			Fields:     []string{"code"},
+		}},
+		Constraints: []goschema.Constraint{{
+			StructName:    "Child",
+			Name:          "fk_" + prefix + "_child_parent",
+			Type:          "FOREIGN KEY",
+			Columns:       []string{"parent_code"},
+			ForeignTable:  parentTable,
+			ForeignColumn: "code",
+		}},
+	}
+}
+
+func execStatements(c *qt.C, db *sql.DB, statements []string) {
+	c.Helper()
+	for _, statement := range statements {
+		_, err := db.Exec(statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", statement))
+	}
+}
+
+func execConnectionStatements(c *qt.C, conn *dbschema.DatabaseConnection, statements []string) {
+	c.Helper()
+	for _, statement := range statements {
+		_, err := conn.Exec(statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed:\n%s", statement))
+	}
+}
+
+func cleanupPostgreSQLCycleSchema(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(`DROP SCHEMA IF EXISTS ptah_cycle_137 CASCADE`)
+	c.Assert(err, qt.IsNil)
+}
+
+func cleanupPostgreSQLReadCycleSchema(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(`DROP SCHEMA IF EXISTS ptah_cycle_read_137 CASCADE`)
+	c.Assert(err, qt.IsNil)
+}
+
+func cleanupPostgreSQLFamilyCycleTables(c *qt.C, db *sql.DB, prefix string) {
+	c.Helper()
+	_, err := db.Exec(`DROP TABLE IF EXISTS "` + prefix + `_left", "` + prefix + `_right" CASCADE`)
+	c.Assert(err, qt.IsNil)
+}
+
+func cleanupMySQLFamilyCycleTables(c *qt.C, db *sql.DB, prefix string) {
+	c.Helper()
+	ctx := context.Background()
+	session, err := db.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	defer func() {
+		c.Check(session.Close(), qt.IsNil)
+	}()
+	_, err = session.ExecContext(ctx, `SET FOREIGN_KEY_CHECKS = 0`)
+	c.Check(err, qt.IsNil)
+	defer func() {
+		_, restoreErr := session.ExecContext(ctx, `SET FOREIGN_KEY_CHECKS = 1`)
+		c.Check(restoreErr, qt.IsNil)
+	}()
+	_, err = session.ExecContext(ctx, "DROP TABLE IF EXISTS `"+prefix+"_left`")
+	c.Check(err, qt.IsNil)
+	_, err = session.ExecContext(ctx, "DROP TABLE IF EXISTS `"+prefix+"_right`")
+	c.Check(err, qt.IsNil)
+}
+
+func cleanupMySQLFamilyIndexedTables(c *qt.C, conn *dbschema.DatabaseConnection, prefix string) {
+	c.Helper()
+	err := conn.WithSession(context.Background(), func(session *dbschema.DatabaseConnection) error {
+		_, disableErr := session.ExecContext(context.Background(), `SET FOREIGN_KEY_CHECKS = 0`)
+		c.Check(disableErr, qt.IsNil)
+		defer func() {
+			_, restoreErr := session.ExecContext(context.Background(), `SET FOREIGN_KEY_CHECKS = 1`)
+			c.Check(restoreErr, qt.IsNil)
+		}()
+		_, dropChildErr := session.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+prefix+"_child`")
+		c.Check(dropChildErr, qt.IsNil)
+		_, dropParentErr := session.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+prefix+"_parent`")
+		c.Check(dropParentErr, qt.IsNil)
+		return nil
+	})
+	c.Check(err, qt.IsNil)
+}
+
+func cleanupMySQLFamilyCycleTablesWithConnection(c *qt.C, conn *dbschema.DatabaseConnection, prefix string) {
+	c.Helper()
+	err := conn.WithSession(context.Background(), func(session *dbschema.DatabaseConnection) error {
+		_, disableErr := session.ExecContext(context.Background(), `SET FOREIGN_KEY_CHECKS = 0`)
+		c.Check(disableErr, qt.IsNil)
+		defer func() {
+			_, restoreErr := session.ExecContext(context.Background(), `SET FOREIGN_KEY_CHECKS = 1`)
+			c.Check(restoreErr, qt.IsNil)
+		}()
+		_, dropLeftErr := session.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+prefix+"_left`")
+		c.Check(dropLeftErr, qt.IsNil)
+		_, dropRightErr := session.ExecContext(context.Background(), "DROP TABLE IF EXISTS `"+prefix+"_right`")
+		c.Check(dropRightErr, qt.IsNil)
+		return nil
+	})
+	c.Check(err, qt.IsNil)
+}
+
+func cleanupSQLServerCycleTables(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(`
+IF OBJECT_ID(N'ptah_cycle_137_mssql_left', N'U') IS NOT NULL
+   AND EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'fk_ptah_cycle_137_mssql_left_right')
+  ALTER TABLE [ptah_cycle_137_mssql_left] DROP CONSTRAINT [fk_ptah_cycle_137_mssql_left_right];
+IF OBJECT_ID(N'ptah_cycle_137_mssql_right', N'U') IS NOT NULL
+   AND EXISTS (SELECT 1 FROM sys.foreign_keys WHERE name = N'fk_ptah_cycle_137_mssql_right_left')
+  ALTER TABLE [ptah_cycle_137_mssql_right] DROP CONSTRAINT [fk_ptah_cycle_137_mssql_right_left];
+DROP TABLE IF EXISTS [ptah_cycle_137_mssql_left];
+DROP TABLE IF EXISTS [ptah_cycle_137_mssql_right];`)
+	c.Assert(err, qt.IsNil)
+}

--- a/integration/gonative/circular_fk_hardening_integration_test.go
+++ b/integration/gonative/circular_fk_hardening_integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema"
+	"github.com/stokaro/ptah/internal/convert/dbschematogo"
 )
 
 func TestPostgreSQLSchemaRenderCircularForeignKeysApplyIntegration(t *testing.T) {
@@ -130,9 +131,28 @@ ALTER TABLE ptah_cycle_read_137.right_nodes
 	c.Assert(stdout.String(), qt.Contains, "fk_cycle_read_right_left")
 	c.Assert(stderr.String(), qt.Contains, "Connected to postgres database successfully!")
 
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	liveSchema, err := dbschema.ReadSchemaWithSchemas(conn, []string{"ptah_cycle_read_137"})
+	c.Assert(err, qt.IsNil)
+	// Roles and grants are cluster-global. Replaying them inside the source
+	// cluster must fail closed, so this same-cluster assertion renders only the
+	// schema-local objects from the structured snapshot.
+	liveSchema.Roles = nil
+	liveSchema.Grants = nil
+	database := dbschematogo.ConvertDBSchemaToGoSchema(liveSchema)
+	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
+		database,
+		conn.Info().Dialect,
+		conn.Info().Capabilities,
+	)
+	c.Assert(err, qt.IsNil)
+	replaySQL := strings.Join(statements, "\n\n")
+
 	cleanupPostgreSQLReadCycleSchema(c, db)
-	_, err = db.Exec(stdout.String())
-	c.Assert(err, qt.IsNil, qt.Commentf("db read SQL:\n%s", stdout.String()))
+	_, err = db.Exec(replaySQL)
+	c.Assert(err, qt.IsNil, qt.Commentf("schema-local db read SQL:\n%s", replaySQL))
 
 	var foreignKeyCount int
 	err = db.QueryRow(`

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -3,15 +3,18 @@
 package gonative_test
 
 import (
+	"bytes"
 	"database/sql"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
+	"github.com/stokaro/ptah/cmd/readdb"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
@@ -27,10 +30,10 @@ func TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration(t *testing.T) {
 
 	db, err := sql.Open("pgx", dsn)
 	c.Assert(err, qt.IsNil)
-	defer db.Close()
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
 
-	cleanupRolesGrantsIntegration(t, db)
-	defer cleanupRolesGrantsIntegration(t, db)
+	cleanupRolesGrantsIntegration(c, db)
+	c.Cleanup(func() { cleanupRolesGrantsIntegration(c, db) })
 
 	target := rolesGrantsTarget()
 	diff := schemadiff.Compare(target, &dbschematypes.DBSchema{})
@@ -44,7 +47,6 @@ func TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration(t *testing.T) {
 		_, err = db.Exec(stmt)
 		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", stmt))
 	}
-
 	reader := postgres.NewPostgreSQLReader(db, "public")
 	live, err := reader.ReadSchema()
 	c.Assert(err, qt.IsNil)
@@ -68,6 +70,62 @@ func TestPostgreSQLRolesGrantsRoundTripAndBehaviorIntegration(t *testing.T) {
 	assertWriterRoleBehavior(t, db)
 }
 
+func TestPostgreSQLDBReadRoleCommentReplayIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	cleanupDBReadRoleIntegration(c, db)
+	c.Cleanup(func() { cleanupDBReadRoleIntegration(c, db) })
+
+	_, err = db.Exec(`
+CREATE ROLE ptah_db_read_role_137;
+COMMENT ON ROLE ptah_db_read_role_137 IS 'Database read replay role';`)
+	c.Assert(err, qt.IsNil)
+
+	cmd := readdb.NewReadDBCommand()
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetContext(t.Context())
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dsn,
+		"--schemas", "ptah_db_read_empty_schema_137",
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout.String(), qt.Contains, `CREATE ROLE "ptah_db_read_role_137"`)
+	c.Assert(stdout.String(), qt.Contains, `COMMENT ON ROLE "ptah_db_read_role_137" IS 'Database read replay role';`)
+	c.Assert(stderr.String(), qt.Contains, "Connected to postgres database successfully!")
+	roleStatements := slices.DeleteFunc(
+		migrator.SplitSQLStatements(stdout.String()),
+		func(statement string) bool {
+			return !strings.Contains(statement, "ptah_db_read_role_137")
+		},
+	)
+	c.Assert(roleStatements, qt.HasLen, 2)
+
+	cleanupDBReadRoleIntegration(c, db)
+	for _, statement := range roleStatements {
+		_, replayErr := db.Exec(statement)
+		c.Assert(replayErr, qt.IsNil, qt.Commentf("role restore failed: %s", statement))
+	}
+	_, collisionErr := db.Exec(roleStatements[0])
+	c.Assert(collisionErr, qt.ErrorMatches, `.*role "ptah_db_read_role_137" already exists.*`)
+
+	var comment string
+	err = db.QueryRow(`
+SELECT shobj_description(oid, 'pg_authid')
+FROM pg_roles
+WHERE rolname = 'ptah_db_read_role_137'`).Scan(&comment)
+	c.Assert(err, qt.IsNil)
+	c.Assert(comment, qt.Equals, "Database read replay role")
+}
+
 func rolesGrantsTarget() *goschema.Database {
 	target := &goschema.Database{
 		Tables: []goschema.Table{
@@ -82,8 +140,8 @@ func rolesGrantsTarget() *goschema.Database {
 			{StructName: "RolesGrantAuditLog", Name: "message", Type: "TEXT", Nullable: false},
 		},
 		Roles: []goschema.Role{
-			{Name: "ptah_grants_reader", Inherit: true},
-			{Name: "ptah_grants_writer", Inherit: true},
+			{Name: "ptah_grants_reader", Inherit: true, Comment: "Read tenant data"},
+			{Name: "ptah_grants_writer", Inherit: true, Comment: "Write tenant data"},
 		},
 		Grants: []goschema.Grant{
 			{Role: "ptah_grants_reader", Privileges: []string{"USAGE"}, OnSchema: "public"},
@@ -116,7 +174,7 @@ func assertReaderRoleBehavior(t *testing.T, db *sql.DB) {
 
 	tx, err := db.Begin()
 	c.Assert(err, qt.IsNil)
-	defer tx.Rollback()
+	defer func() { c.Check(tx.Rollback(), qt.IsNil) }()
 
 	_, err = tx.Exec("SET LOCAL ROLE ptah_grants_reader")
 	c.Assert(err, qt.IsNil)
@@ -129,7 +187,7 @@ func assertReaderRoleBehavior(t *testing.T, db *sql.DB) {
 	c.Assert(count, qt.Equals, 1)
 
 	_, err = tx.Exec("INSERT INTO ptah_grants_users (id, tenant_id, email) VALUES (3, 1, 'reader-write@example.test')")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
 func assertWriterRoleBehavior(t *testing.T, db *sql.DB) {
@@ -138,7 +196,7 @@ func assertWriterRoleBehavior(t *testing.T, db *sql.DB) {
 
 	tx, err := db.Begin()
 	c.Assert(err, qt.IsNil)
-	defer tx.Rollback()
+	defer func() { c.Check(tx.Rollback(), qt.IsNil) }()
 
 	_, err = tx.Exec("SET LOCAL ROLE ptah_grants_writer")
 	c.Assert(err, qt.IsNil)
@@ -151,18 +209,45 @@ func assertWriterRoleBehavior(t *testing.T, db *sql.DB) {
 	c.Assert(err, qt.IsNil)
 
 	_, err = tx.Exec("INSERT INTO ptah_grants_users (id, tenant_id, email) VALUES (5, 2, 'writer-rls-blocked@example.test')")
-	c.Assert(err, qt.Not(qt.IsNil))
+	c.Assert(err, qt.IsNotNil)
 }
 
-func cleanupRolesGrantsIntegration(t *testing.T, db *sql.DB) {
-	t.Helper()
-	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_grants_audit_log CASCADE")
-	_, _ = db.Exec("DROP TABLE IF EXISTS ptah_grants_users CASCADE")
-	for _, roleName := range []string{"ptah_grants_reader", "ptah_grants_writer"} {
-		_, _ = db.Exec("REVOKE ALL PRIVILEGES ON SCHEMA public FROM " + roleName)
-		_, _ = db.Exec("DROP OWNED BY " + roleName)
-		_, _ = db.Exec("DROP ROLE IF EXISTS " + roleName)
-	}
+func cleanupRolesGrantsIntegration(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec("DROP TABLE IF EXISTS ptah_grants_audit_log CASCADE")
+	c.Check(err, qt.IsNil)
+	_, err = db.Exec("DROP TABLE IF EXISTS ptah_grants_users CASCADE")
+	c.Check(err, qt.IsNil)
+	_, err = db.Exec(`
+DO $ptah_cleanup_roles$
+DECLARE
+    role_name text;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['ptah_grants_reader', 'ptah_grants_writer'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE %I FROM %I', role_name, current_user);
+            EXECUTE format('DROP OWNED BY %I', role_name);
+            EXECUTE format('DROP ROLE %I', role_name);
+        END IF;
+    END LOOP;
+END
+$ptah_cleanup_roles$;`)
+	c.Check(err, qt.IsNil)
+}
+
+func cleanupDBReadRoleIntegration(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(`
+DO $ptah_cleanup_role$
+BEGIN
+    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ptah_db_read_role_137') THEN
+        EXECUTE format('REVOKE %I FROM %I', 'ptah_db_read_role_137', current_user);
+        DROP OWNED BY ptah_db_read_role_137;
+        DROP ROLE ptah_db_read_role_137;
+    END IF;
+END
+$ptah_cleanup_role$;`)
+	c.Check(err, qt.IsNil)
 }
 
 func filterRolesGrantsIntegrationSchema(in *dbschematypes.DBSchema) *dbschematypes.DBSchema {

--- a/integration/scenarios_dynamic.go
+++ b/integration/scenarios_dynamic.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
 	"github.com/stokaro/ptah/dbschema"
 	"github.com/stokaro/ptah/dbschema/types"
@@ -86,9 +87,11 @@ func GetDynamicScenarios() []TestScenario {
 
 		// Complex schema change scenarios
 		{
-			Name:             "dynamic_circular_dependencies",
-			Description:      "Test handling of circular foreign key dependencies",
-			EnhancedTestFunc: testDynamicCircularDependencies,
+			Name:                          "dynamic_circular_dependencies",
+			Description:                   "Render, apply, and introspect mutually dependent foreign keys",
+			EnhancedTestFunc:              testDynamicCircularDependencies,
+			PostgresDistributedCompatible: true,
+			SQLServerCompatible:           true,
 		},
 		{
 			Name:             "dynamic_data_migration",
@@ -1290,68 +1293,53 @@ func testDynamicConcurrentMigrations(ctx context.Context, conn *dbschema.Databas
 // ============================================================================
 
 // testDynamicCircularDependencies tests handling of circular foreign key dependencies
-func testDynamicCircularDependencies(ctx context.Context, conn *dbschema.DatabaseConnection, fixtures fs.FS, recorder *StepRecorder) error {
-	vem, err := NewVersionedEntityManager(fixtures)
-	if err != nil {
-		return fmt.Errorf("failed to create versioned entity manager: %w", err)
-	}
-	defer vem.Cleanup()
-
+func testDynamicCircularDependencies(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	_ fs.FS,
+	recorder *StepRecorder,
+) error {
 	return recorder.RecordStep("Test Circular Dependencies", "Create tables with circular foreign key references", func() error {
-		dialect := conn.Info().Dialect
-		// Create migrations that establish circular dependencies
-
-		// First, create tables without foreign keys
-		var createSQL string
-		if dialect == "mysql" || dialect == "mariadb" {
-			createSQL = `CREATE TABLE departments (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255));
-			 CREATE TABLE employees (id INT AUTO_INCREMENT PRIMARY KEY, name VARCHAR(255), department_id INTEGER);`
-		} else {
-			createSQL = `CREATE TABLE departments (id SERIAL PRIMARY KEY, name VARCHAR(255));
-			 CREATE TABLE employees (id SERIAL PRIMARY KEY, name VARCHAR(255), department_id INTEGER);`
+		database := &goschema.Database{
+			Tables: []goschema.Table{
+				{StructName: "Department", Name: "departments"},
+				{StructName: "Employee", Name: "employees"},
+			},
+			Fields: []goschema.Field{
+				{StructName: "Department", Name: "id", Type: "BIGINT", Primary: true},
+				{StructName: "Department", Name: "manager_id", Type: "BIGINT", Foreign: "employees(id)", ForeignKeyName: "fk_dept_manager"},
+				{StructName: "Employee", Name: "id", Type: "BIGINT", Primary: true},
+				{StructName: "Employee", Name: "department_id", Type: "BIGINT", Foreign: "departments(id)", ForeignKeyName: "fk_emp_dept"},
+			},
+		}
+		info := conn.Info()
+		statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(database, info.Dialect, info.Capabilities)
+		if err != nil {
+			return fmt.Errorf("render circular foreign keys: %w", err)
+		}
+		for _, statement := range statements {
+			if _, err := conn.ExecContext(ctx, statement); err != nil {
+				return fmt.Errorf("execute circular foreign-key statement: %w", err)
+			}
 		}
 
-		migration1 := migrator.CreateMigrationFromSQL(
-			1,
-			"Create tables without FK",
-			createSQL,
-			`DROP TABLE employees; DROP TABLE departments;`,
-		)
-		// Create a migrator and register all migrations with both up and down
-		m := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migration1))
-
-		if err := m.MigrateUp(ctx); err != nil {
-			return fmt.Errorf("failed to create initial tables: %w", err)
-		}
-
-		// Then add foreign keys that create circular dependency
-		migration2 := migrator.CreateMigrationFromSQL(
-			2,
-			"Add circular foreign keys",
-			`ALTER TABLE departments ADD COLUMN manager_id INTEGER;
-			 ALTER TABLE employees ADD CONSTRAINT fk_emp_dept FOREIGN KEY (department_id) REFERENCES departments(id);
-			 ALTER TABLE departments ADD CONSTRAINT fk_dept_manager FOREIGN KEY (manager_id) REFERENCES employees(id);`,
-			`ALTER TABLE departments DROP CONSTRAINT fk_dept_manager;
-			 ALTER TABLE employees DROP CONSTRAINT fk_emp_dept;
-			 ALTER TABLE departments DROP COLUMN manager_id;`,
-		)
-		// Create a migrator and register all migrations with both up and down
-		m2 := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migration2))
-
-		// This should succeed - most databases handle circular FKs if created properly
-		if err := m2.MigrateUp(ctx); err != nil {
-			return fmt.Errorf("failed to add circular foreign keys: %w", err)
-		}
-
-		// Verify the schema has both tables with foreign keys
 		schema, err := conn.Reader().ReadSchema()
 		if err != nil {
-			return fmt.Errorf("failed to read schema: %w", err)
+			return fmt.Errorf("read circular foreign-key schema: %w", err)
 		}
-
-		// Should have 2 tables plus schema_migrations
-		if len(schema.Tables) < 2 {
-			return fmt.Errorf("expected at least 2 tables, got %d", len(schema.Tables))
+		expected := map[string]bool{
+			"fk_dept_manager": false,
+			"fk_emp_dept":     false,
+		}
+		for _, constraint := range schema.Constraints {
+			if _, tracked := expected[constraint.Name]; tracked && constraint.Type == "FOREIGN KEY" {
+				expected[constraint.Name] = true
+			}
+		}
+		for name, found := range expected {
+			if !found {
+				return fmt.Errorf("introspection did not return foreign key %q", name)
+			}
 		}
 
 		return nil

--- a/integration/scenarios_test.go
+++ b/integration/scenarios_test.go
@@ -223,6 +223,7 @@ func TestSQLServerCompatibleScenariosAreExplicit(t *testing.T) {
 		"idempotency_up_to_date",
 		"parallel_migrate_smoke",
 		"cleanup_support",
+		"dynamic_circular_dependencies",
 		"dynamic_sqlserver_identity_schema_bracket_reserved_words",
 	})
 }

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -848,7 +848,7 @@ table "posts" {
 	c.Assert(db.Dependencies["posts"], qt.DeepEquals, []string{"accounts"})
 
 	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "mysql"), "\n"))
-	c.Assert(sql, qt.Contains, `CONSTRAINT owner_ref FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE ON UPDATE NO_ACTION`)
+	c.Assert(sql, qt.Contains, `CONSTRAINT owner_ref FOREIGN KEY (tenant_id, owner_id) REFERENCES accounts(tenant_id, id) ON DELETE CASCADE ON UPDATE NO ACTION`)
 }
 
 func TestParseDefaultsAndChecks(t *testing.T) {

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -50,6 +50,7 @@
 package fromschema
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"log/slog"
 	"maps"
@@ -60,6 +61,8 @@ import (
 	"github.com/stokaro/ptah/core/ast"
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/identifier"
+	"github.com/stokaro/ptah/internal/planner/tablelookup"
 	"github.com/stokaro/ptah/internal/sqlident"
 )
 
@@ -72,8 +75,8 @@ func escapeSQLStringLiteral(value string) string {
 	return "'" + escaped + "'"
 }
 
-func sqlServerBracketIdentifier(identifier string) string {
-	return "[" + strings.ReplaceAll(identifier, "]", "]]") + "]"
+func sqlServerBracketIdentifier(value string) string {
+	return "[" + strings.ReplaceAll(value, "]", "]]") + "]"
 }
 
 // GenerateForeignKeyName generates a consistent foreign key constraint name
@@ -202,6 +205,12 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		defaultSet,
 		defaultExpr,
 	)
+}
+
+// EffectiveFieldForPlatform returns the field definition after applying the
+// same platform overrides used by AST conversion.
+func EffectiveFieldForPlatform(field goschema.Field, targetPlatform string) goschema.Field {
+	return applyPlatformOverrides(field, targetPlatform)
 }
 
 func platformFieldType(fieldType, targetPlatform string) string {
@@ -771,7 +780,7 @@ func fromTableWithFieldConverter(
 			if tableLevelPK && slices.Contains(newTable.PrimaryKey, field.Name) {
 				field.Primary = false
 			}
-			field = withDefaultForeignKeyName(newTable.Name, field)
+			field = withDefaultForeignKeyName(newTable.Name, field, targetPlatform)
 			createTable.AddColumn(convertField(field, enums, targetPlatform))
 		}
 	}
@@ -801,11 +810,15 @@ func fromTableWithoutForeignKeys(
 	return fromTableWithFieldConverter(table, fields, enums, targetPlatform, FromFieldWithoutForeignKeys)
 }
 
-func withDefaultForeignKeyName(tableName string, field goschema.Field) goschema.Field {
+func withDefaultForeignKeyName(tableName string, field goschema.Field, targetPlatform string) goschema.Field {
 	if field.Foreign == "" || field.ForeignKeyName != "" {
 		return field
 	}
-	field.ForeignKeyName = GenerateForeignKeyName(tableName, field.Name)
+	field.ForeignKeyName = generatedForeignKeyName(
+		GenerateForeignKeyName(tableName, field.Name),
+		fieldForeignKeyIdentity(field),
+		targetPlatform,
+	)
 	return field
 }
 
@@ -903,7 +916,13 @@ const (
 	tableConstraintsWithForeignKeys
 )
 
-func addTableConstraints(createTable *ast.CreateTableNode, table goschema.Table, constraints []goschema.Constraint, mode tableConstraintMode) {
+func addTableConstraints(
+	createTable *ast.CreateTableNode,
+	table goschema.Table,
+	constraints []goschema.Constraint,
+	mode tableConstraintMode,
+	targetPlatform string,
+) {
 	for _, constraint := range constraints {
 		if !constraintBelongsToTable(constraint, table) {
 			continue
@@ -911,7 +930,7 @@ func addTableConstraints(createTable *ast.CreateTableNode, table goschema.Table,
 		if isForeignKeyConstraint(constraint) && mode != tableConstraintsWithForeignKeys {
 			continue
 		}
-		constraint = withDefaultConstraintForeignKeyName(table.Name, constraint)
+		constraint = withDefaultConstraintForeignKeyName(table.Name, constraint, targetPlatform)
 
 		node := FromConstraint(constraint)
 		if node != nil {
@@ -924,16 +943,290 @@ func isForeignKeyConstraint(constraint goschema.Constraint) bool {
 	return strings.EqualFold(constraint.Type, "FOREIGN KEY")
 }
 
-func withDefaultConstraintForeignKeyName(tableName string, constraint goschema.Constraint) goschema.Constraint {
+func withDefaultConstraintForeignKeyName(tableName string, constraint goschema.Constraint, targetPlatform string) goschema.Constraint {
 	if !isForeignKeyConstraint(constraint) || constraint.Name != "" {
 		return constraint
 	}
+	constraint.Name = generatedForeignKeyName(
+		defaultConstraintForeignKeyName(tableName, constraint),
+		constraintForeignKeyIdentity(constraint),
+		targetPlatform,
+	)
+	return constraint
+}
+
+func defaultConstraintForeignKeyName(tableName string, constraint goschema.Constraint) string {
 	columnName := strings.Join(constraint.Columns, "_")
 	if columnName == "" {
 		columnName = "foreign_key"
 	}
-	constraint.Name = GenerateForeignKeyName(tableName, columnName)
-	return constraint
+	return GenerateForeignKeyName(tableName, columnName)
+}
+
+func assignDefaultForeignKeyNames(
+	tables []goschema.Table,
+	fields []goschema.Field,
+	constraints []goschema.Constraint,
+	targetPlatform string,
+) ([]goschema.Field, []goschema.Constraint) {
+	assignedFields := slices.Clone(fields)
+	assignedConstraints := slices.Clone(constraints)
+	allocations := make(map[string]*foreignKeyNameAllocation)
+	for _, table := range tables {
+		reserved, counts := foreignKeyNameReservations(table, assignedFields, assignedConstraints, targetPlatform)
+		scope := foreignKeyNameAllocationScope(table, targetPlatform)
+		allocation := allocations[scope]
+		if allocation == nil {
+			allocation = &foreignKeyNameAllocation{
+				allocated: make(map[string]struct{}),
+				counts:    make(map[string]int),
+			}
+			allocations[scope] = allocation
+		}
+		maps.Copy(allocation.allocated, reserved)
+		for name, count := range counts {
+			allocation.counts[name] += count
+		}
+	}
+	for _, table := range tables {
+		allocation := allocations[foreignKeyNameAllocationScope(table, targetPlatform)]
+		assignFieldForeignKeyNames(table, assignedFields, allocation.counts, allocation.allocated, targetPlatform)
+		assignConstraintForeignKeyNames(table, assignedConstraints, allocation.counts, allocation.allocated, targetPlatform)
+	}
+	return assignedFields, assignedConstraints
+}
+
+type foreignKeyNameAllocation struct {
+	allocated map[string]struct{}
+	counts    map[string]int
+}
+
+func foreignKeyNameAllocationScope(table goschema.Table, targetPlatform string) string {
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB:
+		return "database"
+	case platform.SQLServer, platform.Spanner:
+		schema := strings.TrimSpace(table.Schema)
+		if schema == "" {
+			schema = identifier.ForDialect(targetPlatform).DefaultSchema
+		}
+		return "schema:" + strings.ToLower(schema)
+	default:
+		return "table:" + table.QualifiedName()
+	}
+}
+
+func foreignKeyNameReservations(
+	table goschema.Table,
+	fields []goschema.Field,
+	constraints []goschema.Constraint,
+	targetPlatform string,
+) (map[string]struct{}, map[string]int) {
+	reserved := make(map[string]struct{})
+	counts := make(map[string]int)
+	for _, field := range fields {
+		if field.StructName != table.StructName || field.Foreign == "" {
+			continue
+		}
+		if field.ForeignKeyName != "" && !field.GeneratedFromEmbedded {
+			reserved[foreignKeyNameReservationKey(field.ForeignKeyName, targetPlatform)] = struct{}{}
+			continue
+		}
+		base := defaultFieldForeignKeyName(table.Name, field)
+		candidate := generatedForeignKeyName(base, fieldForeignKeyIdentity(field), targetPlatform)
+		counts[foreignKeyNameReservationKey(candidate, targetPlatform)]++
+	}
+	for _, constraint := range constraints {
+		if !isForeignKeyConstraint(constraint) || !constraintBelongsToTable(constraint, table) {
+			continue
+		}
+		if constraint.Name != "" {
+			reserved[foreignKeyNameReservationKey(constraint.Name, targetPlatform)] = struct{}{}
+			continue
+		}
+		base := defaultConstraintForeignKeyName(table.Name, constraint)
+		candidate := generatedForeignKeyName(base, constraintForeignKeyIdentity(constraint), targetPlatform)
+		counts[foreignKeyNameReservationKey(candidate, targetPlatform)]++
+	}
+	return reserved, counts
+}
+
+func assignFieldForeignKeyNames(
+	table goschema.Table,
+	fields []goschema.Field,
+	counts map[string]int,
+	allocated map[string]struct{},
+	targetPlatform string,
+) {
+	for i := range fields {
+		field := &fields[i]
+		if field.StructName != table.StructName || field.Foreign == "" ||
+			(field.ForeignKeyName != "" && !field.GeneratedFromEmbedded) {
+			continue
+		}
+		base := defaultFieldForeignKeyName(table.Name, *field)
+		candidate := generatedForeignKeyName(base, fieldForeignKeyIdentity(*field), targetPlatform)
+		field.ForeignKeyName = allocateForeignKeyName(
+			base,
+			counts[foreignKeyNameReservationKey(candidate, targetPlatform)],
+			fieldForeignKeyIdentity(*field),
+			allocated,
+			targetPlatform,
+		)
+	}
+}
+
+func defaultFieldForeignKeyName(tableName string, field goschema.Field) string {
+	if field.GeneratedFromEmbedded && field.ForeignKeyName != "" {
+		return field.ForeignKeyName
+	}
+	return GenerateForeignKeyName(tableName, field.Name)
+}
+
+func assignConstraintForeignKeyNames(
+	table goschema.Table,
+	constraints []goschema.Constraint,
+	counts map[string]int,
+	allocated map[string]struct{},
+	targetPlatform string,
+) {
+	for i := range constraints {
+		constraint := &constraints[i]
+		if constraint.Name != "" || !isForeignKeyConstraint(*constraint) || !constraintBelongsToTable(*constraint, table) {
+			continue
+		}
+		base := defaultConstraintForeignKeyName(table.Name, *constraint)
+		candidate := generatedForeignKeyName(base, constraintForeignKeyIdentity(*constraint), targetPlatform)
+		constraint.Name = allocateForeignKeyName(
+			base,
+			counts[foreignKeyNameReservationKey(candidate, targetPlatform)],
+			constraintForeignKeyIdentity(*constraint),
+			allocated,
+			targetPlatform,
+		)
+	}
+}
+
+func fieldForeignKeyIdentity(field goschema.Field) string {
+	return strings.Join([]string{
+		"field",
+		field.StructName,
+		field.Name,
+		field.Foreign,
+		field.OnDelete,
+		field.OnUpdate,
+	}, "\x00")
+}
+
+func constraintForeignKeyIdentity(constraint goschema.Constraint) string {
+	return strings.Join([]string{
+		"constraint",
+		constraint.StructName,
+		constraint.Table,
+		strings.Join(constraint.Columns, ","),
+		constraint.ForeignTable,
+		strings.Join(constraint.ForeignColumnsOrDefault(), ","),
+		constraint.OnDelete,
+		constraint.OnUpdate,
+	}, "\x00")
+}
+
+func allocateForeignKeyName(
+	base string,
+	candidateCount int,
+	identity string,
+	allocated map[string]struct{},
+	targetPlatform string,
+) string {
+	candidate := generatedForeignKeyName(base, identity, targetPlatform)
+	reservationKey := foreignKeyNameReservationKey(candidate, targetPlatform)
+	if _, conflict := allocated[reservationKey]; candidateCount == 1 && !conflict {
+		allocated[reservationKey] = struct{}{}
+		return candidate
+	}
+
+	suffix := foreignKeyNameHashSuffix(base, identity)
+	candidate = foreignKeyNameWithSuffix(base, suffix, targetPlatform)
+	for ordinal := 2; ; ordinal++ {
+		reservationKey = foreignKeyNameReservationKey(candidate, targetPlatform)
+		if _, conflict := allocated[reservationKey]; !conflict {
+			allocated[reservationKey] = struct{}{}
+			return candidate
+		}
+		ordinalSuffix := fmt.Sprintf("_%d", ordinal)
+		candidate = foreignKeyNameWithSuffix(base, suffix+ordinalSuffix, targetPlatform)
+	}
+}
+
+func foreignKeyNameReservationKey(name, targetPlatform string) string {
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB, platform.SQLServer, platform.Spanner:
+		return strings.ToLower(name)
+	default:
+		return name
+	}
+}
+
+func generatedForeignKeyName(base, identity, targetPlatform string) string {
+	if foreignKeyNameFits(base, targetPlatform) {
+		return base
+	}
+	return foreignKeyNameWithSuffix(base, foreignKeyNameHashSuffix(base, identity), targetPlatform)
+}
+
+func foreignKeyNameHashSuffix(base, identity string) string {
+	digest := sha256.Sum256([]byte(base + "\x00" + identity))
+	return fmt.Sprintf("_%x", digest[:4])
+}
+
+func foreignKeyNameFits(name, targetPlatform string) bool {
+	switch {
+	case platform.NormalizeDialect(targetPlatform) == platform.SQLServer,
+		platform.NormalizeDialect(targetPlatform) == platform.Spanner:
+		return len([]rune(name)) <= 128
+	case platform.IsPostgresFamily(targetPlatform):
+		return len(name) <= 63
+	case isMySQLFamilyTarget(targetPlatform):
+		return len([]rune(name)) <= 64
+	default:
+		return true
+	}
+}
+
+func foreignKeyNameWithSuffix(base, suffix, targetPlatform string) string {
+	switch {
+	case platform.NormalizeDialect(targetPlatform) == platform.SQLServer,
+		platform.NormalizeDialect(targetPlatform) == platform.Spanner:
+		return truncateIdentifierCharacters(base, 128-len([]rune(suffix))) + suffix
+	case platform.IsPostgresFamily(targetPlatform):
+		return truncateIdentifierBytes(base, 63-len(suffix)) + suffix
+	case isMySQLFamilyTarget(targetPlatform):
+		return truncateIdentifierCharacters(base, 64-len([]rune(suffix))) + suffix
+	default:
+		return base + suffix
+	}
+}
+
+func truncateIdentifierBytes(value string, maxBytes int) string {
+	if len(value) <= maxBytes {
+		return value
+	}
+	end := 0
+	for index := range value {
+		if index > maxBytes {
+			break
+		}
+		end = index
+	}
+	return value[:end]
+}
+
+func truncateIdentifierCharacters(value string, maxCharacters int) string {
+	runes := []rune(value)
+	if len(runes) <= maxCharacters {
+		return value
+	}
+	return string(runes[:maxCharacters])
 }
 
 func constraintBelongsToTable(constraint goschema.Constraint, table goschema.Table) bool {
@@ -1327,7 +1620,7 @@ func appendForeignKeyConstraintStatements(
 	targetPlatform string,
 ) {
 	appendFieldForeignKeyConstraintStatements(statements, tables, fields, targetPlatform)
-	appendTableForeignKeyConstraintStatements(statements, tables, constraints)
+	appendTableForeignKeyConstraintStatements(statements, tables, constraints, targetPlatform)
 }
 
 func appendFieldForeignKeyConstraintStatements(
@@ -1345,11 +1638,12 @@ func appendFieldForeignKeyConstraintStatements(
 			if field.Foreign == "" {
 				continue
 			}
-			field = withDefaultForeignKeyName(table.Name, field)
+			field = withDefaultForeignKeyName(table.Name, field, targetPlatform)
 			fkRef := ParseForeignKeyReference(field.Foreign)
 			if fkRef == nil {
 				continue
 			}
+			fkRef.Table = tablelookup.ResolveReference(tables, table, fkRef.Table)
 			fkRef.OnDelete = field.OnDelete
 			fkRef.OnUpdate = field.OnUpdate
 			fkRef.Name = field.ForeignKeyName
@@ -1369,13 +1663,15 @@ func appendTableForeignKeyConstraintStatements(
 	statements *ast.StatementList,
 	tables []goschema.Table,
 	constraints []goschema.Constraint,
+	targetPlatform string,
 ) {
 	for _, table := range tables {
 		for _, constraint := range constraints {
 			if !constraintBelongsToTable(constraint, table) || !isForeignKeyConstraint(constraint) {
 				continue
 			}
-			constraint = withDefaultConstraintForeignKeyName(table.Name, constraint)
+			constraint = withDefaultConstraintForeignKeyName(table.Name, constraint, targetPlatform)
+			constraint.ForeignTable = tablelookup.ResolveReference(tables, table, constraint.ForeignTable)
 			node := FromConstraint(constraint)
 			if node == nil {
 				continue
@@ -1491,6 +1787,80 @@ func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
 		SetComment(grant.Comment)
 }
 
+// AssignDefaultForeignKeyNames returns a clone whose foreign keys have stable,
+// dialect-valid names. The input is never mutated. Dialect-specific comparison,
+// planning, and rendering paths use this normalization so generated and
+// explicit names share the same namespace and length rules.
+func AssignDefaultForeignKeyNames(database *goschema.Database, targetPlatform string) *goschema.Database {
+	if database == nil {
+		return nil
+	}
+
+	assigned := *database
+	assigned.Tables = slices.Clone(database.Tables)
+	assigned.EmbeddedFields = slices.Clone(database.EmbeddedFields)
+	assigned.Fields = ProcessEmbeddedFields(assigned.EmbeddedFields, database.Fields)
+	assigned.Fields, assigned.Constraints = assignDefaultForeignKeyNames(
+		assigned.Tables,
+		assigned.Fields,
+		database.Constraints,
+		targetPlatform,
+	)
+	assigned.SelfReferencingForeignKeys = assignedSelfReferencingForeignKeys(
+		database.SelfReferencingForeignKeys,
+		assigned.Tables,
+		assigned.Fields,
+	)
+	return &assigned
+}
+
+func assignedSelfReferencingForeignKeys(
+	foreignKeys map[string][]goschema.SelfReferencingFK,
+	tables []goschema.Table,
+	fields []goschema.Field,
+) map[string][]goschema.SelfReferencingFK {
+	if foreignKeys == nil {
+		return nil
+	}
+	assigned := make(map[string][]goschema.SelfReferencingFK, len(foreignKeys))
+	for tableName, tableForeignKeys := range foreignKeys {
+		cloned := slices.Clone(tableForeignKeys)
+		table := foreignKeyOwnerTable(tables, tableName)
+		for i := range cloned {
+			cloned[i].ForeignKeyName = assignedSelfReferencingForeignKeyName(table, cloned[i], fields)
+		}
+		assigned[tableName] = cloned
+	}
+	return assigned
+}
+
+func foreignKeyOwnerTable(tables []goschema.Table, tableName string) *goschema.Table {
+	for i := range tables {
+		if tables[i].QualifiedName() == tableName || tables[i].Name == tableName {
+			return &tables[i]
+		}
+	}
+	return nil
+}
+
+func assignedSelfReferencingForeignKeyName(
+	table *goschema.Table,
+	foreignKey goschema.SelfReferencingFK,
+	fields []goschema.Field,
+) string {
+	if table == nil {
+		return foreignKey.ForeignKeyName
+	}
+	for _, field := range fields {
+		if field.StructName == table.StructName &&
+			field.Name == foreignKey.FieldName &&
+			field.Foreign == foreignKey.Foreign {
+			return field.ForeignKeyName
+		}
+	}
+	return foreignKey.ForeignKeyName
+}
+
 // FromDatabase converts a complete goschema.Database to an ast.StatementList containing all DDL statements.
 //
 // This function creates a comprehensive database schema by converting all schema elements
@@ -1511,7 +1881,8 @@ func FromGrant(grant goschema.Grant) *ast.GrantPrivilegeNode {
 //  3. Enum type definitions (CREATE TYPE statements)
 //  4. Table definitions (CREATE TABLE statements) with embedded fields processed, but without foreign keys
 //  5. PostgreSQL roles and functions
-//  6. Unique index definitions (CREATE UNIQUE INDEX statements)
+//  6. Unique index definitions (CREATE UNIQUE INDEX statements), plus all
+//     MySQL-family indexes required before foreign-key creation
 //  7. Foreign key constraints (ALTER TABLE statements)
 //  8. Dialect-specific objects such as views, RLS policies, grants, and triggers
 //  9. Non-unique index definitions (CREATE INDEX statements)
@@ -1574,8 +1945,10 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		Statements: make([]ast.Node, 0),
 	}
 
-	// Process embedded fields to generate additional fields for each table
-	allFields := ProcessEmbeddedFields(database.EmbeddedFields, database.Fields)
+	// Normalize once so every conversion path consumes the same names.
+	assigned := AssignDefaultForeignKeyNames(&database, targetPlatform)
+	database = *assigned
+	allFields := database.Fields
 
 	// 1. Add schema definitions first (they may be referenced by tables)
 	appendSchemaStatements(statements, database.Schemas)
@@ -1638,6 +2011,10 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// index as the referenced key for a foreign key, so it must exist before
 	// the FK constraint is added.
 	appendUniqueIndexStatements(statements, database.Tables, database.Indexes)
+	mysqlFamily := isMySQLFamilyTarget(targetPlatform)
+	if mysqlFamily {
+		appendNonUniqueIndexStatements(statements, database.Tables, database.Indexes)
+	}
 
 	// 7. Add foreign key constraints after all tables and unique indexes exist.
 	if !isSQLiteTarget(targetPlatform) {
@@ -1652,8 +2029,11 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		appendViewAndTriggerStatements(statements, database)
 	}
 
-	// 9. Add non-unique indexes last.
-	appendNonUniqueIndexStatements(statements, database.Tables, database.Indexes)
+	// 9. Add non-unique indexes last, except on MySQL-family targets where both
+	// sides of a foreign key need their declared indexes before ADD CONSTRAINT.
+	if !mysqlFamily {
+		appendNonUniqueIndexStatements(statements, database.Tables, database.Indexes)
+	}
 
 	return statements
 }
@@ -1674,7 +2054,7 @@ func appendTableStatements(
 		if sqliteTarget {
 			tableNode = FromTable(table, allFields, database.Enums, targetPlatform)
 		}
-		addTableConstraints(tableNode, table, database.Constraints, mode)
+		addTableConstraints(tableNode, table, database.Constraints, mode, targetPlatform)
 		statements.Statements = append(statements.Statements, tableNode)
 	}
 }
@@ -1766,6 +2146,10 @@ func appendViewAndTriggerStatements(statements *ast.StatementList, database gosc
 
 func isSQLiteTarget(targetPlatform string) bool {
 	return strings.EqualFold(targetPlatform, "sqlite") || strings.EqualFold(targetPlatform, "sqlite3")
+}
+
+func isMySQLFamilyTarget(targetPlatform string) bool {
+	return strings.EqualFold(targetPlatform, "mysql") || strings.EqualFold(targetPlatform, "mariadb")
 }
 
 func appendSchemaStatements(statements *ast.StatementList, schemas []goschema.Schema) {
@@ -2057,13 +2441,33 @@ func fieldKeyFor(field goschema.Field) fieldKey {
 
 func processEmbeddedInlineMode(generatedFields []goschema.Field, embedded goschema.EmbeddedField, allFields []goschema.Field, allEmbeddedFields []goschema.EmbeddedField, structName string) []goschema.Field {
 	// INLINE MODE: Expand embedded struct fields as individual table columns
-	generatedFields = processEmbeddedInlineModeRecursive(generatedFields, embedded, allFields, allEmbeddedFields, structName)
+	generatedFields = processEmbeddedInlineModeRecursive(
+		generatedFields,
+		embedded,
+		allFields,
+		allEmbeddedFields,
+		structName,
+		make(map[string]bool),
+	)
 	return generatedFields
 }
 
 // processEmbeddedInlineModeRecursive recursively processes embedded fields in inline mode.
 // This handles nested embedded structs by recursively expanding embedded fields within embedded types.
-func processEmbeddedInlineModeRecursive(generatedFields []goschema.Field, embedded goschema.EmbeddedField, allFields []goschema.Field, allEmbeddedFields []goschema.EmbeddedField, structName string) []goschema.Field {
+func processEmbeddedInlineModeRecursive(
+	generatedFields []goschema.Field,
+	embedded goschema.EmbeddedField,
+	allFields []goschema.Field,
+	allEmbeddedFields []goschema.EmbeddedField,
+	structName string,
+	activeTypes map[string]bool,
+) []goschema.Field {
+	if embedded.EmbeddedTypeName == "" || activeTypes[embedded.EmbeddedTypeName] {
+		return generatedFields
+	}
+	activeTypes[embedded.EmbeddedTypeName] = true
+	defer delete(activeTypes, embedded.EmbeddedTypeName)
+
 	// Step 1: Add direct fields from the embedded type
 	for _, field := range allFields {
 		if field.StructName != embedded.EmbeddedTypeName {
@@ -2072,6 +2476,8 @@ func processEmbeddedInlineModeRecursive(generatedFields []goschema.Field, embedd
 		// Clone the field and reassign to target struct
 		newField := field
 		newField.StructName = structName
+		newField.Overrides = mergePlatformOverrides(field.Overrides, embedded.Overrides)
+		newField.GeneratedFromEmbedded = true
 
 		// Apply prefix to column name if specified
 		if embedded.Prefix != "" {
@@ -2087,23 +2493,30 @@ func processEmbeddedInlineModeRecursive(generatedFields []goschema.Field, embedd
 			continue
 		}
 
-		// Only process inline mode embedded fields recursively
-		if nestedEmbedded.Mode == "inline" {
-			// Create a new embedded field with the target struct name and combined prefix
-			recursiveEmbedded := nestedEmbedded
-			recursiveEmbedded.StructName = structName
+		recursiveEmbedded := nestedEmbedded
+		recursiveEmbedded.StructName = structName
+		recursiveEmbedded.Overrides = mergePlatformOverrides(
+			nestedEmbedded.Overrides,
+			embedded.Overrides,
+		)
+		recursiveEmbedded.Prefix = embedded.Prefix + nestedEmbedded.Prefix
 
-			// Combine prefixes: if the parent has a prefix, prepend it to the nested prefix
-			if embedded.Prefix != "" {
-				if recursiveEmbedded.Prefix != "" {
-					recursiveEmbedded.Prefix = embedded.Prefix + recursiveEmbedded.Prefix
-				} else {
-					recursiveEmbedded.Prefix = embedded.Prefix
-				}
-			}
-
-			// Recursively process the nested embedded field
-			generatedFields = processEmbeddedInlineModeRecursive(generatedFields, recursiveEmbedded, allFields, allEmbeddedFields, structName)
+		switch nestedEmbedded.Mode {
+		case "json":
+			generatedFields = processEmbeddedJSONMode(generatedFields, recursiveEmbedded, structName)
+		case "relation":
+			generatedFields = processEmbeddedRelationMode(generatedFields, recursiveEmbedded, structName)
+		case "skip":
+			continue
+		default:
+			generatedFields = processEmbeddedInlineModeRecursive(
+				generatedFields,
+				recursiveEmbedded,
+				allFields,
+				allEmbeddedFields,
+				structName,
+				activeTypes,
+			)
 		}
 	}
 
@@ -2117,6 +2530,7 @@ func processEmbeddedJSONMode(generatedFields []goschema.Field, embedded goschema
 		// Auto-generate column name: "Meta" -> "meta_data"
 		columnName = strings.ToLower(embedded.EmbeddedTypeName) + "_data"
 	}
+	columnName = embedded.Prefix + columnName
 
 	columnType := embedded.Type
 	if columnType == "" {
@@ -2131,7 +2545,9 @@ func processEmbeddedJSONMode(generatedFields []goschema.Field, embedded goschema
 		Type:       columnType,
 		Nullable:   embedded.Nullable,
 		Comment:    embedded.Comment,
-		Overrides:  embedded.Overrides, // Platform-specific type overrides (JSON vs JSONB vs TEXT)
+		Overrides:  mergePlatformOverrides(nil, embedded.Overrides),
+
+		GeneratedFromEmbedded: true,
 	})
 
 	return generatedFields
@@ -2152,8 +2568,8 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 		refType = "VARCHAR(36)" // Standard UUID length
 	}
 
-	// Generate automatic foreign key constraint name following convention
-	foreignKeyName := GenerateForeignKeyName(structName, embedded.Field)
+	fieldName := embedded.Prefix + embedded.Field
+	foreignKeyName := GenerateForeignKeyName(structName, fieldName)
 
 	// Create platform-specific overrides for MySQL/MariaDB compatibility
 	// MySQL/MariaDB use INT for SERIAL types, so foreign keys should also use INT
@@ -2162,12 +2578,13 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 		overrides["mysql"] = map[string]string{"type": "INT"}
 		overrides["mariadb"] = map[string]string{"type": "INT"}
 	}
+	overrides = mergePlatformOverrides(overrides, embedded.Overrides)
 
 	// Create the foreign key field
 	generatedFields = append(generatedFields, goschema.Field{
 		StructName:     structName,
 		FieldName:      embedded.EmbeddedTypeName,
-		Name:           embedded.Field,    // e.g., "user_id"
+		Name:           fieldName,         // e.g., "user_id"
 		Type:           refType,           // INTEGER or VARCHAR(36)
 		Nullable:       embedded.Nullable, // Can the relationship be optional?
 		Foreign:        embedded.Ref,      // e.g., "users(id)"
@@ -2176,9 +2593,31 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 		OnUpdate:       embedded.OnUpdate, // ON UPDATE action (CASCADE, SET NULL, etc.)
 		Comment:        embedded.Comment,  // Documentation for the relationship
 		Overrides:      overrides,         // Platform-specific type overrides
+
+		GeneratedFromEmbedded: true,
 	})
 
 	return generatedFields
+}
+
+func mergePlatformOverrides(
+	base map[string]map[string]string,
+	explicit map[string]map[string]string,
+) map[string]map[string]string {
+	if len(base) == 0 && len(explicit) == 0 {
+		return nil
+	}
+	result := make(map[string]map[string]string, len(base)+len(explicit))
+	for dialect, values := range base {
+		result[dialect] = maps.Clone(values)
+	}
+	for dialect, values := range explicit {
+		if result[dialect] == nil {
+			result[dialect] = make(map[string]string)
+		}
+		maps.Copy(result[dialect], values)
+	}
+	return result
 }
 
 // processEmbeddedFieldsForStruct processes embedded fields for a specific struct and generates corresponding schema fields.

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -2560,12 +2560,15 @@ func processEmbeddedRelationMode(generatedFields []goschema.Field, embedded gosc
 		return generatedFields
 	}
 
-	// Intelligent type inference based on reference pattern
-	refType := "INTEGER" // Default assumption: numeric primary key
-	if strings.Contains(embedded.Ref, "VARCHAR") || strings.Contains(embedded.Ref, "TEXT") ||
-		strings.Contains(strings.ToLower(embedded.Ref), "uuid") {
-		// Reference suggests string-based key (likely UUID)
-		refType = "VARCHAR(36)" // Standard UUID length
+	// An explicit relation type is authoritative. When it is omitted, use the
+	// conservative numeric or string heuristic documented for relation fields.
+	refType := strings.TrimSpace(embedded.Type)
+	if refType == "" {
+		refType = "INTEGER"
+		if strings.Contains(embedded.Ref, "VARCHAR") || strings.Contains(embedded.Ref, "TEXT") ||
+			strings.Contains(strings.ToLower(embedded.Ref), "uuid") {
+			refType = "VARCHAR(36)"
+		}
 	}
 
 	fieldName := embedded.Prefix + embedded.Field

--- a/internal/convert/fromschema/fromschema_test.go
+++ b/internal/convert/fromschema/fromschema_test.go
@@ -2763,6 +2763,7 @@ func TestProcessEmbeddedFields_PropagatesNestedPlatformOverrides(t *testing.T) {
 			Mode:             "relation",
 			Field:            "tenant_id",
 			Ref:              "tenants(id)",
+			Type:             "BIGINT",
 			Overrides: map[string]map[string]string{
 				"postgres": {"type": "BIGINT"},
 			},
@@ -2779,10 +2780,10 @@ func TestProcessEmbeddedFields_PropagatesNestedPlatformOverrides(t *testing.T) {
 		"postgres": {"type": "CITEXT"},
 	})
 	c.Assert(got[2].Name, qt.Equals, "owner_tenant_id")
+	c.Assert(got[2].Type, qt.Equals, "BIGINT")
 	c.Assert(got[2].GeneratedFromEmbedded, qt.IsTrue)
 	c.Assert(got[2].Overrides, qt.DeepEquals, map[string]map[string]string{
 		"mysql":    {"type": "BIGINT"},
-		"mariadb":  {"type": "INT"},
 		"postgres": {"type": "BIGINT"},
 	})
 }

--- a/internal/convert/fromschema/fromschema_test.go
+++ b/internal/convert/fromschema/fromschema_test.go
@@ -1,7 +1,9 @@
 package fromschema_test
 
 import (
+	"strings"
 	"testing"
+	"unicode/utf8"
 
 	qt "github.com/frankban/quicktest"
 
@@ -160,6 +162,45 @@ func foreignKeyAlterStatementIndexByName(statements *ast.StatementList, constrai
 		}
 	}
 	return -1
+}
+
+func foreignKeyConstraintNames(statements *ast.StatementList) []string {
+	var names []string
+	for _, statement := range statements.Statements {
+		alter, ok := statement.(*ast.AlterTableNode)
+		if !ok {
+			continue
+		}
+		for _, operation := range alter.Operations {
+			add, ok := operation.(*ast.AddConstraintOperation)
+			if ok && add.Constraint.Type == ast.ForeignKeyConstraint {
+				names = append(names, add.Constraint.Name)
+			}
+		}
+	}
+	return names
+}
+
+func databaseWithGeneratedForeignKeys(tableName string, fieldNames ...string) goschema.Database {
+	fields := []goschema.Field{
+		{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+		{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+	}
+	for _, fieldName := range fieldNames {
+		fields = append(fields, goschema.Field{
+			StructName: "Child",
+			Name:       fieldName,
+			Type:       "INTEGER",
+			Foreign:    "parents(id)",
+		})
+	}
+	return goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: tableName},
+		},
+		Fields: fields,
+	}
 }
 
 func TestFromField_BasicProperties(t *testing.T) {
@@ -1081,6 +1122,328 @@ func TestFromDatabase_UniqueIndexesPrecedeForeignKeys(t *testing.T) {
 	c.Assert(function < uniqueIndex, qt.IsTrue)
 	c.Assert(uniqueIndex < foreignKey, qt.IsTrue)
 	c.Assert(foreignKey < nonUniqueIndex, qt.IsTrue)
+}
+
+func TestFromDatabase_DefaultForeignKeyNamesDoNotCollideAcrossSources(t *testing.T) {
+	c := qt.New(t)
+
+	database := goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:    "Child",
+			Type:          "FOREIGN KEY",
+			Columns:       []string{"parent_id"},
+			ForeignTable:  "parents",
+			ForeignColumn: "id",
+		}},
+	}
+
+	statements := fromschema.FromDatabase(database, "postgres")
+	fieldAlter := statements.Statements[2].(*ast.AlterTableNode)
+	fieldOperation := fieldAlter.Operations[0].(*ast.AddConstraintOperation)
+	tableAlter := statements.Statements[3].(*ast.AlterTableNode)
+	tableOperation := tableAlter.Operations[0].(*ast.AddConstraintOperation)
+
+	c.Assert(fieldOperation.Constraint.Name, qt.Matches, `fk_children_parent_id_[0-9a-f]{8}`)
+	c.Assert(tableOperation.Constraint.Name, qt.Matches, `fk_children_parent_id_[0-9a-f]{8}`)
+	c.Assert(fieldOperation.Constraint.Name, qt.Not(qt.Equals), tableOperation.Constraint.Name)
+}
+
+func TestFromDatabase_ExplicitForeignKeyNameReservesAutomaticName(t *testing.T) {
+	c := qt.New(t)
+
+	database := goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:    "Child",
+			Name:          "fk_children_parent_id",
+			Type:          "FOREIGN KEY",
+			Columns:       []string{"parent_id"},
+			ForeignTable:  "parents",
+			ForeignColumn: "id",
+		}},
+	}
+
+	statements := fromschema.FromDatabase(database, "postgres")
+	fieldAlter := statements.Statements[2].(*ast.AlterTableNode)
+	fieldOperation := fieldAlter.Operations[0].(*ast.AddConstraintOperation)
+	tableAlter := statements.Statements[3].(*ast.AlterTableNode)
+	tableOperation := tableAlter.Operations[0].(*ast.AddConstraintOperation)
+
+	c.Assert(fieldOperation.Constraint.Name, qt.Matches, `fk_children_parent_id_[0-9a-f]{8}`)
+	c.Assert(tableOperation.Constraint.Name, qt.Equals, "fk_children_parent_id")
+}
+
+func TestFromDatabase_MySQLFamilyExplicitForeignKeyNameReservesCaseInsensitiveAutomaticName(t *testing.T) {
+	c := qt.New(t)
+
+	database := goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+			{StructName: "Audit", Name: "audit_entries"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+			{StructName: "Audit", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Audit", Name: "parent_id", Type: "INTEGER"},
+		},
+		Constraints: []goschema.Constraint{{
+			StructName:    "Audit",
+			Name:          "FK_CHILDREN_PARENT_ID",
+			Type:          "FOREIGN KEY",
+			Columns:       []string{"parent_id"},
+			ForeignTable:  "parents",
+			ForeignColumn: "id",
+		}},
+	}
+
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "MySQL", dialect: platform.MySQL},
+		{name: "MariaDB", dialect: platform.MariaDB},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			names := foreignKeyConstraintNames(fromschema.FromDatabase(database, test.dialect))
+
+			c.Assert(names, qt.HasLen, 2)
+			c.Assert(names[0], qt.Matches, `fk_children_parent_id_[0-9a-f]{8}`)
+			c.Assert(names[1], qt.Equals, "FK_CHILDREN_PARENT_ID")
+		})
+	}
+}
+
+func TestFromDatabase_GeneratedForeignKeyNamesRespectPostgreSQLByteLimit(t *testing.T) {
+	c := qt.New(t)
+	database := databaseWithGeneratedForeignKeys(
+		strings.Repeat("shared_table_prefix_", 4),
+		strings.Repeat("shared_column_prefix_", 4)+"alpha",
+		strings.Repeat("shared_column_prefix_", 4)+"beta",
+	)
+
+	names := foreignKeyConstraintNames(fromschema.FromDatabase(database, platform.Postgres))
+
+	c.Assert(names, qt.HasLen, 2)
+	c.Assert([]byte(names[0]), qt.HasLen, 63)
+	c.Assert([]byte(names[1]), qt.HasLen, 63)
+	c.Assert(names[0], qt.Matches, `.*_[0-9a-f]{8}`)
+	c.Assert(names[1], qt.Matches, `.*_[0-9a-f]{8}`)
+	c.Assert(names[0], qt.Not(qt.Equals), names[1])
+}
+
+func TestFromDatabase_GeneratedForeignKeyNamesPreservePostgreSQLUTF8(t *testing.T) {
+	c := qt.New(t)
+	database := databaseWithGeneratedForeignKeys(
+		strings.Repeat("界", 30),
+		strings.Repeat("列", 20),
+	)
+
+	names := foreignKeyConstraintNames(fromschema.FromDatabase(database, platform.Postgres))
+
+	c.Assert(names, qt.HasLen, 1)
+	c.Assert(utf8.ValidString(names[0]), qt.IsTrue)
+	c.Assert([]byte(names[0]), qt.HasLen, 63)
+	c.Assert(names[0], qt.Matches, `.*_[0-9a-f]{8}`)
+}
+
+func TestFromDatabase_GeneratedForeignKeyNamesRespectMySQLFamilyCharacterLimit(t *testing.T) {
+	c := qt.New(t)
+	database := databaseWithGeneratedForeignKeys(
+		strings.Repeat("資料", 40),
+		strings.Repeat("欄位", 20),
+	)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "MySQL", dialect: platform.MySQL},
+		{name: "MariaDB", dialect: platform.MariaDB},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			names := foreignKeyConstraintNames(fromschema.FromDatabase(database, test.dialect))
+
+			c.Assert(names, qt.HasLen, 1)
+			c.Assert(utf8.RuneCountInString(names[0]), qt.Equals, 64)
+			c.Assert(len(names[0]) > 64, qt.IsTrue)
+			c.Assert(names[0], qt.Matches, `.*_[0-9a-f]{8}`)
+		})
+	}
+}
+
+func TestFromDatabase_GeneratedForeignKeyNamesRespectSQLServerAndSpannerCharacterLimit(t *testing.T) {
+	c := qt.New(t)
+	database := databaseWithGeneratedForeignKeys(
+		strings.Repeat("資料", 70),
+		strings.Repeat("欄位", 40),
+	)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "SQL Server", dialect: platform.SQLServer},
+		{name: "Spanner", dialect: platform.Spanner},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			names := foreignKeyConstraintNames(fromschema.FromDatabase(database, test.dialect))
+
+			c.Assert(names, qt.HasLen, 1)
+			c.Assert(utf8.RuneCountInString(names[0]), qt.Equals, 128)
+			c.Assert(len(names[0]) > 128, qt.IsTrue)
+			c.Assert(names[0], qt.Matches, `.*_[0-9a-f]{8}`)
+		})
+	}
+}
+
+func TestFromDatabase_SchemaScopedForeignKeyNamesReserveExplicitNames(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name           string
+		dialect        string
+		explicitSchema string
+	}{
+		{name: "SQL Server default dbo", dialect: platform.SQLServer, explicitSchema: "dbo"},
+		{name: "Spanner default public", dialect: platform.Spanner, explicitSchema: "public"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "Parent", Name: "parents"},
+					{StructName: "Child", Name: "children"},
+					{StructName: "Audit", Schema: test.explicitSchema, Name: "audit_entries"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "Child", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+					{
+						StructName:     "Audit",
+						Name:           "parent_id",
+						Type:           "INTEGER",
+						Foreign:        "parents(id)",
+						ForeignKeyName: "FK_CHILDREN_PARENT_ID",
+					},
+				},
+			}
+
+			names := foreignKeyConstraintNames(fromschema.FromDatabase(database, test.dialect))
+
+			c.Assert(names, qt.HasLen, 2)
+			c.Assert(names[0], qt.Matches, `fk_children_parent_id_[0-9a-f]{8}`)
+			c.Assert(names[1], qt.Equals, "FK_CHILDREN_PARENT_ID")
+		})
+	}
+}
+
+func TestFromDatabase_SchemaScopedForeignKeyNamesMayRepeatAcrossSchemas(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "SQL Server", dialect: platform.SQLServer},
+		{name: "Spanner", dialect: platform.Spanner},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "Parent", Name: "parents"},
+					{StructName: "TenantChild", Schema: "tenant", Name: "children"},
+					{StructName: "ArchiveChild", Schema: "archive", Name: "children"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "TenantChild", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+					{StructName: "ArchiveChild", Name: "parent_id", Type: "INTEGER", Foreign: "parents(id)"},
+				},
+			}
+
+			names := foreignKeyConstraintNames(fromschema.FromDatabase(database, test.dialect))
+
+			c.Assert(names, qt.DeepEquals, []string{"fk_children_parent_id", "fk_children_parent_id"})
+		})
+	}
+}
+
+func TestAssignDefaultForeignKeyNames_IsIdempotentAndCloneOnly(t *testing.T) {
+	c := qt.New(t)
+	database := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Location", Name: "locations"},
+			{StructName: "Area", Name: "areas"},
+		},
+		Fields: []goschema.Field{{
+			StructName:     "Ownable",
+			Name:           "tenant_id",
+			Type:           "INTEGER",
+			Foreign:        "tenants(id)",
+			ForeignKeyName: "fk_entity_tenant",
+		}},
+		EmbeddedFields: []goschema.EmbeddedField{
+			{StructName: "Location", Mode: "inline", EmbeddedTypeName: "Ownable"},
+			{StructName: "Area", Mode: "inline", EmbeddedTypeName: "Ownable"},
+		},
+	}
+
+	first := fromschema.AssignDefaultForeignKeyNames(database, platform.MySQL)
+	second := fromschema.AssignDefaultForeignKeyNames(first, platform.MySQL)
+
+	c.Assert(second, qt.DeepEquals, first)
+	c.Assert(database.Fields, qt.DeepEquals, []goschema.Field{{
+		StructName:     "Ownable",
+		Name:           "tenant_id",
+		Type:           "INTEGER",
+		Foreign:        "tenants(id)",
+		ForeignKeyName: "fk_entity_tenant",
+	}})
+	c.Assert(database.EmbeddedFields, qt.HasLen, 2)
+}
+
+func TestFromDatabase_GeneratedForeignKeyNamesAreDeterministic(t *testing.T) {
+	c := qt.New(t)
+	database := databaseWithGeneratedForeignKeys(
+		strings.Repeat("deterministic_table_", 4),
+		strings.Repeat("deterministic_column_", 4)+"alpha",
+		strings.Repeat("deterministic_column_", 4)+"beta",
+	)
+
+	first := foreignKeyConstraintNames(fromschema.FromDatabase(database, platform.Postgres))
+	second := foreignKeyConstraintNames(fromschema.FromDatabase(database, platform.Postgres))
+
+	c.Assert(first, qt.HasLen, 2)
+	c.Assert(second, qt.DeepEquals, first)
+	c.Assert(first, qt.DeepEquals, []string{
+		"fk_deterministic_table_deterministic_table_determinist_89ec4fc1",
+		"fk_deterministic_table_deterministic_table_determinist_cf1cecb2",
+	})
 }
 
 func TestFromDatabase_SQLiteForeignKeysAreInline(t *testing.T) {
@@ -2372,6 +2735,56 @@ func TestFromDatabase_EmbeddedFields_JsonModeDoesNotDuplicateAlreadyProcessedFie
 	table := tableStatementByName(statements, "users")
 	c.Assert(table, qt.IsNotNil)
 	c.Assert(countColumns(table, "metadata"), qt.Equals, 1)
+}
+
+func TestProcessEmbeddedFields_PropagatesNestedPlatformOverrides(t *testing.T) {
+	c := qt.New(t)
+	fields := []goschema.Field{{
+		StructName: "Ownership",
+		Name:       "label",
+		Type:       "TEXT",
+		Overrides: map[string]map[string]string{
+			"postgres": {"type": "CITEXT"},
+		},
+	}}
+	embeddedFields := []goschema.EmbeddedField{
+		{
+			StructName:       "Order",
+			EmbeddedTypeName: "Ownership",
+			Mode:             "inline",
+			Prefix:           "owner_",
+			Overrides: map[string]map[string]string{
+				"mysql": {"type": "BIGINT"},
+			},
+		},
+		{
+			StructName:       "Ownership",
+			EmbeddedTypeName: "Tenant",
+			Mode:             "relation",
+			Field:            "tenant_id",
+			Ref:              "tenants(id)",
+			Overrides: map[string]map[string]string{
+				"postgres": {"type": "BIGINT"},
+			},
+		},
+	}
+
+	got := fromschema.ProcessEmbeddedFields(embeddedFields, fields)
+
+	c.Assert(got, qt.HasLen, 4)
+	c.Assert(got[1].Name, qt.Equals, "owner_label")
+	c.Assert(got[1].GeneratedFromEmbedded, qt.IsTrue)
+	c.Assert(got[1].Overrides, qt.DeepEquals, map[string]map[string]string{
+		"mysql":    {"type": "BIGINT"},
+		"postgres": {"type": "CITEXT"},
+	})
+	c.Assert(got[2].Name, qt.Equals, "owner_tenant_id")
+	c.Assert(got[2].GeneratedFromEmbedded, qt.IsTrue)
+	c.Assert(got[2].Overrides, qt.DeepEquals, map[string]map[string]string{
+		"mysql":    {"type": "BIGINT"},
+		"mariadb":  {"type": "INT"},
+		"postgres": {"type": "BIGINT"},
+	})
 }
 
 func TestFromDatabase_EmbeddedFields_RelationMode(t *testing.T) {

--- a/internal/goannotationexport/testdata/parity/models.go
+++ b/internal/goannotationexport/testdata/parity/models.go
@@ -65,7 +65,7 @@ type User struct {
 	//ptah:embedded mode="json" name="metadata" type="JSONB" nullable="true" comment="User metadata" platform.mysql.type="JSON"
 	Metadata map[string]any
 
-	//ptah:embedded mode="relation" field="manager_id" ref="app.accounts(id)" nullable="true" on_delete="SET NULL" on_update="CASCADE" comment="Manager" platform.mysql.type="BIGINT UNSIGNED"
+	//ptah:embedded mode="relation" field="manager_id" ref="app.accounts(id)" type="BIGINT" nullable="true" on_delete="SET NULL" on_update="CASCADE" comment="Manager" platform.mysql.type="BIGINT UNSIGNED"
 	Manager Account
 }
 

--- a/internal/planner/dialects/mysql/capability_gating_test.go
+++ b/internal/planner/dialects/mysql/capability_gating_test.go
@@ -157,7 +157,7 @@ func TestPlanner_CapabilityGating_NoGenericClauseFallbacks(t *testing.T) {
 		// The DROP INDEX spelling is version-universal (issue #195), so every
 		// preset uses it — including targets without the generic clause,
 		// where DROP CONSTRAINT would be invalid SQL.
-		for _, caps := range []capability.Capabilities{capability.MySQL8016(), capability.MySQL80()} {
+		for _, caps := range []capability.Capabilities{capability.MySQL8016(), capability.MySQL84()} {
 			nodes, err := mysql.NewWithCapabilities(caps).GenerateMigrationASTChecked(diff, &goschema.Database{})
 			c.Assert(err, qt.IsNil)
 			sql, err := renderer.RenderSQL("mysql", nodes...)

--- a/internal/planner/dialects/mysql/mysql.go
+++ b/internal/planner/dialects/mysql/mysql.go
@@ -65,7 +65,7 @@ type Planner struct {
 	// MySQL planner serves both MySQL and MariaDB (GetPlanner maps both here);
 	// the capability set is what tells them apart — e.g. MariaDB accepts the
 	// IF EXISTS guard on constraint drops, MySQL does not. The nil zero value
-	// defaults to the current MySQL line preset (capability.MySQL80) via the
+	// defaults to the current MySQL line preset (capability.MySQL84) via the
 	// capabilities accessor, so a bare &Planner{} — the construction shown in
 	// this type's own example — behaves exactly like New(). Pass an explicit
 	// preset (e.g. capability.MySQLLegacy()) to restrict emissions.
@@ -77,9 +77,9 @@ type Planner struct {
 }
 
 // New returns a planner configured with the current MySQL line preset
-// (capability.MySQL80: 8.0.19+ and 9.x).
+// (capability.MySQL84: 8.4+ and 9.x).
 func New() *Planner {
-	return NewWithCapabilities(capability.MySQL80())
+	return NewWithCapabilities(capability.MySQL84())
 }
 
 // NewWithCapabilities returns a planner for a specific capability set — e.g.
@@ -88,7 +88,7 @@ func New() *Planner {
 // The set is expected to be valid (capability.Capabilities.Validate); presets
 // from the capability package always are. The set is cloned, so later
 // mutations by the caller cannot affect the planner. A nil set defaults to
-// the capability.MySQL80 preset.
+// the capability.MySQL84 preset.
 func NewWithCapabilities(caps capability.Capabilities) *Planner {
 	return NewForDialect(DialectName, caps)
 }

--- a/internal/planner/dialects/sqlite/sqlite_test.go
+++ b/internal/planner/dialects/sqlite/sqlite_test.go
@@ -22,7 +22,7 @@ func TestPlannerCreatesTableWithInlineConstraints(t *testing.T) {
 			{Name: "users", StructName: "User", Strict: true},
 		},
 		Fields: []goschema.Field{
-			{Name: "id", Type: "INTEGER", StructName: "accounts", Primary: true},
+			{Name: "id", Type: "INTEGER", StructName: "Account", Primary: true},
 			{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
 			{Name: "account_id", Type: "INTEGER", StructName: "User", Nullable: false},
 			{Name: "email", Type: "TEXT", StructName: "User", Nullable: false},
@@ -238,7 +238,12 @@ func TestPlannerRejectsUnsafeTableRebuildPreconditions(t *testing.T) {
 					{Name: "users", StructName: "User"},
 					{Name: "memberships", StructName: "Membership"},
 				},
-				Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+				Fields: []goschema.Field{
+					{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+					{Name: "tenant_id", Type: "INTEGER", StructName: "User", Primary: true},
+					{Name: "user_id", Type: "INTEGER", StructName: "Membership"},
+					{Name: "tenant_id", Type: "INTEGER", StructName: "Membership"},
+				},
 				Constraints: []goschema.Constraint{{
 					Type:           "FOREIGN KEY",
 					Table:          "memberships",
@@ -342,8 +347,14 @@ func TestPlannerRejectsAddColumnShapesThatNeedRebuild(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 			generated := &goschema.Database{
-				Tables: []goschema.Table{{Name: "users", StructName: "User"}},
-				Fields: []goschema.Field{tt.field},
+				Tables: []goschema.Table{
+					{Name: "users", StructName: "User"},
+					{Name: "accounts", StructName: "Account"},
+				},
+				Fields: []goschema.Field{
+					{Name: "id", Type: "INTEGER", StructName: "Account", Primary: true},
+					tt.field,
+				},
 			}
 			diff := &types.SchemaDiff{TablesModified: []types.TableDiff{{
 				TableName:    "users",

--- a/migration/generator/fk_coltype_down_internal_test.go
+++ b/migration/generator/fk_coltype_down_internal_test.go
@@ -76,6 +76,8 @@ func TestGenerateMigration_ForeignKeyColumnTypeChange_UpDownInverse(t *testing.T
 // and MODIFY.
 func TestGenerateMigration_ForeignKeyColumnTypeChange_CoincidentActionChange(t *testing.T) {
 	gen, dbSchema := fkColumnTypeFixtures("SET NULL")
+	gen.Fields[3].Nullable = true
+	dbSchema.Tables[1].Columns[1].IsNullable = "YES"
 
 	for _, tc := range fkColumnTypeDialects {
 		t.Run(tc.name, func(t *testing.T) {
@@ -94,7 +96,7 @@ func TestGenerateMigration_ForeignKeyColumnTypeChange_CoincidentActionChange(t *
 			// asserted by assertOrderedOnce against the dialect-specific spelling.
 			c.Assert(strings.Count(up, "ADD CONSTRAINT fk_posts_user_slug"), qt.Equals, 1, qt.Commentf("UP:\n%s", up))
 			assertOrderedOnce(c, up, tc.drop,
-				"ALTER TABLE posts MODIFY COLUMN user_slug VARCHAR(100) NOT NULL;",
+				"ALTER TABLE posts MODIFY COLUMN user_slug VARCHAR(100);",
 				"ALTER TABLE posts ADD CONSTRAINT fk_posts_user_slug FOREIGN KEY (user_slug) REFERENCES users(slug) ON DELETE SET NULL;")
 
 			down, err := generateDownMigrationSQL(upDiff, gen, dbSchema, tc.name)
@@ -103,7 +105,7 @@ func TestGenerateMigration_ForeignKeyColumnTypeChange_CoincidentActionChange(t *
 			c.Assert(strings.Count(down, "ADD CONSTRAINT fk_posts_user_slug"), qt.Equals, 1, qt.Commentf("DOWN:\n%s", down))
 			// Down restores the prior CASCADE action, after its own drop and MODIFY.
 			assertOrderedOnce(c, down, tc.drop,
-				"ALTER TABLE posts MODIFY COLUMN user_slug varchar(50) NOT NULL;",
+				"ALTER TABLE posts MODIFY COLUMN user_slug varchar(50);",
 				"ALTER TABLE posts ADD CONSTRAINT fk_posts_user_slug FOREIGN KEY (user_slug) REFERENCES users(slug) ON DELETE CASCADE")
 		})
 	}

--- a/migration/generator/foreign_key_names_internal_test.go
+++ b/migration/generator/foreign_key_names_internal_test.go
@@ -1,0 +1,74 @@
+package generator
+
+// White-box testing required: these tests exercise the unexported SQL-only
+// generation stage without introducing filesystem or live-database setup from
+// the exported migration-file API.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	dbschematypes "github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/migration/schemadiff"
+)
+
+var generatorForeignKeyNamePattern = regexp.MustCompile(`fk_[[:alnum:]_]+_[0-9a-f]{8}`)
+
+func TestGenerateUpMigrationSQL_AssignsLengthLimitedForeignKeyNames(t *testing.T) {
+	c := qt.New(t)
+	tableName := strings.Repeat("children_", 6) + "records"
+	fieldName := strings.Repeat("parent_", 5) + "id"
+	schema := generatorForeignKeyNameSchema(tableName, fieldName)
+	goschema.Finalize(schema)
+	diff := schemadiff.CompareWithDialect(schema, &dbschematypes.DBSchema{}, platform.MySQL)
+
+	sql, err := generateUpMigrationSQL(diff, schema, platform.MySQL)
+
+	c.Assert(err, qt.IsNil)
+	matches := generatorForeignKeyNamePattern.FindAllString(sql, -1)
+	c.Assert(matches, qt.HasLen, 1)
+	c.Assert(utf8.RuneCountInString(matches[0]), qt.Equals, 64)
+	c.Assert(schema.Fields[2].ForeignKeyName, qt.Equals, "")
+}
+
+func TestGenerateUpMigrationSQL_AvoidsExplicitAndGeneratedForeignKeyNameCollision(t *testing.T) {
+	c := qt.New(t)
+	schema := generatorForeignKeyNameSchema("children", "parent_id")
+	schema.Fields = append(schema.Fields, goschema.Field{
+		StructName:     "Child",
+		Name:           "backup_parent_id",
+		Type:           "INTEGER",
+		Foreign:        "parents(id)",
+		ForeignKeyName: "FK_CHILDREN_PARENT_ID",
+	})
+	goschema.Finalize(schema)
+	diff := schemadiff.CompareWithDialect(schema, &dbschematypes.DBSchema{}, platform.MySQL)
+
+	sql, err := generateUpMigrationSQL(diff, schema, platform.MySQL)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "FK_CHILDREN_PARENT_ID")
+	c.Assert(sql, qt.Matches, `(?s).*fk_children_parent_id_[0-9a-f]{8}.*`)
+	c.Assert(strings.Count(strings.ToLower(sql), "add constraint"), qt.Equals, 2)
+	c.Assert(schema.Fields[2].ForeignKeyName, qt.Equals, "")
+}
+
+func generatorForeignKeyNameSchema(tableName, fieldName string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: tableName},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: fieldName, Type: "INTEGER", Foreign: "parents(id)"},
+		},
+	}
+}

--- a/migration/generator/multihost_fk_down_test.go
+++ b/migration/generator/multihost_fk_down_test.go
@@ -7,6 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/ptaherr"
 	dbschematypes "github.com/stokaro/ptah/dbschema/types"
 	"github.com/stokaro/ptah/migration/schemadiff"
 	"github.com/stokaro/ptah/migration/schemadiff/types"
@@ -30,11 +31,13 @@ import (
 // embedded into each host table.
 func multiHostMixinGenerated(onDelete string, hosts ...string) *goschema.Database {
 	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Tenant", Name: "tenants"}},
 		Fields: []goschema.Field{
+			{StructName: "Tenant", Name: "id", Type: "VARCHAR(255)", Primary: true},
 			{
 				StructName:     "Ownable",
 				Name:           "tenant_id",
-				Type:           "TEXT",
+				Type:           "VARCHAR(255)",
 				Foreign:        "tenants(id)",
 				ForeignKeyName: "fk_entity_tenant",
 				OnDelete:       onDelete,
@@ -57,13 +60,19 @@ func multiHostMixinGenerated(onDelete string, hosts ...string) *goschema.Databas
 // multiHostMixinDB builds the introspected (pre-change) DB: each host has the
 // tenant FK with the given delete rule.
 func multiHostMixinDB(deleteRule string, hosts ...string) *dbschematypes.DBSchema {
-	db := &dbschematypes.DBSchema{}
+	varcharLength := 255
+	db := &dbschematypes.DBSchema{Tables: []dbschematypes.DBTable{{
+		Name: "tenants",
+		Columns: []dbschematypes.DBColumn{
+			{Name: "id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "NO", IsPrimaryKey: true},
+		},
+	}}}
 	for _, h := range hosts {
 		db.Tables = append(db.Tables, dbschematypes.DBTable{
 			Name: h,
 			Columns: []dbschematypes.DBColumn{
-				{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
-				{Name: "tenant_id", DataType: "text", IsNullable: "NO"},
+				{Name: "id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "tenant_id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "NO"},
 			},
 		})
 		db.Constraints = append(db.Constraints, dbschematypes.DBConstraint{
@@ -81,54 +90,53 @@ func multiHostMixinDB(deleteRule string, hosts ...string) *dbschematypes.DBSchem
 // generated DOWN must, for EACH host, drop the (CASCADE) constraint and re-add
 // it with the prior NO ACTION — table-qualified so no host collides.
 func TestGenerateDownMigration_MultiHostMixinFKModify_RestoresPriorActionPerHost(t *testing.T) {
+	c := qt.New(t)
 	hosts := []string{"locations", "areas", "commodities"}
+	gen := multiHostMixinGenerated("CASCADE", hosts...)
+	dbSchema := multiHostMixinDB("NO ACTION", hosts...)
 
-	for _, dialect := range []string{"postgres", "mysql"} {
-		t.Run(dialect, func(t *testing.T) {
-			c := qt.New(t)
+	upDiff := schemadiff.CompareWithDialect(gen, dbSchema, "postgres")
+	c.Assert(upDiff.HasChanges(), qt.IsTrue)
+	c.Assert(countConstraint(upDiff.ConstraintsAdded, "fk_entity_tenant"), qt.Equals, len(hosts))
+	c.Assert(countConstraint(upDiff.ConstraintsRemoved, "fk_entity_tenant"), qt.Equals, len(hosts))
 
-			// Generated = CASCADE; DB (pre-change) = converged NO ACTION.
-			gen := multiHostMixinGenerated("CASCADE", hosts...)
-			dbSchema := multiHostMixinDB("NO ACTION", hosts...)
+	downSQL, err := generateDownMigrationSQL(upDiff, gen, dbSchema, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
 
-			upDiff := schemadiff.CompareWithDialect(gen, dbSchema, dialect)
-			c.Assert(upDiff.HasChanges(), qt.IsTrue)
-			// The shared FK name is added + removed once per host (a modification).
-			c.Assert(countConstraint(upDiff.ConstraintsAdded, "fk_entity_tenant"), qt.Equals, len(hosts))
-			c.Assert(countConstraint(upDiff.ConstraintsRemoved, "fk_entity_tenant"), qt.Equals, len(hosts))
+	for _, host := range hosts {
+		dropStatement := "ALTER TABLE " + host + " DROP CONSTRAINT IF EXISTS fk_entity_tenant;"
+		addStatement := "ALTER TABLE " + host + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)"
 
-			downSQL, err := generateDownMigrationSQL(upDiff, gen, dbSchema, dialect)
-			c.Assert(err, qt.IsNil)
-			downSQL = legacyRenderedSQL(downSQL)
+		c.Assert(strings.Count(downSQL, dropStatement), qt.Equals, 1,
+			qt.Commentf("host %s: expected exactly one table-qualified DROP in DOWN, got:\n%s", host, downSQL))
+		c.Assert(strings.Count(downSQL, addStatement), qt.Equals, 1,
+			qt.Commentf("host %s: expected exactly one re-ADD in DOWN, got:\n%s", host, downSQL))
 
-			for _, h := range hosts {
-				var dropStmt string
-				if dialect == "mysql" {
-					dropStmt = "ALTER TABLE " + h + " DROP FOREIGN KEY fk_entity_tenant;"
-				} else {
-					dropStmt = "ALTER TABLE " + h + " DROP CONSTRAINT IF EXISTS fk_entity_tenant;"
-				}
-				addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)"
-
-				c.Assert(strings.Count(downSQL, dropStmt), qt.Equals, 1,
-					qt.Commentf("host %s: expected exactly one table-qualified DROP in DOWN, got:\n%s", h, downSQL))
-				c.Assert(strings.Count(downSQL, addStmt), qt.Equals, 1,
-					qt.Commentf("host %s: expected exactly one re-ADD in DOWN, got:\n%s", h, downSQL))
-
-				dropIdx := strings.Index(downSQL, dropStmt)
-				addIdx := strings.Index(downSQL, addStmt)
-				c.Assert(dropIdx >= 0 && addIdx >= 0 && dropIdx < addIdx, qt.IsTrue,
-					qt.Commentf("host %s: DOWN DROP must precede the re-ADD; drop@%d add@%d\n%s", h, dropIdx, addIdx, downSQL))
-			}
-
-			// The DOWN restores the PRIOR action (NO ACTION), never the new CASCADE.
-			c.Assert(downSQL, qt.Not(qt.Contains), "ON DELETE CASCADE",
-				qt.Commentf("DOWN must restore the prior action, not re-apply CASCADE:\n%s", downSQL))
-			// Never the mixin struct name.
-			c.Assert(downSQL, qt.Not(qt.Contains), "Ownable",
-				qt.Commentf("DOWN must not reference the mixin struct name:\n%s", downSQL))
-		})
+		dropIndex := strings.Index(downSQL, dropStatement)
+		addIndex := strings.Index(downSQL, addStatement)
+		c.Assert(dropIndex >= 0 && addIndex >= 0 && dropIndex < addIndex, qt.IsTrue,
+			qt.Commentf("host %s: DOWN DROP must precede the re-ADD; drop@%d add@%d\n%s", host, dropIndex, addIndex, downSQL))
 	}
+
+	c.Assert(downSQL, qt.Not(qt.Contains), "ON DELETE CASCADE",
+		qt.Commentf("DOWN must restore the prior action, not re-apply CASCADE:\n%s", downSQL))
+	c.Assert(downSQL, qt.Not(qt.Contains), "Ownable",
+		qt.Commentf("DOWN must not reference the mixin struct name:\n%s", downSQL))
+}
+
+func TestGenerateDownMigration_MultiHostMixinFKModify_MySQLRejectsDuplicateNames(t *testing.T) {
+	c := qt.New(t)
+	hosts := []string{"locations", "areas", "commodities"}
+	generated := multiHostMixinGenerated("CASCADE", hosts...)
+	dbSchema := multiHostMixinDB("NO ACTION", hosts...)
+	diff := schemadiff.CompareWithDialect(generated, dbSchema, "mysql")
+
+	downSQL, err := generateDownMigrationSQL(diff, generated, dbSchema, "mysql")
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `error generating down migration SQL: invalid foreign key: foreign-key name "fk_entity_tenant" is duplicated in database constraint namespace`)
+	c.Assert(downSQL, qt.Equals, "")
 }
 
 // TestGenerateDownMigration_MultiHostMixinFKModify_NameOnlyCounterfactual proves

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -977,16 +977,21 @@ func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *test
 	noAction := "NO ACTION"
 	filesTable := "files"
 	idCol := "id"
+	varcharLength := 255
 
 	// Generated (target) schema: file_id FK now uses ON DELETE SET NULL.
 	generatedSchema := &goschema.Database{
-		Tables: []goschema.Table{{StructName: "Export", Name: "exports"}},
+		Tables: []goschema.Table{
+			{StructName: "Export", Name: "exports"},
+			{StructName: "File", Name: "files"},
+		},
 		Fields: []goschema.Field{
-			{StructName: "Export", Name: "id", Type: "TEXT", Primary: true},
+			{StructName: "File", Name: "id", Type: "VARCHAR(255)", Primary: true},
+			{StructName: "Export", Name: "id", Type: "VARCHAR(255)", Primary: true},
 			{
 				StructName:     "Export",
 				Name:           "file_id",
-				Type:           "TEXT",
+				Type:           "VARCHAR(255)",
 				Nullable:       true,
 				Foreign:        "files(id)",
 				ForeignKeyName: "fk_export_file",
@@ -1000,10 +1005,16 @@ func TestGenerateDownMigrationSQL_Issue189_RestoresPriorForeignKeyAction(t *test
 	dbSchema := &dbschematypes.DBSchema{
 		Tables: []dbschematypes.DBTable{
 			{
+				Name: "files",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "NO", IsPrimaryKey: true},
+				},
+			},
+			{
 				Name: "exports",
 				Columns: []dbschematypes.DBColumn{
-					{Name: "id", DataType: "text", IsNullable: "NO", IsPrimaryKey: true},
-					{Name: "file_id", DataType: "text", IsNullable: "YES"},
+					{Name: "id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "NO", IsPrimaryKey: true},
+					{Name: "file_id", DataType: "varchar", CharacterMaxLength: &varcharLength, IsNullable: "YES"},
 				},
 			},
 		},

--- a/migration/planner/foreign_key_name_test.go
+++ b/migration/planner/foreign_key_name_test.go
@@ -1,0 +1,70 @@
+package planner_test
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+	"unicode/utf8"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+var generatedForeignKeyNamePattern = regexp.MustCompile(`fk_[[:alnum:]_]+_[0-9a-f]{8}`)
+
+func TestGenerateSchemaDiffSQL_AssignsLengthLimitedForeignKeyNames(t *testing.T) {
+	c := qt.New(t)
+	tableName := strings.Repeat("children_", 6) + "records"
+	fieldName := strings.Repeat("parent_", 5) + "id"
+	schema := plannerForeignKeyNameSchema(tableName, fieldName)
+	goschema.Finalize(schema)
+	diff := &types.SchemaDiff{TablesAdded: []string{"parents", tableName}}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, schema, platform.MySQL)
+
+	c.Assert(err, qt.IsNil)
+	matches := generatedForeignKeyNamePattern.FindAllString(sql, -1)
+	c.Assert(matches, qt.HasLen, 1)
+	c.Assert(utf8.RuneCountInString(matches[0]), qt.Equals, 64)
+	c.Assert(schema.Fields[2].ForeignKeyName, qt.Equals, "")
+}
+
+func TestGenerateSchemaDiffSQL_AvoidsExplicitAndGeneratedForeignKeyNameCollision(t *testing.T) {
+	c := qt.New(t)
+	schema := plannerForeignKeyNameSchema("children", "parent_id")
+	schema.Fields = append(schema.Fields, goschema.Field{
+		StructName:     "Child",
+		Name:           "backup_parent_id",
+		Type:           "INTEGER",
+		Foreign:        "parents(id)",
+		ForeignKeyName: "FK_CHILDREN_PARENT_ID",
+	})
+	goschema.Finalize(schema)
+	diff := &types.SchemaDiff{TablesAdded: []string{"parents", "children"}}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, schema, platform.MySQL)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "FK_CHILDREN_PARENT_ID")
+	c.Assert(sql, qt.Matches, `(?s).*fk_children_parent_id_[0-9a-f]{8}.*`)
+	c.Assert(strings.Count(strings.ToLower(sql), "add constraint"), qt.Equals, 2)
+	c.Assert(schema.Fields[2].ForeignKeyName, qt.Equals, "")
+}
+
+func plannerForeignKeyNameSchema(tableName, fieldName string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: tableName},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: fieldName, Type: "INTEGER", Foreign: "parents(id)"},
+		},
+	}
+}

--- a/migration/planner/foreign_key_validation_test.go
+++ b/migration/planner/foreign_key_validation_test.go
@@ -1,0 +1,129 @@
+package planner_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"github.com/stokaro/ptah/core/goschema"
+	"github.com/stokaro/ptah/core/platform"
+	"github.com/stokaro/ptah/core/platform/identifier"
+	"github.com/stokaro/ptah/core/ptaherr"
+	"github.com/stokaro/ptah/migration/planner"
+	"github.com/stokaro/ptah/migration/schemadiff/types"
+)
+
+func TestGenerateSchemaDiffAST_ValidatesTargetForeignKeys_FailurePath(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		diff    *types.SchemaDiff
+		schema  *goschema.Database
+		wantIs  error
+		wantErr string
+	}{
+		{
+			name:    "mysql nonunique referenced key",
+			dialect: platform.MySQL,
+			diff:    &types.SchemaDiff{},
+			schema:  plannerIndexedForeignKeyDatabase(),
+			wantIs:  ptaherr.ErrUnsupportedFeature,
+			wantErr: `mysql requires referenced columns tenant_id, code on table "parents" to be declared unique`,
+		},
+		{
+			name:    "sql server cascade cycle",
+			dialect: platform.SQLServer,
+			diff:    plannerSQLServerDiff(),
+			schema:  plannerCascadeCycleDatabase(),
+			wantIs:  ptaherr.ErrUnsupportedFeature,
+			wantErr: `sqlserver does not allow ON DELETE cycles or multiple cascade paths reaching table .*`,
+		},
+		{
+			name:    "postgres incompatible types",
+			dialect: platform.Postgres,
+			diff:    &types.SchemaDiff{},
+			schema:  plannerTypeMismatchDatabase(),
+			wantIs:  ptaherr.ErrInvalidSchemaDiff,
+			wantErr: `foreign-key columns "children"\."parent_id" \(BIGINT\) and "parents"\."id" \(INTEGER\) have incompatible types`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			nodes, err := planner.GenerateSchemaDiffAST(test.diff, test.schema, test.dialect)
+			c.Assert(err, qt.ErrorIs, test.wantIs, qt.Commentf("error: %v", err))
+			c.Assert(err, qt.ErrorMatches, `.*`+test.wantErr)
+			c.Assert(nodes, qt.IsNil)
+		})
+	}
+}
+
+func plannerSQLServerDiff() *types.SchemaDiff {
+	semantics := identifier.ForSQLServerCatalog("SQL_Latin1_General_CP1_CI_AS").
+		WithResolvedNames([]identifier.ResolvedName{
+			{Name: "dbo", Key: "dbo"},
+			{Name: "left_nodes", Key: "left_nodes"},
+			{Name: "right_nodes", Key: "right_nodes"},
+			{Name: "id", Key: "id"},
+			{Name: "left_id", Key: "left_id"},
+			{Name: "right_id", Key: "right_id"},
+		})
+	return &types.SchemaDiff{IdentifierSemantics: &semantics}
+}
+
+func plannerIndexedForeignKeyDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "tenant_id", Type: "INTEGER"},
+			{StructName: "Parent", Name: "code", Type: "INTEGER"},
+			{StructName: "Child", Name: "tenant_id", Type: "INTEGER"},
+			{StructName: "Child", Name: "parent_code", Type: "INTEGER"},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "Parent",
+			Name:       "idx_parents_tenant_code",
+			Fields:     []string{"tenant_id", "code"},
+		}},
+		Constraints: []goschema.Constraint{{
+			StructName:     "Child",
+			Name:           "fk_children_parents",
+			Type:           "FOREIGN KEY",
+			Columns:        []string{"tenant_id", "parent_code"},
+			ForeignTable:   "parents",
+			ForeignColumns: []string{"tenant_id", "code"},
+		}},
+	}
+}
+
+func plannerCascadeCycleDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Left", Name: "left_nodes"},
+			{StructName: "Right", Name: "right_nodes"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Left", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Left", Name: "right_id", Type: "INTEGER", Foreign: "right_nodes(id)", OnDelete: "CASCADE"},
+			{StructName: "Right", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Right", Name: "left_id", Type: "INTEGER", Foreign: "left_nodes(id)", OnDelete: "CASCADE"},
+		},
+	}
+}
+
+func plannerTypeMismatchDatabase() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Parent", Name: "parents"},
+			{StructName: "Child", Name: "children"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Parent", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "Child", Name: "parent_id", Type: "BIGINT", Foreign: "parents(id)"},
+		},
+	}
+}

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -81,6 +81,7 @@ import (
 	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/core/sqlutil"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
 	"github.com/stokaro/ptah/internal/planner/dialects/clickhouse"
 	"github.com/stokaro/ptah/internal/planner/dialects/mssql"
 	"github.com/stokaro/ptah/internal/planner/dialects/mysql"
@@ -222,7 +223,7 @@ func RegisteredDialects() []string {
 //     SERIAL columns, and PostgreSQL-specific constraints
 //   - "mysql": Returns a MySQL-specific planner with support for AUTO_INCREMENT,
 //     ENGINE specifications, and MySQL-specific features, configured with the
-//     capability.MySQL80 preset (no IF EXISTS guards — exactly-once drops)
+//     capability.MySQL84 preset (no IF EXISTS guards — exactly-once drops)
 //   - "mariadb": Returns the same MySQL planner configured with the
 //     capability.MariaDB1011 preset, which additionally requests IF EXISTS
 //     guards on constraint drops (issue #226)
@@ -466,7 +467,9 @@ func GenerateSchemaDiffASTWithOptions(
 	dialect string,
 	opts Options,
 ) ([]ast.Node, error) {
+	caps := opts.CapabilitiesFor(dialect)
 	semantics := diff.EffectiveIdentifierSemantics(dialect)
+	preparedGenerated := fromschema.AssignDefaultForeignKeyNames(generated, dialect)
 	if diff != nil &&
 		diff.IdentifierSemantics != nil &&
 		!diff.IdentifierSemantics.IsZero() &&
@@ -480,17 +483,22 @@ func GenerateSchemaDiffASTWithOptions(
 		)
 	}
 	if err := identifiervalidation.ValidateTarget(
-		generated,
+		preparedGenerated,
 		dialect,
 		semantics,
 	); err != nil {
 		return nil, wrapPlanError(dialect, err)
 	}
+	if preparedGenerated != nil {
+		if err := renderer.ValidateSchemaWithCapabilities(preparedGenerated, dialect, caps); err != nil {
+			return nil, wrapPlanError(dialect, err)
+		}
+	}
 	planner, err := GetPlannerWithOptions(dialect, opts)
 	if err != nil {
 		return nil, wrapPlanError(dialect, err)
 	}
-	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	nodes, err := planner.GenerateMigrationASTChecked(diff, preparedGenerated)
 	if err != nil {
 		return nil, wrapPlanError(dialect, err)
 	}

--- a/migration/schemadiff/embedded_fk_drift_test.go
+++ b/migration/schemadiff/embedded_fk_drift_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/stokaro/ptah/core/goschema"
 	"github.com/stokaro/ptah/core/renderer"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
 	"github.com/stokaro/ptah/internal/planner/dialects/mysql"
 	"github.com/stokaro/ptah/internal/planner/dialects/postgres"
 	"github.com/stokaro/ptah/migration/schemadiff"
@@ -250,7 +251,8 @@ func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
 		c := qt.New(t)
 
 		gen := ownableMixinSchemaWithTenantOnDelete("CASCADE", hosts...)
-		diff := schemadiff.CompareWithDialect(gen, ownableMixinConvergedDB(hosts...), "mysql")
+		converged := ownableMixinConvergedDBForDialect(gen, "mysql", hosts...)
+		diff := schemadiff.CompareWithDialect(gen, converged, "mysql")
 		c.Assert(diff.HasChanges(), qt.IsTrue)
 
 		nodes, err := mysql.New().GenerateMigrationASTChecked(diff, gen)
@@ -260,8 +262,9 @@ func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
 		sql = legacyRenderedSQL(sql)
 
 		for _, h := range hosts {
-			dropStmt := "ALTER TABLE " + h + " DROP FOREIGN KEY fk_entity_tenant;"
-			addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT fk_entity_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;"
+			constraintName := assignedForeignKeyName(gen, "mysql", h, "tenant_id")
+			dropStmt := "ALTER TABLE " + h + " DROP FOREIGN KEY " + constraintName + ";"
+			addStmt := "ALTER TABLE " + h + " ADD CONSTRAINT " + constraintName + " FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE;"
 
 			c.Assert(strings.Count(sql, dropStmt), qt.Equals, 1,
 				qt.Commentf("host %s: expected one DROP FOREIGN KEY, got:\n%s", h, sql))
@@ -274,6 +277,35 @@ func TestEmbeddedInlineMixinFK_MultiHostActionDrift(t *testing.T) {
 				qt.Commentf("host %s: DROP must precede ADD; drop@%d add@%d\n%s", h, dropIdx, addIdx, sql))
 		}
 	})
+}
+
+func ownableMixinConvergedDBForDialect(
+	generated *goschema.Database,
+	dialect string,
+	hostTables ...string,
+) *types.DBSchema {
+	database := ownableMixinConvergedDB(hostTables...)
+	for i := range database.Constraints {
+		constraint := &database.Constraints[i]
+		constraint.Name = assignedForeignKeyName(generated, dialect, constraint.TableName, constraint.ColumnName)
+	}
+	return database
+}
+
+func assignedForeignKeyName(generated *goschema.Database, dialect, tableName, columnName string) string {
+	assigned := fromschema.AssignDefaultForeignKeyNames(generated, dialect)
+	structName := ""
+	for _, table := range assigned.Tables {
+		if table.Name == tableName {
+			structName = table.StructName
+		}
+	}
+	for _, field := range assigned.Fields {
+		if field.StructName == structName && field.Name == columnName {
+			return field.ForeignKeyName
+		}
+	}
+	return ""
 }
 
 // TestEmbeddedInlineMixinFK_MixedModifyAndAdd_NoPhantomDrop covers the MIXED

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stokaro/ptah/core/platform/identifier"
 	"github.com/stokaro/ptah/core/ptaherr"
 	"github.com/stokaro/ptah/dbschema/types"
+	"github.com/stokaro/ptah/internal/convert/fromschema"
 	"github.com/stokaro/ptah/migration/internal/identifiervalidation"
 	"github.com/stokaro/ptah/migration/schemadiff/internal/compare"
 	difftypes "github.com/stokaro/ptah/migration/schemadiff/types"
@@ -51,6 +52,7 @@ func CompareWithDatabaseInfo(
 		merged.IgnoredExtensions = slices.Clone(opts.IgnoredExtensions)
 	}
 	merged.Dialect = info.Dialect
+	generated = fromschema.AssignDefaultForeignKeyNames(generated, info.Dialect)
 	semantics := info.IdentifierSemantics.Normalize(info.Dialect)
 	if !info.IdentifierSemantics.IsZero() &&
 		!info.IdentifierSemantics.Equal(semantics) {
@@ -102,6 +104,9 @@ func CompareWithDatabaseInfo(
 func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, opts *config.CompareOptions) *difftypes.SchemaDiff {
 	if opts == nil {
 		opts = config.DefaultCompareOptions()
+	}
+	if opts.Dialect != "" {
+		generated = fromschema.AssignDefaultForeignKeyNames(generated, opts.Dialect)
 	}
 
 	diff := &difftypes.SchemaDiff{}


### PR DESCRIPTION
## Summary

- harden circular foreign-key handling across Go schema generation, database reads, schema diffing, migration planning, and direct rendering
- order tables deterministically by strongly connected components and render non-SQLite foreign keys in a second phase
- validate foreign-key capabilities, referenced keys, column compatibility, actions, storage engines, and SQL Server cascade topology before emitting SQL
- allocate deterministic collision-free foreign-key names within each dialect's real identifier namespace and length limit
- keep renderer output atomic so unsupported schemas never leave partial SQL on stdout
- make PostgreSQL role restoration fail closed instead of granting privileges to an unexpected preexisting role

## Root cause

The migration planners already had a two-phase path. The broken surfaces were the direct `ptah generate` and `ptah read-db` paths through `FromDatabase`, plus incomplete validation around the renderer. The previous dynamic circular-dependency scenario also used handwritten SQL and therefore did not exercise the production renderer.

This change moves dependency handling and validation into the shared schema/rendering path and replaces the scenario with generated SQL that is applied to real databases.

## Behavior

- PostgreSQL-family, MySQL/MariaDB, and SQL Server schemas with mutual foreign keys emit tables first and constraints second.
- SQLite retains inline foreign keys because table alteration cannot add them later.
- MySQL/MariaDB require InnoDB for rendered foreign keys and honor their referenced-index behavior.
- Explicit and generated constraint names share the correct dialect scope and character limit.
- Direct AST callers receive the same safety checks as Go-schema callers, including `NOT NULL` with `ON DELETE SET NULL`.
- Without `--dialect`, CLI generation emits SQL only when every built-in review target accepts the schema.

## Verification

- `go test -count=1 ./...`
- targeted race tests for schema, renderer, capability, conversion, diff, planner, and generator packages
- live circular-FK integration coverage for PostgreSQL, CockroachDB, YugabyteDB, MySQL, MariaDB, and SQL Server
- live PostgreSQL role/grant round-trip and duplicate-role failure tests
- `golangci-lint run --fix ./...` followed by `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `go vet ./...`
- `go mod tidy -diff`
- public API, API snapshot, and released API guards
- documentation style, links, redirects, page health, core links, exit-code checks, production build, and responsive route checks
- `npm audit`: 0 vulnerabilities

Closes #137
