### PR TITLE
schema test: accept .sql and .hcl desired-schema sources

### DIFF
--- a/cmd/atlas/schema_test_forward_test.go
+++ b/cmd/atlas/schema_test_forward_test.go
@@ -191,3 +191,99 @@ func TestNewCompatCommand_SchemaTestResolvesAtRoot(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "atlas schema test [flags] [paths]")
 	c.Assert(out.String(), qt.Contains, "-u, --url")
 }
+
+// writeDistinctSourceFixture writes three desired-schema sources that each
+// declare a DIFFERENT table, plus a test case asserting the SQL-sourced one.
+//
+// The distinct table names are the point. With every source declaring the same
+// table, a run passes whether or not the source was read at all, so it would
+// not show that -u resolved anything.
+func writeDistinctSourceFixture(c *qt.C, dir, testsDir string) (sqlFile, hclFile, modelsDir string) {
+	c.Helper()
+	modelsDir = filepath.Join(dir, "models")
+	c.Assert(os.MkdirAll(modelsDir, 0o750), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "user.go"), []byte(`package models
+
+//ptah:schema:table name="users_from_go"
+type User struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+
+	sqlFile = filepath.Join(dir, "schema.sql")
+	c.Assert(os.WriteFile(sqlFile,
+		[]byte("CREATE TABLE orders_from_sql (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+	hclFile = filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(hclFile, []byte(`schema "main" {
+}
+table "widgets_from_hcl" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`), 0o600), qt.IsNil)
+
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "sql.yaml"), []byte(`cases:
+  - name: sql-sourced table exists
+    steps:
+      - assert:
+          query: "SELECT count(*) FROM orders_from_sql"
+          row_count: 1
+`), 0o600), qt.IsNil)
+	return sqlFile, hclFile, modelsDir
+}
+
+func runCompatSchemaTest(c *qt.C, testsDir, source string) (string, error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "test", testsDir,
+		"-u", "file://" + source,
+		"--dev-url", "sqlite://" + filepath.Join(c.TempDir(), "dev.db"),
+	})
+	return func() (string, error) { err := cmd.Execute(); return out.String(), err }()
+}
+
+// TestCompatCommand_SchemaTestAcceptsSQLFileSource covers a .sql desired schema.
+// The Go-annotation directory is the control: it declares a different table, so
+// the same case fails against it. Without that half, a pass would not
+// distinguish "read the SQL file" from "read anything at all".
+func TestCompatCommand_SchemaTestAcceptsSQLFileSource(t *testing.T) {
+	c := qt.New(t)
+	dir, testsDir := t.TempDir(), t.TempDir()
+	sqlFile, _, modelsDir := writeDistinctSourceFixture(c, dir, testsDir)
+
+	out, err := runCompatSchemaTest(c, testsDir, sqlFile)
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "1 cases, 1 passed, 0 failed")
+
+	controlOut, controlErr := runCompatSchemaTest(c, testsDir, modelsDir)
+	c.Assert(controlErr, qt.IsNotNil)
+	c.Assert(controlOut, qt.Contains, "no such table: orders_from_sql")
+}
+
+// TestCompatCommand_SchemaTestAcceptsHCLFileSource covers a .hcl desired schema.
+func TestCompatCommand_SchemaTestAcceptsHCLFileSource(t *testing.T) {
+	c := qt.New(t)
+	dir, testsDir := t.TempDir(), t.TempDir()
+	_, hclFile, _ := writeDistinctSourceFixture(c, dir, testsDir)
+	c.Assert(os.Remove(filepath.Join(testsDir, "sql.yaml")), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "hcl.yaml"), []byte(`cases:
+  - name: hcl-sourced table exists
+    steps:
+      - assert:
+          query: "SELECT count(*) FROM widgets_from_hcl"
+          row_count: 1
+`), 0o600), qt.IsNil)
+
+	out, err := runCompatSchemaTest(c, testsDir, hclFile)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, "1 cases, 1 passed, 0 failed")
+}

--- a/cmd/schema/test.go
+++ b/cmd/schema/test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"slices"
 
 	"github.com/spf13/cobra"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
+	"go.5x5.cz/ptah/cmd/internal/schemaload"
+	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/migration/dbtest"
 )
 
@@ -74,7 +77,8 @@ The command exits non-zero if any case fails.`,
 
 	flags := cmd.Flags()
 	flags.StringVar(&opts.dir, testDirFlag, "./tests", "Directory containing declarative test-case YAML files")
-	flags.StringVar(&opts.rootDir, testRootDirFlag, "./models", "Root directory to scan for Go schema annotations")
+	flags.StringVar(&opts.rootDir, testRootDirFlag, "./models",
+		"Desired schema source: a directory of Go schema annotations, or a .sql or .hcl schema file")
 	flags.StringVar(&opts.seedDir, testSeedDirFlag, "", "Default directory for seed steps that omit dir")
 	flags.StringVar(&opts.dbURL, testDBURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
 	flags.StringVar(&opts.report, testReportFlag, testReportFormatText, "Report format: text, json, or html")
@@ -104,9 +108,15 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 		return fmt.Errorf("no test cases found in %s", opts.dir)
 	}
 
+	desired, err := resolveTestDesiredSchema(ctx, opts.rootDir)
+	if err != nil {
+		return err
+	}
+
 	report, err := dbtest.RunSchemaTest(ctx, dbtest.SchemaOptions{
 		Cases:   cases,
 		RootDir: opts.rootDir,
+		Desired: desired,
 		SeedDir: opts.seedDir,
 		DBURL:   opts.dbURL,
 	})
@@ -125,4 +135,24 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 		return exitcode.New(1, fmt.Errorf("schema tests failed"))
 	}
 	return nil
+}
+
+// resolveTestDesiredSchema turns the desired-schema source into a schema.
+//
+// A directory keeps the historical Go-annotation path and is left to the runner
+// so its error wording does not change. A .sql or .hcl file goes through the
+// shared loader every other schema-consuming verb already uses -- `schema diff
+// --to file://schema.sql` and `--to file://schema.hcl` both work, and only this
+// verb was restricted to Go annotations.
+func resolveTestDesiredSchema(ctx context.Context, source string) (*goschema.Database, error) {
+	info, err := os.Stat(source)
+	if err != nil || info.IsDir() {
+		// Leave a missing path to the runner, which names it in its own error.
+		return nil, nil //nolint:nilerr // the runner reports this source
+	}
+	database, err := schemaload.LoadContext(ctx, schemaload.Options{SchemaFiles: []string{source}})
+	if err != nil {
+		return nil, fmt.Errorf("load desired schema from %s: %w", source, err)
+	}
+	return database, nil
 }

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5811,7 +5811,13 @@ type SchemaOptions struct {
     // schema. It is parsed with goschema.ParseDir and converged through the live
     // diff and planner path before any case runs (once per ephemeral per-case
     // database, or once for a shared explicit database).
+    //
+    // Desired takes precedence when set, which is how callers supply a schema
+    // resolved from a source RootDir cannot express -- a .sql or .hcl file.
     RootDir string
+    // Desired is an already-resolved desired schema. When non-nil RootDir is
+    // used only to name the source in errors.
+    Desired *goschema.Database
     // SeedDir is the default directory of seed files for seed steps that omit
     // their own [SeedStep.Dir].
     SeedDir string

--- a/migration/dbtest/schema.go
+++ b/migration/dbtest/schema.go
@@ -23,7 +23,13 @@ type SchemaOptions struct {
 	// schema. It is parsed with goschema.ParseDir and converged through the live
 	// diff and planner path before any case runs (once per ephemeral per-case
 	// database, or once for a shared explicit database).
+	//
+	// Desired takes precedence when set, which is how callers supply a schema
+	// resolved from a source RootDir cannot express -- a .sql or .hcl file.
 	RootDir string
+	// Desired is an already-resolved desired schema. When non-nil RootDir is
+	// used only to name the source in errors.
+	Desired *goschema.Database
 	// SeedDir is the default directory of seed files for seed steps that omit
 	// their own [SeedStep.Dir].
 	SeedDir string
@@ -55,9 +61,13 @@ func RunSchemaTest(ctx context.Context, opts SchemaOptions) (*Report, error) {
 		return nil, fmt.Errorf("invalid test cases: %w", err)
 	}
 
-	schema, err := goschema.ParseDir(opts.RootDir)
-	if err != nil {
-		return nil, fmt.Errorf("parse desired schema from %s: %w", opts.RootDir, err)
+	schema := opts.Desired
+	if schema == nil {
+		parsed, err := goschema.ParseDir(opts.RootDir)
+		if err != nil {
+			return nil, fmt.Errorf("parse desired schema from %s: %w", opts.RootDir, err)
+		}
+		schema = parsed
 	}
 	if err := validateTestSchema(schema); err != nil {
 		return nil, err


### PR DESCRIPTION
Part of #951 — the `schema test -u` source-kinds item.

`schema test -u` was the only schema-consuming verb on the compat surface restricted to a directory of Go annotations. Measured on master, the siblings are not:

```
schema inspect --url sqlite://live.db                    -> renders
schema diff --from sqlite://live.db --to file://x.sql    -> plans
schema diff --from sqlite://live.db --to file://x.hcl    -> plans
schema test  -u file://x.sql                             -> Go annotations only
```

So the restriction belonged to this verb, not to the surface. A source that resolves to a file now goes through the same loader every other verb already uses. A directory keeps the historical path untouched, error wording included.

## Live database URLs stay refused

That one is not exposure. Nothing in the tree converts an introspected `DBSchema` into the `goschema.Database` the test runner needs — `core/convert` has no such function — so it is new machinery rather than routing. Left to its own change so this one stays reviewable.

## The tests would pass without the feature, so they were rebuilt

The first fixture had the Go directory and the SQL file both declaring `users`, and the run passed for both. That proves nothing: with the sources coinciding, a pass is consistent with `-u` being ignored entirely.

Rewritten so each source declares a **different** table — `users_from_go`, `orders_from_sql`, `widgets_from_hcl` — the same case separates them:

```
-u <models dir>   FAIL  no such table: orders_from_sql
-u schema.sql     PASS  1 cases, 1 passed, 0 failed
-u schema.hcl     PASS  1 cases, 1 passed, 0 failed
```

The failing control ships as part of the SQL test rather than being run once by hand.

## Verification

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint`, `scripts/check-public-api.sh` and `scripts/check-public-api-released.sh` are clean.

`docs/public_api.snapshot` is refreshed: `dbtest.SchemaOptions` gains a `Desired *goschema.Database` field. The change is additive — `RootDir` keeps working unchanged and is still what the runner names in its errors — and the released-API gate confirms no break.
