### PR TITLE
Let read-only analysis proceed past a transaction mode it cannot read

### DIFF
--- a/cmd/atlas/migrate_lint_default_test.go
+++ b/cmd/atlas/migrate_lint_default_test.go
@@ -228,3 +228,30 @@ func TestCompatCommand_MigrateLintProjectEnvLintLog(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Equals, "2\n")
 }
+
+// TestCompatCommand_MigrateLintTolerAtesUnreadableTxMode covers a directory
+// carrying a transaction-mode directive nothing can read.
+//
+// `migrate lint` analyzes and reports; it executes nothing on the target, and
+// its dev-database replay is dropped immediately afterwards. A directive that
+// only decides how the file would be APPLIED therefore cannot make the analysis
+// wrong, and refusing left a user unable to lint a directory at all.
+//
+// Measured on the pinned community binary over the same fixture: `migrate lint`
+// exits 0 and analyzes, while `migrate apply` exits 1 with the same complaint
+// Ptah makes. Both halves are asserted here, because tolerating it everywhere
+// would be the opposite defect.
+func TestCompatCommand_MigrateLintToleratesUnreadableTxMode(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	devDB := "sqlite://" + filepath.Join(t.TempDir(), "txmode.db")
+	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n")
+	writeAtlasLintFile(c, dir, "2.sql",
+		"-- atlas:txmode unknown\n\nCREATE TABLE pets (id int);\n")
+
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
+	c.Assert(stdout, qt.Contains, "analyzing version 2")
+	c.Assert(stdout, qt.Not(qt.Contains), "unknown txmode")
+}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6786,6 +6786,7 @@ type OutOfOrderError struct{ ... }
     func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
 type ParsedMigrationUp struct{ ... }
     func ParseMigrationUp(filename, sql string) (ParsedMigrationUp, error)
+    func ParseMigrationUpForAnalysis(filename, sql string) (ParsedMigrationUp, error)
 type PreMigrationHook func(ctx context.Context, plan MigrationPlan) error
 type RegisteredMigrationProvider struct{ ... }
     func NewRegisteredMigrationProvider(migrations ...*Migration) *RegisteredMigrationProvider
