### PR TITLE
ci: run every documented install command on a schedule

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -1,0 +1,44 @@
+name: Install Smoke
+
+# Runs the `go install` commands the documentation publishes, against the
+# published module, and fails when any of them stops producing a working binary.
+#
+# This exists because those commands were broken and nothing noticed: the vanity
+# host answered the Go toolchain with a redirect loop, every documented install
+# failed, and no job ran one. See stokaro/ptah#1024.
+#
+# It is deliberately NOT a pull-request gate. It resolves go.5x5.cz and the
+# module proxy, so a network or host problem would turn unrelated PRs red and
+# train people to ignore it. A schedule catches a broken host within the day,
+# which is what the failure it guards against actually needs.
+on:
+  schedule:
+    - cron: "17 6 * * *"
+  workflow_dispatch:
+  push:
+    branches:
+      - master
+    paths:
+      - "scripts/check-documented-install.sh"
+      - ".github/workflows/install-smoke.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  documented-install:
+    name: Documented install commands
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: false
+
+      # The published module is the subject, so the checkout is used only to
+      # discover which commands the documentation currently publishes.
+      - name: Run every documented install command
+        run: scripts/check-documented-install.sh

--- a/scripts/check-documented-install.sh
+++ b/scripts/check-documented-install.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# Runs every `go install` command the documentation publishes, and fails if any
+# of them does not produce a working binary.
+#
+# The commands are discovered from the tracked files rather than listed here, so
+# a newly documented install command is covered the day it is written instead of
+# the day someone remembers to add it.
+#
+# Discovery failing closed is the point of MIN_EXPECTED. A grep that silently
+# matches nothing would make this script exit 0 while testing nothing at all,
+# which is the failure mode it exists to prevent -- the documented commands were
+# broken for days precisely because no job ran them.
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+readonly MIN_EXPECTED=2
+
+# A read loop rather than mapfile: mapfile is bash 4+, and the bash shipped on
+# macOS is 3.2, so a developer running this locally would otherwise get
+# "command not found" and, because it sits in a pipeline, a zero exit status.
+commands=()
+while IFS= read -r line; do
+	commands+=("$line")
+done < <(
+	git grep -hoE 'go install go\.5x5\.cz/ptah/cmd/[a-z-]+@latest' -- \
+		'*.md' '*.mdx' '*.yml' '*.yaml' '*.sh' |
+		sort -u
+)
+
+if [ "${#commands[@]}" -lt "$MIN_EXPECTED" ]; then
+	echo "install-smoke: found ${#commands[@]} documented install command(s), expected at least $MIN_EXPECTED" >&2
+	echo "install-smoke: either the docs changed shape or the pattern stopped matching; refusing to pass without testing anything" >&2
+	exit 1
+fi
+
+bindir="$(mktemp -d)"
+trap 'rm -rf "$bindir"' EXIT
+
+echo "install-smoke: ${#commands[@]} documented command(s)"
+failed=0
+
+for command in "${commands[@]}"; do
+	binary="${command#go install go.5x5.cz/ptah/cmd/}"
+	binary="${binary%@latest}"
+
+	echo "-- $command"
+	if ! GOBIN="$bindir" GOFLAGS= $command; then
+		echo "install-smoke: FAILED to install $binary" >&2
+		failed=1
+		continue
+	fi
+
+	# Installing is not enough: a vanity-host or module problem can still leave a
+	# binary that cannot run, so the installed program has to say something.
+	#
+	# No single spelling works for all of them, measured on v0.2.0:
+	#
+	#   ptah          version -> "Version: ..."   --version -> "ptah version ..."
+	#   ptah-compat   version -> "Version: ..."   --version -> unknown flag
+	#   ptah-ls       version -> empty, exit 0    --version -> "Version: ..."
+	#
+	# So both are tried and the answer must be NON-EMPTY. Exit status alone would
+	# pass ptah-ls without it having said anything, which is the exact shape of
+	# failure this script exists to catch. The inconsistency itself is tracked
+	# separately in stokaro/ptah#1064; this check does not depend on it being
+	# resolved.
+	#
+	# stdin is closed because one of these binaries is a language server, and a
+	# check that can block forever is not a check. The `|| true` keeps a failing
+	# spelling from aborting the script under `set -e` before it can report.
+	reported="$("$bindir/$binary" version </dev/null 2>/dev/null | head -1 || true)"
+	if [ -z "$reported" ]; then
+		reported="$("$bindir/$binary" --version </dev/null 2>/dev/null | head -1 || true)"
+	fi
+	if [ -z "$reported" ]; then
+		echo "install-smoke: $binary installed but neither 'version' nor '--version' printed anything" >&2
+		failed=1
+		continue
+	fi
+	echo "   ok: $reported"
+done
+
+if [ "$failed" -ne 0 ]; then
+	echo "install-smoke: at least one documented install command is broken" >&2
+	exit 1
+fi
+
+echo "install-smoke: every documented install command works"


