### PR TITLE
test(atlas): pin migrate lint wrap boundary

### DIFF
--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -1,14 +1,15 @@
 package atlasreport
 
 // White-box testing required: these tests pin deterministic report rendering
-// through writeMigrateLintText's injected clock. The clock is deliberately not
-// part of the exported API, so these assertions cannot be expressed through
-// the public WriteMigrateLintText entry point alone.
+// through writeMigrateLintText's injected clock and the Atlas-measured wrapping
+// boundary. Neither implementation detail belongs in the exported API, so
+// these assertions cannot be expressed through WriteMigrateLintText alone.
 
 import (
 	"bytes"
 	"cmp"
 	"slices"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -21,6 +22,38 @@ import (
 
 func fixedZeroClock() func() time.Time {
 	return func() time.Time { return time.Unix(0, 0) }
+}
+
+func TestWrapContent_AtlasWidthBoundary(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		text string
+		want []string
+	}{
+		{
+			name: "88 content columns remain on one line",
+			text: strings.Repeat("x", 88),
+			want: []string{strings.Repeat("x", 88)},
+		},
+		{
+			name: "word reaching column 89 wraps",
+			text: strings.Repeat("x", 87) + " y",
+			want: []string{strings.Repeat("x", 87), "y"},
+		},
+		{
+			name: "word reaching column 90 wraps",
+			text: strings.Repeat("x", 87) + " yy",
+			want: []string{strings.Repeat("x", 87), "yy"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(wrapContent(test.text, lintWrapWidth), qt.DeepEquals, test.want)
+		})
+	}
 }
 
 // analyzeMigrations builds a lint analysis for the given migration files,


### PR DESCRIPTION
## Summary
- pin the Atlas-measured 88-column compatibility wrap boundary directly
- prove that content fitting at column 88 stays on one line
- prove that words reaching columns 89 and 90 wrap
- extend the white-box justification to cover the unexported renderer boundary

## Why
PR #1045 fixed the real upstream MF103 fixture regression and documented that Atlas's width was bracketed with boundary fixtures. The merged test caught the original 100-column bug, but it did not distinguish 88 from 89 or 90. This closes that evidence gap without changing production behavior.

## Verification
- ok  	go.5x5.cz/ptah/internal/atlasreport	0.458s
- 
- teststyle: OK (175 conditional groups, 45 white-box files)
- 0 issues.
- 