### PR TITLE
observability: record that the OTel scope name moved with the module

### DIFF
--- a/cmd/internal/cliobs/otel_observability.go
+++ b/cmd/internal/cliobs/otel_observability.go
@@ -20,6 +20,15 @@ import (
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
+// instrumentationName is the OpenTelemetry instrumentation-scope identity, not
+// an import path -- it is emitted as otel.scope.name on every span this CLI
+// produces. It tracked the module path before the move to go.5x5.cz/ptah and
+// deliberately still does, following the OTel convention that a scope is named
+// after the instrumenting library. That makes the import-path move a BREAKING
+// OBSERVABILITY CHANGE as well: a dashboard, alert or query filtering on the
+// previous scope name goes blank rather than erroring, so it has to be updated
+// alongside the import paths. Pin this to a literal instead if downstream
+// dashboards must survive a future rename untouched.
 const instrumentationName = "go.5x5.cz/ptah"
 
 func startOTel(ctx context.Context, opts Options) (migrator.Observer, func(context.Context) error, error) {


### PR DESCRIPTION
Follow-up to #1022. An adversarial sweep over that rename found one occurrence that a mechanical import-path rewrite changed **by shape alone, not by decision** — and that no gate in the repository can observe.

## The finding

`cmd/internal/cliobs/otel_observability.go:23`

```go
const instrumentationName = "go.5x5.cz/ptah"
```

This is not an import path. It is passed to `provider.Tracer(instrumentationName)` and emitted as `otel.scope.name` on **every span the CLI produces**. The rename rewrote it because it looked like a package path.

Why nothing caught it:

- The value is only ever sent on the wire. It is never compared, parsed, or asserted, so build, vet, and the whole test suite are indifferent to it.
- The failure mode downstream is **silence, not an error**: a dashboard, alert, or query filtering on the old scope name returns no data rather than breaking. That is the hardest shape to notice.
- The file sits behind `//go:build observability`, and **no CI job compiles tag-gated code** (`go list -f '{{.IgnoredGoFiles}}' ./cmd/internal/cliobs` shows it ignored in an untagged build). So even the compilation of the renamed file was never gated.

## The decision

**The value stays `go.5x5.cz/ptah`.** The OpenTelemetry convention is to name a scope after the instrumenting library, and it tracked the module path before the move, so following the module is the consistent choice.

What this PR adds is the *consequence*, written down at the constant: the import-path move is a breaking observability change too, and consumers have to update scope-name filters alongside their imports. Without that comment the next reader has no way to tell whether the string was chosen or merely swept along — and the next rename would sweep it again, just as silently.

The alternative — pinning it to a literal so dashboards survive future renames — is stated in the comment as the deliberate opposite choice, so it is a decision rather than a default.

## Verification

Tag-gated code is not covered by the normal suite, so it was built explicitly:

```
go build -tags observability ./...          EXIT=0
go vet   -tags observability ./...          EXIT=0
go build -tags integration   ./...          EXIT=0
```

Comment-only otherwise; the emitted value is unchanged from what #1022 merged.

## Related, not fixed here

The same sweep found that `.github/workflows/go-lint.yml` never builds with any build tag, so `//go:build observability` and `//go:build integration` code is compiled by no CI job at all. That is a pre-existing coverage gap rather than a rename defect, and it deserves its own change.