### PR TITLE
feat(atlas): accept and drop unknown schema-HCL names, as Atlas CE does (#1016)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -57,6 +57,33 @@ jobs:
           -run '^TestSumFileNamesDifferentialFuzz(RealisticFlyway|OtherFormats)?$'
           ./internal/atlasmigrateimport
 
+      # The schema-HCL unknown-name policy (stokaro/ptah#1016) is the only other
+      # thing in this repo whose contract IS the community binary's behavior. It
+      # is listed before it is run so an empty selection fails the job instead of
+      # reporting a green run that measured nothing.
+      - name: Verify schema-HCL conformance selection
+        run: |
+          GOWORK=off go test -list '^TestOracle' \
+            ./internal/atlashcl > "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          cat "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          grep -Fx 'TestOracleAcceptsAndDropsUnknownSchemaHCLNames' "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          grep -Fx 'TestOracleRefusesUnevaluableDroppedBodies' "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          grep -Fx 'TestOracleAcceptsReferencesPtahRefuses' "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          grep -Fx 'TestOraclePartitionIsDialectSplit' "$RUNNER_TEMP/atlas-schema-hcl-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-schema-hcl-tests")" -eq 4
+
+      - name: Run schema-HCL conformance tests
+        run: |
+          GOWORK=off go test -count=1 -v -run '^TestOracle' ./internal/atlashcl \
+            > "$RUNNER_TEMP/atlas-schema-hcl-run" 2>&1 || {
+              cat "$RUNNER_TEMP/atlas-schema-hcl-run"
+              exit 1
+            }
+          cat "$RUNNER_TEMP/atlas-schema-hcl-run"
+          # A missing oracle skips these silently. That is the exact failure
+          # mode this job exists to prevent, so a skip fails the job.
+          ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-schema-hcl-run"
+
       - name: Regenerate Atlas CE corpus
         run: >-
           internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -226,6 +226,10 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		TxMode:     txMode,
 		DryRun:     opts.dryRun,
 		ProjectEnv: projectEnv,
+
+		// Atlas-compatible surface: a schema file written for another tool
+		// must not be refused over a name this parser does not model.
+		IgnoreUnknownHCLNames: true,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -372,7 +376,10 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 
 	var desired *goschema.Database
 	if len(opts.toURLs) > 0 {
-		desired, err = schemafile.LoadAll(opts.toURLs, schemafile.Options{Dialect: conn.Info().Dialect})
+		desired, err = schemafile.LoadAll(opts.toURLs, schemafile.Options{
+			Dialect:               conn.Info().Dialect,
+			IgnoreUnknownHCLNames: true,
+		})
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))
 		}

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -130,6 +130,9 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 		Include:    opts.include,
 		Policy:     policy,
 		ProjectEnv: projectEnv,
+
+		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
+		IgnoreUnknownHCLNames: true,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -131,6 +131,9 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 		Diagnostics:    cmd.ErrOrStderr(),
 		ProjectEnv:     projectEnv,
 		ConnectTimeout: dbcli.DefaultConnectTimeout,
+
+		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
+		IgnoreUnknownHCLNames: true,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -171,6 +171,9 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 		ToURLs:  opts.toURLs,
 		Exclude: opts.exclude,
 		Policy:  policy,
+
+		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
+		IgnoreUnknownHCLNames: true,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_plan_validate.go
+++ b/cmd/atlas/schema_plan_validate.go
@@ -151,7 +151,10 @@ func runAtlasSchemaPlanValidate(cmd *cobra.Command, opts atlasSchemaPlanValidate
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{Dialect: conn.Info().Dialect})
+	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{
+		Dialect:               conn.Info().Dialect,
+		IgnoreUnknownHCLNames: true,
+	})
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))
 	}

--- a/cmd/atlas/unknown_hcl_names_surface_test.go
+++ b/cmd/atlas/unknown_hcl_names_surface_test.go
@@ -1,0 +1,117 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/cmd/root"
+)
+
+// unknownNameSchemaHCL carries a top-level block and a column attribute that
+// Ptah's schema-HCL parser does not model. The community binary reads this file
+// to completion and emits DDL identical to the same schema without them.
+const unknownNameSchemaHCL = `
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+}
+schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type      = int
+    invisible = true
+  }
+}
+`
+
+// TestSchemaInspectUnknownHCLNamesSplitByCommandTree pins the split
+// stokaro/ptah#1016 left to this change: the SAME file is accepted by the
+// Atlas-compatible command tree and refused by Ptah's own.
+//
+// One fixture, two command trees, opposite verdicts -- which is the only shape
+// that can catch the tolerance leaking from one tree into the other. It leaked
+// in exactly that direction once already: the option was set unconditionally
+// inside the shared resolver, so `ptah schema inspect` silently dropped typos
+// while the documentation said it named them.
+func TestSchemaInspectUnknownHCLNamesSplitByCommandTree(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(schemaPath, []byte(unknownNameSchemaHCL), 0o600), qt.IsNil)
+
+	compat := atlas.NewCompatCommand("atlas")
+	var compatOut bytes.Buffer
+	compat.SetOut(&compatOut)
+	compat.SetErr(&compatOut)
+	compat.SetArgs([]string{
+		"schema", "inspect",
+		"--url", "file://" + schemaPath,
+		"--dev-url", "sqlite://" + filepath.Join(dir, "compat.db"),
+	})
+	compatErr := compat.Execute()
+
+	native := root.NewRootCommand()
+	var nativeOut bytes.Buffer
+	native.SetOut(&nativeOut)
+	native.SetErr(&nativeOut)
+	native.SetArgs([]string{
+		"schema", "inspect",
+		"--schema-file", schemaPath,
+		"--dev-url", "sqlite://" + filepath.Join(dir, "native.db"),
+	})
+	nativeErr := native.Execute()
+
+	c.Assert(compatErr, qt.IsNil)
+	c.Assert(compatOut.String(), qt.Contains, `table "t"`)
+	c.Assert(compatOut.String(), qt.Contains, `column "id"`)
+	c.Assert(nativeErr, qt.ErrorMatches, `.*unsupported top-level block "annotation".*`)
+}
+
+// TestSchemaDiffUnknownHCLNamesSplitByCommandTree is the same split on the diff
+// command, which reaches the loader through a different resolver call than
+// inspect does. Both had the tolerance hard-wired on; a test on one of them
+// would not have caught the other.
+func TestSchemaDiffUnknownHCLNamesSplitByCommandTree(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	schemaPath := filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(schemaPath, []byte(unknownNameSchemaHCL), 0o600), qt.IsNil)
+	emptyPath := filepath.Join(dir, "empty.hcl")
+	c.Assert(os.WriteFile(emptyPath, []byte("schema \"main\" {\n}\n"), 0o600), qt.IsNil)
+
+	compat := atlas.NewCompatCommand("atlas")
+	var compatOut bytes.Buffer
+	compat.SetOut(&compatOut)
+	compat.SetErr(&compatOut)
+	compat.SetArgs([]string{
+		"schema", "diff",
+		"--from", "file://" + emptyPath,
+		"--to", "file://" + schemaPath,
+		"--dev-url", "sqlite://" + filepath.Join(dir, "compat.db"),
+	})
+	compatErr := compat.Execute()
+
+	native := root.NewRootCommand()
+	var nativeOut bytes.Buffer
+	native.SetOut(&nativeOut)
+	native.SetErr(&nativeOut)
+	native.SetArgs([]string{
+		"schema", "diff",
+		"--from", "file://" + emptyPath,
+		"--to", "file://" + schemaPath,
+		"--dev-url", "sqlite://" + filepath.Join(dir, "native.db"),
+	})
+	nativeErr := native.Execute()
+
+	c.Assert(compatErr, qt.IsNil)
+	c.Assert(compatOut.String(), qt.Contains, `"t"`)
+	c.Assert(nativeErr, qt.ErrorMatches, `.*unsupported top-level block "annotation".*`)
+}

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -85,6 +85,105 @@ current schema IR:
 Unsupported schema semantics are rejected with an explicit parse error instead
 of being silently dropped from the generated Ptah IR.
 
+### Unknown names: strict on Ptah's own commands, tolerant on the Atlas surface
+
+Whether an unmodeled name is a parse error depends on which surface reads the
+file, because the two surfaces answer to different contracts.
+
+**Strict — an unmodeled name is a parse error.** This covers `--schema-file`,
+every other path through Ptah's own schema loading, the schema artifact reader,
+the Go-annotation exporter's render-then-reparse fidelity check, **and the
+native `ptah schema apply`, `ptah schema diff`, `ptah schema inspect` and
+`ptah schema plan` commands**. Here the file is read by Ptah's own CLI, an
+unmodeled name is almost always a typo, and naming it is more useful than
+dropping it. The exporter check is the sharper reason: it re-parses HCL that
+Ptah itself rendered, so tolerance there would let a renderer that emits a
+misspelled attribute pass unnoticed.
+
+**Tolerant — an unmodeled name is dropped.** This covers the Atlas-compatible
+command tree only: `ptah-compat schema apply`, `schema inspect`, `schema diff`,
+`schema plan`, `schema plan validate` and `migrate diff` reading a `file://`
+HCL source. Those files are written for another tool, which accepts constructs
+Ptah does not model and drops them without a word; refusing the whole file where
+that tool proceeds makes Ptah a non-starter as a replacement.
+
+The split is the one stokaro/ptah#1016 left open, and it is a split in the
+command tree, not in the file format: the same `schema.hcl` is refused by
+`ptah schema inspect` and accepted by `ptah-compat schema inspect`.
+
+Measured on the community Atlas binary with `schema inspect -u file://...`,
+each time comparing the emitted DDL of a schema carrying the construct against
+the same schema with it deleted: a top-level `annotation` block, a table-nested
+`annotation` block, an unknown block nested in a `column` or an `index` body, an
+`invisible = true` column attribute, and an unknown attribute in the `column`,
+`table`, `index`, `schema`, `primary_key`, `foreign_key`, `check`, `enum` and
+`view` positions all come back exit 0 with byte-identical DDL. Nonsense controls
+(`frobnicate_nonsense`, `zzz_nonsense_attr`, `zzz_nonsense_block`) behave the
+same as the real names in every one of those positions, which is what makes this
+a general "drop names I do not model" policy rather than support for any
+particular name. The tolerance therefore covers every position, not a shortlist.
+
+Three limits are deliberate.
+
+Tolerance is name-level, never subtree-level. The body of a dropped construct is
+still *evaluated*, so `annotation { gql = "Thing" }` is accepted while each of
+these is refused, exactly as the community binary refuses them:
+
+| inside a dropped construct | diagnostic |
+| --- | --- |
+| `ref = not_a_real_identifier` | unknown variable |
+| `ref = variable.v` (the root is `var`, never `variable`) | unknown variable |
+| `ref = frobnicate_nonsense("a")` | call to unknown function |
+| `ref = 1 + "abc"` | invalid operand |
+| `ref = 1 + string` | invalid operand |
+
+Tolerance never repairs structure. A construct whose only nested block was
+dropped is still incomplete: `partition { type = "HASH"  zzz_nonsense {} }`
+fails with `partition requires columns attribute or by blocks`.
+
+The scope a dropped body is evaluated in is *closed*. It holds three names —
+`string`, `int` and `bool`, the only bare identifiers measured to resolve inside
+a dropped body on every dialect — plus a measured function table (`format`,
+`join`, `jsonencode`, `lower`, `split`, `title`, `trimspace`, `upper`). Nothing
+in it is derived from the file being parsed, so a reference to the file's own
+blocks or variables does not resolve:
+
+| inside a dropped construct | community binary | Ptah |
+| --- | --- | --- |
+| `ref = table.t`, `ref = table.t.column.id` | exit 0 | refused, unknown variable `table` |
+| `ref = column.id` inside a table body | exit 0 | refused, unknown variable `column` |
+| `ref = var.v` with `variable "v"` declared | exit 0 | refused, unknown variable `var` |
+| `ref = attr.name` naming a block nested in the dropped one | exit 0 | refused, unknown variable `attr` |
+| a call to a function outside the table above | exit 0 | refused, call to unknown function |
+
+Each of those refuses a file the community binary accepts, which is the safe
+direction — it costs a user an error message, where the opposite direction would
+load a schema the real tool would have rejected. It is the direction this parser
+takes on purpose, because the alternative is to model the file's blocks and
+variables as reference roots, and every attempt to do that has had to stand in
+for something it could not enumerate — an unlabeled block, a variable of unknown
+type. Each such stand-in turned into an *accept*-where-the-binary-refuses
+divergence: `var.v.nope` on a string variable, `1 + var.v`, `primary_key.nope`,
+`inner["typo"]`, `table.t.column` and eight more, all measured. A closed scope
+cannot have that failure mode, because there is nothing in it whose members are
+guessed.
+
+`partition` is dialect-split on the community binary and cannot be pinned to one
+verdict by a dialect-agnostic parser: `type = HASH` unquoted is exit 1 on MySQL
+(`There is no variable named "HASH"`) and exit 0 on PostgreSQL, which models
+partitions. `type = "HASH"` quoted is exit 0 on both, and on MySQL the whole
+`partition` block is dropped from the emitted DDL. What is dialect-independent,
+and is pinned, is that `HASH` is not a reference root: `annotation { ref = HASH }`
+is exit 1 on both dialects and here.
+
+Dropping an unknown column attribute changes the DDL Ptah emits, so a
+misspelled attribute (`nul = false`, `uniqe = true`) becomes an inert no-op on
+the tolerant surface rather than a diagnostic. That is the behavior the
+Atlas-compatible surface has to reproduce, and it is the reason the strict
+default is kept on Ptah's own commands. Callers that want to say something about
+what was dropped can pass `atlashcl.Options.RecordIgnored`, the schema-HCL
+counterpart of the atlas.hcl parser's `Config.IgnoredConstructs`.
+
 ## Ptah Go-annotation parity extensions
 
 Ptah accepts the Atlas-compatible subset above and a small set of explicitly

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -3,6 +3,7 @@ package atlashcl
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -17,20 +18,52 @@ import (
 	"go.5x5.cz/ptah/internal/tableref"
 )
 
