### PR TITLE
feat(atlas): read Atlas-format .test.hcl cases on schema test and migrate test

### DIFF
--- a/cmd/migrationstest/migrationstest.go
+++ b/cmd/migrationstest/migrationstest.go
@@ -102,7 +102,7 @@ func run(ctx context.Context, out io.Writer, opts options) error {
 		return err
 	}
 
-	cases, err := dbtest.LoadCases(opts.dir)
+	cases, err := dbtest.LoadCasesOfKind(opts.dir, dbtest.AtlasTestKindMigrate)
 	if err != nil {
 		return fmt.Errorf("failed to load test cases: %w", err)
 	}

--- a/cmd/schema/test.go
+++ b/cmd/schema/test.go
@@ -89,7 +89,7 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 		return fmt.Errorf("unsupported report format %q: want text, json, or html", opts.report)
 	}
 
-	cases, err := dbtest.LoadCases(opts.dir)
+	cases, err := dbtest.LoadCasesOfKind(opts.dir, dbtest.AtlasTestKindSchema)
 	if err != nil {
 		return fmt.Errorf("failed to load test cases: %w", err)
 	}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5628,9 +5628,13 @@ type RowUpdate struct {
 ## go.5x5.cz/ptah/migration/dbtest
 
 type Assertion struct{ ... }
+type AtlasTestKind string
+    const AtlasTestKindSchema AtlasTestKind = "schema" ...
 type Case struct{ ... }
     func FilterCases(cases []Case, pattern string) ([]Case, error)
     func LoadCases(dir string) ([]Case, error)
+    func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error)
+    func ParseAtlasTestCases(data []byte, filename string, kind AtlasTestKind) ([]Case, error)
     func ParseCases(data []byte) ([]Case, error)
 type CaseResult struct{ ... }
 type Options struct{ ... }
