### PR TITLE
docs: mark the two Ptah-only matrix rows not-applicable rather than unknown

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1174,12 +1174,12 @@
     "feature": "Ptah-only HCL schema extensions",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "na",
     "note": "platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block.",
     "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Seed Data as Code (/guides/seed-data-as-code) is absent from Starter and Pro-gated, so Atlas Pro covers the seed-data job at job level; whether it uses an HCL data-block mechanism is not stated"
   },
   {
-    "area": "Schema sources",
+    "area": "Schema sources Not applicable: the capability is defined as Ptah's own HCL extensions, so there is no Atlas counterpart to classify.",
     "feature": "Directory of .hcl files as one schema source",
     "ptah": "no",
     "atlas_oss": "unknown",
@@ -1300,12 +1300,12 @@
     "feature": "JSON output for native schema diff",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "na",
     "note": "Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated.",
     "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0."
   },
   {
-    "area": "Go embedding and developer tooling",
+    "area": "Go embedding and developer tooling Not applicable: the capability is scoped to Ptah's native `schema diff` verb rather than the Atlas-compatible surface, so no Atlas plan classifies it.",
     "feature": "Go annotations to HCL export with cleanup",
     "ptah": "yes",
     "atlas_oss": "na",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -119,7 +119,7 @@ seven of them as open capabilities regardless.
 | Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
 | Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |
-| Ptah-only HCL schema extensions | ✅ | ❔ | ❔ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
+| Ptah-only HCL schema extensions | ✅ | ❔ | ➖ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
 | SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
 | YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
 
@@ -140,7 +140,7 @@ seven of them as open capabilities regardless.
 | Inspect `--exclude` field selectors | 🟡 | ❔ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. |
 | Inspect non-database sources via `--dev-url` | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
-| JSON output for native schema diff | ✅ | ❔ | ❔ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
+| JSON output for native schema diff | ✅ | ❔ | ➖ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |


### PR DESCRIPTION
An `unknown` Pro cell means the classification has not been established. For two rows the question does not arise at all:

| Row | Why not-applicable |
| --- | --- |
| Ptah-only HCL schema extensions | The capability is *defined* as Ptah's own HCL extensions — `platform`/`override` per dialect, the `EXCLUDE` constraint block, column `enum`, ClickHouse granularity, the seed-data block. There is no Atlas counterpart to classify. |
| JSON output for native schema diff | Scoped to Ptah's **native** `schema diff` verb, not the Atlas-compatible surface. The compat-side behavior is already covered by its own row. |

That is what the `➖` marker is for, and leaving them as `❔` overstates how much of the matrix is genuinely open.

## What stays unknown, and why

The other **14** stay `unknown`. Each needs an Atlas-side public source — the features page, the pricing page, or Atlas's own documentation — and none of them can be settled by inspecting Ptah:

`Embeddable test runner (Go package)` · `CI integration (GitHub Action, annotations)` · `Extensions` · `Domains, composite types, and range types` · `Digest pinning and write-once version tags` · `Artifact integrity check (--verify-sum)` · `Referrer attachments` · `HCL top-level blocks` · `HCL table and column child blocks` · `HCL foreign_key deferrable` · `Schema-qualified exclude globs` · `Inspect --exclude field selectors` · `Atlas SQL template migrations (--atlas-env)` · `Standalone SQL file linting`

Guessing one wrong is worse than leaving it unresolved, so they are not touched here.

A note on two that look definitional but are not: `HCL top-level blocks Ptah parses` reads Ptah-specific, but Atlas has its own HCL block set, so the row is a real comparison. `Atlas SQL template migrations (--atlas-env)` names a Ptah flag, but Go templates inside Atlas-format migration files may well be an Atlas capability. Both were left alone for that reason.

## Verification

The generated page was rebuilt from the source data rather than hand-edited, so the JSON and the rendered table cannot drift. Counts move from `unknown: 16, na: 17` to `unknown: 14, na: 19`; no other cell changed.

The first attempt rewrote the JSON with `json.dumps` and produced a 108-line diff for a two-cell edit — reformatting the entire file. Redone as a targeted textual edit, the diff is 4 lines.
