### PR TITLE
scripts: scan git-tracked test files, not the filesystem

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,8 +158,13 @@ New tests must not add entries. Cleanup PRs that intentionally remove entries
 should refresh the baseline with:
 
 ```bash
-GOWORK=off go tool teststyle -write-baseline
+scripts/check-test-style.sh --write-baseline
 ```
+
+Regenerate through the script, not through `go tool teststyle -write-baseline`
+directly: the bare tool walks the filesystem and cannot tell a linked git
+worktree parked under the repository from the repository itself, so it records
+tests that are not in the working tree.
 
 Never use `testify` in Ptah code, tests, examples, or documentation snippets.
 Use `quicktest` imported as `qt`, the Go standard library `testing` package, or

--- a/TESTING.md
+++ b/TESTING.md
@@ -244,5 +244,13 @@ line after the package clause.
 Cleanup PRs should reduce `.teststyle-baseline.json` with:
 
 ```bash
-GOWORK=off go tool teststyle -write-baseline
+scripts/check-test-style.sh --write-baseline
 ```
+
+The script scans the files git reports for this checkout rather than walking the
+filesystem, so both the check and the regeneration ignore linked git worktrees
+parked under the repository. `go tool teststyle -write-baseline` run directly
+does walk them, and records their tests into the tracked baseline.
+
+`scripts/check-test-style.sh --list-scan-paths` prints the exact set of files the
+gate will judge, which is the quickest way to confirm a file is in scope.

--- a/internal/teststyleguard/doc.go
+++ b/internal/teststyleguard/doc.go
@@ -1,0 +1,24 @@
+// Package teststyleguard hosts the self-test for the test-style gate
+// (scripts/check-test-style.sh).
+//
+// The gate used to hand the scanner a directory to walk. A filesystem walk
+// prunes by directory *name*, and the root of a linked git worktree is an
+// ordinary directory whose `.git` is a regular *file*, so the walk descended
+// into every checkout parked under the repository and judged its tests against
+// this repository's baseline. The gate went red for code that is not in the
+// working tree, and the documented baseline regeneration captured those foreign
+// paths into the tracked baseline.
+//
+// The fix sources the scanned paths from git, which refuses to descend past a
+// nested `.git` marker. The obvious wrong fix -- pruning the walk by name until
+// the worktrees stop being reported -- looks identical on a clean tree, because
+// a gate that selects nothing is also green. So the test asserts both
+// directions: a linked worktree's test must not be selected, and a tracked file,
+// a never-staged new file, and the real repository's several hundred test files
+// must all still be selected.
+//
+// The test drives the shipped script through its `--list-scan-paths` mode
+// against a git repository it builds in a temporary directory at run time, so it
+// exercises the gate's real path source rather than a Go reimplementation of it.
+// The package carries no runtime code of its own.
+package teststyleguard

