### PR TITLE
feat(compat): schema-side Atlas flags, and a named decision on --export/--web

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -574,6 +574,11 @@ func atlasMigrateVersionValue(value string) (string, error) {
 // native Go-annotation root directory, --dev-url selects the throwaway
 // database (ephemeral SQLite when omitted), and the optional [paths]
 // positional selects the directory of Ptah-native YAML test cases.
+//
+// -s/--schema restricts the desired schema before the cases run. Atlas registers
+// it as a repeatable `strings` flag (atlasgo.io/cli-reference); the arg mapper
+// rewrites every occurrence, and the native flag is a string array, so repeated
+// values accumulate instead of the last one winning.
 func atlasSchemaTestVerb() atlasVerb {
 	return atlasVerb{
 		use:                "test",
@@ -588,6 +593,7 @@ func atlasSchemaTestVerb() atlasVerb {
 			atlasargs.NativeLocalDir("url", "u", "Desired schema URL: local file:// directory with Go schema annotations", "root-dir"),
 			atlasargs.NativeString("dev-url", "", "Dev database URL the test cases run against", "db-url"),
 			atlasargs.String("run", "", "Run only test cases matching a Go regular expression"),
+			atlasargs.String(atlasSchemaFlagName, atlasSchemaFlagShorthand, "Restrict the desired schema to these schema names"),
 		},
 	}
 }

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -200,11 +200,16 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 		{
 			name: "schema_inspect",
 			path: []string{"schema", "inspect"},
-			// --include is a Pro-surface flag the pinned Atlas CE binary does
-			// not register on inspect; compat implements it so Pro pipelines
-			// port. --output, --web, and --export stay unregistered.
-			flags:     []string{"--url", "--dev-url", "--env", "--schema", "--exclude", "--format", "--include"},
-			forbidden: []string{"--output", "--web", "--export"},
+			// --include and --output are Pro-surface flags the pinned Atlas CE
+			// binary does not register on inspect; compat implements both so
+			// Pro pipelines port. --web is registered as a named refusal
+			// (see schema_ui_flags.go). --export stays unregistered: it is a
+			// separate item of stokaro/ptah#951.
+			flags: []string{
+				"--url", "--dev-url", "--env", "--schema", "--exclude",
+				"--format", "--include", "--output", "--web",
+			},
+			forbidden: []string{"--export"},
 		},
 		{
 			name:  "schema_apply",
@@ -1288,13 +1293,18 @@ func TestCompatCommand_SchemaInspectUsesAtlasProjectFormatAndSchemaMode(t *testi
 }
 
 // TestCompatCommand_SchemaInspectRejectsProOnlyOutputFlags pins the inspect
-// flags Atlas registers that compat deliberately does not:
-// --output, --web, and --export are separate items of stokaro/ptah#951.
-// --include is registered and covered by schema_inspect_include_test.go.
+// flags Atlas registers that compat deliberately does not.
+//
+// The list has shrunk to --export. --output is implemented
+// (schema_inspect_output_test.go) and --web is a registered refusal
+// (schema_ui_flags_test.go); --export on inspect is the twin of the
+// `schema diff --export` decision and stays a separate item of
+// stokaro/ptah#951. --include is registered and covered by
+// schema_inspect_include_test.go.
 func TestCompatCommand_SchemaInspectRejectsProOnlyOutputFlags(t *testing.T) {
 	c := qt.New(t)
 
-	for _, flag := range []string{"--output", "--web", "--export"} {
+	for _, flag := range []string{"--export"} {
 		c.Run(flag, func(c *qt.C) {
 			cmd := NewCompatCommand("atlas")
 			var out bytes.Buffer

--- a/cmd/atlas/output_file.go
+++ b/cmd/atlas/output_file.go
@@ -1,0 +1,61 @@
+package atlas
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"go.5x5.cz/ptah/internal/fsdurable"
+)
+
+// writeAtlasOutputFile publishes a rendered document at path atomically.
+//
+// The document is staged in the destination directory and then renamed over the
+// destination, so a concurrent reader sees either the previous file or the
+// complete new one. A schema inspection redirected into a file is routinely read
+// back by the next pipeline step (`schema apply --to file://…`), and a truncated
+// read there is a schema with objects missing, which is exactly the failure a
+// half-written file would produce.
+func writeAtlasOutputFile(path string, document []byte) error {
+	dir := filepath.Dir(path)
+	staged, err := os.CreateTemp(dir, ".ptah-output-*.tmp")
+	if err != nil {
+		return fmt.Errorf("stage output file: %w", err)
+	}
+	stagedPath := staged.Name()
+	if err := prepareAtlasOutputFile(staged, stagedPath, document); err != nil {
+		return err
+	}
+	if err := fsdurable.ReplaceFile(stagedPath, path); err != nil {
+		return errors.Join(fmt.Errorf("publish output file: %w", err), removeAtlasOutputStage(stagedPath))
+	}
+	if err := fsdurable.SyncDir(dir); err != nil {
+		return fmt.Errorf("sync published output file directory: %w", err)
+	}
+	return nil
+}
+
+func prepareAtlasOutputFile(staged *os.File, path string, document []byte) error {
+	if _, err := staged.Write(document); err != nil {
+		return errors.Join(err, staged.Close(), removeAtlasOutputStage(path))
+	}
+	if err := staged.Chmod(0o644); err != nil {
+		return errors.Join(err, staged.Close(), removeAtlasOutputStage(path))
+	}
+	if err := staged.Sync(); err != nil {
+		return errors.Join(err, staged.Close(), removeAtlasOutputStage(path))
+	}
+	if err := staged.Close(); err != nil {
+		return errors.Join(err, removeAtlasOutputStage(path))
+	}
+	return nil
+}
+
+func removeAtlasOutputStage(path string) error {
+	err := os.Remove(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -22,6 +22,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/schemafile"
+	migrationlint "go.5x5.cz/ptah/migration/lint"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -40,9 +41,14 @@ type atlasSchemaApplyOptions struct {
 	planURL     string
 	lockTimeout string
 	edit        bool
+	skipLint    bool
 	// formatOutput is derived at run time: true when --format was passed or
 	// atlas.hcl provides format.schema.apply.
 	formatOutput bool
+	// lintPolicy is the atlas.hcl lint block, resolved at run time. It decides
+	// both which rules the plan is linted against and whether there is a lint
+	// pass at all.
+	lintPolicy projectconfig.LintConfig
 }
 
 func newAtlasSchemaApplyCommand() *cobra.Command {
@@ -89,7 +95,13 @@ what both comparison sides see: --schema names define the schema universe,
 env.schema.mode subtract from the result. A selected object that depends on
 an unselected object refuses the plan with an explicit diagnostic instead of
 emitting incomplete SQL, and a selection that matches nothing reports a
-synced schema.`,
+synced schema.
+
+When the selected atlas.hcl env declares a ` + "`lint`" + ` policy, the planned
+SQL is linted against exactly the rules that policy names before anything is
+executed, and a finding the policy rates as an error refuses the apply.
+--skip-lint runs the apply without that check. A project with no lint policy
+has no lint pass to skip, so --skip-lint changes nothing there.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaApply(cmd, opts)
 		},
@@ -109,6 +121,7 @@ synced schema.`,
 	flags.StringVar(&opts.planURL, "plan", "", "URL to a pre-planned migration (e.g., file://<name>"+atlasschema.PlanFileSuffixHCL+" or file://<name>"+atlasschema.PlanFileSuffix+")")
 	flags.BoolVar(&opts.edit, "edit", false, "Open the generated SQL in an editor")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring the database lock")
+	flags.BoolVar(&opts.skipLint, "skip-lint", false, "Skip linting the planned migration")
 	if err := cmdflags.DisableEnvBinding(flags, "auto-approve"); err != nil {
 		panic(err)
 	}
@@ -152,6 +165,7 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		if err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
+		opts.lintPolicy = projectCfg.Lint
 	}
 	opts.formatOutput = formatOutput
 	if strings.TrimSpace(opts.planURL) != "" {
@@ -258,6 +272,12 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		fmt.Fprint(cmd.OutOrStdout(), formattedPlan)
 	} else {
 		printAtlasSchemaApplyPlan(cmd.OutOrStdout(), sqlText)
+	}
+	// The lint verdict covers the statements that would run, edits included,
+	// and lands before the --dry-run exit so a dry run reports the same refusal
+	// the real apply would.
+	if err := lintAtlasSchemaApplyPlan(opts, conn.Info().Dialect, statements); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	if opts.dryRun {
 		return nil
@@ -414,6 +434,13 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 		fmt.Fprint(cmd.OutOrStdout(), formattedPlan)
 	} else {
 		printAtlasSchemaApplyPlan(cmd.OutOrStdout(), plan.SQL())
+	}
+	// A pre-approved plan file is still SQL this command is about to run
+	// against the target, so the project's lint policy applies to it too.
+	// Exempting it would make --skip-lint inert on the one path an operator is
+	// most likely to be scripting.
+	if err := lintAtlasSchemaApplyPlan(opts, conn.Info().Dialect, statements); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	if err := validateAtlasSchemaApplyDiffPolicy(txMode, conn, statements); err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -674,6 +701,46 @@ func confirmAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions, f
 		fmt.Fprintln(cmd.OutOrStdout())
 	}
 	return promptAtlasSchemaApplyConfirmation(cmd.OutOrStdout(), cmd.InOrStdin())
+}
+
+// lintAtlasSchemaApplyPlan refuses a plan the project's lint policy rates as an
+// error, unless --skip-lint was passed.
+//
+// The pass exists only where a policy does. Atlas CE's `schema apply` neither
+// lints nor registers --skip-lint (measured on the pinned community binary), so
+// a project without a `lint` block keeps byte-identical CE behavior and
+// --skip-lint has nothing to skip there. Where the block is present, the same
+// severities that decide `migrate lint` decide this, which is the point: one
+// policy, applied wherever SQL is about to reach a database.
+func lintAtlasSchemaApplyPlan(opts atlasSchemaApplyOptions, dialect string, statements []string) error {
+	if opts.skipLint || len(statements) == 0 {
+		return nil
+	}
+	findings, err := atlasschema.LintPlan(statements, atlasSchemaApplyLintOptions(opts, dialect))
+	if err != nil {
+		return err
+	}
+	if len(findings) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"the planned changes are refused by the atlas.hcl lint policy:%s\nreview the plan, or rerun with --skip-lint to apply it anyway",
+		atlasschema.FormatPlanLintFindings(findings))
+}
+
+func atlasSchemaApplyLintOptions(opts atlasSchemaApplyOptions, dialect string) atlasschema.PlanLintOptions {
+	rules := make(map[string]migrationlint.RuleConfig, len(opts.lintPolicy.RuleConfigs))
+	for code, rule := range opts.lintPolicy.RuleConfigs {
+		rules[code] = migrationlint.RuleConfig{
+			Severity: migrationlint.Severity(rule.Severity),
+			Exclude:  slices.Clone(rule.Exclude),
+		}
+	}
+	return atlasschema.PlanLintOptions{
+		Dialect:     dialect,
+		RuleConfigs: rules,
+		Disabled:    slices.Clone(opts.lintPolicy.DisabledRules),
+	}
 }
 
 func validateAtlasSchemaApplyDiffPolicy(

--- a/cmd/atlas/schema_apply_skip_lint_test.go
+++ b/cmd/atlas/schema_apply_skip_lint_test.go
@@ -1,0 +1,144 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// destructiveLintPolicy is an atlas.hcl that rates a destructive change as an
+// error. It is the only thing that turns the lint pass on.
+const destructiveLintPolicy = `lint {
+  destructive {
+    error = true
+  }
+}
+`
+
+// warningLintPolicy declares the same analyzer at warning severity, so the pass
+// runs and finds the same statement without blocking.
+const warningLintPolicy = `lint {
+  destructive {
+    error = false
+  }
+}
+`
+
+// schemaApplySkipLintFixture builds a working directory holding the optional
+// atlas.hcl, a live SQLite database with one table, and a desired schema that
+// drops it. Applying the desired state therefore plans a DROP TABLE, which is
+// what the destructive analyzer reports.
+func schemaApplySkipLintFixture(c *qt.C, policy string) (dir, dbPath string) {
+	c.Helper()
+	dir = c.TempDir()
+	dbPath = filepath.Join(dir, "target.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "schema.sql"),
+		[]byte("CREATE TABLE keep (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	if policy != "" {
+		c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(policy), 0o600), qt.IsNil)
+	}
+	return dir, dbPath
+}
+
+// runSchemaApplyInDir runs `atlas schema apply --dry-run` with dir as the
+// working directory, so the optional atlas.hcl beside it is the one that loads.
+func runSchemaApplyInDir(c *qt.C, dir, dbPath string, extra ...string) (string, error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	args := append([]string{
+		"schema", "apply",
+		"--url", "sqlite://" + dbPath,
+		"--to", "file://schema.sql",
+		"--dev-url", "sqlite://" + filepath.Join(dir, "dev.db"),
+		"--dry-run",
+	}, extra...)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestSchemaApplySkipLint pins what the flag changes.
+//
+// Reverted, the --skip-lint rows fail with `unknown flag: --skip-lint` and the
+// "policy refuses" row fails because nothing lints the plan, so a destructive
+// apply that the project rated as an error succeeds silently.
+func TestSchemaApplySkipLint(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		extra   []string
+		wantErr bool
+		want    string
+		absent  string
+	}{
+		{
+			name:    "error policy refuses the destructive plan",
+			policy:  destructiveLintPolicy,
+			wantErr: true,
+			want:    "DS101",
+		},
+		{
+			name:    "skip-lint applies the same plan",
+			policy:  destructiveLintPolicy,
+			extra:   []string{"--skip-lint"},
+			wantErr: false,
+			want:    `DROP TABLE IF EXISTS "users"`,
+			absent:  "DS101",
+		},
+		{
+			name:    "warning policy does not block",
+			policy:  warningLintPolicy,
+			wantErr: false,
+			want:    `DROP TABLE IF EXISTS "users"`,
+			absent:  "DS101",
+		},
+		{
+			name:    "no policy is no lint pass",
+			policy:  "",
+			wantErr: false,
+			want:    `DROP TABLE IF EXISTS "users"`,
+			absent:  "DS101",
+		},
+		{
+			name:    "skip-lint without a policy changes nothing",
+			policy:  "",
+			extra:   []string{"--skip-lint"},
+			wantErr: false,
+			want:    `DROP TABLE IF EXISTS "users"`,
+			absent:  "DS101",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir, dbPath := schemaApplySkipLintFixture(c, test.policy)
+			// The atlas.hcl lookup is relative to the working directory, and
+			// t.Chdir restores it and rejects a parallel test outright.
+			t.Chdir(dir)
+
+			out, err := runSchemaApplyInDir(c, dir, dbPath, test.extra...)
+
+			c.Assert(err != nil, qt.Equals, test.wantErr, qt.Commentf("%s", out))
+			c.Assert(out, qt.Contains, test.want)
+			c.Assert(schemaApplyOutputExcludes(out, test.absent), qt.IsTrue, qt.Commentf("%s", out))
+		})
+	}
+}
+
+// schemaApplyOutputExcludes reports whether out omits absent. An empty absent
+// is vacuously satisfied, which keeps the table rows free of conditionals.
+func schemaApplyOutputExcludes(out, absent string) bool {
+	return absent == "" || !bytes.Contains([]byte(out), []byte(absent))
+}

--- a/cmd/atlas/schema_clean.go
+++ b/cmd/atlas/schema_clean.go
@@ -14,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/cmd/internal/dbcli"
 	"go.5x5.cz/ptah/config/projectconfig"
 	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasfilter"
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/schemaclean"
 )
@@ -23,6 +24,14 @@ type atlasSchemaCleanOptions struct {
 	dryRun      bool
 	format      string
 	autoApprove bool
+	include     []string
+	exclude     []string
+}
+
+// scoped reports whether a selector narrowed the cleanup plan. A scoped run
+// executes the plan itself; an unscoped run keeps the whole-database drop.
+func (o atlasSchemaCleanOptions) scoped() bool {
+	return len(o.include) > 0 || len(o.exclude) > 0
 }
 
 func newAtlasSchemaCleanCommand() *cobra.Command {
@@ -34,7 +43,17 @@ func newAtlasSchemaCleanCommand() *cobra.Command {
 
 Cleans user-owned schema objects through Ptah's destructive database cleanup
 runtime. The implementation supports direct database URLs, dry-run planning,
-explicit auto-approval, and Atlas Go-template output over the cleanup plan.`,
+explicit auto-approval, and Atlas Go-template output over the cleanup plan.
+
+--include and --exclude narrow the cleanup to part of the database, using the
+same selectors as ` + "`schema apply`" + `, ` + "`schema diff`" + ` and
+` + "`schema inspect`" + `: --include positively selects top-level objects and
+--exclude subtracts from the result. Child objects (a table's foreign keys)
+ride along with their parent. A narrowed run executes exactly the changes it
+printed, one statement at a time, instead of the whole-database drop an
+unflagged run performs — so what the plan lists is what is destroyed. Drop
+statements still carry the dialect's cascade behavior, so removing a selected
+object can take dependent objects with it whether or not they were selected.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaClean(cmd, opts)
 		},
@@ -44,6 +63,8 @@ explicit auto-approval, and Atlas Go-template output over the cleanup plan.`,
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Show planned cleanup without applying it")
 	flags.StringVar(&opts.format, "format", "", "Atlas Go template output format")
 	flags.BoolVar(&opts.autoApprove, "auto-approve", false, "Skip interactive approval")
+	flags.StringArrayVar(&opts.include, "include", nil, "Schema objects to include in the cleanup")
+	flags.StringArrayVar(&opts.exclude, "exclude", nil, "Schema objects to exclude from the cleanup")
 	if err := cmdflags.DisableEnvBinding(flags, "auto-approve"); err != nil {
 		panic(err)
 	}
@@ -67,6 +88,11 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 		formatValue := projectCfg.StringValue(projectconfig.StringFormatSchemaClean)
 		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
 		formatOutput = formatOutput || formatValue.Present
+		// An atlas.hcl exclude that every other schema verb honors must reach
+		// the destructive one too. Ignoring it here is the dangerous direction:
+		// an operator who excluded a table from their schema workflow would
+		// still watch this command drop it.
+		opts.exclude = effectiveAtlasExclude(cmd, opts.exclude, projectCfg)
 	}
 	if formatOutput && strings.TrimSpace(opts.format) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("--format must not be empty"))
@@ -75,6 +101,14 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 		if err := atlasreport.ValidateSchemaCleanTemplate(opts.format); err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
+	}
+	// Selector syntax is checked before the database is contacted, so a
+	// malformed pattern cannot half-clean a database on its way to failing.
+	if err := atlasfilter.ValidateIncludeSelectors(opts.include); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	if err := atlasfilter.ValidateExcludeSelectors(opts.exclude); err != nil {
+		return cmdutil.Fail(cmd, err)
 	}
 	if strings.TrimSpace(opts.url) == "" {
 		return cmdutil.Fail(cmd, fmt.Errorf("--url is required"))
@@ -91,6 +125,16 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 	plan, err := schemaclean.Inspect(conn)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
+	}
+	if opts.scoped() {
+		plan, err = scopeAtlasSchemaCleanPlan(plan, atlasfilter.Scope{
+			Include:       opts.include,
+			Exclude:       opts.exclude,
+			DefaultSchema: conn.Info().Schema,
+		}, conn.Info().Dialect)
+		if err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 	if formatOutput && !opts.dryRun {
 		if err := validateAtlasSchemaCleanActualFormat(opts, conn, plan); err != nil {
@@ -135,7 +179,7 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 		return nil
 	}
 
-	if err := schemaclean.Apply(cmd.Context(), conn); err != nil {
+	if err := applyAtlasSchemaClean(cmd, opts, conn, plan); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	if formatOutput {
@@ -148,6 +192,25 @@ func runAtlasSchemaClean(cmd *cobra.Command, opts atlasSchemaCleanOptions) error
 	}
 	fmt.Fprintln(cmd.OutOrStdout(), "Schema clean completed successfully.")
 	return nil
+}
+
+// applyAtlasSchemaClean destroys what the plan describes.
+//
+// An unscoped run keeps the whole-database drop, which is what it has always
+// been and what the writer's DropAllTables implements. A scoped run executes the
+// plan's own statements instead: the printed plan is the contract --include and
+// --exclude changed, and handing a narrowed plan to a routine that drops
+// everything would make both flags cosmetic.
+func applyAtlasSchemaClean(
+	cmd *cobra.Command,
+	opts atlasSchemaCleanOptions,
+	conn *dbschema.DatabaseConnection,
+	plan schemaclean.Plan,
+) error {
+	if opts.scoped() {
+		return schemaclean.ApplyPlan(cmd.Context(), conn, plan)
+	}
+	return schemaclean.Apply(cmd.Context(), conn)
 }
 
 func printAtlasSchemaCleanPlan(

--- a/cmd/atlas/schema_clean_scope.go
+++ b/cmd/atlas/schema_clean_scope.go
@@ -1,0 +1,143 @@
+package atlas
+
+import (
+	"fmt"
+
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasfilter"
+	"go.5x5.cz/ptah/internal/schemaclean"
+)
+
+// scopeAtlasSchemaCleanPlan restricts a cleanup plan to the objects selected by
+// --include and --exclude.
+//
+// The selection is decided by the same engine `schema apply`, `schema diff` and
+// `schema inspect` use — [atlasfilter] — rather than by a second glob matcher
+// written for this verb. The input to the engine is a synthetic schema built
+// from the objects the plan already enumerates, so the selection can only ever
+// narrow what [schemaclean.Inspect] found: whatever the planner learns to
+// enumerate flows through this projection without the projection having to
+// learn about it separately.
+//
+// Two deliberate differences from the apply/diff projection, both consequences
+// of this being a drop rather than a comparison:
+//
+//   - The synthetic schema carries identities only, not columns or foreign
+//     keys, so atlasfilter's cross-scope dependency validation stays quiet. That
+//     validation refuses a projection that keeps an object whose dependency it
+//     dropped, which is right when the projection describes a desired state and
+//     wrong when it describes a drop list: dropping "orders" while leaving
+//     "users" alone is a perfectly good scoped clean, and refusing it would make
+//     --include unusable on any schema with foreign keys.
+//   - An object kind the mapping does not know is refused rather than silently
+//     kept or silently dropped. Either silent answer would mis-scope a future
+//     object kind while still printing a plausible plan; see stokaro/ptah#940,
+//     which is widening exactly this enumeration.
+func scopeAtlasSchemaCleanPlan(
+	plan schemaclean.Plan,
+	scope atlasfilter.Scope,
+	dialect string,
+) (schemaclean.Plan, error) {
+	synthetic, err := atlasSchemaCleanSyntheticSchema(plan)
+	if err != nil {
+		return schemaclean.Plan{}, err
+	}
+	var projected *dbschematypes.DBSchema
+	if scope.Positive() {
+		projected, err = atlasfilter.ScopeDatabase(synthetic, scope)
+		if err != nil {
+			return schemaclean.Plan{}, fmt.Errorf("apply --include to the cleanup plan: %w", err)
+		}
+	} else {
+		projected, err = atlasfilter.ExcludeDatabase(synthetic, scope.Exclude)
+		if err != nil {
+			return schemaclean.Plan{}, fmt.Errorf("apply --exclude to the cleanup plan: %w", err)
+		}
+	}
+	kept := atlasSchemaCleanKeptObjects(projected)
+	selected := make([]schemaclean.Object, 0, len(plan.Objects))
+	for _, object := range plan.Objects {
+		keep, err := atlasSchemaCleanObjectKept(kept, object)
+		if err != nil {
+			return schemaclean.Plan{}, err
+		}
+		if keep {
+			selected = append(selected, object)
+		}
+	}
+	return schemaclean.PlanFromObjects(selected, dialect), nil
+}
+
+// atlasSchemaCleanObjectIdentity is the (type, schema, name) key the projection
+// round-trips an enumerated object through.
+type atlasSchemaCleanObjectIdentity struct {
+	objectType string
+	schema     string
+	name       string
+}
+
+// atlasSchemaCleanSyntheticSchema renders the planned objects as the smallest
+// introspected schema that carries their identities.
+func atlasSchemaCleanSyntheticSchema(plan schemaclean.Plan) (*dbschematypes.DBSchema, error) {
+	schema := &dbschematypes.DBSchema{}
+	for _, object := range plan.Objects {
+		switch object.Type {
+		case schemaclean.ObjectTypeTable:
+			schema.Tables = append(schema.Tables, dbschematypes.DBTable{
+				Name:   object.Name,
+				Schema: object.Schema,
+				Type:   "BASE TABLE",
+			})
+		case schemaclean.ObjectTypeEnum:
+			schema.Enums = append(schema.Enums, dbschematypes.DBEnum{Name: object.Name})
+		case schemaclean.ObjectTypeSequence:
+			schema.Sequences = append(schema.Sequences, dbschematypes.DBSequence{
+				Name:   object.Name,
+				Schema: object.Schema,
+			})
+		case schemaclean.ObjectTypeForeignKey:
+			// A foreign key is a child resource: atlasfilter refuses to select
+			// one on its own, so it rides along with the table that owns it.
+		default:
+			return nil, fmt.Errorf(
+				"--include/--exclude cannot scope cleanup object kind %q; the selector engine has no mapping for it",
+				object.Type)
+		}
+	}
+	return schema, nil
+}
+
+func atlasSchemaCleanKeptObjects(schema *dbschematypes.DBSchema) map[atlasSchemaCleanObjectIdentity]struct{} {
+	kept := make(map[atlasSchemaCleanObjectIdentity]struct{})
+	if schema == nil {
+		return kept
+	}
+	for _, table := range schema.Tables {
+		kept[atlasSchemaCleanObjectIdentity{schemaclean.ObjectTypeTable, table.Schema, table.Name}] = struct{}{}
+	}
+	for _, enum := range schema.Enums {
+		kept[atlasSchemaCleanObjectIdentity{schemaclean.ObjectTypeEnum, "", enum.Name}] = struct{}{}
+	}
+	for _, sequence := range schema.Sequences {
+		kept[atlasSchemaCleanObjectIdentity{schemaclean.ObjectTypeSequence, sequence.Schema, sequence.Name}] = struct{}{}
+	}
+	return kept
+}
+
+func atlasSchemaCleanObjectKept(
+	kept map[atlasSchemaCleanObjectIdentity]struct{},
+	object schemaclean.Object,
+) (bool, error) {
+	switch object.Type {
+	case schemaclean.ObjectTypeTable, schemaclean.ObjectTypeEnum, schemaclean.ObjectTypeSequence:
+		_, ok := kept[atlasSchemaCleanObjectIdentity{object.Type, object.Schema, object.Name}]
+		return ok, nil
+	case schemaclean.ObjectTypeForeignKey:
+		_, ok := kept[atlasSchemaCleanObjectIdentity{schemaclean.ObjectTypeTable, object.Schema, object.Table}]
+		return ok, nil
+	default:
+		return false, fmt.Errorf(
+			"--include/--exclude cannot scope cleanup object kind %q; the selector engine has no mapping for it",
+			object.Type)
+	}
+}

--- a/cmd/atlas/schema_clean_scope_test.go
+++ b/cmd/atlas/schema_clean_scope_test.go
@@ -1,0 +1,185 @@
+package atlas_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// runSchemaCleanScope runs `atlas schema clean` against dbPath with extra
+// selector arguments and returns the combined output.
+func runSchemaCleanScope(c *qt.C, dbPath string, extra ...string) (string, error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	args := append([]string{"schema", "clean", "--url", "sqlite://" + dbPath}, extra...)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestSchemaCleanSelectorsNarrowThePlan pins what the selectors print.
+//
+// Reverted, every row fails with `unknown flag: --include` (or --exclude): the
+// flags do not exist on master.
+func TestSchemaCleanSelectorsNarrowThePlan(t *testing.T) {
+	tests := []struct {
+		name    string
+		args    []string
+		planned []string
+		absent  []string
+	}{
+		{
+			name:    "no selector plans every table",
+			args:    []string{"--dry-run"},
+			planned: []string{`DROP TABLE IF EXISTS "users"`, `DROP TABLE IF EXISTS "audit_log"`},
+		},
+		{
+			name:    "include keeps only the named table",
+			args:    []string{"--dry-run", "--include", "users"},
+			planned: []string{`DROP TABLE IF EXISTS "users"`},
+			absent:  []string{`DROP TABLE IF EXISTS "audit_log"`},
+		},
+		{
+			name:    "exclude subtracts the named table",
+			args:    []string{"--dry-run", "--exclude", "audit_log"},
+			planned: []string{`DROP TABLE IF EXISTS "users"`},
+			absent:  []string{`DROP TABLE IF EXISTS "audit_log"`},
+		},
+		{
+			name:    "include accepts the type selector spelling",
+			args:    []string{"--dry-run", "--include", "users[type=table]"},
+			planned: []string{`DROP TABLE IF EXISTS "users"`},
+			absent:  []string{`DROP TABLE IF EXISTS "audit_log"`},
+		},
+		{
+			name:    "include accepts a glob",
+			args:    []string{"--dry-run", "--include", "a*"},
+			planned: []string{`DROP TABLE IF EXISTS "audit_log"`},
+			absent:  []string{`DROP TABLE IF EXISTS "users"`},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(t.TempDir(), "clean-scope.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+			createSQLiteSchemaCleanTable(c, dbPath, "audit_log")
+
+			out, err := runSchemaCleanScope(c, dbPath, test.args...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			for _, planned := range test.planned {
+				c.Assert(out, qt.Contains, planned)
+			}
+			for _, absent := range test.absent {
+				c.Assert(out, qt.Not(qt.Contains), absent)
+			}
+		})
+	}
+}
+
+// TestSchemaCleanSelectorsNarrowWhatIsDestroyed is the load-bearing one. A
+// selector that only shapes the printed plan while the executed drop still goes
+// through the whole-database path would pass the plan assertions above and
+// still destroy the excluded table.
+//
+// Reverted, the run fails with `unknown flag: --include`. With the selector
+// routed to the plan but the execution left on the whole-database drop, the
+// remaining-table assertion fails instead.
+func TestSchemaCleanSelectorsNarrowWhatIsDestroyed(t *testing.T) {
+	tests := []struct {
+		name      string
+		args      []string
+		dropped   string
+		surviving string
+	}{
+		{
+			name:      "include drops only the selected table",
+			args:      []string{"--auto-approve", "--include", "users"},
+			dropped:   "users",
+			surviving: "audit_log",
+		},
+		{
+			name:      "exclude spares the excluded table",
+			args:      []string{"--auto-approve", "--exclude", "audit_log"},
+			dropped:   "users",
+			surviving: "audit_log",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(t.TempDir(), "clean-scope-apply.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+			createSQLiteSchemaCleanTable(c, dbPath, "audit_log")
+
+			out, err := runSchemaCleanScope(c, dbPath, test.args...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			c.Assert(sqliteTableCount(c, dbPath, test.dropped), qt.Equals, 0)
+			c.Assert(sqliteTableCount(c, dbPath, test.surviving), qt.Equals, 1)
+		})
+	}
+}
+
+// TestSchemaCleanUnselectedRunStillDropsEverything pins the unflagged path, so
+// routing the selectors cannot quietly turn a plain `schema clean` into a
+// partial one.
+func TestSchemaCleanUnselectedRunStillDropsEverything(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "clean-scope-full.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+	createSQLiteSchemaCleanTable(c, dbPath, "audit_log")
+
+	out, err := runSchemaCleanScope(c, dbPath, "--auto-approve")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(sqliteTableCount(c, dbPath, "users"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, dbPath, "audit_log"), qt.Equals, 0)
+}
+
+// TestSchemaCleanRejectsUnsupportedSelectorsBeforeConnecting checks that a
+// selector form the engine refuses is refused before any database is touched.
+func TestSchemaCleanRejectsUnsupportedSelectorsBeforeConnecting(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "include cannot name a child resource",
+			args: []string{"--dry-run", "--include", "users[type=column]"},
+			want: "cannot be included on their own",
+		},
+		{
+			name: "include cannot name a schema",
+			args: []string{"--dry-run", "--include", "main[type=schema]"},
+			want: "use --schema to select schemas",
+		},
+		{
+			name: "exclude rejects an unsupported field selector",
+			args: []string{"--dry-run", "--exclude", "users[type=table].name"},
+			want: "unsupported Atlas exclude field selector",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(t.TempDir(), "clean-scope-invalid.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+
+			out, err := runSchemaCleanScope(c, dbPath, test.args...)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(out, qt.Contains, test.want)
+			c.Assert(sqliteTableCount(c, dbPath, "users"), qt.Equals, 1)
+		})
+	}
+}

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -50,7 +50,9 @@ schema universe, --include selectors pick top-level resources inside it, and
 --exclude plus env.schema.mode subtract from the result. A selected object
 that depends on an unselected object refuses the diff with an explicit
 diagnostic, and a selection that matches nothing reports synced schemas.
-Hosted report output is not implemented.`,
+Hosted report output is not implemented. --export is registered and refused:
+it selects an exporter declared by an atlas.hcl ` + "`exporter`" + ` block,
+which Ptah does not evaluate.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaDiff(cmd, opts)
 		},
@@ -63,11 +65,17 @@ Hosted report output is not implemented.`,
 	flags.StringVar(&opts.format, "format", "", "Atlas Go template output format")
 	registerAtlasSchemaFlag(flags, &opts.schemas, "Schemas to diff when a database URL is used")
 	flags.StringArrayVar(&opts.include, "include", nil, "Schema objects to include in diffing")
+	registerAtlasUIFlag(cmd, atlasSchemaExportFlag())
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	return cmd
 }
 
 func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
+	// The refusal lands before any config or database work: a flag Ptah does
+	// not implement must not be answered with a diff that ignored it.
+	if err := refuseAtlasUIFlag(cmd, "schema", "diff", atlasSchemaExportFlag()); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	formatConfigured := cmd.Flags().Changed("format")
 	policy := atlasschema.DiffPolicy{}
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -20,6 +20,7 @@ type atlasSchemaInspectOptions struct {
 	include []string
 	exclude []string
 	format  string
+	output  string
 }
 
 func newAtlasSchemaInspectCommand() *cobra.Command {
@@ -63,7 +64,15 @@ identifier holding a dot is selected as ` + "`main.\"my.table\"`" + ` or
 ambiguous with schema.table.column. A selection that keeps an object whose dependency it
 dropped is refused rather than rendered, so inspected output never references
 an object it omitted. The flag is absent from Atlas CE, which rejects it as an
-unknown flag on this command.`,
+unknown flag on this command.
+
+-o/--output writes the rendered schema to a file instead of stdout. The file is
+staged beside its destination and published atomically, so a reader either sees
+the previous contents or the complete new document, never a partial one. Nothing
+is written to stdout on the --output path.
+
+-w/--web is registered and refused: opening a viewer has no local counterpart,
+and the ERD itself is available as data through --format '{{ mermaid . }}'.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runAtlasSchemaInspect(cmd, opts)
 		},
@@ -75,11 +84,18 @@ unknown flag on this command.`,
 	flags.StringArrayVar(&opts.include, "include", nil, "Schema objects to include in inspection")
 	flags.StringArrayVar(&opts.exclude, "exclude", nil, "Schema objects to exclude from inspection")
 	flags.StringVar(&opts.format, "format", "", "Output format or Go template: hcl, sql, json, or custom template")
+	flags.StringVarP(&opts.output, "output", "o", "", "Write the inspected schema to this file instead of stdout")
+	registerAtlasUIFlag(cmd, atlasSchemaWebFlag())
 	cmdutil.ConfigureCommandArgs(cmd, cmdutil.NoPositionalArgs)
 	return cmd
 }
 
 func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) error {
+	// The refusal lands before any config or database work: a flag Ptah does
+	// not implement must not be answered with an inspection that ignored it.
+	if err := refuseAtlasUIFlag(cmd, "schema", "inspect", atlasSchemaWebFlag()); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	formatConfigured := cmd.Flags().Changed("format")
 	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
 	if needsAtlasSchemaInspectConfig(cmd) {
@@ -134,6 +150,12 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
+	}
+	if path := strings.TrimSpace(opts.output); path != "" {
+		if err := writeAtlasOutputFile(path, []byte(rendered)); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
+		return nil
 	}
 	fmt.Fprint(cmd.OutOrStdout(), rendered)
 	return nil

--- a/cmd/atlas/schema_inspect_output_test.go
+++ b/cmd/atlas/schema_inspect_output_test.go
@@ -1,0 +1,122 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// runSchemaInspectOutput runs `atlas schema inspect` against dbPath with extra
+// arguments and returns what reached stdout.
+func runSchemaInspectOutput(c *qt.C, dbPath string, extra ...string) (string, error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	args := append([]string{"schema", "inspect", "--url", "sqlite://" + dbPath}, extra...)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestSchemaInspectOutputWritesTheFile pins where the rendered schema goes.
+//
+// Reverted, every row fails with `unknown flag: --output` (or `-o`).
+func TestSchemaInspectOutputWritesTheFile(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagName string
+		format   []string
+		contains string
+	}{
+		{
+			name:     "long flag writes HCL",
+			flagName: "--output",
+			contains: `table "users"`,
+		},
+		{
+			name:     "shorthand writes HCL",
+			flagName: "-o",
+			contains: `table "users"`,
+		},
+		{
+			name:     "the chosen format is what lands in the file",
+			flagName: "--output",
+			format:   []string{"--format", "sql"},
+			contains: "CREATE TABLE",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			dbPath := filepath.Join(dir, "inspect-output.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+			target := filepath.Join(dir, "schema.out")
+
+			args := append([]string{test.flagName, target}, test.format...)
+			out, err := runSchemaInspectOutput(c, dbPath, args...)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			// Nothing on stdout: the file is the output, and a pipeline that
+			// redirects both would otherwise get the document twice.
+			c.Assert(out, qt.Equals, "")
+			written, readErr := os.ReadFile(target)
+			c.Assert(readErr, qt.IsNil)
+			c.Assert(string(written), qt.Contains, test.contains)
+		})
+	}
+}
+
+// TestSchemaInspectWithoutOutputStillPrints pins the unflagged path, so routing
+// the file write cannot silence the default.
+func TestSchemaInspectWithoutOutputStillPrints(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(c.TempDir(), "inspect-stdout.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+
+	out, err := runSchemaInspectOutput(c, dbPath)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	c.Assert(out, qt.Contains, `table "users"`)
+}
+
+// TestSchemaInspectOutputReplacesAnExistingFile pins that a repeated
+// inspection overwrites rather than refusing or appending.
+func TestSchemaInspectOutputReplacesAnExistingFile(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	dbPath := filepath.Join(dir, "inspect-replace.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+	target := filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(target, []byte("stale contents\n"), 0o600), qt.IsNil)
+
+	out, err := runSchemaInspectOutput(c, dbPath, "--output", target)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+	written, readErr := os.ReadFile(target)
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(written), qt.Not(qt.Contains), "stale contents")
+	c.Assert(string(written), qt.Contains, `table "users"`)
+}
+
+// TestSchemaInspectOutputReportsAnUnwritableDestination checks that a bad
+// destination fails loudly instead of dropping the inspection on the floor.
+func TestSchemaInspectOutputReportsAnUnwritableDestination(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	dbPath := filepath.Join(dir, "inspect-unwritable.db")
+	createSQLiteSchemaCleanTable(c, dbPath, "users")
+	target := filepath.Join(dir, "no-such-directory", "schema.hcl")
+
+	out, err := runSchemaInspectOutput(c, dbPath, "--output", target)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(out, qt.Contains, "stage output file")
+}

--- a/cmd/atlas/schema_test_schema_scope_test.go
+++ b/cmd/atlas/schema_test_schema_scope_test.go
@@ -1,0 +1,121 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// writeSchemaTestScopeFixture writes a desired schema whose two tables live in
+// two different schemas, plus a case that only needs the one in "main".
+//
+// The fixture is discriminating on purpose. On SQLite only "main" exists, so
+// provisioning the unscoped schema fails outright on the "other" table: a
+// --schema that was parsed and then ignored cannot make this pass, and a
+// --schema that kept both tables cannot either.
+func writeSchemaTestScopeFixture(c *qt.C, modelsDir, testsDir string) {
+	c.Helper()
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "models.go"), []byte(`package models
+
+//ptah:schema:table name="users" schema="main"
+type User struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+
+//ptah:schema:table name="audit" schema="other"
+type Audit struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(testsDir, "users.yaml"), []byte(
+		"cases:\n"+
+			"  - name: users is provisioned\n"+
+			"    steps:\n"+
+			"      - name: users is empty\n"+
+			"        assert:\n"+
+			"          query: SELECT COUNT(*) FROM users\n"+
+			"          scalar: \"0\"\n"), 0o600), qt.IsNil)
+}
+
+// TestSchemaTestSchemaSelection pins what -s/--schema does to the desired
+// schema a test run provisions.
+//
+// Reverted, the flagged rows fail with `unknown flag: --schema`, because the
+// spelling reaches the native runner untranslated.
+func TestSchemaTestSchemaSelection(t *testing.T) {
+	tests := []struct {
+		name    string
+		extra   []string
+		wantErr bool
+		want    string
+	}{
+		{
+			name:    "no selection provisions every schema and fails on SQLite",
+			wantErr: true,
+			want:    `unknown database "other"`,
+		},
+		{
+			name:    "long flag keeps only the selected schema",
+			extra:   []string{"--schema", "main"},
+			wantErr: false,
+			want:    `PASS  case "users is provisioned"`,
+		},
+		{
+			name:    "shorthand keeps only the selected schema",
+			extra:   []string{"-s", "main"},
+			wantErr: false,
+			want:    `PASS  case "users is provisioned"`,
+		},
+		{
+			name:    "comma-separated values union",
+			extra:   []string{"--schema", "main,nosuch"},
+			wantErr: false,
+			want:    `PASS  case "users is provisioned"`,
+		},
+		{
+			name: "repeated values accumulate rather than the last one winning",
+			// With last-wins forwarding this run would be scoped to "nosuch"
+			// alone and refuse; it passes only if "main" survived too.
+			extra:   []string{"-s", "main", "-s", "nosuch"},
+			wantErr: false,
+			want:    `PASS  case "users is provisioned"`,
+		},
+		{
+			name:    "a selection that keeps nothing is refused",
+			extra:   []string{"--schema", "nosuch"},
+			wantErr: true,
+			want:    "selects no tables out of the desired schema",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			modelsDir, testsDir := c.TempDir(), c.TempDir()
+			writeSchemaTestScopeFixture(c, modelsDir, testsDir)
+			devDB := "sqlite://" + filepath.Join(c.TempDir(), "dev.db")
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			args := append([]string{
+				"schema", "test", testsDir,
+				"-u", "file://" + modelsDir,
+				"--dev-url", devDB,
+			}, test.extra...)
+			cmd.SetArgs(args)
+
+			err := cmd.Execute()
+
+			c.Assert(err != nil, qt.Equals, test.wantErr, qt.Commentf("%s", out.String()))
+			c.Assert(out.String(), qt.Contains, test.want)
+		})
+	}
+}

--- a/cmd/atlas/schema_ui_flags.go
+++ b/cmd/atlas/schema_ui_flags.go
@@ -1,0 +1,73 @@
+package atlas
+
+import (
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/internal/atlasargs"
+)
+
+// The UI-bound schema flags, and why they are registered refusals rather than
+// implementations or absences.
+//
+// Both have an Atlas-side source: Atlas's published CLI reference
+// (atlasgo.io/cli-reference) lists `-w, --web  open the schema ERD in the
+// browser` on `schema inspect` and `--export  use exporter defined in env` on
+// `schema diff`. Neither is registered by the pinned community binary, measured
+// by running the spelling: both answer `unknown flag` there, with `--format`
+// present and `--frobnicate-nonsense` missing as controls. So the reference is
+// the source, and the spelling below matches it.
+//
+// Neither is implemented, and the reasons differ:
+//
+//   - --web names a browser action. Its payload is not the problem: Ptah renders
+//     the same ERD locally, as `schema inspect --format '{{ mermaid . }}'` and as
+//     `ptah viz`. What Ptah has no counterpart for is opening a viewer, and a
+//     CLI that launches a browser is the wrong shape for the pipelines this
+//     surface exists to serve. The refusal names the local spelling that
+//     produces the diagram, so the capability stays reachable.
+//   - --export selects an exporter declared by an atlas.hcl `exporter` block.
+//     Ptah's project-config evaluator tolerates that block and evaluates nothing
+//     from it, so there is no exporter for the flag to select. Accepting the
+//     flag would silently emit the default output and call it an export.
+//
+// Accepting either silently is the failure this issue exists to prevent, and
+// leaving both unregistered would leave a script no way to learn why its
+// spelling did nothing. A registered refusal answers the question in one line
+// and cannot be mistaken for success: it exits non-zero before any database is
+// contacted.
+//
+// The same verdict and the same source cover the twins this batch did not touch
+// — `schema inspect --export`, `schema diff --web`, `migrate lint --web` — left
+// out to stay inside the batch rather than because they differ.
+const (
+	atlasSchemaWebFlagName    = "web"
+	atlasSchemaExportFlagName = "export"
+)
+
+func atlasSchemaWebFlag() atlasargs.Flag {
+	return atlasargs.UnsupportedBoolReason(
+		atlasSchemaWebFlagName, "w", "Open the schema ERD in the browser",
+		"opening a viewer is a UI action with no local counterpart; the ERD itself is local — render it with --format '{{ mermaid . }}' or `ptah viz`",
+	)
+}
+
+func atlasSchemaExportFlag() atlasargs.Flag {
+	return atlasargs.UnsupportedBoolReason(
+		atlasSchemaExportFlagName, "", "Use the exporter defined in the atlas.hcl env",
+		"an exporter is declared by an atlas.hcl `exporter` block, which Ptah does not evaluate; there is no exporter to select, and emitting the default output instead would report an export that never happened",
+	)
+}
+
+// refuseAtlasUIFlag rejects a registered UI-bound flag that was actually passed.
+// Registration alone is help parity; the refusal is what keeps the flag from
+// being accepted and ignored.
+func refuseAtlasUIFlag(cmd *cobra.Command, group, use string, flag atlasargs.Flag) error {
+	if !cmd.Flags().Changed(flag.Name) {
+		return nil
+	}
+	return atlasargs.UnsupportedFlagError(group, use, flag, "--"+flag.Name)
+}
+
+func registerAtlasUIFlag(cmd *cobra.Command, flag atlasargs.Flag) {
+	cmd.Flags().BoolP(flag.Name, flag.Shorthand, false, flag.Usage)
+}

--- a/cmd/atlas/schema_ui_flags_test.go
+++ b/cmd/atlas/schema_ui_flags_test.go
@@ -1,0 +1,127 @@
+package atlas_test
+
+import (
+	"bytes"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// TestSchemaUIFlagsAreRegisteredRefusals pins the decision taken on the two
+// UI-bound flags: they parse, and they refuse with a named reason.
+//
+// Reverted, both rows fail with `unknown flag`, which is the state that made a
+// script passing the spelling unable to learn anything. Turned into a silent
+// accept, both rows fail on the exit status instead — which is the outcome this
+// pins against, because an accepted-and-ignored --export would report an export
+// that never happened.
+func TestSchemaUIFlagsAreRegisteredRefusals(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(dbPath string) []string
+		want string
+	}{
+		{
+			name: "schema inspect --web",
+			args: func(dbPath string) []string {
+				return []string{"schema", "inspect", "--url", "sqlite://" + dbPath, "--web"}
+			},
+			want: "atlas schema inspect accepts --web, but Ptah does not implement its behavior",
+		},
+		{
+			name: "schema inspect -w",
+			args: func(dbPath string) []string {
+				return []string{"schema", "inspect", "--url", "sqlite://" + dbPath, "-w"}
+			},
+			want: "render it with --format '{{ mermaid . }}'",
+		},
+		{
+			name: "schema diff --export",
+			args: func(dbPath string) []string {
+				return []string{
+					"schema", "diff",
+					"--from", "sqlite://" + dbPath,
+					"--to", "sqlite://" + dbPath,
+					"--export",
+				}
+			},
+			want: "atlas schema diff accepts --export, but Ptah does not implement its behavior",
+		},
+		{
+			name: "schema diff --export names what it would need",
+			args: func(dbPath string) []string {
+				return []string{
+					"schema", "diff",
+					"--from", "sqlite://" + dbPath,
+					"--to", "sqlite://" + dbPath,
+					"--export",
+				}
+			},
+			want: "atlas.hcl `exporter` block",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(c.TempDir(), "ui-flags.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(test.args(dbPath))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(out.String(), qt.Contains, test.want)
+		})
+	}
+}
+
+// TestSchemaUIFlagsUnpassedDoNotInterfere pins that registering the refusals
+// leaves the ordinary paths alone.
+func TestSchemaUIFlagsUnpassedDoNotInterfere(t *testing.T) {
+	tests := []struct {
+		name string
+		args func(dbPath string) []string
+		want string
+	}{
+		{
+			name: "schema inspect without --web",
+			args: func(dbPath string) []string {
+				return []string{"schema", "inspect", "--url", "sqlite://" + dbPath}
+			},
+			want: `table "users"`,
+		},
+		{
+			name: "schema diff without --export",
+			args: func(dbPath string) []string {
+				return []string{"schema", "diff", "--from", "sqlite://" + dbPath, "--to", "sqlite://" + dbPath}
+			},
+			want: "Schemas are synced",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(c.TempDir(), "ui-flags-clear.db")
+			createSQLiteSchemaCleanTable(c, dbPath, "users")
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(test.args(dbPath))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+			c.Assert(out.String(), qt.Contains, test.want)
+		})
+	}
+}

