### PR TITLE
Make rooted publication conditional on the destination it replaces (#948)

### DIFF
--- a/internal/fsdurable/destination.go
+++ b/internal/fsdurable/destination.go
@@ -1,0 +1,78 @@
+package fsdurable
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+)
+
+type destinationKind uint8
+
+const (
+	destinationUnset destinationKind = iota
+	destinationAbsent
+	destinationFile
+)
+
+// Destination is the state a rooted publication requires at its target name at
+// the instant the commit takes effect. Publication is conditional on that
+// state, so a concurrent writer that reaches the target first is reported
+// rather than overwritten.
+//
+// The zero value expresses no expectation and is rejected: every publication
+// must state what it replaces, which keeps "publish over anything" from being
+// reachable by omission.
+type Destination struct {
+	kind destinationKind
+	info fs.FileInfo
+}
+
+// ExpectAbsent requires that no entry exists at the target name.
+func ExpectAbsent() Destination {
+	return Destination{kind: destinationAbsent}
+}
+
+// ExpectFile requires that the target name still identifies the regular file
+// captured by info through an os.Stat, os.Lstat or os.File.Stat operation.
+// Identity, size and modification time must all still match, because inode
+// numbers alone are reused by some filesystems.
+func ExpectFile(info fs.FileInfo) Destination {
+	return Destination{kind: destinationFile, info: info}
+}
+
+func (d Destination) validate(targetName string) error {
+	switch d.kind {
+	case destinationAbsent:
+		return nil
+	case destinationFile:
+		if d.info == nil {
+			return destinationChangedError(targetName, errNilDestinationIdentity)
+		}
+		if !d.info.Mode().IsRegular() {
+			return destinationChangedError(targetName, errIrregularDestinationIdentity)
+		}
+		return nil
+	case destinationUnset:
+	}
+	return destinationChangedError(targetName, errUnstatedDestination)
+}
+
+// matches reports whether actual is still the file the caller expected. Mode is
+// deliberately excluded: publication applies the final mode to the staged file,
+// so a caller that expects the file it published earlier compares against the
+// staged identity whose recorded mode predates that change.
+func (d Destination) matches(actual fs.FileInfo) bool {
+	return d.kind == destinationFile &&
+		actual != nil &&
+		actual.Mode().IsRegular() &&
+		os.SameFile(actual, d.info) &&
+		actual.Size() == d.info.Size() &&
+		actual.ModTime().Equal(d.info.ModTime())
+}
+
+var (
+	errNilDestinationIdentity       = fmt.Errorf("expected destination identity is nil")
+	errIrregularDestinationIdentity = fmt.Errorf("expected destination is not a regular file")
+	errUnstatedDestination          = fmt.Errorf("publication states no destination expectation")
+	errDisplacedDestination         = fmt.Errorf("the destination was replaced before the commit took effect")
+)

--- a/internal/fsdurable/doc.go
+++ b/internal/fsdurable/doc.go
@@ -1,3 +1,11 @@
 // Package fsdurable provides filesystem operations for durable artifact
 // publication across supported operating systems.
+//
+// PublishFileAt is conditional: the caller states the destination it expects
+// through a Destination, and the commit primitive itself binds that state, so
+// no time-of-check/time-of-use gap remains between a caller's validation and
+// the rename. Losing the race yields ErrDestinationChanged with the rival's
+// bytes untouched. Platforms and filesystems that cannot supply a conditional
+// rename fail with ErrConditionalPublicationUnsupported rather than degrading
+// to an unconditional one.
 package fsdurable

--- a/internal/fsdurable/errors.go
+++ b/internal/fsdurable/errors.go
@@ -12,11 +12,42 @@ var (
 	// ErrStagedFileChanged reports that a rooted staged entry no longer
 	// identifies the file captured by its caller.
 	ErrStagedFileChanged = errors.New("staged file identity or metadata changed")
+	// ErrDestinationChanged reports that the publication target did not hold
+	// the state the caller required when the commit was attempted. The
+	// publication is refused unless the error also wraps
+	// ErrReplacementCommitted.
+	ErrDestinationChanged = errors.New("publication destination identity or metadata changed")
+	// ErrConditionalPublicationUnsupported reports that the filesystem or
+	// platform cannot commit a publication conditionally on the destination
+	// state. Publication fails closed instead of degrading to an
+	// unconditional rename.
+	ErrConditionalPublicationUnsupported = errors.New("conditional publication is unsupported here")
 )
+
+// errConditionalRenameUnavailable marks a platform or filesystem that ships no
+// usable conditional rename primitive, so every platform can report the same
+// fail-closed cause through ErrConditionalPublicationUnsupported.
+var errConditionalRenameUnavailable = errors.New("no conditional rename primitive available")
 
 func replacementCommittedError(err error) error {
 	if err == nil {
 		return nil
 	}
 	return fmt.Errorf("%w: %w", ErrReplacementCommitted, err)
+}
+
+func destinationChangedError(targetName string, cause error) error {
+	if cause == nil {
+		return fmt.Errorf("%w: %s", ErrDestinationChanged, targetName)
+	}
+	return fmt.Errorf("%w: %s: %w", ErrDestinationChanged, targetName, cause)
+}
+
+func unsupportedPublicationError(targetName string, cause error) error {
+	return fmt.Errorf(
+		"%w: %s: the filesystem rejected the conditional rename primitive: %w",
+		ErrConditionalPublicationUnsupported,
+		targetName,
+		cause,
+	)
 }

--- a/internal/fsdurable/publication_darwin.go
+++ b/internal/fsdurable/publication_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package fsdurable
+
+import "golang.org/x/sys/unix"
+
+// renameNoReplaceAt fails with EEXIST instead of replacing newName. Measured on
+// APFS and on a FAT32 volume, where plain rename(2) silently replaced the
+// destination and os.Link is not supported at all.
+func renameNoReplaceAt(dirfd int, oldName, newName string) error {
+	return unix.RenameatxNp(dirfd, oldName, dirfd, newName, unix.RENAME_EXCL)
+}
+
+// renameExchangeAt swaps the two entries atomically, which is the only way to
+// replace an existing destination while keeping the file that was replaced
+// reachable for verification.
+func renameExchangeAt(dirfd int, oldName, newName string) error {
+	return unix.RenameatxNp(dirfd, oldName, dirfd, newName, unix.RENAME_SWAP)
+}

--- a/internal/fsdurable/publication_linux.go
+++ b/internal/fsdurable/publication_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package fsdurable
+
+import "golang.org/x/sys/unix"
+
+// renameNoReplaceAt fails with EEXIST instead of replacing newName. Measured on
+// overlayfs, tmpfs and virtiofs; filesystems that reject the flag surface
+// EINVAL and are reported as unsupported rather than retried unconditionally.
+func renameNoReplaceAt(dirfd int, oldName, newName string) error {
+	return unix.Renameat2(dirfd, oldName, dirfd, newName, unix.RENAME_NOREPLACE)
+}
+
+// renameExchangeAt swaps the two entries atomically, which is the only way to
+// replace an existing destination while keeping the file that was replaced
+// reachable for verification.
+func renameExchangeAt(dirfd int, oldName, newName string) error {
+	return unix.Renameat2(dirfd, oldName, dirfd, newName, unix.RENAME_EXCHANGE)
+}

--- a/internal/fsdurable/publication_nonwindows.go
+++ b/internal/fsdurable/publication_nonwindows.go
@@ -3,6 +3,8 @@
 package fsdurable
 
 import (
+	"errors"
+	"fmt"
 	"io/fs"
 	"os"
 )
@@ -11,15 +13,64 @@ func openPublicationFile(root *os.Root, name string) (*os.File, error) {
 	return root.OpenFile(name, os.O_RDWR, 0)
 }
 
