### PR TITLE
Refuse a directory the integrity glob matches

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -472,6 +472,11 @@ func verifyConvertedAtlasApplyChecksum(
 	switch {
 	case errors.Is(err, migratesum.ErrSumFileMalformed):
 		return migratevalidate.FailAtlasChecksumMismatch(cmd, nil)
+	case errors.Is(err, migratesum.ErrCoveredEntryUnreadable):
+		// A covered entry that is a directory (#991). It reaches here on the
+		// converted path too, because SumFileNames selects by name and the
+		// captured snapshot now records such a directory instead of dropping it.
+		return migratevalidate.FailAtlasChecksumUnreadableEntry(cmd, err)
 	case err != nil:
 		return err
 	case !hashed && len(names) == 0:

--- a/cmd/atlas/migrate_integrity_gate.go
+++ b/cmd/atlas/migrate_integrity_gate.go
@@ -74,6 +74,11 @@ func checkNativeAtlasDirChecksum(cmd *cobra.Command, fsys fs.FS) error {
 		// A malformed atlas.sum has no entry-level mismatch to point at; the
 		// validate surface reports it as a plain checksum mismatch.
 		return migratevalidate.FailAtlasChecksumMismatch(cmd, nil)
+	case errors.Is(err, migratesum.ErrCoveredEntryUnreadable):
+		// A covered entry that is a directory (#991). The community binary
+		// prints the checksum preamble here, not a bare error, so routing it
+		// anywhere else would lose the stream layout this gate exists to match.
+		return migratevalidate.FailAtlasChecksumUnreadableEntry(cmd, err)
 	case err != nil:
 		return err
 	case !hashed:

--- a/cmd/atlas/migrate_integrity_resolution_test.go
+++ b/cmd/atlas/migrate_integrity_resolution_test.go
@@ -269,6 +269,12 @@ func TestCompatMigrateValidateConvertedDevURL_FailurePath(t *testing.T) {
 	})
 }
 
+// atlasChecksumPreamble is the guidance block Atlas CE writes to STDOUT before
+// refusing a directory over its integrity file, with no `L<n>:` line because
+// nothing mismatched — the directory could not be hashed at all.
+const atlasChecksumPreamble = "You have a checksum error in your migration directory.\n" +
+	"Please check your migration files and run 'atlas migrate hash' to re-hash the contents\n\n"
+
 // directoryNamedSQLRefusal is the message every verb reports for a covered
 // entry that turns out to be a directory. Ptah's wording is deliberately not
 // the community binary's: see migratesum's coveredDirectoryError.
@@ -420,4 +426,112 @@ func TestCompatMigrateHashDirectoryNamedSQL(t *testing.T) {
 			tt.assert(c, dir, err)
 		})
 	}
+}
+
+// TestCompatMigrateNativeDirectoryNamedSQL pins the four NATIVE verbs that
+// verify a captured snapshot rather than the live directory.
+//
+// This is the half a fix confined to the file-set selection does not reach, and
+// it was measured to be exactly that: with the selection corrected and the
+// snapshot untouched, `migrate apply` still exited 0 here. Those verbs verify an
+// fsnapshot.Snapshot, which recorded only files, so a directory holding no
+// captured file vanished between the capture and the check and the recomputed
+// sum still matched.
+//
+// Every row is seeded by hashing the directory while it is clean, so the sum
+// under test is one Atlas CE itself would have written; the directory appears
+// afterwards. Measured against the pinned binary v1.3.0 on 2026-08-03, that
+// binary exits 1 on all four verbs, printing the checksum preamble on stdout
+// and the read failure on stderr. Nothing unverified executes — a directory
+// holds no SQL — so this is a loss of tamper DETECTION rather than of execution
+// safety, and it is still exit 0 where the community binary exits 1.
+//
+// The second shape (a non-SQL file inside the directory) is not decoration: the
+// capture predicate admits *.sql and the metadata names, so a note.txt was
+// filtered out and, with nothing left underneath, the directory disappeared
+// again.
+func TestCompatMigrateNativeDirectoryNamedSQL(t *testing.T) {
+	c := qt.New(t)
+
+	shapes := []struct {
+		name  string
+		files map[string]string
+		dirs  []string
+	}{{
+		name: "empty directory",
+		dirs: []string{"2_evil.sql"},
+	}, {
+		name:  "directory holding an uncaptured file",
+		files: map[string]string{"2_evil.sql/note.txt": "hello\n"},
+	}}
+
+	verbs := []struct {
+		name string
+		args func(dir, dbPath string) []string
+		// assertStreams pins where each verb writes its refusal. apply, status
+		// and set reproduce the community binary's layout exactly; lint reports
+		// through its own integrity surface, a divergence that predates #991 and
+		// shows identically on an ordinary tampered directory.
+		assertStreams func(c *qt.C, stdout, stderr string)
+	}{{
+		name: "apply",
+		args: func(dir, dbPath string) []string {
+			return []string{"migrate", "apply", "--dir", "file://" + dir, "--url", "sqlite://" + dbPath}
+		},
+		assertStreams: assertAtlasChecksumStreams,
+	}, {
+		name: "status",
+		args: func(dir, dbPath string) []string {
+			return []string{"migrate", "status", "--dir", "file://" + dir, "--url", "sqlite://" + dbPath}
+		},
+		assertStreams: assertAtlasChecksumStreams,
+	}, {
+		name: "set",
+		args: func(dir, dbPath string) []string {
+			return []string{"migrate", "set", "1", "--dir", "file://" + dir, "--url", "sqlite://" + dbPath}
+		},
+		assertStreams: assertAtlasChecksumStreams,
+	}, {
+		name: "lint",
+		args: func(dir, dbPath string) []string {
+			return []string{
+				"migrate", "lint", "--dir", "file://" + dir,
+				"--dev-url", "sqlite://" + dbPath + "?mode=memory", "--latest", "1",
+			}
+		},
+		assertStreams: func(c *qt.C, _, stderr string) {
+			c.Assert(stderr, qt.Contains, fmt.Sprintf(directoryNamedSQLRefusal, "2_evil.sql"))
+		},
+	}}
+
+	for _, shape := range shapes {
+		for _, verb := range verbs {
+			c.Run(shape.name+"/"+verb.name, func(c *qt.C) {
+				dir := writeDirectoryNamedSQLFixture(c,
+					map[string]string{"1_init.sql": "CREATE TABLE w (id INTEGER PRIMARY KEY);\n"}, nil)
+				hashOut, _, hashErr := runCompatExit("migrate", "hash", "--dir", "file://"+dir)
+				c.Assert(hashErr, qt.IsNil, qt.Commentf("seed:\n%s", hashOut))
+
+				// The sum above covers only 1_init.sql, exactly as the community
+				// binary's would; the directory appears afterwards.
+				writeDirectoryNamedSQLEntries(c, dir, shape.files, shape.dirs)
+
+				stdout, stderr, err := runCompatExit(
+					verb.args(dir, filepath.Join(c.TempDir(), "evil.db"))...)
+
+				c.Assert(exitcode.Code(err, 0), qt.Equals, 1,
+					qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+				verb.assertStreams(c, stdout, stderr)
+			})
+		}
+	}
+}
+
+// assertAtlasChecksumStreams pins the stream layout the community binary uses
+// for a checksum refusal: guidance on stdout, the reason on stderr.
+func assertAtlasChecksumStreams(c *qt.C, stdout, stderr string) {
+	c.Helper()
+	c.Assert(stdout, qt.Equals, atlasChecksumPreamble)
+	c.Assert(stderr, qt.Equals,
+		"Error: "+fmt.Sprintf(directoryNamedSQLRefusal, "2_evil.sql")+"\n")
 }

--- a/cmd/atlas/migrate_integrity_resolution_test.go
+++ b/cmd/atlas/migrate_integrity_resolution_test.go
@@ -1,8 +1,10 @@
 package atlas_test
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -267,91 +269,155 @@ func TestCompatMigrateValidateConvertedDevURL_FailurePath(t *testing.T) {
 	})
 }
 
