### PR TITLE
fix(atlas): wrap migrate lint diagnostics at Atlas's width, measured not chosen

### DIFF
--- a/internal/atlasreport/migrate_lint_text.go
+++ b/internal/atlasreport/migrate_lint_text.go
@@ -13,9 +13,15 @@ import (
 	migrationlint "go.5x5.cz/ptah/migration/lint"
 )
 
-// lintWrapWidth keeps diagnostics readable without coupling Ptah's prose to
-// another tool's presentation details.
-const lintWrapWidth = 100
+// lintWrapWidth is the content width Atlas wraps lint diagnostics at, measured
+// on the pinned CE binary rather than chosen.
+//
+// It is bracketed, not guessed. A message whose content is 88 columns does NOT
+// wrap; one whose next word would reach 89 DOES. Two fixtures with table names
+// sized to land the boundary on 89 and on 90 both wrap, which rules out those
+// values -- without them, 88, 89 and 90 all reproduce the everyday cases
+// identically and the constant would have been unpinned.
+const lintWrapWidth = 88
 
 // WriteMigrateLintText renders the default Atlas-compatible migration-analysis
 // text report. It preserves the compatibility surface's per-version analysis

--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -202,8 +202,8 @@ func TestWriteMigrateLintText_RendersPtahDiagnostics(t *testing.T) {
 				"\n" +
 				"  -- analyzing version 2\n" +
 				"    -- data dependent changes detected:\n" +
-				"      -- L1: Adding a non-nullable \"text\" column \"name\" will fail in case table \"users\" is not empty\n" +
-				"         https://atlasgo.io/lint/analyzers#MF103\n" +
+				"      -- L1: Adding a non-nullable \"text\" column \"name\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
 				"  -- ok (0s)\n" +
 				"\n" +
 				"  -------------------------\n" +


### PR DESCRIPTION
Follow-up to #1044, which matched Atlas's diagnostic wording and fix layout and got three of the four upstream `cli-migrate-lint` txtar fixtures passing. **The fourth now passes too.**

## The divergence

```
CE:     -- L1: Adding a non-nullable "text" column "name" will fail in case table "users" is not
           empty https://atlasgo.io/lint/analyzers#MF103

compat: -- L1: Adding a non-nullable "text" column "name" will fail in case table "users" is not empty
           https://atlasgo.io/lint/analyzers#MF103
```

Atlas wraps content at **88** columns; we wrapped at 100.

## Third divergence in this format that one fixture could not see

Worth stating plainly, because the pattern repeated three times in one change:

| Divergence | Invisible until |
| --- | --- |
| message wording | — (caught immediately) |
| **fix layout** — Atlas collects fixes under one header, we interleaved | two diagnostics land in **one group**; with one fix the layouts are byte-identical |
| **wrap width** | a message exceeds 88 columns; the `add-notnull` fixture (`"int"`, `"c2"`) fits either width identically |

Each time the check against the oracle was real, and each time the fixture could not separate the candidates. This is the project's own rule — *a fixture where both candidate answers coincide is not a test* — failing three times on the same change.

## The width is bracketed, not guessed

A message whose content is 88 columns does **not** wrap; one whose next word would reach 89 **does**. But **88, 89 and 90 all reproduce every everyday case identically** — the constant would have shipped unpinned, with two of the three values wrong and nothing to say so.

So two fixtures were constructed with table names sized to land the wrap boundary exactly on 89 and on 90:

```
w89 (boundary at 89)   CE wraps  ->  rules out 89 and 90
w90 (boundary at 90)   CE wraps  ->  rules out 90
```

88 is the only value consistent with every measurement. All four cases — the two everyday ones and the two constructed — now match CE exactly:

```
case   CE   compat
m      97   97   MATCH      (add-notnull, short)
m3     94   94   MATCH      (nolint-by-code, long)
w89    95   95   MATCH      (constructed discriminator)
w90    96   96   MATCH      (constructed discriminator)
```

## Suppression was never the problem

Before chasing the wrap, all five `-- atlas:nolint` spellings were measured against CE — bare, by analyzer name, by code, file-scoped (directive followed by a blank line), and file-scoped by name. **Every one already matched.** The fixture's name suggested a suppression gap; it was a formatting one.

## Verification

```
PTAH_COMPAT_BIN=<this branch> go test ./internal/probe/ -run TestTxtarScriptProbeExecutesSQLiteMigrateLintFixtures
  ok — all four fixtures

go build ./...           BUILD=0
golangci-lint run ./...  0 issues
go test ./... -count=1   TEST=0
```

Run against a build of this branch rather than the conformance module pin, which is on `v0.2.0` and predates both fixes.

Refs #1043, stokaro/ptah-atlas-conformance#256.