### PR TITLE
Reject duplicate test case names when loading

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,6 +63,12 @@ cases:
 Unknown YAML fields are rejected. Multi-document YAML files are supported, and
 all documents contribute cases.
 
+Case names must be unique across the whole test directory, in both formats: a
+name repeated in two files, in two documents of one file, or twice in one
+`cases` list fails the load and names the files that collide. Names are compared
+exactly, so `dup` and `DUP` are distinct — that matches how `--run` selects them,
+since the pattern is applied to the raw name.
+
 ## Assertions
 
 An `assert` step requires `query` and exactly one condition:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -63,11 +63,24 @@ cases:
 Unknown YAML fields are rejected. Multi-document YAML files are supported, and
 all documents contribute cases.
 
-Case names must be unique across the whole test directory, in both formats: a
-name repeated in two files, in two documents of one file, or twice in one
-`cases` list fails the load and names the files that collide. Names are compared
-exactly, so `dup` and `DUP` are distinct — that matches how `--run` selects them,
-since the pattern is applied to the raw name.
+Case names must be unique across everything one run loads: a name repeated in
+two files, in two documents of one file, or twice in one `cases` list fails the
+load. A collision between two files names both of them; a collision inside one
+file names that one.
+
+Comparison removes surrounding whitespace but does not fold case, because that
+is the line the report and `--run` already draw. `dup` and `dup ` collide —
+`--run dup` selects both, and the HTML report renders the two rows identically —
+while `dup` and `DUP` are two distinct cases, since `--run dup` selects only the
+first.
+
+Both commands also read Atlas-format `*.test.hcl` files from `--dir` alongside
+the YAML above. Each `test` block there is labeled with the kind it belongs to,
+and a run loads only blocks of its own kind, so uniqueness is checked over what
+that run actually loads rather than over everything on disk. A directory pairing
+`dup` in `a.yaml` with a `test "migrate" "dup"` block therefore loads clean
+under `ptah schema test`, which never sees the migrate case, and is rejected by
+`ptah migrations test`, which loads both.
 
 ## Assertions
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -69,10 +69,10 @@ load. A collision between two files names both of them; a collision inside one
 file names that one.
 
 Comparison removes surrounding whitespace but does not fold case, because that
-is the line the report and `--run` already draw. `dup` and `dup ` collide —
-`--run dup` selects both, and the HTML report renders the two rows identically —
-while `dup` and `DUP` are two distinct cases, since `--run dup` selects only the
-first.
+is the line `--run` already draws. `--run` is an unanchored regular expression,
+so `--run dup` selects both `dup` and `dup ` — write it expecting one case and
+you silently run two. It selects only the first of `dup` and `DUP`, so those
+stay two distinct cases.
 
 Both commands also read Atlas-format `*.test.hcl` files from `--dir` alongside
 the YAML above. Each `test` block there is labeled with the kind it belongs to,

--- a/migration/dbtest/atlashcl_test.go
+++ b/migration/dbtest/atlashcl_test.go
@@ -235,3 +235,57 @@ func TestLoadCasesOfKind_KindFilterPrecedesUniqueness(t *testing.T) {
 	c.Assert(cases, qt.HasLen, 1)
 	c.Assert(cases[0].Name, qt.Equals, "dup")
 }
