### PR TITLE
fix(lint): report every object a multi-target statement affects

### DIFF
--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -110,10 +110,62 @@ func TestRunLint_DefaultTextKeepsNativePtahDiagnostics(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(stderr, qt.Equals, "")
-	c.Assert(stdout, qt.Contains, "DROP TABLE permanently deletes the table and every row in it")
+	c.Assert(stdout, qt.Contains, "DROP TABLE permanently deletes table users and every row in it")
 	c.Assert(stdout, qt.Contains, "verified backup first and consider a rename-and-retire window instead")
 	c.Assert(stdout, qt.Not(qt.Contains), `Dropping table "users"`)
 	c.Assert(stdout, qt.Not(qt.Contains), "https://atlasgo.io/lint/analyzers")
+}
+
+// sarifResultMessagesOf collects each SARIF result's message text, in order.
+func sarifResultMessagesOf(results []sarifResultForTest) []string {
+	messages := make([]string, 0, len(results))
+	for _, result := range results {
+		messages = append(messages, result.Message.Text)
+	}
+	return messages
+}
+
+// distinctSARIFFingerprints collects the set of primary-location fingerprints
+// across results.
+func distinctSARIFFingerprints(results []sarifResultForTest) map[string]struct{} {
+	fingerprints := make(map[string]struct{}, len(results))
+	for _, result := range results {
+		fingerprints[result.PartialFingerprints["primaryLocationLineHash"]] = struct{}{}
+	}
+	return fingerprints
+}
+
+// TestRunLint_MultiTargetDropFingerprintsEveryTable pins the SARIF consequence
+// of reporting one finding per dropped table. All three results share a rule, a
+// file and a line, so their fingerprints can only differ through the message.
+// Were the three to carry one shared message, GitHub code scanning would fold
+// them into a single alert and two of the three destroyed tables would never
+// reach the security tab.
+func TestRunLint_MultiTargetDropFingerprintsEveryTable(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	writeLintTestFile(c, dir, "0000000001_init.up.sql",
+		"CREATE TABLE mid (id INT);\nCREATE TABLE zeta (id INT);\nCREATE TABLE alpha (id INT);\n")
+	writeLintTestFile(c, dir, "0000000001_init.down.sql", "DROP TABLE alpha;\n")
+	writeLintTestFile(c, dir, "0000000002_drop.up.sql", "DROP TABLE zeta, alpha, mid;\n")
+	writeLintTestFile(c, dir, "0000000002_drop.down.sql", "CREATE TABLE mid (id INT);\n")
+
+	stdout, _, err := execute("--dir", dir, "--dir-format", "ptah", "--format", "sarif", "--fail-on", "none")
+
+	c.Assert(err, qt.IsNil)
+	assertSARIFSchemaValid(c, stdout)
+	var report sarifForTest
+	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
+	results := report.Runs[0].Results
+	c.Assert(sarifResultMessagesOf(results), qt.DeepEquals, []string{
+		"table dropped: DROP TABLE permanently deletes table alpha and every row in it; " +
+			"take a verified backup first and consider a rename-and-retire window instead",
+		"table dropped: DROP TABLE permanently deletes table mid and every row in it; " +
+			"take a verified backup first and consider a rename-and-retire window instead",
+		"table dropped: DROP TABLE permanently deletes table zeta and every row in it; " +
+			"take a verified backup first and consider a rename-and-retire window instead",
+	})
+	c.Assert(distinctSARIFFingerprints(results), qt.HasLen, 3)
 }
 
 func TestRunLint_CuratedFixtureProducesExpectedRuleHits(t *testing.T) {

--- a/cmd/lint/testdata/sarif/expected.sarif.json
+++ b/cmd/lint/testdata/sarif/expected.sarif.json
@@ -32,7 +32,7 @@
           "ruleIndex": 0,
           "level": "error",
           "message": {
-            "text": "table dropped: DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead"
+            "text": "table dropped: DROP TABLE permanently deletes table users and every row in it; take a verified backup first and consider a rename-and-retire window instead"
           },
           "locations": [
             {
@@ -48,7 +48,7 @@
             }
           ],
           "partialFingerprints": {
-            "primaryLocationLineHash": "0f47f9683f61183796e0c41055e31d99"
+            "primaryLocationLineHash": "618fc9eb376f3327f08df40af6c57535"
           }
         }
       ]

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -615,6 +615,24 @@ suggested-fix layout. Ptah-only diagnostics remain visibly labeled and do not
 link to unproven Atlas analyzer codes. Native `ptah migrations lint` keeps
 Ptah's more detailed diagnostic prose and remediation guidance.
 
+A statement affecting several objects reports per object, and the two
+destructive shapes are not the same:
+
+- A `DROP TABLE` naming several tables produces one diagnostic and one suggested
+  fix per dropped table, ordered by table name compared byte-wise, so the
+  suggested-fix header pluralizes and the diagnostic count rises with the number
+  of tables.
+- One `ALTER TABLE` dropping several columns produces one diagnostic naming
+  every dropped column in clause order, under a single suggested fix.
+- One `ALTER TABLE` adding several non-nullable columns without a default
+  produces one diagnostic per column, in clause order.
+
+Native `ptah migrations lint` splits its findings the same way, so the two
+surfaces never disagree about how many objects a statement affects. Each
+per-object finding names its object in the native message, which is also what
+keeps each SARIF result's fingerprint distinct when several of them share a
+rule, a file, and a line.
+
 The report is written to stdout even when findings fail, and error-severity
 findings still exit with code 1. The native `ptah migrations lint` output is
 unchanged. Custom output is selected by `--format`, by `format.migrate.lint`,

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -264,7 +264,7 @@ with `--allow-destructive` after review:
 
 ```text
 error: error running migrations: pending migrations contain destructive statements; rerun with --allow-destructive after review:
-- 0000000003_drop_users.up.sql:1 DS101 error: DROP TABLE permanently deletes the table and every row in it; ...
+- 0000000003_drop_users.up.sql:1 DS101 error: DROP TABLE permanently deletes table users and every row in it; ...
 ```
 
 Both gates are covered in depth in

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -348,7 +348,7 @@ ptah migrations lint --dir ./migrations --dialect sqlite
 A finding names the file, line, rule, and remediation (exit `1`):
 
 ```text
-migrations/0000000003_drop_users.up.sql:1 [error] DS101: DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead (table dropped)
+migrations/0000000003_drop_users.up.sql:1 [error] DS101: DROP TABLE permanently deletes table users and every row in it; take a verified backup first and consider a rename-and-retire window instead (table dropped)
 
 1 finding(s).
 ```