+// Options configures HCL schema parsing.
+type Options struct {
+	// IgnoreUnknownNames accepts and drops HCL names this parser does not
+	// model instead of refusing the whole file.
+	//
+	// Off by default. It is opt-in because three callers depend on the
+	// refusal: Ptah's own schema loading and the native `ptah schema`
+	// commands, where an unmodeled name is a user error worth naming, and
+	// internal/goannotationexport, which re-parses HCL Ptah itself rendered as
+	// a round-trip fidelity check -- tolerance there would let a renderer typo
+	// pass unnoticed.
+	//
+	// Turning it on does not make the body of a dropped name unchecked: see
+	// tolerateUnknownBlock.
+	IgnoreUnknownNames bool
+
+	// RecordIgnored receives every name dropped under IgnoreUnknownNames, in
+	// the order the parser reached them. Optional; nil discards them, which is
+	// what the community binary does.
+	RecordIgnored func(IgnoredName)
+}
+
 // ParseFile parses an HCL schema file into the same Database IR used by
 // Go annotations and YAML schema files.
 func ParseFile(path string) (*goschema.Database, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		return nil, fmt.Errorf("read HCL schema file: %w", err)
-	}
-
-	return Parse(data, path)
+	return ParseFileWithOptions(path, Options{})
 }
 
 // Parse parses HCL schema text into the same Database IR used by Go
 // annotations and YAML schema files.
 func Parse(data []byte, filename string) (*goschema.Database, error) {
+	return ParseWithOptions(data, filename, Options{})
+}
+
+// ParseFileWithOptions parses an HCL schema file under the given options.
+func ParseFileWithOptions(path string, opts Options) (*goschema.Database, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read HCL schema file: %w", err)
+	}
+
+	return ParseWithOptions(data, path, opts)
+}
+
+// ParseWithOptions parses HCL schema text under the given options.
+func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Database, error) {
 	if filename == "" {
 		filename = "schema.hcl"
 	}
@@ -44,9 +77,11 @@ func Parse(data []byte, filename string) (*goschema.Database, error) {
 	}
 
 	p := parser{
-		src:       data,
-		sourceDir: filepath.Dir(filename),
-		db:        &goschema.Database{},
+		src:           data,
+		sourceDir:     filepath.Dir(filename),
+		db:            &goschema.Database{},
+		tolerant:      opts.IgnoreUnknownNames,
+		recordIgnored: opts.RecordIgnored,
 	}
 	if err := p.parseBody(body); err != nil {
 		return nil, err
@@ -59,6 +94,12 @@ type parser struct {
 	src       []byte
 	sourceDir string
 	db        *goschema.Database
+
+	// tolerant enables the unknown-name policy described on Options.
+	tolerant bool
+	// recordIgnored receives the names dropped under that policy. Nil discards
+	// them.
+	recordIgnored func(IgnoredName)
 }
 
 func (p *parser) parseBody(body *hclsyntax.Body) error {
@@ -109,7 +150,7 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		// They do not define schema objects directly.
 		return nil
 	default:
-		return p.blockError(block, "unsupported top-level block %q", block.Type)
+		return p.rejectUnsupportedBlock(block, "top-level")
 	}
 }
 
@@ -319,7 +360,7 @@ func (p *parser) parseAdditionalTableBlock(table *goschema.Table, block *hclsynt
 		// Parsed before the child walk so duplicate dialect/key pairs are
 		// detected across all platform blocks on the table.
 	default:
-		return p.blockError(block, "unsupported table block %q", block.Type)
+		return p.rejectUnsupportedBlock(block, "table")
 	}
 	return nil
 }
@@ -334,6 +375,12 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		return goschema.Field{}, p.blockError(block, "column %q requires type", name)
 	}
 	if err := p.rejectUnsupportedColumnAttrs(block); err != nil {
+		return goschema.Field{}, err
+	}
+	// Once, here, rather than in each of the two body walks below: they both
+	// iterate the same blocks, so leaving the gate in their default arms would
+	// report a dropped name twice.
+	if err := p.rejectUnsupportedColumnBlocks(block); err != nil {
 		return goschema.Field{}, err
 	}
 	generated, err := p.parseGeneratedColumn(block)