@@ -7086,6 +7087,7 @@ type Migration struct {
 func CreateMigrationFromSQL(version int64, description, upSQL, downSQL string) *Migration
 func NewMigrationFromSQLFiles(version int64, description, upFilename, downFilename string, fsys fs.FS) (*Migration, error)
 func NewMigrationFromSQLFilesWithInterceptor(version int64, description, upFilename, downFilename string, fsys fs.FS, ...) (*Migration, error)
+func (m *Migration) UpForReplay(ctx context.Context, conn *dbschema.DatabaseConnection) error
 
 ### go.5x5.cz/ptah/migration/migrator.MigrationDirFormat
 
@@ -7451,6 +7453,7 @@ type ParsedMigrationUp struct {
     Atlas txtar migration file.
 
 func ParseMigrationUp(filename, sql string) (ParsedMigrationUp, error)
+func ParseMigrationUpForAnalysis(filename, sql string) (ParsedMigrationUp, error)
 
 ### go.5x5.cz/ptah/migration/migrator.PreMigrationHook
 

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -233,7 +233,7 @@ func replayMigrations(
 		return fmt.Errorf("clean dev database: %w", err)
 	}
 	for _, migration := range migrations {
-		if err := migration.Up(ctx, conn); err != nil {
+		if err := migration.UpForReplay(ctx, conn); err != nil {
 			return fmt.Errorf("replay migration %d on dev database: %w", migration.Version, err)
 		}
 	}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -515,7 +515,7 @@ func prepareFile(
 			}
 			sql = rendered
 		}
-		up, err := migrator.ParseMigrationUp(name, sql)
+		up, err := migrator.ParseMigrationUpForAnalysis(name, sql)
 		if err != nil {
 			return File{}, err
 		}

--- a/migration/migrator/file_tx_mode.go
+++ b/migration/migrator/file_tx_mode.go
@@ -56,6 +56,49 @@ func ParseMigrationUp(filename, sql string) (ParsedMigrationUp, error) {
 	return result, nil
 }
 
+// ParseMigrationUpForAnalysis is [ParseMigrationUp] for read-only analysis,
+// where an unrecognized transaction mode is not a reason to refuse the file.
+//
+// `migrate lint` reads a directory to report on it and executes nothing, so a
+// directive that only decides how the file would be APPLIED cannot make the
+// analysis wrong. Refusing there also diverges: measured on the pinned
+// community binary, `migrate lint` over a directory carrying
+// `-- atlas:txmode unknown` exits 0 and analyzes normally, while refusing it
+// left a user unable to lint a directory they could still apply-check.
+//
+// Only the transaction mode is forgiven. A malformed file, a bad txtar
+// envelope, or anything else [ParseMigrationUp] rejects is still an error, and
+// the apply path keeps using [ParseMigrationUp] unchanged -- executing a file
+// whose transaction mode we could not read is a different question with a
+// different answer.
+func ParseMigrationUpForAnalysis(filename, sql string) (ParsedMigrationUp, error) {
+	parsed, err := ParseMigrationUp(filename, sql)
+	if err == nil {
+		return parsed, nil
+	}
+	stripped, txErr := parseMigrationUpIgnoringTxMode(filename, sql)
+	if txErr != nil {
+		return ParsedMigrationUp{}, err
+	}
+	return stripped, nil
+}
+
+// parseMigrationUpIgnoringTxMode repeats [ParseMigrationUp] without consulting
+// the transaction-mode directive, so a caller can tell a txmode complaint apart
+// from a file it genuinely cannot read.
+func parseMigrationUpIgnoringTxMode(filename, sql string) (ParsedMigrationUp, error) {
+	parsed, isTxtar, err := parseAtlasTxtarSQL(filename, sql)
+	if err != nil {
+		return ParsedMigrationUp{}, err
+	}
+	result := ParsedMigrationUp{SQL: sql}
+	if isTxtar {
+		result.SQL = parsed.migrationSQL
+		result.SourceLineOffset = parsed.migrationLineOffset
+	}
+	return result, nil
+}
+
 func parseAtlasFileTxMode(filename, sql string) (MigrationFileTxMode, bool, error) {
 	if !strings.HasPrefix(sql, "--") {
 		return MigrationFileTxModeUnspecified, false, nil

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -683,6 +683,30 @@ func (m *Migration) downExecutionMode() migrationExecutionMode {
 	return migrationExecutionTransactional
 }
 
+// UpForReplay executes the up direction against a THROWAWAY dev database,
+// ignoring an unreadable transaction-mode directive.
+//
+// Replay exists to reconstruct a schema so something else can be computed from
+// it -- a lint analysis, a diff. The transaction mode decides how statements are
+// wrapped when a real database is migrated; on a database that is dropped
+// immediately afterwards it changes nothing anyone can observe, so a directive
+// we cannot read is not a reason to refuse the whole operation.
+//
+// The apply path keeps refusing, and that matches: measured on the pinned
+// community binary, `migrate apply` over a directory carrying
+// `-- atlas:txmode unknown` exits 1 with the same complaint, while
+// `migrate lint` over the same directory exits 0 and analyzes it.
+//
+// A migration with no SQL function falls back to [Migration.Up], which still
+// refuses. That path is for programmatic migrations, which carry no file
+// directive to be unreadable in the first place.
+func (m *Migration) UpForReplay(ctx context.Context, conn *dbschema.DatabaseConnection) error {
+	if m.upSQLFunc != nil {
+		return m.upSQLFunc(ctx, conn, m.upExecutionMode())
+	}
+	return m.Up(ctx, conn)
+}
+
 func (m *Migration) executeUp(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
 	if m.upTxModeErr != nil {
 		return m.upTxModeErr


### PR DESCRIPTION
`ptah-compat migrate lint` refused a migration directory carrying an unrecognized `-- atlas:txmode` directive. The pinned community binary analyzes the same directory and exits 0.

## The boundary, measured on both verbs

One fixture, four runs, so the line is not a guess:

| | community binary | ptah-compat before |
| --- | --- | --- |
| `migrate lint` | exit 0, analyzes | **exit 1, refuses** |
| `migrate apply` | exit 1, `unknown txmode "unknown"` | exit 1, same message |

`apply` already matched and is unchanged. Only `lint` diverged, and it diverged in the direction that costs a user something real: they could not lint a directory at all because of a directive that has no bearing on the analysis.

## Why lint is different

The directive decides how a file's statements are wrapped when a **real** database is migrated. `migrate lint` executes nothing on the target, and the dev database it replays into is dropped immediately afterwards. A wrapping choice on a database nobody will ever look at again cannot make the analysis wrong.

`apply` executes for real, so a mode we cannot read there is a genuine reason to stop — which is also what the community binary does.

## Two call sites, which is why the first attempt only half-worked

Making the analysis parse lenient moved lint's error from the parser to the replay underneath it:

```
Error: error validating migration SQL on dev database: replay migration 20220925094021
on dev database: unknown txmode "unknown" found in file directive "..."
```

The replay needed the same treatment. Both are now scoped, and `ParseMigrationUp` — the apply path — is untouched.

## What is deliberately not forgiven

Only the transaction mode. A malformed file, a bad txtar envelope, or anything else the strict parse rejects is still an error. A migration with no SQL function still goes through the refusing path; those are programmatic migrations, which carry no file directive to be unreadable in the first place.

## Verification

The test asserts lint exits 0 **and** never mentions the directive — the second half matters, because a lint that "succeeded" while printing the complaint would pass a weaker assertion.

Confirmed to discriminate: reverting both call sites turns it red.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint`, and both public-API gates are clean. `docs/public_api.snapshot` gains `ParseMigrationUpForAnalysis` and `Migration.UpForReplay`; the change is additive and the released-API gate confirms no break.

## How it was found

Conformance, after the module pin moved past the per-file txmode work. The `sqlitetx4` fixture went red, which is the fixture existing precisely to carry an unreadable txmode. The corpus budget is 0, so this had to be a real fix rather than a recorded divergence — and it should be, since the community binary's behavior here is the more useful one.
