### PR TITLE
fix(compat): preserve Atlas txmode diagnostics

### DIFF
--- a/cmd/ptah-compat/main_test.go
+++ b/cmd/ptah-compat/main_test.go
@@ -416,25 +416,48 @@ func TestCompatBinaryAtlasFailurePaths(t *testing.T) {
 func TestCompatBinaryMigrateApplyRejectsMalformedAtlasTxMode(t *testing.T) {
 	c := qt.New(t)
 	binPath := buildCompatBinary(c)
-	dir := malformedAtlasTxModeDir(c)
-	run := newCompatProcess(
-		binPath,
-		"migrate", "apply",
-		"--url", "sqlite://"+filepath.Join(c.TempDir(), "state.db"),
-		"--dir", "file://"+dir,
-	)
-	var stdout, stderr bytes.Buffer
-	run.Stdout = &stdout
-	run.Stderr = &stderr
+	tests := []struct {
+		name      string
+		filename  string
+		directive string
+		want      string
+	}{
+		{
+			name:      "unknown directive",
+			filename:  "1_unknown.sql",
+			directive: "-- atlas:txmode bogus\n\n",
+			want:      "Error: unknown txmode \"bogus\" found in file directive \"1_unknown.sql\"\n",
+		},
+		{
+			name:      "duplicate directive",
+			filename:  "1_duplicate.sql",
+			directive: "-- atlas:txmode none\n-- atlas:txmode file\n\n",
+			want:      "Error: multiple txmode values found in file \"1_duplicate.sql\": [\"none\" \"file\"]\n",
+		},
+	}
 
-	err := run.Run()
-	var exitErr *exec.ExitError
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := malformedAtlasTxModeDir(c, test.filename, test.directive)
+			run := newCompatProcess(
+				binPath,
+				"migrate", "apply",
+				"--url", "sqlite://"+filepath.Join(c.TempDir(), "state.db"),
+				"--dir", "file://"+dir,
+			)
+			var stdout, stderr bytes.Buffer
+			run.Stdout = &stdout
+			run.Stderr = &stderr
 
-	c.Assert(err, qt.ErrorAs, &exitErr)
-	c.Assert(exitErr.ExitCode(), qt.Equals, 1)
-	c.Assert(stderr.String(), qt.Equals,
-		"Error: error applying migrations: unknown txmode \"bogus\" found in file directive \"1_invalid.sql\"\n")
-	c.Assert(stdout.String(), qt.Equals, "")
+			err := run.Run()
+			var exitErr *exec.ExitError
+
+			c.Assert(err, qt.ErrorAs, &exitErr)
+			c.Assert(exitErr.ExitCode(), qt.Equals, 1)
+			c.Assert(stderr.String(), qt.Equals, test.want)
+			c.Assert(stdout.String(), qt.Equals, "")
+		})
+	}
 }
 
 func buildCompatBinary(c *qt.C) string {
@@ -475,11 +498,11 @@ func atlasDirWithoutSum(c *qt.C) string {
 	return dir
 }
 
-func malformedAtlasTxModeDir(c *qt.C) string {
+func malformedAtlasTxModeDir(c *qt.C, filename, directive string) string {
 	c.Helper()
 	dir := c.TempDir()
-	c.Assert(os.WriteFile(filepath.Join(dir, "1_invalid.sql"), []byte(
-		"-- atlas:txmode bogus\n\nCREATE TABLE invalid_txmode (id INTEGER PRIMARY KEY);\n",
+	c.Assert(os.WriteFile(filepath.Join(dir, filename), []byte(
+		directive+"CREATE TABLE invalid_txmode (id INTEGER PRIMARY KEY);\n",
 	), 0o600), qt.IsNil)
 	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -121,6 +121,10 @@ txtar content. The two directions remain independent; the migrator resolves
 the up value against its global transaction mode and treats an unspecified
 down value as `file`.
 
+Atlas transaction-mode directive validation errors expose
+`migrator.AtlasTxModeDirectiveError` through `errors.As`. The leaf error keeps
+the source file and transaction-mode details in its message.
+
 This pre-GA API replaces the former `UpNoTransaction` and
 `DownNoTransaction` Boolean fields. `NewMigrationFromSQLFiles` and its
 interceptor variant return a complete `Migration`, preserving both directions'

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6722,6 +6722,7 @@ type AtlasRevisionSetResult struct{ ... }
 type AtlasRevisionType uint
     const AtlasRevisionTypeUnknown AtlasRevisionType = iota ...
 type AtlasTemplateData struct{ ... }
+type AtlasTxModeDirectiveError struct{ ... }
 type BaselineOptions struct{ ... }
 type Check struct{ ... }
     func ParseChecks(source, dialect string) ([]Check, error)
@@ -6876,6 +6877,18 @@ type AtlasTemplateData struct {
 }
     AtlasTemplateData is the default data object used for Atlas SQL templates.
 
+
+### go.5x5.cz/ptah/migration/migrator.AtlasTxModeDirectiveError
+
+package migrator // import "go.5x5.cz/ptah/migration/migrator"
+
+type AtlasTxModeDirectiveError struct {
+    // Has unexported fields.
+}
+    AtlasTxModeDirectiveError reports an invalid or conflicting Atlas
+    transaction-mode file directive.
+
+func (e *AtlasTxModeDirectiveError) Error() string
 
 ### go.5x5.cz/ptah/migration/migrator.BaselineOptions
 

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -767,7 +767,9 @@ Per-file `atlas:txmode` precedence and validation match the measured Atlas CE
 none overrides and validate files as execution reaches them. Global `all`
 rejects every explicit file mode before starting the selected batch. Unknown,
 duplicate, and file-level all values fail before the affected migration body
-or revision row changes.
+or revision row changes. The compatibility surface prints Atlas's leaf
+transaction-mode diagnostic; native commands retain Ptah's broader apply
+context.
 
 Ptah also applies those modes independently to `migration.sql` and `down.sql`
 inside txtar files. Atlas CE `v1.3.0` ignores section-local modes. Ptah rejects

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -241,6 +241,9 @@ before the affected migration body or revision row changes. Validation follows
 the selected plan: global `all` validates the complete selected batch first;
 global `file` and `none` validate each file as execution reaches it. An amount
 or baseline that excludes a malformed file does not validate that file.
+On `ptah-compat`, these failures use Atlas's leaf diagnostic without Ptah's
+internal `error applying migrations:` wrapper. The native command keeps its
+`error running migrations:` context.
 
 Inside a Ptah-supported txtar migration, `migration.sql` and `down.sql` carry
 independent modes. Ptah rejects a transaction-mode header placed before

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -105,6 +105,10 @@ with `MigrationFileTxModeUnspecified`, `MigrationFileTxModeFile`, or
 executable up-direction SQL, explicit mode, and source-line offset from plain
 SQL or Atlas txtar content. Up and down values remain independent.
 
+Atlas transaction-mode directive validation errors expose
+`migrator.AtlasTxModeDirectiveError` through `errors.As`; the leaf error keeps
+the source file and transaction-mode details in its message.
+
 This pre-GA API replaces the former Boolean transaction fields. Use
 `NewMigrationFromSQLFiles` or its interceptor variant to load an up/down pair:
 they return a complete `Migration` with transaction modes, timeouts, source

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -189,6 +189,10 @@ func (p ApplyPlan) execute(ctx context.Context, hook migrator.PreMigrationHook) 
 		result.Applied = executionStarted && !p.DryRun
 		result.ApplyError = err
 		result.ErrorText = err.Error()
+		var txModeErr *migrator.AtlasTxModeDirectiveError
+		if errors.As(err, &txModeErr) {
+			return result, txModeErr
+		}
 		return result, fmt.Errorf("error applying migrations: %w", err)
 	}
 	if !executionStarted {

--- a/internal/atlasmigrate/apply_test.go
+++ b/internal/atlasmigrate/apply_test.go
@@ -562,7 +562,9 @@ func TestPrepareApplyExecute_ValidationErrorUsesLockedPlan(t *testing.T) {
 		},
 	)
 
-	c.Assert(err, qt.ErrorMatches, `error applying migrations: unknown txmode "bogus" found in file directive "2_invalid.sql"`)
+	var txModeErr *migrator.AtlasTxModeDirectiveError
+	c.Assert(err, qt.ErrorAs, &txModeErr)
+	c.Assert(err, qt.ErrorMatches, `unknown txmode "bogus" found in file directive "2_invalid.sql"`)
 	c.Assert(result.Applied, qt.IsFalse)
 	c.Assert(result.CurrentVersion, qt.Equals, int64(1))
 	c.Assert(result.SelectedVersions, qt.DeepEquals, []int64{2})

--- a/migration/migrator/atlas_tx_mode_matrix_test.go
+++ b/migration/migrator/atlas_tx_mode_matrix_test.go
@@ -109,6 +109,8 @@ func assertAtlasTxModeRejectedBeforeWrites(
 ) {
 	err := mig.MigrateUp(c.Context())
 	c.Assert(err, qt.IsNotNil)
+	var txModeErr *migrator.AtlasTxModeDirectiveError
+	c.Assert(err, qt.ErrorAs, &txModeErr)
 	c.Assert(err.Error(), qt.Equals, wantErr)
 	c.Assert(atlasTxModeTableExists(c, conn), qt.IsFalse)
 	c.Assert(atlasTxModeRevisionCount(c, conn), qt.Equals, 0)

--- a/migration/migrator/file_tx_mode.go
+++ b/migration/migrator/file_tx_mode.go
@@ -19,6 +19,20 @@ const (
 
 const atlasFileTxModeKey = "atlas:txmode"
 
+// AtlasTxModeDirectiveError reports an invalid or conflicting Atlas
+// transaction-mode file directive.
+type AtlasTxModeDirectiveError struct {
+	message string
+}
+
+func (e *AtlasTxModeDirectiveError) Error() string {
+	return e.message
+}
+
+func newAtlasTxModeDirectiveError(format string, args ...any) *AtlasTxModeDirectiveError {
+	return &AtlasTxModeDirectiveError{message: fmt.Sprintf(format, args...)}
+}
+
 // ParsedMigrationUp is the executable up-direction view of a plain SQL or
 // Atlas txtar migration file.
 type ParsedMigrationUp struct {
@@ -152,7 +166,7 @@ func parseAtlasFileTxMode(filename, sql string) (MigrationFileTxMode, bool, erro
 		return MigrationFileTxModeUnspecified, false, nil
 	}
 	if len(values) > 1 {
-		return MigrationFileTxModeUnspecified, true, fmt.Errorf(
+		return MigrationFileTxModeUnspecified, true, newAtlasTxModeDirectiveError(
 			"multiple txmode values found in file %q: %q", filename, values,
 		)
 	}
@@ -162,14 +176,14 @@ func parseAtlasFileTxMode(filename, sql string) (MigrationFileTxMode, bool, erro
 	case MigrationFileTxModeFile, MigrationFileTxModeNone:
 		return mode, true, nil
 	case "all":
-		return MigrationFileTxModeUnspecified, true, fmt.Errorf(
+		return MigrationFileTxModeUnspecified, true, newAtlasTxModeDirectiveError(
 			"txmode %q is not allowed in file directive %q. Use %q instead",
 			mode,
 			filename,
 			MigrationFileTxModeFile,
 		)
 	default:
-		return MigrationFileTxModeUnspecified, true, fmt.Errorf(
+		return MigrationFileTxModeUnspecified, true, newAtlasTxModeDirectiveError(
 			"unknown txmode %q found in file directive %q", mode, filename,
 		)
 	}

--- a/migration/migrator/tx_mode.go
+++ b/migration/migrator/tx_mode.go
@@ -71,7 +71,7 @@ func (m *Migrator) resolveUpMigrationTxMode(migration *Migration) (MigrationTxMo
 				migration.UpTxMode,
 			)
 		}
-		return "", fmt.Errorf(
+		return "", newAtlasTxModeDirectiveError(
 			"cannot set txmode directive to %q in %q when txmode %q is set globally",
 			migration.UpTxMode,
 			migrationTxModeSourceName(migration.upSourcePath, migration.Description),


### PR DESCRIPTION
Closes #1076

## Summary

- classify invalid and conflicting Atlas transaction-mode directives with a typed leaf error
- remove only Ptah's internal `error applying migrations:` context from those errors on the `ptah-compat migrate apply` surface
- preserve native `ptah migrations up` context and the existing wrapper for SQL/runtime failures
- pin byte-exact compat stderr for unknown and duplicate directives
- verify every rejected transaction-mode matrix case executes no SQL and writes no revision row
- document the compatibility behavior and the public error classification

## Self-review

Two complete passes were performed.

1. The first pass replaced a sentinel-based classification that could leak future intermediate wrappers with `errors.As` and a typed leaf diagnostic.
2. The second pass removed a meaningless public `Unwrap` layer, checked every rejection path and unaffected error path, corrected the API wording for valid-but-conflicting modes, and regenerated the API snapshot to eliminate stale output.

Security and data-integrity review: the change does not alter SQL selection or execution. Validation still runs at the same point; the live SQLite matrix confirms zero schema and revision mutations for all rejected cases.

## Verification

- `go test -count=1 -race ./migration/migrator ./internal/atlasmigrate ./cmd/ptah-compat ./cmd/ptah`
- `go test -race ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `scripts/check-public-api.sh`
- `scripts/check-public-api-snapshot.sh`
- `scripts/check-public-api-released.sh`
- documentation link, redirect, page-health, exit-code, style, and version self-tests
- `npm run build`
- `npm run check:responsive:selftest`
- `npm run check:responsive` (60 routes x 2 viewports)
