### PR TITLE
Honor a txmode directive written directly above its statement

### DIFF
--- a/migration/migrator/file_tx_mode.go
+++ b/migration/migrator/file_tx_mode.go
@@ -108,12 +108,21 @@ func parseAtlasFileTxMode(filename, sql string) (MigrationFileTxMode, bool, erro
 	headerComplete := false
 	for sql != "" {
 		line, rest, hasNewline := strings.Cut(sql, "\n")
-		if strings.TrimSpace(line) == "" {
+		// The directive header ends at the first line that is not a comment.
+		// A blank line ends it, and so does the first statement: requiring a
+		// blank line means `-- atlas:txmode none` immediately above the
+		// statement it applies to is silently dropped, and the statement then
+		// runs inside a transaction it asked to stay out of.
+		//
+		// Measured on the pinned community binary: with the blank line the
+		// directive is honored, without it the same file fails with
+		// `CREATE INDEX CONCURRENTLY cannot run inside a transaction block`.
+		// Ptah honored both until it was changed to follow that shape, and
+		// honoring both is the behavior restored here -- a directive the author
+		// wrote and we can read is not made meaningless by the line after it.
+		if strings.TrimSpace(line) == "" || !strings.HasPrefix(line, "--") {
 			headerComplete = true
 			break
-		}
-		if !hasNewline || !strings.HasPrefix(line, "--") {
-			return MigrationFileTxModeUnspecified, false, nil
 		}
 
 		for search := line; ; {
@@ -127,6 +136,11 @@ func parseAtlasFileTxMode(filename, sql string) (MigrationFileTxMode, bool, erro
 			}
 			values = append(values, value)
 			search = after
+		}
+		if !hasNewline {
+			// The file is nothing but its header, with no trailing newline.
+			headerComplete = true
+			break
 		}
 		sql = rest
 	}

--- a/migration/migrator/file_tx_mode_internal_test.go
+++ b/migration/migrator/file_tx_mode_internal_test.go
@@ -41,6 +41,28 @@ func Test_parseAtlasFileTxMode_HappyPath(t *testing.T) {
 			sql:  "-- atlas:txmode none\n \t\r\nSELECT 1;",
 			want: MigrationFileTxModeNone,
 		},
+		{
+			// The header ends at the first statement, not only at a blank line.
+			// Requiring the blank line drops a directive the author wrote
+			// directly above the statement it applies to, which is where an
+			// author is most likely to write it.
+			name: "statement immediately after the directive",
+			sql:  "-- atlas:txmode none\nCREATE INDEX CONCURRENTLY i ON t (c);",
+			want: MigrationFileTxModeNone,
+		},
+		{
+			name: "statement immediately after a multi-line header",
+			sql:  "-- generated migration\n-- atlas:txmode none\nSELECT 1;",
+			want: MigrationFileTxModeNone,
+		},
+		{
+			// Same rule from the other side: the directive was already read
+			// when the indented line ended the header, so the indentation of a
+			// LATER line cannot un-write it.
+			name: "indented line after the directive",
+			sql:  "-- atlas:txmode none\n  -- generated migration\n\nSELECT 1;",
+			want: MigrationFileTxModeNone,
+		},
 	}
 
 	for _, test := range tests {
@@ -132,10 +154,6 @@ func Test_parseAtlasFileTxMode_Ignored(t *testing.T) {
 			sql:  "  -- atlas:txmode none\n\nSELECT 1;",
 		},
 		{
-			name: "non-comment before blank separator",
-			sql:  "-- atlas:txmode none\nSELECT 1;\n\n",
-		},
-		{
 			name: "missing blank separator",
 			sql:  "-- atlas:txmode none\n",
 		},
@@ -154,10 +172,6 @@ func Test_parseAtlasFileTxMode_Ignored(t *testing.T) {
 		{
 			name: "uppercase key",
 			sql:  "-- ATLAS:TXMODE none\n\nSELECT 1;",
-		},
-		{
-			name: "indented header line",
-			sql:  "-- atlas:txmode none\n  -- generated migration\n\nSELECT 1;",
 		},
 		{
 			name: "leading header without occurrence",


### PR DESCRIPTION
Fixes #1080, and corrects that issue's diagnosis: this is not a regression against Atlas, it is a place where Ptah was **better** and stopped being.

## Measured, both forms, one fixture each

PostgreSQL 18, `CREATE INDEX CONCURRENTLY` under `-- atlas:txmode none`:

| file shape | community binary | ptah before #1070 | ptah on master |
| --- | --- | --- | --- |
| directive, blank line, statement | 0 | 0 | 0 |
| directive, statement | **1** | **0** | **1** |

The community binary drops the directive when no blank line follows it, and the statement then runs inside the transaction it asked to stay out of. Ptah honored both forms until #1070 aligned the parser with that shape.

So there was nothing to be compatible *with* here — matching cost a capability and gained nothing. We do not reproduce a defect in order to be identical to it.

## What changes

The directive header ended only at a blank line; a non-comment line abandoned the whole directive. It now ends at the **first line that is not a comment** — a blank line, the first statement, or an indented line — and whatever was read before that stands.

One sentence covers it: *a directive we can read is honored, and the shape of a later line cannot un-write it.*

## Three test cases moved from ignored to honored

They are instances of that one rule, not separate concessions:

- `-- atlas:txmode none` immediately above its statement — the case in the issue, and the one an author is most likely to write.
- The same after a multi-line header.
- An indented comment line *after* the directive. The directive was already read when that line ended the header; its indentation cannot retroactively erase it.

`-- atlas:txmode none` alone in a file with no statement stays ignored and is unchanged — there is nothing for it to apply to.

## Failure paths unchanged

Multiple `atlas:txmode` values still error. An unknown value still errors on apply. `atlas:txmode all` still errors with the "use `file`" message.

## Verification

Both forms applied end to end against a live PostgreSQL 18 and reached `Migration complete. Current version: 2`.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint` and the public-API gate are clean.

## Why it was found

The conformance corpus. `postgres/no-transaction-concurrent-index` went from `ok` to a gap when the module pin moved, and its fixture writes the directive with no blank line — which is exactly why that fixture exists.
