### PR TITLE
Use one diagnostic prefix on the Atlas-compatible surface

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -118,6 +118,7 @@ jobs:
           npm run check:redirects
           npm run check:core-doc-links
           npm run check:page-health
+          npm run check:exit-codes:selftest
           npm run check:exit-codes
           npm run check:style:selftest
           npm run check:style
@@ -150,6 +151,7 @@ jobs:
             fi
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:core-doc-links
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:page-health
+            DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes:selftest
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style:selftest
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -61,10 +61,16 @@ type atlasPositionalArg struct {
 const (
 	atlasDirFormatDefault = "atlas"
 	atlasErrorExitCode    = 1
+	// atlasErrorPrefix is the diagnostic prefix of the whole compat surface.
+	// It is declared once on the root command (see NewCompatCommand) and
+	// resolved from the command tree at print time, so every diagnostic below
+	// the root carries it whether it is printed here or by shared cmdutil
+	// machinery.
+	atlasErrorPrefix = "Error"
 )
 
 func failAtlasCommand(cmd *cobra.Command, err error) error {
-	if _, writeErr := fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", err); writeErr != nil {
+	if _, writeErr := fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\n", cmdutil.ErrorPrefix(cmd), err); writeErr != nil {
 		return exitcode.New(
 			atlasErrorExitCode,
 			fmt.Errorf("%w: write Atlas diagnostic: %w", err, writeErr),
@@ -94,6 +100,12 @@ expect commands such as migrate apply or schema inspect. Commands that have an
 existing Ptah equivalent forward to that native command.`)
 	cmdflags.InstallEnvBinding("PTAH", cmd)
 	cmdutil.SetErrorCodePolicy(cmd, atlasErrorExitCode)
+	// The prefix is a property of the surface, exactly like the exit code
+	// above: declaring it on the root is what makes every diagnostic below it
+	// -- including the ones cobra routes through cmdutil's shared printers --
+	// answer with the same prefix, instead of it depending on which file
+	// happened to override a printer.
+	cmdutil.SetErrorPrefixPolicy(cmd, atlasErrorPrefix)
 	return cmd
 }
 
@@ -216,7 +228,7 @@ func atlasRootArgs(cmd *cobra.Command, args []string) error {
 
 	unknownErr := fmt.Errorf("unknown command %q for %q", args[0], "atlas")
 	var diagnostic strings.Builder
-	fmt.Fprintf(&diagnostic, "Error: %s\n", unknownErr)
+	fmt.Fprintf(&diagnostic, "%s: %s\n", cmdutil.ErrorPrefix(cmd), unknownErr)
 
 	suggestions := cmd.SuggestionsFor(args[0])
 	if len(suggestions) > 0 {
@@ -263,7 +275,7 @@ func atlasCompletionShellArgs(cmd *cobra.Command, args []string) error {
 	}
 
 	unknownErr := fmt.Errorf("unknown command %q for %q", args[0], "atlas completion "+cmd.Name())
-	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", unknownErr); err != nil {
+	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\n", cmdutil.ErrorPrefix(cmd), unknownErr); err != nil {
 		return exitcode.New(atlasErrorExitCode, fmt.Errorf("%w: write diagnostic: %w", unknownErr, err))
 	}
 	return exitcode.New(atlasErrorExitCode, unknownErr)
@@ -287,7 +299,7 @@ func newAtlasUnsupportedCommand(verb atlasUnsupportedVerb) *cobra.Command {
 		Long:  "This compatibility command is not implemented by Ptah.",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			err := fmt.Errorf("%s is not implemented by Ptah", cmd.CommandPath())
-			if _, writeErr := fmt.Fprintf(cmd.ErrOrStderr(), "Error: %s\n", err); writeErr != nil {
+			if _, writeErr := fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\n", cmdutil.ErrorPrefix(cmd), err); writeErr != nil {
 				return exitcode.New(1, fmt.Errorf("%w: write diagnostic: %w", err, writeErr))
 			}
 			return exitcode.New(1, err)

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -2031,7 +2031,7 @@ func TestCompatCommand_SchemaDiffRejectsUnsupportedRemoteTarget(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `--from "atlas://remote/schema": atlas:// registry URLs are not supported; use oci://.*`)
-	c.Assert(out.String(), qt.Contains, `error: --from "atlas://remote/schema": atlas:// registry URLs are not supported`)
+	c.Assert(out.String(), qt.Contains, `Error: --from "atlas://remote/schema": atlas:// registry URLs are not supported`)
 }
 
 func TestCompatCommand_SchemaDiffFormatsCustomSQLTemplate(t *testing.T) {
@@ -2246,7 +2246,7 @@ env "local" {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `atlas variable overrides must use name=value, got "destructive"`)
-	c.Assert(out.String(), qt.Contains, `error: atlas variable overrides must use name=value, got "destructive"`)
+	c.Assert(out.String(), qt.Contains, `Error: atlas variable overrides must use name=value, got "destructive"`)
 }
 
 func TestCompatCommand_SchemaDiffUsesAtlasProjectDefaultsWithExplicitTargetFlags(t *testing.T) {
@@ -2325,7 +2325,7 @@ func TestCompatCommand_SchemaDiffRejectsUnsupportedAtlasProjectDiffPolicy(t *tes
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `atlas\.hcl diff\.concurrent_index\.drop is not supported yet`)
-	c.Assert(out.String(), qt.Contains, `error: atlas.hcl diff.concurrent_index.drop is not supported yet`)
+	c.Assert(out.String(), qt.Contains, `Error: atlas.hcl diff.concurrent_index.drop is not supported yet`)
 }
 
 func TestCompatCommand_SchemaDiffRejectsInvalidFormatBeforeLoadingFiles(t *testing.T) {
@@ -3119,7 +3119,7 @@ func TestCompatCommand_MigrateDiffSchemaShorthandParses(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `atlas migrate diff accepts docker --dev-url values, but Ptah requires a directly connectable dev database URL`)
-	c.Assert(out.String(), qt.Contains, `error: atlas migrate diff accepts docker --dev-url values, but Ptah requires a directly connectable dev database URL`)
+	c.Assert(out.String(), qt.Contains, `Error: atlas migrate diff accepts docker --dev-url values, but Ptah requires a directly connectable dev database URL`)
 }
 
 func TestCompatCommand_MigrateDiffCreatesAtlasMigrationFromLocalSchema(t *testing.T) {
@@ -4594,7 +4594,7 @@ func TestCompatCommand_MigrateImportRejectsRemoteSource(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.ErrorMatches, `import --from: only local file:// migration directories are supported`)
-	c.Assert(out.String(), qt.Contains, "error: import --from: only local file:// migration directories are supported")
+	c.Assert(out.String(), qt.Contains, "Error: import --from: only local file:// migration directories are supported")
 }
 
 func TestCompatCommand_HelpUsesAtlasPathForForwardedParentedCommand(t *testing.T) {

--- a/cmd/atlas/atlas_usage_test.go
+++ b/cmd/atlas/atlas_usage_test.go
@@ -83,7 +83,13 @@ func TestCompatCommand_ForwardedNativeFailureExits1(t *testing.T) {
 
 	c.Assert(err, qt.ErrorMatches, "migrations directory .*")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out.String(), qt.Contains, "error: migrations directory")
+	// The message is printed by the native implementation, which the adapter
+	// runs detached from this tree, so it cannot reach the compat prefix by
+	// walking parents. It still has to answer with it: per stokaro/ptah#1019
+	// the prefix belongs to the surface the user invoked, not to whichever
+	// package happens to own the failing code.
+	c.Assert(out.String(), qt.Contains, "Error: migrations directory")
+	c.Assert(out.String(), qt.Not(qt.Contains), "error: migrations directory")
 }
 
 func TestAtlasCompatibilityRoots_UnknownCommandMatchesAtlasCE(t *testing.T) {

--- a/cmd/atlas/migrate_lint_integrity_test.go
+++ b/cmd/atlas/migrate_lint_integrity_test.go
@@ -1,0 +1,69 @@
+package atlas_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/exitcode"
+)
+
+// TestCompatCommand_MigrateLintIntegrityFindingIsReportContent pins the one
+// stderr line on the compat surface that carries no diagnostic prefix, so the
+// exception recorded in docs/exit_codes.md stays a measured fact rather than a
+// remembered one.
+//
+// This is a characterization pin, not a regression pin for stokaro/ptah#1019:
+// the behavior predates that change and the rows are green without it. It
+// exists because the #1019 rule ("every process-level diagnostic on this
+// surface is prefixed `Error: `") is only true once this line is classified
+// out of that set, and the classification is what the two rows measure. The
+// `--format` row is the evidence: the identical `checksum mismatch` text is
+// report content, rendered into the lint report on stdout, and the default
+// text report merely spills it to stderr instead of embedding it. A future
+// change that prefixes this line would be changing a report body, and should
+// have to say so here.
+//
+// The stream itself is a known divergence and is not endorsed by this test.
+func TestCompatCommand_MigrateLintIntegrityFindingIsReportContent(t *testing.T) {
+	tests := []struct {
+		name       string
+		formatArgs []string
+		wantStdout string
+		wantStderr string
+	}{
+		{
+			name:       "default text report spills the finding to stderr unprefixed",
+			formatArgs: nil,
+			wantStdout: "",
+			wantStderr: "checksum mismatch\n",
+		},
+		{
+			name:       "format report renders the same finding to stdout",
+			formatArgs: []string{"--format", "{{ with .Steps }}{{ range . }}{{ .Error }}{{ end }}{{ end }}"},
+			wantStdout: "checksum mismatch",
+			wantStderr: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			devDB := "sqlite://" + filepath.Join(t.TempDir(), "integrity.db")
+			writeAtlasLintFile(c, dir, "20240101000000_init.sql", "CREATE TABLE t1 (id integer);\n")
+			writeAtlasApplyProjectSum(c, dir)
+			// Edit the hashed file so the recorded sum no longer matches it.
+			writeAtlasLintFile(c, dir, "20240101000000_init.sql", "CREATE TABLE t1 (id integer, extra text);\n")
+
+			args := append([]string{"migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1"}, tt.formatArgs...)
+			stdout, stderr, err := runAtlasMigrateLint(c, args...)
+
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(err, qt.ErrorMatches, "checksum mismatch")
+			c.Assert(stdout, qt.Equals, tt.wantStdout)
+			c.Assert(stderr, qt.Equals, tt.wantStderr)
+		})
+	}
+}

--- a/cmd/atlas/migrate_set.go
+++ b/cmd/atlas/migrate_set.go
@@ -51,7 +51,6 @@ given version applied, without executing migration SQL.`,
 	flags.StringVar(&opts.dirFormat, "dir-format", opts.dirFormat, "Migration directory format")
 	flags.StringVar(&opts.revisionsSchema, "revisions-schema", "", "Schema for the revision table")
 	cmdutil.ConfigureCommandArgs(cmd, nil)
-	cmd.SetFlagErrorFunc(failAtlasCommand)
 	return cmd
 }
 

--- a/cmd/internal/cmdadapter/cmdadapter.go
+++ b/cmd/internal/cmdadapter/cmdadapter.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdflags"
+	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 )
 
 const envPrefix = "PTAH"
@@ -169,6 +170,20 @@ func newForwardCommandWithArgsMapper(
 			target.SetOut(cmd.OutOrStdout())
 			target.SetErr(cmd.ErrOrStderr())
 			defer resetCommandIO(target)
+			// The target runs detached from the calling surface's tree, so it
+			// cannot reach that surface's diagnostic prefix through
+			// cmdutil.ErrorPrefix's parent walk. Adopt it explicitly, or a
+			// diagnostic printed by the native implementation keeps the native
+			// prefix while everything around it uses the caller's.
+			//
+			// Restored on the way out for the same reason as the contexts,
+			// flags and IO above: a factory is free to hand back a command that
+			// outlives this execution (the parent re-attach a few lines up
+			// exists precisely because some already do), and a target that
+			// keeps a borrowed prefix would carry it into a later run on
+			// another surface.
+			restorePrefix := cmdutil.AdoptErrorPrefixPolicy(target, cmd)
+			defer restorePrefix()
 			return target.Execute()
 		},
 	}

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -13,10 +13,15 @@ import (
 )
 
 const (
-	configuredAnnotation      = "ptah.exitcode_configured"
-	errorCodePolicyAnnotation = "ptah.error_code_policy"
-	unconfiguredErrorCode     = -1
-	nativeCommandErrorCode    = 2
+	configuredAnnotation        = "ptah.exitcode_configured"
+	errorCodePolicyAnnotation   = "ptah.error_code_policy"
+	errorPrefixPolicyAnnotation = "ptah.error_prefix_policy"
+	unconfiguredErrorCode       = -1
+	nativeCommandErrorCode      = 2
+	// nativeErrorPrefix is the diagnostic prefix of the native ptah surface.
+	// Surfaces that need a different one declare it with
+	// [SetErrorPrefixPolicy] on their root command.
+	nativeErrorPrefix = "error"
 )
 
 // ConfigureCommand installs Ptah's common CLI error contract on cmd. It is
@@ -70,15 +75,66 @@ func NormalizeCommandError(cmd *cobra.Command, err error, fallback int) error {
 		case code:
 			return err
 		case unconfiguredErrorCode:
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+			printDiagnostic(cmd, err)
 		}
 		return exitcode.New(code, err)
 	}
 	if exitcode.Code(err, unconfiguredErrorCode) != unconfiguredErrorCode {
 		return err
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	printDiagnostic(cmd, err)
 	return exitcode.New(fallback, err)
+}
+
+// SetErrorPrefixPolicy marks cmd and its descendants with the diagnostic
+// prefix every process-level diagnostic below cmd is printed with. The prefix
+// is punctuation owned by the surface, not by the message: the native ptah
+// tree keeps [nativeErrorPrefix], and the Atlas-compatible tree declares its
+// own so a contributor predicts the prefix from the binary alone.
+func SetErrorPrefixPolicy(cmd *cobra.Command, prefix string) {
+	if cmd.Annotations == nil {
+		cmd.Annotations = make(map[string]string)
+	}
+	cmd.Annotations[errorPrefixPolicyAnnotation] = prefix
+}
+
+// ErrorPrefix resolves the nearest configured ancestor prefix policy for cmd,
+// defaulting to the native prefix. Every printer in this package routes through
+// it, so a surface declares its prefix once on its root instead of at each of
+// the call sites that print.
+func ErrorPrefix(cmd *cobra.Command) string {
+	for current := cmd; current != nil; current = current.Parent() {
+		prefix, ok := current.Annotations[errorPrefixPolicyAnnotation]
+		if ok && prefix != "" {
+			return prefix
+		}
+	}
+	return nativeErrorPrefix
+}
+
+// AdoptErrorPrefixPolicy copies the prefix policy resolved for source onto
+// target and returns a function that restores target's previous policy.
+//
+// Forwarding adapters need this because a forwarded target is a detached
+// command tree that cannot reach the calling surface's root through
+// [ErrorPrefix]'s parent walk. Run the returned restore before the process
+// executes anything else: a target that outlives one forwarded execution would
+// otherwise carry the borrowed prefix into a later run on another surface.
+func AdoptErrorPrefixPolicy(target, source *cobra.Command) func() {
+	previous, configured := target.Annotations[errorPrefixPolicyAnnotation]
+	SetErrorPrefixPolicy(target, ErrorPrefix(source))
+	return func() {
+		if configured {
+			target.Annotations[errorPrefixPolicyAnnotation] = previous
+			return
+		}
+		delete(target.Annotations, errorPrefixPolicyAnnotation)
+	}
+}
+
+// printDiagnostic writes err to cmd's stderr under the surface's prefix.
+func printDiagnostic(cmd *cobra.Command, err error) {
+	fmt.Fprintf(cmd.ErrOrStderr(), "%s: %s\n", ErrorPrefix(cmd), err)
 }
 
 func commandErrorCode(cmd *cobra.Command) (int, bool) {
@@ -103,7 +159,7 @@ func WrapRunE(run func(*cobra.Command, []string) error) func(*cobra.Command, []s
 		if err == nil || exitcode.Code(err, unconfiguredErrorCode) != unconfiguredErrorCode {
 			return err
 		}
-		fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+		printDiagnostic(cmd, err)
 		return exitcode.New(nativeCommandErrorCode, err)
 	}
 }
@@ -112,7 +168,7 @@ func WrapRunE(run func(*cobra.Command, []string) error) func(*cobra.Command, []s
 // error. Commands that set SilenceErrors must route their usage failures
 // through this so the message still reaches the user.
 func Fail(cmd *cobra.Command, err error) error {
-	fmt.Fprintf(cmd.ErrOrStderr(), "error: %s\n", err)
+	printDiagnostic(cmd, err)
 	return exitcode.New(nativeCommandErrorCode, err)
 }
 

--- a/cmd/internal/cmdutil/cmdutil.go
+++ b/cmd/internal/cmdutil/cmdutil.go
@@ -91,17 +91,33 @@ func NormalizeCommandError(cmd *cobra.Command, err error, fallback int) error {
 // is punctuation owned by the surface, not by the message: the native ptah
 // tree keeps [nativeErrorPrefix], and the Atlas-compatible tree declares its
 // own so a contributor predicts the prefix from the binary alone.
+//
+// It panics on an empty prefix. A surface cannot declare "no prefix": every
+// printer here writes "<prefix>: <message>", so an empty value would emit a
+// leading ": ". Rejecting it at the wiring call is what keeps the
+// misconfiguration loud; silently ignoring it would resolve the surface to
+// whatever an ancestor declares, which is the class of accident this policy
+// exists to remove.
 func SetErrorPrefixPolicy(cmd *cobra.Command, prefix string) {
+	if prefix == "" {
+		panic("cmdutil: empty error prefix policy for command " + cmd.CommandPath())
+	}
 	if cmd.Annotations == nil {
 		cmd.Annotations = make(map[string]string)
 	}
 	cmd.Annotations[errorPrefixPolicyAnnotation] = prefix
 }
 
-// ErrorPrefix resolves the nearest configured ancestor prefix policy for cmd,
-// defaulting to the native prefix. Every printer in this package routes through
-// it, so a surface declares its prefix once on its root instead of at each of
-// the call sites that print.
+// ErrorPrefix resolves the nearest declared prefix policy for cmd, defaulting
+// to the native prefix. Every printer in this package routes through it, so a
+// surface declares its prefix once on its root instead of at each of the call
+// sites that print.
+//
+// The walk starts at cmd, so the nearest declaration wins: a subtree may
+// declare a prefix that differs from its root's. That is deliberate rather
+// than an oversight — [AdoptErrorPrefixPolicy] depends on it to hand a
+// detached forwarded target the calling surface's prefix. Ptah's own trees
+// declare the policy only on their roots.
 func ErrorPrefix(cmd *cobra.Command) string {
 	for current := cmd; current != nil; current = current.Parent() {
 		prefix, ok := current.Annotations[errorPrefixPolicyAnnotation]
@@ -120,12 +136,23 @@ func ErrorPrefix(cmd *cobra.Command) string {
 // [ErrorPrefix]'s parent walk. Run the returned restore before the process
 // executes anything else: a target that outlives one forwarded execution would
 // otherwise carry the borrowed prefix into a later run on another surface.
+//
+// The restore returns target's annotations to their exact previous state,
+// including dropping the map [SetErrorPrefixPolicy] allocated for a target
+// that had none. Restoring "the key is gone" but leaving an allocated empty
+// map behind would make the restore observably incomplete to anything that
+// reads Annotations rather than a single key.
 func AdoptErrorPrefixPolicy(target, source *cobra.Command) func() {
+	allocated := target.Annotations == nil
 	previous, configured := target.Annotations[errorPrefixPolicyAnnotation]
 	SetErrorPrefixPolicy(target, ErrorPrefix(source))
 	return func() {
 		if configured {
 			target.Annotations[errorPrefixPolicyAnnotation] = previous
+			return
+		}
+		if allocated {
+			target.Annotations = nil
 			return
 		}
 		delete(target.Annotations, errorPrefixPolicyAnnotation)

--- a/cmd/internal/cmdutil/cmdutil_test.go
+++ b/cmd/internal/cmdutil/cmdutil_test.go
@@ -308,6 +308,95 @@ func TestAdoptErrorPrefixPolicyRestoresTheTargetPolicy(t *testing.T) {
 	}
 }
 
+// TestAdoptErrorPrefixPolicyRestoresTheAnnotationMap pins that the restore is
+// a restore of the annotations, not only of the one key it wrote.
+// [cmdutil.SetErrorPrefixPolicy] allocates the map when a command has none, so
+// a restore that only deletes its key hands back a command whose Annotations
+// changed from nil to an allocated empty map. Forwarded targets are
+// package-level singletons that survive the execution, so that difference
+// outlives the call and is visible to anything that reads Annotations rather
+// than a single key.
+//
+// The second row is the control: the restore must not reach beyond its own key
+// and clear annotations the target already carried.
+func TestAdoptErrorPrefixPolicyRestoresTheAnnotationMap(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*cobra.Command)
+		want      map[string]string
+	}{
+		{
+			name:      "target that carried no annotations at all",
+			configure: func(*cobra.Command) {},
+			want:      nil,
+		},
+		{
+			name: "target that carried unrelated annotations",
+			configure: func(target *cobra.Command) {
+				target.Annotations = map[string]string{"ptah.unrelated": "kept"}
+			},
+			want: map[string]string{"ptah.unrelated": "kept"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			source := &cobra.Command{Use: "source"}
+			cmdutil.SetErrorPrefixPolicy(source, "Error")
+			target := &cobra.Command{Use: "target"}
+			tt.configure(target)
+
+			restore := cmdutil.AdoptErrorPrefixPolicy(target, source)
+			held := cmdutil.ErrorPrefix(target)
+			restore()
+
+			c.Assert(held, qt.Equals, "Error")
+			c.Assert(target.Annotations, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+// TestSetErrorPrefixPolicyRejectsAnEmptyPrefix pins that a surface cannot
+// declare "no prefix". Every printer in this package writes
+// "<prefix>: <message>", so an empty prefix has no printable meaning; before
+// this was rejected the call was silently ignored and the surface resolved to
+// whatever an ancestor declared, or to the native prefix — the exact class of
+// accident stokaro/ptah#1019 removed from the compat surface.
+func TestSetErrorPrefixPolicyRejectsAnEmptyPrefix(t *testing.T) {
+	tests := []struct {
+		name      string
+		configure func(*cobra.Command)
+	}{
+		{
+			name:      "command with no annotations",
+			configure: func(*cobra.Command) {},
+		},
+		{
+			name: "command that already declares a prefix",
+			configure: func(cmd *cobra.Command) {
+				cmdutil.SetErrorPrefixPolicy(cmd, "Error")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cmd := &cobra.Command{Use: "surface"}
+			tt.configure(cmd)
+
+			c.Assert(
+				func() { cmdutil.SetErrorPrefixPolicy(cmd, "") },
+				qt.PanicMatches,
+				`cmdutil: empty error prefix policy for command surface`,
+			)
+		})
+	}
+}
+
 func commandError(message string) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, _ []string) error {
 		return errors.New(message)

--- a/cmd/internal/cmdutil/cmdutil_test.go
+++ b/cmd/internal/cmdutil/cmdutil_test.go
@@ -167,6 +167,147 @@ func TestExactArgs_FailurePath(t *testing.T) {
 	}
 }
 
+// TestErrorPrefixPolicyGovernsEveryPrinter pins that the diagnostic prefix is
+// resolved from the command tree rather than hardcoded at each print site
+// (stokaro/ptah#1019). Every printer in this package is covered, because the
+// defect being prevented is a surface whose prefix depends on which route a
+// given failure happens to take: before the policy existed, one command
+// overriding one printer was enough to give a single binary two prefixes for
+// the same class of failure.
+//
+// The "inherited by a descendant" rows are the load-bearing ones: a surface
+// declares the prefix once on its root, and hundreds of call sites below it
+// answer with it without naming it.
+func TestErrorPrefixPolicyGovernsEveryPrinter(t *testing.T) {
+	tests := []struct {
+		name string
+		// emit exercises one printer against a command tree whose root has
+		// already had the policy under test applied.
+		emit func(root, leaf *cobra.Command) error
+	}{
+		{
+			name: "Fail",
+			emit: func(_, leaf *cobra.Command) error {
+				return cmdutil.Fail(leaf, errors.New("boom"))
+			},
+		},
+		{
+			name: "FlagErrorFunc",
+			emit: func(_, leaf *cobra.Command) error {
+				return cmdutil.FlagErrorFunc(leaf, errors.New("boom"))
+			},
+		},
+		{
+			name: "WrapRunE",
+			emit: func(_, leaf *cobra.Command) error {
+				return cmdutil.WrapRunE(commandError("boom"))(leaf, nil)
+			},
+		},
+		{
+			// NormalizeCommandError's configured-policy branch.
+			name: "NormalizeCommandError under an exit-code policy",
+			emit: func(root, leaf *cobra.Command) error {
+				cmdutil.SetErrorCodePolicy(root, 1)
+				return cmdutil.NormalizeCommandError(leaf, errors.New("boom"), 2)
+			},
+		},
+		{
+			// NormalizeCommandError's fallback branch, reached when no
+			// ancestor declares an exit code.
+			name: "NormalizeCommandError without an exit-code policy",
+			emit: func(_, leaf *cobra.Command) error {
+				return cmdutil.NormalizeCommandError(leaf, errors.New("boom"), 2)
+			},
+		},
+	}
+
+	policies := []struct {
+		name  string
+		apply func(*cobra.Command)
+		want  string
+	}{
+		{
+			name:  "no declared policy prints the native prefix",
+			apply: func(*cobra.Command) {},
+			want:  "error: boom\n",
+		},
+		{
+			name:  "a declared policy replaces the native prefix",
+			apply: func(root *cobra.Command) { cmdutil.SetErrorPrefixPolicy(root, "Error") },
+			want:  "Error: boom\n",
+		},
+	}
+
+	for _, tt := range tests {
+		for _, policy := range policies {
+			t.Run(tt.name+"/"+policy.name, func(t *testing.T) {
+				c := qt.New(t)
+
+				var stderr bytes.Buffer
+				root := &cobra.Command{Use: "root"}
+				leaf := &cobra.Command{Use: "leaf"}
+				root.AddCommand(leaf)
+				root.SetErr(&stderr)
+				policy.apply(root)
+
+				err := tt.emit(root, leaf)
+
+				c.Assert(err, qt.ErrorMatches, "boom")
+				c.Assert(stderr.String(), qt.Equals, policy.want)
+			})
+		}
+	}
+}
+
+// TestAdoptErrorPrefixPolicyRestoresTheTargetPolicy pins the restore discipline
+// forwarding adapters depend on. Command factories hand back package-level
+// singletons, so a target that adopts the compat prefix and never gives it back
+// leaks "Error: " into the next native execution in the same process.
+func TestAdoptErrorPrefixPolicyRestoresTheTargetPolicy(t *testing.T) {
+	tests := []struct {
+		name          string
+		configure     func(*cobra.Command)
+		wantRestored  string
+		wantWhileHeld string
+	}{
+		{
+			name:          "target without a policy of its own",
+			configure:     func(*cobra.Command) {},
+			wantWhileHeld: "Error: boom\n",
+			wantRestored:  "error: boom\n",
+		},
+		{
+			name:          "target with a policy of its own",
+			configure:     func(target *cobra.Command) { cmdutil.SetErrorPrefixPolicy(target, "target") },
+			wantWhileHeld: "Error: boom\n",
+			wantRestored:  "target: boom\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			var stderr bytes.Buffer
+			source := &cobra.Command{Use: "source"}
+			cmdutil.SetErrorPrefixPolicy(source, "Error")
+			target := &cobra.Command{Use: "target"}
+			target.SetErr(&stderr)
+			tt.configure(target)
+
+			restore := cmdutil.AdoptErrorPrefixPolicy(target, source)
+			cmdutil.Fail(target, errors.New("boom"))
+			held := stderr.String()
+			stderr.Reset()
+			restore()
+			cmdutil.Fail(target, errors.New("boom"))
+
+			c.Assert(held, qt.Equals, tt.wantWhileHeld)
+			c.Assert(stderr.String(), qt.Equals, tt.wantRestored)
+		})
+	}
+}
+
 func commandError(message string) func(*cobra.Command, []string) error {
 	return func(_ *cobra.Command, _ []string) error {
 		return errors.New(message)

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -50,6 +50,23 @@ func TestCompatBinaryNamedAtlasResolvesRootCommands(t *testing.T) {
 // single table is what makes that kind of drift a red test: the rows reach the
 // shared cmdutil printers, the compat-local printers, and the forwarded native
 // targets respectively, and a fix that lands on only some of them fails here.
+//
+// This table is currently the only byte-exact guard on the class. The
+// stokaro/ptah#1019 definition of done also asks for an exact-stderr assertion
+// in the conformance harness, whose `cli-exit-behavior` "unknown flag" case
+// still matches the substring "unknown flag" — true under either prefix, which
+// is why the split went unnoticed. That assertion is deferred rather than
+// forgotten, and the reason is sequencing, not effort:
+// ptah-atlas-conformance builds its compat binary from the go.5x5.cz/ptah
+// version its own go.mod pins, so the assertion can only be added after a
+// release containing this change is pinned there. Measured, same argv
+// (`migrate validate --totally-unknown-flag`), same machine:
+//
+//	this tree                   -> "Error: unknown flag: --totally-unknown-flag\n"
+//	the currently pinned module -> "error: unknown flag: --totally-unknown-flag\n"
+//
+// Adding the exact-bytes assertion before that bump turns the conformance gate
+// red against the module it actually builds.
 func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -36,69 +36,113 @@ func TestCompatBinaryNamedAtlasResolvesRootCommands(t *testing.T) {
 	c.Assert(output, qt.Not(qt.Contains), "atlas atlas migrate down")
 }
 
+// TestCompatBinaryCommandFailuresExit1 pins the whole process-level diagnostic
+// class of the compat surface in one table, byte-exact on stderr.
+//
+// Per stokaro/ptah#1019 the prefix is punctuation owned by the surface, not by
+// the message: everything this binary prints as a process-level diagnostic is
+// prefixed "Error: ", and the native ptah binary prefixes "error: " (pinned by
+// TestNativeDiagnosticsKeepTheNativePrefix in cmd/root). Before that decision
+// the two prefixes were split inside this one binary — `migrate set` was the
+// only command that overrode a printer, so it answered "Error: unknown flag"
+// while `migrate status`, `schema inspect`, `version` and the rest answered
+// "error: unknown flag" for the identical failure. Keeping every route in a
+// single table is what makes that kind of drift a red test: the rows reach the
+// shared cmdutil printers, the compat-local printers, and the forwarded native
+// targets respectively, and a fix that lands on only some of them fails here.
 func TestCompatBinaryCommandFailuresExit1(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
 
 	tests := []struct {
 		name       string
-		command    func(string) *exec.Cmd
+		args       []string
 		wantStderr string
 	}{
+		// Reaches cmdutil's shared flag-error printer.
 		{
-			name: "unknown flag",
-			command: func(binPath string) *exec.Cmd {
-				return newCompatProcess(binPath, "version", "--bogus-flag")
-			},
-			wantStderr: "error: unknown flag: --bogus-flag\n",
+			name:       "unknown flag",
+			args:       []string{"version", "--bogus-flag"},
+			wantStderr: "Error: unknown flag: --bogus-flag\n",
 		},
+		{
+			name:       "schema inspect unknown flag",
+			args:       []string{"schema", "inspect", "--zzz"},
+			wantStderr: "Error: unknown flag: --zzz\n",
+		},
+		{
+			name:       "schema inspect flag without a value",
+			args:       []string{"schema", "inspect", "--url"},
+			wantStderr: "Error: flag needs an argument: --url\n",
+		},
+		{
+			name:       "migrate status unknown flag",
+			args:       []string{"migrate", "status", "--zzz"},
+			wantStderr: "Error: unknown flag: --zzz\n",
+		},
+		// Reaches cmdutil's shared post-execution normalizer.
 		{
 			name: "mutually exclusive flags",
-			command: func(binPath string) *exec.Cmd {
-				return newCompatProcess(
-					binPath,
-					"schema", "apply",
-					"--url", "sqlite://schema.db",
-					"--to", "file://schema.sql",
-					"--file", "schema.sql",
-					"--dry-run",
-				)
+			args: []string{
+				"schema", "apply",
+				"--url", "sqlite://schema.db",
+				"--to", "file://schema.sql",
+				"--file", "schema.sql",
+				"--dry-run",
 			},
-			wantStderr: "error: if any flags in the group [file to] are set none of the others can be; [file to] were all set\n",
+			wantStderr: "Error: if any flags in the group [file to] are set none of the others can be; [file to] were all set\n",
 		},
+		// The verb that used to be the only one answering "Error:".
 		{
-			name: "lazy completion command",
-			command: func(binPath string) *exec.Cmd {
-				return newCompatProcess(binPath, "completion", "bash", "extra")
-			},
+			name:       "migrate set unknown flag",
+			args:       []string{"migrate", "set", "--unknown"},
+			wantStderr: "Error: unknown flag: --unknown\n",
+		},
+		// Reaches a native command the adapter executes detached from this
+		// tree, so its diagnostic is printed by the native package's own
+		// cmdutil.Fail call rather than by anything under cmd/atlas.
+		{
+			name:       "forwarded native target failure",
+			args:       []string{"migrate", "rm", "20990101000000"},
+			wantStderr: "Error: migrations directory migrations: stat migrations: no such file or directory\n",
+		},
+		// Reaches the compat-local printers.
+		{
+			name:       "lazy completion command",
+			args:       []string{"completion", "bash", "extra"},
 			wantStderr: "Error: unknown command \"extra\" for \"atlas completion bash\"\n",
 		},
 		{
 			name: "unknown root command",
-			command: func(binPath string) *exec.Cmd {
-				return exec.Command(binPath, "definitely-not-a-command")
-			},
+			args: []string{"definitely-not-a-command"},
 			wantStderr: "Error: unknown command \"definitely-not-a-command\" for \"atlas\"\n" +
 				"Run 'atlas --help' for usage.\n",
 		},
 		{
-			name: "registered command without an implementation",
-			command: func(binPath string) *exec.Cmd {
-				return newCompatProcess(binPath, "migrate", "push")
-			},
+			name:       "registered command without an implementation",
+			args:       []string{"migrate", "push"},
 			wantStderr: "Error: atlas migrate push is not implemented by Ptah\n",
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			run := tt.command(binPath)
-			runOut, err := run.CombinedOutput()
+			run := newCompatProcess(binPath, tt.args...)
+			// An empty working directory: the forwarded-target row resolves the
+			// default relative migration directory from the process cwd, and
+			// must not find the repository's own.
+			run.Dir = c.TempDir()
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
 			var exitErr *exec.ExitError
 
-			c.Assert(err, qt.ErrorAs, &exitErr, qt.Commentf("%s", runOut))
+			c.Assert(err, qt.ErrorAs, &exitErr, qt.Commentf("stderr: %s", stderr.String()))
 			c.Assert(exitErr.ExitCode(), qt.Equals, 1)
-			c.Assert(string(runOut), qt.Equals, tt.wantStderr)
+			c.Assert(stdout.String(), qt.Equals, "")
+			c.Assert(stderr.String(), qt.Equals, tt.wantStderr)
 		})
 	}
 }

--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -433,7 +433,7 @@ func TestCompatBinaryMigrateApplyRejectsMalformedAtlasTxMode(t *testing.T) {
 	c.Assert(err, qt.ErrorAs, &exitErr)
 	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
 	c.Assert(stderr.String(), qt.Equals,
-		"error: error applying migrations: unknown txmode \"bogus\" found in file directive \"1_invalid.sql\"\n")
+		"Error: error applying migrations: unknown txmode \"bogus\" found in file directive \"1_invalid.sql\"\n")
 	c.Assert(stdout.String(), qt.Equals, "")
 }
 

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -75,7 +75,7 @@ func executeWithRecovery(cmd *cobra.Command) (err error) {
 	defer func() {
 		if recovered := recover(); recovered != nil {
 			err = exitcode.New(2, fmt.Errorf("internal error: %v", recovered))
-			fmt.Fprintf(cmd.ErrOrStderr(), "error: %v\n", err)
+			fmt.Fprintf(cmd.ErrOrStderr(), "%s: %v\n", cmdutil.ErrorPrefix(cmd), err)
 		}
 	}()
 

--- a/cmd/root/root_internal_test.go
+++ b/cmd/root/root_internal_test.go
@@ -69,6 +69,49 @@ func TestNewRootCommand_AtlasLookingRootPathsStayRejected(t *testing.T) {
 	}
 }
 
+// TestNativeDiagnosticsKeepTheNativePrefix pins the native half of the
+// stokaro/ptah#1019 rule: a process-level diagnostic on the native ptah surface
+// is prefixed "error: " at exit 2, while the same failure on the compat surface
+// is prefixed "Error: " at exit 1 (pinned by
+// TestCompatBinaryCommandFailuresExit1 in cmd/ptah-compat).
+//
+// The assertion is byte-exact rather than a substring on purpose. cmdutil's
+// printers are shared by both surfaces, so the cheap way to make the compat
+// pins green is to edit the literal inside them — which would silently rewrite
+// every native diagnostic in the binary. That shortcut turns this test red;
+// resolving the prefix from the command tree keeps both green.
+func TestNativeDiagnosticsKeepTheNativePrefix(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		wantStderr string
+	}{
+		{
+			name:       "unknown flag",
+			args:       []string{"version", "--bogus-flag"},
+			wantStderr: "error: unknown flag: --bogus-flag\n",
+		},
+		{
+			name:       "unknown command",
+			args:       []string{"definitely-not-a-command"},
+			wantStderr: "error: unknown command \"definitely-not-a-command\" for \"ptah\"\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			stdout, stderr, err := executeRoot(tt.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stdout, qt.Equals, "")
+			c.Assert(stderr, qt.Equals, tt.wantStderr)
+		})
+	}
+}
+
 func TestExecuteWithRecovery_ConvertsCommandPanicToError(t *testing.T) {
 	c := qt.New(t)
 

--- a/cmd/root/root_internal_test.go
+++ b/cmd/root/root_internal_test.go
@@ -13,6 +13,7 @@ import (
 	qt "github.com/frankban/quicktest"
 	"github.com/spf13/cobra"
 
+	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
 )
 
@@ -112,23 +113,56 @@ func TestNativeDiagnosticsKeepTheNativePrefix(t *testing.T) {
 	}
 }
 
+// TestExecuteWithRecovery_ConvertsCommandPanicToError covers the recovered
+// panic at the process boundary, which the exit-code documentation names as a
+// member of the process-level diagnostic class.
+//
+// It has two rows because one is not a discriminator. With only the default
+// root, reverting the prefix lookup to a hardcoded "error: " leaves the whole
+// suite green -- this is the one printer in the documented class that no other
+// gate watches, so a later simplification back to the literal would silently
+// reintroduce the split the policy exists to close.
 func TestExecuteWithRecovery_ConvertsCommandPanicToError(t *testing.T) {
-	c := qt.New(t)
-
-	var stderr bytes.Buffer
-	cmd := &cobra.Command{
-		Use: "panic",
-		RunE: func(_ *cobra.Command, _ []string) error {
-			panic("bad annotation")
+	tests := []struct {
+		name string
+		// declare wires the surface's prefix policy. The native row leaves it
+		// alone rather than passing an empty prefix, because
+		// [cmdutil.SetErrorPrefixPolicy] rejects that by design.
+		declare    func(*cobra.Command)
+		wantStderr string
+	}{
+		{
+			name:       "native default",
+			declare:    func(*cobra.Command) {},
+			wantStderr: "error: internal error: bad annotation",
+		},
+		{
+			name:       "surface declaring its own prefix",
+			declare:    func(cmd *cobra.Command) { cmdutil.SetErrorPrefixPolicy(cmd, "Error") },
+			wantStderr: "Error: internal error: bad annotation",
 		},
 	}
-	cmd.SetErr(&stderr)
 
-	err := executeWithRecovery(cmd)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			var stderr bytes.Buffer
+			cmd := &cobra.Command{
+				Use: "panic",
+				RunE: func(_ *cobra.Command, _ []string) error {
+					panic("bad annotation")
+				},
+			}
+			cmd.SetErr(&stderr)
+			tt.declare(cmd)
 
-	c.Assert(err, qt.ErrorMatches, "internal error: bad annotation")
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
-	c.Assert(stderr.String(), qt.Contains, "error: internal error: bad annotation")
+			err := executeWithRecovery(cmd)
+
+			c.Assert(err, qt.ErrorMatches, "internal error: bad annotation")
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr.String(), qt.Contains, tt.wantStderr)
+		})
+	}
 }
 
 func TestZZZRootUnknownSubcommandExits2WithoutUsage(t *testing.T) {

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -14,6 +14,37 @@ surfaces intentionally use Atlas CE's narrower process contract: `0` for
 success and help, and `1` for command, usage, validation, and runtime failures.
 An internal panic recovered by Ptah's process boundary still exits `2`.
 
+## Diagnostic Prefix
+
+The prefix on a process-level diagnostic is punctuation owned by the surface,
+not by the message. There is exactly one rule, and the only input is which
+binary printed the line:
+
+| Surface | Prefix | Exit code |
+| --- | --- | --- |
+| Native `ptah` | `error: ` | `2` |
+| Compatibility `ptah-compat` | `Error: ` | `1` |
+
+This holds for every process-level diagnostic the binary emits, regardless of
+which package produced the underlying error. In particular, a `ptah-compat`
+verb that delegates to a native command still prints `Error: `, because the
+user invoked the compatibility surface.
+
+The rule covers the prefix only. The message text after it stays Ptah-owned
+prose, so `ptah-compat schema inspect` with no `--url` reports Ptah's own
+`--url is required` rather than any wording copied from another tool.
+
+Report bodies are not process-level diagnostics and are unaffected: the
+`Error:` field inside a `migrate status` dirty-revision block or a
+`migrate validate` checksum report is part of that report's format on both
+surfaces.
+
+Implementation: the prefix is an inherited command-tree policy
+(`cmdutil.SetErrorPrefixPolicy`), declared once on a surface's root command
+next to its exit-code policy and resolved at print time by walking to the
+nearest ancestor that declares one. Adding a command or a diagnostic requires no
+prefix decision, and no individual command may override it.
+
 ## Native Commands
 
 The grouped command tree is the native Ptah surface. Ptah is pre-GA, so old

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -51,10 +51,11 @@ diagnostic — with `--format` the same content is rendered into the report on
 stdout — so the prefix rule does not reach it. Its stream is a known
 divergence, not an endorsed format.
 
-Implementation: the prefix is an inherited command-tree policy
-(`cmdutil.SetErrorPrefixPolicy`), declared once on a surface's root command
-next to its exit-code policy and resolved at print time by walking from the
-printing command up to the nearest ancestor that declares one. Adding a command
+Implementation: the prefix is an inherited command-tree policy resolved at
+print time by walking from the printing command up to the nearest ancestor that
+declares one. Only the Atlas-compatible surface declares anything
+(`cmdutil.SetErrorPrefixPolicy`, on its root command next to its exit-code
+policy); the native tree declares nothing and falls through to the default. Adding a command
 or a diagnostic therefore requires no prefix decision.
 
 The walk starts at the printing command, so the nearest declaration wins and a

--- a/docs/exit_codes.md
+++ b/docs/exit_codes.md
@@ -16,34 +16,54 @@ An internal panic recovered by Ptah's process boundary still exits `2`.
 
 ## Diagnostic Prefix
 
-The prefix on a process-level diagnostic is punctuation owned by the surface,
-not by the message. There is exactly one rule, and the only input is which
-binary printed the line:
+A *process-level diagnostic* is the single line a surface prints when a command
+terminates with a failure: the line produced by Ptah's CLI error contract
+(`cmdutil.Fail`, the Cobra flag-error and `RunE` wrappers, the post-execution
+error normalizer, the compatibility tree's own printers, and the recovered
+panic at the process boundary). Its prefix is punctuation owned by the surface,
+not by the message, and the only input is which binary printed the line:
 
 | Surface | Prefix | Exit code |
 | --- | --- | --- |
 | Native `ptah` | `error: ` | `2` |
 | Compatibility `ptah-compat` | `Error: ` | `1` |
 
-This holds for every process-level diagnostic the binary emits, regardless of
-which package produced the underlying error. In particular, a `ptah-compat`
-verb that delegates to a native command still prints `Error: `, because the
-user invoked the compatibility surface.
+This holds for every diagnostic in that class, regardless of which package
+produced the underlying error. In particular, a `ptah-compat` verb that
+delegates to a native command still prints `Error: `, because the user invoked
+the compatibility surface.
 
 The rule covers the prefix only. The message text after it stays Ptah-owned
 prose, so `ptah-compat schema inspect` with no `--url` reports Ptah's own
 `--url is required` rather than any wording copied from another tool.
 
-Report bodies are not process-level diagnostics and are unaffected: the
-`Error:` field inside a `migrate status` dirty-revision block or a
-`migrate validate` checksum report is part of that report's format on both
-surfaces.
+Other stderr output is outside the class and keeps its own format. Report
+bodies are the main case: the `Error:` field inside a `migrate status`
+dirty-revision block, or inside the Atlas-format checksum report
+`ptah-compat migrate validate` writes, is part of that report's format. So are
+`warning: ` lines and progress logs, which do not terminate the command.
+
+One report line currently reaches stderr with no prefix at all:
+`ptah-compat migrate lint` writes a bare `checksum mismatch` before exiting `1`
+when the directory does not match `atlas.sum` and no `--format` was given. That
+line is the lint report's integrity finding rather than a process-level
+diagnostic — with `--format` the same content is rendered into the report on
+stdout — so the prefix rule does not reach it. Its stream is a known
+divergence, not an endorsed format.
 
 Implementation: the prefix is an inherited command-tree policy
 (`cmdutil.SetErrorPrefixPolicy`), declared once on a surface's root command
-next to its exit-code policy and resolved at print time by walking to the
-nearest ancestor that declares one. Adding a command or a diagnostic requires no
-prefix decision, and no individual command may override it.
+next to its exit-code policy and resolved at print time by walking from the
+printing command up to the nearest ancestor that declares one. Adding a command
+or a diagnostic therefore requires no prefix decision.
+
+The walk starts at the printing command, so the nearest declaration wins and a
+subtree can declare a prefix that differs from its root's. Ptah's own trees do
+not: each declares the policy only on its root. The capability exists because
+`cmdutil.AdoptErrorPrefixPolicy` needs it — a `ptah-compat` verb that forwards
+to a native command runs that command detached from the compatibility tree, so
+it cannot reach the surface's prefix by walking parents and is handed it
+directly for the duration of the call.
 
 ## Native Commands
 

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -11,6 +11,7 @@
     "preview": "astro preview",
     "astro": "astro",
     "check:exit-codes": "node scripts/check-exit-codes.mjs",
+    "check:exit-codes:selftest": "node scripts/check-exit-codes.mjs --selftest",
     "check:core-doc-links": "node scripts/check-core-doc-links.mjs",
     "check:page-health": "node scripts/check-page-health.mjs",
     "check:links": "node scripts/check-links.mjs",

--- a/docs/site/scripts/check-exit-codes.mjs
+++ b/docs/site/scripts/check-exit-codes.mjs
@@ -9,17 +9,95 @@ const repoRoot = join(siteRoot, '..', '..');
 const sourcePath = join(repoRoot, 'docs', 'exit_codes.md');
 const sitePath = join(siteRoot, 'src', 'content', 'docs', 'reference', 'exit-codes.md');
 
+// A separator row carries no content to mirror: every cell is dashes and
+// optional alignment colons.
+const separatorRow = /^\|(\s*:?-+:?\s*\|)+$/;
+
+// tableRows returns every content row of every Markdown table in source,
+// header rows included.
+//
+// It deliberately does not require a row to open with a code span. That
+// narrower filter silently excluded whole tables whose first column is prose:
+// the Diagnostic Prefix table added for stokaro/ptah#1019 opens
+// `| Native \`ptah\` |`, so the checker reported OK while comparing none of its
+// rows. A checker that decides what to compare from the shape of the first
+// cell reports on the rows it happens to recognize, not on the reference.
 function tableRows(source) {
   return source
     .split('\n')
     .map((line) => line.trim())
-    .filter((line) => line.startsWith('| `'));
+    .filter((line) => line.startsWith('|') && !separatorRow.test(line));
+}
+
+// missingRows returns the reference rows the site page does not reproduce.
+function missingRows(source, site) {
+  return tableRows(source).filter((row) => !site.includes(row));
+}
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+// selftest proves the checker fails on the omission it exists to catch, and in
+// particular on a table whose first cell is prose rather than a code span —
+// the case the previous filter passed over in silence.
+function selftest() {
+  const source = [
+    '| Code | Meaning |',
+    '| --- | --- |',
+    '| `0` | Success. |',
+    '',
+    '| Surface | Prefix |',
+    '| :-- | --: |',
+    '| Native `ptah` | `error: ` |',
+    '',
+  ].join('\n');
+
+  const mirrored = [
+    '| Code | Meaning |',
+    '| --- | --- |',
+    '| `0` | Success. |',
+    '| Surface | Prefix |',
+    '| --- | --- |',
+    '| Native `ptah` | `error: ` |',
+  ].join('\n');
+
+  const rows = tableRows(source);
+  assert(rows.length === 4, `expected 4 content rows, got ${rows.length}: ${JSON.stringify(rows)}`);
+  assert(!rows.some((row) => separatorRow.test(row)), 'separator rows must not be compared');
+  assert(rows.includes('| Surface | Prefix |'), 'a prose header row must be compared');
+  assert(rows.includes('| Native `ptah` | `error: ` |'), 'a prose-first-cell row must be compared');
+
+  assert(missingRows(source, mirrored).length === 0, 'a fully mirrored page must pass');
+
+  const withoutProseTable = mirrored
+    .split('\n')
+    .filter((line) => !line.includes('Surface') && !line.includes('Native'))
+    .join('\n');
+  const droppedProse = missingRows(source, withoutProseTable);
+  assert(
+    droppedProse.length === 2,
+    `expected the 2 dropped prose rows, got ${JSON.stringify(droppedProse)}`,
+  );
+
+  const withoutCodeRow = mirrored.replace('| `0` | Success. |\n', '');
+  assert(
+    missingRows(source, withoutCodeRow).includes('| `0` | Success. |'),
+    'a dropped code-span row must still be caught',
+  );
+
+  console.log('check-exit-codes.mjs --selftest: OK');
 }
 
 function main() {
-  const sourceRows = tableRows(readFileSync(sourcePath, 'utf8'));
+  if (process.argv[2] === '--selftest') {
+    selftest();
+    return;
+  }
+
+  const source = readFileSync(sourcePath, 'utf8');
   const site = readFileSync(sitePath, 'utf8');
-  const missing = sourceRows.filter((row) => !site.includes(row));
+  const missing = missingRows(source, site);
 
   if (missing.length > 0) {
     console.error(`${sitePath} is missing ${missing.length} exit-code reference row(s):`);
@@ -30,7 +108,7 @@ function main() {
     return;
   }
 
-  console.log(`check-exit-codes.mjs: OK (${sourceRows.length} reference rows)`);
+  console.log(`check-exit-codes.mjs: OK (${tableRows(source).length} reference rows)`);
 }
 
 main();

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -366,7 +366,7 @@
     "atlas_oss": "no",
     "atlas_pro": "yes",
     "note": "Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either.",
-    "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web`, `ptah-compat schema diff --web`, `ptah migrations lint --web` each print `error: unknown flag: --web`. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
+    "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web` and `ptah-compat schema diff --web` print `Error: unknown flag: --web` (exit 1), `ptah migrations lint --web` prints `error: unknown flag: --web` (exit 2); the prefix and code follow the surface, per #1019. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
   },
   {
     "area": "Testing framework",

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -30,6 +30,54 @@ remediation. A `1` means the command successfully found a condition you asked
 it to check; a `2` means the command itself did not complete correctly.
 Atlas-compatible surfaces use `1` for both classes to match Atlas CE.
 
+## Diagnostic prefix
+
+A *process-level diagnostic* is the single line a surface prints when a command
+terminates with a failure: the line produced by Ptah's CLI error contract
+(`cmdutil.Fail`, the Cobra flag-error and `RunE` wrappers, the post-execution
+error normalizer, the compatibility tree's own printers, and the recovered
+panic at the process boundary). Its prefix is punctuation owned by the surface,
+not by the message, and the only input is which binary printed the line:
+
+| Surface | Prefix | Exit code |
+| --- | --- | --- |
+| Native `ptah` | `error: ` | `2` |
+| Compatibility `ptah-compat` | `Error: ` | `1` |
+
+This holds for every diagnostic in that class, regardless of which package
+produced the underlying error. In particular, a `ptah-compat` verb that
+delegates to a native command still prints `Error: `, because the user invoked
+the compatibility surface. If you grep stderr in a script, match the prefix of
+the binary you actually run.
+
+The rule covers the prefix only. The message text after it stays Ptah-owned
+prose, so `ptah-compat schema inspect` with no `--url` reports Ptah's own
+`--url is required` rather than any wording copied from another tool.
+
+Other stderr output is outside the class and keeps its own format. Report
+bodies are the main case: the `Error:` field inside a `migrate status`
+dirty-revision block, or inside the Atlas-format checksum report
+`ptah-compat migrate validate` writes, is part of that report's format. So are
+`warning: ` lines and progress logs, which do not terminate the command.
+
+One report line currently reaches stderr with no prefix at all:
+`ptah-compat migrate lint` writes a bare `checksum mismatch` before exiting `1`
+when the directory does not match `atlas.sum` and no `--format` was given. That
+line is the lint report's integrity finding rather than a process-level
+diagnostic — with `--format` the same content is rendered into the report on
+stdout — so the prefix rule does not reach it. Its stream is a known
+divergence, not an endorsed format.
+
+Internally the prefix is an inherited command-tree policy declared once on a
+surface's root command, next to its exit-code policy, and resolved at print
+time by walking from the printing command up to the nearest ancestor that
+declares one. Adding a command or a diagnostic therefore requires no prefix
+decision. The nearest declaration wins, so a subtree *can* declare its own
+prefix; Ptah's trees do not, but a `ptah-compat` verb that forwards to a native
+command relies on it, because the forwarded command runs detached from the
+compatibility tree and is handed the surface's prefix for the duration of the
+call.
+
 ## Native commands
 
 The grouped command tree is the native Ptah surface. Ptah is pre-GA, so old

--- a/docs/site/src/content/docs/reference/exit-codes.md
+++ b/docs/site/src/content/docs/reference/exit-codes.md
@@ -68,10 +68,11 @@ diagnostic — with `--format` the same content is rendered into the report on
 stdout — so the prefix rule does not reach it. Its stream is a known
 divergence, not an endorsed format.
 
-Internally the prefix is an inherited command-tree policy declared once on a
-surface's root command, next to its exit-code policy, and resolved at print
+Internally the prefix is an inherited command-tree policy resolved at print
 time by walking from the printing command up to the nearest ancestor that
-declares one. Adding a command or a diagnostic therefore requires no prefix
+declares one. Only the Atlas-compatible surface declares one, on its root
+command next to its exit-code policy; the native tree declares nothing and
+falls through to the default. Adding a command or a diagnostic therefore requires no prefix
 decision. The nearest declaration wins, so a subtree *can* declare its own
 prefix; Ptah's trees do not, but a `ptah-compat` verb that forwards to a native
 command relies on it, because the forwarded command runs detached from the


### PR DESCRIPTION
Closes #1019.

`ptah-compat` printed `Error:` for container diagnostics and `error:` for cobra flag diagnostics. One surface, two prefixes, decided by which printer happened to run. The compat surface now uses `Error:` throughout; the native `ptah` tree keeps `error:` and is untouched.

## Direction, measured across the whole surface

Not looser anywhere. The reviewer enumerated **38 compat command paths from the branch binary's own help tree × 4 failure shapes = 151 argvs**, run against master-built compat, branch-built compat, and the pinned community binary:

- exit codes changed base → branch: **0**
- stdout changed: **0**
- all 128 stderr deltas are exactly the first `error: ` → `Error: ` and nothing else
- stderr byte-identical to the community binary: **12 → 78 of 151**; parity lost: **0**

Plus 24 semantic fixtures (tampered `atlas.sum`, unhashed directory, bad URLs, missing `--dev-url`, missing directories, remote sources, forwarded targets) — exit codes identical on all 24.

## The gap that made this needs-work

The recovered panic at the process boundary had **no discriminator anywhere in the repo**. Reverting that one line to a hardcoded `"error: "` left `go test ./...` fully green.

That is the one printer in the documented class nothing watched, and the exit-code documentation names it as a member — so a later simplification back to the literal would have silently reintroduced exactly the split this issue exists to close.

The test now has two rows, and it discriminates:

```
printer reverted to the literal
  --- FAIL .../surface_declaring_its_own_prefix
      got  "error: internal error: bad annotation"
      want "Error: internal error: bad annotation"
```

The native row leaves the policy alone rather than passing an empty prefix — `SetErrorPrefixPolicy` panics on empty by design, which is itself the right call — and the wiring goes through a function in the table so the test body carries no branching.

## A documentation claim that was false

Both exit-code documents said the prefix is "declared once on a surface's root command". Only the compat surface declares anything; the native tree declares nothing and falls through to the default. A reader would have gone looking for a call that does not exist. Corrected in both.

## One expectation flipped

`TestCompatBinaryMigrateApplyRejectsMalformedAtlasTxMode` arrived on master after this branch was cut and asserts the old lowercase prefix. It is a compat process-level diagnostic, so it takes the compat prefix; the pinned community binary prints `Error:` for the comparable failure, which is the direction this whole change moves.

## Left for a separate issue

The sweep found a pre-existing looseness unrelated to this diff and identical on master: `migrate lint --dir file://mig --latest 1` with no `--dev-url` exits 0 where the community binary does not. Not touched here.

## Verification

Rebased onto current master. `go build`, `go vet`, `go test ./... -count=1`, `golangci-lint run ./...`, `check-style.mjs` and the public-API gate are clean.