@@ -5668,6 +5672,22 @@ type Assertion struct {
     or ErrorContains.
 
 
+### go.5x5.cz/ptah/migration/dbtest.AtlasTestKind
+
+package dbtest // import "go.5x5.cz/ptah/migration/dbtest"
+
+type AtlasTestKind string
+    AtlasTestKind selects which family of Atlas `.test.hcl` cases to load.
+
+    Atlas labels every case with its kind, `test "schema" "name"` or `test
+    "migrate" "name"`, and the two are not interchangeable: a migrate case
+    drives the migration directory to a version, which is meaningless in a
+    schema test run and would execute migrations the caller did not ask for.
+    Loading is therefore always scoped to one kind rather than returning
+    whatever the file happens to contain.
+
+const AtlasTestKindSchema AtlasTestKind = "schema" ...
+
 ### go.5x5.cz/ptah/migration/dbtest.Case
 
 package dbtest // import "go.5x5.cz/ptah/migration/dbtest"
@@ -5681,6 +5701,8 @@ type Case struct {
 
 func FilterCases(cases []Case, pattern string) ([]Case, error)
 func LoadCases(dir string) ([]Case, error)
+func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error)
+func ParseAtlasTestCases(data []byte, filename string, kind AtlasTestKind) ([]Case, error)
 func ParseCases(data []byte) ([]Case, error)
 
 ### go.5x5.cz/ptah/migration/dbtest.CaseResult

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1,1433 +1,1433 @@
 [
- {
-  "area": "Schema sources",
-  "feature": "Go struct annotations",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program.",
-  "evidence": "ptah schema render --help (--root-dir); docs/site/src/content/docs/schema/go-annotations.md; docs/site/src/content/docs/schema/orm-and-external.md:65 (atlas-provider-gorm)"
- },
- {
-  "area": "Schema sources",
-  "feature": "YAML schema files",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs.",
-  "evidence": "ptah schema render --help (--schema-file accepts YAML); docs/site/src/content/docs/reference/yaml-schema.md; docs/site/src/content/docs/atlas/comparison.md:411"
- },
- {
-  "area": "Schema sources",
-  "feature": "SQL DDL schema files",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped.",
-  "evidence": "ptah schema render --help; ptah-compat schema diff --help (.sql accepted on --from/--to); docs/site/src/content/docs/atlas/docs-coverage.md:202 (Atlas: 'Open sources include SQL, HCL, and external schema')"
- },
- {
-  "area": "Schema sources",
-  "feature": "Live database as desired state",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively.",
-  "evidence": "ptah-compat schema apply/diff --help; ptah-compat migrate diff --help; ptah db read --help; docs/site/src/content/docs/atlas/docs-coverage.md:148-190 (declarative apply and diff: 'Open')"
- },
- {
-  "area": "Schema sources",
-  "feature": "Migration directory as a source",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff.",
-  "evidence": "ptah schema inspect --help (--migrations-dir, requires --dev-url); ptah-compat schema apply --help; ptah-compat schema diff --help; ptah-compat migrate diff --help"
- },
- {
-  "area": "Schema sources",
-  "feature": "External program / ORM loaders",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "`--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML.",
-  "evidence": "ptah schema render --help (--schema-cmd, --schema-format, --allow-external-schema); docs/site/src/content/docs/schema/orm-and-external.md; examples/orm-loaders/gorm; examples/orm-loaders/sqlalchemy; orm-and-external.md records this as the open counterpart of Atlas's external_schema source and its ORM providers"
- },
- {
-  "area": "Schema sources",
-  "feature": "Atlas HCL data \"external_schema\"",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Ptah evaluates the data source and runs the program, gated behind `--allow-external-schema`/`PTAH_ALLOW_EXTERNAL_SCHEMA`. Community Atlas rejects `data.external_schema`.",
-  "evidence": "config/projectconfig/atlas.go (configureDataSources external_schema branch); repro: PTAH_ALLOW_EXTERNAL_SCHEMA=1 ptah-compat schema apply --url sqlite://app.db --env dev --dry-run --auto-approve emits the program's CREATE TABLE; ptah schema render --env dev --allow-external-schema renders it natively; go test ./cmd/atlas -run TestSchemaDiffExternalSchemaSource. Measured 2026-08-01, Atlas CE v1.2.0 logged out: atlas.hcl data \"external_schema\" -> exit 1 'Error: data.external_schema is not supported by the community version of Atlas.'"
- },
- {
-  "area": "Schema sources",
-  "feature": "Composite multi-source desired schema",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source.",
-  "evidence": "ptah schema render --help ('repeatable; multiple sources merge into one composite schema'); docs/site/src/content/docs/schema/composite.md:58; docs/site/src/content/docs/atlas/comparison.md:407,413. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): atlas.hcl with `data \"composite_schema\"` -> exit 1 'missing data source handler for \"composite_schema\"'. Atlas pricing page (retrieved 2026-08-01): 'Schema compositions' is Pro, not Starter. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Schema compositions' is unchecked for Starter and checked for Pro/Enterprise, linking to the composite_schema data source. `data \"composite_schema\"` with local file parts works in Atlas (measured; observation study, scenario, atlas-hcl-pro-constructs)"
- },
- {
-  "area": "Schema sources",
-  "feature": "Live database to Go annotation source",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "`ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow.",
-  "evidence": "ptah introspect --help (--db-url, --out, --package); docs/site/src/content/docs/atlas/comparison.md:536-540 ('Native Go annotations'); conformance cli-surface.md (Atlas CE inventory)"
- },
- {
-  "area": "Project config",
-  "feature": "Atlas project config (atlas.hcl)",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema.",
-  "evidence": "config/projectconfig/atlas.go:214 (collectAtlasTopBlock default -> unsupportedBlock), :402 (parseEnvAttr default), :475 (parseMigration default); each rejection reproduced with /tmp/pc-audit at exit 1; Atlas-side block inventory from https://atlasgo.io/atlas-schema/projects (top-level variable, locals, atlas, env, script, lint, diff, exporter, deployment)"
- },
- {
-  "area": "Project config",
-  "feature": "Native project config (ptah.yaml)",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail.",
-  "evidence": "config/projectconfig/yaml.go:17-92 (typed key set; the desired-source key is `schemas`, not `src`). Repro: `src: [\"s.sql\"]` in ptah.yaml -> `error: failed to parse ptah config ptah.yaml: yaml: unmarshal errors: line 2: field src not found in type projectconfig.yamlDocument`"
- },
- {
-  "area": "Project config",
-  "feature": "Variables, locals, and HCL functions",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected.",
-  "evidence": "config/projectconfig/atlas.go:126-133 (five-function eval context), parseVariableBlock/convertAtlasVariableOverride (type constraints with typed --var conversion, sensitive redaction, validation rejected), :402 (for_each hits the env attribute default). Repro: `dev = urlsetpath(\"sqlite://file.db\",\"x\")` -> `error: unsupported atlas.hcl construct \"dev\" at atlas.hcl:2`; upper, lower, join, split, concat, trimspace, coalesce, toupper, abspath, urlescape, urlqueryset, print all fail the same way, while file, fileset, format, getenv, jsonencode evaluate; `variable \"schema_file\" { type = string }` + `--var schema_file=schema.sql` inspects on both binaries"
- },
- {
-  "area": "Project config",
-  "feature": "data \"hcl_schema\" reference",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected.",
-  "evidence": "config/projectconfig/atlas.go:1034-1080 (hclSchemaDataSource accepts only path/paths), :1416-1431 (validateAtlasLocalPathValue, atlasLocalFileURL). Atlas documents path, paths, vars in and url out (https://atlasgo.io/atlas-schema/projects). Repro: vars -> `error: unsupported atlas.hcl construct \"vars\" at atlas.hcl:3`"
- },
- {
-  "area": "Project config",
-  "feature": "env:// desired-state references",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently.",
-  "evidence": "internal/atlassource/atlassource.go:266-282 expandEnv attribute allowlist; env:// classification is reached only from --to/--from ClassifySet. Reproduced: `--exclude env://exclude` with env.exclude=[\"users\"] still emitted the users table"
- },
- {
-  "area": "Project config",
-  "feature": "Remote and template directory sources",
-  "ptah": "no",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path.",
-  "evidence": "ptah-compat migrate status --env prod with migration.dir set to atlas:// or oci:// -> exit 1 'atlas migrate status --dir: only local file:// migration directories are supported'"
- },
- {
-  "area": "Go embedding",
-  "feature": "Reusable Go packages (embedder API)",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs.",
-  "evidence": "docs/site/src/content/docs/extend/public-api.md (stable package table); docs/site/src/content/docs/extend/components.md (component map)"
- },
- {
-  "area": "Go embedding",
-  "feature": "Public API compatibility gate",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line.",
-  "evidence": "scripts/check-public-api.sh; scripts/check-public-api-released.sh; docs/public_api_approvals.txt"
- },
- {
-  "area": "Go embedding",
-  "feature": "Query builder for parameterized SQL",
-  "ptah": "partial",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error.",
-  "evidence": "core/query/query.go (InnerJoin/LeftJoin/RightJoin/FullJoin, Distinct, GroupBy, Having) and core/query/write.go (InsertInto/Update/DeleteFrom, Returning); core/ast/select.go:17-18 records arithmetic, LIKE, subqueries and window functions as follow-ups; core/ast/write.go:13-16 records upsert, INSERT..SELECT, CTEs and multi-table UPDATE/DELETE as out of scope; core/renderer/select.go:84-89 maps placeholders for postgres/cockroachdb/yugabytedb/mysql/mariadb/sqlite only; executed probe over renderer.RenderInsert confirms sqlserver, mssql, clickhouse and spanner return \"renderer: INSERT rendering is not supported for dialect ...\""
- },
- {
-  "area": "Schema visualization",
-  "feature": "Schema visualization (ERD diagrams)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas ERD lives in the hosted service (any plan per its pricing page); the CE binary rejects `--web`.",
-  "evidence": "ptah viz --help; docs/site/src/content/docs/schema/visualize.md; docs/site/src/content/docs/atlas/comparison.md (cites atlasgo.io/features: visualization is Pro); conformance cli-surface.md CE inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema inspect --url sqlite://t.db --web` -> exit 1 'unknown flag: --web'. Atlas pricing page (retrieved 2026-08-01) checks ERD visualization for every plan including free Starter - hosted-service side. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'ERD visualization' is checked for the free Starter plan — a plan-level claim that may be login/cloud-side; the pinned CE v1.2.0 binary registers no visualization command, so atlas_oss stays no"
- },
- {
-  "area": "API schema export",
-  "feature": "API schema export: OpenAPI 3.0 and GraphQL",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list.",
-  "evidence": "ptah schema export --help (--to openapi-v3|graphql); docs/site/src/content/docs/schema/export.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
- },
- {
-  "area": "API schema export",
-  "feature": "Protobuf schema export with pinned field numbers",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory.",
-  "evidence": "ptah schema export --help (--proto-type-removal, --proto-on-name-reuse, --proto-on-incompatible-change); internal/protobufrender/render.go; docs/site/src/content/docs/schema/protobuf.md; conformance cli-surface.md CE inventory"
- },
- {
-  "area": "API schema export",
-  "feature": "Annotation metadata as JSON Schema",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to.",
-  "evidence": "ptah schema annotations --help; docs/site/src/content/docs/reference/native-commands.md (line 17)"
- },
- {
-  "area": "Data management",
-  "feature": "Declarative reference data",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "//ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature.",
-  "evidence": "ptah migrations data --help; docs/site/src/content/docs/versioned/reference-data.md (Reversibility section); docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features: declarative data management is Pro); conformance PARITY.md managed-data-workflow. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Seed Data as Code' is unchecked for Starter and checked for Pro/Enterprise"
- },
- {
-  "area": "Data management",
-  "feature": "Environment-scoped SQL seed runner",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list.",
-  "evidence": "ptah seed --help (--env, --protected-env, --allow-prod); docs/site/src/content/docs/operate/seed-data.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list). Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Seed Data as Code' is a Pro checkmark — declarative seed definitions, not an environment-scoped SQL seed runner, so atlas_pro stays no for this mechanism"
- },
- {
-  "area": "Editor tooling",
-  "feature": "ptah-ls annotation language server",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax.",
-  "evidence": "cmd/ptah-ls/main.go (builds via go build ./cmd/ptah-ls); editors/vscode/package.json and extension.js; docs/site/src/content/docs/reference/go-annotations.md (Editor support)"
- },
- {
-  "area": "Go-first modeling",
-  "feature": "Annotated Go models from a live database",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list.",
-  "evidence": "ptah introspect --help (--add-db-tags, --add-json-tags, --per-table); docs/site/src/content/docs/reference/native-commands.md (line 74); conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`atlas://` vendor protocol",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "The scheme is Cloud-bound and rejected with a named error; every function behind it is available natively over `oci://`. The compat binary mirrors the Atlas surface, which has no `oci://`.",
-  "evidence": "ptah-compat schema apply --to atlas://myorg/myrepo -> exit 1 'atlas:// registry URLs are not supported; use oci:// with a native Ptah command'; atlas.hcl migration.dir = atlas:// -> exit 1 'only local file:// migration directories are supported'; ptah-compat schema apply --to oci://localhost:5555/demo/schema:v1 -> exit 1 'unsupported desired-state URL scheme \"oci\"'; atlas.hcl migration.dir = oci:// -> exit 1 'only local file:// migration directories are supported'. Native `ptah schema push/pull` and `ptah migrations push/pull` use OCI artifacts. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' is unchecked for Starter and checked for Pro (limited to 500 objects), matching oss no / pro yes for the registry-backed `atlas://` scheme"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`migrate push` and `schema push`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "ptah-compat boundary stubs report that the command is not implemented and exit 1. The native equivalents are `ptah schema push` and `ptah migrations push`.",
-  "evidence": "ptah-compat schema push -> exit 1 and reports that the command is not implemented by Ptah; cli-surface.md lines 35 and 58 mark both absent from CE v1.2.0. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema push` and `atlas migrate push demo` -> exit 1 community-abort"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan` registry sub-verbs (approve, list, pull, push, rm)",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "These five arbitrate plan state in a remote registry; Ptah's local plan-file workflow replaces the function rather than the service.",
-  "evidence": "ptah-compat schema plan approve. Measured 2026-08-02, CE v1.2.0 (scratch env): CE has NO `schema plan` sub-verbs at all — `atlas schema plan approve` prints \"Abort: 'atlas schema plan' is not supported by the community version.\" naming the PARENT, byte-identical to the nonsense control `atlas schema plan frobnicate-nonsense`; the control showing that an unknown command can look different one level up is `atlas schema frobnicate`, which prints the `schema` group help at exit 0. Each of the five takes `--url` in the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), which is what makes them registry-bound."
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan new` and `schema plan validate`",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Implemented. Flag sets follow the published Atlas CLI reference; their behavior is read out of Atlas docs and unverified, and each run says so on stderr.",
-  "evidence": "Verified: `ptah-compat schema plan new --from sqlite://x.db --to file://s.sql` writes <timestamp>.plan.hcl with no --save flag registered, and `ptah-compat schema plan validate --from sqlite://x.db --to file://s.sql --file file://p.plan.hcl` exits 0 with EMPTY stdout and leaves the target schema AND its rows unchanged (cmd/atlas/schema_plan_new_test.go, cmd/atlas/schema_plan_validate_test.go). SURFACE follows the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), which lists on `new` exactly {auto-approve, dev-url, edit, exclude, format, from, include, lock-timeout, name, name-format, output, repo, schema, to} and on `validate` exactly {auto-approve, dev-url, exclude, file, format, from, include, lock-timeout, repo, schema, to}, both pinned by TestAtlasSchemaPlanVerbFlagSetsMatchAtlas. BEHAVIOR is DOCUMENTED-not-measured: `new` is described as \"Create a new plan file for the schema transition\" and lists neither --save nor --dry-run, so writing unconditionally is a reading, not an observation; `validate` is described as \"Validate a plan file against the schema transition\" and the from-must-match rule is documented for `test \"plan\"` blocks (atlasgo.io/hcl/testing), but the checks it runs, their order, its exit code and its output are inferred. Atlas CE aborts the whole `schema plan` path (measured 2026-08-02, CE v1.2.0), so no oracle exists for either verb; an awaiting-oracle conformance fixture is proposed rather than a green row. `validate` refuses a --dev-url that resolves to the target: without that guard it resets the target destructively and applies the plan while exiting 0 (measured: one table with 3 rows came back with the plan's new table and 0 rows)"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan lint` and `schema plan test`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Local by their flag sets (neither takes `--url`) but deferred: neither has a measured output contract, and guessing one puts a narrower checker in a gating position.",
-  "evidence": "ptah-compat schema plan lint -> unsupported-boundary stub. `lint` adds only -f/--file to the shared transition set and `test` takes --dev-url, --run and positional [paths] in the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), so both are local. `lint` is deferred because Atlas documents no output shape, failure threshold or exit code for it, and the engine that would back it (the `migrate lint` analyzer set) reports on a migration DIRECTORY; a plan linter covering fewer analyzers than Atlas's would report clean on a plan Atlas flags, which is a silent wrong answer in a gating position. `test` is deferred because it consumes `test \"plan\"` blocks in `.test.hcl` files (schema{url} + apply{url}, with the documented hard rule that the plan's `from` must match the schema block's state, and `-- PASS: <name> (2ms)` output) and nothing in Ptah parses `.test.hcl` yet — the engine reads YAML cases. `.test.hcl` ingestion is a shared item with `migrate test` and `schema test`"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan --push`, `--pending`, `--repo`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`--push`, `--pending` and `--repo` stay recorded waivers: they address the Atlas Registry, and Ptah's plan workflow saves local files instead.",
-  "evidence": "ptah-compat schema plan --push --from sqlite://x.db --to file://s.sql; conformance cli-surface.md classifies `atlas schema plan` as absent from the pinned CE binary. `--push` `--repo` `--pending` registered (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan --edit` and `--name-format`",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`--edit` preserves comments and re-derives dialect-aware severity; `--name-format` uses Atlas-shaped Base64 .FromHash/.ToHash values.",
-  "evidence": "Verified: `ptah-compat schema plan --from sqlite://x.db --to file://s.sql --save --edit --name-format 'plan_{{ slice .ToHash 0 12 }}'` (cmd/atlas/schema_plan_output_flags_test.go, internal/atlasschema/plan_edit_test.go). Measured 2026-08-02, CE v1.2.0 logged out: `schema plan` declares no own flags at all — each of the five answers `unknown flag` byte-identically to the nonsense controls `--name-formxxxx` and `--totally-bogus-flag`, and so does `--dev-url`, a flag CE knows on sibling verbs; only inherited `--env`/`-c`/`--var` parse and they reach the community abort, so CE never evaluates atlas.hcl for this verb (`schema plan --env nosuchenv` aborts where `schema inspect --env nosuchenv` says 'env not defined'). Registered on Atlas; live local runs verify that `.FromHash` and `.ToHash` are the untagged standard-Base64 values written to the plan block. An edit round-trips statement text verbatim, comments included, so quitting the editor unchanged reproduces the plan byte for byte."
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan --skip-lint`",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Accepted, and does nothing: `schema plan` runs no lint step, so there is nothing to skip. A Pro pipeline passing it keeps working; no check is loosened.",
-  "evidence": "Verified: `ptah-compat schema plan --from sqlite://x.db --to file://s.sql --output p.plan.json --skip-lint` produces byte-identical reported output AND a byte-identical plan document to the same run without the flag, over a DESTRUCTIVE fixture — the input any plausible linter would report on (cmd/atlas/schema_plan_output_flags_test.go TestSchemaPlanSkipLintIsANoOp). Measured 2026-08-02, CE v1.2.0: `unknown flag`, same as the nonsense controls; registered on Atlas's own help surface as 'skip linting migration plan', help text only. `internal/atlasschema.PreparePlanFile` invokes no linter — `migration/lint` is not imported on this path. The no-op status is a gap against Pro, not parity: Atlas lints the plan and Ptah does not, so a Pro pipeline relying on `schema plan` FAILING on an unlinted destructive change gets no such refusal here"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "`schema plan --format` and `--directive`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Both fail loudly, by design. `--format` is implemented on the eight compat verbs whose CE counterpart works and whose payload can therefore be measured; `schema plan` is the one verb where CE aborts.",
-  "evidence": "ptah-compat schema plan --format '{{ json . }}' -> 'Ptah does not implement --format for schema plan yet'. Measured 2026-08-02, CE v1.2.0: both answer `unknown flag`, same as the nonsense controls. Registered on Atlas's own help surface with help text only: `--format` 'output format', `-d/--directive` 'set a directive for the migration plan'. The rule is consistent rather than an exception: `--format` ships on `migrate apply/diff/lint/status` and `schema apply/clean/diff/inspect` because CE executes those verbs, so their report payload is measurable; `schema plan` aborts on CE and Atlas publishes help text only, so its payload field names are unknown and a Ptah-shaped payload would fail Pro templates referencing Atlas's. `--directive` is deferred because the measured Atlas `.plan.hcl` artifact (internal/atlasschema/testdata/atlas.plan.hcl) carries only from/to/migration, so a directive would have to ride inside the migration heredoc in an unmeasured spelling — and Ptah's own Atlas-format reader ignores `-- atlas:checkpoint` today (#954), so emitted directives would be silent no-ops"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Dynamic down planning (`migrate down --plan`)",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files.",
-  "evidence": "ptah-compat migrate down --plan --url sqlite://x.db --dir file://m; conformance cli-surface.md CE inventory. `migrate down` registers `--plan`, `--to-tag`, `--skip-checks` (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "Atlas Cloud deployment reporting",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "No Atlas account model or deployment API. Ptah attaches a deployment-report referrer to its own OCI artifact after an oci:// migrations up.",
-  "evidence": "migrations up over oci:// then oci referrers -> application/vnd.stokaro.ptah.deployment.v1, sha256:cffc640a; --skip-report opts out; docs-coverage.md:499-505 records Atlas Cloud reporting as Cloud and out of scope"
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "Schema monitoring, hosted UI, login",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check.",
-  "evidence": "docs/site/src/content/docs/atlas/docs-coverage.md. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Schema Monitoring section is marked not available on Starter and priced $39/mo per monitored database on Pro, covering schema changelog and drift detection & alerts"
- },
- {
-  "area": "Approval and policy workflows",
-  "feature": "Reviewer approval and policy workflows",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope.",
-  "evidence": "docs/site/src/content/docs/atlas/comparison.md. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Protected flows & policies' is unchecked for Starter and checked for Pro"
- },
- {
-  "area": "Dev databases",
-  "feature": "Docker dev databases (`docker://` `--dev-url`)",
-  "ptah": "no",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL.",
-  "evidence": "ptah-compat migrate diff --dev-url docker://postgres/16/dev --dir file://m --to file://s.sql; conformance cli-surface.md lists `--dev-url` in the CE `atlas migrate diff` flag set"
- },
- {
-  "area": "Migration linting",
-  "feature": "Atlas web reports (`--web`)",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either.",
-  "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web`, `ptah-compat schema diff --web`, `ptah migrations lint --web` each print `error: unknown flag: --web`. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
- },
- {
-  "area": "Testing framework",
-  "feature": "Atlas `.test.hcl` ingestion",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "No .test.hcl parser; a directory of them reports 'no test cases found' (`ptah-compat` exit 1, native exit 2).",
-  "evidence": "Built ptah-compat: `migrate test --dir file://migrations --dev-url sqlite://dev2.db hcltests` where hcltests holds one basic.test.hcl exits 1 with \"error: no test cases found in hcltests\"; migration/dbtest/parse.go reads YAML cases only; conformance cli-surface.md line 40 classifies `atlas migrate test` out-of-scope for CE. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Testing Framework' is unchecked for Starter and checked for Pro/Enterprise. authored .test.hcl fixtures run locally on sqlite; a single file is accepted as [paths] while ptah-compat requires a directory (measured; observation study, scenario, test-hcl)"
- },
- {
-  "area": "Schema inspection filters",
-  "feature": "`schema inspect --include` filtering",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects.",
-  "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; pinned Atlas CE v1.2.0 `schema inspect -u sqlite://app.db --include users` exits 1 with \"Error: unknown flag: --include\". Built ptah-compat after this change: `schema inspect -u sqlite://app.db --include t1` renders t1 with its columns and drops t2; `--include main.t1.*` exits 1 before connecting; `--include t2` refuses the projection because t2's foreign key targets unselected t1. `--include t1` matches Ptah, `--include '*.t1'` is read at child depth and renders t1 without columns plus an empty t2 shell, `--include 'main.t1.*'` exits 1 with \"too many parts in pattern\" (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Migration directory formats",
-  "feature": "Flyway repeatable (`R__`) migration import",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Compat import converts `R__` to a one-time migration ordered last, as Atlas CE runs it. Editing the body then fails on a Ptah revision checksum where CE exits 0.",
-  "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. CE hashes AND executes R__ files: on V1__init.sql + R__repeat.sql, atlas.sum covers both and `atlas migrate apply` runs both, recording the repeatable with an EMPTY version. Every repeatable carries that empty version whatever its own token - R__a.sql, R1__a.sql and Rfoo.sql all execute as version \"\" - so two repeatables in one directory are a duplicate CE cannot execute (it runs the first, then panics with index out of range, exit 2) and ptah-compat refuses up front with \"Flyway migrations R1__a.sql and R2__b.sql both carry the empty Atlas version\". Before stokaro/ptah#982 compat import aborted the whole directory on any R__ file while still hashing it, which was an over-refusal on a directory the oracle applies. STILL PARTIAL after #982: editing a repeatable body and re-hashing is the normal Flyway lifecycle, and there CE reports \"No migration files to execute\" exit 0 while ptah-compat exits 1 with \"migration 9223372036854775807 checksum mismatch\" - Ptah's own per-revision checksum over the converted SQL, not the directory sum (both `migrate validate` calls exit 0). Ptah's Atlas migrator skips Repeatable-marked files entirely, so re-run-on-change would need repeatable support in migration/migrator. `ptah migrations import --from flyway` wrote 0000000002_repeatable_active_users.up.sql. Atlas side: the vendored Atlas corpus carries import/flyway/R__views.sql and its golden output import/flyway_gold/3R_views.sql (conformance gaps.md:571,577)."
- },
- {
-  "area": "Migration directory formats",
-  "feature": "External `--dir-format` outside `migrate import`",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "hash and validate read every Atlas source layout, under both `?format=` and `--dir-format`; lint, new, set and status still take only atlas and need migrate import first.",
-  "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. `ptah-compat migrate hash --dir 'file://m?format=goose'` and `--dir file://m --dir-format goose` write an atlas.sum byte-identical to CE's, for atlas plus all five external formats, over a fixture holding goose, golang-migrate and Flyway V/B/R/U files and a nested migration; `migrate validate` matches CE's exit code and stdout/stderr on unhashed, clean and tampered directories for each. When the two spellings disagree the query wins, measured both ways round: `?format=goose --dir-format flyway` covers the goose set and `?format=flyway --dir-format goose` covers the Flyway one. Still refused, unchanged: `ptah-compat migrate lint --dir-format goose` -> \"Atlas accepts --dir-format=goose, but Ptah does not implement that directory format yet\" (same on new, set, status, edit, rebase, rm, test and checkpoint; checkpoint now accepts atlas and ptah but still refuses the five external formats). Three inputs stay refused where CE exits 0, all loudly: an empty --dir-format value, a query parameter other than format, and a repeated format parameter. Measured 2026-08-02, still open: `?format=` is accepted only by apply, hash and validate - checkpoint, lint, new, set, status and diff reject every query parameter with \"migration directory URL query parameters are not supported for this command\". On lint, new and diff that is a CE parity defect, not a design choice: CE exits 0 and FUNCTIONALLY honors the parameter (on a golang-migrate directory `?format=golang-migrate` turns `L2: 1_init.down.sql was added` exit 1 into `Migration Status: PENDING` exit 0) and validates the value (`?format=totally-bogus` -> `unknown dir format`, not ignored). On checkpoint alone the refusal is correct, because CE aborts every invocation of that verb and so has no contract to diverge from. Unknown-key intolerance is a separate defect on ALL eight verbs including the three that work: `apply --dir 'file://m?nonsense=1'` exits 1 where CE applies at exit 0, so a typo'd `?format=atals` is a footgun. Tracking: stokaro/ptah#1002 covers status and set; #990 covers empty --dir-format, non-format keys and repeated keys on hash and validate only; #1013 covers `?format=` on lint/new/diff and the unknown-key case on every verb."
- },
- {
-  "area": "Migration directory formats",
-  "feature": "Atlas-format checkpoint output",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`migrate checkpoint --dir-format atlas` writes the single `-- atlas:checkpoint` file plus atlas.sum, and is compat's default; `--dir-format ptah` writes the reversible pair. Up-only, as Atlas is.",
-  "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. CE registers `migrate checkpoint` but gates it (bare invocation -> 'Abort: not supported by the community version', exit 1) and registers NONE of its own flags: flag parsing precedes the gate, so --dir-format/--dir/--dev-url/--edit/--format/--qualifier/--schema/--lock-name/--lock-timeout all return 'unknown flag' while --config/--env reach the abort; the nonsense control `atlas migrate frobnicate` instead prints the migrate group help, exit 0. So there is no CE flag surface to conform to and this is a Pro-surface addition (issue #951 second standing constraint); Atlas Pro registers --dir-format with default 'atlas', which is why compat now defaults to atlas while native `ptah migrations checkpoint` stays ptah. Write side verified end to end: `ptah-compat migrate checkpoint --dir file://m --dev-url sqlite://s.db` wrote 20260802120402_checkpoint.sql (directive on line 1) and an atlas.sum covering all three files; the PINNED CE binary then `migrate validate` exit 0, `migrate apply` on a fresh db ran only the checkpoint and recorded 20260802120402|checkpoint|2|1|1, and on a pre-checkpoint db printed 'No migration files to execute' exit 0 - ptah-compat produced the identical revision row and identical sqlite schema. Note CE cannot WRITE a checkpoint but does HONOR the directive on read, so the pinned oracle covers both halves. Two shapes are refused before anything is written, both found by review rather than by a failing test: a checkpoint that would leave BOTH ptah.sum and atlas.sum behind (--dir-format auto then refuses the directory outright), and an atlas checkpoint into a directory holding ptah-convention files at all, hashed or not - an UNHASHED ptah directory has no sum to detect, and converting it made the checkpoint permanently invisible (discovery reads the ptah pair, while validate found the new atlas.sum and called the directory sound). Version resolution takes the MAXIMUM of the Atlas timestamp and one above the newest migration from a RECURSIVE walk: the timestamp helper scans only the top level, so on m/20250801000001_init.sql + m/sub/29990101000000_future.sql the checkpoint replayed the nested file into its body yet sorted below it, and a fresh apply then re-ran it - 'table future_tbl already exists', exit 1, dirty revision row, i.e. #954 reproduced by our own writer. That was also a we-fail-where-CE-succeeds divergence, since CE's reader is shallow and applied the same directory at exit 0 with one clean row. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration checkpoints' is Starter ✗ / Pro ✓, grounding oss=no and pro=yes (stokaro/ptah#951, #954)"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "schema inspect to HCL, SQL, or JSON",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Default HCL; `--format` sql|json|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export.",
-  "evidence": "`ptah-compat schema inspect --help`; conformance cli-surface.md row `atlas schema inspect`"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Inspect non-database sources via `--dev-url`",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails.",
-  "evidence": "conformance gaps.md probe `inspect-source-workflow`; /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/docs/site/src/content/docs/atlas/schema-commands.md"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Inspect split/write file exports",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`{{ hcl . | split | write \"dir\" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community.",
-  "evidence": "Verified: `ptah-compat schema inspect --format '{{ hcl . | split | write \"exp\" }}'` wrote exp/tables/{posts,users}.hcl; comparison.md:139"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "schema apply against a live database",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite.",
-  "evidence": "Verified: `ptah-compat schema apply --url sqlite://target.db --to file://new.sql --auto-approve`; conformance cli-surface.md `atlas schema apply`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema apply --url sqlite://t.db --to file://schema.sql --dev-url 'sqlite://file?mode=memory' --auto-approve` planned and applied, exit 0; without `--dev-url` CE errors '--dev-url cannot be empty'. The pricing page's 'Declarative migrations' Starter cross refers to the plan/approve product flow, not to `schema apply`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Declarative migrations' is listed Starter ✗ / Pro ✓ and links /declarative/plan — tension with the measured CE apply; read as covering the pre-planned (`schema plan`) flow, not plain `schema apply`, so the measured oss=yes stands"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "`--dry-run`, `--auto-approve`, and `--edit`",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied.",
-  "evidence": "Verified: a scripted $EDITOR replaced the plan and `schema apply --edit --auto-approve` applied the edited SQL; `ptah-compat schema apply --help`; conformance cli-surface.md lists all three in the CE `atlas schema apply` flag set"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Dev-database rehearsal before apply",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row.",
-  "evidence": "Reproduced: `pc schema apply --url sqlite://t4.db --to file://b.sql --auto-approve --dev-url sqlite://dv4.db` -> `Schema apply completed successfully.` (exit 0); `--dev-url sqlite://r1.db` equal to --url -> `error: --dev-url must not point at the target database: the dev database is reset destructively before the plan is rehearsed on it` (exit 1). Conformance gaps.md lines 25-27 record the reset, failed-rehearsal, and dev!=target observations. The only refused form is docker://, covered by the existing ❌ 'Docker dev databases' row"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Apply advisory lock and `--lock-timeout`",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note.",
-  "evidence": "internal/dblock/dblock.go:54-64 returns true for Postgres, YugabyteDB, MySQL, MariaDB, SQLServer — the previous note wrongly listed YugabyteDB as unlocked. cmd/atlas/schema_apply.go:578 emits the stderr note. Reproduced: `pc schema apply --url sqlite://t1.db --to file://b.sql --auto-approve --lock-timeout 10s` -> `note: schema apply locking is not supported for dialect \"sqlite\"; --lock-timeout is ignored and the apply proceeds without a database lock` then a successful apply (exit 0). CE registers --lock-timeout on schema apply per cli-surface.md:43"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Desired-state sources for `--to` and `--from`",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early.",
-  "evidence": "internal/atlassource/atlassource.go:245-264 classifyLocal only promotes a directory to a source when atlas.sum is present; :123-124 atlas:// rejection. Reproduced: `ptah-compat schema diff --to file://sqldir` -> \"schema file is a directory\""
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Local pre-approved plan files",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check.",
-  "evidence": "Fixed by #958 (measured: mutual plan-file unreadability, opposite --plan/--to contracts, foreign fingerprints). Verified: `schema apply --url sqlite://b.db --to file://desired.sql --plan file://atlas.plan.hcl --auto-approve` applies the real Atlas-authored oracle plan end to end (cmd/atlas/schema_apply_planhcl_test.go); `schema plan --from sqlite://x.db --to file://new.sql --output x.plan.hcl` round-trips; internal/atlasschema/testdata/atlas.plan.hcl is Atlas's own artifact. Ptah-written `.plan.hcl` parses in Atlas's reader but its sha256 fingerprints cannot satisfy Atlas's own hash verification (no local recipe, either direction)."
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "schema diff between two schema states",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply.",
-  "evidence": "internal/planner/dialects/sqlite/sqlite.go:87-105 and :489 return unsupportedFeaturef for these cases. Reproduced: TEXT->INTEGER and NOT NULL->nullable both give `error: generate schema diff SQL: sqlite: modifying columns on table users requires a table rebuild plan` (exit 1); adding a column with UNIQUE gives `sqlite: adding column email to table users requires a table rebuild plan`. Plain adds and table drops still plan cleanly. CE registers schema diff per cli-surface.md:45"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "`--schema` / -s scoping of both sides",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically.",
-  "evidence": "conformance gaps.md `atlas schema apply -s` and `atlas schema diff -s` shorthand rows; docs/site/src/content/docs/atlas/schema-commands.md"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "`--include` resource selectors",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics.",
-  "evidence": "cli-surface.md lines 43,45 (--include registered on CE apply/diff); atlas/comparison.md: 'Atlas CE aborts --include as a non-community feature'; schema-scope-workflow probe in gaps.md; pinned CE v1.2.0 `schema diff --include users` exits 1 with \"Abort: 'atlas schema diff --include' is not supported by the community version\", and `schema inspect --include users` exits 1 with \"Error: unknown flag: --include\""
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "`--exclude` glob and type selectors",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums.",
-  "evidence": "internal/atlasfilter/filter.go:341-346 (filterFunctions matches function.Name only) and :298-302 (filterEnums matches value.Name only); dbschema/types/types.go:358-367 DBFunction and :106-109 DBEnum carry no Schema field; internal/tableref/tableref.go:14-21 Canonical returns the bare name when schema is empty; live PostgreSQL 16 repro with the built ptah-compat binary; Atlas CE side from conformance cli-surface.md line 43/45/47 (--exclude registered on schema apply, diff, inspect)"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "schema fmt (HCL canonical layout)",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate.",
-  "evidence": "`ptah-compat schema fmt --help`; conformance cli-surface.md flags and usage rows for `atlas schema fmt`"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "schema clean",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables.",
-  "evidence": "internal/schemaclean/clean.go:109-147 enumerates only foreign keys, tables and enums; :75-81 executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty — the unreported view v_const was dropped as well. CE registers schema clean per cli-surface.md:44"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Drift detection against desired schema",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope.",
-  "evidence": "`ptah schema drift --help`; docs/site/src/content/docs/atlas/docs-coverage.md section \"Drift detection\". Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Drift detection & alerts' is listed under the Schema Monitoring product, Starter ✗, with Schema Monitoring itself unavailable on Starter and priced $39/mo per monitored database on Pro — Atlas-side support for oss=no (no free-tier drift) and for pro=yes as paid Schema Monitoring, per the note's Cloud-scope caveat"
- },
- {
-  "area": "Declarative / direct schema workflow",
-  "feature": "Go-template `--format` output",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only.",
-  "evidence": "internal/atlasreport/schema_apply.go:45-47 and schema_diff.go:66 register only \"sql\"; schema_inspect.go:161-173 registers base64url/hcl/json/mermaid/sql/split/write. Reproduced: `pc schema diff ... --format '{{ json . }}'` -> `error: parse --format template: template: atlas-schema-diff-format:1: function \"json\" not defined` (exit 1); same on schema apply; `{{ .Realm }}` on diff -> `can't evaluate field Realm in type atlasreport.SchemaDiff`. `{{ json . }}` works on schema inspect, schema clean, and migrate status. `{{ json . }}` on `schema diff` is also undefined in Atlas - parity on that sub-point (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations — execution",
-  "feature": "Apply pending migrations (apply/up)",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format table creation remains #950; Ptah-format is covered.",
-  "evidence": "Dry-run tests cover native and compat CLIs, dirty/checksum/tx-mode validation, exact legacy and rejected partial SQLite layouts, seven live database targets, PostgreSQL multi-schema search_path and explicit schemas, plus deterministic Spanner SQL. External directory formats remain verified by apply fixtures."
- },
- {
-  "area": "Versioned migrations — execution",
-  "feature": "Roll back applied migrations (down)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Ptah validates all selected down bodies before changing state. Dry-run reports distinguish preflight rejection from attempted rollback. Registry flags remain waivers.",
-  "evidence": "internal/atlasmigrate/down_test.go covers missing-down preservation, dry-run validation, and dirty preflight; cmd/atlas/migrate_down_format_test.go proves preflight failures render no reverted files. CE v1.2.0 logged out aborts as unsupported. `migrate down` works locally, deletes reverted revision rows (including Ptah-written rows), and inserts `.atlas_cloud_identifier`, which Ptah cannot yet read (#957; observation study scenario migrate-down-revisions). Fixed 2026-08-01 (stokaro/ptah#957): Ptah revision readers now treat dot-prefixed versions as metadata - skipped in version/status/pending math, never rewritten or deleted - and dry-run down reads the live revision table instead of reporting version 0"
- },
- {
-  "area": "Versioned migrations — execution",
-  "feature": "Failed rollback state is recorded and recoverable",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "Native `ptah migrations down` marks the row failed with the error and completed-statement count, so status reports it dirty and `migrations repair` clears it; compat matches Atlas, which records none.",
-  "evidence": "Measured: a down whose second statement fails rolls the body back and leaves the revision row at applied=2, total=2, error='' - `atlas migrate status` still reports the version applied - and a repaired retry succeeds and deletes the row. In the pinned CE binary `migrate down` is a registered community-abort stub, so the capability is unreachable there. Ptah splits by surface: migration/migrator reproducesAtlasDownBookkeeping keeps Atlas semantics for Atlas-format revisions (always the case on ptah-compat) and keeps Ptah's dirty-state bookkeeping natively; both directions are pinned by migration/migrator/atlas_down_bookkeeping_test.go, including the ptah-format regression guard and the repair path (stokaro/ptah#957) Correction after review: `applied` is the number of down statements that completed (StatementIndex-1), not a constant 0 - measured (2,'failed',1,2) for a second-statement failure on sqlite; it is forced to 0 only when the dialect rolled the body back or the first statement failed. `repair --resume-from` is up-direction only (resumeMigration replays migration.UpSQL) so it is not the failed-down recovery lever; plain `repair --version N` is. A down marked `-- atlas:txmode none` leaves a half-reverted schema behind an unchanged row on the Atlas surface, matching Atlas."
- },
- {
-  "area": "Versioned migrations — execution",
-  "feature": "Migration status report",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next.",
-  "evidence": "/tmp/ptah-compat migrate status --format '{{ .Env }}|{{ len .Available }}|{{ len .Applied }}|{{ len .Pending }}|{{ .Current }}|{{ .Next }}' against SQLite; conformance cli-surface.md row `atlas migrate status` (oss)"
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Directory integrity file: hash, validate, and apply-time gate",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "hash writes `ptah.sum` or `atlas.sum`; validate checks it. Compat apply refuses a stale or missing `atlas.sum`, including via `?format=`, over that layout's file set; native up gates hashed dirs only.",
-  "evidence": "/tmp/ptah migrations hash/validate --help; verified create→hash→validate (exit 0) then tampered file→validate exit 1; ptah migrations hash --dir-format atlas wrote atlas.sum. Apply-time gate: a tampered hashed directory refuses on both surfaces before executing anything (stokaro/ptah#955, PR #962). Missing sum file measured 2026-08-01 against Atlas CE v1.2.0 (stokaro/ptah#970): on a directory with no atlas.sum, Atlas exits 1 with `Error: checksum file not found` and never creates the target database; ptah-compat migrate apply now matches that output byte for byte (same code path as ptah-compat migrate validate). The refusal keys on the presence of any *.sql file, also measured: CE gates an unhashed dir holding only foo.sql, and reports `No migration files to execute` at exit 0 for an empty or .gitkeep-only dir. Ptah scans that tree recursively while CE reads only the top level, so an unhashed dir whose only migration sits in a subdirectory exits 1 here and 0 on CE — deliberate, because Ptah's registrar executes those files (stokaro/ptah#976). Native `ptah migrations up` deliberately stays permissive on a never-hashed directory and reports `migration sum verification failed: atlas.sum not found; run 'ptah migrations hash --dir-format atlas' to create it` only under --verify-sum (exit 2). Directories read through ?format= (goose/flyway/liquibase/dbmate/golang-migrate) are gated on the atlas.sum the SOURCE directory carries, verified before the source layout is parsed and before the database is opened (stokaro/ptah#973, on top of #984 and #992). Measured 2026-08-02 against Atlas CE v1.2.0 with scripts/probe-atlas-apply-gate.sh: five formats x {never hashed, hashed clean, edited, file added, file removed} match CE's exit code and refusal text, with the L<n> line naming the SOURCE file (1_init.up.sql for golang-migrate, V1__init.sql for flyway). The covered set is per layout, so editing a golang-migrate down file, a Flyway undo file, or a file a Flyway baseline squashes is invisible to both tools, and an empty covered set is exempt from the missing-sum refusal (CE exits 0 with `No migration files to execute` on golang-migrate down-only and Flyway undo-only). Flyway is the one layout whose sum reaches into subdirectories, so an unhashed flyway dir holding only sub/V2__nested.sql is refused by both while the same shape read as goose is exempt. Still open on those exempt rows: ptah-compat reports `no importable migration files found` and exits 1 where CE exits 0 (stokaro/ptah#980). `ptah-compat migrate status` on an unhashed dir exits 0 where CE exits 1: stokaro/ptah#974. What the gate verifies is also what apply executes, for every layout, since stokaro/ptah#982: the importer selects the files it converts with the same SumFileNames rule the gate hashes. Before that, Flyway alone ran a wider set - measured 2026-08-02, a superseded baseline (B1 under B2) and a lowercase prefix (v2__evil.sql) both executed on a directory `migrate validate` called clean on BOTH tools, so SQL ran that no checksum covered. scripts/probe-atlas-apply-gate.sh section 9a now asserts parity on both shapes plus a repeatable, a nested migration and a baseline outranking its survivor, comparing the number each tool ran against the covered-set size rather than only against each other."
- },
- {
-  "area": "Versioned migrations — safety",
-  "feature": "Migration linting",
-  "ptah": "yes",
-  "atlas_oss": "partial",
-  "atlas_pro": "yes",
-  "note": "CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time.",
-  "evidence": "Executed: `ptah-compat migrate lint --dir file://migrations --latest 1` reports \"destructive changes detected -- L1: DROP COLUMN ... #DS103\" and exits 1; `--format '{{ range .Files }}{{ .Name }}{{ end }}'` renders the Atlas template. No rule-loading flag in `ptah migrations lint --help`; custom rules come from migration/lint/rules.go:20 (Register) and lint.Options.ExtraRules (migration/lint/lint.go:107). Atlas CE registers migrate lint (conformance cli-surface.md:33). Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate lint --dir file://m --dev-url sqlite --latest 1` analyzed and reported 'destructive changes detected', exit 1 - the binary lints logged out. The pricing page places 'Migration linting' outside Starter; that classifies the plan, not the binary. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' listed Starter ✗ / Pro ✓, corroborating the features-page Pro classification; the measured pinned CE binary still registers `migrate lint` with the basic rule set, so oss stays partial rather than flipping to no. logged out, current upstream `migrate lint` aborts 'Starting with v0.38, atlas migrate lint is available only to Atlas Pro users' - the pinned CE v1.2.0 behavior no longer matches current upstream (measured; observation study, scenario, lint-test-pro)"
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Create an empty migration file",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR.",
-  "evidence": "verified `ptah-compat migrate new init_users --dir file://atlasdir` wrote one .sql plus atlas.sum, and `ptah migrations create` wrote an up/down pair; ptah migrations create --help (--editor defaults to $VISUAL then $EDITOR)"
- },
- {
-  "area": "Versioned migrations — revision state",
-  "feature": "Set revision state to a version",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set.",
-  "evidence": "docs/site/src/content/docs/atlas/comparison.md#versioned-migrations (`ptah-compat migrate set` paragraph); /tmp/ptah-compat migrate set --help; conformance gaps-migrate-runtime.md fixture `sqlite/set-repair-state`"
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Generate migrations from a schema diff",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry.",
-  "evidence": "Executed: `ptah-compat migrate diff --dir file://migrations --dev-url sqlite://... --to file://desired.sql first` into an empty dir wrote 1785514646_first.sql; into a dir whose latest was 20240101000000 it wrote 20240101000001_add_posts.sql; `ptah-compat migrate new ... hello` wrote 20260731161705_hello.sql. Code: migration/generator/generator.go:414 seeds from migrator.GetNextMigrationVersion (migration/migrator/util.go:302, time.Now().Unix()) while generator.go:228 uses \"20060102150405\". Atlas fixture versions are 14-digit (20220318104614_initial.sql, gaps.md)."
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Migration import from other tools",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed.",
-  "evidence": "Executed: `ptah-compat migrate import --from https://example.com/m` and `--from atlas://myrepo` both fail \"only local file:// migration directories are supported\"; `--dir-format liquibase` on a changelog.xml fails \"liquibase XML/YAML/JSON changelogs are not yet supported\". golang-migrate, goose and dbmate dirs import to single up-only Atlas files (down bodies dropped). Conformance PARITY.md:147 records Liquibase XML/YAML/JSON as a follow-up.; ptah migrations import --help (--from golang-migrate, goose, flyway, liquibase, dbmate); conformance cli-surface.md (atlas migrate import, class oss); do"
- },
- {
-  "area": "Versioned migrations — revision state",
-  "feature": "Baseline an existing database",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`.",
-  "evidence": "/tmp/ptah migrations baseline --help (--shadow-db, --dry-run, --version); conformance cli-surface.md `atlas migrate apply` flag list (--baseline)"
- },
- {
-  "area": "Versioned migrations — revision state",
-  "feature": "Repair dirty or partial revision state",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "`ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence.",
-  "evidence": "/tmp/ptah migrations repair --help (--resume-from executes remaining up statements before marking applied); conformance cli-surface.md Atlas CE inventory (no `atlas migrate repair` row)"
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Migration checkpoints (squash history)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Replays the directory on `--shadow-db` into a cumulative checkpoint: the ptah reversible pair, or Atlas's single `-- atlas:checkpoint` file under `--dir-format atlas`. CE gates the verb.",
-  "evidence": "/tmp/ptah migrations checkpoint --help (--shadow-db required); conformance cli-surface.md `atlas migrate checkpoint` (out-of-scope: Pro, absent from CE); PARITY.md `checkpoint-workflow`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate checkpoint` -> exit 1 community-abort. Pricing page: 'Migration checkpoints' is Pro, not Starter"
- },
- {
-  "area": "Versioned migrations — directory",
-  "feature": "Directory maintenance: edit, rebase, rm",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Each rewrites `ptah.sum`/`atlas.sum` and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs.",
-  "evidence": "/tmp/ptah migrations edit|rebase|rm --help (\"refusing already-applied migrations\", --force, --db-url); conformance cli-surface.md rows `atlas migrate edit|rebase|rm` (out-of-scope: Pro); PARITY.md `pro-maint-workflow`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate edit`, `migrate rebase 1`, `migrate rm` each -> exit 1 community-abort"
- },
- {
-  "area": "Versioned migrations — revision state",
-  "feature": "Revision table format and placement",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "`--revision-format` ptah|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows.",
-  "evidence": "/tmp/ptah migrations up --help (--revision-format default ptah, --migrations-table, --migrations-schema); conformance gaps-migrate-runtime.md `sqlite/project-config-apply-oracle` and `postgres/custom-revisions-schema`"
- },
- {
-  "area": "Safety gates",
-  "feature": "Pre-migration assertion checks",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Scalar SELECTs; txtar checks.sql and checks/*.sql support all-of/oneof groups. CE ignores checks. Compat bypass is PTAH_SKIP_CHECKS.",
-  "evidence": "TestMigrateApplyDryRunTxModeAllDiagnosticDoesNotSuggestUnsupportedFlag proves compat dry-run rejects checked files without suggesting its unsupported `--skip-checks`; cmd/migrateup registers that flag only on native `ptah migrations up`. Measured 2026-08-01: CE v1.2.0 applies failing checks.sql unenforced; Atlas enforces it before the body and exposes `--skip-checks` on down, not apply (measured; observation study scenarios txtar-checks-enforcement and verbs-and-flags). Updated 2026-08-01 (stokaro/ptah#956): txtar checks.sql and ordered checks/*.sql sections run through the same pre-migration check engine on both binaries. Files default to all-of and support file-level atlas:assert oneof as documented by Atlas. Assertions are split with the live database dialect, restricted to top-level SELECT, and require exactly one column and one row; mutating and multi-row checks fail closed. Checks use a dedicated physical session. Transaction-capable drivers roll back, ClickHouse runs directly because its driver has no transaction support, and SQL Server NEXT VALUE FOR is rejected because sequence advances survive rollback. A failed check records NO revision row (checks run before the pending-revision insert), so the retry after fixing the data succeeds with no bypass flag, matching Atlas, which also writes nothing when its checks fail. Correction after review: ptah-compat migrate apply registers no --skip-checks but DOES register --allow-dirty; that flag cannot clear a dirty row because the retry fails on the revision re-insert with UNIQUE constraint failed (stokaro/ptah#966, measured on both surfaces), so a recorded check failure would have left no working in-band recovery (stokaro/ptah#964 review). Updated 2026-08-02 (stokaro/ptah#951): ptah-compat migrate apply reads the PTAH_SKIP_CHECKS environment variable as its bypass, wired through atlasmigrate.ApplyOptions.SkipChecks; the flag surface is unchanged and TestMigrateApplyHasNoSkipChecksFlag still pins the unknown-flag refusal. Measured 2026-08-02 on the pinned CE v1.2.0 binary: `migrate apply --skip-checks` answers `unknown flag: --skip-checks`, byte-identical to the nonsense control `--skip-chxxxx`, so the flag is unregistered rather than registered-and-gated; `migrate down --help` is community-aborted entirely on CE. Atlas's own help surface lists --skip-checks under `atlas migrate down` only — across the whole surface it appears on no other verb, and `atlas migrate apply` carries --skip-lock and --to-version but no --skip-checks."
- },
- {
-  "area": "Safety gates",
-  "feature": "Check bypass on the compat surface",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down.",
-  "evidence": "Measured 2026-08-02: pinned CE v1.2.0 answers `migrate apply --skip-checks` with `unknown flag: --skip-checks`, identical to the control `--skip-chxxxx`; Atlas's own help surface registers --skip-checks on `migrate down` only. Implemented in cmd/atlas/migrate_apply.go (atlasApplySkipChecksFromEnv) and internal/atlasmigrate ApplyOptions.SkipChecks. The variable is the PTAH_<FLAG> twin of native `ptah migrations up --skip-checks`. Both binaries agree on the name and on every valid boolean; they differ on an invalid one, which compat refuses outright while native discards the parse error and enforces (cmd/internal/cmdflags/env.go drops the flags.Set error) — both fail safe. It bypasses pre-migration checks only: TestMigrateApplySkipChecksEnvDoesNotBypassChecksumVerification pins that atlas.sum verification still refuses a tampered directory, and TestMigrateApplySkipChecksEnvStillRecordsRevisions pins unchanged bookkeeping. On `migrate down` the --skip-checks waiver is explicit-only (atlasargs.ExplicitUnsupportedBoolReason plus atlasMigrateDownExplicitOnlyFlags, one per parsing path, and cmdflags.DisableEnvBinding so --help stops advertising the twin): before this, PTAH_SKIP_CHECKS=1 made every `ptah-compat migrate down` fail with `accepts --skip-checks, but Ptah does not implement its behavior` on both the default and --format paths. The exclusion is deliberately ONE flag — --to-tag and --plan keep their twins because setting them is a genuine request, and discarding PTAH_TO_TAG would leave an empty target that reverts the entire history (measured 2026-08-02: users table and its row dropped)."
- },
- {
-  "area": "Versioned migrations — runtime policy",
-  "feature": "Transaction modes (`--tx-mode` file/all/none)",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks.",
-  "evidence": "migration/migrator/migrator.go validateTxModeAllDialect and rejectChecksUnderTxModeAll (also rejects no_transaction and per-migration timeouts); conformance gaps-migrate-runtime.md `sqlite/tx-mode-all|file|none`; /tmp/ptah migrations up --help"
- },
- {
-  "area": "Versioned migrations — runtime policy",
-  "feature": "Execution order (`--exec-order`)",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it.",
-  "evidence": "/tmp/ptah migrations up --help (--exec-order linear|linear-skip|non-linear); docs/site/src/content/docs/versioned/apply.md lines 138-141; conformance cli-surface.md `atlas migrate apply --exec-order`"
- },
- {
-  "area": "Versioned migrations — runtime policy",
-  "feature": "Migration lock and lock timeout",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`.",
-  "evidence": "/tmp/ptah migrations up --help (--lock-timeout per-migration, --migration-lock-timeout advisory); docs/site/src/content/docs/atlas/migrate-commands.md line 356; conformance cli-surface.md `atlas migrate apply --lock-timeout`"
- },
- {
-  "area": "Test frameworks",
-  "feature": "Migration test framework (`ptah migrations test`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set.",
-  "evidence": "`ptah migrations test --help`; docs/site/src/content/docs/reference/test-cases.md (Isolation); conformance cli-surface.md classifies `atlas migrate test` as absent from the pinned CE binary. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate test` -> exit 1 community-abort. Pricing page: 'Testing Framework' is Pro, not Starter. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Testing Framework' (linked to /testing/schema) is unchecked on Starter and checked on Pro — Starter absence corroborates the measured CE no, and the Pro check is the first Atlas-side source cited for the Pro column"
- },
- {
-  "area": "Test frameworks",
-  "feature": "Schema test framework (`ptah schema test`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb.",
-  "evidence": "ptah-atlas-conformance cli-surface.md (`atlas schema test` = out-of-scope); `ptah schema test --help`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema test` -> exit 1 community-abort. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Testing Framework' (linked to /testing/schema) is unchecked on Starter and checked on Pro — corroborates the measured CE absence and supplies an Atlas-side source for the Pro column"
- },
- {
-  "area": "Test frameworks",
-  "feature": "Atlas-shaped migrate test / schema test verbs",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`.",
-  "evidence": "Built ptah-compat `schema test --help` (flags: --dev-url, --run, -u only) and `migrate test --help` (--dev-url, --dir, --dir-format, --run only); `schema test -u file:///path/schema.sql` exits 1 with \"parse desired schema from ...: stat .: not a directory\"; `-u sqlite://target.db` and `-u env://src` exit 1 with \"only local file:// migration directories are supported\"; `migrate test --report json` is parsed as a positional path. Passing baseline: `migrate test --dir file://migrations --dev-url sqlite://dev.db tests` exits 0. Atlas side from cli-surface.md lines 40/59 (out-of-scope in CE) and lines 138-140/168-170. Atlas's `migrate test` and `schema test` also lack `--report` and `--seed-dir`; `schema test -u` accepts a SQL file and a live sqlite URL (both PASS) (measured; observation study, scenario, lint-test-pro, test-hcl)"
- },
- {
-  "area": "Test frameworks",
-  "feature": "Embeddable test runner (Go package)",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package.",
-  "evidence": "migration/dbtest/engine.go:247 RunMigrationTest and migration/dbtest/schema.go:53 RunSchemaTest; conformance cli-surface.md measures CLI commands only, and gaps.md lines 167-172 show the corpus imports atlasexec fixtures, so Atlas does have an observable Go package surface — the previous ❌/❌ cells asserted an Atlas distribution fact no cited source establishes"
- },
- {
-  "area": "Lint analyzers",
-  "feature": "Native migration lint rule set",
-  "ptah": "yes",
-  "atlas_oss": "partial",
-  "atlas_pro": "yes",
-  "note": "42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro.",
-  "evidence": "`ptah migrations lint --help` registers `--dialect` gating postgres/mysql/mariadb/sqlite/clickhouse/cockroachdb/yugabytedb/spanner; migration/lint/rules.go carries the DS/CD/DD/MF/BC/PG/MY/LT/TX families. Atlas feature availability page: \"Migration Linting\" = Pro, with \"Destructive changes\" and \"Backward incompatible changes\" listed Open and \"Concurrent index changes\" listed Pro. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter and checked on Pro — tension with the features page listing destructive and backward-incompatible rules as Open; the measured CE binary registers `atlas migrate lint` (cli-surface.md), so the partial verdict stands."
- },
- {
-  "area": "Lint analyzers",
-  "feature": "Atlas Pro analyzer code coverage",
-  "ptah": "partial",
-  "atlas_oss": "na",
-  "atlas_pro": "yes",
-  "note": "OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones.",
-  "evidence": "Reproduced on postgres: `ALTER TABLE t ALTER COLUMN c TYPE bigint` -> DS103 (PG301); `ALTER TABLE t2 ADD PRIMARY KEY (c)` -> PG104 (PG304). On mysql: `ALTER TABLE t CONVERT TO CHARACTER SET utf8mb4` -> MY101 (MY136); migration/lint/rules.go:1095 scanConvertCharset. gaps.md lint-analyzer-catalog records all five as `covered (mapped)`. comparison.md:488 records OW101/OW102 as account-bound waivers."
- },
- {
-  "area": "Lint analyzers",
-  "feature": "Default-firing Atlas analyzer concern mapping",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus.",
-  "evidence": "gaps.md lint-analyzer-catalog rows (lines 395-436) are all `ok` across the DS, MF, BC, CD, PG1, PG3, PG110, MY, LT and TX families. PARITY.md:178-203 states every default-firing concern is covered and that an uncovered concern added later fails closed to a red `missing` gap."
- },
- {
-  "area": "Lint analyzers",
-  "feature": "Custom lint rules and check-level policy",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail.",
-  "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} — no rule definition. config/projectconfig/atlas.go:536 parseLintPolicyBlocks accepts only concurrent_index, data_depend, destructive, git, nestedtx, incompatible; atlas.go:613 rejects `force`. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
- },
- {
-  "area": "Lint policy and suppression",
-  "feature": "Inline nolint suppression",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored.",
-  "evidence": "internal/atlaslint/rules.go:41 NativeSuppressionTargets maps 5 analyzer names + ds102/ds103/mf103 only, default returns nil. Reproduced: `ptah-compat migrate lint` reports `[PG101]` yet `-- atlas:nolint PG101` leaves the diagnostic. CE side: PARITY.md:420 records the imported Atlas fixtures asserting `-- atlas:nolint` suppression for `atlas migrate lint`; gaps.md:814 runs cli-migrate-lint-ignore.txtar with 57 assertions. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter — a plan-tier claim in tension with the measured CE fixtures asserting `-- atlas:nolint` suppression; the measured yes stands. `-- atlas:nolint <CODE>` and analyzer-name spellings both suppress; matching is exact, not blanket (measured; observation study, scenario, lint-test-pro)"
- },
- {
-  "area": "Lint policy and suppression",
-  "feature": "Per-rule severity policy",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "partial",
-  "note": "Severity vocabulary is warning|error only (info errors out). Measured, Atlas is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist.",
-  "evidence": "migration/lint/config.go:78 validateConfig admits only SeverityWarning/SeverityError. Reproduced: `severity: info` -> `error: failed to parse lint config .ptah-lint.yaml: rule DS101 has unsupported severity \"info\"` (exit 2); `severity: warning` demotes DS101 from error. config/projectconfig/atlas.go:594 parseLintAnalyzer takes only `error` bool. No cited Atlas source establishes CE severity-policy behavior; the Atlas features page classifies the linting CLI as Pro. analyzer blocks and .rule.hcl reject a `severity` attribute; the only per-analyzer control is boolean error (measured; observation study, scenario, lint-test-pro)"
- },
- {
-  "area": "Lint output and CI",
-  "feature": "SARIF 2.1.0 lint report",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "na",
-  "note": "Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint.",
-  "evidence": "Reproduced: `ptah migrations lint --format sarif` emits version 2.1.0 with driver \"ptah migrations lint\", a rules array, and a result carrying ruleId DS101, level warning, artifactLocation and region.startLine. gaps-migrate-runtime.md:34 `fidelity: sarif output shape` records the same. cli-surface.md:33 shows CE `--format` is the Atlas Go template only."
- },
- {
-  "area": "Lint output and CI",
-  "feature": "CI integration (GitHub Action, annotations)",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations.",
-  "evidence": "`ptah migrations lint --help` registers `--format ... github-actions`. Atlas side: docs/site/src/content/docs/atlas/docs-coverage.md:533 \"Atlas integration parity is unmeasured\"; the Atlas feature availability page does not address GitHub Actions integration, and cli-surface.md inventories no action. Nothing cited settles either Atlas column. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines section lists 'CI/CD integrations (K8s, TF, GH, GitLab, BitBucket)' as Basic on the free tier and checked on Pipelines Pro — a separately priced product ($59/mo per project requiring Atlas Pro seats), so it does not settle either CLI-plan column."
- },
- {
-  "area": "Safety gates",
-  "feature": "Apply-time destructive-change gate",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "na",
-  "note": "migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file.",
-  "evidence": "Reproduced: `ptah migrations up` aborts with `pending migrations contain destructive statements; rerun with --allow-destructive after review: - 0000000002_drop.up.sql:1 DS101 error`. Adding `.ptah-lint.yaml` with `disabled-rules: [DS101]` let the same up succeed; ptah.sum was byte-identical and `ptah migrations validate` still printed `OK: migrations directory matches ptah.sum`. Atlas side: cli-surface.md:27 lists no destructive-gate flag on `atlas migrate apply`."
- },
- {
-  "area": "Safety gates",
-  "feature": "Statement safety classification report",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "plan `--report` text|html|json and generate `--report` html|json emit highest severity, a destructive flag, and per-statement assessments.",
-  "evidence": "`ptah migrations plan --help` registers `--report string  Safety report format: text, html, or json (default \"text\")`; `ptah migrations generate --help` registers `--report string  Safety report format next to the migration files: \"\", html, or json`."
- },
- {
-  "area": "Verification and contracts",
-  "feature": "Dev / shadow database verification",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "`--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely.",
-  "evidence": "Built ptah binary --help: --shadow-db on `migrations generate`, `migrations checkpoint`, `migrations baseline`, `migrations down`; `migrations validate --dev-url docker://postgres/16/dev` exits 2 with \"docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for migration SQL replay\"; ptah-compat `schema apply --dev-url sqlite:///nonexistent-dir-xyz/dev.db --dry-run` exits 0 and prints a plan, while the same dev URL with --auto-approve exits 1 with \"connect to --dev-url: failed to ping database: unable to open database file (14)\"; conformance PARITY.md line 48 (dbtest-workflow) for the working replay path"
- },
- {
-  "area": "Verification and contracts",
-  "feature": "Exit-code contract for CI gates",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "na",
-  "note": "Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2.",
-  "evidence": "docs/site/src/content/docs/reference/exit-codes.md; docs/site/src/content/docs/reference/test-cases.md (Exit contract)"
- },
- {
-  "area": "Database engines",
-  "feature": "PostgreSQL 12+ (postgres, postgresql)",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner.",
-  "evidence": "/tmp/ptah-mx schema render --dialect postgres (built from /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/cmd/ptah); core/platform/capability/capability.go Postgres13/Postgres16/Postgres17 + ForServerVersion; docs/site/src/content/docs/databases/postgresql.md (Version-dependent behavior); comparison.md#supported-databases cites the Atlas Open driver list. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating PostgreSQL on the free tier"
- },
- {
-  "area": "Database engines",
-  "feature": "MySQL and MariaDB",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback.",
-  "evidence": "Live MySQL 9.7 `ptah schema apply --dry-run` fails with \"materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target\"; with the matview removed the plan contains only tables, a view, a trigger and the FK — the extension, function, sequence, domain, role, grant and RLS objects produce no statement and no warning. capability.go:358 MariaDB1011 sets Sequences=true, yet `schema render --dialect mariadb` emits no CREATE SEQUENCE. Atlas side: comparison.md:398 lists MySQL and MariaDB as Open drivers. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating MySQL and MariaDB on the free tier."
- },
- {
-  "area": "Database engines",
-  "feature": "SQLite (sqlite, sqlite3)",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with \"modifying columns ... requires a table rebuild plan\". PG-only objects error one at a time.",
-  "evidence": "`ptah schema diff --from a.sql --to b.sql --dev-url sqlite://dev.db` (TEXT->INTEGER) errors \"sqlite: modifying columns on table t requires a table rebuild plan\"; same error for NOT NULL removal, DEFAULT add and column UNIQUE add. Dropping a column instead emits the full \"__ptah_rebuild_t\" CREATE/INSERT/DROP/RENAME sequence. internal/planner/dialects/sqlite/sqlite.go:91 and :96. Live SQLite apply rejects matview, extension, function, sequence and user-defined types with one error each. Atlas side: comparison.md:398 lists SQLite as an Open driver. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating SQLite on the free tier."
- },
- {
-  "area": "Database engines",
-  "feature": "SQL Server and Azure SQL (sqlserver, mssql, tsql)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews.",
-  "evidence": "`ptah schema render --dialect sqlserver` emits 6 statements including CREATE VIEW and CREATE TRIGGER; `--dialect mssql` and `--dialect tsql` emit 4 with both missing, reproducible across 3 runs. Root cause fromschema.go:1747 supportsStandaloneViewsAndTriggers compares the raw string. cmd/generate/generate.go:113 default list omits sqlserver; :69 help text omits it. capability.go:481 SQLServer2022 sets Sequences/RLS/RoleManagement=false. Atlas side: comparison.md:400 lists SQL Server as Pro."
- },
- {
-  "area": "Database engines",
-  "feature": "ClickHouse (clickhouse, ch)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic.",
-  "evidence": "Live ClickHouse 24.12: `ptah schema apply --root-dir <fixture> --db-url clickhouse://... --dry-run` planned only the two CREATE TABLE statements from a 13-object fixture. Offline `schema render` emits skip comments for extension/enum/FK but nothing for views or triggers. capability.go:430 ClickHouse24 sets ForeignKeys=false, CheckConstraintsEnforced=false. Atlas side: comparison.md:400 lists ClickHouse as a Pro driver."
- },
- {
-  "area": "Database engines",
-  "feature": "CockroachDB (cockroachdb, crdb)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers.",
-  "evidence": "capability.go:507 CockroachDB23. `ptah schema render --dialect cockroachdb` errors: \"cockroachdb does not support sequence-backed type SERIAL; use a platform-specific type override\"; on a non-SERIAL fixture it emits 5 statements against postgres's 15, dropping view/matview/function/trigger/role/grant/RLS/domain/sequence. Root cause fromschema.go:110 isPostgreSQLPlatform matches only \"postgres\"/\"postgresql\". Atlas side: comparison.md:400 lists CockroachDB as Pro."
- },
- {
-  "area": "Database engines",
-  "feature": "YugabyteDB (yugabytedb, ysql)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them.",
-  "evidence": "Live YugabyteDB 2026.1.0.0: `ptah schema apply --db-url yugabytedb://... --dry-run` planned CREATE ROLE, CREATE SEQUENCE, CREATE DOMAIN, CREATE VIEW, CREATE MATERIALIZED VIEW, CREATE FUNCTION, CREATE TRIGGER and GRANT, and no RLS statement. `ptah schema render --dialect yugabytedb` on the same fixture emits 5 statements with all of those absent. capability.go:521 YugabyteDB25 sets RowLevelSecurity=false, RoleManagement=true. Atlas side: comparison.md:400 lists YugabyteDB as Pro."
- },
- {
-  "area": "Database engines",
-  "feature": "Spanner PostgreSQL interface (spanner)",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists.",
-  "evidence": "`ptah schema render --dialect spanner` emits \"-- SPANNER: enum type user_status is not supported by this target; skipped.\" and \"-- SPANNER: constraint \\\"fk_orders_user_id\\\" is not supported by this target; skipped.\"; with SERIAL it errors \"spanner does not support sequence-backed type SERIAL\". capability.go:532 SpannerPostgres. docker-compose.yaml has no spanner service (cockroachdb:71 and sqlserver:101 do); internal/dbschema/ has no spanner package. Atlas side: comparison.md:400 lists Spanner as Pro."
- },
- {
-  "area": "Database engines",
-  "feature": "TiDB and LibSQL",
-  "ptah": "no",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Both names fail dialect normalization: \"unsupported database dialect: tidb\" / \"...: libsql\". No renderer, planner or driver entry.",
-  "evidence": "`ptah schema render --dialect tidb` -> \"error: error rendering tidb schema: unsupported database dialect: tidb\"; same for libsql. platform/constants.go:19 NormalizeDialect has no tidb or libsql case. Atlas side: comparison.md:398 lists TiDB and LibSQL as Open drivers. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names only MySQL, MariaDB, PostgreSQL and SQLite (Pro: All) — tension with the Open-driver listing for TiDB and LibSQL; cells kept on the features-page classification pending a measured check of the CE binary."
- },
- {
-  "area": "Database engines",
-  "feature": "Oracle, Snowflake, Redshift, Databricks",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers.",
-  "evidence": "`ptah schema render --dialect oracle` -> \"error: error rendering oracle schema: unsupported database dialect: oracle\". platform/constants.go:19. Atlas side: comparison.md:400 lists Oracle, Snowflake, Redshift and Databricks as Pro drivers."
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Enum types",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim.",
-  "evidence": "internal/convert/fromschema/fromschema.go:268 `if !strings.HasPrefix(field.Type, \"enum_\") { return field }`; reproduced with /tmp/pt-audit schema render. Atlas CE column from stokaro/ptah-atlas-conformance gaps-diff.md rows `mysql/02-enum`, `postgres/02-enum`, `sqlite/02-enum` (compare against Atlas CE inspect, ok)"
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Views and materialized views",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1758-1764 appends only Views (never MaterializedViews) for the non-PostgreSQL path; `ptah schema render --dialect mysql` emitted no matview statement, while `ptah schema apply` against live MySQL 9.7 failed with \"materialized views are not supported by MySQL or MariaDB\""
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Functions",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1632-1634 appends functions only when isPostgreSQLPlatform; live MySQL 9.7 `ptah schema apply --dry-run` planned no function and printed no diagnostic. Atlas columns from stokaro/ptah-atlas-conformance PARITY.md: \"Atlas CE silently omits Pro-gated objects (views, triggers, functions, sequences) from inspection — no error, exit 0\""
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Triggers",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1747-1756 matches platform.SQLServer (\"sqlserver\") without normalizing; core/renderer/internal/dialects/mysqllike/mysqllike.go:643 hard-codes FOR EACH ROW; core/renderer/internal/dialects/mssql/mssql.go:626-628 maps BEFORE to AFTER; core/renderer/internal/dialects/sqlite/sqlite.go:313 errors on FOR EACH STATEMENT"
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Standalone sequences",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1593 gates CREATE SEQUENCE on isPostgreSQLPlatform; live YugabyteDB apply planned CREATE SEQUENCE \"yb_seq\" START WITH 1; SQL source: \"unsupported CREATE target: SEQUENCE\". Atlas columns from PARITY.md Pro-gated-object sentence"
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Extensions",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment.",
-  "evidence": "core/renderer/internal/dialects/mysql/mysql.go:26-30 copies the bufwriter by value so VisitExtension (line 132) writes to a buffer Output() never reads; verified live: `ptah schema compare` against PostgreSQL 18 proposed DROP EXTENSION for pg_trgm and left plpgsql alone"
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Roles, grants, and row-level security",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1710-1745 (roles/grants/RLS behind isPostgreSQLPlatform); live YugabyteDB apply planned CREATE ROLE \"yb_role\"; `ptah schema render --schema-file` rejects CREATE ROLE / GRANT / CREATE POLICY / ALTER TABLE ... ENABLE ROW LEVEL SECURITY. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `schema apply` with `role \"app\" { }` on sqlite -> exit 0 'Schema is synced, no changes to be made' (silent no-op). Atlas pricing page (atlasgo.io/pricing, retrieved 2026-08-01): 'Database Security as Code' is Pro, not Starter"
- },
- {
-  "area": "Schema object kinds",
-  "feature": "Domains, composite types, and range types",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all.",
-  "evidence": "internal/convert/fromschema/fromschema.go:1616 gates domain/range/composite emission on isPostgreSQLPlatform (postgres|postgresql only); migration/schemadiff/internal/compare/usertypes.go:158-174 compares ranges by name only; live YugabyteDB 2026.1.0.0 `ptah schema apply --dry-run` planned CREATE DOMAIN \"yb_domain\" AS TEXT"
- },
- {
-  "area": "Data and distribution",
-  "feature": "Registry-backed distribution: `oci://` vs `atlas://`",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`atlas://` functions — publish, pull, digest-pin, run migrations directly, schemas via `--schema-file` — over any OCI registry, no account. See [OCI registry artifacts](../../operate/oci-registry/).",
-  "evidence": "ptah schema push oci://localhost:5555/demo/schema:v1 --root-dir ./models --plain-http -> exit 0; cli-surface.md lines 35 and 58 classify `atlas migrate push` and `atlas schema push` as not present in the pinned CE binary; ptah migrations up --db-url sqlite://app.db --migrations-dir oci://localhost:5555/demo/mg:c1 --plain-http -> applied version 1785514698, exit 0; ptah migrations down --target 0 over the same reference rolled back, exit 0; internal/ociartifact/client.go:46 credentials.NewStoreFromDocker; htpasswd-protected registry: push without creds -> exit 2 'basic credential not found', sa. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' (Pipelines section) is unchecked on the free tier and checked on Pro with a 500-object limit — corroborates the measured CE absence of push verbs and supplies an Atlas-side source for the Pro column"
- },
- {
-  "area": "Schema sources",
-  "feature": "Desired-schema artifacts in an OCI registry",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "`ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2.",
-  "evidence": "push -> Digest sha256:2ebd84f93717f397e89cb5862913f6e7679064d624a9f1e22b7092504bd1de92; ptah schema pull --out pulled.hcl returned the same digest and a valid table block. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' is unchecked on the free tier and checked on Pro (500-object limit) — first Atlas-side source cited on this row, supporting atlas_oss no and atlas_pro yes"
- },
- {
-  "area": "Data and distribution",
-  "feature": "oci:// as a `--schema-file` desired-state source",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose `--plain-http`.",
-  "evidence": "ptah schema drift/compare --schema-file oci://... --plain-http -> works; ptah schema inspect --schema-file oci://... -> 'unsupported desired-state URL scheme \"oci\"'; ptah schema render/plan/apply and migrations generate -> 'unknown flag: --plain-http'. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines tier table lists Atlas Registry as absent from Starter and included in Pro (limited to 500 objects) — Atlas-side confirmation that registry-backed schema sources are Pro-gated"
- },
- {
-  "area": "Data and distribution",
-  "feature": "Digest pinning and write-once version tags",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "unknown",
-  "note": "Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move.",
-  "evidence": "push to @sha256:2ebd84f9... -> exit 2 'cannot push to a digest reference'; re-push --version rel1 with changed content -> exit 2 'OCI write-once tag already exists'; tag v1 moved from sha256:869dd082 to sha256:70575f30 across pushes while rel1 stayed pinned"
- },
- {
-  "area": "Data and distribution",
-  "feature": "Artifact integrity check (`--verify-sum`)",
-  "ptah": "partial",
-  "atlas_oss": "na",
-  "atlas_pro": "unknown",
-  "note": "On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes.",
-  "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'"
- },
- {
-  "area": "OCI artifacts",
-  "feature": "Referrer attachments: lint, plan, deployment reports",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "unknown",
-  "note": "lint `--attach`, migrations plan `--attach` and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload.",
-  "evidence": "oci referrers --format json returns digest/artifact_type/media_type/size/annotations only; flags are --format, --type, --plain-http; the manifest's deployment.json layer (362 bytes) is reachable only through the raw registry API; cmd/oci/oci.go:69 calls ocireferrers.List"
- },
- {
-  "area": "Schema sources",
-  "feature": "Atlas CE inspect HCL parses back into Ptah",
-  "ptah": "yes",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "30 atlas-differential observations parse Atlas CE 1.2.0 `schema inspect` HCL on Postgres/MySQL/SQLite with zero schema-fact mismatches.",
-  "evidence": "conformance gaps-diff.md (30 ok / 0 gap, probe atlas-differential, Atlas pinned a5e0aec); PARITY.md: \"Atlas's view comes from `schema inspect` in its native HCL, parsed by Ptah's own core/atlashcl\""
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL top-level blocks Ptah parses",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data.",
-  "evidence": "internal/atlashcl/atlashcl.go:73-113; a fixture exercising all 16 renders 17 PostgreSQL statements via `ptah schema render --schema-file all.hcl --dialect postgres`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Database Security as Code (linked /atlas-schema/hcl#roles-and-permissions) and Seed Data as Code are absent from Starter and Pro-gated — this bears on the role, permission and data blocks only, so both Atlas cells stay unknown"
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL table and column child blocks",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform.",
-  "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes"
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL variable blocks and var.* references",
-  "ptah": "no",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "`variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error.",
-  "evidence": "internal/atlashcl/atlashcl.go:107-110 and 1478-1484; conformance gaps.md atlas-hcl-parse row `schemahcl/testdata/variables.hcl` — \"only non-schema top-level blocks: variable\". `variable` + var.x inside a schema file substitutes in Atlas (measured; observation study, scenario, hcl-semantics)"
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL function calls in schema files",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "partial",
-  "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally.",
-  "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496; render emits column type `sql(\"geometry(Point,4326)\")`. `sql(...)` as a column type works in Atlas; `sql(...)` inside an index where clause is rejected under the sqlite dialect (measured; observation study, scenario, hcl-semantics)"
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL locals, lock, atlas, dynamic/for_each",
-  "ptah": "no",
-  "atlas_oss": "unknown",
-  "atlas_pro": "partial",
-  "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\".",
-  "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error. `locals` works in a schema file in Atlas; `lock` and `atlas` top-level blocks are rejected under the sqlite dialect; `dynamic` was not probed in Atlas (measured; observation study, scenario, hcl-semantics)"
- },
- {
-  "area": "Schema sources",
-  "feature": "HCL foreign_key deferrable",
-  "ptah": "no",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too.",
-  "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff. `deferrable = true` rejected under the sqlite dialect; engine-gated, so the Atlas cell stays unresolved for PostgreSQL (measured; observation study, scenario, hcl-semantics)"
- },
- {
-  "area": "Schema sources",
-  "feature": "Ptah-only HCL schema extensions",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block.",
-  "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Seed Data as Code (/guides/seed-data-as-code) is absent from Starter and Pro-gated, so Atlas Pro covers the seed-data job at job level; whether it uses an HCL data-block mechanism is not stated"
- },
- {
-  "area": "Schema sources",
-  "feature": "Directory of .hcl files as one schema source",
-  "ptah": "no",
-  "atlas_oss": "unknown",
-  "atlas_pro": "yes",
-  "note": "`--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file.",
-  "evidence": "cmd/internal/schemaload/schemaload.go:257-259; `ptah-compat schema diff --to file://dir` prints \"load --to schema: schema file is a directory\". a directory of .hcl files as `--url file://dir` works on schema inspect (measured; observation study, scenario, hcl-semantics)"
- },
- {
-  "area": "Schema inspection filters",
-  "feature": "Schema-qualified exclude globs for enums and functions",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only.",
-  "evidence": "internal/atlasfilter/filter.go:299-303 (filterEnums matches value.Name) and :342-346 (filterFunctions matches function.Name) versus :348-356 and :327-340 which build qualifiedNameCandidates for views and extensions. docs/site/src/content/docs/atlas/schema-commands.md:96-98 records the same limitation. Nothing in cli-surface.md, gaps.md, gaps-live.md, or gaps-diff.md establishes Atlas CE's qualification semantics for enum and function exclude globs, so both Atlas columns are ❔"
- },
- {
-  "area": "Project config",
-  "feature": "atlas.hcl from the native ptah binary",
-  "ptah": "partial",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved.",
-  "evidence": "cmd/internal/dbcli/project_config.go:66-80 (the atlas.hcl path and --var forwarding flags are hidden adapter-only), config/projectconfig/load.go:20-24 (AtlasPath defaults to AtlasFileName in the working directory). Repro: `ptah schema compare --env local --schema-file s.sql --var dburl=sqlite://file.db` -> `error: unknown flag: --var`; `ptah schema compare --config atlas.hcl --env local` -> `error: failed to parse ptah config atlas.hcl: yaml: unmarshal errors`"
- },
- {
-  "area": "Schema inspection filters",
-  "feature": "Inspect `--exclude` field selectors",
-  "ptah": "partial",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted.",
-  "evidence": "internal/atlasfilter/filter.go:188-200 parseFieldSelector accepts only field==\"version\" with hasOnlyType(types,\"extension\"), and :132-135 rejects a second [type= segment; built ptah-compat on live PostgreSQL: `--exclude '*[type=extension].version'` blanks the version, `--exclude '*[type=table].comment'` exits 1 \"unsupported Atlas exclude field selector \\\".comment\\\"\", `--exclude '*[type=table]*'` exits 1 \"unsupported Atlas exclude field selector suffix \\\"*\\\"\". Atlas columns downgraded to unknown: conformance cli-surface.md line 47 establishes that --exclude exists on Atlas CE schema inspect but nothing cited establishes which field-selector forms Atlas honors, and no cited source defines an \"exporter block\" at all. `--exclude '*[type=table].comment'` parses and runs on sqlite (exit 0), but sqlite has no comment support, so filtering is unobserved - syntactic acceptance only (measured; observation study, scenario verbs-and-flags)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Pre-migration webhook and shell hook gates",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "`--webhook` POSTs migration metadata and requires HTTP 200; `--pre-up-hook`/`--pre-down-hook` run a shell command that must exit 0, else the run aborts. Also ptah.yaml migration.webhook/pre_up_hook.",
-  "evidence": "/tmp/c-ptah migrations up --help shows --webhook and --pre-up-hook; down shows --pre-down-hook. Atlas-side: cli-surface.md line 27 lists every atlas migrate apply flag; no webhook or hook flag. docs/site/src/content/docs/versioned/apply.md:154-158. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Webhooks (Pipelines) and Pre-migration safety checks (/versioned/checks) are absent from Starter and Pro-gated; Starter absence matches the measured CE no, but Atlas webhooks are service event notifications rather than an apply-time gate like `--webhook`, no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Pre-migration database backups (`--pg-dump-to`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "`--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to.",
-  "evidence": "/tmp/c-ptah migrations up --help and down --help show --pg-dump-to/--mysqldump-to. Atlas-side: cli-surface.md line 27 migrate apply flag list has no backup flag. docs/site/src/content/docs/reference/configuration.md:87. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Prometheus metrics endpoint (`--metrics-addr`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run.",
-  "evidence": "/tmp/c-ptah migrations up/down/status --help all show \"--metrics-addr Address for the Prometheus /metrics endpoint, such as :9090\". Atlas-side: cli-surface.md lines 27/39 list migrate apply and status flags; none exposes a metrics endpoint. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Structured JSON log output (`--log-format`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "migrations up, down, and status take `--log-format` text|json and `--log-level` debug|info|warn|error for machine-readable run logs.",
-  "evidence": "/tmp/c-ptah migrations up --help shows --log-format and --log-level. Atlas-side: cli-surface.md line 27 migrate apply flag list has no log flags (only output --format). no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Online DDL routing via gh-ost or pt-osc",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "no",
-  "note": "ptah.yaml online_ddl.tool (ghost|pt-osc), threshold_rows, args, and fallback (error|plain) route large-table ALTERs through an online-DDL tool during migrations up/down.",
-  "evidence": "config/projectconfig/config.go:22-35,407-447 defines the config; cmd/migrateup/migrateup.go:374 consumes it; config/projectconfig/online_ddl_test.go. docs/site/src/content/docs/reference/configuration.md:89 documents the four keys. Matrix mentions online_ddl only as a ptah.yaml key name. no gh-ost/pt-osc routing on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Atlas txtar migration sections (-- atlas:txtar)",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "yes",
-  "note": "`-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored.",
-  "evidence": "migration/migrator/migrations.go parses migration.sql, down.sql, checks.sql, and ordered checks/*.sql sections; docs/site/src/content/docs/atlas/migrate-commands.md documents the behavior. The down row's \"Atlas single-file dirs have no down body\" note does not cover this exception. txtar migrations run with checks.sql ENFORCED as a pre-migration gate (failing assertion aborts, exit 1) (measured; observation study, scenario, txtar-checks-enforcement). Fixed 2026-08-01 (stokaro/ptah#956) and hardened after review: check files map onto the same engine, preserve archive order, default to all-of, and honor file-level atlas:assert oneof; a failing assertion aborts before migration.sql; --skip-checks bypasses on native ptah migrations up, compat migrate apply has no such flag (parity), and --tx-mode all refuses checked txtar files. A failed check records NO revision row, so retry after fixing data succeeds without repair."
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Atlas SQL template migrations (`--atlas-env`)",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs.",
-  "evidence": "migration/migrator/atlas_template.go:15-45 (AtlasTemplateData{Env}, RenderAtlasTemplateSQL); /tmp/c-ptah migrations up --help shows \"--atlas-env Value exposed as .Env when rendering Atlas SQL template migrations\"."
- },
- {
-  "area": "Linting and safety",
-  "feature": "Generation-time destructive-change gate",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "no",
-  "note": "migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row.",
-  "evidence": "/tmp/c-ptah migrations generate --help and plan --help show --check-destructive/--allow-destructive. Atlas-side: cli-surface.md line 29 migrate diff flag list has no destructive gate flag. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Linting and safety",
-  "feature": "Standalone SQL file linting (`ptah sql lint`)",
-  "ptah": "yes",
-  "atlas_oss": "no",
-  "atlas_pro": "unknown",
-  "note": "Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not.",
-  "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based. no standalone SQL-file lint verb; `atlas schema lint` exists but lints schema sources, a different mechanism (measured; observation study, scenario, lint-test-pro, ptah-extension-equivalents)"
- },
- {
-  "area": "Declarative and direct schema changes",
-  "feature": "JSON output for native schema diff",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "unknown",
-  "note": "Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated.",
-  "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0."
- },
- {
-  "area": "Go embedding and developer tooling",
-  "feature": "Go annotations to HCL export with cleanup",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Writes HCL from Go annotations; cleanup requires zero diagnostics. Function, view, materialized-view, and trigger bodies are emitted as opaque HCL text, reported, and block cleanup.",
-  "evidence": "/tmp/c-ptah schema export --to hcl --root-dir . --out schema.hcl produced a table \"products\" HCL file, exit 0; export --help shows the three cleanup flags. Atlas has no //ptah annotation set for the concept to apply to (matrix's own ➖ rationale)."
- },
- {
-  "area": "Configuration and dev databases",
-  "feature": "PTAH_* environment-variable flag equivalents",
-  "ptah": "yes",
-  "atlas_oss": "unknown",
-  "atlas_pro": "no",
-  "note": "Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag.",
-  "evidence": "All 49 --help screens annotate each flag with [env: PTAH_*]; verified live: PTAH_FORMAT=dot /tmp/c-ptah viz --root-dir . emitted Graphviz DOT instead of the mermaid default, exit 0. No Atlas-side env-var inventory is cited by the page. no documented ATLAS_* env-var flag twins in Atlas's help (measured; observation study, scenario, ptah-extension-equivalents)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "migrate apply `--allow-dirty` semantics",
-  "ptah": "partial",
-  "atlas_oss": "yes",
-  "atlas_pro": "yes",
-  "note": "Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite).",
-  "evidence": "/tmp/c-compat migrate apply onto SQLite with a pre-existing table succeeded with no flag ('Migration complete'); after a failed migration, apply refuses ('is dirty'), and --allow-dirty errors 'UNIQUE constraint failed: atlas_schema_revisions.version'. Flag in CE inventory, cli-surface.md line 27; help: 'Allow applying migrations when the revision table is dirty'."
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Upstream verb `migrate ls`",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Beyond the CE pin: works in Atlas against a local directory; ptah-compat rejects it as unknown command; native `ptah migrations status` lists versions and states.",
-  "evidence": "Verified: /tmp/c-compat migrate ls -> 'unknown command'; /tmp/c-ptah migrations status --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin' records it absent from pinned CE v1.2.0 (unknown command, not an abort stub) while present in current Atlas docs. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate ls` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas migrate ls` works against a local migration directory (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Versioned migrations",
-  "feature": "Upstream verb `migrate show`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Beyond the CE pin: prints a migration's SQL upstream; no compat or native Ptah verb exists, and the gap register triages it as future work.",
-  "evidence": "Verified: /tmp/c-compat migrate show -> 'unknown command'; comparison.md:699-701 triage 'migrate show (print a migration's SQL) is future work with no native verb today'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate show` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas migrate show` prints local migration file contents (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Declarative and direct schema changes",
-  "feature": "Upstream verb `schema validate`",
-  "ptah": "partial",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Beyond the CE pin: no validate verb; the gap register triage covers it with native schema render parse/load validation plus schema test and schema apply `--dry-run`.",
-  "evidence": "Verified: /tmp/c-compat schema validate -> 'unknown command'; /tmp/c-ptah schema render --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema validate` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas schema validate` exists in Atlas (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Declarative and direct schema changes",
-  "feature": "Upstream verb `schema stats`",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Beyond the CE pin: in Atlas it exists as `schema stats inspect` (OpenMetrics) and rejects SQLite at runtime; the gap register triages it out of scope as observability.",
-  "evidence": "Verified: /tmp/c-compat schema stats -> 'unknown command'; comparison.md:699-701 triage 'schema stats (OpenMetrics database statistics) is out of scope'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema stats` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Schema statistics appears only in the Schema Monitoring product (absent from Starter, Pro at $39/mo per monitored database); consistent with the measured CE no, but the pricing label does not name the `schema stats` verb, registered as `atlas schema stats inspect`, OpenMetrics output, rejects sqlite targets at runtime (measured; observation study, scenario, verbs-and-flags)"
- },
- {
-  "area": "Go embedding and developer tooling",
-  "feature": "Statement observer and validator hooks (Go API)",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "migrator.WithStatementObserver runs a read-only callback per executed statement; WithStatementValidator gates all statements pre-execution; both compose with StatementInterceptor.",
-  "evidence": "migration/migrator/migration_provider.go:98 (WithStatementValidator), :106 (WithStatementObserver); StatementObservationError in migration/migrator/revisions.go:144. Documented at docs/site/src/content/docs/extend/public-api.md:59-99. Atlas cells na per the matrix's own convention for Go-API rows: CE conformance measures CLI commands, not Go APIs."
- },
- {
-  "area": "Go embedding and developer tooling",
-  "feature": "Pinned database sessions (WithSession)",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "`WithSession` on `DatabaseConnection` pins one physical session for a callback, rebinding reader/writer/SQL runner, and discards the connection so session state cannot leak.",
-  "evidence": "dbschema/connection.go:262; docs/site/src/content/docs/extend/public-api.md:78-87. Atlas cells na per the matrix's convention for Go-API rows (CE conformance measures CLI commands, not Go APIs)."
- },
- {
-  "area": "Go embedding and developer tooling",
-  "feature": "Concurrency-guarded migration plan publication",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "generator.PlanMigration binds a plan to a directory snapshot; WriteFiles rejects changed history (ErrMigrationDirectoryChanged) under a cross-process lock; concurrent reuse fails (ErrMigrationPlanInUs",
-  "evidence": "migration/generator/plan_test.go:84 (qt.ErrorIs generator.ErrMigrationDirectoryChanged), :91 (TestMigrationPlanWriteFilesContext_RejectsConcurrentUse); docs/site/src/content/docs/extend/public-api.md:115-126. Atlas cells na per the matrix's Go-API row convention."
- },
- {
-  "area": "Go embedding and developer tooling",
-  "feature": "testkit companion module for database tests",
-  "ptah": "yes",
-  "atlas_oss": "na",
-  "atlas_pro": "na",
-  "note": "Separate module go.5x5.cz/ptah/testkit wraps testcontainers-go for tests needing real databases; versions independently and stays out of the main module graph.",
-  "evidence": "testkit/go.mod line 1: module go.5x5.cz/ptah/testkit; testkit/testkit.go, containers_test.go present. Documented at docs/site/src/content/docs/extend/public-api.md:54-57. Distinct from the existing \"Embeddable test runner (Go package)\" row, which is migration/dbtest. Atlas cells na per the matrix's Go-API row convention."
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "Column-level data lineage",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Hosted Atlas Cloud view tracing column-to-column dependencies across schemas. No Ptah surface: no lineage verb or flag; the nearest output is `ptah viz`, whose ERD edges are table-level FKs only.",
-  "evidence": "No lineage surface in `ptah --help` inventory; docs/site/src/content/docs/atlas/docs-coverage.md scope statement (Pro, Cloud, registry, account, UI behavior is out of scope). Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Column-level data lineage' is Starter absent / Pro checked in both the Atlas Pipelines and Schema Monitoring tables."
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "Hosted Schema Docs (schema documentation)",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "Auto-generated schema documentation pages in Atlas Cloud. Ptah has no docs generator: `ptah schema export` emits HCL, OpenAPI, GraphQL, or protobuf definitions; `ptah viz` covers ERD only.",
-  "evidence": "`ptah schema export --help` and `ptah viz --help` show no documentation-page generator (export targets are openapi-v3, graphql, proto, hcl per the existing export rows); docs/site/src/content/docs/atlas/docs-coverage.md scope statement. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'ERD & Schema Docs' is Starter absent / Pro checked in the Atlas Pipelines and Schema Monitoring tables."
- },
- {
-  "area": "Atlas Registry and Cloud",
-  "feature": "Atlas Copilot (AI assistant)",
-  "ptah": "no",
-  "atlas_oss": "no",
-  "atlas_pro": "yes",
-  "note": "AI assistant gated to Pro accounts; absent from the pinned CE v1.2.0 command inventory. No Ptah equivalent; the closest developer-assist surface is the `ptah-ls` language server.",
-  "evidence": "No copilot verb in `ptah --help` inventory; conformance cli-surface.md pinned CE v1.2.0 inventory contains no copilot command. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Pro card bullet 'Access to Atlas Copilot'; the bullet is absent from the Starter card."
- }
+  {
+    "area": "Schema sources",
+    "feature": "Go struct annotations",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program.",
+    "evidence": "ptah schema render --help (--root-dir); docs/site/src/content/docs/schema/go-annotations.md; docs/site/src/content/docs/schema/orm-and-external.md:65 (atlas-provider-gorm)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "YAML schema files",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs.",
+    "evidence": "ptah schema render --help (--schema-file accepts YAML); docs/site/src/content/docs/reference/yaml-schema.md; docs/site/src/content/docs/atlas/comparison.md:411"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "SQL DDL schema files",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped.",
+    "evidence": "ptah schema render --help; ptah-compat schema diff --help (.sql accepted on --from/--to); docs/site/src/content/docs/atlas/docs-coverage.md:202 (Atlas: 'Open sources include SQL, HCL, and external schema')"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Live database as desired state",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively.",
+    "evidence": "ptah-compat schema apply/diff --help; ptah-compat migrate diff --help; ptah db read --help; docs/site/src/content/docs/atlas/docs-coverage.md:148-190 (declarative apply and diff: 'Open')"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Migration directory as a source",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff.",
+    "evidence": "ptah schema inspect --help (--migrations-dir, requires --dev-url); ptah-compat schema apply --help; ptah-compat schema diff --help; ptah-compat migrate diff --help"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "External program / ORM loaders",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "`--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML.",
+    "evidence": "ptah schema render --help (--schema-cmd, --schema-format, --allow-external-schema); docs/site/src/content/docs/schema/orm-and-external.md; examples/orm-loaders/gorm; examples/orm-loaders/sqlalchemy; orm-and-external.md records this as the open counterpart of Atlas's external_schema source and its ORM providers"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Atlas HCL data \"external_schema\"",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Ptah evaluates the data source and runs the program, gated behind `--allow-external-schema`/`PTAH_ALLOW_EXTERNAL_SCHEMA`. Community Atlas rejects `data.external_schema`.",
+    "evidence": "config/projectconfig/atlas.go (configureDataSources external_schema branch); repro: PTAH_ALLOW_EXTERNAL_SCHEMA=1 ptah-compat schema apply --url sqlite://app.db --env dev --dry-run --auto-approve emits the program's CREATE TABLE; ptah schema render --env dev --allow-external-schema renders it natively; go test ./cmd/atlas -run TestSchemaDiffExternalSchemaSource. Measured 2026-08-01, Atlas CE v1.2.0 logged out: atlas.hcl data \"external_schema\" -> exit 1 'Error: data.external_schema is not supported by the community version of Atlas.'"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Composite multi-source desired schema",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source.",
+    "evidence": "ptah schema render --help ('repeatable; multiple sources merge into one composite schema'); docs/site/src/content/docs/schema/composite.md:58; docs/site/src/content/docs/atlas/comparison.md:407,413. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): atlas.hcl with `data \"composite_schema\"` -> exit 1 'missing data source handler for \"composite_schema\"'. Atlas pricing page (retrieved 2026-08-01): 'Schema compositions' is Pro, not Starter. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Schema compositions' is unchecked for Starter and checked for Pro/Enterprise, linking to the composite_schema data source. `data \"composite_schema\"` with local file parts works in Atlas (measured; observation study, scenario, atlas-hcl-pro-constructs)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Live database to Go annotation source",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "`ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow.",
+    "evidence": "ptah introspect --help (--db-url, --out, --package); docs/site/src/content/docs/atlas/comparison.md:536-540 ('Native Go annotations'); conformance cli-surface.md (Atlas CE inventory)"
+  },
+  {
+    "area": "Project config",
+    "feature": "Atlas project config (atlas.hcl)",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema.",
+    "evidence": "config/projectconfig/atlas.go:214 (collectAtlasTopBlock default -> unsupportedBlock), :402 (parseEnvAttr default), :475 (parseMigration default); each rejection reproduced with /tmp/pc-audit at exit 1; Atlas-side block inventory from https://atlasgo.io/atlas-schema/projects (top-level variable, locals, atlas, env, script, lint, diff, exporter, deployment)"
+  },
+  {
+    "area": "Project config",
+    "feature": "Native project config (ptah.yaml)",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail.",
+    "evidence": "config/projectconfig/yaml.go:17-92 (typed key set; the desired-source key is `schemas`, not `src`). Repro: `src: [\"s.sql\"]` in ptah.yaml -> `error: failed to parse ptah config ptah.yaml: yaml: unmarshal errors: line 2: field src not found in type projectconfig.yamlDocument`"
+  },
+  {
+    "area": "Project config",
+    "feature": "Variables, locals, and HCL functions",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected.",
+    "evidence": "config/projectconfig/atlas.go:126-133 (five-function eval context), parseVariableBlock/convertAtlasVariableOverride (type constraints with typed --var conversion, sensitive redaction, validation rejected), :402 (for_each hits the env attribute default). Repro: `dev = urlsetpath(\"sqlite://file.db\",\"x\")` -> `error: unsupported atlas.hcl construct \"dev\" at atlas.hcl:2`; upper, lower, join, split, concat, trimspace, coalesce, toupper, abspath, urlescape, urlqueryset, print all fail the same way, while file, fileset, format, getenv, jsonencode evaluate; `variable \"schema_file\" { type = string }` + `--var schema_file=schema.sql` inspects on both binaries"
+  },
+  {
+    "area": "Project config",
+    "feature": "data \"hcl_schema\" reference",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected.",
+    "evidence": "config/projectconfig/atlas.go:1034-1080 (hclSchemaDataSource accepts only path/paths), :1416-1431 (validateAtlasLocalPathValue, atlasLocalFileURL). Atlas documents path, paths, vars in and url out (https://atlasgo.io/atlas-schema/projects). Repro: vars -> `error: unsupported atlas.hcl construct \"vars\" at atlas.hcl:3`"
+  },
+  {
+    "area": "Project config",
+    "feature": "env:// desired-state references",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently.",
+    "evidence": "internal/atlassource/atlassource.go:266-282 expandEnv attribute allowlist; env:// classification is reached only from --to/--from ClassifySet. Reproduced: `--exclude env://exclude` with env.exclude=[\"users\"] still emitted the users table"
+  },
+  {
+    "area": "Project config",
+    "feature": "Remote and template directory sources",
+    "ptah": "no",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path.",
+    "evidence": "ptah-compat migrate status --env prod with migration.dir set to atlas:// or oci:// -> exit 1 'atlas migrate status --dir: only local file:// migration directories are supported'"
+  },
+  {
+    "area": "Go embedding",
+    "feature": "Reusable Go packages (embedder API)",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs.",
+    "evidence": "docs/site/src/content/docs/extend/public-api.md (stable package table); docs/site/src/content/docs/extend/components.md (component map)"
+  },
+  {
+    "area": "Go embedding",
+    "feature": "Public API compatibility gate",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line.",
+    "evidence": "scripts/check-public-api.sh; scripts/check-public-api-released.sh; docs/public_api_approvals.txt"
+  },
+  {
+    "area": "Go embedding",
+    "feature": "Query builder for parameterized SQL",
+    "ptah": "partial",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error.",
+    "evidence": "core/query/query.go (InnerJoin/LeftJoin/RightJoin/FullJoin, Distinct, GroupBy, Having) and core/query/write.go (InsertInto/Update/DeleteFrom, Returning); core/ast/select.go:17-18 records arithmetic, LIKE, subqueries and window functions as follow-ups; core/ast/write.go:13-16 records upsert, INSERT..SELECT, CTEs and multi-table UPDATE/DELETE as out of scope; core/renderer/select.go:84-89 maps placeholders for postgres/cockroachdb/yugabytedb/mysql/mariadb/sqlite only; executed probe over renderer.RenderInsert confirms sqlserver, mssql, clickhouse and spanner return \"renderer: INSERT rendering is not supported for dialect ...\""
+  },
+  {
+    "area": "Schema visualization",
+    "feature": "Schema visualization (ERD diagrams)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas ERD lives in the hosted service (any plan per its pricing page); the CE binary rejects `--web`.",
+    "evidence": "ptah viz --help; docs/site/src/content/docs/schema/visualize.md; docs/site/src/content/docs/atlas/comparison.md (cites atlasgo.io/features: visualization is Pro); conformance cli-surface.md CE inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema inspect --url sqlite://t.db --web` -> exit 1 'unknown flag: --web'. Atlas pricing page (retrieved 2026-08-01) checks ERD visualization for every plan including free Starter - hosted-service side. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'ERD visualization' is checked for the free Starter plan \u2014 a plan-level claim that may be login/cloud-side; the pinned CE v1.2.0 binary registers no visualization command, so atlas_oss stays no"
+  },
+  {
+    "area": "API schema export",
+    "feature": "API schema export: OpenAPI 3.0 and GraphQL",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list.",
+    "evidence": "ptah schema export --help (--to openapi-v3|graphql); docs/site/src/content/docs/schema/export.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+  },
+  {
+    "area": "API schema export",
+    "feature": "Protobuf schema export with pinned field numbers",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory.",
+    "evidence": "ptah schema export --help (--proto-type-removal, --proto-on-name-reuse, --proto-on-incompatible-change); internal/protobufrender/render.go; docs/site/src/content/docs/schema/protobuf.md; conformance cli-surface.md CE inventory"
+  },
+  {
+    "area": "API schema export",
+    "feature": "Annotation metadata as JSON Schema",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to.",
+    "evidence": "ptah schema annotations --help; docs/site/src/content/docs/reference/native-commands.md (line 17)"
+  },
+  {
+    "area": "Data management",
+    "feature": "Declarative reference data",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "//ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature.",
+    "evidence": "ptah migrations data --help; docs/site/src/content/docs/versioned/reference-data.md (Reversibility section); docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features: declarative data management is Pro); conformance PARITY.md managed-data-workflow. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Seed Data as Code' is unchecked for Starter and checked for Pro/Enterprise"
+  },
+  {
+    "area": "Data management",
+    "feature": "Environment-scoped SQL seed runner",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list.",
+    "evidence": "ptah seed --help (--env, --protected-env, --allow-prod); docs/site/src/content/docs/operate/seed-data.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list). Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Seed Data as Code' is a Pro checkmark \u2014 declarative seed definitions, not an environment-scoped SQL seed runner, so atlas_pro stays no for this mechanism"
+  },
+  {
+    "area": "Editor tooling",
+    "feature": "ptah-ls annotation language server",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax.",
+    "evidence": "cmd/ptah-ls/main.go (builds via go build ./cmd/ptah-ls); editors/vscode/package.json and extension.js; docs/site/src/content/docs/reference/go-annotations.md (Editor support)"
+  },
+  {
+    "area": "Go-first modeling",
+    "feature": "Annotated Go models from a live database",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Writes Ptah annotation source from introspection, with optional db/json tags. No Go-model generator in the CE inventory or Pro list.",
+    "evidence": "ptah introspect --help (--add-db-tags, --add-json-tags, --per-table); docs/site/src/content/docs/reference/native-commands.md (line 74); conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`atlas://` vendor protocol",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "The scheme is Cloud-bound and rejected with a named error; every function behind it is available natively over `oci://`. The compat binary mirrors the Atlas surface, which has no `oci://`.",
+    "evidence": "ptah-compat schema apply --to atlas://myorg/myrepo -> exit 1 'atlas:// registry URLs are not supported; use oci:// with a native Ptah command'; atlas.hcl migration.dir = atlas:// -> exit 1 'only local file:// migration directories are supported'; ptah-compat schema apply --to oci://localhost:5555/demo/schema:v1 -> exit 1 'unsupported desired-state URL scheme \"oci\"'; atlas.hcl migration.dir = oci:// -> exit 1 'only local file:// migration directories are supported'. Native `ptah schema push/pull` and `ptah migrations push/pull` use OCI artifacts. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' is unchecked for Starter and checked for Pro (limited to 500 objects), matching oss no / pro yes for the registry-backed `atlas://` scheme"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`migrate push` and `schema push`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "ptah-compat boundary stubs report that the command is not implemented and exit 1. The native equivalents are `ptah schema push` and `ptah migrations push`.",
+    "evidence": "ptah-compat schema push -> exit 1 and reports that the command is not implemented by Ptah; cli-surface.md lines 35 and 58 mark both absent from CE v1.2.0. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema push` and `atlas migrate push demo` -> exit 1 community-abort"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan` registry sub-verbs (approve, list, pull, push, rm)",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "These five arbitrate plan state in a remote registry; Ptah's local plan-file workflow replaces the function rather than the service.",
+    "evidence": "ptah-compat schema plan approve. Measured 2026-08-02, CE v1.2.0 (scratch env): CE has NO `schema plan` sub-verbs at all \u2014 `atlas schema plan approve` prints \"Abort: 'atlas schema plan' is not supported by the community version.\" naming the PARENT, byte-identical to the nonsense control `atlas schema plan frobnicate-nonsense`; the control showing that an unknown command can look different one level up is `atlas schema frobnicate`, which prints the `schema` group help at exit 0. Each of the five takes `--url` in the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), which is what makes them registry-bound."
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan new` and `schema plan validate`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Implemented. Flag sets follow the published Atlas CLI reference; their behavior is read out of Atlas docs and unverified, and each run says so on stderr.",
+    "evidence": "Verified: `ptah-compat schema plan new --from sqlite://x.db --to file://s.sql` writes <timestamp>.plan.hcl with no --save flag registered, and `ptah-compat schema plan validate --from sqlite://x.db --to file://s.sql --file file://p.plan.hcl` exits 0 with EMPTY stdout and leaves the target schema AND its rows unchanged (cmd/atlas/schema_plan_new_test.go, cmd/atlas/schema_plan_validate_test.go). SURFACE follows the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), which lists on `new` exactly {auto-approve, dev-url, edit, exclude, format, from, include, lock-timeout, name, name-format, output, repo, schema, to} and on `validate` exactly {auto-approve, dev-url, exclude, file, format, from, include, lock-timeout, repo, schema, to}, both pinned by TestAtlasSchemaPlanVerbFlagSetsMatchAtlas. BEHAVIOR is DOCUMENTED-not-measured: `new` is described as \"Create a new plan file for the schema transition\" and lists neither --save nor --dry-run, so writing unconditionally is a reading, not an observation; `validate` is described as \"Validate a plan file against the schema transition\" and the from-must-match rule is documented for `test \"plan\"` blocks (atlasgo.io/hcl/testing), but the checks it runs, their order, its exit code and its output are inferred. Atlas CE aborts the whole `schema plan` path (measured 2026-08-02, CE v1.2.0), so no oracle exists for either verb; an awaiting-oracle conformance fixture is proposed rather than a green row. `validate` refuses a --dev-url that resolves to the target: without that guard it resets the target destructively and applies the plan while exiting 0 (measured: one table with 3 rows came back with the plan's new table and 0 rows)"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan lint` and `schema plan test`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Local by their flag sets (neither takes `--url`) but deferred: neither has a measured output contract, and guessing one puts a narrower checker in a gating position.",
+    "evidence": "ptah-compat schema plan lint -> unsupported-boundary stub. `lint` adds only -f/--file to the shared transition set and `test` takes --dev-url, --run and positional [paths] in the published Atlas CLI reference (https://atlasgo.io/cli-reference, retrieved 2026-08-02), so both are local. `lint` is deferred because Atlas documents no output shape, failure threshold or exit code for it, and the engine that would back it (the `migrate lint` analyzer set) reports on a migration DIRECTORY; a plan linter covering fewer analyzers than Atlas's would report clean on a plan Atlas flags, which is a silent wrong answer in a gating position. `test` is deferred because it consumes `test \"plan\"` blocks in `.test.hcl` files (schema{url} + apply{url}, with the documented hard rule that the plan's `from` must match the schema block's state, and `-- PASS: <name> (2ms)` output) and nothing in Ptah parses `.test.hcl` yet \u2014 the engine reads YAML cases. `.test.hcl` ingestion is a shared item with `migrate test` and `schema test`"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan --push`, `--pending`, `--repo`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`--push`, `--pending` and `--repo` stay recorded waivers: they address the Atlas Registry, and Ptah's plan workflow saves local files instead.",
+    "evidence": "ptah-compat schema plan --push --from sqlite://x.db --to file://s.sql; conformance cli-surface.md classifies `atlas schema plan` as absent from the pinned CE binary. `--push` `--repo` `--pending` registered (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan --edit` and `--name-format`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`--edit` preserves comments and re-derives dialect-aware severity; `--name-format` uses Atlas-shaped Base64 .FromHash/.ToHash values.",
+    "evidence": "Verified: `ptah-compat schema plan --from sqlite://x.db --to file://s.sql --save --edit --name-format 'plan_{{ slice .ToHash 0 12 }}'` (cmd/atlas/schema_plan_output_flags_test.go, internal/atlasschema/plan_edit_test.go). Measured 2026-08-02, CE v1.2.0 logged out: `schema plan` declares no own flags at all \u2014 each of the five answers `unknown flag` byte-identically to the nonsense controls `--name-formxxxx` and `--totally-bogus-flag`, and so does `--dev-url`, a flag CE knows on sibling verbs; only inherited `--env`/`-c`/`--var` parse and they reach the community abort, so CE never evaluates atlas.hcl for this verb (`schema plan --env nosuchenv` aborts where `schema inspect --env nosuchenv` says 'env not defined'). Registered on Atlas; live local runs verify that `.FromHash` and `.ToHash` are the untagged standard-Base64 values written to the plan block. An edit round-trips statement text verbatim, comments included, so quitting the editor unchanged reproduces the plan byte for byte."
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan --skip-lint`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Accepted, and does nothing: `schema plan` runs no lint step, so there is nothing to skip. A Pro pipeline passing it keeps working; no check is loosened.",
+    "evidence": "Verified: `ptah-compat schema plan --from sqlite://x.db --to file://s.sql --output p.plan.json --skip-lint` produces byte-identical reported output AND a byte-identical plan document to the same run without the flag, over a DESTRUCTIVE fixture \u2014 the input any plausible linter would report on (cmd/atlas/schema_plan_output_flags_test.go TestSchemaPlanSkipLintIsANoOp). Measured 2026-08-02, CE v1.2.0: `unknown flag`, same as the nonsense controls; registered on Atlas's own help surface as 'skip linting migration plan', help text only. `internal/atlasschema.PreparePlanFile` invokes no linter \u2014 `migration/lint` is not imported on this path. The no-op status is a gap against Pro, not parity: Atlas lints the plan and Ptah does not, so a Pro pipeline relying on `schema plan` FAILING on an unlinted destructive change gets no such refusal here"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "`schema plan --format` and `--directive`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Both fail loudly, by design. `--format` is implemented on the eight compat verbs whose CE counterpart works and whose payload can therefore be measured; `schema plan` is the one verb where CE aborts.",
+    "evidence": "ptah-compat schema plan --format '{{ json . }}' -> 'Ptah does not implement --format for schema plan yet'. Measured 2026-08-02, CE v1.2.0: both answer `unknown flag`, same as the nonsense controls. Registered on Atlas's own help surface with help text only: `--format` 'output format', `-d/--directive` 'set a directive for the migration plan'. The rule is consistent rather than an exception: `--format` ships on `migrate apply/diff/lint/status` and `schema apply/clean/diff/inspect` because CE executes those verbs, so their report payload is measurable; `schema plan` aborts on CE and Atlas publishes help text only, so its payload field names are unknown and a Ptah-shaped payload would fail Pro templates referencing Atlas's. `--directive` is deferred because the measured Atlas `.plan.hcl` artifact (internal/atlasschema/testdata/atlas.plan.hcl) carries only from/to/migration, so a directive would have to ride inside the migration heredoc in an unmeasured spelling \u2014 and Ptah's own Atlas-format reader ignores `-- atlas:checkpoint` today (#954), so emitted directives would be silent no-ops"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Dynamic down planning (`migrate down --plan`)",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`--plan`, `--to-tag` and `--skip-checks` are recorded waivers that fail loudly; Ptah reverts only through pre-planned down files.",
+    "evidence": "ptah-compat migrate down --plan --url sqlite://x.db --dir file://m; conformance cli-surface.md CE inventory. `migrate down` registers `--plan`, `--to-tag`, `--skip-checks` (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "Atlas Cloud deployment reporting",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "No Atlas account model or deployment API. Ptah attaches a deployment-report referrer to its own OCI artifact after an oci:// migrations up.",
+    "evidence": "migrations up over oci:// then oci referrers -> application/vnd.stokaro.ptah.deployment.v1, sha256:cffc640a; --skip-report opts out; docs-coverage.md:499-505 records Atlas Cloud reporting as Cloud and out of scope"
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "Schema monitoring, hosted UI, login",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Out of scope: no login, registry UI, promotion or monitoring. Native `ptah schema drift` is a local one-shot check.",
+    "evidence": "docs/site/src/content/docs/atlas/docs-coverage.md. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Schema Monitoring section is marked not available on Starter and priced $39/mo per monitored database on Pro, covering schema changelog and drift detection & alerts"
+  },
+  {
+    "area": "Approval and policy workflows",
+    "feature": "Reviewer approval and policy workflows",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Local `-- +ptah check` pre-migration assertions exist; the Cloud-gated reviewer-approval half is out of scope.",
+    "evidence": "docs/site/src/content/docs/atlas/comparison.md. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Protected flows & policies' is unchecked for Starter and checked for Pro"
+  },
+  {
+    "area": "Dev databases",
+    "feature": "Docker dev databases (`docker://` `--dev-url`)",
+    "ptah": "no",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL.",
+    "evidence": "ptah-compat migrate diff --dev-url docker://postgres/16/dev --dir file://m --to file://s.sql; conformance cli-surface.md lists `--dev-url` in the CE `atlas migrate diff` flag set"
+  },
+  {
+    "area": "Migration linting",
+    "feature": "Atlas web reports (`--web`)",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either.",
+    "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web`, `ptah-compat schema diff --web`, `ptah migrations lint --web` each print `error: unknown flag: --web`. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
+  },
+  {
+    "area": "Testing framework",
+    "feature": "Atlas `.test.hcl` ingestion",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Implemented: `.test.hcl` is read alongside native YAML by `schema test` and `migrate test`. Adding `output` to an `exec` makes it an assertion; step order is preserved and cases are selected by kind.",
+    "evidence": "migration/dbtest/atlashcl.go (ParseAtlasTestCases) and LoadCasesOfKind in parse.go; wired at cmd/schema/test.go and cmd/migrationstest/migrationstest.go. End to end on a directory holding one basic.test.hcl: `ptah-compat schema test -u file://models --dev-url sqlite://... t` reports `PASS case \"sanity\"` / `scalar \"1\"` exit 0, and the same case with a mismatched output reports `expected scalar \"999\", got \"1\"` exit 1 -- the assertion is real in both directions. Three mutations killed by exactly one test each: output no longer mapping to an assertion, matching on filepath.Ext instead of the compound `.test.hcl` suffix (which would also swallow a schema .hcl), and dropping the kind filter. The pre-existing exported LoadCases keeps its YAML-only contract, pinned by its own test, so the public API only gains symbols."
+  },
+  {
+    "area": "Schema inspection filters",
+    "feature": "`schema inspect --include` filtering",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects.",
+    "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; pinned Atlas CE v1.2.0 `schema inspect -u sqlite://app.db --include users` exits 1 with \"Error: unknown flag: --include\". Built ptah-compat after this change: `schema inspect -u sqlite://app.db --include t1` renders t1 with its columns and drops t2; `--include main.t1.*` exits 1 before connecting; `--include t2` refuses the projection because t2's foreign key targets unselected t1. `--include t1` matches Ptah, `--include '*.t1'` is read at child depth and renders t1 without columns plus an empty t2 shell, `--include 'main.t1.*'` exits 1 with \"too many parts in pattern\" (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Migration directory formats",
+    "feature": "Flyway repeatable (`R__`) migration import",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Compat import converts `R__` to a one-time migration ordered last, as Atlas CE runs it. Editing the body then fails on a Ptah revision checksum where CE exits 0.",
+    "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. CE hashes AND executes R__ files: on V1__init.sql + R__repeat.sql, atlas.sum covers both and `atlas migrate apply` runs both, recording the repeatable with an EMPTY version. Every repeatable carries that empty version whatever its own token - R__a.sql, R1__a.sql and Rfoo.sql all execute as version \"\" - so two repeatables in one directory are a duplicate CE cannot execute (it runs the first, then panics with index out of range, exit 2) and ptah-compat refuses up front with \"Flyway migrations R1__a.sql and R2__b.sql both carry the empty Atlas version\". Before stokaro/ptah#982 compat import aborted the whole directory on any R__ file while still hashing it, which was an over-refusal on a directory the oracle applies. STILL PARTIAL after #982: editing a repeatable body and re-hashing is the normal Flyway lifecycle, and there CE reports \"No migration files to execute\" exit 0 while ptah-compat exits 1 with \"migration 9223372036854775807 checksum mismatch\" - Ptah's own per-revision checksum over the converted SQL, not the directory sum (both `migrate validate` calls exit 0). Ptah's Atlas migrator skips Repeatable-marked files entirely, so re-run-on-change would need repeatable support in migration/migrator. `ptah migrations import --from flyway` wrote 0000000002_repeatable_active_users.up.sql. Atlas side: the vendored Atlas corpus carries import/flyway/R__views.sql and its golden output import/flyway_gold/3R_views.sql (conformance gaps.md:571,577)."
+  },
+  {
+    "area": "Migration directory formats",
+    "feature": "External `--dir-format` outside `migrate import`",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "hash and validate read every Atlas source layout, under both `?format=` and `--dir-format`; lint, new, set and status still take only atlas and need migrate import first.",
+    "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. `ptah-compat migrate hash --dir 'file://m?format=goose'` and `--dir file://m --dir-format goose` write an atlas.sum byte-identical to CE's, for atlas plus all five external formats, over a fixture holding goose, golang-migrate and Flyway V/B/R/U files and a nested migration; `migrate validate` matches CE's exit code and stdout/stderr on unhashed, clean and tampered directories for each. When the two spellings disagree the query wins, measured both ways round: `?format=goose --dir-format flyway` covers the goose set and `?format=flyway --dir-format goose` covers the Flyway one. Still refused, unchanged: `ptah-compat migrate lint --dir-format goose` -> \"Atlas accepts --dir-format=goose, but Ptah does not implement that directory format yet\" (same on new, set, status, edit, rebase, rm, test and checkpoint; checkpoint now accepts atlas and ptah but still refuses the five external formats). Three inputs stay refused where CE exits 0, all loudly: an empty --dir-format value, a query parameter other than format, and a repeated format parameter. Measured 2026-08-02, still open: `?format=` is accepted only by apply, hash and validate - checkpoint, lint, new, set, status and diff reject every query parameter with \"migration directory URL query parameters are not supported for this command\". On lint, new and diff that is a CE parity defect, not a design choice: CE exits 0 and FUNCTIONALLY honors the parameter (on a golang-migrate directory `?format=golang-migrate` turns `L2: 1_init.down.sql was added` exit 1 into `Migration Status: PENDING` exit 0) and validates the value (`?format=totally-bogus` -> `unknown dir format`, not ignored). On checkpoint alone the refusal is correct, because CE aborts every invocation of that verb and so has no contract to diverge from. Unknown-key intolerance is a separate defect on ALL eight verbs including the three that work: `apply --dir 'file://m?nonsense=1'` exits 1 where CE applies at exit 0, so a typo'd `?format=atals` is a footgun. Tracking: stokaro/ptah#1002 covers status and set; #990 covers empty --dir-format, non-format keys and repeated keys on hash and validate only; #1013 covers `?format=` on lint/new/diff and the unknown-key case on every verb."
+  },
+  {
+    "area": "Migration directory formats",
+    "feature": "Atlas-format checkpoint output",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`migrate checkpoint --dir-format atlas` writes the single `-- atlas:checkpoint` file plus atlas.sum, and is compat's default; `--dir-format ptah` writes the reversible pair. Up-only, as Atlas is.",
+    "evidence": "Measured 2026-08-02 against pinned Atlas CE v1.2.0. CE registers `migrate checkpoint` but gates it (bare invocation -> 'Abort: not supported by the community version', exit 1) and registers NONE of its own flags: flag parsing precedes the gate, so --dir-format/--dir/--dev-url/--edit/--format/--qualifier/--schema/--lock-name/--lock-timeout all return 'unknown flag' while --config/--env reach the abort; the nonsense control `atlas migrate frobnicate` instead prints the migrate group help, exit 0. So there is no CE flag surface to conform to and this is a Pro-surface addition (issue #951 second standing constraint); Atlas Pro registers --dir-format with default 'atlas', which is why compat now defaults to atlas while native `ptah migrations checkpoint` stays ptah. Write side verified end to end: `ptah-compat migrate checkpoint --dir file://m --dev-url sqlite://s.db` wrote 20260802120402_checkpoint.sql (directive on line 1) and an atlas.sum covering all three files; the PINNED CE binary then `migrate validate` exit 0, `migrate apply` on a fresh db ran only the checkpoint and recorded 20260802120402|checkpoint|2|1|1, and on a pre-checkpoint db printed 'No migration files to execute' exit 0 - ptah-compat produced the identical revision row and identical sqlite schema. Note CE cannot WRITE a checkpoint but does HONOR the directive on read, so the pinned oracle covers both halves. Two shapes are refused before anything is written, both found by review rather than by a failing test: a checkpoint that would leave BOTH ptah.sum and atlas.sum behind (--dir-format auto then refuses the directory outright), and an atlas checkpoint into a directory holding ptah-convention files at all, hashed or not - an UNHASHED ptah directory has no sum to detect, and converting it made the checkpoint permanently invisible (discovery reads the ptah pair, while validate found the new atlas.sum and called the directory sound). Version resolution takes the MAXIMUM of the Atlas timestamp and one above the newest migration from a RECURSIVE walk: the timestamp helper scans only the top level, so on m/20250801000001_init.sql + m/sub/29990101000000_future.sql the checkpoint replayed the nested file into its body yet sorted below it, and a fresh apply then re-ran it - 'table future_tbl already exists', exit 1, dirty revision row, i.e. #954 reproduced by our own writer. That was also a we-fail-where-CE-succeeds divergence, since CE's reader is shallow and applied the same directory at exit 0 with one clean row. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration checkpoints' is Starter \u2717 / Pro \u2713, grounding oss=no and pro=yes (stokaro/ptah#951, #954)"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "schema inspect to HCL, SQL, or JSON",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Default HCL; `--format` sql|json|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export.",
+    "evidence": "`ptah-compat schema inspect --help`; conformance cli-surface.md row `atlas schema inspect`"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Inspect non-database sources via `--dev-url`",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails.",
+    "evidence": "conformance gaps.md probe `inspect-source-workflow`; /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/docs/site/src/content/docs/atlas/schema-commands.md"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Inspect split/write file exports",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`{{ hcl . | split | write \"dir\" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community.",
+    "evidence": "Verified: `ptah-compat schema inspect --format '{{ hcl . | split | write \"exp\" }}'` wrote exp/tables/{posts,users}.hcl; comparison.md:139"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "schema apply against a live database",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite.",
+    "evidence": "Verified: `ptah-compat schema apply --url sqlite://target.db --to file://new.sql --auto-approve`; conformance cli-surface.md `atlas schema apply`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema apply --url sqlite://t.db --to file://schema.sql --dev-url 'sqlite://file?mode=memory' --auto-approve` planned and applied, exit 0; without `--dev-url` CE errors '--dev-url cannot be empty'. The pricing page's 'Declarative migrations' Starter cross refers to the plan/approve product flow, not to `schema apply`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Declarative migrations' is listed Starter \u2717 / Pro \u2713 and links /declarative/plan \u2014 tension with the measured CE apply; read as covering the pre-planned (`schema plan`) flow, not plain `schema apply`, so the measured oss=yes stands"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`--dry-run`, `--auto-approve`, and `--edit`",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied.",
+    "evidence": "Verified: a scripted $EDITOR replaced the plan and `schema apply --edit --auto-approve` applied the edited SQL; `ptah-compat schema apply --help`; conformance cli-surface.md lists all three in the CE `atlas schema apply` flag set"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Dev-database rehearsal before apply",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row.",
+    "evidence": "Reproduced: `pc schema apply --url sqlite://t4.db --to file://b.sql --auto-approve --dev-url sqlite://dv4.db` -> `Schema apply completed successfully.` (exit 0); `--dev-url sqlite://r1.db` equal to --url -> `error: --dev-url must not point at the target database: the dev database is reset destructively before the plan is rehearsed on it` (exit 1). Conformance gaps.md lines 25-27 record the reset, failed-rehearsal, and dev!=target observations. The only refused form is docker://, covered by the existing \u274c 'Docker dev databases' row"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Apply advisory lock and `--lock-timeout`",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note.",
+    "evidence": "internal/dblock/dblock.go:54-64 returns true for Postgres, YugabyteDB, MySQL, MariaDB, SQLServer \u2014 the previous note wrongly listed YugabyteDB as unlocked. cmd/atlas/schema_apply.go:578 emits the stderr note. Reproduced: `pc schema apply --url sqlite://t1.db --to file://b.sql --auto-approve --lock-timeout 10s` -> `note: schema apply locking is not supported for dialect \"sqlite\"; --lock-timeout is ignored and the apply proceeds without a database lock` then a successful apply (exit 0). CE registers --lock-timeout on schema apply per cli-surface.md:43"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Desired-state sources for `--to` and `--from`",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early.",
+    "evidence": "internal/atlassource/atlassource.go:245-264 classifyLocal only promotes a directory to a source when atlas.sum is present; :123-124 atlas:// rejection. Reproduced: `ptah-compat schema diff --to file://sqldir` -> \"schema file is a directory\""
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Local pre-approved plan files",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check.",
+    "evidence": "Fixed by #958 (measured: mutual plan-file unreadability, opposite --plan/--to contracts, foreign fingerprints). Verified: `schema apply --url sqlite://b.db --to file://desired.sql --plan file://atlas.plan.hcl --auto-approve` applies the real Atlas-authored oracle plan end to end (cmd/atlas/schema_apply_planhcl_test.go); `schema plan --from sqlite://x.db --to file://new.sql --output x.plan.hcl` round-trips; internal/atlasschema/testdata/atlas.plan.hcl is Atlas's own artifact. Ptah-written `.plan.hcl` parses in Atlas's reader but its sha256 fingerprints cannot satisfy Atlas's own hash verification (no local recipe, either direction)."
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "schema diff between two schema states",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply.",
+    "evidence": "internal/planner/dialects/sqlite/sqlite.go:87-105 and :489 return unsupportedFeaturef for these cases. Reproduced: TEXT->INTEGER and NOT NULL->nullable both give `error: generate schema diff SQL: sqlite: modifying columns on table users requires a table rebuild plan` (exit 1); adding a column with UNIQUE gives `sqlite: adding column email to table users requires a table rebuild plan`. Plain adds and table drops still plan cleanly. CE registers schema diff per cli-surface.md:45"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`--schema` / -s scoping of both sides",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically.",
+    "evidence": "conformance gaps.md `atlas schema apply -s` and `atlas schema diff -s` shorthand rows; docs/site/src/content/docs/atlas/schema-commands.md"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`--include` resource selectors",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics.",
+    "evidence": "cli-surface.md lines 43,45 (--include registered on CE apply/diff); atlas/comparison.md: 'Atlas CE aborts --include as a non-community feature'; schema-scope-workflow probe in gaps.md; pinned CE v1.2.0 `schema diff --include users` exits 1 with \"Abort: 'atlas schema diff --include' is not supported by the community version\", and `schema inspect --include users` exits 1 with \"Error: unknown flag: --include\""
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`--exclude` glob and type selectors",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums.",
+    "evidence": "internal/atlasfilter/filter.go:341-346 (filterFunctions matches function.Name only) and :298-302 (filterEnums matches value.Name only); dbschema/types/types.go:358-367 DBFunction and :106-109 DBEnum carry no Schema field; internal/tableref/tableref.go:14-21 Canonical returns the bare name when schema is empty; live PostgreSQL 16 repro with the built ptah-compat binary; Atlas CE side from conformance cli-surface.md line 43/45/47 (--exclude registered on schema apply, diff, inspect)"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "schema fmt (HCL canonical layout)",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate.",
+    "evidence": "`ptah-compat schema fmt --help`; conformance cli-surface.md flags and usage rows for `atlas schema fmt`"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "schema clean",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables.",
+    "evidence": "internal/schemaclean/clean.go:109-147 enumerates only foreign keys, tables and enums; :75-81 executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty \u2014 the unreported view v_const was dropped as well. CE registers schema clean per cli-surface.md:44"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Drift detection against desired schema",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope.",
+    "evidence": "`ptah schema drift --help`; docs/site/src/content/docs/atlas/docs-coverage.md section \"Drift detection\". Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Drift detection & alerts' is listed under the Schema Monitoring product, Starter \u2717, with Schema Monitoring itself unavailable on Starter and priced $39/mo per monitored database on Pro \u2014 Atlas-side support for oss=no (no free-tier drift) and for pro=yes as paid Schema Monitoring, per the note's Cloud-scope caveat"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "Go-template `--format` output",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only.",
+    "evidence": "internal/atlasreport/schema_apply.go:45-47 and schema_diff.go:66 register only \"sql\"; schema_inspect.go:161-173 registers base64url/hcl/json/mermaid/sql/split/write. Reproduced: `pc schema diff ... --format '{{ json . }}'` -> `error: parse --format template: template: atlas-schema-diff-format:1: function \"json\" not defined` (exit 1); same on schema apply; `{{ .Realm }}` on diff -> `can't evaluate field Realm in type atlasreport.SchemaDiff`. `{{ json . }}` works on schema inspect, schema clean, and migrate status. `{{ json . }}` on `schema diff` is also undefined in Atlas - parity on that sub-point (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations \u2014 execution",
+    "feature": "Apply pending migrations (apply/up)",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format table creation remains #950; Ptah-format is covered.",
+    "evidence": "Dry-run tests cover native and compat CLIs, dirty/checksum/tx-mode validation, exact legacy and rejected partial SQLite layouts, seven live database targets, PostgreSQL multi-schema search_path and explicit schemas, plus deterministic Spanner SQL. External directory formats remain verified by apply fixtures."
+  },
+  {
+    "area": "Versioned migrations \u2014 execution",
+    "feature": "Roll back applied migrations (down)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Ptah validates all selected down bodies before changing state. Dry-run reports distinguish preflight rejection from attempted rollback. Registry flags remain waivers.",
+    "evidence": "internal/atlasmigrate/down_test.go covers missing-down preservation, dry-run validation, and dirty preflight; cmd/atlas/migrate_down_format_test.go proves preflight failures render no reverted files. CE v1.2.0 logged out aborts as unsupported. `migrate down` works locally, deletes reverted revision rows (including Ptah-written rows), and inserts `.atlas_cloud_identifier`, which Ptah cannot yet read (#957; observation study scenario migrate-down-revisions). Fixed 2026-08-01 (stokaro/ptah#957): Ptah revision readers now treat dot-prefixed versions as metadata - skipped in version/status/pending math, never rewritten or deleted - and dry-run down reads the live revision table instead of reporting version 0"
+  },
+  {
+    "area": "Versioned migrations \u2014 execution",
+    "feature": "Failed rollback state is recorded and recoverable",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Native `ptah migrations down` marks the row failed with the error and completed-statement count, so status reports it dirty and `migrations repair` clears it; compat matches Atlas, which records none.",
+    "evidence": "Measured: a down whose second statement fails rolls the body back and leaves the revision row at applied=2, total=2, error='' - `atlas migrate status` still reports the version applied - and a repaired retry succeeds and deletes the row. In the pinned CE binary `migrate down` is a registered community-abort stub, so the capability is unreachable there. Ptah splits by surface: migration/migrator reproducesAtlasDownBookkeeping keeps Atlas semantics for Atlas-format revisions (always the case on ptah-compat) and keeps Ptah's dirty-state bookkeeping natively; both directions are pinned by migration/migrator/atlas_down_bookkeeping_test.go, including the ptah-format regression guard and the repair path (stokaro/ptah#957) Correction after review: `applied` is the number of down statements that completed (StatementIndex-1), not a constant 0 - measured (2,'failed',1,2) for a second-statement failure on sqlite; it is forced to 0 only when the dialect rolled the body back or the first statement failed. `repair --resume-from` is up-direction only (resumeMigration replays migration.UpSQL) so it is not the failed-down recovery lever; plain `repair --version N` is. A down marked `-- atlas:txmode none` leaves a half-reverted schema behind an unchanged row on the Atlas surface, matching Atlas."
+  },
+  {
+    "area": "Versioned migrations \u2014 execution",
+    "feature": "Migration status report",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next.",
+    "evidence": "/tmp/ptah-compat migrate status --format '{{ .Env }}|{{ len .Available }}|{{ len .Applied }}|{{ len .Pending }}|{{ .Current }}|{{ .Next }}' against SQLite; conformance cli-surface.md row `atlas migrate status` (oss)"
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Directory integrity file: hash, validate, and apply-time gate",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "hash writes `ptah.sum` or `atlas.sum`; validate checks it. Compat apply refuses a stale or missing `atlas.sum`, including via `?format=`, over that layout's file set; native up gates hashed dirs only.",
+    "evidence": "/tmp/ptah migrations hash/validate --help; verified create\u2192hash\u2192validate (exit 0) then tampered file\u2192validate exit 1; ptah migrations hash --dir-format atlas wrote atlas.sum. Apply-time gate: a tampered hashed directory refuses on both surfaces before executing anything (stokaro/ptah#955, PR #962). Missing sum file measured 2026-08-01 against Atlas CE v1.2.0 (stokaro/ptah#970): on a directory with no atlas.sum, Atlas exits 1 with `Error: checksum file not found` and never creates the target database; ptah-compat migrate apply now matches that output byte for byte (same code path as ptah-compat migrate validate). The refusal keys on the presence of any *.sql file, also measured: CE gates an unhashed dir holding only foo.sql, and reports `No migration files to execute` at exit 0 for an empty or .gitkeep-only dir. Ptah scans that tree recursively while CE reads only the top level, so an unhashed dir whose only migration sits in a subdirectory exits 1 here and 0 on CE \u2014 deliberate, because Ptah's registrar executes those files (stokaro/ptah#976). Native `ptah migrations up` deliberately stays permissive on a never-hashed directory and reports `migration sum verification failed: atlas.sum not found; run 'ptah migrations hash --dir-format atlas' to create it` only under --verify-sum (exit 2). Directories read through ?format= (goose/flyway/liquibase/dbmate/golang-migrate) are gated on the atlas.sum the SOURCE directory carries, verified before the source layout is parsed and before the database is opened (stokaro/ptah#973, on top of #984 and #992). Measured 2026-08-02 against Atlas CE v1.2.0 with scripts/probe-atlas-apply-gate.sh: five formats x {never hashed, hashed clean, edited, file added, file removed} match CE's exit code and refusal text, with the L<n> line naming the SOURCE file (1_init.up.sql for golang-migrate, V1__init.sql for flyway). The covered set is per layout, so editing a golang-migrate down file, a Flyway undo file, or a file a Flyway baseline squashes is invisible to both tools, and an empty covered set is exempt from the missing-sum refusal (CE exits 0 with `No migration files to execute` on golang-migrate down-only and Flyway undo-only). Flyway is the one layout whose sum reaches into subdirectories, so an unhashed flyway dir holding only sub/V2__nested.sql is refused by both while the same shape read as goose is exempt. Still open on those exempt rows: ptah-compat reports `no importable migration files found` and exits 1 where CE exits 0 (stokaro/ptah#980). `ptah-compat migrate status` on an unhashed dir exits 0 where CE exits 1: stokaro/ptah#974. What the gate verifies is also what apply executes, for every layout, since stokaro/ptah#982: the importer selects the files it converts with the same SumFileNames rule the gate hashes. Before that, Flyway alone ran a wider set - measured 2026-08-02, a superseded baseline (B1 under B2) and a lowercase prefix (v2__evil.sql) both executed on a directory `migrate validate` called clean on BOTH tools, so SQL ran that no checksum covered. scripts/probe-atlas-apply-gate.sh section 9a now asserts parity on both shapes plus a repeatable, a nested migration and a baseline outranking its survivor, comparing the number each tool ran against the covered-set size rather than only against each other."
+  },
+  {
+    "area": "Versioned migrations \u2014 safety",
+    "feature": "Migration linting",
+    "ptah": "yes",
+    "atlas_oss": "partial",
+    "atlas_pro": "yes",
+    "note": "CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time.",
+    "evidence": "Executed: `ptah-compat migrate lint --dir file://migrations --latest 1` reports \"destructive changes detected -- L1: DROP COLUMN ... #DS103\" and exits 1; `--format '{{ range .Files }}{{ .Name }}{{ end }}'` renders the Atlas template. No rule-loading flag in `ptah migrations lint --help`; custom rules come from migration/lint/rules.go:20 (Register) and lint.Options.ExtraRules (migration/lint/lint.go:107). Atlas CE registers migrate lint (conformance cli-surface.md:33). Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate lint --dir file://m --dev-url sqlite --latest 1` analyzed and reported 'destructive changes detected', exit 1 - the binary lints logged out. The pricing page places 'Migration linting' outside Starter; that classifies the plan, not the binary. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' listed Starter \u2717 / Pro \u2713, corroborating the features-page Pro classification; the measured pinned CE binary still registers `migrate lint` with the basic rule set, so oss stays partial rather than flipping to no. logged out, current upstream `migrate lint` aborts 'Starting with v0.38, atlas migrate lint is available only to Atlas Pro users' - the pinned CE v1.2.0 behavior no longer matches current upstream (measured; observation study, scenario, lint-test-pro)"
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Create an empty migration file",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR.",
+    "evidence": "verified `ptah-compat migrate new init_users --dir file://atlasdir` wrote one .sql plus atlas.sum, and `ptah migrations create` wrote an up/down pair; ptah migrations create --help (--editor defaults to $VISUAL then $EDITOR)"
+  },
+  {
+    "area": "Versioned migrations \u2014 revision state",
+    "feature": "Set revision state to a version",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Removes revision rows above the target, keeps rows at or below it, and inserts missing rows through it as manually set.",
+    "evidence": "docs/site/src/content/docs/atlas/comparison.md#versioned-migrations (`ptah-compat migrate set` paragraph); /tmp/ptah-compat migrate set --help; conformance gaps-migrate-runtime.md fixture `sqlite/set-repair-state`"
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Generate migrations from a schema diff",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry.",
+    "evidence": "Executed: `ptah-compat migrate diff --dir file://migrations --dev-url sqlite://... --to file://desired.sql first` into an empty dir wrote 1785514646_first.sql; into a dir whose latest was 20240101000000 it wrote 20240101000001_add_posts.sql; `ptah-compat migrate new ... hello` wrote 20260731161705_hello.sql. Code: migration/generator/generator.go:414 seeds from migrator.GetNextMigrationVersion (migration/migrator/util.go:302, time.Now().Unix()) while generator.go:228 uses \"20060102150405\". Atlas fixture versions are 14-digit (20220318104614_initial.sql, gaps.md)."
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Migration import from other tools",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed.",
+    "evidence": "Executed: `ptah-compat migrate import --from https://example.com/m` and `--from atlas://myrepo` both fail \"only local file:// migration directories are supported\"; `--dir-format liquibase` on a changelog.xml fails \"liquibase XML/YAML/JSON changelogs are not yet supported\". golang-migrate, goose and dbmate dirs import to single up-only Atlas files (down bodies dropped). Conformance PARITY.md:147 records Liquibase XML/YAML/JSON as a follow-up.; ptah migrations import --help (--from golang-migrate, goose, flyway, liquibase, dbmate); conformance cli-surface.md (atlas migrate import, class oss); do"
+  },
+  {
+    "area": "Versioned migrations \u2014 revision state",
+    "feature": "Baseline an existing database",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`.",
+    "evidence": "/tmp/ptah migrations baseline --help (--shadow-db, --dry-run, --version); conformance cli-surface.md `atlas migrate apply` flag list (--baseline)"
+  },
+  {
+    "area": "Versioned migrations \u2014 revision state",
+    "feature": "Repair dirty or partial revision state",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "`ptah migrations repair` `--resume-from` finishes remaining statements. No repair verb in the pinned CE inventory or reviewed Atlas evidence.",
+    "evidence": "/tmp/ptah migrations repair --help (--resume-from executes remaining up statements before marking applied); conformance cli-surface.md Atlas CE inventory (no `atlas migrate repair` row)"
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Migration checkpoints (squash history)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Replays the directory on `--shadow-db` into a cumulative checkpoint: the ptah reversible pair, or Atlas's single `-- atlas:checkpoint` file under `--dir-format atlas`. CE gates the verb.",
+    "evidence": "/tmp/ptah migrations checkpoint --help (--shadow-db required); conformance cli-surface.md `atlas migrate checkpoint` (out-of-scope: Pro, absent from CE); PARITY.md `checkpoint-workflow`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate checkpoint` -> exit 1 community-abort. Pricing page: 'Migration checkpoints' is Pro, not Starter"
+  },
+  {
+    "area": "Versioned migrations \u2014 directory",
+    "feature": "Directory maintenance: edit, rebase, rm",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Each rewrites `ptah.sum`/`atlas.sum` and refuses a migration applied in `--db-url` unless `--force`; CE aborts all three as non-community verbs.",
+    "evidence": "/tmp/ptah migrations edit|rebase|rm --help (\"refusing already-applied migrations\", --force, --db-url); conformance cli-surface.md rows `atlas migrate edit|rebase|rm` (out-of-scope: Pro); PARITY.md `pro-maint-workflow`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate edit`, `migrate rebase 1`, `migrate rm` each -> exit 1 community-abort"
+  },
+  {
+    "area": "Versioned migrations \u2014 revision state",
+    "feature": "Revision table format and placement",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "`--revision-format` ptah|atlas plus `--migrations-table` and `--migrations-schema`; the compat path defaults to Atlas rows.",
+    "evidence": "/tmp/ptah migrations up --help (--revision-format default ptah, --migrations-table, --migrations-schema); conformance gaps-migrate-runtime.md `sqlite/project-config-apply-oracle` and `postgres/custom-revisions-schema`"
+  },
+  {
+    "area": "Safety gates",
+    "feature": "Pre-migration assertion checks",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Scalar SELECTs; txtar checks.sql and checks/*.sql support all-of/oneof groups. CE ignores checks. Compat bypass is PTAH_SKIP_CHECKS.",
+    "evidence": "TestMigrateApplyDryRunTxModeAllDiagnosticDoesNotSuggestUnsupportedFlag proves compat dry-run rejects checked files without suggesting its unsupported `--skip-checks`; cmd/migrateup registers that flag only on native `ptah migrations up`. Measured 2026-08-01: CE v1.2.0 applies failing checks.sql unenforced; Atlas enforces it before the body and exposes `--skip-checks` on down, not apply (measured; observation study scenarios txtar-checks-enforcement and verbs-and-flags). Updated 2026-08-01 (stokaro/ptah#956): txtar checks.sql and ordered checks/*.sql sections run through the same pre-migration check engine on both binaries. Files default to all-of and support file-level atlas:assert oneof as documented by Atlas. Assertions are split with the live database dialect, restricted to top-level SELECT, and require exactly one column and one row; mutating and multi-row checks fail closed. Checks use a dedicated physical session. Transaction-capable drivers roll back, ClickHouse runs directly because its driver has no transaction support, and SQL Server NEXT VALUE FOR is rejected because sequence advances survive rollback. A failed check records NO revision row (checks run before the pending-revision insert), so the retry after fixing the data succeeds with no bypass flag, matching Atlas, which also writes nothing when its checks fail. Correction after review: ptah-compat migrate apply registers no --skip-checks but DOES register --allow-dirty; that flag cannot clear a dirty row because the retry fails on the revision re-insert with UNIQUE constraint failed (stokaro/ptah#966, measured on both surfaces), so a recorded check failure would have left no working in-band recovery (stokaro/ptah#964 review). Updated 2026-08-02 (stokaro/ptah#951): ptah-compat migrate apply reads the PTAH_SKIP_CHECKS environment variable as its bypass, wired through atlasmigrate.ApplyOptions.SkipChecks; the flag surface is unchanged and TestMigrateApplyHasNoSkipChecksFlag still pins the unknown-flag refusal. Measured 2026-08-02 on the pinned CE v1.2.0 binary: `migrate apply --skip-checks` answers `unknown flag: --skip-checks`, byte-identical to the nonsense control `--skip-chxxxx`, so the flag is unregistered rather than registered-and-gated; `migrate down --help` is community-aborted entirely on CE. Atlas's own help surface lists --skip-checks under `atlas migrate down` only \u2014 across the whole surface it appears on no other verb, and `atlas migrate apply` carries --skip-lock and --to-version but no --skip-checks."
+  },
+  {
+    "area": "Safety gates",
+    "feature": "Check bypass on the compat surface",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down.",
+    "evidence": "Measured 2026-08-02: pinned CE v1.2.0 answers `migrate apply --skip-checks` with `unknown flag: --skip-checks`, identical to the control `--skip-chxxxx`; Atlas's own help surface registers --skip-checks on `migrate down` only. Implemented in cmd/atlas/migrate_apply.go (atlasApplySkipChecksFromEnv) and internal/atlasmigrate ApplyOptions.SkipChecks. The variable is the PTAH_<FLAG> twin of native `ptah migrations up --skip-checks`. Both binaries agree on the name and on every valid boolean; they differ on an invalid one, which compat refuses outright while native discards the parse error and enforces (cmd/internal/cmdflags/env.go drops the flags.Set error) \u2014 both fail safe. It bypasses pre-migration checks only: TestMigrateApplySkipChecksEnvDoesNotBypassChecksumVerification pins that atlas.sum verification still refuses a tampered directory, and TestMigrateApplySkipChecksEnvStillRecordsRevisions pins unchanged bookkeeping. On `migrate down` the --skip-checks waiver is explicit-only (atlasargs.ExplicitUnsupportedBoolReason plus atlasMigrateDownExplicitOnlyFlags, one per parsing path, and cmdflags.DisableEnvBinding so --help stops advertising the twin): before this, PTAH_SKIP_CHECKS=1 made every `ptah-compat migrate down` fail with `accepts --skip-checks, but Ptah does not implement its behavior` on both the default and --format paths. The exclusion is deliberately ONE flag \u2014 --to-tag and --plan keep their twins because setting them is a genuine request, and discarding PTAH_TO_TAG would leave an empty target that reverts the entire history (measured 2026-08-02: users table and its row dropped)."
+  },
+  {
+    "area": "Versioned migrations \u2014 runtime policy",
+    "feature": "Transaction modes (`--tx-mode` file/all/none)",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "all is limited to transactional-DDL dialects and rejects no_transaction files, per-file timeouts, and pre-migration checks.",
+    "evidence": "migration/migrator/migrator.go validateTxModeAllDialect and rejectChecksUnderTxModeAll (also rejects no_transaction and per-migration timeouts); conformance gaps-migrate-runtime.md `sqlite/tx-mode-all|file|none`; /tmp/ptah migrations up --help"
+  },
+  {
+    "area": "Versioned migrations \u2014 runtime policy",
+    "feature": "Execution order (`--exec-order`)",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "linear fails on a pending migration below the current version, linear-skip warns and leaves it pending, non-linear applies it.",
+    "evidence": "/tmp/ptah migrations up --help (--exec-order linear|linear-skip|non-linear); docs/site/src/content/docs/versioned/apply.md lines 138-141; conformance cli-surface.md `atlas migrate apply --exec-order`"
+  },
+  {
+    "area": "Versioned migrations \u2014 runtime policy",
+    "feature": "Migration lock and lock timeout",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`.",
+    "evidence": "/tmp/ptah migrations up --help (--lock-timeout per-migration, --migration-lock-timeout advisory); docs/site/src/content/docs/atlas/migrate-commands.md line 356; conformance cli-surface.md `atlas migrate apply --lock-timeout`"
+  },
+  {
+    "area": "Test frameworks",
+    "feature": "Migration test framework (`ptah migrations test`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set.",
+    "evidence": "`ptah migrations test --help`; docs/site/src/content/docs/reference/test-cases.md (Isolation); conformance cli-surface.md classifies `atlas migrate test` as absent from the pinned CE binary. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate test` -> exit 1 community-abort. Pricing page: 'Testing Framework' is Pro, not Starter. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Testing Framework' (linked to /testing/schema) is unchecked on Starter and checked on Pro \u2014 Starter absence corroborates the measured CE no, and the Pro check is the first Atlas-side source cited for the Pro column"
+  },
+  {
+    "area": "Test frameworks",
+    "feature": "Schema test framework (`ptah schema test`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb.",
+    "evidence": "ptah-atlas-conformance cli-surface.md (`atlas schema test` = out-of-scope); `ptah schema test --help`. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema test` -> exit 1 community-abort. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Testing Framework' (linked to /testing/schema) is unchecked on Starter and checked on Pro \u2014 corroborates the measured CE absence and supplies an Atlas-side source for the Pro column"
+  },
+  {
+    "area": "Test frameworks",
+    "feature": "Atlas-shaped migrate test / schema test verbs",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`.",
+    "evidence": "Built ptah-compat `schema test --help` (flags: --dev-url, --run, -u only) and `migrate test --help` (--dev-url, --dir, --dir-format, --run only); `schema test -u file:///path/schema.sql` exits 1 with \"parse desired schema from ...: stat .: not a directory\"; `-u sqlite://target.db` and `-u env://src` exit 1 with \"only local file:// migration directories are supported\"; `migrate test --report json` is parsed as a positional path. Passing baseline: `migrate test --dir file://migrations --dev-url sqlite://dev.db tests` exits 0. Atlas side from cli-surface.md lines 40/59 (out-of-scope in CE) and lines 138-140/168-170. Atlas's `migrate test` and `schema test` also lack `--report` and `--seed-dir`; `schema test -u` accepts a SQL file and a live sqlite URL (both PASS) (measured; observation study, scenario, lint-test-pro, test-hcl)"
+  },
+  {
+    "area": "Test frameworks",
+    "feature": "Embeddable test runner (Go package)",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package.",
+    "evidence": "migration/dbtest/engine.go:247 RunMigrationTest and migration/dbtest/schema.go:53 RunSchemaTest; conformance cli-surface.md measures CLI commands only, and gaps.md lines 167-172 show the corpus imports atlasexec fixtures, so Atlas does have an observable Go package surface \u2014 the previous \u274c/\u274c cells asserted an Atlas distribution fact no cited source establishes"
+  },
+  {
+    "area": "Lint analyzers",
+    "feature": "Native migration lint rule set",
+    "ptah": "yes",
+    "atlas_oss": "partial",
+    "atlas_pro": "yes",
+    "note": "42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro.",
+    "evidence": "`ptah migrations lint --help` registers `--dialect` gating postgres/mysql/mariadb/sqlite/clickhouse/cockroachdb/yugabytedb/spanner; migration/lint/rules.go carries the DS/CD/DD/MF/BC/PG/MY/LT/TX families. Atlas feature availability page: \"Migration Linting\" = Pro, with \"Destructive changes\" and \"Backward incompatible changes\" listed Open and \"Concurrent index changes\" listed Pro. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter and checked on Pro \u2014 tension with the features page listing destructive and backward-incompatible rules as Open; the measured CE binary registers `atlas migrate lint` (cli-surface.md), so the partial verdict stands."
+  },
+  {
+    "area": "Lint analyzers",
+    "feature": "Atlas Pro analyzer code coverage",
+    "ptah": "partial",
+    "atlas_oss": "na",
+    "atlas_pro": "yes",
+    "note": "OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones.",
+    "evidence": "Reproduced on postgres: `ALTER TABLE t ALTER COLUMN c TYPE bigint` -> DS103 (PG301); `ALTER TABLE t2 ADD PRIMARY KEY (c)` -> PG104 (PG304). On mysql: `ALTER TABLE t CONVERT TO CHARACTER SET utf8mb4` -> MY101 (MY136); migration/lint/rules.go:1095 scanConvertCharset. gaps.md lint-analyzer-catalog records all five as `covered (mapped)`. comparison.md:488 records OW101/OW102 as account-bound waivers."
+  },
+  {
+    "area": "Lint analyzers",
+    "feature": "Default-firing Atlas analyzer concern mapping",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus.",
+    "evidence": "gaps.md lint-analyzer-catalog rows (lines 395-436) are all `ok` across the DS, MF, BC, CD, PG1, PG3, PG110, MY, LT and TX families. PARITY.md:178-203 states every default-firing concern is covered and that an uncovered concern added later fails closed to a red `missing` gap."
+  },
+  {
+    "area": "Lint analyzers",
+    "feature": "Custom lint rules and check-level policy",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail.",
+    "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} \u2014 no rule definition. config/projectconfig/atlas.go:536 parseLintPolicyBlocks accepts only concurrent_index, data_depend, destructive, git, nestedtx, incompatible; atlas.go:613 rejects `force`. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
+  },
+  {
+    "area": "Lint policy and suppression",
+    "feature": "Inline nolint suppression",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored.",
+    "evidence": "internal/atlaslint/rules.go:41 NativeSuppressionTargets maps 5 analyzer names + ds102/ds103/mf103 only, default returns nil. Reproduced: `ptah-compat migrate lint` reports `[PG101]` yet `-- atlas:nolint PG101` leaves the diagnostic. CE side: PARITY.md:420 records the imported Atlas fixtures asserting `-- atlas:nolint` suppression for `atlas migrate lint`; gaps.md:814 runs cli-migrate-lint-ignore.txtar with 57 assertions. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter \u2014 a plan-tier claim in tension with the measured CE fixtures asserting `-- atlas:nolint` suppression; the measured yes stands. `-- atlas:nolint <CODE>` and analyzer-name spellings both suppress; matching is exact, not blanket (measured; observation study, scenario, lint-test-pro)"
+  },
+  {
+    "area": "Lint policy and suppression",
+    "feature": "Per-rule severity policy",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "partial",
+    "note": "Severity vocabulary is warning|error only (info errors out). Measured, Atlas is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist.",
+    "evidence": "migration/lint/config.go:78 validateConfig admits only SeverityWarning/SeverityError. Reproduced: `severity: info` -> `error: failed to parse lint config .ptah-lint.yaml: rule DS101 has unsupported severity \"info\"` (exit 2); `severity: warning` demotes DS101 from error. config/projectconfig/atlas.go:594 parseLintAnalyzer takes only `error` bool. No cited Atlas source establishes CE severity-policy behavior; the Atlas features page classifies the linting CLI as Pro. analyzer blocks and .rule.hcl reject a `severity` attribute; the only per-analyzer control is boolean error (measured; observation study, scenario, lint-test-pro)"
+  },
+  {
+    "area": "Lint output and CI",
+    "feature": "SARIF 2.1.0 lint report",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "na",
+    "note": "Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint.",
+    "evidence": "Reproduced: `ptah migrations lint --format sarif` emits version 2.1.0 with driver \"ptah migrations lint\", a rules array, and a result carrying ruleId DS101, level warning, artifactLocation and region.startLine. gaps-migrate-runtime.md:34 `fidelity: sarif output shape` records the same. cli-surface.md:33 shows CE `--format` is the Atlas Go template only."
+  },
+  {
+    "area": "Lint output and CI",
+    "feature": "CI integration (GitHub Action, annotations)",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations.",
+    "evidence": "`ptah migrations lint --help` registers `--format ... github-actions`. Atlas side: docs/site/src/content/docs/atlas/docs-coverage.md:533 \"Atlas integration parity is unmeasured\"; the Atlas feature availability page does not address GitHub Actions integration, and cli-surface.md inventories no action. Nothing cited settles either Atlas column. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines section lists 'CI/CD integrations (K8s, TF, GH, GitLab, BitBucket)' as Basic on the free tier and checked on Pipelines Pro \u2014 a separately priced product ($59/mo per project requiring Atlas Pro seats), so it does not settle either CLI-plan column."
+  },
+  {
+    "area": "Safety gates",
+    "feature": "Apply-time destructive-change gate",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "na",
+    "note": "migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file.",
+    "evidence": "Reproduced: `ptah migrations up` aborts with `pending migrations contain destructive statements; rerun with --allow-destructive after review: - 0000000002_drop.up.sql:1 DS101 error`. Adding `.ptah-lint.yaml` with `disabled-rules: [DS101]` let the same up succeed; ptah.sum was byte-identical and `ptah migrations validate` still printed `OK: migrations directory matches ptah.sum`. Atlas side: cli-surface.md:27 lists no destructive-gate flag on `atlas migrate apply`."
+  },
+  {
+    "area": "Safety gates",
+    "feature": "Statement safety classification report",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "plan `--report` text|html|json and generate `--report` html|json emit highest severity, a destructive flag, and per-statement assessments.",
+    "evidence": "`ptah migrations plan --help` registers `--report string  Safety report format: text, html, or json (default \"text\")`; `ptah migrations generate --help` registers `--report string  Safety report format next to the migration files: \"\", html, or json`."
+  },
+  {
+    "area": "Verification and contracts",
+    "feature": "Dev / shadow database verification",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "`--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely.",
+    "evidence": "Built ptah binary --help: --shadow-db on `migrations generate`, `migrations checkpoint`, `migrations baseline`, `migrations down`; `migrations validate --dev-url docker://postgres/16/dev` exits 2 with \"docker --dev-url values are accepted by Atlas, but Ptah requires a directly connectable dev database URL for migration SQL replay\"; ptah-compat `schema apply --dev-url sqlite:///nonexistent-dir-xyz/dev.db --dry-run` exits 0 and prints a plan, while the same dev URL with --auto-approve exits 1 with \"connect to --dev-url: failed to ping database: unable to open database file (14)\"; conformance PARITY.md line 48 (dbtest-workflow) for the working replay path"
+  },
+  {
+    "area": "Verification and contracts",
+    "feature": "Exit-code contract for CI gates",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "na",
+    "note": "Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2.",
+    "evidence": "docs/site/src/content/docs/reference/exit-codes.md; docs/site/src/content/docs/reference/test-cases.md (Exit contract)"
+  },
+  {
+    "area": "Database engines",
+    "feature": "PostgreSQL 12+ (postgres, postgresql)",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner.",
+    "evidence": "/tmp/ptah-mx schema render --dialect postgres (built from /Users/buster/Work/denis/ptah/.codex/worktress/docs-feature-matrix/cmd/ptah); core/platform/capability/capability.go Postgres13/Postgres16/Postgres17 + ForServerVersion; docs/site/src/content/docs/databases/postgresql.md (Version-dependent behavior); comparison.md#supported-databases cites the Atlas Open driver list. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating PostgreSQL on the free tier"
+  },
+  {
+    "area": "Database engines",
+    "feature": "MySQL and MariaDB",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback.",
+    "evidence": "Live MySQL 9.7 `ptah schema apply --dry-run` fails with \"materialized views are not supported by MySQL or MariaDB; remove matview definitions for this target\"; with the matview removed the plan contains only tables, a view, a trigger and the FK \u2014 the extension, function, sequence, domain, role, grant and RLS objects produce no statement and no warning. capability.go:358 MariaDB1011 sets Sequences=true, yet `schema render --dialect mariadb` emits no CREATE SEQUENCE. Atlas side: comparison.md:398 lists MySQL and MariaDB as Open drivers. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating MySQL and MariaDB on the free tier."
+  },
+  {
+    "area": "Database engines",
+    "feature": "SQLite (sqlite, sqlite3)",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with \"modifying columns ... requires a table rebuild plan\". PG-only objects error one at a time.",
+    "evidence": "`ptah schema diff --from a.sql --to b.sql --dev-url sqlite://dev.db` (TEXT->INTEGER) errors \"sqlite: modifying columns on table t requires a table rebuild plan\"; same error for NOT NULL removal, DEFAULT add and column UNIQUE add. Dropping a column instead emits the full \"__ptah_rebuild_t\" CREATE/INSERT/DROP/RENAME sequence. internal/planner/dialects/sqlite/sqlite.go:91 and :96. Live SQLite apply rejects matview, extension, function, sequence and user-defined types with one error each. Atlas side: comparison.md:398 lists SQLite as an Open driver. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names MySQL, MariaDB, PostgreSQL and SQLite, corroborating SQLite on the free tier."
+  },
+  {
+    "area": "Database engines",
+    "feature": "SQL Server and Azure SQL (sqlserver, mssql, tsql)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews.",
+    "evidence": "`ptah schema render --dialect sqlserver` emits 6 statements including CREATE VIEW and CREATE TRIGGER; `--dialect mssql` and `--dialect tsql` emit 4 with both missing, reproducible across 3 runs. Root cause fromschema.go:1747 supportsStandaloneViewsAndTriggers compares the raw string. cmd/generate/generate.go:113 default list omits sqlserver; :69 help text omits it. capability.go:481 SQLServer2022 sets Sequences/RLS/RoleManagement=false. Atlas side: comparison.md:400 lists SQL Server as Pro."
+  },
+  {
+    "area": "Database engines",
+    "feature": "ClickHouse (clickhouse, ch)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic.",
+    "evidence": "Live ClickHouse 24.12: `ptah schema apply --root-dir <fixture> --db-url clickhouse://... --dry-run` planned only the two CREATE TABLE statements from a 13-object fixture. Offline `schema render` emits skip comments for extension/enum/FK but nothing for views or triggers. capability.go:430 ClickHouse24 sets ForeignKeys=false, CheckConstraintsEnforced=false. Atlas side: comparison.md:400 lists ClickHouse as a Pro driver."
+  },
+  {
+    "area": "Database engines",
+    "feature": "CockroachDB (cockroachdb, crdb)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers.",
+    "evidence": "capability.go:507 CockroachDB23. `ptah schema render --dialect cockroachdb` errors: \"cockroachdb does not support sequence-backed type SERIAL; use a platform-specific type override\"; on a non-SERIAL fixture it emits 5 statements against postgres's 15, dropping view/matview/function/trigger/role/grant/RLS/domain/sequence. Root cause fromschema.go:110 isPostgreSQLPlatform matches only \"postgres\"/\"postgresql\". Atlas side: comparison.md:400 lists CockroachDB as Pro."
+  },
+  {
+    "area": "Database engines",
+    "feature": "YugabyteDB (yugabytedb, ysql)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them.",
+    "evidence": "Live YugabyteDB 2026.1.0.0: `ptah schema apply --db-url yugabytedb://... --dry-run` planned CREATE ROLE, CREATE SEQUENCE, CREATE DOMAIN, CREATE VIEW, CREATE MATERIALIZED VIEW, CREATE FUNCTION, CREATE TRIGGER and GRANT, and no RLS statement. `ptah schema render --dialect yugabytedb` on the same fixture emits 5 statements with all of those absent. capability.go:521 YugabyteDB25 sets RowLevelSecurity=false, RoleManagement=true. Atlas side: comparison.md:400 lists YugabyteDB as Pro."
+  },
+  {
+    "area": "Database engines",
+    "feature": "Spanner PostgreSQL interface (spanner)",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists.",
+    "evidence": "`ptah schema render --dialect spanner` emits \"-- SPANNER: enum type user_status is not supported by this target; skipped.\" and \"-- SPANNER: constraint \\\"fk_orders_user_id\\\" is not supported by this target; skipped.\"; with SERIAL it errors \"spanner does not support sequence-backed type SERIAL\". capability.go:532 SpannerPostgres. docker-compose.yaml has no spanner service (cockroachdb:71 and sqlserver:101 do); internal/dbschema/ has no spanner package. Atlas side: comparison.md:400 lists Spanner as Pro."
+  },
+  {
+    "area": "Database engines",
+    "feature": "TiDB and LibSQL",
+    "ptah": "no",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Both names fail dialect normalization: \"unsupported database dialect: tidb\" / \"...: libsql\". No renderer, planner or driver entry.",
+    "evidence": "`ptah schema render --dialect tidb` -> \"error: error rendering tidb schema: unsupported database dialect: tidb\"; same for libsql. platform/constants.go:19 NormalizeDialect has no tidb or libsql case. Atlas side: comparison.md:398 lists TiDB and LibSQL as Open drivers. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Starter 'Databases engines' names only MySQL, MariaDB, PostgreSQL and SQLite (Pro: All) \u2014 tension with the Open-driver listing for TiDB and LibSQL; cells kept on the features-page classification pending a measured check of the CE binary."
+  },
+  {
+    "area": "Database engines",
+    "feature": "Oracle, Snowflake, Redshift, Databricks",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers.",
+    "evidence": "`ptah schema render --dialect oracle` -> \"error: error rendering oracle schema: unsupported database dialect: oracle\". platform/constants.go:19. Atlas side: comparison.md:400 lists Oracle, Snowflake, Redshift and Databricks as Pro drivers."
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Enum types",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim.",
+    "evidence": "internal/convert/fromschema/fromschema.go:268 `if !strings.HasPrefix(field.Type, \"enum_\") { return field }`; reproduced with /tmp/pt-audit schema render. Atlas CE column from stokaro/ptah-atlas-conformance gaps-diff.md rows `mysql/02-enum`, `postgres/02-enum`, `sqlite/02-enum` (compare against Atlas CE inspect, ok)"
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Views and materialized views",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1758-1764 appends only Views (never MaterializedViews) for the non-PostgreSQL path; `ptah schema render --dialect mysql` emitted no matview statement, while `ptah schema apply` against live MySQL 9.7 failed with \"materialized views are not supported by MySQL or MariaDB\""
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Functions",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1632-1634 appends functions only when isPostgreSQLPlatform; live MySQL 9.7 `ptah schema apply --dry-run` planned no function and printed no diagnostic. Atlas columns from stokaro/ptah-atlas-conformance PARITY.md: \"Atlas CE silently omits Pro-gated objects (views, triggers, functions, sequences) from inspection \u2014 no error, exit 0\""
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Triggers",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1747-1756 matches platform.SQLServer (\"sqlserver\") without normalizing; core/renderer/internal/dialects/mysqllike/mysqllike.go:643 hard-codes FOR EACH ROW; core/renderer/internal/dialects/mssql/mssql.go:626-628 maps BEFORE to AFTER; core/renderer/internal/dialects/sqlite/sqlite.go:313 errors on FOR EACH STATEMENT"
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Standalone sequences",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1593 gates CREATE SEQUENCE on isPostgreSQLPlatform; live YugabyteDB apply planned CREATE SEQUENCE \"yb_seq\" START WITH 1; SQL source: \"unsupported CREATE target: SEQUENCE\". Atlas columns from PARITY.md Pro-gated-object sentence"
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Extensions",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment.",
+    "evidence": "core/renderer/internal/dialects/mysql/mysql.go:26-30 copies the bufwriter by value so VisitExtension (line 132) writes to a buffer Output() never reads; verified live: `ptah schema compare` against PostgreSQL 18 proposed DROP EXTENSION for pg_trgm and left plpgsql alone"
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Roles, grants, and row-level security",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1710-1745 (roles/grants/RLS behind isPostgreSQLPlatform); live YugabyteDB apply planned CREATE ROLE \"yb_role\"; `ptah schema render --schema-file` rejects CREATE ROLE / GRANT / CREATE POLICY / ALTER TABLE ... ENABLE ROW LEVEL SECURITY. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `schema apply` with `role \"app\" { }` on sqlite -> exit 0 'Schema is synced, no changes to be made' (silent no-op). Atlas pricing page (atlasgo.io/pricing, retrieved 2026-08-01): 'Database Security as Code' is Pro, not Starter"
+  },
+  {
+    "area": "Schema object kinds",
+    "feature": "Domains, composite types, and range types",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1616 gates domain/range/composite emission on isPostgreSQLPlatform (postgres|postgresql only); migration/schemadiff/internal/compare/usertypes.go:158-174 compares ranges by name only; live YugabyteDB 2026.1.0.0 `ptah schema apply --dry-run` planned CREATE DOMAIN \"yb_domain\" AS TEXT"
+  },
+  {
+    "area": "Data and distribution",
+    "feature": "Registry-backed distribution: `oci://` vs `atlas://`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`atlas://` functions \u2014 publish, pull, digest-pin, run migrations directly, schemas via `--schema-file` \u2014 over any OCI registry, no account. See [OCI registry artifacts](../../operate/oci-registry/).",
+    "evidence": "ptah schema push oci://localhost:5555/demo/schema:v1 --root-dir ./models --plain-http -> exit 0; cli-surface.md lines 35 and 58 classify `atlas migrate push` and `atlas schema push` as not present in the pinned CE binary; ptah migrations up --db-url sqlite://app.db --migrations-dir oci://localhost:5555/demo/mg:c1 --plain-http -> applied version 1785514698, exit 0; ptah migrations down --target 0 over the same reference rolled back, exit 0; internal/ociartifact/client.go:46 credentials.NewStoreFromDocker; htpasswd-protected registry: push without creds -> exit 2 'basic credential not found', sa. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' (Pipelines section) is unchecked on the free tier and checked on Pro with a 500-object limit \u2014 corroborates the measured CE absence of push verbs and supplies an Atlas-side source for the Pro column"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Desired-schema artifacts in an OCI registry",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2.",
+    "evidence": "push -> Digest sha256:2ebd84f93717f397e89cb5862913f6e7679064d624a9f1e22b7092504bd1de92; ptah schema pull --out pulled.hcl returned the same digest and a valid table block. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Atlas Registry' is unchecked on the free tier and checked on Pro (500-object limit) \u2014 first Atlas-side source cited on this row, supporting atlas_oss no and atlas_pro yes"
+  },
+  {
+    "area": "Data and distribution",
+    "feature": "oci:// as a `--schema-file` desired-state source",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Accepted by schema render/compare/drift/plan/apply and migrations plan/generate. schema inspect rejects it, and only three of those expose `--plain-http`.",
+    "evidence": "ptah schema drift/compare --schema-file oci://... --plain-http -> works; ptah schema inspect --schema-file oci://... -> 'unsupported desired-state URL scheme \"oci\"'; ptah schema render/plan/apply and migrations generate -> 'unknown flag: --plain-http'. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines tier table lists Atlas Registry as absent from Starter and included in Pro (limited to 500 objects) \u2014 Atlas-side confirmation that registry-backed schema sources are Pro-gated"
+  },
+  {
+    "area": "Data and distribution",
+    "feature": "Digest pinning and write-once version tags",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "unknown",
+    "note": "Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move.",
+    "evidence": "push to @sha256:2ebd84f9... -> exit 2 'cannot push to a digest reference'; re-push --version rel1 with changed content -> exit 2 'OCI write-once tag already exists'; tag v1 moved from sha256:869dd082 to sha256:70575f30 across pushes while rel1 stayed pinned"
+  },
+  {
+    "area": "Data and distribution",
+    "feature": "Artifact integrity check (`--verify-sum`)",
+    "ptah": "partial",
+    "atlas_oss": "na",
+    "atlas_pro": "unknown",
+    "note": "On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes.",
+    "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'"
+  },
+  {
+    "area": "OCI artifacts",
+    "feature": "Referrer attachments: lint, plan, deployment reports",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "unknown",
+    "note": "lint `--attach`, migrations plan `--attach` and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload.",
+    "evidence": "oci referrers --format json returns digest/artifact_type/media_type/size/annotations only; flags are --format, --type, --plain-http; the manifest's deployment.json layer (362 bytes) is reachable only through the raw registry API; cmd/oci/oci.go:69 calls ocireferrers.List"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Atlas CE inspect HCL parses back into Ptah",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "30 atlas-differential observations parse Atlas CE 1.2.0 `schema inspect` HCL on Postgres/MySQL/SQLite with zero schema-fact mismatches.",
+    "evidence": "conformance gaps-diff.md (30 ok / 0 gap, probe atlas-differential, Atlas pinned a5e0aec); PARITY.md: \"Atlas's view comes from `schema inspect` in its native HCL, parsed by Ptah's own core/atlashcl\""
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL top-level blocks Ptah parses",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data.",
+    "evidence": "internal/atlashcl/atlashcl.go:73-113; a fixture exercising all 16 renders 17 PostgreSQL statements via `ptah schema render --schema-file all.hcl --dialect postgres`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Database Security as Code (linked /atlas-schema/hcl#roles-and-permissions) and Seed Data as Code are absent from Starter and Pro-gated \u2014 this bears on the role, permission and data blocks only, so both Atlas cells stay unknown"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL table and column child blocks",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform.",
+    "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL variable blocks and var.* references",
+    "ptah": "no",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "`variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 \u2014 no substitution and no error.",
+    "evidence": "internal/atlashcl/atlashcl.go:107-110 and 1478-1484; conformance gaps.md atlas-hcl-parse row `schemahcl/testdata/variables.hcl` \u2014 \"only non-schema top-level blocks: variable\". `variable` + var.x inside a schema file substitutes in Atlas (measured; observation study, scenario, hcl-semantics)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL function calls in schema files",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "partial",
+    "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally.",
+    "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496; render emits column type `sql(\"geometry(Point,4326)\")`. `sql(...)` as a column type works in Atlas; `sql(...)` inside an index where clause is rejected under the sqlite dialect (measured; observation study, scenario, hcl-semantics)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL locals, lock, atlas, dynamic/for_each",
+    "ptah": "no",
+    "atlas_oss": "unknown",
+    "atlas_pro": "partial",
+    "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\".",
+    "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error. `locals` works in a schema file in Atlas; `lock` and `atlas` top-level blocks are rejected under the sqlite dialect; `dynamic` was not probed in Atlas (measured; observation study, scenario, hcl-semantics)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "HCL foreign_key deferrable",
+    "ptah": "no",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too.",
+    "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff. `deferrable = true` rejected under the sqlite dialect; engine-gated, so the Atlas cell stays unresolved for PostgreSQL (measured; observation study, scenario, hcl-semantics)"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Ptah-only HCL schema extensions",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block.",
+    "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Seed Data as Code (/guides/seed-data-as-code) is absent from Starter and Pro-gated, so Atlas Pro covers the seed-data job at job level; whether it uses an HCL data-block mechanism is not stated"
+  },
+  {
+    "area": "Schema sources",
+    "feature": "Directory of .hcl files as one schema source",
+    "ptah": "no",
+    "atlas_oss": "unknown",
+    "atlas_pro": "yes",
+    "note": "`--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file.",
+    "evidence": "cmd/internal/schemaload/schemaload.go:257-259; `ptah-compat schema diff --to file://dir` prints \"load --to schema: schema file is a directory\". a directory of .hcl files as `--url file://dir` works on schema inspect (measured; observation study, scenario, hcl-semantics)"
+  },
+  {
+    "area": "Schema inspection filters",
+    "feature": "Schema-qualified exclude globs for enums and functions",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only.",
+    "evidence": "internal/atlasfilter/filter.go:299-303 (filterEnums matches value.Name) and :342-346 (filterFunctions matches function.Name) versus :348-356 and :327-340 which build qualifiedNameCandidates for views and extensions. docs/site/src/content/docs/atlas/schema-commands.md:96-98 records the same limitation. Nothing in cli-surface.md, gaps.md, gaps-live.md, or gaps-diff.md establishes Atlas CE's qualification semantics for enum and function exclude globs, so both Atlas columns are \u2754"
+  },
+  {
+    "area": "Project config",
+    "feature": "atlas.hcl from the native ptah binary",
+    "ptah": "partial",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved.",
+    "evidence": "cmd/internal/dbcli/project_config.go:66-80 (the atlas.hcl path and --var forwarding flags are hidden adapter-only), config/projectconfig/load.go:20-24 (AtlasPath defaults to AtlasFileName in the working directory). Repro: `ptah schema compare --env local --schema-file s.sql --var dburl=sqlite://file.db` -> `error: unknown flag: --var`; `ptah schema compare --config atlas.hcl --env local` -> `error: failed to parse ptah config atlas.hcl: yaml: unmarshal errors`"
+  },
+  {
+    "area": "Schema inspection filters",
+    "feature": "Inspect `--exclude` field selectors",
+    "ptah": "partial",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted.",
+    "evidence": "internal/atlasfilter/filter.go:188-200 parseFieldSelector accepts only field==\"version\" with hasOnlyType(types,\"extension\"), and :132-135 rejects a second [type= segment; built ptah-compat on live PostgreSQL: `--exclude '*[type=extension].version'` blanks the version, `--exclude '*[type=table].comment'` exits 1 \"unsupported Atlas exclude field selector \\\".comment\\\"\", `--exclude '*[type=table]*'` exits 1 \"unsupported Atlas exclude field selector suffix \\\"*\\\"\". Atlas columns downgraded to unknown: conformance cli-surface.md line 47 establishes that --exclude exists on Atlas CE schema inspect but nothing cited establishes which field-selector forms Atlas honors, and no cited source defines an \"exporter block\" at all. `--exclude '*[type=table].comment'` parses and runs on sqlite (exit 0), but sqlite has no comment support, so filtering is unobserved - syntactic acceptance only (measured; observation study, scenario verbs-and-flags)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Pre-migration webhook and shell hook gates",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "`--webhook` POSTs migration metadata and requires HTTP 200; `--pre-up-hook`/`--pre-down-hook` run a shell command that must exit 0, else the run aborts. Also ptah.yaml migration.webhook/pre_up_hook.",
+    "evidence": "/tmp/c-ptah migrations up --help shows --webhook and --pre-up-hook; down shows --pre-down-hook. Atlas-side: cli-surface.md line 27 lists every atlas migrate apply flag; no webhook or hook flag. docs/site/src/content/docs/versioned/apply.md:154-158. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Webhooks (Pipelines) and Pre-migration safety checks (/versioned/checks) are absent from Starter and Pro-gated; Starter absence matches the measured CE no, but Atlas webhooks are service event notifications rather than an apply-time gate like `--webhook`, no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Pre-migration database backups (`--pg-dump-to`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "`--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to.",
+    "evidence": "/tmp/c-ptah migrations up --help and down --help show --pg-dump-to/--mysqldump-to. Atlas-side: cli-surface.md line 27 migrate apply flag list has no backup flag. docs/site/src/content/docs/reference/configuration.md:87. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Prometheus metrics endpoint (`--metrics-addr`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run.",
+    "evidence": "/tmp/c-ptah migrations up/down/status --help all show \"--metrics-addr Address for the Prometheus /metrics endpoint, such as :9090\". Atlas-side: cli-surface.md lines 27/39 list migrate apply and status flags; none exposes a metrics endpoint. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Structured JSON log output (`--log-format`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "migrations up, down, and status take `--log-format` text|json and `--log-level` debug|info|warn|error for machine-readable run logs.",
+    "evidence": "/tmp/c-ptah migrations up --help shows --log-format and --log-level. Atlas-side: cli-surface.md line 27 migrate apply flag list has no log flags (only output --format). no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Online DDL routing via gh-ost or pt-osc",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "no",
+    "note": "ptah.yaml online_ddl.tool (ghost|pt-osc), threshold_rows, args, and fallback (error|plain) route large-table ALTERs through an online-DDL tool during migrations up/down.",
+    "evidence": "config/projectconfig/config.go:22-35,407-447 defines the config; cmd/migrateup/migrateup.go:374 consumes it; config/projectconfig/online_ddl_test.go. docs/site/src/content/docs/reference/configuration.md:89 documents the four keys. Matrix mentions online_ddl only as a ptah.yaml key name. no gh-ost/pt-osc routing on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Atlas txtar migration sections (-- atlas:txtar)",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "yes",
+    "note": "`-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored.",
+    "evidence": "migration/migrator/migrations.go parses migration.sql, down.sql, checks.sql, and ordered checks/*.sql sections; docs/site/src/content/docs/atlas/migrate-commands.md documents the behavior. The down row's \"Atlas single-file dirs have no down body\" note does not cover this exception. txtar migrations run with checks.sql ENFORCED as a pre-migration gate (failing assertion aborts, exit 1) (measured; observation study, scenario, txtar-checks-enforcement). Fixed 2026-08-01 (stokaro/ptah#956) and hardened after review: check files map onto the same engine, preserve archive order, default to all-of, and honor file-level atlas:assert oneof; a failing assertion aborts before migration.sql; --skip-checks bypasses on native ptah migrations up, compat migrate apply has no such flag (parity), and --tx-mode all refuses checked txtar files. A failed check records NO revision row, so retry after fixing data succeeds without repair."
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Atlas SQL template migrations (`--atlas-env`)",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs.",
+    "evidence": "migration/migrator/atlas_template.go:15-45 (AtlasTemplateData{Env}, RenderAtlasTemplateSQL); /tmp/c-ptah migrations up --help shows \"--atlas-env Value exposed as .Env when rendering Atlas SQL template migrations\"."
+  },
+  {
+    "area": "Linting and safety",
+    "feature": "Generation-time destructive-change gate",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row.",
+    "evidence": "/tmp/c-ptah migrations generate --help and plan --help show --check-destructive/--allow-destructive. Atlas-side: cli-surface.md line 29 migrate diff flag list has no destructive gate flag. no equivalent flag on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Linting and safety",
+    "feature": "Standalone SQL file linting (`ptah sql lint`)",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "unknown",
+    "note": "Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not.",
+    "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based. no standalone SQL-file lint verb; `atlas schema lint` exists but lints schema sources, a different mechanism (measured; observation study, scenario, lint-test-pro, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Declarative and direct schema changes",
+    "feature": "JSON output for native schema diff",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "unknown",
+    "note": "Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated.",
+    "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0."
+  },
+  {
+    "area": "Go embedding and developer tooling",
+    "feature": "Go annotations to HCL export with cleanup",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Writes HCL from Go annotations; cleanup requires zero diagnostics. Function, view, materialized-view, and trigger bodies are emitted as opaque HCL text, reported, and block cleanup.",
+    "evidence": "/tmp/c-ptah schema export --to hcl --root-dir . --out schema.hcl produced a table \"products\" HCL file, exit 0; export --help shows the three cleanup flags. Atlas has no //ptah annotation set for the concept to apply to (matrix's own \u2796 rationale)."
+  },
+  {
+    "area": "Configuration and dev databases",
+    "feature": "PTAH_* environment-variable flag equivalents",
+    "ptah": "yes",
+    "atlas_oss": "unknown",
+    "atlas_pro": "no",
+    "note": "Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag.",
+    "evidence": "All 49 --help screens annotate each flag with [env: PTAH_*]; verified live: PTAH_FORMAT=dot /tmp/c-ptah viz --root-dir . emitted Graphviz DOT instead of the mermaid default, exit 0. No Atlas-side env-var inventory is cited by the page. no documented ATLAS_* env-var flag twins in Atlas's help (measured; observation study, scenario, ptah-extension-equivalents)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "migrate apply `--allow-dirty` semantics",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite).",
+    "evidence": "/tmp/c-compat migrate apply onto SQLite with a pre-existing table succeeded with no flag ('Migration complete'); after a failed migration, apply refuses ('is dirty'), and --allow-dirty errors 'UNIQUE constraint failed: atlas_schema_revisions.version'. Flag in CE inventory, cli-surface.md line 27; help: 'Allow applying migrations when the revision table is dirty'."
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Upstream verb `migrate ls`",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Beyond the CE pin: works in Atlas against a local directory; ptah-compat rejects it as unknown command; native `ptah migrations status` lists versions and states.",
+    "evidence": "Verified: /tmp/c-compat migrate ls -> 'unknown command'; /tmp/c-ptah migrations status --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin' records it absent from pinned CE v1.2.0 (unknown command, not an abort stub) while present in current Atlas docs. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate ls` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas migrate ls` works against a local migration directory (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Versioned migrations",
+    "feature": "Upstream verb `migrate show`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Beyond the CE pin: prints a migration's SQL upstream; no compat or native Ptah verb exists, and the gap register triages it as future work.",
+    "evidence": "Verified: /tmp/c-compat migrate show -> 'unknown command'; comparison.md:699-701 triage 'migrate show (print a migration's SQL) is future work with no native verb today'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas migrate show` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas migrate show` prints local migration file contents (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Declarative and direct schema changes",
+    "feature": "Upstream verb `schema validate`",
+    "ptah": "partial",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Beyond the CE pin: no validate verb; the gap register triage covers it with native schema render parse/load validation plus schema test and schema apply `--dry-run`.",
+    "evidence": "Verified: /tmp/c-compat schema validate -> 'unknown command'; /tmp/c-ptah schema render --help exists; comparison.md gap register 'Upstream Atlas verbs beyond the CE pin'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema validate` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. `atlas schema validate` exists in Atlas (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Declarative and direct schema changes",
+    "feature": "Upstream verb `schema stats`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Beyond the CE pin: in Atlas it exists as `schema stats inspect` (OpenMetrics) and rejects SQLite at runtime; the gap register triages it out of scope as observability.",
+    "evidence": "Verified: /tmp/c-compat schema stats -> 'unknown command'; comparison.md:699-701 triage 'schema stats (OpenMetrics database statistics) is out of scope'; absent from cli-surface.md inventory. Measured 2026-08-01, CE v1.2.0 logged out (scratch env): `atlas schema stats` falls through to the parent group help, exit 0 - never registered, distinct from the community-abort stubs. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Schema statistics appears only in the Schema Monitoring product (absent from Starter, Pro at $39/mo per monitored database); consistent with the measured CE no, but the pricing label does not name the `schema stats` verb, registered as `atlas schema stats inspect`, OpenMetrics output, rejects sqlite targets at runtime (measured; observation study, scenario, verbs-and-flags)"
+  },
+  {
+    "area": "Go embedding and developer tooling",
+    "feature": "Statement observer and validator hooks (Go API)",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "migrator.WithStatementObserver runs a read-only callback per executed statement; WithStatementValidator gates all statements pre-execution; both compose with StatementInterceptor.",
+    "evidence": "migration/migrator/migration_provider.go:98 (WithStatementValidator), :106 (WithStatementObserver); StatementObservationError in migration/migrator/revisions.go:144. Documented at docs/site/src/content/docs/extend/public-api.md:59-99. Atlas cells na per the matrix's own convention for Go-API rows: CE conformance measures CLI commands, not Go APIs."
+  },
+  {
+    "area": "Go embedding and developer tooling",
+    "feature": "Pinned database sessions (WithSession)",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "`WithSession` on `DatabaseConnection` pins one physical session for a callback, rebinding reader/writer/SQL runner, and discards the connection so session state cannot leak.",
+    "evidence": "dbschema/connection.go:262; docs/site/src/content/docs/extend/public-api.md:78-87. Atlas cells na per the matrix's convention for Go-API rows (CE conformance measures CLI commands, not Go APIs)."
+  },
+  {
+    "area": "Go embedding and developer tooling",
+    "feature": "Concurrency-guarded migration plan publication",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "generator.PlanMigration binds a plan to a directory snapshot; WriteFiles rejects changed history (ErrMigrationDirectoryChanged) under a cross-process lock; concurrent reuse fails (ErrMigrationPlanInUs",
+    "evidence": "migration/generator/plan_test.go:84 (qt.ErrorIs generator.ErrMigrationDirectoryChanged), :91 (TestMigrationPlanWriteFilesContext_RejectsConcurrentUse); docs/site/src/content/docs/extend/public-api.md:115-126. Atlas cells na per the matrix's Go-API row convention."
+  },
+  {
+    "area": "Go embedding and developer tooling",
+    "feature": "testkit companion module for database tests",
+    "ptah": "yes",
+    "atlas_oss": "na",
+    "atlas_pro": "na",
+    "note": "Separate module go.5x5.cz/ptah/testkit wraps testcontainers-go for tests needing real databases; versions independently and stays out of the main module graph.",
+    "evidence": "testkit/go.mod line 1: module go.5x5.cz/ptah/testkit; testkit/testkit.go, containers_test.go present. Documented at docs/site/src/content/docs/extend/public-api.md:54-57. Distinct from the existing \"Embeddable test runner (Go package)\" row, which is migration/dbtest. Atlas cells na per the matrix's Go-API row convention."
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "Column-level data lineage",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Hosted Atlas Cloud view tracing column-to-column dependencies across schemas. No Ptah surface: no lineage verb or flag; the nearest output is `ptah viz`, whose ERD edges are table-level FKs only.",
+    "evidence": "No lineage surface in `ptah --help` inventory; docs/site/src/content/docs/atlas/docs-coverage.md scope statement (Pro, Cloud, registry, account, UI behavior is out of scope). Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Column-level data lineage' is Starter absent / Pro checked in both the Atlas Pipelines and Schema Monitoring tables."
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "Hosted Schema Docs (schema documentation)",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Auto-generated schema documentation pages in Atlas Cloud. Ptah has no docs generator: `ptah schema export` emits HCL, OpenAPI, GraphQL, or protobuf definitions; `ptah viz` covers ERD only.",
+    "evidence": "`ptah schema export --help` and `ptah viz --help` show no documentation-page generator (export targets are openapi-v3, graphql, proto, hcl per the existing export rows); docs/site/src/content/docs/atlas/docs-coverage.md scope statement. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'ERD & Schema Docs' is Starter absent / Pro checked in the Atlas Pipelines and Schema Monitoring tables."
+  },
+  {
+    "area": "Atlas Registry and Cloud",
+    "feature": "Atlas Copilot (AI assistant)",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "AI assistant gated to Pro accounts; absent from the pinned CE v1.2.0 command inventory. No Ptah equivalent; the closest developer-assist surface is the `ptah-ls` language server.",
+    "evidence": "No copilot verb in `ptah --help` inventory; conformance cli-surface.md pinned CE v1.2.0 inventory contains no copilot command. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Pro card bullet 'Access to Atlas Copilot'; the bullet is absent from the Starter card."
+  }
 ]

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -74,11 +74,11 @@ Across the 159 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 86 |
+| Ptah supports it fully | 87 |
 | Ptah supports it with a stated limitation | 48 |
-| Ptah does not implement it | 25 |
+| Ptah does not implement it | 24 |
 | Ptah and Atlas CE both support it | 24 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 36 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 37 |
 | Ptah has it and neither Atlas edition does | 15 |
 | Atlas CE has it and Ptah does not, or only in part | 24 |
 | An Atlas column is ❔ — not established by this page's evidence | 23 |
@@ -212,7 +212,7 @@ seven of them as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas `.test.hcl` ingestion | ❌ | ❌ | ✅ | No .test.hcl parser; a directory of them reports 'no test cases found' (`ptah-compat` exit 1, native exit 2). |
+| Atlas `.test.hcl` ingestion | ✅ | ❌ | ✅ | Implemented: `.test.hcl` is read alongside native YAML by `schema test` and `migrate test`. Adding `output` to an `exec` makes it an assertion; step order is preserved and cases are selected by kind. |
 | Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`. |
 | Dev / shadow database verification | 🟡 | ✅ | ✅ | `--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely. |
 | Embeddable test runner (Go package) | ✅ | ❔ | ❔ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |

--- a/migration/dbtest/atlashcl.go
+++ b/migration/dbtest/atlashcl.go
@@ -1,0 +1,200 @@
+package dbtest
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// AtlasTestKind selects which family of Atlas `.test.hcl` cases to load.
+//
+// Atlas labels every case with its kind, `test "schema" "name"` or
+// `test "migrate" "name"`, and the two are not interchangeable: a migrate case
+// drives the migration directory to a version, which is meaningless in a schema
+// test run and would execute migrations the caller did not ask for. Loading is
+// therefore always scoped to one kind rather than returning whatever the file
+// happens to contain.
+type AtlasTestKind string
+
+const (
+	// AtlasTestKindSchema selects `test "schema" "..."` cases.
+	AtlasTestKindSchema AtlasTestKind = "schema"
+	// AtlasTestKindMigrate selects `test "migrate" "..."` cases.
+	AtlasTestKindMigrate AtlasTestKind = "migrate"
+)
+
+// ParseAtlasTestCases parses an Atlas-format `.test.hcl` document and returns
+// the cases of the requested kind, translated to the native [Case] shape.
+//
+// The Atlas shape is a sequence of labelled `test` blocks whose bodies are
+// ordered steps:
+//
+//	test "schema" "users_insert_select" {
+//	  exec {
+//	    sql = "INSERT INTO users (id, name) VALUES (1, 'ada')"
+//	  }
+//	  exec {
+//	    sql    = "SELECT name FROM users WHERE id = 1"
+//	    output = "ada"
+//	  }
+//	}
+//
+// Step order is significant and is preserved: an `exec` that seeds a row must
+// run before the `exec` that reads it back. hclsyntax reports blocks in source
+// order, so the translation walks Body.Blocks directly rather than using a
+// schema-driven decode, which groups blocks by type and would silently reorder
+// interleaved steps.
+//
+// The `output` attribute turns an `exec` into an assertion rather than a bare
+// statement, because that is what it means in Atlas: the statement runs and its
+// first result is compared. An `exec` without `output` is a plain statement.
+func ParseAtlasTestCases(data []byte, filename string, kind AtlasTestKind) ([]Case, error) {
+	file, diags := hclsyntax.ParseConfig(data, filename, hcl.Pos{Line: 1, Column: 1})
+	if diags.HasErrors() {
+		return nil, fmt.Errorf("parse %s: %s", filename, diags.Error())
+	}
+	body, ok := file.Body.(*hclsyntax.Body)
+	if !ok {
+		return nil, fmt.Errorf("parse %s: unexpected body type %T", filename, file.Body)
+	}
+
+	var cases []Case
+	for _, block := range body.Blocks {
+		if block.Type != "test" {
+			return nil, fmt.Errorf("%s:%d: unsupported block %q: only `test` blocks are supported",
+				filename, block.TypeRange.Start.Line, block.Type)
+		}
+		if len(block.Labels) != 2 {
+			return nil, fmt.Errorf("%s:%d: `test` needs exactly two labels (kind and name), got %d",
+				filename, block.TypeRange.Start.Line, len(block.Labels))
+		}
+		blockKind, name := AtlasTestKind(block.Labels[0]), block.Labels[1]
+		switch blockKind {
+		case AtlasTestKindSchema, AtlasTestKindMigrate:
+		default:
+			return nil, fmt.Errorf("%s:%d: unsupported test kind %q: want %q or %q",
+				filename, block.TypeRange.Start.Line, blockKind,
+				AtlasTestKindSchema, AtlasTestKindMigrate)
+		}
+		if blockKind != kind {
+			continue
+		}
+
+		steps, err := atlasTestSteps(block, filename)
+		if err != nil {
+			return nil, err
+		}
+		cases = append(cases, Case{Name: name, Steps: steps})
+	}
+
+	if err := validateCases(cases); err != nil {
+		return nil, err
+	}
+	return cases, nil
+}
+
+// atlasTestSteps translates one `test` block body into ordered native steps.
+func atlasTestSteps(block *hclsyntax.Block, filename string) ([]Step, error) {
+	if len(block.Body.Attributes) > 0 {
+		names := make([]string, 0, len(block.Body.Attributes))
+		for attrName := range block.Body.Attributes {
+			names = append(names, attrName)
+		}
+		sort.Strings(names)
+		return nil, fmt.Errorf("%s:%d: `test` body takes step blocks, not attributes: %v",
+			filename, block.TypeRange.Start.Line, names)
+	}
+
+	steps := make([]Step, 0, len(block.Body.Blocks))
+	for _, step := range block.Body.Blocks {
+		line := step.TypeRange.Start.Line
+		switch step.Type {
+		case "exec":
+			sql, err := atlasRequiredString(step, "sql", filename)
+			if err != nil {
+				return nil, err
+			}
+			output, hasOutput, err := atlasOptionalString(step, "output", filename)
+			if err != nil {
+				return nil, err
+			}
+			if err := atlasRejectUnknownAttrs(step, filename, "sql", "output"); err != nil {
+				return nil, err
+			}
+			if hasOutput {
+				steps = append(steps, Step{Assert: &Assertion{Query: sql, Scalar: &output}})
+				continue
+			}
+			steps = append(steps, Step{Exec: sql})
+		case "migrate":
+			to, err := atlasRequiredString(step, "to", filename)
+			if err != nil {
+				return nil, err
+			}
+			if err := atlasRejectUnknownAttrs(step, filename, "to"); err != nil {
+				return nil, err
+			}
+			steps = append(steps, Step{MigrateTo: to})
+		default:
+			return nil, fmt.Errorf("%s:%d: unsupported step %q: want `exec` or `migrate`",
+				filename, line, step.Type)
+		}
+	}
+	return steps, nil
+}
+
+func atlasRequiredString(block *hclsyntax.Block, name, filename string) (string, error) {
+	value, ok, err := atlasOptionalString(block, name, filename)
+	if err != nil {
+		return "", err
+	}
+	if !ok {
+		return "", fmt.Errorf("%s:%d: `%s` requires %s",
+			filename, block.TypeRange.Start.Line, block.Type, name)
+	}
+	return value, nil
+}
+
+func atlasOptionalString(block *hclsyntax.Block, name, filename string) (string, bool, error) {
+	attr, ok := block.Body.Attributes[name]
+	if !ok {
+		return "", false, nil
+	}
+	value, diags := attr.Expr.Value(nil)
+	if diags.HasErrors() {
+		return "", false, fmt.Errorf("%s:%d: %s: %s",
+			filename, attr.NameRange.Start.Line, name, diags.Error())
+	}
+	if value.Type() != cty.String {
+		return "", false, fmt.Errorf("%s:%d: %s must be a string",
+			filename, attr.NameRange.Start.Line, name)
+	}
+	return value.AsString(), true, nil
+}
+
+// atlasRejectUnknownAttrs fails on an attribute the step does not define.
+//
+// Unlike atlas.hcl itself, which tolerates unknown names, a test file is our own
+// ingestion surface: a typo in `output` would silently downgrade an assertion to
+// a bare statement, and the case would pass while checking nothing.
+func atlasRejectUnknownAttrs(block *hclsyntax.Block, filename string, allowed ...string) error {
+	known := make(map[string]bool, len(allowed))
+	for _, name := range allowed {
+		known[name] = true
+	}
+	var unknown []string
+	for name := range block.Body.Attributes {
+		if !known[name] {
+			unknown = append(unknown, name)
+		}
+	}
+	if len(unknown) == 0 {
+		return nil
+	}
+	sort.Strings(unknown)
+	return fmt.Errorf("%s:%d: `%s` does not take %v: want %v",
+		filename, block.TypeRange.Start.Line, block.Type, unknown, allowed)
+}

--- a/migration/dbtest/atlashcl_test.go
+++ b/migration/dbtest/atlashcl_test.go
@@ -1,0 +1,198 @@
+package dbtest_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/dbtest"
+)
+
+// The Atlas fixture shape, reproduced exactly as Atlas writes it.
+const atlasSchemaTestHCL = `test "schema" "users_insert_select" {
+  exec {
+    sql = "INSERT INTO users (id, name) VALUES (1, 'ada')"
+  }
+  exec {
+    sql    = "SELECT name FROM users WHERE id = 1"
+    output = "ada"
+  }
+}
+`
+
+const atlasMigrateTestHCL = `test "migrate" "users_table_exists" {
+  migrate {
+    to = "20240101000000"
+  }
+  exec {
+    sql    = "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'"
+    output = "1"
+  }
+}
+`
+
+func TestParseAtlasTestCasesTranslatesExecAndOutput(t *testing.T) {
+	c := qt.New(t)
+
+	cases, err := dbtest.ParseAtlasTestCases([]byte(atlasSchemaTestHCL), "schema.test.hcl", dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 1)
+	c.Assert(cases[0].Name, qt.Equals, "users_insert_select")
+	c.Assert(cases[0].Steps, qt.HasLen, 2)
+
+	// An `exec` without `output` is a bare statement; with `output` it is an
+	// assertion. Getting this backwards would make the second step run and
+	// check nothing, so both halves are pinned.
+	c.Assert(cases[0].Steps[0].Exec, qt.Equals, "INSERT INTO users (id, name) VALUES (1, 'ada')")
+	c.Assert(cases[0].Steps[0].Assert, qt.IsNil)
+
+	c.Assert(cases[0].Steps[1].Exec, qt.Equals, "")
+	c.Assert(cases[0].Steps[1].Assert, qt.IsNotNil)
+	c.Assert(cases[0].Steps[1].Assert.Query, qt.Equals, "SELECT name FROM users WHERE id = 1")
+	c.Assert(cases[0].Steps[1].Assert.Scalar, qt.IsNotNil)
+	c.Assert(*cases[0].Steps[1].Assert.Scalar, qt.Equals, "ada")
+}
+
+// TestParseAtlasTestCasesPreservesStepOrder is the discriminator for the
+// decision to walk Body.Blocks rather than decode against an hcl schema: a
+// schema-driven decode groups blocks by type, which would move the `migrate`
+// step after both `exec` steps and silently change what the case does.
+func TestParseAtlasTestCasesPreservesStepOrder(t *testing.T) {
+	c := qt.New(t)
+
+	const interleaved = `test "migrate" "ordered" {
+  exec {
+    sql = "SELECT 1"
+  }
+  migrate {
+    to = "20240101000000"
+  }
+  exec {
+    sql = "SELECT 2"
+  }
+}
+`
+	cases, err := dbtest.ParseAtlasTestCases([]byte(interleaved), "m.test.hcl", dbtest.AtlasTestKindMigrate)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 1)
+	c.Assert(cases[0].Steps, qt.HasLen, 3)
+	c.Assert(cases[0].Steps[0].Exec, qt.Equals, "SELECT 1")
+	c.Assert(cases[0].Steps[1].MigrateTo, qt.Equals, "20240101000000")
+	c.Assert(cases[0].Steps[2].Exec, qt.Equals, "SELECT 2")
+}
+
+// TestParseAtlasTestCasesSelectsByKind pins that the two kinds are separated.
+// A migrate case loaded into a schema run would drive the migration directory,
+// which the caller did not ask for.
+func TestParseAtlasTestCasesSelectsByKind(t *testing.T) {
+	c := qt.New(t)
+
+	both := atlasSchemaTestHCL + "\n" + atlasMigrateTestHCL
+
+	schemaCases, err := dbtest.ParseAtlasTestCases([]byte(both), "both.test.hcl", dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.IsNil)
+	c.Assert(schemaCases, qt.HasLen, 1)
+	c.Assert(schemaCases[0].Name, qt.Equals, "users_insert_select")
+
+	migrateCases, err := dbtest.ParseAtlasTestCases([]byte(both), "both.test.hcl", dbtest.AtlasTestKindMigrate)
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrateCases, qt.HasLen, 1)
+	c.Assert(migrateCases[0].Name, qt.Equals, "users_table_exists")
+}
+
+func TestParseAtlasTestCasesRejectsMalformedInput(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		contains string
+	}{
+		{
+			name:     "unknown attribute on exec",
+			input:    "test \"schema\" \"x\" {\n  exec {\n    sql = \"SELECT 1\"\n    outpu = \"1\"\n  }\n}\n",
+			contains: "does not take",
+		},
+		{
+			name:     "unknown step block",
+			input:    "test \"schema\" \"x\" {\n  frobnicate {\n    sql = \"SELECT 1\"\n  }\n}\n",
+			contains: "unsupported step",
+		},
+		{
+			name:     "exec without sql",
+			input:    "test \"schema\" \"x\" {\n  exec {\n    output = \"1\"\n  }\n}\n",
+			contains: "requires sql",
+		},
+		{
+			name:     "unknown test kind",
+			input:    "test \"frobnicate\" \"x\" {\n  exec {\n    sql = \"SELECT 1\"\n  }\n}\n",
+			contains: "unsupported test kind",
+		},
+		{
+			name:     "wrong label count",
+			input:    "test \"schema\" {\n  exec {\n    sql = \"SELECT 1\"\n  }\n}\n",
+			contains: "exactly two labels",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := dbtest.ParseAtlasTestCases([]byte(tt.input), "bad.test.hcl", dbtest.AtlasTestKindSchema)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, tt.contains)
+		})
+	}
+}
+
+// TestLoadCasesOfKindReadsAtlasFilesAndLeavesSchemaHCLAlone is the file-suffix
+// discriminator. A directory holding both a `.test.hcl` and a plain `.hcl`
+// schema file must load the first and ignore the second -- matching on
+// filepath.Ext, which yields ".hcl" for both, would try to parse the schema as
+// a test document and fail the whole run.
+func TestLoadCasesOfKindReadsAtlasFilesAndLeavesSchemaHCLAlone(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema.test.hcl"), []byte(atlasSchemaTestHCL), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema.hcl"),
+		[]byte("table \"users\" {\n  schema = schema.main\n}\n"), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 1)
+	c.Assert(cases[0].Name, qt.Equals, "users_insert_select")
+}
+
+// TestLoadCasesOfKindStillReadsNativeYAML pins that adding the Atlas reader did
+// not displace the native format; both live in one directory.
+func TestLoadCasesOfKindStillReadsNativeYAML(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "native.yaml"),
+		[]byte("cases:\n  - name: native_case\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.test.hcl"), []byte(atlasSchemaTestHCL), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 2)
+
+	names := []string{cases[0].Name, cases[1].Name}
+	c.Assert(names, qt.Contains, "native_case")
+	c.Assert(names, qt.Contains, "users_insert_select")
+}
+
+// TestLoadCasesKeepsItsYAMLOnlyContract pins that the pre-existing exported
+// LoadCases was not widened. It skips `.test.hcl` exactly as it did before, so
+// no caller of the old function changes behavior under it.
+func TestLoadCasesKeepsItsYAMLOnlyContract(t *testing.T) {
+	c := qt.New(t)
+
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.test.hcl"), []byte(atlasSchemaTestHCL), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 0)
+}

--- a/migration/dbtest/parse.go
+++ b/migration/dbtest/parse.go
@@ -91,3 +91,60 @@ func isCaseFile(name string) bool {
 		return false
 	}
 }
+
+// LoadCasesOfKind reads the test cases of one kind from dir, accepting both the
+// native YAML documents [LoadCases] reads and Atlas-format `*.test.hcl` files.
+//
+// The kind is explicit rather than inferred because Atlas labels each case with
+// it and the two are not interchangeable: a `test "migrate"` case drives the
+// migration directory to a version, which a schema test run must not do. Native
+// YAML cases carry no kind and are returned for either.
+func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("read test-case directory %s: %w", dir, err)
+	}
+
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		if !isCaseFile(entry.Name()) && !isAtlasCaseFile(entry.Name()) {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	sort.Strings(names)
+
+	var cases []Case
+	for _, name := range names {
+		path := filepath.Join(dir, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read test-case file %s: %w", path, err)
+		}
+		var parsed []Case
+		if isAtlasCaseFile(name) {
+			parsed, err = ParseAtlasTestCases(data, name, kind)
+		} else {
+			parsed, err = ParseCases(data)
+		}
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", name, err)
+		}
+		cases = append(cases, parsed...)
+	}
+	return cases, nil
+}
+
+// isAtlasCaseFile reports whether name is an Atlas-format test document.
+//
+// The suffix is `.test.hcl`, not `.hcl`: a bare .hcl file in the same directory
+// is a schema definition, and reading one as a test document would fail on
+// every table block. Matching the compound suffix is what separates the two,
+// and it is why filepath.Ext alone -- which yields ".hcl" for both -- will not
+// do.
+func isAtlasCaseFile(name string) bool {
+	return strings.HasSuffix(strings.ToLower(name), ".test.hcl")
+}


### PR DESCRIPTION
Closes the last open item of the drop-in umbrella #951.

## The defect

A directory of Atlas `.test.hcl` files reported `error: no test cases found`. For someone porting an Atlas pipeline that is the worst shape of failure: their entire test suite does not run, and the message says there was nothing to run rather than that we could not read it.

```
$ ptah-compat schema test --dev-url sqlite://... t     # t/ holds basic.test.hcl
error: no test cases found in t                        # before
```

## The translation

```hcl
test "schema" "users_insert_select" {
  exec { sql = "INSERT INTO users (id, name) VALUES (1, 'ada')" }
  exec { sql = "SELECT name FROM users WHERE id = 1", output = "ada" }
}
```

`exec { sql }` is a statement · `exec { sql, output }` is an assertion on the first scalar · `migrate { to }` is a version step.

## Four decisions that are deliberate, not incidental

**Step order is preserved by walking `Body.Blocks`.** A schema-driven `hcl` decode groups blocks by type, which would move a `migrate` step after both `exec` steps and silently change what the case does. Order is load-bearing here: an `exec` that seeds a row must run before the one reading it back. Pinned by `TestParseAtlasTestCasesPreservesStepOrder` with an interleaved fixture — the only shape that separates the two implementations.

**Cases are selected by kind.** Atlas labels each case `test "schema" "..."` or `test "migrate" "..."` and they are not interchangeable — a migrate case drives the migration directory to a version, which a schema test run must not do.

**The exported `LoadCases` keeps its YAML-only contract.** The Atlas reader is reachable through a new `LoadCasesOfKind`. Widening the existing function would have been a public API change for no benefit; its unchanged behavior is pinned by its own test, and the snapshot diff is **22 additions, 0 removals**, so `check-public-api-released.sh` exits 0.

**An unknown attribute inside a step is refused, not ignored.** This surface is our own ingestion, not `atlas.hcl`: a typo in `output` would downgrade an assertion to a bare statement and the case would pass while checking nothing. That is the opposite call from #1014, and for the opposite reason.

## Verification

End to end, **in both directions** — a passing case proves the reader ran, only a failing one proves the assertion is real:

```
matching output    PASS  case "sanity" / scalar "1"                    exit 0
mismatched output  FAIL  expected scalar "999", got "1"                exit 1
```

Three mutations, each killed by exactly one test:

| Mutation | Killed by |
| --- | --- |
| `output` no longer maps to an assertion | `…TranslatesExecAndOutput` |
| match on `filepath.Ext` instead of the compound `.test.hcl` suffix | `…ReadsAtlasFilesAndLeavesSchemaHCLAlone` |
| kind filter dropped | `…SelectsByKind` |

The suffix mutation matters because `filepath.Ext` yields `.hcl` for a *schema* file too — the fixture puts `schema.hcl` and `schema.test.hcl` in one directory, which is the only layout that tells the two rules apart.

```
go build ./...                                  BUILD=0
go vet ./...                                    VET=0
go test ./migration/... ./cmd/... -count=1      TEST=0
scripts/check-public-api.sh                     API_EXIT=0
scripts/check-public-api-snapshot.sh            SNAPSHOT_CHECK=0
scripts/check-public-api-released.sh            RELEASED_EXIT=0
build-feature-matrix.mjs --check                OK (159 rows)
testify imports tree-wide                       0
```

`scripts/check-test-style.sh` exits 1, **identically on master** (`MASTER_STYLE=1`): it scans untracked scratch worktrees inside the repo (`.codex/worktress/…`, `.claude/worktrees/…`) and reports 16 766 violations from them. Violations in tracked source: **0**. That the checker walks untracked directories is a gate defect worth its own issue — anyone with a scratch worktree in the repo gets a red check unrelated to their change.

Refs #951.