### PR TITLE
Implement the three atlas.hcl constructs the community binary enforces

### DIFF
--- a/cmd/atlas/migrate_lint_condrop_test.go
+++ b/cmd/atlas/migrate_lint_condrop_test.go
@@ -1,0 +1,242 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/exitcode"
+)
+
+// atlasCondropProjectConfig gives one env per analyzer knob over the same
+// migration directory, so a single fixture separates condrop from every
+// neighbouring analyzer.
+//
+// On the pinned community binary, over a migration that drops a foreign key,
+// the same separation was measured directly:
+//
+//	no lint block          -> exit 0, "1 version with warnings"
+//	condrop     error=true -> exit 1, "1 version with errors"
+//	destructive error=true -> exit 0, "1 version with warnings"
+//
+// condrop moves the constraint-deletion diagnostic and destructive does not.
+// Ptah's default severity for its own CD101 is error rather than warning, so
+// the knob is exercised in the other direction here -- error = false -- but the
+// separation being pinned is the same one: condrop moves CD101, its neighbours
+// leave it alone.
+const atlasCondropProjectConfig = `env "baseline" {
+  lint {
+    latest = 1
+  }
+}
+
+env "condrop_warn" {
+  lint {
+    latest = 1
+    condrop {
+      error = false
+    }
+  }
+}
+
+env "destructive_warn" {
+  lint {
+    latest = 1
+    destructive {
+      error = false
+    }
+  }
+}
+
+env "data_depend_warn" {
+  lint {
+    latest = 1
+    data_depend {
+      error = false
+    }
+  }
+}
+`
+
+// TestCompatCommand_MigrateLintCondropSeverity is the end-to-end half of
+// stokaro/ptah#1048's condrop arm.
+//
+// Three different mistakes are pinned, and they fail differently.
+//
+// Reverting the parser arm makes every row -- including the two that name no
+// condrop block -- print `unsupported atlas.hcl construct "condrop" at
+// atlas.hcl:10` and exit 1, because env structures are validated up front and
+// all four envs share one file. Measured on the pre-change binary over this
+// exact config; no row renders a lint report at all.
+//
+// Aiming condrop at the wrong family leaves CD101 an error, so the condrop row
+// stays at exit 1 while the controls stay put. Measured by substituting DD for
+// the constraint family: only "condrop downgrades the foreign-key drop" failed.
+//
+// Widening a neighbour to cover the constraint family instead drops that
+// neighbour's control row to exit 0. Measured by adding CD to destructive: only
+// "destructive leaves the foreign-key drop alone" failed. That is why the
+// controls share this table rather than sitting in a separate test -- an exit
+// code that moves on the wrong row is the only evidence that the selector is
+// narrow enough.
+func TestCompatCommand_MigrateLintCondropSeverity(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     string
+		code    int
+		summary string
+	}{
+		{
+			// CD101 is an error by default, so the run fails without a policy.
+			name:    "baseline reports the foreign-key drop as an error",
+			env:     "baseline",
+			code:    1,
+			summary: "  -- 1 version with errors\n",
+		},
+		{
+			// The discriminator: only this row's exit code and summary move.
+			name:    "condrop downgrades the foreign-key drop",
+			env:     "condrop_warn",
+			code:    0,
+			summary: "  -- 1 version with warnings\n",
+		},
+		{
+			// Negative control. Atlas's destructive analyzer does not own the
+			// constraint-deletion diagnostic -- measured -- so pointing condrop
+			// at Ptah's destructive family would make this row move too.
+			name:    "destructive leaves the foreign-key drop alone",
+			env:     "destructive_warn",
+			code:    1,
+			summary: "  -- 1 version with errors\n",
+		},
+		{
+			// Second negative control, aimed at the specific wrong turn
+			// stokaro/ptah#1048 warned about: the community binary reports
+			// condrop's decode failure under datadepend's option struct, which
+			// made condrop look like an alias for data_depend. It is not.
+			name:    "data_depend leaves the foreign-key drop alone",
+			env:     "data_depend_warn",
+			code:    1,
+			summary: "  -- 1 version with errors\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "1.sql",
+				"CREATE TABLE pets (id int PRIMARY KEY);\n")
+			writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "2.sql",
+				"ALTER TABLE pets DROP FOREIGN KEY fk_pets_owner;\n")
+			c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"),
+				[]byte(atlasCondropProjectConfig), 0o600), qt.IsNil)
+			t.Chdir(dir)
+
+			stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", tt.env)
+
+			c.Assert(exitcode.Code(err, 0), qt.Equals, tt.code)
+			// The report body is identical in all four rows -- the diagnostic
+			// is found either way -- so the summary line is the only byte-level
+			// evidence of the severity, and asserting the whole report would
+			// hide which half of it actually moved.
+			c.Assert(stdout, qt.Contains, "-- L1 [CD101]: dropping a foreign key removes referential-integrity enforcement")
+			c.Assert(stdout, qt.Contains, tt.summary)
+		})
+	}
+}
+
+// atlasDropSchemaProjectConfig sets the one diff.skip knob Ptah's planner has
+// no statement to omit. See DiffSkipConfig.DropSchema for what the community
+// binary does with it, and why accepting it cannot make Ptah emit a schema drop
+// the binary would have withheld.
+const atlasDropSchemaProjectConfig = `env "skip_drop_schema" {
+  diff {
+    skip {
+      drop_schema = true
+    }
+  }
+  lint {
+    latest = 1
+  }
+}
+`
+
+// TestCompatCommand_MigrateLintRunsWithDropSchemaConfigured pins the divergence
+// stokaro/ptah#1048 opened with: a config carrying diff.skip.drop_schema made
+// ptah-compat exit 1 on commands that never consult a diff policy, while the
+// community binary ran them normally.
+//
+// Reverting the parser arm makes this print
+// `unsupported atlas.hcl construct "drop_schema" at atlas.hcl:4` and exit 1
+// before any analysis happens, so the report assertion below never renders.
+func TestCompatCommand_MigrateLintRunsWithDropSchemaConfigured(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "1.sql", "CREATE TABLE users (id int);\n")
+	writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "2.sql", "CREATE TABLE pets (id int);\n")
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"),
+		[]byte(atlasDropSchemaProjectConfig), 0o600), qt.IsNil)
+	t.Chdir(dir)
+
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "skip_drop_schema")
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
+	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
+		"Analyzing changes from version 1 to 2 (1 migration in total):\n"+
+			"\n"+
+			"  -- analyzing version 2\n"+
+			"    -- no diagnostics found\n"+
+			"  -- ok (DUR)\n"+
+			"\n"+
+			"  -------------------------\n"+
+			"  -- DUR\n"+
+			"  -- 1 version ok\n"+
+			"  -- 1 schema change\n")
+}
+
+// atlasSchemaRepoProjectConfig names a schema repository. The community binary
+// type-checks the name and then does nothing with it on every schema verb it
+// has -- see SchemaRepoConfig for the runs that establish that.
+const atlasSchemaRepoProjectConfig = `env "repo" {
+  schema {
+    repo {
+      name = "myapp"
+    }
+  }
+  lint {
+    latest = 1
+  }
+}
+`
+
+// TestCompatCommand_MigrateLintRunsWithSchemaRepoConfigured is the schema.repo
+// counterpart: reverting the parser arm makes this print
+// `unsupported atlas.hcl construct "repo" at atlas.hcl:3` and exit 1 instead of
+// the report asserted below.
+func TestCompatCommand_MigrateLintRunsWithSchemaRepoConfigured(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "1.sql", "CREATE TABLE users (id int);\n")
+	writeAtlasLintFile(c, filepath.Join(dir, "migrations"), "2.sql", "CREATE TABLE pets (id int);\n")
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"),
+		[]byte(atlasSchemaRepoProjectConfig), 0o600), qt.IsNil)
+	t.Chdir(dir)
+
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "repo")
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
+	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
+		"Analyzing changes from version 1 to 2 (1 migration in total):\n"+
+			"\n"+
+			"  -- analyzing version 2\n"+
+			"    -- no diagnostics found\n"+
+			"  -- ok (DUR)\n"+
+			"\n"+
+			"  -------------------------\n"+
+			"  -- DUR\n"+
+			"  -- 1 version ok\n"+
+			"  -- 1 schema change\n")
+}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -300,11 +300,16 @@ func (p atlasParser) ignoredConstructs() []IgnoredAtlasConstruct {
 // `migrate diff` purely because that command never reads baseline.
 // lint.destructive is decoded by CE too, but Ptah already implements it, so it
 // never reaches the tolerance path and is not listed here.
-var ceEnforcedConstructs = map[string]struct{}{
-	"lint.condrop":          {},
-	"diff.skip.drop_schema": {},
-	"schema.repo":           {},
-}
+//
+// The map is empty. lint.condrop, diff.skip.drop_schema and schema.repo were
+// its three entries until stokaro/ptah#1048 gave each a parser arm of its own,
+// which puts them in the same position as lint.destructive: decoded, so never
+// reaching the tolerance path, so nothing to hold back here. The map and
+// enforcedByCE stay because the criterion above is the standing rule for the
+// next name a probe catches -- an entry here is the holding pen for a construct
+// CE acts on that Ptah has not implemented yet, and refusing is where such a
+// construct waits.
+var ceEnforcedConstructs = map[string]struct{}{}
 
 // enforcedByCE reports whether a scope-qualified name is one CE acts on.
 //
@@ -525,15 +530,23 @@ func (p atlasParser) parseSchema(block *hclsyntax.Block, cfg *Config) error {
 			}
 		}
 	}
