### PR TITLE
Warn when --verify-sum vouches for bytes a movable tag can swap

### DIFF
--- a/cmd/internal/migrationsource/source.go
+++ b/cmd/internal/migrationsource/source.go
@@ -28,6 +28,17 @@ type OCI struct {
 	Client     *ociartifact.Client
 	Reference  string
 	Descriptor ocispec.Descriptor
+	// Tag is the registry tag the operator named, or the empty string when the
+	// reference named none. A tag is a movable pointer, so it says nothing
+	// about which bytes it will select on the next pull.
+	Tag string
+	// PinnedByDigest reports whether the reference selected exact content by
+	// digest. This is the provenance bit callers need to tell an artifact whose
+	// bytes the operator chose from one whoever last moved Tag chose for them.
+	PinnedByDigest bool
+	// DigestReference is the canonical oci:// form pinning Descriptor's exact
+	// bytes, so a caller can print the reference that removes the tag's say.
+	DigestReference string
 }
 
 // Source is an immutable migration filesystem and its display metadata.
@@ -222,9 +233,12 @@ func resolveOCI(ctx context.Context, raw string, opts Options) (Source, error) {
 		Display:    ref.String(),
 		DirFormat:  artifact.DirFormat,
 		OCI: &OCI{
-			Client:     client,
-			Reference:  ref.String(),
-			Descriptor: artifact.Descriptor,
+			Client:          client,
+			Reference:       ref.String(),
+			Descriptor:      artifact.Descriptor,
+			Tag:             ref.Tag(),
+			PinnedByDigest:  ref.IsDigest(),
+			DigestReference: ref.PinnedString(artifact.Descriptor.Digest.String()),
 		},
 	}, nil
 }

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -138,7 +138,14 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.migrationsDir, migrationsFlag, "", "Local directory or oci:// reference containing migration files (required)")
 	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Show what migrations would be applied without actually running them")
 	flags.BoolVar(&opts.verbose, verboseFlag, false, "Enable verbose output")
-	flags.BoolVar(&opts.verifySum, verifySumFlag, false, "Require a sum file: a missing ptah.sum or atlas.sum is an error (hashed directories always verify before applying)")
+	flags.BoolVar(
+		&opts.verifySum,
+		verifySumFlag,
+		false,
+		"Require a sum file: a missing ptah.sum or atlas.sum is an error (hashed directories always "+
+			"verify before applying). A sum checks a directory against the sum stored beside it, so an "+
+			"oci:// tag source proves internal consistency only; pin a digest for authenticity",
+	)
 	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatAuto), "Migration directory format: auto, ptah, or atlas")
 	flags.StringVar(&opts.atlasEnv, atlasEnvFlag, "", "Value exposed as .Env when rendering Atlas SQL template migrations")
 	flags.StringVar(&opts.execOrder, execOrderFlag, string(migrator.ExecOrderLinear), "Execution order policy for pending migrations below the current version: linear, linear-skip, or non-linear")
@@ -329,20 +336,7 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	migrationsDir = source.Display
 	settings.dirFormat = source.DirFormat
 
-	if opts.verifySum {
-		result, err := verifyMigrationIntegrity(migrationsFS, settings.dirFormat)
-		if err != nil {
-			return err
-		}
-		if opts.verbose {
-			emit.Printf("%s verified: migrations directory is intact\n", result.SumFileName)
-		}
-	} else if err := verifyHashedMigrationIntegrity(migrationsFS, settings.dirFormat); err != nil {
-		// Integrity gate (#955): a hashed directory (ptah.sum or atlas.sum
-		// present) always verifies before anything is applied, so a tampered
-		// migration — including a tampered checkpoint — never executes. An
-		// unhashed directory keeps its ungated behavior; --verify-sum keeps
-		// its stricter contract that a missing sum file is itself an error.
+	if err := runIntegrityGate(emit, runtime, source, settings.dirFormat, opts); err != nil {
 		return err
 	}
 
@@ -562,6 +556,56 @@ func lintPathPrefixForSource(requested string, source migrationsource.Source) st
 	return filepath.ToSlash(requested)
 }
 
