### PR TITLE
Refuse a project file handed to a schema source (#1073)

### DIFF
--- a/atlascompat/atlascompat.go
+++ b/atlascompat/atlascompat.go
@@ -27,11 +27,17 @@ const PtahSumFileName = "ptah.sum"
 const AtlasSumFileName = "atlas.sum"
 
 // ParseAtlasHCL parses an Atlas schema HCL document into Ptah's Go schema IR.
+//
+// A document carrying a top-level env block is an atlas.hcl project file, not a
+// schema file, and is refused with an error naming the block and its position.
+// Parsing one as a schema would yield an empty IR, which a caller diffing
+// against a live database cannot tell apart from "drop everything".
 func ParseAtlasHCL(data []byte, filename string) (*goschema.Database, error) {
 	return atlashcl.Parse(data, filename)
 }
 
 // ParseAtlasHCLFile parses an Atlas schema HCL file into Ptah's Go schema IR.
+// It refuses project files on the same terms as [ParseAtlasHCL].
 func ParseAtlasHCLFile(path string) (*goschema.Database, error) {
 	return atlashcl.ParseFile(path)
 }

--- a/atlascompat/atlascompat_test.go
+++ b/atlascompat/atlascompat_test.go
@@ -37,6 +37,35 @@ table "users" {
 	c.Assert(db.Fields, qt.HasLen, 1)
 }
 
+// projectFileWithEnv is a genuine atlas.hcl: an env block and not one schema
+// object. It is the exported-surface twin of the internal classification
+// fixture, kept here because ParseAtlasHCL is public API and its refusal is part
+// of the contract callers compile against.
+const projectFileWithEnv = `env "local" {
+  url = "sqlite://local.db"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`
+
+// TestParseAtlasHCLRefusesProjectFile pins the refusal on the exported wrapper,
+// not only on the internal parser. Without the change this returns a nil error
+// and an EMPTY Database, so a red run prints that empty IR rather than a bare
+// "wanted an error" -- the erasure itself is the failure message.
+func TestParseAtlasHCLRefusesProjectFile(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlascompat.ParseAtlasHCL([]byte(projectFileWithEnv), "atlas.hcl")
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf(
+		"project file parsed as a schema: err=nil and the returned IR is %+v -- an empty desired state, which a diff cannot tell apart from a request to drop every table",
+		db))
+	c.Assert(db, qt.IsNil)
+	c.Assert(err.Error(), qt.Contains, `cannot parse project file "atlas.hcl" as a schema file`)
+	c.Assert(err.Error(), qt.Contains, `"env"`)
+}
+
 func TestParseSQL(t *testing.T) {
 	c := qt.New(t)
 	list, err := atlascompat.ParseSQL("CREATE TABLE users (id int PRIMARY KEY);", atlascompat.ParseSQLOptions{})

--- a/cmd/atlas/schema_project_file_test.go
+++ b/cmd/atlas/schema_project_file_test.go
@@ -1,0 +1,172 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// projectFileHCL is a genuine Atlas project file: variables and an env block,
+// and not one schema object. Handed to a command as a desired state, it must be
+// refused. Parsed as a schema it yields an EMPTY desired state, and "empty" is
+// indistinguishable from "drop everything".
+const projectFileHCL = `variable "db" {
+  type    = string
+  default = "sqlite://app.db"
+}
+
+env "local" {
+  url = var.db
+  dev = "sqlite://dev?mode=memory"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`
+
+// plainSchemaFileHCL is the control: a real schema file that must keep working.
+const plainSchemaFileHCL = `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`
+
+// envSchemaFileHCL is plainSchemaFileHCL plus a project-file env block, so any
+// difference in outcome between the two is caused by that block alone.
+const envSchemaFileHCL = `schema "main" {
+}
+
+env "local" {
+  url = "sqlite://local.db"
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`
+
+// writeProjectFileFixtures lays down the three HCL files plus an empty migration
+// directory and returns the directory holding them.
+func writeProjectFileFixtures(t *testing.T) string {
+	t.Helper()
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "plain.hcl"), []byte(plainSchemaFileHCL), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas_project.hcl"), []byte(projectFileHCL), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "env.hcl"), []byte(envSchemaFileHCL), 0o600), qt.IsNil)
+	c.Assert(os.MkdirAll(filepath.Join(dir, "migrations"), 0o750), qt.IsNil)
+	return dir
+}
+
+// projectFileCommandCase drives one compat invocation. Both fields are per-row
+// funcs so argument wiring and expectations live in the row rather than in the
+// loop body.
+type projectFileCommandCase struct {
+	name   string
+	args   func(dir string) []string
+	assert func(c *qt.C, dir, out string, err error)
+}
+
+// TestCompatRefusesProjectFileAsSchemaSource is the acceptance test for issue
+// #1073 at the command boundary.
+//
+// Every assertion here is on BYTES, not on exit status alone, because exit
+// status cannot see this bug: before the fix both commands SUCCEEDED, and a
+// success that silently drops the user's schema shares its exit code with a
+// success that did the right thing. An exit-code-only assertion would also be
+// satisfied by a fix that refused the file for an unrelated reason.
+func TestCompatRefusesProjectFileAsSchemaSource(t *testing.T) {
+	cases := []projectFileCommandCase{
+		{
+			// Measured before the fix: exit 0 with
+			//   -- WARNING: This will delete all data!
+			//   DROP TABLE IF EXISTS "main"."users";
+			// The project file was read as an empty desired state, so the
+			// entire real schema was planned away.
+			name: "schema diff refuses a project file as the desired state",
+			args: func(dir string) []string {
+				return []string{
+					"schema", "diff",
+					"--from", "file://" + filepath.Join(dir, "plain.hcl"),
+					"--to", "file://" + filepath.Join(dir, "atlas_project.hcl"),
+					"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+				}
+			},
+			assert: func(c *qt.C, _, out string, err error) {
+				// Bytes first, on purpose: a red run then reports the
+				// destructive statement it actually emitted rather than a bare
+				// "wanted an error".
+				c.Assert(out, qt.Not(qt.Contains), "DROP TABLE")
+				c.Assert(out, qt.Not(qt.Contains), "This will delete all data")
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, "cannot parse project file")
+				c.Assert(err.Error(), qt.Contains, `"env"`)
+			},
+		},
+		{
+			// Measured before the fix: exit 0, and it wrote both a migration
+			// file and atlas.sum for a desired state it had silently emptied.
+			name: "migrate diff writes nothing for a file carrying an env block",
+			args: func(dir string) []string {
+				return []string{
+					"migrate", "diff", "x",
+					"--to", "file://" + filepath.Join(dir, "env.hcl"),
+					"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+					"--dir", "file://" + filepath.Join(dir, "migrations"),
+				}
+			},
+			assert: func(c *qt.C, dir, out string, err error) {
+				// The directory contents are the load-bearing assertion: the
+				// pre-fix failure mode was files on disk, not a message.
+				entries, readErr := os.ReadDir(filepath.Join(dir, "migrations"))
+				c.Assert(readErr, qt.IsNil)
+				c.Assert(entries, qt.HasLen, 0)
+				c.Assert(out, qt.Not(qt.Contains), "Created migration file")
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, "cannot parse project file")
+			},
+		},
+		{
+			// The control. A refusal that also broke real schema files would
+			// trade one defect for a worse one, so this row has to stay green.
+			name: "schema inspect still reads a plain schema file",
+			args: func(dir string) []string {
+				return []string{
+					"schema", "inspect",
+					"--url", "file://" + filepath.Join(dir, "plain.hcl"),
+					"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+				}
+			},
+			assert: func(c *qt.C, _, out string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(out, qt.Contains, `table "users"`)
+				c.Assert(out, qt.Contains, `column "id"`)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := writeProjectFileFixtures(t)
+			out, err := runCompatCommand(t, tc.args(dir)...)
+			tc.assert(c, dir, out, err)
+		})
+	}
+}

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -501,7 +501,16 @@ Atlas features that Ptah cannot represent without losing semantics, including:
 - HCL objects outside direct schema definitions, such as realms and other
   dialect-specific object types
 