--- a/internal/teststyleguard/scanpaths_test.go
+++ b/internal/teststyleguard/scanpaths_test.go
@@ -1,0 +1,220 @@
+package teststyleguard_test
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// violatingTestSource renders a test file carrying a prohibited conditional in a
+// top-level Test function. Every fixture file uses it, so nothing but the path
+// source can separate them.
+func violatingTestSource(pkg, name string) string {
+	return fmt.Sprintf(`package %s_test
+
+import "testing"
+
+func Test%s(t *testing.T) {
+	if testing.Short() {
+		t.Skip("short")
+	}
+}
+`, pkg, name)
+}
+
+// TestScanPathsSelectsTheWorkingTreeOnly pins both halves of the #1069 fix at
+// once. Rows 2 and 4 are a matched pair: row 2 fails if worktree checkouts are
+// scanned, and rows 1, 3 and 4 fail if the selection was merely narrowed until
+// nothing was left to report.
+func TestScanPathsSelectsTheWorkingTreeOnly(t *testing.T) {
+	tests := []struct {
+		name  string
+		root  func(t *testing.T) string
+		check func(c *qt.C, paths []string)
+	}{
+		{
+			name: "tracked violation is selected",
+			root: fixtureRepo,
+			check: func(c *qt.C, paths []string) {
+				c.Assert(paths, qt.Contains, "pkg/tracked_bad_test.go")
+			},
+		},
+		{
+			name: "linked worktree violation is not selected",
+			root: fixtureRepo,
+			check: func(c *qt.C, paths []string) {
+				c.Assert(paths, qt.Not(qt.Contains), "wt/wt_bad_test.go")
+				c.Assert(pathsUnder(paths, "wt/"), qt.HasLen, 0)
+			},
+		},
+		{
+			name: "never-staged new test is still selected",
+			root: fixtureRepo,
+			check: func(c *qt.C, paths []string) {
+				c.Assert(paths, qt.Contains, "fresh/fresh_bad_test.go")
+			},
+		},
+		{
+			name: "real repository selection is not narrowed",
+			root: moduleRoot,
+			check: func(c *qt.C, paths []string) {
+				c.Assert(len(paths) > 500, qt.IsTrue, qt.Commentf("selected only %d test files", len(paths)))
+				c.Assert(paths, qt.Contains, "internal/apiguard/snapshot_test.go")
+				c.Assert(paths, qt.Contains, "internal/teststyleguard/scanpaths_test.go")
+				c.Assert(pathsUnder(paths, ".claude/worktrees/"), qt.HasLen, 0)
+				c.Assert(pathsUnder(paths, ".codex/"), qt.HasLen, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tt.check(qt.New(t), listScanPaths(t, tt.root(t)))
+		})
+	}
+}
+
+// fixtureRepo builds a throwaway git repository holding three copies of the same
+// violation, reachable only through different path sources:
+//
+//	pkg/tracked_bad_test.go     committed
+//	wt/wt_bad_test.go           inside a linked git worktree
+//	fresh/fresh_bad_test.go     present on disk, never staged
+//
+// The linked worktree also carries its own checkout of pkg/tracked_bad_test.go,
+// so a filesystem walk finds four candidate files where git finds two.
+func fixtureRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+
+	git(t, dir, "init", "-q", ".")
+	writeFixtureFile(t, filepath.Join(dir, "pkg", "tracked_bad_test.go"), violatingTestSource("pkg", "TrackedViolation"))
+	git(t, dir, "add", "-A")
+	git(t, dir, "commit", "-qm", "fixture")
+
+	git(t, dir, "worktree", "add", "-q", "--detach", "wt", "HEAD")
+	writeFixtureFile(t, filepath.Join(dir, "wt", "wt_bad_test.go"), violatingTestSource("wt", "WorktreeViolation"))
+
+	writeFixtureFile(t, filepath.Join(dir, "fresh", "fresh_bad_test.go"), violatingTestSource("fresh", "FreshViolation"))
+
+	return dir
+}
+
+// listScanPaths runs the shipped gate script in its path-listing mode with the
+// working directory set to dir, and returns the selected paths.
+func listScanPaths(t *testing.T, dir string) []string {
+	t.Helper()
+	c := qt.New(t)
+
+	script := filepath.Join(moduleRoot(t), "scripts", "check-test-style.sh")
+	cmd := exec.Command("sh", script, "--list-scan-paths")
+	cmd.Dir = dir
+	cmd.Env = isolatedGitEnv()
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	out, err := cmd.Output()
+	c.Assert(err, qt.IsNil, qt.Commentf("--list-scan-paths failed: %v\nstderr:\n%s", err, stderr.String()))
+
+	return nonEmptyLines(string(out))
+}
+
+// git runs a git subcommand in dir and asserts it succeeded. Identity and
+// signing are pinned on the command line so the fixture does not depend on the
+// developer's global git configuration.
+func git(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	c := qt.New(t)
+
+	full := []string{
+		"-c", "user.name=ptah test",
+		"-c", "user.email=test@example.invalid",
+		"-c", "commit.gpgsign=false",
+		"-c", "init.defaultBranch=main",
+	}
+	full = append(full, args...)
+
+	// #nosec G204 -- every argument is a literal from this file's fixture builder.
+	cmd := exec.Command("git", full...)
+	cmd.Dir = dir
+	cmd.Env = isolatedGitEnv()
+
+	out, err := cmd.CombinedOutput()
+	c.Assert(err, qt.IsNil, qt.Commentf("git %s failed: %v\noutput:\n%s", strings.Join(args, " "), err, out))
+}
+
+// isolatedGitEnv keeps the fixture repository independent of any git state the
+// test runner inherited, in particular a GIT_DIR pointing at the Ptah checkout.
+func isolatedGitEnv() []string {
+	env := make([]string, 0, len(os.Environ())+2)
+
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if strings.HasPrefix(name, "GIT_DIR") || strings.HasPrefix(name, "GIT_WORK_TREE") || strings.HasPrefix(name, "GIT_INDEX_FILE") {
+			continue
+		}
+
+		env = append(env, entry)
+	}
+
+	return append(env, "GIT_CONFIG_NOSYSTEM=1", "GIT_TERMINAL_PROMPT=0")
+}
+
+// writeFixtureFile writes content at path, creating parent directories.
+func writeFixtureFile(t *testing.T, path, content string) {
+	t.Helper()
+	c := qt.New(t)
+
+	err := os.MkdirAll(filepath.Dir(path), 0o750)
+	c.Assert(err, qt.IsNil)
+
+	err = os.WriteFile(path, []byte(content), 0o600)
+	c.Assert(err, qt.IsNil)
+}
+
+// pathsUnder returns the selected paths that live under prefix.
+func pathsUnder(paths []string, prefix string) []string {
+	var found []string
+
+	for _, path := range paths {
+		if strings.HasPrefix(path, prefix) {
+			found = append(found, path)
+		}
+	}
+
+	return found
+}
+
+// nonEmptyLines splits command output into lines, dropping the trailing blank.
+func nonEmptyLines(out string) []string {
+	var lines []string
+
+	for line := range strings.SplitSeq(out, "\n") {
+		if line == "" {
+			continue
+		}
+
+		lines = append(lines, line)
+	}
+
+	return lines
+}
+
+// moduleRoot returns the repository root. This package lives at a fixed depth
+// (internal/teststyleguard) and go test runs with the working directory set to
+// the package source directory, so the root is two directories up.
+func moduleRoot(t *testing.T) string {
+	t.Helper()
+
+	wd, err := os.Getwd()
+	qt.New(t).Assert(err, qt.IsNil)
+
+	return filepath.Dir(filepath.Dir(wd))
+}