--- a/cmd/schema/test.go
+++ b/cmd/schema/test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"slices"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -13,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
 	"go.5x5.cz/ptah/cmd/internal/schemaload"
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/schemascope"
 	"go.5x5.cz/ptah/migration/dbtest"
 )
 
@@ -23,6 +25,7 @@ const (
 	testDBURLFlag   = "db-url"
 	testReportFlag  = "report"
 	testRunFlag     = "run"
+	testSchemaFlag  = "schema"
 
 	testReportFormatText = "text"
 )
@@ -37,6 +40,7 @@ type testOptions struct {
 	dbURL   string
 	report  string
 	run     string
+	schemas []string
 }
 
 // NewSchemaTestCommand returns the "test" command for the schema namespace. It
@@ -63,6 +67,12 @@ steps; each step performs exactly one action:
 Seed steps may specify their own dir. When omitted, --seed-dir supplies the
 default directory for the run.
 
+--schema restricts the desired schema to the named schemas before it is applied,
+so the cases run against that subset only. Repeated and comma-separated values
+union. A selection that keeps nothing is refused rather than run, because an
+empty desired schema makes every case fail on a missing object instead of
+reporting the selection as the cause.
+
 A migrate_to step is not valid in a schema test (use "ptah migrations test").
 
 When --db-url is omitted, an ephemeral SQLite database is provisioned in a
