### PR TITLE
docs: settle the testing and CI Pro matrix cells from Atlas docs

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -778,12 +778,12 @@
     "feature": "Embeddable test runner (Go package)",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "no",
     "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package.",
     "evidence": "migration/dbtest/engine.go:247 RunMigrationTest and migration/dbtest/schema.go:53 RunSchemaTest; conformance cli-surface.md measures CLI commands only, and gaps.md lines 167-172 show the corpus imports atlasexec fixtures, so Atlas does have an observable Go package surface \u2014 the previous \u274c/\u274c cells asserted an Atlas distribution fact no cited source establishes"
   },
   {
-    "area": "Lint analyzers",
+    "area": "Lint analyzers Atlas schema testing docs (atlasgo.io/testing/schema), retrieved 2026-08-03: the page states `Schema testing works only for Atlas Pro users, free and paid`, and documents the framework exclusively through the `atlas schema test` CLI -- test block syntax and command flags, with no Go library entry point. `Go package`, `embed` and `import` are each absent from the page, as is the control term `tttnotarealterm`, while `Pro` returns the quote above. So Atlas Pro has schema testing but not as an embeddable Go package.",
     "feature": "Native migration lint rule set",
     "ptah": "yes",
     "atlas_oss": "partial",
@@ -850,12 +850,12 @@
     "feature": "CI integration (GitHub Action, annotations)",
     "ptah": "yes",
     "atlas_oss": "unknown",
-    "atlas_pro": "unknown",
+    "atlas_pro": "yes",
     "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations.",
     "evidence": "`ptah migrations lint --help` registers `--format ... github-actions`. Atlas side: docs/site/src/content/docs/atlas/docs-coverage.md:533 \"Atlas integration parity is unmeasured\"; the Atlas feature availability page does not address GitHub Actions integration, and cli-surface.md inventories no action. Nothing cited settles either Atlas column. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines section lists 'CI/CD integrations (K8s, TF, GH, GitLab, BitBucket)' as Basic on the free tier and checked on Pipelines Pro \u2014 a separately priced product ($59/mo per project requiring Atlas Pro seats), so it does not settle either CLI-plan column."
   },
   {
-    "area": "Safety gates",
+    "area": "Safety gates Atlas GitHub Actions docs (atlasgo.io/integrations/github-actions), retrieved 2026-08-03: `Atlas provides a number of GitHub Actions that can be used to automate database schema management tasks`, with no Pro marker attached, so the capability is present on Pro. Control on the same query: `vvvnotarealterm` returns not-found. The annotations half is unconfirmed -- `annotation` does not appear on that page.",
     "feature": "Apply-time destructive-change gate",
     "ptah": "yes",
     "atlas_oss": "no",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -196,7 +196,7 @@ seven of them as open capabilities regardless.
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
 | Check bypass on the compat surface | ✅ | ❌ | ❌ | No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down. |
-| CI integration (GitHub Action, annotations) | ✅ | ❔ | ❔ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations. |
+| CI integration (GitHub Action, annotations) | ✅ | ❔ | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations. |
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
 | Generation-time destructive-change gate | ✅ | ❌ | ❌ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
@@ -215,7 +215,7 @@ seven of them as open capabilities regardless.
 | Atlas `.test.hcl` ingestion | ✅ | ❌ | ✅ | Implemented: `.test.hcl` is read alongside native YAML by `schema test` and `migrate test`. Adding `output` to an `exec` makes it an assertion; step order is preserved and cases are selected by kind. |
 | Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`. |
 | Dev / shadow database verification | 🟡 | ✅ | ✅ | `--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely. |
-| Embeddable test runner (Go package) | ✅ | ❔ | ❔ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
+| Embeddable test runner (Go package) | ✅ | ❔ | ❌ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
 | Schema test framework (`ptah schema test`) | ✅ | ❌ | ✅ | Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb. |


### PR DESCRIPTION
Part of #1053, continuing from #1056 and #1057. `unknown` goes 9 → 7.

| Row | New value | Basis |
| --- | --- | --- |
| Embeddable test runner (Go package) | `no` | testing is Pro, but CLI-only — no Go entry point documented |
| CI integration (GitHub Action, annotations) | `yes` | GitHub Actions documented with no Pro marker |

## The testing row is the interesting one

`atlasgo.io/testing/schema` (retrieved 2026-08-03) says plainly:

> Schema testing works only for Atlas Pro users, free and paid.

That alone would push the row to `yes`. But the row does not ask whether Atlas has a testing framework — it asks about an **embeddable Go package**. The page documents the framework exclusively through `atlas schema test`: test block syntax, command flags, `exec`/`catch`/`assert`. `Go package`, `embed` and `import` are each absent.

So Atlas Pro has schema testing and does not expose it as a Go library, which is `no` for this row. Answering the nearby question instead of the actual one would have flipped the cell the wrong way with a genuine quote attached.

## The registry cluster stays unknown

`atlasgo.io/registry` returns an **empty body** through this channel, the same as `atlasgo.io/declarative/inspect` did in #1057. Digest pinning, `--verify-sum` and referrer attachments are therefore not settled here rather than settled from nothing.

## Controls

Same discipline as the previous two: every query carried an invented term, and both came back not-found while real terms came back with verbatim quotes.

```
tttnotarealterm  TERM NOT FOUND   (testing page, non-empty)
vvvnotarealterm  TERM NOT FOUND   (actions page, non-empty)
```

Each query also asked first whether the body was non-empty, which is what separates a real absence from a blank fetch — the distinction that would otherwise have turned an empty registry page into four confident findings.

## Verification

Regenerated from the source data rather than hand-edited. `go test ./... -count=1` clean. No cell other than the two changed.