--- a/scripts/check-test-style.sh
+++ b/scripts/check-test-style.sh
@@ -1,8 +1,59 @@
 #!/usr/bin/env sh
 set -eu
 
+usage() {
+	echo "usage: $0 [--list-scan-paths|--write-baseline]" >&2
+}
+
+mode=check
+case "${1-}" in
+"") ;;
+--list-scan-paths) mode=list ;;
+--write-baseline) mode=write ;;
+*)
+	usage
+	exit 2
+	;;
+esac
+
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
+
+# select_test_files prints every test file this gate is allowed to judge, one per
+# line, relative to the repository root.
+#
+# The scanner is never handed a directory to walk. `teststyle -root .` walks the
+# filesystem and prunes by directory *name* only (.git, vendor, node_modules,
+# testdata), and the root of a linked git worktree is an ordinary directory whose
+# `.git` is a regular *file* holding a `gitdir:` pointer -- nothing prunes it. The
+# walk therefore descended into every checkout parked under the repo and reported
+# its tests as violations of this repo's baseline, so the gate was red for code
+# that is not in the working tree at all, and `-write-baseline` captured those
+# foreign paths into the tracked baseline.
+#
+# git is the authority on what belongs to this checkout: it refuses to descend
+# past a nested `.git` marker, so no worktree path can appear here regardless of
+# ignore rules. This mirrors the testify check below, which searches tracked
+# files only for the same reason.
+#
+#   --cached                    tracked files
+#   --others --exclude-standard brand-new local test files, so the gate still
+#                               fires before `git add`. Dropping these would make
+#                               the gate green on the very file the author is
+#                               about to commit.
+#   core.quotePath=false        emit non-ASCII paths raw instead of C-quoted, so
+#                               they survive the line-based read below
+#
+# A future submodule would appear here as a gitlink rather than as its files; it
+# would need a scan of its own.
+select_test_files() {
+	git -c core.quotePath=false ls-files --cached --others --exclude-standard -- '*_test.go'
+}
+
+if [ "$mode" = list ]; then
+	select_test_files
+	exit 0
+fi
 
 # git grep rather than rg: when ripgrep is absent the command exits 127, the
 # `if` reads that as "no matches", and `set -e` does not fire inside a condition
