### PR TITLE
Refuse importing a directory already in the target format

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -4551,12 +4551,17 @@ func TestCompatCommand_MigrateImportConvertsFlywayDirectory(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Imported migration files:")
+	c.Assert(out.String(), qt.Equals, "")
 	// The surviving baseline B1 lands in the low band and V2 in the versioned
-	// band, so the baseline executes first whatever its own version.
-	c.Assert(out.String(), qt.Contains, filepath.Join(target, "81608_baseline.sql"))
-	c.Assert(out.String(), qt.Contains, filepath.Join(target, "4611686018427510315_add_posts.sql"))
-	c.Assert(out.String(), qt.Contains, filepath.Join(target, "atlas.sum"))
+	// band, so the baseline executes first whatever its own version. A silent
+	// import reports itself through the destination directory, so the names are
+	// asserted on disk rather than in the progress listing that used to exist.
+	_, statErr := os.Stat(filepath.Join(target, "81608_baseline.sql"))
+	c.Assert(statErr, qt.IsNil)
+	_, statErr = os.Stat(filepath.Join(target, "4611686018427510315_add_posts.sql"))
+	c.Assert(statErr, qt.IsNil)
+	_, statErr = os.Stat(filepath.Join(target, "atlas.sum"))
+	c.Assert(statErr, qt.IsNil)
 	c.Assert(readAtlasTestFile(c, target, "81608_baseline.sql"), qt.Equals, "CREATE TABLE baseline (id int);\n")
 	c.Assert(readAtlasTestFile(c, target, "4611686018427510315_add_posts.sql"), qt.Equals, "CREATE TABLE posts (id int);\n")
 	c.Assert(readAtlasTestFile(c, target, "atlas.sum"), qt.Contains, "4611686018427510315_add_posts.sql h1:")
@@ -4578,7 +4583,9 @@ func TestNewCompatCommand_MigrateImportResolvesAtRoot(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, filepath.Join(target, "1_initial.sql"))
+	c.Assert(out.String(), qt.Equals, "")
+	_, statErr := os.Stat(filepath.Join(target, "1_initial.sql"))
+	c.Assert(statErr, qt.IsNil)
 	c.Assert(readAtlasTestFile(c, target, "1_initial.sql"), qt.Equals, "CREATE TABLE users (id int);\n")
 	c.Assert(readAtlasTestFile(c, target, "atlas.sum"), qt.Contains, "1_initial.sql h1:")
 }

