### PR TITLE
Refuse repair over a half-built concurrent index

### DIFF
--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -283,6 +283,13 @@ statement's outcome as unknown. Inspect the database before repair. Ptah
 rejects `repair --resume-from` while this marker is present because the SQL may
 already have committed.
 
+**A concurrent index build failed on PostgreSQL.** The invalid index left
+behind keeps the name, so retrying the generated `IF NOT EXISTS` statement is
+skipped rather than retried and reports no error. Ptah refuses to repair the
+migration while the index is unusable and names the `REINDEX INDEX
+CONCURRENTLY` that rebuilds it — `--force` does not bypass that refusal. See
+[Maintain migration history](../maintain-history/).
+
 **A pre-migration check blocked the migration.** Nothing is applied and no
 revision row is written, so the run is recorded as never started. Fix the data
 the check guarded and re-run; no repair step and no bypass flag is involved.

--- a/docs/site/src/content/docs/versioned/maintain-history.md
+++ b/docs/site/src/content/docs/versioned/maintain-history.md
@@ -184,6 +184,29 @@ error: migration 1 is not dirty; rerun with --force to rewrite it
 `--force` rewrites (or creates) the revision row anyway — a last resort for
 reconciling revision metadata that no longer matches reality.
 
+### Repair over a half-built concurrent index
+
+On PostgreSQL, a `CREATE INDEX CONCURRENTLY` that fails partway leaves an
+**invalid** index behind. The leftover keeps the name, so the generated
+`IF NOT EXISTS` form of the same statement is skipped rather than retried and
+reports no error. Repair refuses to record such a migration (exit `2`):
+
+```text
+error: migration 5 cannot be repaired: PostgreSQL reports index "public"."idx_members_email" (indisvalid=false, indisready=false) unusable, so recording the migration applied would report a constraint that is not enforced; run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", or drop the index and rerun the migration, then repair again
+```
+
+Refusing leaves a dirty state you can still see, rather than a green one that
+is wrong: an invalid unique index enforces nothing, so duplicate rows keep
+being accepted while `status` reports the database up to date. Rebuild the
+index with the `REINDEX INDEX CONCURRENTLY` the message names — or drop it and
+rerun the migration — and repair again.
+
+`--force` does not bypass this. It relaxes a precondition about the revision
+row; the index being unusable is a fact about the database, and the fix for it
+is `REINDEX`. Only indexes the migration itself creates are checked, so an
+unrelated invalid index elsewhere never blocks a repair. Other dialects have no
+concurrent index build to leave half-finished and are unaffected.
+
 ## Set the revision boundary (set)
 
 `repair` fixes one dirty row and `baseline` only records existing history as