-// TestCompatMigrateHashDirectoryNamedSQL_KnownDivergence pins MINOR 7, measured
-// against the pinned CE binary on 2026-08-02.
+// directoryNamedSQLRefusal is the message every verb reports for a covered
+// entry that turns out to be a directory. Ptah's wording is deliberately not
+// the community binary's: see migratesum's coveredDirectoryError.
+const directoryNamedSQLRefusal = `read file "%s": is a directory, not a migration file; ` +
+	`rename it or move it out of the migration directory`
+
+// writeDirectoryNamedSQLEntries writes files and empty directories under dir.
+// Directories are created before files so a case can nest a migration inside a
+// directory whose own name ends in .sql.
+func writeDirectoryNamedSQLEntries(c *qt.C, dir string, files map[string]string, dirs []string) {
+	c.Helper()
+	for _, name := range dirs {
+		c.Assert(os.MkdirAll(filepath.Join(dir, filepath.FromSlash(name)), 0o755), qt.IsNil)
+	}
+	for name, content := range files {
+		full := filepath.Join(dir, filepath.FromSlash(name))
+		c.Assert(os.MkdirAll(filepath.Dir(full), 0o755), qt.IsNil)
+		c.Assert(os.WriteFile(full, []byte(content), 0o600), qt.IsNil)
+	}
+}
+
+func writeDirectoryNamedSQLFixture(c *qt.C, files map[string]string, dirs []string) string {
+	c.Helper()
+	dir := c.TempDir()
+	writeDirectoryNamedSQLEntries(c, dir, files, dirs)
+	return dir
+}
+
+// wantDirectoryRefusal renders the refusal message for name as an anchored
+// regexp, so the assertion pins the whole string rather than a substring.
+func wantDirectoryRefusal(name string) string {
+	return regexp.QuoteMeta(fmt.Sprintf(directoryNamedSQLRefusal, name))
+}
+
+func assertNoAtlasSum(c *qt.C, dir string) {
+	c.Helper()
+	_, statErr := os.Stat(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(os.IsNotExist(statErr), qt.IsTrue, qt.Commentf("an atlas.sum was written for a refused directory"))
+}
+
+// TestCompatMigrateHashDirectoryNamedSQL pins the per-format membership rule for
+// a DIRECTORY whose name matches the layout's glob, measured against the pinned
+// community binary v1.3.0 on 2026-08-03 (stokaro/ptah#991).
 //
-// A DIRECTORY whose name ends in .sql is matched by Atlas CE's own glob, which
-// then fails to read it, so CE refuses to hash the whole directory and writes
-// nothing:
+// Atlas CE reaches every non-Flyway layout through a per-format glob, and a
+// glob matches on the name alone, so a directory called weird.sql is a member of
+// the covered set. The read that follows fails and the oracle refuses the whole
+// directory, writing no atlas.sum:
 //
 //	$ atlas migrate hash --dir 'file://w?format=goose'
 //	Error: sql/migrate: read file "weird.sql": read w/weird.sql: is a directory
 //	exit=1, no atlas.sum written
 //
-// atlasmigrateimport.SumFileNames skips directories, so the converted path
-// writes a sum instead — a sum CE then refuses to read:
+// Ptah used to skip the entry and write a sum over the remainder — a sum the
+// community binary then refused to read, which is the trap #991 reports. Every
+// row here separates the fix from a plausible alternative, so passing is
+// evidence about the RULE and not only about the headline shape:
 //
-//	$ atlas migrate validate --dir 'file://w?format=goose'   # sum written by Ptah
-//	Error: sql/migrate: read file "weird.sql": read w/weird.sql: is a directory
-//
-// An earlier version of this comment called that the only direction that
-// matters, because CE can never produce such a sum itself. That is true and
-// beside the point: CE hashes the directory BEFORE the *.sql directory exists,
-// and the shape then appears on a directory whose sum CE wrote. Measured on
-// 2026-08-02, that is a refusal on CE and an apply here:
-//
-//	$ mkdir 2_evil.sql            # after `atlas migrate hash`
-//	$ atlas       migrate apply … Error: … read "2_evil.sql": … is a directory   exit=1
-//	$ ptah-compat migrate apply … Migration complete. Current version: 1         exit=0
-//
-// Nothing unverified executes — a directory holds no SQL — so this is loss of
-// tamper DETECTION rather than of execution safety. It is still CE refusing
-// where Ptah applies, so the apply direction is pinned here alongside the
-// hash and validate ones (stokaro/ptah#991).
-//
-// The native atlas path globs like CE and fails, differently worded. The two
-// Ptah paths therefore disagree with each other, which is why this is pinned
-// rather than left to be discovered.
-func TestCompatMigrateHashDirectoryNamedSQL_KnownDivergence(t *testing.T) {
+//   - goose with the directory, and goose without it. The second is what stops
+//     "always refuse" from passing.
+//   - golang-migrate beside weird.sql (accepted) and beside weird.up.sql
+//     (refused). The oracle globs *.up.sql for that format, so this pair pins
+//     that the suffix filter decides membership rather than the read.
+//   - flyway beside weird.sql, and with a migration nested inside it. The
+//     oracle WALKS a Flyway tree instead of globbing it, so a directory is a
+//     node it descends into and never reads: both tools exit 0 and produce
+//     byte-identical sums. These rows fail if the fix is applied to treeNames
+//     or expressed as "reject any .sql directory".
+func TestCompatMigrateHashDirectoryNamedSQL(t *testing.T) {
 	c := qt.New(t)
 
-	c.Run("converted layout skips it and writes a sum", func(c *qt.C) {
-		dir := c.TempDir()
-		c.Assert(os.MkdirAll(filepath.Join(dir, "weird.sql"), 0o755), qt.IsNil)
-		c.Assert(os.WriteFile(filepath.Join(dir, "1_init.sql"),
-			[]byte("-- +goose Up\nCREATE TABLE w (id int);\n"), 0o600), qt.IsNil)
+	const gooseBody = "-- +goose Up\nCREATE TABLE w (id int);\n"
+	const plainBody = "CREATE TABLE w (id int);\n"
 
-		stdout, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=goose")
+	tests := []struct {
+		name   string
+		format string
+		files  map[string]string
+		dirs   []string
+		assert func(c *qt.C, dir string, err error)
+	}{{
+		name:   "goose refuses a directory its glob matches",
+		format: "goose",
+		files:  map[string]string{"1_init.sql": gooseBody},
+		dirs:   []string{"weird.sql"},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(err, qt.ErrorMatches, wantDirectoryRefusal("weird.sql"))
+			assertNoAtlasSum(c, dir)
+		},
+	}, {
+		name:   "goose hashes the same layout without the directory",
+		format: "goose",
+		files:  map[string]string{"1_init.sql": gooseBody},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(sumEntryNames(c, dir), qt.DeepEquals, []string{"1_init.sql"})
+		},
+	}, {
+		name:   "golang-migrate ignores a directory outside its glob",
+		format: "golang-migrate",
+		files:  map[string]string{"1_init.up.sql": plainBody},
+		dirs:   []string{"weird.sql"},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(sumEntryNames(c, dir), qt.DeepEquals, []string{"1_init.up.sql"})
+		},
+	}, {
+		name:   "golang-migrate refuses a directory its glob matches",
+		format: "golang-migrate",
+		files:  map[string]string{"1_init.up.sql": plainBody},
+		dirs:   []string{"weird.up.sql"},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(err, qt.ErrorMatches, wantDirectoryRefusal("weird.up.sql"))
+			assertNoAtlasSum(c, dir)
+		},
+	}, {
+		name:   "flyway walks past a directory named sql",
+		format: "flyway",
+		files:  map[string]string{"V1__init.sql": plainBody},
+		dirs:   []string{"weird.sql"},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(sumEntryNames(c, dir), qt.DeepEquals, []string{"V1__init.sql"})
+		},
+	}, {
+		name:   "flyway still covers a migration nested inside one",
+		format: "flyway",
+		files: map[string]string{
+			"V1__init.sql":             plainBody,
+			"weird.sql/V2__nested.sql": "CREATE TABLE n (id int);\n",
+		},
+		assert: func(c *qt.C, dir string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(sumEntryNames(c, dir), qt.DeepEquals,
+				[]string{"V1__init.sql", "weird.sql/V2__nested.sql"})
+		},
+	}}
 
-		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-		c.Assert(stdout, qt.Equals, "")
-		c.Assert(sumEntryNames(c, dir), qt.DeepEquals, []string{"1_init.sql"})
-	})
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dir := writeDirectoryNamedSQLFixture(c, tt.files, tt.dirs)
 
-	c.Run("apply accepts a sum CE wrote before the directory appeared", func(c *qt.C) {
-		dir := c.TempDir()
-		c.Assert(os.WriteFile(filepath.Join(dir, "1_init.sql"),
-			[]byte("-- +goose Up\nCREATE TABLE w (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
-		// Hashed while the directory holds only the migration, so the sum is one
-		// Atlas CE would have written too.
-		stdout, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=goose")
-		c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-		c.Assert(os.MkdirAll(filepath.Join(dir, "2_evil.sql"), 0o755), qt.IsNil)
+			stdout, stderr, err := runCompatExit(
+				"migrate", "hash", "--dir", "file://"+dir+"?format="+tt.format)
 
-		dbPath := filepath.Join(c.TempDir(), "evil.db")
-		stdout, stderr, err := runCompatExit(
-			"migrate", "apply",
-			"--url", "sqlite://"+dbPath,
-			"--dir", "file://"+dir+"?format=goose",
-		)
-
-		// Atlas CE exits 1 here. Ptah applies, because SumFileNames skips the
-		// directory and the recomputed sum still matches.
-		c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-		c.Assert(stdout, qt.Not(qt.Contains), "checksum")
-	})
-
-	c.Run("native atlas layout refuses it", func(c *qt.C) {
-		dir := c.TempDir()
-		c.Assert(os.MkdirAll(filepath.Join(dir, "weird.sql"), 0o755), qt.IsNil)
-		c.Assert(os.WriteFile(filepath.Join(dir, "1_init.sql"),
-			[]byte("CREATE TABLE w (id int);\n"), 0o600), qt.IsNil)
-
-		_, _, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir)
-
-		c.Assert(err, qt.ErrorMatches, `failed to read weird.sql: .*is a directory`)
-		c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-		_, statErr := os.Stat(filepath.Join(dir, migratesum.AtlasFileName))
-		c.Assert(os.IsNotExist(statErr), qt.IsTrue)
-	})
+			c.Assert(stdout, qt.Equals, "", qt.Commentf("stderr:\n%s", stderr))
+			tt.assert(c, dir, err)
+		})
+	}
 }

--- a/cmd/atlas/migrate_validate.go
+++ b/cmd/atlas/migrate_validate.go
@@ -68,6 +68,10 @@ func runAtlasMigrateValidate(cmd *cobra.Command, source atlasMigrateSource) erro
 	case errors.Is(err, migratesum.ErrSumFileMalformed):
 		// A malformed atlas.sum has no entry-level mismatch to point at.
 		return migratevalidate.FailAtlasChecksumMismatch(cmd, nil)
