### PR TITLE
config/projectconfig: tolerate nested atlas.hcl names Atlas ignores

### DIFF
--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -200,7 +200,7 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 	if err != nil {
 		return Config{}, err
 	}
-	if err := validateAtlasEnvStructures(blocks.envs); err != nil {
+	if err := p.validateAtlasEnvStructures(blocks.envs); err != nil {
 		return Config{}, err
 	}
 
@@ -272,6 +272,83 @@ func (p atlasParser) ignoredConstructs() []IgnoredAtlasConstruct {
 	out := make([]IgnoredAtlasConstruct, len(*p.ignored))
 	copy(out, *p.ignored)
 	return out
+}
+
+// ceEnforcedConstructs lists scope-qualified names that Atlas CE genuinely
+// decodes and acts on, but Ptah does not implement.
+//
+// These must keep being refused rather than swept into the unknown-name
+// tolerance. Accepting them would produce the worst outcome available: the user
+// writes a policy, nothing enforces it, and nothing says so. A loud refusal is
+// a divergence from CE, but it is the safe direction; silent non-enforcement is
+// not. Each entry was measured on the pinned CE binary by planting a value the
+// target field cannot hold and checking whether CE reports a decode failure --
+// a name CE ignores cannot produce one:
+//
+//	lint { destructive { error = "x" } } -> "parsing destructive check options"
+//	lint { condrop { error = "x" } }     -> "parsing datadepend check options"
+//	diff { skip { drop_schema = "x" } }  -> attr "drop_schema" cannot be read as bool
+//	env { schema { repo { name = 1 } } } -> attr "name" cannot be read as string
+//
+// The same probe run against lint.naming, lint.statement, lint.non_linear,
+// lint.ownership, lint.check, lint.rule, destructive.allow_table and
+// schema.mode.sensitive stays silent, so those are tolerated.
+//
+// Note the probe only proves the positive: a decode failure means CE reads the
+// field. Silence alone means nothing unless a known-decoded name in the SAME
+// command produces a failure -- `migration { baseline = [1,2] }` is silent under
+// `migrate diff` purely because that command never reads baseline.
+// lint.destructive is decoded by CE too, but Ptah already implements it, so it
+// never reaches the tolerance path and is not listed here.
+var ceEnforcedConstructs = map[string]struct{}{
+	"lint.condrop":          {},
+	"diff.skip.drop_schema": {},
+	"schema.repo":           {},
+}
+
+// enforcedByCE reports whether a scope-qualified name is one CE acts on.
+//
+// The same block may sit at the top level or inside env -- `lint` and `diff`
+// are both -- so the env prefix is stripped before the lookup rather than every
+// name being registered twice.
+func enforcedByCE(scope, name string) bool {
+	if _, ok := ceEnforcedConstructs[scope+"."+name]; ok {
+		return true
+	}
+	_, ok := ceEnforcedConstructs[strings.TrimPrefix(scope, "env.")+"."+name]
+	return ok
+}
+
+// tolerateUnknownAttr accepts an attribute name Atlas CE does not recognize.
+//
+// The expression is still evaluated and its failure still returned: CE's
+// tolerance is name-level, not subtree-level, so `env { frobnicate = var.nope }`
+// is fatal on CE even though `env { frobnicate = "x" }` is not.
+//
+// scope is the dotted path of the enclosing body, used to keep names CE really
+// enforces out of the tolerance -- see ceEnforcedConstructs.
+func (p atlasParser) tolerateUnknownAttr(scope, name string, attr *hclsyntax.Attribute) error {
+	if enforcedByCE(scope, name) {
+		return unsupported(name, attr.NameRange)
+	}
+	if _, diags := attr.Expr.Value(p.ctx); diags.HasErrors() {
+		return p.evaluationFailed(name, attr, diags)
+	}
+	p.noteIgnored("attribute", name, attr.NameRange)
+	return nil
+}
+
+// tolerateUnknownBlock accepts a block name Atlas CE does not recognize, with
+// the same name-level and enforced-name rules as tolerateUnknownAttr.
+func (p atlasParser) tolerateUnknownBlock(scope string, block *hclsyntax.Block) error {
+	if enforcedByCE(scope, block.Type) {
+		return unsupported(block.Type, block.TypeRange)
+	}
+	if err := p.evaluateIgnoredBody(block.Body); err != nil {
+		return err
+	}
+	p.noteIgnored("block", block.Type, block.TypeRange)
+	return nil
 }
 
 // noteIgnored records a construct tolerated under the unknown-name policy.
@@ -425,7 +502,7 @@ func (p atlasParser) parseEnvBlock(block *hclsyntax.Block, seen map[string]struc
 	case "schema":
 		return p.parseSchema(block, cfg)
 	default:
-		return unsupportedBlock(block)
+		return p.tolerateUnknownBlock("env", block)
 	}
 }
 