--- a/integration/gonative/repair_invalid_index_integration_test.go
+++ b/integration/gonative/repair_invalid_index_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// A failed CREATE UNIQUE INDEX CONCURRENTLY leaves an invalid index occupying
+// the name, so re-issuing the generated IF NOT EXISTS statement is skipped
+// rather than retried and nothing errors. These tests pin what repair does with
+// that residue: it refuses while the index is unusable, and it does not
+// interfere once the index is usable.
+const (
+	repairInvalidIndexTable   = "ptah_issue1101_members"
+	repairInvalidIndexName    = "idx_ptah_issue1101_members_email"
+	repairInvalidIndexTracker = "schema_migrations_issue_1101"
+	repairInvalidIndexVersion = int64(1785756328)
+)
+
+func TestPostgreSQLRepairRefusesOverInvalidUniqueIndexIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRepairInvalidIndexDB(c, dsn)
+	seedRepairInvalidIndexTable(c, db, "'shared@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := repairInvalidIndexMigrator(conn)
+
+	// The concurrent build fails on the duplicates and leaves the index behind.
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, "(?s).*could not create unique index.*")
+	valid, ready := repairInvalidIndexFlags(c, db)
+	c.Assert(valid, qt.IsFalse)
+	c.Assert(ready, qt.IsFalse)
+
+	// The operator fixes the data that broke the build, which is the whole
+	// prerequisite for repair. The leftover index is still unusable.
+	_, err = db.ExecContext(ctx, "DELETE FROM "+repairInvalidIndexTable+" WHERE id > 1")
+	c.Assert(err, qt.IsNil)
+
+	err = mig.RepairMigration(ctx, migrator.RepairMigrationOptions{
+		Version:    repairInvalidIndexVersion,
+		ResumeFrom: 1,
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `"public"."`+repairInvalidIndexName+`"`)
+	c.Assert(err.Error(), qt.Contains, "indisvalid=false, indisready=false")
+	c.Assert(err.Error(), qt.Contains, "REINDEX INDEX CONCURRENTLY")
+
+	// --force relaxes a precondition about the revision row, not a fact about
+	// the database, so it does not buy past an unenforced constraint.
+	err = mig.RepairMigration(ctx, migrator.RepairMigrationOptions{
+		Version:    repairInvalidIndexVersion,
+		ResumeFrom: 1,
+		Force:      true,
+	})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "REINDEX INDEX CONCURRENTLY")
+
+	// The dirty state the operator can still see is the point of refusing.
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+	c.Assert(status.DirtyRevision.Version, qt.Equals, repairInvalidIndexVersion)
+	c.Assert(status.AppliedMigrations, qt.HasLen, 0)
+
+	// Rebuilding the index is the escape hatch the refusal names, and it works.
+	_, err = db.ExecContext(ctx, `REINDEX INDEX CONCURRENTLY "public"."`+repairInvalidIndexName+`"`)
+	c.Assert(err, qt.IsNil)
+	valid, ready = repairInvalidIndexFlags(c, db)
+	c.Assert(valid, qt.IsTrue)
+	c.Assert(ready, qt.IsTrue)
+
+	err = mig.RepairMigration(ctx, migrator.RepairMigrationOptions{
+		Version:    repairInvalidIndexVersion,
+		ResumeFrom: 1,
+	})
+	c.Assert(err, qt.IsNil)
+	status, err = mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{repairInvalidIndexVersion})
+	c.Assert(repairInvalidIndexDuplicateInsert(ctx, db), qt.IsNotNil)
+}
+
+// TestPostgreSQLRepairLeavesUsableIndexAloneIntegration is the control. On data
+// where the concurrent build succeeds, nothing about the probe may show: the
+// migration applies, the index is usable, the constraint is enforced, and a
+// later repair over that same migration still records it. A check that refused
+// whenever a migration created an index would fail here.
+func TestPostgreSQLRepairLeavesUsableIndexAloneIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRepairInvalidIndexDB(c, dsn)
+	seedRepairInvalidIndexTable(c, db, "'user' || g || '@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := repairInvalidIndexMigrator(conn)
+
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	valid, ready := repairInvalidIndexFlags(c, db)
+	c.Assert(valid, qt.IsTrue)
+	c.Assert(ready, qt.IsTrue)
+	c.Assert(repairInvalidIndexDuplicateInsert(ctx, db), qt.IsNotNil)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{repairInvalidIndexVersion})
+
+	err = mig.RepairMigration(ctx, migrator.RepairMigrationOptions{
+		Version: repairInvalidIndexVersion,
+		Force:   true,
+	})
+	c.Assert(err, qt.IsNil)
+}
+
+func repairInvalidIndexMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"-- +ptah no_transaction\nCREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q (%q);",
+		repairInvalidIndexName, repairInvalidIndexTable, "email",
+	)
+	down := fmt.Sprintf("-- +ptah no_transaction\nDROP INDEX IF EXISTS %q;", repairInvalidIndexName)
+	migration := migrator.CreateMigrationFromSQL(repairInvalidIndexVersion, "add unique email", up, down)
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migration)).
+		WithMigrationsTable("", repairInvalidIndexTracker)
+}
+
+func openRepairInvalidIndexDB(c *qt.C, dsn string) *sql.DB {
+	c.Helper()
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	return db
+}
+
+// seedRepairInvalidIndexTable rebuilds the fixture from scratch so a previous
+// run cannot decide this one's outcome. emailExpr is evaluated per generated
+// row: a constant produces the duplicates that break a unique build, and an
+// expression over g produces distinct values that let it succeed.
+func seedRepairInvalidIndexTable(c *qt.C, db *sql.DB, emailExpr string) {
+	c.Helper()
+	cleanup := func() {
+		_, err := db.Exec("DROP TABLE IF EXISTS " + repairInvalidIndexTable + " CASCADE")
+		c.Check(err, qt.IsNil)
+		_, err = db.Exec("DROP TABLE IF EXISTS " + repairInvalidIndexTracker + " CASCADE")
+		c.Check(err, qt.IsNil)
+	}
+	cleanup()
+	c.Cleanup(cleanup)
+
+	_, err := db.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, email TEXT NOT NULL)", repairInvalidIndexTable,
+	))
+	c.Assert(err, qt.IsNil)
+	// PostgreSQL only picks a concurrent-build-worthy plan on a table it knows
+	// has rows, so the seed is populated and analyzed before the migration runs.
+	_, err = db.Exec(fmt.Sprintf(
+		"INSERT INTO %s SELECT g, %s FROM generate_series(1, 5000) g", repairInvalidIndexTable, emailExpr,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec("ANALYZE " + repairInvalidIndexTable)
+	c.Assert(err, qt.IsNil)
+}
+
+func repairInvalidIndexFlags(c *qt.C, db *sql.DB) (valid, ready bool) {
+	c.Helper()
+	err := db.QueryRow(`
+		SELECT ix.indisvalid, ix.indisready
+		FROM pg_index ix
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_class t ON t.oid = ix.indrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE n.nspname = 'public' AND i.relname = $1`,
+		repairInvalidIndexName,
+	).Scan(&valid, &ready)
+	c.Assert(err, qt.IsNil)
+	return valid, ready
+}
+
+// repairInvalidIndexDuplicateInsert returns the error PostgreSQL raises for a
+// second row carrying an email that already exists, or nil when the write is
+// accepted. Nil is the shape of the defect: the index exists and is recorded
+// applied while enforcing nothing.
+func repairInvalidIndexDuplicateInsert(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (id, email) SELECT 999999, email FROM %s ORDER BY id LIMIT 1",
+		repairInvalidIndexTable, repairInvalidIndexTable,
+	))
+	return err
+}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -687,6 +687,19 @@ statement could duplicate committed SQL. A custom `MigrationFunc` is opaque to
 Ptah and can only be recorded at function completion; use SQL-backed migrations
 when statement-level crash progress is required.
 