+	case errors.Is(err, migratesum.ErrCoveredEntryUnreadable):
+		// A covered entry that is a directory (#991): a checksum refusal with
+		// the guidance preamble, not a bare command failure.
+		return migratevalidate.FailAtlasChecksumUnreadableEntry(cmd, err)
 	case err != nil:
 		return cmdutil.Fail(cmd, err)
 	case !hashed:

--- a/cmd/migratevalidate/migratevalidate.go
+++ b/cmd/migratevalidate/migratevalidate.go
@@ -49,6 +49,24 @@ func FailAtlasChecksumMismatch(cmd *cobra.Command, mismatch *migratesum.Mismatch
 	return failAtlasChecksum(cmd, mismatch, errAtlasChecksumMismatch)
 }
 
+// FailAtlasChecksumUnreadableEntry writes the Atlas CE checksum guidance for a
+// directory holding a covered entry that cannot be read, and returns the exit-1
+// error carrying cause's own message.
+//
+// The community binary treats this as a checksum error and not as an ordinary
+// command failure: it prints the same stdout guidance block it prints for
+// drift, then the read failure on stderr, on `migrate validate`, `apply`,
+// `status` and `set` alike. Measured against the pinned v1.3.0 binary, that is
+// the shape reproduced here (stokaro/ptah#991). There is no `L<n>:` line
+// because no entry mismatched — the directory could not be hashed at all.
+//
+// `migrate hash` is the one verb that does NOT get the preamble, on that binary
+// and here: there is no recorded sum to be in error with, so the read failure
+// is reported bare.
+func FailAtlasChecksumUnreadableEntry(cmd *cobra.Command, cause error) error {
+	return failAtlasChecksum(cmd, nil, cause)
+}
+
 // FailAtlasChecksumFileNotFound writes the Atlas CE checksum guidance for a
 // directory that carries no integrity file and returns the exit-1 "checksum
 // file not found" error. Apply-time integrity gates use it so refusing an
@@ -114,6 +132,11 @@ func runAtlasValidate(cmd *cobra.Command, dir, dirFormatValue, devURL string) er
 	case errors.Is(err, migratesum.ErrSumFileMalformed):
 		// A malformed sum file has no entry-level mismatch to point at.
 		return FailAtlasChecksumMismatch(cmd, nil)
+	case errors.Is(err, migratesum.ErrCoveredEntryUnreadable):
+		// A covered entry that is a directory (#991). The community binary
+		// prints the checksum preamble for it, so this is a checksum refusal
+		// and not a usage failure.
+		return FailAtlasChecksumUnreadableEntry(cmd, err)
 	case err != nil:
 		return cmdutil.Fail(cmd, err)
 	}

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -191,6 +191,31 @@ check, exactly as it is in Atlas. A directory that carries no `atlas.sum` and
 whose covered set is empty — a golang-migrate directory holding only a down
 file, say — is not a checksum error and is not refused.
 
