### PR TITLE
fix: make compat migrate down non-interactive

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -310,10 +310,13 @@ func atlasMigrateDownVerb() atlasVerb {
 		// An Atlas-surface verb defaults to Atlas revision bookkeeping, like
 		// `migrate set` above: without this prefix the native --revision-format
 		// default of "ptah" silently no-ops against the atlas_schema_revisions
-		// rows `atlas migrate apply` writes. User args are appended after the
-		// prefix, so an explicit native `--revision-format ptah` pass-through
-		// still overrides it (pflag keeps the last value).
-		prefixArgs:          []string{"--revision-format", "atlas"},
+		// rows `atlas migrate apply` writes. --confirm suppresses the native
+		// safety prompt because Atlas migrate down executes non-interactively.
+		// User args are appended after the prefix, so an explicit native
+		// `--revision-format ptah` pass-through still overrides the format
+		// default (pflag keeps the last value).
+		prefixArgs:          []string{"--revision-format", "atlas", "--confirm"},
+		nativeOnlyFlags:     []string{"confirm"},
 		nativeProjectConfig: true,
 		flags: []atlasargs.Flag{
 			atlasargs.NativeString("url", "u", "Database URL", "db-url"),

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -96,7 +96,6 @@ type atlasMigrateDownFormatOptions struct {
 	revisionsSchema string
 	lockTimeout     string
 	dryRun          bool
-	confirm         bool
 
 	flagSet *pflag.FlagSet
 	// rawDir preserves the pre-resolution --dir value for the report's Env.Dir.
@@ -194,16 +193,6 @@ func runAtlasMigrateDownFormat(
 		}
 	}
 
-	if !opts.dryRun && !opts.confirm && !plan.Noop() {
-		confirmed, err := confirmAtlasMigrateDownFormat(cmd, plan)
-		if err != nil {
-			return err
-		}
-		if !confirmed {
-			return nil
-		}
-	}
-
 	result, execErr := plan.Execute(cmd.Context())
 	writeErr := atlasreport.WriteMigrateDownFormat(cmd.OutOrStdout(), opts.format, atlasreport.MigrateDownResultOptions{
 		Driver:           conn.Info().Dialect,
@@ -233,10 +222,11 @@ func runAtlasMigrateDownFormat(
 // parseAtlasMigrateDownFormatArgs parses the Atlas down flag surface for the
 // format path. The default output path forwards unrecognized flags to the
 // native command; the format path executes directly, so an unrecognized flag
-// fails loudly here instead of being silently dropped. The native --confirm
-// flag is accepted because it reaches the native command through the default
-// path's pass-through and is the only non-interactive confirmation.
+// fails loudly here instead of being silently dropped.
 func parseAtlasMigrateDownFormatArgs(verb atlasVerb, args []string) (*atlasMigrateDownFormatOptions, error) {
+	if err := rejectNativeOnlyAtlasFlags("migrate", verb, args); err != nil {
+		return nil, err
+	}
 	opts := &atlasMigrateDownFormatOptions{}
 	var toTag string
 	var skipChecks, forcePlan bool
@@ -253,7 +243,6 @@ func parseAtlasMigrateDownFormatArgs(verb atlasVerb, args []string) (*atlasMigra
 	flagSet.StringVar(&opts.lockTimeout, "lock-timeout", "", "")
 	flagSet.BoolVar(&skipChecks, "skip-checks", false, "")
 	flagSet.BoolVar(&forcePlan, "plan", false, "")
-	flagSet.BoolVar(&opts.confirm, "confirm", false, "")
 	if err := flagSet.Parse(args); err != nil {
 		return nil, fmt.Errorf("atlas migrate down: %w", err)
 	}
@@ -452,28 +441,4 @@ func parseAtlasMigrateDownTarget(value string) (int64, error) {
 		return 0, fmt.Errorf("--to-version must be greater than or equal to zero")
 	}
 	return target, nil
-}
-
-// confirmAtlasMigrateDownFormat asks for the same YES confirmation the native
-// down command requires, on stderr so the rendered report stays alone on
-// stdout. A declined confirmation cancels without writing a report.
-func confirmAtlasMigrateDownFormat(cmd *cobra.Command, plan atlasmigrate.DownPlan) (bool, error) {
-	prompt := cmd.ErrOrStderr()
-	fmt.Fprintln(prompt, "⚠️  WARNING: Rolling back migrations can result in data loss!")
-	fmt.Fprintf(prompt, "This will roll back the database from version %d to version %d.\n", plan.CurrentVersion, plan.TargetVersion)
-	if len(plan.PlannedVersions) > 0 {
-		fmt.Fprintf(prompt, "The following %d migration(s) will be rolled back: %v\n", len(plan.PlannedVersions), plan.PlannedVersions)
-	}
-	fmt.Fprint(prompt, "Are you sure you want to continue? Type 'YES' to confirm: ")
-
-	var confirmation string
-	if _, err := fmt.Fscan(cmd.InOrStdin(), &confirmation); err != nil {
-		return false, fmt.Errorf("read rollback confirmation: %w", err)
-	}
-	if confirmation != "YES" {
-		fmt.Fprintln(prompt, "Migration rollback canceled.")
-		return false, nil
-	}
-	fmt.Fprintln(prompt)
-	return true, nil
 }

--- a/cmd/atlas/migrate_down_format_test.go
+++ b/cmd/atlas/migrate_down_format_test.go
@@ -74,10 +74,11 @@ func TestCompatCommand_MigrateDownFormatRendersReportAndReverts(t *testing.T) {
 	migrationsDir := filepath.Join(dir, "migrations")
 	dbPath := filepath.Join(dir, "down-format.db")
 	writeMigrateDownFixture(c, migrationsDir, dbPath)
+	t.Setenv("PTAH_CONFIRM", "not-a-boolean")
 
 	cmd := atlas.NewCompatCommand("atlas")
 	var out, errOut bytes.Buffer
-	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetIn(bytes.NewReader(nil))
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{
@@ -91,8 +92,8 @@ func TestCompatCommand_MigrateDownFormatRendersReportAndReverts(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", out.String(), errOut.String()))
-	// The report is alone on stdout; the confirmation prompt went to stderr.
-	c.Assert(errOut.String(), qt.Contains, "Type 'YES' to confirm")
+	// Atlas migrate down does not read stdin or emit a confirmation prompt.
+	c.Assert(errOut.String(), qt.Equals, "")
 	var report migrateDownJSONReport
 	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil, qt.Commentf("stdout=%s", out.String()))
 	c.Assert(report.Driver, qt.Equals, "sqlite")
@@ -193,7 +194,6 @@ func TestCompatCommand_MigrateDownFormatReportsFirstRollbackFailure(t *testing.T
 
 	cmd := atlas.NewCompatCommand("atlas")
 	var out, errOut bytes.Buffer
-	cmd.SetIn(strings.NewReader("YES\n"))
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{
@@ -253,7 +253,6 @@ func TestCompatCommand_MigrateDownFormatDevURLVerifiesThenApplies(t *testing.T) 
 
 	cmd := atlas.NewCompatCommand("atlas")
 	var out, errOut bytes.Buffer
-	cmd.SetIn(strings.NewReader("YES\n"))
 	cmd.SetOut(&out)
 	cmd.SetErr(&errOut)
 	cmd.SetArgs([]string{
@@ -297,8 +296,7 @@ func TestCompatCommand_MigrateDownFormatDevURLFailureAbortsTarget(t *testing.T) 
 
 	err := cmd.Execute()
 
-	// The dev replay fails before the confirmation prompt and before the
-	// target is touched.
+	// The dev replay fails before the target is touched.
 	c.Assert(err, qt.ErrorMatches, `(?s)rollback verification failed: .*no_such_table.*`)
 	c.Assert(out.String(), qt.Equals, "")
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
@@ -314,7 +312,6 @@ func TestCompatCommand_MigrateDownDevURLForwardsToNativeShadowVerification(t *te
 
 	cmd := atlas.NewCompatCommand("atlas")
 	var out bytes.Buffer
-	cmd.SetIn(strings.NewReader("YES\n"))
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
@@ -364,11 +361,12 @@ func TestCompatCommand_MigrateDownDevURLForwardFailureAbortsTarget(t *testing.T)
 }
 
 // TestCompatCommand_MigrateDownDefaultOutputMatchesNativeCommand pins the
-// byte-identity contract: without --format, the wrapped verb forwards to the
-// native `ptah migrations down` and its stdout is exactly the native
-// command's stdout. The native invocation selects --revision-format atlas
-// explicitly because the forward injects that default itself, so both runs
-// perform the same real rollback against the Atlas revision table.
+// byte-identity contract: without --format, the wrapped verb's execution
+// output is exactly the output from a pre-approved native
+// `ptah migrations down` run. The native invocation selects
+// --revision-format atlas explicitly because the forward injects that default
+// itself, so both runs perform the same real rollback against the Atlas
+// revision table.
 func TestCompatCommand_MigrateDownDefaultOutputMatchesNativeCommand(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -387,7 +385,7 @@ func TestCompatCommand_MigrateDownDefaultOutputMatchesNativeCommand(t *testing.T
 	atlasOut := runDown("atlas-default", func(migrationsDir, dbPath string) (string, error) {
 		cmd := atlas.NewCompatCommand("atlas")
 		var out, errOut bytes.Buffer
-		cmd.SetIn(strings.NewReader("YES\n"))
+		cmd.SetIn(bytes.NewReader(nil))
 		cmd.SetOut(&out)
 		cmd.SetErr(&errOut)
 		cmd.SetArgs([]string{
@@ -403,7 +401,6 @@ func TestCompatCommand_MigrateDownDefaultOutputMatchesNativeCommand(t *testing.T
 	nativeOut := runDown("native-default", func(migrationsDir, dbPath string) (string, error) {
 		cmd := migratedown.NewMigrateDownCommand()
 		var out, errOut bytes.Buffer
-		cmd.SetIn(strings.NewReader("YES\n"))
 		cmd.SetOut(&out)
 		cmd.SetErr(&errOut)
 		cmd.SetArgs([]string{
@@ -411,6 +408,7 @@ func TestCompatCommand_MigrateDownDefaultOutputMatchesNativeCommand(t *testing.T
 			"--migrations-dir", migrationsDir,
 			"--target", "1",
 			"--revision-format", "atlas",
+			"--confirm",
 		})
 		err := cmd.Execute()
 		return strings.ReplaceAll(out.String(), dbPath, "<db>"), err
@@ -432,7 +430,7 @@ func TestCompatCommand_MigrateDownDefaultsToAtlasRevisionFormat(t *testing.T) {
 
 	cmd := atlas.NewCompatCommand("atlas")
 	var out bytes.Buffer
-	cmd.SetIn(strings.NewReader("YES\n"))
+	cmd.SetIn(bytes.NewReader(nil))
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
@@ -445,6 +443,7 @@ func TestCompatCommand_MigrateDownDefaultsToAtlasRevisionFormat(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Not(qt.Contains), "Type 'YES' to confirm")
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_users"), qt.Equals, 1)
 	c.Assert(sqliteAtlasRevisionVersions(c, dbPath), qt.DeepEquals, []string{"1"})
@@ -483,7 +482,7 @@ func TestCompatCommand_MigrateDownRevisionFormatPtahOverridesDefault(t *testing.
 	c.Assert(sqliteAtlasRevisionVersions(c, dbPath), qt.DeepEquals, []string{"1", "2"})
 }
 
-func TestCompatCommand_MigrateDownFormatDeclinedConfirmationWritesNoReport(t *testing.T) {
+func TestCompatCommand_MigrateDownFormatDoesNotTreatStdinAsConfirmation(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	migrationsDir := filepath.Join(dir, "migrations")
@@ -504,12 +503,14 @@ func TestCompatCommand_MigrateDownFormatDeclinedConfirmationWritesNoReport(t *te
 
 	err := cmd.Execute()
 
-	// Declining keeps the native contract: exit 0, nothing reverted, and no
-	// report bytes on stdout.
-	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Equals, "")
-	c.Assert(errOut.String(), qt.Contains, "Migration rollback canceled.")
-	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 1)
+	// Atlas does not consume stdin as a confirmation answer. Even a value that
+	// the native command treats as a decline cannot cancel the compat rollback.
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", out.String(), errOut.String()))
+	var report migrateDownJSONReport
+	c.Assert(json.Unmarshal(out.Bytes(), &report), qt.IsNil)
+	c.Assert(report.Reverted, qt.HasLen, 2)
+	c.Assert(errOut.String(), qt.Equals, "")
+	c.Assert(sqliteTableCount(c, dbPath, "down_fmt_audit"), qt.Equals, 0)
 }
 
 func TestCompatCommand_MigrateDownFormatUsesAtlasProjectConfig(t *testing.T) {
@@ -594,6 +595,11 @@ func TestCompatCommand_MigrateDownFormatValidation(t *testing.T) {
 			want: `atlas migrate down: unknown flag: --pre-down-hook`,
 		},
 		{
+			name: "native_confirmation_flag_rejected",
+			args: []string{"--format", "{{ json . }}", "--confirm"},
+			want: `atlas migrate down does not accept native Ptah flag --confirm`,
+		},
+		{
 			name: "remote_dir_rejected",
 			args: []string{"--format", "{{ json . }}", "--url", "sqlite://x.db", "--dir", "atlas://repo"},
 			want: `atlas migrate down --dir: only local file:// migration directories are supported`,
@@ -612,6 +618,32 @@ func TestCompatCommand_MigrateDownFormatValidation(t *testing.T) {
 			err := cmd.Execute()
 
 			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}
+
+func TestCompatCommand_MigrateDownRejectsNativeConfirmationFlag(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "forward", args: []string{"--confirm"}},
+		{name: "forward_false", args: []string{"--confirm=false"}},
+		{name: "format_false", args: []string{"--format", "{{ json . }}", "--confirm=false"}},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(append([]string{"migrate", "down"}, test.args...))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, `atlas migrate down does not accept native Ptah flag --confirm`)
 		})
 	}
 }

--- a/cmd/atlas/migrate_down_unsupported_env_test.go
+++ b/cmd/atlas/migrate_down_unsupported_env_test.go
@@ -124,7 +124,6 @@ func TestMigrateDownIgnoresTheSkipChecksEnvironmentTwin(t *testing.T) {
 				"--url", "sqlite://" + dbPath,
 				"--dir", "file://" + migrationsDir,
 				"--to-version", "20260801000001",
-				"--confirm",
 			}, tc.pathArgs...)
 
 			out, err := executeAtlasProjectCommand(args...)
@@ -178,7 +177,6 @@ func TestMigrateDownRefusesUnsupportedFlagEnvironmentTwins(t *testing.T) {
 				"migrate", "down",
 				"--url", "sqlite://" + dbPath,
 				"--dir", "file://" + migrationsDir,
-				"--confirm",
 			}, tc.pathArgs...)
 
 			out, err := executeAtlasProjectCommand(args...)
@@ -292,7 +290,6 @@ func TestMigrateDownStillRefusesExplicitUnsupportedFlags(t *testing.T) {
 				"--url", "sqlite://" + dbPath,
 				"--dir", "file://" + migrationsDir,
 				"--to-version", "20260801000001",
-				"--confirm",
 				tc.flag,
 			}, tc.pathArgs...)
 

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -2,6 +2,7 @@ package main_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"io"
 	"os"
@@ -12,11 +13,12 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
-// The Atlas-compatible binary is quiet: the pinned Atlas CE v1.2.0 binary
+// The Atlas-compatible binary is quiet: the pinned Atlas CE v1.3.0 binary
 // writes nothing to stderr for a dry run, and `--format` consumers redirect
 // stderr into stdout (`2>&1 | jq`), which the conformance harness's
 // atlas-cli-report-format probe does. The dry-run revision-state fix
@@ -56,6 +58,46 @@ func applyForReal(c *qt.C, binPath, dbPath, migrationsDir string) {
 	)
 	out, err := run.CombinedOutput()
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+}
+
+func TestCompatBinaryMigrateDownRunsWithEOFStdin(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+	dbPath := filepath.Join(c.TempDir(), "down-eof.db")
+	applyForReal(c, binPath, dbPath, migrationsDir)
+	t.Setenv("PTAH_CONFIRM", "not-a-boolean")
+
+	run := newCompatProcess(binPath,
+		"migrate", "down",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+		"--to-version", "0",
+	)
+	var stdout, stderr bytes.Buffer
+	run.Stdin = bytes.NewReader(nil)
+	run.Stdout = &stdout
+	run.Stderr = &stderr
+
+	err := run.Run()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", stdout.String(), stderr.String()))
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "Type 'YES' to confirm")
+	c.Assert(stderr.String(), qt.Contains, "All migrations rolled back successfully")
+	c.Assert(stderr.String(), qt.Not(qt.Contains), "Type 'YES' to confirm")
+	c.Assert(stderr.String(), qt.Not(qt.Contains), "read rollback confirmation")
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	row := conn.QueryRowContext(context.Background(),
+		`SELECT COUNT(*) FROM sqlite_schema WHERE type = 'table' AND name = 'quiet_users'`)
+	var tableCount int
+	c.Assert(row.Scan(&tableCount), qt.IsNil)
+	c.Assert(tableCount, qt.Equals, 0)
+	row = conn.QueryRowContext(context.Background(), `SELECT COUNT(*) FROM atlas_schema_revisions`)
+	var revisionCount int
+	c.Assert(row.Scan(&revisionCount), qt.IsNil)
+	c.Assert(revisionCount, qt.Equals, 0)
 }
 
 // assertSingleJSONDocument asserts that combined holds exactly one JSON

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -64,11 +64,11 @@ The Atlas-compatible test verbs run Ptah-native YAML/Go test cases; Atlas
 
 **Native Ptah.** `ptah migrations down --shadow-db` replays the rollback plan on a disposable shadow database before the target is touched.
 
-**Atlas-compatible Ptah surface.** `ptah-compat migrate down --dev-url` maps to the shadow verification, and `--format` renders an Atlas Go-template down report (`.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, `.Error`); the forward defaults to Atlas revision bookkeeping (`--revision-format atlas`, like `migrate set`), with the native `--revision-format ptah` pass-through as the escape hatch; the registry-bound `--to-tag`, `--skip-checks`, and `--plan` flags are recorded waivers that fail loudly with their rationale.
+**Atlas-compatible Ptah surface.** `ptah-compat migrate down --dev-url` maps to the shadow verification, and `--format` renders an Atlas Go-template down report (`.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, `.Error`); real rollbacks never read stdin, matching Atlas, while native `ptah migrations down` keeps its prompt; the forward defaults to Atlas revision bookkeeping (`--revision-format atlas`, like `migrate set`), with the native `--revision-format ptah` pass-through as the escape hatch; the registry-bound `--to-tag`, `--skip-checks`, and `--plan` flags are recorded waivers that fail loudly with their rationale.
 
 **Atlas CE.** `migrate down` does not exist in the community binary; the CE notice lists down migrations among excluded features.
 
-**Evidence.** Unit tests over live SQLite cover verification success and pre-target abort on both paths, report rendering (including partial-failure reports), the waiver rejections, a byte-identity regression pinning the default forward output to the native command's output, and revision-format regressions proving a bare `ptah-compat migrate down` reverts revisions written by `ptah-compat migrate apply` while an explicit ptah override leaves them untouched.
+**Evidence.** Unit tests over live SQLite cover verification success and pre-target abort on both paths, report rendering (including partial-failure reports), waiver rejections, non-interactive execution with EOF stdin, rejection of the non-Atlas `--confirm` flag, byte-identical execution output against a pre-approved native run, and revision-format regressions proving a bare `ptah-compat migrate down` reverts revisions written by `ptah-compat migrate apply` while an explicit ptah override leaves them untouched. A subprocess test runs the built `ptah-compat` binary with EOF stdin and checks the SQLite end state.
 
 
 ### Pre-approved declarative plans

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -71,7 +71,7 @@ behavior such as migration apply, the license notice, or schema formatting.
 | `ptah-compat version` | `ptah version` |
 | `ptah-compat license` | Ptah license notice |
 | `ptah-compat migrate apply` | Atlas-format apply path equivalent to `ptah migrations up` |
-| `ptah-compat migrate down` | `ptah migrations down`; with `--format`, an Atlas Go-template down report over the same rollback engine (prompt on stderr, report on stdout, same success/failure codes) |
+| `ptah-compat migrate down` | Non-interactive rollback through the same engine as `ptah migrations down`; with `--format`, an Atlas Go-template down report (no confirmation prompt, same success/failure codes) |
 | `ptah-compat migrate diff` | Atlas-style migration diff from a supported desired schema source, `atlas.sum` update, or dry-run output printed |
 | `ptah-compat migrate import` | Import local migrations into a separate directory and write `atlas.sum` |
 | `ptah-compat migrate status` | Atlas-format migration status with Atlas revision-table metadata |

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -252,7 +252,7 @@ Docker dev databases remain a gap.
 
 `ptah-compat migrate new --edit` opens the created migration file in the same editor and refreshes `atlas.sum`. `ptah-compat migrate edit`, `rebase`, and `rm` forward to the native `ptah migrations edit`, `rebase`, and `rm` directory-maintenance commands with Atlas-shaped `--dir`/`--dir-format` flags and `{name | version}` positionals.
 
-`ptah-compat migrate down` forwards to Ptah's pre-planned down-file rollback path, maps Atlas-compatible flags whose behavior matches native Ptah behavior, and fails explicitly for Atlas dynamic down-planning and output-format behavior that is not implemented yet.
+`ptah-compat migrate down` executes Ptah's pre-planned down-file rollback path, maps Atlas-compatible flags, and renders Atlas Go-template reports with `--format`. Dynamic down planning remains a recorded gap and fails explicitly.
 
 `ptah-compat migrate import` imports local `file://` directories from Atlas-supported formats into a separate Atlas single-file directory and writes `atlas.sum`, but rejects Flyway repeatable migrations until Ptah can execute Atlas R-suffixed imported migrations.
 
@@ -626,7 +626,7 @@ tracked. This table is the index; the sections carry the boundary detail.
 
 The forward defaults to Atlas revision bookkeeping (`--revision-format atlas`, like `migrate set`), so a bare invocation reverts the revisions `ptah-compat migrate apply` wrote; the native `--revision-format ptah` pass-through selects ptah bookkeeping.
 
-`--dev-url` replays and verifies the rollback plan on the dev database before the target is touched (the native `ptah migrations down --shadow-db` verification), and `--format` renders an Atlas Go-template report over `.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, and `.Error` with the confirmation prompt on stderr.
+`--dev-url` replays and verifies the rollback plan on the dev database before the target is touched (the native `ptah migrations down --shadow-db` verification), and `--format` renders an Atlas Go-template report over `.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, and `.Error`. Both output paths start real rollbacks without reading stdin, matching Atlas; native `ptah migrations down` keeps its confirmation prompt.
 
 The registry-bound `--to-tag`, `--skip-checks`, and `--plan` flags are recorded waivers that fail loudly with their rationale.
 

--- a/docs/site/src/content/docs/atlas/conformance.md
+++ b/docs/site/src/content/docs/atlas/conformance.md
@@ -92,11 +92,11 @@ are triaged in the comparison gap register rather than measured here.
 
 **Native Ptah.** `ptah migrations down --shadow-db` replays the rollback plan on a disposable shadow database before the target is touched
 
-**Atlas-compatible Ptah surface.** `ptah-compat migrate down --dev-url` maps to the shadow verification, and `--format` renders an Atlas Go-template down report (`.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, `.Error`); the forward defaults to Atlas revision bookkeeping (`--revision-format atlas`) with the native `--revision-format ptah` pass-through as the escape hatch; `--to-tag`, `--skip-checks`, and `--plan` are recorded registry-bound waivers that fail loudly.
+**Atlas-compatible Ptah surface.** `ptah-compat migrate down --dev-url` maps to the shadow verification, and `--format` renders an Atlas Go-template down report (`.Env`, `.Planned`, `.Reverted`, `.Current`, `.Target`, `.Total`, `.Error`); real rollbacks never read stdin, matching Atlas, while native `ptah migrations down` keeps its prompt; the forward defaults to Atlas revision bookkeeping (`--revision-format atlas`) with the native `--revision-format ptah` pass-through as the escape hatch; `--to-tag`, `--skip-checks`, and `--plan` are recorded registry-bound waivers that fail loudly.
 
 **Atlas CE.** `migrate down` does not exist in the community binary; the CE notice lists down migrations among excluded features
 
-**Evidence.** Unit coverage over live SQLite: verification success and pre-target abort on both paths, report rendering including partial-failure reports, waiver rejections, a byte-identity regression pinning the default forward output to the native command, and revision-format regressions proving a bare `ptah-compat migrate down` reverts revisions written by `ptah-compat migrate apply`
+**Evidence.** Unit coverage over live SQLite: verification success and pre-target abort on both paths, report rendering including partial-failure reports, waiver rejections, non-interactive execution with EOF stdin, rejection of the non-Atlas `--confirm` flag, byte-identical execution output against a pre-approved native run, and revision-format regressions proving a bare `ptah-compat migrate down` reverts revisions written by `ptah-compat migrate apply`. A subprocess test runs the built `ptah-compat` binary with EOF stdin and checks the SQLite end state
 
 
 ### Pre-approved declarative plans

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -119,8 +119,8 @@ Status: Database is up to date
 ```
 
 Roll back using the `down.sql` section. A bare `ptah-compat migrate down` reads
-the Atlas revision rows `migrate apply` wrote, and asks for a `YES`
-confirmation before touching the database (`--dry-run` skips both):
+the Atlas revision rows `migrate apply` wrote and starts the rollback without
+reading stdin:
 
 ```bash
 ptah-compat migrate down \
@@ -135,6 +135,10 @@ Expected output ends with:
 ✅ Migration rollback completed successfully!
 Database is now at version: 0
 ```
+
+Review the URL, migration directory, and target before running the command.
+The Atlas-compatible surface has no confirmation prompt and does not accept
+the native `--confirm` flag. Native `ptah migrations down` keeps its prompt.
 
 Ptah validates every selected down body before rollback starts. If one is
 missing, the command leaves both the schema and Atlas revision rows unchanged.

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -193,11 +193,16 @@ Forwards to `ptah migrations down` with mapped Atlas flags.
 | Flag | Behavior |
 | --- | --- |
 | `--dev-url` | Replays and verifies the rollback plan on the dev database before the target is touched (native `--shadow-db`). |
-| `--format` | Flag or `PTAH_FORMAT`; renders an Atlas Go-template report with the `YES` confirmation prompt on stderr. `--dry-run` and the native `--confirm` pass-through skip the prompt. |
+| `--format` | Flag or `PTAH_FORMAT`; renders an Atlas Go-template report. Real and dry-run rollbacks are non-interactive. |
 | `--revision-format` | Defaults to `atlas`, like `migrate set`. The native `ptah` pass-through selects ptah bookkeeping. |
 
 Because the forward defaults to Atlas revision bookkeeping, a bare invocation
 reverts the revisions `ptah-compat migrate apply` wrote.
+
+The command starts a real rollback without reading stdin, matching Atlas. It
+does not accept the native `--confirm` flag. Review `--url`, `--dir`, and
+`--to-version` before running it. Native `ptah migrations down` keeps its
+interactive confirmation.
 
 The registry-bound `--to-tag`, `--skip-checks`, and `--plan` flags are recorded
 waivers that fail loudly with their rationale. `--to-tag` and `--plan` are also

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -87,7 +87,7 @@ behavior such as migration apply, the license notice, or schema formatting.
 | `ptah-compat version` | `ptah version` |
 | `ptah-compat license` | Ptah license notice |
 | `ptah-compat migrate apply` | Atlas-format apply path equivalent to `ptah migrations up` |
-| `ptah-compat migrate down` | `ptah migrations down`; with `--format`, an Atlas Go-template down report over the same rollback engine (prompt on stderr, report on stdout, same success/failure codes) |
+| `ptah-compat migrate down` | Non-interactive rollback through the same engine as `ptah migrations down`; with `--format`, an Atlas Go-template down report (no confirmation prompt, same success/failure codes) |
 | `ptah-compat migrate diff` | Atlas-style migration diff from a supported desired schema source, `atlas.sum` update, or dry-run output printed |
 | `ptah-compat migrate import` | Import local migrations into a separate directory and write `atlas.sum` |
 | `ptah-compat migrate status` | Atlas-format migration status with Atlas revision-table metadata |

--- a/docs/site/src/content/docs/versioned/rollback.md
+++ b/docs/site/src/content/docs/versioned/rollback.md
@@ -48,6 +48,10 @@ run without confirmation aborts with
 `error: read rollback confirmation: EOF`. Pass `--confirm` to skip the prompt
 — only in scripts where the target and blast radius are already reviewed.
 
+This confirmation belongs only to the native command. The Atlas-compatible
+`ptah-compat migrate down` matches Atlas by starting a real rollback without
+reading stdin; it does not accept `--confirm`.
+
 Verify with status: the rolled-back version moves from applied back to
 pending.
 


### PR DESCRIPTION
Closes #971.

## What changed

- make both default and `--format` `ptah-compat migrate down` paths execute without reading stdin, matching Atlas
- keep the native `ptah migrations down` confirmation prompt unchanged
- reject the native-only `--confirm` flag instead of exposing a non-Atlas compatibility surface
- add an actual-binary EOF regression test that verifies both the SQLite schema end state and cleared Atlas revision state
- document the non-interactive compatibility behavior and its safety boundary

## Verification

- `GOWORK=off go test -race ./... -timeout 10m`
- `golangci-lint run --timeout=30m ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- complete docs-site pipeline: links, redirects, page health, exit-code references, style, production build, responsive checks, and npm audit

The full race suite was also rerun outside the sandbox because several existing tests require package-local temporary files and localhost listeners.
