### PR TITLE
docs: settle two Pro matrix cells from Atlas's public features page

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1030,12 +1030,12 @@
     "feature": "Extensions",
     "ptah": "partial",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "yes",
     "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment.",
     "evidence": "core/renderer/internal/dialects/mysql/mysql.go:26-30 copies the bufwriter by value so VisitExtension (line 132) writes to a buffer Output() never reads; verified live: `ptah schema compare` against PostgreSQL 18 proposed DROP EXTENSION for pg_trgm and left plpgsql alone"
   },
   {
-    "area": "Schema object kinds",
+    "area": "Schema object kinds Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Extensions` is listed under the PostgreSQL Pro Plan features. Control on the same page and the same query: `Database Inspection` carries the tier label `Open`, and `deferrable` is absent entirely, so the page distinguishes tiers rather than labelling everything Pro.",
     "feature": "Roles, grants, and row-level security",
     "ptah": "partial",
     "atlas_oss": "no",
@@ -1048,12 +1048,12 @@
     "feature": "Domains, composite types, and range types",
     "ptah": "partial",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "yes",
     "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all.",
     "evidence": "internal/convert/fromschema/fromschema.go:1616 gates domain/range/composite emission on isPostgreSQLPlatform (postgres|postgresql only); migration/schemadiff/internal/compare/usertypes.go:158-174 compares ranges by name only; live YugabyteDB 2026.1.0.0 `ptah schema apply --dry-run` planned CREATE DOMAIN \"yb_domain\" AS TEXT"
   },
   {
-    "area": "Data and distribution",
+    "area": "Data and distribution Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Domain types`, `Composite types` and `Range types` are each listed under the PostgreSQL Pro Plan features. Same control as the extensions row.",
     "feature": "Registry-backed distribution: `oci://` vs `atlas://`",
     "ptah": "yes",
     "atlas_oss": "no",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -240,9 +240,9 @@ seven of them as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic. |
 | CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers. |
-| Domains, composite types, and range types | 🟡 | ❔ | ❔ | PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all. |
+| Domains, composite types, and range types | 🟡 | ❔ | ✅ | PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all. |
 | Enum types | 🟡 | ✅ | ✅ | MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim. |
-| Extensions | 🟡 | ❔ | ❔ | PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. |
+| Extensions | 🟡 | ❔ | ✅ | PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. |
 | Functions | 🟡 | ❌ | ✅ | `schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently. |
 | MySQL and MariaDB | 🟡 | ✅ | ✅ | Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback. |
 | Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers. |


### PR DESCRIPTION
Part of #1053. Two of the fourteen unknown Pro cells are now cited; twelve stay unknown.

| Row | New value | Source |
| --- | --- | --- |
| Extensions | `yes` | `Extensions` under the PostgreSQL Pro Plan, atlasgo.io/features, retrieved 2026-08-03 |
| Domains, composite types, and range types | `yes` | `Domain types`, `Composite types`, `Range types` in the same Pro list |

## The pricing page cannot settle any cell, and nearly fooled me into thinking it settled all of them

#1053's acceptance criterion named the pricing page. It does not work: the plan matrix encodes inclusion **visually**, and through text extraction every cell arrives identical.

The first pass came back with a clean table reporting ✓ for Starter, Pro and Enterprise on **every** row — including `Migration linting` and `Testing Framework`, which an earlier capture in this repo recorded as unchecked on Starter. Asked directly whether the page contains any cross, dash or negative marker, and to quote the Starter cell for those two rows character by character, the answer was explicit:

> The check and non-check cells are indistinguishable in the text provided.

So the first result was the extraction filling in a plausible table, not the page saying anything. Fourteen cells written from it would have been wrong and would have looked well-sourced.

## The features page does work, and here is the control that shows it

It states tiers in text rather than glyphs, and it distinguishes them. Same page, same query shape:

```
Database Inspection  -> Open
Extensions           -> Pro
Domain types         -> Pro
Composite types      -> Pro
Range types          -> Pro
deferrable           -> TERM NOT FOUND
```

One `Open`, several `Pro`, one absent. Without that spread a run of `Pro` answers would be indistinguishable from a summarizer defaulting to `Pro`, which is exactly what the pricing page did.

## Why only two

The remaining terms are simply not on the page. Asked for the same seven with the same method, every one came back `TERM NOT FOUND`: `GitHub Action`, `Atlas Registry`, `verify-sum`, `referrer`, `digest`, `Go package`/`embeddable`, `exclude`. That a batch of found-and-tiered answers and a batch of all-absent answers came from the same method is itself the check that the method is reading rather than guessing.

## Verification

Regenerated from the source data rather than hand-edited. Counts move from `unknown: 14, yes: 106` to `unknown: 12, yes: 108`; no other cell changed. `go test ./... -count=1` clean.

#1053 is updated with the pricing-page finding so the next attempt does not repeat it.