+:::caution[A **directory** whose name matches is covered too, and cannot be hashed]
+Membership in the covered set is decided by the name, so a *directory* called
+`weird.sql` is a member for `atlas`, `goose`, `dbmate` and `liquibase`, and one
+called `weird.up.sql` is a member for `golang-migrate`. Reading it fails, so
+there is no sum to write and no sum to verify: `hash`, `validate`, `apply`,
+`status`, `set` and `lint` all refuse the directory and exit `1`, matching
+Atlas. Rename the directory or move it out of the migrations directory.
+
+```text
+$ ptah-compat migrate hash --dir 'file://migrations?format=goose'
+Error: read file "weird.sql": is a directory, not a migration file; rename it or move it out of the migration directory
+```
+
+**This is a behavior change.** Releases up to v0.1.2 skipped such a directory
+and wrote an `atlas.sum` over the remaining files — a file Atlas itself then
+refused to read, so the directory looked hashed here and was rejected there
+([#991](https://github.com/stokaro/ptah/issues/991)). A project with a
+legitimately named `*.sql` directory that hashed cleanly before will now be
+refused.
+
+`flyway` is exempt on both tools, and not by special-casing: Atlas walks a
+Flyway tree instead of globbing it, so a directory is a node it descends into
+and never reads. A migration nested inside one is covered as usual.
+:::
+
 For every layout, "not covered by `atlas.sum`" also means "not executed": the
 set `migrate apply` runs is the set the checksum it verified covers. Flyway was
 the exception until [#982](https://github.com/stokaro/ptah/issues/982) — its

--- a/internal/atlasmigrateimport/sumfiles.go
+++ b/internal/atlasmigrateimport/sumfiles.go
@@ -27,17 +27,34 @@ import (
 //
 // Formats differ in which files count and how deep Atlas looks:
 //
-//   - atlas, goose, dbmate, liquibase: every top-level *.sql file, ordered by
+//   - atlas, goose, dbmate, liquibase: every top-level *.sql ENTRY, ordered by
 //     name. File names carry no meaning to the hasher, so a non-versioned
 //     foo.sql counts while a sibling .go or .xml file does not.
-//   - golang-migrate: every top-level *.up.sql file, ordered by name. The down
+//   - golang-migrate: every top-level *.up.sql entry, ordered by name. The down
 //     file of a pair is not covered, so editing it is invisible to the
 //     integrity check — matching Atlas CE, which never reads it.
 //   - flyway: the whole tree, and not in name order. See flywaySumFileNames.
 //
+// "Entry", not "file", is deliberate. Atlas CE reaches those four formats and
+// golang-migrate through a per-format glob (*.sql, or *.up.sql for
+// golang-migrate) that matches on the NAME, so a DIRECTORY called weird.sql is
+// a member of the covered set. The read that follows fails with "is a
+// directory" and the oracle refuses the whole directory, writing no atlas.sum
+// at all. This returns the directory's name for exactly that reason: skipping
+// it, as Ptah did before stokaro/ptah#991, hashed the remainder and wrote a sum
+// Atlas CE then declines to read — the caller's read is what refuses, and it
+// must be given the chance to fail.
+//
 // Flyway is the sole format Atlas CE recurses into. Every other format sees
 // only the top level, so a migration one directory down is not covered by the
-// integrity file at all.
+// integrity file at all. That recursion is also why Flyway is exempt from the
+// paragraph above and why treeNames keeps skipping directories: Atlas CE walks
+// a Flyway tree instead of globbing it, so there a directory is a walk node it
+// descends into and never attempts to read. Both tools hash V1__init.sql beside
+// a directory named weird.sql without complaint, and produce byte-identical
+// sums. Expressing the #991 fix as "reject any .sql directory", or applying it
+// to treeNames, would refuse three measured-identical Flyway shapes and a
+// golang-migrate directory holding weird.sql.
 //
 // The .sql suffix match is case-sensitive: Atlas CE covers no file named
 // 1_init.SQL, and neither does this.
@@ -103,6 +120,20 @@ func sumCoversNestedFile(format Format, name string) bool {
 	return true
 }
 
+// topLevelNames returns every top-level entry name, DIRECTORIES INCLUDED.
+//
+// Atlas CE reaches the top level of a non-Flyway layout through a glob, and a
+// glob matches on the name alone. A directory called weird.sql is therefore a
+// member of the covered set, and the read that follows fails with "is a
+// directory", which is why the oracle refuses to hash the whole directory
+// rather than skipping the entry (stokaro/ptah#991). Filtering directories out
+// here produced the opposite: a sum over the remainder that Atlas CE then
+// declines to read.
+//
+// The filtering is left to the caller's suffix rule so that membership is
+// decided by the same test for a directory as for a file — golang-migrate globs
+// *.up.sql, so a directory named weird.sql is NOT a member there while
+// weird.up.sql is. Both measured against the pinned oracle.
 func topLevelNames(fsys fs.FS) ([]string, error) {
 	entries, err := fs.ReadDir(fsys, ".")
 	if err != nil {
@@ -110,9 +141,6 @@ func topLevelNames(fsys fs.FS) ([]string, error) {
 	}
 	names := make([]string, 0, len(entries))
 	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
 		names = append(names, entry.Name())
 	}
 	// fs.ReadDir is documented to sort, but the order decides the sum, so it is
@@ -131,6 +159,14 @@ func skipHiddenDir(base string) bool {
 // path: sorting would place "sub.sql" before "sub/V1__x.sql" ('.' sorts below
 // '/') while a walk visits the directory first, and Flyway selection depends on
 // visit order. skipDir, when non-nil, prunes a directory by its base name.
+//
+// Directories are visited but never emitted, and unlike topLevelNames that is
+// CORRECT here rather than the #991 bug: Flyway is the only format Atlas CE
+// walks, so a directory named V2__x.sql is a node it descends into, not a path
+// it tries to read. Measured on all three Flyway shapes — an empty .sql
+// directory, one holding a nested migration, and one holding neither — both
+// tools exit 0 and write byte-identical sums. Emitting directories here would
+// invent a refusal the oracle does not make.
 func treeNames(fsys fs.FS, skipDir func(base string) bool) ([]string, error) {
 	var names []string
 	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, err error) error {

--- a/internal/atlasmigrateimport/sumfiles_fuzz_test.go
+++ b/internal/atlasmigrateimport/sumfiles_fuzz_test.go
@@ -168,20 +168,31 @@ func checkFlywayLayout(c *qt.C, oracle string, layout []string) {
 	dir := c.TempDir()
 	writeLayout(c, dir, layout)
 
-	want := oracleSum(c, oracle, dir, "flyway")
+	outcome := oracleHash(c, oracle, dir, "flyway")
+	names, hashable := assertPtahMatchesOracle(c, dir, atlasmigrateimport.FormatFlyway, outcome, layout)
 
-	fsys := os.DirFS(dir)
-	names, err := atlasmigrateimport.SumFileNames(fsys, atlasmigrateimport.FormatFlyway)
-
-	c.Assert(err, qt.IsNil)
-
-	sum, err := migratesum.ComputeAtlasFiles(fsys, names)
-	c.Assert(err, qt.IsNil)
-
-	c.Assert(string(sum.Bytes()), qt.Equals, want,
-		qt.Commentf("PTAH_ATLAS_FUZZ_LAYOUT=%s", strings.Join(layout, ",")))
+	// The capture cross-check applies either way: the gate must recompute the
+	// same covered set from the snapshot it verifies whether or not that set
+	// turns out to be hashable.
 	assertCaptureSelectsTheSame(c, dir, atlasmigrateimport.FormatFlyway, names, layout)
+	if !hashable {
+		return
+	}
 	assertImporterConsumesTheCoveredSet(c, dir, names, layout)
+}
+
+// checkPlainLayout is checkFlywayLayout for the suffix-filter formats. It is a
+// helper rather than an inline test body so the refusal branch does not count
+// against the repository's test-conditional ratchet.
+func checkPlainLayout(c *qt.C, oracle string, format atlasmigrateimport.Format, layout []string) {
+	c.Helper()
+
+	dir := c.TempDir()
+	writeLayout(c, dir, layout)
+
+	outcome := oracleHash(c, oracle, dir, string(format))
+	names, _ := assertPtahMatchesOracle(c, dir, format, outcome, layout)
+	assertCaptureSelectsTheSame(c, dir, format, names, layout)
 }
 
 // TestSumFileNamesDifferentialFuzzRealisticFlyway restricts generation to what
@@ -274,19 +285,7 @@ func TestSumFileNamesDifferentialFuzzOtherFormats(t *testing.T) {
 		for i := range 40 {
 			layout := randomPlainLayout(rng)
 			c.Run(fmt.Sprintf("%s-%02d", format, i), func(c *qt.C) {
-				dir := c.TempDir()
-				writeLayout(c, dir, layout)
-
-				want := oracleSum(c, oracle, dir, string(format))
-
-				fsys := os.DirFS(dir)
-				names, err := atlasmigrateimport.SumFileNames(fsys, format)
-				c.Assert(err, qt.IsNil)
-				sum, err := migratesum.ComputeAtlasFiles(fsys, names)
-				c.Assert(err, qt.IsNil)
-
-				c.Assert(string(sum.Bytes()), qt.Equals, want, qt.Commentf("layout:\n  %s", strings.Join(layout, "\n  ")))
-				assertCaptureSelectsTheSame(c, dir, format, names, layout)
+				checkPlainLayout(c, oracle, format, layout)
 			})
 		}
 	}
@@ -342,31 +341,122 @@ func requireOracle(t *testing.T) string {
 	return oracle
 }
 
-func oracleSum(c *qt.C, oracle, dir, format string) string {
+// oracleOutcome is what the pinned binary did with one generated directory.
+// A refusal is an OBSERVATION to compare against, not a harness failure.
+//
+// It used to be one. oracleSum asserted the oracle's exit was nil, so any shape
+// the oracle declined aborted the run instead of being recorded — and the shape
+// it declines is exactly the one #991 is about. A differential harness that can
+// only represent agreement certifies agreement.
+type oracleOutcome struct {
+	sum     string
+	refused bool
+	output  string
+}
+
+func oracleHash(c *qt.C, oracle, dir, format string) oracleOutcome {
 	c.Helper()
 
 	//nolint:gosec // operator-provided oracle path, and dir is a test temp dir
 	cmd := exec.Command(oracle, "migrate", "hash", "--dir", "file://"+dir+"?format="+format)
 	out, err := cmd.CombinedOutput()
-	c.Assert(err, qt.IsNil, qt.Commentf("oracle hash failed: %s", out))
+	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
+	if err != nil {
+		_, statErr := os.Stat(sumPath)
+		c.Assert(os.IsNotExist(statErr), qt.IsTrue,
+			qt.Commentf("the oracle refused but still wrote atlas.sum: %s", out))
+		return oracleOutcome{refused: true, output: string(out)}
+	}
 
-	recorded, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+	recorded, err := os.ReadFile(sumPath)
 	c.Assert(err, qt.IsNil)
 
 	// The oracle's own sum file must not feed back into Ptah's computation.
-	c.Assert(os.Remove(filepath.Join(dir, migratesum.AtlasFileName)), qt.IsNil)
-	return string(recorded)
+	c.Assert(os.Remove(sumPath), qt.IsNil)
+	return oracleOutcome{sum: string(recorded)}
 }
 
+// oracleSum is oracleHash for populations where a refusal would itself be the
+// bug (see TestSumFileNamesDifferentialFuzzRealisticFlyway).
+func oracleSum(c *qt.C, oracle, dir, format string) string {
+	c.Helper()
+	outcome := oracleHash(c, oracle, dir, format)
+	c.Assert(outcome.refused, qt.IsFalse,
+		qt.Commentf("the oracle refused a shape it must accept:\n%s", outcome.output))
+	return outcome.sum
+}
+
+// assertPtahMatchesOracle compares Ptah against the oracle in BOTH directions
+// for one directory: the sum when the oracle wrote one, and the refusal when it
+// wrote none. It returns the covered set and whether the directory was hashable.
+//
+// Selection is asserted to succeed either way. Membership and readability are
+// separate questions, and #991 was Ptah answering the first one by silently
+// dropping an entry it could not answer the second for.
+func assertPtahMatchesOracle(
+	c *qt.C,
+	dir string,
+	format atlasmigrateimport.Format,
+	outcome oracleOutcome,
+	layout []string,
+) (names []string, hashable bool) {
+	c.Helper()
+	comment := qt.Commentf("PTAH_ATLAS_FUZZ_LAYOUT=%s", strings.Join(layout, ","))
+
+	fsys := os.DirFS(dir)
+	names, err := atlasmigrateimport.SumFileNames(fsys, format)
+	c.Assert(err, qt.IsNil, comment)
+
+	sum, sumErr := migratesum.ComputeAtlasFiles(fsys, names)
+	if outcome.refused {
+		c.Assert(sumErr, qt.ErrorIs, migratesum.ErrCoveredEntryUnreadable,
+			qt.Commentf("the oracle refused this directory and Ptah did not: PTAH_ATLAS_FUZZ_LAYOUT=%s\noracle said:\n%s",
+				strings.Join(layout, ","), outcome.output))
+		return names, false
+	}
+	c.Assert(sumErr, qt.IsNil, comment)
+	c.Assert(string(sum.Bytes()), qt.Equals, outcome.sum, comment)
+	return names, true
+}
+
+// writeLayout materializes one generated layout. An entry ending in "/" is a
+// LEAF DIRECTORY rather than a file.
+//
+// That spelling exists because the generator previously created directories
+// only as os.MkdirAll(filepath.Dir(...)) — parents of files it was about to
+// write — so a directory with nothing inside it was unreachable, and the
+// PTAH_ATLAS_FUZZ_LAYOUT round trip that makes a failure reducible had no way
+// to name one. Neither could the layout name a directory whose own name ends in
+// .sql, which is the shape #991 turns on.
 func writeLayout(c *qt.C, dir string, layout []string) {
 	c.Helper()
 	for i, name := range layout {
 		full := filepath.Join(dir, filepath.FromSlash(name))
+		if strings.HasSuffix(name, "/") {
+			c.Assert(os.MkdirAll(full, 0o750), qt.IsNil)
+			continue
+		}
 		c.Assert(os.MkdirAll(filepath.Dir(full), 0o750), qt.IsNil)
 		// Distinct bodies so a misordered sum cannot coincidentally match.
 		body := fmt.Sprintf("CREATE TABLE t%d (id INTEGER PRIMARY KEY);\n", i)
 		c.Assert(os.WriteFile(full, []byte(body), 0o600), qt.IsNil)
 	}
+}
+
+// randomLeafDirectories returns leaf-directory entries for a layout. The pool
+// leans on names a per-format glob matches, because those are the ones that
+// change the answer: *.sql for four formats, *.up.sql for golang-migrate, and
+// neither for Flyway, which walks.
+func randomLeafDirectories(rng *rand.Rand) []string {
+	pool := [...]string{
+		"weird.sql/", "2_evil.sql/", "V2__dir.sql/", "weird.up.sql/",
+		"1_x.up.sql/", "notes.SQL/", "plain/", "sub/nested.sql/",
+	}
+	out := make([]string, 0, 2)
+	for range rng.IntN(3) {
+		out = append(out, pool[rng.IntN(len(pool))])
+	}
+	return out
 }
 
 // randomFlywayLayout builds a realistic-to-adversarial Flyway directory: mostly
@@ -383,7 +473,12 @@ func randomFlywayLayout(rng *rand.Rand) []string {
 			"sub", "views", "a/b", ".archive", ".hidden/deep",
 			"0archive", "1old", "2tmp", "9z", "Archive", "Legacy",
 			"B3", "V", "a/0b", "-dash", "_under",
-		}[rng.IntN(16)])
+			// Directory names the other formats' globs would match. Flyway walks
+			// rather than globs, so these must stay invisible to the sum here —
+			// which is what makes them a control on the #991 rule rather than a
+			// restatement of it.
+			"weird.sql", "V2__dir.sql", "weird.up.sql",
+		}[rng.IntN(19)])
 	}
 
 	count := 1 + rng.IntN(7)
@@ -397,7 +492,7 @@ func randomFlywayLayout(rng *rand.Rand) []string {
 		seen[name] = true
 		layout = append(layout, name)
 	}
-	return layout
+	return append(layout, randomLeafDirectories(rng)...)
 }
 
 func randomFlywayName(rng *rand.Rand) string {
@@ -455,7 +550,7 @@ func randomPlainLayout(rng *rand.Rand) []string {
 		seen[name] = true
 		layout = append(layout, name)
 	}
-	return layout
+	return append(layout, randomLeafDirectories(rng)...)
 }
 
 func path4Join(dir, name string) string {

--- a/internal/atlasmigrateimport/sumfiles_test.go
+++ b/internal/atlasmigrateimport/sumfiles_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -15,11 +16,22 @@ import (
 	"go.5x5.cz/ptah/internal/migratesum"
 )
 
-// ceSumCorpusCases is the number of directory shapes in testdata/ce-sums. The
-// corpus test walks the tree, so a corpus that failed to load would otherwise
-// pass vacuously; asserting the count makes an empty or partial walk fail.
-// Adding a shape is expected to change this number.
-const ceSumCorpusCases = 89
+// ceSumCorpusCases is the number of directory shapes in testdata/ce-sums the
+// oracle SEALED with an atlas.sum. The corpus test walks the tree, so a corpus
+// that failed to load would otherwise pass vacuously; asserting the count makes
+// an empty or partial walk fail. Adding a shape is expected to change this
+// number.
+const ceSumCorpusCases = 92
+
+// ceRefusedCorpusCases is the number of shapes the oracle DECLINED to hash,
+// recorded as an atlas.refused marker instead of an atlas.sum.
+//
+// The two counts are separate on purpose. Until #991 the corpus had no way to
+// represent a refusal at all — regenerate.sh ran under `set -e` and any
+// non-zero oracle exit aborted the whole regeneration — so the only outcome it
+// could hold was agreement, and the shape Atlas CE refuses was structurally
+// unrecordable.
+const ceRefusedCorpusCases = 5
 
 const sqlBody = "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"
 
@@ -65,6 +77,64 @@ func TestSumFileNamesMatchesAtlasCE(t *testing.T) {
 			want, err := fs.ReadFile(os.DirFS(root), sumPath)
 			c.Assert(err, qt.IsNil)
 			c.Assert(string(sum.Bytes()), qt.Equals, string(want))
+		})
+	}
+}
+
+// oracleRefusedEntry returns the entry name the oracle's recorded refusal
+// blames, so the assertion below compares the two tools' answers rather than
+// merely observing that both said no.
+func oracleRefusedEntry(c *qt.C, marker string) string {
+	c.Helper()
+	matches := regexp.MustCompile(`read file "([^"]+)"`).FindStringSubmatch(marker)
+	c.Assert(matches, qt.HasLen, 2, qt.Commentf("unparsed oracle refusal: %s", marker))
+	return matches[1]
+}
+
+// TestSumFileNamesMatchesAtlasCERefusals replays the shapes the pinned oracle
+// DECLINED to hash: a directory whose name the layout's glob matches
+// (stokaro/ptah#991).
+//
+// Membership and readability are separate questions, and this test keeps them
+// that way. SumFileNames must still return the directory's name — dropping it,
+// which is what Ptah did before #991, is precisely the defect: it produced a sum
+// over the remainder that the community binary then refused to read. The
+// refusal has to come from the READ, so the assertion is that selection
+// succeeds and hashing fails, and that the entry Ptah blames is the one the
+// oracle blamed.
+func TestSumFileNamesMatchesAtlasCERefusals(t *testing.T) {
+	c := qt.New(t)
+
+	root := filepath.Join("testdata", "ce-sums")
+	refused, err := fs.Glob(os.DirFS(root), "*/*/atlas.refused")
+	c.Assert(err, qt.IsNil)
+	c.Assert(refused, qt.HasLen, ceRefusedCorpusCases)
+
+	for _, markerPath := range refused {
+		caseDir := path.Dir(markerPath)
+		formatName, _, _ := strings.Cut(caseDir, "/")
+
+		c.Run(caseDir, func(c *qt.C) {
+			fsys := os.DirFS(filepath.Join(root, filepath.FromSlash(caseDir)))
+
+			names, err := atlasmigrateimport.SumFileNames(
+				fsys,
+				atlasmigrateimport.Format(formatName),
+			)
+			c.Assert(err, qt.IsNil)
+
+			marker, err := fs.ReadFile(os.DirFS(root), markerPath)
+			c.Assert(err, qt.IsNil)
+			blamed := oracleRefusedEntry(c, string(marker))
+			c.Assert(names, qt.Contains, blamed)
+
+			_, err = migratesum.ComputeAtlasFiles(fsys, names)
+			c.Assert(err, qt.ErrorIs, migratesum.ErrCoveredEntryUnreadable)
+			c.Assert(err, qt.ErrorMatches, `read file "`+regexp.QuoteMeta(blamed)+`": is a directory.*`)
+
+			// The oracle wrote no atlas.sum, and neither may the corpus hold one.
+			_, statErr := fs.Stat(fsys, migratesum.AtlasFileName)
+			c.Assert(statErr, qt.ErrorIs, fs.ErrNotExist)
 		})
 	}
 }

--- a/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/1_init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/1_init.sql
@@ -1,0 +1,1 @@
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/atlas.refused
+++ b/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/atlas.refused
@@ -1,0 +1,1 @@
+Error: sql/migrate: read file "weird.sql": read <case-dir>/weird.sql: is a directory

--- a/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/atlas/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/1_init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/1_init.sql
@@ -1,0 +1,4 @@
+-- migrate:up
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);
+-- migrate:down
+DROP TABLE widgets;