@@ -83,6 +93,7 @@ The command exits non-zero if any case fails.`,
 	flags.StringVar(&opts.dbURL, testDBURLFlag, "", "Throwaway database URL (optional). An ephemeral SQLite database is used when empty.")
 	flags.StringVar(&opts.report, testReportFlag, testReportFormatText, "Report format: text, json, or html")
 	flags.StringVar(&opts.run, testRunFlag, "", "Run only case names matching this Go regular expression")
+	flags.StringArrayVar(&opts.schemas, testSchemaFlag, nil, "Restrict the desired schema to these schema names")
 
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
@@ -108,7 +119,7 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 		return fmt.Errorf("no test cases found in %s", opts.dir)
 	}
 
-	desired, err := resolveTestDesiredSchema(ctx, opts.rootDir)
+	desired, err := resolveTestDesiredSchema(ctx, opts.rootDir, opts.schemas)
 	if err != nil {
 		return err
 	}
@@ -137,22 +148,56 @@ func runSchemaTest(ctx context.Context, out io.Writer, opts testOptions) error {
 	return nil
 }
 
-// resolveTestDesiredSchema turns the desired-schema source into a schema.
+// resolveTestDesiredSchema turns the desired-schema source into a schema,
+// restricted to schemas when a schema selection is present.
 //
-// A directory keeps the historical Go-annotation path and is left to the runner
-// so its error wording does not change. A .sql or .hcl file goes through the
-// shared loader every other schema-consuming verb already uses -- `schema diff
-// --to file://schema.sql` and `--to file://schema.hcl` both work, and only this
-// verb was restricted to Go annotations.
-func resolveTestDesiredSchema(ctx context.Context, source string) (*goschema.Database, error) {
+// Without a selection a directory keeps the historical Go-annotation path and is
+// left to the runner so its error wording does not change. A .sql or .hcl file
+// goes through the shared loader every other schema-consuming verb already uses
+// -- `schema diff --to file://schema.sql` and `--to file://schema.hcl` both
+// work, and only this verb was restricted to Go annotations.
+//
+// A schema selection has to be applied here rather than inside the runner,
+// because the runner's own parse produces the schema it immediately provisions.
+// Resolving the directory eagerly on that path is the price of the selection;
+// the parse is the same [goschema.ParseDir] the runner would have run.
+func resolveTestDesiredSchema(ctx context.Context, source string, schemas []string) (*goschema.Database, error) {
+	selection := schemascope.SplitNames(schemas)
 	info, err := os.Stat(source)
 	if err != nil || info.IsDir() {
-		// Leave a missing path to the runner, which names it in its own error.
-		return nil, nil //nolint:nilerr // the runner reports this source
+		if len(selection) == 0 {
+			// Leave a missing path to the runner, which names it in its own error.
+			return nil, nil //nolint:nilerr // the runner reports this source
+		}
+		parsed, parseErr := goschema.ParseDir(source)
+		if parseErr != nil {
+			return nil, fmt.Errorf("parse desired schema from %s: %w", source, parseErr)
+		}
+		return scopeTestDesiredSchema(parsed, selection)
 	}
 	database, err := schemaload.LoadContext(ctx, schemaload.Options{SchemaFiles: []string{source}})
 	if err != nil {
 		return nil, fmt.Errorf("load desired schema from %s: %w", source, err)
 	}
-	return database, nil
+	return scopeTestDesiredSchema(database, selection)
+}
+
+// scopeTestDesiredSchema restricts database to the selected schemas through the
+// same allow-list every other schema-scoped verb uses.
+//
+// A selection that keeps no tables out of a schema that had some is refused. The
+// alternative is provisioning an empty database and letting every case fail on a
+// missing relation, which reports the symptom and hides the cause -- the
+// zero-match false green that stokaro/ptah#979 exists to prevent.
+func scopeTestDesiredSchema(database *goschema.Database, selection []string) (*goschema.Database, error) {
+	if len(selection) == 0 || database == nil {
+		return database, nil
+	}
+	scoped := schemascope.FilterGenerated(database, selection)
+	if len(database.Tables) > 0 && len(scoped.Tables) == 0 {
+		return nil, fmt.Errorf(
+			"--%s %s selects no tables out of the desired schema",
+			testSchemaFlag, strings.Join(selection, ","))
+	}
+	return scoped, nil
 }

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -361,12 +361,21 @@
   },
   {
     "area": "Migration linting",
+    "feature": "`schema apply --skip-lint`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "With an atlas.hcl `lint` policy, the planned SQL is linted against the rules it names and an error-rated finding refuses the apply; `--skip-lint` applies anyway. No policy, no lint pass, as in CE.",
+    "evidence": "Added under #951; Atlas-side source atlasgo.io/cli-reference (`--skip-lint  skip linting migration plan` on schema apply). The pinned community binary v1.3.0 does not register it and does not lint on apply, measured by running the spelling: `schema apply --skip-lint` -> `unknown flag`, with `--dry-run` present and `--frobnicate-nonsense` missing as controls. Verified over a destructive fixture (live `users`, desired schema without it, so the plan is a DROP TABLE): with `lint { destructive { error = true } }` the dry run exits 1 naming DS101; with `--skip-lint` the same run exits 0 and prints the DROP; with `error = false` it exits 0; with no atlas.hcl at all it exits 0 and `--skip-lint` changes nothing (cmd/atlas/schema_apply_skip_lint_test.go). Only the rules the policy names run: the engine also ships rules a declarative plan cannot answer -- a plan is not a directory, so it has no paired down file -- and enabling the whole registry would refuse applies over findings nobody asked about. This is the opposite of the `schema plan --skip-lint` row, where the flag is still a no-op because that verb runs no lint step"
+  },
+  {
+    "area": "Migration linting",
     "feature": "Atlas web reports (`--web`)",
     "ptah": "no",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either.",
-    "evidence": "Reproduced on all three surfaces: `ptah-compat migrate lint --web` and `ptah-compat schema diff --web` print `Error: unknown flag: --web` (exit 1), `ptah migrations lint --web` prints `error: unknown flag: --web` (exit 2); the prefix and code follow the surface, per #1019. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
+    "note": "`schema inspect --web` is a registered refusal naming the local ERD spelling; migrate lint and schema diff still reject it as unknown. Pinned Atlas CE registers it on none of them.",
+    "evidence": "Decided under #951: opening a viewer has no local counterpart, but the diagram does, so the refusal names it. Verified: `ptah-compat schema inspect --url sqlite://t.db --web` prints `atlas schema inspect accepts --web, but Ptah does not implement its behavior: opening a viewer is a UI action with no local counterpart; the ERD itself is local` (exit 1, cmd/atlas/schema_ui_flags_test.go). Still unknown flags elsewhere: `ptah-compat migrate lint --web` and `ptah-compat schema diff --web` print `Error: unknown flag: --web` (exit 1), `ptah migrations lint --web` prints `error: unknown flag: --web` (exit 2); the prefix and code follow the surface, per #1019. Atlas-side source for the spelling: atlasgo.io/cli-reference lists `-w, --web  open the schema ERD in the browser` on schema inspect. Measured 2026-08-03 on the pinned community binary v1.3.0, by running the spelling: `schema inspect --web` -> `unknown flag`, with `--format` present and `--frobnicate-nonsense` missing as controls. cli-surface.md:33 lists the full CE `atlas migrate lint` flag set with no --web."
   },
   {
     "area": "Testing framework",
@@ -545,8 +554,26 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables.",
-    "evidence": "internal/schemaclean/clean.go:109-147 enumerates only foreign keys, tables and enums; :75-81 executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty \u2014 the unreported view v_const was dropped as well. CE registers schema clean per cli-surface.md:44"
+    "note": "`--include`/`--exclude` narrow the cleanup through the apply/diff selector engine, and a narrowed run executes only what it printed. An unflagged run still drops views it never listed.",
+    "evidence": "Selectors added under #951 with the Atlas-side source atlasgo.io/cli-reference (`--exclude strings`, `--include strings` on schema clean); the pinned community binary v1.3.0 registers neither, measured by running the spelling (`--url` present, `--frobnicate-nonsense` missing as controls). Verified: on a SQLite database holding `users` and `audit_log`, `schema clean --include users --auto-approve` drops `users` and leaves `audit_log` in place, and `--exclude audit_log` does the same (cmd/atlas/schema_clean_scope_test.go). A narrowed plan is executed statement by statement via schemaclean.ApplyPlan rather than DropAllTables, so the printed plan is what runs. The unflagged path is unchanged and still over-drops: internal/schemaclean/clean.go enumerates only foreign keys, tables and enums, then executes conn.SchemaWriter().DropAllTables(ctx). Reproduced on a SQLite database holding one table and one standalone view: `pc schema clean --url sqlite://cl3.db --dry-run --format '{{ range .Changes }}{{ .Cmd }}{{ end }}'` printed only `DROP TABLE IF EXISTS \"users\"`, then `--auto-approve` left sqlite_master empty \u2014 the unreported view v_const was dropped as well; that half is #940. CE registers schema clean per cli-surface.md:44"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`schema inspect --output`",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "`-o/--output` writes the rendered schema to a file instead of stdout, published atomically so a reader never sees a partial document.",
+    "evidence": "Added under #951; Atlas-side source atlasgo.io/cli-reference (`-o, --output string  output file path` on schema inspect). The pinned community binary v1.3.0 does not register it, measured by running the spelling: `schema inspect --output f.hcl` -> `unknown flag`, with `--format` present and `--frobnicate-nonsense` missing as controls. Verified: long flag and `-o` both write the file, `--format sql` decides what lands in it, stdout stays empty, an existing file is replaced rather than appended to, and an undirectory destination fails with `stage output file` instead of losing the inspection (cmd/atlas/schema_inspect_output_test.go)"
+  },
+  {
+    "area": "Declarative / direct schema workflow",
+    "feature": "`schema diff --export`",
+    "ptah": "no",
+    "atlas_oss": "no",
+    "atlas_pro": "yes",
+    "note": "Registered and refused by name. The flag selects an exporter declared by an atlas.hcl `exporter` block, and Ptah evaluates no such block, so there is nothing to select.",
+    "evidence": "Decided under #951 rather than implemented: accepting it would emit the default diff and report an export that never happened, and leaving it unregistered would give a script no way to learn why its spelling did nothing. Atlas-side source atlasgo.io/cli-reference (`--export  use exporter defined in env` on schema diff and schema inspect). The pinned community binary v1.3.0 registers it on neither, measured by running the spelling, with `--format` present and `--frobnicate-nonsense` missing as controls. Verified: `ptah-compat schema diff --from ... --to ... --export` exits 1 naming the missing `exporter` block, before any config or database work (cmd/atlas/schema_ui_flags_test.go). config/projectconfig tolerates an `exporter` block and evaluates nothing from it. The twin `schema inspect --export` carries the same verdict and is still unregistered, left to a later batch of #951"
   },
   {
     "area": "Declarative / direct schema workflow",
@@ -770,8 +797,8 @@
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`.",
-    "evidence": "Built ptah-compat `schema test --help` (flags: --dev-url, --run, -u only) and `migrate test --help` (--dev-url, --dir, --dir-format, --run only); `schema test -u file:///path/schema.sql` exits 1 with \"parse desired schema from ...: stat .: not a directory\"; `-u sqlite://target.db` and `-u env://src` exit 1 with \"only local file:// migration directories are supported\"; `migrate test --report json` is parsed as a positional path. Passing baseline: `migrate test --dir file://migrations --dev-url sqlite://dev.db tests` exits 0. Atlas side from cli-surface.md lines 40/59 (out-of-scope in CE) and lines 138-140/168-170. Atlas's `migrate test` and `schema test` also lack `--report` and `--seed-dir`; `schema test -u` accepts a SQL file and a live sqlite URL (both PASS) (measured; observation study, scenario, lint-test-pro, test-hcl)"
+    "note": "schema test carries `-s/--schema` and takes a .sql or .hcl file on `-u`; a live database URL still fails. `migrate test --revisions-schema` is missing. Neither verb exposes `--report`.",
+    "evidence": "`-s/--schema` added under #951; Atlas-side source atlasgo.io/cli-reference (`-s, --schema strings  set schema names` on schema test). Verified with a fixture whose two tables live in two schemas: unscoped the run fails on SQLite with `unknown database \"other\"`, `--schema main` passes, `-s main -s nosuch` also passes (so repeated values accumulate rather than the last one winning), and `--schema nosuch` is refused with `selects no tables out of the desired schema` instead of provisioning nothing (cmd/atlas/schema_test_schema_scope_test.go). File sources on -u landed in #1054: `schema test -u file://schema.sql` runs. Live database URLs on -u remain refused (#1055). `migrate test --revisions-schema` remains missing, measured by running the spelling. Atlas side from cli-surface.md lines 40/59 (out-of-scope in CE) and lines 138-140/168-170. Atlas's `migrate test` and `schema test` also lack `--report` and `--seed-dir` (measured; observation study, scenario, lint-test-pro, test-hcl)"
   },
   {
     "area": "Test frameworks",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -70,15 +70,15 @@ row for a migration decision.
 
 ## At a glance
 
-Across the 159 capabilities below:
+Across the 162 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 86 |
+| Ptah supports it fully | 88 |
 | Ptah supports it with a stated limitation | 49 |
-| Ptah does not implement it | 24 |
+| Ptah does not implement it | 25 |
 | Ptah and Atlas CE both support it | 23 |
-| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 37 |
+| Ptah implements it openly where Atlas gates it behind Pro or Cloud | 39 |
 | Ptah has it and neither Atlas edition does | 16 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
 | An Atlas column is ❔ — not established by this page's evidence | 21 |
@@ -131,7 +131,9 @@ seven of them as open capabilities regardless.
 | `--exclude` glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
 | `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics. |
 | `--schema` / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
+| `schema diff --export` | ❌ | ❌ | ✅ | Registered and refused by name. The flag selects an exporter declared by an atlas.hcl `exporter` block, and Ptah evaluates no such block, so there is nothing to select. |
 | `schema inspect --include` filtering | ✅ | ❌ | ✅ | Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects. |
+| `schema inspect --output` | ✅ | ❌ | ✅ | `-o/--output` writes the rendered schema to a file instead of stdout, published atomically so a reader never sees a partial document. |
 | Apply advisory lock and `--lock-timeout` | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
 | Desired-state sources for `--to` and `--from` | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
@@ -143,7 +145,7 @@ seven of them as open capabilities regardless.
 | JSON output for native schema diff | ✅ | ❔ | ➖ | Native ptah schema diff `--format` json emits a machine-readable statements document; the Go-template row only states that {{ json . }} fails on the compat diff, leaving native JSON unstated. |
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
-| schema clean | 🟡 | ✅ | ✅ | Plan and `--dry-run` list tables (plus PostgreSQL enums/sequences, SQL Server FKs), but the apply drops views too via DropAllTables. |
+| schema clean | 🟡 | ✅ | ✅ | `--include`/`--exclude` narrow the cleanup through the apply/diff selector engine, and a narrowed run executes only what it printed. An unflagged run still drops views it never listed. |
 | schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
@@ -192,9 +194,10 @@ seven of them as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
+| `schema apply --skip-lint` | ✅ | ❌ | ✅ | With an atlas.hcl `lint` policy, the planned SQL is linted against the rules it names and an error-rated finding refuses the apply; `--skip-lint` applies anyway. No policy, no lint pass, as in CE. |
 | Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file. |
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
-| Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
+| Atlas web reports (`--web`) | ❌ | ❌ | ✅ | `schema inspect --web` is a registered refusal naming the local ERD spelling; migrate lint and schema diff still reject it as unknown. Pinned Atlas CE registers it on none of them. |
 | Check bypass on the compat surface | ✅ | ❌ | ❌ | No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down. |
 | CI integration (GitHub Action, annotations) | ✅ | ❔ | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. Atlas features page omits CI integrations. |
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
@@ -213,7 +216,7 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Atlas `.test.hcl` ingestion | ✅ | ❌ | ✅ | Implemented: `.test.hcl` is read alongside native YAML by `schema test` and `migrate test`. Adding `output` to an `exec` makes it an assertion; step order is preserved and cases are selected by kind. |
-| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test -u takes only a Go-annotation directory; SQL/HCL files and DB URLs fail. Neither verb exposes `--report` or `--seed-dir`. |
+| Atlas-shaped migrate test / schema test verbs | 🟡 | ❌ | ✅ | schema test carries `-s/--schema` and takes a .sql or .hcl file on `-u`; a live database URL still fails. `migrate test --revisions-schema` is missing. Neither verb exposes `--report`. |
 | Dev / shadow database verification | 🟡 | ✅ | ✅ | `--shadow-db` on generate, checkpoint, baseline and down; docker:// is refused, and schema apply `--dry-run` skips the rehearsal entirely. |
 | Embeddable test runner (Go package) | ✅ | ❔ | ❌ | migration/dbtest exports RunMigrationTest and RunSchemaTest. Nothing cited establishes an Atlas Go test-runner package. |
 | Exit-code contract for CI gates | ✅ | ✅ | ➖ | Native 0/1/2 separates expected negative results from command errors; ptah-compat collapses to Atlas CE 0/1, recovered panics still exit 2. |

--- a/internal/atlasschema/applylint.go
+++ b/internal/atlasschema/applylint.go
@@ -1,0 +1,119 @@
+package atlasschema
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.5x5.cz/ptah/migration/lint"
+	"go.5x5.cz/ptah/migration/risk"
+)
+
+// planLintFileName is the name the planned statements are linted under. The
+// lint engine reads migration files, so the plan is presented as one, and the
+// name is what findings point at.
+const planLintFileName = "0001_schema_apply.up.sql"
+
+// PlanLintOptions configures a lint pass over a planned schema apply.
+type PlanLintOptions struct {
+	// Dialect gates dialect-specific rules and selects the lexer.
+	Dialect string
+	// RuleConfigs carries the per-rule severities the project's lint policy
+	// declares. It also decides which rules run at all: see [LintPlan].
+	RuleConfigs map[string]lint.RuleConfig
+	// Disabled lists additional rule codes or prefixes to skip.
+	Disabled []string
+}
+
+// LintPlan runs the lint rules the project's policy configures over the
+// statements a schema apply would execute, and returns the blocking findings.
+//
+// Only rules the policy names run. The engine ships rules for concerns a
+// declarative apply cannot answer -- a plan is not a migration directory, so it
+// has no paired down file and no history to be non-linear against -- and
+// enabling the whole registry would refuse applies over findings the operator
+// never asked about. Naming the policy's own codes keeps the pass equal to what
+// the atlas.hcl `lint` block declares and nothing else, which is also why an
+// empty policy is not a lint pass at all: the caller skips it entirely.
+//
+// The statements are linted as a migration file in a scratch directory because
+// the engine reads a filesystem. Nothing is left behind.
+func LintPlan(statements []string, opts PlanLintOptions) ([]lint.Finding, error) {
+	enabled := lintPlanEnabledCodes(opts.RuleConfigs)
+	if len(enabled) == 0 {
+		return nil, nil
+	}
+	dir, err := os.MkdirTemp("", "ptah-apply-lint-")
+	if err != nil {
+		return nil, fmt.Errorf("stage schema apply lint input: %w", err)
+	}
+	defer func() { _ = os.RemoveAll(dir) }()
+	path := filepath.Join(dir, planLintFileName)
+	if err := os.WriteFile(path, []byte(FormatMigrationSQL(statements)), 0o600); err != nil {
+		return nil, fmt.Errorf("stage schema apply lint input: %w", err)
+	}
+
+	findings, err := lint.LintFS(os.DirFS(dir), lint.Options{
+		Dialect:     opts.Dialect,
+		Disabled:    append(lintPlanDisabledCodes(enabled), opts.Disabled...),
+		RuleConfigs: opts.RuleConfigs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("lint schema apply plan: %w", err)
+	}
+	blocking := make([]lint.Finding, 0, len(findings))
+	for _, finding := range findings {
+		if risk.IsBlocking(finding.Severity) {
+			blocking = append(blocking, finding)
+		}
+	}
+	return blocking, nil
+}
+
+// lintPlanEnabledCodes returns the non-empty rule code selectors the policy
+// declares.
+func lintPlanEnabledCodes(configs map[string]lint.RuleConfig) []string {
+	enabled := make([]string, 0, len(configs))
+	for code := range configs {
+		if strings.TrimSpace(code) != "" {
+			enabled = append(enabled, code)
+		}
+	}
+	return enabled
+}
+
+// lintPlanDisabledCodes lists every registered rule that no enabled selector
+// covers, so the pass runs exactly the policy's rules.
+func lintPlanDisabledCodes(enabled []string) []string {
+	var disabled []string
+	for _, rule := range lint.Rules() {
+		if !lintPlanRuleEnabled(rule.Code, enabled) {
+			disabled = append(disabled, rule.Code)
+		}
+	}
+	return disabled
+}
+
+func lintPlanRuleEnabled(code string, enabled []string) bool {
+	for _, selector := range enabled {
+		if strings.HasPrefix(code, selector) {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatPlanLintFindings renders blocking findings for a refusal message.
+func FormatPlanLintFindings(findings []lint.Finding) string {
+	var out strings.Builder
+	for _, finding := range findings {
+		out.WriteString("\n  - ")
+		out.WriteString(finding.Rule)
+		out.WriteString(" ")
+		out.WriteString(string(finding.Severity))
+		out.WriteString(": ")
+		out.WriteString(finding.Message)
+	}
+	return out.String()
+}

--- a/internal/schemaclean/clean.go
+++ b/internal/schemaclean/clean.go
@@ -80,6 +80,27 @@ func Apply(ctx context.Context, conn *dbschema.DatabaseConnection) error {
 	return nil
 }
 
+// ApplyPlan executes exactly the changes plan carries, in plan order.
+//
+// It is the execution half of a narrowed plan. [Apply] hands the whole database
+// to the writer's DropAllTables, which is correct only when the plan describes
+// the whole database; a caller that removed objects from the plan must not then
+// reach for a routine that ignores the plan, or the flag that narrowed it would
+// print one thing and destroy another.
+func ApplyPlan(ctx context.Context, conn *dbschema.DatabaseConnection, plan Plan) error {
+	conn.SchemaWriter().SetDryRun(false)
+	executor := conn.Writer()
+	for _, change := range plan.Changes {
+		if strings.TrimSpace(change.Cmd) == "" {
+			continue
+		}
+		if err := executor.ExecuteSQL(ctx, change.Cmd); err != nil {
+			return fmt.Errorf("drop schema object %s %q: %w", change.Type, change.Name, err)
+		}
+	}
+	return nil
+}
+
 func PlanFromSchema(schema *dbschematypes.DBSchema, dialect string) Plan {
 	if schema == nil {
 		return Plan{}


### PR DESCRIPTION
Refs #951 — the schema-side group of the flag checklist (item 3), plus the explicit decision item 4 asked for on the two UI-bound flags.

## Atlas-side source for every flag

The pinned community binary v1.3.0 registers **none** of these. Measured by running the spelling, never by grepping `--help`, and every probe carries both controls:

```
### schema apply                (pinned community binary v1.3.0)
--dry-run             [POSITIVE CONTROL]    present
--frobnicate-nonsense [NEG CONTROL]         MISSING
--skip-lint           [SUBJECT]             MISSING
### schema clean
--url                 [POSITIVE CONTROL]    present
--frobnicate-nonsense [NEG CONTROL]         MISSING
--include / --exclude [SUBJECT]             MISSING
### schema inspect
--format              [POSITIVE CONTROL]    present
--frobnicate-nonsense [NEG CONTROL]         MISSING
--output / --web      [SUBJECT]             MISSING
### schema diff
--format              [POSITIVE CONTROL]    present
--frobnicate-nonsense [NEG CONTROL]         MISSING
--export              [SUBJECT]             MISSING
```

(`schema test` is community-gated there: even its positive control `--run` answers `unknown flag`, so the binary is no oracle for that verb.)

So the source for all six is Atlas's published CLI reference, https://atlasgo.io/cli-reference, quoted verbatim below. The spelling, type, shorthand and default match it.

| verb | flag | reference text |
| --- | --- | --- |
| `schema apply` | `--skip-lint` | `--skip-lint    skip linting migration plan` |
| `schema clean` | `--exclude strings` | `list of glob patterns used to filter resources from applying` |
| `schema clean` | `--include strings` | `list of glob patterns used to select which resources to keep in inspection` |
| `schema inspect` | `-o, --output string` | `output file path` |
| `schema test` | `-s, --schema strings` | `set schema names` |
| `schema diff` | `--export` | `use exporter defined in env` |
| `schema inspect` | `-w, --web` | `open the schema ERD in the browser` |

## Measurement, before and after

Same probe, same controls, against `ptah-compat` built from this branch's base and then from its head:

| verb | flag | before | after |
| --- | --- | --- | --- |
| `schema apply` | `--skip-lint` | MISSING | present |
| `schema clean` | `--include` | MISSING | present |
| `schema clean` | `--exclude` | MISSING | present |
| `schema inspect` | `--output` | MISSING | present |
| `schema inspect` | `--web` | MISSING | present (refuses) |
| `schema test` | `--schema` | MISSING | present |
| `schema diff` | `--export` | MISSING | present (refuses) |
| `schema diff` | `--web` | MISSING | MISSING (not in this batch) |

Every positive control answered present and every `--frobnicate-nonsense` answered MISSING, in both runs.

## What each flag does

**`schema apply --skip-lint`.** Compat's `schema apply` did not lint at all, so registering the flag over nothing would have been the accept-and-ignore failure this issue exists to prevent. The apply now lints the planned statements — edits included, and the pre-approved `--plan` path too — whenever the selected `atlas.hcl` env declares a `lint` policy, using the same severities that decide `migrate lint`. A finding the policy rates as an error refuses the apply, before the `--dry-run` exit so a dry run reports the same verdict. `--skip-lint` runs it anyway.

Only the rules the policy *names* run. The engine ships rules a declarative plan cannot answer — a plan is not a migration directory, so it has no paired down file and no history to be non-linear against — and enabling the whole registry would refuse applies over findings nobody asked about. A project with no `lint` block therefore has no lint pass, which keeps an unflagged CE-shaped `schema apply` byte-identical to what it did before.

**`schema clean --include/--exclude`.** Routed to `internal/atlasfilter`, the selector engine `schema apply`, `schema diff` and `schema inspect` already share — no second glob matcher. The engine is fed a synthetic schema built from the objects the plan already enumerates, so the selection can only narrow what `schemaclean.Inspect` found, and whatever the planner learns to enumerate flows through unchanged. An object kind the mapping does not know is refused rather than silently kept or dropped, which is the guard #940 needs while it widens that enumeration.

The important half is execution. `schemaclean.Apply` hands the whole database to `DropAllTables`, which is correct only for a plan describing the whole database; a narrowed run now executes the plan's own statements via a new `schemaclean.ApplyPlan`, so the printed plan is what is destroyed. The unflagged path is untouched and still calls `DropAllTables`.

Two consequences worth stating: `atlas.hcl` `exclude` now reaches `schema clean` like every other schema verb (ignoring it was the dangerous direction — an operator who excluded a table from their workflow would still have watched this command drop it); and drop statements keep the dialect's cascade behavior, so removing a selected object can still take dependents with it.

**`schema inspect -o/--output`.** Writes the rendered schema to a file instead of stdout, staged beside the destination and renamed over it, so a pipeline that reads the file back (`schema apply --to file://…`) cannot read a truncated schema.

**`schema test -s/--schema`.** Restricts the desired schema through `internal/schemascope`'s existing allow-list before the cases run. A selection that keeps no tables out of a schema that had some is refused rather than provisioning an empty database and failing every case on a missing relation — the zero-match false green from #979. The native `ptah schema test` gains the same flag; the compat arg mapper rewrites every occurrence and the native flag is a string array, so repeated `-s` values accumulate instead of the last one winning.

## The two UI-bound flags: registered refusals, and why

Written into the code at `cmd/atlas/schema_ui_flags.go`, into the two commands' help, and into the feature matrix.

- **`schema inspect -w/--web`** — refused. Its payload is not the problem: Ptah renders the same ERD locally, as `schema inspect --format '{{ mermaid . }}'` and as `ptah viz`. What has no counterpart is *opening a viewer*, and a CLI that launches a browser is the wrong shape for the pipelines this surface serves. The refusal names the local spelling, so the capability stays reachable.
- **`schema diff --export`** — refused. It selects an exporter declared by an `atlas.hcl` `exporter` block. `config/projectconfig` tolerates that block and evaluates nothing from it, so there is no exporter to select; accepting the flag would emit the default diff and report an export that never happened.

Registering the refusal rather than leaving the flags absent is the point: a script that passes either spelling gets one line saying what is missing and a non-zero exit, before any database is contacted. Both are covered by tests that fail if the refusal is turned into a silent accept.

## What each test prints if the change is reverted

| test | on revert |
| --- | --- |
| `TestSchemaApplySkipLint` | `unknown flag: --skip-lint` on the two `--skip-lint` rows; the "error policy refuses the destructive plan" row fails on `wantErr` because nothing lints, so a `DROP TABLE` the project rated an error applies silently |
| `TestSchemaCleanSelectorsNarrowThePlan` | `unknown flag: --include` / `--exclude` on every row |
| `TestSchemaCleanSelectorsNarrowWhatIsDestroyed` | same unknown flag; and with the selector wired to the plan but execution left on `DropAllTables`, it fails on `sqliteTableCount(audit_log) == 1` — the plan says one table, the database lost two |
| `TestSchemaCleanUnselectedRunStillDropsEverything` | fails if routing the selectors quietly turned a plain `schema clean` into a partial one |
| `TestSchemaCleanRejectsUnsupportedSelectorsBeforeConnecting` | fails if a malformed selector reaches the database before failing |
| `TestSchemaInspectOutputWritesTheFile` | `unknown flag: --output` / `-o`; also fails if `--output` writes the file *and* still prints to stdout |
| `TestSchemaInspectOutputReportsAnUnwritableDestination` | fails if a bad destination drops the inspection instead of failing loudly |
| `TestSchemaTestSchemaSelection` | `unknown flag: --schema`; the repeated-`-s` row fails under last-wins forwarding because the run would be scoped to `nosuch` alone; the zero-match row fails if an empty selection is provisioned instead of refused |
| `TestSchemaUIFlagsAreRegisteredRefusals` | `unknown flag` on revert; and on the exit status if either refusal is turned into a silent accept |

The `schema test` fixture is discriminating on purpose: its two tables live in two schemas, and on SQLite only `main` exists, so the unscoped run fails outright on the other table. A `--schema` that parsed and was then ignored cannot make it pass, and neither can one that kept both tables.

## Gates

| gate | result |
| --- | --- |
| `go build ./...` | clean |
| `go vet ./...` | clean |
| `go test ./... -count=1` | all packages pass |
| `golangci-lint run ./...` | `0 issues.` |
| `scripts/check-test-style.sh` | `teststyle: OK (175 conditional groups, 45 white-box files)` |
| `scripts/check-public-api.sh` | exit 0 |
| `scripts/check-public-api-snapshot.sh` | exit 0 |
| `node docs/site/scripts/check-style.mjs` | `check-style.mjs: OK (100 documentation files)` |
| `node docs/site/scripts/build-feature-matrix.mjs --check` | `OK (162 rows)` |

Both public-API gates are silent on success, so each was broken first to prove it runs: adding an exported `PtahGateProbeSymbol` to `migration/lint` drove the snapshot gate to exit 1 with a diff, and adding a `gateprobe/` package drove the package gate to exit 1 with `undocumented public package`. Both probes were removed and both gates re-run green.

Two existing assertions in `cmd/atlas/atlas_test.go` encoded the previous decision (`--output`, `--web`, `--export` all unregistered on `schema inspect`) and were updated to the new one, keeping `--export` on inspect as still-unregistered.

## Flags NOT added, and why

- **`schema diff --web`, `schema inspect --export`, `migrate lint --web`** — same Atlas-side source and same verdict as their twins here, left out to stay inside this batch rather than because they differ. `migrate lint --web` in particular overlaps whoever owns the lint rows.
- **`schema apply --lock-name`, `--skip-lock`** — the named-lock family is owned by another agent in parallel; touching them here would produce two implementations of one feature.
- **`schema test --report`, `--seed-dir`** — unchanged verdict: Atlas registers neither on either test verb, so compat must not either. Reachable natively (`ptah schema test --report`), and a compat-side control would go through a `PTAH_*` variable.
- **`schema clean --schema`** — not registered by Atlas on this verb per the reference (`-u`, `--exclude`, `--include`, `--dry-run`, `--format`, `--auto-approve` is the whole set), so the cleanup scope is `--include`/`--exclude` only.

Nothing in this batch was undecidable: every flag had a documented Atlas-side source.

## Note for #940

`internal/schemaclean` is being reworked under #940 for planning less than it destroys. This branch adds `ApplyPlan` beside `Apply` and does not change `Inspect`, `cleanupObjects` or `inspectRuntimeObjects`, so the enumeration that issue is widening stays entirely its own. The selector projection consumes whatever the plan enumerates and refuses an object kind it has no mapping for, so a new kind arriving from #940 surfaces as a loud refusal on a scoped clean rather than as a silently mis-scoped drop.