### PR TITLE
Accept --dir query parameters on the verbs that verify the directory first

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -200,7 +200,15 @@ func newAtlasMigrateCommand() *cobra.Command {
 			native:     "migrations create",
 			factory:    migrate.NewMigrateCreateCommand,
 			flags: []atlasargs.Flag{
-				atlasNativeAtlasLocalDirFlag("dir", "", "Migration directory", "migrations-dir"),
+				// `new` keeps the strict mapper, which refuses a query, while
+				// the verbs above accept one. That asymmetry is deliberate and
+				// temporary: this verb runs no atlas.sum integrity gate, so
+				// accepting the query here would turn a refusal into a write
+				// over a directory nothing verified -- measured, the pinned
+				// community binary exits 1 on an unhashed directory and this
+				// surface exits 0 and writes. The relaxation lands once the
+				// gate does. See stokaro/ptah#1086.
+				atlasargs.NativeLocalDir("dir", "", "Migration directory", "migrations-dir"),
 				atlasMigrateDirFormatFlag("dir-format"),
 				atlasargs.NativeBool("edit", "", "Edit the created migration files", "edit"),
 			},

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -200,7 +200,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 			native:     "migrations create",
 			factory:    migrate.NewMigrateCreateCommand,
 			flags: []atlasargs.Flag{
-				atlasargs.NativeLocalDir("dir", "", "Migration directory", "migrations-dir"),
+				atlasNativeAtlasLocalDirFlag("dir", "", "Migration directory", "migrations-dir"),
 				atlasMigrateDirFormatFlag("dir-format"),
 				atlasargs.NativeBool("edit", "", "Edit the created migration files", "edit"),
 			},
@@ -595,12 +595,22 @@ func atlasMigrateDirFormatFlag(nativeName string) atlasargs.Flag {
 	return flag
 }
 
+// atlasMigrateDirFormatValue maps the Atlas --dir-format value onto the native
+// directory format.
+//
+// An EMPTY value selects the native Atlas layout rather than being refused.
+// Measured against the pinned community binary v1.3.0, `--dir-format ""` exits 0
+// and reads the directory as Atlas on every verb that registers the flag —
+// hash, validate, lint, new, status and set were each checked, not just the one
+// stokaro/ptah#990 named — and `migrate checkpoint` already agreed with that
+// through atlasCheckpointDirFormatValue. Refusing it here was the odd one out.
+//
+// This is the flag spelling. The query spelling of the same choice, `?format=`
+// with an empty value, already resolves to the Atlas layout in
+// atlasmigrate.ResolveApplyDirFormat, so the two spellings now agree.
 func atlasMigrateDirFormatValue(value string) (string, error) {
 	normalized := strings.ToLower(strings.TrimSpace(value))
-	if normalized == "" {
-		return "", fmt.Errorf("migration directory format must not be empty")
-	}
-	if normalized == atlasDirFormatDefault {
+	if normalized == "" || normalized == atlasDirFormatDefault {
 		return atlasDirFormatDefault, nil
 	}
 	if slices.Contains(unsupportedAtlasDirFormats, normalized) {

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -90,7 +90,6 @@ func runAtlasMigrateApply(
 	args []string,
 ) (runErr error) {
 	formatOutput := cmd.Flags().Changed("format")
-	projectDirFormatPresent := false
 	mode := ignoreMissingEnvSelection
 	if needsAtlasMigrateApplyConfig(cmd) {
 		mode = reportMissingEnvSelection
@@ -115,7 +114,6 @@ func runAtlasMigrateApply(
 			projectCfg.StringValue(projectconfig.StringMigrationDir),
 		)
 		dirFormat := projectCfg.StringValue(projectconfig.StringMigrationFormat)
-		projectDirFormatPresent = dirFormat.Present
 		if dirFormat.Present {
 			opts.dirFormat = dirFormat.Value
 		}
@@ -173,11 +171,13 @@ func runAtlasMigrateApply(
 	if err != nil {
 		return fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
-	if projectDirFormatPresent && opts.dirFormat == "" {
-		if _, queryOverridesProjectFormat := localDir.Query["format"]; !queryOverridesProjectFormat {
-			return fmt.Errorf("atlas migrate apply --dir: migration directory format must not be empty")
-		}
-	}
+	// An atlas.hcl `migration { format = "" }` selects the native Atlas layout
+	// rather than being refused. `migrate apply` registers no --dir-format flag,
+	// so atlas.hcl is the only way to reach an empty configured format here, and
+	// measured against the pinned community binary v1.3.0 a hashed directory
+	// under that config applies cleanly and exits 0 (stokaro/ptah#990 item 1).
+	// ResolveApplyDirFormat below maps the empty value to the Atlas format, the
+	// same as the empty --dir-format the other verbs accept.
 
 	amount, err := atlasmigrate.ParseApplyAmount(args)
 	if err != nil {

--- a/cmd/atlas/migrate_apply_converted_integrity_test.go
+++ b/cmd/atlas/migrate_apply_converted_integrity_test.go
@@ -815,29 +815,91 @@ func TestCompatMigrateApply_ConvertedDirFromProjectConfigIsGated(t *testing.T) {
 	}
 }
 
-// TestCompatMigrateApply_ConvertedEmptyDirReportsImportError_KnownDivergence
-// pins behavior, NOT parity. On every shape whose covered set is empty the gate
-// exempts the directory and Atlas CE exits 0 with "No migration files to
-// execute", but ptah-compat's converter then reports "no importable migration
-// files found" and exits 1.
+// TestCompatMigrateApply_ConvertedEmptyCoveredSetReportsNothingToExecute closes
+// stokaro/ptah#980. A converted directory with nothing to execute now exits 0
+// with "No migration files to execute" instead of the converter's "no
+// importable migration files found", matching the pinned community binary
+// v1.3.0 on all six rows below.
 //
-// That divergence predates this gate — it is what master already did, before
-// and after the restructure — and it is deliberately not fixed here.
-// stokaro/ptah#980 has to distinguish two cases this error currently conflates:
-// an empty covered set, where reporting nothing to execute is right, and a
-// NON-empty covered set whose files Ptah's importer refuses, where Atlas CE
-// really does execute something (an unhashed-then-hashed goose directory
-// holding only `foo.sql` runs on CE as version "foo"). Collapsing both to exit
-// 0 would replace a loud refusal with a silent no-op. atlasmigrateimport.SumFileNames
-// is what makes telling them apart possible; spending it is that issue's call.
-func TestCompatMigrateApply_ConvertedEmptyDirReportsImportError_KnownDivergence(t *testing.T) {
+// The table spans the two axes the issue names — three directory shapes, each
+// with and without atlas.sum — because hashing first is what would implicate
+// the integrity gate rather than the converter, and it does not: all six
+// diverged before the fix and all six agree after it.
+//
+// This is the half of the split #980 asked for. Its twin, a NON-empty covered
+// set whose files the converter produces no entry for, deliberately keeps the
+// loud refusal and is pinned by
+// TestCompatMigrateApply_ConvertedUnreadableCoveredSetStillRefuses below.
+func TestCompatMigrateApply_ConvertedEmptyCoveredSetReportsNothingToExecute(t *testing.T) {
+	subdirOnly := map[string]string{
+		"sub/1_init.sql": "-- +goose Up\nCREATE TABLE widgets (id INTEGER PRIMARY KEY);\n",
+	}
+	readmeOnly := map[string]string{"README.md": "notes\n"}
+	// hash is the {no atlas.sum, hashed} axis, carried as per-row wiring rather
+	// than a branch in the body. The hashed rows go through the same
+	// `migrate hash` a user runs, so they exercise the hash-then-apply round
+	// trip the issue measured.
+	leaveUnhashed := func(*qt.C, string) {}
+	writeSum := func(c *qt.C, dir string) {
+		c.Helper()
+		_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir+"?format=goose")
+		c.Assert(err, qt.IsNil)
+	}
+
+	tests := []struct {
+		name  string
+		files map[string]string
+		hash  func(*qt.C, string)
+	}{
+		{name: "empty directory", files: nil, hash: leaveUnhashed},
+		{name: "empty directory hashed", files: nil, hash: writeSum},
+		{name: "README only", files: readmeOnly, hash: leaveUnhashed},
+		{name: "README only hashed", files: readmeOnly, hash: writeSum},
+		{name: "SQL in a subdirectory only", files: subdirOnly, hash: leaveUnhashed},
+		{name: "SQL in a subdirectory only hashed", files: subdirOnly, hash: writeSum},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			tempDir := c.TempDir()
+			dir := filepath.Join(tempDir, "m")
+			c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+			writeConvertedApplyDir(c, dir, tt.files)
+			tt.hash(c, dir)
+			dbPath := filepath.Join(tempDir, "converted.db")
+
+			stdout, stderr, err := compatApplyConverted(dir, "goose", dbPath)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+			c.Assert(stdout, qt.Contains, "No migration files to execute")
+			// Nothing executed means nothing executed: a subdirectory migration
+			// the community binary skips must not have created its table.
+			c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 0)
+		})
+	}
+}
+
+// TestCompatMigrateApply_ConvertedUnreadableCoveredSetStillRefuses is the guard
+// that keeps #980's relaxation from becoming a silent no-op.
+//
+// A Goose directory holding only `foo.sql` has a NON-empty covered set — the
+// community binary applies it, as version "foo" — while Ptah's converter
+// produces no entry for it. Reporting "nothing to execute" here would exit 0
+// having skipped a migration the source tool runs, which is worse than the
+// refusal it replaced. So the covered set, not the converted entry count, is
+// what decides, and this directory keeps exiting 1.
+func TestCompatMigrateApply_ConvertedUnreadableCoveredSetStillRefuses(t *testing.T) {
 	c := qt.New(t)
 	tempDir := c.TempDir()
 	dir := filepath.Join(tempDir, "m")
 	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
-	writeConvertedApplyDir(c, dir, map[string]string{"1_init.down.sql": "DROP TABLE widgets;\n"})
+	writeConvertedApplyDir(c, dir, map[string]string{"foo.sql": "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"})
+	_, _, hashErr := runCompat("migrate", "hash", "--dir", "file://"+dir+"?format=goose")
+	c.Assert(hashErr, qt.IsNil)
+	dbPath := filepath.Join(tempDir, "converted.db")
 
-	_, _, err := compatApplyConverted(dir, "golang-migrate", filepath.Join(tempDir, "converted.db"))
+	_, _, err := compatApplyConverted(dir, "goose", dbPath)
 
-	c.Assert(err, qt.ErrorMatches, `atlas migrate apply --dir: no importable migration files found in .* for format "golang-migrate"`)
+	c.Assert(err, qt.ErrorMatches, `atlas migrate apply --dir: no importable migration files found in .* for format "goose"`)
 }

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -167,10 +167,8 @@ func runAtlasMigrateDiff(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
 	}
-	if len(localDir.Query) > 0 {
-		return cmdutil.Fail(cmd, fmt.Errorf(
-			"atlas migrate diff --dir: migration directory URL query parameters are not supported for this command",
-		))
+	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
 	}
 	migrationsDir, err := resolveMigrateDiffDirectory(localDir)
 	if err != nil {

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -167,8 +167,14 @@ func runAtlasMigrateDiff(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
 	}
-	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
+	// Same reasoning as `migrate new`: this verb writes a migration and a fresh
+	// atlas.sum without running the integrity gate, so accepting a query here
+	// would relax a refusal into a write over a directory nothing verified.
+	// See stokaro/ptah#1086.
+	if len(localDir.Query) > 0 {
+		return cmdutil.Fail(cmd, fmt.Errorf(
+			"atlas migrate diff --dir: migration directory URL query parameters are not supported for this command",
+		))
 	}
 	migrationsDir, err := resolveMigrateDiffDirectory(localDir)
 	if err != nil {

--- a/cmd/atlas/migrate_dir_query.go
+++ b/cmd/atlas/migrate_dir_query.go
@@ -1,0 +1,71 @@
+package atlas
+
+import (
+	"fmt"
+	"net/url"
+
+	"go.5x5.cz/ptah/internal/atlasargs"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+)
+
+// checkNativeAtlasDirQuery validates the query of an Atlas --dir migration
+// directory URL for a verb that can only read a NATIVE Atlas directory.
+//
+// Every verb that registers --dir used to refuse a non-empty query outright.
+// That refused two very different inputs with one message. Measured against the
+// pinned community binary v1.3.0 on a hashed native Atlas directory,
+// `?nonsense=1` exits 0 on apply, hash, validate, lint, status and set: an
+// unrecognized key is dropped, and the directory reads as Atlas exactly as it
+// would with no query at all (stokaro/ptah#1013 section 2). Ignoring it is
+// therefore the matching behavior, and it is
+// [atlasmigrate.ResolveApplyDirFormat] that does the ignoring, so the rule lives
+// in one place for all eight verbs rather than being restated per verb.
+//
+// A `?format=` naming a foreign layout is a different input and stays refused
+// here. The community binary honors it on these verbs — `migrate lint
+// --dir 'file://gm?format=golang-migrate'` exits 0 where the same directory
+// without the query exits 1 on a checksum mismatch, so it is functionally
+// honored and not decoration — but converting a foreign directory for lint,
+// status and set, and WRITING one for new and diff, is a larger change than
+// accepting the query (stokaro/ptah#1013 section 1 and stokaro/ptah#1002 remain
+// open). Refusing is the strict side: it never exits 0 where the community
+// binary exits 1.
+//
+// An empty `?format=` value selects the native Atlas layout and so passes, which
+// is what the community binary does with it too.
+func checkNativeAtlasDirQuery(query url.Values) error {
+	format, err := atlasmigrate.ResolveApplyDirFormat("", query)
+	if err != nil {
+		return err
+	}
+	if !atlasmigrate.ReadsNativeAtlasDir(format) {
+		return fmt.Errorf(
+			"Atlas accepts ?format=%s, but Ptah does not implement that directory format for this command yet",
+			format,
+		)
+	}
+	return nil
+}
+
+// nativeAtlasLocalDirValue converts a local Atlas file:// migration directory
+// URL to a native local path for a verb that reads only a native Atlas
+// directory, ignoring the query keys the community binary ignores and refusing
+// the foreign layouts Ptah cannot produce here. See [checkNativeAtlasDirQuery].
+func nativeAtlasLocalDirValue(value string) (string, error) {
+	dir, err := atlasargs.ParseLocalDir(value)
+	if err != nil {
+		return "", err
+	}
+	if err := checkNativeAtlasDirQuery(dir.Query); err != nil {
+		return "", err
+	}
+	return dir.Path, nil
+}
+
+// atlasNativeAtlasLocalDirFlag creates the Atlas --dir flag for a verb that
+// reads only a native Atlas directory.
+func atlasNativeAtlasLocalDirFlag(name, shorthand, usage, nativeName string) atlasargs.Flag {
+	flag := atlasargs.NativeString(name, shorthand, usage, nativeName)
+	flag.MapValue = nativeAtlasLocalDirValue
+	return flag
+}

--- a/cmd/atlas/migrate_dir_query.go
+++ b/cmd/atlas/migrate_dir_query.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/url"
 
-	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
 )
 
@@ -45,27 +44,4 @@ func checkNativeAtlasDirQuery(query url.Values) error {
 		)
 	}
 	return nil
-}
-
-// nativeAtlasLocalDirValue converts a local Atlas file:// migration directory
-// URL to a native local path for a verb that reads only a native Atlas
-// directory, ignoring the query keys the community binary ignores and refusing
-// the foreign layouts Ptah cannot produce here. See [checkNativeAtlasDirQuery].
-func nativeAtlasLocalDirValue(value string) (string, error) {
-	dir, err := atlasargs.ParseLocalDir(value)
-	if err != nil {
-		return "", err
-	}
-	if err := checkNativeAtlasDirQuery(dir.Query); err != nil {
-		return "", err
-	}
-	return dir.Path, nil
-}
-
-// atlasNativeAtlasLocalDirFlag creates the Atlas --dir flag for a verb that
-// reads only a native Atlas directory.
-func atlasNativeAtlasLocalDirFlag(name, shorthand, usage, nativeName string) atlasargs.Flag {
-	flag := atlasargs.NativeString(name, shorthand, usage, nativeName)
-	flag.MapValue = nativeAtlasLocalDirValue
-	return flag
 }

--- a/cmd/atlas/migrate_dir_query_test.go
+++ b/cmd/atlas/migrate_dir_query_test.go
@@ -1,0 +1,235 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// These tests pin the migration directory URL query against the pinned
+// community binary v1.3.0, measured through
+// ptah-atlas-conformance/bin/atlas on 2026-08-03 (stokaro/ptah#1013).
+//
+// The community binary registers --dir on exactly eight migrate verbs — apply,
+// hash, validate, lint, new, diff, status and set — and ignores an unrecognized
+// query key on every one of them, reading the directory exactly as it would with
+// no query at all. Ptah refused any non-empty query on all eight, through two
+// different chokepoints and with two different messages.
+
+// writeQueryFixtureDir writes a hashed native Atlas migration directory and
+// returns its path. The sum is written with `migrate hash` so the directory is
+// one the integrity gate accepts, which is what lets the query rows below turn
+// on the query rather than on a checksum refusal.
+func writeQueryFixtureDir(c *qt.C) string {
+	c.Helper()
+	dir := filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "20240101000000_init.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+// TestCompatMigrateDirQuery_IgnoresUnknownKeysOnEveryVerb closes stokaro/ptah#1013
+// section 2 across all eight verbs that register --dir.
+//
+// Each row runs the verb twice on identical directories, once with
+// `?nonsense=1` and once without, and asserts the two runs agree. The control
+// run is what makes the assertion mean something: an exit-0 assertion alone
+// would also pass if the verb had started ignoring the whole --dir value, and a
+// verb that is broken for an unrelated reason fails both runs instead of
+// reporting a false pass.
+func TestCompatMigrateDirQuery_IgnoresUnknownKeysOnEveryVerb(t *testing.T) {
+	tests := []struct {
+		name string
+		// run invokes the verb against dir, with query appended to the --dir
+		// URL. Each verb needs different companion flags, so the invocation is
+		// per-row wiring rather than a branch in the body.
+		run func(c *qt.C, dir, query string) error
+	}{
+		{
+			name: "apply",
+			run: func(c *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "apply",
+					"--dir", "file://"+dir+query,
+					"--url", "sqlite://"+filepath.Join(c.TempDir(), "apply.db"))
+				return err
+			},
+		},
+		{
+			name: "hash",
+			run: func(_ *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir+query)
+				return err
+			},
+		},
+		{
+			name: "validate",
+			run: func(_ *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "validate", "--dir", "file://"+dir+query)
+				return err
+			},
+		},
+		{
+			name: "lint",
+			run: func(c *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "lint",
+					"--dir", "file://"+dir+query,
+					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+					"--latest", "1")
+				return err
+			},
+		},
+		{
+			name: "status",
+			run: func(c *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "status",
+					"--dir", "file://"+dir+query,
+					"--url", "sqlite://"+filepath.Join(c.TempDir(), "status.db"))
+				return err
+			},
+		},
+		{
+			name: "set",
+			run: func(c *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "set", "20240101000000",
+					"--dir", "file://"+dir+query,
+					"--url", "sqlite://"+filepath.Join(c.TempDir(), "set.db"))
+				return err
+			},
+		},
+		{
+			name: "new",
+			run: func(_ *qt.C, dir, query string) error {
+				_, _, err := runCompat("migrate", "new", "demo", "--dir", "file://"+dir+query)
+				return err
+			},
+		},
+		{
+			name: "diff",
+			run: func(c *qt.C, dir, query string) error {
+				target := filepath.Join(c.TempDir(), "target.sql")
+				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+				_, _, err := runCompat("migrate", "diff", "dd",
+					"--dir", "file://"+dir+query,
+					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+					"--to", "file://"+target)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			withQuery := tt.run(c, writeQueryFixtureDir(c), "?nonsense=1")
+			control := tt.run(c, writeQueryFixtureDir(c), "")
+
+			c.Assert(control, qt.IsNil, qt.Commentf("control run without a query must succeed"))
+			c.Assert(withQuery, qt.IsNil)
+		})
+	}
+}
+
+// TestCompatMigrateDirQuery_FailurePathForeignFormat pins the part of the query
+// that is NOT ignored on the five verbs that read only a native Atlas
+// directory.
+//
+// The community binary honors `?format=` on these verbs; Ptah does not convert
+// (lint, status, set) or write (new, diff) a foreign layout there yet, so it
+// refuses rather than reading the directory under the wrong layout — the strict
+// side of the divergence. stokaro/ptah#1013 section 1 and stokaro/ptah#1002
+// track closing it.
+//
+// The refusal has to survive the relaxation above, which is why it is pinned:
+// once unknown keys are ignored, nothing else stops a `?format=goose` from
+// being ignored too and the directory being silently read as Atlas.
+func TestCompatMigrateDirQuery_FailurePathForeignFormat(t *testing.T) {
+	const want = `atlas migrate \w+ --dir: Atlas accepts \?format=goose, ` +
+		`but Ptah does not implement that directory format for this command yet`
+
+	tests := []struct {
+		name string
+		run  func(c *qt.C, dir string) error
+	}{
+		{
+			name: "lint",
+			run: func(c *qt.C, dir string) error {
+				_, _, err := runCompat("migrate", "lint",
+					"--dir", "file://"+dir+"?format=goose",
+					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+					"--latest", "1")
+				return err
+			},
+		},
+		{
+			name: "status",
+			run: func(c *qt.C, dir string) error {
+				_, _, err := runCompat("migrate", "status",
+					"--dir", "file://"+dir+"?format=goose",
+					"--url", "sqlite://"+filepath.Join(c.TempDir(), "status.db"))
+				return err
+			},
+		},
+		{
+			name: "set",
+			run: func(c *qt.C, dir string) error {
+				_, _, err := runCompat("migrate", "set", "20240101000000",
+					"--dir", "file://"+dir+"?format=goose",
+					"--url", "sqlite://"+filepath.Join(c.TempDir(), "set.db"))
+				return err
+			},
+		},
+		{
+			name: "new",
+			run: func(_ *qt.C, dir string) error {
+				_, _, err := runCompat("migrate", "new", "demo", "--dir", "file://"+dir+"?format=goose")
+				return err
+			},
+		},
+		{
+			name: "diff",
+			run: func(c *qt.C, dir string) error {
+				target := filepath.Join(c.TempDir(), "target.sql")
+				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+				_, _, err := runCompat("migrate", "diff", "dd",
+					"--dir", "file://"+dir+"?format=goose",
+					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+					"--to", "file://"+target)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := tt.run(c, writeQueryFixtureDir(c))
+
+			c.Assert(err, qt.ErrorMatches, want)
+		})
+	}
+}
+
+// TestCompatMigrateDirQuery_EmptyFormatValueReadsAtlasLayout pins the one
+// `?format=` value the five verbs above still accept. An empty value selects
+// the native Atlas layout on the community binary, so refusing it would turn
+// the relaxation into a new divergence one character wide.
+func TestCompatMigrateDirQuery_EmptyFormatValueReadsAtlasLayout(t *testing.T) {
+	c := qt.New(t)
+	dir := writeQueryFixtureDir(c)
+
+	_, _, err := runCompat("migrate", "status",
+		"--dir", "file://"+dir+"?format=",
+		"--url", "sqlite://"+filepath.Join(c.TempDir(), "status.db"))
+
+	c.Assert(err, qt.IsNil)
+}

