### PR TITLE
scripts: make the testify prohibition actually run without ripgrep

### DIFF
--- a/cmd/atlas/schema_plan_new_test.go
+++ b/cmd/atlas/schema_plan_new_test.go
@@ -278,13 +278,17 @@ func TestSchemaPlanNewEditRoundTripsTheStatementsVerbatim(t *testing.T) {
 	withoutEdit := filepath.Join(dir, "without.plan.hcl")
 	withEdit := filepath.Join(dir, "with.plan.hcl")
 
+	// The name is pinned because the default is a timestamp with one-second
+	// resolution, so the two runs disagree whenever they straddle a second
+	// boundary -- rare locally, routine on CI. This test is about the editor
+	// round trip, not about naming.
 	out, err := runSchemaPlanSubverb(atlas.NewCompatCommand("atlas"), "new",
-		fixture.args("--output", withoutEdit)...)
+		fixture.args("--name", "roundtrip", "--output", withoutEdit)...)
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 
 	installScriptEditor(t, "true")
 	out, err = runSchemaPlanSubverb(atlas.NewCompatCommand("atlas"), "new",
-		fixture.args("--output", withEdit, "--edit")...)
+		fixture.args("--name", "roundtrip", "--output", withEdit, "--edit")...)
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 
 	plain, readErr := os.ReadFile(withoutEdit)

--- a/scripts/check-test-style.sh
+++ b/scripts/check-test-style.sh
@@ -4,7 +4,12 @@ set -eu
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-if rg -n 'github\.com/stretchr/testify|\b(assert|require)\.' --glob '*.go' .; then
+# git grep rather than rg: when ripgrep is absent the command exits 127, the
+# `if` reads that as "no matches", and `set -e` does not fire inside a condition
+# -- so this gate reported success without ever running. It did exactly that on
+# CI, which has no ripgrep. git grep is always present here and searches tracked
+# files only, which also keeps stray worktrees out of the result.
+if git grep -nE 'github\.com/stretchr/testify|\b(assert|require)\.' -- '*.go'; then
 	echo "teststyle: testify/assert/require usage is prohibited; use quicktest as qt instead" >&2
 	exit 1
 fi


### PR DESCRIPTION
The testify prohibition in `scripts/check-test-style.sh` has not been running.

```sh
if rg -n 'github\.com/stretchr/testify|\b(assert|require)\.' --glob '*.go' .; then
	echo "teststyle: testify/assert/require usage is prohibited..." >&2
	exit 1
fi
```

With ripgrep absent the command exits 127. The `if` reads a non-zero status as "no matches", and `set -e` does not fire inside a condition, so the script continues to the next step and the gate passes. CI has no ripgrep, and the job log for #1047 says so directly:

```
scripts/check-test-style.sh: 7: rg: not found
```

Every green run of this check has been green because the search never happened.

## Fix

`git grep` is always available in a checkout, has the same exit-code contract, and searches tracked files only — which additionally keeps stray local worktrees out of the result.

## Verification

Running the check is not evidence that it works, so the rule was broken on purpose:

| State | Result |
| --- | --- |
| clean tree | no match, gate passes |
| tracked file importing `stretchr/testify` | match, gate fails with the message |
| file removed | no match, gate passes |

The pathspec reaches nested packages, not just the repo root: `git grep -l 'func Test' -- '*.go'` returns 675 files, the deepest 5 directories down.

Worth noting the planted file had to be `git add`-ed to be seen — `git grep` skips untracked files. That is correct for CI, where the checkout is fully tracked, and it is why the first attempt to verify this fix appeared to fail.