-func renamePublicationFile(
+// commitPublicationFile publishes the staged entry over targetName only while
+// the target still holds dest. Unix has no single syscall that both replaces an
+// existing file and binds the file it replaces, so the two expectations use
+// different primitives: an absent destination is a no-replace rename, and an
+// expected file is an atomic exchange whose displaced side is verified
+// afterwards and swapped back when it turns out to belong to someone else.
+func commitPublicationFile(
 	root *os.Root,
 	_ *os.File,
 	stagedName, targetName string,
+	dest Destination,
+	hooks publicationHooks,
 ) (bool, error) {
-	if err := root.Rename(stagedName, targetName); err != nil {
+	if dest.kind == destinationAbsent {
+		hooks.runBeforeCommit()
+		if err := rootRenameNoReplace(root, stagedName, targetName); err != nil {
+			if errors.Is(err, fs.ErrExist) {
+				return false, destinationChangedError(targetName, err)
+			}
+			return false, err
+		}
+		return true, nil
+	}
+	return exchangePublicationFile(root, stagedName, targetName, dest, hooks)
+}
+
+func exchangePublicationFile(
+	root *os.Root,
+	stagedName, targetName string,
+	dest Destination,
+	hooks publicationHooks,
+) (bool, error) {
+	hooks.runBeforeCommit()
+	if err := rootRenameExchange(root, stagedName, targetName); err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return false, destinationChangedError(targetName, err)
+		}
 		return false, err
 	}
-	return true, nil
+	displacedInfo, statErr := root.Lstat(stagedName)
+	if statErr == nil && dest.matches(displacedInfo) {
+		return true, removeDisplacedFile(root, stagedName)
+	}
+	restoreErr := rootRenameExchange(root, stagedName, targetName)
+	if restoreErr == nil {
+		return false, destinationChangedError(
+			targetName,
+			errors.Join(errDisplacedDestination, statErr),
+		)
+	}
+	recovery, preserveErr := preserveDisplacedFile(root, stagedName, targetName)
+	return true, fmt.Errorf(
+		"%w: %s: the displaced destination could not be restored and is preserved at %s: %w",
+		ErrDestinationChanged,
+		targetName,
+		recovery,
+		errors.Join(errDisplacedDestination, statErr, restoreErr, preserveErr),
+	)
 }
 
 func modesEqual(actual, expected fs.FileMode) bool {

--- a/internal/fsdurable/publication_unix.go
+++ b/internal/fsdurable/publication_unix.go
@@ -1,0 +1,82 @@
+//go:build !windows
+
+package fsdurable
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+// withRootDirFD runs fn with a descriptor for the directory root guards.
+// os.Root exposes no descriptor, so the directory is reopened through the root
+// itself and the descriptor is borrowed under SyscallConn.Control, which keeps
+// the runtime from closing it while the syscall is in flight.
+func withRootDirFD(root *os.Root, fn func(dirfd int) error) error {
+	dir, err := root.Open(".")
+	if err != nil {
+		return err
+	}
+	conn, err := dir.SyscallConn()
+	if err != nil {
+		return errors.Join(err, dir.Close())
+	}
+	var opErr error
+	controlErr := conn.Control(func(fd uintptr) {
+		opErr = fn(int(fd))
+	})
+	closeErr := dir.Close()
+	if opErr != nil {
+		return errors.Join(opErr, controlErr, closeErr)
+	}
+	return errors.Join(controlErr, closeErr)
+}
+
+func rootRenameNoReplace(root *os.Root, oldName, newName string) error {
+	return classifyConditionalRename(
+		"renameat-noreplace",
+		oldName,
+		newName,
+		withRootDirFD(root, func(dirfd int) error {
+			return renameNoReplaceAt(dirfd, oldName, newName)
+		}),
+	)
+}
+
+func rootRenameExchange(root *os.Root, oldName, newName string) error {
+	return classifyConditionalRename(
+		"renameat-exchange",
+		oldName,
+		newName,
+		withRootDirFD(root, func(dirfd int) error {
+			return renameExchangeAt(dirfd, oldName, newName)
+		}),
+	)
+}
+
+// classifyConditionalRename separates "the caller lost the race" from "this
+// filesystem cannot do conditional renames at all". The second case must fail
+// closed: silently retrying with rename(2) would restore the unconditional
+// replacement this package exists to prevent, and the developer filesystems
+// that do support the flags would never show it.
+func classifyConditionalRename(op, oldName, newName string, err error) error {
+	if err == nil {
+		return nil
+	}
+	if isUnsupportedRenameError(err) {
+		return unsupportedPublicationError(newName, &os.LinkError{
+			Op:  op,
+			Old: oldName,
+			New: newName,
+			Err: err,
+		})
+	}
+	return &os.LinkError{Op: op, Old: oldName, New: newName, Err: err}
+}
+
+func isUnsupportedRenameError(err error) bool {
+	return errors.Is(err, syscall.EINVAL) ||
+		errors.Is(err, syscall.ENOSYS) ||
+		errors.Is(err, syscall.EOPNOTSUPP) ||
+		errors.Is(err, errConditionalRenameUnavailable)
+}

--- a/internal/fsdurable/publication_unix_other.go
+++ b/internal/fsdurable/publication_unix_other.go
@@ -1,0 +1,16 @@
+//go:build !windows && !darwin && !linux
+
+package fsdurable
+
+// The released platforms are linux, darwin and windows. Other unix targets
+// still compile this package, so they need a conditional rename that fails
+// closed: reporting ErrConditionalPublicationUnsupported keeps an unbuilt
+// platform from quietly falling back to an unconditional rename.
+
+func renameNoReplaceAt(_ int, _, _ string) error {
+	return errConditionalRenameUnavailable
+}
+
+func renameExchangeAt(_ int, _, _ string) error {
+	return errConditionalRenameUnavailable
+}

--- a/internal/fsdurable/publication_windows.go
+++ b/internal/fsdurable/publication_windows.go
@@ -1,6 +1,7 @@
 package fsdurable
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -20,6 +21,26 @@ type fileRenameInformationEx struct {
 }
 
 func openPublicationFile(root *os.Root, name string) (*os.File, error) {
+	return openRootedHandle(
+		root,
+		name,
+		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.DELETE,
+	)
+}
+
+// openPublicationDestination opens the entry a publication intends to replace.
+// It requests only what the conditional commit needs, because a destination
+// carrying the read-only attribute cannot be opened for writing and still has
+// to be verifiable and movable.
+func openPublicationDestination(root *os.Root, name string) (*os.File, error) {
+	return openRootedHandle(
+		root,
+		name,
+		windows.DELETE|windows.FILE_READ_ATTRIBUTES|windows.SYNCHRONIZE,
+	)
+}
+
+func openRootedHandle(root *os.Root, name string, access uint32) (*os.File, error) {
 	rootDir, err := root.Open(".")
 	if err != nil {
 		return nil, err
@@ -41,7 +62,7 @@ func openPublicationFile(root *os.Root, name string) (*os.File, error) {
 	)
 	openErr := windows.NtCreateFile(
 		&handle,
-		windows.FILE_GENERIC_READ|windows.FILE_GENERIC_WRITE|windows.DELETE,
+		access,
 		attributes,
 		&ioStatus,
 		&allocationSize,
@@ -55,7 +76,7 @@ func openPublicationFile(root *os.Root, name string) (*os.File, error) {
 	closeRootErr := rootDir.Close()
 	if openErr != nil {
 		return nil, errors.Join(
-			&fs.PathError{Op: "openat", Path: name, Err: openErr},
+			&fs.PathError{Op: "openat", Path: name, Err: mapNTStatus(openErr)},
 			closeRootErr,
 		)
 	}
@@ -73,20 +94,93 @@ func openPublicationFile(root *os.Root, name string) (*os.File, error) {
 	return file, nil
 }
 
-func renamePublicationFile(
+// commitPublicationFile publishes the staged entry over targetName only while
+// the target still holds dest.
+//
+// Windows has no exchange primitive, but it renames by handle rather than by
+// name, which supplies the same guarantee from the other direction: the
+// expected destination is opened, verified, and then moved aside through that
+// handle, so the move can only ever act on the object that was verified. The
+// staged file is then published with no-replace semantics, which fails closed
+// if anyone reached the freed name first.
+func commitPublicationFile(
 	root *os.Root,
 	staged *os.File,
-	stagedName string,
-	targetName string,
+	stagedName, targetName string,
+	dest Destination,
+	hooks publicationHooks,
 ) (bool, error) {
+	if dest.kind == destinationAbsent {
+		hooks.runBeforeCommit()
+		if err := renameFileHandle(root, staged, stagedName, targetName); err != nil {
+			return false, classifyWindowsPublicationError(targetName, err)
+		}
+		return true, nil
+	}
+	return replaceVerifiedDestination(root, staged, stagedName, targetName, dest, hooks)
+}
+
+func replaceVerifiedDestination(
+	root *os.Root,
+	staged *os.File,
+	stagedName, targetName string,
+	dest Destination,
+	hooks publicationHooks,
+) (bool, error) {
+	destination, err := openPublicationDestination(root, targetName)
+	if err != nil {
+		return false, destinationChangedError(targetName, err)
+	}
+	destinationInfo, statErr := destination.Stat()
+	if statErr != nil || !dest.matches(destinationInfo) {
+		return false, errors.Join(
+			destinationChangedError(targetName, errors.Join(errDisplacedDestination, statErr)),
+			destination.Close(),
+		)
+	}
+	hooks.runBeforeCommit()
+	displacedName := targetName + ".ptah-displaced-" + rand.Text()
+	if err := renameFileHandle(root, destination, targetName, displacedName); err != nil {
+		return false, errors.Join(
+			classifyWindowsPublicationError(targetName, err),
+			destination.Close(),
+		)
+	}
+	publishErr := renameFileHandle(root, staged, stagedName, targetName)
+	if publishErr == nil {
+		return true, errors.Join(destination.Close(), removeDisplacedFile(root, displacedName))
+	}
+	restoreErr := renameFileHandle(root, destination, displacedName, targetName)
+	if restoreErr == nil {
+		return false, errors.Join(
+			classifyWindowsPublicationError(targetName, publishErr),
+			destination.Close(),
+		)
+	}
+	closeErr := destination.Close()
+	recovery, preserveErr := preserveDisplacedFile(root, displacedName, targetName)
+	return false, fmt.Errorf(
+		"%w: %s: the displaced destination could not be restored and is preserved at %s: %w",
+		ErrDestinationChanged,
+		targetName,
+		recovery,
+		errors.Join(errDisplacedDestination, publishErr, restoreErr, preserveErr, closeErr),
+	)
+}
+
+// renameFileHandle renames the object behind file to newName inside root
+// without replacing an existing entry. Replacement is never requested: every
+// destination this package replaces is moved aside first, so a collision here
+// always means someone else reached the name.
+func renameFileHandle(root *os.Root, file *os.File, oldName, newName string) error {
 	rootDir, err := root.Open(".")
 	if err != nil {
-		return false, err
+		return err
 	}
-	targetUTF16, err := windows.UTF16FromString(targetName)
+	targetUTF16, err := windows.UTF16FromString(newName)
 	if err != nil {
-		return false, errors.Join(
-			&os.LinkError{Op: "renameat", Old: stagedName, New: targetName, Err: err},
+		return errors.Join(
+			&os.LinkError{Op: "renameat", Old: oldName, New: newName, Err: err},
 			rootDir.Close(),
 		)
 	}
@@ -95,8 +189,7 @@ func renamePublicationFile(
 	bufferSize := int(unsafe.Offsetof(layout.fileName)) + nameLength
 	buffer := make([]byte, bufferSize)
 	info := (*fileRenameInformationEx)(unsafe.Pointer(&buffer[0]))
-	info.flags = windows.FILE_RENAME_REPLACE_IF_EXISTS |
-		windows.FILE_RENAME_POSIX_SEMANTICS |
+	info.flags = windows.FILE_RENAME_POSIX_SEMANTICS |
 		windows.FILE_RENAME_IGNORE_READONLY_ATTRIBUTE
 	info.rootDirectory = windows.Handle(rootDir.Fd())
 	info.fileNameLength = uint32(nameLength)
@@ -106,24 +199,65 @@ func renamePublicationFile(
 	)
 	var ioStatus windows.IO_STATUS_BLOCK
 	renameErr := windows.NtSetInformationFile(
-		windows.Handle(staged.Fd()),
+		windows.Handle(file.Fd()),
 		&ioStatus,
 		&buffer[0],
 		uint32(bufferSize),
 		fileRenameInformationExClass,
 	)
+	closeErr := rootDir.Close()
 	if renameErr != nil {
-		return false, errors.Join(
+		return errors.Join(
 			&os.LinkError{
 				Op:  "renameat",
-				Old: stagedName,
-				New: targetName,
-				Err: renameErr,
+				Old: oldName,
+				New: newName,
+				Err: mapNTStatus(renameErr),
 			},
-			rootDir.Close(),
+			closeErr,
 		)
 	}
-	return true, rootDir.Close()
+	return closeErr
+}
+
+func rootRenameNoReplace(root *os.Root, oldName, newName string) error {
+	file, err := openPublicationDestination(root, oldName)
+	if err != nil {
+		return err
+	}
+	return errors.Join(renameFileHandle(root, file, oldName, newName), file.Close())
+}
+
+func classifyWindowsPublicationError(targetName string, err error) error {
+	if errors.Is(err, fs.ErrExist) {
+		return destinationChangedError(targetName, err)
+	}
+	if errors.Is(err, errConditionalRenameUnavailable) {
+		return unsupportedPublicationError(targetName, err)
+	}
+	return err
+}
+
+// mapNTStatus turns the NT statuses this package acts on into the portable
+// io/fs sentinels, so callers can match a lost race the same way on every
+// platform.
+func mapNTStatus(err error) error {
+	var status windows.NTStatus
+	if !errors.As(err, &status) {
+		return err
+	}
+	switch status {
+	case windows.STATUS_OBJECT_NAME_COLLISION:
+		return fmt.Errorf("%w: %w", fs.ErrExist, err)
+	case windows.STATUS_OBJECT_NAME_NOT_FOUND, windows.STATUS_OBJECT_PATH_NOT_FOUND:
+		return fmt.Errorf("%w: %w", fs.ErrNotExist, err)
+	case windows.STATUS_NOT_SUPPORTED,
+		windows.STATUS_INVALID_PARAMETER,
+		windows.STATUS_INVALID_INFO_CLASS,
+		windows.STATUS_INVALID_DEVICE_REQUEST:
+		return fmt.Errorf("%w: %w", errConditionalRenameUnavailable, err)
+	}
+	return err
 }
 
 func modesEqual(actual, expected fs.FileMode) bool {

--- a/internal/fsdurable/publish_destination_test.go
+++ b/internal/fsdurable/publish_destination_test.go
@@ -1,0 +1,177 @@
+package fsdurable_test
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/fsdurable"
+)
+
+// TestPublishFileAt_FailurePath_RefusesChangedDestination covers the guarantee
+// the callers cannot provide for themselves: their own destination checks are a
+// separate, earlier syscall, so only the commit primitive can bind what it
+// replaces. Every row mutates the destination after the expectation was
+// captured and asserts the rival's bytes, not just the exit status, because a
+// silent overwrite and a refusal both leave a file at the target name.
+func TestPublishFileAt_FailurePath_RefusesChangedDestination(t *testing.T) {
+	c := qt.New(t)
+	rival := "concurrent writer bytes\n"
+	tests := []struct {
+		name        string
+		prepare     func(c *qt.C, publishedPath string) fsdurable.Destination
+		mutate      func(c *qt.C, publishedPath string)
+		wantErrorIs error
+	}{
+		{
+			name: "expected file edited in place",
+			prepare: func(c *qt.C, publishedPath string) fsdurable.Destination {
+				c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+				info, err := os.Stat(publishedPath)
+				c.Assert(err, qt.IsNil)
+				return fsdurable.ExpectFile(info)
+			},
+			mutate: func(c *qt.C, publishedPath string) {
+				c.Assert(os.WriteFile(publishedPath, []byte(rival), 0o600), qt.IsNil)
+			},
+			wantErrorIs: fsdurable.ErrDestinationChanged,
+		},
+		{
+			name: "expected file replaced by rename",
+			prepare: func(c *qt.C, publishedPath string) fsdurable.Destination {
+				c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+				info, err := os.Stat(publishedPath)
+				c.Assert(err, qt.IsNil)
+				return fsdurable.ExpectFile(info)
+			},
+			mutate: func(c *qt.C, publishedPath string) {
+				replacement := publishedPath + ".rival"
+				c.Assert(os.WriteFile(replacement, []byte(rival), 0o600), qt.IsNil)
+				c.Assert(os.Rename(replacement, publishedPath), qt.IsNil)
+			},
+			wantErrorIs: fsdurable.ErrDestinationChanged,
+		},
+		{
+			name: "expected file removed and recreated",
+			prepare: func(c *qt.C, publishedPath string) fsdurable.Destination {
+				c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+				info, err := os.Stat(publishedPath)
+				c.Assert(err, qt.IsNil)
+				return fsdurable.ExpectFile(info)
+			},
+			mutate: func(c *qt.C, publishedPath string) {
+				c.Assert(os.Remove(publishedPath), qt.IsNil)
+				c.Assert(os.WriteFile(publishedPath, []byte(rival), 0o600), qt.IsNil)
+			},
+			wantErrorIs: fsdurable.ErrDestinationChanged,
+		},
+		{
+			name: "expected absent destination created",
+			prepare: func(*qt.C, string) fsdurable.Destination {
+				return fsdurable.ExpectAbsent()
+			},
+			mutate: func(c *qt.C, publishedPath string) {
+				c.Assert(os.WriteFile(publishedPath, []byte(rival), 0o600), qt.IsNil)
+			},
+			wantErrorIs: fsdurable.ErrDestinationChanged,
+		},
+		{
+			name: "unstated destination expectation",
+			prepare: func(c *qt.C, publishedPath string) fsdurable.Destination {
+				c.Assert(os.WriteFile(publishedPath, []byte(rival), 0o600), qt.IsNil)
+				return fsdurable.Destination{}
+			},
+			mutate:      func(*qt.C, string) {},
+			wantErrorIs: fsdurable.ErrDestinationChanged,
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := c.TempDir()
+			stagedPath := filepath.Join(dir, "staged")
+			publishedPath := filepath.Join(dir, "published")
+			c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+			stagedInfo, err := os.Stat(stagedPath)
+			c.Assert(err, qt.IsNil)
+			dest := test.prepare(c, publishedPath)
+			root, err := os.OpenRoot(dir)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				c.Check(root.Close(), qt.IsNil)
+			})
+			test.mutate(c, publishedPath)
+
+			err = fsdurable.PublishFileAt(
+				root,
+				"staged",
+				"published",
+				stagedInfo,
+				0o600,
+				dest,
+			)
+
+			c.Assert(err, qt.ErrorIs, test.wantErrorIs)
+			c.Assert(err, qt.Not(qt.ErrorIs), fsdurable.ErrReplacementCommitted)
+			assertPublicationBytes(c, publishedPath, rival)
+			assertPublicationBytes(c, stagedPath, "new")
+		})
+	}
+}
+
+// TestPublishFileAt_HappyPath_PublishesOverTheExpectedFile pins the other side
+// of the same comparison: the identical sequence with an accurate expectation
+// must still publish, so the refusals above cannot be satisfied by a primitive
+// that rejects everything.
+func TestPublishFileAt_HappyPath_PublishesOverTheExpectedFile(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	stagedPath := filepath.Join(dir, "staged")
+	publishedPath := filepath.Join(dir, "published")
+	c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	stagedInfo, err := os.Stat(stagedPath)
+	c.Assert(err, qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		stagedInfo,
+		0o600,
+		fsdurable.ExpectFile(originalInfo),
+	)
+
+	c.Assert(err, qt.IsNil)
+	assertPublicationBytes(c, publishedPath, "new")
+	publishedInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.SameFile(stagedInfo, publishedInfo), qt.IsTrue)
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(publicationEntryNames(entries), qt.DeepEquals, []string{"published"})
+}
+
+func assertPublicationBytes(c *qt.C, path, want string) {
+	c.Helper()
+	contents, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, want)
+}
+
+func publicationEntryNames(entries []fs.DirEntry) []string {
+	names := make([]string, len(entries))
+	for i, entry := range entries {
+		names[i] = entry.Name()
+	}
+	return names
+}

--- a/internal/fsdurable/publish_root.go
+++ b/internal/fsdurable/publish_root.go
@@ -15,11 +15,20 @@ import (
 // identify direct children of root. Errors after rename wrap
 // ErrReplacementCommitted. FinalMode follows os.Chmod semantics; on Windows,
 // its owner-write bit controls the read-only attribute.
+//
+// The publication is conditional on dest: the commit primitive itself binds the
+// state the caller expects at targetName, so a destination that changed after
+// the caller's own checks is reported through ErrDestinationChanged and left
+// byte-intact rather than replaced. A caller cannot opt out; the zero
+// Destination is rejected. Platforms and filesystems without a conditional
+// rename primitive fail with ErrConditionalPublicationUnsupported instead of
+// degrading to an unconditional rename.
 func PublishFileAt(
 	root *os.Root,
 	stagedName, targetName string,
 	stagedInfo fs.FileInfo,
 	finalMode fs.FileMode,
+	dest Destination,
 ) error {
 	return publishFileAt(
 		root,
@@ -27,8 +36,29 @@ func PublishFileAt(
 		targetName,
 		stagedInfo,
 		finalMode,
-		func() {},
+		dest,
+		publicationHooks{},
 	)
+}
+
+// publicationHooks injects deterministic waits into the commit sequence. The
+// window this package closes is a single syscall wide, so the tests that prove
+// it cannot reach it by polling from another goroutine.
+type publicationHooks struct {
+	beforeCommit func()
+	afterCommit  func()
+}
+
+func (h publicationHooks) runBeforeCommit() {
+	if h.beforeCommit != nil {
+		h.beforeCommit()
+	}
+}
+
+func (h publicationHooks) runAfterCommit() {
+	if h.afterCommit != nil {
+		h.afterCommit()
+	}
 }
 
 func publishFileAt(
@@ -36,12 +66,16 @@ func publishFileAt(
 	stagedName, targetName string,
 	stagedInfo fs.FileInfo,
 	finalMode fs.FileMode,
-	afterRename func(),
+	dest Destination,
+	hooks publicationHooks,
 ) error {
 	if err := validateDirectChildName("publishat", stagedName); err != nil {
 		return err
 	}
 	if err := validateDirectChildName("publishat", targetName); err != nil {
+		return err
+	}
+	if err := dest.validate(targetName); err != nil {
 		return err
 	}
 	staged, err := openExpectedWritableFile(root, stagedName, stagedInfo)
@@ -51,11 +85,11 @@ func publishFileAt(
 	if err := prepareOpenedFile(root, staged, stagedName, stagedInfo, finalMode); err != nil {
 		return errors.Join(err, staged.Close())
 	}
-	renamed, renameErr := renamePublicationFile(root, staged, stagedName, targetName)
+	renamed, renameErr := commitPublicationFile(root, staged, stagedName, targetName, dest, hooks)
 	if !renamed {
 		return errors.Join(renameErr, staged.Close())
 	}
-	afterRename()
+	hooks.runAfterCommit()
 
 	publishedInfo, verifyErr := root.Lstat(targetName)
 	if verifyErr != nil {

--- a/internal/fsdurable/publish_root_internal_test.go
+++ b/internal/fsdurable/publish_root_internal_test.go
@@ -21,24 +21,34 @@ func Test_publishFileAt_FailurePath_ReportsPostCommitIdentityChange(t *testing.T
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
 	stagedInfo, err := os.Stat(stagedPath)
 	c.Assert(err, qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = publishFileAt(root, "staged", "published", stagedInfo, 0o600, func() {
-		c.Assert(root.Rename("published", "displaced"), qt.IsNil)
-		replacement, openErr := root.OpenFile(
-			"published",
-			os.O_WRONLY|os.O_CREATE|os.O_EXCL,
-			0o600,
-		)
-		c.Assert(openErr, qt.IsNil)
-		_, writeErr := replacement.WriteString("replacement")
-		c.Assert(writeErr, qt.IsNil)
-		c.Assert(replacement.Close(), qt.IsNil)
-	})
+	err = publishFileAt(
+		root,
+		"staged",
+		"published",
+		stagedInfo,
+		0o600,
+		ExpectFile(originalInfo),
+		publicationHooks{afterCommit: func() {
+			c.Assert(root.Rename("published", "displaced"), qt.IsNil)
+			replacement, openErr := root.OpenFile(
+				"published",
+				os.O_WRONLY|os.O_CREATE|os.O_EXCL,
+				0o600,
+			)
+			c.Assert(openErr, qt.IsNil)
+			_, writeErr := replacement.WriteString("replacement")
+			c.Assert(writeErr, qt.IsNil)
+			c.Assert(replacement.Close(), qt.IsNil)
+		}},
+	)
 
 	c.Assert(err, qt.ErrorIs, ErrReplacementCommitted)
 	c.Assert(err, qt.ErrorIs, ErrStagedFileChanged)

--- a/internal/fsdurable/publish_root_test.go
+++ b/internal/fsdurable/publish_root_test.go
@@ -22,6 +22,8 @@ func TestPublishFileAt_HappyPath_AppliesReadOnlyMode(t *testing.T) {
 	c.Assert(os.Chmod(publishedPath, 0o400), qt.IsNil)
 	stagedInfo, err := os.Stat(stagedPath)
 	c.Assert(err, qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
@@ -29,7 +31,14 @@ func TestPublishFileAt_HappyPath_AppliesReadOnlyMode(t *testing.T) {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o400)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		stagedInfo,
+		0o400,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.IsNil)
 	contents, err := os.ReadFile(publishedPath)
@@ -83,7 +92,14 @@ func TestPublishFileAt_HappyPath_CreatesMissingDestination(t *testing.T) {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o600)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		stagedInfo,
+		0o600,
+		fsdurable.ExpectAbsent(),
+	)
 
 	c.Assert(err, qt.IsNil)
 	contents, err := os.ReadFile(publishedPath)
@@ -104,13 +120,22 @@ func TestPublishFileAt_FailurePath_RejectsReplacedStagedEntry(t *testing.T) {
 	c.Assert(os.Remove(stagedPath), qt.IsNil)
 	c.Assert(os.WriteFile(stagedPath, []byte("replacement"), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o640)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		expectedInfo,
+		0o640,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
 	contents, err := os.ReadFile(stagedPath)
@@ -131,13 +156,22 @@ func TestPublishFileAt_FailurePath_RejectsModifiedStagedFile(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.WriteFile(stagedPath, []byte("modified staged contents"), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o640)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		expectedInfo,
+		0o640,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
 	contents, err := os.ReadFile(stagedPath)
@@ -157,13 +191,22 @@ func TestPublishFileAt_FailurePath_RejectsMissingStagedEntry(t *testing.T) {
 	expectedInfo, err := os.Stat(expectedPath)
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "missing", "published", expectedInfo, 0o600)
+	err = fsdurable.PublishFileAt(
+		root,
+		"missing",
+		"published",
+		expectedInfo,
+		0o600,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	contents, err := os.ReadFile(publishedPath)
@@ -181,6 +224,8 @@ func TestPublishFileAt_FailurePath_RejectsChangedStagedMode(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.Chmod(stagedPath, 0o400), qt.IsNil)
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
@@ -188,7 +233,14 @@ func TestPublishFileAt_FailurePath_RejectsChangedStagedMode(t *testing.T) {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o600)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		expectedInfo,
+		0o600,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
 	contents, err := os.ReadFile(publishedPath)
@@ -207,13 +259,22 @@ func TestPublishFileAt_FailurePath_RejectsChangedStagedModTime(t *testing.T) {
 	changedTime := expectedInfo.ModTime().Add(time.Hour)
 	c.Assert(os.Chtimes(stagedPath, changedTime, changedTime), qt.IsNil)
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	root, err := os.OpenRoot(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", expectedInfo, 0o600)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		expectedInfo,
+		0o600,
+		fsdurable.ExpectFile(originalInfo),
+	)
 
 	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
 	contents, err := os.ReadFile(publishedPath)
@@ -253,6 +314,7 @@ func TestPublishFileAt_FailurePath_RejectsPathComponents(t *testing.T) {
 				test.targetName,
 				expectedInfo,
 				0o600,
+				fsdurable.ExpectAbsent(),
 			)
 			c.Assert(err, qt.ErrorIs, fs.ErrInvalid)
 		})

--- a/internal/fsdurable/publish_root_unix_test.go
+++ b/internal/fsdurable/publish_root_unix_test.go
@@ -26,7 +26,14 @@ func TestPublishFileAt_HappyPath_AppliesExactUnixMode(t *testing.T) {
 		c.Check(root.Close(), qt.IsNil)
 	})
 
-	err = fsdurable.PublishFileAt(root, "staged", "published", stagedInfo, 0o640)
+	err = fsdurable.PublishFileAt(
+		root,
+		"staged",
+		"published",
+		stagedInfo,
+		0o640,
+		fsdurable.ExpectAbsent(),
+	)
 
 	c.Assert(err, qt.IsNil)
 	publishedInfo, err := os.Stat(publishedPath)

--- a/internal/fsdurable/publish_window_internal_test.go
+++ b/internal/fsdurable/publish_window_internal_test.go
@@ -1,0 +1,110 @@
+package fsdurable
+
+// White-box testing required: the window these rows enter is a single syscall
+// wide. It is reachable only through the unexported publication hook, which
+// fires after every check this package could make and immediately before the
+// platform commit primitive.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+const windowRivalBytes = "concurrent writer bytes\n"
+
+// Test_publishFileAt_FailurePath_RefusesDestinationTakenInsideTheCommitWindow
+// is the row that separates a conditional commit primitive from another
+// pre-rename Lstat, which is the design #948 rules out.
+//
+// Every other publication test mutates the destination before publishFileAt is
+// entered, so all of them are satisfied by an implementation that stats the
+// target and then commits with an unconditional rename. These rows mutate
+// through beforeCommit instead, where no earlier check can observe it: only a
+// commit that binds the destination at the instant it takes effect refuses
+// them.
+//
+// The control row runs the identical sequence with nothing entering the window,
+// so the refusal cannot be satisfied by a primitive that rejects everything.
+func Test_publishFileAt_FailurePath_RefusesDestinationTakenInsideTheCommitWindow(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		prepare func(c *qt.C, publishedPath string) Destination
+		inject  func(c *qt.C, publishedPath string)
+		assert  func(c *qt.C, err error, stagedPath, publishedPath string)
+	}{
+		{
+			name: "absent destination created inside the commit window",
+			prepare: func(*qt.C, string) Destination {
+				return ExpectAbsent()
+			},
+			inject: func(c *qt.C, publishedPath string) {
+				c.Assert(os.WriteFile(publishedPath, []byte(windowRivalBytes), 0o600), qt.IsNil)
+			},
+			assert: func(c *qt.C, err error, stagedPath, publishedPath string) {
+				c.Assert(err, qt.ErrorIs, ErrDestinationChanged)
+				c.Assert(err, qt.Not(qt.ErrorIs), ErrReplacementCommitted)
+				assertWindowBytes(c, publishedPath, windowRivalBytes)
+				assertWindowBytes(c, stagedPath, "new")
+			},
+		},
+		{
+			name: "control: nothing enters the commit window",
+			prepare: func(*qt.C, string) Destination {
+				return ExpectAbsent()
+			},
+			inject: func(*qt.C, string) {},
+			assert: func(c *qt.C, err error, stagedPath, publishedPath string) {
+				c.Assert(err, qt.IsNil)
+				assertWindowBytes(c, publishedPath, "new")
+				assertWindowAbsent(c, stagedPath)
+			},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := c.TempDir()
+			stagedPath := filepath.Join(dir, "staged")
+			publishedPath := filepath.Join(dir, "published")
+			c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+			stagedInfo, err := os.Stat(stagedPath)
+			c.Assert(err, qt.IsNil)
+			dest := test.prepare(c, publishedPath)
+			root, err := os.OpenRoot(dir)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				c.Check(root.Close(), qt.IsNil)
+			})
+
+			err = publishFileAt(
+				root,
+				"staged",
+				"published",
+				stagedInfo,
+				0o600,
+				dest,
+				publicationHooks{beforeCommit: func() {
+					test.inject(c, publishedPath)
+				}},
+			)
+
+			test.assert(c, err, stagedPath, publishedPath)
+		})
+	}
+}
+
+func assertWindowBytes(c *qt.C, path, want string) {
+	c.Helper()
+	contents, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, want)
+}
+
+func assertWindowAbsent(c *qt.C, path string) {
+	c.Helper()
+	_, err := os.Lstat(path)
+	c.Assert(os.IsNotExist(err), qt.IsTrue)
+}

--- a/internal/fsdurable/publish_window_unix_internal_test.go
+++ b/internal/fsdurable/publish_window_unix_internal_test.go
@@ -1,0 +1,106 @@
+//go:build unix
+
+package fsdurable
+
+// White-box testing required: these rows enter the commit window of the
+// expected-file path, which is an atomic exchange here and is reachable only
+// through the unexported publication hook.
+//
+// Unix-only on purpose. The Windows path holds an open handle on the
+// destination across the same window, so replacing that entry from a test
+// would measure Windows sharing semantics rather than the publication
+// contract. The portable expected-absent row in publish_window_internal_test.go
+// covers every platform.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Test_publishFileAt_FailurePath_RefusesExpectedFileTakenInsideTheCommitWindow
+// exercises the exchange path with the rival arriving after the last check and
+// before the swap. The displaced side is verified after the exchange and put
+// back, so the rival's bytes must still be at the target and the staged file
+// must still be staged.
+//
+// The control row publishes through the identical sequence, which keeps the
+// refusals from being satisfiable by a primitive that never commits.
+func Test_publishFileAt_FailurePath_RefusesExpectedFileTakenInsideTheCommitWindow(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name   string
+		inject func(c *qt.C, publishedPath string)
+		assert func(c *qt.C, err error, stagedPath, publishedPath string)
+	}{
+		{
+			name: "expected file replaced by rename inside the commit window",
+			inject: func(c *qt.C, publishedPath string) {
+				replacement := publishedPath + ".rival"
+				c.Assert(os.WriteFile(replacement, []byte(windowRivalBytes), 0o600), qt.IsNil)
+				c.Assert(os.Rename(replacement, publishedPath), qt.IsNil)
+			},
+			assert: func(c *qt.C, err error, stagedPath, publishedPath string) {
+				c.Assert(err, qt.ErrorIs, ErrDestinationChanged)
+				c.Assert(err, qt.Not(qt.ErrorIs), ErrReplacementCommitted)
+				assertWindowBytes(c, publishedPath, windowRivalBytes)
+				assertWindowBytes(c, stagedPath, "new")
+			},
+		},
+		{
+			name: "expected file edited in place inside the commit window",
+			inject: func(c *qt.C, publishedPath string) {
+				c.Assert(os.WriteFile(publishedPath, []byte(windowRivalBytes), 0o600), qt.IsNil)
+			},
+			assert: func(c *qt.C, err error, stagedPath, publishedPath string) {
+				c.Assert(err, qt.ErrorIs, ErrDestinationChanged)
+				c.Assert(err, qt.Not(qt.ErrorIs), ErrReplacementCommitted)
+				assertWindowBytes(c, publishedPath, windowRivalBytes)
+				assertWindowBytes(c, stagedPath, "new")
+			},
+		},
+		{
+			name:   "control: nothing enters the commit window",
+			inject: func(*qt.C, string) {},
+			assert: func(c *qt.C, err error, stagedPath, publishedPath string) {
+				c.Assert(err, qt.IsNil)
+				assertWindowBytes(c, publishedPath, "new")
+				assertWindowAbsent(c, stagedPath)
+			},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dir := c.TempDir()
+			stagedPath := filepath.Join(dir, "staged")
+			publishedPath := filepath.Join(dir, "published")
+			c.Assert(os.WriteFile(stagedPath, []byte("new"), 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+			stagedInfo, err := os.Stat(stagedPath)
+			c.Assert(err, qt.IsNil)
+			originalInfo, err := os.Stat(publishedPath)
+			c.Assert(err, qt.IsNil)
+			root, err := os.OpenRoot(dir)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				c.Check(root.Close(), qt.IsNil)
+			})
+
+			err = publishFileAt(
+				root,
+				"staged",
+				"published",
+				stagedInfo,
+				0o600,
+				ExpectFile(originalInfo),
+				publicationHooks{beforeCommit: func() {
+					test.inject(c, publishedPath)
+				}},
+			)
+
+			test.assert(c, err, stagedPath, publishedPath)
+		})
+	}
+}

--- a/internal/fsdurable/recovery.go
+++ b/internal/fsdurable/recovery.go
@@ -1,0 +1,69 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strconv"
+	"time"
+)
+
+// recoveryNameLayout renders a filename-safe UTC instant. Windows forbids
+// colons in filenames, so RFC 3339 cannot be used here.
+const recoveryNameLayout = "20060102T150405.000000000Z"
+
+const recoveryNameAttempts = 1_000
+
+// preserveDisplacedFile gives a destination that a conditional publication
+// displaced but could not put back a stable, greppable name next to the
+// target, and syncs the parent directory before the caller reports anything.
+//
+// The ordering matters: the recovery entry must be durable before the error
+// reaches a human, otherwise a crash during reporting turns a recoverable
+// displacement into silent data loss. The name is deliberately not a dotfile,
+// because the only recovery artifact this package produced before was a hidden
+// random name that nobody could find.
+func preserveDisplacedFile(root *os.Root, displacedName, targetName string) (string, error) {
+	stamp := time.Now().UTC().Format(recoveryNameLayout)
+	for attempt := range recoveryNameAttempts {
+		name := targetName + ".ptah-recovery-" + stamp
+		if attempt > 0 {
+			name += "-" + strconv.Itoa(attempt)
+		}
+		err := rootRenameNoReplace(root, displacedName, name)
+		if errors.Is(err, fs.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return recoveryPath(root, displacedName), err
+		}
+		return recoveryPath(root, name), SyncRoot(root)
+	}
+	return recoveryPath(root, displacedName), &fs.PathError{
+		Op:   "preserve",
+		Path: targetName,
+		Err:  fs.ErrExist,
+	}
+}
+
+func recoveryPath(root *os.Root, name string) string {
+	path := filepath.Join(root.Name(), name)
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return path
+	}
+	return absolute
+}
+
+// removeDisplacedFile discards the destination a conditional publication
+// displaced on purpose. Failure leaves a stale entry behind but never loses the
+// published content, so the caller reports it as a post-commit defect.
+func removeDisplacedFile(root *os.Root, displacedName string) error {
+	err := root.Remove(displacedName)
+	if err == nil || errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("remove displaced publication destination %s: %w", displacedName, err)
+}

--- a/internal/fsdurable/recovery_internal_test.go
+++ b/internal/fsdurable/recovery_internal_test.go
@@ -1,0 +1,44 @@
+package fsdurable
+
+// White-box testing required: the recovery artifact is produced inside the
+// commit primitive on a branch that only a failed swap-back reaches, which no
+// public API can drive deterministically.
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// Test_preserveDisplacedFile_HappyPath_UsesAStableVisibleName pins the naming
+// contract, not just the fact that something survived. The only recovery
+// artifact this package produced before was a hidden random dotfile, which is
+// durable and useless: nobody can find it without knowing the error text.
+func Test_preserveDisplacedFile_HappyPath_UsesAStableVisibleName(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	displacedPath := filepath.Join(dir, ".schema.hcl.tmp-XYZ")
+	c.Assert(os.WriteFile(displacedPath, []byte("rival"), 0o600), qt.IsNil)
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+
+	recovered, err := preserveDisplacedFile(root, ".schema.hcl.tmp-XYZ", "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(filepath.IsAbs(recovered), qt.IsTrue)
+	name := filepath.Base(recovered)
+	c.Assert(strings.HasPrefix(name, "schema.hcl.ptah-recovery-"), qt.IsTrue)
+	c.Assert(strings.HasPrefix(name, "."), qt.IsFalse)
+	c.Assert(strings.ContainsAny(name, `:\/`), qt.IsFalse)
+	contents, err := os.ReadFile(recovered)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "rival")
+	_, err = os.Stat(displacedPath)
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}

--- a/internal/goannotationcleanup/cleanup.go
+++ b/internal/goannotationcleanup/cleanup.go
@@ -57,9 +57,33 @@ type filePlan struct {
 	removed []removedLine
 }
 
+// applyHooks injects deterministic waits into the apply sequence.
+// beforeCommit and beforeRestore land after the last validation barrier and
+// before the forward and rollback commits, which is the only place a concurrent
+// writer can reach a source file undetected.
 type applyHooks struct {
-	revalidate  func() error
-	afterCommit func()
+	revalidate    func() error
+	afterCommit   func()
+	beforeCommit  func()
+	beforeRestore func()
+}
+
+func (h applyHooks) runAfterCommit() {
+	if h.afterCommit != nil {
+		h.afterCommit()
+	}
+}
+
+func (h applyHooks) runBeforeCommit() {
+	if h.beforeCommit != nil {
+		h.beforeCommit()
+	}
+}
+
+func (h applyHooks) runBeforeRestore() {
+	if h.beforeRestore != nil {
+		h.beforeRestore()
+	}
 }
 
 type openedPlan struct {
@@ -142,10 +166,7 @@ func (p *Plan) Apply() error {
 	if err := p.snapshot.Revalidate(); err != nil {
 		return fmt.Errorf("revalidate Go annotation sources before cleanup: %w", err)
 	}
-	return applyPlans(p.changes, applyHooks{
-		revalidate:  p.snapshot.Revalidate,
-		afterCommit: func() {},
-	})
+	return applyPlans(p.changes, applyHooks{revalidate: p.snapshot.Revalidate})
 }
 
 func planFile(source goannotationsource.File) (filePlan, error) {
@@ -192,7 +213,7 @@ func applyPlans(plans []filePlan, hooks applyHooks) error {
 			fmt.Errorf("revalidate Go annotation sources before cleanup commit: %w", err),
 		)
 	}
-	if err := commitStagedPlans(staged, hooks.afterCommit); err != nil {
+	if err := commitStagedPlans(staged, hooks); err != nil {
 		return finishApply(opened, staged, err)
 	}
 	return finishApply(opened, staged, nil)
@@ -334,12 +355,22 @@ func validateOpenPlanEntry(
 	return nil
 }
 
-func validatePlanPath(opened *openedPlan) error {
+// validatePlanPath revalidates the source about to be replaced and returns the
+// identity the conditional commit must still find there.
+func validatePlanPath(opened *openedPlan) (fs.FileInfo, error) {
 	file, err := openValidatedPlan(opened.parent, opened.targetName, opened.plan)
 	if err != nil {
-		return err
+		return nil, err
 	}
-	return file.Close()
+	info, statErr := file.Stat()
+	if err := errors.Join(statErr, file.Close()); err != nil {
+		return nil, fmt.Errorf(
+			"stat validated Go source %s: %w",
+			opened.plan.result.Path,
+			err,
+		)
+	}
+	return info, nil
 }
 
 func validatePlanContent(file *os.File, expected []byte, displayPath string) error {
@@ -435,21 +466,27 @@ func stageFile(opened *openedPlan, kind string, data []byte) (stagedFile, error)
 	return staged, nil
 }
 
-func commitStagedPlans(staged []stagedPlan, afterCommit func()) error {
+func commitStagedPlans(staged []stagedPlan, hooks applyHooks) error {
 	for i := range staged {
 		if err := staged[i].opened.parent.Revalidate(); err != nil {
 			return errors.Join(
 				fmt.Errorf("revalidate Go source parent before cleanup %s: %w", staged[i].opened.plan.result.Path, err),
-				rollbackStagedPlans(staged[:i]),
+				rollbackStagedPlans(staged[:i], hooks),
 			)
 		}
-		if err := validatePlanPath(staged[i].opened); err != nil {
-			return errors.Join(err, rollbackStagedPlans(staged[:i]))
+		sourceInfo, err := validatePlanPath(staged[i].opened)
+		if err != nil {
+			return errors.Join(err, rollbackStagedPlans(staged[:i], hooks))
 		}
-		committed, err := commitStagedFile(&staged[i], &staged[i].cleaned)
+		committed, err := commitStagedFile(
+			&staged[i],
+			&staged[i].cleaned,
+			fsdurable.ExpectFile(sourceInfo),
+			hooks.runBeforeCommit,
+		)
 		staged[i].committed = committed
 		if committed {
-			afterCommit()
+			hooks.runAfterCommit()
 		}
 		if err != nil {
 			rollbackEnd := i
@@ -458,22 +495,34 @@ func commitStagedPlans(staged []stagedPlan, afterCommit func()) error {
 			}
 			return errors.Join(
 				fmt.Errorf("commit cleaned Go source %s: %w", staged[i].opened.plan.result.Path, err),
-				rollbackStagedPlans(staged[:rollbackEnd]),
+				rollbackStagedPlans(staged[:rollbackEnd], hooks),
 			)
 		}
 	}
 	return nil
 }
 
-func commitStagedFile(plan *stagedPlan, staged *stagedFile) (bool, error) {
+// commitStagedFile publishes staged over the plan's source path, conditional on
+// dest still describing that path. The forward commit expects the source
+// identity validated a moment earlier; a rollback expects the cleaned file this
+// run committed. Either way the rename refuses rather than overwrites when a
+// third party got there first.
+func commitStagedFile(
+	plan *stagedPlan,
+	staged *stagedFile,
+	dest fsdurable.Destination,
+	beforeCommit func(),
+) (bool, error) {
 	if err := plan.opened.parent.Revalidate(); err != nil {
 		return false, err
 	}
+	beforeCommit()
 	replaceErr := plan.opened.parent.PublishFile(
 		staged.name,
 		plan.opened.targetName,
 		staged.info,
 		plan.opened.plan.source.Mode(),
+		dest,
 	)
 	committed := replaceErr == nil || errors.Is(replaceErr, fsdurable.ErrReplacementCommitted)
 	if !committed {
@@ -491,7 +540,7 @@ func replacementCommittedError(err error) error {
 	return fmt.Errorf("%w: %w", fsdurable.ErrReplacementCommitted, err)
 }
 
-func rollbackStagedPlans(staged []stagedPlan) error {
+func rollbackStagedPlans(staged []stagedPlan, hooks applyHooks) error {
 	var rollbackErr error
 	for i := range slices.Backward(staged) {
 		if !staged[i].committed {
@@ -513,7 +562,12 @@ func rollbackStagedPlans(staged []stagedPlan) error {
 			)
 			continue
 		}
-		committed, err := commitStagedFile(&staged[i], &staged[i].backup)
+		committed, err := commitStagedFile(
+			&staged[i],
+			&staged[i].backup,
+			fsdurable.ExpectFile(staged[i].cleaned.info),
+			hooks.runBeforeRestore,
+		)
 		if committed {
 			staged[i].committed = false
 		}
@@ -522,6 +576,10 @@ func rollbackStagedPlans(staged []stagedPlan) error {
 		}
 		if !committed {
 			staged[i].preserveBackup = true
+		}
+		if !committed && errors.Is(err, fsdurable.ErrDestinationChanged) {
+			rollbackErr = errors.Join(rollbackErr, rollbackConflictError(&staged[i], err))
+			continue
 		}
 		rollbackErr = errors.Join(
 			rollbackErr,

--- a/internal/goannotationcleanup/cleanup_internal_test.go
+++ b/internal/goannotationcleanup/cleanup_internal_test.go
@@ -201,6 +201,192 @@ func TestApplyPlans_FailurePath_RejectsReplacedStagedFile(t *testing.T) {
 	c.Assert(internalEntryNames(entries), qt.DeepEquals, []string{"model.go"})
 }
 
+// TestApplyPlans_FailurePath_RefusesForwardCommitOverConcurrentEdit measures
+// the gap between validatePlanPath and the rename that replaces the source.
+// Before the commit became conditional the injected edit was destroyed with no
+// error at all, so the assertion is on the surviving bytes rather than on the
+// exit status.
+//
+// The control row runs the identical mutation one step earlier, where
+// validatePlanPath already rejects it.
+func TestApplyPlans_FailurePath_RefusesForwardCommitOverConcurrentEdit(t *testing.T) {
+	c := qt.New(t)
+	original := []byte(
+		"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+	)
+	rival := []byte("package models\n\n// hand edit by another writer\ntype User struct{}\n")
+	editInPlace := func(c *qt.C, sourcePath string) {
+		c.Assert(os.WriteFile(sourcePath, rival, 0o600), qt.IsNil)
+	}
+	replaceByRename := func(c *qt.C, sourcePath string) {
+		replacement := sourcePath + ".rival"
+		c.Assert(os.WriteFile(replacement, rival, 0o600), qt.IsNil)
+		c.Assert(os.Rename(replacement, sourcePath), qt.IsNil)
+	}
+	commitWindow := func(revalidate func() error, inject func()) applyHooks {
+		return applyHooks{revalidate: revalidate, beforeCommit: inject}
+	}
+	validationWindow := func(_ func() error, inject func()) applyHooks {
+		return applyHooks{revalidate: func() error {
+			inject()
+			return nil
+		}}
+	}
+	tests := []struct {
+		name   string
+		inject func(c *qt.C, sourcePath string)
+		hooks  func(revalidate func() error, inject func()) applyHooks
+		check  func(c *qt.C, err error)
+	}{
+		{
+			name:   "in-place edit inside the commit window",
+			inject: editInPlace,
+			hooks:  commitWindow,
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorIs, fsdurable.ErrDestinationChanged)
+			},
+		},
+		{
+			name:   "rename replacement inside the commit window",
+			inject: replaceByRename,
+			hooks:  commitWindow,
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorIs, fsdurable.ErrDestinationChanged)
+			},
+		},
+		{
+			name:   "control: in-place edit before the last validation",
+			inject: editInPlace,
+			hooks:  validationWindow,
+			check: func(c *qt.C, err error) {
+				c.Assert(err.Error(), qt.Contains, "go source changed before cleanup")
+			},
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			sourcePath := filepath.Join(root, "model.go")
+			c.Assert(os.WriteFile(sourcePath, original, 0o600), qt.IsNil)
+			snapshot, err := goannotationsource.Capture(root)
+			c.Assert(err, qt.IsNil)
+			plan, err := NewPlan(snapshot)
+			c.Assert(err, qt.IsNil)
+
+			applyErr := applyPlans(plan.changes, test.hooks(snapshot.Revalidate, func() {
+				test.inject(c, sourcePath)
+			}))
+
+			c.Assert(applyErr, qt.IsNotNil)
+			c.Assert(applyErr, qt.Not(qt.ErrorIs), fsdurable.ErrReplacementCommitted)
+			test.check(c, applyErr)
+			assertInternalFileBytes(c, sourcePath, rival)
+			entries, err := os.ReadDir(root)
+			c.Assert(err, qt.IsNil)
+			c.Assert(internalEntryNames(entries), qt.DeepEquals, []string{"model.go"})
+		})
+	}
+}
+
+// TestApplyPlans_FailurePath_RefusesRollbackOverPostCommitEdit measures the
+// restoration window. It is the most damaging of the three gaps: a rollback
+// that loses this race overwrites a third party's post-commit edit with bytes
+// captured before the run, content that never existed in any artifact anyone
+// could recover from.
+//
+// The control row moves the identical mutation one step earlier, where
+// validateCommittedPlan already refuses.
+func TestApplyPlans_FailurePath_RefusesRollbackOverPostCommitEdit(t *testing.T) {
+	c := qt.New(t)
+	firstOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"first\"\ntype First struct{}\n",
+	)
+	secondOriginal := []byte(
+		"package models\n\n//ptah:schema:table name=\"second\"\ntype Second struct{}\n",
+	)
+	firstConcurrent := []byte("package models\n\ntype First struct{ Concurrent bool }\n")
+	secondConcurrent := []byte("package models\n\ntype Second struct{ Concurrent bool }\n")
+	editInPlace := func(c *qt.C, path string) {
+		c.Assert(os.WriteFile(path, firstConcurrent, 0o600), qt.IsNil)
+	}
+	replaceByRename := func(c *qt.C, path string) {
+		replacement := path + ".rival"
+		c.Assert(os.WriteFile(replacement, firstConcurrent, 0o600), qt.IsNil)
+		c.Assert(os.Rename(replacement, path), qt.IsNil)
+	}
+	restoreWindow := func(base applyHooks, injectFirst func()) applyHooks {
+		base.beforeRestore = injectFirst
+		return base
+	}
+	validationWindow := func(base applyHooks, injectFirst func()) applyHooks {
+		failSecond := base.afterCommit
+		base.afterCommit = func() {
+			failSecond()
+			injectFirst()
+		}
+		return base
+	}
+	tests := []struct {
+		name   string
+		inject func(c *qt.C, path string)
+		hooks  func(base applyHooks, injectFirst func()) applyHooks
+	}{
+		{
+			name:   "in-place edit inside the restoration window",
+			inject: editInPlace,
+			hooks:  restoreWindow,
+		},
+		{
+			name:   "rename replacement inside the restoration window",
+			inject: replaceByRename,
+			hooks:  restoreWindow,
+		},
+		{
+			name:   "control: in-place edit before the last validation",
+			inject: editInPlace,
+			hooks:  validationWindow,
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			firstPath := filepath.Join(root, "a.go")
+			secondPath := filepath.Join(root, "z.go")
+			c.Assert(os.WriteFile(firstPath, firstOriginal, 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(secondPath, secondOriginal, 0o600), qt.IsNil)
+			c.Assert(os.Chmod(firstPath, 0o640), qt.IsNil)
+			c.Assert(os.Chmod(secondPath, 0o640), qt.IsNil)
+			snapshot, err := goannotationsource.Capture(root)
+			c.Assert(err, qt.IsNil)
+			plan, err := NewPlan(snapshot)
+			c.Assert(err, qt.IsNil)
+			base := applyHooks{
+				revalidate: snapshot.Revalidate,
+				afterCommit: func() {
+					c.Assert(os.WriteFile(secondPath, secondConcurrent, 0o600), qt.IsNil)
+				},
+			}
+
+			applyErr := applyPlans(plan.changes, test.hooks(base, func() {
+				test.inject(c, firstPath)
+			}))
+
+			c.Assert(applyErr, qt.ErrorIs, ErrRollbackConflict)
+			c.Assert(applyErr.Error(), qt.Contains, "preserved backup")
+			assertInternalFileBytes(c, firstPath, firstConcurrent)
+			assertInternalFileBytes(c, secondPath, secondConcurrent)
+			backups, err := filepath.Glob(filepath.Join(root, ".a.go.ptah-backup-*"))
+			c.Assert(err, qt.IsNil)
+			c.Assert(backups, qt.HasLen, 1)
+			assertInternalFileBytes(c, backups[0], firstOriginal)
+			c.Assert(applyErr.Error(), qt.Contains, backups[0])
+			cleanedFiles, err := filepath.Glob(filepath.Join(root, ".*.ptah-cleaned-*"))
+			c.Assert(err, qt.IsNil)
+			c.Assert(cleanedFiles, qt.HasLen, 0)
+		})
+	}
+}
+
 func assertInternalFileBytes(c *qt.C, path string, want []byte) {
 	c.Helper()
 	got, err := os.ReadFile(path)

--- a/internal/goannotationexport/export.go
+++ b/internal/goannotationexport/export.go
@@ -102,10 +102,31 @@ type stagedOutput struct {
 // Export renders Go annotations to HCL and optionally applies one validated
 // cleanup plan after the output has been committed.
 func Export(opts Options) (Result, error) {
-	return export(opts, func() {})
+	return export(opts, exportHooks{})
 }
 
-func export(opts Options, afterOutputStage func()) (Result, error) {
+// exportHooks injects deterministic mutations into the publication sequence.
+// afterOutputStage lands before the destination barriers; beforeCommit lands
+// after the last barrier and before the commit, which is the only place a
+// concurrent writer can reach the destination undetected.
+type exportHooks struct {
+	afterOutputStage func()
+	beforeCommit     func()
+}
+
+func (h exportHooks) runAfterOutputStage() {
+	if h.afterOutputStage != nil {
+		h.afterOutputStage()
+	}
+}
+
+func (h exportHooks) runBeforeCommit() {
+	if h.beforeCommit != nil {
+		h.beforeCommit()
+	}
+}
+
+func export(opts Options, hooks exportHooks) (Result, error) {
 	plan, err := prepareExport(opts)
 	if err != nil {
 		return Result{}, err
@@ -118,14 +139,14 @@ func export(opts Options, afterOutputStage func()) (Result, error) {
 	if err != nil {
 		return Result{}, err
 	}
-	afterOutputStage()
+	hooks.runAfterOutputStage()
 	if err := plan.validatePublication(rendered.database.ManagedData); err != nil {
 		return Result{}, errors.Join(err, staged.cleanup())
 	}
 	if err := staged.validateDestination(); err != nil {
 		return Result{}, errors.Join(err, staged.cleanup())
 	}
-	if err := staged.commit(); err != nil {
+	if err := staged.commit(hooks); err != nil {
 		return Result{}, errors.Join(err, staged.cleanup())
 	}
 	if err := staged.close(); err != nil {
@@ -637,7 +658,18 @@ func (s *stagedOutput) validateDestination() error {
 	return nil
 }
 
-func (s *stagedOutput) commit() error {
+// expectedDestination states what the commit is allowed to replace. The
+// pre-commit validateDestination call stays as the cheap early reject that also
+// compares bytes; this is the guarantee, because it is enforced by the rename
+// itself rather than by an earlier syscall.
+func (s *stagedOutput) expectedDestination() fsdurable.Destination {
+	if s.original.exists {
+		return fsdurable.ExpectFile(s.original.info)
+	}
+	return fsdurable.ExpectAbsent()
+}
+
+func (s *stagedOutput) commit(hooks exportHooks) error {
 	if err := s.validateDestination(); err != nil {
 		return err
 	}
@@ -648,9 +680,19 @@ func (s *stagedOutput) commit() error {
 			err,
 		)
 	}
-	replaceErr := s.parent.PublishFile(s.tempName, s.targetName, s.tempInfo, s.mode)
+	hooks.runBeforeCommit()
+	replaceErr := s.parent.PublishFile(
+		s.tempName,
+		s.targetName,
+		s.tempInfo,
+		s.mode,
+		s.expectedDestination(),
+	)
 	committed := replaceErr == nil || errors.Is(replaceErr, fsdurable.ErrReplacementCommitted)
 	if !committed {
+		if errors.Is(replaceErr, fsdurable.ErrDestinationChanged) {
+			return fmt.Errorf("%w: %s: %w", ErrOutputChanged, s.outputPath, replaceErr)
+		}
 		return fmt.Errorf("commit HCL output: %w", replaceErr)
 	}
 	s.tempName = ""

--- a/internal/goannotationexport/export_ancestor_unix_internal_test.go
+++ b/internal/goannotationexport/export_ancestor_unix_internal_test.go
@@ -35,10 +35,10 @@ func TestExport_FailurePath_AncestorSwapAbortsHCLPublication(t *testing.T) {
 	result, err := export(Options{
 		RootDir:    root,
 		OutputPath: output,
-	}, func() {
+	}, exportHooks{afterOutputStage: func() {
 		c.Assert(os.Rename(outputDir, capturedDir), qt.IsNil)
 		c.Assert(os.Symlink(outsideDir, outputDir), qt.IsNil)
-	})
+	}})
 
 	c.Assert(err, qt.ErrorIs, ErrOutputChanged)
 	c.Assert(result, qt.DeepEquals, Result{})

--- a/internal/goannotationexport/export_internal_test.go
+++ b/internal/goannotationexport/export_internal_test.go
@@ -81,9 +81,9 @@ func TestExport_FailurePath_RevalidatesSourcesAfterOutputStaging(t *testing.T) {
 				RootDir:    root,
 				OutputPath: output,
 				Cleanup:    true,
-			}, func() {
+			}, exportHooks{afterOutputStage: func() {
 				test.mutate(c, root, source, original)
-			})
+			}})
 
 			c.Assert(err, qt.ErrorIs, goannotationsource.ErrChanged)
 			c.Assert(result, qt.DeepEquals, Result{})
@@ -129,9 +129,9 @@ func TestExport_FailurePath_PreservesConcurrentOutputChangeAfterStaging(t *testi
 				RootDir:    root,
 				OutputPath: output,
 				Cleanup:    true,
-			}, func() {
+			}, exportHooks{afterOutputStage: func() {
 				c.Assert(os.WriteFile(output, concurrentOutput, 0o600), qt.IsNil)
-			})
+			}})
 
 			c.Assert(err, qt.ErrorIs, ErrOutputChanged)
 			c.Assert(result, qt.DeepEquals, Result{})
@@ -163,13 +163,13 @@ func TestExport_FailurePath_RejectsReplacedStagedOutput(t *testing.T) {
 		RootDir:    root,
 		OutputPath: output,
 		Cleanup:    true,
-	}, func() {
+	}, exportHooks{afterOutputStage: func() {
 		staged, err := filepath.Glob(filepath.Join(root, ".schema.hcl.tmp-*"))
 		c.Assert(err, qt.IsNil)
 		c.Assert(staged, qt.HasLen, 1)
 		c.Assert(os.Remove(staged[0]), qt.IsNil)
 		c.Assert(os.WriteFile(staged[0], []byte("attacker-controlled\n"), 0o600), qt.IsNil)
-	})
+	}})
 
 	c.Assert(err, qt.ErrorIs, fsdurable.ErrStagedFileChanged)
 	c.Assert(result, qt.DeepEquals, Result{})
@@ -181,6 +181,110 @@ func TestExport_FailurePath_RejectsReplacedStagedOutput(t *testing.T) {
 		"model.go",
 		"schema.hcl",
 	})
+}
+
+// TestExport_FailurePath_RefusesDestinationChangedInsideCommitWindow measures
+// the gap between the last destination barrier and the rename. Before the
+// commit became conditional, every commit-window row returned a nil error and
+// left the staged HCL at the destination, so the CLI reported a successful
+// export while the other writer's file was gone. Each row therefore asserts the
+// rival's bytes, not merely a nonzero exit.
+//
+// The control rows run the identical mutation one step earlier, where
+// validateDestination already caught it. Same mutation, opposite side of the
+// last barrier: that is what makes this fixture measure the window rather than
+// "any concurrent write".
+func TestExport_FailurePath_RefusesDestinationChangedInsideCommitWindow(t *testing.T) {
+	c := qt.New(t)
+	previousOutput := []byte("previous schema\n")
+	rival := []byte("concurrent writer bytes\n")
+	writePrevious := func(c *qt.C, output string) {
+		c.Assert(os.WriteFile(output, previousOutput, 0o600), qt.IsNil)
+	}
+	leaveAbsent := func(*qt.C, string) {}
+	editInPlace := func(c *qt.C, output string) {
+		c.Assert(os.WriteFile(output, rival, 0o600), qt.IsNil)
+	}
+	replaceByRename := func(c *qt.C, output string) {
+		replacement := output + ".rival"
+		c.Assert(os.WriteFile(replacement, rival, 0o600), qt.IsNil)
+		c.Assert(os.Rename(replacement, output), qt.IsNil)
+	}
+	commitWindow := func(inject func()) exportHooks {
+		return exportHooks{beforeCommit: inject}
+	}
+	stagingWindow := func(inject func()) exportHooks {
+		return exportHooks{afterOutputStage: inject}
+	}
+	tests := []struct {
+		name    string
+		prepare func(c *qt.C, output string)
+		inject  func(c *qt.C, output string)
+		hooks   func(inject func()) exportHooks
+	}{
+		{
+			name:    "existing destination edited in place inside the commit window",
+			prepare: writePrevious,
+			inject:  editInPlace,
+			hooks:   commitWindow,
+		},
+		{
+			name:    "existing destination replaced by rename inside the commit window",
+			prepare: writePrevious,
+			inject:  replaceByRename,
+			hooks:   commitWindow,
+		},
+		{
+			name:    "absent destination created inside the commit window",
+			prepare: leaveAbsent,
+			inject:  editInPlace,
+			hooks:   commitWindow,
+		},
+		{
+			name:    "control: existing destination edited before the last barrier",
+			prepare: writePrevious,
+			inject:  editInPlace,
+			hooks:   stagingWindow,
+		},
+		{
+			name:    "control: absent destination created before the last barrier",
+			prepare: leaveAbsent,
+			inject:  editInPlace,
+			hooks:   stagingWindow,
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			source := filepath.Join(root, "model.go")
+			output := filepath.Join(root, "schema.hcl")
+			sourceData := []byte(
+				"package models\n\n//ptah:schema:table name=\"users\"\ntype User struct{}\n",
+			)
+			c.Assert(os.WriteFile(source, sourceData, 0o600), qt.IsNil)
+			test.prepare(c, output)
+
+			result, err := export(Options{
+				RootDir:    root,
+				OutputPath: output,
+				Cleanup:    true,
+			}, test.hooks(func() {
+				test.inject(c, output)
+			}))
+
+			c.Assert(err, qt.ErrorIs, ErrOutputChanged)
+			c.Assert(err, qt.Not(qt.ErrorIs), fsdurable.ErrReplacementCommitted)
+			c.Assert(result, qt.DeepEquals, Result{})
+			assertExportInternalFileBytes(c, output, rival)
+			assertExportInternalFileBytes(c, source, sourceData)
+			entries, err := os.ReadDir(root)
+			c.Assert(err, qt.IsNil)
+			c.Assert(exportInternalEntryNames(entries), qt.DeepEquals, []string{
+				"model.go",
+				"schema.hcl",
+			})
+		})
+	}
 }
 
 func assertExportInternalFileBytes(c *qt.C, path string, want []byte) {

--- a/internal/goannotationexport/export_symlink_unix_internal_test.go
+++ b/internal/goannotationexport/export_symlink_unix_internal_test.go
@@ -38,10 +38,10 @@ type Country struct {
 		RootDir:    root,
 		OutputPath: output,
 		Cleanup:    true,
-	}, func() {
+	}, exportHooks{afterOutputStage: func() {
 		c.Assert(os.Remove(output), qt.IsNil)
 		c.Assert(os.Link(dataPath, output), qt.IsNil)
-	})
+	}})
 
 	c.Assert(err, qt.ErrorIs, ErrOutputAliasesManagedData)
 	c.Assert(result, qt.DeepEquals, Result{})

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -76,12 +76,17 @@ func (d *OpenedDirectory) ReplaceFile(oldName, newName string) error {
 // by expectedInfo from os.Stat or os.File.Stat. The final mode is applied before
 // rename. Both names must identify direct children. An error wrapping
 // fsdurable.ErrReplacementCommitted means the rename succeeded.
+//
+// The commit is conditional on dest, so a destination that changed after the
+// caller's own validation is reported through fsdurable.ErrDestinationChanged
+// and left untouched instead of being overwritten.
 func (d *OpenedDirectory) PublishFile(
 	oldName, newName string,
 	expectedInfo fs.FileInfo,
 	finalMode fs.FileMode,
+	dest fsdurable.Destination,
 ) error {
-	return fsdurable.PublishFileAt(d.root, oldName, newName, expectedInfo, finalMode)
+	return fsdurable.PublishFileAt(d.root, oldName, newName, expectedInfo, finalMode, dest)
 }
 
 // FinalizeFile applies finalMode to a staged regular file with the supplied

--- a/internal/pathguard/opened_directory_ops_test.go
+++ b/internal/pathguard/opened_directory_ops_test.go
@@ -9,6 +9,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/pathguard"
 )
 
@@ -109,6 +110,8 @@ func TestOpenedDirectoryPublication_HappyPath(t *testing.T) {
 	dir := c.TempDir()
 	publishedPath := filepath.Join(dir, "published")
 	c.Assert(os.WriteFile(publishedPath, []byte("old"), 0o600), qt.IsNil)
+	originalInfo, err := os.Stat(publishedPath)
+	c.Assert(err, qt.IsNil)
 	opened, err := pathguard.OpenDirectory(dir)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() {
@@ -136,7 +139,13 @@ func TestOpenedDirectoryPublication_HappyPath(t *testing.T) {
 		c.Check(os.Chmod(backupPath, 0o600), qt.IsNil)
 	})
 
-	c.Assert(opened.PublishFile(stagedName, "published", stagedInfo, 0o400), qt.IsNil)
+	c.Assert(opened.PublishFile(
+		stagedName,
+		"published",
+		stagedInfo,
+		0o400,
+		fsdurable.ExpectFile(originalInfo),
+	), qt.IsNil)
 	c.Assert(opened.FinalizeFile(backupName, backupInfo, 0o400), qt.IsNil)
 	c.Assert(opened.Revalidate(), qt.IsNil)
 


### PR DESCRIPTION
Closes #948.

`fsdurable.PublishFileAt` had no destination parameter. It validated the staged
entry exhaustively and then committed with an unconditional replace, so every
destination guarantee lived in the callers as a separate, earlier syscall. This
makes the expected destination state an argument of the commit primitive
itself, so the rename is conditional on what it replaces.

The branch was written against `92213b39` and had no PR. It is rebased onto
`da1c4cd2` (current master) with no conflicts — master had moved by exactly one
commit, #1097, which touches compat txmode diagnostics and nothing here.

## The defect still reproduces on master

Not assumed — replayed against `da1c4cd2` with the exact caller sequence from
the issue: validate the destination, let an uncooperative writer replace it,
then commit.

    MEASURE: destination validated, size=9
    MEASURE: rival replaced the destination
    MEASURE: PublishFileAt err = <nil>
    MEASURE: bytes surviving at destination = "ptah-output\n"

The rival's bytes are gone and nothing is reported. The same harness against
this branch:

    MEASURE: destination validated, size=9
    MEASURE: rival replaced the destination
    MEASURE: PublishFileAt err = publication destination identity or metadata changed: schema.hcl: the destination was replaced before the commit took effect
    MEASURE: errors.Is ErrDestinationChanged = true
    MEASURE: bytes surviving at destination = "RIVAL-WROTE-THIS\n"

Master's `PublishFileAt` still takes no `Destination` at all, so this is not
superseded by #949 (which closed #900 and explicitly left this primitive to
#948).

## What the review found and changed

`fsdurable.publicationHooks.beforeCommit` was wired into every platform commit
path and used by **no test**. Every publication test — at the fsdurable level
*and* at the caller level — mutated the destination before `publishFileAt` was
entered. `goannotationexport`'s own `beforeCommit` fires before `PublishFile`
is called, so its commit-window rows sit outside the primitive too.

That means the whole suite was satisfied by "another pre-rename Lstat", which
is exactly the design the issue rules out. Proven by mutation: replacing
`commitPublicationFile` on non-Windows with `root.Lstat(target)` +
`dest.matches` + `root.Rename` left everything green.

    ok  go.5x5.cz/ptah/internal/fsdurable
    ok  go.5x5.cz/ptah/internal/goannotationexport
    ok  go.5x5.cz/ptah/internal/goannotationcleanup
    ok  go.5x5.cz/ptah/internal/pathguard

Two new white-box test files mutate through the fsdurable hook instead, which
fires after every check the package could make and immediately before the
platform syscall. The mutant was re-run against them and the implementation
restored afterwards; the diff contains no production changes beyond the
original commit.

## What each test prints if the change is reverted

Reverting the change outright removes the `Destination` parameter, so every
test below fails to compile. The interesting question is the weaker revert —
keeping the signature, dropping atomicity — so each row is stated against the
pre-rename-Lstat mutant.

| Test | Under the mutant |
| --- | --- |
| `Test_publishFileAt_..._RefusesDestinationTakenInsideTheCommitWindow` / absent destination created inside the window | **red**: `got nil error but want non-nil` / `want: e"publication destination identity or metadata changed"` |
| `Test_publishFileAt_..._RefusesExpectedFileTakenInsideTheCommitWindow` / expected file replaced by rename inside the window | **red**, same output |
| `Test_publishFileAt_..._RefusesExpectedFileTakenInsideTheCommitWindow` / expected file edited in place inside the window | **red**, same output |
| both tables' `control: nothing enters the commit window` rows | **green** either way, by design — they exist so the refusals cannot be satisfied by a primitive that rejects everything |
| `TestPublishFileAt_FailurePath_RefusesChangedDestination` (5 rows) | **green** either way. Contract coverage: it pins that a stated expectation is enforced, not that enforcement is atomic |
| `TestPublishFileAt_HappyPath_PublishesOverTheExpectedFile` | **green** either way; pins that an accurate expectation still publishes |
| `TestExport_FailurePath_RefusesDestinationChangedInsideCommitWindow` (3 window + 2 control rows) | **green** either way. Measures the *caller's* window, which is what the issue's first paragraph describes; returned `nil` before this change |
| `Test_publishFileAt_FailurePath_ReportsPostCommitIdentityChange` | **green** either way; it drives `afterCommit` and pins the `ErrReplacementCommitted` signal |
| `Test_preserveDisplacedFile_HappyPath_UsesAStableVisibleName` | **green** either way, but it does discriminate against the plausible weakening: restoring the old hidden random dotfile fails `strings.HasPrefix(name, ".")` |

The rows that were green either way are kept deliberately — they are the only
coverage that publication still works at all, and they are the contract half of
the pair. The new rows are the ones that measure atomicity.

## Direction of the change: strict only

Enumerating every new branch — unstated expectation, expected-absent collision,
expected-file mismatch, expected-file absent, unsupported primitive, failed
swap-back — none turns a previous failure into a success. The old code reached
`root.Rename`, which succeeded whether or not the target existed; both new
primitives are strictly narrower.

`ptah-compat` cannot reach the changed code at all. Measured rather than
assumed: `cmd/atlas` registers only `schema.NewSchemaTestCommand`, and the
built binary confirms it:

    $ ptah-compat schema --help
    Available Commands:
      apply  clean  diff  fmt  inspect  plan  push  test

There is no `schema export`, and Go annotation cleanup has no compat surface
either, so no compat exit code can change in either direction.

## Parity, half (b): we decline to reproduce the community behavior

`ptah schema export --to hcl` and Go annotation cleanup are Ptah-only surfaces
with no community counterpart, so half (b) is answered against the nearest
comparable surface, `atlas.sum` rewriting. Re-measured for this PR with the
pinned community build (`atlas community version v1.3.0`), running
`migrate hash` twice over the same directory with a hard link made in between:

    CE:     inode 283411495 -> 283411495
    CE:     atlas.sum changed = yes
    CE:     hardlink holds OLD bytes = no

    COMPAT: inode 283416791 -> 283416795
    COMPAT: atlas.sum changed = yes
    COMPAT: hardlink holds OLD bytes = yes

    byte-identical atlas.sum across both binaries: yes

The community build truncates and writes `atlas.sum` in place — same inode, and
the pre-made hard link shows the new bytes. A crash or a full disk mid-write
leaves a truncated `atlas.sum`, which fails checksum verification and blocks
every subsequent migration command. Ptah publishes by rename to a new inode and
its hard link still holds the old bytes. Both exit 0 and produce byte-identical
output, so the divergence is invisible to any output-comparing gate and has to
be stated deliberately.

## Gates

    go build ./...                          exit 0
    go vet ./...                            exit 0
    go test ./... -count=1                  exit 0 (176 packages ok, 0 FAIL)
    golangci-lint run ./...                 exit 0 ("0 issues.")
    scripts/check-test-style.sh             exit 0 ("OK (175 conditional groups, 45 white-box files)")
    scripts/check-public-api.sh             exit 0
    scripts/check-public-api-snapshot.sh    exit 0

`check-test-style.sh` was red first — it rejected the unix file's justification
comment for not carrying the literal `// White-box testing required:` prefix —
so it demonstrably ran rather than reporting a vacuous pass. `check-public-api`
skips `internal/*` by design, and this diff is entirely under `internal/`, so
it is green but carries no information about this change; it does refuse to
pass vacuously if the allowlist is empty.

Additionally:

    go test -race -count=5 ./internal/fsdurable ./internal/goannotationexport \
        ./internal/goannotationcleanup ./internal/pathguard   exit 0
    GOOS=windows GOARCH=amd64 go build ./...                  exit 0
    GOOS=windows GOARCH=amd64 go vet <4 changed packages>     exit 0
    GOOS=linux   GOARCH=amd64 go build ./...                  exit 0
    GOOS=freebsd GOARCH=amd64 go build ./...                  exit 0

The freebsd build is not incidental: it is what the `publication_unix_other.go`
catch-all exists for. Without it the fail-closed branch would break a target
that compiles today.

End to end, with a freshly built `ptah`:

    absent destination:  exit=0   Exported HCL schema to .../schema.hcl
    own prior output:    exit=0   Exported HCL schema to .../schema.hcl
      bytes stable across runs: yes
      leftover staged entries: 0

## Docs

No file under `docs/` is touched, so `check-style.mjs` and
`build-feature-matrix.mjs --check` were not run. The changed packages are all
`internal/` and have no reader-facing page.

## What this deliberately does NOT do

- **No force-push over `fix/issue-948`.** This PR is opened from `fix/948-land`,
  which is that branch rebased onto master plus the review commit. The original
  remote branch is left untouched rather than rewritten under other agents.
- **`fsdurable.MoveFileNoReplace` is unchanged.** On non-Windows it is still
  `os.Link` + `os.Remove` and returns `EOPNOTSUPP` on filesystems without hard
  links. The package therefore holds two no-replace publications with different
  platform reach. Named as deliberate rather than silently inconsistent; it is
  outside this issue's scope.
- **No Windows runtime row for the expected-file commit window.** The Windows
  path holds an open handle on the destination across that window, so injecting
  a replacement from a test would measure Windows sharing semantics rather than
  the publication contract. The portable expected-absent window row runs there
  and kills the same mutant. The Windows expected-file path is covered by
  cross-vet and by the existing consumer suites on the native runner.
- **No fallback to `rename(2)`** when a filesystem rejects the conditional
  flags. That would reintroduce the exact defect while staying green on APFS
  and ext4, so those cases fail closed with
  `ErrConditionalPublicationUnsupported` naming the path.
- **No integration tests were run.** They need Docker and live databases and are
  behind the `integration` build tag, so `go test ./...` does not include them.