### PR TITLE
fix(atlas): match Atlas's migrate lint diagnostic format on the compat surface

### DIFF
--- a/cmd/atlas/migrate_lint_default_test.go
+++ b/cmd/atlas/migrate_lint_default_test.go
@@ -80,8 +80,9 @@ func TestCompatCommand_MigrateLintDefaultTextDestructive(t *testing.T) {
 			"\n"+
 			"  -- analyzing version 2\n"+
 			"    -- destructive changes detected:\n"+
-			"      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a verified backup\n"+
-			"         first and consider a rename-and-retire window instead\n"+
+			"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n"+
+			"    -- suggested fix:\n"+
+			"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n"+
 			"  -- ok (DUR)\n"+
 			"\n"+
 			"  -------------------------\n"+
@@ -106,8 +107,8 @@ func TestCompatCommand_MigrateLintDefaultTextDataDependentWarning(t *testing.T) 
 			"\n"+
 			"  -- analyzing version 2\n"+
 			"    -- data dependent changes detected:\n"+
-			"      -- L1 [MF103]: adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it\n"+
-			"         nullable, backfill, then enforce NOT NULL in a later migration\n"+
+			"      -- L1: Adding a non-nullable \"int\" column \"c2\" will fail in case table \"users\" is not empty\n"+
+			"         https://atlasgo.io/lint/analyzers#MF103\n"+
 			"  -- ok (DUR)\n"+
 			"\n"+
 			"  -------------------------\n"+
@@ -141,8 +142,8 @@ func TestCompatCommand_MigrateLintDefaultTextAddNotNullFixture(t *testing.T) {
 			"\n"+
 			"  -- analyzing version 2\n"+
 			"    -- data dependent changes detected:\n"+
-			"      -- L1 [MF103]: adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it\n"+
-			"         nullable, backfill, then enforce NOT NULL in a later migration\n"+
+			"      -- L1: Adding a non-nullable \"int\" column \"c2\" will fail in case table \"users\" is not empty\n"+
+			"         https://atlasgo.io/lint/analyzers#MF103\n"+
 			"  -- ok (DUR)\n"+
 			"\n"+
 			"  -------------------------\n"+

--- a/internal/atlasreport/migrate_lint_atlas_text.go
+++ b/internal/atlasreport/migrate_lint_atlas_text.go
@@ -1,0 +1,57 @@
+package atlasreport
+
+import (
+	"fmt"
+
+	migrationlint "go.5x5.cz/ptah/migration/lint"
+)
+
+// atlasAnalyzerDocsURL is where Atlas points a reader for an analyzer code. The
+// code travels in the fragment rather than inline as `[CODE]`, which is why the
+// compat renderer does not print it twice.
+const atlasAnalyzerDocsURL = "https://atlasgo.io/lint/analyzers#"
+
+// atlasDiagnosticText renders one finding the way Atlas words it, plus the
+// suggested fix Atlas prints under it.
+//
+// Ptah's own message is deliberately different and usually says more -- compare
+// "Dropping table \"pets\"" with "DROP TABLE permanently deletes the table and
+// every row in it; take a verified backup first and consider a rename-and-retire
+// window instead". Losing that would be a real cost, so it is not lost: this is
+// the compat surface only, and native `ptah migrations lint` keeps the fuller
+// prose. That is the surface split, applied where it belongs.
+//
+// It is reconstructed from the finding's STRUCTURED subjects rather than by
+// rewriting the analyzers, so neither surface has to know about the other. When
+// a code has no Atlas wording here, or the subjects it needs are absent, the
+// native message is used unchanged -- being wordier than Atlas is a smaller
+// divergence than inventing a sentence Atlas never prints.
+func atlasDiagnosticText(code string, finding migrationlint.Finding) (message, fix string) {
+	subject := atlasPrimarySubject(finding)
+	switch code {
+	case "DS102":
+		if subject == nil || subject.Name == "" {
+			return finding.Message, ""
+		}
+		return fmt.Sprintf("Dropping table %q", subject.Name),
+			fmt.Sprintf("Add a pre-migration check to ensure table %q is empty before dropping it",
+				subject.Name)
+	case "MF103":
+		if subject == nil || subject.Name == "" || subject.Parent == "" || subject.DataType == "" {
+			return finding.Message, ""
+		}
+		return fmt.Sprintf(
+			"Adding a non-nullable %q column %q will fail in case table %q is not empty",
+			subject.DataType, subject.Name, subject.Parent), ""
+	default:
+		return finding.Message, ""
+	}
+}
+
+// atlasPrimarySubject returns the schema object a diagnostic is about.
+func atlasPrimarySubject(finding migrationlint.Finding) *migrationlint.Subject {
+	if finding.Context == nil || len(finding.Context.Subjects) == 0 {
+		return nil
+	}
+	return &finding.Context.Subjects[0]
+}

--- a/internal/atlasreport/migrate_lint_text.go
+++ b/internal/atlasreport/migrate_lint_text.go
@@ -75,9 +75,36 @@ func writeMigrateLintTextGroup(w io.Writer, group migrateLintTextGroup) error {
 	if _, err := fmt.Fprintf(w, "    -- %s detected:\n", group.label); err != nil {
 		return err
 	}
+	// Atlas prints every diagnostic in the group first, then collects the
+	// suggested fixes under ONE header at the end -- pluralised when there is
+	// more than one. Interleaving fix-after-diagnostic produces identical
+	// output for a single diagnostic, which is why that layout has to be
+	// checked against a group with two.
+	var fixes []string
 	for _, diag := range group.diags {
-		content := fmt.Sprintf("L%d [%s]: %s", diag.line, diag.code, diag.message)
+		content := fmt.Sprintf("L%d: %s", diag.line, diag.message)
+		if diag.code != "" {
+			content += " " + atlasAnalyzerDocsURL + diag.code
+		}
 		if err := writeWrapped(w, "      -- ", "         ", content); err != nil {
+			return err
+		}
+		if diag.fix != "" {
+			fixes = append(fixes, diag.fix)
+		}
+	}
+	if len(fixes) == 0 {
+		return nil
+	}
+	header := "    -- suggested fix:"
+	if len(fixes) > 1 {
+		header = "    -- suggested fixes:"
+	}
+	if _, err := fmt.Fprintln(w, header); err != nil {
+		return err
+	}
+	for _, fix := range fixes {
+		if err := writeWrapped(w, "      -> ", "         ", fix); err != nil {
 			return err
 		}
 	}
@@ -160,9 +187,12 @@ type migrateLintTextGroup struct {
 }
 
 type migrateLintTextDiag struct {
-	line     int
-	code     string
-	message  string
+	line    int
+	code    string
+	message string
+	// fix is the Atlas-shaped suggested fix, printed under its own header.
+	// Empty for analyzers where Atlas prints none.
+	fix      string
 	group    string
 	severity migrationlint.Severity
 }
@@ -245,10 +275,12 @@ func diagnosticsByFile(findings []migrationlint.Finding) map[string][]migrateLin
 // but uses the native Ptah finding as the sole source of human-readable prose.
 func compatibilityDiagnostic(finding migrationlint.Finding) migrateLintTextDiag {
 	rule := atlaslint.RuleForNativeCode(finding.Rule)
+	message, fix := atlasDiagnosticText(rule.Code, finding)
 	return migrateLintTextDiag{
 		line:     finding.Line,
 		code:     rule.Code,
-		message:  finding.Message,
+		message:  message,
+		fix:      fix,
 		group:    analyzerGroupLabel(rule.Analyzer),
 		severity: finding.Severity,
 	}

--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -66,12 +66,43 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 		"3.sql": "DROP TABLE pets;\n",
 	}
 
+	// Two destructive statements in ONE version, so both diagnostics land in a
+	// single group. Every other destructive fixture here puts them in separate
+	// versions, where "a fix after each diagnostic" and "fixes collected at the
+	// end of the group" render identically -- so none of them can tell the two
+	// layouts apart. Atlas collects them, and pluralises the header.
+	groupedDestructiveFiles := map[string]string{
+		"1.sql": "CREATE TABLE users (id int);\n\nCREATE TABLE pets (id int);\n",
+		"2.sql": "DROP TABLE users;\nDROP TABLE pets;\n",
+	}
+
 	tests := []struct {
 		name   string
 		files  map[string]string
 		latest int
 		want   string
 	}{
+		{
+			name:   "two diagnostics in one group collect their fixes",
+			files:  groupedDestructiveFiles,
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L2: Dropping table \"pets\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"pets\" is empty before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 2 diagnostics\n",
+		},
 		{
 			name:   "destructive latest 1",
 			files:  destructiveFiles,
@@ -80,8 +111,9 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 3\n" +
 				"    -- destructive changes detected:\n" +
-				"      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a verified backup\n" +
-				"         first and consider a rename-and-retire window instead\n" +
+				"      -- L1: Dropping table \"pets\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"pets\" is empty before dropping it\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +
@@ -98,14 +130,16 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 2\n" +
 				"    -- destructive changes detected:\n" +
-				"      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a verified backup\n" +
-				"         first and consider a rename-and-retire window instead\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -- analyzing version 3\n" +
 				"    -- destructive changes detected:\n" +
-				"      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a verified backup\n" +
-				"         first and consider a rename-and-retire window instead\n" +
+				"      -- L1: Dropping table \"pets\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"pets\" is empty before dropping it\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +
@@ -146,8 +180,9 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 2\n" +
 				"    -- destructive changes detected:\n" +
-				"      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a verified backup\n" +
-				"         first and consider a rename-and-retire window instead\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +
@@ -167,8 +202,8 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 2\n" +
 				"    -- data dependent changes detected:\n" +
-				"      -- L1 [MF103]: adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it\n" +
-				"         nullable, backfill, then enforce NOT NULL in a later migration\n" +
+				"      -- L1: Adding a non-nullable \"text\" column \"name\" will fail in case table \"users\" is not empty\n" +
+				"         https://atlasgo.io/lint/analyzers#MF103\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +
@@ -195,8 +230,8 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 2\n" +
 				"    -- data dependent changes detected:\n" +
-				"      -- L1 [MF103]: adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it\n" +
-				"         nullable, backfill, then enforce NOT NULL in a later migration\n" +
+				"      -- L1: Adding a non-nullable \"int\" column \"c2\" will fail in case table \"users\" is not empty\n" +
+				"         https://atlasgo.io/lint/analyzers#MF103\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +


### PR DESCRIPTION
Closes #1043.

## The defect

```
Atlas:
      -- L1: Dropping table "pets" https://atlasgo.io/lint/analyzers#DS102
    -- suggested fix:
      -> Add a pre-migration check to ensure table "pets" is empty before dropping it

ptah-compat (before):
      -- L1 [DS102]: DROP TABLE permanently deletes the table and every row in it; take a
         verified backup first and consider a rename-and-retire window instead
```

Everything around the diagnostic already matched — the analyzing header, the group label, `-- ok (…)`, the summary counts. It was the diagnostic line and a missing section. Under the CE drop-in rule that is a defect: anything parsing lint output breaks on it, which is what the vendored upstream txtar fixtures exist to represent.

Checked first that it was not a stream problem — `ptah-compat migrate lint` writes to **stdout** with an empty stderr, matching Atlas. The divergence was the message shape.

## Ptah's wording is kept, not replaced

> "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead"

says considerably more than `Dropping table "pets"`, and losing it would be a real cost. So this is the **surface split**: native `ptah migrations lint` keeps the fuller prose, only the compat renderer speaks Atlas.

```
native  : DS101: DROP TABLE permanently deletes the table and every row in it; take a
          verified backup first and consider a rename-and-retire window instead
compat  : -- L1: Dropping table "pets" https://atlasgo.io/lint/analyzers#DS102
          -- suggested fix:
            -> Add a pre-migration check to ensure table "pets" is empty before dropping it
```

**This was only possible because `Finding.Context.Subjects` carries structured fields** — `Name`, `Parent`, `DataType`. The Atlas wording is reconstructed in `internal/atlasreport` from data rather than by rewriting the analyzers, so neither surface has to know about the other. Had the finding carried only a rendered string, matching Atlas would have meant changing what the analyzers produce, and the split would have cost an architecture change instead of one file.

Where a code has no Atlas wording here, or the subjects it needs are absent, the native message is used unchanged. Being wordier than Atlas is a smaller divergence than inventing a sentence Atlas never prints.

## Verification against the oracle

DS102 and MF103 match the upstream fixtures **byte for byte**, including the wrap position and the nine-space continuation indent:

```
      -- L1: Adding a non-nullable "int" column "c2" will fail in case table "users" is not empty
         https://atlasgo.io/lint/analyzers#MF103
```

That is what makes rewriting the nine test expectations legitimate — the oracle is the fixture, not this code.

**The expectations were rewritten per case, not by search-and-replace.** The old message carried no table name, so all four `DS102` blocks were textually identical, while the new ones differ (`pets`, `users`, `pets`, `users`). A blanket substitution would have put the wrong name in three of them and left the suite green on it.

```
go build ./...           BUILD=0
golangci-lint run ./...  0 issues
go test ./... -count=1   TEST=0
```

## What this unblocks

stokaro/ptah-atlas-conformance#256: those four `cli-migrate-lint-*.txtar` fixtures were the last blocker to moving the conformance module pin onto `go.5x5.cz/ptah`. The pin is currently stuck on a `github.com/stokaro/ptah` pseudo-version dated 2026-08-01 — a path nothing publishes to any more — so every tier has been measuring a build from before the rename, and would have kept doing so indefinitely.