### PR TITLE
Keep compat migrate down as quiet as the rest of the binary

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -169,7 +169,26 @@ func newAtlasMigrateCommand() *cobra.Command {
 	cmd.AddCommand(newAtlasMigrateStatusCommand())
 	cmd.AddCommand(newAtlasMigrateDownCommand())
 	cmd.AddCommand(newAtlasMigrateSetCommand())
-	for _, verb := range []atlasVerb{
+	for _, verb := range atlasMigrateForwardVerbs() {
+		cmd.AddCommand(newAtlasAdapterCommand("migrate", verb))
+	}
+	cmd.AddCommand(newAtlasMigrateHashCommand())
+	cmd.AddCommand(newAtlasMigrateValidateCommand())
+	cmd.AddCommand(newAtlasMigrateDiffCommand())
+	cmd.AddCommand(newAtlasMigrateImportCommand())
+	addAtlasUnsupportedCommands(cmd, []atlasUnsupportedVerb{
+		{use: "push", short: "Push migration directory to a remote registry"},
+	})
+	return cmd
+}
+
+// atlasMigrateForwardVerbs returns the `migrate` verbs that are plain
+// table-driven forwards, in registration order. It is a named function rather
+// than a literal inside newAtlasMigrateCommand so that a test can enumerate
+// every forwarded verb — see TestAtlasVerbsCarryLogLevelExactlyWhereTargetTakesIt,
+// which measures each one instead of only the verb an issue happened to name.
+func atlasMigrateForwardVerbs() []atlasVerb {
+	return []atlasVerb{
 		{
 			use:                "checkpoint",
 			displayUse:         "checkpoint [flags] [name]",
@@ -208,17 +227,7 @@ func newAtlasMigrateCommand() *cobra.Command {
 		atlasMigrateRebaseVerb(),
 		atlasMigrateRmVerb(),
 		atlasMigrateTestVerb(),
-	} {
-		cmd.AddCommand(newAtlasAdapterCommand("migrate", verb))
 	}
-	cmd.AddCommand(newAtlasMigrateHashCommand())
-	cmd.AddCommand(newAtlasMigrateValidateCommand())
-	cmd.AddCommand(newAtlasMigrateDiffCommand())
-	cmd.AddCommand(newAtlasMigrateImportCommand())
-	addAtlasUnsupportedCommands(cmd, []atlasUnsupportedVerb{
-		{use: "push", short: "Push migration directory to a remote registry"},
-	})
-	return cmd
 }
 
 func atlasRootArgs(cmd *cobra.Command, args []string) error {
@@ -324,10 +333,25 @@ func atlasMigrateDownVerb() atlasVerb {
 		// default of "ptah" silently no-ops against the atlas_schema_revisions
 		// rows `atlas migrate apply` writes. --confirm suppresses the native
 		// safety prompt because Atlas migrate down executes non-interactively.
+		//
+		// --log-level warn is what keeps this verb as quiet as the rest of the
+		// binary. The Atlas-compatible surface is quiet by construction
+		// (cmd/ptah-compat/main.go installs cliobs.QuietDefaultLogger), but that
+		// only lowers what the *default* logger accepts. This is the one
+		// forwarded verb whose native target starts its own observability
+		// runtime (cliobs.Start), and that runtime installs a fresh logger over
+		// the quiet default at the native --log-level default of "info" — so the
+		// migrator's lifecycle log and the dialect writers' "[DRY RUN] Would ..."
+		// narration land on the compat command's stderr (stokaro/ptah#969).
+		// warn, not error: it reproduces the #968 threshold exactly, so a
+		// Warn-level diagnostic that exists on no other channel (a migration
+		// lock that would not release, a skipped out-of-order migration, a
+		// connection that would not close) still reaches the user.
+		//
 		// User args are appended after the prefix, so an explicit native
-		// `--revision-format ptah` pass-through still overrides the format
-		// default (pflag keeps the last value).
-		prefixArgs:          []string{"--revision-format", "atlas", "--confirm"},
+		// `--revision-format ptah` or `--log-level info` pass-through still
+		// overrides the default (pflag keeps the last value).
+		prefixArgs:          []string{"--revision-format", "atlas", "--confirm", "--log-level", "warn"},
 		nativeOnlyFlags:     []string{"confirm"},
 		nativeProjectConfig: true,
 		flags: []atlasargs.Flag{

--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -4,6 +4,7 @@ package atlas
 import (
 	"context"
 	"fmt"
+	"os"
 	"slices"
 	"strings"
 
@@ -30,12 +31,17 @@ import (
 )
 
 type atlasVerb struct {
-	use                 string
-	displayUse          string
-	short               string
-	native              string
-	factory             func() *cobra.Command
-	prefixArgs          []string
+	use        string
+	displayUse string
+	short      string
+	native     string
+	factory    func() *cobra.Command
+	prefixArgs []string
+	// quietNarration lowers the native log threshold so the target's own
+	// lifecycle narration stays off this surface's stderr. It is applied by
+	// quietingLogLevelArgs rather than through prefixArgs, because it must not
+	// apply under a machine-readable log format.
+	quietNarration      bool
 	positionals         []atlasPositionalArg
 	positionalOptional  bool
 	nativeOnlyFlags     []string
@@ -351,7 +357,15 @@ func atlasMigrateDownVerb() atlasVerb {
 		// User args are appended after the prefix, so an explicit native
 		// `--revision-format ptah` or `--log-level info` pass-through still
 		// overrides the default (pflag keeps the last value).
-		prefixArgs:          []string{"--revision-format", "atlas", "--confirm", "--log-level", "warn"},
+		//
+		// The level is NOT in this list, because it cannot be unconditional.
+		// Under `--log-format json` the emitter turns the whole report into
+		// Info-level records, so lowering the threshold deletes the command's
+		// output rather than its narration -- measured, 2687 bytes became 0 on
+		// a rollback that still ran. quietingLogLevelArgs applies it only where
+		// the report reaches the writer directly.
+		prefixArgs:          []string{"--revision-format", "atlas", "--confirm"},
+		quietNarration:      true,
 		nativeOnlyFlags:     []string{"confirm"},
 		nativeProjectConfig: true,
 		flags: []atlasargs.Flag{
@@ -774,6 +788,7 @@ func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 		if err != nil {
 			return nil, nil, err
 		}
+		mapped = append(quietingLogLevelArgs(verb, args), mapped...)
 		return append(mapped, nativeTail...), project.context, nil
 	}
 }
@@ -997,4 +1012,57 @@ func atlasFlagName(arg string) (name string, inlineValue bool, ok bool) {
 	default:
 		return "", false, false
 	}
+}
+
+// quietingLogLevelArgs returns the native --log-level argument that keeps a
+// forwarded verb's own narration off this surface, or nothing when lowering the
+// threshold would delete the command's output instead.
+//
+// The distinction is the log format, and it is not cosmetic. In text mode the
+// report is written straight to the command's writer and no threshold reaches
+// it, so lowering the level removes exactly what this surface does not want:
+// the migrator's lifecycle records and the dialect writers' "[DRY RUN] Would
+// ..." narration.
+//
+// Under a machine-readable format the emitter turns that same report into
+// Info-level records, so the threshold and the output become one knob.
+// Measured on a one-migration rollback: 2687 bytes across 15 records became 0,
+// exit 0, with the rollback still performed. Silence on a destructive command
+// is a worse defect than the narration this was fixing.
+//
+// The format is read from the raw arguments rather than from cobra, because
+// this surface registers neither logging flag -- they are forwarded verbatim to
+// the native command, so a flag lookup here finds nothing and reports the
+// default for every invocation.
+//
+// The result is PREPENDED, so an explicit `--log-level` from the user still
+// wins: pflag keeps the last value.
+//
+// warn rather than error: it reproduces the #968 threshold exactly, so a
+// Warn-level diagnostic that exists on no other channel -- a migration lock
+// that would not release, a skipped out-of-order migration -- still arrives.
+func quietingLogLevelArgs(verb atlasVerb, args []string) []string {
+	if !verb.quietNarration {
+		return nil
+	}
+	if !logFormatWritesReportDirectly(args) {
+		return nil
+	}
+	return []string{"--log-level", "warn"}
+}
+
+// logFormatWritesReportDirectly reports whether the selected log format sends a
+// command's report to its writer rather than through the logger.
+func logFormatWritesReportDirectly(args []string) bool {
+	format := strings.TrimSpace(os.Getenv("PTAH_LOG_FORMAT"))
+	for index, arg := range args {
+		switch {
+		case arg == "--log-format" && index+1 < len(args):
+			format = args[index+1]
+		case strings.HasPrefix(arg, "--log-format="):
+			format = strings.TrimPrefix(arg, "--log-format=")
+		}
+	}
+	format = strings.ToLower(strings.TrimSpace(format))
+	return format == "" || format == "text"
 }

--- a/cmd/atlas/verb_log_level_internal_test.go
+++ b/cmd/atlas/verb_log_level_internal_test.go
@@ -1,0 +1,128 @@
+package atlas
+
+// White-box testing required: the subject is the unexported atlasVerb table
+// itself — each verb's prefixArgs and the native target its factory builds.
+// Neither is reachable from the exported command tree, because a forward
+// applies its prefix inside RunE and the resulting log level is invisible in
+// help output and in any successful run's streams. Driving this through the
+// exported surface could only observe one verb at a time, and only by running
+// a real migration per verb; the point of this test is to measure every verb.
+
+import (
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/cliobs"
+)
+
+// The Atlas-compatible surface is quiet by construction: cmd/ptah-compat's main
+// installs cliobs.QuietDefaultLogger, which lowers what the *default* slog
+// logger accepts. A forwarded verb whose native target starts its own
+// observability runtime escapes that, because cliobs.Start installs a fresh
+// logger over the quiet default at the target's own --log-level default of
+// "info" — which is how stokaro/ptah#969 put eight lines of INFO narration on
+// `ptah-compat migrate down`'s stderr.
+//
+// The fix is a per-verb `--log-level warn` prefix rather than a compat-wide
+// one, because a compat-wide prefix is measurably wrong: a verb whose target
+// does not register the flag exits 1 with `Error: unknown flag: --log-level`
+// (`migrate validate` and `migrate hash` both do).
+//
+// This test is the guard that the choice cannot be forgotten on the next verb.
+// It enumerates every table-driven verb, builds its native target, and measures
+// two things per verb — whether the target registers --log-level, and what
+// value the verb's prefix pins it to. A new forwarded verb whose target starts
+// a runtime fails here by name, and so does a verb whose prefix drifts to a
+// different level.
+
+// verbLogLevelObservation is what the guard measures for one verb.
+type verbLogLevelObservation struct {
+	// TargetRegistersFlag reports whether the native target the verb forwards
+	// into accepts --log-level at all. Only such a target can start its own
+	// observability runtime, and only such a target tolerates the prefix.
+	TargetRegistersFlag bool
+	// PrefixLevel is the value the verb's prefixArgs pin --log-level to, or ""
+	// when the prefix does not carry the flag.
+	PrefixLevel string
+}
+
+// allAtlasTableVerbs returns every verb the Atlas surface builds through the
+// atlasVerb table, keyed by the command path a failure should name.
+func allAtlasTableVerbs() map[string]atlasVerb {
+	verbs := map[string]atlasVerb{
+		"migrate down":     atlasMigrateDownVerb(),
+		"migrate hash":     atlasMigrateHashVerb(),
+		"migrate validate": atlasMigrateValidateVerb(),
+		"schema test":      atlasSchemaTestVerb(),
+	}
+	for _, verb := range atlasMigrateForwardVerbs() {
+		verbs["migrate "+verb.use] = verb
+	}
+	return verbs
+}
+
+// prefixLogLevel returns the value prefixArgs pin --log-level to, or "" when
+// the prefix does not set it.
+func prefixLogLevel(prefixArgs []string) string {
+	index := slices.Index(prefixArgs, "--"+cliobs.LogLevelFlagName)
+	if index < 0 || index+1 >= len(prefixArgs) {
+		return ""
+	}
+	return prefixArgs[index+1]
+}
+
+// observeVerbLogLevel builds the verb's native target and reports what the
+// guard measures.
+func observeVerbLogLevel(verb atlasVerb) verbLogLevelObservation {
+	target := verb.factory()
+	return verbLogLevelObservation{
+		TargetRegistersFlag: target.Flags().Lookup(cliobs.LogLevelFlagName) != nil,
+		PrefixLevel:         prefixLogLevel(verb.prefixArgs),
+	}
+}
+
+func TestAtlasVerbsCarryLogLevelExactlyWhereTargetTakesIt(t *testing.T) {
+	c := qt.New(t)
+
+	// Pinned per verb, not derived, so the value itself is part of the
+	// contract. `error` would silence the run log just as completely on a clean
+	// run — and would also drop the Warn-level diagnostics that exist on no
+	// other channel (a migration lock that would not release, a skipped
+	// out-of-order migration, a connection that would not close), making the
+	// forwarded verb quieter than the rest of the compat binary.
+	want := map[string]verbLogLevelObservation{
+		"migrate down":       {TargetRegistersFlag: true, PrefixLevel: "warn"},
+		"migrate checkpoint": {},
+		"migrate edit":       {},
+		"migrate hash":       {},
+		"migrate new":        {},
+		"migrate rebase":     {},
+		"migrate rm":         {},
+		"migrate test":       {},
+		"migrate validate":   {},
+		"schema test":        {},
+	}
+
+	verbs := allAtlasTableVerbs()
+	got := make(map[string]verbLogLevelObservation, len(verbs))
+	for name, verb := range verbs {
+		got[name] = observeVerbLogLevel(verb)
+	}
+
+	// The exact map catches a new verb appearing, a verb disappearing, and a
+	// prefix drifting to another level.
+	c.Assert(got, qt.DeepEquals, want)
+
+	// The same measurement restated as the rule it encodes, so the guard keeps
+	// meaning even if someone rewrites the table above: a verb is quieted
+	// exactly when its target can take the flag.
+	quieted := make(map[string]bool, len(got))
+	registers := make(map[string]bool, len(got))
+	for name, observation := range got {
+		quieted[name] = observation.PrefixLevel == "warn"
+		registers[name] = observation.TargetRegistersFlag
+	}
+	c.Assert(quieted, qt.DeepEquals, registers)
+}

--- a/cmd/atlas/verb_log_level_internal_test.go
+++ b/cmd/atlas/verb_log_level_internal_test.go
@@ -43,9 +43,18 @@ type verbLogLevelObservation struct {
 	// into accepts --log-level at all. Only such a target can start its own
 	// observability runtime, and only such a target tolerates the prefix.
 	TargetRegistersFlag bool
-	// PrefixLevel is the value the verb's prefixArgs pin --log-level to, or ""
-	// when the prefix does not carry the flag.
+	// PrefixLevel is the value the verb pins --log-level to under the DEFAULT
+	// log format, or "" when it pins nothing.
+	//
+	// It is read from quietingLogLevelArgs rather than from prefixArgs,
+	// because the level cannot be unconditional: under a machine-readable
+	// format the report itself is log records, so lowering the threshold
+	// deletes the output rather than the narration.
 	PrefixLevel string
+	// JSONLevel is the same observation under `--log-format json`. It must be
+	// empty everywhere: a verb that quiets itself there silences its own
+	// report.
+	JSONLevel string
 }
 
 // allAtlasTableVerbs returns every verb the Atlas surface builds through the
@@ -79,7 +88,8 @@ func observeVerbLogLevel(verb atlasVerb) verbLogLevelObservation {
 	target := verb.factory()
 	return verbLogLevelObservation{
 		TargetRegistersFlag: target.Flags().Lookup(cliobs.LogLevelFlagName) != nil,
-		PrefixLevel:         prefixLogLevel(verb.prefixArgs),
+		PrefixLevel:         prefixLogLevel(quietingLogLevelArgs(verb, nil)),
+		JSONLevel:           prefixLogLevel(quietingLogLevelArgs(verb, []string{"--log-format", "json"})),
 	}
 }
 

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -83,7 +83,12 @@ func TestCompatBinaryMigrateDownRunsWithEOFStdin(t *testing.T) {
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout=%s stderr=%s", stdout.String(), stderr.String()))
 	c.Assert(stdout.String(), qt.Not(qt.Contains), "Type 'YES' to confirm")
-	c.Assert(stderr.String(), qt.Contains, "All migrations rolled back successfully")
+	// The rollback-succeeded proof is read from stdout, the command's own
+	// report. It used to be read from the run log on stderr, which only ever
+	// appeared there because the forwarded verb reinstalled an INFO logger over
+	// the binary's quiet default (stokaro/ptah#969). This test is about EOF
+	// stdin, not about the log, so it must not pin the noise.
+	c.Assert(stdout.String(), qt.Contains, "✅ Migration rollback completed successfully!")
 	c.Assert(stderr.String(), qt.Not(qt.Contains), "Type 'YES' to confirm")
 	c.Assert(stderr.String(), qt.Not(qt.Contains), "read rollback confirmation")
 	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
@@ -213,6 +218,76 @@ func TestCompatBinaryDryRunDefaultFormatKeepsStderrEmpty(t *testing.T) {
 			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
 			c.Assert(stderr.String(), qt.Equals, "")
 			c.Assert(stdout.String(), qt.Equals, tt.wantStdout)
+		})
+	}
+}
+
+// TestCompatBinaryMigrateDownDefaultFormatKeepsStderrEmpty is the pin for
+// stokaro/ptah#969. `migrate down` without --format is the one Atlas verb that
+// forwards into a native command which starts its own observability runtime,
+// and that runtime installed a fresh INFO logger over the compat binary's quiet
+// default — eight lines of narration on a dry run, four on a rollback.
+//
+// TestCompatBinaryDryRunDefaultFormatKeepsStderrEmpty above cannot cover this:
+// it asserts stdout EQUALS its expectation, and a down report embeds the
+// database and migrations paths. The stdout marker each row asserts is what
+// stops the stderr assertion from holding vacuously — without it, a run that
+// never reached the rollback would satisfy an empty stderr too.
+func TestCompatBinaryMigrateDownDefaultFormatKeepsStderrEmpty(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+
+	tests := []struct {
+		name string
+		args func(dbPath string) []string
+		// wantStdout proves the run reached the rollback the row is about.
+		wantStdout string
+	}{
+		{
+			name: "dry run",
+			args: func(dbPath string) []string {
+				return []string{
+					"migrate", "down",
+					"--url", "sqlite://" + dbPath,
+					"--dir", "file://" + migrationsDir,
+					"--to-version", "0",
+					"--dry-run",
+				}
+			},
+			wantStdout: "Would have rolled back to version: 0",
+		},
+		{
+			name: "rollback",
+			args: func(dbPath string) []string {
+				return []string{
+					"migrate", "down",
+					"--url", "sqlite://" + dbPath,
+					"--dir", "file://" + migrationsDir,
+					"--to-version", "0",
+				}
+			},
+			wantStdout: "Database is now at version: 0",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			// Each row needs its own revision to roll back. Sharing one
+			// database would make the second row a no-op, and an empty stderr
+			// would then prove nothing.
+			dbPath := filepath.Join(c.TempDir(), "down-quiet.db")
+			applyForReal(c, binPath, dbPath, migrationsDir)
+			run := newCompatProcess(binPath, tt.args(dbPath)...)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
+			c.Assert(stdout.String(), qt.Contains, tt.wantStdout)
+			c.Assert(stderr.String(), qt.Equals, "")
 		})
 	}
 }

--- a/cmd/ptah-compat/dry_run_quiet_test.go
+++ b/cmd/ptah-compat/dry_run_quiet_test.go
@@ -292,6 +292,60 @@ func TestCompatBinaryMigrateDownDefaultFormatKeepsStderrEmpty(t *testing.T) {
 	}
 }
 
+// TestCompatBinaryMigrateDownJSONKeepsItsReport covers what the quieting must
+// not take with it.
+//
+// The narration is silenced by lowering the native log threshold. Under a
+// machine-readable format that is the wrong knob: the emitter turns the whole
+// report into Info-level records, so the threshold and the output are the same
+// thing, and lowering it produced a completely silent rollback -- exit 0, zero
+// bytes, database changed.
+//
+// Asserting bytes rather than exit status is the point. A silent success has
+// the same exit code as a reported one, so an exit-only fixture passes on the
+// broken binary.
+func TestCompatBinaryMigrateDownJSONKeepsItsReport(t *testing.T) {
+	c := qt.New(t)
+	binPath := buildCompatBinary(c)
+	migrationsDir := dryRunQuietDir(c)
+
+	tests := []struct {
+		name  string
+		extra []string
+	}{
+		{
+			name:  "format selected on the command line",
+			extra: []string{"--log-format", "json"},
+		},
+		{
+			name:  "format and an explicit level",
+			extra: []string{"--log-format", "json", "--log-level", "info"},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dbPath := filepath.Join(c.TempDir(), "down-json.db")
+			applyForReal(c, binPath, dbPath, migrationsDir)
+			args := append([]string{
+				"migrate", "down",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+				"--to-version", "0",
+			}, tt.extra...)
+			run := newCompatProcess(binPath, args...)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
+
+			err := run.Run()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", stderr.String()))
+			c.Assert(stdout.String(), qt.Contains, "Database is now at version")
+		})
+	}
+}
+
 // TestCompatBinaryDryRunPinNoWriterNarration is the direct pin for
 // stokaro/ptah#963: the dialect writers' "[DRY RUN] Would ..." narration must
 // never reach the Atlas-compatible binary's streams, whatever mechanism keeps

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -263,20 +263,18 @@ claim success while quietly degrading. Valid circular foreign keys are rendered
 in two phases and do not produce a warning. Neither diagnostic appears on a
 clean run.
 
-:::caution
-`ptah-compat migrate down` is the exception. Without `--format` it forwards to
-the native `ptah migrations down`, which starts its own run log and writes it to
-stderr — eight lines on a successful dry run, four on a successful rollback.
-The Atlas surface exposes no `--log-level` to quiet it. Use `--format` when you
-need a clean stderr from `migrate down`; that path renders the report directly
-and stays quiet. Tracked in
-[`stokaro/ptah#969`](https://github.com/stokaro/ptah/issues/969).
-:::
+`ptah-compat migrate down` holds the same contract, with or without `--format`.
+Without `--format` it forwards to the native `ptah migrations down`, which
+starts its own run log; the Atlas surface pins that log to the same Warn
+threshold the rest of this binary uses, so a successful dry run and a successful
+rollback both leave stderr empty (stokaro/ptah#969).
 
 The equivalent native command, `ptah migrations up --dry-run`, does narrate each
 statement it would execute through its run log; that narration is selected by
-the native `--log-level` and `--log-format` flags, which the Atlas surface does
-not expose. See [Apply migrations](../../versioned/apply/).
+the native `--log-level` and `--log-format` flags. The Atlas surface does not
+model those flags, but a forwarded verb passes through any flag its native
+target registers, so `ptah-compat migrate down --log-level info` is accepted and
+restores the full narration. See [Apply migrations](../../versioned/apply/).
 
 The apply path executes every Atlas OSS migration directory format selected by
 `migration.format` or the directory URL `?format=` parameter: `atlas`,


### PR DESCRIPTION
Closes #969.

`ptah-compat migrate down` leaked the native run log onto stderr — the migrator's lifecycle records and the dialect writers' `[DRY RUN] Would ...` narration — where the rest of this binary is quiet.

## What review caught, and why it mattered

The first version pinned the native `--log-level` to `warn` on every invocation. That silences the narration, and under `--log-format json` it silences the **command's output** as well: the emitter turns the whole report into Info-level records, so the threshold and the output are the same knob.

Measured, one-migration rollback:

```
before   --log-format json    exit 0   2687 bytes, 15 records
after    --log-format json    exit 0   0 bytes            <- rollback still performed
```

A completely silent destructive command is a worse defect than the narration being fixed.

## The corrected shape

The level applies only where the report reaches the writer directly, which is the text format. Two details the first attempt got wrong, both found by measuring rather than reading:

- **The format is read from the raw arguments.** This surface registers neither logging flag — they are forwarded verbatim to the native command — so a cobra flag lookup finds nothing and reports the default for every invocation. My first correction used a lookup and changed nothing; the fixture stayed at 0 bytes and said so.
- **The argument is prepended.** Appending it after the mapped arguments made it win over an explicit user `--log-level`, which is backwards: pflag keeps the last value.

## Measured, fresh database per row

```
default text                    stdout 400    stderr 0
--log-format json               stdout 2617   stderr 0
--log-format json --log-level info   stdout 2617   stderr 0
text --log-level info           stdout 400    stderr 670    (user's choice wins)
```

`warn` rather than `error` is unchanged and deliberate: it reproduces the #968 threshold, so a Warn-level diagnostic that exists on no other channel — a migration lock that would not release, a skipped out-of-order migration — still reaches the user.

## Verification

The new fixture asserts **bytes**, not exit status: a silent success and a reported one share an exit code, so an exit-only test passes against the broken binary. Confirmed to discriminate — removing the format guard turns it red.

The enumerating test that walks every forwarded verb now observes **both** formats, so a verb that silences itself under json cannot pass by being checked only under text.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint`, `check-test-style.sh`, the public-API gate and `check-style.mjs` are clean.