-	seenMode := false
+	seen := map[string]struct{}{}
 	for _, nested := range block.Body.Blocks {
 		switch nested.Type {
 		case "mode":
-			if seenMode {
+			if _, duplicate := seen[nested.Type]; duplicate {
 				return unsupportedBlock(nested)
 			}
-			seenMode = true
+			seen[nested.Type] = struct{}{}
 			if err := p.parseSchemaMode(nested, cfg); err != nil {
+				return err
+			}
+		case "repo":
+			if _, duplicate := seen[nested.Type]; duplicate {
+				return unsupportedBlock(nested)
+			}
+			seen[nested.Type] = struct{}{}
+			if err := p.parseSchemaRepo(nested, cfg); err != nil {
 				return err
 			}
 		default:
@@ -543,6 +556,35 @@ func (p atlasParser) parseSchema(block *hclsyntax.Block, cfg *Config) error {
 				return err
 			}
 		}
+	}
+	return nil
+}
+
+// parseSchemaRepo decodes env.schema.repo, whose only decoded attribute is a
+// string `name`. See SchemaRepoConfig for what the pinned community binary was
+// measured to do with the value: type-check it, and nothing else.
+func (p atlasParser) parseSchemaRepo(block *hclsyntax.Block, cfg *Config) error {
+	if len(block.Labels) > 0 {
+		return unsupportedBlock(block)
+	}
+	for _, attrName := range sortedAttributeNames(block.Body.Attributes) {
+		attr := block.Body.Attributes[attrName]
+		switch attrName {
+		case "name":
+			value, err := p.stringAttr(attrName, attr)
+			if err != nil {
+				return err
+			}
+			cfg.Schema.Repo.Name = value
+			cfg.presence.mark(fieldSchemaRepoName)
+		default:
+			if err := p.tolerateUnknownAttr("env.schema.repo", attrName, attr); err != nil {
+				return err
+			}
+		}
+	}
+	if len(block.Body.Blocks) > 0 {
+		return unsupportedBlock(block.Body.Blocks[0])
 	}
 	return nil
 }
@@ -768,6 +810,29 @@ func (p atlasParser) parseLintPolicyBlocks(block *hclsyntax.Block, cfg *Config) 
 		case "concurrent_index":
 			if err := p.parseSingleLintBlock(nested, seen, func() error {
 				return p.parseLintAnalyzer(nested, cfg, "PG101", "PG103")
+			}); err != nil {
+				return err
+			}
+		case "condrop":
+			// Atlas's condrop analyzer owns the constraint-deletion family, and
+			// it is a distinct analyzer from data_depend despite CE's decode
+			// error naming datadepend's option struct. Measured on the pinned
+			// community binary against a migration that drops a foreign key:
+			//
+			//	no lint block          -> exit 0, "1 version with warnings"
+			//	condrop     error=true -> exit 1, "1 version with errors"
+			//	destructive error=true -> exit 0, "1 version with warnings"
+			//
+			// so condrop, not destructive, escalates the diagnostic CE reports
+			// as CD101. Ptah's CD family (CD101 foreign key, CD102 check, CD103
+			// primary key) is the same family. DS105 rides with it because it is
+			// Ptah's untyped fallback for the ANSI `DROP CONSTRAINT <name>` form
+			// whose type the SQL does not reveal -- and that is precisely the
+			// statement CE attributed to CD101 in the measurement above, so
+			// leaving it out would let `condrop { error = false }` be accepted
+			// and change nothing for the most common spelling.
+			if err := p.parseSingleLintBlock(nested, seen, func() error {
+				return p.parseLintAnalyzer(nested, cfg, "CD", "DS105")
 			}); err != nil {
 				return err
 			}
@@ -1032,9 +1097,7 @@ func (p atlasParser) parseDiffSkip(block *hclsyntax.Block, cfg *Config) error {
 		case "drop_table":
 			cfg.Diff.Skip.DropTable = value
 		case "drop_schema":
-			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
-				return err
-			}
+			cfg.Diff.Skip.DropSchema = value
 		default:
 			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
 				return err