+
+// TestLoadCasesOfKind_MigrateKindRejectsWhatSchemaKindAccepts is the other half
+// of the test above, on a byte-identical directory. Checking the post-filter set
+// makes directory validity depend on the kind being loaded, and only pinning the
+// accepting half would leave a reader believing this directory is simply valid.
+// `ptah schema test --dir X` loads it and `ptah migrations test --dir X` refuses
+// it, because only the migrate run loads both cases and only that run has an
+// ambiguity to report.
+func TestLoadCasesOfKind_MigrateKindRejectsWhatSchemaKindAccepts(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: dup\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.test.hcl"),
+		[]byte("test \"migrate\" \"dup\" {\n  migrate {\n    to = \"latest\"\n  }\n}\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindMigrate)
+	c.Assert(err, qt.ErrorMatches, `duplicate test case "dup" in a\.yaml and b\.test\.hcl`)
+}
+
+// TestLoadCasesOfKind_RejectsDuplicateAcrossTwoHCLFiles covers HCL/HCL, the one
+// pairing the issue's definition of done left out. It is the arrangement most
+// exposed to a change in the isAtlasCaseFile routing: were `.test.hcl` files to
+// stop being recognized, the YAML/HCL test would still fail loudly, but a
+// directory of only HCL would quietly load zero cases and report nothing.
+func TestLoadCasesOfKind_RejectsDuplicateAcrossTwoHCLFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.test.hcl"),
+		[]byte("test \"schema\" \"dup\" {\n  exec {\n    sql = \"SELECT 1\"\n  }\n}\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.test.hcl"),
+		[]byte("test \"schema\" \"dup\" {\n  exec {\n    sql = \"SELECT 2\"\n  }\n}\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.ErrorMatches, `duplicate test case "dup" in a\.test\.hcl and b\.test\.hcl`)
+}
+
+// TestLoadCasesOfKind_RejectsDuplicateInOneHCLFile is the HCL counterpart of the
+// per-file path: two same-named blocks in one document are caught by
+// ParseAtlasTestCases and carry that file's prefix, so the union check only ever
+// compares cases that came from different files.
+func TestLoadCasesOfKind_RejectsDuplicateInOneHCLFile(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.test.hcl"),
+		[]byte("test \"schema\" \"dup\" {\n  exec {\n    sql = \"SELECT 1\"\n  }\n}\n"+
+			"test \"schema\" \"dup\" {\n  exec {\n    sql = \"SELECT 2\"\n  }\n}\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.ErrorMatches, `a\.test\.hcl: duplicate test case "dup"`)
+}

--- a/migration/dbtest/atlashcl_test.go
+++ b/migration/dbtest/atlashcl_test.go
@@ -196,3 +196,42 @@ func TestLoadCasesKeepsItsYAMLOnlyContract(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(cases, qt.HasLen, 0)
 }
+
+// TestLoadCasesOfKind_RejectsDuplicateAcrossFormats is the cross-format half of
+// issue #1038. It is a separate code path from the YAML/YAML case: a different
+// parser, reached through the other branch of the isAtlasCaseFile switch, so
+// the YAML/YAML test passing does not imply this one does. Converting a YAML
+// case to `.test.hcl` and leaving the original in place is exactly the mid-
+// migration mistake that made this worth closing.
+func TestLoadCasesOfKind_RejectsDuplicateAcrossFormats(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: dup\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.test.hcl"),
+		[]byte("test \"schema\" \"dup\" {\n  exec {\n    sql = \"SELECT 2\"\n  }\n}\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.ErrorMatches, `duplicate test case "dup" in a\.yaml and b\.test\.hcl`)
+}
+
+// TestLoadCasesOfKind_KindFilterPrecedesUniqueness pins the check to the
+// post-filter set. ParseAtlasTestCases drops blocks of the other kind before
+// returning, so a schema-kind load never sees the `test "migrate"` case and
+// must not report a collision. A fix that scanned raw names out of the files
+// would pass every other test here and fail only this one.
+func TestLoadCasesOfKind_KindFilterPrecedesUniqueness(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: dup\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.test.hcl"),
+		[]byte("test \"migrate\" \"dup\" {\n  migrate {\n    to = \"latest\"\n  }\n}\n"), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCasesOfKind(dir, dbtest.AtlasTestKindSchema)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 1)
+	c.Assert(cases[0].Name, qt.Equals, "dup")
+}

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -202,15 +202,20 @@ func validateCases(cases []Case) error {
 // The two normalizations are not alike, and the difference is measurable rather
 // than a matter of taste:
 //
-//   - `dup` and `dup ` are the same case in every way that the report and the
-//     filter can see. [FilterCases] compiles --run as an unanchored Go regular
-//     expression, so `--run dup` selects both, and [Report.HTML] emits each name
-//     inside `case &ldquo;…&rdquo;`, where a browser collapses the trailing
-//     space and renders the two rows identically. Accepting that pair would
-//     reproduce the exact symptom this check exists to stop.
-//   - `dup` and `DUP` are not. `--run dup` selects only `dup`, and no report
-//     format renders the two alike, so folding here would reject a pair the
-//     filter and the reader both keep apart.
+//   - `dup` and `dup ` are the same case to the one thing that selects cases.
+//     [FilterCases] compiles --run as an unanchored Go regular expression, so
+//     `--run dup` selects both, and a reader who writes that expecting one case
+//     silently runs two. Accepting that pair would reproduce the exact symptom
+//     this check exists to stop.
+//
+//     The reports are not the argument. Measured: [Report.HTML] emits
+//     `case &ldquo;dup &rdquo;`, and a browser collapses runs of whitespace and
+//     the edges of a block, not a single interior space, so the rows are
+//     distinguishable there; the text report escapes the name with %q and shows
+//     it outright.
+//
+//   - `dup` and `DUP` are not. `--run dup` selects only `dup`, so folding here
+//     would reject a pair the filter already keeps apart.
 //
 // Cases are scanned in slice order and the first collision returns, so the
 // reported pair is deterministic. Both loaders sort file names before reading,

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -54,8 +54,9 @@
 //
 // Case names must be unique across everything a single load returns, so a name
 // repeated within one document or across two files in a directory is an error
-// rather than two indistinguishable cases in the report. Names are compared
-// exactly, matching how [FilterCases] applies its pattern to the raw name.
+// rather than two indistinguishable cases in the report. Surrounding whitespace
+// is not significant to that comparison — `dup` and `dup ` collide — but case is,
+// so `dup` and `DUP` are two different cases.
 //
 // # Schema tests
 //
@@ -194,12 +195,22 @@ func validateCases(cases []Case) error {
 }
 
 // validateUniqueCaseNames rejects a repeated case name. origins[i] is the file
-// case i came from, or "" when the cases were authored in Go; a nil origins
-// slice omits the file names from the message entirely.
+// case i came from; a nil origins slice omits the file names from the message
+// entirely, which is how Go-authored cases report a collision.
 //
-// Names are compared exactly: no case folding and no trimming. [FilterCases]
-// matches the raw name with a Go regular expression, so normalizing here would
-// reject pairs that --run still selects separately.
+// Surrounding whitespace is removed before comparing, but case is not folded.
+// The two normalizations are not alike, and the difference is measurable rather
+// than a matter of taste:
+//
+//   - `dup` and `dup ` are the same case in every way that the report and the
+//     filter can see. [FilterCases] compiles --run as an unanchored Go regular
+//     expression, so `--run dup` selects both, and [Report.HTML] emits each name
+//     inside `case &ldquo;…&rdquo;`, where a browser collapses the trailing
+//     space and renders the two rows identically. Accepting that pair would
+//     reproduce the exact symptom this check exists to stop.
+//   - `dup` and `DUP` are not. `--run dup` selects only `dup`, and no report
+//     format renders the two alike, so folding here would reject a pair the
+//     filter and the reader both keep apart.
 //
 // Cases are scanned in slice order and the first collision returns, so the
 // reported pair is deterministic. Both loaders sort file names before reading,
@@ -207,21 +218,45 @@ func validateCases(cases []Case) error {
 func validateUniqueCaseNames(cases []Case, origins []string) error {
 	firstIndex := make(map[string]int, len(cases))
 	for i := range cases {
-		name := cases[i].Name
-		previous, seen := firstIndex[name]
+		key := strings.TrimSpace(cases[i].Name)
+		previous, seen := firstIndex[key]
 		if !seen {
-			firstIndex[name] = i
+			firstIndex[key] = i
 			continue
 		}
-		if previous >= len(origins) || i >= len(origins) {
-			return fmt.Errorf("duplicate test case %q", name)
-		}
-		if origins[previous] == origins[i] {
-			return fmt.Errorf("duplicate test case %q in %s", name, origins[i])
-		}
-		return fmt.Errorf("duplicate test case %q in %s and %s", name, origins[previous], origins[i])
+		return duplicateCaseNameError(cases[previous].Name, cases[i].Name, key, caseOriginClause(origins, previous, i))
 	}
 	return nil
+}
+
+// caseOriginClause renders the clause naming where the colliding pair came
+// from, or "" when origins does not cover them.
+//
+// Only the two-file shape exists. Both loaders validate each file through
+// [ParseCases] or [ParseAtlasTestCases] — each of which runs the same check
+// with nil origins — before concatenating, so a same-origin pair is reported by
+// the per-file path as `a.yaml: duplicate test case "dup"` and never reaches the
+// union check. The bounds guard tests current alone because previous is always
+// the earlier index, so a current within range implies previous is too.
+func caseOriginClause(origins []string, previous, current int) string {
+	if current >= len(origins) {
+		return ""
+	}
+	return fmt.Sprintf(" in %s and %s", origins[previous], origins[current])
+}
+
+// duplicateCaseNameError renders a collision between two case names that share
+// a key. When the raw names are not byte-equal the message quotes both, so a
+// pair that collides only after trimming never reports a name that appears
+// verbatim in neither file.
+func duplicateCaseNameError(first, second, key, origins string) error {
+	if first == second {
+		return fmt.Errorf("duplicate test case %q%s", second, origins)
+	}
+	return fmt.Errorf(
+		"duplicate test case %q%s: %q and %q differ only in surrounding whitespace",
+		key, origins, first, second,
+	)
 }
 
 // validateCasesForRun validates structural case data and run-level defaults.

--- a/migration/dbtest/case.go
+++ b/migration/dbtest/case.go
@@ -52,6 +52,11 @@
 //	          query: SELECT * FROM does_not_exist
 //	          error_contains: does_not_exist
 //
+// Case names must be unique across everything a single load returns, so a name
+// repeated within one document or across two files in a directory is an error
+// rather than two indistinguishable cases in the report. Names are compared
+// exactly, matching how [FilterCases] applies its pattern to the raw name.
+//
 // # Schema tests
 //
 // [RunSchemaTest] reuses the same step and assertion vocabulary but applies a
@@ -184,6 +189,37 @@ func validateCases(cases []Case) error {
 		if err := cases[i].validate(); err != nil {
 			return fmt.Errorf("case %d: %w", i+1, err)
 		}
+	}
+	return validateUniqueCaseNames(cases, nil)
+}
+
+// validateUniqueCaseNames rejects a repeated case name. origins[i] is the file
+// case i came from, or "" when the cases were authored in Go; a nil origins
+// slice omits the file names from the message entirely.
+//
+// Names are compared exactly: no case folding and no trimming. [FilterCases]
+// matches the raw name with a Go regular expression, so normalizing here would
+// reject pairs that --run still selects separately.
+//
+// Cases are scanned in slice order and the first collision returns, so the
+// reported pair is deterministic. Both loaders sort file names before reading,
+// which makes that order stable across runs.
+func validateUniqueCaseNames(cases []Case, origins []string) error {
+	firstIndex := make(map[string]int, len(cases))
+	for i := range cases {
+		name := cases[i].Name
+		previous, seen := firstIndex[name]
+		if !seen {
+			firstIndex[name] = i
+			continue
+		}
+		if previous >= len(origins) || i >= len(origins) {
+			return fmt.Errorf("duplicate test case %q", name)
+		}
+		if origins[previous] == origins[i] {
+			return fmt.Errorf("duplicate test case %q in %s", name, origins[i])
+		}
+		return fmt.Errorf("duplicate test case %q in %s and %s", name, origins[previous], origins[i])
 	}
 	return nil
 }

--- a/migration/dbtest/parse.go
+++ b/migration/dbtest/parse.go
@@ -149,10 +149,19 @@ func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error) {
 			origins = append(origins, name)
 		}
 	}
-	// Checked over the post-filter set: ParseAtlasTestCases has already dropped
-	// the blocks of the other kind, so a `test "migrate"` case never collides
-	// with a same-named YAML case in a schema-kind load. Emitted unwrapped for
-	// the reason given in LoadCases.
+	// Checked over the post-filter set, which makes directory validity depend on
+	// kind. One directory holding `a.yaml: dup` and `b.test.hcl: test "migrate"
+	// "dup"` loads clean for schema and is rejected for migrate:
+	//
+	//	LoadCasesOfKind(dir, AtlasTestKindSchema)  -> err=<nil>, 1 case
+	//	LoadCasesOfKind(dir, AtlasTestKindMigrate) -> duplicate test case "dup" in a.yaml and b.test.hcl
+	//
+	// That asymmetry is the point rather than an oversight. ParseAtlasTestCases
+	// drops the blocks of the other kind, so a schema run never loads the
+	// migrate case: --run selects one case, the report shows one row, and there
+	// is nothing to disambiguate. The migrate run does load both and is exactly
+	// the ambiguity this check exists to reject. Both directions are pinned by
+	// tests. Emitted unwrapped for the reason given in LoadCases.
 	if err := validateUniqueCaseNames(cases, origins); err != nil {
 		return nil, err
 	}

--- a/migration/dbtest/parse.go
+++ b/migration/dbtest/parse.go
@@ -68,6 +68,7 @@ func LoadCases(dir string) ([]Case, error) {
 	sort.Strings(names)
 
 	var cases []Case
+	var origins []string
 	for _, name := range names {
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
@@ -79,6 +80,15 @@ func LoadCases(dir string) ([]Case, error) {
 			return nil, fmt.Errorf("%s: %w", name, err)
 		}
 		cases = append(cases, parsed...)
+		for range parsed {
+			origins = append(origins, name)
+		}
+	}
+	// Deliberately not wrapped with the per-file prefix above: the union error
+	// already names both colliding files, and a prefix would read as
+	// `b.yaml: duplicate test case "dup" in a.yaml and b.yaml`.
+	if err := validateUniqueCaseNames(cases, origins); err != nil {
+		return nil, err
 	}
 	return cases, nil
 }
@@ -118,6 +128,7 @@ func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error) {
 	sort.Strings(names)
 
 	var cases []Case
+	var origins []string
 	for _, name := range names {
 		path := filepath.Join(dir, name)
 		data, err := os.ReadFile(path)
@@ -134,6 +145,16 @@ func LoadCasesOfKind(dir string, kind AtlasTestKind) ([]Case, error) {
 			return nil, fmt.Errorf("%s: %w", name, err)
 		}
 		cases = append(cases, parsed...)
+		for range parsed {
+			origins = append(origins, name)
+		}
+	}
+	// Checked over the post-filter set: ParseAtlasTestCases has already dropped
+	// the blocks of the other kind, so a `test "migrate"` case never collides
+	// with a same-named YAML case in a schema-kind load. Emitted unwrapped for
+	// the reason given in LoadCases.
+	if err := validateUniqueCaseNames(cases, origins); err != nil {
+		return nil, err
 	}
 	return cases, nil
 }