--- a/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/atlas.refused
+++ b/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/atlas.refused
@@ -1,0 +1,1 @@
+Error: sql/migrate: read file "weird.sql": read <case-dir>/weird.sql: is a directory

--- a/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/dbmate/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/V1__init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/V1__init.sql
@@ -1,0 +1,1 @@
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/atlas.sum
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/atlas.sum
@@ -1,0 +1,3 @@
+h1:+OFiCM8p85yEqlR4bkTM24KsH7+xTsFCgfm2QE3XR3c=
+V1__init.sql h1:Lcem1A1NyIMMjubsHiTK//OSyDNIY0ZIWtlHgWMHzB0=
+weird.sql/V2__nested.sql h1:p+9dtkzgWnnPb8XwaqD2u1z2Ube6QI17k6oB7X6RdOs=

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/weird.sql/V2__nested.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql-nested/weird.sql/V2__nested.sql
@@ -1,0 +1,1 @@
+CREATE TABLE gadgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/V1__init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/V1__init.sql
@@ -1,0 +1,1 @@
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/atlas.sum
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/atlas.sum
@@ -1,0 +1,2 @@
+h1:JgadXWUJDWcE3tTqFmxhkX7ZPxDzCIfqUKZ6rADoM3A=
+V1__init.sql h1:Lcem1A1NyIMMjubsHiTK//OSyDNIY0ZIWtlHgWMHzB0=

--- a/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/flyway/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/1_init.up.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/1_init.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/atlas.sum
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/atlas.sum
@@ -1,0 +1,2 @@
+h1:kLQfGRFTT89eJ+AUaleT+/c077hkM+x6tfc4UypYjZs=
+1_init.up.sql h1:Mkd1ScxYQTnH/OgnXF2f/CMiaucf3GrraUCxWMd25G8=

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/1_init.up.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/1_init.up.sql
@@ -1,0 +1,1 @@
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/atlas.refused
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/atlas.refused
@@ -1,0 +1,1 @@
+Error: sql/migrate: read file "weird.up.sql": read <case-dir>/weird.up.sql: is a directory

--- a/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/weird.up.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/golang-migrate/directory-named-up-sql/weird.up.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/1_init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/1_init.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);
+-- +goose Down
+DROP TABLE widgets;

--- a/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/atlas.refused
+++ b/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/atlas.refused
@@ -1,0 +1,1 @@
+Error: sql/migrate: read file "weird.sql": read <case-dir>/weird.sql: is a directory

--- a/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/goose/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/1_init.sql
+++ b/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/1_init.sql
@@ -1,0 +1,3 @@
+--liquibase formatted sql
+--changeset ptah:1
+CREATE TABLE widgets (id INTEGER PRIMARY KEY);

--- a/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/atlas.refused
+++ b/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/atlas.refused
@@ -1,0 +1,1 @@
+Error: sql/migrate: read file "weird.sql": read <case-dir>/weird.sql: is a directory

--- a/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/weird.sql/note.txt
+++ b/internal/atlasmigrateimport/testdata/ce-sums/liquibase/directory-named-sql/weird.sql/note.txt
@@ -1,0 +1,1 @@
+not a migration

--- a/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
+++ b/internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh
@@ -86,6 +86,36 @@ seal() {
 	printf '  %-52s %s\n' "${case_dir#"$HERE"/}" "$(head -1 "$case_dir/atlas.sum")"
 }
 
+# seal_refused records a shape the oracle DECLINES to hash.
+#
+# seal() cannot express one. `set -e` aborts the whole regeneration on a
+# non-zero oracle exit, and the corpus format -- a committed atlas.sum per case
+# -- has no way to say "no sum exists for this shape". That gap is why the
+# directory-named-*.sql family (stokaro/ptah#991) went unrecorded: the only
+# outcome the corpus could hold was agreement.
+#
+# The refusal is stored as atlas.refused holding the oracle's own message with
+# the machine-specific case path replaced by a placeholder. That file is inert
+# for every format under test: it carries no .sql suffix, so no glob matches it
+# and the Flyway walk does not parse it.
+seal_refused() {
+	local format="$1" out ec
+	set +e
+	out="$("$ATLAS" migrate hash --dir "file://$case_dir?format=$format" 2>&1)"
+	ec=$?
+	set -e
+	if [ "$ec" -eq 0 ]; then
+		echo "regenerate: expected a refusal for ${case_dir#"$HERE"/}, oracle exited 0" >&2
+		exit 1
+	fi
+	if [ -e "$case_dir/atlas.sum" ]; then
+		echo "regenerate: oracle refused ${case_dir#"$HERE"/} but still wrote atlas.sum" >&2
+		exit 1
+	fi
+	printf '%s\n' "$out" | sed "s|$case_dir|<case-dir>|g" >"$case_dir/atlas.refused"
+	printf '  %-52s %s\n' "${case_dir#"$HERE"/}" "REFUSED (exit $ec)"
+}
+
 echo "regenerating Atlas CE corpus with $actual_version"
 
 # --- atlas (native) -------------------------------------------------------
