### PR TITLE
Read a converted migration directory on migrate status and migrate set

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1837,10 +1837,18 @@ func TestCompatCommand_MigrateSetFailurePathVersionArgument(t *testing.T) {
 }
 
 // TestCompatCommand_MigrateMetadataRejectsUnsupportedAtlasDirFormat covers the
-// metadata verbs that still accept only the atlas layout. `migrate hash` and
-// `migrate validate` are deliberately absent: they read a directory rather than
-// rewrite one, so they implement every Atlas source layout under both
-// spellings (see migrate_integrity_formats_test.go) instead of rejecting it.
+// metadata verbs that still accept only the atlas layout.
+//
+// Four verbs are deliberately absent, and the reason is the same for all four:
+// they READ a directory rather than rewrite one, so a foreign layout can be
+// converted in memory and reported on. `migrate hash` and `migrate validate`
+// have been in that set since #992 (see migrate_integrity_formats_test.go);
+// `migrate status` and `migrate set` joined it in #1002 (see
+// migrate_revision_converted_test.go).
+//
+// The verbs that remain here WRITE, and writing a layout is a larger change
+// than reading one: it needs the converted form emitted back in the source
+// convention, which nothing here does yet.
 func TestCompatCommand_MigrateMetadataRejectsUnsupportedAtlasDirFormat(t *testing.T) {
 	tests := []struct {
 		name string
@@ -1865,14 +1873,6 @@ func TestCompatCommand_MigrateMetadataRejectsUnsupportedAtlasDirFormat(t *testin
 		{
 			name: "rm",
 			args: []string{"migrate", "rm", "1", "--dir", t.TempDir(), "--dir-format", "liquibase"},
-		},
-		{
-			name: "set",
-			args: []string{"migrate", "set", "20260723120000", "--url", "sqlite://state.db", "--dir", t.TempDir(), "--dir-format", "dbmate"},
-		},
-		{
-			name: "status",
-			args: []string{"migrate", "status", "--url", "sqlite://state.db", "--dir", t.TempDir(), "--dir-format", "liquibase"},
 		},
 		{
 			name: "test",

--- a/cmd/atlas/migrate_dir_query_test.go
+++ b/cmd/atlas/migrate_dir_query_test.go
@@ -120,14 +120,14 @@ func TestCompatMigrateDirQuery_IgnoresUnknownKeysOnEveryVerb(t *testing.T) {
 }
 
 // TestCompatMigrateDirQuery_FailurePathForeignFormat pins the part of the query
-// that is NOT ignored on the five verbs that read only a native Atlas
-// directory.
+// that is NOT ignored on the verbs that read only a native Atlas directory.
 //
-// The community binary honors `?format=` on these verbs; Ptah does not convert
-// (lint, status, set) or write (new, diff) a foreign layout there yet, so it
-// refuses rather than reading the directory under the wrong layout — the strict
-// side of the divergence. stokaro/ptah#1013 section 1 and stokaro/ptah#1002
-// track closing it.
+// The community binary honors `?format=` on these verbs. Ptah converts a
+// foreign layout for the verbs that only read one — status and set joined that
+// set in #1002 — and still refuses it on `migrate lint`, which reads the
+// directory into a dev-database replay, and on `migrate new` and `migrate diff`,
+// which WRITE into it. Refusing is the strict side of the divergence:
+// stokaro/ptah#1013 section 1 tracks closing it for lint.
 //
 // The refusal has to survive the relaxation above, which is why it is pinned:
 // once unknown keys are ignored, nothing else stops a `?format=goose` from
@@ -147,24 +147,6 @@ func TestCompatMigrateDirQuery_FailurePathForeignFormat(t *testing.T) {
 					"--dir", "file://"+dir+"?format=goose",
 					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
 					"--latest", "1")
-				return err
-			},
-		},
-		{
-			name: "status",
-			run: func(c *qt.C, dir string) error {
-				_, _, err := runCompat("migrate", "status",
-					"--dir", "file://"+dir+"?format=goose",
-					"--url", "sqlite://"+filepath.Join(c.TempDir(), "status.db"))
-				return err
-			},
-		},
-		{
-			name: "set",
-			run: func(c *qt.C, dir string) error {
-				_, _, err := runCompat("migrate", "set", "20240101000000",
-					"--dir", "file://"+dir+"?format=goose",
-					"--url", "sqlite://"+filepath.Join(c.TempDir(), "set.db"))
 				return err
 			},
 		},

--- a/cmd/atlas/migrate_revision_converted_test.go
+++ b/cmd/atlas/migrate_revision_converted_test.go
@@ -1,0 +1,295 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// These tests pin stokaro/ptah#1002 on `ptah-compat migrate status` and
+// `migrate set`: a migration directory laid out in a foreign tool's convention
+// is read through both spellings that select it, so a directory converted on
+// apply has a route to inspect and repair its revision table.
+//
+// Before this change both verbs refused every foreign layout, under both
+// spellings, with `Ptah does not implement that directory format ... yet` —
+// which is what every assertion below would print again if the change were
+// reverted, except where a row names something else.
+//
+// Measured against the pinned community binary v1.3.0 on the same fixture: a
+// hashed Flyway directory holding V1__first.sql and V2__second.sql reports
+// `Migration Status: PENDING` with two pending files on status, and
+// `Current version is 1 (1 set)` on `migrate set 1`, both exit 0.
+
+const (
+	revisionConvertedFirst  = "V1__first.sql"
+	revisionConvertedSecond = "V2__second.sql"
+)
+
+// writeConvertedFlywayDir writes a two-migration Flyway directory and no
+// atlas.sum.
+func writeConvertedFlywayDir(c *qt.C) string {
+	c.Helper()
+	dir := c.TempDir()
+	writeAtlasApplyProjectMigration(c, dir, revisionConvertedFirst,
+		"CREATE TABLE t1 (id INTEGER PRIMARY KEY);\n")
+	writeAtlasApplyProjectMigration(c, dir, revisionConvertedSecond,
+		"CREATE TABLE t2 (id INTEGER PRIMARY KEY);\n")
+	return dir
+}
+
+// hashConvertedFlywayDir writes the atlas.sum the community binary writes for
+// the Flyway layout, over the file set that layout covers. It goes through
+// `migrate hash` rather than a helper so the sum these tests gate against is
+// the one the shipped verb produces (#984, #992).
+func hashConvertedFlywayDir(c *qt.C, dir string) {
+	c.Helper()
+	_, stderr, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=flyway")
+	c.Assert(err, qt.IsNil, qt.Commentf("hash stderr: %s", stderr))
+}
+
+// convertedFlywayVersions returns the Atlas versions the Flyway directory
+// converts to, in execution order.
+//
+// They are read from the importer rather than written into the test, because
+// they are not the Flyway tokens. Ptah's migrator identifies a migration by an
+// int64 while the community binary identifies a Flyway migration by an opaque
+// string, so the conversion projects one space onto the other and the numbers
+// it produces are large and synthetic. Pinning them literally here would pin
+// that projection, which is not what these tests are about.
+func convertedFlywayVersions(c *qt.C, dir string) []string {
+	c.Helper()
+	loaded, err := atlasmigrateimport.LoadFS(
+		os.DirFS(dir),
+		dir,
+		atlasmigrateimport.FormatFlyway,
+	)
+	c.Assert(err, qt.IsNil)
+	versions := make([]string, 0, len(loaded.Entries))
+	for _, entry := range loaded.Entries {
+		name, _, found := strings.Cut(entry.Name, "_")
+		c.Assert(found, qt.IsTrue, qt.Commentf("converted entry %q carries no version prefix", entry.Name))
+		versions = append(versions, name)
+	}
+	return versions
+}
+
+// revisionDBURL returns a URL for a database file that does not exist yet, so
+// each row starts from an empty revision table.
+func revisionDBURL(c *qt.C) string {
+	c.Helper()
+	return "sqlite://" + filepath.Join(c.TempDir(), "revisions.db")
+}
+
+// TestCompatMigrateStatus_ConvertedDirIsRead is the discriminator for the
+// status half of #1002: both spellings that select a foreign layout now report
+// on it instead of refusing it.
+func TestCompatMigrateStatus_ConvertedDirIsRead(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		args func(dir string) []string
+	}{
+		{
+			name: "dir_query",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir + "?format=flyway"}
+			},
+		},
+		{
+			name: "dir_format_flag",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir, "--dir-format", "flyway"}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			dir := writeConvertedFlywayDir(c)
+			hashConvertedFlywayDir(c, dir)
+			args := append([]string{"migrate", "status"}, test.args(dir)...)
+			stdout, stderr, err := runCompatExit(append(args, "--url", revisionDBURL(c))...)
+			c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
+			c.Assert(stdout, qt.Contains, "Total Migrations: 2")
+			c.Assert(stdout, qt.Contains, "Pending Migrations: 2")
+			c.Assert(stdout, qt.Contains, "Applied Migrations: 0")
+		})
+	}
+}
+
+// TestCompatMigrateStatus_ConvertedDirRefusesDrift pins the ORDER of the two
+// changes, not just their sum. Integrity is verified on the source directory,
+// over the file set atlas.sum covers for the Flyway layout, BEFORE the layout
+// is converted.
+//
+// Reverting only the gate — converting first and gating the rebuilt filesystem
+// — would print `checksum file not found` for both rows, because a converted
+// directory carries no atlas.sum by construction. The edited row is what
+// separates the two: it must report a mismatch against a sum that exists.
+func TestCompatMigrateStatus_ConvertedDirRefusesDrift(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		prepare func(c *qt.C, dir string)
+		want    string
+	}{
+		{
+			name:    "unhashed",
+			prepare: func(*qt.C, string) {},
+			want:    atlasChecksumNotFoundErr,
+		},
+		{
+			name: "edited_after_hashing",
+			prepare: func(c *qt.C, dir string) {
+				hashConvertedFlywayDir(c, dir)
+				writeAtlasApplyProjectMigration(c, dir, revisionConvertedFirst,
+					"CREATE TABLE t1 (id INTEGER PRIMARY KEY, extra TEXT);\n")
+			},
+			want: atlasChecksumMismatchErr,
+		},
+		{
+			name: "covered_file_removed_after_hashing",
+			prepare: func(c *qt.C, dir string) {
+				hashConvertedFlywayDir(c, dir)
+				c.Assert(os.Remove(filepath.Join(dir, revisionConvertedSecond)), qt.IsNil)
+			},
+			want: atlasChecksumMismatchErr,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			dir := writeConvertedFlywayDir(c)
+			test.prepare(c, dir)
+			_, stderr, err := runCompatExit(
+				"migrate", "status",
+				"--dir", "file://"+dir+"?format=flyway",
+				"--url", revisionDBURL(c),
+			)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(stderr, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestCompatMigrateSet_ConvertedDirWritesConvertedVersion is the discriminator
+// for the set half of #1002, and for what `migrate set` writes: the revision it
+// records is the version the SAME directory would be applied under, so a status
+// run afterwards reports the first migration executed and the second pending.
+//
+// Asserting the status that follows is the point. A `migrate set` that merely
+// stopped refusing the layout, and recorded a version no converted file
+// carries, would still exit 0 here — and would then report two pending
+// migrations rather than one.
+func TestCompatMigrateSet_ConvertedDirWritesConvertedVersion(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	dir := writeConvertedFlywayDir(c)
+	hashConvertedFlywayDir(c, dir)
+	versions := convertedFlywayVersions(c, dir)
+	c.Assert(versions, qt.HasLen, 2)
+	url := revisionDBURL(c)
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "set", versions[0],
+		"--dir", "file://"+dir+"?format=flyway",
+		"--url", url,
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, qt.Contains, "Current version is "+versions[0])
+
+	stdout, stderr, err = runCompatExit(
+		"migrate", "status",
+		"--dir", "file://"+dir+"?format=flyway",
+		"--url", url,
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, qt.Contains, "Applied Migrations: 1")
+	c.Assert(stdout, qt.Contains, "Pending Migrations: 1")
+}
+
+// TestCompatMigrateRevisionVerbs_DirFormatIsVerbatim pins the case rule these
+// two verbs now share with `migrate apply`.
+//
+// The community binary matches the format value verbatim: measured on v1.3.0,
+// `--dir-format ATLAS`, `--dir-format ' atlas '` and `?format=FLYWAY` each exit
+// 1 with `unknown dir format`, while the lowercase spellings exit 0. Status and
+// set used to lower-and-trim the flag, so the first two exited 0 — looser than
+// the binary being mirrored, which is the direction that must never happen.
+//
+// Reverting the change makes the two `ATLAS` rows and the two ` atlas ` rows
+// exit 0. The `?format=FLYWAY` row held before it too — the query spelling was
+// already resolved verbatim — and is here so the two spellings stay pinned to
+// one rule rather than drifting apart again.
+func TestCompatMigrateRevisionVerbs_DirFormatIsVerbatim(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name string
+		verb string
+		args func(dir string) []string
+	}{
+		{
+			name: "status_uppercase_atlas_flag",
+			verb: "status",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir, "--dir-format", "ATLAS"}
+			},
+		},
+		{
+			name: "status_padded_atlas_flag",
+			verb: "status",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir, "--dir-format", " atlas "}
+			},
+		},
+		{
+			name: "status_uppercase_flyway_query",
+			verb: "status",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir + "?format=FLYWAY"}
+			},
+		},
+		{
+			name: "set_uppercase_atlas_flag",
+			verb: "set",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir, "--dir-format", "ATLAS"}
+			},
+		},
+		{
+			name: "set_padded_atlas_flag",
+			verb: "set",
+			args: func(dir string) []string {
+				return []string{"--dir", "file://" + dir, "--dir-format", " atlas "}
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			dir := writeConvertedFlywayDir(c)
+			hashConvertedFlywayDir(c, dir)
+			args := append([]string{"migrate", test.verb}, test.args(dir)...)
+			args = append(args, "--url", revisionDBURL(c))
+			_, stderr, err := runCompatExit(append(args, revisionSetVersionArg(test.verb)...)...)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(stderr, qt.Contains, "unknown Atlas migration directory format")
+		})
+	}
+}
+
+// revisionSetVersionArg supplies the positional version `migrate set` requires
+// and `migrate status` refuses, so one table can drive both verbs without a
+// branch in the test body.
+func revisionSetVersionArg(verb string) []string {
+	return map[string][]string{"set": {"1"}}[verb]
+}