--- a/migration/dbtest/parse_test.go
+++ b/migration/dbtest/parse_test.go
@@ -262,11 +262,14 @@ func TestLoadCases_AllowsDistinctNamesAcrossFiles(t *testing.T) {
 }
 
 // TestLoadCases_RejectsNamesDifferingOnlyBySurroundingWhitespace closes the
-// member of the class that a trailing space used to slip through. It is the
-// issue's first bullet verbatim: `--run dup` compiles unanchored, so it matched
-// `dup` and `dup ` alike and ran both, and Report.HTML renders each name inside
-// `case &ldquo;…&rdquo;`, where a browser collapses the trailing space into two
-// visually identical rows.
+// member of the class that a trailing space used to slip through: `--run`
+// compiles unanchored, so `--run dup` matched `dup` and `dup ` alike and ran
+// both while the author expected one.
+//
+// The issue also argued the two are visually identical in the HTML report.
+// That part is not true and is not what this test rests on -- Report.HTML
+// emits `case &ldquo;dup &rdquo;`, and a browser collapses runs of whitespace
+// and block edges, not a single interior space.
 func TestLoadCases_RejectsNamesDifferingOnlyBySurroundingWhitespace(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/migration/dbtest/parse_test.go
+++ b/migration/dbtest/parse_test.go
@@ -220,3 +220,106 @@ func TestLoadCases_MissingDir(t *testing.T) {
 	_, err := dbtest.LoadCases(filepath.Join(t.TempDir(), "does-not-exist"))
 	c.Assert(err, qt.IsNotNil)
 }
+
+// TestLoadCases_RejectsDuplicateNameAcrossFiles is the issue's primary
+// reproduction: a name unique within each file but repeated across the
+// directory. Before the union check, this loaded clean and returned two cases
+// both named "dup", which --run then matched twice.
+func TestLoadCases_RejectsDuplicateNameAcrossFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: dup\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("cases:\n  - name: dup\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+
+	// The message names both files, because the name alone does not say where
+	// the duplicate came from. No per-file prefix: `b.yaml: duplicate ... in
+	// a.yaml and b.yaml` would name b.yaml twice.
+	_, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.ErrorMatches, `duplicate test case "dup" in a\.yaml and b\.yaml`)
+}
+
+// TestLoadCases_AllowsDistinctNamesAcrossFiles is the negative half of the pair
+// above. The directory shape is identical -- two YAML files, one case each --
+// and only the names differ. Without it the union check is indistinguishable
+// from one that simply rejects any multi-file directory.
+func TestLoadCases_AllowsDistinctNamesAcrossFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: alpha\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("cases:\n  - name: beta\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 2)
+	c.Assert(cases[0].Name, qt.Equals, "alpha")
+	c.Assert(cases[1].Name, qt.Equals, "beta")
+}
+
+// TestParseCases_RejectsDuplicateNameInOneDocument covers the single-document
+// collision. The issue attributes the gap to validateCases running per document
+// and only the union escaping, which implies this case was already handled; it
+// was not, so the check had to be written rather than relocated. With no file
+// names to report, the message carries the case name alone.
+func TestParseCases_RejectsDuplicateNameInOneDocument(t *testing.T) {
+	tests := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "same name twice in one cases list",
+			yaml: "cases:\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 1\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 2\n",
+			want: `duplicate test case "dup"`,
+		},
+		{
+			name: "same name across two documents in one file",
+			yaml: "cases:\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 1\n" +
+				"---\n" +
+				"cases:\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 2\n",
+			want: `duplicate test case "dup"`,
+		},
+		{
+			// Names are compared exactly. FilterCases matches the raw name with
+			// a Go regexp, so folding case here would reject a pair that --run
+			// still selects separately.
+			name: "names differing only by case are distinct",
+			yaml: "cases:\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 1\n" +
+				"  - name: DUP\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 2\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 3\n",
+			want: `duplicate test case "dup"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			_, err := dbtest.ParseCases([]byte(tt.yaml))
+			c.Assert(err, qt.ErrorMatches, tt.want)
+		})
+	}
+}

--- a/migration/dbtest/parse_test.go
+++ b/migration/dbtest/parse_test.go
@@ -261,6 +261,68 @@ func TestLoadCases_AllowsDistinctNamesAcrossFiles(t *testing.T) {
 	c.Assert(cases[1].Name, qt.Equals, "beta")
 }
 
+// TestLoadCases_RejectsNamesDifferingOnlyBySurroundingWhitespace closes the
+// member of the class that a trailing space used to slip through. It is the
+// issue's first bullet verbatim: `--run dup` compiles unanchored, so it matched
+// `dup` and `dup ` alike and ran both, and Report.HTML renders each name inside
+// `case &ldquo;…&rdquo;`, where a browser collapses the trailing space into two
+// visually identical rows.
+func TestLoadCases_RejectsNamesDifferingOnlyBySurroundingWhitespace(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: \"dup\"\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("cases:\n  - name: \"dup \"\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.ErrorMatches,
+		`duplicate test case "dup" in a\.yaml and b\.yaml: "dup" and "dup " differ only in surrounding whitespace`)
+}
+
+// TestLoadCases_AllowsNamesDifferingInInteriorWhitespace is the negative half of
+// the test above, and it fixes how far the normalization goes. Only surrounding
+// whitespace is removed; a check that stripped whitespace everywhere, or one
+// that collapsed runs of it, would collide these two and pass every other test
+// in this file.
+func TestLoadCases_AllowsNamesDifferingInInteriorWhitespace(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n  - name: \"users load\"\n    steps:\n      - exec: SELECT 1\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("cases:\n  - name: \"users  load\"\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+
+	cases, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(cases, qt.HasLen, 2)
+	c.Assert(cases[0].Name, qt.Equals, "users load")
+	c.Assert(cases[1].Name, qt.Equals, "users  load")
+}
+
+// TestLoadCases_ReportsWithinFileDuplicateFromThePerFilePath pins the invariant
+// that lets the union check assume its two origins always differ: each file is
+// validated by ParseCases before the concatenation, so a collision inside one
+// file is reported with that file's own prefix and never reaches the union.
+// Were that ordering to change, this message would become the union's
+// `duplicate test case "dup" in a.yaml and a.yaml`.
+func TestLoadCases_ReportsWithinFileDuplicateFromThePerFilePath(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "a.yaml"),
+		[]byte("cases:\n"+
+			"  - name: dup\n    steps:\n      - exec: SELECT 1\n"+
+			"  - name: dup\n    steps:\n      - exec: SELECT 2\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "b.yaml"),
+		[]byte("cases:\n  - name: other\n    steps:\n      - exec: SELECT 3\n"), 0o600), qt.IsNil)
+
+	_, err := dbtest.LoadCases(dir)
+	c.Assert(err, qt.ErrorMatches, `a\.yaml: duplicate test case "dup"`)
+}
+
 // TestParseCases_RejectsDuplicateNameInOneDocument covers the single-document
 // collision. The issue attributes the gap to validateCases running per document
 // and only the union escaping, which implies this case was already handled; it
@@ -297,9 +359,12 @@ func TestParseCases_RejectsDuplicateNameInOneDocument(t *testing.T) {
 			want: `duplicate test case "dup"`,
 		},
 		{
-			// Names are compared exactly. FilterCases matches the raw name with
-			// a Go regexp, so folding case here would reject a pair that --run
-			// still selects separately.
+			// Case is not folded. FilterCases matches the raw name with a Go
+			// regexp, so `--run dup` selects `dup` and not `DUP`, and no report
+			// format renders the two alike; folding here would reject a pair
+			// the filter keeps apart. The third case supplies the collision, so
+			// this subtest still asserts an error and cannot pass by accident
+			// on a build where the whole check is gone.
 			name: "names differing only by case are distinct",
 			yaml: "cases:\n" +
 				"  - name: dup\n" +
@@ -312,6 +377,19 @@ func TestParseCases_RejectsDuplicateNameInOneDocument(t *testing.T) {
 				"    steps:\n" +
 				"      - exec: SELECT 3\n",
 			want: `duplicate test case "dup"`,
+		},
+		{
+			// Surrounding whitespace IS folded, and the message quotes both raw
+			// forms rather than a name that appears verbatim in neither entry.
+			name: "names differing only by trailing whitespace collide",
+			yaml: "cases:\n" +
+				"  - name: dup\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 1\n" +
+				"  - name: \"dup \"\n" +
+				"    steps:\n" +
+				"      - exec: SELECT 2\n",
+			want: `duplicate test case "dup": "dup" and "dup " differ only in surrounding whitespace`,
 		},
 	}
 


### PR DESCRIPTION
Closes #1038.

Duplicate test-case names across files loaded silently, and nothing validated the union. `LoadCases` and `LoadCasesOfKind` now reject a duplicate and name both origins; names differing only in surrounding whitespace collide too.

## Direction

Stricter only. The verbs this touches — `schema test` and `migrate test` — are refused outright by the pinned community binary, so there is no shared surface to be looser on, and within the diff every change adds a rejection and removes none. No position moves from exit 1 to exit 0.

## Two adversarial passes, and the defect that survived both code reviews

The mechanism and the tests were sound from the start; the reviewers confirmed the discriminators by mutation, and I re-confirmed them after rebasing. What failed twice was the **rationale**.

The first pass found that names differing by whitespace still reproduced the symptom, and that the comment justifying leaving them open asserted the opposite of what was measured. That was fixed — the rule now trims.

The second pass found the replacement rationale carried its own false measurement, in four places including user-facing docs:

> `Report.HTML` emits each name inside `case &ldquo;…&rdquo;`, where a browser collapses the trailing space and renders the two rows identically.

I verified it myself rather than take either side on trust, by rendering both names through the real report:

```
"case &ldquo;dup&rdquo;"
"case &ldquo;dup &rdquo;"
```

The space is preserved, sitting between `p` and the closing quote. A browser collapses **runs** of whitespace and the edges of a block — not a single interior space — so the rows are distinguishable, and the text report escapes with `%q` and shows it outright.

## What the rule actually rests on

The filter, which is the one thing that selects cases. `--run` compiles as an unanchored regular expression, so `--run dup` selects both `dup` and `dup `: an author who writes that expecting one case silently runs two. That is the symptom, and it is measured.

Case folding stays rejected for the mirror reason — `--run dup` selects only `dup`, not `DUP`, so folding would reject a pair the filter already keeps apart.

The rule and its behavior are unchanged. Only the justification moved, in all four places. A rationale that misstates measured behavior is a defect even when the code it defends is right — and this one had already caused one wrong decision, which is how the whitespace member came to be left open in the first place.

## Verification

Rebased onto current master. `go build`, `go vet`, `go test ./... -count=1`, `golangci-lint run ./...` and `check-style.mjs` clean.

Discriminators, re-proved by reverting only the source change: `TestLoadCases_RejectsDuplicateNameAcrossFiles`, `TestParseCases_RejectsDuplicateNameInOneDocument` (3 subtests) and `TestLoadCasesOfKind_RejectsDuplicateAcrossFormats` all go red. The two negative fixtures pass with and without the change, as guards should.