@@ -609,6 +639,68 @@ new_case flyway/baseline-ordinary-project
 put B1__baseline.sql "$SQL_PLAIN"
 put V2__init.sql "$SQL_SECOND"
 put views/V3__view.sql "$SQL_PLAIN"
+seal flyway
+
+# --- a DIRECTORY whose name the layout's glob matches (#991) ---------------
+# The four globbing formats select covered entries by name, so a directory
+# called weird.sql is a member and the read that follows fails: the oracle
+# refuses the whole directory and writes nothing. Every case carries a real file
+# inside the directory because git does not track empty ones -- and note.txt
+# also proves the refusal keys on the directory itself rather than on anything
+# it holds.
+new_case atlas/directory-named-sql
+put 1_init.sql "$SQL_PLAIN"
+put weird.sql/note.txt 'not a migration
+'
+seal_refused atlas
+
+new_case goose/directory-named-sql
+put 1_init.sql "$SQL_GOOSE"
+put weird.sql/note.txt 'not a migration
+'
+seal_refused goose
+
+new_case dbmate/directory-named-sql
+put 1_init.sql "$SQL_DBMATE"
+put weird.sql/note.txt 'not a migration
+'
+seal_refused dbmate
+
+new_case liquibase/directory-named-sql
+put 1_init.sql "$SQL_LIQUIBASE"
+put weird.sql/note.txt 'not a migration
+'
+seal_refused liquibase
+
+# golang-migrate globs *.up.sql, so the pair below separates the SUFFIX FILTER
+# from the read: the same directory name is ignored under one suffix and refused
+# under the other. A fix expressed as "reject any .sql directory" reddens the
+# first of these.
+new_case golang-migrate/directory-named-sql
+put 1_init.up.sql "$SQL_PLAIN"
+put weird.sql/note.txt 'not a migration
+'
+seal golang-migrate
+
+new_case golang-migrate/directory-named-up-sql
+put 1_init.up.sql "$SQL_PLAIN"
+put weird.up.sql/note.txt 'not a migration
+'
+seal_refused golang-migrate
+
+# Flyway is exempt in BOTH tools, and not by special-casing: the oracle WALKS a
+# Flyway tree rather than globbing it, so a directory is a node it descends into
+# and never reads. The nested case pins that the recursion still covers what is
+# inside such a directory.
+new_case flyway/directory-named-sql
+put V1__init.sql "$SQL_PLAIN"
+put weird.sql/note.txt 'not a migration
+'
+seal flyway
+
+new_case flyway/directory-named-sql-nested
+put V1__init.sql "$SQL_PLAIN"
+put weird.sql/V2__nested.sql "$SQL_SECOND"
 seal flyway
 
 echo "done"

--- a/internal/atlasreport/migrate_lint.go
+++ b/internal/atlasreport/migrate_lint.go
@@ -102,6 +102,12 @@ func InspectMigrateLintIntegrity(fsys fs.FS) (MigrateLintIntegrity, error) {
 		return MigrateLintIntegrity{}, fmt.Errorf("stat %s: %w", migratesum.AtlasFileName, err)
 	}
 	result, err := migratesum.VerifyWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	if errors.Is(err, migratesum.ErrCoveredEntryUnreadable) {
+		// A covered entry that is a directory (#991). The directory could not be
+		// hashed at all, so calling it a mismatch would name the wrong fault and
+		// send the reader looking for an edited migration that does not exist.
+		return MigrateLintIntegrity{Checked: true, Error: err.Error()}, nil
+	}
 	if err != nil {
 		return MigrateLintIntegrity{Checked: true, Error: "checksum mismatch"}, nil
 	}

--- a/internal/fsnapshot/snapshot.go
+++ b/internal/fsnapshot/snapshot.go
@@ -14,41 +14,56 @@ import (
 	"time"
 )
 
+// errIsDirectory is the reason a read of a directory fails. The text matches
+// what a real filesystem reports through syscall.EISDIR, so a snapshot-backed
+// read and an os.DirFS-backed read of the same path render identically.
+var errIsDirectory = errors.New("is a directory")
+
 // Snapshot is an immutable in-memory filesystem. Its read methods return
 // independent values, and Clone returns an independent filesystem view.
