### PR TITLE
fix(atlas): make migrate hash success silent

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -840,7 +840,9 @@ env "local" {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommand_AdapterCommandUsesAttachedConfigShorthand(t *testing.T) {
@@ -873,7 +875,9 @@ env "local" {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommand_AdapterCommandUsesParentAtlasProjectFlags(t *testing.T) {
@@ -907,7 +911,9 @@ env "local" {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommand_AdapterCommandForwardsAtlasProjectConfigToNativeLoader(t *testing.T) {
@@ -1372,7 +1378,7 @@ func TestCompatCommand_MigrateHashDefaultsToAtlasSum(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "atlas.sum")
+	c.Assert(out.String(), qt.Equals, "")
 	_, err = os.Stat(filepath.Join(dir, "atlas.sum"))
 	c.Assert(err, qt.IsNil)
 	_, err = os.Stat(filepath.Join(dir, "ptah.sum"))
@@ -3766,7 +3772,7 @@ func TestCompatCommand_MigrateHashResolvesProjectRelativeMigrationDir(t *testing
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
 	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
 	c.Assert(err, qt.IsNil)
 }

--- a/cmd/atlas/migrate_hash.go
+++ b/cmd/atlas/migrate_hash.go
@@ -1,7 +1,7 @@
 package atlas
 
 import (
-	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -22,12 +22,25 @@ func newAtlasMigrateHashCommand() *cobra.Command {
 	return newAtlasMigrateIntegrityCommand(atlasMigrateHashVerb(), runAtlasMigrateHash)
 }
 
+func newSilentNativeMigrateHashCommand() *cobra.Command {
+	cmd := migratehash.NewMigrateHashCommand()
+	run := cmd.RunE
+	cmd.RunE = func(cmd *cobra.Command, args []string) error {
+		// Atlas CE writes only the checksum file on success. The adapter creates
+		// this native target for each execution, so suppressing its progress does
+		// not retain a writer on the reusable compatibility command.
+		cmd.SetOut(io.Discard)
+		return run(cmd, args)
+	}
+	return cmd
+}
+
 func atlasMigrateHashVerb() atlasVerb {
 	return atlasVerb{
 		use:     "hash",
 		short:   "Write or update the migration directory checksum",
 		native:  "migrations hash",
-		factory: migratehash.NewMigrateHashCommand,
+		factory: newSilentNativeMigrateHashCommand,
 		flags: []atlasargs.Flag{
 			atlasargs.NativeLocalDir("dir", "", "Migration directory", "dir"),
 			atlasMigrateDirFormatFlag("dir-format"),
@@ -42,11 +55,6 @@ func atlasMigrateHashVerb() atlasVerb {
 // reproduces Atlas CE's per-format selection, and the rolling hash from
 // migratesum.ComputeAtlasFiles — the same pair `migrate validate` verifies
 // with, so a directory this writes is one that verifies.
-//
-// The success output is the native command's, not Atlas CE's: CE writes
-// nothing at all on a successful hash. That divergence predates this path and
-// is tracked separately; reproducing the native output here keeps the two
-// layouts of the same verb consistent with each other.
 func runAtlasMigrateHash(cmd *cobra.Command, source atlasMigrateSource) error {
 	if err := cmdutil.StatDir(source.dir); err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -64,8 +72,5 @@ func runAtlasMigrateHash(cmd *cobra.Command, source atlasMigrateSource) error {
 		return cmdutil.Fail(cmd, err)
 	}
 
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Wrote %s/%s\n", source.dir, migratesum.AtlasFileName)
-	fmt.Fprintf(out, "%d migration file(s) hashed\n", len(sum.Entries))
 	return nil
 }

--- a/cmd/atlas/migrate_integrity_formats_test.go
+++ b/cmd/atlas/migrate_integrity_formats_test.go
@@ -275,8 +275,10 @@ func TestCompatMigrateHashAtlasLayoutUnmoved_HappyPath(t *testing.T) {
 	}
 
 	baseline := writeIntegrityFixture(c)
-	baselineOut, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+baseline)
-	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", baselineOut))
+	baselineOut, baselineErrOut, err := runCompatExit("migrate", "hash", "--dir", "file://"+baseline)
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", baselineOut, baselineErrOut))
+	c.Assert(baselineOut, qt.Equals, "")
+	c.Assert(baselineErrOut, qt.Equals, "")
 	wantSum := sumBytes(c, baseline)
 
 	for _, tt := range tests {
@@ -287,15 +289,14 @@ func TestCompatMigrateHashAtlasLayoutUnmoved_HappyPath(t *testing.T) {
 
 			c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", stdout, stderr))
 			c.Assert(sumBytes(c, dir), qt.Equals, wantSum)
-			c.Assert(stdout, qt.Equals, "Wrote "+dir+"/atlas.sum\n8 migration file(s) hashed\n")
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, "")
 		})
 	}
 }
 
-// TestCompatMigrateHashConvertedDirOutput_HappyPath pins the converted path's
-// stdout to the native path's. Atlas CE prints nothing on a successful hash;
-// that divergence predates this path and is tracked separately, so what this
-// holds is that naming a layout does not change the reporting.
+// TestCompatMigrateHashConvertedDirOutput_HappyPath pins Atlas CE's silent
+// success contract for converted migration directory formats.
 func TestCompatMigrateHashConvertedDirOutput_HappyPath(t *testing.T) {
 	c := qt.New(t)
 	dir := writeIntegrityFixture(c)
@@ -303,8 +304,9 @@ func TestCompatMigrateHashConvertedDirOutput_HappyPath(t *testing.T) {
 	stdout, stderr, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=golang-migrate")
 
 	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", stdout, stderr))
-	c.Assert(stdout, qt.Equals, "Wrote "+dir+"/atlas.sum\n1 migration file(s) hashed\n")
+	c.Assert(stdout, qt.Equals, "")
 	c.Assert(stderr, qt.Equals, "")
+	c.Assert(sumEntryNames(c, dir), qt.DeepEquals, golangMigrateCoveredSet)
 }
 
 // TestCompatMigrateHashEmptySourceSet_HappyPath covers the seam with the apply
@@ -338,7 +340,7 @@ func TestCompatMigrateHashEmptySourceSet_HappyPath(t *testing.T) {
 			stdout, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format="+tt.format)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-			c.Assert(stdout, qt.Contains, "0 migration file(s) hashed")
+			c.Assert(stdout, qt.Equals, "")
 			// Measured CE empty-set sum, identical across formats.
 			c.Assert(sumBytes(c, dir), qt.Equals, "h1:47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=\n")
 

--- a/cmd/atlas/migrate_integrity_resolution_test.go
+++ b/cmd/atlas/migrate_integrity_resolution_test.go
@@ -173,7 +173,7 @@ func TestCompatMigrateIntegrityEnvironment_HappyPath(t *testing.T) {
 		stdout, _, err := runCompatExit("migrate", "hash")
 
 		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-		c.Assert(stdout, qt.Equals, "Wrote "+dir+"/atlas.sum\n8 migration file(s) hashed\n")
+		c.Assert(stdout, qt.Equals, "")
 		c.Assert(sumEntryNames(c, dir), qt.DeepEquals, sqlSuffixCoveredSet)
 	})
 }
@@ -314,7 +314,7 @@ func TestCompatMigrateHashDirectoryNamedSQL_KnownDivergence(t *testing.T) {
 		stdout, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=goose")
 
 		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-		c.Assert(stdout, qt.Contains, "1 migration file(s) hashed")
+		c.Assert(stdout, qt.Equals, "")
 		c.Assert(sumEntryNames(c, dir), qt.DeepEquals, []string{"1_init.sql"})
 	})
 

--- a/cmd/atlas/project_config_snapshot_test.go
+++ b/cmd/atlas/project_config_snapshot_test.go
@@ -309,7 +309,9 @@ func TestCompatCommandProjectConfigDefersToDirectoryEnvironment(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "2 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(environmentDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommandProjectSelectionDoesNotLeakAcrossRootReuse(t *testing.T) {
@@ -348,7 +350,9 @@ func TestCompatCommandProjectSelectionDoesNotLeakAcrossRootReuse(t *testing.T) {
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommandProjectSelectionDoesNotLeakAfterArgumentValidationFailure(t *testing.T) {
@@ -387,7 +391,9 @@ func TestCompatCommandProjectSelectionDoesNotLeakAfterArgumentValidationFailure(
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommandProjectSelectionDoesNotLeakAfterFlagGroupValidationFailure(t *testing.T) {
@@ -483,14 +489,47 @@ func TestCompatCommandProjectEnvironmentRemainsEffectiveAcrossRootReuse(t *testi
 	firstErr := cmd.Execute()
 
 	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, statErr := os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(statErr, qt.IsNil)
 	out.Reset()
 	cmd.SetArgs([]string{"migrate", "hash"})
 
 	secondErr := cmd.Execute()
 
 	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+}
+
+func TestCompatMigrateHashHelpUsesUpdatedRootWriter(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_init.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var firstOut bytes.Buffer
+	cmd.SetOut(&firstOut)
+	cmd.SetErr(&firstOut)
+	cmd.SetArgs([]string{"migrate", "hash", "--dir", "file://" + dir})
+
+	firstErr := cmd.Execute()
+
+	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", firstOut.String()))
+	c.Assert(firstOut.String(), qt.Equals, "")
+	var secondOut bytes.Buffer
+	cmd.SetOut(&secondOut)
+	cmd.SetErr(&secondOut)
+	cmd.SetArgs([]string{"migrate", "hash", "--help"})
+
+	secondErr := cmd.Execute()
+
+	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", secondOut.String()))
+	c.Assert(firstOut.String(), qt.Equals, "")
+	c.Assert(secondOut.String(), qt.Contains, "Usage:\n  atlas migrate hash [flags]")
 }
 
 func TestCompatCommandProjectSelectionDoesNotLeakAfterRootHelp(t *testing.T) {
@@ -532,7 +571,9 @@ func TestCompatCommandProjectSelectionDoesNotLeakAfterRootHelp(t *testing.T) {
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommandProjectSelectionDoesNotLeakAfterRootArgumentFailure(t *testing.T) {
@@ -574,7 +615,9 @@ func TestCompatCommandProjectSelectionDoesNotLeakAfterRootArgumentFailure(t *tes
 	err = cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
-	c.Assert(out.String(), qt.Contains, "1 migration file(s) hashed")
+	c.Assert(out.String(), qt.Equals, "")
+	_, err = os.Stat(filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(err, qt.IsNil)
 }
 
 func TestCompatCommandDirectExecutionRefreshesContextAcrossRootReuse(t *testing.T) {

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -87,14 +87,8 @@ ptah-compat migrate hash --dir file://migrations
 ptah-compat migrate validate --dir file://migrations
 ```
 
-Expected output includes:
-
-```text
-Wrote migrations/atlas.sum
-1 migration file(s) hashed
-```
-
-A successful `validate` is silent.
+Successful `hash` and `validate` commands are silent. The hash command writes
+`migrations/atlas.sum`; commit that file with the migration.
 
 Apply it, then check status:
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -96,7 +96,9 @@ Native twin: [`ptah migrations status`](../native-commands/).
 
 Writes `atlas.sum` for the migration directory. `--dir-format` defaults to
 `atlas`, so the compatibility path writes `atlas.sum` by default, and the
-atlas layout forwards to `ptah migrations hash`.
+atlas layout forwards to `ptah migrations hash`. A successful compatibility
+hash is silent, matching Atlas CE; inspect or commit the resulting `atlas.sum`
+instead of relying on a progress message.
 
 ### `ptah-compat migrate validate`
 


### PR DESCRIPTION
## Summary

- match Atlas CE by keeping successful `ptah-compat migrate hash` runs silent for both native Atlas and converted migration layouts
- preserve stderr errors and reusable Cobra root help routing by suppressing output only on each fresh forwarded native command
- replace progress-message assertions with checksum artifact assertions and document the compatibility behavior

This closes the Goose hash process-boundary gap found while hardening Atlas CE v1.3.0 conformance.

## Verification

- `make check`
- `go test -race ./cmd/atlas`
- `scripts/check-test-style.sh`
- `node docs/site/scripts/check-style.mjs`
- `node docs/site/scripts/check-style.mjs --selftest`
- `node docs/site/scripts/build-feature-matrix.mjs --check`
- real Atlas CE v1.3.0 Goose hash: byte-identical `atlas.sum`, silent success, and cross-validation in both directions
- independent follow-up code review: no findings