--- a/cmd/atlas/migrate_dir_query_test.go
+++ b/cmd/atlas/migrate_dir_query_test.go
@@ -104,25 +104,6 @@ func TestCompatMigrateDirQuery_IgnoresUnknownKeysOnEveryVerb(t *testing.T) {
 				return err
 			},
 		},
-		{
-			name: "new",
-			run: func(_ *qt.C, dir, query string) error {
-				_, _, err := runCompat("migrate", "new", "demo", "--dir", "file://"+dir+query)
-				return err
-			},
-		},
-		{
-			name: "diff",
-			run: func(c *qt.C, dir, query string) error {
-				target := filepath.Join(c.TempDir(), "target.sql")
-				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
-				_, _, err := runCompat("migrate", "diff", "dd",
-					"--dir", "file://"+dir+query,
-					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
-					"--to", "file://"+target)
-				return err
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -187,25 +168,6 @@ func TestCompatMigrateDirQuery_FailurePathForeignFormat(t *testing.T) {
 				return err
 			},
 		},
-		{
-			name: "new",
-			run: func(_ *qt.C, dir string) error {
-				_, _, err := runCompat("migrate", "new", "demo", "--dir", "file://"+dir+"?format=goose")
-				return err
-			},
-		},
-		{
-			name: "diff",
-			run: func(c *qt.C, dir string) error {
-				target := filepath.Join(c.TempDir(), "target.sql")
-				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
-				_, _, err := runCompat("migrate", "diff", "dd",
-					"--dir", "file://"+dir+"?format=goose",
-					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
-					"--to", "file://"+target)
-				return err
-			},
-		},
 	}
 
 	for _, tt := range tests {
@@ -232,4 +194,57 @@ func TestCompatMigrateDirQuery_EmptyFormatValueReadsAtlasLayout(t *testing.T) {
 		"--url", "sqlite://"+filepath.Join(c.TempDir(), "status.db"))
 
 	c.Assert(err, qt.IsNil)
+}
+
+// TestCompatMigrateDirQuery_NewAndDiffStillRefuseAQuery pins the two verbs the
+// relaxation deliberately skips.
+//
+// Every verb that accepts a `--dir` query runs the atlas.sum integrity gate
+// first, so a converted directory is verified before anything reads it. These
+// two do not: they WRITE a migration and a fresh sum, and they do it over a
+// directory nothing checked. Measured on the pinned community binary, an
+// unhashed directory exits 1 there and 0 here, so accepting the query would
+// turn a refusal into a write.
+//
+// The asymmetry is temporary and belongs to stokaro/ptah#1086, which adds the
+// gate. This test is here so the relaxation cannot be extended to these verbs
+// by symmetry alone, without the gate arriving with it.
+func TestCompatMigrateDirQuery_NewAndDiffStillRefuseAQuery(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func(c *qt.C, dir string) error
+	}{
+		{
+			name: "new",
+			run: func(_ *qt.C, dir string) error {
+				_, _, err := runCompat("migrate", "new", "demo", "--dir", "file://"+dir+"?nonsense=1")
+				return err
+			},
+		},
+		{
+			name: "diff",
+			run: func(c *qt.C, dir string) error {
+				target := filepath.Join(c.TempDir(), "target.sql")
+				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+				_, _, err := runCompat("migrate", "diff", "dd",
+					"--dir", "file://"+dir+"?nonsense=1",
+					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+					"--to", "file://"+target)
+				return err
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			c.Assert(os.WriteFile(filepath.Join(dir, "20240101000000_init.sql"),
+				[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+			err := tt.run(c, dir)
+
+			c.Assert(err, qt.ErrorMatches, `.*query parameters are not supported.*`)
+		})
+	}
 }

--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -124,11 +124,12 @@ func resolveAtlasMigrateSource(
 	configured, _ := atlasNativeArgValue(mapped, atlasVerbNativeName(verb, "dir-format"))
 	format, err := atlasmigrate.ResolveApplyDirFormat(configured, localDir.Query)
 	if err != nil {
-		// A non-empty query is the only thing that can carry a format value
-		// other than the configured one, and it is also the only source of the
-		// unknown-parameter and repeated-parameter errors, so it names --dir.
+		// A ?format= query is the only thing that can carry a format value other
+		// than the configured one, so it is the only thing that can be blamed
+		// for a rejected one. A query carrying only ignored keys selects
+		// nothing, and the blame stays on --dir-format.
 		spelling := "--dir-format"
-		if len(localDir.Query) > 0 {
+		if atlasmigrate.DirFormatFromQuery(localDir.Query) {
 			spelling = "--dir"
 		}
 		return atlasMigrateSource{}, fmt.Errorf("atlas migrate %s %s: %w", verb.use, spelling, err)
@@ -141,7 +142,12 @@ func resolveAtlasMigrateSource(
 		devURL:      devURL,
 		forwardArgs: args,
 	}
-	if _, queried := localDir.Query["format"]; queried {
+	// Any query at all is dropped before forwarding, not just one carrying
+	// ?format=. The forwarded native command's --dir mapper is query-free by
+	// construction, so leaving an ignored key such as ?nonsense=1 on the URL
+	// would resurrect the blanket refusal one layer down — exit 1 where the
+	// community binary exits 0 (stokaro/ptah#1013 section 2).
+	if len(localDir.Query) > 0 {
 		source.forwardArgs = rewriteAtlasMigrateSourceArgs(verb, args, atlasDirWithoutQuery(rawDir), string(format))
 	}
 	if atlasmigrate.ReadsNativeAtlasDir(format) {
@@ -222,8 +228,10 @@ func atlasNativeArgValue(args []string, name string) (string, bool) {
 }
 
 // atlasDirWithoutQuery drops the URL query from a migration directory value.
-// ResolveApplyDirFormat has already rejected every query parameter other than
-// format, so nothing but the format selection is being discarded.
+// The format selection it carried has already been resolved and is forwarded as
+// --dir-format instead; every other key is one the community binary ignores, so
+// dropping it here is what makes the forwarded invocation identical to the one
+// the same directory gets with no query at all.
 func atlasDirWithoutQuery(raw string) string {
 	before, _, _ := strings.Cut(raw, "?")
 	return before

--- a/cmd/atlas/migrate_integrity_formats_test.go
+++ b/cmd/atlas/migrate_integrity_formats_test.go
@@ -92,6 +92,15 @@ func writeIntegrityFixture(c *qt.C) string {
 	return dir
 }
 
+// sumFileExists reports whether the directory carries an atlas.sum, so a
+// refusal can be checked to have written nothing rather than only to have
+// returned an error.
+func sumFileExists(c *qt.C, dir string) bool {
+	c.Helper()
+	_, err := os.Stat(filepath.Join(dir, migratesum.AtlasFileName))
+	return err == nil
+}
+
 func readSumFile(c *qt.C, dir string) *migratesum.SumFile {
 	c.Helper()
 	raw, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
@@ -541,13 +550,76 @@ func TestCompatMigrateSourceFormat_FailurePathUnknownFormat(t *testing.T) {
 	}
 }
 
-// TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery pins the query
-// shapes Ptah refuses and Atlas CE accepts. Both are measured divergences kept
-// deliberately: the resolver is shared with `migrate apply`, where relaxing
-// them would silently widen what an integrity gate accepts.
+// TestCompatMigrateSourceFormatQuery_HappyPath pins the two query-parsing rules
+// that used to be refusals (stokaro/ptah#990 items 2 and 3, stokaro/ptah#1013
+// section 2). Both were measured on the pinned community binary v1.3.0:
 //
-//	$ atlas migrate hash --dir 'file://d?format=goose&other=1'      exit=0
-//	$ atlas migrate hash --dir 'file://d?format=goose&format=flyway' exit=0 (goose)
+//	$ atlas migrate hash --dir 'file://d?format=flyway&other=1'      exit=0, flyway set
+//	$ atlas migrate hash --dir 'file://d?other=1'                    exit=0, atlas set
+//	$ atlas migrate hash --dir 'file://d?format=flyway&format=goose' exit=0, flyway set
+//	$ atlas migrate hash --dir 'file://d?format=goose&format=flyway' exit=0, goose set
+//
+// Every row asserts the COVERED SET, not just the exit code. That is what makes
+// them separable: integrityFixture reads differently under every format, so an
+// implementation that merely ignored the whole query would write the atlas set
+// and fail rows 1, 3 and 4, and one that took the last repeated value rather
+// than the first would swap rows 3 and 4.
+func TestCompatMigrateSourceFormatQuery_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		query string
+		want  []string
+	}{
+		{
+			name:  "ignored parameter beside format keeps the format",
+			query: "?format=flyway&other=1",
+			want:  flywayCoveredSet,
+		},
+		{
+			name:  "ignored parameter alone reads the atlas layout",
+			query: "?other=1",
+			want:  sqlSuffixCoveredSet,
+		},
+		{
+			name:  "repeated format takes the first value",
+			query: "?format=flyway&format=goose",
+			want:  flywayCoveredSet,
+		},
+		{
+			name:  "repeated format takes the first value in the other order",
+			query: "?format=goose&format=flyway",
+			want:  sqlSuffixCoveredSet,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dir := writeIntegrityFixture(c)
+
+			stdout, stderr, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+tt.query)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", stdout, stderr))
+			c.Assert(sumEntryNames(c, dir), qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+// TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery pins the query
+// shapes that stay refused once the two above were relaxed.
+//
+// The semicolon is a deliberate, recorded divergence rather than an oversight.
+// Measured, `?format=flyway;x=1` exits 0 on the community binary but silently
+// drops the WHOLE pair and reads the directory as the atlas layout — covering
+// nine files where the caller asked for the five flyway covers. A semicolon
+// there costs you the format you asked for, so refusing is the safe side
+// (stokaro/ptah#990 item 6).
+//
+// The bogus value is the control that keeps the relaxation honest: query keys
+// are ignored, but the format VALUE still goes through the strict verbatim
+// parser, so an unknown layout is refused whether or not an ignored key rides
+// along with it.
 func TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery(t *testing.T) {
 	c := qt.New(t)
 
@@ -557,19 +629,19 @@ func TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery(t *testing.T) {
 		want  string
 	}{
 		{
-			name:  "unknown parameter beside format",
-			query: "?format=goose&other=1",
-			want:  `atlas migrate hash --dir: unsupported migration directory URL query parameter "other"`,
+			name:  "semicolon separator",
+			query: "?format=flyway;x=1",
+			want:  "atlas migrate hash --dir: parse migration directory URL query: invalid semicolon separator in query",
 		},
 		{
-			name:  "unknown parameter alone",
-			query: "?other=1",
-			want:  `atlas migrate hash --dir: unsupported migration directory URL query parameter "other"`,
+			name:  "unknown format value",
+			query: "?format=totally-bogus",
+			want:  `atlas migrate hash --dir: unknown Atlas migration directory format "totally-bogus": expected .*`,
 		},
 		{
-			name:  "repeated format parameter",
-			query: "?format=goose&format=flyway",
-			want:  "atlas migrate hash --dir: migration directory URL contains multiple format parameters",
+			name:  "unknown format value beside an ignored key",
+			query: "?format=totally-bogus&other=1",
+			want:  `atlas migrate hash --dir: unknown Atlas migration directory format "totally-bogus": expected .*`,
 		},
 	}
 
@@ -581,6 +653,7 @@ func TestCompatMigrateSourceFormat_FailurePathUnsupportedQuery(t *testing.T) {
 
 			c.Assert(err, qt.ErrorMatches, tt.want)
 			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(sumFileExists(c, dir), qt.IsFalse)
 		})
 	}
 }
@@ -632,33 +705,36 @@ func TestCompatMigrateIntegrityRepeatedDir_FailurePath(t *testing.T) {
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 }
 
-// TestCompatMigrateIntegrity_FailurePathEmptyDirFormat pins the one
-// --dir-format value Atlas CE accepts and Ptah still refuses. CE treats an
-// empty value as the atlas layout and exits 0. Ptah rejects it on all nine
-// metadata verbs through one shared mapper; fixing it on two of them would
-// leave the surface less consistent than it is now.
-func TestCompatMigrateIntegrity_FailurePathEmptyDirFormat(t *testing.T) {
+// TestCompatMigrateIntegrityEmptyDirFormat_HappyPath pins an empty
+// --dir-format as the atlas layout (stokaro/ptah#990 item 1). The community
+// binary exits 0 and reads the directory as Atlas; Ptah refused it on all nine
+// metadata verbs through one shared mapper, so it is relaxed on all of them at
+// once.
+//
+// hash asserts the covered set rather than only the exit code: the empty value
+// has to resolve to the ATLAS layout specifically, and on integrityFixture that
+// set differs from every other format's.
+func TestCompatMigrateIntegrityEmptyDirFormat_HappyPath(t *testing.T) {
 	c := qt.New(t)
 
-	tests := []struct {
-		name string
-		verb string
-	}{
-		{name: "hash", verb: "hash"},
-		{name: "validate", verb: "validate"},
-	}
+	c.Run("hash writes the atlas covered set", func(c *qt.C) {
+		dir := writeIntegrityFixture(c)
 
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			dir := writeIntegrityFixture(c)
+		stdout, stderr, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir, "--dir-format", "")
 
-			_, _, err := runCompatExit("migrate", tt.verb, "--dir", "file://"+dir, "--dir-format", "")
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", stdout, stderr))
+		c.Assert(sumEntryNames(c, dir), qt.DeepEquals, sqlSuffixCoveredSet)
+	})
 
-			c.Assert(err, qt.ErrorMatches,
-				"atlas migrate "+tt.verb+" --dir-format: migration directory format must not be empty")
-			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-		})
-	}
+	c.Run("validate accepts the directory hash wrote", func(c *qt.C) {
+		dir := writeIntegrityFixture(c)
+		_, _, hashErr := runCompatExit("migrate", "hash", "--dir", "file://"+dir, "--dir-format", "")
+		c.Assert(hashErr, qt.IsNil)
+
+		stdout, stderr, err := runCompatExit("migrate", "validate", "--dir", "file://"+dir, "--dir-format", "")
+
+		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s%s", stdout, stderr))
+	})
 }
 
 // TestCompatMigrateIntegrityConvertedDir_FailurePathBadArgs holds the converted

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -139,10 +139,8 @@ func runAtlasMigrateLint(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate lint --dir: %w", err))
 	}
-	if len(localDir.Query) > 0 {
-		return cmdutil.Fail(cmd, fmt.Errorf(
-			"atlas migrate lint --dir: migration directory URL query parameters are not supported for this command",
-		))
+	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate lint --dir: %w", err))
 	}
 	source, err := project.captureLocal(localDir)
 	if err != nil {

--- a/cmd/atlas/migrate_set.go
+++ b/cmd/atlas/migrate_set.go
@@ -199,9 +199,8 @@ func prepareAtlasMigrateSet(
 	if err != nil {
 		return prepared, fmt.Errorf("atlas migrate set --dir: %w", err)
 	}
-	if len(localDir.Query) > 0 {
-		return prepared,
-			fmt.Errorf("atlas migrate set --dir: migration directory URL query parameters are not supported for this command")
+	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
+		return prepared, fmt.Errorf("atlas migrate set --dir: %w", err)
 	}
 	// Preserve Atlas-compatible directory diagnostics; the subsequent
 	// CaptureLocal call remains the authoritative rooted read and rejects any

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -130,10 +130,8 @@ func runAtlasMigrateStatus(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
 	}
-	if len(localDir.Query) > 0 {
-		return cmdutil.Fail(cmd, fmt.Errorf(
-			"atlas migrate status --dir: migration directory URL query parameters are not supported for this command",
-		))
+	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
 	}
 	source, err := project.captureLocal(localDir)
 	if err != nil {
@@ -149,8 +147,9 @@ func runAtlasMigrateStatus(
 	// connection (it is emitted even when --url is unreachable) and it covers a
 	// directory resolved from atlas.hcl as well as one named by --dir, which is
 	// why it sits here rather than beside the flag parsing. Only the native
-	// branch of the gate is reachable: a `?format=` query and a non-atlas
-	// --dir-format are both rejected above.
+	// branch of the gate is reachable: checkNativeAtlasDirQuery above admits a
+	// `?format=` only when it resolves to the Atlas layout, and a non-atlas
+	// --dir-format is rejected above too.
 	//
 	// Returned bare on purpose — cmdutil.Fail would prepend `error: ` and move
 	// the message off the stream the community binary writes it to.

--- a/cmd/atlas/project_config_presence_test.go
+++ b/cmd/atlas/project_config_presence_test.go
@@ -32,9 +32,19 @@ func TestCompatCommand_ProjectConfigExplicitEmptyMigrationDirFails(t *testing.T)
 	c.Assert(err, qt.ErrorMatches, `atlas\.hcl migration\.dir: migration directories URL is required`)
 }
 
-func TestCompatCommand_ProjectConfigExplicitEmptyMigrationFormatFails(t *testing.T) {
+func TestCompatCommand_ProjectConfigExplicitEmptyMigrationFormatReadsAtlasLayout(t *testing.T) {
 	c := qt.New(t)
 	t.Chdir(t.TempDir())
+	c.Assert(os.Mkdir("migrations", 0o750), qt.IsNil)
+	// A layout the atlas and goose readers disagree about: read as atlas the
+	// directive lines are part of the migration, read as goose they are stripped
+	// and only the up half survives. atlas.sum then covers both files under the
+	// atlas layout and would cover a different set under any other, so the
+	// assertion below cannot pass for the wrong format.
+	c.Assert(os.WriteFile(filepath.Join("migrations", "1_init.sql"),
+		[]byte("-- +goose Up\nCREATE TABLE users (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join("migrations", "V1__x.sql"),
+		[]byte("CREATE TABLE v (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
   migration {
     format = ""
@@ -50,7 +60,11 @@ func TestCompatCommand_ProjectConfigExplicitEmptyMigrationFormatFails(t *testing
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, `atlas migrate hash --dir-format: migration directory format must not be empty`)
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", out.String()))
+	sum, readErr := os.ReadFile(filepath.Join("migrations", "atlas.sum"))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(sum), qt.Contains, "1_init.sql")
+	c.Assert(string(sum), qt.Contains, "V1__x.sql")
 }
 
 func TestCompatCommand_ProjectConfigEmptyGitBaseKeepsLatestSelector(t *testing.T) {

--- a/internal/atlasmigrate/format.go
+++ b/internal/atlasmigrate/format.go
@@ -3,9 +3,7 @@ package atlasmigrate
 import (
 	"fmt"
 	"io/fs"
-	"maps"
 	"net/url"
-	"slices"
 
 	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/fsnapshot"
@@ -116,17 +114,24 @@ func ReadsNativeAtlasDir(format atlasmigrateimport.Format) bool {
 
 // ResolveApplyDirFormat resolves the migration directory format an apply reads:
 // the ?format= URL query value when present (an empty value selects the native
-// Atlas format), otherwise the configured project format.
+// Atlas format), otherwise the configured project format. Query keys other than
+// format are ignored — see [applyDirURLFormat] for what that does and does not
+// widen.
 func ResolveApplyDirFormat(configured string, query url.Values) (atlasmigrateimport.Format, error) {
-	queryFormat, found, err := applyDirURLFormat(query)
-	if err != nil {
-		return "", err
-	}
 	value := configured
-	if found {
+	if queryFormat, found := applyDirURLFormat(query); found {
 		value = queryFormat
 	}
 	return parseApplyDirFormat(value)
+}
+
+// DirFormatFromQuery reports whether a migration directory URL query selects the
+// directory's format, so a caller can name the spelling — --dir or --dir-format
+// — that carried a value [ResolveApplyDirFormat] rejected. A query holding only
+// ignored keys selects nothing, so the blame stays on --dir-format.
+func DirFormatFromQuery(query url.Values) bool {
+	_, found := applyDirURLFormat(query)
+	return found
 }
 
 // parseApplyDirFormat maps a directory format string to a supported format. It
@@ -151,18 +156,43 @@ func parseApplyDirFormat(value string) (atlasmigrateimport.Format, error) {
 	}
 }
 
-func applyDirURLFormat(query url.Values) (string, bool, error) {
-	for _, key := range slices.Sorted(maps.Keys(query)) {
-		if key != "format" {
-			return "", false, fmt.Errorf("unsupported migration directory URL query parameter %q", key)
-		}
-	}
+// applyDirURLFormat reads the format selection out of a migration directory
+// URL query. Only the `format` key carries meaning; the return reports the
+// selected value and whether the key was present at all, because a present but
+// EMPTY value selects the native Atlas format and outranks the configured one.
+//
+// Two rules here look lax and are not. Both were measured against the pinned
+// community binary v1.3.0 on a directory holding 1_init.sql, V1__x.sql and
+// U1__undo.sql — a fixture whose covered set differs per format (atlas 3 files,
+// flyway 1, golang-migrate 0), so each row is separable rather than three
+// formats agreeing by accident (stokaro/ptah#990):
+//
+//   - A key other than `format` is IGNORED, not refused. `?format=flyway&other=1`
+//     exits 0 covering exactly V1__x.sql, so the foreign key is dropped while the
+//     format is still honored; `?other=1` alone exits 0 covering all three, i.e.
+//     it reads as the native Atlas format rather than as an error.
+//   - A repeated `format` takes the FIRST value. `?format=flyway&format=goose`
+//     covers V1__x.sql and `?format=goose&format=flyway` covers all three, so the
+//     winner tracks position and not the format name.
+//
+// Loosening this widens what the apply-time integrity gate (stokaro/ptah#973)
+// accepts, since the gate selects its covered file set from the format resolved
+// here. What it admits is one more spelling of the same three formats — the
+// value itself still goes through the strict, verbatim [parseApplyDirFormat],
+// so `?format=totally-bogus&x=1` is still refused. No directory becomes
+// ungated, and no file set becomes uncovered.
+//
+// A semicolon in the query stays refused, one step earlier, out of
+// url.ParseQuery inside atlasargs.ParseLocalDir. That is a deliberate, recorded
+// divergence: measured, `?format=flyway;x=1` exits 0 on the community binary but
+// silently drops the WHOLE pair and reads the directory as native Atlas — a
+// semicolon costs you the format you asked for, covering three files where you
+// asked for one. Refusing is the safe side of that, so it is kept
+// (stokaro/ptah#990 item 6).
+func applyDirURLFormat(query url.Values) (string, bool) {
 	formats := query["format"]
-	if len(formats) > 1 {
-		return "", false, fmt.Errorf("migration directory URL contains multiple format parameters")
+	if len(formats) > 0 {
+		return formats[0], true
 	}
-	if len(formats) == 1 {
-		return formats[0], true, nil
-	}
-	return "", false, nil
+	return "", false
 }

--- a/internal/atlasmigrate/format_test.go
+++ b/internal/atlasmigrate/format_test.go
@@ -126,6 +126,38 @@ func TestResolveApplyDir_ConvertsExternalFormatsToUpOnly(t *testing.T) {
 			wantFile:   "1_init.sql",
 			wantSQL:    "CREATE TABLE goose_url (id int);\n",
 		},
+		// The three rows below pin the relaxed query parsing (stokaro/ptah#990
+		// items 2 and 3). Each is separable because a goose source converts to
+		// its up half only, while the same bytes read as the atlas layout pass
+		// through verbatim with the directives intact — so the SQL, not just the
+		// exit path, says which format won.
+		{
+			name:       "an ignored key beside format keeps the format",
+			configured: "atlas",
+			query:      url.Values{"format": []string{"goose"}, "other": []string{"1"}},
+			file:       "1_init.sql",
+			source:     "-- +goose Up\nCREATE TABLE goose_kept (id int);\n-- +goose Down\nDROP TABLE goose_kept;\n",
+			wantFile:   "1_init.sql",
+			wantSQL:    "CREATE TABLE goose_kept (id int);\n",
+		},
+		{
+			name:       "an ignored key alone reads the atlas layout",
+			configured: "atlas",
+			query:      url.Values{"other": []string{"1"}},
+			file:       "1_init.sql",
+			source:     "-- +goose Up\nCREATE TABLE goose_raw (id int);\n-- +goose Down\nDROP TABLE goose_raw;\n",
+			wantFile:   "1_init.sql",
+			wantSQL:    "-- +goose Up\nCREATE TABLE goose_raw (id int);\n-- +goose Down\nDROP TABLE goose_raw;\n",
+		},
+		{
+			name:       "repeated format takes the first value",
+			configured: "flyway",
+			query:      url.Values{"format": []string{"goose", "atlas"}},
+			file:       "1_init.sql",
+			source:     "-- +goose Up\nCREATE TABLE goose_first (id int);\n-- +goose Down\nDROP TABLE goose_first;\n",
+			wantFile:   "1_init.sql",
+			wantSQL:    "CREATE TABLE goose_first (id int);\n",
+		},
 	}
 
 	for _, tt := range tests {
@@ -186,22 +218,16 @@ func TestResolveApplyDir_FailurePath(t *testing.T) {
 			want:       `unknown Atlas migration directory format " atlas ": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`,
 		},
 		{
-			name:       "unknown query parameter",
+			name:       "an ignored key does not rescue an unknown format value",
 			configured: "atlas",
-			query:      url.Values{"version": []string{"1"}},
-			want:       `unsupported migration directory URL query parameter "version"`,
+			query:      url.Values{"format": []string{"custom"}, "version": []string{"1"}},
+			want:       `unknown Atlas migration directory format "custom": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`,
 		},
 		{
-			name:       "unknown query parameters are reported deterministically",
+			name:       "the FIRST repeated format is the one validated",
 			configured: "atlas",
-			query:      url.Values{"version": []string{"1"}, "checksum": []string{"required"}},
-			want:       `unsupported migration directory URL query parameter "checksum"`,
-		},
-		{
-			name:       "multiple format query parameters",
-			configured: "atlas",
-			query:      url.Values{"format": []string{"atlas", "goose"}},
-			want:       "migration directory URL contains multiple format parameters",
+			query:      url.Values{"format": []string{"custom", "goose"}},
+			want:       `unknown Atlas migration directory format "custom": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`,
 		},
 	}
 
@@ -235,8 +261,17 @@ func TestResolveApplyDir_RejectsUnexecutableAndEmptyDirectories(t *testing.T) {
 		c.Assert(gotFS, qt.DeepEquals, fsnapshot.Snapshot{})
 	})
 
-	c.Run("empty external directory", func(c *qt.C) {
+	// An external directory whose COVERED SET is non-empty but whose files the
+	// converter produces no entry for keeps its refusal (stokaro/ptah#980). The
+	// community binary really does execute this one — a Goose directory holding
+	// only foo.sql runs it as version "foo" — so reporting "nothing to execute"
+	// here would silently skip a migration rather than diverge loudly. Its twin,
+	// the empty covered set that now converts cleanly, is
+	// TestResolveApplyDir_EmptyCoveredSetConvertsToNothingToExecute.
+	c.Run("non-empty covered set the converter cannot read", func(c *qt.C) {
 		dir := c.TempDir()
+		writeFormatFile(c, dir, "foo.sql", "CREATE TABLE foo (id int);\n")
+
 		gotFS, err := resolveApplySource(os.DirFS(dir), dir, "goose", nil)
 
 		c.Assert(err, qt.ErrorMatches, `no importable migration files found in .* for format "goose"`)

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -215,7 +215,10 @@ func Import(opts Options) (*Result, error) {
 }
 
 // LoadDir securely snapshots the source migration directory at dir and
-// converts it to in-memory Atlas single-file entries.
+// converts it to in-memory Atlas single-file entries. A source that yields no
+// importable migration is an error here, because the only caller is the import
+// (write) path: importing nothing would write an empty target directory and
+// report success.
 func LoadDir(dir string, format Format) (*Loaded, error) {
 	root, err := os.OpenRoot(dir)
 	if err != nil {
@@ -232,7 +235,14 @@ func LoadDir(dir string, format Format) (*Loaded, error) {
 	if closeErr != nil {
 		return nil, fmt.Errorf("close source migration directory: %w", closeErr)
 	}
-	return LoadFS(snapshot, dir, format)
+	loaded, err := LoadFS(snapshot, dir, format)
+	if err != nil {
+		return nil, err
+	}
+	if len(loaded.Entries) == 0 {
+		return nil, fmt.Errorf("no importable migration files found in %s for format %q", dir, format)
+	}
+	return loaded, nil
 }
 
 // CaptureFS captures the files that define a source directory in format:
@@ -325,7 +335,27 @@ func sourceExtensionIncluded(format Format, extension string) bool {
 // LoadFS converts one caller-owned migration filesystem into in-memory Atlas
 // single-file entries for the given format. It never opens a pathname, writes
 // to disk, or opens a database connection. Unknown formats, malformed layouts,
-// unsupported migrations, and empty results return an error.
+// and unsupported migrations return an error.
+//
+// A source with NOTHING TO CONVERT is not an error: it returns a Loaded with no
+// entries, which executes as "No migration files to execute", exit 0, matching
+// the pinned community binary v1.3.0 on an empty directory, one holding only a
+// README, and one whose only SQL sits in a subdirectory — with and without
+// atlas.sum, all six rows measured (stokaro/ptah#980).
+//
+// "Nothing to convert" is keyed on the COVERED SET being empty, not on the
+// converted entries being empty, and the difference is the whole point. The two
+// are not the same predicate: a Goose directory holding only `foo.sql` has a
+// covered set of exactly that file — the community binary applies it, as version
+// "foo" — while Ptah's converter produces no entry for it. Keying on the entries
+// would report "nothing to execute" and exit 0 for that directory, replacing a
+// loud refusal with a silent no-op that skips a migration the source tool runs.
+// Measured: on that directory the community binary creates the table and Ptah
+// must not claim there was nothing to do. So a covered set that is non-empty
+// keeps the refusal below.
+//
+// [LoadDir], which feeds the import (write) path, refuses an empty result
+// outright: importing nothing would write an empty target and report success.
 func LoadFS(fsys fs.FS, display string, format Format) (*Loaded, error) {
 	if fsys == nil {
 		return nil, fmt.Errorf("source migration filesystem is required")
@@ -335,7 +365,13 @@ func LoadFS(fsys fs.FS, display string, format Format) (*Loaded, error) {
 		return nil, err
 	}
 	if len(entries) == 0 {
-		return nil, fmt.Errorf("no importable migration files found in %s for format %q", display, format)
+		covered, err := SumFileNames(fsys, format)
+		if err != nil {
+			return nil, err
+		}
+		if len(covered) > 0 {
+			return nil, fmt.Errorf("no importable migration files found in %s for format %q", display, format)
+		}
 	}
 	// External formats convert each source file to a single up-only Atlas
 	// migration whose version is the leading number of the file name. Distinct


### PR DESCRIPTION
Closes #990 and #980. Advances #1013 and #1002; the remainder is #1086.

Four issues that read as separate turned out to be one family on the `--dir` axis, with four chokepoints:

| | what refused | issues |
| --- | --- | --- |
| A | blanket query refusal on five verbs that never learned `?format=` | #1013 §1, the `?format=` half of #1002 |
| B | over-strict query parsing where the query *was* parsed — unknown key, repeated format | #990 items 2/3/6, #1013 §2 |
| C | `--dir-format` refusing an empty value and refusing foreign formats | #990 item 1, the `--dir-format` half of #1002 |
| D | an empty covered set being fatal in the importer | #980 |

A and B had to move together: routing the five verbs through the shared resolver would have handed them B's unknown-key refusal. D had to move first, or fixing A would have handed the `no importable migration files found` divergence to three more verbs as new surface.

## What deliberately does not change

`migrate new` and `migrate diff` keep refusing a `--dir` query.

Every verb that accepts one runs the `atlas.sum` integrity gate first, so a converted directory is verified before anything reads it. These two do not — they **write** a migration and a fresh sum. Measured on an unhashed directory:

```
migrate new demo --dir file://d     community binary 1   ptah-compat 0, writes
```

Accepting the query there would turn a refusal into a write over a directory nothing verified. That trades one divergence for a worse one, so the relaxation stops short of it. The gate is #1086, and the relaxation lands with it.

The asymmetry is commented at both sites with its reason, and `TestCompatMigrateDirQuery_NewAndDiffStillRefuseAQuery` pins it — so it cannot be extended to these verbs by symmetry alone, without the gate arriving too.

This is the correction from review. The first version relaxed all eight verbs and its commit asserted "zero rows exit 0 here where the pinned binary exits 1"; the reviewer measured that `new` and `diff` did exactly that, and that the sweep behind the claim had omitted those two.

## Verification

Measured after narrowing, against the pinned community binary:

```
migrate new  --dir 'file://d?nonsense=1'   CE 1  ptah 1   MATCH
migrate diff --dir 'file://d?nonsense=1'   CE 1  ptah 1   MATCH
migrate hash --dir 'file://d?nonsense=1'   CE 0  ptah 0   MATCH
```

The two helpers written for the relaxed spelling are removed rather than left unused, so the linter would notice if #1086 forgot to reintroduce them alongside the gate.

`go build`, `go vet`, `golangci-lint`, both public-API gates and the affected package tests are clean. One suite-wide flake, `cmd/viz TestSVGReportsGraphvizStderrOnFailure`, is a load-sensitive kill of a fake `dot` that passes in isolation and is untouched by this diff.