+On PostgreSQL, `RepairMigration` also refuses to record the revision while an
+index the migration creates is still unusable. A `CREATE INDEX CONCURRENTLY`
+that fails partway leaves an invalid index occupying the name, so re-issuing
+the same `IF NOT EXISTS` statement is skipped rather than retried and nothing
+errors; recording the migration applied would report a constraint the database
+is not enforcing. Ptah reads `pg_index.indisvalid` and `indisready` for the
+index names the migration's up SQL creates, resolving an unqualified name
+through the same search path the statement used, and returns an error naming
+each unusable index and the `REINDEX INDEX CONCURRENTLY` that rebuilds it.
+`Force` does not relax this refusal: it relaxes a precondition about the
+revision row, not a fact about the database. Other dialects have no concurrent
+index build to leave half-finished and run no probe.
+
 Atlas-format down execution is the deliberate exception. It leaves the
 revision row unchanged before and during the down body to reproduce Atlas's
 measured bookkeeping. A non-transactional Atlas-format down can therefore

--- a/migration/migrator/invalid_index.go
+++ b/migration/migrator/invalid_index.go
@@ -1,0 +1,289 @@
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/sqlutil"
+	"go.5x5.cz/ptah/internal/lexer"
+	"go.5x5.cz/ptah/internal/sqlident"
+)
+
+// postgresIndexRef is one index a migration's up SQL creates, spelled the way
+// the PostgreSQL catalog stores it. Schema is empty when the statement left the
+// name unqualified, which means PostgreSQL resolved it through the search path.
+type postgresIndexRef struct {
+	Schema string
+	Name   string
+}
+
+// postgresUnusableIndex is a catalog row for an index PostgreSQL will not use:
+// indisvalid or indisready is false. A failed CREATE INDEX CONCURRENTLY leaves
+// exactly that state behind, and the leftover keeps the name occupied, so a
+// re-run of the same IF NOT EXISTS statement is skipped rather than retried.
+type postgresUnusableIndex struct {
+	Schema string
+	Name   string
+	Valid  bool
+	Ready  bool
+}
+
+func (i postgresUnusableIndex) quotedName() string {
+	return sqlident.Qualified(platform.Postgres, i.Schema, i.Name)
+}
+
+// refuseRepairOverUnusableIndex refuses to record a migration applied while
+// PostgreSQL still reports an index that migration creates as unusable.
+//
+// A concurrent unique index build that fails partway leaves an invalid index
+// behind. Because it occupies the name, re-issuing the generated
+// CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS is skipped with a notice
+// instead of retried, so nothing errors and the revision row would be written
+// as applied over a constraint the database is not enforcing. Refusing leaves
+// the operator with a dirty state they can still see.
+//
+// The probe is PostgreSQL-only by nature: no other supported dialect has a
+// concurrent index build that can be left half-finished, so every other dialect
+// returns here before any query runs and keeps its existing code path. This
+// deliberately ignores opts.Force. --force is documented as "Rewrite or create
+// the revision row even when it is not dirty" -- it relaxes a precondition
+// about the metadata, not a fact about the database. The escape hatch is
+// REINDEX INDEX CONCURRENTLY, which fixes the database rather than the
+// bookkeeping about it.
+func (m *Migrator) refuseRepairOverUnusableIndex(ctx context.Context, migration *Migration) error {
+	if m.conn == nil || platform.NormalizeDialect(m.conn.Info().Dialect) != platform.Postgres {
+		return nil
+	}
+	refs := postgresCreatedIndexNames(migration.UpSQL)
+	if len(refs) == 0 {
+		return nil
+	}
+	unusable, err := m.postgresUnusableIndexes(ctx, refs)
+	if err != nil {
+		return err
+	}
+	if len(unusable) == 0 {
+		return nil
+	}
+	return unusableIndexRepairError(migration.Version, unusable)
+}
+
+// unusableIndexRepairError renders the refusal. It names every index that is
+// unusable together with the catalog flags that say so, and points at the
+// PostgreSQL command that rebuilds one without holding writes.
+func unusableIndexRepairError(version int64, unusable []postgresUnusableIndex) error {
+	details := make([]string, 0, len(unusable))
+	rebuild := make([]string, 0, len(unusable))
+	for _, index := range unusable {
+		details = append(details, fmt.Sprintf(
+			"%s (indisvalid=%t, indisready=%t)",
+			index.quotedName(), index.Valid, index.Ready,
+		))
+		rebuild = append(rebuild, "REINDEX INDEX CONCURRENTLY "+index.quotedName())
+	}
+	noun := "index"
+	if len(unusable) > 1 {
+		noun = "indexes"
+	}
+	return fmt.Errorf(
+		"migration %d cannot be repaired: PostgreSQL reports %s %s unusable, "+
+			"so recording the migration applied would report a constraint that is not enforced; "+
+			"run %s, or drop the %s and rerun the migration, then repair again",
+		version,
+		noun,
+		strings.Join(details, ", "),
+		strings.Join(rebuild, "; "),
+		noun,
+	)
+}
+
+// postgresUnusableIndexes returns the subset of refs the catalog reports as
+// unusable. An unqualified ref is resolved through pg_table_is_visible, which
+// is the same search-path rule PostgreSQL applied when the statement ran, so a
+// same-named invalid index parked in an unrelated schema is not this repair's
+// business and does not block it.
+func (m *Migrator) postgresUnusableIndexes(ctx context.Context, refs []postgresIndexRef) ([]postgresUnusableIndex, error) {
+	predicates := make([]string, 0, len(refs))
+	args := make([]any, 0, len(refs)*2)
+	for _, ref := range refs {
+		if ref.Schema == "" {
+			predicates = append(predicates, "(i.relname = ? AND pg_catalog.pg_table_is_visible(i.oid))")
+			args = append(args, ref.Name)
+			continue
+		}
+		predicates = append(predicates, "(i.relname = ? AND n.nspname = ?)")
+		args = append(args, ref.Name, ref.Schema)
+	}
+
+	query := sqlutil.Rebind(m.conn.Info().Dialect, fmt.Sprintf(`
+		SELECT n.nspname, i.relname, ix.indisvalid, ix.indisready
+		FROM pg_index ix
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_class t ON t.oid = ix.indrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE NOT (ix.indisvalid AND ix.indisready)
+		AND (%s)
+		ORDER BY n.nspname, i.relname`, strings.Join(predicates, " OR ")))
+
+	rows, err := m.conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to inspect index validity: %w", err)
+	}
+	defer rows.Close()
+
+	var unusable []postgresUnusableIndex
+	for rows.Next() {
+		var index postgresUnusableIndex
+		if err := rows.Scan(&index.Schema, &index.Name, &index.Valid, &index.Ready); err != nil {
+			return nil, fmt.Errorf("failed to scan index validity: %w", err)
+		}
+		unusable = append(unusable, index)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read index validity: %w", err)
+	}
+	return unusable, nil
+}
+
+// postgresCreatedIndexNames returns every index name created by a statement in
+// sqlText, in order and without duplicates.
+//
+// The scan is token-based rather than textual: names are read as whole
+// identifier tokens, so idx_members can never be recognized in a statement that
+// creates idx_members_email, and a name that appears in a comment or inside a
+// string literal is not a name at all. Both spellings this repository generates
+// are handled -- the quoted "idx_members_email" keeps its bytes, and a bare
+// idx_members_email folds to lower case exactly as PostgreSQL folds it when
+// storing the catalog entry.
+func postgresCreatedIndexNames(sqlText string) []postgresIndexRef {
+	tokens := significantSQLTokens(sqlText, platform.Postgres)
+	var (
+		refs []postgresIndexRef
+		seen = make(map[postgresIndexRef]struct{})
+	)
+	for i, token := range tokens {
+		// CREATE must open a statement. Anywhere else the word is part of some
+		// larger construct, not a DDL verb whose object name follows.
+		if i > 0 && tokens[i-1].Type != lexer.TokenSemicolon {
+			continue
+		}
+		if !token.MatchIdentifierValue("CREATE") {
+			continue
+		}
+		ref, ok := parseCreateIndexName(tokens[i+1:])
+		if !ok {
+			continue
+		}
+		if _, duplicate := seen[ref]; duplicate {
+			continue
+		}
+		seen[ref] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+// parseCreateIndexName reads the index name out of the tail of a CREATE
+// statement, given the tokens that follow the CREATE keyword. It follows the
+// PostgreSQL grammar
+//
+//	CREATE [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] name ON ...
+//
+// and reports false for any other CREATE, including the name-less
+// CREATE INDEX ON table (...) form where PostgreSQL derives the name itself.
+func parseCreateIndexName(tokens []lexer.Token) (postgresIndexRef, bool) {
+	rest, ok := consumeCreateIndexPrefix(tokens)
+	if !ok {
+		return postgresIndexRef{}, false
+	}
+	return parseIndexNameTokens(rest)
+}
+
+// consumeCreateIndexPrefix consumes the keywords that stand between CREATE and
+// an index name -- [UNIQUE] INDEX [CONCURRENTLY] [IF NOT EXISTS] -- and returns
+// the tokens that follow them. It reports false for a CREATE that is not a
+// CREATE INDEX, and for a CREATE INDEX that runs out of tokens before naming
+// anything.
+func consumeCreateIndexPrefix(tokens []lexer.Token) ([]lexer.Token, bool) {
+	tokens = skipKeywordToken(tokens, "UNIQUE")
+	if len(tokens) == 0 || !tokens[0].MatchIdentifierValue("INDEX") {
+		return nil, false
+	}
+	tokens = skipKeywordToken(tokens[1:], "CONCURRENTLY")
+	if len(tokens) > 0 && tokens[0].MatchIdentifierValue("IF") {
+		if len(tokens) < 3 || !tokens[1].MatchIdentifierValue("NOT") || !tokens[2].MatchIdentifierValue("EXISTS") {
+			return nil, false
+		}
+		tokens = tokens[3:]
+	}
+	return tokens, len(tokens) > 0
+}
+
+// skipKeywordToken drops a leading optional keyword when it is present.
+func skipKeywordToken(tokens []lexer.Token, keyword string) []lexer.Token {
+	if len(tokens) > 0 && tokens[0].MatchIdentifierValue(keyword) {
+		return tokens[1:]
+	}
+	return tokens
+}
+
+// parseIndexNameTokens reads one optionally schema-qualified index name from
+// the head of a non-empty token slice.
+func parseIndexNameTokens(tokens []lexer.Token) (postgresIndexRef, bool) {
+	// CREATE INDEX ON t (c) names nothing; ON here is the clause, not a name.
+	if tokens[0].MatchIdentifierValue("ON") {
+		return postgresIndexRef{}, false
+	}
+	first, ok := postgresIdentifierValue(tokens[0])
+	if !ok {
+		return postgresIndexRef{}, false
+	}
+	if len(tokens) < 3 || !tokens[1].MatchOperatorValue(".") {
+		return postgresIndexRef{Name: first}, true
+	}
+	second, ok := postgresIdentifierValue(tokens[2])
+	if !ok {
+		return postgresIndexRef{}, false
+	}
+	return postgresIndexRef{Schema: first, Name: second}, true
+}
+
+// postgresIdentifierValue returns the catalog spelling of one identifier token.
+// A double-quoted identifier keeps its bytes with "" collapsed to a single
+// quote; an unquoted one folds to lower case, matching how PostgreSQL stores
+// it. The lexer emits a double-quoted identifier as a string token, so both
+// token types are accepted here.
+func postgresIdentifierValue(token lexer.Token) (string, bool) {
+	switch token.Type {
+	case lexer.TokenIdentifier:
+		return strings.ToLower(token.Value), true
+	case lexer.TokenString:
+		value := token.Value
+		if len(value) < 2 || value[0] != '"' || value[len(value)-1] != '"' {
+			return "", false
+		}
+		return strings.ReplaceAll(value[1:len(value)-1], `""`, `"`), true
+	default:
+		return "", false
+	}
+}
+
+// significantSQLTokens tokenizes sqlText for dialect and drops whitespace and
+// comments, leaving the token stream a grammar scan can walk by position.
+func significantSQLTokens(sqlText, dialect string) []lexer.Token {
+	lexr := lexer.NewLexerWithOptions(sqlText, checkLexerOptions(dialect))
+	var tokens []lexer.Token
+	for {
+		token := lexr.NextToken()
+		switch token.Type {
+		case lexer.TokenEOF:
+			return tokens
+		case lexer.TokenWhitespace, lexer.TokenComment:
+			continue
+		default:
+			tokens = append(tokens, token)
+		}
+	}
+}

--- a/migration/migrator/invalid_index_internal_test.go
+++ b/migration/migrator/invalid_index_internal_test.go
@@ -1,0 +1,166 @@
+package migrator
+
+// White-box testing required: postgresCreatedIndexNames and
+// unusableIndexRepairError are the pure halves of a refusal whose other half is
+// a live pg_index query. Reaching them through RepairMigration needs a
+// PostgreSQL connection and a half-built concurrent index, so the boundary
+// cases exercised here -- substring near-misses, quoted and unquoted spellings,
+// comments and string literals, the name-less CREATE INDEX form -- are only
+// observable directly. The end-to-end behavior is covered against a live
+// database in integration/gonative.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestPostgresCreatedIndexNames(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		sql  string
+		want []postgresIndexRef
+	}{
+		{
+			name: "generated concurrent unique index",
+			sql: "-- +ptah no_transaction\n" +
+				`CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");`,
+			want: []postgresIndexRef{{Name: "idx_members_email"}},
+		},
+		{
+			name: "unquoted name folds to lower case like the catalog",
+			sql:  `CREATE INDEX CONCURRENTLY IdX_Members_Email ON members (email);`,
+			want: []postgresIndexRef{{Name: "idx_members_email"}},
+		},
+		{
+			name: "quoted name keeps its bytes",
+			sql:  `CREATE INDEX "IdX_Members_Email" ON members (email);`,
+			want: []postgresIndexRef{{Name: "IdX_Members_Email"}},
+		},
+		{
+			name: "quoted name unescapes a doubled quote",
+			sql:  `CREATE INDEX "odd""name" ON members (email);`,
+			want: []postgresIndexRef{{Name: `odd"name`}},
+		},
+		{
+			name: "schema qualified name keeps both parts",
+			sql:  `CREATE UNIQUE INDEX CONCURRENTLY "app"."idx_members_email" ON "app"."members" ("email");`,
+			want: []postgresIndexRef{{Schema: "app", Name: "idx_members_email"}},
+		},
+		{
+			name: "a name that is another name's prefix stays distinct from it",
+			sql: `CREATE INDEX "idx_members" ON members (id);` + "\n" +
+				`CREATE INDEX "idx_members_email" ON members (email);`,
+			want: []postgresIndexRef{{Name: "idx_members"}, {Name: "idx_members_email"}},
+		},
+		{
+			name: "several statements yield every name in order",
+			sql: `CREATE INDEX "idx_a" ON members (a);` + "\n" +
+				`CREATE UNIQUE INDEX CONCURRENTLY "idx_b" ON members (b);`,
+			want: []postgresIndexRef{{Name: "idx_a"}, {Name: "idx_b"}},
+		},
+		{
+			name: "a repeated name is reported once",
+			sql: `CREATE INDEX IF NOT EXISTS "idx_a" ON members (a);` + "\n" +
+				`CREATE INDEX IF NOT EXISTS "idx_a" ON members (a);`,
+			want: []postgresIndexRef{{Name: "idx_a"}},
+		},
+		{
+			name: "a name inside a comment is not a name",
+			sql:  "-- CREATE INDEX idx_commented ON members (email);\nCREATE INDEX idx_real ON members (email);",
+			want: []postgresIndexRef{{Name: "idx_real"}},
+		},
+		{
+			name: "a name inside a string literal is not a name",
+			sql:  `INSERT INTO audit (note) VALUES ('CREATE INDEX idx_quoted ON members (email)');`,
+			want: nil,
+		},
+		{
+			name: "CREATE TABLE names no index",
+			sql:  `CREATE TABLE members (id INTEGER PRIMARY KEY, email TEXT NOT NULL);`,
+			want: nil,
+		},
+		{
+			name: "the name-less CREATE INDEX form yields nothing",
+			sql:  `CREATE INDEX ON members (email);`,
+			want: nil,
+		},
+		{
+			name: "DROP INDEX names nothing for this probe",
+			sql:  `DROP INDEX CONCURRENTLY IF EXISTS "idx_members_email";`,
+			want: nil,
+		},
+		{
+			name: "CREATE inside a larger construct is not a statement start",
+			sql:  `SELECT 1; GRANT CREATE ON SCHEMA app TO ptah;`,
+			want: nil,
+		},
+		{
+			name: "empty SQL yields nothing",
+			sql:  "",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(postgresCreatedIndexNames(tt.sql), qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+func TestUnusableIndexRepairError(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		unusable []postgresUnusableIndex
+		want     string
+	}{
+		{
+			name: "one index names it, its flags, and the rebuild command",
+			unusable: []postgresUnusableIndex{
+				{Schema: "public", Name: "idx_members_email"},
+			},
+			want: `migration 1785756328 cannot be repaired: PostgreSQL reports index ` +
+				`"public"."idx_members_email" (indisvalid=false, indisready=false) unusable, ` +
+				`so recording the migration applied would report a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", ` +
+				`or drop the index and rerun the migration, then repair again`,
+		},
+		{
+			name: "a ready but invalid index reports both flags as measured",
+			unusable: []postgresUnusableIndex{
+				{Schema: "public", Name: "idx_members_email", Ready: true},
+			},
+			want: `migration 1785756328 cannot be repaired: PostgreSQL reports index ` +
+				`"public"."idx_members_email" (indisvalid=false, indisready=true) unusable, ` +
+				`so recording the migration applied would report a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", ` +
+				`or drop the index and rerun the migration, then repair again`,
+		},
+		{
+			name: "two indexes are both named and both get a rebuild command",
+			unusable: []postgresUnusableIndex{
+				{Schema: "app", Name: "idx_a"},
+				{Schema: "public", Name: "idx_b", Valid: true},
+			},
+			want: `migration 1785756328 cannot be repaired: PostgreSQL reports indexes ` +
+				`"app"."idx_a" (indisvalid=false, indisready=false), ` +
+				`"public"."idx_b" (indisvalid=true, indisready=false) unusable, ` +
+				`so recording the migration applied would report a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "app"."idx_a"; REINDEX INDEX CONCURRENTLY "public"."idx_b", ` +
+				`or drop the indexes and rerun the migration, then repair again`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			err := unusableIndexRepairError(1785756328, tt.unusable)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, tt.want)
+		})
+	}
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -1600,6 +1600,12 @@ func (m *Migrator) setPtahRevisionAppliedSQL() string {
 
 // RepairMigration clears dirty migration metadata after an operator has fixed
 // the database manually, or resumes the up migration from a specific statement.
+//
+// On PostgreSQL the revision is not recorded while an index the migration
+// creates is still unusable -- the residue a failed CREATE INDEX CONCURRENTLY
+// leaves behind. The repair is refused instead, so an unenforced constraint
+// cannot be signed off as applied. See refuseRepairOverUnusableIndex, including
+// why Force does not relax it.
 func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOptions) error {
 	if opts.Version <= 0 {
 		return fmt.Errorf("repair version must be greater than zero")
@@ -1632,6 +1638,9 @@ func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOpti
 		if err := m.resumeMigration(ctx, migration, opts.ResumeFrom); err != nil {
 			return err
 		}
+	}
+	if err := m.refuseRepairOverUnusableIndex(ctx, migration); err != nil {
+		return err
 	}
 	return m.forceAppliedMigration(ctx, migration)
 }


### PR DESCRIPTION
Closes #1101.

`ptah migrations repair` could report success on a migration whose unique index was never built, after which the database reported green while the constraint the migration existed to add was not enforced.

Two things lined up. A failed `CREATE UNIQUE INDEX CONCURRENTLY` leaves an invalid index occupying the name, so re-issuing the generated `IF NOT EXISTS` form is skipped with a notice rather than retried and reports no error. `RepairMigration` then called `forceAppliedMigration` unconditionally. Nothing between the skipped statement and the revision write asked whether the object was usable.

Before recording the revision, PostgreSQL repairs now probe `pg_index` for `NOT (indisvalid AND indisready)` over the index names the migration's up SQL creates, and **refuse** rather than record when one is unusable.

```text
error: migration 1785756328 cannot be repaired: PostgreSQL reports index "public"."idx_members_email" (indisvalid=false, indisready=false) unusable, so recording the migration applied would report a constraint that is not enforced; run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", or drop the index and rerun the migration, then repair again
```

## Measurement

Live `postgres:16-alpine`, the issue's fixture: `members` with 5000 rows all carrying `shared@example.com`, `ANALYZE`d, model declaring `unique="true"` on `email`. `migrations generate` emits `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");` under `-- +ptah no_transaction`, `migrations up` fails with SQLSTATE 23505, and the operator then deletes the duplicates.

**WITHOUT the change** (`da1c4cd2`, the binary built before the hook existed):

| step | result |
| --- | --- |
| `migrations repair --version ... --resume-from 1` | `Repaired migration 1785756328`, exit `0` |
| `migrations status` | `Current Version: 1785756328 / Applied Migrations: 1 / Status: Database is up to date` |
| `SELECT indisvalid, indisready FROM pg_index ...` | `f │ f` |
| `INSERT INTO members VALUES (99,'shared@example.com')` | `INSERT 0 1`, exit `0`; `count(*) WHERE email='shared@example.com'` → `2` |

**WITH the change**, same fixture rebuilt from scratch:

| step | result |
| --- | --- |
| `migrations repair --version ... --resume-from 1` | refused, exit `2`, message above |
| `migrations repair ... --force` | refused, exit `2`, same message |
| `schema_migrations` after both attempts | `1785756328 │ failed` — unchanged |
| `migrations status` | `Status: ❌ Dirty migration state detected / Dirty Migration: version=1785756328 state=failed applied=0/1` |

The dirty state stays visible, which is the point of refusing. Following the message out is a real fix, not a bypass: `REINDEX INDEX CONCURRENTLY "public"."idx_members_email"` flips the flags to `t │ t`, the same repair then succeeds (`Repaired migration 1785756328`, status up to date), and the duplicate insert is rejected with `duplicate key value violates unique constraint "idx_members_email"`, exit `1`.

**CONTROL**, identical models and commands on a database seeded so the index builds cleanly (5000 distinct emails):

| step | result |
| --- | --- |
| `migrations up` | exit `0` |
| `SELECT indisvalid, indisready` | `t │ t` |
| `INSERT` a duplicate email | `ERROR: duplicate key value violates unique constraint`, exit `1` |
| `migrations status` | `Status: ✅ Database is up to date` |

A check that refused everything would pass the first two rows and fail this one.

## What each test prints if the change is reverted

`TestPostgreSQLRepairRefusesOverInvalidUniqueIndexIntegration` and `TestPostgreSQLRepairLeavesUsableIndexAloneIntegration` (`integration/gonative`, `integration` build tag, `POSTGRES_TEST_DSN`) were run against both mutants, not assumed.

**Mutant 1 — the hook removed from `RepairMigration`.** The refusal test fails at the `RepairMigration` call:

```text
--- FAIL: TestPostgreSQLRepairRefusesOverInvalidUniqueIndexIntegration
    repair_invalid_index_integration_test.go:57:
        error: got nil value but want non-nil
        got: nil
```

The control still passes, correctly — it asserts non-interference, which reverting does not break. Its discriminator is the other mutant.

**Mutant 2 — the probe made to refuse unconditionally.** The control fails on the repair it must still allow:

```text
--- FAIL: TestPostgreSQLRepairLeavesUsableIndexAloneIntegration
    repair_invalid_index_integration_test.go:131:
        error: got non-nil error
        got: e`migration 1785756328 cannot be repaired: PostgreSQL reports index "public"."idx_ptah_issue1101_members_email" ...`
```

The refusal test also goes red under this mutant, at line 90 — the repair after `REINDEX` must succeed.

The unit tests are the pure halves, in `migration/migrator/invalid_index_internal_test.go`:

- `TestPostgresCreatedIndexNames` — 15 rows over name extraction. Drop the token walk for a `strings.Contains` and the `a name that is another name's prefix stays distinct from it`, `a name inside a comment is not a name`, and `a name inside a string literal is not a name` rows print a `values are not equal` diff naming the extra or missing ref. Drop the case folding and `unquoted name folds to lower case like the catalog` prints `got: idx_members_email` against `want: IdX_Members_Email`'s counterpart. Drop the `ON` guard and `the name-less CREATE INDEX form yields nothing` reports `[]postgresIndexRef{{Name:"on"}}` against `nil`.
- `TestUnusableIndexRepairError` — 3 rows over the message. Drop the index name, the catalog flags, or the `REINDEX INDEX CONCURRENTLY` and each row prints the full expected string against what was rendered.

## The `--force` decision

**`--force` does not bypass the refusal.**

The flag is documented as *"Rewrite or create the revision row even when it is not dirty"*, and every existing use of it in `RepairMigration` gates a precondition about the metadata: no revision row, or a row that is not dirty. An unusable index is not a metadata precondition — it is a fact about the database, and the value of this change is precisely that green metadata over an unenforced unique constraint is a silent integrity lie. A flag whose documented meaning is bookkeeping should not quietly re-enable it.

This is also consistent with the neighboring guard in the same function: `RepairMigration` already rejects `--resume-from` while the unknown-statement-outcome marker is present, and `--force` does not clear that one either. Both refusals say the same thing — inspect and fix the database, then repair.

The escape hatch is the one the message names. `REINDEX INDEX CONCURRENTLY` (or dropping the index and rerunning) makes the refusal go away by making the claim true, and that path is measured above.

## Deliberately left out

- **The `migrations up` success path.** The issue raises it and explicitly does not claim it; no measurement here covers it. The narrow remaining hole is a fresh `up` of `CREATE ... IF NOT EXISTS` against a name already occupied by an invalid index from outside this migration's history — worth its own issue and its own fixture rather than an unmeasured extension of this one.
- **`migrations set` and `baseline`.** They also write applied rows and could paper over the same residue. Same reason: not measured here.
- **A failed `DROP INDEX CONCURRENTLY`.** It leaves an invalid index too, but the remedy is another `DROP`, not `REINDEX`, so folding it into this message would misdirect. `DROP INDEX` names nothing for this probe today, and there is a test row pinning that.
- **Non-PostgreSQL dialects.** No concurrent index build exists to leave half-finished, so they return before any query runs rather than growing a no-op probe. No exported symbols were added, so the public-API snapshot is unchanged.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go vet -tags integration ./integration/gonative/`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh` (OK, 175 conditional groups, 45 white-box files), `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, and `node docs/site/scripts/check-style.mjs` (OK, 100 documentation files) all pass.

Docs updated in the same change: the repair how-to (`versioned/maintain-history.md`) gains a section on the refusal and the `--force` reasoning, the failure catalog in `versioned/apply.md` gains the matching entry, and `migration/migrator/README.md` documents the `RepairMigration` behavior next to the existing unknown-outcome paragraph.