### PR TITLE
refactor(atlas): split the overloaded atlas.hcl error into three classes

### DIFF
--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -123,6 +123,17 @@ type atlasParser struct {
 	baseDir string
 	// externalSchemas holds the declared data.external_schema sources by name.
 	externalSchemas map[string]externalSchemaDataSource
+	// sensitiveValues holds the resolved values of variables declared
+	// `sensitive = true`, so they can be scrubbed from any diagnostic before it
+	// reaches stderr. HCL renders function arguments into its own error text --
+	// `file(var.secret)` produces `openat <the secret>: no such file` -- so a
+	// diagnostic that is merely passed through leaks exactly what `sensitive`
+	// exists to protect.
+	//
+	// It is a pointer for the same reason ctx is: the parser is passed by
+	// value, so a plain slice field would be appended to on a copy and the
+	// values would never reach the scrubber.
+	sensitiveValues *[]string
 }
 
 func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser, error) {
@@ -131,6 +142,7 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 		return atlasParser{}, err
 	}
 	return atlasParser{
+		sensitiveValues: &[]string{},
 		ctx: &hcl.EvalContext{
 			Variables: map[string]cty.Value{},
 			Functions: map[string]function.Function{
@@ -892,6 +904,12 @@ func (p atlasParser) configureVariables(blocks []*hclsyntax.Block) error {
 		if err != nil {
 			return err
 		}
+		if variable.sensitive && p.sensitiveValues != nil &&
+			value.Type() == cty.String && !value.IsNull() {
+			if raw := value.AsString(); raw != "" {
+				*p.sensitiveValues = append(*p.sensitiveValues, raw)
+			}
+		}
 		vars[name] = value
 	}
 	for name, value := range p.varOverride {
@@ -1526,8 +1544,11 @@ func selectAtlasEnvBlock(envs []atlasEnvBlock, envName string) (atlasEnvBlock, e
 
 func (p atlasParser) stringAttr(name string, attr *hclsyntax.Attribute) (string, error) {
 	value, diags := attr.Expr.Value(p.ctx)
-	if diags.HasErrors() || value.Type() != cty.String {
-		return "", unsupportedAttr(name, attr)
+	if diags.HasErrors() {
+		return "", p.evaluationFailed(name, attr, diags)
+	}
+	if value.Type() != cty.String {
+		return "", wrongValueType(name, attr, "a string")
 	}
 	return value.AsString(), nil
 }
@@ -1538,7 +1559,7 @@ func (p atlasParser) nonEmptyStringAttr(name string, attr *hclsyntax.Attribute) 
 		return "", err
 	}
 	if strings.TrimSpace(value) == "" {
-		return "", unsupportedAttr(name, attr)
+		return "", emptyValue(name, attr)
 	}
 	return value, nil
 }
@@ -1565,7 +1586,7 @@ func (p atlasParser) sensitiveModeAttr(name string, attr *hclsyntax.Attribute) (
 	case "ALLOW":
 		return true, nil
 	default:
-		return false, unsupportedAttr(name, attr)
+		return false, wrongValueType(name, attr, "one of DENY, ALLOW")
 	}
 }
 
@@ -1576,11 +1597,11 @@ func (p atlasParser) identifierOrStringAttr(name string, attr *hclsyntax.Attribu
 	}
 	traversal, ok := attr.Expr.(*hclsyntax.ScopeTraversalExpr)
 	if !ok || len(traversal.Traversal) != 1 {
-		return "", unsupportedAttr(name, attr)
+		return "", wrongValueType(name, attr, "a string or a bare identifier")
 	}
 	root, ok := traversal.Traversal[0].(hcl.TraverseRoot)
 	if !ok {
-		return "", unsupportedAttr(name, attr)
+		return "", wrongValueType(name, attr, "a string or a bare identifier")
 	}
 	return root.Name, nil
 }
@@ -1596,11 +1617,11 @@ func (p atlasParser) scopedEnumOrStringAttr(
 	}
 	traversal, ok := attr.Expr.(*hclsyntax.ScopeTraversalExpr)
 	if !ok || len(traversal.Traversal) != 1 {
-		return "", unsupportedAttr(name, attr)
+		return "", wrongValueType(name, attr, "one of "+strings.Join(allowed, ", "))
 	}
 	root, ok := traversal.Traversal[0].(hcl.TraverseRoot)
 	if !ok || !slices.Contains(allowed, root.Name) {
-		return "", unsupportedAttr(name, attr)
+		return "", wrongValueType(name, attr, "one of "+strings.Join(allowed, ", "))
 	}
 	return root.Name, nil
 }
@@ -1615,8 +1636,11 @@ func (p atlasParser) configBoolAttr(name string, attr *hclsyntax.Attribute) (Con
 
 func (p atlasParser) boolAttr(name string, attr *hclsyntax.Attribute) (bool, error) {
 	value, diags := attr.Expr.Value(p.ctx)
-	if diags.HasErrors() || value.Type() != cty.Bool {
-		return false, unsupportedAttr(name, attr)
+	if diags.HasErrors() {
+		return false, p.evaluationFailed(name, attr, diags)
+	}
+	if value.Type() != cty.Bool {
+		return false, wrongValueType(name, attr, "a bool")
 	}
 	return value.True(), nil
 }
@@ -1624,7 +1648,7 @@ func (p atlasParser) boolAttr(name string, attr *hclsyntax.Attribute) (bool, err
 func (p atlasParser) stringOrStringListAttr(name string, attr *hclsyntax.Attribute) ([]string, error) {
 	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() {
-		return nil, unsupportedAttr(name, attr)
+		return nil, p.evaluationFailed(name, attr, diags)
 	}
 	if value.Type() == cty.String {
 		return []string{value.AsString()}, nil
@@ -1634,12 +1658,15 @@ func (p atlasParser) stringOrStringListAttr(name string, attr *hclsyntax.Attribu
 
 func (p atlasParser) intAttr(name string, attr *hclsyntax.Attribute) (int, error) {
 	value, diags := attr.Expr.Value(p.ctx)
-	if diags.HasErrors() || value.Type() != cty.Number {
-		return 0, unsupportedAttr(name, attr)
+	if diags.HasErrors() {
+		return 0, p.evaluationFailed(name, attr, diags)
+	}
+	if value.Type() != cty.Number {
+		return 0, wrongValueType(name, attr, "a number")
 	}
 	raw, accuracy := value.AsBigFloat().Int64()
 	if accuracy != big.Exact {
-		return 0, unsupportedAttr(name, attr)
+		return 0, wrongValueType(name, attr, "a whole number")
 	}
 	return int(raw), nil
 }
@@ -1647,7 +1674,7 @@ func (p atlasParser) intAttr(name string, attr *hclsyntax.Attribute) (int, error
 func (p atlasParser) stringListAttr(name string, attr *hclsyntax.Attribute) ([]string, error) {
 	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() {
-		return nil, unsupportedAttr(name, attr)
+		return nil, p.evaluationFailed(name, attr, diags)
 	}
 	return stringListValue(name, attr, value)
 }
@@ -1655,14 +1682,14 @@ func (p atlasParser) stringListAttr(name string, attr *hclsyntax.Attribute) ([]s
 func stringListValue(name string, attr *hclsyntax.Attribute, value cty.Value) ([]string, error) {
 	valueType := value.Type()
 	if !value.CanIterateElements() || (!valueType.IsTupleType() && !valueType.IsListType()) {
-		return nil, unsupportedAttr(name, attr)
+		return nil, wrongValueType(name, attr, "a list of strings")
 	}
 	values := make([]string, 0, value.LengthInt())
 	it := value.ElementIterator()
 	for it.Next() {
 		_, item := it.Element()
 		if item.Type() != cty.String {
-			return nil, unsupportedAttr(name, attr)
+			return nil, wrongValueType(name, attr, "a list of strings")
 		}
 		values = append(values, item.AsString())
 	}
@@ -1888,4 +1915,62 @@ func unsupportedAttr(name string, attr *hclsyntax.Attribute) error {
 
 func unsupported(name string, rng hcl.Range) error {
 	return fmt.Errorf("unsupported atlas.hcl construct %q at %s:%d", name, rng.Filename, rng.Start.Line)
+}
+
+// The three failures below all used to be reported as "unsupported atlas.hcl
+// construct", which made them indistinguishable to a reader and to a test.
+//
+// They are not the same thing, and the difference is load-bearing for the work
+// in stokaro/ptah#1014. Atlas CE tolerates an unknown NAME while still failing
+// on a bad VALUE and on an expression it cannot evaluate -- so an
+// accept-and-ignore change must relax exactly the first and leave the other two
+// alone. While one message covers all three, no test can tell whether a
+// refusal came from the branch that is meant to relax or from a branch that is
+// meant to stay, and a relaxation would silently convert real agreements with
+// CE into coincidental ones.
+//
+// Exit codes are unchanged: all three still fail. Only the message tells them
+// apart.
+
+// evaluationFailed reports an expression that could not be evaluated -- an
+// undefined reference, a failing function call. The HCL diagnostic is carried
+// through because it names the offending sub-expression, which our own message
+// cannot.
+func (p atlasParser) evaluationFailed(name string, attr *hclsyntax.Attribute, diags hcl.Diagnostics) error {
+	return fmt.Errorf("cannot evaluate atlas.hcl %q at %s:%d: %s",
+		name, attr.NameRange.Filename, attr.NameRange.Start.Line,
+		p.scrubSensitive(diags.Error()))
+}
+
+// scrubSensitive removes the values of `sensitive = true` variables from text
+// that is about to be shown to the user.
+//
+// It is needed because HCL renders evaluated arguments into its own diagnostics
+// -- `file(var.secret)` fails with `openat <the secret>: no such file or
+// directory` -- so passing a diagnostic through verbatim publishes the value
+// that `sensitive` exists to hide. The rest of this parser already refuses to
+// put variable values in messages; this keeps that invariant when the message
+// comes from HCL rather than from us.
+func (p atlasParser) scrubSensitive(text string) string {
+	if p.sensitiveValues == nil {
+		return text
+	}
+	for _, secret := range *p.sensitiveValues {
+		text = strings.ReplaceAll(text, secret, "(sensitive value)")
+	}
+	return text
+}
+
+// wrongValueType reports a known key given a value of the wrong type. The key
+// is supported; the value is not.
+func wrongValueType(name string, attr *hclsyntax.Attribute, want string) error {
+	return fmt.Errorf("atlas.hcl %q at %s:%d must be %s",
+		name, attr.NameRange.Filename, attr.NameRange.Start.Line, want)
+}
+
+// emptyValue reports a known key given a value that is syntactically fine but
+// carries nothing usable.
+func emptyValue(name string, attr *hclsyntax.Attribute) error {
+	return fmt.Errorf("atlas.hcl %q at %s:%d must not be empty",
+		name, attr.NameRange.Filename, attr.NameRange.Start.Line)
 }

--- a/config/projectconfig/atlas_root_unix_test.go
+++ b/config/projectconfig/atlas_root_unix_test.go
@@ -35,7 +35,7 @@ func TestParseAtlasFSWithOptionsRejectsFileSymlinkEscape(t *testing.T) {
 		projectconfig.AtlasLoadOptions{EnvName: "local"},
 	)
 
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "url" at atlas\.hcl:2`)
+	c.Assert(err, qt.ErrorMatches, `cannot evaluate atlas\.hcl "url" at atlas\.hcl:2: .*path escapes from parent.*`)
 }
 
 func TestParseAtlasFSWithOptionsRejectsFilesetSymlinkEscape(t *testing.T) {
@@ -67,5 +67,5 @@ env "local" {
 		projectconfig.AtlasLoadOptions{EnvName: "local"},
 	)
 
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "paths" at atlas\.hcl:2`)
+	c.Assert(err, qt.ErrorMatches, `cannot evaluate atlas\.hcl "paths" at atlas\.hcl:2: .*`)
 }

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -302,37 +302,37 @@ func TestParseAtlasProjectConfigMigrationEnumIdentifiersFailurePath(t *testing.T
 		{
 			name:    "unknown format",
 			attr:    "format = atals",
-			wantErr: `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "format" at atlas\.hcl:3 must be one of .*`,
 		},
 		{
 			name:    "unknown execution order",
 			attr:    "exec_order = LINER",
-			wantErr: `unsupported atlas\.hcl construct "exec_order" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "exec_order" at atlas\.hcl:3 must be one of .*`,
 		},
 		{
 			name:    "bare transaction mode",
 			attr:    "tx_mode = file",
-			wantErr: `unsupported atlas\.hcl construct "tx_mode" at atlas\.hcl:3`,
+			wantErr: `cannot evaluate atlas\.hcl "tx_mode" at atlas\.hcl:3: .*Unknown variable.*`,
 		},
 		{
 			name:    "enum traversal",
 			attr:    "format = local.format",
-			wantErr: `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "format" at atlas\.hcl:3 must be one of .*`,
 		},
 		{
 			name:    "uppercase format identifier",
 			attr:    "format = ATLAS",
-			wantErr: `unsupported atlas\.hcl construct "format" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "format" at atlas\.hcl:3 must be one of .*`,
 		},
 		{
 			name:    "lowercase linear identifier",
 			attr:    "exec_order = linear",
-			wantErr: `unsupported atlas\.hcl construct "exec_order" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "exec_order" at atlas\.hcl:3 must be one of .*`,
 		},
 		{
 			name:    "lowercase linear skip identifier",
 			attr:    "exec_order = linear_skip",
-			wantErr: `unsupported atlas\.hcl construct "exec_order" at atlas\.hcl:3`,
+			wantErr: `atlas\.hcl "exec_order" at atlas\.hcl:3 must be one of .*`,
 		},
 	}
 
@@ -1227,7 +1227,7 @@ env "prod" {
 	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://dev.db")
 
 	_, err = projectconfig.ParseAtlas(raw, "atlas.hcl", "prod")
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "url" at atlas\.hcl:5`)
+	c.Assert(err, qt.ErrorMatches, `cannot evaluate atlas\.hcl "url" at atlas\.hcl:5: .*Unknown variable.*`)
 }
 
 func TestParseAtlasProjectConfigRejectsUnsupportedConstructsInUnselectedEnv(t *testing.T) {
@@ -1610,7 +1610,7 @@ env "local" {
   default   = "sqlite://typed.db"
 }
 `,
-			err: `unsupported atlas\.hcl construct "sensitive" at atlas\.hcl:2`,
+			err: `atlas\.hcl "sensitive" at atlas\.hcl:2 must be a bool`,
 		},
 		{
 			name: "variable validation block is unsupported",
@@ -1642,7 +1642,7 @@ locals {
   url = file("../secret.txt")
 }
 `,
-			err: `unsupported atlas\.hcl construct "url" at atlas\.hcl:2`,
+			err: `cannot evaluate atlas\.hcl "url" at atlas\.hcl:2: .*path escapes atlas\.hcl directory.*`,
 		},
 		{
 			name: "file function rejects absolute paths",
@@ -1650,7 +1650,7 @@ locals {
   url = file("/tmp/secret.txt")
 }
 `,
-			err: `unsupported atlas\.hcl construct "url" at atlas\.hcl:2`,
+			err: `cannot evaluate atlas\.hcl "url" at atlas\.hcl:2: .*absolute paths are not supported.*`,
 		},
 		{
 			name: "hcl schema data source rejects remote path",
@@ -1666,7 +1666,7 @@ locals {
   paths = fileset("../*.hcl")
 }
 `,
-			err: `unsupported atlas\.hcl construct "paths" at atlas\.hcl:2`,
+			err: `cannot evaluate atlas\.hcl "paths" at atlas\.hcl:2: .*`,
 		},
 		{
 			name: "unknown migration attribute",
@@ -1693,7 +1693,7 @@ locals {
   exclude = { tmp = "tmp_*" }
 }
 `,
-			err: `unsupported atlas\.hcl construct "exclude" at atlas\.hcl:2`,
+			err: `atlas\.hcl "exclude" at atlas\.hcl:2 must be a list of strings`,
 		},
 	}
 
@@ -1824,4 +1824,110 @@ func TestParseAtlasProjectConfigLintLogRejectsEmpty(t *testing.T) {
 	_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
 
 	c.Assert(err, qt.IsNotNil)
+}
+
+// TestAtlasParserDistinguishesFailureClasses pins that an unknown NAME, a bad
+// VALUE on a known key, and an expression that cannot be evaluated produce
+// three different errors.
+//
+// They were one message until stokaro/ptah#1014, and collapsing them again is
+// the specific regression this test exists to catch. The distinction is
+// load-bearing: Atlas CE tolerates an unknown name while still failing on the
+// other two, so an accept-and-ignore change has to relax exactly one branch.
+// While the three share a message, no test can tell whether a refusal came from
+// the branch meant to relax or from one meant to stay, and a relaxation would
+// silently turn real agreements with CE into coincidental ones.
+func TestAtlasParserDistinguishesFailureClasses(t *testing.T) {
+	c := qt.New(t)
+
+	const envBody = `
+  dev = "sqlite://dev.db?mode=memory&_fk=1"
+}
+`
+	tests := []struct {
+		name    string
+		urlExpr string
+		wantErr string
+	}{
+		{
+			name:    "evaluation failure on a known key",
+			urlExpr: "var.nope",
+			wantErr: `cannot evaluate atlas\.hcl "url" .*`,
+		},
+		{
+			name:    "wrong value type on a known key",
+			urlExpr: "42",
+			wantErr: `atlas\.hcl "url" .* must be a string`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			body := "env \"local\" {\n  url = " + tt.urlExpr + envBody
+			_, err := projectconfig.ParseAtlas([]byte(body), "atlas.hcl", "local")
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+
+	// The third class, for contrast: an unknown NAME keeps the original
+	// message, and must not be reported as either of the two above.
+	unknown := "frobnicate = \"yes\"\nenv \"local\" {\n  url = \"sqlite://m.db\"" + envBody
+	_, err := projectconfig.ParseAtlas([]byte(unknown), "atlas.hcl", "local")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "frobnicate" .*`)
+}
+
+// TestAtlasParserScrubsSensitiveValuesFromDiagnostics is a regression test for
+// a leak this package's own error-class split introduced.
+//
+// Carrying the HCL diagnostic through is what makes an evaluation failure
+// readable — it names the offending sub-expression, and for file()/fileset() it
+// reports the sandbox violation. But HCL renders *evaluated arguments* into its
+// text: `file(var.secret)` fails with `openat <the secret>: no such file`. So
+// passing the diagnostic through verbatim publishes exactly the value that
+// `sensitive = true` exists to hide, on stderr, where it lands in CI logs.
+//
+// The rest of this parser already refuses to put variable values in messages
+// (see redactedAtlasVariableValue and the default-mismatch error). This keeps
+// that invariant when the text comes from HCL rather than from us.
+func TestAtlasParserScrubsSensitiveValuesFromDiagnostics(t *testing.T) {
+	c := qt.New(t)
+
+	const secret = "SUPERSECRET_TOKEN_12345"
+	raw := []byte(`
+variable "secret" {
+  type      = string
+  default   = "` + secret + `"
+  sensitive = true
+}
+env "local" {
+  url = file(var.secret)
+  dev = "sqlite://dev.db?mode=memory&_fk=1"
+}
+`)
+
+	_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "local")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Not(qt.Contains), secret)
+	c.Assert(err.Error(), qt.Contains, "(sensitive value)")
+
+	// The control: a NON-sensitive variable keeps its value in the diagnostic,
+	// because that is what makes the message actionable. Without this half, a
+	// scrubber that redacted everything would pass the test above while
+	// destroying every diagnostic in the package.
+	rawOpen := []byte(`
+variable "path" {
+  type    = string
+  default = "VISIBLE_PATH_VALUE"
+}
+env "local" {
+  url = file(var.path)
+  dev = "sqlite://dev.db?mode=memory&_fk=1"
+}
+`)
+	_, err = projectconfig.ParseAtlas(rawOpen, "atlas.hcl", "local")
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "VISIBLE_PATH_VALUE")
 }


### PR DESCRIPTION
Step 1 of #1014. **No tolerance is introduced here** — this is the change that makes step 2 verifiable.

## The problem

`config/projectconfig/atlas.go` funnelled **79 call sites** into a single `unsupported()` helper, and the type-coercion helpers routed evaluation failures and type errors through it too:

```go
func (p atlasParser) stringAttr(name string, attr *hclsyntax.Attribute) (string, error) {
    value, diags := attr.Expr.Value(p.ctx)
    if diags.HasErrors() || value.Type() != cty.String {
        return "", unsupportedAttr(name, attr)     // three failures, one message
    }
```

So `env { url = var.nope }`, `env { url = 42 }` and a genuinely unknown top-level name all produced the byte-identical `unsupported atlas.hcl construct "..."`.

## Why this has to land before any relaxation

Measured against the pinned CE binary: on the 17 positions where **CE exits 1**, `ptah-compat` also exits 1 — 17/17. But only **one** of those agreements is by mechanism. The other sixteen agree because compat refuses on the construct **name** before evaluating anything, while CE fails because it **evaluated** the body and the expression inside did not resolve.

While the three share a message, no test can tell those apart. A relaxation applied first would convert sixteen real agreements into coincidental ones — **the parity suite would go greener while going wronger**.

## What changed

Nine coercion helpers now report their own class. Exit codes are unchanged; all three still fail.

| Helper | Reports |
| --- | --- |
| `evaluationFailed` | carries the HCL diagnostic, which names the offending sub-expression |
| `wrongValueType` | names what was wanted |
| `emptyValue` | a known key given nothing usable |

**Two helpers deliberately keep ignoring `diags`.** `identifierOrStringAttr` and `scopedEnumOrStringAttr` accept a bare identifier, and a bare enum identifier such as `file` *always* fails evaluation — that is the intended path there. Reporting an evaluation failure would reject valid input. Only their wrong-value branches moved.

## The messages got markedly better, and not by accident

A shared string could not say anything specific. Once each class has its own, each can:

```diff
-unsupported atlas.hcl construct "format" at atlas.hcl:3
+atlas.hcl "format" at atlas.hcl:3 must be one of atlas, golang-migrate, goose, flyway, liquibase, dbmate

-unsupported atlas.hcl construct "url" at atlas.hcl:2
+cannot evaluate atlas.hcl "url" at atlas.hcl:2: Call to function "file" failed: path escapes atlas.hcl directory: ../secret.txt
```

That second one matters beyond readability: the `file()`/`fileset()` sandbox diagnostics — `path escapes atlas.hcl directory`, `absolute paths are not supported`, `path escapes from parent` — are **security-relevant** and were entirely hidden behind the word "unsupported".

## The failing tests were the point

Ten existing assertions broke, and every one of them had been asserting "unsupported construct" on what is really an evaluation failure or a wrong value. Each is now updated to assert its actual class, so the test says what it tests.

`TestAtlasParserDistinguishesFailureClasses` pins the invariant directly, and a mutation that merges the classes back into one message is killed by **ten** tests.

## Verification

```
go build ./...                        BUILD=0
go vet ./...                          VET=0
go test ./... -count=1                TEST=0
mutation: re-merge the three classes  10 tests fail; restored -> 0
```

Completeness was checked rather than assumed — the first attempt at this split covered two helpers of nine and looked done. `awk` over the coercion range now reports **zero** remaining collapsed sites; the 66 surviving `unsupportedAttr`/`unsupportedBlock` calls are the genuine unknown-name surface, which is exactly what step 2 will relax.