@@ -443,7 +520,9 @@ func (p atlasParser) parseSchema(block *hclsyntax.Block, cfg *Config) error {
 			cfg.SchemaSources = values
 			cfg.presence.mark(fieldSchemaSources)
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("env.schema", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	seenMode := false
@@ -458,7 +537,11 @@ func (p atlasParser) parseSchema(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 		default:
-			return unsupportedBlock(nested)
+			// Same in-loop rule as the attribute switches: returning here
+			// would end the loop and skip every later block.
+			if err := p.tolerateUnknownBlock("env.schema", nested); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -492,10 +575,14 @@ func (p atlasParser) parseSchemaMode(block *hclsyntax.Block, cfg *Config) error 
 			cfg.Schema.Mode.Views = value
 		case "sensitive":
 			if value.Value {
-				return unsupportedAttr(attrName, attr)
+				if err := p.tolerateUnknownAttr("env.schema.mode", attrName, attr); err != nil {
+					return err
+				}
 			}
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("env.schema.mode", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -535,7 +622,9 @@ func (p atlasParser) parseEnvAttr(attrName string, attr *hclsyntax.Attribute, cf
 		cfg.Exclude = values
 		cfg.presence.mark(fieldExclude)
 	default:
-		return unsupportedAttr(attrName, attr)
+		if err := p.tolerateUnknownAttr("env", attrName, attr); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -608,7 +697,9 @@ func (p atlasParser) parseMigration(block *hclsyntax.Block, cfg *Config) error {
 			migration.TxMode = value
 			cfg.presence.mark(fieldMigrationTxMode)
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("env.migration", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -663,7 +754,9 @@ func (p atlasParser) parseLintAttr(attrName string, attr *hclsyntax.Attribute, c
 		cfg.Format.Migrate.Lint = value
 		cfg.presence.mark(fieldFormatMigrateLint)
 	default:
-		return unsupportedAttr(attrName, attr)
+		if err := p.tolerateUnknownAttr("lint", attrName, attr); err != nil {
+			return err
+		}
 	}
 	return nil
 }
@@ -709,7 +802,11 @@ func (p atlasParser) parseLintPolicyBlocks(block *hclsyntax.Block, cfg *Config) 
 				return err
 			}
 		default:
-			return unsupportedBlock(nested)
+			// Same in-loop rule as the attribute switches: returning here
+			// would end the loop and skip every later block.
+			if err := p.tolerateUnknownBlock("lint", nested); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
@@ -746,9 +843,13 @@ func (p atlasParser) parseLintAnalyzer(block *hclsyntax.Block, cfg *Config, code
 				setLintRuleSeverity(cfg, code, severity)
 			}
 		case "force":
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("lint.analyzer", attrName, attr); err != nil {
+				return err
+			}
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("lint.analyzer", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -800,7 +901,9 @@ func (p atlasParser) parseLintGit(block *hclsyntax.Block, cfg *Config) error {
 			cfg.Lint.GitDir = value
 			cfg.presence.mark(fieldLintGitDir)
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("lint.git", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -809,40 +912,55 @@ func (p atlasParser) parseLintGit(block *hclsyntax.Block, cfg *Config) error {
 	return nil
 }
 
-func (p atlasParser) parseFormat(block *hclsyntax.Block, cfg *Config) error {
+// atlasNestedParser parses one known child of a container block.
+type atlasNestedParser func(*hclsyntax.Block, *Config) error
+
+// parseContainerBlock parses an unlabeled block that carries no attributes of
+// its own and a fixed set of nested blocks, each allowed once.
+//
+// Attributes are all unknown by definition and go to the tolerance path;
+// unknown nested blocks do too. Neither `return`s from inside the loop on the
+// tolerated path -- that would end the loop and silently skip every later
+// name, which map iteration order would make intermittent.
+func (p atlasParser) parseContainerBlock(
+	scope string,
+	block *hclsyntax.Block,
+	cfg *Config,
+	nested map[string]atlasNestedParser,
+) error {
 	if len(block.Labels) > 0 {
 		return unsupportedBlock(block)
 	}
-	if len(block.Body.Attributes) > 0 {
-		for name, attr := range block.Body.Attributes {
-			return unsupportedAttr(name, attr)
+	for _, name := range sortedAttributeNames(block.Body.Attributes) {
+		if err := p.tolerateUnknownAttr(scope, name, block.Body.Attributes[name]); err != nil {
+			return err
 		}
 	}
-	seenMigrate := false
-	seenSchema := false
-	for _, nested := range block.Body.Blocks {
-		switch nested.Type {
-		case "migrate":
-			if seenMigrate {
-				return unsupportedBlock(nested)
-			}
-			seenMigrate = true
-			if err := p.parseMigrateFormat(nested, cfg); err != nil {
+	seen := map[string]struct{}{}
+	for _, child := range block.Body.Blocks {
+		parse, known := nested[child.Type]
+		if !known {
+			if err := p.tolerateUnknownBlock(scope, child); err != nil {
 				return err
 			}
-		case "schema":
-			if seenSchema {
-				return unsupportedBlock(nested)
-			}
-			seenSchema = true
-			if err := p.parseSchemaFormat(nested, cfg); err != nil {
-				return err
-			}
-		default:
-			return unsupportedBlock(nested)
+			continue
+		}
+		if _, duplicate := seen[child.Type]; duplicate {
+			return unsupportedBlock(child)
+		}
+		seen[child.Type] = struct{}{}
+		if err := parse(child, cfg); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+func (p atlasParser) parseFormat(block *hclsyntax.Block, cfg *Config) error {
+	return p.parseContainerBlock("format", block, cfg, map[string]atlasNestedParser{
+		"migrate": p.parseMigrateFormat,
+		"schema":  p.parseSchemaFormat,
+	})
 }
 
 func (p atlasParser) parseMigrateFormat(block *hclsyntax.Block, cfg *Config) error {
@@ -895,39 +1013,10 @@ func (p atlasParser) parseFormatAttributes(
 }
 
 func (p atlasParser) parseDiff(block *hclsyntax.Block, cfg *Config) error {
-	if len(block.Labels) > 0 {
-		return unsupportedBlock(block)
-	}
-	if len(block.Body.Attributes) > 0 {
-		for name, attr := range block.Body.Attributes {
-			return unsupportedAttr(name, attr)
-		}
-	}
-	seenSkip := false
-	seenConcurrentIndex := false
-	for _, nested := range block.Body.Blocks {
-		switch nested.Type {
-		case "skip":
-			if seenSkip {
-				return unsupportedBlock(nested)
-			}
-			seenSkip = true
-			if err := p.parseDiffSkip(nested, cfg); err != nil {
-				return err
-			}
-		case "concurrent_index":
-			if seenConcurrentIndex {
-				return unsupportedBlock(nested)
-			}
-			seenConcurrentIndex = true
-			if err := p.parseDiffConcurrentIndex(nested, cfg); err != nil {
-				return err
-			}
-		default:
-			return unsupportedBlock(nested)
-		}
-	}
-	return nil
+	return p.parseContainerBlock("diff", block, cfg, map[string]atlasNestedParser{
+		"skip":             p.parseDiffSkip,
+		"concurrent_index": p.parseDiffConcurrentIndex,
+	})
 }
 
 func (p atlasParser) parseDiffSkip(block *hclsyntax.Block, cfg *Config) error {
@@ -943,9 +1032,13 @@ func (p atlasParser) parseDiffSkip(block *hclsyntax.Block, cfg *Config) error {
 		case "drop_table":
 			cfg.Diff.Skip.DropTable = value
 		case "drop_schema":
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
+				return err
+			}
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -969,7 +1062,9 @@ func (p atlasParser) parseDiffConcurrentIndex(block *hclsyntax.Block, cfg *Confi
 		case "drop":
 			cfg.Diff.ConcurrentIndex.Drop = value
 		default:
-			return unsupportedAttr(attrName, attr)
+			if err := p.tolerateUnknownAttr("diff.concurrent_index", attrName, attr); err != nil {
+				return err
+			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {

--- a/config/projectconfig/atlas_structure.go
+++ b/config/projectconfig/atlas_structure.go
@@ -87,34 +87,52 @@ func atlasEnvBodyStructure() atlasBodyStructure {
 	}
 }
 
-func validateAtlasEnvStructures(envs []atlasEnvBlock) error {
+func (p atlasParser) validateAtlasEnvStructures(envs []atlasEnvBlock) error {
 	structure := atlasEnvBodyStructure()
 	for _, env := range envs {
-		if err := validateAtlasBodyStructure(env.block.Body, structure); err != nil {
+		if err := p.validateAtlasBodyStructure("env", env.block.Body, structure); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func validateAtlasBodyStructure(body *hclsyntax.Body, structure atlasBodyStructure) error {
+// scope is the dotted path of body within atlas.hcl ("env", "env.schema", ...).
+// It is what lets the unknown-name tolerance stay clear of the handful of names
+// Atlas CE really does decode -- see ceEnforcedConstructs.
+func (p atlasParser) validateAtlasBodyStructure(scope string, body *hclsyntax.Body, structure atlasBodyStructure) error {
+	// This validator, not the per-block parsers, is what refuses an unknown
+	// name anywhere under `env` -- it runs first and recurses, so relaxing the
+	// parsers' own switch defaults would have changed nothing here.
 	for _, name := range sortedAttributeNames(body.Attributes) {
 		if !slices.Contains(structure.attributes, name) {
-			return unsupportedAttr(name, body.Attributes[name])
+			if err := p.tolerateUnknownAttr(scope, name, body.Attributes[name]); err != nil {
+				return err
+			}
+			continue
 		}
 	}
 
 	seen := map[string]struct{}{}
 	for _, block := range body.Blocks {
 		blockStructure, ok := structure.blocks[block.Type]
-		if !ok || len(block.Labels) != blockStructure.labels {
+		if !ok {
+			if err := p.tolerateUnknownBlock(scope, block); err != nil {
+				return err
+			}
+			continue
+		}
+		if len(block.Labels) != blockStructure.labels {
+			// Label arity is left refusing for now. CE applies the block and
+			// ignores the extra labels -- measured -- so this is a known
+			// remaining divergence, not the rule above.
 			return unsupportedBlock(block)
 		}
 		if _, duplicate := seen[block.Type]; duplicate {
 			return unsupportedBlock(block)
 		}
 		seen[block.Type] = struct{}{}
-		if err := validateAtlasBodyStructure(block.Body, blockStructure.body); err != nil {
+		if err := p.validateAtlasBodyStructure(scope+"."+block.Type, block.Body, blockStructure.body); err != nil {
 			return err
 		}
 	}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1245,12 +1245,14 @@ env "prod" {
 // Label arity and duplicate blocks are the two positions still refused in an
 // unselected env; the community binary accepts both. They are tracked as known
 // remaining divergences rather than folded into the unknown-name tolerance.
-func TestParseAtlasProjectConfigUnsupportedConstructsInUnselectedEnv(t *testing.T) {
+// The community binary never decodes an env it was not asked for, so an unknown
+// name there is accepted -- measured: `--env dev` with an unresolvable reference
+// in `prod` exits 0.
+func TestParseAtlasProjectConfigAcceptsUnknownNamesInUnselectedEnv(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
-		name    string
-		raw     string
-		wantErr string
+		name string
+		raw  string
 	}{
 		{
 			name: "environment attribute",
@@ -1262,10 +1264,6 @@ env "prod" {
   project = "production"
 }
 `,
-			// The community binary never decodes an env it was not asked for, so
-			// an unknown name there is accepted. Measured: `--env dev` with an
-			// unresolvable reference in `prod` exits 0.
-			wantErr: "",
 		},
 		{
 			name: "environment block",
@@ -1277,7 +1275,6 @@ env "prod" {
   cloud {}
 }
 `,
-			wantErr: "",
 		},
 		{
 			name: "nested migration attribute",
@@ -1292,8 +1289,25 @@ env "prod" {
   }
 }
 `,
-			wantErr: "",
 		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := projectconfig.ParseAtlas([]byte(test.raw), "atlas.hcl", "dev")
+
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigUnsupportedConstructsInUnselectedEnv(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		raw     string
+		wantErr string
+	}{
 		{
 			name: "labeled nested block",
 			raw: `env "dev" {
@@ -1331,10 +1345,6 @@ env "prod" {
 		c.Run(test.name, func(c *qt.C) {
 			_, err := projectconfig.ParseAtlas([]byte(test.raw), "atlas.hcl", "dev")
 
-			if test.wantErr == "" {
-				c.Assert(err, qt.IsNil)
-				return
-			}
 			c.Assert(err, qt.ErrorMatches, test.wantErr)
 		})
 	}

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -116,6 +116,23 @@ func TestParseAtlasProjectConfigGolden_HappyPath(t *testing.T) {
 	}
 }
 
+// The unsupported-attribute fixture is no longer a failure path: `project` is a
+// name the community binary parses and ignores, so refusing it was stricter
+// than Atlas. The fixture is kept and asserted from the tolerant side.
+func TestParseAtlasProjectConfigGoldenUnknownAttributeIsIgnored(t *testing.T) {
+	c := qt.New(t)
+	raw := readAtlasProjectConfigFixture(c, "unsupported-attribute.hcl")
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(cfg.IgnoredConstructs))
+	for _, ignored := range cfg.IgnoredConstructs {
+		names = append(names, ignored.Name)
+	}
+	c.Assert(names, qt.Contains, "project")
+}
+
 func TestParseAtlasProjectConfigGolden_FailurePath(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
@@ -127,11 +144,6 @@ func TestParseAtlasProjectConfigGolden_FailurePath(t *testing.T) {
 			name:    "hosted service block",
 			input:   "unsupported-cloud.hcl",
 			wantErr: `atlas block is not supported by the community version of Atlas`,
-		},
-		{
-			name:    "unknown environment attribute",
-			input:   "unsupported-attribute.hcl",
-			wantErr: `unsupported atlas\.hcl construct "project" at atlas\.hcl:2`,
 		},
 	}
 
@@ -1230,7 +1242,10 @@ env "prod" {
 	c.Assert(err, qt.ErrorMatches, `cannot evaluate atlas\.hcl "url" at atlas\.hcl:5: .*Unknown variable.*`)
 }
 
-func TestParseAtlasProjectConfigRejectsUnsupportedConstructsInUnselectedEnv(t *testing.T) {
+// Label arity and duplicate blocks are the two positions still refused in an
+// unselected env; the community binary accepts both. They are tracked as known
+// remaining divergences rather than folded into the unknown-name tolerance.
+func TestParseAtlasProjectConfigUnsupportedConstructsInUnselectedEnv(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
@@ -1247,7 +1262,10 @@ env "prod" {
   project = "production"
 }
 `,
-			wantErr: `unsupported atlas\.hcl construct "project" at atlas\.hcl:6`,
+			// The community binary never decodes an env it was not asked for, so
+			// an unknown name there is accepted. Measured: `--env dev` with an
+			// unresolvable reference in `prod` exits 0.
+			wantErr: "",
 		},
 		{
 			name: "environment block",
@@ -1259,7 +1277,7 @@ env "prod" {
   cloud {}
 }
 `,
-			wantErr: `unsupported atlas\.hcl construct "cloud" at atlas\.hcl:6`,
+			wantErr: "",
 		},
 		{
 			name: "nested migration attribute",
@@ -1274,7 +1292,7 @@ env "prod" {
   }
 }
 `,
-			wantErr: `unsupported atlas\.hcl construct "remote_dir" at atlas\.hcl:8`,
+			wantErr: "",
 		},
 		{
 			name: "labeled nested block",
@@ -1313,6 +1331,10 @@ env "prod" {
 		c.Run(test.name, func(c *qt.C) {
 			_, err := projectconfig.ParseAtlas([]byte(test.raw), "atlas.hcl", "dev")
 
+			if test.wantErr == "" {
+				c.Assert(err, qt.IsNil)
+				return
+			}
 			c.Assert(err, qt.ErrorMatches, test.wantErr)
 		})
 	}
@@ -1375,12 +1397,160 @@ env "prod" {
 	c.Assert(err, qt.ErrorMatches, `atlas\.hcl contains multiple env blocks; pass --env`)
 }
 
+// TestParseAtlasProjectConfigToleratesConstructsCEIgnores covers atlas.hcl names
+// that are real Atlas constructs but that the community binary parses and never
+// acts on. Refusing them would be stricter than Atlas; each was measured by
+// planting a value the field cannot hold and confirming the community binary
+// reports no decode failure, with a name it does decode used as the control in
+// the same command.
+//
+// Names the community binary DOES decode stay in the rejection table above --
+// tolerating those would accept a policy and silently not enforce it.
+func TestParseAtlasProjectConfigToleratesConstructsCEIgnores(t *testing.T) {
+	tests := []struct {
+		name    string
+		raw     string
+		ignored string
+	}{
+		{
+			name: "schema mode sensitive allow",
+			raw: `env "local" {
+  schema {
+    mode {
+      sensitive = "ALLOW"
+    }
+  }
+}
+`,
+			ignored: "sensitive",
+		},
+		{
+			name: "lint format attr",
+			raw: `lint {
+  format = "{{ json . }}"
+}
+`,
+			ignored: "format",
+		},
+		{
+			name: "lint destructive force",
+			raw: `lint {
+  destructive {
+    force = true
+  }
+}
+`,
+			ignored: "force",
+		},
+		{
+			name: "lint check block",
+			raw: `lint {
+  check "DS102" {
+    error = true
+  }
+}
+`,
+			ignored: "check",
+		},
+		{
+			name: "lint custom rule",
+			raw: `lint {
+  rule "hcl" "custom" {
+    src = ["schema.rule.hcl"]
+  }
+}
+`,
+			ignored: "rule",
+		},
+		{
+			name: "lint non linear block",
+			raw: `lint {
+  non_linear {
+    error = true
+  }
+}
+`,
+			ignored: "non_linear",
+		},
+		{
+			name: "lint naming block",
+			raw: `lint {
+  naming {
+    error = true
+  }
+}
+`,
+			ignored: "naming",
+		},
+		{
+			name: "lint ownership block",
+			raw: `lint {
+  ownership "github" {
+    repo = "stokaro/ptah"
+  }
+}
+`,
+			ignored: "ownership",
+		},
+		{
+			name: "lint statement block",
+			raw: `lint {
+  statement {
+    error = true
+  }
+}
+`,
+			ignored: "statement",
+		},
+		{
+			name: "unknown migration attribute",
+			raw: `env "local" {
+  migration {
+    remote_dir = "atlas://example"
+  }
+}
+`,
+			ignored: "remote_dir",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "local")
+
+			c.Assert(err, qt.IsNil)
+			names := make([]string, 0, len(cfg.IgnoredConstructs))
+			for _, ignored := range cfg.IgnoredConstructs {
+				names = append(names, ignored.Name)
+			}
+			c.Assert(names, qt.Contains, tt.ignored)
+		})
+	}
+}
+
 func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 	tests := []struct {
 		name string
 		raw  string
 		err  string
 	}{
+		{
+			// Unquoted ALLOW is an HCL variable reference, and the tolerance is
+			// name-level: the body of an ignored name is still evaluated. The
+			// community binary reports the same diagnostic, word for word.
+			name: "schema mode sensitive bare identifier",
+			raw: `env "local" {
+  schema {
+    mode {
+      sensitive = ALLOW
+    }
+  }
+}
+`,
+			err: `cannot evaluate atlas\.hcl "sensitive" at atlas\.hcl:4: .*There is no variable named "ALLOW"\.`,
+		},
 		{
 			name: "schema repo block",
 			raw: `env "local" {
@@ -1394,18 +1564,6 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 			err: `unsupported atlas\.hcl construct "repo" at atlas\.hcl:3`,
 		},
 		{
-			name: "schema mode sensitive allow",
-			raw: `env "local" {
-  schema {
-    mode {
-      sensitive = ALLOW
-    }
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "sensitive" at atlas\.hcl:4`,
-		},
-		{
 			name: "diff skip drop schema",
 			raw: `diff {
   skip {
@@ -1414,24 +1572,6 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 }
 `,
 			err: `unsupported atlas\.hcl construct "drop_schema" at atlas\.hcl:3`,
-		},
-		{
-			name: "lint format attr",
-			raw: `lint {
-  format = "{{ json . }}"
-}
-`,
-			err: `unsupported atlas\.hcl construct "format" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint destructive force",
-			raw: `lint {
-  destructive {
-    force = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "force" at atlas\.hcl:3`,
 		},
 		{
 			name: "lint destructive allow table",
@@ -1457,66 +1597,6 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 }
 `,
 			err: `unsupported atlas\.hcl construct "destructive" at atlas\.hcl:5`,
-		},
-		{
-			name: "lint check block",
-			raw: `lint {
-  check "DS102" {
-    error = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "check" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint custom rule",
-			raw: `lint {
-  rule "hcl" "custom" {
-    src = ["schema.rule.hcl"]
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "rule" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint non linear block",
-			raw: `lint {
-  non_linear {
-    error = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "non_linear" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint naming block",
-			raw: `lint {
-  naming {
-    error = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "naming" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint ownership block",
-			raw: `lint {
-  ownership "github" {
-    repo = "stokaro/ptah"
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "ownership" at atlas\.hcl:2`,
-		},
-		{
-			name: "lint statement block",
-			raw: `lint {
-  statement {
-    error = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "statement" at atlas\.hcl:2`,
 		},
 		{
 			name: "lint constraint drop block",
@@ -1667,16 +1747,6 @@ locals {
 }
 `,
 			err: `cannot evaluate atlas\.hcl "paths" at atlas\.hcl:2: .*`,
-		},
-		{
-			name: "unknown migration attribute",
-			raw: `env "local" {
-  migration {
-    remote_dir = "atlas://example"
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "remote_dir" at atlas\.hcl:3`,
 		},
 		{
 			name: "duplicate migration block",
@@ -1874,13 +1944,14 @@ func TestAtlasParserDistinguishesFailureClasses(t *testing.T) {
 	// The third class, for contrast: an unknown NAME still has its own message
 	// and must not be reported as either of the two above.
 	//
-	// The position matters. A top-level unknown name is now TOLERATED, so this
-	// uses a nested one, which is the surface the next increment relaxes --
-	// when it does, this fixture moves rather than the assertion being deleted.
-	unknown := "env \"local\" {\n  frobnicate = \"yes\"\n  url = \"sqlite://m.db\"" + envBody
+	// The position matters. Unknown names are now tolerated at every level, so
+	// this uses `schema.repo` -- one of the few names the community binary
+	// genuinely decodes, which is why Ptah still refuses it rather than
+	// accepting a policy it does not enforce.
+	unknown := "env \"local\" {\n  schema {\n    repo {\n      name = \"app\"\n    }\n  }\n  url = \"sqlite://m.db\"" + envBody
 	_, err := projectconfig.ParseAtlas([]byte(unknown), "atlas.hcl", "local")
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "frobnicate" .*`)
+	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "repo" .*`)
 }
 
 // TestAtlasParserScrubsSensitiveValuesFromDiagnostics is a regression test for

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1406,6 +1406,41 @@ env "prod" {
 //
 // Names the community binary DOES decode stay in the rejection table above --
 // tolerating those would accept a policy and silently not enforce it.
+// The names the community binary decodes are refused by scope-qualified path,
+// not by bare name: `repo` is refused under schema and tolerated anywhere else.
+// Without this the deny-list would over-refuse every unrelated `repo`.
+func TestParseAtlasProjectConfigEnforcedNamesAreScopeQualified(t *testing.T) {
+	c := qt.New(t)
+
+	refused := `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    repo {
+      name = "app"
+    }
+  }
+}
+`
+	_, err := projectconfig.ParseAtlas([]byte(refused), "atlas.hcl", "local")
+	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "repo" .*`)
+
+	elsewhere := `env "local" {
+  url = "sqlite://s.db"
+  migration {
+    dir  = "file://m"
+    repo = "x"
+  }
+}
+`
+	cfg, err := projectconfig.ParseAtlas([]byte(elsewhere), "atlas.hcl", "local")
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(cfg.IgnoredConstructs))
+	for _, ignored := range cfg.IgnoredConstructs {
+		names = append(names, ignored.Name)
+	}
+	c.Assert(names, qt.Contains, "repo")
+}
+
 func TestParseAtlasProjectConfigToleratesConstructsCEIgnores(t *testing.T) {
 	tests := []struct {
 		name    string


### PR DESCRIPTION
Closes #1014 (step 2).

Unknown names anywhere under `env`, `lint`, `diff` and `format` are now accepted and recorded instead of refused. The community binary parses a name it does not recognize and drops the decoded result, so refusing was stricter than Atlas.

## What stays refused, and why that is not an oversight

Relaxing the nested layer made 17 existing tests fail, and they were not asserting nonsense names — they covered real Atlas constructs. The question that decides each one is **not** whether the community binary parses it, but whether it *acts* on it. Measuring with `migrate status` proves nothing, because that command never consults `lint` or `diff`.

The probe: plant a value the target field cannot hold and check whether the binary reports a decode failure. A name it ignores cannot produce one.

| Construct | Probe result | Verdict |
| --- | --- | --- |
| `lint.destructive` | `parsing destructive check options` | decoded — already implemented |
| `lint.condrop` | `parsing datadepend check options` | **decoded — stays refused** |
| `diff.skip.drop_schema` | attr cannot be read as bool | **decoded — stays refused** |
| `schema.repo` | attr cannot be read as string | **decoded — stays refused** |
| `lint.naming`, `lint.statement`, `lint.non_linear`, `lint.ownership`, `lint.check`, `lint.rule`, `lint.format`, `destructive.force`, `destructive.allow_table`, `schema.mode.sensitive` | silent | ignored — now tolerated |

Tolerating the three decoded names would accept a policy and silently not enforce it. That is the worst outcome available and the failure class this project already tracks, so they keep refusing. The cost is stated plainly rather than hidden: **compat is stricter than Atlas on commands that never consult those blocks** — `migrate status` with a `condrop` block exits 0 on Atlas and 1 here. Both branches diverge; this is the loud one. The only real fix is implementing them, filed separately.

`lint.naming` was additionally confirmed behaviorally: with a badly-named table created in the analyzed migration, `naming { match = "^[a-z_]+$" }` produces no diagnostic at all.

## Two behaviors pinned by new fixtures

**Tolerance is name-level, not subtree-level.** The body of an ignored name is still evaluated, so `sensitive = ALLOW` (a bare identifier) is fatal on both implementations — word for word, `There is no variable named "ALLOW"` — while `sensitive = "ALLOW"` is accepted by both.

**An unselected env is not validated at all.** The community binary never decodes an env it was not asked for: `--env dev` with an unresolvable reference in `prod` exits 0. Three cases moved from the rejection table to accepting. Label arity and duplicate blocks are still refused there and remain documented divergences.

## What the probe does not prove

It only proves the positive. Silence means nothing unless a known-decoded name in the *same command* produces a failure — `migration { baseline = [1,2] }` is silent under `migrate diff` purely because that command never reads `baseline`. That control failing is what kept `schema.mode.sensitive` from being decided until `schema.repo` supplied a working control inside the same block.

## Verification

`go build`, `go vet`, `go test ./... -count=1` and `golangci-lint run` are clean. `parseFormat` and `parseDiff` collapsed into one container parser once both grew the same tolerance branch — they had become literal duplicates, which the linter caught.

Positions re-measured against the pinned community binary after the refactor, all matching: unknown block and unknown attribute in `format`, duplicate `format.migrate`, unknown block in `diff`, `lint.naming`, an unresolvable reference inside an ignored block, `variable`, and the `atlas` block.