-Project-level `env` and `variable` blocks may appear next to schema objects in
-schema HCL files, but they are not executed by `ptah schema render --schema-file`.
-Command-level `atlas.hcl` project config support is documented in
+A top-level `env` block is refused. It marks the file as an `atlas.hcl` project
+file rather than a schema file, and a project file holds no schema objects, so
+reading one as a schema would produce an empty desired state and plan to drop
+every table the real schema defines. The error names the offending block and its
+position. Only a top-level `env` block is treated this way: an `env` attribute is
+untouched, and a nested `env` block keeps reporting the surrounding object's own
+error. Command-level `atlas.hcl` project config support is documented in
 [Atlas Project Config](atlas_project_config.md).
+
+A top-level `variable` block is accepted but not evaluated. References such as
+`var.name` are not substituted, and a variable with no default is not reported as
+missing, so a schema file relying on variables renders the reference as literal
+text. Schema-file variable evaluation is tracked separately in issue #926.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -45,8 +45,18 @@ func Parse(data []byte, filename string) (*goschema.Database, error) {
 
 	p := parser{
 		src:       data,
+		filename:  filename,
 		sourceDir: filepath.Dir(filename),
 		db:        &goschema.Database{},
+	}
+	// Classify before validating the schema body. A file carrying a project-file
+	// marker is the wrong kind of file, and that verdict must not depend on
+	// whether some unrelated block later in the file also happens to be invalid.
+	// Measured on a fixture holding both an env block and a bogus table block:
+	// the pinned Atlas community binary reports the project-file error, not the
+	// block error, so the classification has to run ahead of the body walk.
+	if err := classifyProjectFile(body, filename); err != nil {
+		return nil, err
 	}
 	if err := p.parseBody(body); err != nil {
 		return nil, err
@@ -55,8 +65,60 @@ func Parse(data []byte, filename string) (*goschema.Database, error) {
 	return p.db, nil
 }
 
+// projectFileBlocks names the top-level blocks that mark an HCL file as an Atlas
+// project file (atlas.hcl) rather than a schema file. Handing a project file to a
+// schema source is a wrong-kind-of-file mistake: it has no schema objects, so
+// parsing it as a schema silently yields an EMPTY desired state, and the caller
+// plans to drop everything the real schema contains.
+//
+// The set is deliberately exactly one name. It comes from a measurement, not a
+// guess: each of ten top-level block names was prepended to a valid schema file
+// and run through `schema inspect` on the pinned Atlas community binary (v1.3.0).
+// Only `env` made it refuse the file. `atlas`, `lint`, `diff`, `format`,
+// `docker`, `run` and `locals` are accepted and silently dropped there; Ptah
+// already rejects those as unsupported top-level blocks, which is stricter and
+// safe, so they are not added here. `variable` is a legitimate schema-file
+// construct -- see the case arm in parseTopLevelBlock.
+//
+// Extend this set only from a new measurement against the pinned binary.
+var projectFileBlocks = map[string]bool{"env": true}
+
+// classifyProjectFile refuses a schema file that carries a project-file marker.
+//
+// It inspects TOP-LEVEL blocks only, which is what makes the three neighboring
+// shapes behave correctly: a nested `env` block inside a table keeps its existing
+// "unsupported table block" error, an `env = "x"` ATTRIBUTE is not a block at all
+// and never triggers, and only a file-scope `env` block is classified. Contents
+// and labels are irrelevant -- an unlabeled env, an empty body and a body full of
+// nonsense all mark the file, matching the measured trigger.
+func classifyProjectFile(body *hclsyntax.Body, filename string) error {
+	for _, block := range body.Blocks {
+		if projectFileBlocks[block.Type] {
+			return projectFileError(filename, block)
+		}
+	}
+	return nil
+}
+
+// projectFileError builds the refusal. The leading sentence is the one the Atlas
+// community binary emits, kept verbatim so existing scripts that match on it keep
+// working; the clause after the colon is Ptah going past that binary, which names
+// the file but never the construct, leaving a user who pasted a fragment with
+// nothing to act on. Naming the offending block and its position is additive.
+//
+// The quoted path is spelled the way the caller handed it to Parse. Ptah's
+// schema-file loader resolves paths before parsing, so in practice this prints an
+// absolute path where the community binary prints the path as typed.
+func projectFileError(filename string, block *hclsyntax.Block) error {
+	return fmt.Errorf(
+		"cannot parse project file %q as a schema file: top-level %q block at %s is a project-file construct",
+		filename, block.Type, block.TypeRange.String(),
+	)
+}
+
 type parser struct {
 	src       []byte
+	filename  string
 	sourceDir string
 	db        *goschema.Database
 }
@@ -104,9 +166,29 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		return p.parsePermission(block)
 	case "data":
 		return p.parseManagedData(block)
-	case "env", "variable":
-		// Project-level HCL can carry env/variable blocks next to schema blocks.
-		// They do not define schema objects directly.
+	case "env":
+		// Parse classifies a file carrying a top-level env block before the body
+		// walk begins, so this arm is a guard rather than the usual path. It
+		// returns the identical error so the message cannot drift between the
+		// two routes.
+		return projectFileError(p.filename, block)
+	case "variable":
+		// Left accepted on purpose; do not fold this into the env arm.
+		//
+		// `variable` is a genuine schema-file construct in Atlas: the community
+		// binary accepts it, EVALUATES var.X references against it, and fails
+		// with `missing value for required variable %q` only when a typed
+		// variable has neither a default nor a --var override. Measured on the
+		// pinned binary: a schema file with `variable "status" { default =
+		// "active" }` and a column default of var.status inspects successfully.
+		//
+		// Ptah has no schema-file variable evaluation, so accepting and ignoring
+		// is knowingly looser than that binary on the no-default case, and it
+		// renders var.X into DDL as literal text. Both are real defects. Moving
+		// this name to the default arm would "fix" them by refusing files the
+		// community binary fully supports -- a new stricter break, not parity.
+		// The fix is evaluation plus --var plumbing, tracked in issue #926
+		// ("HCL schema files: expressions are not evaluated").
 		return nil
 	default:
 		return p.blockError(block, "unsupported top-level block %q", block.Type)

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -179,12 +179,22 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		// binary accepts it, EVALUATES var.X references against it, and fails
 		// with `missing value for required variable %q` only when a typed
 		// variable has neither a default nor a --var override. Measured on the
-		// pinned binary: a schema file with `variable "status" { default =
-		// "active" }` and a column default of var.status inspects successfully.
+		// pinned binary, a schema file whose column default is var.status:
+		//
+		//   variable "status" { type = string, default = "active" }
+		//     -> exit 0, renders `default = "active"`
+		//
+		// The `type` argument carries the example. Drop it and the same file
+		// exits 1 with `The argument "type" is required`, which would argue for
+		// refusing `variable` -- the exact conclusion this comment exists to
+		// prevent. Quote the typed spelling or the measurement says the opposite
+		// of what it is cited for.
 		//
 		// Ptah has no schema-file variable evaluation, so accepting and ignoring
-		// is knowingly looser than that binary on the no-default case, and it
-		// renders var.X into DDL as literal text. Both are real defects. Moving
+		// is knowingly looser than that binary on BOTH spellings it refuses --
+		// a variable missing `type`, and a typed variable with no default and no
+		// --var -- and it renders var.X into DDL as literal text. Real defects,
+		// all three, and all of them predate this arm's split. Moving
 		// this name to the default arm would "fix" them by refusing files the
 		// community binary fully supports -- a new stricter break, not parity.
 		// The fix is evaluation plus --var plumbing, tracked in issue #926

--- a/internal/atlashcl/project_file_test.go
+++ b/internal/atlashcl/project_file_test.go
@@ -1,0 +1,278 @@
+package atlashcl_test
+
+import (
+	"reflect"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// plainSchemaHCL and envSchemaHCL differ by exactly one thing: the top-level
+// env block. That is what makes them a discriminating pair for issue #1073 --
+// any difference in outcome between the two is attributable to the marker
+// block alone.
+const plainSchemaHCL = `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+
+const envSchemaHCL = `schema "main" {
+}
+
+env "local" {
+  url = "sqlite://local.db"
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+
+// TestParseProjectFileIsNotSilentlyErased pins the exact damage issue #1073
+// reports. Before the fix, a schema file carrying a project-file env block
+// parsed successfully into an IR indistinguishable from the same file with the
+// block deleted: the project-level content was erased with no schema object and
+// no diagnostic to show for it.
+//
+// The discriminating assertion is deliberately not "some error happened". The
+// comment carries the IR equality, so a red run states that the two parses
+// agreed -- which is the erasure itself -- rather than merely that an expected
+// error was missing.
+func TestParseProjectFileIsNotSilentlyErased(t *testing.T) {
+	c := qt.New(t)
+
+	withoutEnv, err := atlashcl.Parse([]byte(plainSchemaHCL), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+
+	withEnv, errEnv := atlashcl.Parse([]byte(envSchemaHCL), "schema.hcl")
+
+	c.Assert(errEnv, qt.IsNotNil, qt.Commentf(
+		"env block was erased silently: parse succeeded and the IR is identical to the same file with the block deleted (IRs equal = %v)",
+		reflect.DeepEqual(withoutEnv, withEnv)))
+	c.Assert(withEnv, qt.IsNil)
+}
+
+// projectFileCase drives one file shape through Parse. Each row carries its own
+// assert func so the per-row expectations stay in the row instead of turning the
+// loop body into a decision tree.
+type projectFileCase struct {
+	name   string
+	hcl    string
+	assert func(c *qt.C, db *goschema.Database, err error)
+}
+
+// refusesAsProjectFile asserts the classification refusal: the file is rejected,
+// the message keeps the sentence the Atlas community binary emits, and it goes
+// past that binary by naming the offending construct and where it sits.
+func refusesAsProjectFile() func(c *qt.C, db *goschema.Database, err error) {
+	return func(c *qt.C, db *goschema.Database, err error) {
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(db, qt.IsNil)
+		c.Assert(err.Error(), qt.Contains, `cannot parse project file "schema.hcl" as a schema file`)
+		c.Assert(err.Error(), qt.Contains, `"env"`)
+		c.Assert(err.Error(), qt.Contains, "schema.hcl:")
+	}
+}
+
+// parsesWithUsersTable asserts the file is accepted and really produced the
+// table, so a row cannot pass by returning an empty IR.
+func parsesWithUsersTable() func(c *qt.C, db *goschema.Database, err error) {
+	return func(c *qt.C, db *goschema.Database, err error) {
+		c.Assert(err, qt.IsNil)
+		c.Assert(db, qt.IsNotNil)
+		c.Assert(db.Tables, qt.HasLen, 1)
+		c.Assert(db.Tables[0].Name, qt.Equals, "users")
+	}
+}
+
+// failsWith asserts an unrelated pre-existing error survives the change
+// untouched.
+func failsWith(want string) func(c *qt.C, db *goschema.Database, err error) {
+	return func(c *qt.C, db *goschema.Database, err error) {
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Contains, want)
+	}
+}
+
+// TestParseProjectFileClassification fixes the trigger boundary measured against
+// the pinned Atlas community binary: a top-level env block marks the file
+// regardless of label, body or surrounding content, while a nested env block and
+// an env attribute are different constructs and must keep their own behavior.
+//
+// The negative rows share the table with the positive ones on purpose. A fix
+// that classified too eagerly -- on any occurrence of the name rather than on a
+// top-level block -- would pass every refusal row and fail here.
+func TestParseProjectFileClassification(t *testing.T) {
+	cases := []projectFileCase{
+		{
+			name:   "labeled env block",
+			hcl:    envSchemaHCL,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			name: "unlabeled env block",
+			hcl: `schema "main" {
+}
+
+env {
+  url = "sqlite://local.db"
+}
+`,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			name: "env block with empty body",
+			hcl: `schema "main" {
+}
+
+env "local" {
+}
+`,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			name: "env-only file with no schema objects",
+			hcl: `env "local" {
+  url = "sqlite://local.db"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			name: "env block with contents that are nonsense",
+			hcl: `schema "main" {
+}
+
+env "local" {
+  totally_not_a_project_attr = 1
+  weird_block "x" {
+    y = 2
+  }
+}
+`,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			// Classification must win over schema-body validation. The community
+			// binary reports the project-file error on this shape, not the block
+			// error, so the pre-pass has to run before the body walk.
+			name: "env block alongside an invalid table block",
+			hcl: `schema "main" {
+}
+
+env "local" {
+  url = "sqlite://local.db"
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  bogus_block "x" {
+    y = 2
+  }
+}
+`,
+			assert: refusesAsProjectFile(),
+		},
+		{
+			name:   "plain schema file",
+			hcl:    plainSchemaHCL,
+			assert: parsesWithUsersTable(),
+		},
+		{
+			// The community binary accepts and evaluates variable in a schema
+			// file. Ptah accepts and ignores it. Refusing it here would be a new
+			// stricter break, so this row guards the arm #1073 must not touch.
+			name: "variable block with a default",
+			hcl: `variable "status" {
+  type    = string
+  default = "active"
+}
+
+schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			assert: parsesWithUsersTable(),
+		},
+		{
+			name: "top-level env attribute is not a block",
+			hcl: `env = "notablock"
+
+schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			assert: parsesWithUsersTable(),
+		},
+		{
+			name: "env block nested inside a table",
+			hcl: `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  env "local" {
+    url = "sqlite://x.db"
+  }
+}
+`,
+			assert: failsWith(`unsupported table block "env"`),
+		},
+		{
+			name: "env attribute inside a table",
+			hcl: `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  env    = "notablock"
+  column "id" {
+    type = int
+  }
+}
+`,
+			assert: failsWith(`unsupported table attribute "env"`),
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			db, err := atlashcl.Parse([]byte(tc.hcl), "schema.hcl")
+			tc.assert(c, db, err)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1073.

`internal/atlashcl` had `case "env", "variable": return nil` in `parseTopLevelBlock`. Returning nil accepted the block, produced no schema object and no diagnostic, so an `atlas.hcl` parsed as a schema file with all of its project-level content erased. `Parse` now classifies the file before walking its body: a top-level block named in `projectFileBlocks` refuses the file.

The branch predates current master. It was rebased from base `92213b39` onto `da1c4cd2` (clean, no conflicts), then re-measured from scratch rather than trusted. It is pushed as `fix/issue-1073-rebased` because the original `fix/issue-1073` is checked out in another working copy and a rebase cannot fast-forward it; the old ref is left untouched.

## The bug still reproduces on current master

Not superseded. Measured on `da1c4cd2`, `ptah-compat` built from master vs. from this branch, against the pinned community binary (`atlas community version v1.3.0`).

```
$ atlas schema inspect --url file://env.hcl --dev-url sqlite://dev1.db
exit=1
Error: cannot parse project file "env.hcl" as a schema file

$ compat-master schema inspect --url file://env.hcl --dev-url sqlite://dev1.db
exit=0
// Code generated by ptah; DO NOT EDIT.

table "users" {
  column "id" {
    type = INT
  }
  ...

$ compat-branch schema inspect --url file://env.hcl --dev-url sqlite://dev1.db
exit=1
Error: cannot parse project file ".../env.hcl" as a schema file: top-level "env" block at .../env.hcl:4,1-4 is a project-file construct
```

Erased is the operative word. `schema inspect` on a schema file carrying an `env` block and on the same file with the block deleted produce byte-identical stdout on master:

```
with env block:    sha1=94c3e9678604a9e10047c75b8e706e4b0547f27d
without env block: sha1=94c3e9678604a9e10047c75b8e706e4b0547f27d
IDENTICAL: the env block left no trace
```

The damage is not cosmetic. Handed a genuine project file as the desired state:

```
$ atlas schema diff --from file://plain.hcl --to file://atlas_project.hcl --dev-url sqlite://dev2.db
exit=1
Error: cannot parse project file "atlas_project.hcl" as a schema file

$ compat-master schema diff --from file://plain.hcl --to file://atlas_project.hcl --dev-url sqlite://dev2.db
exit=0
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "main"."users";

$ compat-branch ... same args
exit=1
Error: load --to schema: cannot parse project file ".../atlas_project.hcl" as a schema file: top-level "env" block at ...:6,1-4 is a project-file construct
```

`migrate diff` is worse, because it leaves state behind:

```
$ atlas migrate diff x --to file://env.hcl --dev-url sqlite://dev3.db --dir file://migrations
exit=1                                          migrations_dir_entries=0

$ compat-master migrate diff x ... (same args)
exit=0                                          migrations_dir_entries=2
Created migration file: .../migrations/1785756592_x.sql
Updated migration checksum: .../migrations/atlas.sum

$ compat-branch migrate diff x ... (same args)
exit=1                                          migrations_dir_entries=0
```

Control, which must keep working: `schema inspect --url file://plain.hcl` is exit 0 with identical stdout on master and on this branch.

## Direction sweep

21 fixtures, `schema inspect --url file://f.hcl --dev-url sqlite://...`, sqlite dev. Column = exit code.

```
FIXTURE                CE   MASTER   BRANCH   DIRECTION
env_labeled            1    0        1        match
env_unlabeled          1    0        1        match
env_empty_body         1    0        1        match
env_only_file          1    0        1        match
env_nonsense_body      1    0        1        match
env_plus_bad_table     1    1        1        match
env_attr_toplevel      0    0        0        match
env_block_in_table     0    1        1        stricter (also on master)
env_attr_in_table      0    1        1        stricter (also on master)
top_atlas              0    1        1        stricter (also on master)
top_lint               0    1        1        stricter (also on master)
top_diff               0    1        1        stricter (also on master)
top_format             0    1        1        stricter (also on master)
top_docker             0    1        1        stricter (also on master)
top_run                0    1        1        stricter (also on master)
top_locals             0    1        1        stricter (also on master)
var_untyped            1    0        0        LOOSER
var_typed_default      0    0        0        match
var_typed_nodefault    1    0        0        LOOSER
plain_schema           0    0        0        match
empty_file             0    0        0        match

looser rows (CE=1, ptah=0):  master=7  branch=2
```

**No row moves into the looser direction.** Nothing on this branch exits 0 where the community binary exits 1 that did not already do so on master. Both remaining looser rows are `variable` spellings, untouched here, tracked in #926.

Every `stricter` row is already 1 on master. This change introduces no new strictness.

Ordering is measured, not assumed. On a fixture carrying both an `env` block and a bogus table block, the community binary reports the project-file error, not the block error — so classification runs ahead of schema-body validation:

```
CE      exit=1  Error: cannot parse project file "f.hcl" as a schema file
master  exit=1  Error: parse HCL schema at .../f.hcl:13,3-14: unsupported table block "bogus_block"
branch  exit=1  Error: cannot parse project file ".../f.hcl" as a schema file: top-level "env" block at .../f.hcl:4,1-4 is a project-file construct
```

## What each test prints if the change is reverted

Reverting `internal/atlashcl/atlashcl.go` alone to master, in a scratch worktree, leaving every test file in place.

`internal/atlashcl.TestParseProjectFileIsNotSilentlyErased`:

```
comment: env block was erased silently: parse succeeded and the IR is identical
         to the same file with the block deleted (IRs equal = true)
```

The discriminator is the IR equality, so a red run states the erasure rather than "an expected error was missing".

`internal/atlashcl.TestParseProjectFileClassification` — 6 of 11 rows red:

```
--- FAIL: labeled_env_block
--- FAIL: unlabeled_env_block
--- FAIL: env_block_with_empty_body
--- FAIL: env-only_file_with_no_schema_objects
--- FAIL: env_block_with_contents_that_are_nonsense
--- FAIL: env_block_alongside_an_invalid_table_block
```

The other 5 rows stay green on purpose. They are the guard rows: a plain schema file, `variable` with a default, a top-level `env` attribute, a nested `env` block (keeps `unsupported table block "env"`), and an `env` attribute inside a table. A fix that classified on the name rather than on a top-level block passes every refusal row and fails those.

`cmd/atlas.TestCompatRefusesProjectFileAsSchemaSource` — 2 of 3 rows red, and both print the damage, not a missing error:

```
--- FAIL: schema diff refuses a project file as the desired state
    container: "-- WARNING: This will delete all data!\nDROP TABLE IF EXISTS \"main\".\"users\";\n"
    want:      "DROP TABLE"        (asserted absent)

--- FAIL: migrate diff writes nothing for a file carrying an env block
    len(got): 2
    got:      1785756761_x.sql, atlas.sum
    want length: 0
```

The third row (`schema inspect` on a plain schema file) stays green — it is the control.

`atlascompat.TestParseAtlasHCLRefusesProjectFile` (new, see below):

```
comment: project file parsed as a schema: err=nil and the returned IR is
         &{Schemas:[] Tables:[] Fields:[] Indexes:[] ...} -- an empty desired
         state, which a diff cannot tell apart from a request to drop every table
```

Every assertion in the command test is on BYTES, not exit status, because exit status cannot see this bug: before the fix both commands SUCCEEDED, and a success that drops the user's schema shares its exit code with one that did the right thing.

## Review corrections made on top of the original commit

Two claims did not survive re-measurement and are fixed in the second commit.

**The `variable` comment quoted a fixture the community binary rejects.** It read `variable "status" { default = "active" }` and claimed exit 0. That exact file exits 1:

```
$ atlas schema inspect --url file://var_untyped.hcl --dev-url sqlite://d.db
exit=1
Error: f.hcl:1,19-19: Missing required argument; The argument "type" is required, but no definition was found.
```

Adding `type = string` reproduces the claimed behavior:

```
$ atlas schema inspect --url file://var_typed.hcl --dev-url sqlite://d.db
exit=0
  column "state" {
    default = "active"
```

That comment exists to stop a future maintainer folding `variable` into the `env` refusal. Quoted without `type`, it measures the opposite of what it is cited for. Corrected, with the untyped result recorded beside it. The test-table row already had `type = string`, so no test changed meaning — only the prose was wrong.

**The looser-row tally was understated.** The original commit said "4 looser rows -> 1". Over the 21-fixture sweep above it is 7 -> 2, and the two residual rows are two distinct `variable` spellings (missing `type`; typed with no default), not one.

**The blast-radius list was incomplete.** It named native `--schema-file` and `core/schemasource` but not `atlascompat.ParseAtlasHCL` / `ParseAtlasHCLFile`, which are exported wrappers over the parser this change touches. Their godoc now states the refusal, and a new test pins it on the exported surface. Signatures are unchanged, so `check-public-api` and the snapshot are unaffected.

## Parity calls

**MATCHED** the exit-1 refusal, on every path that reads a schema file, not only the one the issue named. The alternative is a silent success for a run that should have been refused.

**WENT PAST** the community binary on the message text only. Its sentence is kept verbatim as the prefix — same exit code, same stream, so anything matching on it keeps working — and the offending block type plus its HCL position are appended. Additive, not divergent. Honest caveat: Ptah's schema-file loader resolves paths before parsing, so Ptah prints an absolute path where that binary prints the path as typed. A substring match on the sentence still matches; a full-line match does not.

## What I deliberately did NOT do

- **Did not touch `variable`.** Same line of code, opposite direction. The community binary accepts and evaluates it; dropping it alongside `env` would make Ptah exit 1 where that binary exits 0. The two looser `variable` rows above stay looser and belong to #926, which needs evaluation plus `--var` plumbing.
- **Did not extend the marker set** to `atlas`, `lint`, `diff`, `format`, `docker`, `run`, `locals`. Measured: the community binary accepts and silently drops all seven; Ptah already rejects them, which is stricter and safe. Loosening them is #1016's question.
- **Did not fix the empty-desired-state divergence.** Measured, pre-existing, unchanged by this branch, and unrelated to project files — it reproduces on a literally empty `.hcl` file:

  ```
  $ atlas       schema diff --from file://plain.hcl --to file://empty.hcl --dev-url sqlite://d.db
  exit=1  Error: ... unsupported change *schema.DropSchema
  $ compat-master  (same args)   exit=0  DROP TABLE IF EXISTS "main"."users";
  $ compat-branch  (same args)   exit=0  DROP TABLE IF EXISTS "main"."users";
  ```

  It needs its own issue rather than being folded in here.
- **Did not remove the `case "env"` arm** in `parseTopLevelBlock`. It is unreachable, because `Parse` classifies before the body walk, and no test can cover it. It is kept as a guard that returns the identical error so the message cannot drift if a future entry point ever reaches `parseBody` directly; the comment says exactly that.

## Gates

Run in this worktree on `528759a3`.

| Gate | Result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 1, see below |
| `golangci-lint run ./...` | exit 0 — `0 issues.` |
| `scripts/check-test-style.sh` | exit 0 — `teststyle: OK (175 conditional groups, 45 white-box files)` |
| `scripts/check-public-api.sh` | exit 0 |
| `scripts/check-public-api-snapshot.sh` | exit 0 |
| `node docs/site/scripts/check-style.mjs` | exit 0 — `OK (100 documentation files)` |
| `node docs/site/scripts/build-feature-matrix.mjs --check` | exit 0 — `OK (159 rows)` |

`go test ./... -count=1` exited 1 on all three full runs, and stating it as green would be false. Every failure was a wall-clock budget overrun in a package this diff does not touch, on a machine running many concurrent checkouts:

- run 1: `cmd/viz TestSVGReportsGraphvizStderrOnFailure` (10s budget, `signal: killed`)
- run 2: the same, plus `cmd/ptah-ls TestPtahLSArgumentHandling/version_positional_answers` and `TestPtahLSVersionSpellingsPrintIdenticalBytes` (20s budget, `context deadline exceeded` / `signal: killed`)
- run 3: `cmd/viz TestSVGReportsGraphvizStderrOnFailure` only

None is an assertion about logic; all are timeouts. Run in isolation both packages are green on this branch and on a clean `da1c4cd2` worktree:

```
$ go test ./cmd/ptah-ls/ ./cmd/viz/ -count=1        # this branch
ok  go.5x5.cz/ptah/cmd/ptah-ls  13.354s
ok  go.5x5.cz/ptah/cmd/viz       7.753s
exit=0
$ go test -C <master worktree> ./cmd/ptah-ls/ ./cmd/viz/ -count=1
exit=0
```

Every package the change touches is green in the full run: `atlascompat`, `cmd/atlas`, `core/schemasource`, `internal/atlashcl`, `internal/atlashclfmt`, `internal/atlashclrender`, `internal/schemafile`.

Two gates print nothing on success, so they were checked for liveness rather than taken on trust. `check-public-api-snapshot.sh` uses cwd-relative paths; adding one exported symbol to `atlascompat` turned it red naming that symbol, and it returned to exit 0 when the probe was removed:

```
+func ProbeExportedSymbolForGateCheck() int
exit=1
```

`check-test-style.sh --list-scan-paths` was confirmed to list all three test files in this diff, so its OK is not a vacuous pass over an empty file set.