### PR TITLE
Report every object kind schema clean destroys

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -258,6 +258,7 @@ jobs:
           go test -v -count=1 ./internal/dbschema/clickhouse -run '^TestWriterDropDatabaseRealm_(Live|RejectsExternalDependencyLive|RejectsLegacyServerLive)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/mssql -run '^TestWriterDropDatabaseRealm_(Live|RejectsDatabaseScopedArtifactLive|RejectsPreservedSchemaPermissionLive)$' -timeout 3m
           go test -v -count=1 ./internal/dbschema/postgres -tags=integration -run '^TestWriterDropDatabaseRealm_Live(PostgresFamilyCleansCrossSchemaGraph|PostgresCleansLargeObjects|PostgresRejectsPublication|RejectsProtectedDatabase)$' -timeout 5m
+          go test -v -count=1 ./internal/schemaclean -tags=integration -run '^TestInspectNamesEveryObjectApplyDestroys_PostgresLive$' -timeout 5m
           go test -v -count=1 ./internal/migrationreplay -tags=integration -run '^TestWithReplayedSnapshot_(ClickHouse|SQLServer)Live$' -timeout 5m
           go test -v -count=1 ./integration -tags=integration -run '^TestAtlasMigrateDiff(MySQLFamilyDatabaseDesiredState|PostgresFamilyDevCleanup)E2E$' -timeout 12m
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -545,8 +545,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables.",
-    "evidence": "internal/schemaclean/clean.go:109-147 enumerates only foreign keys, tables and enums; :75-81 executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty \u2014 the unreported view v_const was dropped as well. CE registers schema clean per cli-surface.md:44"
+    "note": "Plan and `--dry-run` list every object kind that dialect's cleanup destroys. The revision table is still dropped unreported everywhere except SQLite.",
+    "evidence": "internal/schemaclean/clean.go coverageFor maps each dialect onto its writer's coverage; internal/schemaclean/clean_live_test.go compares the plan against the objects that actually disappeared on a live PostgreSQL. Measured on PostgreSQL 18 with a table, view, materialized view, enum, domain, composite, range, sequence, function and FK: the plan named 11 objects and the catalog census showed exactly those 11 destroyed, while a control schema `keepme` appeared in neither set. SQLite case from the original report now prints `DROP TABLE IF EXISTS \"users\"` and `DROP VIEW IF EXISTS \"v_const\"`. Remaining gap: `schema_migrations` is dropped by the PostgreSQL, MySQL, SQL Server and ClickHouse writers but excluded by their readers, so it never reaches the plan. CE registers schema clean per cli-surface.md:44"
   },
   {
     "area": "Declarative / direct schema workflow",

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -235,7 +235,7 @@ Atlas CE aborts `--include` as a non-community feature, so Ptah's implementation
 
 `ptah-compat schema clean` plans supported cleanup objects from the live database, supports `--dry-run`, preserves destructive confirmation unless `--auto-approve` is explicit, reads `env.url` and `format.schema.clean` from `atlas.hcl`, and supports Atlas-style `--format` templates such as `{{ json . }}` over `.Env`, `.DryRun`, `.Applied`, `.Objects`, and `.Changes`.
 
-Cleanup report changes cover the object types Ptah cleanly models and drops today: user tables across supported dialects, PostgreSQL enum types and sequences, and SQL Server foreign-key constraints that must be dropped before tables.
+Cleanup report changes cover the object kinds the target dialect's cleanup really destroys, so the report is not narrower than the apply: foreign keys, tables, views, materialized views, enum/domain/composite/range types and functions on the PostgreSQL family (plus standalone sequences on PostgreSQL itself); foreign keys, tables, views, stored functions and procedures, events and MariaDB sequences on MySQL and MariaDB; tables and views on SQLite; foreign keys and tables on SQL Server; base tables on ClickHouse. Objects that vanish as collateral of a listed drop — indexes, triggers, non-foreign-key constraints, RLS policies, comments — are not listed separately.
 
 **Atlas OSS.** Atlas OSS documents schema diffing, declarative migrations, HCL formatting, and schema cleanup as open CLI features.
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -143,7 +143,7 @@ seven of them as open capabilities regardless.
 | JSON output for native schema diff | ✅ | ❔ | ➖ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
-| schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
+| schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list every object kind that dialect's cleanup destroys. The revision table is still dropped unreported everywhere except SQLite. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -624,14 +624,20 @@ schema objects. Preview first:
 ptah-compat schema clean --url "$DATABASE_URL" --dry-run
 ```
 
-Against a SQLite database containing one `users` table, expected output
-includes:
+Against a SQLite database containing one `users` table and one `v_const` view,
+expected output includes:
 
 ```text
-Planned cleanup changes: 1
+Planned cleanup changes: 2
 - DROP TABLE IF EXISTS "users"
+- DROP VIEW IF EXISTS "v_const"
 [DRY RUN] No changes were applied.
 ```
+
+The plan lists the object kinds the target dialect's cleanup really destroys —
+see the [per-dialect coverage table](../../reference/atlas-commands/#ptah-compat-schema-clean).
+Rows are ordered alphabetically by object kind; that is a report order, not the
+order the statements run in.
 
 :::danger
 Without `--dry-run`, cleanup drops the listed objects after confirmation

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -803,9 +803,22 @@ runtime.
 | `--format` | Renders Atlas-style templates over the cleanup plan. |
 | `--env` | Reads `env.url` and `format.schema.clean` from `atlas.hcl`. |
 
-Cleanup covers the object types Ptah cleanly models and drops today: user
-tables across supported dialects, PostgreSQL enum types and sequences, and SQL
-Server foreign-key constraints that must be dropped before tables.
+The plan reports the object kinds the target dialect's cleanup really destroys,
+so a `--dry-run` or `--format` report is not narrower than the apply:
+
+| Dialect | Reported and destroyed |
+| --- | --- |
+| PostgreSQL family | Foreign keys, tables, views, materialized views, enum, domain, composite and range types, and functions; standalone sequences on PostgreSQL itself. |
+| MySQL, MariaDB | Foreign keys, tables, views, stored functions and procedures, events, and MariaDB sequences. |
+| SQLite | Tables and views. |
+| SQL Server | Foreign keys and tables. Views are not dropped, so they are not reported. |
+| ClickHouse | Base tables. Views are not dropped, so they are not reported. |
+
+Objects that vanish as collateral of a listed drop are not listed separately:
+indexes, triggers, non-foreign-key constraints, RLS policies, and comments. The
+rendered `Cmd` describes the object being destroyed; it is not the exact
+statement the cleanup runtime executes, and the report order is alphabetical by
+object kind rather than an execution order.
 
 Native twin: [`ptah schema clean`](../native-commands/).
 

--- a/internal/schemaclean/clean.go
+++ b/internal/schemaclean/clean.go
@@ -12,17 +12,40 @@ import (
 	"go.5x5.cz/ptah/internal/sqlident"
 )
 
+// Object kinds a cleanup plan can name. Every constant here must correspond to
+// an object kind that at least one dialect's SchemaWriter.DropAllTables really
+// destroys — see coverageFor for the per-dialect mapping and for the writer
+// files that define each dialect's coverage.
 const (
-	ObjectTypeEnum       = "enum"
-	ObjectTypeForeignKey = "foreign_key"
-	ObjectTypeSequence   = "sequence"
-	ObjectTypeTable      = "table"
+	ObjectTypeComposite        = "composite"
+	ObjectTypeDomain           = "domain"
+	ObjectTypeEnum             = "enum"
+	ObjectTypeEvent            = "event"
+	ObjectTypeForeignKey       = "foreign_key"
+	ObjectTypeFunction         = "function"
+	ObjectTypeMaterializedView = "materialized_view"
+	ObjectTypeProcedure        = "procedure"
+	ObjectTypeRange            = "range"
+	ObjectTypeSequence         = "sequence"
+	ObjectTypeTable            = "table"
+	ObjectTypeView             = "view"
 )
 
 type Options struct {
 	DryRun bool
 }
 
+// Plan is the report an operator reviews before approving a destructive
+// cleanup. Its contract is: it names every object for which
+// SchemaWriter.DropAllTables issues its own drop statement on this dialect.
+//
+// It deliberately does not name dependent objects that vanish as collateral of
+// a listed drop and for which the writer issues no statement of its own —
+// indexes, triggers, non-foreign-key constraints, RLS policies, comments, and
+// (on PostgreSQL) the constructor functions a range type owns. Foreign keys are
+// listed on the dialects whose writer drops them explicitly before the tables.
+// Enumerating the full transitive closure of a DROP is not tractable; "what the
+// writer names" is.
 type Plan struct {
 	Objects []Object
 	Changes []Change
@@ -35,12 +58,52 @@ type Object struct {
 	Name   string
 }
 
+// Change is one line of the cleanup report: an object that Apply destroys, plus
+// a rendered DROP statement describing that destruction.
+//
+// Cmd is documentation, not the statement Apply runs. Apply delegates to
+// SchemaWriter.DropAllTables, which builds its own statements from a live
+// catalog query; those differ in detail (the PostgreSQL writer, for instance,
+// emits RESTRICT where this report renders CASCADE, and drops overloaded
+// functions by full signature where this report renders the bare name). Cmd
+// exists so an operator can read what a plan line means before approving a
+// destructive command.
 type Change struct {
 	Type   string
 	Schema string
 	Table  string
 	Name   string
 	Cmd    string
+}
+
+// dialectCoverage records which object kinds a dialect's
+// dbschema/types.SchemaWriter.DropAllTables implementation actually destroys.
+// It is the one place this package decides what a cleanup plan is allowed to
+// claim, so plan coverage and execution coverage cannot drift kind by kind.
+//
+// Tables are not a field: every writer drops tables, so every dialect's plan
+// lists them unconditionally.
+//
+// Each field is populated in coverageFor, which names the writer file and the
+// function inside it that decides that dialect's coverage. Widening a writer
+// REQUIRES widening the matching entry here; the live tests in
+// clean_live_test.go turn a missed widening into a failure by comparing the
+// plan against the objects that really disappeared.
+type dialectCoverage struct {
+	// Reader-sourced kinds, taken from the dbschema reader's schema snapshot.
+	foreignKeys       bool
+	views             bool
+	materializedViews bool
+	enums             bool
+	domains           bool
+	composites        bool
+	ranges            bool
+	functions         bool
+
+	// Runtime-sourced kinds: the reader's snapshot does not carry them, so
+	// Inspect queries the live catalog for them. See inspectRuntimeObjects.
+	postgresSequences  bool
+	mysqlStoredObjects bool
 }
 
 func Inspect(conn *dbschema.DatabaseConnection) (Plan, error) {
@@ -106,25 +169,115 @@ func PlanFromObjects(objects []Object, dialect string) Plan {
 	}
 }
 
+// coverageFor maps a dialect onto the object kinds its writer destroys.
+//
+// PostgreSQL family — internal/dbschema/postgres/writer.go, DropAllTables ->
+// dropSchemaObjects -> collectAllObjects. The catalog query emits foreign-key
+// constraints, views, materialized views, foreign tables, sequences, tables,
+// functions/procedures/aggregates, types (enum, domain, range, composite),
+// collations, and default privileges.
+//
+// MySQL and MariaDB — internal/dbschema/mysql/writer.go, DropAllTables ->
+// dropAllTablesOnConnection -> dropDatabaseObjects, which drops the foreign
+// keys from listInternalForeignKeys and then the objects from
+// listCleanupObjects: events, views, routines (FUNCTION and PROCEDURE), tables,
+// and MariaDB sequences.
+//
+// SQLite — internal/dbschema/sqlite/writer.go, DropAllTables -> dropAllTables
+// -> listCleanupObjects, which reads pragma_table_list and emits only tables
+// (including virtual tables) and views.
+//
+// SQL Server — internal/dbschema/mssql/writer.go, DropAllTables drops the
+// foreign keys from listForeignKeys and the tables from listTables, and nothing
+// else. Its reader does populate Views, but the writer never drops them, so
+// views must stay out of the plan.
+//
+// ClickHouse — internal/dbschema/clickhouse/writer.go, DropAllTables selects
+// from system.tables filtered to persistent table engines with
+// `engine NOT LIKE '%View'`, so it drops base tables only.
+func coverageFor(dialect string) dialectCoverage {
+	normalized := normalizeDialect(dialect)
+	switch normalized {
+	case "postgres", "postgresql", "cockroachdb", "yugabytedb":
+		return dialectCoverage{
+			foreignKeys:       true,
+			views:             true,
+			materializedViews: true,
+			enums:             true,
+			domains:           true,
+			composites:        true,
+			ranges:            true,
+			functions:         true,
+			// The standalone-sequence probe stays restricted to PostgreSQL
+			// proper because that is the only PostgreSQL-family engine this
+			// package has been measured against, and widening it is not this
+			// change's subject. The CockroachDB and YugabyteDB writers do drop
+			// sequences, so their plans still understate cleanup by that kind.
+			postgresSequences: normalized == "postgres" || normalized == "postgresql",
+		}
+	case "mysql", "mariadb":
+		return dialectCoverage{
+			foreignKeys:        true,
+			views:              true,
+			mysqlStoredObjects: true,
+		}
+	case "sqlite", "sqlite3":
+		return dialectCoverage{views: true}
+	case "sqlserver", "mssql":
+		return dialectCoverage{foreignKeys: true}
+	default:
+		// ClickHouse, and any dialect this package has not measured: report
+		// tables only, which every writer drops.
+		//
+		// Spanner lands here even though dbschema hands it the PostgreSQL
+		// writer, because Spanner's PostgreSQL interface does not accept the
+		// CASCADE and DROP TYPE forms the PostgreSQL rows above render, and no
+		// Spanner instance was available to measure the real coverage against.
+		// Its plan therefore still understates cleanup.
+		return dialectCoverage{}
+	}
+}
+
+func normalizeDialect(dialect string) string {
+	return strings.ToLower(strings.TrimSpace(dialect))
+}
+
+// cleanupObjects turns the reader's schema snapshot into plan rows. Tables are
+// unconditional; every other kind is gated on this dialect's writer coverage,
+// paired with its collector below so a coverage field can never be added
+// without a collector or the other way round.
 func cleanupObjects(schema *dbschematypes.DBSchema, dialect string) []Object {
 	if schema == nil {
 		return nil
 	}
-	objects := make([]Object, 0, len(schema.Tables)+len(schema.Enums)+len(schema.Constraints))
-	if supportsExplicitForeignKeyCleanup(dialect) {
-		for _, constraint := range schema.Constraints {
-			if !isForeignKeyConstraint(constraint) {
-				continue
-			}
-			objects = append(objects, Object{
-				Type:   ObjectTypeForeignKey,
-				Schema: constraint.Schema,
-				Table:  constraint.TableName,
-				Name:   constraint.Name,
-			})
+	coverage := coverageFor(dialect)
+	objects := tableObjects(schema)
+	for _, kind := range []struct {
+		covered bool
+		collect func(*dbschematypes.DBSchema) []Object
+	}{
+		{coverage.foreignKeys, foreignKeyObjects},
+		{coverage.views, viewObjects},
+		{coverage.materializedViews, materializedViewObjects},
+		{coverage.enums, enumObjects},
+		{coverage.domains, domainObjects},
+		{coverage.composites, compositeObjects},
+		{coverage.ranges, rangeObjects},
+		{coverage.functions, functionObjects},
+	} {
+		if !kind.covered {
+			continue
 		}
+		objects = append(objects, kind.collect(schema)...)
 	}
+	return objects
+}
+
+func tableObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Tables))
 	for _, table := range schema.Tables {
+		// Readers that surface views through DBSchema.Tables as well as
+		// DBSchema.Views tag them here, and viewObjects reports them once.
 		if !isCleanupTableType(table.Type) {
 			continue
 		}
@@ -134,9 +287,54 @@ func cleanupObjects(schema *dbschematypes.DBSchema, dialect string) []Object {
 			Name:   table.Name,
 		})
 	}
-	if !supportsStandaloneEnums(dialect) {
-		return objects
+	return objects
+}
+
+func foreignKeyObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Constraints))
+	for _, constraint := range schema.Constraints {
+		if !isForeignKeyConstraint(constraint) {
+			continue
+		}
+		objects = append(objects, Object{
+			Type:   ObjectTypeForeignKey,
+			Schema: constraint.Schema,
+			Table:  constraint.TableName,
+			Name:   constraint.Name,
+		})
 	}
+	return objects
+}
+
+func viewObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Views))
+	for _, view := range schema.Views {
+		objects = append(objects, Object{
+			Type:   ObjectTypeView,
+			Schema: view.Schema,
+			Name:   view.Name,
+		})
+	}
+	return objects
+}
+
+func materializedViewObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.MatViews))
+	for _, matView := range schema.MatViews {
+		objects = append(objects, Object{
+			Type:   ObjectTypeMaterializedView,
+			Schema: matView.Schema,
+			Name:   matView.Name,
+		})
+	}
+	return objects
+}
+
+// enumObjects reports PostgreSQL enum types. DBEnum carries no schema: the
+// reader reads enums per schema but does not record which one, so enum rows
+// stay unqualified.
+func enumObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Enums))
 	for _, enum := range schema.Enums {
 		objects = append(objects, Object{
 			Type: ObjectTypeEnum,
@@ -146,10 +344,71 @@ func cleanupObjects(schema *dbschematypes.DBSchema, dialect string) []Object {
 	return objects
 }
 
+func domainObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Domains))
+	for _, domain := range schema.Domains {
+		objects = append(objects, Object{
+			Type:   ObjectTypeDomain,
+			Schema: domain.Schema,
+			Name:   domain.Name,
+		})
+	}
+	return objects
+}
+
+func compositeObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Composites))
+	for _, composite := range schema.Composites {
+		objects = append(objects, Object{
+			Type:   ObjectTypeComposite,
+			Schema: composite.Schema,
+			Name:   composite.Name,
+		})
+	}
+	return objects
+}
+
+func rangeObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Ranges))
+	for _, rangeType := range schema.Ranges {
+		objects = append(objects, Object{
+			Type:   ObjectTypeRange,
+			Schema: rangeType.Schema,
+			Name:   rangeType.Name,
+		})
+	}
+	return objects
+}
+
+// functionObjects reports PostgreSQL functions. DBFunction carries neither a
+// schema nor a signature, so overloads appear as repeated rows sharing one
+// name. Each row is still one function the writer destroys.
+func functionObjects(schema *dbschematypes.DBSchema) []Object {
+	objects := make([]Object, 0, len(schema.Functions))
+	for _, function := range schema.Functions {
+		objects = append(objects, Object{
+			Type: ObjectTypeFunction,
+			Name: function.Name,
+		})
+	}
+	return objects
+}
+
+// inspectRuntimeObjects enumerates the object kinds a dialect's writer destroys
+// that the dbschema reader's snapshot does not carry.
 func inspectRuntimeObjects(conn *dbschema.DatabaseConnection) ([]Object, error) {
-	if !supportsStandaloneSequences(conn.Info().Dialect) {
+	coverage := coverageFor(conn.Info().Dialect)
+	switch {
+	case coverage.postgresSequences:
+		return inspectPostgresSequences(conn)
+	case coverage.mysqlStoredObjects:
+		return inspectMySQLStoredObjects(conn)
+	default:
 		return nil, nil
 	}
+}
+
+func inspectPostgresSequences(conn *dbschema.DatabaseConnection) ([]Object, error) {
 	schema := strings.TrimSpace(conn.Info().Schema)
 	if schema == "" {
 		schema = "public"
@@ -182,6 +441,99 @@ func inspectRuntimeObjects(conn *dbschema.DatabaseConnection) ([]Object, error) 
 	return objects, nil
 }
 
+// inspectMySQLStoredObjects reports the stored programs and MariaDB sequences
+// that the MySQL writer's listCleanupObjects returns but the MySQL reader never
+// records: information_schema.routines, information_schema.events, and the
+// SEQUENCE rows of information_schema.tables.
+//
+// The scope mirrors mysql.Writer.cleanupSchema: the configured schema when the
+// connection pins one, otherwise the session's current database.
+func inspectMySQLStoredObjects(conn *dbschema.DatabaseConnection) ([]Object, error) {
+	schema := strings.TrimSpace(conn.Info().Schema)
+	rows, err := conn.Query(`
+		SELECT object_name, object_kind
+		FROM (
+			SELECT routine_name AS object_name, routine_type AS object_kind
+			FROM information_schema.routines
+			WHERE routine_schema = COALESCE(NULLIF(?, ''), DATABASE())
+
+			UNION ALL
+
+			SELECT event_name, 'EVENT'
+			FROM information_schema.events
+			WHERE event_schema = COALESCE(NULLIF(?, ''), DATABASE())
+
+			UNION ALL
+
+			SELECT table_name, 'SEQUENCE'
+			FROM information_schema.tables
+			WHERE table_schema = COALESCE(NULLIF(?, ''), DATABASE())
+			  AND table_type = 'SEQUENCE'
+		) AS cleanup_objects
+		ORDER BY object_kind, object_name`,
+		schema, schema, schema,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("inspect cleanup stored objects: %w", err)
+	}
+	defer rows.Close()
+
+	objects := []Object{}
+	for rows.Next() {
+		var name string
+		var kind string
+		if err := rows.Scan(&name, &kind); err != nil {
+			return nil, fmt.Errorf("scan cleanup stored object: %w", err)
+		}
+		objectType, ok := mysqlStoredObjectType(kind)
+		if !ok {
+			return nil, fmt.Errorf("inspect cleanup stored objects: unsupported object kind %q", kind)
+		}
+		objects = append(objects, Object{
+			Type: objectType,
+			Name: name,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterate cleanup stored objects: %w", err)
+	}
+	return objects, nil
+}
+
+func mysqlStoredObjectType(kind string) (string, bool) {
+	switch strings.ToUpper(strings.TrimSpace(kind)) {
+	case "EVENT":
+		return ObjectTypeEvent, true
+	case "FUNCTION":
+		return ObjectTypeFunction, true
+	case "PROCEDURE":
+		return ObjectTypeProcedure, true
+	case "SEQUENCE":
+		return ObjectTypeSequence, true
+	default:
+		return "", false
+	}
+}
+
+// sortObjects orders the report by (type, schema, table, name): object kind
+// first, alphabetically by the ObjectType* string, then by location within the
+// kind. That is what orders objects of different kinds relative to each other —
+// nothing else does, and in particular nothing about dependency direction does.
+//
+// This is a REPORT ORDER, NOT AN EXECUTION ORDER. Reading it top to bottom does
+// not describe the sequence Apply performs, and replaying the rendered Cmd
+// strings in this order would fail: "table" sorts before "view", so a view's
+// backing table is listed first even though the writer drops views first. Apply
+// delegates to SchemaWriter.DropAllTables, whose execution order comes from the
+// writer's own dependency-aware catalog query — for PostgreSQL, `ORDER BY
+// priority, dependency_depth DESC, ...` in internal/dbschema/postgres/writer.go.
+// This package cannot reproduce that order because the reader's snapshot
+// carries no dependency depth.
+//
+// Alphabetical-by-kind is chosen because it is dialect independent, stable
+// across releases, and diffs cleanly when a schema gains or loses one object.
+// Adding a kind slots it in alphabetically without reordering the kinds already
+// present relative to one another.
 func sortObjects(objects []Object) {
 	slices.SortFunc(objects, func(a, b Object) int {
 		if cmp := strings.Compare(a.Type, b.Type); cmp != 0 {
@@ -200,29 +552,71 @@ func sortObjects(objects []Object) {
 func dropCommand(dialect string, object Object) string {
 	name := sqlident.Qualified(dialect, object.Schema, object.Name)
 	switch object.Type {
-	case ObjectTypeEnum:
+	case ObjectTypeComposite, ObjectTypeEnum, ObjectTypeRange:
+		// Composite, enum, and range types are all pg_type rows, and
+		// PostgreSQL drops all three with DROP TYPE.
 		return "DROP TYPE IF EXISTS " + name + " CASCADE"
+	case ObjectTypeDomain:
+		return "DROP DOMAIN IF EXISTS " + name + " CASCADE"
+	case ObjectTypeEvent:
+		return "DROP EVENT IF EXISTS " + name
 	case ObjectTypeForeignKey:
-		return "ALTER TABLE " + sqlident.Qualified(dialect, object.Schema, object.Table) +
-			" DROP CONSTRAINT " + sqlident.Quote(dialect, object.Name)
+		return dropForeignKeyCommand(dialect, object)
+	case ObjectTypeFunction:
+		return dropRoutineCommand(dialect, "FUNCTION", name)
+	case ObjectTypeMaterializedView:
+		return "DROP MATERIALIZED VIEW IF EXISTS " + name + " CASCADE"
+	case ObjectTypeProcedure:
+		return dropRoutineCommand(dialect, "PROCEDURE", name)
 	case ObjectTypeSequence:
-		return "DROP SEQUENCE IF EXISTS " + name + " CASCADE"
+		return dropSequenceCommand(dialect, name)
 	case ObjectTypeTable:
 		return dropTableCommand(dialect, name)
+	case ObjectTypeView:
+		return dropViewCommand(dialect, name)
 	default:
 		return ""
 	}
 }
 
-func dropTableCommand(dialect, name string) string {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "postgres", "postgresql", "cockroachdb", "yugabytedb":
-		return "DROP TABLE IF EXISTS " + name + " CASCADE"
-	case "clickhouse":
-		return "DROP TABLE IF EXISTS " + name + " SYNC"
-	default:
-		return "DROP TABLE IF EXISTS " + name
+func dropForeignKeyCommand(dialect string, object Object) string {
+	table := sqlident.Qualified(dialect, object.Schema, object.Table)
+	constraint := sqlident.Quote(dialect, object.Name)
+	if isMySQLFamily(dialect) {
+		return "ALTER TABLE " + table + " DROP FOREIGN KEY " + constraint
 	}
+	return "ALTER TABLE " + table + " DROP CONSTRAINT " + constraint
+}
+
+func dropRoutineCommand(dialect, keyword, name string) string {
+	if isPostgresFamily(dialect) {
+		return "DROP " + keyword + " IF EXISTS " + name + " CASCADE"
+	}
+	return "DROP " + keyword + " IF EXISTS " + name
+}
+
+func dropSequenceCommand(dialect, name string) string {
+	if isPostgresFamily(dialect) {
+		return "DROP SEQUENCE IF EXISTS " + name + " CASCADE"
+	}
+	return "DROP SEQUENCE IF EXISTS " + name
+}
+
+func dropViewCommand(dialect, name string) string {
+	if isPostgresFamily(dialect) {
+		return "DROP VIEW IF EXISTS " + name + " CASCADE"
+	}
+	return "DROP VIEW IF EXISTS " + name
+}
+
+func dropTableCommand(dialect, name string) string {
+	if isPostgresFamily(dialect) {
+		return "DROP TABLE IF EXISTS " + name + " CASCADE"
+	}
+	if normalizeDialect(dialect) == "clickhouse" {
+		return "DROP TABLE IF EXISTS " + name + " SYNC"
+	}
+	return "DROP TABLE IF EXISTS " + name
 }
 
 func isCleanupTableType(tableType string) bool {
@@ -238,17 +632,8 @@ func isForeignKeyConstraint(constraint dbschematypes.DBConstraint) bool {
 	return strings.EqualFold(strings.TrimSpace(constraint.Type), "FOREIGN KEY")
 }
 
-func supportsExplicitForeignKeyCleanup(dialect string) bool {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "sqlserver", "mssql":
-		return true
-	default:
-		return false
-	}
-}
-
-func supportsStandaloneEnums(dialect string) bool {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
+func isPostgresFamily(dialect string) bool {
+	switch normalizeDialect(dialect) {
 	case "postgres", "postgresql", "cockroachdb", "yugabytedb":
 		return true
 	default:
@@ -256,9 +641,9 @@ func supportsStandaloneEnums(dialect string) bool {
 	}
 }
 
-func supportsStandaloneSequences(dialect string) bool {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "postgres", "postgresql":
+func isMySQLFamily(dialect string) bool {
+	switch normalizeDialect(dialect) {
+	case "mysql", "mariadb":
 		return true
 	default:
 		return false

--- a/internal/schemaclean/clean_live_test.go
+++ b/internal/schemaclean/clean_live_test.go
@@ -1,0 +1,255 @@
+//go:build integration
+
+package schemaclean_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"slices"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/schemaclean"
+)
+
+// postgresCleanupFixture creates one object of every kind the PostgreSQL writer
+// destroys, plus a control schema the schema-scoped cleanup never touches.
+var postgresCleanupFixture = []string{
+	`CREATE TYPE mood AS ENUM ('happy', 'sad')`,
+	`CREATE DOMAIN d_email AS text CHECK (VALUE LIKE '%@%')`,
+	`CREATE TYPE c_addr AS (street text, city text)`,
+	`CREATE TYPE r_int AS RANGE (subtype = int4)`,
+	`CREATE SEQUENCE s_counter`,
+	`CREATE TABLE users (id integer PRIMARY KEY, email d_email, feeling mood)`,
+	`CREATE TABLE posts (id integer PRIMARY KEY, author_id integer NOT NULL REFERENCES users (id))`,
+	`CREATE VIEW v_users AS SELECT id, email FROM users`,
+	`CREATE MATERIALIZED VIEW mv_users AS SELECT id FROM users`,
+	`CREATE FUNCTION f_touch() RETURNS trigger LANGUAGE plpgsql AS 'BEGIN RETURN NEW; END;'`,
+	`CREATE TRIGGER trg_users BEFORE INSERT ON users FOR EACH ROW EXECUTE FUNCTION f_touch()`,
+	`CREATE INDEX idx_users_email ON users (email)`,
+
+	`CREATE SCHEMA keepme`,
+	`CREATE TYPE keepme.control_mood AS ENUM ('kept')`,
+	`CREATE TABLE keepme.control_table (id integer PRIMARY KEY)`,
+	`CREATE VIEW keepme.control_view AS SELECT id FROM keepme.control_table`,
+	`CREATE FUNCTION keepme.control_fn() RETURNS integer LANGUAGE sql AS 'SELECT 1'`,
+}
+
+// postgresCleanupCensusQuery enumerates, straight from pg_catalog, every object
+// that SchemaWriter.DropAllTables issues a statement for, in the vocabulary of
+// schemaclean.Object.Type. It is deliberately written against the catalog and
+// not against schemaclean's own coverage table, so the comparison below is a
+// measurement rather than a restatement.
+//
+// Dependent objects the writer never names are excluded on purpose, matching
+// the documented Plan contract: indexes, triggers, non-foreign-key constraints,
+// and the constructor routines a range type owns (pg_depend deptype 'i').
+const postgresCleanupCensusQuery = `
+	SELECT
+		CASE c.relkind
+			WHEN 'v' THEN 'view'
+			WHEN 'm' THEN 'materialized_view'
+			WHEN 'S' THEN 'sequence'
+			ELSE 'table'
+		END || '|' || c.relname
+	FROM pg_class c
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE n.nspname IN ('public', 'keepme')
+	  AND c.relkind IN ('r', 'p', 'v', 'm', 'S')
+
+	UNION ALL
+
+	SELECT
+		CASE t.typtype
+			WHEN 'e' THEN 'enum'
+			WHEN 'd' THEN 'domain'
+			WHEN 'r' THEN 'range'
+			ELSE 'composite'
+		END || '|' || t.typname
+	FROM pg_type t
+	JOIN pg_namespace n ON n.oid = t.typnamespace
+	LEFT JOIN pg_class c ON c.oid = t.typrelid
+	WHERE n.nspname IN ('public', 'keepme')
+	  AND (t.typtype IN ('e', 'd', 'r') OR (t.typtype = 'c' AND c.relkind = 'c'))
+
+	UNION ALL
+
+	SELECT
+		CASE p.prokind WHEN 'p' THEN 'procedure' ELSE 'function' END || '|' || p.proname
+	FROM pg_proc p
+	JOIN pg_namespace n ON n.oid = p.pronamespace
+	WHERE n.nspname IN ('public', 'keepme')
+	  AND NOT EXISTS (
+		SELECT 1 FROM pg_depend d
+		WHERE d.classid = 'pg_proc'::regclass AND d.objid = p.oid AND d.deptype = 'i'
+	  )
+
+	UNION ALL
+
+	SELECT 'foreign_key|' || con.conname
+	FROM pg_constraint con
+	JOIN pg_class c ON c.oid = con.conrelid
+	JOIN pg_namespace n ON n.oid = c.relnamespace
+	WHERE n.nspname IN ('public', 'keepme') AND con.contype = 'f'
+
+	ORDER BY 1
+`
+
+// TestInspectNamesEveryObjectApplyDestroys_PostgresLive is the anti-drift gate
+// for issue #940 item 1: it compares the plan schemaclean.Inspect produced
+// against the set of objects that really disappeared when schemaclean.Apply
+// ran, on a throwaway PostgreSQL database.
+//
+// Widening internal/dbschema/postgres/writer.go without widening
+// schemaclean.coverageFor makes the destroyed set larger than the planned set
+// and fails here, which is the property a duplicated constant list cannot give.
+func TestInspectNamesEveryObjectApplyDestroys_PostgresLive(t *testing.T) {
+	c := qt.New(t)
+	ctx := c.Context()
+	conn := newPostgresCleanupLiveConnection(c, ctx)
+	applyPostgresCleanupFixture(c, ctx, conn)
+
+	before := postgresCleanupCensus(c, ctx, conn)
+	plan, err := schemaclean.Inspect(conn)
+	c.Assert(err, qt.IsNil)
+	planned := plannedObjectKeys(plan)
+
+	c.Assert(schemaclean.Apply(ctx, conn), qt.IsNil)
+	after := postgresCleanupCensus(c, ctx, conn)
+
+	c.Assert(destroyedKeys(before, after), qt.DeepEquals, planned)
+
+	// A fixture that failed to create anything would make both sets empty and
+	// the comparison above vacuous. Checked after it so that a genuine coverage
+	// gap reports the missing objects rather than a bare count.
+	c.Assert(len(planned) >= 10, qt.IsTrue, qt.Commentf("planned set is too small: %v", planned))
+
+	// Control: the cleanup is schema scoped, so nothing in "keepme" is
+	// destroyed, and nothing in "keepme" may appear in the plan either.
+	c.Assert(after, qt.DeepEquals, []string{
+		"enum|control_mood",
+		"function|control_fn",
+		"table|control_table",
+		"view|control_view",
+	})
+	c.Assert(planned, qt.Not(qt.Any(qt.Contains)), "control")
+}
+
+func plannedObjectKeys(plan schemaclean.Plan) []string {
+	keys := make([]string, 0, len(plan.Objects))
+	for _, object := range plan.Objects {
+		keys = append(keys, object.Type+"|"+object.Name)
+	}
+	slices.Sort(keys)
+	return keys
+}
+
+// destroyedKeys returns the census rows present before the cleanup and absent
+// after it.
+func destroyedKeys(before, after []string) []string {
+	remaining := make(map[string]int, len(after))
+	for _, key := range after {
+		remaining[key]++
+	}
+	destroyed := make([]string, 0, len(before))
+	for _, key := range before {
+		if remaining[key] > 0 {
+			remaining[key]--
+			continue
+		}
+		destroyed = append(destroyed, key)
+	}
+	slices.Sort(destroyed)
+	return destroyed
+}
+
+func postgresCleanupCensus(
+	c *qt.C,
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) []string {
+	c.Helper()
+	rows, err := conn.QueryContext(ctx, postgresCleanupCensusQuery)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Check(rows.Close(), qt.IsNil) }()
+
+	var census []string
+	for rows.Next() {
+		var key string
+		c.Assert(rows.Scan(&key), qt.IsNil)
+		census = append(census, key)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	slices.Sort(census)
+	return census
+}
+
+func applyPostgresCleanupFixture(
+	c *qt.C,
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) {
+	c.Helper()
+	for _, statement := range postgresCleanupFixture {
+		_, err := conn.ExecContext(ctx, statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement: %s", statement))
+	}
+}
+
+// newPostgresCleanupLiveConnection provisions a throwaway database so a test
+// that deliberately destroys a whole schema cannot damage the shared fixture
+// database other live tests in the same job depend on.
+func newPostgresCleanupLiveConnection(c *qt.C, ctx context.Context) *dbschema.DatabaseConnection {
+	c.Helper()
+	adminURL := requirePostgresCleanupLiveURL(c)
+	admin, err := sql.Open("pgx", adminURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(admin.PingContext(ctx), qt.IsNil)
+
+	name := fmt.Sprintf("ptah_schemaclean_%d", time.Now().UnixNano())
+	nameIdent := pgx.Identifier{name}.Sanitize()
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+nameIdent)
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := url.Parse(adminURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	parsed.RawPath = ""
+
+	conn, err := dbschema.ConnectToDatabase(ctx, parsed.String())
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		dbschema.CloseAndWarn(conn)
+		_, dropErr := admin.ExecContext(
+			context.WithoutCancel(ctx),
+			"DROP DATABASE IF EXISTS "+nameIdent+" WITH (FORCE)",
+		)
+		c.Check(dropErr, qt.IsNil)
+		c.Check(admin.Close(), qt.IsNil)
+	})
+	return conn
+}
+
+func requirePostgresCleanupLiveURL(c *qt.C) string {
+	c.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		raw := os.Getenv(name)
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse(raw)
+		c.Assert(err, qt.IsNil)
+		parsed.Scheme = "postgres"
+		return parsed.String()
+	}
+	c.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	return ""
+}

--- a/internal/schemaclean/clean_test.go
+++ b/internal/schemaclean/clean_test.go
@@ -9,35 +9,285 @@ import (
 	"go.5x5.cz/ptah/internal/schemaclean"
 )
 
-func TestPlanFromSchemaBuildsDeterministicSupportedObjectChanges(t *testing.T) {
-	c := qt.New(t)
-	schema := &dbschematypes.DBSchema{
+// schemaWithEveryReportableKind holds one object of every kind that any
+// dialect's reader can surface into a cleanup plan. Each dialect case below
+// asserts the exact subset its writer destroys, so a dialect that reported a
+// kind it does not drop shows up as an extra row rather than as a silent pass.
+func schemaWithEveryReportableKind() *dbschematypes.DBSchema {
+	return &dbschematypes.DBSchema{
 		Tables: []dbschematypes.DBTable{
 			{Name: "users", Schema: "public"},
-			{Name: "accounts", Schema: "tenant"},
+			{Name: "posts", Schema: "public"},
 		},
-		Enums: []dbschematypes.DBEnum{
-			{Name: "status"},
+		Constraints: []dbschematypes.DBConstraint{
+			{Name: "fk_posts_users", Schema: "public", TableName: "posts", Type: "FOREIGN KEY"},
+			{Name: "pk_posts", Schema: "public", TableName: "posts", Type: "PRIMARY KEY"},
 		},
-		Views: []dbschematypes.DBView{
-			{Name: "active_users", Schema: "public"},
+		Enums:      []dbschematypes.DBEnum{{Name: "mood"}},
+		Views:      []dbschematypes.DBView{{Name: "v_users", Schema: "public"}},
+		MatViews:   []dbschematypes.DBMatView{{Name: "mv_users", Schema: "public"}},
+		Functions:  []dbschematypes.DBFunction{{Name: "f_touch"}},
+		Domains:    []dbschematypes.DBDomain{{Name: "d_email", Schema: "public"}},
+		Composites: []dbschematypes.DBComposite{{Name: "c_addr", Schema: "public"}},
+		Ranges:     []dbschematypes.DBRange{{Name: "r_int", Schema: "public"}},
+	}
+}
+
+// TestPlanFromSchemaNamesEveryKindTheDialectWriterDestroys pins each dialect's
+// plan coverage to what that dialect's SchemaWriter.DropAllTables really drops.
+//
+// The sqlserver and clickhouse rows are the control: their readers do surface
+// views, and their writers do not drop them, so a change that simply listed
+// everything the reader returns would fail those two rows.
+func TestPlanFromSchemaNamesEveryKindTheDialectWriterDestroys(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		want    []schemaclean.Object
+	}{
+		{
+			name:    "postgres drops relations, routines, types and foreign keys",
+			dialect: "postgres",
+			want: []schemaclean.Object{
+				{Type: "composite", Schema: "public", Name: "c_addr"},
+				{Type: "domain", Schema: "public", Name: "d_email"},
+				{Type: "enum", Name: "mood"},
+				{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+				{Type: "function", Name: "f_touch"},
+				{Type: "materialized_view", Schema: "public", Name: "mv_users"},
+				{Type: "range", Schema: "public", Name: "r_int"},
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+				{Type: "view", Schema: "public", Name: "v_users"},
+			},
 		},
-		Functions: []dbschematypes.DBFunction{
-			{Name: "set_context"},
+		{
+			name:    "cockroachdb shares the postgres writer",
+			dialect: "cockroachdb",
+			want: []schemaclean.Object{
+				{Type: "composite", Schema: "public", Name: "c_addr"},
+				{Type: "domain", Schema: "public", Name: "d_email"},
+				{Type: "enum", Name: "mood"},
+				{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+				{Type: "function", Name: "f_touch"},
+				{Type: "materialized_view", Schema: "public", Name: "mv_users"},
+				{Type: "range", Schema: "public", Name: "r_int"},
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+				{Type: "view", Schema: "public", Name: "v_users"},
+			},
+		},
+		{
+			name:    "mysql drops foreign keys, tables and views but has no standalone types",
+			dialect: "mysql",
+			want: []schemaclean.Object{
+				{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+				{Type: "view", Schema: "public", Name: "v_users"},
+			},
+		},
+		{
+			name:    "mariadb shares the mysql writer",
+			dialect: "mariadb",
+			want: []schemaclean.Object{
+				{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+				{Type: "view", Schema: "public", Name: "v_users"},
+			},
+		},
+		{
+			name:    "sqlite drops tables and views only",
+			dialect: "sqlite",
+			want: []schemaclean.Object{
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+				{Type: "view", Schema: "public", Name: "v_users"},
+			},
+		},
+		{
+			name:    "sqlserver drops foreign keys and tables but never views",
+			dialect: "sqlserver",
+			want: []schemaclean.Object{
+				{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+			},
+		},
+		{
+			name:    "clickhouse drops base tables only",
+			dialect: "clickhouse",
+			want: []schemaclean.Object{
+				{Type: "table", Schema: "public", Name: "posts"},
+				{Type: "table", Schema: "public", Name: "users"},
+			},
 		},
 	}
 
-	plan := schemaclean.PlanFromSchema(schema, "postgres")
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			plan := schemaclean.PlanFromSchema(schemaWithEveryReportableKind(), test.dialect)
+
+			c.Assert(plan.Objects, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestPlanFromObjectsRendersDialectSpecificDropCommands pins the rendered
+// report statement for every object kind a plan can name.
+func TestPlanFromObjectsRendersDialectSpecificDropCommands(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		object  schemaclean.Object
+		want    string
+	}{
+		{
+			name:    "postgres view",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "view", Schema: "public", Name: "v_users"},
+			want:    `DROP VIEW IF EXISTS "public"."v_users" CASCADE`,
+		},
+		{
+			name:    "postgres materialized view",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "materialized_view", Schema: "public", Name: "mv_users"},
+			want:    `DROP MATERIALIZED VIEW IF EXISTS "public"."mv_users" CASCADE`,
+		},
+		{
+			name:    "postgres function",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "function", Name: "f_touch"},
+			want:    `DROP FUNCTION IF EXISTS "f_touch" CASCADE`,
+		},
+		{
+			name:    "postgres domain",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "domain", Schema: "public", Name: "d_email"},
+			want:    `DROP DOMAIN IF EXISTS "public"."d_email" CASCADE`,
+		},
+		{
+			name:    "postgres composite type",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "composite", Schema: "public", Name: "c_addr"},
+			want:    `DROP TYPE IF EXISTS "public"."c_addr" CASCADE`,
+		},
+		{
+			name:    "postgres range type",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "range", Schema: "public", Name: "r_int"},
+			want:    `DROP TYPE IF EXISTS "public"."r_int" CASCADE`,
+		},
+		{
+			name:    "postgres foreign key",
+			dialect: "postgres",
+			object: schemaclean.Object{
+				Type:   "foreign_key",
+				Schema: "public",
+				Table:  "posts",
+				Name:   "fk_posts_users",
+			},
+			want: `ALTER TABLE "public"."posts" DROP CONSTRAINT "fk_posts_users"`,
+		},
+		{
+			name:    "mysql view",
+			dialect: "mysql",
+			object:  schemaclean.Object{Type: "view", Name: "v_users"},
+			want:    "DROP VIEW IF EXISTS `v_users`",
+		},
+		{
+			name:    "mysql function",
+			dialect: "mysql",
+			object:  schemaclean.Object{Type: "function", Name: "f_one"},
+			want:    "DROP FUNCTION IF EXISTS `f_one`",
+		},
+		{
+			name:    "mysql procedure",
+			dialect: "mysql",
+			object:  schemaclean.Object{Type: "procedure", Name: "p_noop"},
+			want:    "DROP PROCEDURE IF EXISTS `p_noop`",
+		},
+		{
+			name:    "mysql event",
+			dialect: "mysql",
+			object:  schemaclean.Object{Type: "event", Name: "e_noop"},
+			want:    "DROP EVENT IF EXISTS `e_noop`",
+		},
+		{
+			name:    "mysql foreign key uses DROP FOREIGN KEY",
+			dialect: "mysql",
+			object:  schemaclean.Object{Type: "foreign_key", Table: "posts", Name: "fk_posts_users"},
+			want:    "ALTER TABLE `posts` DROP FOREIGN KEY `fk_posts_users`",
+		},
+		{
+			name:    "mariadb sequence",
+			dialect: "mariadb",
+			object:  schemaclean.Object{Type: "sequence", Name: "s_counter"},
+			want:    "DROP SEQUENCE IF EXISTS `s_counter`",
+		},
+		{
+			name:    "postgres sequence keeps CASCADE",
+			dialect: "postgres",
+			object:  schemaclean.Object{Type: "sequence", Schema: "public", Name: "users_id_seq"},
+			want:    `DROP SEQUENCE IF EXISTS "public"."users_id_seq" CASCADE`,
+		},
+		{
+			name:    "sqlite view",
+			dialect: "sqlite",
+			object:  schemaclean.Object{Type: "view", Name: "v_const"},
+			want:    `DROP VIEW IF EXISTS "v_const"`,
+		},
+		{
+			name:    "sqlserver foreign key keeps DROP CONSTRAINT",
+			dialect: "sqlserver",
+			object: schemaclean.Object{
+				Type:   "foreign_key",
+				Schema: "dbo",
+				Table:  "posts",
+				Name:   "fk_posts_users",
+			},
+			want: "ALTER TABLE [dbo].[posts] DROP CONSTRAINT [fk_posts_users]",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			plan := schemaclean.PlanFromObjects([]schemaclean.Object{test.object}, test.dialect)
+
+			c.Assert(plan.Changes, qt.HasLen, 1)
+			c.Assert(plan.Changes[0].Cmd, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestPlanFromObjectsOrdersReportByKindThenLocation pins the documented report
+// order: kind alphabetically, then schema, table, and name. It is deliberately
+// not the order Apply executes in — "table" sorting before "view" puts a view's
+// backing table above the view even though the writer drops the view first.
+func TestPlanFromObjectsOrdersReportByKindThenLocation(t *testing.T) {
+	c := qt.New(t)
+
+	plan := schemaclean.PlanFromObjects([]schemaclean.Object{
+		{Type: "view", Schema: "public", Name: "v_users"},
+		{Type: "table", Schema: "tenant", Name: "accounts"},
+		{Type: "table", Schema: "public", Name: "users"},
+		{Type: "materialized_view", Schema: "public", Name: "mv_users"},
+		{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+		{Type: "composite", Schema: "public", Name: "c_addr"},
+	}, "postgres")
 
 	c.Assert(plan.Objects, qt.DeepEquals, []schemaclean.Object{
-		{Type: "enum", Name: "status"},
+		{Type: "composite", Schema: "public", Name: "c_addr"},
+		{Type: "foreign_key", Schema: "public", Table: "posts", Name: "fk_posts_users"},
+		{Type: "materialized_view", Schema: "public", Name: "mv_users"},
 		{Type: "table", Schema: "public", Name: "users"},
 		{Type: "table", Schema: "tenant", Name: "accounts"},
-	})
-	c.Assert(plan.Changes, qt.DeepEquals, []schemaclean.Change{
-		{Type: "enum", Name: "status", Cmd: `DROP TYPE IF EXISTS "status" CASCADE`},
-		{Type: "table", Schema: "public", Name: "users", Cmd: `DROP TABLE IF EXISTS "public"."users" CASCADE`},
-		{Type: "table", Schema: "tenant", Name: "accounts", Cmd: `DROP TABLE IF EXISTS "tenant"."accounts" CASCADE`},
+		{Type: "view", Schema: "public", Name: "v_users"},
 	})
 }
 
@@ -62,56 +312,27 @@ func TestPlanFromSchemaIgnoresMySQLColumnEnums(t *testing.T) {
 	})
 }
 
-func TestPlanFromObjectsSupportsPostgreSQLSequences(t *testing.T) {
-	c := qt.New(t)
-
-	plan := schemaclean.PlanFromObjects([]schemaclean.Object{
-		{Type: "sequence", Schema: "public", Name: "users_id_seq"},
-	}, "postgres")
-
-	c.Assert(plan.Objects, qt.DeepEquals, []schemaclean.Object{
-		{Type: "sequence", Schema: "public", Name: "users_id_seq"},
-	})
-	c.Assert(plan.Changes, qt.DeepEquals, []schemaclean.Change{
-		{
-			Type:   "sequence",
-			Schema: "public",
-			Name:   "users_id_seq",
-			Cmd:    `DROP SEQUENCE IF EXISTS "public"."users_id_seq" CASCADE`,
-		},
-	})
-}
-
-func TestPlanFromSchemaReportsSQLServerForeignKeyCleanup(t *testing.T) {
+// TestPlanFromSchemaReportsViewsOnceForReadersThatAlsoListThemAsTables guards
+// the one double-count risk of reporting views: a reader that puts a view into
+// both DBSchema.Tables (with Type "VIEW") and DBSchema.Views must still yield a
+// single view row.
+func TestPlanFromSchemaReportsViewsOnceForReadersThatAlsoListThemAsTables(t *testing.T) {
 	c := qt.New(t)
 	schema := &dbschematypes.DBSchema{
 		Tables: []dbschematypes.DBTable{
-			{Name: "users", Schema: "dbo"},
-			{Name: "posts", Schema: "dbo"},
+			{Name: "users", Type: "BASE TABLE"},
+			{Name: "v_users", Type: "VIEW"},
 		},
-		Constraints: []dbschematypes.DBConstraint{
-			{Name: "fk_posts_users", Schema: "dbo", TableName: "posts", Type: "FOREIGN KEY"},
-			{Name: "pk_posts", Schema: "dbo", TableName: "posts", Type: "PRIMARY KEY"},
+		Views: []dbschematypes.DBView{
+			{Name: "v_users"},
 		},
 	}
 
-	plan := schemaclean.PlanFromSchema(schema, "sqlserver")
+	plan := schemaclean.PlanFromSchema(schema, "postgres")
 
 	c.Assert(plan.Objects, qt.DeepEquals, []schemaclean.Object{
-		{Type: "foreign_key", Schema: "dbo", Table: "posts", Name: "fk_posts_users"},
-		{Type: "table", Schema: "dbo", Name: "posts"},
-		{Type: "table", Schema: "dbo", Name: "users"},
-	})
-	c.Assert(plan.Changes, qt.DeepEquals, []schemaclean.Change{
-		{
-			Type:   "foreign_key",
-			Schema: "dbo",
-			Table:  "posts",
-			Name:   "fk_posts_users",
-			Cmd:    "ALTER TABLE [dbo].[posts] DROP CONSTRAINT [fk_posts_users]",
-		},
-		{Type: "table", Schema: "dbo", Name: "posts", Cmd: "DROP TABLE IF EXISTS [dbo].[posts]"},
-		{Type: "table", Schema: "dbo", Name: "users", Cmd: "DROP TABLE IF EXISTS [dbo].[users]"},
+		{Type: "table", Name: "users"},
+		{Type: "view", Name: "v_users"},
 	})
 }
 


### PR DESCRIPTION
Refs #940.

**Closes item 1** ("Report every object schema clean drops, not just tables"). Items 2, 3, 4 and 5 of #940 remain open and are untouched here.

## The defect

`schemaclean.Apply` calls `conn.SchemaWriter().DropAllTables(ctx)`. The plan an operator reviews before approving that came from `cleanupObjects`, which enumerated four kinds: foreign keys (SQL Server only), tables, PostgreSQL enums, and PostgreSQL sequences. Every other kind the writer destroys was destroyed unannounced.

## Measurements

All three were run against PostgreSQL 18 in Docker, on a fixture holding a table, a view, a materialized view, an enum, a domain, a composite type, a range type, a sequence, a function, a trigger, an index and a foreign key in `public`, plus a control schema `keepme` holding a table, a view, an enum and a function.

`/tmp/census.sql` is a `pg_catalog` census: relations (`relkind` in `r,p,v,m,S`), types (`typtype` in `e,d,r` plus composites), non-implicit routines, foreign-key constraints and triggers, across `public` and `keepme`.

### 1. Without the change — the gap

```
$ go build -o bin/pc-base ./cmd/ptah-compat        # at da1c4cd, before the change
$ ./bin/pc-base schema clean --url 'postgres://.../ptah_test?sslmode=disable' --dry-run
[DRY RUN] Would clean schema objects from database postgres://ptah_user:***@localhost:55940/ptah_test?sslmode=disable
Connected to postgres database successfully.
Planned cleanup changes: 4
- DROP TYPE IF EXISTS "mood" CASCADE
- DROP SEQUENCE IF EXISTS "public"."s_counter" CASCADE
- DROP TABLE IF EXISTS "posts" CASCADE
- DROP TABLE IF EXISTS "users" CASCADE
[DRY RUN] No changes were applied.

$ ./bin/pc-base schema clean --url '...' --auto-approve
Planned cleanup changes: 4
...
Schema clean completed successfully.

$ docker exec ptah940pg psql -U ptah_user -d ptah_test -At -f /tmp/census.sql
relation:keepme.control_table [r]
relation:keepme.control_view [v]
routine:keepme.control_fn
type:keepme.control_mood [e]
```

The plan named 4 objects. `v_users`, `mv_users`, `f_touch`, `d_email`, `c_addr`, `r_int` and `posts_author_id_fkey` were all gone and none of them was ever in the plan.

The report's own SQLite case reproduces the same way and is fixed too:

```
$ ../pc-base schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ "\n" }}{{ end }}'
DROP TABLE IF EXISTS "users"
$ ../pc-fixed schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ "\n" }}{{ end }}'
DROP TABLE IF EXISTS "users"
DROP VIEW IF EXISTS "v_const"
```

### 2. With the change — plan set versus destroyed set

Plan set, as `Type|Name` (`--format '{{ range .Objects }}{{ .Type }}|{{ .Name }}{{ "\n" }}{{ end }}' | sort`):

```
composite|c_addr        foreign_key|posts_author_id_fkey   sequence|s_counter
domain|d_email          function|f_touch                   table|posts
enum|mood               materialized_view|mv_users         table|users
                        range|r_int                        view|v_users
```

Destroyed set, as `census-before` minus `census-after`:

```
constraint:public.posts_author_id_fkey [f]   type:public.c_addr [c]
relation:public.mv_users [m]                 type:public.d_email [d]
relation:public.posts [r]                    type:public.mood [e]
relation:public.s_counter [S]                type:public.r_int [r]
relation:public.users [r]                    routine:public.f_touch
relation:public.v_users [v]                  trigger:public.trg_users
                                             routine:public.r_int x2, r_int_multirange x3
```

The 11 plan rows and the 11 independently-destroyed catalog objects are the same set, one for one. The census residue — `trg_users` and the five implicit range constructor routines — are dependent objects the writer issues no statement for: the trigger dies with `users`, the constructors die with the range type (they carry `pg_depend.deptype = 'i'`, which the writer's own routine query excludes). `Plan`'s doc comment states this contract explicitly.

The live test `TestInspectNamesEveryObjectApplyDestroys_PostgresLive` performs exactly this comparison in code, on a throwaway database, and is wired into the "database-realm cleanup" CI step.

### 3. Control — an object the cleanup does not remove is in neither set

The cleanup is schema scoped to `public`; schema `keepme` is outside it.

```
$ grep -c control plan.txt
0
$ docker exec ptah940pg psql -U ptah_user -d ptah_test -At -f /tmp/census.sql   # after the apply
relation:keepme.control_table [r]
relation:keepme.control_view [v]
routine:keepme.control_fn
type:keepme.control_mood [e]
```

A second control lives in the unit tests: SQL Server and ClickHouse readers do surface views, and their writers never drop them, so those two dialects must not report views. A change that simply listed everything the reader returns would fail those rows.

### Other dialects, measured live

| Dialect | Before | After | Destroyed |
| --- | --- | --- | --- |
| MySQL 9.7 | `table\|posts`, `table\|users` | + `event\|e_noop`, `foreign_key\|fk_posts_users`, `function\|f_one`, `procedure\|p_noop`, `view\|v_users` | all 7, census empty |
| MariaDB 10.11 | `table\|users` | + `function\|f_one`, `sequence\|s_counter`, `view\|v_users` | all 4, census empty |
| SQLite | `table\|users` | + `view\|v_const` | both, `sqlite_master` empty |

## What each test prints if the change is reverted

Verified by mutation, one mutant per claim; every subtest was checked to fail on its own.

- `TestInspectNamesEveryObjectApplyDestroys_PostgresLive` (coverage reverted to the four original kinds):
  ```
  --- FAIL: TestInspectNamesEveryObjectApplyDestroys_PostgresLive
      values are not deep equal
      diff (-got +want):
        - "composite|c_addr", - "domain|d_email", - "foreign_key|posts_author_id_fkey",
        - "function|f_touch", - "materialized_view|mv_users", - "range|r_int", - "view|v_users"
      got:  11 keys (what the cleanup destroyed)
      want:  4 keys (what the plan named)
  ```
- `TestPlanFromSchemaNamesEveryKindTheDialectWriterDestroys/postgres…` and `/cockroachdb…`, same mutant: `got` holds `enum|mood` plus two tables, `want` holds all ten rows.
- `.../mysql…`, `.../mariadb…`, `.../sqlite…` (that dialect's `views` flipped to false): the `view` row is missing from `got`.
- `.../sqlserver…`, `.../clickhouse…` (`views` flipped to true — the control direction): an extra `{Type: "view", …}` row appears in `got`.
- `TestPlanFromObjectsRendersDialectSpecificDropCommands`: inverting the dialect-family predicates and stripping `CASCADE` fails 14 of 16 rows on the exact rendered string; mutating `dropSequenceCommand` separately fails the remaining two.
- `TestPlanFromObjectsOrdersReportByKindThenLocation` (sort keys swapped to schema-before-type): rows reorder to `c_addr, fk_posts_users, mv_users, users, v_users, accounts`.
- `TestPlanFromSchemaReportsViewsOnceForReadersThatAlsoListThemAsTables` (`isCleanupTableType` made permissive): a duplicate `{Type: "table", Name: "v_users"}` row appears.

## What orders the report, and what it is not

`sortObjects` orders by `(type, schema, table, name)` — object kind alphabetically by the `ObjectType*` string, then location. That is the only thing ordering kinds relative to one another; nothing about dependency direction participates. The doc comment says loudly that this is a **report order, not an execution order**: `"table" < "view"`, so a view's backing table is printed above the view even though the writer drops the view first. Replaying the rendered `Cmd` strings top to bottom would fail. Execution order comes from the writer's own dependency-aware catalog query (`ORDER BY priority, dependency_depth DESC, …`), which this package cannot reproduce because the reader's snapshot carries no dependency depth. Alphabetical-by-kind was chosen because it is dialect independent and slots new kinds in without reordering the kinds already present relative to one another.

`Change.Cmd` is documented as describing an object, not as the statement that runs — the PostgreSQL writer emits `RESTRICT` where the report renders `CASCADE`, and drops overloaded functions by full signature where the report renders the bare name.

## Derived where derivable, named where not

`coverageFor` is the single place that decides what a plan may claim, and every dialect entry names the writer file and the function inside it that it mirrors (`internal/dbschema/{postgres,mysql,sqlite,mssql,clickhouse}/writer.go`). Full derivation — having each writer hand back the object list `DropAllTables` will act on — would mean adding a method to the public `dbschema/types.SchemaWriter` interface, touching five writers and every test fake, and would change the rendered statements. That is a bigger change than this item, so instead the live test makes drift *fail* rather than trusting the two lists to stay in step: widen a writer without widening `coverageFor` and the destroyed set outgrows the planned set.

## Deliberately left out

- **The migration revision table.** `schema_migrations` is dropped by the PostgreSQL, MySQL, SQL Server and ClickHouse writers but excluded by name in their readers, so it never reaches the plan. Measured on this branch: create `schema_migrations`, `schema clean --dry-run` lists only the other table, `--auto-approve` leaves `pg_class` empty. This is a name-scoped exclusion in the readers, not a kind-scoped one in `schemaclean`, with a different fix surface (four readers), so it is left for its own item rather than fixed half-way. SQLite is already correct — its writer explicitly excludes the table.
- **CockroachDB and YugabyteDB standalone sequences.** The reader-sourced kinds are enabled for the whole PostgreSQL family, but the standalone-sequence probe stays PostgreSQL-only, as before, because no CockroachDB or YugabyteDB instance was measured. Noted in the code.
- **Spanner.** `dbschema` hands Spanner the PostgreSQL writer, but Spanner's PostgreSQL interface does not accept the `CASCADE` and `DROP TYPE` forms the PostgreSQL rows render, and no instance was available to measure. It keeps the tables-only default and the reason is recorded at the `default` branch of `coverageFor`.
- **PostgreSQL collations, default privileges and foreign tables.** The writer drops all three; `DBSchema` carries none of them, so reporting them needs new reader fields.
- **`ptah db drop-all` prompt copy** still says "ALL tables and enums" (the following line already says "EVERYTHING in the database"). Cosmetic, and changing CLI copy is out of this item's scope.

## Gates

```
go build ./... && go vet ./... && go test ./... -count=1     OK
golangci-lint run ./...                                      0 issues
scripts/check-test-style.sh                                  OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh                                  OK
scripts/check-public-api-snapshot.sh                         OK
```

The snapshot needed no regeneration: `internal/…` is excluded from the public-API surface by both scripts, so the new `ObjectType*` constants are not part of it.

Docs site gates also run clean, and `docs/site/src/content/docs/atlas/feature-matrix.md` was regenerated from its evidence JSON (`node scripts/build-feature-matrix.mjs --check`: OK, 159 rows). Updated alongside the code: the feature-matrix row for `schema clean`, the per-dialect coverage table in the Atlas command reference, the `schema clean` walkthrough in the Atlas schema-commands guide, and the cleanup paragraph in the Atlas comparison page.