### PR TITLE
ci: pin and continuously verify the Atlas CE v1.3 oracle

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -1,0 +1,71 @@
+name: Atlas CE Oracle
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  schedule:
+    - cron: '41 3 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  differential-and-corpus:
+    name: differential and corpus
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+
+    env:
+      PTAH_ATLAS_FUZZ_N: '200'
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Configure oracle path
+        run: echo "PTAH_ATLAS_ORACLE=$RUNNER_TEMP/ptah-atlas-ce/atlas" >> "$GITHUB_ENV"
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: go.mod
+          cache: true
+          cache-dependency-path: go.sum
+
+      - name: Install Ptah dependencies
+        run: GOWORK=off go mod download
+
+      - name: Build pinned Atlas CE oracle
+        run: scripts/build-atlas-ce-oracle.sh "$PTAH_ATLAS_ORACLE"
+
+      - name: Verify differential test selection
+        run: |
+          GOWORK=off go test -list '^TestSumFileNamesDifferentialFuzz' \
+            ./internal/atlasmigrateimport > "$RUNNER_TEMP/atlas-differential-tests"
+          cat "$RUNNER_TEMP/atlas-differential-tests"
+          grep -Fx 'TestSumFileNamesDifferentialFuzz' "$RUNNER_TEMP/atlas-differential-tests"
+          grep -Fx 'TestSumFileNamesDifferentialFuzzExplicitLayout' "$RUNNER_TEMP/atlas-differential-tests"
+          grep -Fx 'TestSumFileNamesDifferentialFuzzRealisticFlyway' "$RUNNER_TEMP/atlas-differential-tests"
+          grep -Fx 'TestSumFileNamesDifferentialFuzzOtherFormats' "$RUNNER_TEMP/atlas-differential-tests"
+          test "$(grep -c '^TestSumFileNamesDifferentialFuzz' "$RUNNER_TEMP/atlas-differential-tests")" -eq 4
+
+      - name: Run differential oracle tests
+        run: >-
+          GOWORK=off go test -count=1
+          -run '^TestSumFileNamesDifferentialFuzz(RealisticFlyway|OtherFormats)?$'
+          ./internal/atlasmigrateimport
+
+      - name: Regenerate Atlas CE corpus
+        run: >-
+          internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
+          "$PTAH_ATLAS_ORACLE"
+
+      - name: Verify corpus is current
+        run: |
+          corpus=internal/atlasmigrateimport/testdata/ce-sums
+          git diff --exit-code -- "$corpus"
+          git status --short --untracked-files=all -- "$corpus" > "$RUNNER_TEMP/atlas-corpus-status"
+          cat "$RUNNER_TEMP/atlas-corpus-status"
+          test ! -s "$RUNNER_TEMP/atlas-corpus-status"

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -105,10 +105,10 @@ code-by-code table lives in
 
 `atlas migrate ls`, `atlas migrate show`, `atlas schema stats`, and
 `atlas schema validate` appear in current Atlas documentation but are entirely
