### PR TITLE
Apply a Goose file with no directives as raw SQL

### DIFF
--- a/cmd/atlas/migrate_apply_formats_test.go
+++ b/cmd/atlas/migrate_apply_formats_test.go
@@ -270,17 +270,25 @@ func TestMigrateApplyRejectsDuplicateConvertedVersionBeforeOpeningDatabase(t *te
 	c.Assert(statErr, qt.ErrorIs, fs.ErrNotExist)
 }
 
+// TestMigrateApplyRejectsMissingUpDirectiveBeforeOpeningDatabase covers dbmate
+// only. It used to cover goose too, asserting that a goose file with no
+// directives was refused; stokaro/ptah#981 is that refusal being wrong. Atlas
+// executes such a file's bytes verbatim and records the revision honestly, and a
+// file with no directives has no rollback section that could leak onto the apply
+// path — measured, including on the goose fixture this test used to carry, which
+// Atlas runs to completion and converts to a byte-identical atlas.sum. The goose
+// behavior now lives in TestMigrateApplyGooseDirectiveParsing, which asserts both
+// that directive-free files execute and that BROKEN directive sets are still
+// refused.
+//
+// The dbmate refusal stays, and stays deliberately: see the divergence table in
+// docs/conformance.md and the doc comment on dbmateUpSQL.
 func TestMigrateApplyRejectsMissingUpDirectiveBeforeOpeningDatabase(t *testing.T) {
 	tests := []struct {
 		name    string
 		format  string
 		content string
 	}{
-		{
-			name:    "goose",
-			format:  "goose",
-			content: "CREATE TABLE never_created (id INTEGER PRIMARY KEY);\nDROP TABLE never_created;",
-		},
 		{
 			name:    "dbmate",
 			format:  "dbmate",
@@ -309,7 +317,7 @@ func TestMigrateApplyRejectsMissingUpDirectiveBeforeOpeningDatabase(t *testing.T
 
 			err := cmd.Execute()
 
-			c.Assert(err, qt.ErrorMatches, `atlas migrate apply --dir: migration file 1_init\.sql has no ".*" section`)
+			c.Assert(err, qt.ErrorMatches, `atlas migrate apply --dir: migration file 1_init\.sql carries no "-- migrate:up" directive.*`)
 			_, statErr := os.Stat(dbPath)
 			c.Assert(statErr, qt.ErrorIs, fs.ErrNotExist)
 		})

--- a/cmd/atlas/migrate_goose_directives_test.go
+++ b/cmd/atlas/migrate_goose_directives_test.go
@@ -1,0 +1,298 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// gooseDirectiveRow is one source directory shape, measured on the pinned
+// community binary (v1.3.0) and asserted identically on every verb that reaches
+// the directive parser.
+//
+// Package-level coverage of the parser lives in
+// internal/atlasmigrateimport/goosedirectives_test.go. These rows exist because
+// the three call sites are what users actually hit, and each reaches LoadFS by a
+// different route: migrate apply via ConvertApplySource, migrate validate via
+// ResolveApplySourceForFormat, and migrate import via LoadDir.
+type gooseDirectiveRow struct {
+	name      string
+	format    string
+	file      string
+	assertErr func(c *qt.C, err error, out string)
+	assertDB  func(c *qt.C, dbPath string)
+}
+
+func gooseDirectiveAccepted() func(c *qt.C, err error, out string) {
+	return func(c *qt.C, err error, out string) {
+		c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", out))
+	}
+}
+
+func gooseDirectiveRefused() func(c *qt.C, err error, out string) {
+	return func(c *qt.C, err error, out string) {
+		c.Assert(err, qt.IsNotNil, qt.Commentf("command output:\n%s", out))
+	}
+}
+
+func gooseDirectiveNoTables(tables ...string) func(c *qt.C, dbPath string) {
+	return func(c *qt.C, dbPath string) {
+		for _, table := range tables {
+			c.Assert(sqliteTableCount(c, dbPath, table), qt.Equals, 0, qt.Commentf("table %s", table))
+		}
+	}
+}
+
+// gooseDirectiveRows is the discriminating table for stokaro/ptah#981.
+//
+// The first two rows are the pair that discriminates, and neither works alone.
+// "no directives" alone is passed by the naive remedy ("if no Up was found,
+// execute the raw file"), which then ships a rollback-execution bug. "body then
+// Down" alone passes without any change at all. Together they admit only a
+// parser that knows the difference between a file with NO directives and a file
+// with a BROKEN set of them.
+func gooseDirectiveRows() []gooseDirectiveRow {
+	const widgets = "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"
+
+	return []gooseDirectiveRow{
+		{
+			// #981: the community binary executes this, creates widgets, and
+			// records the revision. Ptah refused it on all three verbs.
+			name:      "no goose directives executes the body",
+			format:    "goose",
+			file:      widgets,
+			assertErr: gooseDirectiveAccepted(),
+			assertDB: func(c *qt.C, dbPath string) {
+				c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
+			},
+		},
+		{
+			// The naive remedy exits 0 here AND RUNS THE DROP. The community
+			// binary refuses, and so must Ptah: a Down with no Up is a broken
+			// directive set, not a directive-free file.
+			name:      "body followed by a Down section is refused",
+			format:    "goose",
+			file:      widgets + "-- +goose Down\nDROP TABLE widgets;\n",
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("widgets"),
+		},
+		{
+			// Deliberate divergence. The community binary does not recognize the
+			// typo, folds it into the body and executes "DROP TABLE a;" — the
+			// table is created and then dropped, and the migration is recorded
+			// as successful.
+			name:      "lowercase down near miss is refused",
+			format:    "goose",
+			file:      "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose down\nDROP TABLE a;\n",
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("a"),
+		},
+		{
+			// Never-looser: ptah-compat used to exit 0 here and create widgets.
+			name:      "Down before Up is refused",
+			format:    "goose",
+			file:      "-- +goose Down\nDROP TABLE widgets;\n-- +goose Up\n" + widgets,
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("widgets"),
+		},
+		{
+			// Never-looser: ptah-compat used to exit 0 here and create a and b.
+			name:      "a second Up is refused",
+			format:    "goose",
+			file:      "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose Up\nCREATE TABLE b (id INTEGER PRIMARY KEY);\n",
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("a", "b"),
+		},
+		{
+			// Never-looser: ptah-compat used to exit 0 here and create a.
+			name:      "StatementEnd with no StatementBegin is refused",
+			format:    "goose",
+			file:      "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose StatementEnd\n",
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("a"),
+		},
+		{
+			// Silent divergence before the change: Ptah exited 0 but created
+			// only widgets, dropping the author's first statement.
+			name:      "SQL above the Up directive still executes",
+			format:    "goose",
+			file:      "CREATE TABLE pre (id INTEGER PRIMARY KEY);\n-- +goose Up\n" + widgets,
+			assertErr: gooseDirectiveAccepted(),
+			assertDB: func(c *qt.C, dbPath string) {
+				c.Assert(sqliteTableCount(c, dbPath, "pre"), qt.Equals, 1)
+				c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
+			},
+		},
+		{
+			// Deliberate divergence, opposite verdict to the goose row above.
+			// The community binary exits 0, records revision 1 with 0/0
+			// statements, creates nothing, and on import writes a zero-byte file
+			// over the authored bytes.
+			name:      "dbmate file with no migrate:up is refused",
+			format:    "dbmate",
+			file:      widgets,
+			assertErr: gooseDirectiveRefused(),
+			assertDB:  gooseDirectiveNoTables("widgets"),
+		},
+		{
+			// Control: the well-formed shape must not move, and the down section
+			// must still not run.
+			name:      "well-formed Up and Down runs only the up section",
+			format:    "goose",
+			file:      "-- +goose Up\n" + widgets + "-- +goose Down\nCREATE TABLE down_ran (id INTEGER PRIMARY KEY);\n",
+			assertErr: gooseDirectiveAccepted(),
+			assertDB: func(c *qt.C, dbPath string) {
+				c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
+				c.Assert(sqliteTableCount(c, dbPath, "down_ran"), qt.Equals, 0)
+			},
+		},
+	}
+}
+
+func TestMigrateApplyGooseDirectiveParsing(t *testing.T) {
+	for _, tt := range gooseDirectiveRows() {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			migrationsDir := filepath.Join(dir, "migrations")
+			writeAtlasApplyProjectMigration(c, migrationsDir, "1_init.sql", tt.file)
+			hashConvertedApplyDir(c, migrationsDir, tt.format)
+			dbPath := filepath.Join(dir, "apply.db")
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir + "?format=" + tt.format,
+			})
+
+			err := cmd.Execute()
+
+			tt.assertErr(c, err, out.String())
+			tt.assertDB(c, dbPath)
+		})
+	}
+}
+
+func TestMigrateValidateGooseDirectiveParsing(t *testing.T) {
+	for _, tt := range gooseDirectiveRows() {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			migrationsDir := filepath.Join(dir, "migrations")
+			writeAtlasApplyProjectMigration(c, migrationsDir, "1_init.sql", tt.file)
+			hashConvertedApplyDir(c, migrationsDir, tt.format)
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"migrate", "validate",
+				"--dir", "file://" + migrationsDir + "?format=" + tt.format,
+				"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+			})
+
+			err := cmd.Execute()
+
+			tt.assertErr(c, err, out.String())
+		})
+	}
+}
+
+func TestMigrateImportGooseDirectiveParsing(t *testing.T) {
+	for _, tt := range gooseDirectiveRows() {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			migrationsDir := filepath.Join(dir, "migrations")
+			writeAtlasApplyProjectMigration(c, migrationsDir, "1_init.sql", tt.file)
+			hashConvertedApplyDir(c, migrationsDir, tt.format)
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{
+				"migrate", "import",
+				"--from", "file://" + migrationsDir + "?format=" + tt.format,
+				"--to", "file://" + filepath.Join(dir, "out"),
+			})
+
+			err := cmd.Execute()
+
+			tt.assertErr(c, err, out.String())
+		})
+	}
+}
+
+// TestMigrateApplyGooseDirectivesViaEnvFormat pins the fourth spelling. The
+// format can arrive from atlas.hcl instead of the ?format= query, and it reaches
+// the same parser, so #981 reproduced here too.
+func TestMigrateApplyGooseDirectivesViaEnvFormat(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyProjectMigration(c, migrationsDir, "1_init.sql", "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n")
+	hashConvertedApplyDir(c, migrationsDir, "goose")
+	dbPath := filepath.Join(dir, "apply.db")
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  migration {
+    dir    = "file://migrations"
+    format = goose
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "apply",
+		"--env", "local",
+		"--url", "sqlite://" + dbPath,
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", out.String()))
+	c.Assert(sqliteTableCount(c, dbPath, "widgets"), qt.Equals, 1)
+}
+
+// TestMigrateApplyGooseNoDirectivesReallyExecutesTheBody is the control that
+// makes the #981 row mean something. A directive-free file whose body is not
+// SQL must FAIL at execution: if it succeeded, "exit 0" on the valid fixture
+// would prove only that the file was skipped, not that it ran.
+func TestMigrateApplyGooseNoDirectivesReallyExecutesTheBody(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	migrationsDir := filepath.Join(dir, "migrations")
+	writeAtlasApplyProjectMigration(c, migrationsDir, "1_init.sql", "THIS IS NOT SQL;\n")
+	hashConvertedApplyDir(c, migrationsDir, "goose")
+	dbPath := filepath.Join(dir, "apply.db")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--dir", "file://" + migrationsDir + "?format=goose",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out.String(), qt.Contains, "THIS")
+}

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -145,6 +145,29 @@ conformance Atlas pin advances past v1.3.0:
 | `schema stats` | Inspect database schema statistics in OpenMetrics format. | Out of scope: statistics monitoring is a metrics/observability surface, not schema management; Ptah's schema-state surface is `ptah schema compare` and `ptah schema drift`. |
 | `schema validate` | Check that a schema definition parses and loads, optionally against `--dev-url`. | Covered by native: `ptah schema render` parses and loads the desired schema and fails on invalid input; `ptah schema test` and `schema apply --dry-run` exercise it against a throwaway database. |
 
+## Never a Copied Defect
+
+Matching the pinned Atlas CE binary is the floor, not the ceiling. Where its
+behavior is a defect — it silently discards something the author wrote, corrupts
+recorded state, or fails for a reason unrelated to the user's intent — Ptah does
+not reproduce it. Every entry below is stricter than Atlas CE, never looser, so
+none of them can make `ptah-compat` accept input Atlas CE rejects.
+
+Measured against the pinned Atlas CE v1.3.0 binary on SQLite targets. Each
+reproduces on `migrate apply`, `migrate validate` and `migrate import`, under
+both the `?format=` query and the `atlas.hcl` `migration { format = ... }`
+spelling.
+
+| Input | Atlas CE v1.3.0 | Ptah | Why not matched |
+| --- | --- | --- | --- |
+| Goose near-miss section directive, for example `-- +goose down` for `Down` | Exits 0. The misspelled name is not recognized, so it folds into the migration body as a comment and the rollback SQL beneath it executes: the table is created, then dropped, and the migration is recorded as successfully applied. | Refused, naming the offending line and the correct spelling. | A case error in a directive silently rolling back the migration it belongs to is a data-loss defect, not a semantic choice. Scoped to exact near-miss spellings of the four section directives, so `-- +goose Frobnicate` and prose such as `-- +goose up to date` still pass through as comments exactly as Atlas CE treats them. |
+| dbmate migration with no `-- migrate:up` directive | Exits 0. `migrate apply` records the revision with 0 of 0 statements and creates nothing, so the migration is permanently marked done and no later apply will run it. `migrate import` writes a **zero-byte** file over the authored SQL and hashes the empty file into `atlas.sum` as if it were the migration. | Refused, stating that the file carries no `-- migrate:up` so none of its SQL would execute. | Discarding authored SQL and corrupting recorded state in one behavior. A file that *has* the directive with an empty section is a different, legitimate input and is converted and recorded normally. |
+
+Not every difference is deliberate. Goose files carrying no directives at all are
+matched rather than refused, because there Atlas CE is right: it executes the
+file's bytes verbatim, drops nothing, and records the revision honestly. See
+[`stokaro/ptah#981`](https://github.com/stokaro/ptah/issues/981).
+
 ## Reports
 
 - Offline corpus report:

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -319,12 +319,49 @@ three components, or a minor/patch of `100` or more, cannot be represented in an
 int64 and is rejected before the database is opened.
 
 Several inputs still fail before Ptah opens the target database rather than guess
-at semantics: unknown formats; goose/dbmate files missing their up directive
-(never falling back to executing the whole file); Flyway repeatable (`R__`)
+at semantics: unknown formats; goose files whose directives are out of order;
+dbmate files missing their up directive; Flyway repeatable (`R__`)
 migrations, which Ptah cannot yet execute as versioned migrations (matching how
 `ptah-compat migrate import` handles them); and two source files that resolve to
 the same version. See
 [`stokaro/ptah#742`](https://github.com/stokaro/ptah/issues/742).
+
+### Goose directive parsing
+
+Goose directives are parsed as a state machine, not filtered line by line, and
+the accepted set matches Atlas. Directive names are case- and space-sensitive
+exactly as Atlas matches them: `-- +goose Up` is a directive, `-- +goose up`,
+`-- +goose  Up` and `-- +Goose Up` are not. A name may carry trailing text
+(`-- +goose Up extra` is still `Up`). Lines Atlas does not recognize as
+section directives — including `-- +goose NO TRANSACTION` — stay in the
+migration body and are executed with it.
+
+A goose file that contains **no** section directive at all is executed in full:
+the whole file is the migration. Such a file has no rollback section that could
+leak onto the apply path, so there is nothing to protect against. A file with a
+**broken** directive set is a different thing and is still refused — `Down`
+before any `Up`, a second `Up`, `StatementBegin` outside a section, an
+unmatched `StatementEnd`, or any section directive inside a `StatementBegin`
+block. See [`stokaro/ptah#981`](https://github.com/stokaro/ptah/issues/981).
+
+The up section runs from the **start of the file** through the first `Down`, so
+SQL written above the `Up` directive is executed rather than silently dropped.
+An intentionally empty up section is recorded as an applied revision with zero
+statements rather than being skipped.
+
+### Deliberate divergences
+
+Two behaviors differ from Atlas on purpose. Both are cases where matching would
+mean reproducing a defect, so Ptah is stricter — never looser — than Atlas.
+
+| Input | Atlas | Ptah |
+| --- | --- | --- |
+| Goose near-miss directive, for example `-- +goose down` | Exits 0. The typo is not recognized, folds into the body as a comment, and the rollback SQL under it executes — the migration is created, dropped, and recorded as successful. | Refused, naming the line and the correct spelling. A case error in a directive must not silently roll back a migration. |
+| dbmate file with no `-- migrate:up` | Exits 0, records the revision with 0 of 0 statements and creates nothing, so the migration is marked done and never runs. `migrate import` writes a zero-byte file over the authored SQL and hashes it into `atlas.sum`. | Refused, because nothing in the file would execute. |
+
+Ptah refuses only exact near-miss spellings of the four section directives.
+Prose that merely begins with one (`-- +goose up to date`) and unrecognized
+names (`-- +goose Frobnicate`) stay comments, as they do in Atlas.
 Atlas OSS does not register `migrate apply --dir-format`, `--to-version`, or
 `--lock-name`; Ptah follows that surface and rejects those flags on
 `migrate apply`.

--- a/internal/atlasmigrate/apply_source_split_test.go
+++ b/internal/atlasmigrate/apply_source_split_test.go
@@ -219,8 +219,13 @@ func TestConvertApplySourceReadsOnlyTheCapture(t *testing.T) {
 // cannot be read, so the gate gets to speak first.
 func TestConvertApplySourceReportsSourceParseFailures(t *testing.T) {
 	c := qt.New(t)
+	// A Down section with no Up before it. The fixture used to be a file with no
+	// directives at all, which stopped being a parse failure in stokaro/ptah#981:
+	// Atlas executes such a file verbatim and so does Ptah now, so it could no
+	// longer show that conversion is where parsing happens. A broken directive
+	// ORDER still cannot be read, which is what this test needs.
 	dir := writeSplitFixture(c, map[string]string{
-		"1_init.sql": "CREATE TABLE seam (id int);\n",
+		"1_init.sql": "-- +goose Down\nDROP TABLE seam;\n",
 	})
 
 	captured, err := atlasmigrate.CaptureApplySource(os.DirFS(dir), atlasmigrateimport.FormatGoose)
@@ -228,7 +233,7 @@ func TestConvertApplySourceReportsSourceParseFailures(t *testing.T) {
 
 	_, err = atlasmigrate.ConvertApplySource(captured, dir, atlasmigrateimport.FormatGoose)
 
-	c.Assert(err, qt.ErrorMatches, `migration file 1_init\.sql has no "-- \+goose Up" section`)
+	c.Assert(err, qt.ErrorMatches, `migration file 1_init\.sql line 1: unexpected "-- \+goose Down" directive because no up section has been opened yet`)
 }
 
 // TestResolveApplySourceForFormatStillComposesTheHalves keeps the composed

--- a/internal/atlasmigrateimport/goosedirectives_test.go
+++ b/internal/atlasmigrateimport/goosedirectives_test.go
@@ -1,0 +1,248 @@
+package atlasmigrateimport_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// TestLoadFSDirectiveSectionParsing pins the goose and dbmate directive parsers
+// against behavior measured on the pinned community binary (v1.3.0), file by
+// file and byte for byte.
+//
+// The byte assertions are not decoration. `migrate import` writes these bytes and
+// then hashes them into atlas.sum, so a body that differs by one blank line makes
+// the two tools disagree about a directory both call clean — which is worse than
+// the refusal it replaces. Every expected body below was read back from the
+// community binary's own converted output.
+//
+// Rows marked "refuses" split into two kinds, and the distinction is the whole
+// point of the change:
+//
+//   - out-of-order directives, where the community binary ALSO refuses. Ptah used
+//     to accept and execute these, which is the never-looser half of the parity
+//     rule being violated on the same function #981 asked to change.
+//   - near-miss spellings and a dbmate file with no up directive, where the
+//     community binary exits 0. Those are deliberate divergences; see the doc
+//     comments on gooseNearMissPragma and dbmateUpSQL for what it does instead.
+func TestLoadFSDirectiveSectionParsing(t *testing.T) {
+	const widgets = "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"
+
+	body := func(want string) func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+		return func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(loaded.Entries, qt.HasLen, 1)
+			c.Assert(string(loaded.Entries[0].Data), qt.Equals, want)
+		}
+	}
+	refuses := func(pattern string) func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+		return func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+			c.Assert(err, qt.ErrorMatches, pattern)
+		}
+	}
+
+	tests := []struct {
+		name   string
+		format atlasmigrateimport.Format
+		file   string
+		assert func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error)
+	}{
+		{
+			// #981 proper. The community binary executes such a file's bytes
+			// verbatim and records the revision honestly; a file with no
+			// directives has no rollback section that could leak onto the apply
+			// path, so refusing it protected nothing.
+			name:   "goose file with no directives is the migration",
+			format: atlasmigrateimport.FormatGoose,
+			file:   widgets,
+			assert: body(widgets),
+		},
+		{
+			// Pins trimSQL rather than normalizeSQL for the verbatim path: the
+			// community binary converts these 83 bytes to 83 bytes, keeping the
+			// blank line. normalizeSQL would drop it and produce a different
+			// atlas.sum for a directory the other tool calls clean.
+			name:   "goose file with no directives keeps interior blank lines",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "CREATE TABLE a (id INTEGER PRIMARY KEY);\n\nCREATE TABLE b (id INTEGER PRIMARY KEY);\n",
+			assert: body("CREATE TABLE a (id INTEGER PRIMARY KEY);\n\nCREATE TABLE b (id INTEGER PRIMARY KEY);\n"),
+		},
+		{
+			// The up body starts at the FILE START, not at the Up directive.
+			// Ptah used to drop this CREATE silently while still exiting 0.
+			name:   "goose keeps SQL written above the Up directive",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "CREATE TABLE pre (id INTEGER PRIMARY KEY);\n-- +goose Up\n" + widgets,
+			assert: body("CREATE TABLE pre (id INTEGER PRIMARY KEY);\n" + widgets),
+		},
+		{
+			// NO TRANSACTION cannot open or close a section, so the community
+			// binary leaves it in the executed SQL. Recognizing it would change
+			// nothing, so the parser deliberately does not.
+			name:   "goose keeps a NO TRANSACTION directive in the body",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose NO TRANSACTION\n-- +goose Up\n" + widgets,
+			assert: body("-- +goose NO TRANSACTION\n" + widgets),
+		},
+		{
+			name:   "goose keeps an unrecognized +goose line in the body",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Frobnicate\n" + widgets,
+			assert: body("-- +goose Frobnicate\n" + widgets),
+		},
+		{
+			// "Up, Down, Up" is a file the community binary accepts, and it
+			// executes only the first up section.
+			name:   "goose body stops at the first Down even when another Up follows",
+			format: atlasmigrateimport.FormatGoose,
+			file: "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n" +
+				"-- +goose Down\nDROP TABLE a;\n-- +goose Up\nCREATE TABLE b (id INTEGER PRIMARY KEY);\n",
+			assert: body("CREATE TABLE a (id INTEGER PRIMARY KEY);\n"),
+		},
+		{
+			// A directive name runs to the first space, so trailing text is
+			// tolerated and this IS the Up directive.
+			name:   "goose treats trailing text after the directive name as part of the directive",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up extra\n" + widgets,
+			assert: body(widgets),
+		},
+		{
+			// Exactly one space follows "+goose"; a second one breaks the
+			// directive, so the community binary runs the whole file. Ptah
+			// refuses instead — the near-miss guard, see below.
+			name:   "goose refuses a second space before the directive name",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose  Up\n" + widgets,
+			assert: refuses(`(?s)migration file 1_init\.sql line 1: .* is not a goose directive .*Write "-- \+goose Up" instead`),
+		},
+		{
+			// An intentionally empty migration is legitimate. The community
+			// binary records it as an applied revision with 0 statements; Ptah
+			// used to drop it from the converted directory and from
+			// atlas_schema_revisions while still exiting 0.
+			name:   "goose empty up section is an entry, not a skip",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up\n",
+			assert: func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(loaded.Entries, qt.HasLen, 1)
+				c.Assert(loaded.Entries[0].Data, qt.HasLen, 0)
+			},
+		},
+
+		// --- out-of-order directives: the community binary refuses these too ---
+		{
+			name:   "goose refuses Down before any Up",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Down\nDROP TABLE widgets;\n-- +goose Up\n" + widgets,
+			assert: refuses(`migration file 1_init\.sql line 1: unexpected "-- \+goose Down" directive because no up section has been opened yet`),
+		},
+		{
+			name:   "goose refuses a second Up",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose Up\nCREATE TABLE b (id INTEGER PRIMARY KEY);\n",
+			assert: refuses(`migration file 1_init\.sql line 3: unexpected "-- \+goose Up" directive because an up section is already open`),
+		},
+		{
+			name:   "goose refuses StatementEnd with no StatementBegin",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose StatementEnd\n",
+			assert: refuses(`migration file 1_init\.sql line 3: unexpected "-- \+goose StatementEnd" directive because no "-- \+goose StatementBegin" block is open`),
+		},
+		{
+			name:   "goose refuses StatementBegin outside a section",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose StatementBegin\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose StatementEnd\n",
+			assert: refuses(`migration file 1_init\.sql line 1: unexpected "-- \+goose StatementBegin" directive because no up section has been opened yet`),
+		},
+		{
+			// Directives are parsed inside StatementBegin blocks, not passed
+			// through: the community binary refuses this too.
+			name:   "goose refuses a section directive inside a StatementBegin block",
+			format: atlasmigrateimport.FormatGoose,
+			file: "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n" +
+				"-- +goose StatementBegin\n-- +goose Up\nSELECT 1;\n-- +goose StatementEnd\n",
+			assert: refuses(`migration file 1_init\.sql line 4: unexpected "-- \+goose Up" directive because it appears inside a "-- \+goose StatementBegin" block`),
+		},
+		{
+			// Well-formed control: must keep working, and the down section must
+			// not reach the up SQL.
+			name:   "goose well-formed Up and Down keeps only the up section",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up\n" + widgets + "-- +goose Down\nDROP TABLE widgets;\n",
+			assert: body(widgets),
+		},
+		{
+			name:   "goose statement block body survives with its internal semicolons",
+			format: atlasmigrateimport.FormatGoose,
+			file: "-- +goose Up\n-- +goose StatementBegin\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n" +
+				"-- +goose StatementEnd\n-- +goose Down\nDROP TABLE a;\n",
+			assert: body("CREATE TABLE a (id INTEGER PRIMARY KEY);\n"),
+		},
+
+		// --- deliberate divergences: the community binary exits 0 on these ---
+		{
+			// Measured: the community binary folds this typo into the body and
+			// executes "DROP TABLE a;", so the table is created and then dropped
+			// and the migration is recorded as successful. A case error in a
+			// directive must not silently roll back a migration.
+			name:   "goose refuses a lowercase down as a near miss",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose Up\nCREATE TABLE a (id INTEGER PRIMARY KEY);\n-- +goose down\nDROP TABLE a;\n",
+			assert: refuses(`(?s)migration file 1_init\.sql line 3: "-- \+goose down" is not a goose directive .*Write "-- \+goose Down" instead`),
+		},
+		{
+			name:   "goose refuses a lowercase up as a near miss",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose up\n" + widgets,
+			assert: refuses(`(?s)migration file 1_init\.sql line 1: "-- \+goose up" is not a goose directive .*Write "-- \+goose Up" instead`),
+		},
+		{
+			// Scoping proof for the near-miss guard: prose that merely starts
+			// with a directive-looking token stays a comment, because refusing it
+			// would reject files the community binary runs safely.
+			name:   "goose leaves prose after +goose alone",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose up to date\n" + widgets,
+			assert: body("-- +goose up to date\n" + widgets),
+		},
+		{
+			// Measured: the community binary exits 0, records revision 1 with
+			// 0/0 statements and creates nothing, and `migrate import` writes a
+			// ZERO-BYTE file over the 47 authored bytes. Ptah keeps refusing.
+			name:   "dbmate refuses a file with no migrate:up directive",
+			format: atlasmigrateimport.FormatDBMate,
+			file:   widgets,
+			assert: refuses(`migration file 1_init\.sql carries no "-- migrate:up" directive.*`),
+		},
+		{
+			// But an empty up SECTION is legitimate and is recorded, exactly as
+			// the community binary records it.
+			name:   "dbmate empty up section is an entry, not a skip",
+			format: atlasmigrateimport.FormatDBMate,
+			file:   "-- migrate:up\n-- migrate:down\nDROP TABLE a;\n",
+			assert: func(c *qt.C, loaded *atlasmigrateimport.Loaded, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(loaded.Entries, qt.HasLen, 1)
+				c.Assert(loaded.Entries[0].Data, qt.HasLen, 0)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			source := fstest.MapFS{
+				"1_init.sql": &fstest.MapFile{Data: []byte(tt.file)},
+			}
+
+			loaded, err := atlasmigrateimport.LoadFS(source, "migrations", tt.format)
+
+			tt.assert(c, loaded, err)
+		})
+	}
+}