--- a/cmd/atlas/migrate_revision_source.go
+++ b/cmd/atlas/migrate_revision_source.go
@@ -1,0 +1,106 @@
+package atlas
+
+import (
+	"fmt"
+	"io/fs"
+	"net/url"
+
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+	"go.5x5.cz/ptah/internal/fsnapshot"
+)
+
+// resolveAtlasRevisionDirFormat resolves the directory layout a revision-table
+// verb — `migrate status` and `migrate set` — reads, from both spellings that
+// can carry it, and blames the one that did.
+//
+// It is [atlasmigrate.ResolveApplyDirFormat], the resolver `migrate apply`
+// uses, so the verbs that read a converted directory cannot drift on which
+// spelling wins or on which values are accepted. That matters for case in
+// particular: the community binary matches the value verbatim, and measured on
+// v1.3.0 `--dir-format ATLAS`, `--dir-format ' atlas '` and `?format=FLYWAY`
+// each exit 1 with `unknown dir format`. The lower-and-trim normalization these
+// two verbs used to apply accepted all three.
+//
+// The returned error already names the command and the flag, because only this
+// function knows which of the two spellings carried the rejected value.
+func resolveAtlasRevisionDirFormat(
+	verb string,
+	configured string,
+	query url.Values,
+) (atlasmigrateimport.Format, error) {
+	format, err := atlasmigrate.ResolveApplyDirFormat(configured, query)
+	if err == nil {
+		return format, nil
+	}
+	// A ?format= query is the only thing that can carry a format value other
+	// than the configured one, so it is the only thing that can be blamed for a
+	// rejected one. A query holding only ignored keys selects nothing, and the
+	// blame stays on --dir-format.
+	spelling := "--dir-format"
+	if atlasmigrate.DirFormatFromQuery(query) {
+		spelling = "--dir"
+	}
+	return "", fmt.Errorf("atlas migrate %s %s: %w", verb, spelling, err)
+}
+
+// atlasRevisionCapture is a migration directory a revision-table verb has read
+// but not yet interpreted: the bytes its integrity gate verifies, and — for a
+// directory laid out in a foreign tool's convention — the covered source set
+// that gets converted once the gate passes.
+//
+// The two-step shape is the point. Integrity is verified BEFORE the source
+// layout is parsed, because that is where the community binary verifies it: an
+// unhashed Goose directory whose .sql carries no `-- +goose Up` directive is
+// refused with a checksum error, never with a conversion error. Converting
+// first and gating the result would report the wrong failure, and would gate a
+// filesystem rebuilt in memory that carries no integrity file by construction
+// (#973).
+type atlasRevisionCapture struct {
+	format atlasmigrateimport.Format
+	// source is the directory as read. It is what the gate verifies for a
+	// native Atlas directory.
+	source fs.FS
+	// captured is the covered source set for a foreign layout, empty for a
+	// native one. It is both what the gate verifies and what gets converted, so
+	// the bytes that were checked are the bytes that get interpreted rather
+	// than two reads of the same directory that happen to agree.
+	captured fsnapshot.Snapshot
+}
+
+// captureAtlasRevisionSource reads a migration directory in the shape format
+// requires. A native Atlas directory is kept as-is, so the native gate keeps
+// seeing every file in it, including the ones it warns are not covered by
+// atlas.sum.
+func captureAtlasRevisionSource(
+	source fs.FS,
+	format atlasmigrateimport.Format,
+) (atlasRevisionCapture, error) {
+	if atlasmigrate.ReadsNativeAtlasDir(format) {
+		return atlasRevisionCapture{format: format, source: source}, nil
+	}
+	captured, err := atlasmigrate.CaptureApplySource(source, format)
+	if err != nil {
+		return atlasRevisionCapture{}, err
+	}
+	return atlasRevisionCapture{format: format, source: captured, captured: captured}, nil
+}
+
+// gateFS returns the filesystem the integrity gate verifies.
+func (c atlasRevisionCapture) gateFS() fs.FS {
+	return c.source
+}
+
+// migrationFS returns the filesystem the verb interprets as Atlas migrations.
+// A foreign layout is rebuilt in memory as up-only Atlas migrations, which is
+// the same conversion `migrate apply` executes — so the versions a status
+// report names and a `migrate set` writes are the versions an apply of the same
+// directory records.
+//
+// Call it only after the gate has passed.
+func (c atlasRevisionCapture) migrationFS(display string) (fs.FS, error) {
+	if atlasmigrate.ReadsNativeAtlasDir(c.format) {
+		return c.source, nil
+	}
+	return atlasmigrate.ConvertApplySource(c.captured, display, c.format)
+}

