### PR TITLE
docs: state that we do not copy defects to be compatible

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,54 @@
 
 This file gives coding agents repository-local guidance for working in Ptah.
 
+## Compatibility Policy
+
+Ptah aims to be a drop-in replacement for the Atlas CLI. That goal has two
+halves, and only stating the first one is how a capability gets thrown away.
+
+**Never be looser.** A configuration or invocation the community binary refuses
+must not succeed here. Accepting something it rejects means a user's mistake
+passes silently on Ptah and fails somewhere later, which is the worst outcome
+available. Where Ptah cannot yet implement a construct the community binary
+enforces, refuse loudly rather than accept and ignore.
+
+**Matching is the floor, not the ceiling. We do not copy defects.** Where the
+community binary's behavior is a defect -- it silently drops something the
+author wrote, corrupts state, or fails for a reason unrelated to what the user
+asked for -- reproducing it is a wrong answer. Be the same or better. A change
+whose only justification is "this is what the other implementation does" is not
+justified when what it does is broken.
+
+When the two halves pull apart, say so in the commit and in the issue rather
+than picking silently. "We are stricter here, deliberately, and here is the
+measurement" is a complete answer; quietly matching is not.
+
+### A worked example
+
+`-- atlas:txmode none` marks a migration that must run outside a transaction --
+`CREATE INDEX CONCURRENTLY`, for instance. Measured on PostgreSQL 18:
+
+| file shape | community binary | Ptah |
+| --- | --- | --- |
+| directive, blank line, statement | applies | applies |
+| directive, statement immediately below | **fails** | applies |
+
+The community binary requires a blank line after the directive and silently
+drops it otherwise, so the statement runs inside the transaction it asked to
+stay out of and the migration fails partway through. Ptah honored both forms.
+
+A change once "fixed" this by adopting the blank-line requirement, on the
+grounds that it matched. That traded a place where Ptah was better for a place
+where it was merely identical, and it was reverted. The directive is honored in
+both forms, and the divergence is documented rather than hidden.
+
+### Deciding which you are doing
+
+Before matching a measured behavior, ask what it costs the user. If the answer
+is "nothing, it is a different spelling of the same outcome", match it -- wording, exit codes,
+flag names and output shape are worth being identical on, because tooling reads
+them. If the answer is "they lose something they asked for", do not match it.
+
 ## Language And Spelling
 
 Use American English spelling in code, comments, documentation, issue/PR text,

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -14,6 +14,34 @@ ptah-atlas-conformance -> ptah
 ptah                  !-> ptah-atlas-conformance
 ```
 
+## What Conformance Means Here
+
+A green scoreboard means Ptah does not diverge from the community binary in the
+direction that costs a user something. It does not mean Ptah reproduces every
+behavior the community binary has.
+
+Two rules, and the second one is the reason this section exists:
+
+1. **Never looser.** Anything the community binary refuses must not succeed on
+   Ptah. A construct Ptah cannot yet implement is refused loudly rather than
+   accepted and ignored.
+2. **Never a copied defect.** Where the measured behavior is a defect -- it
+   silently drops a directive the author wrote, corrupts state, or fails for a
+   reason unrelated to the request -- Ptah does not reproduce it. Matching is
+   the floor, not the ceiling.
+
+A fixture that fails because Ptah is *better* is not a conformance failure. It
+is recorded as a deliberate divergence, with the measurement that establishes
+which behavior is the defective one, and the report says which of the two rules
+it falls under.
+
+The distinction is not academic. `-- atlas:txmode none` written directly above
+its statement, with no blank line between them, is silently dropped by the
+community binary; the statement then runs inside the transaction it asked to
+stay out of and the migration fails partway through. Ptah honors it. A change
+that once removed that capability in the name of parity was reverted -- see
+`AGENTS.md`, "Compatibility Policy".
+
 ## Current Scoreboard
 
 As of Ptah `18ae5f9d4d63136248986263732524e2314f9d7c`:

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -24,6 +24,29 @@ while also listing a basic Open lint-rule set. Checkpoints, visualization,
 interactive migrations, testing, deployment rollout, database security as code,
 and declarative data management are listed as Pro features.
 
+## What parity means, and what it does not
+
+Ptah aims to be a drop-in replacement, which means two commitments rather than
+one.
+
+Ptah does not accept what Atlas refuses. A configuration or invocation Atlas
+rejects is rejected here too, because accepting it would let a mistake pass
+silently and fail later. Where Ptah has not implemented something Atlas
+enforces, it refuses with a message rather than accepting and ignoring it.
+
+Ptah also does not reproduce defects for the sake of being identical. Where a
+measured behavior loses something the author asked for, Ptah does the better
+thing and documents the difference.
+
+One concrete case: a migration carrying `-- atlas:txmode none` directly above
+its statement, with no blank line between them. That directive marks a statement
+that must run outside a transaction, such as `CREATE INDEX CONCURRENTLY`. In
+that shape Atlas drops the directive, so the statement runs inside a transaction
+and the migration fails partway through. Ptah honors it.
+
+Differences of this kind are listed in the [gap register](#gap-register) with
+the measurement behind them, so you can see which way each one goes.
+
 ## Command parity
 
 | Task | Native Ptah | `ptah-compat` | Atlas OSS |


### PR DESCRIPTION
The drop-in goal was written down as one rule — never be looser than the community binary. Stating only that half is how a working behavior gets traded away for parity, and it already happened once.

## The case that prompted this

`-- atlas:txmode none` marks a migration that must run outside a transaction, such as `CREATE INDEX CONCURRENTLY`. Measured on PostgreSQL 18:

| file shape | community binary | Ptah before | Ptah after "the fix" |
| --- | --- | --- | --- |
| directive, blank line, statement | applies | applies | applies |
| directive, statement immediately below | **fails** | **applies** | **fails** |

The community binary requires a blank line and silently drops the directive otherwise; the statement then runs inside the transaction it asked to stay out of and the migration fails partway through, leaving the directory partly applied.

Ptah handled both forms. A change aligned the parser with that shape because it matched — trading a place where Ptah was better for a place where it was merely identical. Reverted in #1081.

## What the documents now say

**`AGENTS.md`** gains a `Compatibility Policy` section with both halves:

- **Never looser.** Anything the community binary refuses must not succeed here. Where Ptah cannot implement a construct it enforces, refuse loudly rather than accept and ignore.
- **Never a copied defect.** Matching is the floor, not the ceiling. A change whose only justification is "this is what the other implementation does" is not justified when what it does is broken.

When the halves pull apart, say which you chose in the commit rather than picking silently.

It also carries a test for deciding which you are doing: **ask what matching costs the user.** If the answer is "nothing, it is a different spelling of the same outcome" — wording, exit codes, flag names, output shape — match it, because tooling reads those. If the answer is "they lose something they asked for", do not.

**`docs/conformance.md`** says what a green scoreboard does and does not mean. A fixture failing because Ptah is *better* is a recorded divergence, not a conformance failure — recorded with the measurement establishing which behavior is the defective one.

**The comparison page** says the same in the reader's terms, because "drop-in replacement" otherwise reads as "bug-for-bug replacement", which is not the promise.

## Verification

`check-style.mjs` clean over 100 documentation files. Documentation only — no code changes.