--- a/internal/atlasmigrateimport/goosedirectives_test.go
+++ b/internal/atlasmigrateimport/goosedirectives_test.go
@@ -111,13 +111,31 @@ func TestLoadFSDirectiveSectionParsing(t *testing.T) {
 			assert: body(widgets),
 		},
 		{
-			// Exactly one space follows "+goose"; a second one breaks the
-			// directive, so the community binary runs the whole file. Ptah
-			// refuses instead — the near-miss guard, see below.
-			name:   "goose refuses a second space before the directive name",
+			// The separator is any run of whitespace, not one literal space.
+			// Measured on the community binary: `-- +goose  Down` and
+			// `-- +goose<TAB>Down` behave identically to the single-space form
+			// -- same statement count, same resulting tables -- so the section
+			// is parsed in all three.
+			//
+			// This row used to assert a refusal. That was the near-miss guard
+			// firing outside its own stated scope: it exists for a directive
+			// the community binary FAILS to parse and then silently rolls back
+			// (a lowercase "down"), not for one it parses correctly. Refusing
+			// here rejected a file that runs safely, for no benefit.
+			name:   "goose accepts extra whitespace before the directive name",
 			format: atlasmigrateimport.FormatGoose,
 			file:   "-- +goose  Up\n" + widgets,
-			assert: refuses(`(?s)migration file 1_init\.sql line 1: .* is not a goose directive .*Write "-- \+goose Up" instead`),
+			assert: body(widgets),
+		},
+		{
+			// The variant that made this worth fixing rather than tolerating.
+			// A tab-separated directive was invisible, so the file looked
+			// directive-free and the raw-SQL path executed it whole -- table
+			// created by Up, then DROPPED by a Down section Ptah never saw.
+			name:   "goose accepts a tab before the directive name",
+			format: atlasmigrateimport.FormatGoose,
+			file:   "-- +goose\tUp\n" + widgets,
+			assert: body(widgets),
 		},
 		{
 			// An intentionally empty migration is legitimate. The community

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -952,11 +952,12 @@ const (
 // a line as a comment and folds the SQL under it into the up migration. See
 // [gooseNearMissPragma].
 func goosePragmaOf(line string) (goosePragma, bool) {
-	rest, ok := strings.CutPrefix(strings.TrimSpace(line), goosePragmaPrefix)
+	rest, ok := gooseDirectiveRemainder(strings.TrimSpace(line))
 	if !ok {
 		return "", false
 	}
 	name, _, _ := strings.Cut(rest, " ")
+	name = strings.TrimSpace(name)
 	for _, pragma := range goosePragmas {
 		if string(pragma) == name {
 			return pragma, true
@@ -984,12 +985,11 @@ func goosePragmaOf(line string) (goosePragma, bool) {
 // because it reads as prose rather than a mistyped directive. Refusing those
 // would reject files the community binary runs safely, for no benefit.
 func gooseNearMissPragma(line string) (goosePragma, bool) {
-	trimmed := strings.TrimSpace(line)
-	if len(trimmed) < len(goosePragmaPrefix) ||
-		!strings.EqualFold(trimmed[:len(goosePragmaPrefix)], goosePragmaPrefix) {
+	rest, ok := gooseDirectiveRemainderFold(strings.TrimSpace(line))
+	if !ok {
 		return "", false
 	}
-	name := strings.TrimSpace(trimmed[len(goosePragmaPrefix):])
+	name := strings.TrimSpace(rest)
 	for _, pragma := range goosePragmas {
 		if strings.EqualFold(string(pragma), name) {
 			return pragma, true
@@ -1323,4 +1323,40 @@ func defaultString(value, fallback string) string {
 		return fallback
 	}
 	return value
+}
+
+// gooseDirectiveRemainder returns what follows a `-- +goose` marker, or reports
+// that the line does not carry one.
+//
+// The separator is ANY run of whitespace, not one literal space. Requiring the
+// space made a tab-separated directive invisible: the file then looked
+// directive-free, and the raw-SQL path executed it whole. Measured on
+// `-- +goose Up / CREATE TABLE t / -- +goose<TAB>Down / DROP TABLE t`, the
+// community binary parses the Down and keeps the table at exit 0, while Ptah
+// exited 0 having DROPPED it -- the same silent-rollback harm the near-miss
+// guard exists to prevent, one keystroke away from it.
+func gooseDirectiveRemainder(line string) (string, bool) {
+	return gooseDirectiveRest(line, strings.HasPrefix)
+}
+
+// gooseDirectiveRemainderFold is [gooseDirectiveRemainder] for the near-miss
+// guard, which matches the marker case-insensitively.
+func gooseDirectiveRemainderFold(line string) (string, bool) {
+	return gooseDirectiveRest(line, func(s, prefix string) bool {
+		return len(s) >= len(prefix) && strings.EqualFold(s[:len(prefix)], prefix)
+	})
+}
+
+func gooseDirectiveRest(line string, hasPrefix func(string, string) bool) (string, bool) {
+	marker := strings.TrimRight(goosePragmaPrefix, " ")
+	if !hasPrefix(line, marker) {
+		return "", false
+	}
+	rest := line[len(marker):]
+	trimmed := strings.TrimLeft(rest, " \t")
+	if trimmed == rest {
+		// No separator at all: `-- +gooseUp` is not a directive.
+		return "", false
+	}
+	return trimmed, true
 }

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -513,7 +513,7 @@ func loadEntries(fsys fs.FS, display string, format Format) ([]Entry, error) {
 	case FormatGoose:
 		return loadGooseEntries(fsys, files)
 	case FormatDBMate:
-		return loadDirectiveSectionEntries(fsys, files, "-- migrate:up", dbmateUpSQL)
+		return loadDirectiveSectionEntries(fsys, files, dbmateUpSQL)
 	case FormatLiquibase:
 		return loadLiquibaseEntries(fsys, files)
 	case FormatFlyway:
@@ -532,7 +532,7 @@ func loadGooseEntries(fsys fs.FS, files []fs.DirEntry) ([]Entry, error) {
 			return nil, fmt.Errorf("Go-based Goose migration %q is not supported (SQL migrations only)", file.Name())
 		}
 	}
-	return loadDirectiveSectionEntries(fsys, files, "-- +goose Up", gooseUpSQL)
+	return loadDirectiveSectionEntries(fsys, files, gooseUpSQL)
 }
 
 func loadLiquibaseEntries(fsys fs.FS, files []fs.DirEntry) ([]Entry, error) {
@@ -556,7 +556,7 @@ func loadLiquibaseEntries(fsys fs.FS, files []fs.DirEntry) ([]Entry, error) {
 			strings.Join(changelogFiles, ", "),
 		)
 	}
-	return loadDirectiveSectionEntries(fsys, files, "", liquibaseSQL)
+	return loadDirectiveSectionEntries(fsys, files, liquibaseSQL)
 }
 
 func loadAtlasEntries(fsys fs.FS, files []fs.DirEntry) ([]Entry, error) {
@@ -602,33 +602,41 @@ func loadGolangMigrateEntries(fsys fs.FS, files []fs.DirEntry) ([]Entry, error) 
 }
 
 // loadDirectiveSectionEntries reads directive-sectioned migration files (goose,
-// dbmate, liquibase) and keeps only their up SQL. extract reports found=false
-// when a required up directive is absent; that is a hard error rather than a
-// fall back to executing the raw file, so a malformed directive can never cause
-// the down/rollback section to run against a live database. directive names the
-// expected marker for the error message (empty when the format has no required
-// up directive, such as liquibase).
+// dbmate, liquibase) and keeps only their up SQL. extract owns the whole
+// decision: it returns the up SQL, or an error naming why the file cannot be
+// converted. Each format's rules differ enough that a shared "is the marker
+// present" flag could not express them — see [gooseUpSQL] and [dbmateUpSQL].
+//
+// extract receives the file's RAW bytes, not normalized ones. That matters for
+// the one case where the community binary preserves a file verbatim (a goose
+// file carrying no directives): normalizing before extraction would drop blank
+// lines between statements, changing the converted bytes and therefore the
+// atlas.sum entry, so the two tools would disagree about a directory both call
+// clean. Every extractor normalizes what it returns.
+//
+// An empty up section is an entry, not a skip. An intentionally empty migration
+// is a legitimate thing to write, and the community binary records it as an
+// applied revision with 0 statements; dropping it here removed it from the
+// converted directory AND from atlas_schema_revisions while still exiting 0,
+// so a later run would never apply it. Measured on goose, dbmate and liquibase
+// alike (community binary v1.3.0).
 func loadDirectiveSectionEntries(
 	fsys fs.FS,
 	files []fs.DirEntry,
-	directive string,
-	extract func([]byte) ([]byte, bool),
+	extract func(name string, data []byte) ([]byte, error),
 ) ([]Entry, error) {
 	var entries []Entry
 	for _, file := range files {
 		if file.IsDir() || !numberedSQLFileRe.MatchString(file.Name()) {
 			continue
 		}
-		data, err := readImportSQLFile(fsys, file.Name())
+		data, err := readRawImportSQLFile(fsys, file.Name())
 		if err != nil {
 			return nil, err
 		}
-		up, found := extract(data)
-		if !found {
-			return nil, fmt.Errorf("migration file %s has no %q section", file.Name(), directive)
-		}
-		if len(up) == 0 {
-			continue
+		up, err := extract(file.Name(), data)
+		if err != nil {
+			return nil, err
 		}
 		entries = append(entries, Entry{Name: file.Name(), Data: up})
 	}
@@ -872,72 +880,260 @@ func flywayOrderingKey(file flywaySumFile) (int64, error) {
 }
 
 func readImportSQLFile(fsys fs.FS, name string) ([]byte, error) {
-	data, err := fs.ReadFile(fsys, name)
+	data, err := readRawImportSQLFile(fsys, name)
 	if err != nil {
-		return nil, fmt.Errorf("read source migration %s: %w", name, err)
+		return nil, err
 	}
 	return normalizeSQL(data), nil
 }
 
-// gooseUpSQL extracts the up section of a goose migration. It tracks
-// StatementBegin/StatementEnd blocks: inside a block goose suspends annotation
-// parsing, so only StatementEnd is honored and every other line (including a
-// stray -- +goose Up/Down that appears inside a function body) is passed through
-// verbatim. found is false when the file has no -- +goose Up marker; the caller
-// must treat that as an error rather than execute the raw file, so a malformed
-// directive can never leak the down section onto the apply path.
-func gooseUpSQL(data []byte) ([]byte, bool) {
-	var out []string
-	inUp := false
-	foundUp := false
+// readRawImportSQLFile reads a source migration without normalizing it, for the
+// callers that must decide normalization for themselves. See
+// [loadDirectiveSectionEntries].
+func readRawImportSQLFile(fsys fs.FS, name string) ([]byte, error) {
+	data, err := fs.ReadFile(fsys, name)
+	if err != nil {
+		return nil, fmt.Errorf("read source migration %s: %w", name, err)
+	}
+	return data, nil
+}
+
+// goosePragma is one of the four goose directives that change which section the
+// parser is in.
+//
+// "NO TRANSACTION" is deliberately absent, and so is every other "-- +goose ..."
+// line. Goose leaves them in the migration body, and because they cannot open or
+// close a section, recognizing them would change nothing: measured on the
+// community binary v1.3.0, both "-- +goose NO TRANSACTION" and the meaningless
+// "-- +goose Frobnicate" survive into the SQL it executes, whether they sit above
+// the Up directive or inside the up section.
+type goosePragma string
+
+const (
+	goosePragmaUp             goosePragma = "Up"
+	goosePragmaDown           goosePragma = "Down"
+	goosePragmaStatementBegin goosePragma = "StatementBegin"
+	goosePragmaStatementEnd   goosePragma = "StatementEnd"
+)
+
+// goosePragmaPrefix is matched case-sensitively, including its single trailing
+// space. See [goosePragmaOf] for why the spacing is load-bearing.
+const goosePragmaPrefix = "-- +goose "
+
+var goosePragmas = []goosePragma{
+	goosePragmaUp,
+	goosePragmaDown,
+	goosePragmaStatementBegin,
+	goosePragmaStatementEnd,
+}
+
+// gooseSection is which directive section the parser is currently inside.
+type gooseSection int
+
+const (
+	gooseSectionNone gooseSection = iota
+	gooseSectionUp
+	gooseSectionDown
+)
+
+// goosePragmaOf reports the section-changing goose directive a line carries.
+//
+// The spelling rules are the community binary's, and each was measured rather
+// than assumed, because every one of them decides whether a line is a directive
+// or executable SQL:
+//
+//   - surrounding whitespace is ignored, so "  -- +goose Up  " is the Up directive;
+//   - the prefix is case-sensitive, so "-- +Goose Up" is NOT a directive;
+//   - the name runs to the first space, so "-- +goose Up extra" IS the Up directive;
+//   - exactly one space follows "+goose", so "-- +goose  Up" is NOT a directive;
+//   - the name itself is case-sensitive, so "-- +goose up" is NOT a directive.
+//
+// The last two are the dangerous ones: the community binary silently treats such
+// a line as a comment and folds the SQL under it into the up migration. See
+// [gooseNearMissPragma].
+func goosePragmaOf(line string) (goosePragma, bool) {
+	rest, ok := strings.CutPrefix(strings.TrimSpace(line), goosePragmaPrefix)
+	if !ok {
+		return "", false
+	}
+	name, _, _ := strings.Cut(rest, " ")
+	for _, pragma := range goosePragmas {
+		if string(pragma) == name {
+			return pragma, true
+		}
+	}
+	return "", false
+}
+
+// gooseNearMissPragma reports the section directive a line was evidently meant to
+// be but misspells — "-- +goose down" for Down, "-- +goose  Up" for Up.
+//
+// This is a DELIBERATE DIVERGENCE, and the reason is that the community binary's
+// handling of these lines is a defect rather than a decision. It does not
+// recognize the typo, folds the line into the migration body as a comment, and
+// then executes everything below it. Measured on v1.3.0: a file whose only fault
+// is a lowercase "-- +goose down" has its table created and then DROPPED by its
+// own rollback section, and the migration is recorded as successfully applied.
+// A case error in a directive should not silently roll back a migration, so Ptah
+// refuses. Refusing is stricter than the community binary, which exits 0 here, so
+// this cannot make ptah-compat accept anything the community binary rejects.
+//
+// The guard is scoped to the four section-changing names, and requires the
+// remainder to be exactly the name: "-- +goose Frobnicate" stays a comment
+// because it cannot change sections, and "-- +goose up to date" stays a comment
+// because it reads as prose rather than a mistyped directive. Refusing those
+// would reject files the community binary runs safely, for no benefit.
+func gooseNearMissPragma(line string) (goosePragma, bool) {
+	trimmed := strings.TrimSpace(line)
+	if len(trimmed) < len(goosePragmaPrefix) ||
+		!strings.EqualFold(trimmed[:len(goosePragmaPrefix)], goosePragmaPrefix) {
+		return "", false
+	}
+	name := strings.TrimSpace(trimmed[len(goosePragmaPrefix):])
+	for _, pragma := range goosePragmas {
+		if strings.EqualFold(string(pragma), name) {
+			return pragma, true
+		}
+	}
+	return "", false
+}
+
+// gooseUpSQL extracts the up section of a goose migration.
+//
+// It is a state machine over the directive set above, not a line filter, because
+// the community binary is one too and the difference is observable in both
+// directions. Its accept/reject set was measured on v1.3.0 and is reproduced
+// here:
+//
+//   - Up is rejected while already inside an up section (a second Up), but
+//     accepted after a Down — "Up, Down, Up" is a file the community binary runs.
+//   - Down is rejected before any Up has opened a section, but accepted after
+//     another Down.
+//   - StatementBegin is rejected outside a section; an unterminated block is fine.
+//   - StatementEnd is rejected unless a StatementBegin is open.
+//   - Inside a StatementBegin block only StatementEnd is accepted; a directive of
+//     any other kind there is an error rather than passed-through body text.
+//
+// Each of those rejections is a file ptah-compat used to accept and execute, so
+// this is where the never-looser half of the parity rule is paid.
+//
+// The up body runs from the FILE START through the first Down, minus the
+// directive lines themselves. Starting at the file start is what stops SQL
+// written above the Up directive from being silently dropped; stopping at the
+// first Down is the community binary's own reading, so the second up section of
+// an "Up, Down, Up" file is not executed.
+//
+// A file carrying no section directive at all is NOT an error: its whole body is
+// the migration, byte for byte. That is #981. Such a file has no rollback section
+// that could leak onto the apply path, so the caution that governs a MALFORMED
+// directive set does not apply to a file that simply has none, and the community
+// binary executes it, records it honestly, and drops nothing.
+func gooseUpSQL(name string, data []byte) ([]byte, error) {
+	var body []string
+	section := gooseSectionNone
 	inStatement := false
-	for line := range strings.SplitSeq(string(data), "\n") {
-		trimmed := strings.TrimSpace(strings.ToLower(line))
+	collecting := true
+
+	for i, line := range strings.Split(string(data), "\n") {
+		lineNo := i + 1
+		pragma, ok := goosePragmaOf(line)
+		if !ok {
+			if near, isNear := gooseNearMissPragma(line); isNear {
+				return nil, fmt.Errorf(
+					"migration file %s line %d: %q is not a goose directive because directive names are case- and space-sensitive; "+
+						"as written it is an ordinary comment and the SQL below it would be executed as part of the up migration. Write %q instead",
+					name, lineNo, strings.TrimSpace(line), goosePragmaPrefix+string(near),
+				)
+			}
+			if collecting {
+				body = append(body, line)
+			}
+			continue
+		}
 		if inStatement {
-			if trimmed == "-- +goose statementend" {
-				inStatement = false
-				continue
+			// A StatementBegin block ends only at StatementEnd. Any other
+			// directive inside one is an error, not body text.
+			if pragma != goosePragmaStatementEnd {
+				return nil, gooseUnexpectedPragma(name, lineNo, pragma, "it appears inside a \"-- +goose StatementBegin\" block")
 			}
-			if inUp {
-				out = append(out, line)
-			}
+			inStatement = false
 			continue
 		}
-		switch trimmed {
-		case "-- +goose up":
-			inUp = true
-			foundUp = true
-			continue
-		case "-- +goose down":
-			inUp = false
-			continue
-		case "-- +goose statementbegin":
+		switch pragma {
+		case goosePragmaUp:
+			if section == gooseSectionUp {
+				return nil, gooseUnexpectedPragma(name, lineNo, pragma, "an up section is already open")
+			}
+			section = gooseSectionUp
+		case goosePragmaDown:
+			if section == gooseSectionNone {
+				return nil, gooseUnexpectedPragma(name, lineNo, pragma, "no up section has been opened yet")
+			}
+			section = gooseSectionDown
+			collecting = false
+		case goosePragmaStatementBegin:
+			if section == gooseSectionNone {
+				return nil, gooseUnexpectedPragma(name, lineNo, pragma, "no up section has been opened yet")
+			}
 			inStatement = true
-			continue
-		case "-- +goose statementend":
-			continue
-		}
-		if inUp {
-			out = append(out, line)
+		case goosePragmaStatementEnd:
+			return nil, gooseUnexpectedPragma(name, lineNo, pragma, "no \"-- +goose StatementBegin\" block is open")
 		}
 	}
-	if !foundUp {
-		return nil, false
+
+	if section == gooseSectionNone {
+		// No section directive appeared anywhere: the file IS the migration.
+		// Reached only when nothing errored above, and Down, StatementBegin and
+		// StatementEnd all error while the section is None, so this really does
+		// mean "carries no goose directives" rather than "carries a broken set".
+		return trimSQL(data), nil
 	}
-	return normalizeSQL([]byte(strings.Join(out, "\n"))), true
+	return normalizeSQL([]byte(strings.Join(body, "\n"))), nil
+}
+
+// gooseUnexpectedPragma reports a directive that cannot appear where it does.
+// The community binary refuses each of these too; naming the line and the reason
+// is the only difference.
+func gooseUnexpectedPragma(name string, line int, pragma goosePragma, reason string) error {
+	return fmt.Errorf(
+		"migration file %s line %d: unexpected %q directive because %s",
+		name, line, goosePragmaPrefix+string(pragma), reason,
+	)
 }
 
 // dbmateUpSQL extracts the up section of a dbmate migration. Directive lines are
 // matched whole and dropped entirely, so trailing options such as
-// "-- migrate:up transaction:false" never leak into the executable SQL. found is
-// false when there is no -- migrate:up directive.
-func dbmateUpSQL(data []byte) ([]byte, bool) {
+// "-- migrate:up transaction:false" never leak into the executable SQL.
+//
+// A file with no "-- migrate:up" directive is refused. This is a DELIBERATE
+// DIVERGENCE and it is the mirror image of the goose decision above: there,
+// matching the community binary was right; here, matching it would be wrong.
+//
+// Measured on v1.3.0, a dbmate file that carries no "-- migrate:up":
+//
+//   - migrate apply exits 0, records revision 1 with 0 of 0 statements, and
+//     creates nothing. The table is permanently absent AND the migration is
+//     marked done, so no later apply will ever run it.
+//   - migrate import exits 0 and writes a ZERO-BYTE file where 47 authored bytes
+//     were, then hashes the empty file into atlas.sum as if it were the migration.
+//
+// That is silently discarding what the author wrote and corrupting recorded state
+// in one behavior, so Ptah keeps refusing. Note the direction: the community
+// binary exits 0 and ptah-compat exits 1, so the never-looser half of the parity
+// rule would PERMIT copying this — nothing forces the refusal except that
+// reproducing a defect to be identical to it is the wrong answer.
+//
+// Unlike goose, a dbmate file cannot be read as "the body is the migration":
+// dbmate's own format requires the directive, and a file that has one but leaves
+// its section empty is a different, legitimate thing that IS converted (to an
+// empty migration, exactly as the community binary records it).
+func dbmateUpSQL(name string, data []byte) ([]byte, error) {
 	var out []string
 	inUp := false
 	foundUp := false
 	for line := range strings.SplitSeq(string(data), "\n") {
-		if name, ok := dbmateDirective(line); ok {
-			inUp = name == "up"
+		if directive, ok := dbmateDirective(line); ok {
+			inUp = directive == "up"
 			if inUp {
 				foundUp = true
 			}
@@ -948,9 +1144,13 @@ func dbmateUpSQL(data []byte) ([]byte, bool) {
 		}
 	}
 	if !foundUp {
-		return nil, false
+		return nil, fmt.Errorf(
+			"migration file %s carries no %q directive, so none of its SQL would be executed; "+
+				"Ptah refuses rather than recording an empty migration that can never be re-run",
+			name, "-- migrate:up",
+		)
 	}
-	return normalizeSQL([]byte(strings.Join(out, "\n"))), true
+	return normalizeSQL([]byte(strings.Join(out, "\n"))), nil
 }
 
 // dbmateDirective reports whether line is a dbmate "-- migrate:<name>" directive
@@ -972,8 +1172,8 @@ func dbmateDirective(line string) (string, bool) {
 
 // liquibaseSQL keeps a Liquibase formatted-SQL body, dropping the header and any
 // --rollback directive lines. Liquibase has no up/down section marker, so the
-// remainder is the up SQL; found is always true.
-func liquibaseSQL(data []byte) ([]byte, bool) {
+// remainder is the up SQL and there is nothing here that can fail.
+func liquibaseSQL(_ string, data []byte) ([]byte, error) {
 	var out []string
 	for line := range strings.SplitSeq(string(data), "\n") {
 		trimmed := strings.TrimSpace(strings.ToLower(line))
@@ -982,7 +1182,27 @@ func liquibaseSQL(data []byte) ([]byte, bool) {
 		}
 		out = append(out, line)
 	}
-	return normalizeSQL([]byte(strings.Join(out, "\n"))), true
+	return normalizeSQL([]byte(strings.Join(out, "\n"))), nil
+}
+
+// trimSQL normalizes a body the way the community binary normalizes a goose file
+// it found no directives in: surrounding whitespace goes, a single trailing
+// newline is added, and interior blank lines are KEPT.
+//
+// [normalizeSQL] cannot be used for that case. It also drops blank lines between
+// statements, which for a verbatim-preserved file would change the converted
+// bytes and therefore its atlas.sum entry — leaving `atlas migrate import` and
+// `ptah-compat migrate import` to disagree about a directory both call clean.
+// Measured: a directive-free file of 83 bytes with one interior blank line is
+// converted to 83 bytes by the community binary and would be 82 through
+// normalizeSQL. Trailing blank lines and a missing final newline ARE normalized
+// by both, which is why trimming is right and copying the bytes untouched is not.
+func trimSQL(data []byte) []byte {
+	sql := strings.TrimSpace(string(data))
+	if sql == "" {
+		return nil
+	}
+	return []byte(sql + "\n")
 }
 
 func normalizeSQL(data []byte) []byte {

--- a/internal/atlasmigrateimport/loaddir_test.go
+++ b/internal/atlasmigrateimport/loaddir_test.go
@@ -261,6 +261,18 @@ func TestLoadDir_FlywayConvertsThroughTheRealFilesystem(t *testing.T) {
 	})
 }
 
+// TestLoadDir_RejectsMissingUpDirective covers dbmate only.
+//
+// It used to carry two goose rows — a file with no directives, and one whose
+// only marker was the malformed "--+goose Up". stokaro/ptah#981 is those
+// refusals being wrong: Atlas recognizes neither line as a directive, so both
+// files simply have none, and it executes each one's bytes verbatim and records
+// the revision. Measured on both fixtures. A file with no directives has no
+// rollback section that could leak onto the apply path, so the caution that
+// justifies refusing a BROKEN directive set does not reach them.
+//
+// Goose parsing — the directive-free path and the out-of-order refusals that
+// replaced this over-refusal — is pinned in goosedirectives_test.go.
 func TestLoadDir_RejectsMissingUpDirective(t *testing.T) {
 	c := qt.New(t)
 
@@ -269,16 +281,6 @@ func TestLoadDir_RejectsMissingUpDirective(t *testing.T) {
 		format  atlasmigrateimport.Format
 		content string
 	}{
-		{
-			name:    "goose without up marker",
-			format:  atlasmigrateimport.FormatGoose,
-			content: "CREATE TABLE t (id int);\nDROP TABLE t;\n",
-		},
-		{
-			name:    "goose malformed up marker",
-			format:  atlasmigrateimport.FormatGoose,
-			content: "--+goose Up\nCREATE TABLE t (id int);\n",
-		},
 		{
 			name:    "dbmate without up directive",
 			format:  atlasmigrateimport.FormatDBMate,
@@ -293,7 +295,7 @@ func TestLoadDir_RejectsMissingUpDirective(t *testing.T) {
 
 			loaded, err := atlasmigrateimport.LoadDir(dir, tt.format)
 
-			c.Assert(err, qt.ErrorMatches, `migration file 1_x\.sql has no ".*" section`)
+			c.Assert(err, qt.ErrorMatches, `migration file 1_x\.sql carries no "-- migrate:up" directive.*`)
 			c.Assert(loaded, qt.IsNil)
 		})
 	}


### PR DESCRIPTION
Closes #981.

A Goose `.sql` file with no `-- +goose Up` directive was refused; the community binary applies it as raw SQL. It now applies.

## The blocker review found, and it was destroying data

The directive parser matched the literal prefix `-- +goose ` — one space. A tab-separated directive was therefore **invisible**, the file looked directive-free, and the new raw-SQL path executed it whole:

```sql
-- +goose Up
CREATE TABLE t (id int);
-- +goose	Down          <- tab
DROP TABLE t;
```

The community binary parses the `Down` section and keeps the table, exit 0. Ptah exited 0 having **dropped** it. That is the exact silent-rollback harm the near-miss guard is sold on, sitting one keystroke away from it, and the new path widened the reach.

The separator is any run of whitespace. Measured: `-- +goose  Down` and `-- +goose<TAB>Down` behave identically to the single-space form on the community binary — same statement count, same resulting tables — so the section is parsed in all three.

## One row moved from refusing to accepting

`-- +goose  Up` (two spaces) used to be refused by the near-miss guard. That was the guard firing outside its own stated scope: it exists for a directive the community binary **fails** to parse and then silently rolls back — a lowercase `down` — not for one it parses correctly. Its own comment says refusing those *"would reject files the community binary runs safely, for no benefit"*, and that is what it was doing.

The lowercase-typo refusal is unchanged and still deliberate.

## Verification

The tab case is a row of its own and it discriminates: narrowing the separator back to spaces turns it red.

The reviewer independently re-proved the main discriminator — reverting only `importer.go` reddens 19 of 21 rows in the directive-parsing table plus 16 subrows across three compat verbs, with the two well-formed controls correctly staying green.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint` and the public-API gate are clean. Rebased onto current master.