--- a/cmd/atlas/migrate_set.go
+++ b/cmd/atlas/migrate_set.go
@@ -14,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -28,6 +29,7 @@ type atlasMigrateSetOptions struct {
 type atlasMigrateSetPreparation struct {
 	options atlasMigrateSetOptions
 	dir     atlasargs.LocalDir
+	format  atlasmigrateimport.Format
 	project atlasProject
 }
 
@@ -79,6 +81,10 @@ func runAtlasMigrateSet(
 	if err != nil {
 		return failAtlasCommand(cmd, fmt.Errorf("atlas migrate set --dir: %w", err))
 	}
+	captured, err := captureAtlasRevisionSource(source.FileSystem, prepared.format)
+	if err != nil {
+		return failAtlasCommand(cmd, fmt.Errorf("atlas migrate set --dir: %w", err))
+	}
 	// Integrity gate (#974). `migrate set` writes revision rows that declare a
 	// directory's history applied, so running it against a directory nothing has
 	// verified records a state derived from files that may have drifted.
@@ -90,8 +96,12 @@ func runAtlasMigrateSet(
 	// zero or two positionals against an unhashed directory prints the checksum
 	// refusal, not an arity error. Returned bare so the stdout guidance block
 	// and the `Error: ...` line land where that binary puts them.
-	if err := verifyNativeAtlasDirChecksum(cmd, source.FileSystem); err != nil {
+	if err := verifyAtlasApplyChecksum(cmd, captured.gateFS(), prepared.format); err != nil {
 		return err
+	}
+	migrationFS, err := captured.migrationFS(source.Display)
+	if err != nil {
+		return failAtlasCommand(cmd, fmt.Errorf("atlas migrate set --dir: %w", err))
 	}
 
 	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
@@ -114,7 +124,7 @@ func runAtlasMigrateSet(
 	}
 	result, err := atlasmigrate.Set(cmd.Context(), conn, version, atlasmigrate.SetOptions{
 		Dir:             source.Display,
-		FS:              source.FileSystem,
+		FS:              migrationFS,
 		AtlasEnv:        opts.atlasEnv,
 		RevisionsSchema: opts.revisionsSchema,
 	})
@@ -180,12 +190,12 @@ func prepareAtlasMigrateSet(
 	if opts.dir == "" {
 		return prepared, fmt.Errorf("migrations directory is required")
 	}
-	format, err := atlasMigrateDirFormatValue(opts.dirFormat)
-	if err != nil {
-		return prepared, fmt.Errorf("atlas migrate set --dir-format: %w", err)
-	}
-	if format != atlasDirFormatDefault {
-		return prepared, fmt.Errorf("atlas migrate set --dir-format: expected atlas")
+	// The flag value is checked before --dir is parsed, where it was checked
+	// when only the Atlas layout was accepted, so an invocation carrying two bad
+	// values keeps printing the same one of them. The query spelling lives in
+	// --dir and joins the resolution below.
+	if _, err := resolveAtlasRevisionDirFormat("set", opts.dirFormat, nil); err != nil {
+		return prepared, err
 	}
 
 	var localDir atlasargs.LocalDir
@@ -199,8 +209,9 @@ func prepareAtlasMigrateSet(
 	if err != nil {
 		return prepared, fmt.Errorf("atlas migrate set --dir: %w", err)
 	}
-	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
-		return prepared, fmt.Errorf("atlas migrate set --dir: %w", err)
+	format, err := resolveAtlasRevisionDirFormat("set", opts.dirFormat, localDir.Query)
+	if err != nil {
+		return prepared, err
 	}
 	// Preserve Atlas-compatible directory diagnostics; the subsequent
 	// CaptureLocal call remains the authoritative rooted read and rejects any
@@ -214,6 +225,7 @@ func prepareAtlasMigrateSet(
 	}
 	prepared.options = opts
 	prepared.dir = localDir
+	prepared.format = format
 	return prepared, nil
 }
 

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -103,12 +103,14 @@ func runAtlasMigrateStatus(
 	if err := validateAtlasMigrateStatusOptions(opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	format, err := atlasMigrateDirFormatValue(opts.dirFormat)
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir-format: %w", err))
-	}
-	if format != atlasDirFormatDefault {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir-format: expected atlas"))
+	// The flag value is validated here, before --format and before --dir is
+	// parsed, because that is where it was validated when only the Atlas layout
+	// was accepted: moving the whole resolution below --dir would change which
+	// diagnostic an invocation carrying two bad values prints. The query
+	// spelling cannot be resolved yet — it lives in --dir — so this pass sees
+	// the configured value alone and the two are combined below.
+	if _, err := resolveAtlasRevisionDirFormat("status", opts.dirFormat, nil); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	if formatOutput {
 		if err := validateAtlasMigrateStatusFormat(opts.format); err != nil {
@@ -130,10 +132,15 @@ func runAtlasMigrateStatus(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
 	}
-	if err := checkNativeAtlasDirQuery(localDir.Query); err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
+	format, err := resolveAtlasRevisionDirFormat("status", opts.dirFormat, localDir.Query)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	source, err := project.captureLocal(localDir)
+	if err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
+	}
+	captured, err := captureAtlasRevisionSource(source.FileSystem, format)
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
 	}
@@ -146,17 +153,21 @@ func runAtlasMigrateStatus(
 	// Placement is measured, not stylistic. The refusal precedes the database
 	// connection (it is emitted even when --url is unreachable) and it covers a
 	// directory resolved from atlas.hcl as well as one named by --dir, which is
-	// why it sits here rather than beside the flag parsing. Only the native
-	// branch of the gate is reachable: checkNativeAtlasDirQuery above admits a
-	// `?format=` only when it resolves to the Atlas layout, and a non-atlas
-	// --dir-format is rejected above too.
+	// why it sits here rather than beside the flag parsing.
+	//
+	// Both branches are reachable since #1002: a foreign layout is gated over
+	// the file set atlas.sum covers for THAT layout, before it is converted.
 	//
 	// Returned bare on purpose — cmdutil.Fail would prepend `error: ` and move
 	// the message off the stream the community binary writes it to.
-	if err := verifyNativeAtlasDirChecksum(cmd, source.FileSystem); err != nil {
+	if err := verifyAtlasApplyChecksum(cmd, captured.gateFS(), format); err != nil {
 		return err
 	}
 	dir := source.Display
+	migrationFS, err := captured.migrationFS(dir)
+	if err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate status --dir: %w", err))
+	}
 	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
 	defer cancel()
 	conn, err := dbschema.ConnectToDatabase(connectCtx, opts.url)
@@ -167,7 +178,7 @@ func runAtlasMigrateStatus(
 
 	result, err := atlasmigrate.Status(cmd.Context(), conn, atlasmigrate.StatusOptions{
 		Dir:             dir,
-		FS:              source.FileSystem,
+		FS:              migrationFS,
 		AtlasEnv:        opts.atlasEnv,
 		RevisionsSchema: opts.revisionsSchema,
 	})
@@ -179,7 +190,7 @@ func runAtlasMigrateStatus(
 			Driver:           conn.Info().Dialect,
 			URL:              opts.url,
 			Dir:              atlasStatusDirURL(opts.dir),
-			FS:               source.FileSystem,
+			FS:               migrationFS,
 			Status:           result.Status,
 			AppliedRevisions: result.AppliedRevisions,
 		})


### PR DESCRIPTION
Closes #1002.

`migrate status` and `migrate set` refused every foreign directory layout, under both spellings that select one. That left a directory Ptah converts on `migrate apply` with no route to inspect or repair its revision table — and those two verbs are exactly what an operator reaches for when a revision table and a directory disagree. `--baseline` is not a substitute; measured, it refuses once the revisions table is non-empty.

## Measured

Pinned community binary v1.3.0, by absolute path. Fixture: a hashed Flyway directory holding `V1__first.sql` and `V2__second.sql`.

| invocation | community binary | ptah-compat before | ptah-compat after |
|---|---|---|---|
| `migrate status --dir 'file://d?format=flyway'` | rc=0, `Migration Status: PENDING`, 2 pending | rc=1, `does not implement that directory format for this command yet` | rc=0, 2 pending |
| `migrate status --dir file://d --dir-format flyway` | rc=0, same | rc=1, `does not implement that directory format yet` | rc=0, 2 pending |
| `migrate set <version> --dir 'file://d?format=flyway'` | rc=0, `Current version is 1 (1 set)` | rc=1, refused | rc=0, 1 applied / 1 pending afterwards |
| `--dir-format ATLAS` | rc=1, `unknown dir format "ATLAS"` | **rc=0** | rc=1 |
| `--dir-format ' atlas '` | rc=1, `unknown dir format " atlas "` | **rc=0** | rc=1 |
| `?format=FLYWAY` | rc=1 | rc=1 | rc=1 |

The two bolded cells are the opposite divergence, closed by the same change: these verbs lowered and trimmed `--dir-format` while the binary being mirrored matches it verbatim. Exiting 0 where it exits 1 is the direction that must never happen.

## What the change is

Both verbs resolve the layout through `atlasmigrate.ResolveApplyDirFormat` — the resolver `migrate apply` already uses, so the verbs that read a converted directory cannot drift on which spelling wins or which values are accepted. They then capture the source, verify its `atlas.sum` over the file set that layout covers, and convert only after the gate passes.

The order is measured, not stylistic. The community binary verifies integrity **before** it parses the source layout: an unhashed Goose directory whose `.sql` carries no directive is refused with a checksum error, never with a conversion error. Converting first would report the wrong failure, and would gate a filesystem rebuilt in memory that carries no integrity file by construction (#973).

The native branch is deliberately left reading the directory as-is rather than going through the capture, so the native gate keeps seeing every file — including the ones it warns are not covered by `atlas.sum`.

## What each test prints if the change is reverted

Verified by reverting `migrate_status.go` and `migrate_set.go` to master and re-running: 12 of the 13 rows go red.

- `TestCompatMigrateStatus_ConvertedDirIsRead` (2 rows) — `Ptah does not implement that directory format`.
- `TestCompatMigrateStatus_ConvertedDirRefusesDrift` (3 rows) — same refusal instead of the checksum diagnostics. The `edited_after_hashing` and `covered_file_removed_after_hashing` rows are what separate the gate's position from its presence: gating after conversion would print `checksum file not found` for all three, since a converted directory carries no sum.
- `TestCompatMigrateSet_ConvertedDirWritesConvertedVersion` — refusal instead of a recorded revision. It asserts the **following** status run, because a `migrate set` that merely stopped refusing the layout and recorded a version no converted file carries would still exit 0.
- `TestCompatMigrateRevisionVerbs_DirFormatIsVerbatim` — the four `ATLAS` / ` atlas ` rows exit 0. The `?format=FLYWAY` row held before this change too; it is there so the two spellings stay pinned to one rule.

Two existing tests asserted the old refusal and were updated rather than deleted: `TestCompatCommand_MigrateMetadataRejectsUnsupportedAtlasDirFormat` and `TestCompatMigrateDirQuery_FailurePathForeignFormat` both lost their status and set rows, and both gained a comment saying why the verbs that remain are the ones that *write*.

## What this deliberately does not do

- **`migrate lint` still refuses a foreign layout.** It reads the directory into a dev-database replay, which is more than reporting on it. #1013 section 1 tracks that.
- **`migrate new` and `migrate diff` still refuse it.** They write into the directory and run no integrity gate; #1086 tracks that pairing.
- **The Flyway version projection is unchanged.** What `migrate set` writes is the version the same directory would be applied under. For Flyway those are not the Flyway tokens — Ptah's migrator identifies a migration by an int64, the community binary identifies a Flyway migration by an opaque string — so the numbers are large and synthetic. The tests read them from the importer rather than pinning the projection. A consequence of that projection, measured while building this and reported separately, is that the two implementations record different versions for the same converted directory.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `golangci-lint run ./...`, `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all green. No `docs/` changes, so the docs-site checks do not apply.