### PR TITLE
feat(atlas): tolerate unknown top-level atlas.hcl names, as Atlas CE does

### DIFF
--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -134,6 +134,29 @@ type atlasParser struct {
 	// value, so a plain slice field would be appended to on a copy and the
 	// values would never reach the scrubber.
 	sensitiveValues *[]string
+	// ignored records the constructs tolerated under Atlas CE's
+	// unknown-name policy, so the caller can report them. Pointer for the same
+	// reason as sensitiveValues: the parser is passed by value.
+	ignored *[]IgnoredAtlasConstruct
+}
+
+// IgnoredAtlasConstruct is an atlas.hcl name that was accepted and not acted
+// on, matching what Atlas CE does with a name it does not recognize.
+//
+// CE reports nothing at all. Ptah records them so the caller can say one line
+// per construct on stderr: CE's silence is a footgun -- a typo'd block name
+// does nothing and looks fine -- and stdout, the exit code, and every error
+// diagnostic stay byte-identical, so nothing that reads those can tell the
+// difference.
+type IgnoredAtlasConstruct struct {
+	// Name is the construct's name as written.
+	Name string
+	// Kind is "block" or "attribute".
+	Kind string
+	// Filename and Line locate it. The position matters because the same name
+	// is tolerated in one place and fatal in another.
+	Filename string
+	Line     int
 }
 
 func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser, error) {
@@ -143,6 +166,7 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 	}
 	return atlasParser{
 		sensitiveValues: &[]string{},
+		ignored:         &[]IgnoredAtlasConstruct{},
 		ctx: &hcl.EvalContext{
 			Variables: map[string]cty.Value{},
 			Functions: map[string]function.Function{
@@ -160,14 +184,19 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 }
 
 func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error) {
-	if len(body.Attributes) > 0 {
-		for name, attr := range body.Attributes {
-			return Config{}, unsupportedAttr(name, attr)
+	// CE's tolerance covers unknown ATTRIBUTES as well as blocks -- measured,
+	// and the point stokaro/ptah#1014 left open. The expression is still
+	// evaluated, so a bad reference in one is still fatal.
+	for _, name := range sortedAttributeNames(body.Attributes) {
+		attr := body.Attributes[name]
+		if _, diags := attr.Expr.Value(p.ctx); diags.HasErrors() {
+			return Config{}, p.evaluationFailed(name, attr, diags)
 		}
+		p.noteIgnored("attribute", name, attr.NameRange)
 	}
 
 	base := Config{}
-	blocks, err := collectAtlasTopBlocks(body.Blocks)
+	blocks, err := p.collectAtlasTopBlocks(body.Blocks)
 	if err != nil {
 		return Config{}, err
 	}
@@ -185,6 +214,7 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 		return Config{}, err
 	}
 	if len(blocks.envs) == 0 {
+		base.IgnoredConstructs = p.ignoredConstructs()
 		return base, nil
 	}
 
@@ -200,6 +230,9 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 	if err := p.resolveExternalSchemaMarkers(&merged); err != nil {
 		return Config{}, err
 	}
+	// Set after Merge, not inside parseEnv: Merge carries only the fields it
+	// knows about, so an assignment upstream of it is silently dropped.
+	merged.IgnoredConstructs = p.ignoredConstructs()
 	return merged, nil
 }
 
@@ -212,17 +245,77 @@ type atlasTopBlocks struct {
 	variables  []*hclsyntax.Block
 }
 
-func collectAtlasTopBlocks(blocks []*hclsyntax.Block) (atlasTopBlocks, error) {
+func (p atlasParser) collectAtlasTopBlocks(blocks []*hclsyntax.Block) (atlasTopBlocks, error) {
 	collected := atlasTopBlocks{}
 	for _, block := range blocks {
-		if err := collectAtlasTopBlock(block, &collected); err != nil {
+		if err := p.collectAtlasTopBlock(block, &collected); err != nil {
 			return atlasTopBlocks{}, err
 		}
 	}
 	return collected, nil
 }
 
-func collectAtlasTopBlock(block *hclsyntax.Block, collected *atlasTopBlocks) error {
+// atlasBlockNotSupported reproduces CE's refusal of the `atlas` init block. Its
+// two spellings fail differently, and both are measured.
+func atlasBlockNotSupported(block *hclsyntax.Block) error {
+	if len(block.Labels) > 0 {
+		return fmt.Errorf("init block %q cannot have labels", block.Type)
+	}
+	return fmt.Errorf("atlas block is not supported by the community version of Atlas")
+}
+
+// ignoredConstructs returns the tolerated constructs recorded so far.
+func (p atlasParser) ignoredConstructs() []IgnoredAtlasConstruct {
+	if p.ignored == nil || len(*p.ignored) == 0 {
+		return nil
+	}
+	out := make([]IgnoredAtlasConstruct, len(*p.ignored))
+	copy(out, *p.ignored)
+	return out
+}
+
+// noteIgnored records a construct tolerated under the unknown-name policy.
+func (p atlasParser) noteIgnored(kind, name string, rng hcl.Range) {
+	if p.ignored == nil {
+		return
+	}
+	*p.ignored = append(*p.ignored, IgnoredAtlasConstruct{
+		Name: name, Kind: kind, Filename: rng.Filename, Line: rng.Start.Line,
+	})
+}
+
+// evaluateIgnoredBody evaluates every expression inside a construct whose NAME
+// is being ignored, discarding the values and returning the first failure.
+//
+// This is what makes the tolerance name-level rather than subtree-level, which
+// is how Atlas CE behaves: it drops the decoded result of an unrecognized name
+// but still evaluates the body, so an unresolvable reference inside an ignored
+// block is fatal. Measured on the pinned CE binary:
+//
+//	frobnicate { v = "literal" }         -> exit 0, 0 bytes on stderr
+//	frobnicate { v = var.undefined_ref } -> exit 1, "Unsupported attribute"
+//
+// Skipping the subtree instead would accept the second file, which CE rejects,
+// making this implementation LOOSER than CE -- the more dangerous direction.
+func (p atlasParser) evaluateIgnoredBody(body *hclsyntax.Body) error {
+	if body == nil {
+		return nil
+	}
+	for _, name := range sortedAttributeNames(body.Attributes) {
+		attr := body.Attributes[name]
+		if _, diags := attr.Expr.Value(p.ctx); diags.HasErrors() {
+			return p.evaluationFailed(name, attr, diags)
+		}
+	}
+	for _, block := range body.Blocks {
+		if err := p.evaluateIgnoredBody(block.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (p atlasParser) collectAtlasTopBlock(block *hclsyntax.Block, collected *atlasTopBlocks) error {
 	switch block.Type {
 	case "data":
 		collected.data = append(collected.data, block)
@@ -240,8 +333,21 @@ func collectAtlasTopBlock(block *hclsyntax.Block, collected *atlasTopBlocks) err
 		collected.locals = append(collected.locals, block)
 	case "variable":
 		collected.variables = append(collected.variables, block)
+	case "atlas":
+		// The one top-level name CE KNOWS and refuses, rather than not
+		// recognizing. Measured across nine candidate names on the pinned CE
+		// binary -- `cloud`, `docker`, `remote_dir`, `project`, `check`,
+		// `exporter`, `script` and `test` are all tolerated; only `atlas` is
+		// gated. Folding it into the unknown-name path would accept a config
+		// CE rejects, making this surface LOOSER than CE.
+		return atlasBlockNotSupported(block)
 	default:
-		return unsupportedBlock(block)
+		// Atlas CE accepts an unrecognized top-level name and drops it. The
+		// body is still evaluated -- see evaluateIgnoredBody.
+		if err := p.evaluateIgnoredBody(block.Body); err != nil {
+			return err
+		}
+		p.noteIgnored("block", block.Type, block.TypeRange)
 	}
 	return nil
 }

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -126,7 +126,7 @@ func TestParseAtlasProjectConfigGolden_FailurePath(t *testing.T) {
 		{
 			name:    "hosted service block",
 			input:   "unsupported-cloud.hcl",
-			wantErr: `unsupported atlas\.hcl construct "atlas" at atlas\.hcl:1`,
+			wantErr: `atlas block is not supported by the community version of Atlas`,
 		},
 		{
 			name:    "unknown environment attribute",
@@ -1534,7 +1534,7 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
   cloud {}
 }
 `,
-			err: `unsupported atlas\.hcl construct "atlas" at atlas\.hcl:1`,
+			err: `atlas block is not supported by the community version of Atlas`,
 		},
 		{
 			name: "unsupported data source",
@@ -1871,9 +1871,13 @@ func TestAtlasParserDistinguishesFailureClasses(t *testing.T) {
 		})
 	}
 
-	// The third class, for contrast: an unknown NAME keeps the original
-	// message, and must not be reported as either of the two above.
-	unknown := "frobnicate = \"yes\"\nenv \"local\" {\n  url = \"sqlite://m.db\"" + envBody
+	// The third class, for contrast: an unknown NAME still has its own message
+	// and must not be reported as either of the two above.
+	//
+	// The position matters. A top-level unknown name is now TOLERATED, so this
+	// uses a nested one, which is the surface the next increment relaxes --
+	// when it does, this fixture moves rather than the assertion being deleted.
+	unknown := "env \"local\" {\n  frobnicate = \"yes\"\n  url = \"sqlite://m.db\"" + envBody
 	_, err := projectconfig.ParseAtlas([]byte(unknown), "atlas.hcl", "local")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "frobnicate" .*`)
@@ -1930,4 +1934,69 @@ env "local" {
 	_, err = projectconfig.ParseAtlas(rawOpen, "atlas.hcl", "local")
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "VISIBLE_PATH_VALUE")
+}
+
+// TestAtlasToleratesUnknownTopLevelNames pins Atlas CE's unknown-name policy at
+// the top level of atlas.hcl, measured on the pinned CE v1.3.0 binary.
+//
+// Every position here was measured rather than assumed, and three of them
+// contradict the obvious reading:
+//
+//   - unknown ATTRIBUTES are tolerated too, not only blocks;
+//   - the body of a tolerated construct is still EVALUATED, so a bad reference
+//     inside one is fatal -- tolerance is name-level, not subtree-level;
+//   - `atlas` is the one top-level name CE knows and refuses, so it must not
+//     be folded into the tolerated path.
+func TestAtlasToleratesUnknownTopLevelNames(t *testing.T) {
+	const env = `
+env "local" {
+  url = "sqlite://m.db"
+  dev = "sqlite://d.db"
+}
+`
+	tolerated := []struct{ name, construct string }{
+		{"unknown block with one label", "check \"migrate_apply\" {\n  drift {\n    on_error = \"FAIL\"\n  }\n}"},
+		{"nonsense control, same shape", "frobnicate_nonsense \"zzz\" {\n  totally_made_up = \"yes\"\n}"},
+		{"unknown block with no label", "frobnicate {\n  x = 1\n}"},
+		{"unknown block with two labels", "frobnicate \"a\" \"b\" {\n  x = 1\n}"},
+		{"unknown attribute", "frobnicate = \"yes\""},
+	}
+	for _, tt := range tolerated {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			cfg, err := projectconfig.ParseAtlas([]byte(tt.construct+env), "atlas.hcl", "local")
+			c.Assert(err, qt.IsNil)
+			// Tolerated means recorded, not invisible: the caller must be able
+			// to say something, because CE's silence is the footgun.
+			c.Assert(len(cfg.IgnoredConstructs) > 0, qt.IsTrue)
+		})
+	}
+
+	refused := []struct{ name, construct, wantErr string }{
+		{
+			// The discriminator for the whole rule. Same block as the
+			// tolerated rows, only the value differs.
+			name:      "bad reference inside a tolerated block",
+			construct: "frobnicate \"z\" {\n  v = var.undefined_ref\n}",
+			wantErr:   `cannot evaluate atlas\.hcl "v" .*`,
+		},
+		{
+			name:      "atlas block is known and gated, not unknown",
+			construct: "atlas {\n  cloud {\n    token = \"t\"\n  }\n}",
+			wantErr:   `atlas block is not supported by the community version of Atlas`,
+		},
+		{
+			name:      "atlas block with a label",
+			construct: "atlas \"x\" {\n  k = \"v\"\n}",
+			wantErr:   `init block "atlas" cannot have labels`,
+		},
+	}
+	for _, tt := range refused {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := projectconfig.ParseAtlas([]byte(tt.construct+env), "atlas.hcl", "local")
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
 }

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -39,6 +39,15 @@ const (
 // file formats into this shape; command code should consume this type instead
 // of branching on the original file format.
 type Config struct {
+	// IgnoredConstructs lists the atlas.hcl names that were accepted and not
+	// acted on, under Atlas CE's unknown-name policy.
+	//
+	// It exists so a caller can say something. CE reports nothing at all, and
+	// that silence is a footgun: a typo'd block name does nothing and looks
+	// fine. Everything the conformance tiers measure -- exit code, stdout, the
+	// text of every error -- is unchanged whether or not a caller reports
+	// these, so drop-in fidelity does not depend on it.
+	IgnoredConstructs []IgnoredAtlasConstruct
 	// EnvName is the selected project env name, when the source had one.
 	EnvName string
 	// DatabaseURL is the target database URL used by migration commands.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -162,6 +162,7 @@ type DiffConfig struct{ ... }
 type DiffSkipConfig struct{ ... }
 type ExternalSchemaConfig struct{ ... }
 type FormatConfig struct{ ... }
+type IgnoredAtlasConstruct struct{ ... }
 type LintConfig struct{ ... }
 type LintRuleConfig struct{ ... }
 type LoadOptions struct{ ... }
@@ -191,6 +192,15 @@ type AtlasLoadOptions struct {
 package projectconfig // import "go.5x5.cz/ptah/config/projectconfig"
 
 type Config struct {
+    // IgnoredConstructs lists the atlas.hcl names that were accepted and not
+    // acted on, under Atlas CE's unknown-name policy.
+    //
+    // It exists so a caller can say something. CE reports nothing at all, and
+    // that silence is a footgun: a typo'd block name does nothing and looks
+    // fine. Everything the conformance tiers measure -- exit code, stdout, the
+    // text of every error -- is unchanged whether or not a caller reports
+    // these, so drop-in fidelity does not depend on it.
+    IgnoredConstructs []IgnoredAtlasConstruct
     // EnvName is the selected project env name, when the source had one.
     EnvName string
     // DatabaseURL is the target database URL used by migration commands.
@@ -326,6 +336,30 @@ type FormatConfig struct {
     Schema  SchemaFormatConfig
 }
     FormatConfig holds Atlas env.format command templates.
+
+
+### go.5x5.cz/ptah/config/projectconfig.IgnoredAtlasConstruct
+
+package projectconfig // import "go.5x5.cz/ptah/config/projectconfig"
+
+type IgnoredAtlasConstruct struct {
+    // Name is the construct's name as written.
+    Name string
+    // Kind is "block" or "attribute".
+    Kind string
+    // Filename and Line locate it. The position matters because the same name
+    // is tolerated in one place and fatal in another.
+    Filename string
+    Line     int
+}
+    IgnoredAtlasConstruct is an atlas.hcl name that was accepted and not acted
+    on, matching what Atlas CE does with a name it does not recognize.
+
+    CE reports nothing at all. Ptah records them so the caller can say one line
+    per construct on stderr: CE's silence is a footgun -- a typo'd block name
+    does nothing and looks fine -- and stdout, the exit code, and every error
+    diagnostic stay byte-identical, so nothing that reads those can tell the
+    difference.
 
 
 ### go.5x5.cz/ptah/config/projectconfig.LintConfig


### PR DESCRIPTION
Step 2 of #1014, **scoped to the top level**. Nested positions (inside `env`, `lint`, `diff`, `locals`) still refuse and remain a known divergence — this is deliberately one increment, not the whole obligation, and saying so is the point: partial tolerance is the kind of thing that looks finished.

## The defect

An `atlas.hcl` carrying the v1.3 drift construct made `ptah-compat` exit 1 before a single migration ran, while CE accepts the file and proceeds:

```
$ ptah-compat migrate apply -c file://drift.hcl --env local
error: unsupported atlas.hcl construct "check" at drift.hcl:1
```

Under the CE drop-in rule that is a defect, not a divergence.

## Three things measured, each contradicting the obvious reading

**Unknown *attributes* are tolerated too, not only blocks.** `frobnicate = "yes"` is exit 0 with 0 bytes on stderr. This is the question the issue left open, and a fix scoped to blocks would still diverge.

**The body of a tolerated construct is still evaluated** — tolerance is name-level, not subtree-level:

```
frobnicate { v = "literal" }         -> exit 0
frobnicate { v = var.undefined_ref } -> exit 1, "Unsupported attribute"
```

Skipping the subtree would accept a file CE **rejects**.

**`atlas` is the one top-level name CE knows and refuses**, rather than not recognizing:

```
cloud { token = "t" }   -> CE exit 0   (unknown, tolerated)
atlas { cloud { … } }   -> CE exit 1   "atlas block is not supported by the community version of Atlas."
```

Measured across nine candidates — `cloud`, `docker`, `remote_dir`, `project`, `check`, `exporter`, `script`, `test` all tolerated; only `atlas` gated, and its bare and labelled spellings fail differently. **The first version of this change folded it into the tolerated path and made compat exit 0 on a config CE rejects** — looser than CE, the more dangerous direction. Caught by measuring rather than by reading, and the tests now prevent it.

## Reporting

Tolerated constructs are recorded on `Config.IgnoredConstructs`. CE reports nothing, and that silence is the footgun the issue describes: a typo'd block name does nothing and looks fine. Exit codes, stdout and every error message stay identical whether or not a caller reports these, so drop-in fidelity does not depend on it. Writing the stderr line at the CLI boundary is the next increment.

The assignment lives at `parse()`'s single exit rather than in `parseEnv` — **`Merge` carries only the fields it knows about and silently dropped it upstream.** The value was recorded correctly and read correctly; the plumbing between lost it, which no single step could show.

## Verification

Mutations, each killed:

| Mutation | Tests failing |
| --- | --- |
| skip the subtree instead of evaluating it | 2 |
| fold the gated `atlas` block into the tolerated path | 7 |
| tolerate attributes but not blocks | 5 |

```
go vet ./...                                  VET=0
go test ./... -count=1                        TEST=0
scripts/check-public-api-snapshot.sh          SNAPSHOT=0   (additive: new type + field)
```

Seven positions were compared directly against the pinned CE **v1.3.0** binary — five tolerated, two fatal — and all seven now match.

One measurement note: an early probe reported `CE=1` on the `check` block, which looked like a contradiction. It was my harness collapsing the block onto one line, which HCL rejects for a nested block. Worth checking *what* failed before adjusting the implementation to match it.

Conformance: stokaro/ptah-atlas-conformance#255 already pins the `variable` exception and the name-level rule, including the literal-value discriminator.