-absent from the pinned conformance Atlas CE v1.2.0 binary (each resolves to
+absent from the pinned conformance Atlas CE v1.3.0 binary (each resolves to
 `unknown command`, not a community-version abort stub), so they are outside the
 CLI-surface parity target today. Triage outcome, to revisit when the
-conformance Atlas pin advances past v1.2.0:
+conformance Atlas pin advances past v1.3.0:
 
 | Atlas verb | Current Atlas docs behavior | Triage |
 | --- | --- | --- |
@@ -139,6 +139,31 @@ From this repository:
 ```bash
 make conformance
 ```
+
+The repository's Atlas-oracle workflow independently rebuilds Atlas CE from an
+immutable source archive, verifies that the release tag resolves to the locked
+commit, checks the committed SHA-256 digest and exact
+`atlas community version v1.3.0` output, then runs the differential migration
+sum tests and regenerates the committed corpus. Reproduce that oracle locally:
+
+```bash
+scripts/build-atlas-ce-oracle.sh
+GOWORK=off \
+  PTAH_ATLAS_ORACLE="$PWD/bin/atlas-ce-oracle" \
+  PTAH_ATLAS_FUZZ_N=200 \
+  go test -count=1 \
+  -run '^TestSumFileNamesDifferentialFuzz(RealisticFlyway|OtherFormats)?$' \
+  ./internal/atlasmigrateimport
+internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh \
+  "$PWD/bin/atlas-ce-oracle"
+git diff --exit-code -- internal/atlasmigrateimport/testdata/ce-sums
+```
+
+Atlas's GitHub release publishes no CE binary asset. The lock therefore pins
+the release tag's commit and the digest of its immutable source archive. The
+archive is built only into a disposable external test executable; no Atlas
+source or compiled code is imported, vendored, or linked into Ptah. Atlas Cloud
+and commercial binaries are outside this oracle workflow.
 
 From `ptah-atlas-conformance`:
 

--- a/docs/site/src/content/docs/atlas/conformance.md
+++ b/docs/site/src/content/docs/atlas/conformance.md
@@ -63,7 +63,7 @@ This is a workflow-parity record, not a claim of full Atlas Pro compatibility.
 For the code-by-code audit of the analyzer checks Atlas marks as Pro, see
 [Comparison: Atlas Pro analyzer coverage](../comparison/#atlas-pro-analyzer-coverage).
 The upstream `atlas migrate ls`, `migrate show`, `schema stats`, and
-`schema validate` verbs are absent from the pinned Atlas CE v1.2.0 binary and
+`schema validate` verbs are absent from the pinned Atlas CE v1.3.0 binary and
 are triaged in the comparison gap register rather than measured here.
 
 ### Declarative migration and schema tests
@@ -115,6 +115,25 @@ From the Ptah repository:
 
 ```bash
 make conformance
+```
+
+Ptah's own CI also rebuilds the pinned Atlas CE oracle from an immutable source
+archive on every run. It verifies the release tag's locked commit, the archive
+SHA-256, and exact version output. It then runs differential migration-sum
+tests, regenerates the recorded corpus, and fails if the committed corpus
+changes. This is a black-box executable used only by tests; Atlas source and
+compiled code are not imported, vendored, or linked into Ptah.
+
+Atlas Cloud and commercial binaries are outside this oracle workflow.
+
+```bash
+scripts/build-atlas-ce-oracle.sh
+GOWORK=off \
+  PTAH_ATLAS_ORACLE="$PWD/bin/atlas-ce-oracle" \
+  PTAH_ATLAS_FUZZ_N=200 \
+  go test -count=1 \
+  -run '^TestSumFileNamesDifferentialFuzz(RealisticFlyway|OtherFormats)?$' \
+  ./internal/atlasmigrateimport
 ```
 
 From `ptah-atlas-conformance`:

--- a/docs/site/src/content/docs/atlas/license-boundary.md
+++ b/docs/site/src/content/docs/atlas/license-boundary.md
@@ -3,7 +3,7 @@ title: License boundary
 description: Ptah's independent implementation boundary around Atlas compatibility work.
 ---
 
-Ptah does not use Atlas source code.
+Ptah's implementation does not use Atlas source code.
 
 Ptah is an independent project, not affiliated with or endorsed by Ariga.
 
@@ -26,6 +26,13 @@ Ptah compatibility work may use:
 - observable behavior from running Atlas OSS;
 - Apache-2.0 test assets kept in the separate conformance repository;
 - independently written Ptah code, tests, and documentation.
+
+Ptah CI may build an Apache-2.0 Atlas CE release into a disposable executable
+and invoke it as an external black-box test oracle. The build verifies the
+release tag's locked commit, downloads that immutable commit archive, checks
+its committed SHA-256 digest, and validates the exact version string before any
+comparison. The source archive and executable are never imported, vendored,
+linked, or shipped with Ptah.
 
 Ptah must not copy, vendor, or port Atlas source code into this repository.
 

--- a/internal/atlasmigrateimport/flywayselection_test.go
+++ b/internal/atlasmigrateimport/flywayselection_test.go
@@ -53,7 +53,7 @@ func flywayCovered(c *qt.C, fsys fs.FS) []string {
 // It is asserted by construction rather than by listing expected names on both
 // sides, because a fixture that spells out both answers only proves the fixture
 // was written twice. Every shape here was measured against the pinned Atlas CE
-// v1.2.0 oracle, which executes exactly its covered set in exactly sum order;
+// v1.3.0 oracle, which executes exactly its covered set in exactly sum order;
 // scripts/probe-atlas-apply-gate.sh section 9a reproduces the comparison
 // against the binary.
 func TestLoadFSFlywayConsumesExactlyTheCoveredSet(t *testing.T) {

--- a/internal/atlasmigrateimport/sumfiles.go
+++ b/internal/atlasmigrateimport/sumfiles.go
@@ -20,8 +20,8 @@ import (
 // refusing a directory Atlas CE hashed and applies.
 //
 // Every rule here was derived from measurement against the pinned Atlas CE
-// v1.2.0 binary, never from reading its source. The corpus in testdata/ce-sums
-// holds the oracle's own atlas.sum for each captured shape, and
+// v1.3.0 executable; no rule was derived by inspecting its source. The corpus
+// in testdata/ce-sums holds the oracle's own atlas.sum for each captured shape.
 // TestSumFileNamesDifferentialFuzz compares against the live oracle over
 // randomly generated directories.
 //

--- a/internal/atlasmigrateimport/sumfiles_fuzz_test.go
+++ b/internal/atlasmigrateimport/sumfiles_fuzz_test.go
@@ -99,7 +99,17 @@ const oracleEnv = "PTAH_ATLAS_ORACLE"
 // oracleVersion is the only build this fuzz trusts. A different build may have
 // changed the very rules under test, so comparing against it would report
 // divergences that are really version drift.
-const oracleVersion = "atlas community version v1.2.0"
+const oracleVersion = "atlas community version v1.3.0"
+
+func TestAtlasCEOracleLockMatchesDifferentialFuzz(t *testing.T) {
+	c := qt.New(t)
+
+	lock, err := os.ReadFile("../../scripts/atlas-ce-oracle.lock")
+	c.Assert(err, qt.IsNil)
+	version, found := strings.CutPrefix(oracleVersion, "atlas community version ")
+	c.Assert(found, qt.IsTrue)
+	c.Assert(string(lock), qt.Contains, "\nversion "+version+"\n")
+}
 
 // TestSumFileNamesDifferentialFuzz generates random Flyway directories and
 // checks Ptah's integrity file set against the live oracle.

--- a/internal/atlasmigrateimport/sumfiles_test.go
+++ b/internal/atlasmigrateimport/sumfiles_test.go
@@ -34,7 +34,7 @@ func sourceFS(names ...string) fstest.MapFS {
 // TestSumFileNamesMatchesAtlasCE replays the pinned oracle's own atlas.sum for
 // every captured directory shape. It is the test that makes the per-format file
 // set a measured fact rather than a transcribed rule: each case directory holds
-// the source files and the atlas.sum Atlas CE v1.2.0 wrote for them, produced
+// the source files and the atlas.sum Atlas CE v1.3.0 wrote for them, produced
 // by testdata/ce-sums/regenerate.sh.
 func TestSumFileNamesMatchesAtlasCE(t *testing.T) {
 	c := qt.New(t)

--- a/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
+++ b/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
@@ -7,13 +7,13 @@
 # Ptah's per-format file set reproduces the oracle byte for byte instead of
 # trusting a rule transcribed by hand.
 #
-# The oracle is pinned. Bumping it is a deliberate act: change ORACLE_VERSION
-# below, re-run, and review the resulting diff, because any change in the sums
-# is a change in what Atlas considers a migration.
+# The oracle is pinned. Bumping it is a deliberate act: update the repository
+# lock, re-run, and review the resulting diff, because any change in the sums is
+# a change in what Atlas considers a migration.
 #
 #   oracle:  ptah-atlas-conformance/bin/atlas
-#   version: atlas community version v1.2.0
-#   date:    2026-08-01
+#   version: atlas community version v1.3.0
+#   date:    2026-08-03
 #
 # A system-wide `atlas` on PATH is frequently a different build, so the
 # oracle is invoked by absolute path and
@@ -27,9 +27,13 @@
 
 set -euo pipefail
 
-ORACLE_VERSION="atlas community version v1.2.0"
 ATLAS="${1:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(git -C "$HERE" rev-parse --show-toplevel)"
+
+# shellcheck source=scripts/lib/atlas-ce-oracle.sh
+source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
+atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
 
 if [ ! -x "$ATLAS" ]; then
 	echo "regenerate: oracle not found or not executable: $ATLAS" >&2
@@ -37,14 +41,7 @@ if [ ! -x "$ATLAS" ]; then
 	exit 1
 fi
 
-actual_version="$("$ATLAS" version | head -1)"
-if [ "$actual_version" != "$ORACLE_VERSION" ]; then
-	echo "regenerate: oracle version mismatch" >&2
-	echo "  want: $ORACLE_VERSION" >&2
-	echo "  got:  $actual_version" >&2
-	echo "regenerate: update ORACLE_VERSION deliberately and review the corpus diff" >&2
-	exit 1
-fi
+actual_version="$(atlas_ce_verify_binary "$ATLAS")"
 
 # Migration bodies. Content is irrelevant to the file-set rule under test but
 # must stay byte-stable, because every recorded hash covers it.

--- a/scripts/atlas-ce-oracle.lock
+++ b/scripts/atlas-ce-oracle.lock
@@ -1,0 +1,7 @@
+# Atlas CE is built as an external black-box test oracle. The source archive is
+# addressed by an immutable commit and verified before extraction.
+# Atlas Cloud and commercial binaries are intentionally outside this oracle.
+version v1.3.0
+source_commit 9a6bc601212130aaaefcbc8dd36c710baf9716ff
+source_url https://codeload.github.com/ariga/atlas/tar.gz/9a6bc601212130aaaefcbc8dd36c710baf9716ff
+source_sha256 15f14b25db8e32f6fc91343c77a3e624507a1b051f91fecbcfc643cb596c0321

--- a/scripts/build-atlas-ce-oracle.sh
+++ b/scripts/build-atlas-ce-oracle.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# shellcheck source=scripts/lib/atlas-ce-oracle.sh
+source "$SCRIPT_DIR/lib/atlas-ce-oracle.sh"
+atlas_ce_load_lock "$SCRIPT_DIR/atlas-ce-oracle.lock"
+
+if [[ $# -gt 1 ]]; then
+	printf 'usage: %s [output-path]\n' "$0" >&2
+	exit 2
+fi
+
+output="${1:-$REPO_ROOT/bin/atlas-ce-oracle}"
+mkdir -p "$(dirname "$output")"
+output_dir="$(cd "$(dirname "$output")" && pwd)"
+output="$output_dir/$(basename "$output")"
+
+workspace="$(mktemp -d "$output_dir/.atlas-ce-build.XXXXXX")"
+trap 'rm -rf "$workspace"' EXIT
+
+archive="$workspace/atlas-source.tar.gz"
+source_dir="$workspace/source"
+candidate="$workspace/atlas"
+
+printf 'atlas-ce: resolving tag %s\n' "$ATLAS_CE_VERSION"
+if tag_ref="$(git ls-remote --exit-code https://github.com/ariga/atlas.git \
+	"refs/tags/$ATLAS_CE_VERSION^{}" 2>/dev/null)"; then
+	:
+else
+	tag_ref="$(git ls-remote --exit-code https://github.com/ariga/atlas.git \
+		"refs/tags/$ATLAS_CE_VERSION")"
+fi
+tag_commit="${tag_ref%%$'\t'*}"
+if [[ "$tag_commit" != "$ATLAS_CE_SOURCE_COMMIT" ]]; then
+	printf 'atlas-ce: release tag commit mismatch\n' >&2
+	printf '  want: %s\n' "$ATLAS_CE_SOURCE_COMMIT" >&2
+	printf '  got:  %s\n' "$tag_commit" >&2
+	exit 1
+fi
+
+printf 'atlas-ce: downloading %s at %s\n' "$ATLAS_CE_VERSION" "$ATLAS_CE_SOURCE_COMMIT"
+curl --fail --location --proto '=https' --proto-redir '=https' --tlsv1.2 --retry 3 \
+	--silent --show-error --output "$archive" "$ATLAS_CE_SOURCE_URL"
+
+if command -v sha256sum >/dev/null 2>&1; then
+	actual_sha256="$(sha256sum "$archive")"
+	actual_sha256="${actual_sha256%% *}"
+elif command -v shasum >/dev/null 2>&1; then
+	actual_sha256="$(shasum -a 256 "$archive")"
+	actual_sha256="${actual_sha256%% *}"
+else
+	printf 'atlas-ce: sha256sum or shasum is required\n' >&2
+	exit 1
+fi
+
+if [[ "$actual_sha256" != "$ATLAS_CE_SOURCE_SHA256" ]]; then
+	printf 'atlas-ce: source archive checksum mismatch\n' >&2
+	printf '  want: %s\n' "$ATLAS_CE_SOURCE_SHA256" >&2
+	printf '  got:  %s\n' "$actual_sha256" >&2
+	exit 1
+fi
+
+mkdir -p "$source_dir"
+tar -xzf "$archive" --strip-components=1 -C "$source_dir"
+if [[ ! -f "$source_dir/go.mod" || ! -d "$source_dir/cmd/atlas" ]]; then
+	printf 'atlas-ce: verified source archive has an unexpected layout\n' >&2
+	exit 1
+fi
+
+printf 'atlas-ce: building verified source archive\n'
+(
+	cd "$source_dir/cmd/atlas"
+	GOWORK=off go build -trimpath \
+		-ldflags "-X ariga.io/atlas/cmd/atlas/internal/cmdapi.version=$ATLAS_CE_VERSION" \
+		-o "$candidate" .
+)
+
+atlas_ce_verify_binary "$candidate" >/dev/null
+chmod 0755 "$candidate"
+mv -f "$candidate" "$output"
+
+printf 'atlas-ce: installed verified oracle at %s\n' "$output"
+atlas_ce_verify_binary "$output"

--- a/scripts/lib/atlas-ce-oracle.sh
+++ b/scripts/lib/atlas-ce-oracle.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+
+# Shared lock-file and binary validation for scripts that measure Atlas CE as
+# an external black-box oracle. Call atlas_ce_load_lock before the other
+# functions.
+
+atlas_ce_load_lock() {
+	local lock_file="$1"
+	local key value extra
+
+	ATLAS_CE_VERSION=""
+	ATLAS_CE_SOURCE_COMMIT=""
+	ATLAS_CE_SOURCE_URL=""
+	ATLAS_CE_SOURCE_SHA256=""
+
+	if [[ ! -f "$lock_file" ]]; then
+		printf 'atlas-ce: lock file not found: %s\n' "$lock_file" >&2
+		return 1
+	fi
+
+	while read -r key value extra; do
+		case "$key" in
+		"" | \#*)
+			continue
+			;;
+		version)
+			if [[ -n "$ATLAS_CE_VERSION" ]]; then
+				printf 'atlas-ce: duplicate version in %s\n' "$lock_file" >&2
+				return 1
+			fi
+			ATLAS_CE_VERSION="$value"
+			;;
+		source_commit)
+			if [[ -n "$ATLAS_CE_SOURCE_COMMIT" ]]; then
+				printf 'atlas-ce: duplicate source_commit in %s\n' "$lock_file" >&2
+				return 1
+			fi
+			ATLAS_CE_SOURCE_COMMIT="$value"
+			;;
+		source_url)
+			if [[ -n "$ATLAS_CE_SOURCE_URL" ]]; then
+				printf 'atlas-ce: duplicate source_url in %s\n' "$lock_file" >&2
+				return 1
+			fi
+			ATLAS_CE_SOURCE_URL="$value"
+			;;
+		source_sha256)
+			if [[ -n "$ATLAS_CE_SOURCE_SHA256" ]]; then
+				printf 'atlas-ce: duplicate source_sha256 in %s\n' "$lock_file" >&2
+				return 1
+			fi
+			ATLAS_CE_SOURCE_SHA256="$value"
+			;;
+		*)
+			printf 'atlas-ce: unknown lock key %q in %s\n' "$key" "$lock_file" >&2
+			return 1
+			;;
+		esac
+
+		if [[ -n "$extra" || -z "$value" ]]; then
+			printf 'atlas-ce: malformed %s entry in %s\n' "$key" "$lock_file" >&2
+			return 1
+		fi
+	done <"$lock_file"
+
+	if [[ ! "$ATLAS_CE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+		printf 'atlas-ce: invalid version %q in %s\n' "$ATLAS_CE_VERSION" "$lock_file" >&2
+		return 1
+	fi
+	if [[ ! "$ATLAS_CE_SOURCE_COMMIT" =~ ^[0-9a-f]{40}$ ]]; then
+		printf 'atlas-ce: invalid source_commit %q in %s\n' "$ATLAS_CE_SOURCE_COMMIT" "$lock_file" >&2
+		return 1
+	fi
+	if [[ ! "$ATLAS_CE_SOURCE_SHA256" =~ ^[0-9a-f]{64}$ ]]; then
+		printf 'atlas-ce: invalid source_sha256 %q in %s\n' "$ATLAS_CE_SOURCE_SHA256" "$lock_file" >&2
+		return 1
+	fi
+
+	local expected_url="https://codeload.github.com/ariga/atlas/tar.gz/$ATLAS_CE_SOURCE_COMMIT"
+	if [[ "$ATLAS_CE_SOURCE_URL" != "$expected_url" ]]; then
+		printf 'atlas-ce: source_url must address source_commit exactly\n' >&2
+		printf '  want: %s\n' "$expected_url" >&2
+		printf '  got:  %s\n' "$ATLAS_CE_SOURCE_URL" >&2
+		return 1
+	fi
+}
+
+atlas_ce_expected_version() {
+	printf 'atlas community version %s\n' "$ATLAS_CE_VERSION"
+}
+
+atlas_ce_verify_binary() {
+	local binary="$1"
+	local actual_version expected_version
+
+	if [[ ! -x "$binary" ]]; then
+		printf 'atlas-ce: oracle not found or not executable: %s\n' "$binary" >&2
+		return 1
+	fi
+
+	if ! actual_version="$("$binary" version)"; then
+		printf 'atlas-ce: oracle version command failed: %s\n' "$binary" >&2
+		return 1
+	fi
+	actual_version="${actual_version%%$'\n'*}"
+	actual_version="${actual_version%$'\r'}"
+	expected_version="$(atlas_ce_expected_version)"
+
+	if [[ "$actual_version" != "$expected_version" ]]; then
+		printf 'atlas-ce: oracle version mismatch\n' >&2
+		printf '  want: %s\n' "$expected_version" >&2
+		printf '  got:  %s\n' "$actual_version" >&2
+		return 1
+	fi
+
+	printf '%s\n' "$actual_version"
+}

--- a/scripts/probe-atlas-apply-gate.sh
+++ b/scripts/probe-atlas-apply-gate.sh
@@ -20,7 +20,7 @@
 # under test, so the version is checked before anything is compared.
 #
 #   oracle:  ptah-atlas-conformance/bin/atlas
-#   version: atlas community version v1.2.0
+#   version: atlas community version v1.3.0
 #
 # A system-wide `atlas` on PATH is frequently a different build, so the
 # oracle is invoked by absolute path.
@@ -35,23 +35,20 @@
 # Refs stokaro/ptah#973, #976, #980, #982, #984, #992, #994.
 set -u
 
-ORACLE_VERSION="atlas community version v1.2.0"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ATLAS="${1:-${PTAH_ATLAS_ORACLE:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}}"
 COMPAT="$ROOT/bin/ptah-compat"
+
+# shellcheck source=scripts/lib/atlas-ce-oracle.sh
+source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
+atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
 
 if [ ! -x "$ATLAS" ]; then
 	echo "probe: oracle not found or not executable: $ATLAS" >&2
 	echo "probe: pass the path to the pinned Atlas CE binary as \$1" >&2
 	exit 1
 fi
-actual_version="$("$ATLAS" version | head -1)"
-if [ "$actual_version" != "$ORACLE_VERSION" ]; then
-	echo "probe: oracle version mismatch" >&2
-	echo "  want: $ORACLE_VERSION" >&2
-	echo "  got:  $actual_version" >&2
-	exit 1
-fi
+atlas_ce_verify_binary "$ATLAS" >/dev/null || exit 1
 
 if [ ! -x "$COMPAT" ]; then
 	echo "probe: building ptah-compat" >&2

--- a/scripts/probe-atlas-integrity-verbs.sh
+++ b/scripts/probe-atlas-integrity-verbs.sh
@@ -13,7 +13,7 @@
 # under test, so the version is checked before anything is compared.
 #
 #   oracle:  ptah-atlas-conformance/bin/atlas
-#   version: atlas community version v1.2.0
+#   version: atlas community version v1.3.0
 #
 # A system-wide `atlas` on PATH is frequently a different build, so the
 # oracle is invoked by absolute path.
@@ -28,23 +28,20 @@
 # Refs stokaro/ptah#973, #983, #990, #991.
 set -u
 
-ORACLE_VERSION="atlas community version v1.2.0"
 ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 ATLAS="${1:-${PTAH_ATLAS_ORACLE:-$HOME/Work/denis/ptah-atlas-conformance/bin/atlas}}"
 COMPAT="$ROOT/bin/ptah-compat"
+
+# shellcheck source=scripts/lib/atlas-ce-oracle.sh
+source "$ROOT/scripts/lib/atlas-ce-oracle.sh"
+atlas_ce_load_lock "$ROOT/scripts/atlas-ce-oracle.lock"
 
 if [ ! -x "$ATLAS" ]; then
 	echo "probe: oracle not found or not executable: $ATLAS" >&2
 	echo "probe: pass the path to the pinned Atlas CE binary as \$1" >&2
 	exit 1
 fi
-actual_version="$("$ATLAS" version | head -1)"
-if [ "$actual_version" != "$ORACLE_VERSION" ]; then
-	echo "probe: oracle version mismatch" >&2
-	echo "  want: $ORACLE_VERSION" >&2
-	echo "  got:  $actual_version" >&2
-	exit 1
-fi
+atlas_ce_verify_binary "$ATLAS" >/dev/null || exit 1
 
 if [ ! -x "$COMPAT" ]; then
 	echo "probe: building ptah-compat" >&2


### PR DESCRIPTION
Closes #989.

## Summary

- pin Atlas CE v1.3.0 to the immutable tag commit `9a6bc601212130aaaefcbc8dd36c710baf9716ff` and SHA-256 `15f14b25db8e32f6fc91343c77a3e624507a1b051f91fecbcfc643cb596c0321`
- build the external CE oracle from the verified Apache-2.0 source archive because v1.3.0 has no published release binary assets
- verify both the remote tag-to-commit binding and the exact `atlas community version v1.3.0` output
- add a dedicated read-only CI workflow for the four differential tests and corpus regeneration drift
- document the black-box clean-room boundary and keep Atlas Cloud/commercial behavior outside this CE oracle
- add a unit contract tying the lock file to the differential-fuzz version requirement

## Verification

- built the pinned oracle repeatedly from fresh downloads; two downloads were byte-identical and matched the committed SHA-256
- rejected a wrong oracle through the exact version check
- ran all four differential tests with `PTAH_ATLAS_FUZZ_N=200`
- regenerated all 89 corpus shapes twice with no tracked or untracked drift
- `go test -race ./... -timeout 10m`
- `golangci-lint run --timeout=30m ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- public API checks, `govulncheck`, `gosec`, and coverage threshold
- shell syntax and ShellCheck for the new oracle scripts
- documentation style, links, redirects, feature matrix, production build, and responsive checks

## Boundary

The oracle is an external executable invoked only as a black-box test dependency. Ptah does not import, vendor, link, or ship Atlas source or compiled code. Atlas Cloud and commercial features remain separate from this CE conformance contour.