@@ -458,7 +458,7 @@ Destructive statements require explicit policy at two points:
 
 ```text
 error: error running migrations: pending migrations contain destructive statements; rerun with --allow-destructive after review:
-- 0000000003_drop_users.up.sql:1 DS101 error: DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead
+- 0000000003_drop_users.up.sql:1 DS101 error: DROP TABLE permanently deletes table users and every row in it; take a verified backup first and consider a rename-and-retire window instead
 ```
 
 Use `--allow-destructive` only after the plan has been reviewed and the

--- a/integration/atlas_migrate_lint_multi_target_e2e_test.go
+++ b/integration/atlas_migrate_lint_multi_target_e2e_test.go
@@ -1,0 +1,155 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+var (
+	lintE2EOkDurationRe    = regexp.MustCompile(`-- ok \([^)]+\)`)
+	lintE2ETotalDurationRe = regexp.MustCompile(`(?m)^(  -------------------------\n  -- ).+$`)
+)
+
+// redactLintE2EDurations replaces the non-deterministic elapsed durations in the
+// default migrate lint text report with "DUR" so the rest is asserted exactly.
+func redactLintE2EDurations(s string) string {
+	s = lintE2EOkDurationRe.ReplaceAllString(s, "-- ok (DUR)")
+	return lintE2ETotalDurationRe.ReplaceAllString(s, "${1}DUR")
+}
+
+func writeLintE2EFile(c *qt.C, dir, name, body string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600), qt.IsNil)
+}
+
+// runLintE2EBinary runs the built binary with stdout and stderr kept apart, so
+// a report assertion cannot be satisfied by text that was actually a diagnostic
+// on the error stream.
+func runLintE2EBinary(ctx context.Context, binaryPath string, args ...string) (stdout, stderr string, err error) {
+	cmd := exec.CommandContext(ctx, binaryPath, args...)
+	var out, errOut bytes.Buffer
+	cmd.Stdout = &out
+	cmd.Stderr = &errOut
+	err = cmd.Run()
+	return out.String(), errOut.String(), err
+}
+
+// TestAtlasMigrateLintMultiTargetDropE2E covers issue #1074 part 2 against a
+// live PostgreSQL dev database, which is the only place the behavior is
+// reachable end to end: SQLite rejects `DROP TABLE a, b` outright, so the
+// replay step fails before any analyzer runs and the unit-level compat tests
+// cannot carry this fixture.
+//
+// The tables live in the schema the dev URL actually covers. Objects in a
+// schema outside it are a separate axis entirely -- both tools change behavior
+// there for reasons that have nothing to do with how many targets a statement
+// names -- so a fixture built that way would measure schema scope and report it
+// as a multi-target result.
+//
+// The single-target case is the control. Both statements are destructive, both
+// exit 1, and both report; only the number of tables named moves. Without it,
+// a fixture that reported nothing at all would look like a pass for the wrong
+// reason.
+//
+// Three tables rather than two, deliberately: created mid/zeta/alpha and
+// dropped zeta/alpha/mid, so source order, creation order and reverse creation
+// order each give a different answer, and only one of them is the order below.
+func TestAtlasMigrateLintMultiTargetDropE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah-compat")
+	buildPtahCompat(c, ctx, repoRoot, binaryPath)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	tests := []struct {
+		name string
+		drop string
+		want string
+	}{
+		{
+			name: "single target",
+			drop: "DROP TABLE zeta;\n",
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"zeta\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"zeta\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name: "three targets",
+			drop: "DROP TABLE zeta, alpha, mid;\n",
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"alpha\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"mid\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"zeta\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"alpha\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"mid\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"zeta\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 3 schema changes\n" +
+				"  -- 3 diagnostics\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			testDBName := fmt.Sprintf("ptah_lint_mt_e2e_%d", time.Now().UnixNano())
+			createE2EDatabase(c, ctx, adminDB, testDBName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+			migrationsDir := c.TempDir()
+			writeLintE2EFile(c, migrationsDir, "1.sql",
+				"CREATE TABLE mid (id int);\nCREATE TABLE zeta (id int);\nCREATE TABLE alpha (id int);\n")
+			writeLintE2EFile(c, migrationsDir, "2.sql", test.drop)
+
+			stdout, stderr, err := runLintE2EBinary(ctx, binaryPath,
+				"migrate", "lint",
+				"--dir", "file://"+migrationsDir,
+				"--dev-url", replaceDatabaseName(c, dbURL, testDBName),
+				"--latest", "1",
+			)
+
+			c.Assert(err, qt.ErrorMatches, "exit status 1")
+			c.Assert(stderr, qt.Equals, "")
+			c.Assert(redactLintE2EDurations(stdout), qt.Equals, test.want)
+		})
+	}
+}

