### PR TITLE
testkit: pin the published v0.2.0 and gate the pin on resolving

### DIFF
--- a/.github/workflows/testkit.yml
+++ b/.github/workflows/testkit.yml
@@ -39,3 +39,33 @@ jobs:
       - name: Test testkit container helpers
         working-directory: testkit
         run: go test -tags=testkitcontainers ./...
+
+  published-pin:
+    name: Resolve the published root module without replace
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+      # testkit requires the root module AND replaces it with `..`, so every
+      # other job here builds against the working tree and proves nothing about
+      # the version in the require line. That version can name a release that
+      # does not exist -- after the move to go.5x5.cz/ptah it named v0.1.2,
+      # which was only ever published under the old path and can never resolve
+      # under the new one. The replace hid that completely.
+      #
+      # This job drops the replace and builds against the module proxy, so the
+      # require line has to name a release an external consumer can actually
+      # fetch. It fails loudly the moment the pin becomes fiction again.
+      - name: Build against the published module
+        working-directory: testkit
+        run: |
+          set -euo pipefail
+          grep -v '^replace go\.5x5\.cz/ptah => \.\.$' go.mod > go.mod.published
+          mv go.mod.published go.mod
+          # -mod=mod so the checked-in go.sum, which only covers the replaced
+          # local module, may gain the published module's entry. Without it the
+          # build fails on a missing go.sum line whatever the pin says, which
+          # would make this job red for a reason unrelated to what it checks.
+          GOFLAGS=-mod=mod go build ./...

--- a/testkit/go.mod
+++ b/testkit/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/testcontainers/testcontainers-go v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/mysql v0.43.0
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
-	go.5x5.cz/ptah v0.1.2
+	go.5x5.cz/ptah v0.2.0
 )
 
 require (


### PR DESCRIPTION
Closes the last loose end from the import-path move (#1022) and the v0.2.0 release.

## The pin was fiction

`testkit/go.mod` required `go.5x5.cz/ptah v0.1.2`. That version has never existed under that path — v0.1.2 was published as `github.com/stokaro/ptah`, and Go rejects a module whose own `go.mod` declares a different path than the one it was required as:

```
module declares its path as: github.com/stokaro/ptah
        but was required as: go.5x5.cz/ptah
```

No proxy, vanity redirect, or checksum-database entry can paper that over — the mismatch is inside the tagged tree.

Nothing noticed because line 99, `replace go.5x5.cz/ptah => ..`, short-circuits resolution before any version is fetched. **Every existing job in `.github/workflows/testkit.yml` builds against the working tree, so none of them can see the require line at all.** The module was green throughout.

`v0.2.0` is the first release cut from a tree whose `go.mod` already names the new path, so the pin now names something an external consumer can actually fetch.

## The gate

The `published-pin` job drops the `replace` and builds against the module proxy. It is the only check here that exercises the require line.

It was written by mutation rather than by inspection — a gate nobody has watched fail is not evidence:

| Pin | Result |
| --- | --- |
| `v0.1.2` (the old, unresolvable one) | `BAD_BUILD=1`, with the declared-path mismatch above |
| `v0.2.0` (current) | `GOOD_BUILD=0` |

The first attempt at this job was wrong in an instructive way: without `GOFLAGS=-mod=mod` it failed on a **missing `go.sum` entry** — the checked-in `go.sum` only covers the replaced local module — which means it would have been red for a correct pin too. A gate that is red either way distinguishes nothing. The flag, and why it is there, is in a comment on the job.

## Verification

```
cd testkit
go mod tidy                       TIDY=0
go build ./...                    BUILD=0
go test  ./... -count=1           TEST=0   (ok go.5x5.cz/ptah/testkit)

# with the replace dropped, against the proxy
v0.2.0                            NOREPLACE_BUILD=0
v0.1.2                            MUTANT_BUILD=1
```

Related: #1022, #1024.