### PR TITLE
fix(cli): reject malformed flag environment values

### DIFF
--- a/cmd/internal/cmdadapter/cmdadapter.go
+++ b/cmd/internal/cmdadapter/cmdadapter.go
@@ -146,7 +146,7 @@ func newForwardCommandWithArgsMapper(
 			setCommandContext(target, forwardContext)
 			defer restoreCommandContexts(target, targetContexts)
 			resetCommandFlags(target)
-			initializeForwardedTarget(target)
+			installForwardedTargetEnv(target)
 			defer resetCommandFlags(target)
 			parent := target.Parent()
 			if parent != nil {
@@ -201,8 +201,8 @@ func walkCommands(root *cobra.Command, visit func(*cobra.Command)) {
 	}
 }
 
-func initializeForwardedTarget(target *cobra.Command) {
-	cmdflags.InitializeEnv(envPrefix, target)
+func installForwardedTargetEnv(target *cobra.Command) {
+	cmdflags.InstallEnvBinding(envPrefix, target)
 	normalizeEnvUsage(target)
 }
 

--- a/cmd/internal/cmdadapter/cmdadapter_test.go
+++ b/cmd/internal/cmdadapter/cmdadapter_test.go
@@ -554,6 +554,55 @@ func TestForwardCommandStringSliceCLIOverridesEnvironment(t *testing.T) {
 	c.Assert(runs, qt.DeepEquals, [][]string{{"qa", "dev"}})
 }
 
+func TestForwardCommandMalformedEnvironmentFailsBeforeTargetRun(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	var runs int
+	target := &cobra.Command{
+		Use: "target",
+		Run: func(_ *cobra.Command, _ []string) {
+			runs++
+		},
+	}
+	target.Flags().Bool("dry-run", false, "Preview changes")
+	cmd := cmdadapter.NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	c.Assert(runs, qt.Equals, 0)
+}
+
+func TestForwardCommandExplicitCLIWinsOverMalformedEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	var dryRun bool
+	var seenDryRun bool
+	var runs int
+	target := &cobra.Command{
+		Use: "target",
+		Run: func(_ *cobra.Command, _ []string) {
+			seenDryRun = dryRun
+			runs++
+		},
+	}
+	target.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes")
+	cmd := cmdadapter.NewForwardCommandWithTargetHelp("atlas", "Atlas adapter command", "target", func() *cobra.Command {
+		return target
+	})
+	cmd.SetArgs([]string{"--dry-run"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(seenDryRun, qt.IsTrue)
+	c.Assert(runs, qt.Equals, 1)
+}
+
 func newTestTargetCommand(onRun func(string)) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "target",

--- a/cmd/internal/cmdflags/env.go
+++ b/cmd/internal/cmdflags/env.go
@@ -4,18 +4,16 @@ package cmdflags
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
-	"sync"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-const disableEnvAnnotation = "ptah.env.disabled"
-
-var (
-	envOnceMu sync.Mutex
-	envOnce   = make(map[*cobra.Command]*sync.Once)
+const (
+	disableEnvAnnotation   = "ptah.env.disabled"
+	installedEnvAnnotation = "ptah.env.installed"
 )
 
 // DisableEnvBinding makes a flag explicit-only even when the command tree has
@@ -36,49 +34,59 @@ func DisableEnvBinding(flags *pflag.FlagSet, name string) error {
 // tree. Environment variables follow PTAH_<FLAG_NAME>, with '-' and '.'
 // normalized to '_'. Explicit CLI flags still win over environment values.
 func InstallEnvBinding(prefix string, root *cobra.Command) {
-	once := envOnceFor(root)
-	initEnv := func() {
-		once.Do(func() {
-			InitializeEnv(prefix, root)
-		})
-	}
-
-	helpFunc := root.HelpFunc()
-	root.SetHelpFunc(func(cmd *cobra.Command, args []string) {
-		initEnv()
-		helpFunc(cmd, args)
-	})
-	cobra.OnInitialize(initEnv)
-}
-
-// InitializeEnv applies environment defaults and help usage annotations to an
-// already-built command tree. It is also used by forwarding adapters that
-// execute a target command outside the root command's normal initialization.
-func InitializeEnv(prefix string, root *cobra.Command) {
 	visited := make(map[*pflag.Flag]bool)
-	initializeEnvRecursive(prefix, visited, root)
+	annotateEnvRecursive(prefix, visited, root)
+	installEnvValidationRecursive(prefix, root)
 }
 
-func envOnceFor(root *cobra.Command) *sync.Once {
-	envOnceMu.Lock()
-	defer envOnceMu.Unlock()
-	once := envOnce[root]
-	if once == nil {
-		once = &sync.Once{}
-		envOnce[root] = once
+// InitializeEnv applies environment defaults to one selected command after its
+// CLI flags have been parsed. It returns an error before command hooks or work
+// run when a non-empty value is invalid for the corresponding flag.
+func InitializeEnv(prefix string, cmd *cobra.Command) error {
+	cmd.InheritedFlags()
+	annotateEnv(prefix, make(map[*pflag.Flag]bool), cmd.Flags())
+	return applyEnv(prefix, make(map[*pflag.Flag]bool), cmd.Flags())
+}
+
+func installEnvValidationRecursive(prefix string, cmd *cobra.Command) {
+	if !envBindingInstalled(cmd, prefix) {
+		if cmd.Args != nil || !cmd.HasSubCommands() {
+			argsValidator := cmd.Args
+			cmd.Args = func(cmd *cobra.Command, args []string) error {
+				if !cmd.DisableFlagParsing {
+					if err := InitializeEnv(prefix, cmd); err != nil {
+						return err
+					}
+				}
+				if argsValidator == nil {
+					return nil
+				}
+				return argsValidator(cmd, args)
+			}
+		}
+		if cmd.Annotations == nil {
+			cmd.Annotations = make(map[string]string)
+		}
+		cmd.Annotations[installedEnvAnnotation] = prefix
 	}
-	return once
-}
-
-func initializeEnvRecursive(prefix string, visited map[*pflag.Flag]bool, cmd *cobra.Command) {
-	applyEnv(prefix, visited, cmd.Flags())
-	applyEnv(prefix, visited, cmd.PersistentFlags())
 	for _, child := range cmd.Commands() {
-		initializeEnvRecursive(prefix, visited, child)
+		installEnvValidationRecursive(prefix, child)
 	}
 }
 
-func applyEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet) {
+func envBindingInstalled(cmd *cobra.Command, prefix string) bool {
+	return cmd.Annotations[installedEnvAnnotation] == prefix
+}
+
+func annotateEnvRecursive(prefix string, visited map[*pflag.Flag]bool, cmd *cobra.Command) {
+	annotateEnv(prefix, visited, cmd.Flags())
+	annotateEnv(prefix, visited, cmd.PersistentFlags())
+	for _, child := range cmd.Commands() {
+		annotateEnvRecursive(prefix, visited, child)
+	}
+}
+
+func annotateEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet) {
 	flags.VisitAll(func(flag *pflag.Flag) {
 		if visited[flag] {
 			return
@@ -95,15 +103,47 @@ func applyEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet)
 		if !usageContainsEnv(flag.Usage) {
 			flag.Usage = fmt.Sprintf("%s [env: %s]", flag.Usage, envName)
 		}
+	})
+}
+
+func applyEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet) error {
+	var applyErr error
+	flags.VisitAll(func(flag *pflag.Flag) {
+		if applyErr != nil || visited[flag] {
+			return
+		}
+		visited[flag] = true
+		if flag.Name == "help" || envBindingDisabled(flag) {
+			return
+		}
 		if flag.Changed {
 			return
 		}
+		envName := EnvName(prefix, flag.Name)
 		value, ok := os.LookupEnv(envName)
 		if !ok || value == "" {
 			return
 		}
-		_ = flags.Set(flag.Name, value)
+		applyErr = setEnvValue(flags, flag, envName, value)
 	})
+	return applyErr
+}
+
+func setEnvValue(flags *pflag.FlagSet, flag *pflag.Flag, envName, value string) error {
+	switch flag.Value.Type() {
+	case "bool":
+		if _, err := strconv.ParseBool(value); err != nil {
+			return fmt.Errorf("invalid boolean value %q for %s", value, envName)
+		}
+	case "uint", "uint64":
+		if _, err := strconv.ParseUint(value, 0, 64); err != nil {
+			return fmt.Errorf("invalid unsigned integer value %q for %s", value, envName)
+		}
+	}
+	if err := flags.Set(flag.Name, value); err != nil {
+		return fmt.Errorf("invalid value %q for %s: %w", value, envName, err)
+	}
+	return nil
 }
 
 func envBindingDisabled(flag *pflag.Flag) bool {

--- a/cmd/internal/cmdflags/env_test.go
+++ b/cmd/internal/cmdflags/env_test.go
@@ -1,6 +1,7 @@
 package cmdflags_test
 
 import (
+	"bytes"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -29,8 +30,9 @@ func TestInitializeEnvAppliesEnvironmentDefaults(t *testing.T) {
 	child.Flags().BoolVar(&verbose, "verbose", false, "Verbose output")
 	root.AddCommand(child)
 
-	cmdflags.InitializeEnv("PTAH", root)
+	err := cmdflags.InitializeEnv("PTAH", child)
 
+	c.Assert(err, qt.IsNil)
 	c.Assert(dbURL, qt.Equals, "postgres://example")
 	c.Assert(verbose, qt.IsTrue)
 	c.Assert(child.Flags().Lookup("db-url").Changed, qt.IsTrue)
@@ -48,8 +50,9 @@ func TestInitializeEnvDoesNotOverrideExplicitFlag(t *testing.T) {
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL")
 	c.Assert(cmd.Flags().Set("db-url", "postgres://cli"), qt.IsNil)
 
-	cmdflags.InitializeEnv("PTAH", cmd)
+	err := cmdflags.InitializeEnv("PTAH", cmd)
 
+	c.Assert(err, qt.IsNil)
 	c.Assert(dbURL, qt.Equals, "postgres://cli")
 }
 
@@ -61,8 +64,9 @@ func TestInitializeEnvIgnoresEmptyEnvironmentValues(t *testing.T) {
 	cmd := &cobra.Command{Use: "ptah"}
 	cmd.Flags().StringVar(&dbURL, "db-url", "postgres://default", "Database URL")
 
-	cmdflags.InitializeEnv("PTAH", cmd)
+	err := cmdflags.InitializeEnv("PTAH", cmd)
 
+	c.Assert(err, qt.IsNil)
 	c.Assert(dbURL, qt.Equals, "postgres://default")
 }
 
@@ -75,8 +79,9 @@ func TestInitializeEnvSkipsDisabledEnvironmentBinding(t *testing.T) {
 	cmd.Flags().BoolVar(&autoApprove, "auto-approve", false, "Skip confirmation")
 	c.Assert(cmdflags.DisableEnvBinding(cmd.Flags(), "auto-approve"), qt.IsNil)
 
-	cmdflags.InitializeEnv("PTAH", cmd)
+	err := cmdflags.InitializeEnv("PTAH", cmd)
 
+	c.Assert(err, qt.IsNil)
 	c.Assert(autoApprove, qt.IsFalse)
 	c.Assert(cmd.Flags().Lookup("auto-approve").Changed, qt.IsFalse)
 	c.Assert(cmd.Flags().Lookup("auto-approve").Usage, qt.Not(qt.Contains), "[env: PTAH_AUTO_APPROVE]")
@@ -89,8 +94,157 @@ func TestInitializeEnvAnnotatesUsageOnce(t *testing.T) {
 	cmd := &cobra.Command{Use: "ptah"}
 	cmd.Flags().StringVar(&dbURL, "db-url", "", "Database URL")
 
-	cmdflags.InitializeEnv("PTAH", cmd)
-	cmdflags.InitializeEnv("PTAH", cmd)
+	err := cmdflags.InitializeEnv("PTAH", cmd)
+	c.Assert(err, qt.IsNil)
+	err = cmdflags.InitializeEnv("PTAH", cmd)
 
+	c.Assert(err, qt.IsNil)
 	c.Assert(cmd.Flags().Lookup("db-url").Usage, qt.Equals, "Database URL [env: PTAH_DB_URL]")
+}
+
+func TestInitializeEnvRejectsMalformedBoolean(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	var dryRun bool
+	cmd := &cobra.Command{Use: "ptah"}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes")
+
+	err := cmdflags.InitializeEnv("PTAH", cmd)
+
+	c.Assert(err, qt.ErrorMatches, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	c.Assert(dryRun, qt.IsFalse)
+	c.Assert(cmd.Flags().Lookup("dry-run").Changed, qt.IsFalse)
+}
+
+func TestInitializeEnvRejectsMalformedUnsignedIntegerWithoutMutation(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_LIMIT", "many")
+
+	var limit uint64
+	cmd := &cobra.Command{Use: "ptah"}
+	cmd.Flags().Uint64Var(&limit, "limit", 7, "Migration limit")
+
+	err := cmdflags.InitializeEnv("PTAH", cmd)
+
+	c.Assert(err, qt.ErrorMatches, `invalid unsigned integer value "many" for PTAH_LIMIT`)
+	c.Assert(limit, qt.Equals, uint64(7))
+	c.Assert(cmd.Flags().Lookup("limit").Changed, qt.IsFalse)
+}
+
+func TestInstallEnvBindingRejectsMalformedValueBeforeCommandHooks(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	var calls []string
+	cmd := &cobra.Command{
+		Use: "run",
+		Args: func(_ *cobra.Command, _ []string) error {
+			calls = append(calls, "args")
+			return nil
+		},
+		PreRun: func(_ *cobra.Command, _ []string) {
+			calls = append(calls, "pre-run")
+		},
+		Run: func(_ *cobra.Command, _ []string) {
+			calls = append(calls, "run")
+		},
+	}
+	cmd.Flags().Bool("dry-run", false, "Preview changes")
+	cmdflags.InstallEnvBinding("PTAH", cmd)
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	c.Assert(calls, qt.HasLen, 0)
+}
+
+func TestInstallEnvBindingExplicitCLIWinsOverMalformedEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	var dryRun bool
+	var ran bool
+	cmd := &cobra.Command{
+		Use: "run",
+		Run: func(_ *cobra.Command, _ []string) {
+			ran = true
+		},
+	}
+	cmd.Flags().BoolVar(&dryRun, "dry-run", false, "Preview changes")
+	cmdflags.InstallEnvBinding("PTAH", cmd)
+	cmd.SetArgs([]string{"--dry-run"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dryRun, qt.IsTrue)
+	c.Assert(ran, qt.IsTrue)
+}
+
+func TestInstallEnvBindingAppliesInheritedPersistentFlag(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_VERBOSE", "true")
+
+	var verbose bool
+	var ran bool
+	root := &cobra.Command{Use: "ptah"}
+	root.PersistentFlags().BoolVar(&verbose, "verbose", false, "Verbose output")
+	child := &cobra.Command{
+		Use: "run",
+		Run: func(_ *cobra.Command, _ []string) {
+			ran = true
+		},
+	}
+	root.AddCommand(child)
+	cmdflags.InstallEnvBinding("PTAH", root)
+	root.SetArgs([]string{"run"})
+
+	err := root.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(verbose, qt.IsTrue)
+	c.Assert(ran, qt.IsTrue)
+}
+
+func TestInstallEnvBindingIgnoresMalformedValueForUnselectedCommand(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	root := &cobra.Command{Use: "ptah"}
+	preview := &cobra.Command{Use: "preview", Run: func(_ *cobra.Command, _ []string) {}}
+	preview.Flags().Bool("dry-run", false, "Preview changes")
+	var ran bool
+	run := &cobra.Command{
+		Use: "run",
+		Run: func(_ *cobra.Command, _ []string) {
+			ran = true
+		},
+	}
+	root.AddCommand(preview, run)
+	cmdflags.InstallEnvBinding("PTAH", root)
+	root.SetArgs([]string{"run"})
+
+	err := root.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(ran, qt.IsTrue)
+}
+
+func TestInstallEnvBindingHelpDoesNotParseEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	cmd := &cobra.Command{Use: "run", Run: func(_ *cobra.Command, _ []string) {}}
+	cmd.Flags().Bool("dry-run", false, "Preview changes")
+	cmdflags.InstallEnvBinding("PTAH", cmd)
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"--help"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "[env: PTAH_DRY_RUN]")
 }

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -179,6 +179,26 @@ func TestCompatBinaryDryRunDefaultFormatKeepsStderrEmpty(t *testing.T) {
 // stokaro/ptah#963: the dialect writers' "[DRY RUN] Would ..." narration must
 // never reach the Atlas-compatible binary's streams, whatever mechanism keeps
 // it away.
+func TestCompatBinaryMalformedPTAHDryRunAppliesNothing(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+	dbPath := filepath.Join(c.TempDir(), "malformed-env.db")
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+	run := newCompatProcess(binPath,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+
+	combined, err := run.CombinedOutput()
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf("%s", combined))
+	c.Assert(string(combined), qt.Contains, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	_, statErr := os.Stat(dbPath)
+	c.Assert(statErr, qt.ErrorIs, os.ErrNotExist)
+}
+
 func TestCompatBinaryDryRunPinNoWriterNarration(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)

--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -134,6 +134,28 @@ func TestNewRootCommand_PTAHDBURLFeedsCommandFlag(t *testing.T) {
 	c.Assert(err.Error(), qt.Contains, "error connecting to database")
 }
 
+func TestNewRootCommand_MalformedPTAHDryRunAppliesNothing(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+	migrationsDir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "0000000001_users.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(migrationsDir, "0000000001_users.down.sql"),
+		[]byte("DROP TABLE users;\n"), 0o600), qt.IsNil)
+	dbPath := filepath.Join(t.TempDir(), "native-env.db")
+	dbURL := (&url.URL{Scheme: "sqlite", Path: dbPath}).String()
+
+	_, _, err := executeRootCommand(
+		"migrations", "up",
+		"--db-url", dbURL,
+		"--migrations-dir", migrationsDir,
+	)
+
+	c.Assert(err, qt.ErrorMatches, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	_, statErr := os.Stat(dbPath)
+	c.Assert(statErr, qt.ErrorIs, os.ErrNotExist)
+}
+
 func TestNewRootCommand_PTAHAutoApproveDoesNotBypassDropAllConfirmation(t *testing.T) {
 	c := qt.New(t)
 	t.Setenv("PTAH_AUTO_APPROVE", "true")

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -246,6 +246,14 @@ Runtime values resolve in this order:
 4. `ptah.yaml`
 5. Built-in command defaults
 
+A non-empty `PTAH_<FLAG>` value must parse as the corresponding flag type.
+Ptah rejects a malformed value before argument validation, command hooks, or
+database work begins. For example, `PTAH_DRY_RUN=notabool` fails with
+`invalid boolean value "notabool" for PTAH_DRY_RUN` instead of running with
+the default `false` value. An explicit CLI flag wins without reading its
+environment twin, including when that environment value is malformed. Empty
+environment values remain unset.
+
 Project-file merging preserves source presence. For a supported field, an
 explicitly present value replaces the lower-precedence value instead of being
 treated as absent. This includes an empty string, zero, `false`, or an empty

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -129,7 +129,8 @@ exercise a real server dialect — see
   engine (and ideally the same version) as the target.
 - **Every flag has an environment variable.** `PTAH_DB_URL`, `PTAH_DEV_URL`,
   and `PTAH_SHADOW_DB` set the corresponding flags, which keeps credentials
-  out of CI command lines — see [Configuration](../../reference/configuration/).
+  out of CI command lines. A malformed non-empty value fails before command
+  execution. See [Configuration](../../reference/configuration/).
 
 ### Statement forms that fail closed
 

--- a/docs/site/src/content/docs/operate/troubleshooting.md
+++ b/docs/site/src/content/docs/operate/troubleshooting.md
@@ -44,6 +44,28 @@ ptah migrations status --env dev --migrations-dir ./migrations
 
 Explicit flags win over environment variables and config files.
 
+## `invalid boolean value` names a `PTAH_*` variable
+
+The named environment value is not accepted by the corresponding CLI flag.
+Whitespace and quotes are part of the value; Ptah does not trim them.
+
+Inspect the exact value, including leading or trailing whitespace:
+
+```bash
+printf '<%s>\n' "$PTAH_DRY_RUN"
+```
+
+Set an accepted value or remove the variable. Boolean flags accept the values
+recognized by Go's boolean parser, including `true`, `false`, `1`, and `0`:
+
+```bash
+export PTAH_DRY_RUN=true
+ptah migrations up --db-url "$DATABASE_URL" --migrations-dir ./migrations
+```
+
+Ptah validates a malformed non-empty value before command hooks or database
+work. An explicit CLI flag wins without reading its environment twin.
+
 ## Hash validation fails
 
 Regenerate the hash after intentionally changing migrations:

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -13,6 +13,14 @@ Configuration precedence is:
 | 4 | `ptah.yaml` selected environment |
 | 5 | Built-in defaults |
 
+A non-empty `PTAH_<FLAG>` value must parse as the corresponding flag type.
+Ptah rejects a malformed value before argument validation, command hooks, or
+database work begins. For example, `PTAH_DRY_RUN=notabool` fails with
+`invalid boolean value "notabool" for PTAH_DRY_RUN` instead of running with
+the default `false` value. An explicit CLI flag wins without reading its
+environment twin, including when that environment value is malformed. Empty
+environment values remain unset.
+
 Project-file merging preserves source presence. For a supported field, an
 explicitly present value replaces the lower-precedence value instead of being
 treated as absent. This includes an empty string, zero, `false`, or an empty

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -228,7 +228,10 @@ func ParseLocalDir(value string) (LocalDir, error) {
 // Map translates Atlas-style args to native Ptah args using the provided flag
 // descriptors.
 func Map(group, use string, flags []Flag, args []string) ([]string, error) {
-	args = appendEnvArgs(flags, args)
+	args, err := appendEnvArgs(flags, args)
+	if err != nil {
+		return nil, err
+	}
 	args = appendDefaultArgs(flags, args)
 	out := make([]string, 0, len(args))
 	for i := 0; i < len(args); i++ {
@@ -318,7 +321,7 @@ func nativeEnvironmentPresent(flag Flag) bool {
 //
 // Only a flag marked EnvDisabled opts out, and on this surface exactly one
 // does — see ExplicitUnsupportedBoolReason.
-func appendEnvArgs(flags []Flag, args []string) []string {
+func appendEnvArgs(flags []Flag, args []string) ([]string, error) {
 	out := args
 	cloned := false
 	for _, flag := range flags {
@@ -332,8 +335,19 @@ func appendEnvArgs(flags []Flag, args []string) []string {
 		if !ok || value == "" {
 			continue
 		}
-		if flag.Kind == BoolFlag && boolEnvFalse(value) {
-			continue
+		if flag.Kind == BoolFlag {
+			parsed, err := strconv.ParseBool(value)
+			if err != nil {
+				return nil, fmt.Errorf("invalid boolean value %q for %s", value, envName("PTAH", flag.Name))
+			}
+			if !parsed {
+				continue
+			}
+		}
+		if flag.Kind == UintFlag {
+			if _, err := strconv.ParseUint(value, 0, 64); err != nil {
+				return nil, fmt.Errorf("invalid unsigned integer value %q for %s", value, envName("PTAH", flag.Name))
+			}
 		}
 		if !cloned {
 			out = slices.Clone(args)
@@ -341,17 +355,12 @@ func appendEnvArgs(flags []Flag, args []string) []string {
 		}
 		out = append(out, "--"+flag.Name+"="+value)
 	}
-	return out
+	return out, nil
 }
 
 func envName(prefix, flagName string) string {
 	name := strings.NewReplacer("-", "_", ".", "_").Replace(flagName)
 	return strings.ToUpper(prefix + "_" + name)
-}
-
-func boolEnvFalse(value string) bool {
-	parsed, err := strconv.ParseBool(value)
-	return err == nil && !parsed
 }
 
 func flagPresent(args []string, flag Flag) bool {

--- a/internal/atlasargs/args_test.go
+++ b/internal/atlasargs/args_test.go
@@ -265,6 +265,16 @@ func TestMap_HappyPathCLIFlagWinsOverEnvFlag(t *testing.T) {
 	c.Assert(got, qt.DeepEquals, []string{"--db-url", "postgres://cli/db"})
 }
 
+func TestMap_HappyPathExplicitBoolFlagWinsOverMalformedEnvFlag(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	got, err := atlasargs.Map("migrate", "down", migrateDownFlags(), []string{"--dry-run"})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(got, qt.DeepEquals, []string{"--dry-run"})
+}
+
 func TestMap_HappyPathFalseBoolEnvDoesNotEnableFlag(t *testing.T) {
 	c := qt.New(t)
 	t.Setenv("PTAH_PLAN", "false")
@@ -283,6 +293,26 @@ func TestMap_FailurePathRejectsRemoteDir(t *testing.T) {
 	})
 
 	c.Assert(err, qt.ErrorMatches, `atlas migrate down --dir: only local file:// migration directories are supported`)
+}
+
+func TestMap_FailurePathRejectsMalformedBoolEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_DRY_RUN", "notabool")
+
+	got, err := atlasargs.Map("migrate", "down", migrateDownFlags(), nil)
+
+	c.Assert(err, qt.ErrorMatches, `invalid boolean value "notabool" for PTAH_DRY_RUN`)
+	c.Assert(got, qt.IsNil)
+}
+
+func TestMap_FailurePathRejectsMalformedUintEnvironment(t *testing.T) {
+	c := qt.New(t)
+	t.Setenv("PTAH_LATEST", "many")
+
+	got, err := atlasargs.Map("migrate", "lint", migrateLintFlags(), nil)
+
+	c.Assert(err, qt.ErrorMatches, `invalid unsigned integer value "many" for PTAH_LATEST`)
+	c.Assert(got, qt.IsNil)
 }
 
 func TestMap_FailurePathUnsupportedFlagsFailExplicitly(t *testing.T) {

--- a/scripts/mutations/env-flag-parse-errors.json
+++ b/scripts/mutations/env-flag-parse-errors.json
@@ -1,0 +1,65 @@
+{
+  "packages": [
+    "./cmd/internal/cmdflags/",
+    "./cmd/internal/cmdadapter/",
+    "./internal/atlasargs/",
+    "./cmd/root/",
+    "./cmd/ptah-compat/"
+  ],
+  "mutations": [
+    {
+      "name": "environment flag parse errors are discarded again",
+      "file": "cmd/internal/cmdflags/env.go",
+      "old": "\t\tapplyErr = setEnvValue(flags, flag, envName, value)\n",
+      "new": "\t\t_ = setEnvValue(flags, flag, envName, value)\n"
+    },
+    {
+      "name": "a malformed boolean environment value is accepted as unset",
+      "file": "cmd/internal/cmdflags/env.go",
+      "old": "\t\tif _, err := strconv.ParseBool(value); err != nil {\n\t\t\treturn fmt.Errorf(\"invalid boolean value %q for %s\", value, envName)\n\t\t}\n",
+      "new": "\t\tif _, err := strconv.ParseBool(value); err != nil {\n\t\t\treturn nil\n\t\t}\n"
+    },
+    {
+      "name": "a malformed environment value overrides an explicit CLI flag",
+      "file": "cmd/internal/cmdflags/env.go",
+      "old": "\t\tif flag.Changed {\n\t\t\treturn\n\t\t}\n",
+      "new": "\t\tif false {\n\t\t\treturn\n\t\t}\n"
+    },
+    {
+      "name": "an invalid native unsigned integer reaches the mutating pflag parser",
+      "file": "cmd/internal/cmdflags/env.go",
+      "old": "\tcase \"uint\", \"uint64\":\n\t\tif _, err := strconv.ParseUint(value, 0, 64); err != nil {\n\t\t\treturn fmt.Errorf(\"invalid unsigned integer value %q for %s\", value, envName)\n\t\t}\n",
+      "new": ""
+    },
+    {
+      "name": "legacy nil-Args command groups stop rejecting unknown commands",
+      "file": "cmd/internal/cmdflags/env.go",
+      "old": "\t\tif cmd.Args != nil || !cmd.HasSubCommands() {\n",
+      "new": "\t\tif true {\n"
+    },
+    {
+      "name": "forwarded native targets lose environment validation",
+      "file": "cmd/internal/cmdadapter/cmdadapter.go",
+      "old": "\tcmdflags.InstallEnvBinding(envPrefix, target)\n",
+      "new": "\tcmdflags.InstallEnvBinding(envPrefix, &cobra.Command{})\n"
+    },
+    {
+      "name": "the Atlas mapper treats a malformed boolean as false",
+      "file": "internal/atlasargs/args.go",
+      "old": "\t\t\tparsed, err := strconv.ParseBool(value)\n\t\t\tif err != nil {\n\t\t\t\treturn nil, fmt.Errorf(\"invalid boolean value %q for %s\", value, envName(\"PTAH\", flag.Name))\n\t\t\t}\n",
+      "new": "\t\t\tparsed, _ := strconv.ParseBool(value)\n"
+    },
+    {
+      "name": "the Atlas mapper reads a malformed environment twin despite an explicit flag",
+      "file": "internal/atlasargs/args.go",
+      "old": "\t\tif flagPresent(args, flag) {\n\t\t\tcontinue\n\t\t}\n",
+      "new": "\t\tif false {\n\t\t\tcontinue\n\t\t}\n"
+    },
+    {
+      "name": "the Atlas mapper forwards an invalid unsigned integer",
+      "file": "internal/atlasargs/args.go",
+      "old": "\t\tif flag.Kind == UintFlag {\n\t\t\tif _, err := strconv.ParseUint(value, 0, 64); err != nil {\n\t\t\t\treturn nil, fmt.Errorf(\"invalid unsigned integer value %q for %s\", value, envName(\"PTAH\", flag.Name))\n\t\t\t}\n\t\t}\n",
+      "new": ""
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- fail native `PTAH_<FLAG>` binding when a non-empty value cannot be parsed
- preserve CLI-over-environment precedence and validate before argument hooks or database work
- apply the same fail-closed behavior to `ptah-compat` argument mapping and forwarded native targets
- document parsing, empty-value, whitespace, and precedence semantics

## Safety

A malformed `PTAH_DRY_RUN` can no longer fall back to `false` and execute a real migration. Native and compatibility integration tests assert that the SQLite target is not created.

## Validation

- `go test -count=1 ./...`
- targeted `go test -race` for cmdflags, cmdadapter, atlasargs, root, and ptah-compat
- `go vet ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- public API checks
- full documentation links, style, build, responsive, and audit checks
- mutation suite: 9/9 mutants killed

Fixes #1006.