--- a/config/projectconfig/atlas_ce_enforced_test.go
+++ b/config/projectconfig/atlas_ce_enforced_test.go
@@ -1,0 +1,366 @@
+package projectconfig_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+// The three constructs covered here -- lint.condrop, diff.skip.drop_schema and
+// env.schema.repo -- used to be refused outright: parsing any config that
+// mentioned one exited 1 with `unsupported atlas.hcl construct`, even for
+// commands that never consult the block. The pinned community binary accepts
+// all three, so every assertion below prints an `unsupported atlas.hcl
+// construct` error instead of its expected value if the parser arms are
+// reverted.
+//
+// What the community binary was measured to DO with each is recorded next to
+// the corresponding IR field: DiffSkipConfig.DropSchema and SchemaRepoConfig in
+// config.go, and the condrop case in atlas.go.
+
+func TestParseAtlasLintCondropSeverity(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		// want is the severity every code in codes must carry.
+		want  string
+		codes []string
+		// absent lists rule selectors the block must not touch. Empty means the
+		// row asserts only the positive side.
+		absent []string
+	}{
+		{
+			// condrop escalates the constraint-deletion family and nothing
+			// else. The absent list is the negative control: on the pinned
+			// community binary `destructive { error = true }` left the CD101
+			// diagnostic a warning while `condrop { error = true }` made it an
+			// error, so pointing condrop at DS or DD would be aiming a
+			// constraint-drop policy at an unrelated check.
+			name: "error true escalates the constraint family only",
+			raw: `lint {
+  condrop {
+    error = true
+  }
+}
+`,
+			want:   "error",
+			codes:  []string{"CD", "DS105"},
+			absent: []string{"DS", "DD", "BC", "TX201", "PG101", "PG103"},
+		},
+		{
+			name: "error false downgrades the constraint family only",
+			raw: `lint {
+  condrop {
+    error = false
+  }
+}
+`,
+			want:   "warning",
+			codes:  []string{"CD", "DS105"},
+			absent: []string{"DS", "DD", "BC", "TX201", "PG101", "PG103"},
+		},
+		{
+			// Same block inside env, because the parser reaches it by a
+			// different path there: the env structure validator runs before the
+			// lint parser and refused the name on its own.
+			name: "env scoped block is decoded too",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  lint {
+    condrop {
+      error = true
+    }
+  }
+}
+`,
+			want:  "error",
+			codes: []string{"CD", "DS105"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "local")
+
+			c.Assert(err, qt.IsNil)
+			for _, code := range tt.codes {
+				c.Assert(cfg.Lint.RuleConfigs[code].Severity, qt.Equals, tt.want,
+					qt.Commentf("severity for %q", code))
+			}
+			for _, code := range tt.absent {
+				_, present := cfg.Lint.RuleConfigs[code]
+				c.Assert(present, qt.IsFalse, qt.Commentf("selector %q must be untouched", code))
+			}
+		})
+	}
+}
+
+// TestParseAtlasLintCondropRejectsNonBool pins the half of the contract that
+// stays a refusal. The community binary decodes condrop's `error` as a bool and
+// fails the run when it cannot -- measured under `migrate lint`, which is a
+// command that reads the lint block:
+//
+//	lint { condrop { error = "x" } } -> exit 1, parsing datadepend check
+//	                                    options: set field "error"
+//
+// so accepting a string here would be looser than the binary Ptah is matched
+// against.
+func TestParseAtlasLintCondropRejectsNonBool(t *testing.T) {
+	c := qt.New(t)
+
+	raw := `lint {
+  condrop {
+    error = "x"
+  }
+}
+`
+
+	_, err := projectconfig.ParseAtlas([]byte(raw), "atlas.hcl", "local")
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl "error" at atlas\.hcl:3 must be a bool`)
+}
+
+func TestParseAtlasDiffSkipDropSchema(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want projectconfig.ConfigBool
+	}{
+		{
+			name: "global true",
+			raw: `diff {
+  skip {
+    drop_schema = true
+  }
+}
+`,
+			want: projectconfig.ConfigBool{Value: true, Set: true},
+		},
+		{
+			// An explicit false is not the same as absence: the tri-state is
+			// what lets an env override a global true back off.
+			name: "global false is recorded as set",
+			raw: `diff {
+  skip {
+    drop_schema = false
+  }
+}
+`,
+			want: projectconfig.ConfigBool{Value: false, Set: true},
+		},
+		{
+			name: "env scoped",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  diff {
+    skip {
+      drop_schema = true
+    }
+  }
+}
+`,
+			want: projectconfig.ConfigBool{Value: true, Set: true},
+		},
+		{
+			// The env value wins, which is the whole reason the field is a
+			// tri-state rather than a bool.
+			name: "env false overrides global true",
+			raw: `diff {
+  skip {
+    drop_schema = true
+  }
+}
+
+env "local" {
+  url = "sqlite://s.db"
+  diff {
+    skip {
+      drop_schema = false
+    }
+  }
+}
+`,
+			want: projectconfig.ConfigBool{Value: false, Set: true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "local")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(cfg.Diff.Skip.DropSchema, qt.Equals, tt.want)
+			// Nothing new joins the planner vocabulary. Ptah's schema diff has
+			// no removed-schema list and no code path renders DROP SCHEMA, so
+			// there is no change kind for this suppression to omit -- see the
+			// measurement recorded on DiffSkipConfig.DropSchema.
+			c.Assert(cfg.Diff.SkipChangeKinds(), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestParseAtlasDiffSkipDropSchemaRejectsNonBool mirrors the community binary's
+// eager decode: `drop_schema = "x"` is refused there even by `schema inspect`,
+// a command that never plans a diff, with `value of attr "drop_schema" cannot
+// be read as bool`.
+func TestParseAtlasDiffSkipDropSchemaRejectsNonBool(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+	}{
+		{
+			name: "global",
+			raw: `diff {
+  skip {
+    drop_schema = "x"
+  }
+}
+`,
+		},
+		{
+			name: "env scoped",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  diff {
+    skip {
+      drop_schema = "x"
+    }
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "local")
+
+			c.Assert(err, qt.ErrorMatches, `atlas\.hcl "drop_schema" at atlas\.hcl:\d+ must be a bool`)
+		})
+	}
+}
+
+func TestParseAtlasSchemaRepo(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+		// assert carries any per-row expectation beyond the repo name.
+		assert func(c *qt.C, cfg projectconfig.Config)
+	}{
+		{
+			name: "name is decoded",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    repo {
+      name = "myapp"
+    }
+  }
+}
+`,
+			want:   "myapp",
+			assert: func(*qt.C, projectconfig.Config) {},
+		},
+		{
+			// The community binary accepts an empty repo block -- measured at
+			// exit 0 on `schema inspect` -- so an absent name is not an error.
+			name: "empty block leaves the name empty",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    repo {
+    }
+  }
+}
+`,
+			want:   "",
+			assert: func(*qt.C, projectconfig.Config) {},
+		},
+		{
+			// src still parses beside it; adding the repo arm must not shadow
+			// the attribute that shares the block.
+			name: "coexists with schema src",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    src = "file://schema.hcl"
+    repo {
+      name = "myapp"
+    }
+  }
+}
+`,
+			want: "myapp",
+			assert: func(c *qt.C, cfg projectconfig.Config) {
+				c.Assert(cfg.SchemaSources, qt.DeepEquals, []string{"file://schema.hcl"})
+			},
+		},
+		{
+			// An unrecognized attribute inside repo is tolerated, matching the
+			// community binary's measured exit 0 for `repo { name = "myapp"
+			// frobnicate = 1 }`.
+			name: "unknown attribute inside repo is tolerated",
+			raw: `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    repo {
+      name       = "myapp"
+      frobnicate = 1
+    }
+  }
+}
+`,
+			want: "myapp",
+			assert: func(c *qt.C, cfg projectconfig.Config) {
+				names := make([]string, 0, len(cfg.IgnoredConstructs))
+				for _, ignored := range cfg.IgnoredConstructs {
+					names = append(names, ignored.Name)
+				}
+				c.Assert(names, qt.Contains, "frobnicate")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			cfg, err := projectconfig.ParseAtlas([]byte(tt.raw), "atlas.hcl", "local")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(cfg.Schema.Repo.Name, qt.Equals, tt.want)
+			tt.assert(c, cfg)
+		})
+	}
+}
+
+// TestParseAtlasSchemaRepoRejectsNonString is the refusal half for repo. The
+// community binary decodes the name eagerly -- `repo { name = 1 }` exits 1 on
+// `schema inspect` with `value of attr "name" cannot be read as string` -- so
+// accepting a number would be looser than the binary Ptah is matched against.
+func TestParseAtlasSchemaRepoRejectsNonString(t *testing.T) {
+	c := qt.New(t)
+
+	raw := `env "local" {
+  url = "sqlite://s.db"
+  schema {
+    repo {
+      name = 1
+    }
+  }
+}
+`
+
+	_, err := projectconfig.ParseAtlas([]byte(raw), "atlas.hcl", "local")
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl "name" at atlas\.hcl:5 must be a string`)
+}

--- a/config/projectconfig/atlas_structure.go
+++ b/config/projectconfig/atlas_structure.go
@@ -26,7 +26,7 @@ func atlasEnvBodyStructure() atlasBodyStructure {
 						body: atlasBodyStructure{attributes: []string{"create", "drop"}},
 					},
 					"skip": {
-						body: atlasBodyStructure{attributes: []string{"drop_table"}},
+						body: atlasBodyStructure{attributes: []string{"drop_schema", "drop_table"}},
 					},
 				}},
 			},
@@ -45,6 +45,7 @@ func atlasEnvBodyStructure() atlasBodyStructure {
 					attributes: []string{"latest", "log"},
 					blocks: map[string]atlasBlockStructure{
 						"concurrent_index": {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"condrop":          {body: atlasBodyStructure{attributes: []string{"error"}}},
 						"data_depend":      {body: atlasBodyStructure{attributes: []string{"error"}}},
 						"destructive":      {body: atlasBodyStructure{attributes: []string{"error"}}},
 						"git":              {body: atlasBodyStructure{attributes: []string{"base", "dir"}}},
@@ -79,6 +80,9 @@ func atlasEnvBodyStructure() atlasBodyStructure {
 								"types",
 								"views",
 							}},
+						},
+						"repo": {
+							body: atlasBodyStructure{attributes: []string{"name"}},
 						},
 					},
 				},

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1414,15 +1414,16 @@ env "prod" {
 // reports no decode failure, with a name it does decode used as the control in
 // the same command.
 //
-// Names the community binary DOES decode stay in the rejection table above --
-// tolerating those would accept a policy and silently not enforce it.
-// The names the community binary decodes are refused by scope-qualified path,
-// not by bare name: `repo` is refused under schema and tolerated anywhere else.
-// Without this the deny-list would over-refuse every unrelated `repo`.
+// Names the community binary DOES decode stay out of the tolerance --
+// sweeping those in would accept a policy and silently not enforce it. The
+// handling is by scope-qualified path, not by bare name: `repo` under
+// env.schema is the construct the community binary type-checks, so it is
+// decoded into the IR, while `repo` anywhere else is an unknown name and is
+// tolerated. Without the scope qualification one arm would swallow the other.
 func TestParseAtlasProjectConfigEnforcedNamesAreScopeQualified(t *testing.T) {
 	c := qt.New(t)
 
-	refused := `env "local" {
+	decoded := `env "local" {
   url = "sqlite://s.db"
   schema {
     repo {
@@ -1431,8 +1432,14 @@ func TestParseAtlasProjectConfigEnforcedNamesAreScopeQualified(t *testing.T) {
   }
 }
 `
-	_, err := projectconfig.ParseAtlas([]byte(refused), "atlas.hcl", "local")
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "repo" .*`)
+	cfg, err := projectconfig.ParseAtlas([]byte(decoded), "atlas.hcl", "local")
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Schema.Repo.Name, qt.Equals, "app")
+	decodedNames := make([]string, 0, len(cfg.IgnoredConstructs))
+	for _, ignored := range cfg.IgnoredConstructs {
+		decodedNames = append(decodedNames, ignored.Name)
+	}
+	c.Assert(decodedNames, qt.Not(qt.Contains), "repo")
 
 	elsewhere := `env "local" {
   url = "sqlite://s.db"
@@ -1442,8 +1449,9 @@ func TestParseAtlasProjectConfigEnforcedNamesAreScopeQualified(t *testing.T) {
   }
 }
 `
-	cfg, err := projectconfig.ParseAtlas([]byte(elsewhere), "atlas.hcl", "local")
+	cfg, err = projectconfig.ParseAtlas([]byte(elsewhere), "atlas.hcl", "local")
 	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.Schema.Repo.Name, qt.Equals, "")
 	names := make([]string, 0, len(cfg.IgnoredConstructs))
 	for _, ignored := range cfg.IgnoredConstructs {
 		names = append(names, ignored.Name)
@@ -1597,28 +1605,6 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 			err: `cannot evaluate atlas\.hcl "sensitive" at atlas\.hcl:4: .*There is no variable named "ALLOW"\.`,
 		},
 		{
-			name: "schema repo block",
-			raw: `env "local" {
-  schema {
-    repo {
-      name = "app"
-    }
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "repo" at atlas\.hcl:3`,
-		},
-		{
-			name: "diff skip drop schema",
-			raw: `diff {
-  skip {
-    drop_schema = true
-  }
-}
-`,
-			err: `unsupported atlas\.hcl construct "drop_schema" at atlas\.hcl:3`,
-		},
-		{
 			name: "lint destructive allow table",
 			raw: `lint {
   destructive {
@@ -1644,14 +1630,24 @@ func TestParseAtlasProjectConfigRejectsUnsupportedConstructs(t *testing.T) {
 			err: `unsupported atlas\.hcl construct "destructive" at atlas\.hcl:5`,
 		},
 		{
-			name: "lint constraint drop block",
+			// Same duplicate-block policy the `destructive` row above pins,
+			// applied to the analyzer stokaro/ptah#1048 added. The community
+			// binary accepts the duplicate and honors the first block --
+			// measured, `condrop { error = true }` followed by
+			// `condrop { error = false }` still exits 1 -- so Ptah is stricter
+			// here. That is the safe direction, and it is a parser-wide rule
+			// rather than anything specific to condrop.
+			name: "lint duplicate constraint drop block",
 			raw: `lint {
   condrop {
     error = true
   }
+  condrop {
+    error = false
+  }
 }
 `,
-			err: `unsupported atlas\.hcl construct "condrop" at atlas\.hcl:2`,
+			err: `unsupported atlas\.hcl construct "condrop" at atlas\.hcl:5`,
 		},
 		{
 			name: "cloud block",
@@ -1990,13 +1986,13 @@ func TestAtlasParserDistinguishesFailureClasses(t *testing.T) {
 	// and must not be reported as either of the two above.
 	//
 	// The position matters. Unknown names are now tolerated at every level, so
-	// this uses `schema.repo` -- one of the few names the community binary
-	// genuinely decodes, which is why Ptah still refuses it rather than
-	// accepting a policy it does not enforce.
-	unknown := "env \"local\" {\n  schema {\n    repo {\n      name = \"app\"\n    }\n  }\n  url = \"sqlite://m.db\"" + envBody
+	// this uses a nested block inside a lint analyzer -- `destructive` decodes
+	// only `error`, and a block body under it is refused structurally rather
+	// than tolerated, which keeps a name-class refusal reachable.
+	unknown := "env \"local\" {\n  lint {\n    destructive {\n      allow_table {\n        match = \"x\"\n      }\n    }\n  }\n  url = \"sqlite://m.db\"" + envBody
 	_, err := projectconfig.ParseAtlas([]byte(unknown), "atlas.hcl", "local")
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "repo" .*`)
+	c.Assert(err, qt.ErrorMatches, `unsupported atlas\.hcl construct "allow_table" .*`)
 }
 
 // TestAtlasParserScrubsSensitiveValuesFromDiagnostics is a regression test for

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -177,6 +177,7 @@ const (
 	fieldExternalSchemaFormat      configField = "external_schema.format"
 	fieldExternalSchemaWorkingDir  configField = "external_schema.working_dir"
 	fieldExternalSchemaEnv         configField = "external_schema.env"
+	fieldSchemaRepoName            configField = "schema.repo.name"
 	lintRuleConfigFieldPrefix                  = "lint.rules."
 )
 
@@ -500,6 +501,25 @@ type ConfigBool struct {
 // SchemaConfig holds Atlas env.schema settings.
 type SchemaConfig struct {
 	Mode SchemaModeConfig
+	Repo SchemaRepoConfig
+}
+
+// SchemaRepoConfig holds Atlas env.schema.repo settings: the name of the schema
+// repository a hosted registry would store the desired state under.
+//
+// The name is decoded and type-checked because the pinned community binary
+// decodes it -- `repo { name = 1 }` is refused with `value of attr "name"
+// cannot be read as string` on a command as cheap as `schema inspect`. Nothing
+// reads the value afterwards, and that is also measured: with the community
+// binary, `schema inspect`, `schema apply --dry-run`, and `schema apply
+// --auto-approve` (both on an empty database and incrementally) produce
+// byte-identical output with and without the block, and an `atlas://` URL is
+// refused identically either way ("atlas remote state is not supported by the
+// community version of Atlas"). Ptah likewise has no hosted registry --
+// `schema plan --repo` already says so -- so accepting the name and acting on
+// nothing is exact parity, not silent non-enforcement.
+type SchemaRepoConfig struct {
+	Name string
 }
 
 // SchemaModeConfig holds Atlas env.schema.mode settings.
@@ -587,6 +607,24 @@ type DiffSkipConfig struct {
 	DropColumn ConfigBool
 	DropIndex  ConfigBool
 	DropEnum   ConfigBool
+	// DropSchema mirrors Atlas diff.skip.drop_schema. It is decoded and
+	// type-checked because the pinned community binary decodes it eagerly --
+	// `drop_schema = "x"` is refused with `value of attr "drop_schema" cannot be
+	// read as bool` even on `schema inspect`.
+	//
+	// It has no entry in SkipChangeKinds because Ptah's planner has no
+	// schema-removal change kind to omit: migration/schemadiff/types.SchemaDiff
+	// carries no removed-schema list and no code path renders DROP SCHEMA into a
+	// plan. Measured on the community binary, `schema apply --dry-run` against a
+	// realm URL holding a schema the desired state omits prints
+	// `DROP SCHEMA "extra" CASCADE;` by default and `Schema is synced, no changes
+	// to be made` with drop_schema = true; Ptah prints the synced line either way,
+	// so honoring the suppression costs nothing and can never make Ptah emit a
+	// drop the community binary would have withheld. Cleanup is unaffected on
+	// both sides: `schema clean` on the community binary drops every schema with
+	// the setting on -- measured -- and no Ptah code path reads this field at
+	// all.
+	DropSchema ConfigBool
 }
 
 // SkipChangeKinds returns the change kinds this policy skips, in the canonical
@@ -690,7 +728,7 @@ func Merge(base, override Config) Config {
 		override.presence,
 		&result.presence,
 	)
-	result.Schema = mergeSchema(result.Schema, override.Schema)
+	result.Schema = mergeSchema(result.Schema, override.Schema, override.presence, &result.presence)
 	result.Migration = mergeMigration(
 		result.Migration,
 		override.Migration,
@@ -854,8 +892,19 @@ func mergeExternalSchema(
 	return result
 }
 
-func mergeSchema(base, override SchemaConfig) SchemaConfig {
+func mergeSchema(
+	base, override SchemaConfig,
+	overridePresence configPresence,
+	resultPresence *configPresence,
+) SchemaConfig {
 	result := base
+	result.Repo.Name = mergeStringValue(
+		base.Repo.Name,
+		override.Repo.Name,
+		fieldSchemaRepoName,
+		overridePresence,
+		resultPresence,
+	)
 	result.Mode.Funcs = mergeBool(result.Mode.Funcs, override.Mode.Funcs)
 	result.Mode.Objects = mergeBool(result.Mode.Objects, override.Mode.Objects)
 	result.Mode.Permissions = mergeBool(result.Mode.Permissions, override.Mode.Permissions)
@@ -1168,6 +1217,7 @@ func mergeDiff(base, override DiffConfig) DiffConfig {
 	result.Skip.DropColumn = mergeBool(result.Skip.DropColumn, override.Skip.DropColumn)
 	result.Skip.DropIndex = mergeBool(result.Skip.DropIndex, override.Skip.DropIndex)
 	result.Skip.DropEnum = mergeBool(result.Skip.DropEnum, override.Skip.DropEnum)
+	result.Skip.DropSchema = mergeBool(result.Skip.DropSchema, override.Skip.DropSchema)
 	result.ConcurrentIndex.Create = mergeBool(result.ConcurrentIndex.Create, override.ConcurrentIndex.Create)
 	result.ConcurrentIndex.Drop = mergeBool(result.ConcurrentIndex.Drop, override.ConcurrentIndex.Drop)
 	return result

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -98,6 +98,7 @@ The supported attributes map to Ptah settings as follows:
 | `lint.git.dir` | `migrations lint --git-dir` default |
 | `lint.destructive.error` | `DS` lint rule-family severity |
 | `lint.concurrent_index.error` | `PG101` and `PG103` lint rule severity |
+| `lint.condrop.error` | `CD` lint rule-family and `DS105` lint rule severity |
 | `lint.data_depend.error` | `DD` lint rule-family severity |
 | `lint.incompatible.error` | `BC` lint rule-family severity |
 | `lint.nestedtx.error` | `TX201` lint rule severity |
@@ -111,7 +112,9 @@ The supported attributes map to Ptah settings as follows:
 | `format.migrate.lint` | `ptah-compat migrate lint --format` default |
 | `format.migrate.status` | `ptah-compat migrate status --format` default |
 | `diff.skip.drop_table` | Drop-table suppression for local schema diff/apply planning |
+| `diff.skip.drop_schema` | Accepted and type-checked; Ptah's planner emits no schema drop for it to suppress |
 | `diff.concurrent_index.create` | PostgreSQL concurrent index creation where the command can execute without a surrounding transaction |
+| `env.schema.repo.name` | Accepted and type-checked; no local behavior, matching the community binary |
 
 `env.src` and `env.schema.src` accept either one string or a list of strings.
 The nested `schema.src` form matches Atlas project config syntax. Ptah
@@ -194,6 +197,13 @@ schema IR. `sensitive = DENY` is accepted as a no-op because Ptah does not emit
 sensitive values through the supported local workflows. `sensitive = ALLOW` is
 rejected until Ptah has explicit sensitive-value semantics.
 
+`env.schema.repo` names a schema repository in a hosted registry. Its `name` is
+accepted and type-checked as a string, and nothing reads it afterwards — the
+same as the community binary, whose `schema inspect`, `schema apply --dry-run`
+and `schema apply --auto-approve` output is byte-identical with and without the
+block. Registry access itself stays refused on both: an `atlas://` URL fails,
+and `ptah-compat schema plan --repo` reports that Ptah plans are local files.
+
 `format` blocks configure the same Atlas Go-template output strings accepted by
 the matching commands. Ptah supports `schema.inspect`, `schema.apply`,
 `schema.diff`, `migrate.apply`, `migrate.diff`, `migrate.lint`, and
@@ -202,8 +212,13 @@ Atlas-compatible command reference.
 
 `diff.skip.drop_table = true` removes table drops from supported local
 declarative diff/apply plans and also removes index or constraint drops owned by
-those dropped tables. `diff.skip.drop_schema` is rejected because Ptah does not
-currently model schema dropping as an Atlas-compatible policy decision.
+those dropped tables. `diff.skip.drop_schema` is accepted and type-checked but
+changes no plan: Ptah's schema diff has no removed-schema list and no code path
+renders `DROP SCHEMA`, so the suppression has nothing to omit. Because the
+setting only ever removes a statement, honoring it vacuously can never make Ptah
+emit a schema drop Atlas would have withheld. A non-boolean value is refused,
+matching the community binary, which reports `value of attr "drop_schema" cannot
+be read as bool` even on commands that never plan a diff.
 
 `diff.concurrent_index.create = true` maps to PostgreSQL concurrent index
 creation in schema diff planning. For non-dry-run PostgreSQL `schema apply`
@@ -226,9 +241,18 @@ sets them to warning severity.
 
 The supported mappings are `destructive` to the `DS` family, `data_depend` to
 the `DD` family, `incompatible` to the `BC` family, `concurrent_index` to
-`PG101` and `PG103`, and `nestedtx` to `TX201`. Atlas `check` blocks are
-rejected for now because Atlas check IDs and Ptah rule IDs are not a stable
-one-to-one namespace.
+`PG101` and `PG103`, `nestedtx` to `TX201`, and `condrop` to the `CD` family
+plus `DS105`. Atlas `check` blocks are rejected for now because Atlas check IDs
+and Ptah rule IDs are not a stable one-to-one namespace.
+
+`condrop` is a separate analyzer from `destructive` and from `data_depend`, not
+an alias for either. On the community binary, a migration dropping a foreign key
+is reported as a warning by default; `condrop { error = true }` turns that run
+into an error while `destructive { error = true }` leaves it a warning. Ptah's
+`CD` family is the same constraint-deletion family, and `DS105` is included
+because it is Ptah's untyped fallback for the ANSI `ALTER TABLE ... DROP
+CONSTRAINT <name>` form — the exact statement the community binary attributes to
+`condrop`.
 
 Analyzer `force` options, allow-list blocks such as `allow_table` /
 `allow_column`, custom `rule` blocks, and policy families without a matching
@@ -430,7 +454,7 @@ supported `diff` policy.
 
 Ptah intentionally rejects everything outside the documented subset. Unsupported
 attributes, unsupported data sources, unsupported lint policy blocks or attributes,
-Cloud or registry sources such as `schema.repo`, unsupported format blocks,
+Cloud or registry URLs such as `atlas://`, unsupported format blocks,
 unsupported diff policy fields, duplicate `migration` or `lint` blocks,
 variables without defaults that are not supplied through `--var` fail with a
 location-aware error:

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -172,6 +172,7 @@ type OnlineDDLConfig struct{ ... }
 type SchemaConfig struct{ ... }
 type SchemaFormatConfig struct{ ... }
 type SchemaModeConfig struct{ ... }
+type SchemaRepoConfig struct{ ... }
 type StringField uint8
     const StringEnvName StringField = iota ...
 type Value[T any] struct{ ... }
@@ -294,6 +295,24 @@ type DiffSkipConfig struct {
     DropColumn ConfigBool
     DropIndex  ConfigBool
     DropEnum   ConfigBool
+    // DropSchema mirrors Atlas diff.skip.drop_schema. It is decoded and
+    // type-checked because the pinned community binary decodes it eagerly --
+    // `drop_schema = "x"` is refused with `value of attr "drop_schema" cannot be
+    // read as bool` even on `schema inspect`.
+    //
+    // It has no entry in SkipChangeKinds because Ptah's planner has no
+    // schema-removal change kind to omit: migration/schemadiff/types.SchemaDiff
+    // carries no removed-schema list and no code path renders DROP SCHEMA into a
+    // plan. Measured on the community binary, `schema apply --dry-run` against a
+    // realm URL holding a schema the desired state omits prints
+    // `DROP SCHEMA "extra" CASCADE;` by default and `Schema is synced, no changes
+    // to be made` with drop_schema = true; Ptah prints the synced line either way,
+    // so honoring the suppression costs nothing and can never make Ptah emit a
+    // drop the community binary would have withheld. Cleanup is unaffected on
+    // both sides: `schema clean` on the community binary drops every schema with
+    // the setting on -- measured -- and no Ptah code path reads this field at
+    // all.
+    DropSchema ConfigBool
 }
     DiffSkipConfig holds the diff.skip policy: the destructive change kinds a
     project omits from generated migrations. Each field is a tri-state so an
@@ -471,6 +490,7 @@ package projectconfig // import "go.5x5.cz/ptah/config/projectconfig"
 
 type SchemaConfig struct {
     Mode SchemaModeConfig
+    Repo SchemaRepoConfig
 }
     SchemaConfig holds Atlas env.schema settings.
 
@@ -505,6 +525,29 @@ type SchemaModeConfig struct {
     SchemaModeConfig holds Atlas env.schema.mode settings.
 
 func (m SchemaModeConfig) ExcludePatterns() []string
+
+### go.5x5.cz/ptah/config/projectconfig.SchemaRepoConfig
+
+package projectconfig // import "go.5x5.cz/ptah/config/projectconfig"
+
+type SchemaRepoConfig struct {
+    Name string
+}
+    SchemaRepoConfig holds Atlas env.schema.repo settings: the name of the
+    schema repository a hosted registry would store the desired state under.
+
+    The name is decoded and type-checked because the pinned community binary
+    decodes it -- `repo { name = 1 }` is refused with `value of attr "name"
+    cannot be read as string` on a command as cheap as `schema inspect`.
+    Nothing reads the value afterwards, and that is also measured: with the
+    community binary, `schema inspect`, `schema apply --dry-run`, and `schema
+    apply --auto-approve` (both on an empty database and incrementally) produce
+    byte-identical output with and without the block, and an `atlas://` URL is
+    refused identically either way ("atlas remote state is not supported by
+    the community version of Atlas"). Ptah likewise has no hosted registry --
+    `schema plan --repo` already says so -- so accepting the name and acting on
+    nothing is exact parity, not silent non-enforcement.
+
 
 ### go.5x5.cz/ptah/config/projectconfig.StringField
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -816,7 +816,7 @@
     "atlas_oss": "no",
     "atlas_pro": "yes",
     "note": "Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail.",
-    "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} \u2014 no rule definition. config/projectconfig/atlas.go:536 parseLintPolicyBlocks accepts only concurrent_index, data_depend, destructive, git, nestedtx, incompatible; atlas.go:613 rejects `force`. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
+    "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} \u2014 no rule definition. config/projectconfig/atlas.go parseLintPolicyBlocks accepts only concurrent_index, condrop, data_depend, destructive, git, nestedtx, incompatible; parseLintAnalyzer tolerates `force` without acting on it. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
   },
   {
     "area": "Lint policy and suppression",

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -272,7 +272,9 @@ for object kinds represented in Ptah's schema IR. `diff.skip.drop_table = true`
 removes table drops from supported local plans. For non-dry-run PostgreSQL
 `schema apply` plans that actually emit `CREATE INDEX CONCURRENTLY`,
 `diff.concurrent_index.create = true` requires `--tx-mode none`;
-`diff.concurrent_index.drop` and `diff.skip.drop_schema` fail explicitly.
+`diff.concurrent_index.drop` fails explicitly. `diff.skip.drop_schema` is
+accepted and type-checked, but changes no plan: Ptah's schema diff has no
+removed-schema list, so there is no `DROP SCHEMA` for the suppression to omit.
 
 ### Scope the comparison with `--schema` and `--include`
 


### PR DESCRIPTION
Closes #1048.

`lint.condrop`, `diff.skip.drop_schema` and `env.schema.repo` sat in `ceEnforcedConstructs` and were refused outright, so any project config naming one could not run `ptah-compat` at all — not even for commands that never consult the block. All three are now implemented. `ceEnforcedConstructs` is empty; the map and `enforcedByCE` stay as the holding pen for the next construct a probe catches.

Measurement first, because the three turned out to carry three different obligations.

## Environment

Pinned community binary, by absolute path, reporting `atlas community version v1.3.0`:

```
/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas version
```

PostgreSQL 16 in a throwaway container supplied dev/target URLs. SQLite is unusable for these fixtures: it refuses `ALTER TABLE ... DROP CONSTRAINT` with `constraint may not be dropped`, so the dev replay dies before any analysis.

## 1. `lint.condrop` — a real analyzer, with a real knob

Migration directory where version 2 drops a foreign key, one env per policy, same command each time:

```
atlas migrate lint --env local -c file://<config>
```

| config | rc | summary line |
| --- | --- | --- |
| no analyzer block | 0 | `-- 1 version with warnings` |
| `condrop { error = true }` | 1 | `-- 1 version with errors` |
| `condrop { error = false }` | 0 | `-- 1 version with warnings` |
| `destructive { error = true }` | 0 | `-- 1 version with warnings` |

The diagnostic is identical in all four runs:

```
    -- constraint deletion detected:
      -- L1: Dropping foreign-key constraint "fk_orders_user"
         https://atlasgo.io/lint/analyzers#CD101
```

`condrop` moves it; `destructive` does not. That is the negative control the issue's comment asked for, and it rules out the cheap fix the issue originally proposed.

Type check, and a trap worth recording: the lint block is decoded **lazily**.

```
lint { condrop { error = "x" } }
  under `migrate lint`   -> rc 1  sql/sqlcheck: parsing datadepend check options:
                                  set field "error": converting cty.Value to *bool
  under `schema inspect` -> rc 0
```

A probe run under `schema inspect` would have concluded `condrop` is ignored. `drop_schema` and `repo` type-check eagerly and fail even `schema inspect`, so the three do not share a probe verb.

Mapping: `condrop` → Ptah's `CD` family (CD101 foreign key, CD102 check, CD103 primary key) **plus** `DS105`. DS105 is Ptah's untyped fallback for the ANSI `ALTER TABLE ... DROP CONSTRAINT <name>` form — precisely the statement the community binary reported as CD101 above. Leaving DS105 out would let `condrop { error = false }` be accepted and change nothing for the commonest spelling.

## 2. `diff.skip.drop_schema` — really suppresses, but Ptah emits nothing to suppress

Realm-scoped target holding a schema the desired state omits:

```
atlas schema apply --env local -c file://<config> --dry-run
```

| config | rc | stdout |
| --- | --- | --- |
| no `diff` block | 0 | `-- Planned Changes:` / `-- Drop schema named "extra"` / `DROP SCHEMA "extra" CASCADE;` |
| `drop_schema = true` | 0 | `Schema is synced, no changes to be made` |
| `drop_schema = false` | 0 | the `DROP SCHEMA` again |

`schema clean --auto-approve` ignores the setting on the community binary — it still plans `DROP SCHEMA "extra" CASCADE;` and `DROP SCHEMA "public" CASCADE;` — so no cleanup path is in scope.

Wrong type, eager:

```
diff { skip { drop_schema = "x" } }
  -> rc 1  schemahcl: failed reading spec as *cmdapi.Project:
           value of attr "drop_schema" cannot be read as bool: bool value is required
```

Ptah side: `migration/schemadiff/types.SchemaDiff` carries no removed-schema list and no code path renders `DROP SCHEMA` into a plan. Over the same fixture `ptah-compat schema apply --dry-run` prints `Schema is synced, no changes to be made.` with the setting off — it never plans the drop in the first place. So the field is parsed, tri-state, merged, type-checked, and deliberately **absent from `SkipChangeKinds()`**. This is not the accept-and-silently-ignore failure the issue warns about: the setting only ever *removes* a statement, so satisfying it vacuously can never make Ptah emit a schema drop the community binary would have withheld. The `DiffSkipConfig.DropSchema` doc comment records exactly this, and a test asserts `SkipChangeKinds()` stays empty.

## 3. `env.schema.repo` — decoded by the community build, then unused by it

Same env, same commands, run with and without `schema { repo { name = "myapp" } }`:

- `schema inspect --env local` — byte-identical
- `schema apply --env local --dry-run` — byte-identical, both when in sync and when a table is pending
- `schema apply --env local --auto-approve` on a fresh database, then again after adding a column — byte-identical both times
- `schema inspect --url atlas://myapp` — identical refusal either way: `atlas remote state is not supported by the community version of Atlas`

So the obligation is the decode, not a behavior:

```
schema { repo { name = 1 } }   -> rc 1  value of attr "name" cannot be read as string
schema { repo { name = "x" } } -> rc 0
schema { repo { } }            -> rc 0
schema { repo { name = "x" frobnicate = 1 } } -> rc 0
```

Ptah now type-checks `name` as a string, tolerates unknown attributes inside `repo`, and acts on the value nowhere — which is exact parity. Registry access itself stays refused on both sides; `ptah-compat schema inspect --url atlas://myapp` and `ptah-compat schema plan --repo atlas://myapp` were both re-run to confirm they still fail.

## Parity after the change

Same migration directory and equivalent configs on both binaries:

```
atlas       migrate lint --env skip_drop_schema -c file://ce-dropschema.hcl   -> rc 0
ptah-compat migrate lint --env skip_drop_schema -c file://dropschema.hcl      -> rc 0
atlas       migrate lint --env repo -c file://ce-repo.hcl                     -> rc 0
ptah-compat migrate lint --env repo -c file://repo.hcl                        -> rc 0
```

Reports are identical apart from durations. Before this change `ptah-compat` printed, on the same files:

```
Error: unsupported atlas.hcl construct "drop_schema" at dropschema.hcl:4
Error: unsupported atlas.hcl construct "repo" at repo.hcl:3
Error: unsupported atlas.hcl construct "condrop" at atlas.hcl:10
```

## What each new test prints if the change is reverted

`cmd/atlas/migrate_lint_condrop_test.go`

- `TestCompatCommand_MigrateLintCondropSeverity` — all four rows print `unsupported atlas.hcl construct "condrop" at atlas.hcl:10` and exit 1, including the two rows that name no condrop block: env bodies are structure-validated up front, so one construct poisons the whole file. Measured on the pre-change binary over this exact config; no row renders a lint report.
- `TestCompatCommand_MigrateLintRunsWithDropSchemaConfigured` — prints `unsupported atlas.hcl construct "drop_schema" at atlas.hcl:4` and exits 1 instead of the asserted report.
- `TestCompatCommand_MigrateLintRunsWithSchemaRepoConfigured` — prints `unsupported atlas.hcl construct "repo" at atlas.hcl:3` and exits 1 instead of the asserted report.

`config/projectconfig/atlas_ce_enforced_test.go`

- `TestParseAtlasLintCondropSeverity` — each row returns `unsupported atlas.hcl construct "condrop"` where it expects `cfg.Lint.RuleConfigs["CD"].Severity` and `["DS105"].Severity`.
- `TestParseAtlasLintCondropRejectsNonBool` — message changes from `atlas.hcl "error" at atlas.hcl:3 must be a bool` to `unsupported atlas.hcl construct "condrop"`.
- `TestParseAtlasDiffSkipDropSchema` — returns `unsupported atlas.hcl construct "drop_schema"` where it expects `ConfigBool{Value: …, Set: true}`; the env-overrides-global row loses its merge assertion too.
- `TestParseAtlasDiffSkipDropSchemaRejectsNonBool` — env-scoped row's message changes from `must be a bool` to `unsupported atlas.hcl construct "drop_schema"` (the global row already produced the bool message, which is why the env row is in the table).
- `TestParseAtlasSchemaRepo` — every row returns `unsupported atlas.hcl construct "repo"` where it expects `cfg.Schema.Repo.Name`.
- `TestParseAtlasSchemaRepoRejectsNonString` — message changes from `atlas.hcl "name" at atlas.hcl:5 must be a string` to `unsupported atlas.hcl construct "repo"`.

Two further mutations were run to check the condrop selector is narrow enough, since a fixture where both candidate answers coincide proves nothing:

- `condrop` → `DD` instead of the constraint family: only `condrop downgrades the foreign-key drop` failed (exit 1, wanted 0).
- `destructive` widened to `"DS", "CD"`: only `destructive leaves the foreign-key drop alone` failed (exit 0, wanted 1).

The four rows share one `atlas.hcl` and one `--dir`; the report body is identical in all of them, so the summary line (`-- 1 version with errors` vs `-- 1 version with warnings`) is the byte-level evidence and the exit code is the discriminator.

## Deliberately NOT done

- **`destructive` still maps to the `DS` prefix, which covers DS105.** The community binary's destructive analyzer does not own constraint drops, so Ptah's is broader. Narrowing it is a separate decision about an existing construct; exact-code precedence in `ruleConfigForCode` already lets an explicit `condrop` entry win over the `DS` prefix when both blocks appear.
- **Label arity stays refused.** `condrop "x" { … }` and `repo "x" { … }` are honored by the community binary and refused by Ptah. That is the parser-wide policy already documented at `atlas_structure.go`, not anything specific to these three.
- **Duplicate analyzer blocks stay refused.** Measured: the community binary accepts `condrop { error = true }` followed by `condrop { error = false }` and honors the first. Ptah refuses, exactly as it already does for a duplicate `destructive` block. Stricter, which is the safe direction; the test row records the measurement so the divergence is not mistaken for agreement.
- **Ptah's realm-scoped `schema apply` still does not see schemas absent from the desired state.** Over the fixture where the community binary plans `DROP SCHEMA "extra" CASCADE;`, `ptah-compat` reports the schema is synced. That is why `drop_schema` is vacuous, and it is a separate gap — closing it means teaching the schema diff about schema removal, which is well outside this issue.
- **`lint.condrop`'s `force` attribute** is tolerated and ignored, the same as on every other analyzer block. Unchanged.

## Gates

`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, and — because `docs/` is touched — `node docs/site/scripts/check-style.mjs` and `node docs/site/scripts/build-feature-matrix.mjs --check`: all exit 0.

`go test ./... -count=1`: 175 packages ok, one failure that is not this change — `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` reports `render SVG with Graphviz dot: signal: killed`. `cmd/viz/viz.go:111` puts a hard 10-second deadline on the `dot` subprocess, and the failure only appears when several full suites run concurrently on the same machine; the fake `dot` script never gets scheduled inside the deadline. Run on its own the package is green, including `-count=5` on that single test. Reported rather than papered over.