--- a/internal/atlasreport/migrate_lint_atlas_text.go
+++ b/internal/atlasreport/migrate_lint_atlas_text.go
@@ -47,7 +47,7 @@ const atlasAnalyzerDocsURL = "https://atlasgo.io/lint/analyzers#"
 // native message is used unchanged -- being wordier than Atlas is a smaller
 // divergence than inventing a sentence Atlas never prints.
 func atlasDiagnosticText(code string, finding migrationlint.Finding) (atlasDiagnosticCopy, bool) {
-	subject := atlasPrimarySubject(finding)
+	subject := atlasSoleSubject(finding)
 	switch code {
 	case "DS102":
 		if subject == nil || subject.Name == "" {
@@ -64,16 +64,27 @@ func atlasDiagnosticText(code string, finding migrationlint.Finding) (atlasDiagn
 			fixWidth:     atlasDS102FixWidth,
 		}, true
 	case "DS103":
-		if subject == nil || subject.Name == "" {
-			return atlasDiagnosticCopy{}, false
-		}
-		name, ok := atlasIdentifierName(subject.Name)
+		// One ALTER TABLE that drops several columns is ONE diagnostic naming
+		// all of them, not one per column -- the opposite of DS102, and
+		// measured that way rather than assumed. The nouns and the trailing
+		// pronoun move with the count, so both forms are spelled out here
+		// instead of being derived from the single-column string.
+		names, ok := atlasIdentifierNames(finding)
 		if !ok {
 			return atlasDiagnosticCopy{}, false
 		}
+		if len(names) == 1 {
+			return atlasDiagnosticCopy{
+				message:      fmt.Sprintf("Dropping non-virtual column %q", names[0]),
+				fix:          fmt.Sprintf("Add a pre-migration check to ensure column %q is NULL before dropping it", names[0]),
+				messageWidth: atlasDS103MessageWidth,
+				fixWidth:     lintWrapWidth,
+			}, true
+		}
+		list := atlasQuotedList(names)
 		return atlasDiagnosticCopy{
-			message:      fmt.Sprintf("Dropping non-virtual column %q", name),
-			fix:          fmt.Sprintf("Add a pre-migration check to ensure column %q is NULL before dropping it", name),
+			message:      fmt.Sprintf("Dropping non-virtual columns %s", list),
+			fix:          fmt.Sprintf("Add pre-migration checks to ensure columns %s are NULL before dropping them", list),
 			messageWidth: atlasDS103MessageWidth,
 			fixWidth:     lintWrapWidth,
 		}, true
@@ -134,10 +145,49 @@ func atlasDataType(value string) (string, bool) {
 	return "", false
 }
 
-// atlasPrimarySubject returns the schema object a diagnostic is about.
-func atlasPrimarySubject(finding migrationlint.Finding) *migrationlint.Subject {
-	if finding.Context == nil || len(finding.Context.Subjects) == 0 {
+// atlasSoleSubject returns the schema object a one-object diagnostic is about.
+//
+// DS102 and MF103 are one diagnostic per object, so the analyzers emit one
+// finding per object and a finding carrying several of them is a shape this
+// wording cannot render. It returns nil in that case, which drops the caller to
+// Ptah's own labeled prose. The alternative -- rendering the first subject --
+// is what hid the other dropped tables: silently narrowing a destructive
+// finding to one of its objects reads as complete output and is not.
+func atlasSoleSubject(finding migrationlint.Finding) *migrationlint.Subject {
+	if finding.Context == nil || len(finding.Context.Subjects) != 1 {
 		return nil
 	}
 	return &finding.Context.Subjects[0]
+}
+
+// atlasIdentifierNames returns every subject's logical name. It fails as a unit
+// so a diagnostic naming several objects can never render a partial list.
+func atlasIdentifierNames(finding migrationlint.Finding) ([]string, bool) {
+	if finding.Context == nil || len(finding.Context.Subjects) == 0 {
+		return nil, false
+	}
+	names := make([]string, 0, len(finding.Context.Subjects))
+	for _, subject := range finding.Context.Subjects {
+		if subject.Name == "" {
+			return nil, false
+		}
+		name, ok := atlasIdentifierName(subject.Name)
+		if !ok {
+			return nil, false
+		}
+		names = append(names, name)
+	}
+	return names, true
+}
+
+// atlasQuotedList renders two or more names as the measured prose list:
+// comma-separated, with "and" before the last. Callers handle the single-name
+// case, whose surrounding sentence differs by more than the separator.
+func atlasQuotedList(names []string) string {
+	quoted := make([]string, 0, len(names))
+	for _, name := range names {
+		quoted = append(quoted, fmt.Sprintf("%q", name))
+	}
+	last := len(quoted) - 1
+	return strings.Join(quoted[:last], ", ") + " and " + quoted[last]
 }

--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -91,6 +91,50 @@ func TestAtlasDiagnosticText_FallsBackForUnmeasuredSubjects(t *testing.T) {
 	}
 }
 
+// TestAtlasDiagnosticText_FallsBackForMultiSubjectSingleObjectCodes pins the
+// fail-closed direction for the two codes that are one diagnostic per object.
+// A finding carrying several objects is a shape this wording cannot render, and
+// the safe answer is Ptah's own labeled prose naming all of them -- NOT the
+// first subject. Rendering the first is precisely how the other dropped tables
+// went missing: narrowing a destructive finding to one of its objects reads as
+// complete output and is not.
+func TestAtlasDiagnosticText_FallsBackForMultiSubjectSingleObjectCodes(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name     string
+		code     string
+		subjects []migrationlint.Subject
+	}{
+		{
+			name: "two dropped tables in one finding",
+			code: "DS102",
+			subjects: []migrationlint.Subject{
+				{Kind: migrationlint.SubjectTable, Name: "users"},
+				{Kind: migrationlint.SubjectTable, Name: "audit_log"},
+			},
+		},
+		{
+			name: "two added non-nullable columns in one finding",
+			code: "MF103",
+			subjects: []migrationlint.Subject{
+				{Kind: migrationlint.SubjectColumn, Name: "a", Parent: "t", DataType: "int"},
+				{Kind: migrationlint.SubjectColumn, Name: "b", Parent: "t", DataType: "int"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diagnostic, mapped := atlasDiagnosticText(test.code, migrationlint.Finding{
+				Context: &migrationlint.FindingContext{Subjects: test.subjects},
+			})
+
+			c.Assert(mapped, qt.IsFalse)
+			c.Assert(diagnostic, qt.Equals, atlasDiagnosticCopy{})
+		})
+	}
+}
+
 // analyzeMigrations builds a lint analysis for the given migration files,
 // selecting the latest N versions exactly as the migrate lint command does.
 func analyzeMigrations(t *testing.T, files map[string]string, latest int) migrationlint.Analysis {
@@ -170,6 +214,119 @@ func TestWriteMigrateLintText_RendersAtlasDiagnostics(t *testing.T) {
 				"  -- 1 version with errors\n" +
 				"  -- 2 schema changes\n" +
 				"  -- 2 diagnostics\n",
+		},
+		{
+			// Measured, not derived. Three tables created mid/zeta/alpha and
+			// dropped zeta/alpha/mid: source order, creation order and reverse
+			// creation order each give a different answer, so this is the
+			// smallest fixture that shows the order is the table name. The fix
+			// header pluralizes with the count, which a one-diagnostic fixture
+			// cannot show.
+			name: "multi-target drop is one diagnostic per table",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE mid (id int);\nCREATE TABLE zeta (id int);\nCREATE TABLE alpha (id int);\n",
+				"2.sql": "DROP TABLE zeta, alpha, mid;\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"alpha\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"mid\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"zeta\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"alpha\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"mid\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"zeta\" is empty before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 3 schema changes\n" +
+				"  -- 3 diagnostics\n",
+		},
+		{
+			// Dropped COLUMNS go the other way from dropped tables: ONE
+			// diagnostic naming all of them, in clause order, with one fix.
+			// Measured, because it cannot be inferred from the table case --
+			// the two shapes are opposites.
+			name: "multi-column drop is one diagnostic naming every column",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE t (id int, zeta int, alpha int, mid int);\n",
+				"2.sql": "ALTER TABLE t DROP COLUMN zeta, DROP COLUMN alpha, DROP COLUMN mid;\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual columns \"zeta\", \"alpha\" and \"mid\"\n" +
+				"         https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add pre-migration checks to ensure columns \"zeta\", \"alpha\" and \"mid\" are NULL before\n" +
+				"         dropping them\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 3 schema changes\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			// Two columns separate the list separator from the conjunction: at
+			// three the list carries both a comma and an "and", at two only the
+			// "and". A three-column fixture alone cannot tell a ", "-joined
+			// list from one that also puts "and" before the last element.
+			name: "two-column drop joins the pair with and",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE t (id int, zeta int, alpha int);\n",
+				"2.sql": "ALTER TABLE t DROP COLUMN zeta, DROP COLUMN alpha;\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual columns \"zeta\" and \"alpha\"\n" +
+				"         https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add pre-migration checks to ensure columns \"zeta\" and \"alpha\" are NULL before dropping\n" +
+				"         them\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			// The single-column control: the nouns and the trailing pronoun are
+			// singular, which is what shows the plural forms above are keyed to
+			// the count rather than always printed.
+			name: "single-column drop keeps the singular wording",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE t (id int, zeta int);\n",
+				"2.sql": "ALTER TABLE t DROP COLUMN zeta;\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"zeta\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"zeta\" is NULL before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
 		},
 		{
 			name:   "destructive latest 1",

--- a/migration/lint/analysis_test.go
+++ b/migration/lint/analysis_test.go
@@ -179,6 +179,45 @@ func TestAnalyzeFS_SameLineStatementsHaveStableContexts(t *testing.T) {
 	c.Assert(findings[1].Context.StatementIndex, qt.Equals, 1)
 }
 
+// subjectsOf collects each finding's subjects, keeping finding order. Comparing
+// the nested slice in one assertion pins how many findings there are, how many
+// objects each carries, and their order together; a per-finding loop of
+// separate assertions can stay green while the findings are split the wrong way.
+func subjectsOf(findings []lint.Finding) [][]lint.Subject {
+	subjects := make([][]lint.Subject, 0, len(findings))
+	for _, finding := range findings {
+		subjects = append(subjects, finding.Context.Subjects)
+	}
+	return subjects
+}
+
+// messagesOf collects finding messages, keeping finding order.
+func messagesOf(findings []lint.Finding) []string {
+	messages := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		messages = append(messages, finding.Message)
+	}
+	return messages
+}
+
+// statementIndexesOf collects the analyzed statement each finding belongs to.
+func statementIndexesOf(findings []lint.Finding) []int {
+	indexes := make([]int, 0, len(findings))
+	for _, finding := range findings {
+		indexes = append(indexes, finding.Context.StatementIndex)
+	}
+	return indexes
+}
+
+// subjectNamesOf collects the name of each finding's first subject.
+func subjectNamesOf(findings []lint.Finding) []string {
+	names := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		names = append(names, finding.Context.Subjects[0].Name)
+	}
+	return names
+}
+
 func TestAnalyzeFS_MultiTargetDropReportsOnlyUnsafeTables(t *testing.T) {
 	c := qt.New(t)
 	fsys := fixture(map[string]string{
@@ -191,12 +230,11 @@ func TestAnalyzeFS_MultiTargetDropReportsOnlyUnsafeTables(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	findings := analysis.Findings()
-	c.Assert(findings, qt.HasLen, 1)
-	c.Assert(findings[0].Rule, qt.Equals, "DS101")
-	c.Assert(findings[0].Context.StatementIndex, qt.Equals, 1)
-	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
-		{Kind: lint.SubjectTable, Name: "users"},
-		{Kind: lint.SubjectTable, Name: "audit_log"},
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101", "DS101"})
+	c.Assert(statementIndexesOf(findings), qt.DeepEquals, []int{1, 1})
+	c.Assert(subjectsOf(findings), qt.DeepEquals, [][]lint.Subject{
+		{{Kind: lint.SubjectTable, Name: "audit_log"}},
+		{{Kind: lint.SubjectTable, Name: "users"}},
 	})
 }
 
@@ -212,11 +250,186 @@ func TestAnalyzeFS_DropTableSubjectsPreserveIdentifierSpelling(t *testing.T) {
 	})
 
 	c.Assert(err, qt.IsNil)
+	c.Assert(subjectsOf(analysis.Findings()), qt.DeepEquals, [][]lint.Subject{
+		{{Kind: lint.SubjectTable, Name: `"Users"`}},
+		{{Kind: lint.SubjectTable, Name: `public."users"`}},
+	})
+}
+
+// TestAnalyzeFS_MultiTargetDropReportsEveryDroppedTable pins what a DROP TABLE
+// with several targets analyzes into: one finding per destroyed table, each
+// carrying exactly the table it is about.
+//
+// The three tables are created in one order (mid, zeta, alpha), dropped in a
+// second (zeta, alpha, mid), and sort into a third (alpha, mid, zeta), so
+// source order, creation order and reverse creation order each give a different
+// answer here. Two tables cannot separate those three candidates; this is the
+// smallest fixture that can.
+//
+// The single-target row is the control. It is green both before and after this
+// behavior existed, which is what shows the multi-target row is measuring
+// target count rather than something the two fixtures share.
+func TestAnalyzeFS_MultiTargetDropReportsEveryDroppedTable(t *testing.T) {
+	tests := []struct {
+		name  string
+		drop  string
+		rules []string
+		want  [][]lint.Subject
+	}{
+		{
+			name:  "single target is one finding",
+			drop:  "DROP TABLE zeta;",
+			rules: []string{"DS101"},
+			want:  [][]lint.Subject{{{Kind: lint.SubjectTable, Name: "zeta"}}},
+		},
+		{
+			name:  "every target is its own finding, ordered by name",
+			drop:  "DROP TABLE zeta, alpha, mid;",
+			rules: []string{"DS101", "DS101", "DS101"},
+			want: [][]lint.Subject{
+				{{Kind: lint.SubjectTable, Name: "alpha"}},
+				{{Kind: lint.SubjectTable, Name: "mid"}},
+				{{Kind: lint.SubjectTable, Name: "zeta"}},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			fsys := fixture(map[string]string{
+				"1_init.sql": "CREATE TABLE mid (id INTEGER);\nCREATE TABLE zeta (id INTEGER);\nCREATE TABLE alpha (id INTEGER);",
+				"2_drop.sql": test.drop,
+			})
+
+			analysis, err := lint.AnalyzeFS(fsys, lint.Options{DirFormat: migrator.MigrationDirFormatAtlas})
+
+			c.Assert(err, qt.IsNil)
+			findings := analysis.Findings()
+			c.Assert(rulesOf(findings), qt.DeepEquals, test.rules)
+			c.Assert(subjectsOf(findings), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_MultiTargetDropNamesEachTableInItsMessage pins that the
+// per-target findings are distinguishable by message alone. Renderers that read
+// only the message -- the native text report, GitHub annotations, and SARIF,
+// whose result fingerprint is derived from rule, file, line and message -- would
+// otherwise emit N indistinguishable copies of one statement, and a consumer
+// that de-duplicates by fingerprint would drop every table but one.
+func TestAnalyzeFS_MultiTargetDropNamesEachTableInItsMessage(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_init.sql": "CREATE TABLE zeta (id INTEGER);\nCREATE TABLE alpha (id INTEGER);",
+		"2_drop.sql": `DROP TABLE zeta, public."Alpha";`,
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(messagesOf(analysis.Findings()), qt.DeepEquals, []string{
+		`DROP TABLE permanently deletes table public."Alpha" and every row in it; ` +
+			"take a verified backup first and consider a rename-and-retire window instead",
+		"DROP TABLE permanently deletes table zeta and every row in it; " +
+			"take a verified backup first and consider a rename-and-retire window instead",
+	})
+}
+
+// TestAnalyzeFS_MultiTargetDropOrdersByLogicalName pins the sort key against the
+// two candidates that reproduce all-lowercase unqualified fixtures identically:
+// a case-folding comparison, and a comparison of the reference as written.
+func TestAnalyzeFS_MultiTargetDropOrdersByLogicalName(t *testing.T) {
+	tests := []struct {
+		name string
+		drop string
+		want []string
+	}{
+		{
+			// Byte-wise, "Mid" and "Zeta" lead. Case-folded, alpha leads.
+			name: "uppercase sorts ahead of lowercase",
+			drop: `DROP TABLE "Zeta", alpha, "Mid";`,
+			want: []string{`"Mid"`, `"Zeta"`, "alpha"},
+		},
+		{
+			// By logical name: aaa then bbb. By the reference as written,
+			// "public.aaa" would sort after "bbb".
+			name: "qualification is not part of the key",
+			drop: "DROP TABLE public.aaa, bbb;",
+			want: []string{"public.aaa", "bbb"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			fsys := fixture(map[string]string{"1_drop.sql": test.drop})
+
+			analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+				DirFormat: migrator.MigrationDirFormatAtlas,
+				Dialect:   "postgres",
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(subjectNamesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_UnparsableDropTargetsStillReport keeps the fail-closed path
+// intact: a DROP TABLE whose target list cannot be read to the end still
+// reports, as one subject-less finding. Splitting per target must not turn "no
+// target recovered" into "nothing to report".
+func TestAnalyzeFS_UnparsableDropTargetsStillReport(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{"1_drop.sql": "DROP TABLE IF EXISTS;"})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{DirFormat: migrator.MigrationDirFormatAtlas})
+
+	c.Assert(err, qt.IsNil)
 	findings := analysis.Findings()
-	c.Assert(findings, qt.HasLen, 1)
-	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{
-		{Kind: lint.SubjectTable, Name: `"Users"`},
-		{Kind: lint.SubjectTable, Name: `public."users"`},
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DS101"})
+	c.Assert(subjectsOf(findings), qt.DeepEquals, [][]lint.Subject{nil})
+	c.Assert(messagesOf(findings), qt.DeepEquals, []string{
+		"DROP TABLE permanently deletes the table and every row in it; " +
+			"take a verified backup first and consider a rename-and-retire window instead",
+	})
+}
+
+// TestAnalyzeFS_MultiClauseAddNotNullReportsEveryColumn is the ADD-side analogue
+// of [TestAnalyzeFS_MultiTargetDropReportsEveryDroppedTable]: each added column
+// fails against existing rows independently, so each is its own finding. Unlike
+// dropped tables these keep clause order, which is why the fixture writes them
+// out of alphabetical order -- sorting them would fail this test.
+func TestAnalyzeFS_MultiClauseAddNotNullReportsEveryColumn(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"1_init.sql": "CREATE TABLE t (id INTEGER);",
+		"2_add.sql":  "ALTER TABLE t ADD COLUMN zeta int NOT NULL, ADD COLUMN alpha int NOT NULL;",
+	})
+
+	analysis, err := lint.AnalyzeFS(fsys, lint.Options{
+		DirFormat: migrator.MigrationDirFormatAtlas,
+		Dialect:   "postgres",
+	})
+
+	c.Assert(err, qt.IsNil)
+	findings := analysis.Findings()
+	c.Assert(rulesOf(findings), qt.DeepEquals, []string{"DD101", "DD101"})
+	c.Assert(subjectsOf(findings), qt.DeepEquals, [][]lint.Subject{
+		{{Kind: lint.SubjectColumn, Name: "zeta", Parent: "t", DataType: "int"}},
+		{{Kind: lint.SubjectColumn, Name: "alpha", Parent: "t", DataType: "int"}},
+	})
+	c.Assert(messagesOf(findings), qt.DeepEquals, []string{
+		"adding NOT NULL column zeta without a DEFAULT fails or blocks on populated tables; " +
+			"add it nullable, backfill, then enforce NOT NULL in a later migration",
+		"adding NOT NULL column alpha without a DEFAULT fails or blocks on populated tables; " +
+			"add it nullable, backfill, then enforce NOT NULL in a later migration",
 	})
 }
 

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -7,6 +7,8 @@ import (
 	"sync"
 	"unicode"
 	"unicode/utf8"
+
+	"go.5x5.cz/ptah/internal/tableref"
 )
 
 var registeredRules = struct {
@@ -140,6 +142,10 @@ func constraintDeletionRules() []Rule {
 	}
 }
 
+// tableDroppedAdvice is the remediation every DS101 finding carries, kept in one
+// place because the named and unnamed message forms must not drift apart.
+const tableDroppedAdvice = "take a verified backup first and consider a rename-and-retire window instead"
+
 func tableDroppedRule() Rule {
 	return Rule{
 		Code:     "DS101",
@@ -167,23 +173,75 @@ func tableDroppedRule() Rule {
 				if complete && len(unsafeTables) == 0 {
 					continue
 				}
-				subjects := make([]Subject, len(unsafeTables))
-				for j, table := range unsafeTables {
-					subjects[j] = Subject{Kind: SubjectTable, Name: table.name}
-				}
-				findings = append(findings, Finding{
-					Rule:     "DS101",
-					Title:    "table dropped",
-					Severity: SeverityError,
-					File:     file.Path,
-					Line:     stmt.Line,
-					Message:  "DROP TABLE permanently deletes the table and every row in it; take a verified backup first and consider a rename-and-retire window instead",
-					Context:  statementFindingContext(i, subjects...),
-				})
+				findings = append(findings, tableDroppedFindings(file.Path, stmt.Line, i, unsafeTables)...)
 			}
 			return findings
 		},
 	}
+}
+
+// tableDroppedFindings reports one finding per table a single DROP TABLE
+// destroys.
+//
+// `DROP TABLE a, b` destroys two tables independently, so it is two findings,
+// not one finding that happens to carry two subjects. The collapsed shape was
+// reported as one finding, and every renderer that reads a finding's primary
+// subject then showed only the first table -- on a destructive-change analyzer,
+// an operator reviewing a release was never told that `b` was going away
+// either. Per-target findings also give each table its own message, which is
+// what keeps the per-finding SARIF fingerprint (rule, file, line, message)
+// distinct so a code-scanning consumer cannot dedupe the other tables away.
+//
+// Targets are ordered by their logical name -- unqualified and unquoted --
+// compared byte-wise, which puts "Mid" and "Zeta" ahead of "alpha". The order a
+// comma list is written in carries no meaning, so a stable one makes the report
+// diffable, and this is the order measured from the destructive-change analyzer
+// this tool is compatible with.
+//
+// A target list that could not be parsed to the end yields one subject-less
+// finding: the statement is still destructive, and failing closed keeps it
+// reported rather than letting an unreadable target silence the rule.
+func tableDroppedFindings(filePath string, line, statementIndex int, tables []tableReference) []Finding {
+	finding := func(message string, subjects ...Subject) Finding {
+		return Finding{
+			Rule:     "DS101",
+			Title:    "table dropped",
+			Severity: SeverityError,
+			File:     filePath,
+			Line:     line,
+			Message:  message,
+			Context:  statementFindingContext(statementIndex, subjects...),
+		}
+	}
+	if len(tables) == 0 {
+		return []Finding{finding("DROP TABLE permanently deletes the table and every row in it; " + tableDroppedAdvice)}
+	}
+
+	ordered := slices.Clone(tables)
+	slices.SortStableFunc(ordered, func(a, b tableReference) int {
+		return strings.Compare(logicalObjectName(a.name), logicalObjectName(b.name))
+	})
+	findings := make([]Finding, 0, len(ordered))
+	for _, table := range ordered {
+		findings = append(findings, finding(
+			fmt.Sprintf("DROP TABLE permanently deletes table %s and every row in it; %s", table.name, tableDroppedAdvice),
+			Subject{Kind: SubjectTable, Name: table.name},
+		))
+	}
+	return findings
+}
+
+// logicalObjectName reduces a source-spelled reference to the bare object name
+// it denotes, so ordering compares what the reference means rather than how it
+// was written: `public."Users"` and `"Users"` both order as `Users`. A
+// reference that does not parse orders by its source text, which keeps the sort
+// total instead of collapsing unparsable references onto one key.
+func logicalObjectName(ref string) string {
+	parsed, ok := tableref.Parse(ref)
+	if !ok {
+		return ref
+	}
+	return parsed.Name
 }
 
 func columnDroppedRule() Rule {
@@ -338,7 +396,7 @@ func rlsDisabledRule() Rule {
 }
 
 // dataDependentRules covers changes whose safety depends on existing row data.
-const notNullWithoutDefaultMessage = "adding a NOT NULL column without a DEFAULT fails or blocks on populated tables; add it nullable, backfill, then enforce NOT NULL in a later migration"
+const notNullWithoutDefaultAdvice = "fails or blocks on populated tables; add it nullable, backfill, then enforce NOT NULL in a later migration"
 
 func dataDependentRules() []Rule {
 	return []Rule{
@@ -377,14 +435,36 @@ func notNullWithoutDefaultFindings(file *File) []Finding {
 		if refersToCreated(created, alterTableReference(stmt.Words, stmt.sourceWords).normalized) {
 			continue
 		}
+		findings = append(findings, notNullWithoutDefaultFindingsFor(file.Path, stmt.Line, i, subjects)...)
+	}
+	return findings
+}
+
+// notNullWithoutDefaultFindingsFor reports one finding per column an ALTER
+// TABLE adds, for the same reason [tableDroppedFindings] does: each added
+// column fails independently against existing rows, and a single finding
+// carrying several of them left every column past the first unreported.
+//
+// Source order is preserved rather than sorted. A DROP TABLE comma list names
+// tables whose written order means nothing, but ADD COLUMN clauses are the
+// column order the operator wrote and will read the failure in -- and it is the
+// order measured from the analyzer this tool is compatible with, which orders
+// these by clause and dropped tables by name.
+func notNullWithoutDefaultFindingsFor(filePath string, line, statementIndex int, subjects []Subject) []Finding {
+	findings := make([]Finding, 0, len(subjects))
+	for _, subject := range subjects {
 		findings = append(findings, Finding{
 			Rule:     "DD101",
 			Title:    "non-nullable column added without a default",
 			Severity: SeverityWarning,
-			File:     file.Path,
-			Line:     stmt.Line,
-			Message:  notNullWithoutDefaultMessage,
-			Context:  statementFindingContext(i, subjects...),
+			File:     filePath,
+			Line:     line,
+			Message: fmt.Sprintf(
+				"adding NOT NULL column %s without a DEFAULT %s",
+				subject.Name,
+				notNullWithoutDefaultAdvice,
+			),
+			Context: statementFindingContext(statementIndex, subject),
 		})
 	}
 	return findings


### PR DESCRIPTION
Refs #1074 — closes **part 2** (PostgreSQL multi-target `DROP TABLE`). Part 1 (column rename classified `BC101` rather than `DS103`) is untouched and stays open; nothing here changes rename classification.

## The defect

`DROP TABLE a, b` was analyzed into **one** finding carrying two subjects. Every renderer that reads a finding's primary subject then showed only `a`. On a destructive-change analyzer that is a reporting-completeness defect: an operator reviewing a release was never told that `b` was being destroyed either.

Fixed at the analyzer (`migration/lint`), not in the compatibility renderer. Narrowing to `Context.Subjects[0]` in `internal/atlasreport` alone would have left native `ptah migrations lint` reporting one table while the compat surface reported two — two outputs of the same tool disagreeing about how many tables a statement destroys.

## Measurements

Pinned community binary v1.3.0, PostgreSQL 16 in a throwaway container, tables in the schema the dev URL covers, `--latest 1`. Single-target is the control in every fixture: both tools report and exit 1 there, so target count is the only axis that moves.

| fixture | statement | community binary | ptah-compat before | ptah-compat after |
|---|---|---|---|---|
| control | `DROP TABLE users;` | rc=1, 1 DS102 | rc=1, 1 DS102 | rc=1, 1 DS102 |
| two | `DROP TABLE users, audit_log;` | rc=1, **2** DS102 (`audit_log`, `users`) | rc=1, **1** (`users`) | rc=1, **2**, byte-identical |
| three | create `mid,zeta,alpha`; `DROP TABLE zeta, alpha, mid;` | rc=1, **3** (`alpha`, `mid`, `zeta`) | rc=1, **1** (`zeta`) | rc=1, **3**, byte-identical |
| case | `DROP TABLE "Zeta", alpha, "Mid";` | `"Mid"`, `"Zeta"`, `"alpha"` | 1 | byte-identical |
| qualified | `DROP TABLE public.aaa, bbb;` | `aaa`, `bbb` | 1 | byte-identical |
| multistmt | `DROP TABLE ddd, bbb;` then `DROP TABLE ccc, aaa;` | L1 `bbb`,`ddd`; L2 `aaa`,`ccc` | 2 | byte-identical |
| exempt | same-file `CREATE` then `DROP TABLE staging, users;` | 1 (`users`) | 1 | unchanged |

What that pins:

1. **Order is a byte-wise ASCII comparison of the logical table name.** The three-table fixture is deliberate: source order (`zeta, alpha, mid`), creation order (`mid, zeta, alpha`) and reverse creation order (`alpha, zeta, mid`) each give a different answer, so two tables cannot separate them. `case` rules out a case-folding comparison (`"Mid"` and `"Zeta"` lead, not `alpha`). `qualified` rules out comparing the reference as written (`public.aaa` before `bbb`, not after).
2. **Ordering is per statement**, not per file — `multistmt` sorts inside L1 and inside L2 and keeps the statements in source order. A global per-file sort would have produced `aaa, bbb, ccc, ddd`.
3. **The suggested-fix header pluralizes** with the count: `-- suggested fix:` for one, `-- suggested fixes:` for more. Asserted as bytes.
4. **The `-- N diagnostics` counter counts rendered diagnostics, not findings** — measured, not assumed: 3 tables gives `3 diagnostics`, `multistmt` gives `4`. The `-- 1 version with errors` line counts versions and is unaffected.

### The other multi-target statements, measured

The issue asked me to check these rather than infer. Two of them are the same defect, one is not:

| shape | community binary | verdict |
|---|---|---|
| `ALTER TABLE t DROP COLUMN a, DROP COLUMN b, DROP COLUMN c` (DS103) | **one** diagnostic naming all: `Dropping non-virtual columns "zeta", "alpha" and "mid"`, **clause order, not sorted**, one fix: `Add pre-migration checks to ensure columns … are NULL before dropping them` | Same completeness defect, opposite shape. Fixed. Measured at 1, 2 and 3 columns so the list separator, the conjunction, and the singular/plural nouns and pronoun are each pinned by a fixture that separates them. |
| `ALTER TABLE t ADD COLUMN a int NOT NULL, ADD COLUMN b int NOT NULL` (MF103) | **one diagnostic per column, in clause order** (not sorted) | Same defect as DS102 minus the sort. Fixed. |
| `DROP INDEX a, b` | no diagnostic at all | **Not this defect, not fixed.** Ptah emits a `PG106` concurrency warning where the community binary is silent — ptah stricter, permitted direction — and `PG106` carries no subjects, so there is nothing to truncate. Untouched. |

## What changed

- `migration/lint/rules.go` — `tableDroppedRule` emits one `DS101` finding per unsafe dropped table, sorted by logical name; `notNullWithoutDefaultFindings` emits one `DD101` per added column, in clause order. Both messages now name their object. The fail-closed path is preserved: a target list that cannot be parsed to the end still reports, as one subject-less finding with the unnamed message.
- `internal/atlasreport/migrate_lint_atlas_text.go` — `atlasPrimarySubject` becomes `atlasSoleSubject`, which **fails closed** on a multi-subject finding for the one-object codes (`DS102`, `MF103`), dropping to Ptah's own prose naming everything rather than silently reporting one of several destroyed objects. `DS103` renders every subject.
- Docs: the per-object boundary is documented in `docs/site/.../atlas/migrate-commands.md`; three stale quotes of the old `DS101` message updated in `versioned/integrity-and-safety.md` (×2) and `versioned/apply.md`.

### Why the message now names its object

It is not cosmetic. `sarifPartialFingerprints` hashes `rule \0 uri \0 line \0 message`. N findings from one statement share rule, file and line, so with a shared message all N fingerprints collide and a code-scanning consumer folds them into one alert — the other destroyed tables would never reach the security tab. `Describe`, the GitHub-annotation writer and the SARIF writer never read `Context.Subjects`, so the message is the only channel they have.

## Tests, and what each prints if the change is reverted

Verified by actually reverting `migration/lint/rules.go` and `internal/atlasreport/migrate_lint_atlas_text.go` to master and running the suite. Controls stayed green; every other row went red:

| test | reverted output |
|---|---|
| `TestAnalyzeFS_MultiTargetDropReportsEveryDroppedTable/every_target…` | `got: []string{"DS101"}` / `want: []string{"DS101","DS101","DS101"}` |
| …`/single_target_is_one_finding` (control) | **PASS** — by design; it is what shows the row above measures target count |
| `TestAnalyzeFS_MultiTargetDropOrdersByLogicalName/uppercase…` | `got: []string{"\"Zeta\""}` / `want: []string{"\"Mid\"","\"Zeta\"","alpha"}` |
| …`/qualification_is_not_part_of_the_key` | `got: []string{"public.aaa"}` / `want: []string{"public.aaa","bbb"}` |
| `TestAnalyzeFS_MultiTargetDropNamesEachTableInItsMessage` | one message, unnamed (`deletes the table`) instead of two naming `public."Alpha"` and `zeta` |
| `TestAnalyzeFS_MultiTargetDropReportsOnlyUnsafeTables` | one finding with both subjects instead of two findings of one |
| `TestAnalyzeFS_DropTableSubjectsPreserveIdentifierSpelling` | one finding with both subjects |
| `TestAnalyzeFS_UnparsableDropTargetsStillReport` | fails on the message only — the fail-closed finding itself survives, which is the point |
| `TestAnalyzeFS_MultiClauseAddNotNullReportsEveryColumn` | one `DD101` with two subjects instead of two |
| `TestWriteMigrateLintText_RendersAtlasDiagnostics/multi-target_drop…` | one `zeta` line, `-- suggested fix:`, `-- 1 diagnostic` |
| …`/multi-column_drop…` and `/two-column_drop…` | first column only, singular nouns |
| …`/single-column_drop_keeps_the_singular_wording` (control) | **PASS** |
| `TestAtlasDiagnosticText_FallsBackForMultiSubjectSingleObjectCodes` | `mapped` is true and it renders the first subject — the silent narrowing this test exists to forbid |
| `TestRunLint_MultiTargetDropFingerprintsEveryTable` | one result instead of three; with a shared message the fingerprint set would collapse to 1 |
| `TestRunLint_SARIFGoldenOutput`, `TestRunLint_DefaultTextKeepsNativePtahDiagnostics` | old unnamed message |
| `TestAtlasMigrateLintMultiTargetDropE2E/three_targets` (real PostgreSQL) | `zeta` only, `-- suggested fix:`, `-- 1 diagnostic` |
| …`/single_target` (control) | **PASS** |

The end-to-end coverage is a real PostgreSQL test (`integration/`, `integration` build tag) rather than a `cmd/atlas` unit test on purpose: SQLite rejects `DROP TABLE a, b` outright, so the dev-database replay fails before any analyzer runs and that fixture cannot live on a SQLite dev URL.

## Deliberately left out

- **Part 1** of #1074 — rename classified `BC101` rather than `DS103`. Not touched.
- **`-- N schema changes` for a multi-clause `ALTER TABLE`.** Pre-existing and unrelated to diagnostics: the community binary counts one `ALTER TABLE` as 1 change, Ptah counts one per clause (3 vs 1 on the three-column fixture). Present before this change; the diagnostics lines now match exactly while this line still differs.
- **MF103 type spelling.** The community binary prints `"integer"` where Ptah prints `"int"`. Pre-existing on the single-column case too. Fixing it properly needs a dialect-aware mapping and MySQL measurements I did not take, so I left it rather than guess.
- **`DROP INDEX a, b`.** Measured, not fixed — see the table above.
- **Objects in a schema outside the dev database's search path.** Measured before and after: the community binary is silent there and ptah-compat reports, on both single- and multi-target statements. This change does not alter *whether* ptah reports out-of-scope objects, only how many of a statement's targets it reports once it does — so on that fixture it now names both tables instead of one, still in the stricter direction. Not fixed here, and not a side effect worth hiding.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go test -race` on the four touched packages, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, and both docs gates (`check-style.mjs`, `build-feature-matrix.mjs --check`) all pass. The live oracle comparison was re-run against the pinned binary after the final build.