+// runIntegrityGate verifies the resolved migration filesystem before anything
+// is applied and then qualifies what that verification established. Both the
+// --verify-sum branch and the always-on hashed branch check a directory
+// against the sum stored beside it, so both get the same provenance qualifier
+// when the directory came from a movable OCI tag (#944).
+func runIntegrityGate(
+	emit cliobs.Emitter,
+	runtime *cliobs.Runtime,
+	source migrationsource.Source,
+	format migrator.MigrationDirFormat,
+	opts *options,
+) error {
+	var verifiedSumFile string
+	if opts.verifySum {
+		result, err := verifyMigrationIntegrity(source.FileSystem, format)
+		if err != nil {
+			return err
+		}
+		verifiedSumFile = result.SumFileName
+		if opts.verbose {
+			emit.Printf("%s verified: migrations directory is intact\n", verifiedSumFile)
+		}
+	} else {
+		// Integrity gate (#955): a hashed directory (ptah.sum or atlas.sum
+		// present) always verifies before anything is applied, so a tampered
+		// migration — including a tampered checkpoint — never executes. An
+		// unhashed directory keeps its ungated behavior; --verify-sum keeps
+		// its stricter contract that a missing sum file is itself an error.
+		hashedSumFile, err := verifyHashedMigrationIntegrity(source.FileSystem, format)
+		if err != nil {
+			return err
+		}
+		verifiedSumFile = hashedSumFile
+	}
+	// Every error path returned above, so a run that refused to apply never
+	// reaches here and never qualifies a claim it did not make.
+	warning := mutableTagSumWarning(source, verifiedSumFile)
+	if warning == "" {
+		return nil
+	}
+	runtime.Logger().Warn(
+		"migration sum verified through a movable OCI tag",
+		"reference", source.OCI.Reference,
+		"digest", source.OCI.Descriptor.Digest.String(),
+		"sum_file", verifiedSumFile,
+	)
+	emit.Printf("Warning: %s\n", warning)
+	return nil
+}
+
 func verifyMigrationIntegrity(
 	fsys fs.FS,
 	format migrator.MigrationDirFormat,
@@ -580,19 +624,50 @@ func verifyMigrationIntegrity(
 // migration directories: when the filesystem carries the format's integrity
 // file (ptah.sum or atlas.sum), it must verify before anything is applied. An
 // unhashed directory passes without verification. Drift reporting matches
-// `ptah migrations validate` on the same directory.
-func verifyHashedMigrationIntegrity(fsys fs.FS, format migrator.MigrationDirFormat) error {
+// `ptah migrations validate` on the same directory. It returns the name of the
+// integrity file that verified, or the empty string when the directory was
+// never hashed and therefore nothing was checked.
+func verifyHashedMigrationIntegrity(fsys fs.FS, format migrator.MigrationDirFormat) (string, error) {
 	result, hashed, err := migratesum.VerifyHashed(fsys, format)
 	if err != nil {
-		return fmt.Errorf("migration sum verification failed: %w", err)
+		return "", fmt.Errorf("migration sum verification failed: %w", err)
 	}
 	if !hashed {
-		return nil
+		return "", nil
 	}
 	if !result.OK() {
-		return fmt.Errorf("migration sum verification failed:\n%s", result.Describe())
+		return "", fmt.Errorf("migration sum verification failed:\n%s", result.Describe())
 	}
-	return nil
+	return result.SumFileName, nil
+}
+
+// mutableTagSumWarning returns the provenance sentence a sum verification
+// cannot carry on its own, or the empty string when there is nothing to say.
+//
+// A sum file proves that a directory matches the sum recorded beside it. For a
+// local directory that sum was reviewed in version control next to the
+// migrations. For an OCI artifact the sum travels inside the artifact, so the
+// check is self-referential: anyone who can push to the repository can rewrite
+// the migrations, rehash them, and repoint a tag, and the verification still
+// passes over bytes nobody reviewed (#944). Only the reference's own shape
+// separates the two cases, so the warning fires exactly when a verification
+// actually ran and the reference was a tag rather than a digest.
+//
+// verifiedSumFile is the integrity file that verified; the empty string means
+// nothing was verified, so nothing was claimed and nothing needs qualifying.
+func mutableTagSumWarning(source migrationsource.Source, verifiedSumFile string) string {
+	if verifiedSumFile == "" || source.OCI == nil || source.OCI.PinnedByDigest {
+		return ""
+	}
+	return fmt.Sprintf(
+		"%s is a movable tag: %s travels inside the artifact, so verifying it proves the pulled "+
+			"files are internally consistent, not that they are the reviewed ones. "+
+			"This tag resolved to %s; pass %s to pin these exact bytes.",
+		source.OCI.Reference,
+		verifiedSumFile,
+		source.OCI.Descriptor.Digest.String(),
+		source.OCI.DigestReference,
+	)
 }
 
 func publishDeploymentReportIfNeeded(

--- a/cmd/migrateup/verify_sum_provenance_internal_test.go
+++ b/cmd/migrateup/verify_sum_provenance_internal_test.go
@@ -1,0 +1,363 @@
+package migrateup
+
+// White-box testing required: mutableTagSumWarning is the predicate that
+// decides whether a sum verification gets its provenance qualifier
+// (stokaro/ptah#944), and the distinction it draws — a sum reviewed in version
+// control beside the migrations versus a sum shipped inside an artifact a
+// movable tag selected — is not observable through any exported API.
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/opencontainers/go-digest"
+	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
+	"oras.land/oras-go/v2/errdef"
+
+	"go.5x5.cz/ptah/cmd/internal/migrationsource"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/migrationartifact"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+const (
+	provenanceDigest      = "sha256:" + "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	provenanceOtherDigest = "sha256:" + "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func ociTagSource(reference, tag, resolved string) migrationsource.Source {
+	return migrationsource.Source{
+		Display:   reference,
+		DirFormat: migrator.MigrationDirFormatPtah,
+		OCI: &migrationsource.OCI{
+			Reference:       reference,
+			Descriptor:      ocispec.Descriptor{Digest: digest.Digest(resolved)},
+			Tag:             tag,
+			DigestReference: "oci://reg.test/ptah/app@" + resolved,
+		},
+	}
+}
+
+func ociDigestSource(resolved string) migrationsource.Source {
+	reference := "oci://reg.test/ptah/app@" + resolved
+	return migrationsource.Source{
+		Display:   reference,
+		DirFormat: migrator.MigrationDirFormatPtah,
+		OCI: &migrationsource.OCI{
+			Reference:       reference,
+			Descriptor:      ocispec.Descriptor{Digest: digest.Digest(resolved)},
+			PinnedByDigest:  true,
+			DigestReference: reference,
+		},
+	}
+}
+
+func localSource() migrationsource.Source {
+	return migrationsource.Source{
+		Display:   "/srv/app/migrations",
+		DirFormat: migrator.MigrationDirFormatPtah,
+	}
+}
+
+// TestMutableTagSumWarning pins which provenances get the qualifier. Only the
+// tag rows may produce text: a digest reference already names the exact bytes,
+// a local directory carries a sum reviewed beside the migrations, and an
+// unhashed source verified nothing, so it claimed nothing to qualify.
+func TestMutableTagSumWarning(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name            string
+		source          func() migrationsource.Source
+		verifiedSumFile string
+		want            string
+	}{
+		{
+			name: "oci tag verified names tag digest and pin",
+			source: func() migrationsource.Source {
+				return ociTagSource("oci://reg.test/ptah/app:release", "release", provenanceDigest)
+			},
+			verifiedSumFile: "ptah.sum",
+			want: "oci://reg.test/ptah/app:release is a movable tag: ptah.sum travels inside the artifact, " +
+				"so verifying it proves the pulled files are internally consistent, not that they are the " +
+				"reviewed ones. This tag resolved to " + provenanceDigest + "; pass oci://reg.test/ptah/app@" +
+				provenanceDigest + " to pin these exact bytes.",
+		},
+		{
+			name:            "oci digest verified stays silent",
+			source:          func() migrationsource.Source { return ociDigestSource(provenanceDigest) },
+			verifiedSumFile: "ptah.sum",
+			want:            "",
+		},
+		{
+			name:            "local directory verified stays silent",
+			source:          localSource,
+			verifiedSumFile: "ptah.sum",
+			want:            "",
+		},
+		{
+			name: "oci tag with nothing verified stays silent",
+			source: func() migrationsource.Source {
+				return ociTagSource("oci://reg.test/ptah/app:release", "release", provenanceDigest)
+			},
+			verifiedSumFile: "",
+			want:            "",
+		},
+		{
+			name: "oci tag quotes the digest it actually resolved to",
+			source: func() migrationsource.Source {
+				return ociTagSource("oci://reg.test/ptah/app:release", "release", provenanceOtherDigest)
+			},
+			verifiedSumFile: "ptah.sum",
+			want: "oci://reg.test/ptah/app:release is a movable tag: ptah.sum travels inside the artifact, " +
+				"so verifying it proves the pulled files are internally consistent, not that they are the " +
+				"reviewed ones. This tag resolved to " + provenanceOtherDigest + "; pass oci://reg.test/ptah/app@" +
+				provenanceOtherDigest + " to pin these exact bytes.",
+		},
+		{
+			name: "oci tag names the sum file that actually verified",
+			source: func() migrationsource.Source {
+				return ociTagSource("oci://reg.test/ptah/app:stable", "stable", provenanceDigest)
+			},
+			verifiedSumFile: "atlas.sum",
+			want: "oci://reg.test/ptah/app:stable is a movable tag: atlas.sum travels inside the artifact, " +
+				"so verifying it proves the pulled files are internally consistent, not that they are the " +
+				"reviewed ones. This tag resolved to " + provenanceDigest + "; pass oci://reg.test/ptah/app@" +
+				provenanceDigest + " to pin these exact bytes.",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(mutableTagSumWarning(tt.source(), tt.verifiedSumFile), qt.Equals, tt.want)
+		})
+	}
+}
+
+// ociStoredBlob is one content-addressed object the in-process registry serves.
+type ociStoredBlob struct {
+	descriptor ocispec.Descriptor
+	data       []byte
+}
+
+// ociMemoryStore is the minimal oras.Target the in-process registry is built
+// from: digest-addressed content plus a mutable tag table, which is exactly the
+// registry property this test exercises.
+type ociMemoryStore struct {
+	mu    sync.Mutex
+	blobs map[digest.Digest]ociStoredBlob
+	tags  map[string]ocispec.Descriptor
+}
+
+func newOCIMemoryStore() *ociMemoryStore {
+	return &ociMemoryStore{
+		blobs: map[digest.Digest]ociStoredBlob{},
+		tags:  map[string]ocispec.Descriptor{},
+	}
+}
+
+func (s *ociMemoryStore) Push(_ context.Context, expected ocispec.Descriptor, content io.Reader) error {
+	data, err := io.ReadAll(content)
+	if err != nil {
+		return err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.blobs[expected.Digest] = ociStoredBlob{descriptor: expected, data: data}
+	return nil
+}
+
+func (s *ociMemoryStore) Exists(_ context.Context, target ocispec.Descriptor) (bool, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.blobs[target.Digest]
+	return ok, nil
+}
+
+func (s *ociMemoryStore) Fetch(_ context.Context, target ocispec.Descriptor) (io.ReadCloser, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	blob, ok := s.blobs[target.Digest]
+	if !ok {
+		return nil, errdef.ErrNotFound
+	}
+	return io.NopCloser(bytes.NewReader(blob.data)), nil
+}
+
+func (s *ociMemoryStore) Tag(_ context.Context, target ocispec.Descriptor, reference string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.tags[reference] = target
+	return nil
+}
+
+func (s *ociMemoryStore) Resolve(_ context.Context, reference string) (ocispec.Descriptor, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if tagged, ok := s.tags[reference]; ok {
+		return tagged, nil
+	}
+	blob, ok := s.blobs[digest.Digest(reference)]
+	if !ok {
+		return ocispec.Descriptor{}, errdef.ErrNotFound
+	}
+	return blob.descriptor, nil
+}
+
+func (s *ociMemoryStore) serveManifest(writer http.ResponseWriter, request *http.Request) {
+	descriptor, err := s.Resolve(request.Context(), request.PathValue("reference"))
+	if err != nil {
+		http.Error(writer, "manifest unknown", http.StatusNotFound)
+		return
+	}
+	s.mu.Lock()
+	blob := s.blobs[descriptor.Digest]
+	s.mu.Unlock()
+	writer.Header().Set("Content-Type", descriptor.MediaType)
+	writer.Header().Set("Docker-Content-Digest", descriptor.Digest.String())
+	writer.Header().Set("Content-Length", strconv.Itoa(len(blob.data)))
+	writer.WriteHeader(http.StatusOK)
+	_, _ = writer.Write(blob.data)
+}
+
+func (s *ociMemoryStore) serveBlob(writer http.ResponseWriter, request *http.Request) {
+	s.mu.Lock()
+	blob, ok := s.blobs[digest.Digest(request.PathValue("digest"))]
+	s.mu.Unlock()
+	if !ok {
+		http.Error(writer, "blob unknown", http.StatusNotFound)
+		return
+	}
+	writer.Header().Set("Content-Type", "application/octet-stream")
+	writer.Header().Set("Docker-Content-Digest", blob.descriptor.Digest.String())
+	writer.Header().Set("Content-Length", strconv.Itoa(len(blob.data)))
+	writer.WriteHeader(http.StatusOK)
+	_, _ = writer.Write(blob.data)
+}
+
+// startOCITestRegistry serves store over the read half of the OCI distribution
+// API and returns its host:port, so `ptah migrations up --plain-http` resolves
+// a real oci:// reference without a container.
+func startOCITestRegistry(c *qt.C, store *ociMemoryStore, repository string) string {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc("/v2/"+repository+"/manifests/{reference}", store.serveManifest)
+	mux.HandleFunc("/v2/"+repository+"/blobs/{digest}", store.serveBlob)
+	server := httptest.NewServer(mux)
+	c.Cleanup(server.Close)
+	return strings.TrimPrefix(server.URL, "http://")
+}
+
+func writeHashedProvenanceDir(c *qt.C, table string) string {
+	c.Helper()
+	dir := c.TempDir()
+	files := map[string]string{
+		"0000000001_create_" + table + ".up.sql":   "CREATE TABLE " + table + " (id INTEGER PRIMARY KEY);\n",
+		"0000000001_create_" + table + ".down.sql": "DROP TABLE " + table + ";\n",
+	}
+	for name, content := range files {
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatPtah)
+	c.Assert(err, qt.IsNil)
+	return dir
+}
+
+func pushProvenanceArtifact(c *qt.C, store *ociMemoryStore, dir, tag string) string {
+	c.Helper()
+	result, err := migrationartifact.PushTo(
+		context.Background(),
+		store,
+		os.DirFS(dir),
+		migrationartifact.PushOptions{
+			Tags:        []string{tag},
+			DirFormat:   migrator.MigrationDirFormatPtah,
+			Annotations: map[string]string{ocispec.AnnotationCreated: "2026-08-01T00:00:00Z"},
+		},
+	)
+	c.Assert(err, qt.IsNil)
+	return result.Descriptor.Digest.String()
+}
+
+func runUpInternal(args ...string) (string, error) {
+	cmd := NewMigrateUpCommand()
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestMigrateUp_OCISumProvenance runs the real apply path against an
+// in-process registry. It is the wiring half of stokaro/ptah#944: measurement
+// showed `ptah.sum verified: migrations directory is intact` printed
+// byte-identically for a tag whose content had been swapped and for the digest
+// that pinned the reviewed bytes, so the tag row must gain provenance and the
+// digest row must not.
+func TestMigrateUp_OCISumProvenance(t *testing.T) {
+	c := qt.New(t)
+	const repository = "ptah/provenance"
+	store := newOCIMemoryStore()
+	host := startOCITestRegistry(c, store, repository)
+	resolved := pushProvenanceArtifact(c, store, writeHashedProvenanceDir(c, "widgets"), "release")
+	tagReference := "oci://" + host + "/" + repository + ":release"
+	digestReference := "oci://" + host + "/" + repository + "@" + resolved
+
+	tests := []struct {
+		name      string
+		reference func() string
+		verify    func(c *qt.C, out string)
+	}{
+		{
+			name:      "movable tag carries provenance",
+			reference: func() string { return tagReference },
+			verify: func(c *qt.C, out string) {
+				c.Assert(out, qt.Contains, "Warning: "+tagReference+" is a movable tag: ptah.sum travels inside the artifact")
+				c.Assert(out, qt.Contains, "This tag resolved to "+resolved)
+				c.Assert(out, qt.Contains, "pass oci://"+host+"/"+repository+"@"+resolved+" to pin these exact bytes.")
+			},
+		},
+		{
+			name:      "digest pin stays silent",
+			reference: func() string { return digestReference },
+			verify: func(c *qt.C, out string) {
+				c.Assert(out, qt.Not(qt.Contains), "movable tag")
+				c.Assert(out, qt.Not(qt.Contains), "Warning:")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dbPath := filepath.Join(c.TempDir(), "provenance.db")
+
+			out, err := runUpInternal(
+				"--db-url", "sqlite://"+dbPath,
+				"--migrations-dir", tt.reference(),
+				"--verify-sum",
+				"--plain-http",
+				"--skip-report",
+				"--verbose",
+			)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			// The warning qualifies the claim; it never replaces it and never
+			// changes the exit status.
+			c.Assert(out, qt.Contains, "ptah.sum verified: migrations directory is intact")
+			c.Assert(out, qt.Contains, "Database is now at version: 1")
+			tt.verify(c, out)
+		})
+	}
+}

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -18,7 +18,7 @@ OCI artifact distribution is a cross-cutting Ptah capability, not a database
 dialect capability key in `core/platform/capability`.
 
 - **Bring-your-own OCI registry** — native migration and desired-schema push/pull against OCI-compliant registries, authenticated through the Docker credential store.
-- **Reference semantics** — unqualified references resolve to `latest`; tags are movable; `@sha256:` digest pins are immutable; pushes to digest references are rejected.
+- **Reference semantics** — unqualified references resolve to `latest`; tags are movable; `@sha256:` digest pins are immutable; a `:tag@sha256:` reference is accepted and resolves by the digest while keeping the tag in the canonical form; pushes to any digest-carrying reference are rejected.
 - **Direct migration consumption** — `ptah migrations up`, `status`, and `down` accept `oci://` through `--migrations-dir`; `up --verify-sum` verifies the pulled directory against the sum that travelled inside it, and `up` prints the resolved digest and its `@sha256:` pin whenever that check ran over a movable tag.
 - **Direct schema consumption** — `ptah schema compare` and `drift` accept `oci://` through `--schema-file`.
 - **Canonical desired schema** — schema publication emits exactly one lossless canonical `schema.hcl` and fails closed on managed data, lossy diagnostics, or unstable HCL round trips.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -19,7 +19,7 @@ dialect capability key in `core/platform/capability`.
 
 - **Bring-your-own OCI registry** — native migration and desired-schema push/pull against OCI-compliant registries, authenticated through the Docker credential store.
 - **Reference semantics** — unqualified references resolve to `latest`; tags are movable; `@sha256:` digest pins are immutable; pushes to digest references are rejected.
-- **Direct migration consumption** — `ptah migrations up`, `status`, and `down` accept `oci://` through `--migrations-dir`; `up --verify-sum` verifies the pulled directory.
+- **Direct migration consumption** — `ptah migrations up`, `status`, and `down` accept `oci://` through `--migrations-dir`; `up --verify-sum` verifies the pulled directory against the sum that travelled inside it, and `up` prints the resolved digest and its `@sha256:` pin whenever that check ran over a movable tag.
 - **Direct schema consumption** — `ptah schema compare` and `drift` accept `oci://` through `--schema-file`.
 - **Canonical desired schema** — schema publication emits exactly one lossless canonical `schema.hcl` and fails closed on managed data, lossy diagnostics, or unstable HCL round trips.
 - **Deployment reporting** — successful, non-dry-run OCI-backed `migrations up` runs that add committed revisions attach a best-effort, redacted deployment report unless `--skip-report` is set. No-op runs do not publish a report.

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -19,7 +19,7 @@ dialect capability key in `core/platform/capability`.
 
 - **Bring-your-own OCI registry** — native migration and desired-schema push/pull against OCI-compliant registries, authenticated through the Docker credential store.
 - **Reference semantics** — unqualified references resolve to `latest`; tags are movable; `@sha256:` digest pins are immutable; a `:tag@sha256:` reference is accepted and resolves by the digest while keeping the tag in the canonical form; pushes to any digest-carrying reference are rejected.
-- **Direct migration consumption** — `ptah migrations up`, `status`, and `down` accept `oci://` through `--migrations-dir`; `up --verify-sum` verifies the pulled directory against the sum that travelled inside it, and `up` prints the resolved digest and its `@sha256:` pin whenever that check ran over a movable tag.
+- **Direct migration consumption** — `ptah migrations up`, `status`, and `down` accept `oci://` through `--migrations-dir`; `up --verify-sum` verifies the pulled directory against the sum that traveled inside it, and `up` prints the resolved digest and its `@sha256:` pin whenever that check ran over a movable tag.
 - **Direct schema consumption** — `ptah schema compare` and `drift` accept `oci://` through `--schema-file`.
 - **Canonical desired schema** — schema publication emits exactly one lossless canonical `schema.hcl` and fails closed on managed data, lossy diagnostics, or unstable HCL round trips.
 - **Deployment reporting** — successful, non-dry-run OCI-backed `migrations up` runs that add committed revisions attach a best-effort, redacted deployment report unless `--skip-report` is set. No-op runs do not publish a report.

--- a/docs/oci_registry.md
+++ b/docs/oci_registry.md
@@ -67,7 +67,7 @@ oci://ghcr.io/acme/app-migrations:release@sha256:0123456789abcdef0123456789abcde
 The digest decides which bytes are fetched, exactly as with every other OCI
 client when the two disagree. The tag is carried for readability and is echoed
 back in the canonical form; it never selects content and never softens the pin.
-Because the reference is digest-pinned, pushing to it is rejected just like
+Because the reference is digest-pinned, pushing to it is rejected exactly as
 pushing to a bare `@sha256:` reference.
 
 A sum file carries different weight depending on which of those you applied. A
@@ -221,7 +221,7 @@ ptah migrations down \
 For `up`, `status`, and `down`, the artifact is pulled into an immutable
 in-memory filesystem and passed to the existing migration engine. An explicit
 `--dir-format` must match the format recorded in the artifact. The
-`up --verify-sum` gate verifies the pulled files against the sum that travelled
+`up --verify-sum` gate verifies the pulled files against the sum that traveled
 with them, before opening the database. Applied to a digest reference, that
 gate covers exactly the bytes named on the command line. Applied to a tag, it
 covers whatever the tag resolved to at pull time, and `up` prints that digest

--- a/docs/oci_registry.md
+++ b/docs/oci_registry.md
@@ -57,6 +57,16 @@ oci://ghcr.io/acme/app-migrations:v20260728153000
 oci://ghcr.io/acme/app-migrations@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
+A sum file carries different weight depending on which of those you applied. A
+sum verifies a directory against the sum stored beside it; for an OCI artifact
+that sum travels inside the artifact. Anyone who can push to the repository can
+rewrite the migrations, rehash them, and repoint a tag, and the verification
+still passes. So a sum over a tag-resolved artifact proves internal
+consistency, not that the bytes are the reviewed ones. `ptah migrations up`
+says so out loud: when a sum verifies over a tag-resolved artifact it prints
+the digest the tag resolved to and the `@sha256:` reference that pins it. A
+digest reference already names exact bytes and gets no such line.
+
 Every push applies:
 
 - `latest`;
@@ -161,7 +171,11 @@ layer. `--dir-format` accepts `auto`, `ptah`, or `atlas`.
 
 `--verify-sum` is opt-in. When enabled, the push fails before registry upload if
 the required `ptah.sum` or `atlas.sum` is missing, changed, or otherwise
-invalid.
+invalid. On `push` the directory being verified is the local one the author
+controls, so the check has the full weight of a reviewed working tree behind
+it. On `up` the same flag verifies a pulled artifact against the sum shipped
+inside it; see the tag-versus-digest note above for what that does and does not
+establish.
 
 The command prints the canonical reference, manifest digest, version tag, and
 all applied tags. Pin the digest when promoting the exact bytes to another
@@ -194,7 +208,11 @@ ptah migrations down \
 For `up`, `status`, and `down`, the artifact is pulled into an immutable
 in-memory filesystem and passed to the existing migration engine. An explicit
 `--dir-format` must match the format recorded in the artifact. The
-`up --verify-sum` gate verifies the pulled files before opening the database.
+`up --verify-sum` gate verifies the pulled files against the sum that travelled
+with them, before opening the database. Applied to a digest reference, that
+gate covers exactly the bytes named on the command line. Applied to a tag, it
+covers whatever the tag resolved to at pull time, and `up` prints that digest
+alongside the `@sha256:` reference to pin it.
 
 To reconstruct the captured directory:
 

--- a/docs/oci_registry.md
+++ b/docs/oci_registry.md
@@ -57,6 +57,19 @@ oci://ghcr.io/acme/app-migrations:v20260728153000
 oci://ghcr.io/acme/app-migrations@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 ```
 
+A reference may carry a tag and a digest together, which is what a promotion
+pipeline emits — "the artifact we call `:release`, resolved to these bytes":
+
+```text
+oci://ghcr.io/acme/app-migrations:release@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+```
+
+The digest decides which bytes are fetched, exactly as with every other OCI
+client when the two disagree. The tag is carried for readability and is echoed
+back in the canonical form; it never selects content and never softens the pin.
+Because the reference is digest-pinned, pushing to it is rejected just like
+pushing to a bare `@sha256:` reference.
+
 A sum file carries different weight depending on which of those you applied. A
 sum verifies a directory against the sum stored beside it; for an OCI artifact
 that sum travels inside the artifact. Anyone who can push to the repository can
@@ -84,9 +97,9 @@ Positional, `--tag`, and `latest` aliases remain movable.
 The write-once check is a client-side preflight, so two concurrent writers can
 still race when an explicit `--version` is reused. Configure immutable-tag
 policy in the registry for version-tag prefixes when concurrent publishers are
-possible. Use the returned `Digest:` value for a hard pin. Pushing to an
-`@sha256:` reference is rejected, as is a reference containing both a tag and
-a digest. If a later tag update fails after earlier tags moved, Ptah reports
+possible. Use the returned `Digest:` value for a hard pin. Pushing to any
+reference carrying an `@sha256:` digest is rejected, including the
+`:tag@sha256:` form. If a later tag update fails after earlier tags moved, Ptah reports
 the manifest digest, completed tags, and failed tag instead of presenting the
 operation as having no externally visible effect.
 

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -110,6 +110,11 @@ must be hashed. `ptah-compat migrate apply` refuses a never-hashed Atlas
 directory outright, because Atlas does; see
 [Integrity and safety](../integrity-and-safety/).
 
+Either check compares the directory against the sum stored beside it, so what
+it establishes depends on where the directory came from. See
+[Apply from an OCI registry](#apply-from-an-oci-registry) for what that means
+when the directory is a registry artifact.
+
 Applied versions land in the revision table. Rerunning the same command is a
 safe no-op:
 
@@ -233,6 +238,13 @@ ptah migrations up \
   --migrations-dir oci://ghcr.io/acme/app-migrations@sha256:<digest> \
   --verify-sum
 ```
+
+Pin the digest deliberately: `--verify-sum` checks the pulled directory against
+the sum shipped inside the same artifact, so over a movable tag it proves the
+files are internally consistent, not that they are the reviewed ones. `up`
+prints that qualification, along with the digest the tag resolved to and the
+reference that pins it, whenever a sum verifies over a tag-resolved artifact.
+The run still succeeds; a digest reference gets no such line.
 
 See [OCI registry artifacts](../../operate/oci-registry/) for
 authentication, tag and digest semantics, referrer reports, and CI wiring.

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -104,6 +104,26 @@ error: migration sum verification failed: ptah.sum not found; run `ptah migratio
 That flag is the only thing on the native surface that rejects a never-hashed
 directory; a hashed one is always verified with or without it.
 
+**A sum check is worth what the sum's provenance is worth.** Either gate
+compares a directory against the sum stored beside it. For a local directory
+that sum was reviewed in version control next to the migrations. For an
+`oci://` artifact the sum travels inside the artifact, so anyone who can push
+to the repository can rewrite the migrations, rehash them, repoint a tag, and
+watch the check pass over bytes nobody reviewed. `ptah migrations up` therefore
+qualifies the claim when a sum verifies over a tag-resolved artifact, naming
+the digest the tag resolved to and the `@sha256:` reference that pins it:
+
+```text
+Warning: oci://ghcr.io/acme/app-migrations:release is a movable tag: ptah.sum
+travels inside the artifact, so verifying it proves the pulled files are
+internally consistent, not that they are the reviewed ones. This tag resolved
+to sha256:<digest>; pass oci://ghcr.io/acme/app-migrations@sha256:<digest> to
+pin these exact bytes.
+```
+
+The run still succeeds — the check did what it claims. A digest reference and
+a local directory produce no such line.
+
 **`ptah-compat migrate apply`, `migrate status` and `migrate set` refuse an
 unhashed directory.** Atlas treats a missing `atlas.sum` as a checksum error, so
 the compatibility surface does too — measured against the pinned community

--- a/integration/oci_registry_e2e_test.go
+++ b/integration/oci_registry_e2e_test.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/jackc/pgx/v5/stdlib"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 
+	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/ociartifact"
 	"go.5x5.cz/ptah/internal/ocireferrers"
@@ -596,6 +597,154 @@ func digestFromPushOutput(c *qt.C, output string) string {
 
 func digestReference(reference, digest string) string {
 	return strings.TrimSuffix(reference, ":latest") + "@" + digest
+}
+
+// tamperOCIMigrationAndRehash injects a statement nobody reviewed and rehashes,
+// which is exactly what a repository writer can do: the sum file travels inside
+// the artifact, so rehashing keeps every self-consistency check green.
+func tamperOCIMigrationAndRehash(c *qt.C, dir string, version int64, table string) {
+	path := filepath.Join(dir, fmt.Sprintf("%010d_create_%s.up.sql", version, table))
+	file, err := os.OpenFile(path, os.O_APPEND|os.O_WRONLY, 0o600)
+	c.Assert(err, qt.IsNil)
+	_, err = file.WriteString("CREATE TABLE evil (id BIGINT PRIMARY KEY);\n")
+	c.Assert(err, qt.IsNil)
+	c.Assert(file.Close(), qt.IsNil)
+	_, err = migratesum.Write(dir)
+	c.Assert(err, qt.IsNil)
+}
+
+func sqliteTableCount(c *qt.C, ctx context.Context, dbPath, table string) int {
+	conn, err := dbschema.ConnectToDatabase(ctx, "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRowContext(
+		ctx,
+		`SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = ?`,
+		table,
+	).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+// TestOCIMigrationTagSumProvenanceE2E reproduces stokaro/ptah#944 against a
+// live registry. Measured on master: `ptah.sum verified: migrations directory
+// is intact` printed byte-identically for the reviewed artifact and for one
+// whose tag had been repointed at an injected `CREATE TABLE evil`, and `up`
+// printed the resolved digest nowhere, so no operator could learn after the
+// fact which bytes ran. The apply keeps exiting 0 — the flag's contract is
+// honest about what it checks — but a tag-resolved verification must now name
+// the tag, the digest it resolved to, and the pin, while a digest reference
+// must stay silent and must still run the reviewed bytes.
+func TestOCIMigrationTagSumProvenanceE2E(t *testing.T) {
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	registry := requiredOCIRegistry(t)
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah")
+	buildPtah(c, ctx, repoRoot, binaryPath)
+
+	suffix := time.Now().UnixNano()
+	migrationsDir := filepath.Join(t.TempDir(), "migrations")
+	writeOCIMigration(c, migrationsDir, ociMigrationVersion, "widgets")
+	base := fmt.Sprintf("oci://%s/ptah/oci-provenance-%d", registry, suffix)
+	tagReference := base + ":release"
+
+	pushOutput, err := runPtahInDir(
+		ctx,
+		repoRoot,
+		binaryPath,
+		"migrations", "push", tagReference,
+		"--migrations-dir", migrationsDir,
+		"--version", fmt.Sprintf("v%d", suffix),
+		"--verify-sum",
+		"--plain-http",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("push output:\n%s", pushOutput))
+	firstDigest := digestFromPushOutput(c, pushOutput)
+	firstDigestReference := base + "@" + firstDigest
+
+	reviewedDB := filepath.Join(t.TempDir(), "reviewed.db")
+	reviewedOutput, err := runPtahInDir(
+		ctx,
+		repoRoot,
+		binaryPath,
+		"migrations", "up",
+		"--db-url", "sqlite://"+reviewedDB,
+		"--migrations-dir", tagReference,
+		"--verify-sum",
+		"--skip-report",
+		"--plain-http",
+		"--verbose",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("reviewed up output:\n%s", reviewedOutput))
+	c.Assert(reviewedOutput, qt.Contains, "ptah.sum verified: migrations directory is intact")
+	c.Assert(reviewedOutput, qt.Contains, "Warning: "+tagReference+" is a movable tag")
+	c.Assert(reviewedOutput, qt.Contains, "This tag resolved to "+firstDigest)
+	c.Assert(reviewedOutput, qt.Contains, "pass "+firstDigestReference+" to pin these exact bytes.")
+	c.Assert(sqliteTableCount(c, ctx, reviewedDB, "widgets"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, ctx, reviewedDB, "evil"), qt.Equals, 0)
+
+	tamperOCIMigrationAndRehash(c, migrationsDir, ociMigrationVersion, "widgets")
+	repointOutput, err := runPtahInDir(
+		ctx,
+		repoRoot,
+		binaryPath,
+		"migrations", "push", tagReference,
+		"--migrations-dir", migrationsDir,
+		"--version", fmt.Sprintf("v%d", suffix+1),
+		"--verify-sum",
+		"--plain-http",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("repoint push output:\n%s", repointOutput))
+	secondDigest := digestFromPushOutput(c, repointOutput)
+	c.Assert(secondDigest, qt.Not(qt.Equals), firstDigest)
+
+	// Byte-identical command, repointed tag. The sum still verifies, because the
+	// rehashed sum travelled with the rewritten files; the provenance line is
+	// the only thing that reports which bytes that covered.
+	repointedDB := filepath.Join(t.TempDir(), "repointed.db")
+	repointedOutput, err := runPtahInDir(
+		ctx,
+		repoRoot,
+		binaryPath,
+		"migrations", "up",
+		"--db-url", "sqlite://"+repointedDB,
+		"--migrations-dir", tagReference,
+		"--verify-sum",
+		"--skip-report",
+		"--plain-http",
+		"--verbose",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("repointed up output:\n%s", repointedOutput))
+	c.Assert(repointedOutput, qt.Contains, "ptah.sum verified: migrations directory is intact")
+	c.Assert(repointedOutput, qt.Contains, "This tag resolved to "+secondDigest)
+	c.Assert(repointedOutput, qt.Not(qt.Contains), firstDigest)
+	c.Assert(sqliteTableCount(c, ctx, repointedDB, "evil"), qt.Equals, 1)
+
+	// The digest pin selects the reviewed bytes and says nothing extra: there is
+	// no tag left to qualify.
+	pinnedDB := filepath.Join(t.TempDir(), "pinned.db")
+	pinnedOutput, err := runPtahInDir(
+		ctx,
+		repoRoot,
+		binaryPath,
+		"migrations", "up",
+		"--db-url", "sqlite://"+pinnedDB,
+		"--migrations-dir", firstDigestReference,
+		"--verify-sum",
+		"--skip-report",
+		"--plain-http",
+		"--verbose",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("pinned up output:\n%s", pinnedOutput))
+	c.Assert(pinnedOutput, qt.Contains, "ptah.sum verified: migrations directory is intact")
+	c.Assert(pinnedOutput, qt.Not(qt.Contains), "movable tag")
+	c.Assert(pinnedOutput, qt.Not(qt.Contains), "Warning:")
+	c.Assert(sqliteTableCount(c, ctx, pinnedDB, "widgets"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, ctx, pinnedDB, "evil"), qt.Equals, 0)
 }
 
 func readReferrerRecords(c *qt.C, output string) []ocireferrers.Record {

--- a/internal/ociartifact/artifact_test.go
+++ b/internal/ociartifact/artifact_test.go
@@ -610,6 +610,10 @@ func pushManifest(
 	c.Assert(err, qt.IsNil)
 }
 
+// TestPush_DigestReferenceFailsBeforeNetworkAccess pins that every reference
+// carrying a digest is refused by the push gate, including the tag@digest form
+// ParseRef now accepts (stokaro/ptah#944). Accepting that shape must not let a
+// push through: the tag beside the digest is a label, not a push target.
 func TestPush_DigestReferenceFailsBeforeNetworkAccess(t *testing.T) {
 	c := qt.New(t)
 	configDir := t.TempDir()
@@ -618,12 +622,22 @@ func TestPush_DigestReferenceFailsBeforeNetworkAccess(t *testing.T) {
 	t.Setenv("DOCKER_CONFIG", configDir)
 	client, err := ociartifact.NewClient(ociartifact.ClientOptions{})
 	c.Assert(err, qt.IsNil)
-	digestRef := "oci://registry.invalid/acme/migrations@sha256:" +
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	digest := "sha256:" + strings.Repeat("a", 64)
+	tests := []struct {
+		name string
+		ref  string
+	}{
+		{name: "digest only", ref: "oci://registry.invalid/acme/migrations@" + digest},
+		{name: "tag and digest", ref: "oci://registry.invalid/acme/migrations:stable@" + digest},
+	}
 
-	_, err = client.Push(context.Background(), digestRef, fstest.MapFS{
-		"migration.sql": {Data: []byte("SELECT 1;")},
-	}, ociartifact.PushOptions{ArtifactType: ociartifact.MigrationArtifactType})
-	c.Assert(err, qt.ErrorIs, ociartifact.ErrDigestPush)
-	c.Assert(err, qt.Not(qt.ErrorIs), ociartifact.ErrInvalidReference)
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := client.Push(context.Background(), tt.ref, fstest.MapFS{
+				"migration.sql": {Data: []byte("SELECT 1;")},
+			}, ociartifact.PushOptions{ArtifactType: ociartifact.MigrationArtifactType})
+			c.Assert(err, qt.ErrorIs, ociartifact.ErrDigestPush)
+			c.Assert(err, qt.Not(qt.ErrorIs), ociartifact.ErrInvalidReference)
+		})
+	}
 }

--- a/internal/ociartifact/reference.go
+++ b/internal/ociartifact/reference.go
@@ -41,11 +41,18 @@ type Reference struct {
 	registry   string
 	repository string
 	selector   string
+	tag        string
 	digest     bool
 }
 
 // ParseRef parses an oci://registry/repository[:tag][@digest] reference.
 // An omitted selector resolves to :latest.
+//
+// A reference may name a tag and a digest together, which is the shape a
+// promotion pipeline emits: "the artifact we call :release, resolved to these
+// bytes". The digest always decides which bytes are fetched, exactly as every
+// other OCI client behaves when the two disagree; the tag is kept for display
+// only, because dropping what the author wrote is itself a silent discard.
 func ParseRef(raw string) (Reference, error) {
 	if raw == "" || strings.TrimSpace(raw) != raw {
 		return Reference{}, fmt.Errorf("%w: reference must not be empty or contain surrounding whitespace", ErrInvalidReference)
@@ -62,11 +69,19 @@ func ParseRef(raw string) (Reference, error) {
 		return Reference{}, fmt.Errorf("%w: %v", ErrInvalidReference, err)
 	}
 	selector := parsed.ReferenceOrDefault()
+	isDigest := strings.Contains(selector, ":")
+	tag := selector
+	if isDigest {
+		// oras-go resolves tag@digest by the digest and drops the tag from the
+		// parsed value, so recover the author's tag from the raw text.
+		tag = tagBeforeDigest(value)
+	}
 	return Reference{
 		registry:   parsed.Registry,
 		repository: parsed.Repository,
 		selector:   selector,
-		digest:     strings.Contains(selector, ":"),
+		tag:        tag,
+		digest:     isDigest,
 	}, nil
 }
 
@@ -80,8 +95,6 @@ func validateReferenceText(value string) error {
 		return fmt.Errorf("%w: escaped path separators are not supported", ErrInvalidReference)
 	case hasUserInfo(value):
 		return fmt.Errorf("%w: embedded credentials are not supported", ErrInvalidReference)
-	case hasTagAndDigest(value):
-		return fmt.Errorf("%w: a reference cannot contain both a tag and a digest", ErrInvalidReference)
 	default:
 		return nil
 	}
@@ -98,13 +111,20 @@ func hasUserInfo(value string) bool {
 	return firstAt >= 0 && (firstSlash < 0 || firstAt < firstSlash)
 }
 
-func hasTagAndDigest(value string) bool {
+// tagBeforeDigest returns the tag written alongside a digest, or the empty
+// string when the reference named no tag. hasUserInfo already rejected an "@"
+// before the first "/", so the first "@" here starts the digest.
+func tagBeforeDigest(value string) string {
 	beforeDigest, _, hasDigest := strings.Cut(value, "@")
 	if !hasDigest {
-		return false
+		return ""
 	}
 	lastSlash := strings.LastIndexByte(beforeDigest, '/')
-	return strings.Contains(beforeDigest[lastSlash+1:], ":")
+	_, tag, ok := strings.Cut(beforeDigest[lastSlash+1:], ":")
+	if !ok {
+		return ""
+	}
+	return tag
 }
 
 // Registry returns the registry host, with an optional port.
@@ -128,13 +148,12 @@ func (r Reference) IsDigest() bool {
 }
 
 // Tag returns the registry tag the author named, or the empty string when the
-// reference selected content by digest instead. A tag is a movable registry
-// pointer: whoever can push to the repository can repoint it at other bytes.
+// reference named none. A tag is a movable registry pointer: whoever can push
+// to the repository can repoint it at other bytes. A reference that names both
+// a tag and a digest keeps its tag here while resolving by the digest, so the
+// tag is a label, not a selector.
 func (r Reference) Tag() string {
-	if r.digest {
-		return ""
-	}
-	return r.selector
+	return r.tag
 }
 
 // PinnedString renders the canonical oci:// form that selects digest exactly,
@@ -143,13 +162,17 @@ func (r Reference) PinnedString(digest string) string {
 	return Scheme + r.repositoryName() + "@" + digest
 }
 
-// String returns the canonical oci:// form.
+// String returns the canonical oci:// form. A reference that named both a tag
+// and a digest renders both, so round-tripping through String preserves what
+// the author wrote rather than silently narrowing it to the digest.
 func (r Reference) String() string {
-	separator := ":"
-	if r.digest {
-		separator = "@"
+	if !r.digest {
+		return Scheme + r.repositoryName() + ":" + r.selector
 	}
-	return Scheme + r.repositoryName() + separator + r.selector
+	if r.tag == "" {
+		return Scheme + r.repositoryName() + "@" + r.selector
+	}
+	return Scheme + r.repositoryName() + ":" + r.tag + "@" + r.selector
 }
 
 func (r Reference) repositoryName() string {

--- a/internal/ociartifact/reference.go
+++ b/internal/ociartifact/reference.go
@@ -127,6 +127,22 @@ func (r Reference) IsDigest() bool {
 	return r.digest
 }
 
+// Tag returns the registry tag the author named, or the empty string when the
+// reference selected content by digest instead. A tag is a movable registry
+// pointer: whoever can push to the repository can repoint it at other bytes.
+func (r Reference) Tag() string {
+	if r.digest {
+		return ""
+	}
+	return r.selector
+}
+
+// PinnedString renders the canonical oci:// form that selects digest exactly,
+// which is the reference an operator should adopt to stop depending on a tag.
+func (r Reference) PinnedString(digest string) string {
+	return Scheme + r.repositoryName() + "@" + digest
+}
+
 // String returns the canonical oci:// form.
 func (r Reference) String() string {
 	separator := ":"

--- a/internal/ociartifact/reference_test.go
+++ b/internal/ociartifact/reference_test.go
@@ -18,6 +18,7 @@ func TestParseRef_HappyPath(t *testing.T) {
 		registry   string
 		repository string
 		selector   string
+		tag        string
 		digest     bool
 		canonical  string
 	}{
@@ -27,6 +28,7 @@ func TestParseRef_HappyPath(t *testing.T) {
 			registry:   "ghcr.io",
 			repository: "acme/app",
 			selector:   "latest",
+			tag:        "latest",
 			canonical:  "oci://ghcr.io/acme/app:latest",
 		},
 		{
@@ -35,6 +37,7 @@ func TestParseRef_HappyPath(t *testing.T) {
 			registry:   "registry.example:5000",
 			repository: "team/app",
 			selector:   "v1.2.3",
+			tag:        "v1.2.3",
 			canonical:  "oci://registry.example:5000/team/app:v1.2.3",
 		},
 		{
@@ -46,6 +49,29 @@ func TestParseRef_HappyPath(t *testing.T) {
 			digest:     true,
 			canonical:  "oci://ghcr.io/acme/app@" + digest,
 		},
+		{
+			// The readable pin a promotion pipeline emits. The selector must
+			// stay the digest — if it ever became the tag, a display nicety
+			// would have silently downgraded resolution to a movable pointer.
+			name:       "tag and digest",
+			raw:        "oci://ghcr.io/acme/app:stable@" + digest,
+			registry:   "ghcr.io",
+			repository: "acme/app",
+			selector:   digest,
+			tag:        "stable",
+			digest:     true,
+			canonical:  "oci://ghcr.io/acme/app:stable@" + digest,
+		},
+		{
+			name:       "tag and digest with registry port",
+			raw:        "oci://registry.example:5000/team/app:release@" + digest,
+			registry:   "registry.example:5000",
+			repository: "team/app",
+			selector:   digest,
+			tag:        "release",
+			digest:     true,
+			canonical:  "oci://registry.example:5000/team/app:release@" + digest,
+		},
 	}
 
 	for _, tt := range tests {
@@ -55,15 +81,24 @@ func TestParseRef_HappyPath(t *testing.T) {
 			c.Assert(got.Registry(), qt.Equals, tt.registry)
 			c.Assert(got.Repository(), qt.Equals, tt.repository)
 			c.Assert(got.Selector(), qt.Equals, tt.selector)
+			c.Assert(got.Tag(), qt.Equals, tt.tag)
 			c.Assert(got.IsDigest(), qt.Equals, tt.digest)
 			c.Assert(got.String(), qt.Equals, tt.canonical)
+
+			// The canonical form must parse back to the same reference, so
+			// nothing the author wrote is lost by a round trip through a
+			// display string.
+			round, err := ociartifact.ParseRef(got.String())
+			c.Assert(err, qt.IsNil)
+			c.Assert(round.Selector(), qt.Equals, tt.selector)
+			c.Assert(round.Tag(), qt.Equals, tt.tag)
+			c.Assert(round.String(), qt.Equals, tt.canonical)
 		})
 	}
 }
 
 func TestParseRef_FailurePath(t *testing.T) {
 	c := qt.New(t)
-	digest := "sha256:" + strings.Repeat("a", 64)
 	tests := []struct {
 		name string
 		raw  string
@@ -80,7 +115,11 @@ func TestParseRef_FailurePath(t *testing.T) {
 		{name: "encoded backslash", raw: "oci://ghcr.io/acme%5Capp"},
 		{name: "backslash", raw: `oci://ghcr.io/acme\app`},
 		{name: "NUL byte", raw: "oci://ghcr.io/acme/\x00app"},
-		{name: "tag and digest", raw: "oci://ghcr.io/acme/app:stable@" + digest},
+		// A tag next to a digest is accepted, but the digest still has to be a
+		// digest: accepting the shape must not weaken what it selects.
+		{name: "tag and malformed digest", raw: "oci://ghcr.io/acme/app:stable@sha256:beef"},
+		{name: "tag and non-digest suffix", raw: "oci://ghcr.io/acme/app:stable@notadigest"},
+		{name: "tag and unknown digest algorithm", raw: "oci://ghcr.io/acme/app:stable@md5:" + strings.Repeat("a", 32)},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Closes #944.

`--verify-sum` reported `ptah.sum verified: migrations directory is intact` for three materially different provenances — a local directory, an OCI digest, and an OCI **tag** — in byte-identical wording. Only the first two make the claim mean anything.

## The defect, reproduced end to end against a live registry

```
push  oci://.../m944:release --verify-sum     -> exit 0, digest sha256:ea7c87e2...
up    oci://.../m944:release --verify-sum     -> exit 0, "ptah.sum verified", applies 1775000101

# append CREATE TABLE evil, re-hash, re-push to the SAME :release tag
push  oci://.../m944:release --verify-sum     -> exit 0, digest sha256:544b03ae...

# byte-identical command from step 2, fresh database
up    oci://.../m944:release --verify-sum     -> exit 0, byte-identical "verified" line
sqlite3 app2.db .tables                       -> evil  schema_migrations  widgets
```

The check passed while the content it vouched for had been swapped. `migratesum` verifies a filesystem against its own sum — self-consistency, not authenticity — and a movable tag is exactly where those two come apart.

The control that makes this a measurement rather than an anecdote: the same command against the **pre-tamper digest** applies the original migrations and prints the *same* line. Sound and unsound cases were indistinguishable.

## What changes

A run whose sum was verified through a movable OCI tag now says so, and names the digest it actually resolved to, so an operator can learn after the fact which bytes ran. A digest reference and a local directory stay warning-free.

## Verification

I re-proved the discriminator myself in both directions rather than accepting the report, because the review flagged it as unproven:

- **deleting the emission** → `TestMigrateUp_OCISumProvenance` red
- **inverting the guard** so it fires where it should not → `TestMigrateUpCommand_CheckDirectiveFilePassingCheckApplies` red

Both directions matter here: a warning that never fires and a warning that always fires are equally useless, and only one of them is caught by asserting presence.

Half (a) is not engaged. Both surfaces are native-`ptah`-only: the pinned community binary answers `unsupported driver "oci"` and `unknown flag: --verify-sum`, and `ptah-compat` exits 1 in the same places. Nine reference shapes across `status`/`apply`/`lint` measured 1/1 on both.

`go build`, `go vet`, `go test ./... -count=1`, `golangci-lint`, the public-API gate and both docs gates are clean.

## Left for its own issue

`oci://repo:tag@sha256:...` — the canonical way to write "this tag, pinned to this digest" — is refused with `a reference cannot contain both a tag and a digest`. The vendored library accepts the form and resolves by digest; the rejection is Ptah's own. That is additive work rather than part of this warning, and it deserves its own measurement.