### PR DESCRIPTION
Part of #1024. The host half of that issue is already fixed — this is the half that makes the next breakage visible.

## State of #1024, measured

The vanity host now behaves. `https://go.5x5.cz/ptah?go-get=1` returns **200 with no redirects** and serves the tag the toolchain needs:

```
go-import" content="go.5x5.cz/ptah git https://github.com/stokaro/ptah"
```

All three documented commands install and run:

```
-- go install go.5x5.cz/ptah/cmd/ptah-compat@latest    ok: Version: v0.2.0
-- go install go.5x5.cz/ptah/cmd/ptah-ls@latest        ok: Version: v0.2.0
-- go install go.5x5.cz/ptah/cmd/ptah@latest           ok: Version: v0.2.0
```

The remaining half of the issue was "no CI job runs any of them", which was still true: no workflow referenced `go install go.5x5.cz/...`.

## Commands are discovered, not listed

The script greps the tracked docs for the commands rather than hard-coding them, so a newly documented install is covered the day it is written instead of the day someone remembers.

That makes the discovery itself a failure mode, so it fails closed. A grep that silently matched nothing would exit 0 having tested nothing — the exact shape of the problem this guards against. `MIN_EXPECTED` refuses to pass in that case.

## The liveness check needed real measurement

The first version checked exit status of the `version` subcommand. That passes `ptah-ls` while proving nothing, because no single spelling works across the binaries:

| Binary | `version` | `--version` |
| --- | --- | --- |
| `ptah` | `Version: v0.2.0` | `ptah version v0.2.0` |
| `ptah-compat` | `Version: v0.2.0` | `error: unknown flag` |
| `ptah-ls` | **empty, exit 0** | `Version: v0.2.0` |

So the check tries both and requires **non-empty** output. The inconsistency itself is filed as #1064; this job does not depend on it being resolved.

Two smaller things the same run surfaced: `mapfile` is bash 4+ and macOS ships 3.2, so a local run printed `command not found` and — being in a pipeline — reported success; and a failing command substitution under `set -e` aborted the script before its own diagnostic could print. Both are fixed and commented.

## Why it is not a pull-request gate

It resolves `go.5x5.cz` and the module proxy. As a PR gate, a network or host problem would turn unrelated PRs red, and a gate that is red for reasons unrelated to the change is one people learn to ignore. A daily schedule catches a broken host within the day, which is what this failure actually needs. `workflow_dispatch` is there for an immediate check.

## Verified by breaking it

Running it and seeing green is not evidence, so both failure paths were exercised:

```
discovery pattern matched nothing
  -> found 0 documented install command(s), expected at least 2
  -> refusing to pass without testing anything          [exit 1]

unresolvable command added to the install page
  -> 4 documented command(s)
  -> FAILED to install nosuchbinary                     [exit 1]
```

The second also confirms discovery genuinely reads the docs: adding one command to a page raised the count from 3 to 4. The scratch edit was reverted.