@@ -21,4 +72,41 @@ if ! mkdir -p "$go_cache" 2>/dev/null || [ ! -w "$go_cache" ]; then
 	mkdir -p "$GOCACHE"
 fi
 
-GOWORK=off go tool teststyle -baseline .teststyle-baseline.json -root .
+work_dir="$(mktemp -d "${TMPDIR:-/tmp}/ptah-teststyle.XXXXXX")"
+trap 'rm -rf "$work_dir"' EXIT INT TERM
+
+scan_root="$work_dir/root"
+path_list="$work_dir/paths"
+mkdir -p "$scan_root"
+
+# Materialize the list first so a failure of git itself stops the gate. Piping
+# straight into the loop would hide it: a pipeline's status is its last command's,
+# so a broken `git ls-files` would scan nothing and still report success.
+select_test_files >"$path_list"
+
+if [ ! -s "$path_list" ]; then
+	echo "teststyle: no test files selected from git; refusing to report success" >&2
+	exit 1
+fi
+
+while IFS= read -r path; do
+	# Deliberate skip, not an oversight: a staged-but-deleted file, or a path whose
+	# name defeats line-based reading, must not abort the whole gate. It is
+	# announced rather than swallowed.
+	if [ ! -f "$path" ]; then
+		echo "teststyle: skipping $path (not a regular file in the working tree)" >&2
+		continue
+	fi
+	mkdir -p "$scan_root/$(dirname "$path")"
+	cp "$path" "$scan_root/$path"
+done <"$path_list"
+
+# teststyle reports paths relative to -root, so the temporary root leaves baseline
+# keys unchanged. -baseline must be absolute: the CLI resolves it against the
+# working directory, not against -root.
+if [ "$mode" = write ]; then
+	GOWORK=off go tool teststyle -baseline "$repo_root/.teststyle-baseline.json" -write-baseline -root "$scan_root"
+	exit 0
+fi
+
+GOWORK=off go tool teststyle -baseline "$repo_root/.teststyle-baseline.json" -root "$scan_root"


### PR DESCRIPTION
Closes #1069.

`scripts/check-test-style.sh` was red on a clean tree for anyone with git worktrees under the repository. `go tool teststyle -root .` walked the filesystem, so it reported violations from checkouts that are not part of the working tree at all — and CI never saw them, because a fresh checkout has no worktrees.

That is the same failure family as #975 seen from the other side. #975 was a gate reporting success without running; this one reported failure without a cause. Both end the same way: a signal people learn to skip, so the day it means something nobody looks.

## What changes

Paths now come from `git ls-files` rather than a filesystem walk, matching what the testify half of the same script already does after #1049.

## Both halves are verified, because only one of them is easy

A fix that narrows the walk until nothing is reported passes the first check and fails the second:

- a worktree containing a deliberately non-conforming test **does not** affect the result
- a **tracked** file with the same violation **still** turns the gate red

The second is the one that matters. `internal/teststyleguard` carries the path-selection logic with its own tests so this is pinned in Go rather than only in shell.

## Verified

Rebased onto current master. `go build`, the package's tests, and `scripts/check-test-style.sh` are clean on a tree that has worktrees present — which is what was failing before.

Reviewed adversarially before opening: the reviewer re-proved the discriminator by reverting the source change and watching the new tests go red, and confirmed no position where ptah-compat exits 0 while the pinned community binary exits 1.