+//
+// capturedDirs records directory paths observed in their own right, as opposed
+// to the ones buildDirectoryIndex synthesizes from the paths of captured files.
+// Without it a snapshot could only ever answer "which files are here", and a
+// directory holding no captured file simply vanished — which is how a directory
+// named 2_evil.sql, created after Atlas CE hashed a clean directory, stayed
+// invisible to every verb that verifies a snapshot rather than the live
+// directory (stokaro/ptah#991). The community binary refuses such a directory;
+// Ptah applied, and reported status, set a version and linted it clean.
 type Snapshot struct {
-	files       map[string][]byte
-	directories map[string][]fs.DirEntry
+	files        map[string][]byte
+	capturedDirs map[string]struct{}
+	directories  map[string][]fs.DirEntry
 }
 
 // FromFiles returns an immutable snapshot containing files. Every path must be
 // valid for io/fs, and both the map and file contents are cloned.
 func FromFiles(files map[string][]byte) (Snapshot, error) {
-	if err := validateFilePaths(files); err != nil {
+	if err := validatePaths(files, nil); err != nil {
 		return Snapshot{}, err
 	}
 	cloned := make(map[string][]byte, len(files))
 	for name, contents := range files {
 		cloned[name] = slices.Clone(contents)
 	}
-	return snapshotFromValidatedFiles(cloned), nil
+	return snapshotFromValidatedFiles(cloned, nil), nil
 }
 
 // TakeFiles returns an immutable snapshot by taking exclusive ownership of
 // files and their byte slices. The caller must not retain or mutate them after
 // this call. Use FromFiles when ownership cannot be transferred.
 func TakeFiles(files map[string][]byte) (Snapshot, error) {
-	if err := validateFilePaths(files); err != nil {
+	if err := validatePaths(files, nil); err != nil {
 		return Snapshot{}, err
 	}
-	return snapshotFromValidatedFiles(files), nil
+	return snapshotFromValidatedFiles(files, nil), nil
 }
 
-func validateFilePaths(files map[string][]byte) error {
-	for name := range files {
-		if !fs.ValidPath(name) || name == "." {
-			return fmt.Errorf("invalid snapshot file path %q", name)
-		}
+// validatePaths rejects paths io/fs cannot address and any pair where one entry
+// would have to live inside a file. A recorded directory that also names a file
+// is the same contradiction seen from the other side, so it is rejected too.
+func validatePaths(files map[string][]byte, dirs map[string]struct{}) error {
+	containedByFile := func(name string) error {
 		for parent := path.Dir(name); parent != "."; parent = path.Dir(parent) {
 			if _, exists := files[parent]; exists {
 				return fmt.Errorf(
@@ -57,6 +72,26 @@ func validateFilePaths(files map[string][]byte) error {
 					name,
 				)
 			}
+		}
+		return nil
+	}
+	for name := range files {
+		if !fs.ValidPath(name) || name == "." {
+			return fmt.Errorf("invalid snapshot file path %q", name)
+		}
+		if err := containedByFile(name); err != nil {
+			return err
+		}
+	}
+	for name := range dirs {
+		if !fs.ValidPath(name) || name == "." {
+			return fmt.Errorf("invalid snapshot directory path %q", name)
+		}
+		if _, exists := files[name]; exists {
+			return fmt.Errorf("invalid snapshot path %q: recorded as both a file and a directory", name)
+		}
+		if err := containedByFile(name); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -73,7 +108,20 @@ func Capture(fsys fs.FS) (Snapshot, error) {
 	})
 }
 
-// CaptureMatching reads each file accepted by include exactly once.
+// CaptureMatching reads each file accepted by include exactly once, and records
+// each DIRECTORY accepted by include as a directory in its own right.
+//
+// include therefore sees every entry, not only the files, and its fs.DirEntry
+// argument is what distinguishes them. A directory is still descended into
+// whether or not include accepts it, so accepting one costs a map key and never
+// changes which files are captured.
+//
+// Recording directories is what lets a snapshot answer "this name exists and is
+// not a file". A caller that selects entries by name — an Atlas integrity file
+// covers whatever its per-format glob matches — must be able to reach that
+// answer, or a directory whose name matches disappears between the capture and
+// the check and the verb accepts a directory the community binary refuses
+// (stokaro/ptah#991).
 func CaptureMatching(
 	fsys fs.FS,
 	include func(name string, entry fs.DirEntry) bool,
@@ -82,11 +130,17 @@ func CaptureMatching(
 		return snapshot.matching(include), nil
 	}
 	files := map[string][]byte{}
+	dirs := map[string]struct{}{}
 	err := fs.WalkDir(fsys, ".", func(name string, entry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}
-		if entry.IsDir() || !include(name, entry) {
+		// The root is the snapshot itself and has no entry to record.
+		if name == "." || !include(name, entry) {
+			return nil
+		}
+		if entry.IsDir() {
+			dirs[name] = struct{}{}
 			return nil
 		}
 		contents, err := fs.ReadFile(fsys, name)
@@ -99,26 +153,33 @@ func CaptureMatching(
 	if err != nil {
 		return Snapshot{}, fmt.Errorf("capture filesystem snapshot: %w", err)
 	}
-	if err := validateFilePaths(files); err != nil {
+	if err := validatePaths(files, dirs); err != nil {
 		return Snapshot{}, fmt.Errorf("capture filesystem snapshot: %w", err)
 	}
-	return snapshotFromValidatedFiles(files), nil
+	return snapshotFromValidatedFiles(files, dirs), nil
 }
 
 // Clone returns an independent view of the same captured files.
 func (s Snapshot) Clone() Snapshot {
 	cloned := Snapshot{
-		files:       make(map[string][]byte, len(s.files)),
-		directories: s.directories,
+		files:        make(map[string][]byte, len(s.files)),
+		capturedDirs: s.capturedDirs,
+		directories:  s.directories,
 	}
 	maps.Copy(cloned.files, s.files)
 	return cloned
 }
 
 // Equal reports whether both snapshots contain exactly the same paths and
-// bytes.
+// bytes, recorded directories included.
+//
+// Directories count because CaptureStable compares two captures to detect a
+// directory changing underneath it. A directory appearing or disappearing
+// between them is exactly such a change, and ignoring it would let the very
+// entry #991 is about slip through the window the comparison exists to close.
 func (s Snapshot) Equal(other Snapshot) bool {
-	return maps.EqualFunc(s.files, other.files, bytes.Equal)
+	return maps.EqualFunc(s.files, other.files, bytes.Equal) &&
+		maps.Equal(s.capturedDirs, other.capturedDirs)
 }
 
 // WithFiles returns a new immutable snapshot with files added or replaced.
@@ -129,10 +190,10 @@ func (s Snapshot) WithFiles(files map[string][]byte) (Snapshot, error) {
 	for name, contents := range files {
 		combined[name] = slices.Clone(contents)
 	}
-	if err := validateFilePaths(combined); err != nil {
+	if err := validatePaths(combined, s.capturedDirs); err != nil {
 		return Snapshot{}, err
 	}
-	return snapshotFromValidatedFiles(combined), nil
+	return snapshotFromValidatedFiles(combined, s.capturedDirs), nil
 }
 
 func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Snapshot {
@@ -144,7 +205,13 @@ func (s Snapshot) matching(include func(name string, entry fs.DirEntry) bool) Sn
 			filtered[name] = contents
 		}
 	}
-	return snapshotFromValidatedFiles(filtered)
+	filteredDirs := make(map[string]struct{}, len(s.capturedDirs))
+	for _, name := range slices.Sorted(maps.Keys(s.capturedDirs)) {
+		if include(name, snapshotFileInfo{name: path.Base(name), directory: true}) {
+			filteredDirs[name] = struct{}{}
+		}
+	}
+	return snapshotFromValidatedFiles(filtered, filteredDirs)
 }
 
 // Open implements fs.FS.
@@ -169,12 +236,22 @@ func (s Snapshot) Open(name string) (fs.File, error) {
 }
 
 // ReadFile implements fs.ReadFileFS.
+//
+// Reading a directory reports "is a directory" rather than "file does not
+// exist", matching what os.DirFS answers for the same path. The distinction is
+// load-bearing: a caller that selects entries by name and then reads them uses
+// the read failure to decide whether the entry was a migration, and the wrong
+// diagnostic sent Ptah's #991 refusal out as `read 2_evil.sql: file does not
+// exist` on a path the filesystem could see perfectly well.
 func (s Snapshot) ReadFile(name string) ([]byte, error) {
 	if !fs.ValidPath(name) {
 		return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrInvalid}
 	}
 	contents, ok := s.files[name]
 	if !ok {
+		if s.hasDirectory(name) {
+			return nil, &fs.PathError{Op: "read", Path: name, Err: errIsDirectory}
+		}
 		return nil, &fs.PathError{Op: "read", Path: name, Err: fs.ErrNotExist}
 	}
 	return slices.Clone(contents), nil
@@ -206,14 +283,15 @@ func (s Snapshot) Stat(name string) (fs.FileInfo, error) {
 	return nil, &fs.PathError{Op: "stat", Path: name, Err: fs.ErrNotExist}
 }
 
-func snapshotFromValidatedFiles(files map[string][]byte) Snapshot {
+func snapshotFromValidatedFiles(files map[string][]byte, dirs map[string]struct{}) Snapshot {
 	return Snapshot{
-		files:       files,
-		directories: buildDirectoryIndex(files),
+		files:        files,
+		capturedDirs: dirs,
+		directories:  buildDirectoryIndex(files, dirs),
 	}
 }
 
-func buildDirectoryIndex(files map[string][]byte) map[string][]fs.DirEntry {
+func buildDirectoryIndex(files map[string][]byte, dirs map[string]struct{}) map[string][]fs.DirEntry {
 	infos := map[string]map[string]snapshotFileInfo{
 		".": {},
 	}
@@ -226,6 +304,17 @@ func buildDirectoryIndex(files map[string][]byte) map[string][]fs.DirEntry {
 		for directory := parent; directory != "."; directory = path.Dir(directory) {
 			addDirectoryInfo(infos, path.Dir(directory), snapshotFileInfo{
 				name:      path.Base(directory),
+				directory: true,
+			})
+		}
+	}
+	// A recorded directory needs an (possibly empty) entry list of its own, or
+	// it would only exist as long as something below it does.
+	for directory := range dirs {
+		ensureDirectory(infos, directory)
+		for current := directory; current != "."; current = path.Dir(current) {
+			addDirectoryInfo(infos, path.Dir(current), snapshotFileInfo{
+				name:      path.Base(current),
 				directory: true,
 			})
 		}
@@ -250,12 +339,22 @@ func addDirectoryInfo(
 	directory string,
 	info snapshotFileInfo,
 ) {
+	ensureDirectory(directories, directory)[info.name] = info
+}
+
+// ensureDirectory returns directory's entry map, creating an empty one when it
+// has no entries yet. It never replaces an existing map, so recording a
+// directory that already holds captured files keeps them.
+func ensureDirectory(
+	directories map[string]map[string]snapshotFileInfo,
+	directory string,
+) map[string]snapshotFileInfo {
 	entries, ok := directories[directory]
 	if !ok {
 		entries = make(map[string]snapshotFileInfo)
 		directories[directory] = entries
 	}
-	entries[info.name] = info
+	return entries
 }
 
 func (s Snapshot) lookupDirectory(name string) ([]fs.DirEntry, bool) {
@@ -298,7 +397,7 @@ func (d *snapshotDirectory) Stat() (fs.FileInfo, error) {
 }
 
 func (d *snapshotDirectory) Read([]byte) (int, error) {
-	return 0, &fs.PathError{Op: "read", Path: d.info.name, Err: errors.New("is a directory")}
+	return 0, &fs.PathError{Op: "read", Path: d.info.name, Err: errIsDirectory}
 }
 
 func (d *snapshotDirectory) Close() error {

--- a/internal/migratesum/covered_entry.go
+++ b/internal/migratesum/covered_entry.go
@@ -1,0 +1,75 @@
+package migratesum
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+)
+
+// ErrCoveredEntryUnreadable marks a covered entry that exists but cannot be
+// read as a migration file. It is distinct from drift and from a missing
+// integrity file because the directory cannot be hashed AT ALL: no sum can be
+// written, and no recorded sum can be checked against it.
+//
+// Callers that render Atlas-compatible checksum output match on this to emit
+// the checksum guidance preamble, exactly as they do for drift.
+var ErrCoveredEntryUnreadable = errors.New("covered migration entry cannot be read")
+
+// coveredDirectoryError reports that an entry the integrity file covers is a
+// directory rather than a migration file.
+//
+// This is a real and reachable shape, not a curiosity. Atlas CE selects the
+// covered entries of every non-Flyway layout with a per-format glob, and a glob
+// matches names without regard to type, so `mkdir 2_evil.sql` inside an
+// already-hashed migration directory puts an unreadable member into the covered
+// set. The community binary refuses the whole directory over it; so does Ptah
+// (stokaro/ptah#991).
+type coveredDirectoryError struct {
+	name string
+}
+
+// Error names the offending entry, says what it actually is, and says what to
+// do about it.
+//
+// The exit code, the stream layout and the checksum preamble around this
+// message match the pinned community binary v1.3.0 exactly; the wording
+// deliberately does not. That binary reports
+// `sql/migrate: read file "2_evil.sql": read /abs/2_evil.sql: is a directory`,
+// which states the fault without naming the fix — and a checksum tool cannot
+// tell a directory the author named .sql by accident from a migration file that
+// was replaced by a directory, so telling the reader which situation to look
+// for is the whole remedy. Nothing in the conformance corpus asserts this
+// string byte for byte (checked before choosing), and the text carries strictly
+// more than the community binary's does.
+func (e coveredDirectoryError) Error() string {
+	return fmt.Sprintf(
+		"read file %q: is a directory, not a migration file; "+
+			"rename it or move it out of the migration directory",
+		e.name,
+	)
+}
+
+func (e coveredDirectoryError) Is(target error) bool {
+	return target == ErrCoveredEntryUnreadable
+}
+
+// readCoveredEntry reads one covered entry, reporting a directory as the
+// dedicated [ErrCoveredEntryUnreadable] failure rather than as a generic read
+// error.
+//
+// The kind is settled by fs.Stat rather than by matching on the read error's
+// text, so the answer is the same whether fsys is an os.DirFS over the real
+// directory or an [go.5x5.cz/ptah/internal/fsnapshot.Snapshot] captured from it.
+// Those two disagreed before #991: the snapshot had no way to record a
+// directory holding no captured file, so the same tree read as "file does not
+// exist" through one and "is a directory" through the other.
+func readCoveredEntry(fsys fs.FS, name string) ([]byte, error) {
+	data, err := fs.ReadFile(fsys, name)
+	if err == nil {
+		return data, nil
+	}
+	if info, statErr := fs.Stat(fsys, name); statErr == nil && info.IsDir() {
+		return nil, coveredDirectoryError{name: name}
+	}
+	return nil, fmt.Errorf("failed to read %s: %w", name, err)
+}

--- a/internal/migratesum/sum.go
+++ b/internal/migratesum/sum.go
@@ -237,6 +237,11 @@ func computeAtlas(fsys fs.FS) (*SumFile, error) {
 //
 // A file carrying an "atlas:sum ignore" directive contributes its name to the
 // running hash but neither its contents nor an entry, matching Atlas.
+//
+// A covered name that cannot be read fails the whole computation rather than
+// being skipped, so no sum is produced over a subset of what the caller
+// selected. A covered name that turns out to be a DIRECTORY is reported as
+// [ErrCoveredEntryUnreadable]; see readCoveredEntry.
 func ComputeAtlasFiles(fsys fs.FS, names []string) (*SumFile, error) {
 	if err := checkDuplicateNames(names); err != nil {
 		return nil, err
@@ -245,9 +250,9 @@ func ComputeAtlasFiles(fsys fs.FS, names []string) (*SumFile, error) {
 	entries := make([]Entry, 0, len(names))
 	h := sha256.New()
 	for _, name := range names {
-		data, err := fs.ReadFile(fsys, name)
+		data, err := readCoveredEntry(fsys, name)
 		if err != nil {
-			return nil, fmt.Errorf("failed to read %s: %w", name, err)
+			return nil, err
 		}
 		_, _ = h.Write([]byte(name))
 		if atlasSumIgnored(data) {

--- a/internal/migrationsnapshot/snapshot.go
+++ b/internal/migrationsnapshot/snapshot.go
@@ -20,7 +20,16 @@ var metadataFiles = map[string]struct{}{
 }
 
 // Capture reads SQL migrations and their lint or integrity metadata exactly
-// once, excluding unrelated files from the immutable snapshot.
+// once, excluding unrelated entries from the immutable snapshot.
+//
+// The predicate deliberately looks at the NAME and ignores the fs.DirEntry, so
+// a DIRECTORY called 2_evil.sql is captured as a directory in its own right.
+// That is not incidental tidiness: Atlas's integrity file covers whatever its
+// glob matches, glob matching is by name, and a snapshot that recorded only
+// files let such a directory vanish between the capture and the verification —
+// so `migrate apply`, `status`, `set` and `lint` accepted a directory the
+// community binary refuses (stokaro/ptah#991). Narrowing this to entry.Type()
+// would reopen it.
 func Capture(fsys fs.FS) (fsnapshot.Snapshot, error) {
 	snapshot, err := fsnapshot.CaptureMatching(fsys, func(name string, _ fs.DirEntry) bool {
 		if strings.EqualFold(path.Ext(name), ".sql") {

--- a/scripts/probe-atlas-apply-gate.sh
+++ b/scripts/probe-atlas-apply-gate.sh
@@ -516,18 +516,37 @@ flyway_parity "baseline outranking its survivor executes" build_baseline_outrank
 
 echo
 echo "===== 9b. a DIRECTORY named *.sql appears after hashing (stokaro/ptah#991)"
-# CE's shallow glob matches the directory and then hard-errors; SumFileNames
-# skips it, so the recomputed sum still verifies. Nothing unverified executes —
-# a directory holds no SQL — so this is loss of tamper DETECTION, not of
-# execution safety. It is still CE refusing where we apply.
-ce="ce-evildir"; pt="pt-evildir"
-seed "$ce" goose; seed "$pt" goose
-hash_both "$ce" "$pt" goose
-mkdir -p "$ce/2_evil.sql" "$pt/2_evil.sql"
-ceout=$("$ATLAS" migrate apply --url "sqlite://$ce.db" --dir "file://$ce?format=goose" 2>&1); cerc=$?
-ptout=$("$COMPAT" migrate apply --url "sqlite://$pt.db" --dir "file://$pt?format=goose" 2>&1); ptrc=$?
-printf '  %-46s ce exit=%s | ptah exit=%s [%s]\n' "goose + 2_evil.sql/ after hashing" "$cerc" "$ptrc" \
-	"$(echo "$ptout" | tr '\n' '|' | cut -c1-70)"
+# CE's per-format glob matches on the name, so the directory is a member of the
+# covered set and the read that follows fails: CE refuses. Ptah used to skip the
+# entry and verify the remainder, and this section merely REPORTED that gap --
+# it printed both exit codes and asserted nothing, so it stayed green while the
+# two tools disagreed. It asserts now, on both the empty shape and the one
+# holding a file the capture predicate filters out (the shape that kept the
+# directory invisible to the snapshot even after the selection was fixed).
+for evilinner in "" "note.txt"; do
+	label="goose + 2_evil.sql/ after hashing"
+	[ -n "$evilinner" ] && label="goose + 2_evil.sql/$evilinner after hashing"
+	ce="ce-evildir"; pt="pt-evildir"
+	seed "$ce" goose; seed "$pt" goose
+	hash_both "$ce" "$pt" goose
+	mkdir -p "$ce/2_evil.sql" "$pt/2_evil.sql"
+	if [ -n "$evilinner" ]; then
+		printf 'x\n' >"$ce/2_evil.sql/$evilinner"
+		printf 'x\n' >"$pt/2_evil.sql/$evilinner"
+	fi
+	ceout=$("$ATLAS" migrate apply --url "sqlite://$ce.db" --dir "file://$ce?format=goose" 2>&1); cerc=$?
+	ptout=$("$COMPAT" migrate apply --url "sqlite://$pt.db" --dir "file://$pt?format=goose" 2>&1); ptrc=$?
+	printf '  %-46s ce exit=%s | ptah exit=%s [%s]\n' "$label" "$cerc" "$ptrc" \
+		"$(echo "$ptout" | tr '\n' '|' | cut -c1-70)"
+	if [ "$cerc" != "$ptrc" ]; then
+		fail=1
+		echo "       UNEXPECTED: the two tools no longer agree on the exit code"
+	fi
+	if [ "$cerc" != 1 ]; then
+		fail=1
+		echo "       UNEXPECTED: the oracle no longer refuses this shape, so the row proves nothing"
+	fi
+done
 
 echo
 echo "===== 9c. an unreadable source file (dangling symlink under sub/)"


### PR DESCRIPTION
Closes #991.

A directory named `weird.sql` sat in the integrity glob's blind spot: `migrate hash` wrote an `atlas.sum` the pinned community binary then refused to read, and Ptah's two paths disagreed with each other about whether the directory existed at all.

## Parity choice: match the exit code, be better on the message

The community binary's refusal is **not** a defect to avoid. It writes nothing, names the offending path, applies no migration, and is a checksum tool declining to hash an entry it cannot read — it drops nothing silently and is not unrelated to intent. Matching it is right, and it is the direction that removes the trap this issue describes.

Where half (b) applies is the wording, and the choice is stated rather than made silently. The community binary says `read file "2_evil.sql": read /abs/2_evil.sql: is a directory` — the fault without the fix. This surface says `read file "2_evil.sql": is a directory, not a migration file; rename it or move it out of the migration directory`: same entry, same exit code, same streams, same preamble, more information.

Two things deliberately **not** copied or preserved:

- **Flyway's exemption is not a defect.** It falls out of walking rather than globbing; both implementations agree and the sums are byte-identical on all three shapes, including a directory named `V2__x.sql` holding a nested `V3__deep.sql`. Making Flyway refuse `.sql` directories would be a false refusal that breaks real projects.
- **Ptah's own snapshot blindness is fixed, not preserved.** A directory holding a nested file reported `file does not exist` for a path the filesystem could see. `Snapshot.ReadFile` now renders identically to `os.DirFS.ReadFile`.

## Verification

Three mutations, each killed by a distinct row set — including one the reviewer added that regresses the headline while the plain unit run stays green, caught by the oracle-gated differential fuzz that CI runs on every PR.

Parity measured rather than argued: 24 native cells across 8 verbs × 3 inner shapes, every converted layout × 5 formats × 7 verbs, and 10 neighbour shapes on the native surface — dot-directories, `EVIL.SQL/`, symlinks to files and directories, a dangling symlink, `atlas.sum` as a directory, the migration file itself replaced by a directory. All agree.

## Two corrections made before opening this

**The commit's cell accounting did not reconcile** — it described a 36-cell matrix and then reported 22 measurable plus 32 discarded. I could not reconstruct the true figures without re-running the sweep, so the counts are gone rather than restated. An arithmetic that does not add up is not evidence, and leaving it in would have lent false precision to a real measurement.

**An unqualified "0 looser" was hiding one.** `migrate import` verifies no source integrity file at all: on a hashed goose directory with `mkdir 2_evil.sql` the pinned binary exits 1 and this surface exits 0 and writes. I reproduced it on the base binary — it predates this change and is not worsened here — but it was tracked nowhere, while the feature matrix already enumerates `migrate new` and `migrate diff` as untracked divergences of the same kind. It is now named in the commit message and filed as #1095, which also records the worse half: the converted output carries a **fresh** sum, so the tampering is laundered into a directory that looks clean.

## Behavior break worth a changelog line

Directories that hash fine today start exiting 1. That is the intended direction, and it is still a break for any project with a legitimately named `*.sql` directory.