--- a/cmd/atlas/migrate_import.go
+++ b/cmd/atlas/migrate_import.go
@@ -1,8 +1,6 @@
 package atlas
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
@@ -39,16 +37,23 @@ executable representation for Atlas R-suffixed imported migrations.`,
 	return cmd
 }
 
+// runAtlasMigrateImport writes the imported directory and says nothing about
+// it. Atlas CE reports a successful import only through the files on disk, so
+// the destination directory and its atlas.sum are the whole result; a progress
+// listing here is output the compatibility surface is not supposed to produce.
+//
+// Silence is achieved by not writing, never by pointing this command's writer
+// at io.Discard. Unlike the adapter verbs, `migrate import` is registered
+// directly on the compatibility tree, so the command this runs on is the
+// persistent child that survives every Execute on a reused root — not a native
+// target minted per execution. Cobra's getOut prefers a command's own non-nil
+// outWriter over its parent's, so assigning io.Discard here would pin it
+// forever and a later root SetOut would stop reaching `migrate import --help`.
+// Failures still route through cmdutil.Fail, which keeps every error loud.
 func runAtlasMigrateImport(cmd *cobra.Command, opts atlasmigrateimport.Options) error {
-	result, err := atlasmigrateimport.Import(opts)
-	if err != nil {
+	if _, err := atlasmigrateimport.Import(opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	out := cmd.OutOrStdout()
-	fmt.Fprintln(out, "Imported migration files:")
-	for _, file := range result.Files {
-		fmt.Fprintln(out, file)
-	}
-	fmt.Fprintf(out, "Wrote %s\n", result.SumFile)
+
 	return nil
 }

--- a/cmd/atlas/migrate_import_silent_test.go
+++ b/cmd/atlas/migrate_import_silent_test.go
@@ -1,0 +1,247 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+const (
+	gooseImportFixture = `-- +goose Up
+CREATE TABLE users (id int);
+
+-- +goose Down
+DROP TABLE users;
+`
+	dbmateImportFixture = `-- migrate:up
+CREATE TABLE users (id int);
+
+-- migrate:down
+DROP TABLE users;
+`
+)
+
+func writeMigrateImportFixture(c *qt.C, dir, name, body string) {
+	c.Helper()
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600), qt.IsNil)
+}
+
+func runMigrateImport(c *qt.C, args []string) (*bytes.Buffer, error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	out := &bytes.Buffer{}
+	cmd.SetOut(out)
+	cmd.SetErr(out)
+	cmd.SetArgs(append([]string{"migrate", "import"}, args...))
+
+	return out, cmd.Execute()
+}
+
+// TestCompatMigrateImportSuccessIsSilent pins the whole of what a successful
+// compatibility import reports: the destination directory and its atlas.sum,
+// and not a single byte on the command's writer. Both documented spellings of
+// the source format are covered, because the format is resolved from the
+// --from query parameter and from --dir-format on separate code paths.
+func TestCompatMigrateImportSuccessIsSilent(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// prepare writes the source fixture and returns the flags to import it
+		// with, so each spelling carries its own wiring instead of branching in
+		// the loop body.
+		prepare func(c *qt.C, source, target string) []string
+	}{
+		{
+			name: "goose via format query parameter",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "goose via dir-format flag",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source, "--to", "file://" + target, "--dir-format", "goose"}
+			},
+		},
+		{
+			name: "golang-migrate via format query parameter",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "1_init.up.sql", "CREATE TABLE users (id int);\n")
+				writeMigrateImportFixture(c, source, "1_init.down.sql", "DROP TABLE users;\n")
+				return []string{"--from", "file://" + source + "?format=golang-migrate", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "golang-migrate via dir-format flag",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "1_init.up.sql", "CREATE TABLE users (id int);\n")
+				writeMigrateImportFixture(c, source, "1_init.down.sql", "DROP TABLE users;\n")
+				return []string{"--from", "file://" + source, "--to", "file://" + target, "--dir-format", "golang-migrate"}
+			},
+		},
+		{
+			name: "dbmate via format query parameter",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "20240101010101_init.sql", dbmateImportFixture)
+				return []string{"--from", "file://" + source + "?format=dbmate", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "dbmate via dir-format flag",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "20240101010101_init.sql", dbmateImportFixture)
+				return []string{"--from", "file://" + source, "--to", "file://" + target, "--dir-format", "dbmate"}
+			},
+		},
+		{
+			name: "flyway via format query parameter",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "V1__init.sql", "CREATE TABLE users (id int);\n")
+				return []string{"--from", "file://" + source + "?format=flyway", "--to", "file://" + target}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "source")
+			target := filepath.Join(root, "target")
+
+			out, err := runMigrateImport(c, tt.prepare(c, source, target))
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+			c.Assert(out.String(), qt.Equals, "")
+			_, statErr := os.Stat(filepath.Join(target, "atlas.sum"))
+			c.Assert(statErr, qt.IsNil)
+		})
+	}
+}
+
+// TestCompatMigrateImportHelpUsesUpdatedRootWriter is the counterpart of
+// TestCompatMigrateHashHelpUsesUpdatedRootWriter. `migrate import` is
+// registered directly on the compatibility tree rather than through the
+// adapter, so its command object is reused across executions: silencing it by
+// assigning io.Discard to its own writer would survive the root's later
+// SetOut and send this help text nowhere.
+func TestCompatMigrateImportHelpUsesUpdatedRootWriter(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	source := filepath.Join(root, "source")
+	target := filepath.Join(root, "target")
+	writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var firstOut bytes.Buffer
+	cmd.SetOut(&firstOut)
+	cmd.SetErr(&firstOut)
+	cmd.SetArgs([]string{"migrate", "import", "--from", "file://" + source + "?format=goose", "--to", "file://" + target})
+
+	firstErr := cmd.Execute()
+
+	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", firstOut.String()))
+	c.Assert(firstOut.String(), qt.Equals, "")
+	var secondOut bytes.Buffer
+	cmd.SetOut(&secondOut)
+	cmd.SetErr(&secondOut)
+	cmd.SetArgs([]string{"migrate", "import", "--help"})
+
+	secondErr := cmd.Execute()
+
+	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", secondOut.String()))
+	c.Assert(firstOut.String(), qt.Equals, "")
+	c.Assert(secondOut.String(), qt.Contains, "Usage:\n  atlas migrate import [flags]")
+}
+
+// TestCompatMigrateImportFailuresStayLoud keeps the silence scoped to success.
+// Every rejection this verb can produce still reports a diagnostic and a
+// non-nil error, so a later reader cannot widen the deletion into a blanket
+// discard without turning this table red.
+func TestCompatMigrateImportFailuresStayLoud(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// prepare writes whatever the rejection needs to be reachable and
+		// returns the flags that trigger it.
+		prepare func(c *qt.C, source, target string) []string
+	}{
+		{
+			name: "missing source directory",
+			prepare: func(_ *qt.C, source, target string) []string {
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "source and destination are the same directory",
+			prepare: func(c *qt.C, source, _ string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + source}
+			},
+		},
+		{
+			name: "destination already holds migrations",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				writeMigrateImportFixture(c, target, "1_existing.sql", "CREATE TABLE existing (id int);\n")
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "unknown dir-format flag value",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source, "--to", "file://" + target, "--dir-format", "nope"}
+			},
+		},
+		{
+			name: "unknown format query parameter",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source + "?format=nope", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "remote source URL",
+			prepare: func(_ *qt.C, _, target string) []string {
+				return []string{"--from", "atlas://repo/migrations?format=flyway", "--to", "file://" + target}
+			},
+		},
+		{
+			name: "positional argument",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + target, "extra"}
+			},
+		},
+		{
+			name: "unknown flag",
+			prepare: func(c *qt.C, source, target string) []string {
+				writeMigrateImportFixture(c, source, "00001_init.sql", gooseImportFixture)
+				return []string{"--from", "file://" + source + "?format=goose", "--to", "file://" + target, "--nope"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "source")
+			target := filepath.Join(root, "target")
+
+			out, err := runMigrateImport(c, tt.prepare(c, source, target))
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(out.String(), qt.Contains, "Error: ")
+		})
+	}
+}

--- a/cmd/atlas/migrate_import_silent_test.go
+++ b/cmd/atlas/migrate_import_silent_test.go
@@ -245,3 +245,58 @@ func TestCompatMigrateImportFailuresStayLoud(t *testing.T) {
 		})
 	}
 }
+
+// TestCompatMigrateImportRefusesADirectoryAlreadyInTargetFormat covers the
+// spelling that copies without converting anything.
+//
+// Importing a directory that is already in the target format is a no-op
+// dressed as work: it copies the files and writes a fresh sum over a directory
+// whose previous contents nothing verified. The pinned community binary refuses
+// it, and this surface exited 0 and copied — the direction that lets a mistake
+// pass silently.
+//
+// All three spellings that resolve to atlas are covered, because the format
+// arrives on three separate paths: omitted entirely, in the --from query, and
+// on --dir-format. Only checking the explicit ones would leave the default
+// invocation — the likeliest way to hit this — untested.
+func TestCompatMigrateImportRefusesADirectoryAlreadyInTargetFormat(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(from, to string) []string
+	}{
+		{
+			name: "format omitted",
+			args: func(from, to string) []string {
+				return []string{"--from", "file://" + from, "--to", "file://" + to}
+			},
+		},
+		{
+			name: "format in the source query",
+			args: func(from, to string) []string {
+				return []string{"--from", "file://" + from + "?format=atlas", "--to", "file://" + to}
+			},
+		},
+		{
+			name: "format on the flag",
+			args: func(from, to string) []string {
+				return []string{"--from", "file://" + from, "--to", "file://" + to, "--dir-format", "atlas"}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			from := filepath.Join(t.TempDir(), "src")
+			to := filepath.Join(t.TempDir(), "dst")
+			writeMigrateImportFixture(c, from, "20240101010101_init.sql", "CREATE TABLE users (id int);\n")
+
+			_, err := runMigrateImport(c, tt.args(from, to))
+
+			c.Assert(err, qt.ErrorMatches, `cannot import a migration directory already in "atlas" format`)
+			_, statErr := os.Stat(to)
+			c.Assert(os.IsNotExist(statErr), qt.IsTrue,
+				qt.Commentf("the refusal must precede writing anything to the destination"))
+		})
+	}
+}

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -711,6 +711,10 @@ ptah-compat migrate import \
   --to "file://migrations"
 ```
 
