### PR TITLE
docs: settle two more Pro matrix cells from Atlas's CLI reference

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1093,12 +1093,12 @@
     "feature": "Artifact integrity check (`--verify-sum`)",
     "ptah": "partial",
     "atlas_oss": "na",
-    "atlas_pro": "unknown",
+    "atlas_pro": "no",
     "note": "On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes.",
     "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'"
   },
   {
-    "area": "OCI artifacts",
+    "area": "OCI artifacts Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `--verify-sum` does not appear on the page, which enumerates every command and its flags. Scoped to the flag: Atlas's directory-integrity mechanism is atlas.sum with `migrate validate`, which checks a migration directory rather than an artifact against a sum embedded in it. Control as above.",
     "feature": "Referrer attachments: lint, plan, deployment reports",
     "ptah": "partial",
     "atlas_oss": "no",
@@ -1291,12 +1291,12 @@
     "feature": "Standalone SQL file linting (`ptah sql lint`)",
     "ptah": "yes",
     "atlas_oss": "no",
-    "atlas_pro": "unknown",
+    "atlas_pro": "no",
     "note": "Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not.",
     "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based. no standalone SQL-file lint verb; `atlas schema lint` exists but lints schema sources, a different mechanism (measured; observation study, scenario, lint-test-pro, ptah-extension-equivalents)"
   },
   {
-    "area": "Declarative and direct schema changes",
+    "area": "Declarative and direct schema changes Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: no `sql lint` command exists. The two lint verbs take other inputs -- `atlas schema lint` is documented as `Run schema linting` with `-u, --url strings  schema URL(s) to lint`, and `atlas migrate lint` analyzes a migration directory. Asked directly, no command on the reference accepts arbitrary SQL files or stdin for linting. Control on the same query: `rrrnotarealflag` returns not-found while `--exclude` returns its description verbatim.",
     "feature": "JSON output for native schema diff",
     "ptah": "yes",
     "atlas_oss": "unknown",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -79,9 +79,9 @@ Across the 159 capabilities below:
 | Ptah does not implement it | 24 |
 | Ptah and Atlas CE both support it | 24 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 37 |
-| Ptah has it and neither Atlas edition does | 15 |
+| Ptah has it and neither Atlas edition does | 16 |
 | Atlas CE has it and Ptah does not, or only in part | 24 |
-| An Atlas column is ❔ — not established by this page's evidence | 23 |
+| An Atlas column is ❔ — not established by this page's evidence | 21 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
 binary built from this repository; Atlas-column verdicts rest on the cited
@@ -205,7 +205,7 @@ seven of them as open capabilities regardless.
 | Per-rule severity policy | 🟡 | ❔ | 🟡 | Severity vocabulary is warning\|error only (info errors out). Measured, Atlas is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist. |
 | Pre-migration assertion checks | 🟡 | ❌ | ✅ | Scalar SELECTs; txtar checks.sql and checks/*.sql support all-of/oneof groups. CE ignores checks. Compat bypass is PTAH_SKIP_CHECKS. |
 | SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
-| Standalone SQL file linting (`ptah sql lint`) | ✅ | ❌ | ❔ | Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not. |
+| Standalone SQL file linting (`ptah sql lint`) | ✅ | ❌ | ❌ | Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not. |
 | Statement safety classification report | ✅ | ➖ | ➖ | plan `--report` text\|html\|json and generate `--report` html\|json emit highest severity, a destructive flag, and per-statement assessments. |
 
 ## Testing
@@ -293,7 +293,7 @@ control — come from the registry, not from Ptah. The full workflow is on
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Artifact integrity check (`--verify-sum`) | 🟡 | ➖ | ❔ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
+| Artifact integrity check (`--verify-sum`) | 🟡 | ➖ | ❌ | On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes. |
 | Declarative reference data | ✅ | ❌ | ✅ | //ptah:schema:data rows diffed by key into a reversible data migration. Atlas lists declarative data management as a Pro feature. |
 | Digest pinning and write-once version tags | ✅ | ➖ | ❔ | Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move. |
 | Environment-scoped SQL seed runner | ✅ | ❌ | ❌ | NNN_desc.env.sql files recorded in schema_seeds with protected-env gates. No seed verb in the CE inventory or the cited Pro list. |


### PR DESCRIPTION
Part of #1053, continuing from #1056, #1057 and #1058. `unknown` goes 7 → 5.

| Row | New value | Basis |
| --- | --- | --- |
| Standalone SQL file linting (`ptah sql lint`) | `no` | no `sql lint` command; neither lint verb takes SQL files or stdin |
| Artifact integrity check (`--verify-sum`) | `no` | flag absent from a reference that enumerates every command and flag |

Source is Atlas's CLI reference (`atlasgo.io/cli-reference`), retrieved 2026-08-03.

## Why the lint row needed a second query

The first pass found no `sql lint` command, which looks conclusive. It is not: the same page lists `atlas schema lint`, and an equivalent under a different name would make `no` wrong.

So the follow-up asked what `schema lint` actually accepts:

> `Run schema linting` — `-u, --url strings   schema URL(s) to lint`

Schema URLs, not SQL files. `migrate lint` analyzes a migration directory. Asked directly whether *any* command on the reference accepts arbitrary SQL files or stdin for linting, the answer was none. That is what makes the cell `no` rather than "no command with that exact name".

## The `--verify-sum` cell is scoped to the flag

It does not appear on a page that enumerates every command and its flags, which is decent evidence of absence. The cell says so and states the boundary: Atlas's integrity mechanism is `atlas.sum` with `migrate validate`, which checks a **migration directory**, not an artifact against a sum embedded in it. Those are different things, so this is not a claim that Atlas has no integrity checking.

## What stayed unknown, and why one of them nearly did not

Five remain: digest pinning, referrer attachments, the two `--exclude` rows, and `--atlas-env`.

`--exclude` was tempting. The reference documents it as `list of glob patterns used to filter resources from applying`, with no bracketed selector example — which reads like evidence that Atlas has no field selectors. It is not. A terse one-line flag summary in a reference is not an enumeration of accepted syntax, and treating its brevity as an absence would be the same error as reading a blank page as a set of not-founds. Both `--exclude` rows stay `unknown`.

The registry rows stay `unknown` because `atlasgo.io/registry` returns an empty body through this channel.

## Controls

`rrrnotarealflag` returned not-found while `--exclude` returned its description verbatim, on the same query — so the page was read, not reconstructed.

## Verification

Regenerated from the source data rather than hand-edited. `go test ./... -count=1` clean. No cell other than the two changed.
