### PR TITLE
Settle 18 unknown matrix cells by measurement, refile 13 misplaced citations

### DIFF
--- a/docs/site/scripts/build-feature-matrix.mjs
+++ b/docs/site/scripts/build-feature-matrix.mjs
@@ -58,6 +58,49 @@ service, not artifact storage; the storage function is covered under
 [Data and distribution](#data-and-distribution).`,
 };
 
+// Every area label a row is allowed to carry. bucket() matches by prefix, so a
+// citation appended to an area still routes to a section and the page still
+// builds - which is how thirteen rows came to carry another row's evidence in
+// their area field. An exact-match roster is what makes that failure loud.
+const AREAS = new Set([
+  'API schema export',
+  'Approval and policy workflows',
+  'Atlas Registry and Cloud',
+  'Configuration and dev databases',
+  'Data and distribution',
+  'Data management',
+  'Database engines',
+  'Declarative / direct schema workflow',
+  'Declarative and direct schema changes',
+  'Dev databases',
+  'Editor tooling',
+  'Go embedding',
+  'Go embedding and developer tooling',
+  'Go-first modeling',
+  'Lint analyzers',
+  'Lint output and CI',
+  'Lint policy and suppression',
+  'Linting and safety',
+  'Migration directory formats',
+  'Migration linting',
+  'OCI artifacts',
+  'Project config',
+  'Safety gates',
+  'Schema inspection filters',
+  'Schema object kinds',
+  'Schema sources',
+  'Schema visualization',
+  'Test frameworks',
+  'Testing framework',
+  'Verification and contracts',
+  'Versioned migrations',
+  'Versioned migrations — directory',
+  'Versioned migrations — execution',
+  'Versioned migrations — revision state',
+  'Versioned migrations — runtime policy',
+  'Versioned migrations — safety',
+]);
+
 function bucket(area) {
   const text = area.toLowerCase();
   for (const [index, [title, prefixes]] of AREA_MAP.entries()) {
@@ -81,6 +124,11 @@ function validate(rows) {
   const problems = [];
   const seen = new Map();
   for (const row of rows) {
+    if (!AREAS.has(row.area)) {
+      problems.push(
+        `${row.feature}: area ${JSON.stringify(row.area)} is not a known label - if it is a citation, it belongs in the evidence of the row it settles`,
+      );
+    }
     if (row.note.length > 200) problems.push(`${row.feature}: note is ${row.note.length} chars`);
     if (BANNED.test(row.note) || BANNED.test(row.feature)) problems.push(`${row.feature}: banned word`);
     for (const key of ['ptah', 'atlas_oss', 'atlas_pro']) {

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -779,11 +779,11 @@
     "ptah": "yes",
     "atlas_oss": "unknown",
     "atlas_pro": "no",
-    "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package.",
-    "evidence": "migration/dbtest/engine.go:247 RunMigrationTest and migration/dbtest/schema.go:53 RunSchemaTest; conformance cli-surface.md measures CLI commands only, and gaps.md lines 167-172 show the corpus imports atlasexec fixtures, so Atlas does have an observable Go package surface \u2014 the previous \u274c/\u274c cells asserted an Atlas distribution fact no cited source establishes"
+    "note": "migration/dbtest exports RunMigrationTest and RunSchemaTest. CE stays unknown: a CLI probe cannot see a Go API; an Atlas-side source naming a test-runner entry point would settle it.",
+    "evidence": "Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. `atlas schema test --help` and `atlas migrate test --help` each print \"'atlas schema test' is not supported by the community version.\" (exit 0), so the community build exposes no test runner on its CLI. That bounds the CLI surface but not a Go library API, which no command can show. CE cell stays unknown; what would settle it: an Atlas-side source that names a Go entry point for the test runner, of the kind the schema-testing page fails to provide. Atlas schema testing docs (atlasgo.io/testing/schema), retrieved 2026-08-03: the page states `Schema testing works only for Atlas Pro users, free and paid`, and documents the framework exclusively through the `atlas schema test` CLI -- test block syntax and command flags, with no Go library entry point. `Go package`, `embed` and `import` are each absent from the page, as is the control term `tttnotarealterm`, while `Pro` returns the quote above. So Atlas Pro has schema testing but not as an embeddable Go package."
   },
   {
-    "area": "Lint analyzers Atlas schema testing docs (atlasgo.io/testing/schema), retrieved 2026-08-03: the page states `Schema testing works only for Atlas Pro users, free and paid`, and documents the framework exclusively through the `atlas schema test` CLI -- test block syntax and command flags, with no Go library entry point. `Go package`, `embed` and `import` are each absent from the page, as is the control term `tttnotarealterm`, while `Pro` returns the quote above. So Atlas Pro has schema testing but not as an embeddable Go package.",
+    "area": "Lint analyzers",
     "feature": "Native migration lint rule set",
     "ptah": "yes",
     "atlas_oss": "partial",
@@ -831,10 +831,10 @@
     "area": "Lint policy and suppression",
     "feature": "Per-rule severity policy",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "partial",
-    "note": "Severity vocabulary is warning|error only (info errors out). Measured, Atlas is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist.",
-    "evidence": "migration/lint/config.go:78 validateConfig admits only SeverityWarning/SeverityError. Reproduced: `severity: info` -> `error: failed to parse lint config .ptah-lint.yaml: rule DS101 has unsupported severity \"info\"` (exit 2); `severity: warning` demotes DS101 from error. config/projectconfig/atlas.go:594 parseLintAnalyzer takes only `error` bool. No cited Atlas source establishes CE severity-policy behavior; the Atlas features page classifies the linting CLI as Pro. analyzer blocks and .rule.hcl reject a `severity` attribute; the only per-analyzer control is boolean error (measured; observation study, scenario, lint-test-pro)"
+    "note": "Severity vocabulary is warning|error only (info errors out). The community binary carries no severity attribute: it accepts one and ignores it, exactly as it treats an invented attribute.",
+    "evidence": "migration/lint/config.go:78 validateConfig admits only SeverityWarning/SeverityError. Reproduced: `severity: info` -> `error: failed to parse lint config .ptah-lint.yaml: rule DS101 has unsupported severity \"info\"` (exit 2); `severity: warning` demotes DS101 from error. config/projectconfig/atlas.go:594 parseLintAnalyzer takes only `error` bool. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Same directory (CREATE TABLE then DROP TABLE), same command shape `atlas migrate lint -c file://<cfg>.hcl --env dev --dir file://migrations --dev-url <pg> --latest 1`, three configs. destructive { error = true }: exit 1, \"1 version with errors\". Same block plus severity = \"warning\": exit 1, byte-identical report. Same block plus zzznotarealattrib = \"x\": exit 1, byte-identical again - so severity is indistinguishable from an attribute that does not exist. Positive control that the config is read at all: destructive { error = false } prints \"1 version with warnings\" and exits 0."
   },
   {
     "area": "Lint output and CI",
@@ -849,13 +849,13 @@
     "area": "Lint output and CI",
     "feature": "CI integration (GitHub Action, annotations)",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "yes",
-    "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations.",
-    "evidence": "`ptah migrations lint --help` registers `--format ... github-actions`. Atlas side: docs/site/src/content/docs/atlas/docs-coverage.md:533 \"Atlas integration parity is unmeasured\"; the Atlas feature availability page does not address GitHub Actions integration, and cli-surface.md inventories no action. Nothing cited settles either Atlas column. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: the Atlas Pipelines section lists 'CI/CD integrations (K8s, TF, GH, GitLab, BitBucket)' as Basic on the free tier and checked on Pipelines Pro \u2014 a separately priced product ($59/mo per project requiring Atlas Pro seats), so it does not settle either CLI-plan column."
+    "note": "stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. The community binary has no annotation mode; its lint `--format` takes a Go template only.",
+    "evidence": "Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. `atlas migrate lint --help` inventories every flag: --dev-url, --dir, --dir-format, --format (\"Go template to use to format the output\"), --latest, --git-base, --git-dir. No annotation format and no CI-specific output mode. The Action half rests on the cited GitHub Actions page, which carries no plan marker; the annotation half is measured absent from the binary, hence partial. Atlas GitHub Actions docs (atlasgo.io/integrations/github-actions), retrieved 2026-08-03: `Atlas provides a number of GitHub Actions that can be used to automate database schema management tasks`, with no Pro marker attached, so the capability is present on Pro. Control on the same query: `vvvnotarealterm` returns not-found. The annotations half is unconfirmed -- `annotation` does not appear on that page."
   },
   {
-    "area": "Safety gates Atlas GitHub Actions docs (atlasgo.io/integrations/github-actions), retrieved 2026-08-03: `Atlas provides a number of GitHub Actions that can be used to automate database schema management tasks`, with no Pro marker attached, so the capability is present on Pro. Control on the same query: `vvvnotarealterm` returns not-found. The annotations half is unconfirmed -- `annotation` does not appear on that page.",
+    "area": "Safety gates",
     "feature": "Apply-time destructive-change gate",
     "ptah": "yes",
     "atlas_oss": "no",
@@ -1029,13 +1029,13 @@
     "area": "Schema object kinds",
     "feature": "Extensions",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment.",
-    "evidence": "core/renderer/internal/dialects/mysql/mysql.go:26-30 copies the bufwriter by value so VisitExtension (line 132) writes to a buffer Output() never reads; verified live: `ptah schema compare` against PostgreSQL 18 proposed DROP EXTENSION for pg_trgm and left plpgsql alone"
+    "note": "PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. The community binary refuses extension blocks.",
+    "evidence": "Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Two directions. Writing: `atlas schema diff --from file://empty.hcl --to file://b_extension.hcl --dev-url <pg>` exits 1 with \"Error: postgres: extensions are not supported by this version.\" Reading: a live schema that really contains pg_trgm inspects to `table \"anchor\"` and `schema \"kinds\"` only, while ptah-compat on the same URL emits extension \"pg_trgm\" with version 1.6. If the cell were still ❔ the second run would have to be read as \"unmeasured\"; it is not, the object exists and one binary omits it. Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Extensions` is listed under the PostgreSQL Pro Plan features. Control on the same page and the same query: `Database Inspection` carries the tier label `Open`, and `deferrable` is absent entirely, so the page distinguishes tiers rather than labelling everything Pro."
   },
   {
-    "area": "Schema object kinds Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Extensions` is listed under the PostgreSQL Pro Plan features. Control on the same page and the same query: `Database Inspection` carries the tier label `Open`, and `deferrable` is absent entirely, so the page distinguishes tiers rather than labelling everything Pro.",
+    "area": "Schema object kinds",
     "feature": "Roles, grants, and row-level security",
     "ptah": "partial",
     "atlas_oss": "no",
@@ -1047,13 +1047,13 @@
     "area": "Schema object kinds",
     "feature": "Domains, composite types, and range types",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all.",
-    "evidence": "internal/convert/fromschema/fromschema.go:1616 gates domain/range/composite emission on isPostgreSQLPlatform (postgres|postgresql only); migration/schemadiff/internal/compare/usertypes.go:158-174 compares ranges by name only; live YugabyteDB 2026.1.0.0 `ptah schema apply --dry-run` planned CREATE DOMAIN \"yb_domain\" AS TEXT"
+    "note": "PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff. The community binary reports none of the three when they exist.",
+    "evidence": "Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Fixture schema \"kinds\" holds CREATE DOMAIN us_postal, CREATE TYPE addr AS (city text, zip text), CREATE TYPE int_span AS RANGE, a sequence and pg_trgm. `atlas schema inspect --url <pg> -s kinds` returns exactly `table \"anchor\"` plus `schema \"kinds\"`; ptah-compat on the same URL returns domain, composite, range, sequence and extension blocks. In the writing direction a domain or composite block in a schema file leaves the community binary printing \"Schemas are synced, no changes to be made.\" - dropped in silence, not refused. Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Domain types`, `Composite types` and `Range types` are each listed under the PostgreSQL Pro Plan features. Same control as the extensions row."
   },
   {
-    "area": "Data and distribution Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Domain types`, `Composite types` and `Range types` are each listed under the PostgreSQL Pro Plan features. Same control as the extensions row.",
+    "area": "Data and distribution",
     "feature": "Registry-backed distribution: `oci://` vs `atlas://`",
     "ptah": "yes",
     "atlas_oss": "no",
@@ -1086,25 +1086,25 @@
     "atlas_oss": "na",
     "atlas_pro": "unknown",
     "note": "Pushing to an @sha256 reference is refused; `--version` is write-once and a conflict exits 2. The reference tag, `--tag` values and latest all move.",
-    "evidence": "push to @sha256:2ebd84f9... -> exit 2 'cannot push to a digest reference'; re-push --version rel1 with changed content -> exit 2 'OCI write-once tag already exists'; tag v1 moved from sha256:869dd082 to sha256:70575f30 across pushes while rel1 stayed pinned"
+    "evidence": "push to @sha256:2ebd84f9... -> exit 2 'cannot push to a digest reference'; re-push --version rel1 with changed content -> exit 2 'OCI write-once tag already exists'; tag v1 moved from sha256:869dd082 to sha256:70575f30 across pushes while rel1 stayed pinned. Stays unknown deliberately, and here is how far the sources reach. Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `sha256`, `digest` and `immutable` are each absent, so digest pinning is unsupported by that source; but `--tag` (`tag to push the directory with`) and `--version` (`version of the schema to push. Defaults to the current timestamp`) are documented WITHOUT any statement about whether they can be overwritten, so the write-once half is unestablished. One cell cannot honestly read `no` for one half and `unknown` for the other. atlasgo.io/registry returns an empty body through this channel. Control: `jjjnotarealterm` returns not-found."
   },
   {
-    "area": "Data and distribution Stays unknown deliberately, and here is how far the sources reach. Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `sha256`, `digest` and `immutable` are each absent, so digest pinning is unsupported by that source; but `--tag` (`tag to push the directory with`) and `--version` (`version of the schema to push. Defaults to the current timestamp`) are documented WITHOUT any statement about whether they can be overwritten, so the write-once half is unestablished. One cell cannot honestly read `no` for one half and `unknown` for the other. atlasgo.io/registry returns an empty body through this channel. Control: `jjjnotarealterm` returns not-found.",
+    "area": "Data and distribution",
     "feature": "Artifact integrity check (`--verify-sum`)",
     "ptah": "partial",
     "atlas_oss": "na",
     "atlas_pro": "no",
     "note": "On migrations push and up only. It checks the directory against the ptah.sum inside the same artifact, so content rewritten with its sum passes.",
-    "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'"
+    "evidence": "tampered file, unchanged sum: push and up both exit 2 'migration directory does not match ptah.sum: changed: 1785514698_init.up.sql'; tampered file plus re-run migrations hash: up --verify-sum exits 0 and creates table 'evil'. Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `--verify-sum` does not appear on the page, which enumerates every command and its flags. Scoped to the flag: Atlas's directory-integrity mechanism is atlas.sum with `migrate validate`, which checks a migration directory rather than an artifact against a sum embedded in it. Control as above."
   },
   {
-    "area": "OCI artifacts Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `--verify-sum` does not appear on the page, which enumerates every command and its flags. Scoped to the flag: Atlas's directory-integrity mechanism is atlas.sum with `migrate validate`, which checks a migration directory rather than an artifact against a sum embedded in it. Control as above.",
+    "area": "OCI artifacts",
     "feature": "Referrer attachments: lint, plan, deployment reports",
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "unknown",
     "note": "lint `--attach`, migrations plan `--attach` and up attach reports to an exact digest. `oci referrers` lists descriptors only; no flag downloads the payload.",
-    "evidence": "oci referrers --format json returns digest/artifact_type/media_type/size/annotations only; flags are --format, --type, --plain-http; the manifest's deployment.json layer (362 bytes) is reachable only through the raw registry API; cmd/oci/oci.go:69 calls ocireferrers.List"
+    "evidence": "Pro cell stays unknown; what would settle it: an Atlas-side source stating whether reports are attached to an artifact as OCI referrers, which neither the CLI reference nor the registry page addresses. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. The community binary carries no referrer surface to compare against: `atlas` has no oci verb at all."
   },
   {
     "area": "Schema sources",
@@ -1119,22 +1119,22 @@
     "area": "Schema sources",
     "feature": "HCL top-level blocks Ptah parses",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "yes",
-    "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data.",
-    "evidence": "internal/atlashcl/atlashcl.go:73-113; a fixture exercising all 16 renders 17 PostgreSQL statements via `ptah schema render --schema-file all.hcl --dialect postgres`. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Database Security as Code (linked /atlas-schema/hcl#roles-and-permissions) and Seed Data as Code are absent from Starter and Pro-gated \u2014 this bears on the role, permission and data blocks only, so both Atlas cells stay unknown"
+    "note": "schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. The community binary plans DDL for table and enum.",
+    "evidence": "Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. One block per file, `atlas schema diff --from file://empty.hcl --to file://<probe>.hcl --dev-url <pg>`. Plans DDL: table (CREATE TABLE \"t\"), enum (CREATE TYPE \"mood\" AS ENUM). Refuses loudly, exit 1: extension, sequence (\"...are not supported by this version\"). Accepts and drops in silence, exit 0 with \"Schemas are synced, no changes to be made.\": view, domain, composite, role - and an invented block `zzzznotarealblock` behaves identically, which is why exit status alone cannot be the discriminator here and the planned bytes are. Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: schema, table, column, primary_key, foreign_key and index carry no tier marker, while views, materialized views, triggers, functions, procedures, domains, composite types, range types, policies, sequences, extensions and roles/permissions each carry an `Atlas Pro Feature` marker, so the Pro plan covers the whole set. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed."
   },
   {
-    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: schema, table, column, primary_key, foreign_key and index carry no tier marker, while views, materialized views, triggers, functions, procedures, domains, composite types, range types, policies, sequences, extensions and roles/permissions each carry an `Atlas Pro Feature` marker, so the Pro plan covers the whole set. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
+    "area": "Schema sources",
     "feature": "HCL table and column child blocks",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "yes",
-    "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform.",
-    "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes"
+    "note": "column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. The community binary drops row_security silently.",
+    "evidence": "internal/atlashcl/atlashcl.go:244-325 (table switch), 394-478 (as/identity); index `on { column= ops= desc= }` renders operator classes. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Per-child probes through `schema diff`: check -> CONSTRAINT \"n_positive\" CHECK (n > 0); index+unique -> CREATE UNIQUE INDEX; foreign_key -> CONSTRAINT ... REFERENCES; identity -> GENERATED ALWAYS AS IDENTITY; partition -> PARTITION BY RANGE (\"n\"), all on both binaries. row_security { enabled = true } produces no ENABLE ROW LEVEL SECURITY from either binary. Note the divergence worth recording: the HCL reference marks partition an Atlas Pro Feature, and the community binary plans it anyway. Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `check`, `unique`, `index` and `row_security` are documented as table child resources with no tier marker, and `partition` is documented with an `Atlas Pro Feature` marker. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed."
   },
   {
-    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `check`, `unique`, `index` and `row_security` are documented as table child resources with no tier marker, and `partition` is documented with an `Atlas Pro Feature` marker. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
+    "area": "Schema sources",
     "feature": "HCL variable blocks and var.* references",
     "ptah": "no",
     "atlas_oss": "yes",
@@ -1146,55 +1146,55 @@
     "area": "Schema sources",
     "feature": "HCL function calls in schema files",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "partial",
-    "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally.",
-    "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496; render emits column type `sql(\"geometry(Point,4326)\")`. `sql(...)` as a column type works in Atlas; `sql(...)` inside an index where clause is rejected under the sqlite dialect (measured; observation study, scenario, hcl-semantics)"
+    "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr and index.where it leaks into the DDL where the community binary refuses the file.",
+    "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Column type: `type = sql(\"varchar(17)\")` -> community binary plans `\"s\" character varying(17)`, ptah-compat plans `\"s\" sql(\"varchar(17)\")`, which is not valid SQL. check.expr and index.where: `expr = sql(\"n > 0\")` with `where = sql(\"n > 5\")` -> community binary exits 1 with 'schemahcl: failed reading spec as *postgres.doc: value of attr \"expr\" cannot be read as string: incorrect type raw', ptah-compat exits 0 and emits CHECK (sql(\"n > 0\")) and WHERE sql(\"n > 5\"). Ptah accepting where the community binary refuses is the ordinary Pro-parity direction, but here it ships DDL no engine will execute; tracked as a follow-up, not fixed by this docs change."
   },
   {
     "area": "Schema sources",
     "feature": "HCL locals, lock, atlas, dynamic/for_each",
     "ptah": "no",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "partial",
-    "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\".",
-    "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error. `locals` works in a schema file in Atlas; `lock` and `atlas` top-level blocks are rejected under the sqlite dialect; `dynamic` was not probed in Atlas (measured; observation study, scenario, hcl-semantics)"
+    "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\". The community binary honors locals.",
+    "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. locals { dflt = 7 } referenced as `default = local.dflt`: community binary plans `\"n\" integer NOT NULL DEFAULT 7` - the literal 7 is the discriminator, it can only appear if the local resolved - while ptah-compat exits 1 'unsupported top-level block \"locals\"'. lock {} and atlas {} in a schema file: community binary exits 0 and plans the table, so the blocks are accepted and ignored rather than refused. dynamic \"index\" with for_each: community binary exits 0 and plans no index at all, so no expansion happens; the marker name idx_dynamic_marker never appears."
   },
   {
     "area": "Schema sources",
     "feature": "HCL foreign_key deferrable",
     "ptah": "no",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too.",
-    "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff. `deferrable = true` rejected under the sqlite dialect; engine-gated, so the Atlas cell stays unresolved for PostgreSQL (measured; observation study, scenario, hcl-semantics)"
+    "note": "Errors: unsupported foreign_key attribute \"deferrable\". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. The community binary plans no DEFERRABLE either.",
+    "evidence": "internal/atlashcl/atlashcl.go:1324-1331; `grep -rin deferrable --include=*.go` outside tests returns only one code comment in migration/schemadiff. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Two files identical but for `deferrable = true` on the foreign_key. The community binary plans byte-identical DDL for both: CONSTRAINT \"fk_child_parent\" FOREIGN KEY (\"pid\") REFERENCES \"parent\" (\"id\") ON UPDATE NO ACTION ON DELETE NO ACTION, exit 0 either way. If the attribute were honored the deferrable file would carry DEFERRABLE; it does not, so the attribute is accepted and has no effect. ptah-compat exits 1 naming the attribute. Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `foreign_key` is documented but `deferrable` does not appear anywhere on the page, so it is absent from Atlas's documented HCL rather than merely unmeasured. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed."
   },
   {
-    "area": "Schema sources Atlas HCL schema reference (atlasgo.io/atlas-schema/hcl), retrieved 2026-08-03: `foreign_key` is documented but `deferrable` does not appear anywhere on the page, so it is absent from Atlas's documented HCL rather than merely unmeasured. Controls on the same page and query shape: the invented terms `zzzznotarealterm` and `qqqnotarealblock` return not-found while real blocks return verbatim quotes, so the page is being read rather than reconstructed.",
+    "area": "Schema sources",
     "feature": "Ptah-only HCL schema extensions",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "na",
     "atlas_pro": "na",
     "note": "platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block.",
-    "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Seed Data as Code (/guides/seed-data-as-code) is absent from Starter and Pro-gated, so Atlas Pro covers the seed-data job at job level; whether it uses an HCL data-block mechanism is not stated"
+    "evidence": "docs/site/src/content/docs/reference/hcl-schema.md:87-136; mysql render of a platform override emits TYPE=BIGINT UNSIGNED; the data block populates db.ManagedData. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: Seed Data as Code (/guides/seed-data-as-code) is absent from Starter and Pro-gated, so Atlas Pro covers the seed-data job at job level; whether it uses an HCL data-block mechanism is not stated. Not applicable: the capability is defined as Ptah's own HCL extensions, so there is no Atlas counterpart to classify."
   },
   {
-    "area": "Schema sources Not applicable: the capability is defined as Ptah's own HCL extensions, so there is no Atlas counterpart to classify.",
+    "area": "Schema sources",
     "feature": "Directory of .hcl files as one schema source",
     "ptah": "no",
-    "atlas_oss": "unknown",
+    "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "`--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file.",
-    "evidence": "cmd/internal/schemaload/schemaload.go:257-259; `ptah-compat schema diff --to file://dir` prints \"load --to schema: schema file is a directory\". a directory of .hcl files as `--url file://dir` works on schema inspect (measured; observation study, scenario, hcl-semantics)"
+    "note": "`--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. The community binary reads such a directory.",
+    "evidence": "cmd/internal/schemaload/schemaload.go:257-259. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. A directory holding part_a.hcl (schema + table \"ta\") and part_b.hcl (table \"tb\"): `atlas schema diff --from file://empty.hcl --to file://<dir> --dev-url <pg>` exits 0 and plans both CREATE TABLE \"ta\" and CREATE TABLE \"tb\", so the two files are read as one schema. ptah-compat on the same directory exits 1 with \"load --to schema: schema file is a directory\"."
   },
   {
     "area": "Schema inspection filters",
     "feature": "Schema-qualified exclude globs for enums and functions",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "partial",
     "atlas_pro": "unknown",
-    "note": "Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only.",
-    "evidence": "internal/atlasfilter/filter.go:299-303 (filterEnums matches value.Name) and :342-346 (filterFunctions matches function.Name) versus :348-356 and :327-340 which build qualifiedNameCandidates for views and extensions. docs/site/src/content/docs/atlas/schema-commands.md:96-98 records the same limitation. Nothing in cli-surface.md, gaps.md, gaps-live.md, or gaps-diff.md establishes Atlas CE's qualification semantics for enum and function exclude globs, so both Atlas columns are \u2754"
+    "note": "Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. The community binary matches `app.mood`; it reports no functions.",
+    "evidence": "internal/atlasfilter/filter.go:299-303 (filterEnums matches value.Name) and :342-346 (filterFunctions matches function.Name) versus :348-356 and :327-340 which build qualifiedNameCandidates for views and extensions. docs/site/src/content/docs/atlas/schema-commands.md:96-98 records the same limitation. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Fixture schema \"app\" holds enum mood, function add_one, table t. Community binary at database scope: --exclude 'app.mood' removes the enum, --exclude 'app.t' removes the table. ptah-compat with -s app: --exclude 'mood' removes the enum and --exclude 'add_one' removes the function, while --exclude 'app.mood' and --exclude 'app.add_one' leave both in place - the bare-name-only rule, reproduced. The function half cannot be compared: functions never appear in the community binary's inspect output, even when one exists. Pro cell stays unknown; what would settle it: an Atlas-side source stating the qualification rule for enum and function exclude patterns."
   },
   {
     "area": "Project config",
@@ -1209,10 +1209,10 @@
     "area": "Schema inspection filters",
     "feature": "Inspect `--exclude` field selectors",
     "ptah": "partial",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "unknown",
-    "note": "Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted.",
-    "evidence": "internal/atlasfilter/filter.go:188-200 parseFieldSelector accepts only field==\"version\" with hasOnlyType(types,\"extension\"), and :132-135 rejects a second [type= segment; built ptah-compat on live PostgreSQL: `--exclude '*[type=extension].version'` blanks the version, `--exclude '*[type=table].comment'` exits 1 \"unsupported Atlas exclude field selector \\\".comment\\\"\", `--exclude '*[type=table]*'` exits 1 \"unsupported Atlas exclude field selector suffix \\\"*\\\"\". Atlas columns downgraded to unknown: conformance cli-surface.md line 47 establishes that --exclude exists on Atlas CE schema inspect but nothing cited establishes which field-selector forms Atlas honors, and no cited source defines an \"exporter block\" at all. `--exclude '*[type=table].comment'` parses and runs on sqlite (exit 0), but sqlite has no comment support, so filtering is unobserved - syntactic acceptance only (measured; observation study, scenario verbs-and-flags)"
+    "note": "Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. The community binary accepts a .field suffix and ignores it.",
+    "evidence": "internal/atlasfilter/filter.go:188-200 parseFieldSelector accepts only field==\"version\" with hasOnlyType(types,\"extension\"), and :132-135 rejects a second [type= segment; on live PostgreSQL `--exclude '*[type=extension].version'` blanks the version while `--exclude '*[type=table]*'` exits 1 'unsupported Atlas exclude field selector suffix \"*\"'. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Table app.t carries COMMENT 'COMMENT_MARKER_HERE'. Community binary: --exclude 'app.t[type=table]' removes the table (so the pattern shape matches), --exclude 'app.t.comment' and --exclude '*.*[type=table].comment' change nothing at all - table present, marker present, exit 0. Honoring the selector would have kept the table and dropped the comment; the field suffix instead makes the pattern inert in silence. ptah-compat refuses the same pattern, exit 1 'unsupported Atlas exclude field selector \".comment\"'. Pro cell stays unknown; what would settle it: an Atlas-side source enumerating the field selectors --exclude accepts. Note the gap in the other direction: the community binary honors --exclude '*[type=table]*' and ptah-compat exits 1 on the trailing star."
   },
   {
     "area": "Versioned migrations",
@@ -1254,31 +1254,31 @@
     "area": "Versioned migrations",
     "feature": "Online DDL routing via gh-ost or pt-osc",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "ptah.yaml online_ddl.tool (ghost|pt-osc), threshold_rows, args, and fallback (error|plain) route large-table ALTERs through an online-DDL tool during migrations up/down.",
-    "evidence": "config/projectconfig/config.go:22-35,407-447 defines the config; cmd/migrateup/migrateup.go:374 consumes it; config/projectconfig/online_ddl_test.go. docs/site/src/content/docs/reference/configuration.md:89 documents the four keys. Matrix mentions online_ddl only as a ptah.yaml key name. no gh-ost/pt-osc routing on Atlas's own help surface (measured; observation study, scenario, ptah-extension-equivalents)"
+    "note": "ptah.yaml online_ddl.tool (ghost|pt-osc), threshold_rows, args, and fallback (error|plain) route large-table ALTERs through an online-DDL tool during migrations up/down. CE has no such routing.",
+    "evidence": "config/projectconfig/config.go:22-35,407-447 defines the config; cmd/migrateup/migrateup.go:374 consumes it; config/projectconfig/online_ddl_test.go. docs/site/src/content/docs/reference/configuration.md:89 documents the four keys. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. `atlas migrate apply --help` inventories the full flag set: --url, --dir, --format, --revisions-schema, --dry-run, --lock-timeout, --baseline, --tx-mode, --exec-order, --allow-dirty. No gh-ost or pt-osc routing, and no flag that would select an external DDL tool."
   },
   {
     "area": "Versioned migrations",
     "feature": "Atlas txtar migration sections (-- atlas:txtar)",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "`-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored.",
-    "evidence": "migration/migrator/migrations.go parses migration.sql, down.sql, checks.sql, and ordered checks/*.sql sections; docs/site/src/content/docs/atlas/migrate-commands.md documents the behavior. The down row's \"Atlas single-file dirs have no down body\" note does not cover this exception. txtar migrations run with checks.sql ENFORCED as a pre-migration gate (failing assertion aborts, exit 1) (measured; observation study, scenario, txtar-checks-enforcement). Fixed 2026-08-01 (stokaro/ptah#956) and hardened after review: check files map onto the same engine, preserve archive order, default to all-of, and honor file-level atlas:assert oneof; a failing assertion aborts before migration.sql; --skip-checks bypasses on native ptah migrations up, compat migrate apply has no such flag (parity), and --tx-mode all refuses checked txtar files. A failed check records NO revision row, so retry after fixing data succeeds without repair."
+    "note": "`-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored. CE runs every section as plain SQL.",
+    "evidence": "migration/migrator/migrations.go parses migration.sql, down.sql, checks.sql, and ordered checks/*.sql sections; docs/site/src/content/docs/atlas/migrate-commands.md documents the behavior. Fixed 2026-08-01 (stokaro/ptah#956) and hardened after review: check files map onto the same engine, preserve archive order, default to all-of, and honor file-level atlas:assert oneof; a failing assertion aborts before migration.sql; --skip-checks bypasses on native ptah migrations up, compat migrate apply has no such flag (parity), and --tx-mode all refuses checked txtar files. A failed check records NO revision row, so retry after fixing data succeeds without repair. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. One txtar file whose migration.sql creates txtar_marker and whose down.sql drops it, applied to a fresh SQLite database. The community binary reports \"2 sql statements\" and executes both in file order (-> CREATE TABLE txtar_marker; -> DROP TABLE txtar_marker), leaving only atlas_schema_revisions behind; ptah-compat runs the migration.sql section alone and leaves txtar_marker in place. The surviving table name is the discriminator: exit status is 0 for both."
   },
   {
     "area": "Versioned migrations",
     "feature": "Atlas SQL template migrations (`--atlas-env`)",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs.",
-    "evidence": "migration/migrator/atlas_template.go:15-45 (AtlasTemplateData{Env}, RenderAtlasTemplateSQL); /tmp/c-ptah migrations up --help shows \"--atlas-env Value exposed as .Env when rendering Atlas SQL template migrations\"."
+    "note": "Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. CE runs the braces as SQL.",
+    "evidence": "migration/migrator/atlas_template.go:15-45 (AtlasTemplateData{Env}, RenderAtlasTemplateSQL). Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. One migration file containing `CREATE TABLE tpl_{{ .Env }} (n integer);` applied to a fresh SQLite database. `ptah migrations up --atlas-env prod` exits 0 and the database then holds a table named tpl_prod. The community binary on the same directory exits 1: 'sql/migrate: executing statement \"CREATE TABLE tpl_{{ .Env }} (n integer);\" from version \"20260101000001\": unrecognized token: \"{\"' - the braces reach the engine unrendered. The rendered table name is the discriminator. The flag lives on the native verbs; compat `migrate apply --atlas-env` answers \"unknown flag\". Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `template` occurs throughout the page, and every occurrence is `--format string  Go template to use to format the output` -- output formatting. Asked to classify every occurrence, none describes Go templates inside migration file content. Control on the same query: `kkknotarealterm` returns not-found while `--env` returns `set which env from the config file to use`."
   },
   {
-    "area": "Linting and safety Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: `template` occurs throughout the page, and every occurrence is `--format string  Go template to use to format the output` -- output formatting. Asked to classify every occurrence, none describes Go templates inside migration file content. Control on the same query: `kkknotarealterm` returns not-found while `--env` returns `set which env from the config file to use`.",
+    "area": "Linting and safety",
     "feature": "Generation-time destructive-change gate",
     "ptah": "yes",
     "atlas_oss": "no",
@@ -1293,19 +1293,19 @@
     "atlas_oss": "no",
     "atlas_pro": "no",
     "note": "Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not.",
-    "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based. no standalone SQL-file lint verb; `atlas schema lint` exists but lints schema sources, a different mechanism (measured; observation study, scenario, lint-test-pro, ptah-extension-equivalents)"
+    "evidence": "echo \"DROP TABLE users;\" | /tmp/c-ptah sql lint --stdin --dialect postgres --format json exits 0 with a JSON findings document. Atlas-side: cli-surface.md inventory has no standalone SQL lint verb; migrate lint (line 33) is directory-based. no standalone SQL-file lint verb; `atlas schema lint` exists but lints schema sources, a different mechanism (measured; observation study, scenario, lint-test-pro, ptah-extension-equivalents). Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: no `sql lint` command exists. The two lint verbs take other inputs -- `atlas schema lint` is documented as `Run schema linting` with `-u, --url strings  schema URL(s) to lint`, and `atlas migrate lint` analyzes a migration directory. Asked directly, no command on the reference accepts arbitrary SQL files or stdin for linting. Control on the same query: `rrrnotarealflag` returns not-found while `--exclude` returns its description verbatim."
   },
   {
-    "area": "Declarative and direct schema changes Atlas CLI reference (atlasgo.io/cli-reference), retrieved 2026-08-03: no `sql lint` command exists. The two lint verbs take other inputs -- `atlas schema lint` is documented as `Run schema linting` with `-u, --url strings  schema URL(s) to lint`, and `atlas migrate lint` analyzes a migration directory. Asked directly, no command on the reference accepts arbitrary SQL files or stdin for linting. Control on the same query: `rrrnotarealflag` returns not-found while `--exclude` returns its description verbatim.",
+    "area": "Declarative and direct schema changes",
     "feature": "JSON output for native schema diff",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "na",
     "atlas_pro": "na",
     "note": "Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated.",
-    "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0."
+    "evidence": "/tmp/c-ptah schema diff --from a.sql --to b.sql --dev-url sqlite://... --format json returned {\"statements\":[\"ALTER TABLE \\\"t\\\" ADD COLUMN \\\"name\\\" TEXT\"]}, exit 0. Not applicable: the capability is scoped to Ptah's native `schema diff` verb rather than the Atlas-compatible surface, so no Atlas plan classifies it."
   },
   {
-    "area": "Go embedding and developer tooling Not applicable: the capability is scoped to Ptah's native `schema diff` verb rather than the Atlas-compatible surface, so no Atlas plan classifies it.",
+    "area": "Go embedding and developer tooling",
     "feature": "Go annotations to HCL export with cleanup",
     "ptah": "yes",
     "atlas_oss": "na",
@@ -1317,10 +1317,10 @@
     "area": "Configuration and dev databases",
     "feature": "PTAH_* environment-variable flag equivalents",
     "ptah": "yes",
-    "atlas_oss": "unknown",
+    "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag.",
-    "evidence": "All 49 --help screens annotate each flag with [env: PTAH_*]; verified live: PTAH_FORMAT=dot /tmp/c-ptah viz --root-dir . emitted Graphviz DOT instead of the mermaid default, exit 0. No Atlas-side env-var inventory is cited by the page. no documented ATLAS_* env-var flag twins in Atlas's help (measured; observation study, scenario, ptah-extension-equivalents)"
+    "note": "Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable.",
+    "evidence": "All 49 --help screens annotate each flag with [env: PTAH_*]; verified live: PTAH_FORMAT=dot ptah viz --root-dir . emitted Graphviz DOT instead of the mermaid default, exit 0. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. No help screen on the community binary annotates any flag with an environment variable, and `ATLAS_URL=sqlite://file?mode=memory atlas schema inspect` exits 1 with 'Error: required flag(s) \"url\" not set'. Had the twin been honored the run would have printed a schema document and exited 0."
   },
   {
     "area": "Versioned migrations",

--- a/docs/site/scripts/data/feature-matrix.head.md
+++ b/docs/site/scripts/data/feature-matrix.head.md
@@ -55,10 +55,12 @@ the two diverge in both directions. Both examples below were measured on
 
 Where the pricing page settles a Pro-side question, the Pro column cites it.
 Where plan marketing and measured binary behavior differ, the measured behavior
-wins the CE cell and the difference column records the tension. That is why the schema-object rows carry ❔
-in the Atlas columns: this page can show what Ptah emits for a domain or a
-trigger, but nothing it cites establishes what Atlas CE emits for the same
-object.
+wins the CE cell and the difference column records the tension. The
+schema-object rows are the clearest case: the HCL reference marks `partition` a
+Pro feature and the pinned community binary plans `PARTITION BY RANGE` anyway,
+while a live schema holding a domain, a composite type, a range type, a
+sequence and an extension inspects on the same binary to nothing but its one
+table. Both readings are in the row.
 
 :::caution
 A ✅ in the Ptah column means the capability works, not that it is

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -55,10 +55,12 @@ the two diverge in both directions. Both examples below were measured on
 
 Where the pricing page settles a Pro-side question, the Pro column cites it.
 Where plan marketing and measured binary behavior differ, the measured behavior
-wins the CE cell and the difference column records the tension. That is why the schema-object rows carry ❔
-in the Atlas columns: this page can show what Ptah emits for a domain or a
-trigger, but nothing it cites establishes what Atlas CE emits for the same
-object.
+wins the CE cell and the difference column records the tension. The
+schema-object rows are the clearest case: the HCL reference marks `partition` a
+Pro feature and the pinned community binary plans `PARTITION BY RANGE` anyway,
+while a live schema holding a domain, a composite type, a range type, a
+sequence and an extension inspects on the same binary to nothing but its one
+table. Both readings are in the row.
 
 :::caution
 A ✅ in the Ptah column means the capability works, not that it is
@@ -78,10 +80,10 @@ Across the 159 capabilities below:
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
 | Ptah and Atlas CE both support it | 23 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 37 |
-| Ptah has it and neither Atlas edition does | 16 |
-| Atlas CE has it and Ptah does not, or only in part | 25 |
-| An Atlas column is ❔ — not established by this page's evidence | 21 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 40 |
+| Ptah has it and neither Atlas edition does | 19 |
+| Atlas CE has it and Ptah does not, or only in part | 26 |
+| An Atlas column is ❔ — not established by this page's evidence | 5 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
 binary built from this repository; Atlas-column verdicts rest on the cited
@@ -107,19 +109,19 @@ seven of them as open capabilities regardless.
 | Atlas HCL data "external_schema" | ✅ | ❌ | ✅ | Ptah evaluates the data source and runs the program, gated behind `--allow-external-schema`/`PTAH_ALLOW_EXTERNAL_SCHEMA`. Community Atlas rejects `data.external_schema`. |
 | Composite multi-source desired schema | ✅ | ❌ | ✅ | Repeatable `--root-dir`/`--schema-file` merge into one schema; conflicts error. Repo docs cite composite_schema as an Atlas Pro data source. |
 | Desired-schema artifacts in an OCI registry | ✅ | ❌ | ✅ | `ptah schema push/pull` publish and fetch canonical HCL resolved from Go, YAML, HCL or SQL sources. Verified round trip against registry:2. |
-| Directory of .hcl files as one schema source | ❌ | ❔ | ✅ | `--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. |
+| Directory of .hcl files as one schema source | ❌ | ✅ | ✅ | `--schema-file dir` and `--to file://dir` are refused (schema file is a directory); globs are not expanded. Multi-file needs one flag per file. The community binary reads such a directory. |
 | External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
-| HCL foreign_key deferrable | ❌ | ❔ | ❌ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. |
-| HCL function calls in schema files | 🟡 | ❔ | 🟡 | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr, index.where it leaks literally. |
-| HCL locals, lock, atlas, dynamic/for_each | ❌ | ❔ | 🟡 | Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". |
-| HCL table and column child blocks | ✅ | ❔ | ✅ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. |
-| HCL top-level blocks Ptah parses | ✅ | ❔ | ✅ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. |
+| HCL foreign_key deferrable | ❌ | ❌ | ❌ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. The community binary plans no DEFERRABLE either. |
+| HCL function calls in schema files | 🟡 | 🟡 | 🟡 | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr and index.where it leaks into the DDL where the community binary refuses the file. |
+| HCL locals, lock, atlas, dynamic/for_each | ❌ | 🟡 | 🟡 | Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". The community binary honors locals. |
+| HCL table and column child blocks | ✅ | 🟡 | ✅ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. The community binary drops row_security silently. |
+| HCL top-level blocks Ptah parses | ✅ | 🟡 | ✅ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. The community binary plans DDL for table and enum. |
 | HCL variable blocks and var.* references | ❌ | ✅ | ✅ | `variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error. |
 | Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
 | Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |
-| Ptah-only HCL schema extensions | ✅ | ❔ | ➖ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
+| Ptah-only HCL schema extensions | ✅ | ➖ | ➖ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
 | SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
 | YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
 
@@ -137,17 +139,17 @@ seven of them as open capabilities regardless.
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
 | Go-template `--format` output | 🟡 | ✅ | ✅ | schema apply and diff register only the sql helper: {{ json . }} fails to parse. json/hcl/mermaid/split/write and .Realm are inspect-only. |
-| Inspect `--exclude` field selectors | 🟡 | ❔ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. |
+| Inspect `--exclude` field selectors | 🟡 | ❌ | ❔ | Only [type=extension].version is honored; other .field suffixes and non-final [type=...] fail before any database is contacted. The community binary accepts a .field suffix and ignores it. |
 | Inspect non-database sources via `--dev-url` | ✅ | ✅ | ✅ | Schema file, `atlas.sum` migration dir, or env:// is materialized on a reset dev DB then introspected; without `--dev-url` it fails. |
 | Inspect split/write file exports | ✅ | ❌ | ✅ | `{{ hcl . \| split \| write "dir" }}` writes object/schema/type trees; pinned Atlas CE rejects split, write, hcl as non-community. |
-| JSON output for native schema diff | ✅ | ❔ | ➖ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
+| JSON output for native schema diff | ✅ | ➖ | ➖ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
-| Schema-qualified exclude globs for enums and functions | 🟡 | ❔ | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. |
+| Schema-qualified exclude globs for enums and functions | 🟡 | 🟡 | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. The community binary matches `app.mood`; it reports no functions. |
 | Verb `schema stats` | ❌ | ❌ | ✅ | Beyond the CE pin: in Atlas it exists as `schema stats inspect` (OpenMetrics) and rejects SQLite at runtime; the gap register triages it out of scope as observability. |
 | Verb `schema validate` | 🟡 | ❌ | ✅ | Beyond the CE pin: no validate verb; the gap register triage covers it with native schema render parse/load validation plus schema test and schema apply `--dry-run`. |
 
@@ -156,8 +158,8 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format revision tables are covered. |
-| Atlas SQL template migrations (`--atlas-env`) | ✅ | ❔ | ❌ | Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. Flag on 10 migrations verbs. |
-| Atlas txtar migration sections (-- atlas:txtar) | ✅ | ❔ | ✅ | `-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored. |
+| Atlas SQL template migrations (`--atlas-env`) | ✅ | ❌ | ❌ | Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. CE runs the braces as SQL. |
+| Atlas txtar migration sections (-- atlas:txtar) | ✅ | ❌ | ✅ | `-- atlas:txtar` executes migration.sql/down.sql and enforces checks.sql plus ordered checks/*.sql, including atlas:assert oneof; unrelated files are ignored. CE runs every section as plain SQL. |
 | Atlas-format checkpoint output | ✅ | ❌ | ✅ | `migrate checkpoint --dir-format atlas` writes the single `-- atlas:checkpoint` file plus atlas.sum, and is compat's default; `--dir-format ptah` writes the reversible pair. Up-only, as Atlas is. |
 | Baseline an existing database | ✅ | ✅ | ✅ | Ptah adds a standalone baseline verb with `--shadow-db` verification and `--dry-run`; CE exposes baselining as migrate apply `--baseline`. |
 | Create an empty migration file | ✅ | ✅ | ✅ | Native create writes an up/down pair; compat new writes one Atlas .sql skeleton, refreshes `atlas.sum`, `--edit` opens $VISUAL or $EDITOR. |
@@ -175,7 +177,7 @@ seven of them as open capabilities regardless.
 | Migration linting | ✅ | 🟡 | ✅ | CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time. |
 | Migration lock and lock timeout | ✅ | ✅ | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`. |
 | Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
-| Online DDL routing via gh-ost or pt-osc | ✅ | ❔ | ❌ | ptah.yaml online_ddl.tool (ghost\|pt-osc), threshold_rows, args, and fallback (error\|plain) route large-table ALTERs through an online-DDL tool during migrations up/down. |
+| Online DDL routing via gh-ost or pt-osc | ✅ | ❌ | ❌ | ptah.yaml online_ddl.tool (ghost\|pt-osc), threshold_rows, args, and fallback (error\|plain) route large-table ALTERs through an online-DDL tool during migrations up/down. CE has no such routing. |
 | Pre-migration database backups (`--pg-dump-to`) | ✅ | ❌ | ❌ | `--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to. |
 | Pre-migration webhook and shell hook gates | ✅ | ❌ | ❌ | `--webhook` POSTs migration metadata and requires HTTP 200; `--pre-up-hook`/`--pre-down-hook` run a shell command that must exit 0, else the run aborts. Also ptah.yaml migration.webhook/pre_up_hook. |
 | Prometheus metrics endpoint (`--metrics-addr`) | ✅ | ❌ | ❌ | migrations up, down, and status serve a Prometheus /metrics endpoint at the given address for the run. |
@@ -196,13 +198,13 @@ seven of them as open capabilities regardless.
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
 | Check bypass on the compat surface | ✅ | ❌ | ❌ | No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down. |
-| CI integration (GitHub Action, annotations) | ✅ | ❔ | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations. |
+| CI integration (GitHub Action, annotations) | ✅ | 🟡 | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. The community binary has no annotation mode; its lint `--format` takes a Go template only. |
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
 | Generation-time destructive-change gate | ✅ | ❌ | ❌ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
 | Inline nolint suppression | 🟡 | ✅ | ✅ | Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored. |
 | Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
-| Per-rule severity policy | 🟡 | ❔ | 🟡 | Severity vocabulary is warning\|error only (info errors out). Measured, Atlas is no richer: analyzer and rule blocks reject a `severity` attribute; only boolean error toggles exist. |
+| Per-rule severity policy | 🟡 | ❌ | 🟡 | Severity vocabulary is warning\|error only (info errors out). The community binary carries no severity attribute: it accepts one and ignores it, exactly as it treats an invented attribute. |
 | Pre-migration assertion checks | 🟡 | ❌ | ✅ | Scalar SELECTs; txtar checks.sql and checks/*.sql support all-of/oneof groups. CE ignores checks. Compat bypass is PTAH_SKIP_CHECKS. |
 | SARIF 2.1.0 lint report | ✅ | ❌ | ➖ | Native `--format` sarif emits SARIF 2.1.0 with ruleId, level and file:line; Atlas documents Go-template `--format` output for migrate lint. |
 | Standalone SQL file linting (`ptah sql lint`) | ✅ | ❌ | ❌ | Lints arbitrary SQL files or stdin against per-dialect capability presets (9 dialects incl. sqlserver), refined by a `--version` server string; text/json output, rule disable. Not. |
@@ -215,7 +217,7 @@ seven of them as open capabilities regardless.
 | Atlas `.test.hcl` ingestion | ✅ | ❌ | ✅ | Implemented: `.test.hcl` is read alongside native YAML by `schema test` and `migrate test`. Adding `output` to an `exec` makes it an assertion; step order is preserved and cases are selected by kind. |
 | Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`. |
 | Dev / shadow database verification | 🟡 | ✅ | ✅ | `--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely. |
-| Embeddable test runner (Go package) | ✅ | ❔ | ❌ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
+| Embeddable test runner (Go package) | ✅ | ❔ | ❌ | migration/dbtest exports RunMigrationTest and RunSchemaTest. CE stays unknown: a CLI probe cannot see a Go API; an Atlas-side source naming a test-runner entry point would settle it. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |
 | Migration test framework (`ptah migrations test`) | ✅ | ❌ | ✅ | Declarative YAML cases: migrate_to, apply_schema, seed, exec, assert. Fresh ephemeral SQLite per case unless `--db-url` is set. |
 | Schema test framework (`ptah schema test`) | ✅ | ❌ | ✅ | Desired schema from Go annotations converges before steps; migrate_to is rejected. Atlas CE v1.2.0 registers no schema test verb. |
@@ -230,7 +232,7 @@ seven of them as open capabilities regardless.
 | Docker dev databases (`docker://` `--dev-url`) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
 | env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently. |
 | Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail. |
-| PTAH_* environment-variable flag equivalents | ✅ | ❔ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. |
+| PTAH_* environment-variable flag equivalents | ✅ | ❌ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
 | Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected. |
 
@@ -240,9 +242,9 @@ seven of them as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | ClickHouse (clickhouse, ch) | 🟡 | ❌ | ✅ | Tables and indexes only. Views, matviews, functions, triggers, roles, grants, RLS, sequences, domains and CHECKs vanish from the plan with no diagnostic. |
 | CockroachDB (cockroachdb, crdb) | 🟡 | ❌ | ✅ | Preset drops concurrent indexes, sequences, XML, advisory locks, roles and RLS. SERIAL is a hard error. Offline render also omits views, functions and triggers. |
-| Domains, composite types, and range types | 🟡 | ❔ | ✅ | PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff at all. |
+| Domains, composite types, and range types | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` also emits them on YugabyteDB. Range subtype changes produce no diff. The community binary reports none of the three when they exist. |
 | Enum types | 🟡 | ✅ | ✅ | MySQL/SQLite/SQL Server inline-enum rewrite fires only if the type name starts with `enum_`; other names emit the bare type name verbatim. |
-| Extensions | 🟡 | ❔ | ✅ | PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. |
+| Extensions | 🟡 | ❌ | ✅ | PostgreSQL-family only; `plpgsql` ignored by default on compare. MySQL/MariaDB render an empty statement instead of the intended comment. The community binary refuses extension blocks. |
 | Functions | 🟡 | ❌ | ✅ | `schema render`: PostgreSQL only, silent on MySQL/MariaDB. `schema apply` also emits CREATE FUNCTION on YugabyteDB; MySQL drops it silently. |
 | MySQL and MariaDB | 🟡 | ✅ | ✅ | Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback. |
 | Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers. |


### PR DESCRIPTION
Closes #1053.

## The count moved

The issue names 14 unknown Pro cells. The matrix carries **23 unknown cells** across 21 rows:

| Column | Unknown before | Unknown after |
| --- | --- | --- |
| CE (`atlas_oss`) | 19 | 1 |
| Pro (`atlas_pro`) | 4 | 4 |
| Ptah | 0 | 0 |

Ten of the 14 Pro cells the issue lists were settled between the issue being written and now (#1056, #1057, #1058, #1060, #1061): embeddable test runner, CI integration, extensions, domains/composite/range, all three HCL rows, and template migrations. The four that remain are digest pinning, referrer attachments, and the two exclude-filter rows.

What nobody had measured was the **CE column on those same rows** — 19 cells, every one answerable by running the pinned community binary. That is what this PR does.

## What was measured

Pinned community binary at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (reports `atlas community version v1.3.0`) versus a `ptah-compat` built from this branch, against PostgreSQL 16 in Docker and SQLite files. Every command and every byte is in the row's `evidence` field.

**Exit status is not a discriminator here.** The community binary answers `exit 0` / `Schemas are synced, no changes to be made.` for an invented top-level block `zzzznotarealblock` and for a real `view` block alike. So each probe asserts planned bytes or surviving objects, never status alone.

| Row | CE | The measurement that separates the two answers |
| --- | --- | --- |
| Extensions | ❔→❌ | A live schema really containing `pg_trgm` inspects to `table "anchor"` + `schema "kinds"` and nothing else; `ptah-compat` on the same URL emits `extension "pg_trgm"` version 1.6. Writing an `extension` block exits 1: `postgres: extensions are not supported by this version.` |
| Domains, composite and range types | ❔→❌ | Same schema holds `CREATE DOMAIN`, `CREATE TYPE ... AS (...)`, `CREATE TYPE ... AS RANGE`. None appear in the community inspect; all appear in ptah-compat's. |
| HCL top-level blocks | ❔→🟡 | One block per file through `schema diff`. Plans DDL: `table`, `enum`. Refuses loudly: `extension`, `sequence`. Drops in silence: `view`, `domain`, `composite`, `role` — identically to the invented block. |
| HCL table/column child blocks | ❔→🟡 | `check`, `index`+`unique`, `foreign_key`, `identity`, `partition` all plan DDL on both binaries. `row_security { enabled = true }` produces no `ENABLE ROW LEVEL SECURITY` from either. |
| HCL `sql()` calls | ❔→🟡 | `type = sql("varchar(17)")` → community plans `character varying(17)`, ptah-compat plans `sql("varchar(17)")`. |
| `locals`, `lock`, `atlas`, `dynamic` | ❔→🟡 | `locals { dflt = 7 }` + `default = local.dflt` → community plans `DEFAULT 7`; the literal `7` can only appear if the local resolved. `lock`/`atlas` accepted and ignored. `dynamic "index"` expands to nothing: `idx_dynamic_marker` never appears. |
| `foreign_key deferrable` | ❔→❌ | Two files identical but for `deferrable = true`. The community binary plans **byte-identical** DDL for both. |
| Directory of `.hcl` files | ❔→✅ | A directory of `part_a.hcl`+`part_b.hcl` plans both `CREATE TABLE "ta"` and `CREATE TABLE "tb"`; ptah-compat exits 1 `schema file is a directory`. |
| Per-rule severity policy | ❔→❌ | `severity = "warning"` on a `destructive` analyzer gives a byte-identical report to `zzznotarealattrib = "x"`, exit 1 both. Positive control: `error = false` prints `1 version with warnings`, exit 0. |
| CI integration | ❔→🟡 | `migrate lint --help` inventories every flag; `--format` is a Go template and there is no annotation mode. |
| Schema-qualified exclude globs | ❔→🟡 | At database scope `--exclude 'app.mood'` removes the enum. Functions never appear in the community inspect at all. |
| `--exclude` field selectors | ❔→❌ | `app.t[type=table]` removes the table; `app.t.comment` changes nothing — table present, `COMMENT_MARKER_HERE` present, exit 0. |
| Online DDL routing | ❔→❌ | `migrate apply --help` full flag set: no gh-ost, no pt-osc, no external-tool flag. |
| Atlas txtar sections | ❔→❌ | See below. |
| Template migrations | ❔→❌ | See below. |
| `PTAH_*` env twins | ❔→❌ | No help screen annotates any flag with an env var; `ATLAS_URL=... atlas schema inspect` exits 1 `required flag(s) "url" not set`. |
| Ptah-only HCL extensions, native JSON diff | ❔→➖ | Ptah-defined capabilities, no Atlas counterpart — the Pro cells were already ➖ for exactly this reason. |

## Two findings the rows record rather than smooth over

**A txtar file's `down.sql` runs on the way up.** One file, `migration.sql` creating `txtar_marker` and `down.sql` dropping it, applied to a fresh SQLite database:

```
community binary: "2 sql statements"
  -> CREATE TABLE txtar_marker (n integer);
  -> DROP TABLE txtar_marker;
  tables afterwards: atlas_schema_revisions
ptah-compat:
  tables afterwards: atlas_schema_revisions  txtar_marker
```

Exit 0 for both. The surviving table name is the whole discriminator. Ptah runs the `migration.sql` section alone, and this PR does not change that — matching is the floor, not the ceiling.

**`sql()` in `check.expr` / `index.where` breaks parity rule (a).** The community binary exits 1 (`schemahcl: ... value of attr "expr" cannot be read as string: incorrect type raw`); `ptah-compat` exits **0** and emits `ADD CONSTRAINT "n_positive" CHECK (sql("n > 0"))` and `WHERE sql("n > 5")` — DDL no engine will execute. Accepting a richer schema than the community binary is the ordinary Pro-parity direction and I did not treat the `sequence`/`function` cases as breaches; this one is different because the output is invalid. Recorded in the row's evidence and left for a follow-up code change rather than fixed inside a docs PR.

## Five cells stay ❔, each saying what would settle it

- **Embeddable test runner (Go package), CE** — `atlas schema test --help` prints `'atlas schema test' is not supported by the community version.` That bounds the CLI surface; no command can show a Go library API. Settled by: an Atlas-side source naming a Go entry point.
- **Digest pinning, Pro** — already carried its note; refiled onto the right row.
- **Referrer attachments, Pro** — settled by: a source stating whether reports are attached as OCI referrers.
- **Schema-qualified exclude globs, Pro** — settled by: a source stating the qualification rule.
- **`--exclude` field selectors, Pro** — settled by: a source enumerating the accepted field selectors.

## The data was corrupted and the checker was green

Thirteen `area` fields carried the citation belonging to the **previous** row — an off-by-one introduced across #1056–#1061. Example on master:

```json
{ "area": "Schema object kinds Atlas features page (atlasgo.io/features), retrieved 2026-08-03: `Extensions` is listed under...",
  "feature": "Roles, grants, and row-level security", ... }
```

That text settles `Extensions`, the row above. `bucket()` matches area by `startsWith`, so a corrupted label still routed to a section, the page still rendered, and `--check` reported `OK (159 rows)` for five commits. All thirteen are refiled into the `evidence` of the rows they settle.

The guard: an exact-match roster of the 36 area labels. Demonstrated rather than asserted — with one area field corrupted the same way:

```
HEAD's checker:  build-feature-matrix.mjs --check: OK (159 rows)     exit 0
this branch:     REFUSING TO BUILD:
  Extensions: area "Schema object kinds Atlas features page, ..." is not a
  known label - if it is a citation, it belongs in the evidence of the row
  it settles                                                        exit 1
```

## Gates

```
go build ./...                          exit 0
go vet ./...                            exit 0
go test ./... -count=1                  exit 0
golangci-lint run ./...                 0 issues (exit 0)
scripts/check-test-style.sh             OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh             exit 0
scripts/check-public-api-snapshot.sh    exit 0
node scripts/check-style.mjs            OK (100 documentation files)
node scripts/build-feature-matrix.mjs --check   OK (159 rows)
node scripts/check-links.mjs            OK (60 pages, 60 routes, 563 heading anchors)
```

golangci-lint first exited 1 on `ST1000` for a file path in a different checkout on this machine; its generated-file filter could not open the stale absolute path, so it could not suppress a hit in a `DO NOT EDIT` file. `golangci-lint cache clean` then a re-run gives `0 issues`. No Go file is touched by this branch.

## What I deliberately did not do

- **Did not fix the `sql()` leak**, though it is a parity-rule breach. It is a change in `internal/atlashcl` with its own test surface, not a docs edit.
- **Did not fix `schema inspect` at database scope.** `ptah-compat schema inspect --url postgres://...` with no `-s` returns only `public`-adjacent objects and never reaches the `app` schema, where the community binary returns its table and enum. Found while measuring row 132; needs its own issue.
- **Did not touch `--exclude 'app.t'` under `-s app`**, where ptah-compat excludes the table and the community binary does not — a scoping divergence, both exit 0.
- **Did not drive the unknown count to zero.** Five cells have no measurement that separates the answers; the issue says plainly that unknown is the right answer there.
- **Did not re-verify the two dated bullets in the page head** that cite a 2026-08-01 capture; they are attributed and dated, and rewriting them would claim a measurement I did not repeat.