+A successful compatibility import is silent. Inspect the destination directory
+and its `atlas.sum` to see what was written, rather than reading a progress
+message off stdout. Rejections stay loud on stderr.
+
 The command is intentionally fail-closed: use a destination directory different
 from the source directory, and start with a destination that does not already
 contain `.sql` migration files or `atlas.sum`. Flyway repeatable migrations

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -282,8 +282,10 @@ Imports local `file://` migration directories from `atlas`, `golang-migrate`,
 `goose`, `flyway`, `liquibase`, or `dbmate` format into a separate Atlas
 single-file directory and writes `atlas.sum`. Flyway repeatable migrations
 fail explicitly until Ptah can execute Atlas R-suffixed imported migrations.
-The native `ptah migrations import` converts the same source formats into
-Ptah-native migrations instead.
+A successful compatibility import is silent; inspect the destination directory
+and its `atlas.sum` instead of relying on a progress message. Failures are still
+reported on stderr. The native `ptah migrations import` converts the same source
+formats into Ptah-native migrations instead, and reports what it wrote.
 
 ### `ptah-compat migrate checkpoint [name]`
 

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -179,6 +179,17 @@ func Import(opts Options) (*Result, error) {
 	if err != nil {
 		return nil, err
 	}
+	// Importing a directory that is already in the target format is a no-op
+	// dressed as work: it copies files and writes a fresh sum over a directory
+	// whose previous contents nothing verified.
+	//
+	// Measured on the pinned community binary, which refuses it with this
+	// wording. Both spellings that resolve to atlas -- the default with no
+	// format given, and an explicit `?format=atlas` -- exit 1 there and exited
+	// 0 here, which is the direction that lets a mistake pass silently.
+	if format == FormatAtlas {
+		return nil, fmt.Errorf("cannot import a migration directory already in %q format", string(FormatAtlas))
+	}
 
 	loaded, err := LoadDir(from.Dir, format)
 	if err != nil {


### PR DESCRIPTION
Closes #1067.

`ptah-compat migrate import` printed progress on success where the pinned community binary is silent — the same defect #1034 fixed for `migrate hash`. Success is now byte-silent; failures stay loud.

## The silence alone would have made things worse

Review caught that this verb had a second, pre-existing divergence in the same function, and silencing the first one aggravates it:

| invocation | community binary | before | after |
| --- | --- | --- | --- |
| atlas-format source, format omitted | **1**, refuses | 0, copies, 342 bytes | **1**, refuses |
| ... with `?format=atlas` | **1**, refuses | 0, copies, 336 bytes | **1**, refuses |
| goose source | 0, silent | 0, ~340 bytes | 0, **silent** |

Importing a directory already in the target format copies files and writes a fresh `atlas.sum` over contents nothing verified. Making that silent turns a visible no-op into an invisible one.

It is also not the niche the first framing suggested. The guard fires on the **resolved** format, so this is the **default invocation** — `migrate import --from X --to Y` with no format given — plus both explicit spellings of `atlas`.

## What changed

The verb refuses on the resolved format, so all three spellings agree: omitted, in the `--from` query, and on `--dir-format`. Refusing only the explicit ones would have left the default — the likeliest way to hit this — still copying.

The refusal precedes creating the destination, and the test asserts that: a guard firing after the directory exists still leaves the mess behind.

## Verification

Discriminator proved by mutation: removing the guard turns the new rows red, restoring it turns them green. The silence fixtures were already proven the same way in review.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint` and the public-API gate are clean. Rebased onto current master.

## Noted, not fixed here

`migrate import` on this surface carries a `--dir-format` flag the community binary does not have at all — it answers `unknown flag: --dir-format`. That is a *wider* surface rather than a looser one, it predates this change, and it deserves its own measurement rather than a drive-by.