@@ -401,7 +448,8 @@ func (p *parser) parseGeneratedColumn(block *hclsyntax.Block) (generatedColumnSp
 		case "identity", "platform":
 			continue
 		default:
-			return generatedColumnSpec{}, p.blockError(nested, "unsupported column block %q", nested.Type)
+			// Already gated by rejectUnsupportedColumnBlocks.
+			continue
 		}
 	}
 	if attr != nil && len(asBlocks) > 0 {
@@ -447,7 +495,8 @@ func (p *parser) parseIdentityColumn(block *hclsyntax.Block) (identityColumnSpec
 		case "as", "platform":
 			continue
 		default:
-			return identityColumnSpec{}, p.blockError(nested, "unsupported column block %q", nested.Type)
+			// Already gated by rejectUnsupportedColumnBlocks.
+			continue
 		}
 	}
 	if len(identityBlocks) == 0 {
@@ -481,8 +530,14 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	if len(block.Labels) != 1 {
 		return goschema.Index{}, p.blockError(block, "index block requires exactly one label")
 	}
-	if block.Body.Attributes["columns"] != nil && len(block.Body.Blocks) > 0 {
-		return goschema.Index{}, p.blockError(block.Body.Blocks[0], "index cannot mix columns attribute with on blocks")
+	// Gated before the mix check so a dropped block name does not read as an
+	// `on` block and turn tolerance into "cannot mix columns with on blocks".
+	onBlocks, err := p.indexOnBlocks(block)
+	if err != nil {
+		return goschema.Index{}, err
+	}
+	if block.Body.Attributes["columns"] != nil && len(onBlocks) > 0 {
+		return goschema.Index{}, p.blockError(onBlocks[0], "index cannot mix columns attribute with on blocks")
 	}
 	columns, err := p.parseColumnsAttr(block, "columns")
 	if err != nil {
@@ -494,7 +549,7 @@ func (p *parser) parseIndex(structName, tableName string, block *hclsyntax.Block
 	}
 	var parts []goschema.IndexPart
 	if len(columns) == 0 {
-		columns, parts, err = p.parseIndexParts(block)
+		columns, parts, err = p.parseIndexParts(onBlocks)
 		if err != nil {
 			return goschema.Index{}, err
 		}
@@ -553,8 +608,8 @@ func (p *parser) parseConstraint(table *goschema.Table, block *hclsyntax.Block) 
 	if len(block.Labels) != 1 {
 		return goschema.Constraint{}, p.blockError(block, "constraint block requires exactly one label")
 	}
-	if len(block.Body.Blocks) > 0 {
-		return goschema.Constraint{}, p.blockError(block.Body.Blocks[0], "unsupported constraint block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "constraint"); err != nil {
+		return goschema.Constraint{}, err
 	}
 	if err := p.rejectUnsupportedConstraintAttrs(block); err != nil {
 		return goschema.Constraint{}, err
@@ -666,6 +721,12 @@ func (p *parser) parsePlatformBlock(
 		overrides[dialect] = make(map[string]string)
 	}
 	for _, overrideBlock := range block.Body.Blocks {
+		if overrideBlock.Type != "override" {
+			if err := p.rejectUnsupportedBlock(overrideBlock, owner+" platform"); err != nil {
+				return err
+			}
+			continue
+		}
 		override, err := p.parsePlatformOverride(overrideBlock, owner)
 		if err != nil {
 			return err
@@ -689,20 +750,14 @@ type platformOverride struct {
 	value string
 }
 
+// parsePlatformOverride parses one `override` block. The caller has already
+// gated any other block type through the unknown-name policy.
 func (p *parser) parsePlatformOverride(block *hclsyntax.Block, owner string) (platformOverride, error) {
-	if block.Type != "override" {
-		return platformOverride{}, p.blockError(block, "unsupported %s platform block %q", owner, block.Type)
-	}
 	if len(block.Labels) != 1 || strings.TrimSpace(block.Labels[0]) == "" {
 		return platformOverride{}, p.blockError(block, "%s platform override requires exactly one key label", owner)
 	}
-	if len(block.Body.Blocks) > 0 {
-		return platformOverride{}, p.blockError(
-			block.Body.Blocks[0],
-			"unsupported %s platform override block %q",
-			owner,
-			block.Body.Blocks[0].Type,
-		)
+	if err := p.rejectNestedBlocks(block, owner+" platform override"); err != nil {
+		return platformOverride{}, err
 	}
 	if err := p.rejectUnsupportedAttrs(
 		block,
@@ -793,13 +848,26 @@ func (p *parser) parseIndexStorageParams(block *hclsyntax.Block) (map[string]str
 	return params, nil
 }
 
-func (p *parser) parseIndexParts(block *hclsyntax.Block) ([]string, []goschema.IndexPart, error) {
-	var columns []string
-	var parts []goschema.IndexPart
+// indexOnBlocks returns the index body's `on` blocks, sending every other
+// block type through the unknown-name gate.
+func (p *parser) indexOnBlocks(block *hclsyntax.Block) ([]*hclsyntax.Block, error) {
+	onBlocks := make([]*hclsyntax.Block, 0, len(block.Body.Blocks))
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "on" {
-			return nil, nil, p.blockError(nested, "unsupported index block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "index"); err != nil {
+				return nil, err
+			}
+			continue
 		}
+		onBlocks = append(onBlocks, nested)
+	}
+	return onBlocks, nil
+}
+
+func (p *parser) parseIndexParts(onBlocks []*hclsyntax.Block) ([]string, []goschema.IndexPart, error) {
+	var columns []string
+	var parts []goschema.IndexPart
+	for _, nested := range onBlocks {
 		if err := p.rejectUnsupportedIndexOnAttrs(nested); err != nil {
 			return nil, nil, err
 		}
@@ -883,9 +951,15 @@ func (p *parser) parsePartition(block *hclsyntax.Block) (*goschema.PartitionSpec
 	if partitionType == "" {
 		return nil, p.blockError(block, "partition requires type")
 	}
+	// Gated before the mix check so a dropped block name does not read as a
+	// `by` block and turn tolerance into "cannot mix columns with by blocks".
+	byBlocks, err := p.partitionByBlocks(block)
+	if err != nil {
+		return nil, err
+	}
 	if block.Body.Attributes["columns"] != nil {
-		if len(block.Body.Blocks) > 0 {
-			return nil, p.blockError(block.Body.Blocks[0], "partition cannot mix columns attribute with by blocks")
+		if len(byBlocks) > 0 {
+			return nil, p.blockError(byBlocks[0], "partition cannot mix columns attribute with by blocks")
 		}
 		columns, err := p.parseColumnsAttr(block, "columns")
 		if err != nil {
@@ -897,22 +971,32 @@ func (p *parser) parsePartition(block *hclsyntax.Block) (*goschema.PartitionSpec
 		return &goschema.PartitionSpec{Type: partitionType, Parts: partitionColumnParts(columns)}, nil
 	}
 
-	parts, err := p.parsePartitionParts(block)
+	parts, err := p.parsePartitionParts(block, byBlocks)
 	if err != nil {
 		return nil, err
 	}
 	return &goschema.PartitionSpec{Type: partitionType, Parts: parts}, nil
 }
 
-func (p *parser) parsePartitionParts(block *hclsyntax.Block) ([]goschema.PartitionPart, error) {
-	if len(block.Body.Blocks) == 0 {
-		return nil, p.blockError(block, "partition requires columns attribute or by blocks")
-	}
-	parts := make([]goschema.PartitionPart, 0, len(block.Body.Blocks))
+// partitionByBlocks returns the partition body's `by` blocks, sending every
+// other block type through the unknown-name gate.
+func (p *parser) partitionByBlocks(block *hclsyntax.Block) ([]*hclsyntax.Block, error) {
+	byBlocks := make([]*hclsyntax.Block, 0, len(block.Body.Blocks))
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "by" {
-			return nil, p.blockError(nested, "unsupported partition block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "partition"); err != nil {
+				return nil, err
+			}
+			continue
 		}
+		byBlocks = append(byBlocks, nested)
+	}
+	return byBlocks, nil
+}
+
+func (p *parser) parsePartitionParts(block *hclsyntax.Block, byBlocks []*hclsyntax.Block) ([]goschema.PartitionPart, error) {
+	parts := make([]goschema.PartitionPart, 0, len(byBlocks))
+	for _, nested := range byBlocks {
 		if err := p.rejectUnsupportedPartitionByAttrs(nested); err != nil {
 			return nil, err
 		}
@@ -929,6 +1013,12 @@ func (p *parser) parsePartitionParts(block *hclsyntax.Block) ([]goschema.Partiti
 			continue
 		}
 		parts = append(parts, goschema.PartitionPart{Expr: p.exprString(exprAttr)})
+	}
+	// Checked after the walk, not before it: under the unknown-name policy a
+	// body holding nothing but dropped block names leaves no parts behind, and
+	// that is the same structural gap as an empty body.
+	if len(parts) == 0 {
+		return nil, p.blockError(block, "partition requires columns attribute or by blocks")
 	}
 	return parts, nil
 }
@@ -952,13 +1042,13 @@ func (p *parser) validatePrimaryKeyType(block *hclsyntax.Block) error {
 }
 
 func (p *parser) parsePrimaryKeyParts(block *hclsyntax.Block) ([]goschema.PrimaryKeyPart, error) {
-	if len(block.Body.Blocks) == 0 {
-		return nil, p.blockError(block, "primary_key requires columns attribute or on blocks")
-	}
 	parts := make([]goschema.PrimaryKeyPart, 0, len(block.Body.Blocks))
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "on" {
-			return nil, p.blockError(nested, "unsupported primary_key block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "primary_key"); err != nil {
+				return nil, err
+			}
+			continue
 		}
 		if err := p.rejectUnsupportedPrimaryKeyOnAttrs(nested); err != nil {
 			return nil, err
@@ -972,6 +1062,10 @@ func (p *parser) parsePrimaryKeyParts(block *hclsyntax.Block) ([]goschema.Primar
 			Prefix: p.optionalRawExpr(nested.Body.Attributes["prefix"]),
 			Desc:   p.optionalBool(nested.Body.Attributes["desc"], false),
 		})
+	}
+	// See parsePartitionParts: dropped block names leave no parts behind.
+	if len(parts) == 0 {
+		return nil, p.blockError(block, "primary_key requires columns attribute or on blocks")
 	}
 	return parts, nil
 }
@@ -1161,8 +1255,8 @@ func (p *parser) parseColumnRefsAttr(block *hclsyntax.Block, attrName string) ([
 }
 
 func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported schema block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "schema"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"comment": true,
@@ -1172,8 +1266,8 @@ func (p *parser) rejectUnsupportedSchemaBody(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedEnumAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported enum block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "enum"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema": true,
@@ -1247,8 +1341,8 @@ func (p *parser) rejectUnsupportedColumnAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedGeneratedColumnAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported column as block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "column as"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"expr": true,
@@ -1257,8 +1351,8 @@ func (p *parser) rejectUnsupportedGeneratedColumnAttrs(block *hclsyntax.Block) e
 }
 
 func (p *parser) rejectUnsupportedIdentityColumnAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported column identity block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "column identity"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"generated": true,
@@ -1336,18 +1430,76 @@ func (p *parser) rejectUnsupportedCheckAttrs(block *hclsyntax.Block) error {
 	}, "check")
 }
 
+// rejectUnsupportedAttrs is the single gate every attribute allow-list in this
+// package goes through, so the unknown-name policy is one branch rather than a
+// copy per construct.
+//
+// The tolerance covers every scope routed through here, not a shortlist. The
+// community binary drops an unmodeled attribute in each of them -- measured
+// with a nonsense control in the column, table, index, schema, primary_key,
+// foreign_key, check, enum and view positions, each time comparing the emitted
+// DDL against the same schema with the attribute deleted and getting an exact
+// match at exit 0. A shortlist would leave a real ent- or gqlgen-authored file
+// refused in the positions that were left out, which is the defect
+// stokaro/ptah#1016 describes.
 func (p *parser) rejectUnsupportedAttrs(block *hclsyntax.Block, supported map[string]bool, label string) error {
-	var unsupported []string
-	for name := range block.Body.Attributes {
-		if !supported[name] {
-			unsupported = append(unsupported, name)
+	// Sorted so both the tolerated and the refused path pick the same
+	// attribute out of a body carrying several unknown names; map order would
+	// otherwise make the reported error non-deterministic.
+	for _, name := range slices.Sorted(maps.Keys(block.Body.Attributes)) {
+		if supported[name] {
+			continue
+		}
+		if !p.tolerant {
+			return p.blockError(block, "unsupported %s attribute %q", label, name)
+		}
+		if err := p.tolerateUnknownAttr(label, block.Body.Attributes[name]); err != nil {
+			return err
 		}
 	}
-	if len(unsupported) == 0 {
-		return nil
+	return nil
+}
+
+// rejectUnsupportedColumnBlocks gates the nested blocks a column body may
+// carry. `as`, `identity` and `platform` are modeled; anything else goes
+// through the unknown-name gate.
+func (p *parser) rejectUnsupportedColumnBlocks(block *hclsyntax.Block) error {
+	for _, nested := range block.Body.Blocks {
+		switch nested.Type {
+		case "as", "identity", "platform":
+			continue
+		default:
+			if err := p.rejectUnsupportedBlock(nested, "column"); err != nil {
+				return err
+			}
+		}
 	}
-	slices.Sort(unsupported)
-	return p.blockError(block, "unsupported %s attribute %q", label, unsupported[0])
+	return nil
+}
+
+// rejectUnsupportedBlock is the block-side counterpart of
+// rejectUnsupportedAttrs: one gate, so a construct that grows a nested-block
+// allow-list cannot quietly get its own policy.
+func (p *parser) rejectUnsupportedBlock(block *hclsyntax.Block, label string) error {
+	if p.tolerant {
+		return p.tolerateUnknownBlock(label, block)
+	}
+	return p.blockError(block, "unsupported %s block %q", label, block.Type)
+}
+
+// rejectNestedBlocks applies that gate to every block nested in a construct
+// that models no nested blocks at all.
+//
+// Every one of them is checked, not just the first: under the tolerance the
+// first is dropped rather than fatal, so stopping there would leave the rest
+// of the subtree unevaluated.
+func (p *parser) rejectNestedBlocks(block *hclsyntax.Block, label string) error {
+	for _, nested := range block.Body.Blocks {
+		if err := p.rejectUnsupportedBlock(nested, label); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func markPrimaryFields(fields []goschema.Field, columns []string) {

--- a/internal/atlashcl/dropped_scope_internal_test.go
+++ b/internal/atlashcl/dropped_scope_internal_test.go
@@ -1,0 +1,59 @@
+package atlashcl
+
+// White-box testing required: the property under test is a property of the
+// evaluation scope itself, not of any parse result. Reaching it from outside
+// the package would mean enumerating expressions and hoping the list covers the
+// next wildcard someone adds, which is exactly how the last two revisions
+// shipped a hole.
+
+import (
+	"maps"
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// TestDroppedBodyScopeHoldsOnlyKnownOpaqueValues pins the property the whole
+// unknown-name policy rests on, at the one place it can be checked directly.
+//
+// Every previous exit-0-where-the-community-binary-exits-1 divergence in this
+// package came from a value in this scope that was not fully known: a
+// [cty.DynamicVal] standing in for a block whose members could not be
+// enumerated, or one standing in for a variable whose type was not read. An
+// unknown value makes member access, indexing and arithmetic evaluate to
+// unknown instead of failing, so the expression passes and the file is
+// accepted. A known capsule fails all three.
+//
+// Asserting on the scope rather than on a list of expressions is what makes
+// this hold for expressions nobody thought to write down: there is no way to
+// reach an unknown result from a scope that contains none.
+func TestDroppedBodyScopeHoldsOnlyKnownOpaqueValues(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(droppedBodyScope, qt.HasLen, 3)
+	for name, value := range droppedBodyScope {
+		c.Run(name, func(c *qt.C) {
+			c.Assert(value.IsKnown(), qt.IsTrue)
+			c.Assert(value.IsNull(), qt.IsFalse)
+			c.Assert(value.Type().Equals(cty.DynamicPseudoType), qt.IsFalse)
+			c.Assert(value.Type().IsCapsuleType(), qt.IsTrue)
+		})
+	}
+}
+
+// TestDroppedBodyContextIsTheClosedScope pins that the evaluation context is
+// the scope above and nothing else, so a root cannot be added to the context
+// while the assertions above keep passing.
+func TestDroppedBodyContextIsTheClosedScope(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(slices.Sorted(maps.Keys(droppedBodyContext.Variables)), qt.DeepEquals,
+		[]string{"bool", "int", "string"})
+	for name, value := range droppedBodyContext.Variables {
+		c.Assert(value.RawEquals(droppedBodyScope[name]), qt.IsTrue)
+	}
+	c.Assert(slices.Sorted(maps.Keys(droppedBodyContext.Functions)), qt.DeepEquals,
+		slices.Sorted(maps.Keys(droppedBodyFunctions)))
+}

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -79,7 +79,10 @@ func (p *parser) parseFunctionArgs(block *hclsyntax.Block) ([]string, error) {
 	args := make([]string, 0, len(block.Body.Blocks))
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "arg" {
-			return nil, p.blockError(nested, "unsupported function block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "function"); err != nil {
+				return nil, err
+			}
+			continue
 		}
 		if err := p.rejectUnsupportedFunctionArgAttrs(nested); err != nil {
 			return nil, err
@@ -188,7 +191,10 @@ func (p *parser) parseTriggerEvent(block *hclsyntax.Block) (triggerEventSpec, er
 	for _, nested := range block.Body.Blocks {
 		currentTiming := triggerTimingFromBlock(nested.Type)
 		if currentTiming == "" {
-			return triggerEventSpec{}, p.blockError(nested, "unsupported trigger block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "trigger"); err != nil {
+				return triggerEventSpec{}, err
+			}
+			continue
 		}
 		if timing != "" {
 			return triggerEventSpec{}, p.blockError(nested, "trigger contains multiple timing blocks")
@@ -377,8 +383,8 @@ func (p *parser) parseManagedData(block *hclsyntax.Block) error {
 	if len(block.Labels) != 0 {
 		return p.labeledDataBlockError(block)
 	}
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported data block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "data"); err != nil {
+		return err
 	}
 	if err := p.rejectUnsupportedAttrs(block, map[string]bool{
 		"table": true,
@@ -486,8 +492,8 @@ func (p *parser) rawListAttr(block *hclsyntax.Block, attrName string) ([]string,
 }
 
 func (p *parser) rejectUnsupportedExtensionAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported extension block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "extension"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"if_not_exists": true,
@@ -510,8 +516,8 @@ func (p *parser) rejectUnsupportedFunctionAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedFunctionArgAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported function arg block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "function arg"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"type": true,
@@ -519,8 +525,8 @@ func (p *parser) rejectUnsupportedFunctionArgAttrs(block *hclsyntax.Block) error
 }
 
 func (p *parser) rejectUnsupportedViewAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported view block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "view"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema":       true,
@@ -531,8 +537,8 @@ func (p *parser) rejectUnsupportedViewAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedMaterializedAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported materialized block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "materialized"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema":           true,
@@ -553,8 +559,8 @@ func (p *parser) rejectUnsupportedTriggerAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedTriggerEventAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported trigger event block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "trigger event"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"insert":   true,
@@ -565,8 +571,8 @@ func (p *parser) rejectUnsupportedTriggerEventAttrs(block *hclsyntax.Block) erro
 }
 
 func (p *parser) rejectUnsupportedPolicyAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported policy block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "policy"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"on":      true,
@@ -579,8 +585,8 @@ func (p *parser) rejectUnsupportedPolicyAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedRowSecurityAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported row_security block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "row_security"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"enabled": true,
@@ -589,8 +595,8 @@ func (p *parser) rejectUnsupportedRowSecurityAttrs(block *hclsyntax.Block) error
 }
 
 func (p *parser) rejectUnsupportedRoleAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported role block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "role"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"login":       true,
@@ -605,8 +611,8 @@ func (p *parser) rejectUnsupportedRoleAttrs(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedPermissionAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported permission block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "permission"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"to":         true,
@@ -833,8 +839,8 @@ func (p *parser) parseSequence(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedSequenceAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported sequence block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "sequence"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema":        true,
@@ -894,8 +900,8 @@ func (p *parser) parseDomain(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedDomainAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported domain block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "domain"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema":  true,
@@ -940,13 +946,16 @@ func (p *parser) parseCompositeFields(block *hclsyntax.Block) ([]goschema.Compos
 	var fields []goschema.CompositeTypeField
 	for _, nested := range block.Body.Blocks {
 		if nested.Type != "field" {
-			return nil, p.blockError(nested, "unsupported composite block %q", nested.Type)
+			if err := p.rejectUnsupportedBlock(nested, "composite"); err != nil {
+				return nil, err
+			}
+			continue
 		}
 		if len(nested.Labels) != 1 {
 			return nil, p.blockError(nested, "composite field requires exactly one name label")
 		}
-		if len(nested.Body.Blocks) > 0 {
-			return nil, p.blockError(nested.Body.Blocks[0], "unsupported composite field block %q", nested.Body.Blocks[0].Type)
+		if err := p.rejectNestedBlocks(nested, "composite field"); err != nil {
+			return nil, err
 		}
 		if err := p.rejectUnsupportedAttrs(nested, map[string]bool{"type": true}, "composite field"); err != nil {
 			return nil, err
@@ -1004,8 +1013,8 @@ func (p *parser) parseRange(block *hclsyntax.Block) error {
 }
 
 func (p *parser) rejectUnsupportedRangeAttrs(block *hclsyntax.Block) error {
-	if len(block.Body.Blocks) > 0 {
-		return p.blockError(block.Body.Blocks[0], "unsupported range block %q", block.Body.Blocks[0].Type)
+	if err := p.rejectNestedBlocks(block, "range"); err != nil {
+		return err
 	}
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
 		"schema":          true,

--- a/internal/atlashcl/oracle_conformance_test.go
+++ b/internal/atlashcl/oracle_conformance_test.go
@@ -1,0 +1,885 @@
+package atlashcl_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// oracleEnv names the environment variable holding the path to the pinned
+// Atlas CE binary this conformance run compares against.
+const oracleEnv = "PTAH_ATLAS_ORACLE"
+
+// oracleVersion is the only build this conformance run trusts. A different
+// build may have changed the very rules under test, so comparing against it
+// would report divergences that are really version drift.
+const oracleVersion = "atlas community version v1.3.0"
+
+// oracleDevURL is the dev database the oracle evaluates a `file://` schema
+// source on. In-memory SQLite keeps the gate self-contained: no container, no
+// credentials, nothing to leave running. The verdicts below were cross-checked
+// against a PostgreSQL 18 dev database and a MySQL 9.7 dev database and are
+// identical on all three, so none of them is a dialect artifact -- except the
+// `partition` row, which is dialect-split and is recorded as such rather than
+// pinned to one verdict.
+const oracleDevURL = "sqlite://file?mode=memory"
+
+// TestOracleAcceptsAndDropsUnknownSchemaHCLNames is the conformance half of
+// stokaro/ptah#1016's definition of done: every position where Ptah drops an
+// unmodeled name is re-measured against the pinned community binary here,
+// rather than frozen in a comment nothing can invalidate.
+//
+// Each case asserts three things, and the second is the one that carries the
+// weight: the oracle exits 0, the DDL it emits is byte-identical to the DDL of
+// the same schema with the construct deleted (so the name was dropped and not
+// implemented), and Ptah's tolerant parse produces exactly the IR of that same
+// deleted-construct file.
+//
+// The nonsense controls matter more than the real names: they behave
+// identically to `annotation` and `invisible` in every position, which is what
+// makes this a general "drop names I do not model" policy rather than support
+// for any particular name.
+func TestOracleAcceptsAndDropsUnknownSchemaHCLNames(t *testing.T) {
+	oracle := requireSchemaOracle(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		hcl        string
+		equivalent string
+	}{
+		{
+			name: "top-level annotation block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "top-level nonsense block control",
+			hcl: `schema "main" {
+}
+frobnicate_nonsense "zz" {
+  anything = "here"
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "invisible column attribute",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type      = int
+    invisible = true
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "nonsense column attribute control",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type              = int
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "nonsense block nested in a column",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "nonsense index attribute",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns           = [column.id]
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+  }
+}
+`,
+		},
+		{
+			name: "nonsense block nested in an index",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+  }
+}
+`,
+		},
+		{
+			name: "nonsense schema attribute",
+			hcl: `schema "main" {
+  zzz_nonsense_attr = true
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "nonsense primary_key attribute",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns           = [column.id]
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`,
+		},
+		{
+			name: "type keyword inside the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+  ref = int
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			withDDL, withCode := runSchemaOracle(c, oracle, tt.hcl)
+			withoutDDL, withoutCode := runSchemaOracle(c, oracle, tt.equivalent)
+			c.Assert(withCode, qt.Equals, 0, qt.Commentf("oracle output: %s", withDDL))
+			c.Assert(withoutCode, qt.Equals, 0, qt.Commentf("oracle output: %s", withoutDDL))
+			c.Assert(withDDL, qt.Equals, withoutDDL)
+
+			tolerant, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.IsNil)
+			without, err := atlashcl.Parse([]byte(tt.equivalent), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			c.Assert(tolerant, qt.DeepEquals, without)
+		})
+	}
+}
+
+// TestOracleRefusesUnevaluableDroppedBodies is the other half, and the half a
+// tolerance change is most likely to break: every case here is a file the
+// community binary REFUSES, and the tolerant parser must refuse it too.
+//
+// Without this, relaxing a name silently converts each row into an
+// exit-0-where-the-oracle-exits-1 divergence -- the dangerous direction, and
+// invisible to any test that only checks that valid files still parse.
+//
+// The rows are chosen so no single mechanism covers them. The first four fail
+// on four different diagnostics (unknown variable, unknown function, invalid
+// operand, unsupported attribute), so a check that only resolved reference
+// roots would let three through. The rows from "unlabeled block nested in the
+// dropped block" down are the class the earlier revision of this file could
+// not see at all: every fixture it had used a LABELED reference root, so the
+// wildcards that stood in for unlabeled blocks and for declared variables
+// stayed invisible while accepting all twelve of these.
+func TestOracleRefusesUnevaluableDroppedBodies(t *testing.T) {
+	oracle := requireSchemaOracle(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		hcl  string
+	}{
+		{
+			name: "unresolvable reference root",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = not_a_real_identifier
+}
+`,
+		},
+		{
+			name: "variable is not the reference root, var is",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = variable.v
+}
+`,
+		},
+		{
+			name: "call to a function the oracle does not have",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = frobnicate_nonsense("a")
+}
+`,
+		},
+		{
+			name: "operand of the wrong type",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = 1 + "abc"
+}
+`,
+		},
+		{
+			name: "member of a real root that does not exist",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = table.nope
+}
+`,
+		},
+		{
+			name: "nested member of a real root that does not exist",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = table.t.column.nope
+}
+`,
+		},
+		{
+			name: "var member with no variable block declaring it",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = var.v
+}
+`,
+		},
+		{
+			name: "scoped enum name is not a reference root",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = HASH
+}
+`,
+		},
+		{
+			name: "column root is out of scope at the top level",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = column.id
+}
+`,
+		},
+		{
+			name: "unlabeled block nested in the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  inner {
+    a = 1
+  }
+  ref = inner.a
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "member that does not exist under an unlabeled nested block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  inner {
+    a = 1
+  }
+  ref = inner.typo
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "unlabeled block under a labeled block in the dropped body",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    nested {
+      x = 1
+    }
+  }
+  ref = attr.name.nested.typo
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "unlabeled top-level dropped block referenced by its own name",
+			hcl: `schema "main" {
+}
+frobnicate_nonsense {
+  a = 1
+}
+annotation "gql" {
+  ref = frobnicate_nonsense.typo
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "index into an unlabeled nested block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  inner {
+    a = 1
+  }
+  ref = inner["typo"]
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "member that does not exist on a table-body primary_key",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  annotation {
+    ref = primary_key.nope
+  }
+}
+`,
+		},
+		{
+			name: "attribute of a table-body primary_key is not a member either",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  annotation {
+    ref = primary_key.columns
+  }
+}
+`,
+		},
+		{
+			name: "member that does not exist on a table-body partition",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  partition {
+    type    = "HASH"
+    columns = [column.id]
+  }
+  annotation {
+    ref = partition.typo
+  }
+}
+`,
+		},
+		{
+			name: "attribute access on a declared string variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = var.v.nope
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "attribute access on a declared list variable",
+			hcl: `variable "v" {
+  type    = list(string)
+  default = ["x"]
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = var.v.typo
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "arithmetic over a declared string variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = 1 + var.v
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "reference that stops on a block type rather than a block",
+			hcl: `schema "main" {
+}
+table "p" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = table.p.column
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			out, code := runSchemaOracle(c, oracle, tt.hcl)
+			c.Assert(code, qt.Not(qt.Equals), 0, qt.Commentf("oracle output: %s", out))
+
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.IsNotNil, qt.Commentf("oracle refused this file: %s", out))
+		})
+	}
+}
+
+// TestOracleAcceptsReferencesPtahRefuses measures the divergence the closed
+// scope buys, instead of asserting it against a frozen expectation.
+//
+// The oracle exits 0 on each of these and the tolerant parser refuses each of
+// them, because resolving the reference would need a reference root built from
+// the file's own blocks or variables -- and every attempt to build those roots
+// so far has had to guess at some member it could not enumerate, turning into
+// an accept-where-the-oracle-refuses divergence. Refusing is the direction that
+// costs a user a message rather than a wrong schema.
+//
+// This test fails in BOTH directions, which is the point: if the oracle stops
+// accepting one of these the row is no longer a divergence and should move, and
+// if Ptah starts accepting one the trade recorded here has been reversed
+// without being re-argued.
+func TestOracleAcceptsReferencesPtahRefuses(t *testing.T) {
+	oracle := requireSchemaOracle(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		hcl  string
+	}{
+		{
+			name: "declared variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = var.v
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "column root inside a table body",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  column "b" {
+    type              = int
+    zzz_nonsense_attr = column.id
+  }
+}
+`,
+		},
+		{
+			name: "table declared later in the file",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = table.t
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+		{
+			name: "block nested in the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+  ref = attr.name
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			out, code := runSchemaOracle(c, oracle, tt.hcl)
+			c.Assert(code, qt.Equals, 0, qt.Commentf("oracle output: %s", out))
+
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.ErrorMatches, `.*unknown variable .*`)
+		})
+	}
+}
+
+// TestOraclePartitionIsDialectSplit records the one row stokaro/ptah#1016 asked
+// to pin as "not a parity gap" and that turns out not to have a single verdict.
+//
+// On the SQLite and PostgreSQL dev databases the community binary accepts the
+// unquoted `type = HASH` form; on MySQL it exits 1 with `There is no variable
+// named "HASH"`. A parser that never sees the dialect cannot match both, so the
+// dialect-independent fact is pinned instead: `HASH` is not a reference root in
+// a dropped body anywhere, which is the mechanism behind the MySQL refusal.
+func TestOraclePartitionIsDialectSplit(t *testing.T) {
+	oracle := requireSchemaOracle(t)
+	c := qt.New(t)
+
+	const bare = `schema "main" {
+}
+annotation "gql" {
+  ref = HASH
+}
+`
+
+	out, code := runSchemaOracle(c, oracle, bare)
+	c.Assert(code, qt.Not(qt.Equals), 0, qt.Commentf("oracle output: %s", out))
+	c.Assert(out, qt.Contains, `There is no variable named "HASH"`)
+
+	_, err := atlashcl.ParseWithOptions(
+		[]byte(bare),
+		"schema.hcl",
+		atlashcl.Options{IgnoreUnknownNames: true},
+	)
+	c.Assert(err, qt.ErrorMatches, `.*unknown variable "HASH"`)
+}
+
+// requireSchemaOracle resolves the pinned binary, refusing to compare against
+// any other build. The skip is deliberately loud: a silently absent oracle is
+// the failure mode this whole file exists to avoid.
+func requireSchemaOracle(t *testing.T) string {
+	t.Helper()
+
+	oracle := os.Getenv(oracleEnv)
+	if oracle == "" {
+		t.Skipf("SKIPPED: set %s to the pinned Atlas CE binary (%s) to run the schema-HCL conformance run",
+			oracleEnv, oracleVersion)
+	}
+
+	out, err := exec.Command(oracle, "version").Output() //nolint:gosec // the oracle path is operator-provided via PTAH_ATLAS_ORACLE
+	if err != nil {
+		t.Fatalf("%s=%s is not runnable: %v", oracleEnv, oracle, err)
+	}
+	got, _, _ := strings.Cut(string(out), "\n")
+	if strings.TrimSpace(got) != oracleVersion {
+		t.Fatalf("%s=%s reports %q, want %q; a different build may have changed the rules under test",
+			oracleEnv, oracle, strings.TrimSpace(got), oracleVersion)
+	}
+	return oracle
+}
+
+// runSchemaOracle inspects one schema source with the pinned binary and returns
+// its combined output and exit code.
+func runSchemaOracle(c *qt.C, oracle, source string) (string, int) {
+	c.Helper()
+
+	path := filepath.Join(c.TempDir(), "schema.hcl")
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+
+	//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+	cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", oracleDevURL)
+	// The error is the exit status, which is the measurement; a process that
+	// never started leaves ProcessState nil and fails the assertion instead.
+	out, _ := cmd.CombinedOutput() //nolint:errcheck // exit status is read from ProcessState below
+	c.Assert(cmd.ProcessState, qt.IsNotNil, qt.Commentf("the oracle did not run: %s", out))
+	return string(out), cmd.ProcessState.ExitCode()
+}

--- a/internal/atlashcl/unknown_names.go
+++ b/internal/atlashcl/unknown_names.go
@@ -1,0 +1,259 @@
+package atlashcl
+
+import (
+	"fmt"
+	"maps"
+	"reflect"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+// IgnoredName is a schema-HCL name that was accepted and dropped under the
+// unknown-name policy.
+//
+// It exists so a caller can say something about what it silently discarded.
+// The community binary reports nothing at all, and that silence is a footgun:
+// a typo'd attribute name does nothing and looks fine. Nothing about the
+// parse result depends on whether a caller reports these, so drop-in fidelity
+// is unaffected either way. This mirrors what the atlas.hcl parser records in
+// [go.5x5.cz/ptah/config/projectconfig.Config.IgnoredConstructs], so both HCL
+// layers make the same choice.
+type IgnoredName struct {
+	// Name is the block type or attribute name as written.
+	Name string
+	// Kind is "block" or "attribute".
+	Kind string
+	// Scope names the construct that contained it ("top-level", "table",
+	// "column", ...). The position matters because the same name can be
+	// modeled in one place and unmodeled in another.
+	Scope string
+	// Filename and Line locate it.
+	Filename string
+	Line     int
+}
+
+// typeKeyword is the Go type behind the opaque value a bare Atlas type keyword
+// evaluates to inside a dropped body. It carries nothing: the only thing the
+// keyword has to support is being written down.
+type typeKeyword struct{}
+
+// typeKeywordType makes that opacity a property of the cty type system rather
+// than a convention.
+//
+// A capsule supports no conversion, no member access, no index, no iteration
+// and no arithmetic, so every one of those fails here whatever the community
+// binary does with the same expression. An object or a [cty.DynamicVal] would
+// each quietly succeed at some of them, and succeeding where the community
+// binary fails is the one direction this parser may never take.
+var typeKeywordType = cty.Capsule("Atlas type keyword", reflect.TypeFor[typeKeyword]())
+
+// typeKeywordValue is shared by every keyword so that comparing two of them is
+// a comparison of equal values rather than an error.
+var typeKeywordValue = cty.CapsuleVal(typeKeywordType, &typeKeyword{})
+
+// droppedBodyScope is the ENTIRE variable scope a dropped body is evaluated
+// in. It is a fixed table, not a view of the file, and that is the point.
+//
+// Two earlier attempts modeled the file's own blocks and variables as
+// reference roots so that `table.t.column.id`, `attr.name` and `var.v` would
+// resolve inside a dropped body the way they resolve on the community binary.
+// Both had to represent something they had not measured -- an unlabeled block,
+// a variable of unknown type -- and both reached for a wildcard to do it.
+// Every wildcard turned into a position where Ptah accepted a file the
+// community binary refuses: 12 of them, measured, including `var.v.nope` on a
+// string variable, `1 + var.v`, `primary_key.nope` and `inner["typo"]`.
+//
+// So the scope is closed instead. `string`, `int` and `bool` are here because
+// they are the only bare identifiers measured to resolve inside a dropped body
+// on every dialect, and because the construct stokaro/ptah#1016 exists to
+// accept -- `annotation "gql" { attr "name" { type = string } }` -- needs
+// them. Everything else fails to resolve, which refuses some files the
+// community binary accepts (`ref = table.t`, `ref = var.v`) and accepts none
+// it refuses. That asymmetry is deliberate: refusing a file the binary accepts
+// costs a user an error message, while accepting one it refuses ships a schema
+// the real tool would never have loaded.
+var droppedBodyScope = map[string]cty.Value{
+	"string": typeKeywordValue,
+	"int":    typeKeywordValue,
+	"bool":   typeKeywordValue,
+}
+
+// droppedBodyFunctions is the function table used to evaluate the body of a
+// dropped name.
+//
+// Every name here was confirmed present on the pinned community binary, and
+// the argument-count and argument-type diagnostics it emitted for `join` and
+// `split` are the verbatim go-cty stdlib texts, which is what pins the
+// implementation these names resolve to. Any other call is refused, matching
+// the binary's own `Call to unknown function` on a name it does not have.
+//
+// These stay safe under a closed scope for the same reason the scope is
+// closed: the only values that can reach an argument are literals and opaque
+// capsules, so an accepted call is always this go-cty stdlib applied to a
+// literal -- which is exactly what the community binary does with it.
+var droppedBodyFunctions = map[string]function.Function{
+	"format":     stdlib.FormatFunc,
+	"join":       stdlib.JoinFunc,
+	"jsonencode": stdlib.JSONEncodeFunc,
+	"lower":      stdlib.LowerFunc,
+	"split":      stdlib.SplitFunc,
+	"title":      stdlib.TitleFunc,
+	"trimspace":  stdlib.TrimSpaceFunc,
+	"upper":      stdlib.UpperFunc,
+}
+
+// droppedBodyContext is the evaluation context every dropped expression sees.
+// It is built once and never mutated; HCL only reads it, and a for-expression
+// binds its iterator in a child context rather than in this one.
+var droppedBodyContext = &hcl.EvalContext{
+	Variables: droppedBodyScope,
+	Functions: droppedBodyFunctions,
+}
+
+// tolerateUnknownBlock accepts a block name this parser does not model.
+//
+// The block contributes nothing to the IR, but its body is still checked: the
+// community binary evaluates the whole file before it decides which names to
+// decode, so an unresolvable reference inside a construct it is about to drop
+// is still fatal. Measured, same command, same dev database:
+//
+//	annotation { gql = "Thing" }               -> exit 0
+//	annotation { gql = not_a_real_identifier } -> exit 1, "Unknown variable"
+//
+// Skipping the subtree instead would accept the second file, which makes this
+// parser looser than the binary it is matching -- the dangerous direction, and
+// the one that turns today's coincidental agreement into a real divergence.
+func (p *parser) tolerateUnknownBlock(scope string, block *hclsyntax.Block) error {
+	if err := p.checkDroppedBody(block.Body); err != nil {
+		return err
+	}
+	p.noteIgnored(IgnoredName{
+		Name:     block.Type,
+		Kind:     "block",
+		Scope:    scope,
+		Filename: block.TypeRange.Filename,
+		Line:     block.TypeRange.Start.Line,
+	})
+	return nil
+}
+
+// tolerateUnknownAttr accepts an attribute name this parser does not model,
+// with the same name-level rule as tolerateUnknownBlock.
+func (p *parser) tolerateUnknownAttr(scope string, attr *hclsyntax.Attribute) error {
+	if err := p.checkDroppedExpr(attr.Expr); err != nil {
+		return err
+	}
+	p.noteIgnored(IgnoredName{
+		Name:     attr.Name,
+		Kind:     "attribute",
+		Scope:    scope,
+		Filename: attr.NameRange.Filename,
+		Line:     attr.NameRange.Start.Line,
+	})
+	return nil
+}
+
+// noteIgnored hands a dropped name to the caller's recorder, if it set one.
+func (p *parser) noteIgnored(ignored IgnoredName) {
+	if p.recordIgnored == nil {
+		return
+	}
+	p.recordIgnored(ignored)
+}
+
+// checkDroppedBody checks every expression under a dropped name, attributes
+// first and in name order so a body carrying several bad expressions always
+// reports the same one.
+func (p *parser) checkDroppedBody(body *hclsyntax.Body) error {
+	if body == nil {
+		return nil
+	}
+	for _, name := range slices.Sorted(maps.Keys(body.Attributes)) {
+		if err := p.checkDroppedExpr(body.Attributes[name].Expr); err != nil {
+			return err
+		}
+	}
+	for _, block := range body.Blocks {
+		if err := p.checkDroppedBody(block.Body); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkDroppedExpr evaluates one expression under a dropped name and reports
+// the first thing that does not resolve.
+//
+// Evaluating rather than pattern-matching references is what keeps this parser
+// from being looser than the community binary, which evaluates the whole file
+// before deciding what to decode. All four of these exit 1 there and all four
+// reach that verdict through a different diagnostic, so a check that only
+// resolved reference roots would let three of them through:
+//
+//	annotation "gql" { ref = variable.v }                -> Unknown variable
+//	annotation "gql" { ref = frobnicate_nonsense("a") }  -> Call to unknown function
+//	annotation "gql" { ref = 1 + "abc" }                 -> Invalid operand
+//	annotation "gql" { ref = 1 + string }                -> Invalid operand
+//
+// The unresolvable-root case is reported before evaluation only so the message
+// can name the variable and underline the root rather than the whole
+// traversal, which is what the community binary underlines.
+func (p *parser) checkDroppedExpr(expr hclsyntax.Expression) error {
+	if expr == nil {
+		return nil
+	}
+	for _, traversal := range expr.Variables() {
+		if len(traversal) == 0 {
+			continue
+		}
+		root, ok := traversal[0].(hcl.TraverseRoot)
+		if !ok {
+			continue
+		}
+		if _, inScope := droppedBodyScope[root.Name]; inScope {
+			continue
+		}
+		// The root's own range, not the whole traversal's: the community binary
+		// underlines just the name it could not resolve, so `column.id` points
+		// at `column`.
+		return p.unknownVariableError(root.Name, root.SrcRange)
+	}
+	if _, diags := expr.Value(droppedBodyContext); diags.HasErrors() {
+		return p.evaluationFailed(diags)
+	}
+	return nil
+}
+
+// unknownVariableError reports an unresolvable reference at the range of the
+// reference, not the range of the construct that contains it, so the position
+// lines up with the community binary's own diagnostic.
+func (p *parser) unknownVariableError(name string, rng hcl.Range) error {
+	return fmt.Errorf("parse HCL schema at %s: unknown variable %q", rng.String(), name)
+}
+
+// evaluationFailed reports the first evaluation diagnostic in the style of the
+// rest of this package: lower-cased summary, then the detail the HCL library
+// wrote, at the range the diagnostic points to.
+func (p *parser) evaluationFailed(diags hcl.Diagnostics) error {
+	for _, diag := range diags {
+		if diag.Severity != hcl.DiagError {
+			continue
+		}
+		where := "schema.hcl"
+		if diag.Subject != nil {
+			where = diag.Subject.String()
+		}
+		summary := strings.ToLower(diag.Summary)
+		if diag.Detail == "" {
+			return fmt.Errorf("parse HCL schema at %s: %s", where, summary)
+		}
+		return fmt.Errorf("parse HCL schema at %s: %s: %s", where, summary, diag.Detail)
+	}
+	return fmt.Errorf("parse HCL schema: %s", diags.Error())
+}

--- a/internal/atlashcl/unknown_names_test.go
+++ b/internal/atlashcl/unknown_names_test.go
@@ -1,0 +1,1045 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// TestParseIgnoreUnknownNamesDropsTheName pins that a name the parser does not
+// model is dropped rather than refused, and that dropping it leaves exactly the
+// schema the same file would produce with the construct deleted.
+//
+// The equivalent-file comparison is the assertion that matters: it says the
+// construct contributed nothing, which is stronger than "no error" and is the
+// same shape as the DDL comparison the conformance run makes -- the schema WITH
+// the construct against the schema WITHOUT it, on one implementation, rather
+// than a byte comparison across two implementations that already render the
+// same baseline differently.
+//
+// Every position below was measured on the pinned community binary with
+// `schema inspect -u file://...`: exit 0, and DDL byte-identical to the same
+// schema with the construct deleted.
+func TestParseIgnoreUnknownNamesDropsTheName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		hcl        string
+		equivalent string
+		strictErr  string
+	}{
+		{
+			name: "top-level block",
+			hcl: `
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+}
+schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `
+schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported top-level block "annotation".*`,
+		},
+		{
+			name: "top-level block with a nonsense name",
+			hcl: `
+frobnicate_nonsense "zz" {
+  anything = "here"
+}
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported top-level block "frobnicate_nonsense".*`,
+		},
+		{
+			name: "table block",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  annotation {
+    gql = "Thing"
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported table block "annotation".*`,
+		},
+		{
+			name: "table block with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  zzz_nonsense_block {
+    anything = "here"
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported table block "zzz_nonsense_block".*`,
+		},
+		{
+			name: "column attribute",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type      = int
+    invisible = true
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported column attribute "invisible".*`,
+		},
+		{
+			name: "column attribute with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type              = int
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  column "secret" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported column attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "table attribute with a nonsense name",
+			hcl: `
+table "t" {
+  zzz_table_attr = true
+  column "id" {
+    type = int
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported table attribute "zzz_table_attr".*`,
+		},
+		{
+			name: "column block with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+}
+`,
+			strictErr: `.*unsupported column block "zzz_nonsense_block".*`,
+		},
+		{
+			name: "index attribute with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns           = [column.id]
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+  }
+}
+`,
+			strictErr: `.*unsupported index attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "index block with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  index "i" {
+    columns = [column.id]
+  }
+}
+`,
+			strictErr: `.*unsupported index block "zzz_nonsense_block".*`,
+		},
+		{
+			name: "schema attribute with a nonsense name",
+			hcl: `
+schema "main" {
+  zzz_nonsense_attr = true
+}
+`,
+			equivalent: `
+schema "main" {
+}
+`,
+			strictErr: `.*unsupported schema attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "primary_key attribute with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns           = [column.id]
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`,
+			strictErr: `.*unsupported primary_key attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "foreign_key attribute with a nonsense name",
+			hcl: `
+table "p" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+table "t" {
+  column "pid" {
+    type = int
+  }
+  foreign_key "fk" {
+    columns           = [column.pid]
+    ref_columns       = [table.p.column.id]
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `
+table "p" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+table "t" {
+  column "pid" {
+    type = int
+  }
+  foreign_key "fk" {
+    columns     = [column.pid]
+    ref_columns = [table.p.column.id]
+  }
+}
+`,
+			strictErr: `.*unsupported foreign_key attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "check attribute with a nonsense name",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  check "c" {
+    expr              = "id > 0"
+    zzz_nonsense_attr = true
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  check "c" {
+    expr = "id > 0"
+  }
+}
+`,
+			strictErr: `.*unsupported check attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "enum attribute with a nonsense name",
+			hcl: `
+schema "main" {
+}
+enum "e" {
+  schema            = schema.main
+  values            = ["a", "b"]
+  zzz_nonsense_attr = true
+}
+`,
+			equivalent: `
+schema "main" {
+}
+enum "e" {
+  schema = schema.main
+  values = ["a", "b"]
+}
+`,
+			strictErr: `.*unsupported enum attribute "zzz_nonsense_attr".*`,
+		},
+		{
+			name: "partition attribute the community binary drops on MySQL",
+			hcl: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  partition {
+    type       = "HASH"
+    columns    = [column.id]
+    partitions = 4
+  }
+}
+`,
+			equivalent: `
+table "t" {
+  column "id" {
+    type = int
+  }
+  partition {
+    type    = "HASH"
+    columns = [column.id]
+  }
+}
+`,
+			strictErr: `.*unsupported partition attribute "partitions".*`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, strictErr := atlashcl.Parse([]byte(tt.hcl), "schema.hcl")
+			c.Assert(strictErr, qt.ErrorMatches, tt.strictErr)
+
+			tolerant, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.IsNil)
+
+			without, err := atlashcl.Parse([]byte(tt.equivalent), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			c.Assert(tolerant, qt.DeepEquals, without)
+		})
+	}
+}
+
+// TestParseIgnoreUnknownNamesStillEvaluatesTheBody pins that the tolerance is
+// name-level, not subtree-level.
+//
+// The community binary evaluates the whole file before it decides which names
+// to decode, so anything inside a construct it is about to drop that does not
+// evaluate is still fatal. Every case below exits 1 on that binary, measured
+// with `schema inspect -u file://...`, and they do not all fail the same way:
+// an unresolvable root, a call to a function that is not in scope and an
+// operand of the wrong type are three different diagnostics, and a check that
+// only looked at reference roots would accept the last two.
+//
+// The rows from "member of a block declared in the file" down are the ones an
+// earlier revision of this parser ACCEPTED, because it modeled the file's
+// blocks and variables as reference roots and fell back to a wildcard wherever
+// it could not enumerate them. Each is a file the community binary refuses.
+// They are here so that reintroducing any such wildcard fails a test rather
+// than shipping.
+func TestParseIgnoreUnknownNamesStillEvaluatesTheBody(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		hcl     string
+		wantErr string
+	}{
+		{
+			name: "reference under a dropped column attribute",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type              = int
+    zzz_nonsense_attr = not_a_real_identifier
+  }
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:7,25-46: unknown variable "not_a_real_identifier"`,
+		},
+		{
+			name: "reference under a dropped table block",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  annotation {
+    gql = not_a_real_identifier
+  }
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:9,11-32: unknown variable "not_a_real_identifier"`,
+		},
+		{
+			name: "reference under a dropped top-level block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  this_is = not_a_real_identifier
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,13-34: unknown variable "not_a_real_identifier"`,
+		},
+		{
+			name: "column root is out of scope at the top level",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = column.id
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:10,9-15: unknown variable "column"`,
+		},
+		{
+			name: "variable is not a reference root even when the file declares one",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = variable.v
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:8,9-17: unknown variable "variable"`,
+		},
+		{
+			name: "call to a function that is not in scope",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = frobnicate_nonsense("a")
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,9-28: call to unknown function: There is no function named "frobnicate_nonsense".*`,
+		},
+		{
+			name: "operand of the wrong type",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = 1 + "abc"
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,13-18: invalid operand: .*number.*`,
+		},
+		{
+			name: "type keyword is not a number",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = 1 + string
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,13-19: invalid operand: .*number.*`,
+		},
+		{
+			name: "member of a block declared in the file",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = table.nope
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:10,9-14: unknown variable "table"`,
+		},
+		{
+			name: "var member with no variable block declaring it",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = var.v
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,9-12: unknown variable "var"`,
+		},
+		{
+			name: "column root inside a table body",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  annotation {
+    ref = column.nope
+  }
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:9,11-17: unknown variable "column"`,
+		},
+		{
+			name: "scoped enum name is not a reference root",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = HASH
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:4,9-13: unknown variable "HASH"`,
+		},
+		{
+			name: "unlabeled block nested in the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  inner {
+    a = 1
+  }
+  ref = inner.a
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:7,9-14: unknown variable "inner"`,
+		},
+		{
+			name: "index into an unlabeled block nested in the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  inner {
+    a = 1
+  }
+  ref = inner["typo"]
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:7,9-14: unknown variable "inner"`,
+		},
+		{
+			name: "unlabeled top-level block referenced by its own name",
+			hcl: `schema "main" {
+}
+frobnicate_nonsense {
+  a = 1
+}
+annotation "gql" {
+  ref = frobnicate_nonsense.typo
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:7,9-28: unknown variable "frobnicate_nonsense"`,
+		},
+		{
+			name: "unlabeled table-body block referenced from a dropped block",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+  annotation {
+    ref = primary_key.columns
+  }
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:12,11-22: unknown variable "primary_key"`,
+		},
+		{
+			name: "attribute access on a declared string variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = var.v.nope
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:8,9-12: unknown variable "var"`,
+		},
+		{
+			name: "arithmetic over a declared string variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  ref = 1 + var.v
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:8,13-16: unknown variable "var"`,
+		},
+		{
+			name: "reference that stops on a block type rather than a block",
+			hcl: `schema "main" {
+}
+table "p" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+annotation "gql" {
+  ref = table.p.column
+}
+`,
+			wantErr: `parse HCL schema at schema\.hcl:10,9-14: unknown variable "table"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+// TestParseIgnoreUnknownNamesAcceptsEvaluableBodies is the counterpart to
+// TestParseIgnoreUnknownNamesStillEvaluatesTheBody: it pins that the body check
+// rejects expressions that do not evaluate, not expressions as such.
+//
+// Every expression here evaluates on the community binary inside a dropped
+// construct, measured with `schema inspect -u file://...` at exit 0. The first
+// row is the one stokaro/ptah#1016 exists for -- an Atlas v1.3.0 annotation
+// declaration, whose body needs the `string` keyword to resolve.
+func TestParseIgnoreUnknownNamesAcceptsEvaluableBodies(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		hcl  string
+	}{
+		{
+			name: "scalar type keyword",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+}
+`,
+		},
+		{
+			name: "type keyword as the whole value",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = int
+}
+`,
+		},
+		{
+			name: "two type keywords compared",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = string == bool
+}
+`,
+		},
+		{
+			name: "bare object keys are not references",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  annotation {
+    gql = {
+      name   = "Thing"
+      plural = "Things"
+    }
+  }
+}
+`,
+		},
+		{
+			name: "arithmetic over literals",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = 1 + 2
+}
+`,
+		},
+		{
+			name: "call to a function that is in scope",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = upper("a")
+}
+`,
+		},
+		{
+			name: "comprehension over an in-scope function",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = [for v in ["a", "b"] : upper(v)]
+}
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+// TestParseIgnoreUnknownNamesIsStricterThanTheOracleOnReferences records, as
+// executable text, the price of the closed scope.
+//
+// Each file here is accepted by the community binary at exit 0 and refused
+// here, because the reference it carries would need a reference root this
+// parser deliberately does not build. That is the safe direction -- a user gets
+// an error message instead of a schema the real tool would never have loaded --
+// but it is a divergence, and an undocumented divergence is indistinguishable
+// from a bug. If a later change makes any of these parse, this test is where
+// the decision gets revisited rather than quietly reversed.
+func TestParseIgnoreUnknownNamesIsStricterThanTheOracleOnReferences(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		hcl     string
+		wantErr string
+	}{
+		{
+			name: "declared variable",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  gql = var.v
+}
+`,
+			wantErr: `.*unknown variable "var"`,
+		},
+		{
+			name: "column root inside a table body",
+			hcl: `schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+  column "b" {
+    type              = int
+    zzz_nonsense_attr = column.id
+  }
+}
+`,
+			wantErr: `.*unknown variable "column"`,
+		},
+		{
+			name: "reference to a table declared later in the file",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  ref = table.t
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`,
+			wantErr: `.*unknown variable "table"`,
+		},
+		{
+			name: "block nested in the dropped block",
+			hcl: `schema "main" {
+}
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+  ref = attr.name
+}
+`,
+			wantErr: `.*unknown variable "attr"`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+// TestParseIgnoreUnknownNamesKeepsStructuralRefusals pins where the tolerance
+// stops: it drops NAMES, and never turns a construct that is structurally
+// incomplete into one that parses.
+//
+// Both cases below hold a construct whose only nested block is dropped. The
+// name goes; the requirement the block was supposed to satisfy does not.
+func TestParseIgnoreUnknownNamesKeepsStructuralRefusals(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		hcl     string
+		wantErr string
+	}{
+		{
+			name: "partition left with no by blocks",
+			hcl: `table "t" {
+  column "id" {
+    type = int
+  }
+  partition {
+    type = "HASH"
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			wantErr: `.*partition requires columns attribute or by blocks.*`,
+		},
+		{
+			name: "primary_key left with no on blocks",
+			hcl: `table "t" {
+  column "id" {
+    type = int
+  }
+  primary_key {
+    zzz_nonsense_block {
+      anything = "here"
+    }
+  }
+}
+`,
+			wantErr: `.*primary_key requires columns attribute or on blocks.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl),
+				"schema.hcl",
+				atlashcl.Options{IgnoreUnknownNames: true},
+			)
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+// TestParseIgnoreUnknownNamesRecordsWhatItDropped pins that the parser can hand
+// back what it silently discarded.
+//
+// The community binary reports nothing, and that silence is the footgun: a
+// typo'd attribute name becomes an inert no-op that looks fine. The atlas.hcl
+// parser already records its tolerated constructs, so recording them here is
+// what makes the two HCL layers the same choice rather than two.
+func TestParseIgnoreUnknownNamesRecordsWhatItDropped(t *testing.T) {
+	c := qt.New(t)
+
+	const src = `schema "main" {
+}
+annotation "gql" {
+  gql = "Thing"
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type              = int
+    zzz_nonsense_attr = true
+  }
+}
+`
+
+	var dropped []atlashcl.IgnoredName
+	_, err := atlashcl.ParseWithOptions([]byte(src), "schema.hcl", atlashcl.Options{
+		IgnoreUnknownNames: true,
+		RecordIgnored:      func(name atlashcl.IgnoredName) { dropped = append(dropped, name) },
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(dropped, qt.DeepEquals, []atlashcl.IgnoredName{
+		{Name: "annotation", Kind: "block", Scope: "top-level", Filename: "schema.hcl", Line: 3},
+		{Name: "zzz_nonsense_attr", Kind: "attribute", Scope: "column", Filename: "schema.hcl", Line: 10},
+	})
+}
+
+// TestParseStrictRecordsNothing pins that the recorder is only ever fed under
+// the tolerance: with it off the same file is refused, so there is nothing to
+// record and no way to read a dropped name as accepted.
+func TestParseStrictRecordsNothing(t *testing.T) {
+	c := qt.New(t)
+
+	const src = `schema "main" {
+}
+annotation "gql" {
+  gql = "Thing"
+}
+`
+
+	var dropped []atlashcl.IgnoredName
+	_, err := atlashcl.ParseWithOptions([]byte(src), "schema.hcl", atlashcl.Options{
+		RecordIgnored: func(name atlashcl.IgnoredName) { dropped = append(dropped, name) },
+	})
+	c.Assert(err, qt.ErrorMatches, `.*unsupported top-level block "annotation".*`)
+	c.Assert(dropped, qt.HasLen, 0)
+}

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -250,6 +250,9 @@ func resolveDesiredState(
 		DevURL:         devURL,
 		ConnectTimeout: opts.SourceConnectTimeout,
 		DevLockHeld:    true,
+		// `migrate diff` is registered on the Atlas-compatible command tree
+		// only, so this surface always reads files written for another tool.
+		IgnoreUnknownHCLNames: true,
 	})
 	if err != nil {
 		return atlassource.State{}, fmt.Errorf("load --to schema: %w", err)

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -43,6 +43,9 @@ type ApplyOptions struct {
 	// roots and native schema files loaded through the shared desired-source
 	// loader. The Atlas-compatible callers never set it.
 	Desired *goschema.Database
+	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
+	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
+	IgnoreUnknownHCLNames bool
 }
 
 type ApplyPlan struct {
@@ -67,6 +70,9 @@ type ApplyRuntimeOptions struct {
 	// Desired supplies a pre-loaded desired schema model; see
 	// [ApplyOptions.Desired].
 	Desired *goschema.Database
+	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
+	// policy; see [ApplyOptions.IgnoreUnknownHCLNames].
+	IgnoreUnknownHCLNames bool
 }
 
 // ApplyRuntimePlan is a prepared Atlas schema apply operation for one open
@@ -185,16 +191,20 @@ func loadDesiredApplySchema(
 		return opts.Desired, nil
 	}
 	if opts.LocalFilesOnly {
-		return schemafile.LoadAll(opts.ToURLs, schemafile.Options{Dialect: conn.Info().Dialect})
+		return schemafile.LoadAll(opts.ToURLs, schemafile.Options{
+			Dialect:               conn.Info().Dialect,
+			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		})
 	}
 	set, err := atlassource.ClassifySet("--to", opts.ToURLs, opts.ProjectEnv)
 	if err != nil {
 		return nil, err
 	}
 	state, err := set.Resolve(ctx, atlassource.ResolveOptions{
-		Dialect:     conn.Info().Dialect,
-		DialectFlag: "--url",
-		DevURL:      opts.DevURL,
+		Dialect:               conn.Info().Dialect,
+		DialectFlag:           "--url",
+		DevURL:                opts.DevURL,
+		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
 	})
 	if err != nil {
 		return nil, err
@@ -225,6 +235,8 @@ func PrepareApply(
 		DevURL:     opts.DevURL,
 		ProjectEnv: opts.ProjectEnv,
 		Desired:    opts.Desired,
+
+		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
 	})
 	if err != nil {
 		return ApplyRuntimePlan{}, err

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -33,6 +33,9 @@ type DiffOptions struct {
 	// dev database) and reading their initial connection metadata. A zero
 	// value leaves the caller's context deadline unchanged.
 	ConnectTimeout time.Duration
+	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
+	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
+	IgnoreUnknownHCLNames bool
 }
 
 // Diff computes the Atlas schema diff between two desired-state sources.
@@ -64,10 +67,11 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 	}
 
 	resolveOpts := atlassource.ResolveOptions{
-		Dialect:        dialect,
-		DialectFlag:    dialectFlag,
-		DevURL:         opts.DevURL,
-		ConnectTimeout: opts.ConnectTimeout,
+		Dialect:               dialect,
+		DialectFlag:           dialectFlag,
+		DevURL:                opts.DevURL,
+		ConnectTimeout:        opts.ConnectTimeout,
+		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
 	}
 	fromState, err := fromSet.Resolve(ctx, resolveOpts)
 	if err != nil {

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -49,6 +49,9 @@ type InspectSourceOptions struct {
 	// ConnectTimeout bounds the initial database connection attempts. Zero
 	// disables the bound.
 	ConnectTimeout time.Duration
+	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
+	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
+	IgnoreUnknownHCLNames bool
 }
 
 // InspectSource classifies the --url inspection source and renders it with
@@ -121,7 +124,10 @@ func inspectOnDev(
 	var desired *goschema.Database
 	switch set.Kind {
 	case atlassource.KindLocalFile:
-		desired, err = schemafile.LoadAll(sourceRawURLs(set), schemafile.Options{Dialect: dialect})
+		desired, err = schemafile.LoadAll(sourceRawURLs(set), schemafile.Options{
+			Dialect:               dialect,
+			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		})
 		if err != nil {
 			return "", err
 		}

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -72,6 +72,9 @@ type PlanFileOptions struct {
 	// Desired supplies a pre-loaded desired schema model; see
 	// [ApplyOptions.Desired]. When set, ToURLs are ignored.
 	Desired *goschema.Database
+	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
+	// policy; see [ApplyOptions.IgnoreUnknownHCLNames].
+	IgnoreUnknownHCLNames bool
 }
 
 // StalePlanError reports that the target database no longer matches the
@@ -113,6 +116,8 @@ func PreparePlanFile(
 		// stay a `schema plan` follow-up gap.
 		LocalFilesOnly: true,
 		Desired:        opts.Desired,
+
+		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
 	})
 	if err != nil {
 		return PlanFile{}, err

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -49,6 +49,12 @@ type ResolveOptions struct {
 	// DevLockHeld tells migration-directory resolution that the caller already
 	// holds the dev database realm lock across a larger operation.
 	DevLockHeld bool
+	// IgnoreUnknownHCLNames accepts and drops schema-HCL names Ptah does not
+	// model instead of refusing the file. Off by default: it belongs to the
+	// Atlas-compatible command tree, which reads files written for another
+	// tool, and not to Ptah's own commands, where an unmodeled name is a typo
+	// worth naming. See [go.5x5.cz/ptah/internal/schemafile.Options].
+	IgnoreUnknownHCLNames bool
 }
 
 // State is one resolved desired-state. Resolution closes every connection it
@@ -77,7 +83,10 @@ type State struct {
 func (s Set) Resolve(ctx context.Context, opts ResolveOptions) (State, error) {
 	switch s.Kind {
 	case KindLocalFile:
-		schema, err := schemafile.LoadAll(s.rawURLs(), schemafile.Options{Dialect: opts.Dialect})
+		schema, err := schemafile.LoadAll(s.rawURLs(), schemafile.Options{
+			Dialect:               opts.Dialect,
+			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		})
 		if err != nil {
 			return State{}, err
 		}

--- a/internal/schemafile/schemafile.go
+++ b/internal/schemafile/schemafile.go
@@ -23,6 +23,28 @@ import (
 // Options configures schema file loading.
 type Options struct {
 	Dialect string
+	// IgnoreUnknownHCLNames accepts and drops HCL names Ptah's schema HCL
+	// parser does not model instead of refusing the file.
+	//
+	// The split is by COMMAND TREE, not by file format. It is set only by
+	// cmd/atlas -- `schema apply`, `schema inspect`, `schema diff`,
+	// `schema plan`, `schema plan validate` and `migrate diff` on the
+	// Atlas-compatible binary -- which consumes files written for another tool
+	// and must not refuse a construct that tool accepts and ignores.
+	//
+	// It is left off everywhere else, including the native `ptah schema`
+	// commands that share this loader through internal/atlassource: there the
+	// file is read by Ptah's own CLI, where an unmodeled name is a user error
+	// worth naming rather than dropping. Every shared option struct on that
+	// path carries the flag explicitly rather than defaulting it on, because
+	// defaulting it on is exactly how the native commands became tolerant
+	// without anyone intending it.
+	//
+	// There is deliberately no companion hook for reporting what was dropped.
+	// [atlashcl.Options.RecordIgnored] offers one, but nothing on this path
+	// consumes it, and a forwarding field with no producer is a field no test
+	// can hold to account.
+	IgnoreUnknownHCLNames bool
 }
 
 // Load reads one local schema file from either a plain path or file:// URL.
@@ -54,7 +76,9 @@ func LoadPath(path string, opts Options) (*goschema.Database, error) {
 
 	switch strings.ToLower(filepath.Ext(resolved)) {
 	case ".hcl":
-		return atlashcl.ParseFile(resolved)
+		return atlashcl.ParseFileWithOptions(resolved, atlashcl.Options{
+			IgnoreUnknownNames: opts.IgnoreUnknownHCLNames,
+		})
 	case ".yaml", ".yml":
 		return yamlschema.ParseFile(resolved)
 	case ".sql":

--- a/internal/schemafile/unknown_hcl_names_test.go
+++ b/internal/schemafile/unknown_hcl_names_test.go
@@ -1,0 +1,66 @@
+package schemafile_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/schemafile"
+)
+
+// unknownHCLNamesSource carries one unmodeled name in each of the two
+// positions the loader has to forward the option for: a top-level block and a
+// column attribute.
+const unknownHCLNamesSource = `
+annotation "gql" {
+  attr "name" {
+    type = string
+  }
+}
+schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "id" {
+    type      = int
+    invisible = true
+  }
+}
+`
+
+func writeUnknownHCLNamesFixture(c *qt.C) string {
+	path := filepath.Join(c.TempDir(), "schema.hcl")
+	c.Assert(os.WriteFile(path, []byte(unknownHCLNamesSource), 0o600), qt.IsNil)
+	return "file://" + path
+}
+
+// TestLoad_RefusesUnknownHCLNamesByDefault pins the native half of the split:
+// Ptah's own schema loading keeps naming an unmodeled construct instead of
+// dropping it, so a typo in a hand-written schema stays a diagnostic.
+func TestLoad_RefusesUnknownHCLNamesByDefault(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemafile.Load(writeUnknownHCLNamesFixture(c), schemafile.Options{})
+
+	c.Assert(err, qt.ErrorMatches, `.*unsupported top-level block "annotation".*`)
+}
+
+// TestLoad_IgnoresUnknownHCLNamesWhenAsked pins the compat half: the option has
+// to reach the HCL parser rather than being recorded and dropped, and it has to
+// cover both positions in one pass -- the file still parses after the top-level
+// block is dropped only if the column attribute is dropped too.
+func TestLoad_IgnoresUnknownHCLNamesWhenAsked(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := schemafile.Load(
+		writeUnknownHCLNamesFixture(c),
+		schemafile.Options{IgnoreUnknownHCLNames: true},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].Name, qt.Equals, "id")
+}


### PR DESCRIPTION
Closes #1016.

`ptah-compat` refused a schema file over a name it does not model — a top-level `annotation` block, an `invisible = true` column attribute, an unknown attribute anywhere — where the community binary reads the same file to completion. This makes it accept and drop those names, and does so without opening a single position where `ptah-compat` exits 0 and the pinned community binary exits 1.

The branch has been rebased onto current master and squashed. Two earlier revisions of it were rejected for exactly that loose direction; this revision replaces the mechanism rather than patching it.

## What was measured

Oracle: `/…/ptah-atlas-conformance/bin/atlas`, `atlas community version v1.3.0`, by absolute path. Dev database: `sqlite://file?mode=memory`. Command in every row: `<binary> schema inspect -u file://<fixture> --dev-url "sqlite://file?mode=memory"`.

### 1. The issue still reproduces on master — this is not superseded

`ptah-compat` built from master `da1c4cd2`:

```
----- atlasCE     / annot.hcl      -> exit 0    (emits table "t" { column "id" { … } })
----- ptahMaster  / annot.hcl      -> exit 1
Error: parse HCL schema at …/annot.hcl:2,1-11: unsupported top-level block "annotation"

----- atlasCE     / invisible.hcl  -> exit 0    (DDL contains NO INVISIBLE keyword)
----- ptahMaster  / invisible.hcl  -> exit 1
Error: parse HCL schema at …/invisible.hcl:7,3-9: unsupported column attribute "invisible"

----- atlasCE     / nonsense.hcl   -> exit 0
----- ptahMaster  / nonsense.hcl   -> exit 1
Error: parse HCL schema at …/nonsense.hcl:4,3-9: unsupported column attribute "zzz_nonsense_attr"
```

The `invisible` row is worth reading twice: the oracle's DDL carries no `INVISIBLE` keyword, so it did not implement the attribute — it ignored one it does not know, exactly as it ignored `zzz_nonsense_attr`. The nonsense control is what makes that readable.

### 2. The branch as it stood was loose in 12 positions

`ptah-compat` built from the branch head `060eafe1`, over the fixtures the review named. `LOOSE` = candidate exits 0, oracle exits 1.

```
fixture                  atlasCE  master   candidate verdict
L1_inner_a               1        1        0        LOOSE     annotation { inner { a = 1 }  ref = inner.a }
L2_inner_typo            1        1        0        LOOSE     ref = inner.typo
L3_attr_nested_typo      1        1        0        LOOSE     ref = attr.name.nested.typo
L4_toplevel_unlabeled    1        1        0        LOOSE     unlabeled top-level block, ref = <name>.typo
L5_index_typo            1        1        0        LOOSE     ref = inner["typo"]
L6_primary_key_nope      1        1        0        LOOSE     ref = primary_key.nope
L7_primary_key_columns   1        1        0        LOOSE     ref = primary_key.columns
L8_partition_typo        1        1        0        LOOSE     ref = partition.typo
L9_var_string_attr       1        1        0        LOOSE     var.v.nope, variable "v" { type = string }
L10_var_list_attr        1        1        0        LOOSE     var.v.typo, type = list(string)
L11_var_string_arith     1        1        0        LOOSE     1 + var.v, type = string
L12_partial_ref          1        1        0        LOOSE     ref = table.p.column
```

The oracle's own diagnostics on those, for the record:

```
L1  Unsupported attribute; This object does not have an attribute named "a".
L5  Invalid index; The given key does not identify an element in this collection value.
L9  Unsupported attribute; Can't access attributes on a primitive-typed value (string).
L11 Invalid operand; Unsuitable value for right operand: a number is required.
L12 invalid reference used in ref
```

### 3. After this change: zero loose positions over 56 fixtures

Same command, `ptah-compat` built from this branch, across four fixture sets — the 12 above, 5 refusal controls, 20 literal/keyword expression probes, 2 block-reference probes, 15 probes aimed specifically at the type-keyword value:

```
LOOSE positions: 0
```

Every one of the 12 now exits 1 on both. Six fixtures are `strict` (Ptah exits 1, oracle exits 0) and each is listed under "what this deliberately does not do" below.

## The mechanism, and why it changed

The two earlier revisions built reference roots from the file being parsed, so that `table.t.column.id`, `attr.name` and `var.v` would resolve inside a dropped body the way they do on the oracle. Both had to represent something they had not enumerated — an unlabeled block, a variable of unknown type — and both used `cty.DynamicVal` for it. An unknown value makes member access, indexing and arithmetic evaluate to *unknown* instead of failing, so the expression passes and the file is accepted. That is the whole of finding 2 above.

The scope is now closed. It holds three names — `string`, `int`, `bool`, the only bare identifiers measured to resolve inside a dropped body on every dialect, and the ones `annotation "gql" { attr "name" { type = string } }` needs — plus the previously measured function table. Each keyword is an opaque `cty` capsule, so member access, conversion, iteration and arithmetic all fail on it. Nothing in the scope comes from the file, so no member is ever guessed and no value in it is unknown. There is no way to reach an unknown result from a scope that contains none, which is what makes this hold for expressions nobody thought to write down.

## What each test prints if the change is reverted

Every number below is from an applied source mutation with the rest of the tree unchanged; the tree is clean again.

| mutation | red |
| --- | --- |
| `tolerant: false` (tolerance off) | **62 leaf subtests, 12 top-level** across `internal/atlashcl`, `internal/schemafile`, `cmd/atlas` |
| `checkDroppedExpr` returns `nil` (body never evaluated) | **48 leaf subtests, 5 top-level** — every refusal row plus the whole oracle refusal table |
| **`typeKeywordValue = cty.DynamicVal`** (the exact regression class, narrow form) | `TestDroppedBodyScopeHoldsOnlyKnownOpaqueValues/{string,int,bool}` + `…StillEvaluatesTheBody/type_keyword_is_not_a_number` — **4 leaf, 2 top-level** |
| **`cty.DynamicVal` roots for `table`/`column`/`var`/`attr`/`inner`/`primary_key`** (the regression class as it actually shipped) | **32 leaf subtests, 6 top-level**, including 9 rows of `TestOracleRefusesUnevaluableDroppedBodies` and all 4 of `TestOracleAcceptsReferencesPtahRefuses` |
| `int`/`bool` removed from the scope | `TestOracleAcceptsAndDropsUnknownSchemaHCLNames/type_keyword_inside_the_dropped_block`, `…AcceptsEvaluableBodies/{two_type_keywords_compared,type_keyword_as_the_whole_value}` — 3 leaf, 4 top-level |
| scope emptied entirely | 7 leaf, 9 top-level — including the issue's headline `top-level_annotation_block` and both `cmd/atlas` surface tests |
| `IgnoreUnknownHCLNames: true` hard-wired in `internal/atlassource/resolve.go` | `TestSchemaDiffUnknownHCLNamesSplitByCommandTree` |
| `IgnoreUnknownHCLNames: true` hard-wired in `internal/atlasschema/inspect_source.go` | `TestSchemaInspectUnknownHCLNamesSplitByCommandTree` |
| `noteIgnored` made a no-op | `TestParseIgnoreUnknownNamesRecordsWhatItDropped` |

The two hard-wire mutations are separate rows on purpose: `schema inspect` and `schema diff` reach the loader through different resolver calls, and a test on one does not catch the other. That is how the tolerance leaked into the native `ptah schema` commands once already.

`TestDroppedBodyScopeHoldsOnlyKnownOpaqueValues` asserts on the scope rather than on a list of expressions, which is why the narrow `DynamicVal` mutation is caught at all — no expression fixture in the file exercises `1 + string` through a dynamic keyword.

## Conformance gate

`internal/atlashcl/oracle_conformance_test.go` re-measures every claim against the pinned binary: **35 leaf subtests, 0 skips**, up from 19 on the branch head. New coverage is the class the old gate could not see — its nine refusal fixtures all used *labeled* reference roots, so the unlabeled-block and typed-variable wildcards were invisible to it while accepting all twelve loose files.

`TestOracleAcceptsReferencesPtahRefuses` is new and fails in **both** directions: it asserts the oracle exits 0 *and* Ptah refuses, so if the oracle stops accepting one of these the row is no longer a divergence and must move, and if Ptah starts accepting one the trade has been reversed without being re-argued.

`.github/workflows/atlas-oracle.yml` lists the tests before running them and fails on a skip; the expected count moved 3 → 4 for the new test.

## What this deliberately does not do

- **It does not model the file as a scope.** Four measured shapes the oracle accepts at exit 0 are refused here: `ref = table.t` (and `table.t.column.id`), `ref = column.id` inside a table body, `ref = var.v` with the variable declared, `ref = attr.name`. So is a call to a function outside the measured table, and `[for k, v in table.p : k]`. That is the strict direction, it is recorded in `TestOracleAcceptsReferencesPtahRefuses` and in `docs/atlas_hcl_schema.md`, and it is the price of not guessing. Making them resolve is what both previous revisions attempted and is what produced the 12 loose positions.
- **It does not close the `env`-block divergence.** A schema file carrying an `env` block makes the oracle refuse the whole file (`cannot parse project file … as a schema file`); Ptah exits 0. That reproduces on master, is a classification-boundary question between the project-config and schema-file layers, and belongs to its own issue.
- **It does not settle `partition`/`HASH`.** Unquoted `type = HASH` is exit 1 on MySQL and exit 0 on PostgreSQL, which models partitions; a parser that never sees the dialect cannot match both. The dialect-independent half is pinned instead: `HASH` is not a reference root anywhere.
- **It does not turn native `ptah` tolerant.** `Parse`/`ParseFile` stay strict. `ptah schema inspect` still refuses the same file `ptah-compat schema inspect` accepts.
- **It does not keep dead plumbing.** `schemafile.Options.RecordIgnoredHCLName` forwarded to the parser's recorder, had no producer anywhere in the tree and no test — making it a no-op left `internal/schemafile` green. Removed. `atlashcl.Options.RecordIgnored` stays; it has a test that goes red when disabled.

## Gates

| gate | result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 0, 176 packages ok |
| `golangci-lint run ./...` | exit 1 — **both findings are foreign paths**: `../../../../ptah-1101/migration/importer/emit.go:130` and `../wf_57b2b3d8-4aa-2/examples/viz/models/schema.go:3`, two other checkouts parked under the repo. Neither is in this diff. Restricted to the packages this branch touches (`./internal/atlashcl/... ./internal/schemafile/... ./internal/atlasschema/... ./internal/atlassource/... ./internal/atlasmigrate/... ./cmd/atlas/...`): **0 issues**. |
| `scripts/check-test-style.sh` | exit 0 — `teststyle: OK (175 conditional groups, 45 white-box files)`. Went red twice on this branch's own new file (file-name rule, then missing justification) before it went green, so the gate demonstrably ran. |
| `scripts/check-public-api.sh` | exit 0 |
| `scripts/check-public-api-snapshot.sh` | exit 0 |
| `node docs/site/scripts/check-style.mjs` | exit 0 — went red first on `docs/atlas_hcl_schema.md:107` (banned filler "simply"), fixed |
| `node docs/site/scripts/build-feature-matrix.mjs --check` | exit 0 |
| oracle run, `PTAH_ATLAS_ORACLE=…/bin/atlas go test -count=1 -v -run '^TestOracle' ./internal/atlashcl` | exit 0, 35 leaf subtests, 0 skips |

One note on `go test`, stated rather than buried: on two earlier runs made while heavy parallel work was in flight, `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` failed with `render SVG with Graphviz dot: signal: killed` at exactly 10.0s. It reproduced identically on a clean `origin/master` checkout at `c0f86693`, and it passes on a quiet run. It is a load-sensitive timeout in a package this branch does not touch.
