### PR TITLE
docs: settle three HCL Pro matrix cells from Atlas's HCL reference

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1120,21 +1120,21 @@
     "feature": "HCL top-level blocks Ptah parses",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "yes",
     "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data.",
     "evidence": "internal/atlashcl/atlashcl.go:73-113; a fixture exercising all 16 renders 17 PostgreSQL statements via `ptah schema render --schema-file all.hcl --dialect postgres`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Database Security as Code (linked /atlas-schema/hcl#roles-and-permissions) and Seed Data as Code are absent from Starter and Pro-gated \u2014 this bears on the role, permission and data blocks only, so both Atlas cells stay unknown"
   },
   {
-    "area": "Schema sources",
+    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: schema, table, column, primary_key, foreign_key and index carry no tier marker, while views, materialized views, triggers, functions, procedures, domains, composite types, range types, policies, sequences, extensions and roles/permissions each carry an `Atlas Pro Feature` marker, so the Pro plan covers the whole set. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
     "feature": "HCL table and column child blocks",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "yes",
     "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform.",
     "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes"
   },
   {
-    "area": "Schema sources",
+    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `check`, `unique`, `index` and `row_security` are documented as table child resources with no tier marker, and `partition` is documented with an `Atlas Pro Feature` marker. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
     "feature": "HCL variable blocks and var.* references",
     "ptah": "no",
     "atlas_oss": "yes",
@@ -1165,12 +1165,12 @@
     "feature": "HCL foreign_key deferrable",
     "ptah": "no",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "no",
     "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too.",
     "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff. `deferrable = true` rejected under the sqlite dialect; engine-gated, so the Atlas cell stays unresolved for PostgreSQL (measured; observation study, scenario, hcl-semantics)"
   },
   {
-    "area": "Schema sources",
+    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `foreign_key` is documented but `deferrable` does not appear anywhere on the page, so it is absent from Atlas's documented HCL rather than merely unmeasured. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
     "feature": "Ptah-only HCL schema extensions",
     "ptah": "yes",
     "atlas_oss": "unknown",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -110,11 +110,11 @@ seven of them as open capabilities regardless.
 | Directory of .hcl files as one schema source | ❌ | ❔ | ✅ | `--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. |
 | External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
-| HCL foreign_key deferrable | ❌ | ❔ | ❔ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. |
+| HCL foreign_key deferrable | ❌ | ❔ | ❌ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. |
 | HCL function calls in schema files | 🟡 | ❔ | 🟡 | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally. |
 | HCL locals, lock, atlas, dynamic/for_each | ❌ | ❔ | 🟡 | Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". |
-| HCL table and column child blocks | ✅ | ❔ | ❔ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. |
-| HCL top-level blocks Ptah parses | ✅ | ❔ | ❔ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. |
+| HCL table and column child blocks | ✅ | ❔ | ✅ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. |
+| HCL top-level blocks Ptah parses | ✅ | ❔ | ✅ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. |
 | HCL variable blocks and var.* references | ❌ | ✅ | ✅ | `variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error. |
 | Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |


### PR DESCRIPTION
Part of #1053, continuing from #1056. Three more cells cited; `unknown` goes 12 → 9.

| Row | New value | Basis |
| --- | --- | --- |
| HCL top-level blocks Ptah parses | `yes` | basics untiered, the rest marked `Atlas Pro Feature` — Pro covers the set |
| HCL table and column child blocks | `yes` | `check`, `unique`, `index`, `row_security` untiered; `partition` marked Pro |
| HCL foreign_key deferrable | `no` | `foreign_key` documented, `deferrable` absent from the page entirely |

Source is Atlas's HCL schema reference (`atlasgo.io/atlas-schema/hcl`), retrieved 2026-08-03. It marks tiers inline, which is what makes these citable where the pricing page was not.

The `deferrable` row is the one asserting an absence, so it is worth being precise: that page documents `foreign_key` and its attributes, and `deferrable` appears nowhere on it. That makes it absent from Atlas's *documented* HCL — a stronger claim than "unmeasured", and a weaker one than "Atlas cannot do it".

## The controls earned their keep this time

Every query carried an invented term — `zzzznotarealterm`, `qqqnotarealblock` — and both came back not-found while real blocks came back with verbatim quotes.

That is not ceremony. Chasing the `--exclude` rows, `atlasgo.io/declarative/inspect` returns an **empty body** through this channel. The query came back with four confident `TERM NOT FOUND` answers:

```
--exclude        TERM NOT FOUND
[type=           TERM NOT FOUND
glob             TERM NOT FOUND
wwwnotarealflag  TERM NOT FOUND
```

Read without care, that is a measurement showing Atlas has no `--exclude` — which is flatly false. It survived only because the response also said the page was blank, and because a uniform run of not-founds with no found term among them is the same shape as reading nothing at all. Those rows stay `unknown`, and the anchored URL is empty too.

## Verification

Regenerated from the source data rather than hand-edited. `go test ./... -count=1` clean. No cell other than the three changed.
