### PR TITLE
feat(compat): named-lock family on migrate apply and schema apply

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -207,9 +207,14 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 			forbidden: []string{"--output", "--web", "--export"},
 		},
 		{
-			name:  "schema_apply",
-			path:  []string{"schema", "apply"},
-			flags: []string{"--url", "--to", "--dev-url", "--dry-run", "--auto-approve", "--format", "--schema", "--exclude", "--include", "--tx-mode", "--plan", "--edit", "--lock-timeout"},
+			name: "schema_apply",
+			path: []string{"schema", "apply"},
+			// --lock-name and --skip-lock are Pro-surface flags the pinned
+			// Atlas CE binary does not register; Atlas's published CLI
+			// reference does register them on this verb, so compat implements
+			// them. --skip-lint stays unregistered.
+			flags:     []string{"--url", "--to", "--dev-url", "--dry-run", "--auto-approve", "--format", "--schema", "--exclude", "--include", "--tx-mode", "--plan", "--edit", "--lock-timeout", "--lock-name", "--skip-lock"},
+			forbidden: []string{"--skip-lint"},
 		},
 		{
 			name:      "schema_diff",
@@ -242,8 +247,12 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 				"--revisions-schema",
 				"--lock-timeout",
 				"--format",
+				// Pro-surface flags Atlas's published CLI reference registers
+				// on this verb; the pinned CE binary registers neither.
+				"--lock-name",
+				"--skip-lock",
 			},
-			forbidden: []string{"--to-version", "--lock-name"},
+			forbidden: []string{"--to-version"},
 		},
 		{
 			name: "migrate_down",
@@ -3088,18 +3097,6 @@ func TestCompatCommand_MigrateApplyRejectsNonAtlasFlags(t *testing.T) {
 		err := cmd.Execute()
 
 		c.Assert(err, qt.ErrorMatches, `unknown flag: --to-version`)
-	})
-
-	c.Run("lock_name", func(c *qt.C) {
-		cmd := NewCompatCommand("atlas")
-		var out bytes.Buffer
-		cmd.SetOut(&out)
-		cmd.SetErr(&out)
-		cmd.SetArgs([]string{"migrate", "apply", "--lock-name", "custom-lock"})
-
-		err := cmd.Execute()
-
-		c.Assert(err, qt.ErrorMatches, `unknown flag: --lock-name`)
 	})
 }
 

--- a/cmd/atlas/lock_flags.go
+++ b/cmd/atlas/lock_flags.go
@@ -1,0 +1,99 @@
+package atlas
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// The named-lock family: `--lock-name` and `--skip-lock`.
+//
+// ATLAS-SIDE SOURCE. Atlas's published CLI reference (atlasgo.io/cli-reference)
+// registers both flags on `atlas migrate apply` and on `atlas schema apply`,
+// and on no other verb:
+//
+//	--lock-name string   set the name of the advisory lock to use. If not set,
+//	                     the default is used (atlas_migrate_execute)
+//	--skip-lock          skip acquiring a database advisory lock
+//
+// The pinned Atlas community binary v1.3.0 registers neither, on any verb —
+// `migrate apply --lock-name x` and `schema apply --skip-lock` both answer
+// `unknown flag`, with `--dry-run` answering present on the same run and
+// `--frobnicate-nonsense` answering unknown. So this is Pro surface adopted
+// openly, sourced from the published reference rather than from the binary.
+//
+// The same reference does NOT register `--lock-name` on `migrate diff`,
+// `migrate down` or `migrate checkpoint`: those three carry `--lock-timeout`
+// and nothing else from this family. Those spellings are therefore absent here
+// on purpose (stokaro/ptah#951 standing constraint: no compat flag without an
+// Atlas-side source).
+//
+// WHY THE DEFAULT NAME IS NOT atlas_migrate_execute. Ptah's own default lock
+// names (`ptah_migrate`, `ptah_schema_apply`) are unchanged, because moving
+// them would silently de-serialize a fleet mid-upgrade: an older ptah-compat
+// holding `ptah_migrate` and a newer one holding `atlas_migrate_execute` do not
+// see each other. `--lock-name atlas_migrate_execute` is the explicit spelling
+// for coordinating with Atlas, and is why the flag has to exist.
+
+const (
+	atlasLockNameFlag = "lock-name"
+	atlasSkipLockFlag = "skip-lock"
+)
+
+// atlasLockOptions holds the raw named-lock flag values for one compat verb.
+type atlasLockOptions struct {
+	name string
+	skip bool
+}
+
+// atlasLockRequest is the resolved named-lock decision handed to the lock
+// machinery. A zero Name means "this verb's default lock name"; Skip means no
+// lock is requested at all.
+type atlasLockRequest struct {
+	Name string
+	Skip bool
+}
+
+// registerAtlasLockNameFlag registers `--lock-name` on a verb that Atlas
+// registers it on. Type and default match the reference: a string with no
+// default, where "unset" means the tool's own default lock name.
+func registerAtlasLockNameFlag(flags *pflag.FlagSet, opts *atlasLockOptions) {
+	flags.StringVar(&opts.name, atlasLockNameFlag, "",
+		"Name of the database advisory lock to acquire; unset uses the default lock name")
+}
+
+// registerAtlasSkipLockFlag registers `--skip-lock` on a verb that Atlas
+// registers it on.
+func registerAtlasSkipLockFlag(flags *pflag.FlagSet, opts *atlasLockOptions) {
+	flags.BoolVar(&opts.skip, atlasSkipLockFlag, false,
+		"Skip acquiring the database advisory lock")
+}
+
+// resolveAtlasLockRequest turns the raw flag values into the lock decision the
+// machinery receives.
+//
+// Two inputs are refused rather than interpreted:
+//
+//   - An explicit but blank `--lock-name`. Passing it through would fall back
+//     to the default lock name, so a caller that meant to name a lock would
+//     silently coordinate on a different one.
+//   - `--lock-name` together with `--skip-lock`. There is no lock to name when
+//     no lock is taken, and Atlas's reference documents no resolution order for
+//     the pair. Honouring either one would drop the other silently, which is
+//     the failure this whole family exists to avoid; refusing says so instead.
+func resolveAtlasLockRequest(cmd *cobra.Command, opts atlasLockOptions) (atlasLockRequest, error) {
+	flags := cmd.Flags()
+	named := flags.Changed(atlasLockNameFlag)
+	if named && strings.TrimSpace(opts.name) == "" {
+		return atlasLockRequest{}, fmt.Errorf("--%s must not be empty", atlasLockNameFlag)
+	}
+	if named && opts.skip {
+		return atlasLockRequest{}, fmt.Errorf(
+			"--%s and --%s cannot be used together: --%s takes no lock, so there is no lock to name",
+			atlasLockNameFlag, atlasSkipLockFlag, atlasSkipLockFlag,
+		)
+	}
+	return atlasLockRequest{Name: strings.TrimSpace(opts.name), Skip: opts.skip}, nil
+}

--- a/cmd/atlas/lock_flags_test.go
+++ b/cmd/atlas/lock_flags_test.go
@@ -1,0 +1,256 @@
+package atlas_test
+
+// CLI coverage for the named-lock family (`--lock-name`, `--skip-lock`) added
+// for stokaro/ptah#951.
+//
+// Registration is measured by RUNNING each spelling and reading the error, not
+// by grepping `--help`: on several verbs `--help` short-circuits before flag
+// validation, and the string `--foo` appears inside `unknown flag: --foo`, so a
+// help grep answers "registered" in both directions. Every row here carries
+// both controls — a flag the verb certainly has, and a nonsense flag.
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+const (
+	// The note `migrate apply` prints when --lock-name is passed to a dialect
+	// with no advisory locks. Naming the lock in it is what makes the flag's
+	// arrival at the lock machinery observable from the command line.
+	migrateApplyNamedLockNote = `note: migration locking is not supported for dialect "sqlite"; the advisory lock "atlas_migrate_execute" is not acquired and the migrations run without a database lock`
+	schemaApplyNamedLockNote  = `note: schema apply locking is not supported for dialect "sqlite"; the advisory lock "atlas_migrate_execute" is not acquired and the apply proceeds without a database lock`
+)
+
+// TestCompatLockFlagRegistration measures which verbs register which member of
+// the family. The four PRESENT rows are the flags Atlas's published CLI
+// reference registers; the six MISSING rows are the spellings it does not, on
+// verbs that carry only --lock-timeout from this family.
+func TestCompatLockFlagRegistration(t *testing.T) {
+	tests := []struct {
+		name string
+		path []string
+		// positive is a flag the verb certainly registers.
+		positive []string
+		flag     []string
+		want     bool
+	}{
+		{name: "migrate_apply_lock_name", path: []string{"migrate", "apply"}, positive: []string{"--dry-run"}, flag: []string{"--lock-name", "probe"}, want: true},
+		{name: "migrate_apply_skip_lock", path: []string{"migrate", "apply"}, positive: []string{"--dry-run"}, flag: []string{"--skip-lock"}, want: true},
+		{name: "schema_apply_lock_name", path: []string{"schema", "apply"}, positive: []string{"--dry-run"}, flag: []string{"--lock-name", "probe"}, want: true},
+		{name: "schema_apply_skip_lock", path: []string{"schema", "apply"}, positive: []string{"--dry-run"}, flag: []string{"--skip-lock"}, want: true},
+
+		{name: "migrate_diff_lock_name", path: []string{"migrate", "diff"}, positive: []string{"--lock-timeout", "1s"}, flag: []string{"--lock-name", "probe"}, want: false},
+		{name: "migrate_diff_skip_lock", path: []string{"migrate", "diff"}, positive: []string{"--lock-timeout", "1s"}, flag: []string{"--skip-lock"}, want: false},
+		{name: "migrate_down_lock_name", path: []string{"migrate", "down"}, positive: []string{"--lock-timeout", "1s"}, flag: []string{"--lock-name", "probe"}, want: false},
+		{name: "migrate_down_skip_lock", path: []string{"migrate", "down"}, positive: []string{"--lock-timeout", "1s"}, flag: []string{"--skip-lock"}, want: false},
+		{name: "migrate_checkpoint_lock_name", path: []string{"migrate", "checkpoint"}, positive: []string{"--dir-format", "atlas"}, flag: []string{"--lock-name", "probe"}, want: false},
+		{name: "migrate_checkpoint_skip_lock", path: []string{"migrate", "checkpoint"}, positive: []string{"--dir-format", "atlas"}, flag: []string{"--skip-lock"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(compatFlagRegistered(tt.path, tt.positive), qt.IsTrue,
+				qt.Commentf("positive control %v must be registered on %v", tt.positive, tt.path))
+			c.Assert(compatFlagRegistered(tt.path, []string{"--frobnicate-nonsense"}), qt.IsFalse,
+				qt.Commentf("negative control must be unregistered on %v", tt.path))
+
+			c.Assert(compatFlagRegistered(tt.path, tt.flag), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestCompatLockFlagContradictionsRefused pins that the two inputs with no
+// sound interpretation are refused rather than silently resolved: a blank name
+// would fall back to the default lock, and naming a lock that --skip-lock does
+// not take would drop one of the two flags.
+func TestCompatLockFlagContradictionsRefused(t *testing.T) {
+	tests := []struct {
+		name string
+		// verb builds the full argument list for one verb inside dir, so each
+		// row supplies the source flags its own verb requires.
+		verb    func(dir string) []string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "migrate_apply_blank_name",
+			verb:    migrateApplyLockArgs,
+			args:    []string{"--lock-name", "  "},
+			wantErr: `--lock-name must not be empty`,
+		},
+		{
+			name:    "schema_apply_blank_name",
+			verb:    schemaApplyLockArgs,
+			args:    []string{"--lock-name", ""},
+			wantErr: `--lock-name must not be empty`,
+		},
+		{
+			name:    "migrate_apply_name_with_skip",
+			verb:    migrateApplyLockArgs,
+			args:    []string{"--lock-name", "x", "--skip-lock"},
+			wantErr: `--lock-name and --skip-lock cannot be used together: --skip-lock takes no lock, so there is no lock to name`,
+		},
+		{
+			name:    "schema_apply_name_with_skip",
+			verb:    schemaApplyLockArgs,
+			args:    []string{"--lock-name", "x", "--skip-lock"},
+			wantErr: `--lock-name and --skip-lock cannot be used together: --skip-lock takes no lock, so there is no lock to name`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+
+			_, err := runCompatLockCommand(append(tt.verb(dir), tt.args...))
+
+			// The contradiction is refused before the migration directory or
+			// desired schema is read, so neither has to exist.
+			c.Assert(err, qt.ErrorMatches, regexpQuote(tt.wantErr))
+		})
+	}
+}
+
+func migrateApplyLockArgs(dir string) []string {
+	return []string{
+		"migrate", "apply",
+		"--url", "sqlite://" + filepath.Join(dir, "lock.db"),
+		"--dir", "file://" + filepath.Join(dir, "migrations"),
+	}
+}
+
+func schemaApplyLockArgs(dir string) []string {
+	return []string{
+		"schema", "apply",
+		"--url", "sqlite://" + filepath.Join(dir, "lock.db"),
+		"--to", "file://" + filepath.Join(dir, "schema.sql"),
+	}
+}
+
+// TestMigrateApplyNamedLockReachesMigrator drives the flag end to end: the note
+// is printed from the prepared migrator's own lock name, so it can only read
+// "atlas_migrate_execute" if the flag reached the lock machinery. --skip-lock
+// takes no lock at all and therefore has no dialect capability to report.
+func TestMigrateApplyNamedLockReachesMigrator(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantNote bool
+	}{
+		{name: "named lock", args: []string{"--lock-name", "atlas_migrate_execute"}, wantNote: true},
+		{name: "skip lock", args: []string{"--skip-lock"}, wantNote: false},
+		{name: "default", args: nil, wantNote: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "lock-apply.db")
+			migrationsDir := filepath.Join(dir, "migrations")
+			writeAtlasApplyProjectMigration(c, migrationsDir, "20260101000001_init.sql",
+				"CREATE TABLE lock_flag_users (id INTEGER PRIMARY KEY);\n")
+			writeAtlasApplyProjectSum(c, migrationsDir)
+
+			args := append([]string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+			}, tt.args...)
+
+			out, err := runCompatLockCommand(args)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			c.Assert(out, qt.Contains, "Migration complete. Current version: 20260101000001")
+			c.Assert(strings.Contains(out, migrateApplyNamedLockNote), qt.Equals, tt.wantNote,
+				qt.Commentf("output:\n%s", out))
+			c.Assert(sqliteTableCount(c, dbPath, "lock_flag_users"), qt.Equals, 1)
+		})
+	}
+}
+
+// TestSchemaApplyNamedLockReachesLockMachinery is the same proof on the
+// declarative verb: the note names the lock read back from the ACQUIRED lock
+// object, and --skip-lock acquires nothing so there is no lock to name.
+func TestSchemaApplyNamedLockReachesLockMachinery(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantNote bool
+	}{
+		{name: "named lock", args: []string{"--lock-name", "atlas_migrate_execute"}, wantNote: true},
+		{name: "skip lock", args: []string{"--skip-lock"}, wantNote: false},
+		{name: "skip lock silences the timeout note", args: []string{"--skip-lock", "--lock-timeout", "10s"}, wantNote: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			dbPath := filepath.Join(dir, "lock-schema.db")
+			schemaPath := filepath.Join(dir, "schema.sql")
+			c.Assert(os.WriteFile(schemaPath,
+				[]byte(`CREATE TABLE lock_flag_schema (id INTEGER PRIMARY KEY);`), 0o600), qt.IsNil)
+
+			args := append([]string{
+				"schema", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--to", "file://" + schemaPath,
+				"--auto-approve",
+			}, tt.args...)
+
+			out, err := runCompatLockCommand(args)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			c.Assert(out, qt.Contains, "Schema apply completed successfully.")
+			c.Assert(strings.Contains(out, schemaApplyNamedLockNote), qt.Equals, tt.wantNote,
+				qt.Commentf("output:\n%s", out))
+			// The --lock-timeout wording never appears alongside --skip-lock:
+			// a run that takes no lock has no timeout to ignore.
+			c.Assert(out, qt.Not(qt.Contains), schemaApplyLockUnsupportedNote)
+			c.Assert(sqliteTableCount(c, dbPath, "lock_flag_schema"), qt.Equals, 1)
+		})
+	}
+}
+
+// compatFlagRegistered runs the spelling and reports whether the command
+// recognized it. It never inspects help text.
+func compatFlagRegistered(path, flag []string) bool {
+	_, err := runCompatLockCommand(append(append([]string(nil), path...), flag...))
+	if err == nil {
+		return true
+	}
+	return !strings.Contains(err.Error(), "unknown flag: "+flag[0])
+}
+
+func runCompatLockCommand(args []string) (string, error) {
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// regexpQuote escapes a literal error message for qt.ErrorMatches, which
+// anchors and compiles its argument as a regular expression.
+func regexpQuote(literal string) string {
+	replacer := strings.NewReplacer(
+		`\`, `\\`, `.`, `\.`, `+`, `\+`, `*`, `\*`, `?`, `\?`,
+		`(`, `\(`, `)`, `\)`, `[`, `\[`, `]`, `\]`, `{`, `\{`, `}`, `\}`,
+		`^`, `\^`, `$`, `\$`, `|`, `\|`,
+	)
+	return replacer.Replace(literal)
+}

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -22,6 +22,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/atlasmigratereport"
 	"go.5x5.cz/ptah/internal/atlasreport"
+	"go.5x5.cz/ptah/internal/dblock"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
 )
@@ -37,6 +38,7 @@ type atlasMigrateApplyOptions struct {
 	baseline        string
 	revisionsSchema string
 	lockTimeout     string
+	lock            atlasLockOptions
 	format          string
 }
 
@@ -70,6 +72,8 @@ Native Ptah equivalent: ptah migrations up.`,
 	flags.StringVar(&opts.baseline, "baseline", "", "Baseline version to mark applied before running pending migrations")
 	flags.StringVar(&opts.revisionsSchema, "revisions-schema", "", "Schema for the Atlas revisions table")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring the migration lock, such as 10s or 2m")
+	registerAtlasLockNameFlag(flags, &opts.lock)
+	registerAtlasSkipLockFlag(flags, &opts.lock)
 	flags.StringVar(&opts.format, "format", "", "Atlas Go template output format")
 
 	cmdutil.ConfigureCommandArgs(cmd, atlasMigrateApplyArgs)
@@ -199,6 +203,10 @@ func runAtlasMigrateApply(
 	if err != nil {
 		return err
 	}
+	lockRequest, err := resolveAtlasLockRequest(cmd, opts.lock)
+	if err != nil {
+		return err
+	}
 	skipChecks, err := resolveAtlasApplySkipChecks(cmd)
 	if err != nil {
 		return err
@@ -283,6 +291,8 @@ func runAtlasMigrateApply(
 		TxMode:               txMode,
 		RevisionsSchema:      opts.revisionsSchema,
 		MigrationLockTimeout: migrationLockTimeout,
+		MigrationLockName:    lockRequest.Name,
+		SkipMigrationLock:    lockRequest.Skip,
 		Amount:               amount,
 		AllowDirty:           opts.allowDirty,
 		BaselineVersion:      baselineVersion,
@@ -291,6 +301,7 @@ func runAtlasMigrateApply(
 	if err != nil {
 		return err
 	}
+	noteAtlasMigrateApplyLockUnsupported(cmd, opts.lock, plan, conn.Info().Dialect)
 
 	// #982 changed the Atlas version a Flyway file converts to, which is the
 	// key `atlas_schema_revisions` stores. A database migrated by an older Ptah
@@ -340,6 +351,35 @@ func runAtlasMigrateApply(
 	}
 	fmt.Fprintf(out, "Migration complete. Current version: %d\n", result.FinalStatus.CurrentVersion)
 	return nil
+}
+
+// noteAtlasMigrateApplyLockUnsupported surfaces the capability decision behind
+// an explicitly named migration lock on a dialect that has no advisory locks:
+// the name is accepted and then has nothing to name, so the run says so rather
+// than letting `--lock-name` read as serialization it did not get.
+//
+// It fires only when --lock-name was passed, so output for every existing
+// invocation is byte-identical. --skip-lock never reaches here: it is mutually
+// exclusive with --lock-name, and a caller who asked for no lock does not need
+// to be told the dialect has none.
+//
+// The name comes from the prepared plan's migrator rather than from the flag
+// value, so the note reports the lock the machinery resolved.
+func noteAtlasMigrateApplyLockUnsupported(
+	cmd *cobra.Command,
+	lockOpts atlasLockOptions,
+	plan atlasmigrate.ApplyPlan,
+	dialect string,
+) {
+	if strings.TrimSpace(lockOpts.name) == "" || plan.MigrationLockSkipped() {
+		return
+	}
+	if dblock.Supported(dialect) {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"note: migration locking is not supported for dialect %q; the advisory lock %q is not acquired and the migrations run without a database lock\n",
+		dialect, plan.MigrationLockName())
 }
 
 // emitAtlasMigrateApplyDeferredChecks names the pre-migration checks a dry run

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"slices"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -39,6 +40,7 @@ type atlasSchemaApplyOptions struct {
 	include     []string
 	planURL     string
 	lockTimeout string
+	lock        atlasLockOptions
 	edit        bool
 	// formatOutput is derived at run time: true when --format was passed or
 	// atlas.hcl provides format.schema.apply.
@@ -109,6 +111,8 @@ synced schema.`,
 	flags.StringVar(&opts.planURL, "plan", "", "URL to a pre-planned migration (e.g., file://<name>"+atlasschema.PlanFileSuffixHCL+" or file://<name>"+atlasschema.PlanFileSuffix+")")
 	flags.BoolVar(&opts.edit, "edit", false, "Open the generated SQL in an editor")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring the database lock")
+	registerAtlasLockNameFlag(flags, &opts.lock)
+	registerAtlasSkipLockFlag(flags, &opts.lock)
 	if err := cmdflags.DisableEnvBinding(flags, "auto-approve"); err != nil {
 		panic(err)
 	}
@@ -197,6 +201,10 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	lockRequest, err := resolveAtlasLockRequest(cmd, opts.lock)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 
 	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
 	defer cancel()
@@ -209,12 +217,12 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	// The apply lock is held across inspection, planning, simulation,
 	// confirmation, and execution, so the plan cannot go stale between
 	// planning and applying. The deferred release covers every exit path.
-	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, lockTimeout)
+	applyLock, err := acquireAtlasSchemaApplyLock(cmd, conn, lockRequest, lockTimeout)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	defer releaseAtlasSchemaApplyLock(cmd, applyLock)
-	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, applyLock, conn.Info().Dialect)
+	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, opts.lock, applyLock, conn.Info().Dialect)
 
 	plan, err := atlasschema.PrepareApply(cmd.Context(), conn, atlasschema.ApplyRuntimeOptions{
 		DevURL:     opts.devURL,
@@ -342,6 +350,10 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	lockRequest, err := resolveAtlasLockRequest(cmd, opts.lock)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	path, err := atlasSchemaApplyPlanFilePath(opts.planURL)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -381,12 +393,12 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	// The plan verification is the serialized target inspection of the
 	// pre-approved plan path, so the lock is held before it and released on
 	// every exit path.
-	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, lockTimeout)
+	applyLock, err := acquireAtlasSchemaApplyLock(cmd, conn, lockRequest, lockTimeout)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	defer releaseAtlasSchemaApplyLock(cmd, applyLock)
-	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, applyLock, conn.Info().Dialect)
+	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, opts.lock, applyLock, conn.Info().Dialect)
 
 	// A JSON plan always carries a fingerprint contract; a Ptah-written
 	// `.plan.hcl` carries one too (round-trip). Foreign Atlas hashes cannot be
@@ -762,6 +774,25 @@ func renderAtlasSchemaApplyFormat(opts atlasSchemaApplyOptions, statements []str
 	return out.String(), nil
 }
 
+// acquireAtlasSchemaApplyLock takes the schema apply lock the request selects,
+// or takes nothing at all when --skip-lock asked for no lock.
+//
+// A skipped acquisition returns a nil lock rather than a held no-op one, so
+// the difference between "this dialect cannot lock" and "the caller declined
+// to lock" stays visible to everything downstream: a nil lock reports no name
+// and releases as a no-op.
+func acquireAtlasSchemaApplyLock(
+	cmd *cobra.Command,
+	conn *dbschema.DatabaseConnection,
+	request atlasLockRequest,
+	timeout time.Duration,
+) (*atlasschema.ApplyLock, error) {
+	if request.Skip {
+		return nil, nil
+	}
+	return atlasschema.AcquireApplyLock(cmd.Context(), conn, request.Name, timeout)
+}
+
 // releaseAtlasSchemaApplyLock releases the schema apply lock on every exit
 // path. Release runs on its own bounded background context, so it also works
 // when the command context has already been canceled.
@@ -773,15 +804,36 @@ func releaseAtlasSchemaApplyLock(cmd *cobra.Command, lock *atlasschema.ApplyLock
 
 // noteAtlasSchemaApplyLockUnsupported surfaces the capability decision for
 // dialects without advisory-lock semantics: an explicitly requested
-// --lock-timeout is ignored and the apply proceeds without a database lock.
-// The note goes to stderr so --format output on stdout stays machine-clean.
+// --lock-timeout or --lock-name is ignored and the apply proceeds without a
+// database lock. The note goes to stderr so --format output on stdout stays
+// machine-clean.
+//
+// --lock-name gets its own wording because the two flags fail differently: an
+// ignored timeout only means "no wait", while an ignored name means the run is
+// not coordinating with whatever else holds that name. The name printed is
+// read back from the acquired lock, so it is the name the machinery resolved
+// rather than the flag string.
+//
+// --skip-lock produces no note in either wording. It leaves a nil lock behind,
+// and a caller who asked for no lock does not need to be told the dialect has
+// none.
 func noteAtlasSchemaApplyLockUnsupported(
 	cmd *cobra.Command,
 	requestedTimeout string,
+	lockOpts atlasLockOptions,
 	lock *atlasschema.ApplyLock,
 	dialect string,
 ) {
-	if strings.TrimSpace(requestedTimeout) == "" || lock.Supported() {
+	if lock == nil || lock.Supported() {
+		return
+	}
+	if strings.TrimSpace(lockOpts.name) != "" {
+		fmt.Fprintf(cmd.ErrOrStderr(),
+			"note: schema apply locking is not supported for dialect %q; the advisory lock %q is not acquired and the apply proceeds without a database lock\n",
+			dialect, lock.Name())
+		return
+	}
+	if strings.TrimSpace(requestedTimeout) == "" {
 		return
 	}
 	fmt.Fprintf(cmd.ErrOrStderr(),

--- a/cmd/schema/apply.go
+++ b/cmd/schema/apply.go
@@ -216,7 +216,7 @@ func runSchemaApply(cmd *cobra.Command, opts schemaApplyOptions) error {
 	// The apply lock is held across inspection, planning, simulation,
 	// confirmation, and execution, so the plan cannot go stale between
 	// planning and applying. The deferred release covers every exit path.
-	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, lockTimeout)
+	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, "", lockTimeout)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -332,7 +332,7 @@ func runSchemaApplyPlanFile(cmd *cobra.Command, opts schemaApplyOptions) error {
 	// The fingerprint verification is the serialized target inspection of the
 	// pre-approved plan path, so the lock is held before it and released on
 	// every exit path.
-	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, lockTimeout)
+	applyLock, err := atlasschema.AcquireApplyLock(cmd.Context(), conn, "", lockTimeout)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -7380,6 +7380,8 @@ func (m *Migrator) MigrateTo(ctx context.Context, targetVersion int64) (err erro
 func (m *Migrator) MigrateUp(ctx context.Context) error
 func (m *Migrator) MigrateUpWithOptions(ctx context.Context, opts MigrateUpOptions) (err error)
 func (m *Migrator) MigrateUpWithPreflight(ctx context.Context, hook PreMigrationHook) (err error)
+func (m *Migrator) MigrationLockName() string
+func (m *Migrator) MigrationLockSkipped() bool
 func (m *Migrator) MigrationProvider() MigrationProvider
 func (m *Migrator) MigrationsTableIdentifier() string
 func (m *Migrator) RepairMigration(ctx context.Context, opts RepairMigrationOptions) error
@@ -7396,6 +7398,7 @@ func (m *Migrator) WithOutOfOrderExempt(versions []int64) *Migrator
 func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator
 func (m *Migrator) WithSkipChecks(skip bool) *Migrator
 func (m *Migrator) WithTransactionMode(mode MigrationTxMode) *Migrator
+func (m *Migrator) WithoutMigrationLock() *Migrator
 
 ### go.5x5.cz/ptah/migration/migrator.NoopObserver
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -469,12 +469,12 @@
   },
   {
     "area": "Declarative / direct schema workflow",
-    "feature": "Apply advisory lock and `--lock-timeout`",
+    "feature": "Apply advisory lock, `--lock-timeout`, `--lock-name`, `--skip-lock`",
     "ptah": "yes",
-    "atlas_oss": "yes",
+    "atlas_oss": "partial",
     "atlas_pro": "yes",
-    "note": "Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note.",
-    "evidence": "internal/dblock/dblock.go:54-64 returns true for Postgres, YugabyteDB, MySQL, MariaDB, SQLServer \u2014 the previous note wrongly listed YugabyteDB as unlocked. cmd/atlas/schema_apply.go:578 emits the stderr note. Reproduced: `pc schema apply --url sqlite://t1.db --to file://b.sql --auto-approve --lock-timeout 10s` -> `note: schema apply locking is not supported for dialect \"sqlite\"; --lock-timeout is ignored and the apply proceeds without a database lock` then a successful apply (exit 0). CE registers --lock-timeout on schema apply per cli-surface.md:43"
+    "note": "Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; others run unlocked with a note. `--lock-name` and `--skip-lock` are Pro surface adopted openly; CE registers only `--lock-timeout`.",
+    "evidence": "internal/dblock/dblock.go:54-64 returns true for Postgres, YugabyteDB, MySQL, MariaDB, SQLServer \u2014 the previous note wrongly listed YugabyteDB as unlocked. cmd/atlas/schema_apply.go emits the stderr note. Reproduced: `pc schema apply --url sqlite://t1.db --to file://b.sql --auto-approve --lock-timeout 10s` -> `note: schema apply locking is not supported for dialect \"sqlite\"; --lock-timeout is ignored and the apply proceeds without a database lock` then a successful apply (exit 0). CE registers --lock-timeout on schema apply per cli-surface.md:43. Updated 2026-08-03 (stokaro/ptah#951): --lock-name and --skip-lock added. Measured on the pinned community binary v1.3.0 by RUNNING each spelling: `atlas schema apply --lock-name x` and `--skip-lock` both answer `unknown flag`, with `--dry-run` answering present and `--frobnicate-nonsense` answering unknown on the same run, so CE registers neither. Atlas's published CLI reference (atlasgo.io/cli-reference, retrieved 2026-08-03) registers both on `atlas schema apply`, verbatim: `--lock-name string   set the name of the advisory lock to use. If not set, the default is used (atlas_migrate_execute)` and `--skip-lock   skip acquiring a database advisory lock`; controls on the same fetch: `atlas migrate apply` present 10 times, `frobnicate` 0 times, `--lock-name` exactly 2 occurrences across the whole page (migrate apply and schema apply). Ptah's default lock name stays ptah_schema_apply so an in-flight fleet does not de-serialize mid-upgrade; `--lock-name atlas_migrate_execute` is the explicit spelling for coordinating with Atlas. --skip-lock acquires nothing at all (nil lock, no wait, no timeout) and is refused together with --lock-name."
   },
   {
     "area": "Declarative / direct schema workflow",
@@ -739,12 +739,12 @@
   },
   {
     "area": "Versioned migrations \u2014 runtime policy",
-    "feature": "Migration lock and lock timeout",
+    "feature": "Migration lock, lock timeout, `--lock-name`, `--skip-lock`",
     "ptah": "yes",
-    "atlas_oss": "yes",
+    "atlas_oss": "partial",
     "atlas_pro": "yes",
-    "note": "Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`.",
-    "evidence": "/tmp/ptah migrations up --help (--lock-timeout per-migration, --migration-lock-timeout advisory); docs/site/src/content/docs/atlas/migrate-commands.md line 356; conformance cli-surface.md `atlas migrate apply --lock-timeout`"
+    "note": "Compat `--lock-timeout` bounds directory and dev-db locks. `--lock-name` and `--skip-lock` on `migrate apply` are Pro surface adopted openly; CE registers only `--lock-timeout`.",
+    "evidence": "/tmp/ptah migrations up --help (--lock-timeout per-migration, --migration-lock-timeout advisory); docs/site/src/content/docs/atlas/migrate-commands.md; conformance cli-surface.md `atlas migrate apply --lock-timeout`. Updated 2026-08-03 (stokaro/ptah#951): --lock-name and --skip-lock added to `migrate apply`. Measured on the pinned community binary v1.3.0 by RUNNING each spelling: `atlas migrate apply --lock-name x` and `--skip-lock` both answer `unknown flag`, with `--dry-run` present and `--frobnicate-nonsense` unknown on the same run. Atlas's published CLI reference (atlasgo.io/cli-reference, retrieved 2026-08-03) registers both on `atlas migrate apply` verbatim: `--lock-name string   set the name of the advisory lock to use. If not set, the default is used (atlas_migrate_execute)` and `--skip-lock   skip acquiring a database advisory lock`. The same reference registers NEITHER on `migrate diff`, `migrate down` or `migrate checkpoint` — those three carry only `--lock-timeout duration` — so compat leaves `--lock-name` unregistered there; measured on the pinned binary, `migrate down` and `migrate checkpoint` are community-gated and register none of their own flags at all (only inherited --config/--env/--var reach the abort), so the binary is no oracle for them either. Ptah's default lock name stays ptah_migrate; `--lock-name atlas_migrate_execute` is the explicit spelling for coordinating with Atlas. --skip-lock requests no lock at all: migration/migrator.WithoutMigrationLock, proved by the absence of the ptah.lock.acquire observation span."
   },
   {
     "area": "Test frameworks",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -77,7 +77,7 @@ Across the 159 capabilities below:
 | Ptah supports it fully | 86 |
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
-| Ptah and Atlas CE both support it | 23 |
+| Ptah and Atlas CE both support it | 21 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 37 |
 | Ptah has it and neither Atlas edition does | 16 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
@@ -132,7 +132,7 @@ seven of them as open capabilities regardless.
 | `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics. |
 | `--schema` / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
 | `schema inspect --include` filtering | ✅ | ❌ | ✅ | Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. Child-depth patterns fail closed instead of emitting partial objects. |
-| Apply advisory lock and `--lock-timeout` | ✅ | ✅ | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; SQLite, ClickHouse, CockroachDB, Spanner run unlocked with a note. |
+| Apply advisory lock, `--lock-timeout`, `--lock-name`, `--skip-lock` | ✅ | 🟡 | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; others run unlocked with a note. `--lock-name` and `--skip-lock` are Pro surface adopted openly; CE registers only `--lock-timeout`. |
 | Desired-state sources for `--to` and `--from` | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |
@@ -173,7 +173,7 @@ seven of them as open capabilities regardless.
 | Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint: the ptah reversible pair, or Atlas's single `-- atlas:checkpoint` file under `--dir-format atlas`. CE gates the verb. |
 | Migration import from other tools | 🟡 | ✅ | ✅ | Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed. |
 | Migration linting | ✅ | 🟡 | ✅ | CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time. |
-| Migration lock and lock timeout | ✅ | ✅ | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks; native splits per-migration `--lock-timeout` from `--migration-lock-timeout`. |
+| Migration lock, lock timeout, `--lock-name`, `--skip-lock` | ✅ | 🟡 | ✅ | Compat `--lock-timeout` bounds directory and dev-db locks. `--lock-name` and `--skip-lock` on `migrate apply` are Pro surface adopted openly; CE registers only `--lock-timeout`. |
 | Migration status report | ✅ | ✅ | ✅ | Compat status reads Atlas revision metadata and renders Go templates over .Env, .Available, .Applied, .Pending, .Current, .Next. |
 | Online DDL routing via gh-ost or pt-osc | ✅ | ❔ | ❌ | ptah.yaml online_ddl.tool (ghost\|pt-osc), threshold_rows, args, and fallback (error\|plain) route large-table ALTERs through an online-DDL tool during migrations up/down. |
 | Pre-migration database backups (`--pg-dump-to`) | ✅ | ❌ | ❌ | `--pg-dump-to` writes a pg_dump custom-format backup and `--mysqldump-to` a SQL backup before applying or rolling back; ptah.yaml key migration.pg_dump_to. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -216,15 +216,30 @@ ptah-compat migrate apply 2 \
 ```
 
 Supported Atlas apply flags include `--dry-run`, `--tx-mode`, `--exec-order`,
-`--allow-dirty`, `--baseline`, `--revisions-schema`, `--lock-timeout`, and
-`--format`. `--format` executes a Go template against a Ptah apply result that
-mirrors Atlas's public apply-template fields: `Pending`, `Applied`, `Current`,
-`Target`, `Start`, `End`, `Driver`, `URL`, and `Dir`; `{{ json . }}` emits the
-same result as JSON with database credentials redacted. With `--env`, Ptah can
-read `env.url`, `migration`, and `format.migrate.apply` from `atlas.hcl`.
-Dry-run plans read the stored Atlas revision rows and include only migrations
-that a real apply would select. They also run the same dirty-state, checksum,
-execution-order, and transaction-mode validations as a real apply.
+`--allow-dirty`, `--baseline`, `--revisions-schema`, `--lock-timeout`,
+`--lock-name`, `--skip-lock`, and `--format`. `--format` executes a Go template
+against a Ptah apply result that mirrors Atlas's public apply-template fields:
+`Pending`, `Applied`, `Current`, `Target`, `Start`, `End`, `Driver`, `URL`, and
+`Dir`; `{{ json . }}` emits the same result as JSON with database credentials
+redacted. With `--env`, Ptah can read `env.url`, `migration`, and
+`format.migrate.apply` from `atlas.hcl`. Dry-run plans read the stored Atlas
+revision rows and include only migrations that a real apply would select. They
+also run the same dirty-state, checksum, execution-order, and transaction-mode
+validations as a real apply.
+
+`--lock-name` replaces the name of the session advisory lock that serializes
+migration runs (`ptah_migrate` by default). Two runs serialize only when they
+name the same lock, so this is how a Ptah run coordinates with another tool on
+the same database. A lock another process holds makes the run wait, bounded by
+`--lock-timeout`; an elapsed timeout fails the run before any migration
+executes. An empty value is refused rather than falling back to the default
+name.
+
+`--skip-lock` acquires no lock at all: no wait, no timeout, and no
+serialization against another runner. It cannot be combined with `--lock-name`,
+because there is no lock to name. On dialects with no advisory-lock semantics —
+SQLite, ClickHouse, CockroachDB, and Spanner — an explicit `--lock-name` prints
+a note on stderr naming the lock that was not acquired.
 
 Atlas migration files may override global `file` or `none` with a leading
 header followed by a blank line:

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -262,6 +262,19 @@ SQLite, ClickHouse, CockroachDB, YugabyteDB, and Spanner have no advisory-lock
 semantics: the apply proceeds without a lock, and an explicitly passed
 `--lock-timeout` prints a note on stderr.
 
+`--lock-name` replaces the lock name for the run. Two runs serialize only when
+they name the same lock, so this is how a Ptah apply coordinates with another
+tool on the same database — and equally how it deliberately stops coordinating
+with the default. Passing an empty value is refused rather than silently
+falling back to `ptah_schema_apply`. On dialects without advisory locks the
+note on stderr names the lock that was not acquired.
+
+`--skip-lock` acquires no lock at all: no wait, no timeout, and no
+serialization against another runner holding the same name. A lock another
+process holds is ignored rather than waited on, so concurrent applies can
+interleave. It cannot be combined with `--lock-name`, because there is no lock
+to name.
+
 `--exclude` accepts repeated or comma-separated Atlas-style glob patterns,
 including `[type=...]` selectors. Ptah applies the filter to both the current
 live schema and the desired local schema files before planning, so excluded

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -71,8 +71,20 @@ golang-migrate down file and a Flyway undo file are not covered, and a layout
 that carries no `atlas.sum` and whose covered set is empty is not a checksum
 error. What executes is what the verified checksum covers, for every layout.
 
-**Rejected on this verb, matching Atlas OSS:** `--dir-format`, `--to-version`,
-and `--lock-name`.
+**Rejected on this verb, matching Atlas OSS:** `--dir-format` and
+`--to-version`.
+
+**`--lock-name`** replaces the name of the session advisory lock that
+serializes migration runs (`ptah_migrate` by default). Runs serialize only
+against other runs naming the same lock. A lock another process holds makes the
+run wait, bounded by `--lock-timeout`; an elapsed timeout fails the run before
+any migration executes. An empty value is refused rather than silently falling
+back to the default. On a dialect with no advisory-lock semantics the run
+prints a stderr note naming the lock it did not acquire.
+
+**`--skip-lock`** takes no lock at all, so a lock another process holds is
+ignored rather than waited on and concurrent runs can interleave. It cannot be
+combined with `--lock-name`.
 
 Pre-migration checks — `-- +ptah check` directives and Atlas txtar
 `checks.sql` / `checks/*.sql` sections — are enforced here as they are natively.
@@ -564,6 +576,16 @@ and execution, and released on every exit path. Empty waits indefinitely, an
 elapsed timeout fails before the target is inspected, and dialects without
 advisory locks (SQLite, ClickHouse, CockroachDB, YugabyteDB, Spanner) proceed
 unlocked with a stderr note.
+
+**`--lock-name`** replaces the lock name for the run (`ptah_schema_apply` by
+default). Runs serialize only against other runs naming the same lock, which is
+both how a run coordinates with a different tool and how it opts out of the
+default. An empty value is refused; on a dialect without advisory locks the
+stderr note names the lock that was not acquired.
+
+**`--skip-lock`** takes no lock at all: a lock another process holds is ignored
+rather than waited on, so concurrent applies can interleave. It cannot be
+combined with `--lock-name`.
 
 **`--dev-url` rehearsal.** Before a non-dry-run apply, `--dev-url` rehearses the
 exact ordered plan on the dev database — reset, the target's current schema

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -31,9 +31,17 @@ type ApplyOptions struct {
 	TxMode               migrator.MigrationTxMode
 	RevisionsSchema      string
 	MigrationLockTimeout time.Duration
-	Amount               uint64
-	AllowDirty           bool
-	BaselineVersion      int64
+	// MigrationLockName overrides the session advisory lock name the migration
+	// run coordinates on. Empty keeps the migrator default. It carries Atlas's
+	// `migrate apply --lock-name`.
+	MigrationLockName string
+	// SkipMigrationLock runs without the session advisory lock entirely. It
+	// carries Atlas's `migrate apply --skip-lock`, and is the only way this
+	// path executes migrations without serializing against another runner.
+	SkipMigrationLock bool
+	Amount            uint64
+	AllowDirty        bool
+	BaselineVersion   int64
 	// SkipChecks bypasses pre-migration check evaluation. Atlas registers no
 	// flag for this on `migrate apply` (measured on CE v1.2.0 and on
 	// Atlas's own help surface), so the compat command resolves it from
@@ -91,6 +99,8 @@ func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts A
 		txMode:               opts.TxMode,
 		revisionsSchema:      opts.RevisionsSchema,
 		migrationLockTimeout: opts.MigrationLockTimeout,
+		migrationLockName:    opts.MigrationLockName,
+		skipMigrationLock:    opts.SkipMigrationLock,
 		skipChecks:           opts.SkipChecks,
 	})
 	if err != nil {
@@ -136,6 +146,22 @@ func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts A
 // dirty revision requiring recovery.
 func (p ApplyPlan) Noop() bool {
 	return len(p.SelectedVersions) == 0 && p.Status != nil && p.Status.DirtyRevision == nil
+}
+
+// MigrationLockName reports the advisory lock name the prepared migrator will
+// acquire, read back from the migrator rather than from the request, so a
+// caller reporting the lock names what the machinery resolved.
+func (p ApplyPlan) MigrationLockName() string {
+	if p.mig == nil {
+		return ""
+	}
+	return p.mig.MigrationLockName()
+}
+
+// MigrationLockSkipped reports whether the prepared migrator will run without
+// the advisory lock.
+func (p ApplyPlan) MigrationLockSkipped() bool {
+	return p.mig != nil && p.mig.MigrationLockSkipped()
 }
 
 // Execute applies the selected plan. Dry-run and no-op plans return metadata
@@ -288,6 +314,8 @@ type applyMigratorOptions struct {
 	txMode               migrator.MigrationTxMode
 	revisionsSchema      string
 	migrationLockTimeout time.Duration
+	migrationLockName    string
+	skipMigrationLock    bool
 	skipChecks           bool
 }
 
@@ -304,14 +332,19 @@ func newApplyMigrator(
 	if err != nil {
 		return nil, fmt.Errorf("error registering migrations: %w", err)
 	}
-	return mig.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+	mig = mig.WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
 		WithMigrationsTable(opts.revisionsSchema, "").
 		WithExecOrder(opts.execOrder).
 		WithOutOfOrderExempt(opts.outOfOrderExempt).
 		WithTransactionMode(opts.txMode).
 		WithMigrationLockTimeout(opts.migrationLockTimeout).
+		WithMigrationLockName(opts.migrationLockName).
 		WithSkipChecks(opts.skipChecks).
-		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil))), nil
+		WithLogger(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if opts.skipMigrationLock {
+		mig = mig.WithoutMigrationLock()
+	}
+	return mig, nil
 }
 
 func applyBaselineVersions(mig *migrator.Migrator, baselineVersion int64) ([]int64, error) {

--- a/internal/atlasmigrate/apply_lock_internal_test.go
+++ b/internal/atlasmigrate/apply_lock_internal_test.go
@@ -1,0 +1,163 @@
+package atlasmigrate
+
+// White-box testing required: the whole point of this test is that the lock
+// request in ApplyOptions reaches the migrator that PrepareApply builds, and
+// the migrator is an unexported field of ApplyPlan. Observing it from outside
+// the package would need a live PostgreSQL, MySQL, MariaDB or SQL Server
+// instance, since those are the only dialects that take a real advisory lock.
+
+import (
+	"context"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+func TestPrepareApply_LockRequestReachesMigrator(t *testing.T) {
+	tests := []struct {
+		name string
+		// lock applies the named-lock decision to the apply options.
+		lock func(*ApplyOptions)
+		// wantAcquire is the lock.name the executed run must record, or the
+		// empty string when no lock may be requested at all.
+		wantAcquire string
+		wantSkipped bool
+	}{
+		{
+			name:        "default",
+			lock:        func(*ApplyOptions) {},
+			wantAcquire: "ptah_migrate",
+		},
+		{
+			name:        "lock name",
+			lock:        func(o *ApplyOptions) { o.MigrationLockName = "atlas_migrate_execute" },
+			wantAcquire: "atlas_migrate_execute",
+		},
+		{
+			name:        "skip lock",
+			lock:        func(o *ApplyOptions) { o.SkipMigrationLock = true },
+			wantAcquire: "",
+			wantSkipped: true,
+		},
+		{
+			name: "skip lock keeps the name it declined",
+			lock: func(o *ApplyOptions) {
+				o.MigrationLockName = "atlas_migrate_execute"
+				o.SkipMigrationLock = true
+			},
+			wantAcquire: "",
+			wantSkipped: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx := context.Background()
+			dir := t.TempDir()
+			migrationsDir := filepath.Join(dir, "migrations")
+			writeLockTestMigration(c, migrationsDir)
+			conn := connectLockTestSQLite(c, filepath.Join(dir, "apply.db"))
+			defer dbschema.CloseAndWarn(conn)
+
+			opts := ApplyOptions{
+				Dir:       migrationsDir,
+				FS:        os.DirFS(migrationsDir),
+				ExecOrder: migrator.ExecOrderLinear,
+				TxMode:    migrator.MigrationTxModeFile,
+			}
+			tt.lock(&opts)
+
+			plan, err := PrepareApply(ctx, conn, opts)
+			c.Assert(err, qt.IsNil)
+			c.Assert(plan.MigrationLockSkipped(), qt.Equals, tt.wantSkipped)
+
+			observer := &lockRecordingObserver{}
+			plan.mig = plan.mig.WithObserver(observer)
+
+			result, err := plan.Execute(ctx)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.Applied, qt.IsTrue)
+			name, acquired := observer.acquiredLockName()
+			c.Assert(acquired, qt.Equals, tt.wantAcquire != "",
+				qt.Commentf("acquired=%v name=%q", acquired, name))
+			c.Assert(name, qt.Equals, tt.wantAcquire)
+		})
+	}
+}
+
+func writeLockTestMigration(c *qt.C, dir string) {
+	c.Helper()
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_lock.sql"),
+		[]byte("CREATE TABLE apply_lock_probe (id INTEGER PRIMARY KEY);"),
+		0o600,
+	), qt.IsNil)
+}
+
+func connectLockTestSQLite(c *qt.C, path string) *dbschema.DatabaseConnection {
+	c.Helper()
+	dbURL := (&url.URL{Scheme: platform.SQLite, Path: path}).String()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	return conn
+}
+
+// lockRecordingObserver records only what this test asks about: whether an
+// advisory lock acquisition was started, and under which name.
+type lockRecordingObserver struct {
+	lockNames []string
+}
+
+func (o *lockRecordingObserver) StartSpan(
+	ctx context.Context,
+	name string,
+	attrs ...migrator.ObservationAttribute,
+) (context.Context, migrator.ObservationSpan) {
+	o.recordAcquisition(name, attrs)
+	return ctx, lockRecordingSpan{}
+}
+
+func (o *lockRecordingObserver) recordAcquisition(name string, attrs []migrator.ObservationAttribute) {
+	if name != "ptah.lock.acquire" {
+		return
+	}
+	for _, attr := range attrs {
+		if attr.Key == "lock.name" {
+			value, _ := attr.Value.(string)
+			o.lockNames = append(o.lockNames, value)
+		}
+	}
+}
+
+func (o *lockRecordingObserver) AddCounter(
+	context.Context, string, int64, ...migrator.ObservationAttribute,
+) {
+}
+
+func (o *lockRecordingObserver) RecordDuration(
+	context.Context, string, time.Duration, ...migrator.ObservationAttribute,
+) {
+}
+
+func (o *lockRecordingObserver) acquiredLockName() (string, bool) {
+	for _, name := range o.lockNames {
+		return name, true
+	}
+	return "", false
+}
+
+type lockRecordingSpan struct{}
+
+func (lockRecordingSpan) SetAttributes(...migrator.ObservationAttribute) {}
+func (lockRecordingSpan) End(error)                                      {}

--- a/internal/atlasschema/lock.go
+++ b/internal/atlasschema/lock.go
@@ -53,19 +53,34 @@ type ApplyLock struct {
 // waits indefinitely; context cancellation always interrupts the wait, and an
 // elapsed timeout surfaces as a wrapped [dblock.TimeoutError] recognized by
 // [IsLockTimeout].
+//
+// An empty or whitespace-only name selects [ApplyLockName]. Naming the lock is
+// how a caller coordinates with a different tool on the same database: two
+// runners serialize only when they name the same lock, so passing a name is
+// also how a caller opts OUT of serializing against Ptah's default.
 func AcquireApplyLock(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
+	name string,
 	timeout time.Duration,
 ) (*ApplyLock, error) {
 	if conn == nil {
 		return nil, errors.New("schema apply locking requires database connection")
 	}
-	lock, err := dblock.Acquire(ctx, conn, ApplyLockName, timeout)
+	lock, err := dblock.Acquire(ctx, conn, EffectiveApplyLockName(name), timeout)
 	if err != nil {
 		return nil, fmt.Errorf("acquire schema apply lock: %w", err)
 	}
 	return &ApplyLock{lock: lock}, nil
+}
+
+// EffectiveApplyLockName resolves the schema apply lock name a request selects:
+// the trimmed name, or [ApplyLockName] when none was given.
+func EffectiveApplyLockName(name string) string {
+	if trimmed := strings.TrimSpace(name); trimmed != "" {
+		return trimmed
+	}
+	return ApplyLockName
 }
 
 // Supported reports whether the lock is backed by a real database lock. It is
@@ -73,6 +88,17 @@ func AcquireApplyLock(
 // CockroachDB, YugabyteDB, and Spanner), where the apply proceeds unlocked.
 func (l *ApplyLock) Supported() bool {
 	return l != nil && l.lock.Supported()
+}
+
+// Name returns the advisory lock name this lock was acquired under. It is
+// recorded on the no-op path too, so a caller on a dialect without advisory
+// locks can still name the lock it would have taken. A nil lock — which is
+// what a skipped acquisition leaves behind — reports the empty string.
+func (l *ApplyLock) Name() string {
+	if l == nil {
+		return ""
+	}
+	return l.lock.Name()
 }
 
 // Release frees the schema apply lock on its own bounded background context,

--- a/internal/atlasschema/lock_live_test.go
+++ b/internal/atlasschema/lock_live_test.go
@@ -29,7 +29,7 @@ func TestAcquireApplyLock_PostgresTimeoutLive(t *testing.T) {
 	blocked := connectPostgresForLock(c, dbURL)
 
 	start := time.Now()
-	lock, err := atlasschema.AcquireApplyLock(ctx, blocked, 200*time.Millisecond)
+	lock, err := atlasschema.AcquireApplyLock(ctx, blocked, "", 200*time.Millisecond)
 	elapsed := time.Since(start)
 
 	c.Assert(atlasschema.IsLockTimeout(err), qt.IsTrue, qt.Commentf("error: %v", err))
@@ -40,7 +40,7 @@ func TestAcquireApplyLock_PostgresTimeoutLive(t *testing.T) {
 	// Releasing the competing session unblocks a bounded retry, proving the
 	// lock is real, released, and re-acquirable.
 	releaseApplyLockSession(c, holderSession)
-	lock, err = atlasschema.AcquireApplyLock(ctx, blocked, 5*time.Second)
+	lock, err = atlasschema.AcquireApplyLock(ctx, blocked, "", 5*time.Second)
 	c.Assert(err, qt.IsNil)
 	c.Assert(lock.Supported(), qt.IsTrue)
 	c.Assert(lock.Release(), qt.IsNil)
@@ -62,7 +62,7 @@ func TestAcquireApplyLock_PostgresCancellationLive(t *testing.T) {
 	start := time.Now()
 	// A zero timeout waits indefinitely, so only the canceled context can
 	// interrupt the wait; the result must not be misreported as a timeout.
-	lock, err := atlasschema.AcquireApplyLock(ctx, blocked, 0)
+	lock, err := atlasschema.AcquireApplyLock(ctx, blocked, "", 0)
 	elapsed := time.Since(start)
 
 	c.Assert(err, qt.IsNotNil)
@@ -80,16 +80,16 @@ func TestAcquireApplyLock_PostgresSerializesRunsLive(t *testing.T) {
 	first := connectPostgresForLock(c, dbURL)
 	second := connectPostgresForLock(c, dbURL)
 
-	firstLock, err := atlasschema.AcquireApplyLock(ctx, first, 5*time.Second)
+	firstLock, err := atlasschema.AcquireApplyLock(ctx, first, "", 5*time.Second)
 	c.Assert(err, qt.IsNil)
 	c.Assert(firstLock.Supported(), qt.IsTrue)
 
-	_, err = atlasschema.AcquireApplyLock(ctx, second, 200*time.Millisecond)
+	_, err = atlasschema.AcquireApplyLock(ctx, second, "", 200*time.Millisecond)
 	c.Assert(atlasschema.IsLockTimeout(err), qt.IsTrue, qt.Commentf("error: %v", err))
 
 	c.Assert(firstLock.Release(), qt.IsNil)
 
-	secondLock, err := atlasschema.AcquireApplyLock(ctx, second, 5*time.Second)
+	secondLock, err := atlasschema.AcquireApplyLock(ctx, second, "", 5*time.Second)
 	c.Assert(err, qt.IsNil)
 	c.Assert(secondLock.Supported(), qt.IsTrue)
 	c.Assert(secondLock.Release(), qt.IsNil)

--- a/internal/atlasschema/lock_name_live_test.go
+++ b/internal/atlasschema/lock_name_live_test.go
@@ -1,0 +1,87 @@
+package atlasschema_test
+
+// Live PostgreSQL coverage for the NAMED schema apply lock (stokaro/ptah#951).
+//
+// The two questions `--lock-name` raises can only be answered against a real
+// advisory lock: does a run wait on a lock another process holds under the SAME
+// name, and does it run straight through when the names DIFFER. Gated on
+// POSTGRES_TEST_DSN / TEST_DATABASE_URL like the sibling lock live tests.
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/internal/dblock"
+)
+
+const namedLockLive = "atlas_migrate_execute"
+
+func TestAcquireApplyLock_NamedLockContendsLive(t *testing.T) {
+	dbURL := livePostgresURLForLock(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	holder := holdNamedLockSession(c, dbURL, namedLockLive)
+	blocked := connectPostgresForLock(c, dbURL)
+
+	start := time.Now()
+	lock, err := atlasschema.AcquireApplyLock(ctx, blocked, namedLockLive, 200*time.Millisecond)
+	elapsed := time.Since(start)
+
+	// A lock another process holds under the same name makes the apply wait
+	// and then fail before the target is inspected.
+	c.Assert(atlasschema.IsLockTimeout(err), qt.IsTrue, qt.Commentf("error: %v", err))
+	c.Assert(err, qt.ErrorMatches,
+		`acquire schema apply lock: timed out acquiring advisory lock "`+namedLockLive+`" on postgres after 200ms`)
+	c.Assert(lock, qt.IsNil)
+	c.Assert(elapsed < 5*time.Second, qt.IsTrue, qt.Commentf("acquire waited %s", elapsed))
+
+	releaseNamedLockSession(c, holder, namedLockLive)
+	lock, err = atlasschema.AcquireApplyLock(ctx, blocked, namedLockLive, 5*time.Second)
+	c.Assert(err, qt.IsNil)
+	c.Assert(lock.Supported(), qt.IsTrue)
+	c.Assert(lock.Name(), qt.Equals, namedLockLive)
+	c.Assert(lock.Release(), qt.IsNil)
+}
+
+func TestAcquireApplyLock_DistinctNamesDoNotContendLive(t *testing.T) {
+	dbURL := livePostgresURLForLock(t)
+	c := qt.New(t)
+	ctx := context.Background()
+
+	holder := holdNamedLockSession(c, dbURL, namedLockLive)
+	defer releaseNamedLockSession(c, holder, namedLockLive)
+	other := connectPostgresForLock(c, dbURL)
+
+	// The default lock is a different name, so the held lock is irrelevant to
+	// it. This is what makes --lock-name a real choice rather than a label: a
+	// run that names a different lock does not serialize against this holder.
+	lock, err := atlasschema.AcquireApplyLock(ctx, other, "", 200*time.Millisecond)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(lock.Supported(), qt.IsTrue)
+	c.Assert(lock.Name(), qt.Equals, atlasschema.ApplyLockName)
+	c.Assert(lock.Release(), qt.IsNil)
+}
+
+func holdNamedLockSession(c *qt.C, dbURL, name string) *sql.Conn {
+	c.Helper()
+	ctx := context.Background()
+	holder := connectPostgresForLock(c, dbURL)
+	session, err := holder.Conn(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { _ = session.Close() })
+	_, err = session.ExecContext(ctx, "SELECT pg_advisory_lock($1)", dblock.PostgresKey(name))
+	c.Assert(err, qt.IsNil)
+	return session
+}
+
+func releaseNamedLockSession(c *qt.C, session *sql.Conn, name string) {
+	c.Helper()
+	_, _ = session.ExecContext(context.Background(), "SELECT pg_advisory_unlock($1)", dblock.PostgresKey(name))
+}

--- a/internal/atlasschema/lock_name_test.go
+++ b/internal/atlasschema/lock_name_test.go
@@ -1,0 +1,93 @@
+package atlasschema_test
+
+// Coverage for the schema apply lock NAME, which carries Atlas's
+// `schema apply --lock-name`. The acquired lock records the name it was taken
+// under, including on dialects without advisory-lock semantics, so a caller can
+// report which lock a run coordinates on without a live database.
+
+import (
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/internal/dblock"
+)
+
+func TestEffectiveApplyLockName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "empty selects the default", value: "", want: atlasschema.ApplyLockName},
+		{name: "whitespace selects the default", value: "   ", want: atlasschema.ApplyLockName},
+		{name: "named", value: "atlas_migrate_execute", want: "atlas_migrate_execute"},
+		{name: "trimmed", value: "  atlas_migrate_execute  ", want: "atlas_migrate_execute"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(atlasschema.EffectiveApplyLockName(test.value), qt.Equals, test.want)
+		})
+	}
+}
+
+func TestAcquireApplyLock_RecordsRequestedName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		requested string
+		want      string
+	}{
+		{name: "default", requested: "", want: atlasschema.ApplyLockName},
+		{name: "named", requested: "atlas_migrate_execute", want: "atlas_migrate_execute"},
+		{name: "trimmed", requested: "  custom-lock ", want: "custom-lock"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := connectSQLite(c, filepath.Join(c.TB.TempDir(), "lock-name.db"))
+			defer dbschema.CloseAndWarn(conn)
+
+			lock, err := atlasschema.AcquireApplyLock(c.Context(), conn, test.requested, time.Second)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(lock.Name(), qt.Equals, test.want)
+			// The recorded name is the one the dialect-specific acquisition
+			// would use, so the PostgreSQL-family key follows from it.
+			c.Assert(dblock.PostgresKey(lock.Name()), qt.Equals, dblock.PostgresKey(test.want))
+			c.Assert(lock.Release(), qt.IsNil)
+		})
+	}
+}
+
+func TestApplyLock_NilReportsNoName(t *testing.T) {
+	c := qt.New(t)
+
+	// A skipped acquisition leaves a nil lock: no name, no capability claim,
+	// and releasing it touches nothing.
+	var lock *atlasschema.ApplyLock
+	c.Assert(lock.Name(), qt.Equals, "")
+	c.Assert(lock.Supported(), qt.IsFalse)
+	c.Assert(lock.Release(), qt.IsNil)
+}
+
+func TestAcquireApplyLock_DistinctNamesGetDistinctKeys(t *testing.T) {
+	c := qt.New(t)
+
+	// Two runs that name different locks do not serialize against each other.
+	// That is the whole function of --lock-name, so pin that the names map to
+	// different advisory-lock keys rather than collapsing.
+	c.Assert(
+		dblock.PostgresKey(atlasschema.EffectiveApplyLockName("atlas_migrate_execute")),
+		qt.Not(qt.Equals),
+		dblock.PostgresKey(atlasschema.EffectiveApplyLockName("")),
+	)
+}

--- a/internal/atlasschema/lock_test.go
+++ b/internal/atlasschema/lock_test.go
@@ -67,7 +67,7 @@ func TestAcquireApplyLock_HappyPath(t *testing.T) {
 		conn := connectSQLite(c, filepath.Join(c.TB.TempDir(), "lock.db"))
 		defer dbschema.CloseAndWarn(conn)
 
-		lock, err := atlasschema.AcquireApplyLock(c.Context(), conn, time.Second)
+		lock, err := atlasschema.AcquireApplyLock(c.Context(), conn, "", time.Second)
 		c.Assert(err, qt.IsNil)
 		c.Assert(lock.Supported(), qt.IsFalse)
 		c.Assert(lock.Release(), qt.IsNil)
@@ -77,7 +77,7 @@ func TestAcquireApplyLock_HappyPath(t *testing.T) {
 		conn := connectSQLite(c, filepath.Join(c.TB.TempDir(), "lock-idem.db"))
 		defer dbschema.CloseAndWarn(conn)
 
-		lock, err := atlasschema.AcquireApplyLock(c.Context(), conn, 0)
+		lock, err := atlasschema.AcquireApplyLock(c.Context(), conn, "", 0)
 		c.Assert(err, qt.IsNil)
 		c.Assert(lock.Release(), qt.IsNil)
 		c.Assert(lock.Release(), qt.IsNil)
@@ -94,7 +94,7 @@ func TestAcquireApplyLock_FailurePath(t *testing.T) {
 	c := qt.New(t)
 
 	c.Run("nil connection", func(c *qt.C) {
-		lock, err := atlasschema.AcquireApplyLock(c.Context(), nil, time.Second)
+		lock, err := atlasschema.AcquireApplyLock(c.Context(), nil, "", time.Second)
 		c.Assert(err, qt.ErrorMatches, "schema apply locking requires database connection")
 		c.Assert(lock, qt.IsNil)
 	})

--- a/internal/dblock/dblock.go
+++ b/internal/dblock/dblock.go
@@ -69,6 +69,7 @@ func Supported(dialect string) bool {
 // never touches the database.
 type Lock struct {
 	conn    *sql.Conn
+	name    string
 	release func(context.Context) error
 }
 
@@ -88,6 +89,21 @@ func (e *ambiguousAcquisitionError) Unwrap() error {
 // opposed to the no-op lock acquired on dialects without advisory locks.
 func (l *Lock) Supported() bool {
 	return l != nil && l.conn != nil
+}
+
+// Name returns the advisory lock name this lock was acquired under, after the
+// trimming [Acquire] applies. It is recorded on the no-op path too, so a
+// caller on a dialect without advisory locks can still report which lock it
+// would have taken. A nil lock reports the empty string.
+//
+// This is the value the dialect-specific acquisition actually used: the
+// PostgreSQL-family key is [PostgresKey] of it, and MySQL, MariaDB and
+// SQL Server pass it to the server verbatim.
+func (l *Lock) Name() string {
+	if l == nil {
+		return ""
+	}
+	return l.name
 }
 
 // Release releases the advisory lock and closes its dedicated session
@@ -126,7 +142,7 @@ func Acquire(
 	}
 	dialect := platform.NormalizeDialect(conn.Info().Dialect)
 	if !Supported(dialect) {
-		return &Lock{}, nil
+		return &Lock{name: name}, nil
 	}
 
 	session, err := conn.Conn(ctx)
@@ -134,7 +150,7 @@ func Acquire(
 		return nil, err
 	}
 
-	lock := &Lock{conn: session}
+	lock := &Lock{conn: session, name: name}
 	var acquireErr error
 	switch dialect {
 	case platform.Postgres, platform.YugabyteDB:

--- a/migration/migrator/advisory_lock.go
+++ b/migration/migrator/advisory_lock.go
@@ -63,8 +63,36 @@ func (m *Migrator) WithMigrationLockName(name string) *Migrator {
 	return &tmp
 }
 
+// WithoutMigrationLock returns a copy of the migrator that runs without the
+// session-level migration advisory lock: no lock is requested, no wait is
+// observed, and concurrent runners are not serialized against each other.
+//
+// This is a deliberate loss of safety, not a capability decision like the
+// no-op lock returned on dialects that have no advisory locks — there the
+// database cannot serialize, here the caller has asked not to. Callers must
+// surface the choice; the migrator does not warn on its own.
+func (m *Migrator) WithoutMigrationLock() *Migrator {
+	tmp := *m
+	tmp.migrationLockSkipped = true
+	return &tmp
+}
+
+// MigrationLockName returns the advisory lock name this migrator acquires,
+// after the trimming and defaulting [Migrator.WithMigrationLockName] applies.
+// It reports the name even when locking is skipped, so a caller can name the
+// lock it chose not to take.
+func (m *Migrator) MigrationLockName() string {
+	return m.effectiveMigrationLockName()
+}
+
+// MigrationLockSkipped reports whether [Migrator.WithoutMigrationLock] turned
+// the session-level migration advisory lock off.
+func (m *Migrator) MigrationLockSkipped() bool {
+	return m != nil && m.migrationLockSkipped
+}
+
 func (m *Migrator) withMigrationLock(ctx context.Context, operation string, fn func(context.Context) error) error {
-	if m.conn == nil || m.conn.Writer().IsDryRun() {
+	if m.conn == nil || m.conn.Writer().IsDryRun() || m.migrationLockSkipped {
 		return fn(ctx)
 	}
 

--- a/migration/migrator/advisory_lock_name_internal_test.go
+++ b/migration/migrator/advisory_lock_name_internal_test.go
@@ -1,0 +1,125 @@
+package migrator
+
+// White-box testing required: the advisory lock a migration run requests is
+// observable only through the migrator's own observation span, and the span is
+// emitted from an unexported code path. Asserting it through a live database
+// would need PostgreSQL, MySQL, MariaDB or SQL Server, since those are the only
+// dialects with advisory-lock semantics; the span records the request itself,
+// which is what the `--lock-name` and `--skip-lock` compat flags steer.
+
+import (
+	"context"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrateUpLockRequest(t *testing.T) {
+	tests := []struct {
+		name string
+		// configure applies the lock decision under test.
+		configure func(*Migrator) *Migrator
+		// wantAcquire is the lock.name attribute the run must record, or the
+		// empty string when the run must record no acquisition at all.
+		wantAcquire string
+	}{
+		{
+			name:        "default name",
+			configure:   func(m *Migrator) *Migrator { return m },
+			wantAcquire: migrationAdvisoryLockName,
+		},
+		{
+			name:        "named lock",
+			configure:   func(m *Migrator) *Migrator { return m.WithMigrationLockName("atlas_migrate_execute") },
+			wantAcquire: "atlas_migrate_execute",
+		},
+		{
+			name:        "blank name keeps the default",
+			configure:   func(m *Migrator) *Migrator { return m.WithMigrationLockName("   ") },
+			wantAcquire: migrationAdvisoryLockName,
+		},
+		{
+			name:        "skipped lock requests nothing",
+			configure:   func(m *Migrator) *Migrator { return m.WithoutMigrationLock() },
+			wantAcquire: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			conn := openSQLiteMigratorTestDB(t)
+			t.Cleanup(func() {
+				c.Check(conn.Close(), qt.IsNil)
+			})
+			observer := &recordingObserver{}
+			m := tt.configure(newObservedTestMigrator(t, conn, observer))
+
+			c.Assert(m.MigrateUp(context.Background()), qt.IsNil)
+
+			// The migration ran either way: skipping the lock must not skip
+			// the work, and naming it must not change which work is selected.
+			status, err := m.GetMigrationStatus(context.Background())
+			c.Assert(err, qt.IsNil)
+			c.Assert(status.CurrentVersion, qt.Equals, int64(1))
+
+			assertLockAcquisition(c, observer, tt.wantAcquire)
+		})
+	}
+}
+
+func TestMigrationLockAccessors(t *testing.T) {
+	c := qt.New(t)
+
+	base := NewMigrator(nil, nil)
+	c.Assert(base.MigrationLockName(), qt.Equals, migrationAdvisoryLockName)
+	c.Assert(base.MigrationLockSkipped(), qt.IsFalse)
+
+	named := base.WithMigrationLockName("atlas_migrate_execute")
+	c.Assert(named.MigrationLockName(), qt.Equals, "atlas_migrate_execute")
+	c.Assert(named.MigrationLockSkipped(), qt.IsFalse)
+
+	// The skipped migrator still names the lock it declined to take, so a
+	// caller can report the decision precisely.
+	skipped := named.WithoutMigrationLock()
+	c.Assert(skipped.MigrationLockName(), qt.Equals, "atlas_migrate_execute")
+	c.Assert(skipped.MigrationLockSkipped(), qt.IsTrue)
+
+	// Every option returns a copy; the originals are untouched.
+	c.Assert(base.MigrationLockSkipped(), qt.IsFalse)
+	c.Assert(named.MigrationLockSkipped(), qt.IsFalse)
+	c.Assert(base.MigrationLockName(), qt.Equals, migrationAdvisoryLockName)
+}
+
+// assertLockAcquisition asserts the observed acquisition against want, where
+// the empty string means "no lock was requested at all".
+func assertLockAcquisition(c *qt.C, observer *recordingObserver, want string) {
+	c.Helper()
+	got, acquired := observedLockName(observer)
+	c.Assert(acquired, qt.Equals, want != "",
+		qt.Commentf("acquired=%v name=%q spans=%v", acquired, got, spanNames(observer.spans)))
+	c.Assert(got, qt.Equals, want)
+	c.Assert(observedLockWaitRecorded(observer), qt.Equals, want != "")
+}
+
+// observedLockName reports the lock.name attribute of the acquisition span and
+// whether such a span was recorded at all.
+func observedLockName(observer *recordingObserver) (string, bool) {
+	for _, span := range observer.spans {
+		if span.name != "ptah.lock.acquire" {
+			continue
+		}
+		name, _ := attrValue(span.attrs, "lock.name").(string)
+		return name, true
+	}
+	return "", false
+}
+
+func observedLockWaitRecorded(observer *recordingObserver) bool {
+	for _, duration := range observer.durations {
+		if duration.name == "ptah_migration_lock_wait_seconds" {
+			return true
+		}
+	}
+	return false
+}

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -108,7 +108,11 @@
 // advisory lock around the planning and apply window. Use
 // WithMigrationLockName to coordinate on a custom lock name, and use
 // WithMigrationLockTimeout to bound the wait for that lock. Callers can detect
-// acquisition timeouts with IsMigrationLockTimeout.
+// acquisition timeouts with IsMigrationLockTimeout. WithoutMigrationLock turns
+// the lock off entirely for callers that serialize migration runs by some
+// other means; MigrationLockName and MigrationLockSkipped report the resulting
+// decision so a command can name what it acquires, or announce what it does
+// not.
 //
 // # Migration Operations
 //

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -113,6 +113,7 @@ type Migrator struct {
 	txMode               MigrationTxMode
 	migrationLockName    string
 	migrationLockTimeout time.Duration
+	migrationLockSkipped bool
 	initialized          bool
 	// initializedDryRun records the writer's dry-run mode at the time
 	// initialized was set, so the memoized state is never reused across a


### PR DESCRIPTION
Refs #951 — the named-lock family, implemented once over the existing `internal/dblock` machinery.

Four of the seven flags in the batch land. Three do not, because no Atlas-side source registers them.

## What landed, and the Atlas-side source for each

| Verb | Flag | Atlas-side source | Behavior change |
| --- | --- | --- | --- |
| `migrate apply` | `--lock-name string` | Published CLI reference, atlasgo.io/cli-reference (retrieved 2026-08-03) | Replaces the session advisory lock name (default `ptah_migrate`); a run naming a held lock waits and then fails on `--lock-timeout` |
| `migrate apply` | `--skip-lock` (bool) | same | No advisory lock is requested at all; a held lock is ignored rather than waited on |
| `schema apply` | `--lock-name string` | same | Replaces the apply lock name (default `ptah_schema_apply`), same wait/timeout semantics |
| `schema apply` | `--skip-lock` (bool) | same | Same: no lock requested |

Spelling, type and default match that source verbatim:

```
--lock-name string   set the name of the advisory lock to use. If not set, the default is used (atlas_migrate_execute)
--skip-lock          skip acquiring a database advisory lock
```

`--lock-name` is a string with no cobra default (unset means "the tool's own default lock name"), `--skip-lock` a boolean defaulting to false — exactly as published.

The pinned community binary v1.3.0 registers **neither flag, on any verb**. That was measured by running each spelling, not by grepping help. So this is Pro surface adopted openly, sourced from the published reference. That is the same shape as `schema inspect --include` (#977).

## What I did NOT add, and why

| Flag | Pinned community binary | Published CLI reference | Verdict |
| --- | --- | --- | --- |
| `migrate diff --lock-name` | `unknown flag` (verb is **not** gated, so this is authoritative) | absent — `migrate diff` lists `--lock-timeout duration` and no other member of this family | **declined**: no Atlas-side source |
| `migrate down --lock-name` | verb is community-gated and registers **none** of its own flags, so the binary is no oracle | absent — `migrate down` lists `--lock-timeout duration` only | **declined**: no Atlas-side source |
| `migrate checkpoint --lock-name` | same: gated, registers none of its own flags | absent — `migrate checkpoint` lists `--lock-timeout duration` only | **declined**: no Atlas-side source |

The issue's checklist asked for `--lock-name` on five verbs. Measured against both sources, it exists on two. Adding it to the other three would put non-Atlas flags on the compat surface, which is exactly what this issue's standing constraint forbids — the same resolution as `migrate apply --skip-checks` and the `--report`/`--seed-dir` request.

Verbatim from the reference for the three declined verbs (whole flag blocks, so the absence is visible rather than asserted):

```
atlas migrate diff [flags] [name]
  --to strings              ...
  --dev-url string          ...
  --dir string              ...
  --dir-format string       ...
  -s, --schema strings      ...
  --lock-timeout duration   set how long to wait for the database lock (default 10s)
  --format string           ...
  --qualifier string        ...
  --edit

atlas migrate down [flags] [amount]
  -u, --url string            ...
  --to-version string         ...
  --to-tag string             ...
  --dir string                ...
  --dev-url string            ...
  --format string             ...
  --dry-run
  --revisions-schema string   ...
  --lock-timeout duration     set how long to wait for the database lock (default 10s)
  --skip-checks
  --plan

atlas migrate checkpoint [flags] [tag]
  --dev-url string          ...
  --dir string              ...
  --dir-format string       ...
  -s, --schema strings      ...
  --lock-timeout duration   set how long to wait for the database lock (default 10s)
  --format string           ...
  --qualifier string        ...
  --edit
```

Controls on that same fetch, so a blank or partially-rendered page cannot read as an absence: the page is non-empty (50,303 plaintext characters), the control term `atlas migrate apply` occurs 10 times, the invented control `frobnicate` occurs 0 times, and `--lock-name` occurs exactly **2** times across the whole page — once under `migrate apply`, once under `schema apply`. Same count for `--skip-lock`.

## Measurement, before and after

Every row was produced by RUNNING the spelling and looking for `unknown flag`. Never by grepping `--help`. Every row carries both controls, and the controls are reported, not assumed.

### The pinned community binary (v1.3.0)

| Verb | positive control | `--frobnicate-nonsense` | `--lock-name` | `--skip-lock` |
| --- | --- | --- | --- | --- |
| `migrate apply` | `--dry-run` PRESENT | MISSING | MISSING | MISSING |
| `migrate diff` | `--dev-url` PRESENT | MISSING | MISSING | MISSING |
| `migrate down` | `--env` PRESENT (see note) | MISSING | MISSING | MISSING |
| `migrate checkpoint` | `--env` PRESENT (see note) | MISSING | MISSING | MISSING |
| `schema apply` | `--dry-run` PRESENT | MISSING | MISSING | MISSING |

Note on the two gated verbs: my first probe used `--dry-run` / `--dir-format` as the positive control on `migrate down` and `migrate checkpoint` and **both controls failed**, which per the probe rules means the probe was broken, not the row. Investigating rather than believing it: those two verbs are community-gated and register none of their own flags — only inherited `--config`/`--env`/`--var` parse and reach the abort. So the positive control there has to be an inherited flag. With `--env` the control passes and the rows are readable. This is the same shape #1011 recorded for `migrate checkpoint`; it now also holds for `migrate down` on v1.3.0.

### ptah-compat, before (`c0f86693`) and after

| Verb | flag | before | after |
| --- | --- | --- | --- |
| `migrate apply` | `--lock-name` | MISSING | **PRESENT** |
| `migrate apply` | `--skip-lock` | MISSING | **PRESENT** |
| `schema apply` | `--lock-name` | MISSING | **PRESENT** |
| `schema apply` | `--skip-lock` | MISSING | **PRESENT** |
| `migrate diff` | `--lock-name` / `--skip-lock` | MISSING | MISSING (unchanged, deliberate) |
| `migrate down` | `--lock-name` / `--skip-lock` | MISSING | MISSING (unchanged, deliberate) |
| `migrate checkpoint` | `--lock-name` / `--skip-lock` | MISSING | MISSING (unchanged, deliberate) |

Positive control `--dry-run` PRESENT and negative control `--frobnicate-nonsense` MISSING on every verb, in both binaries, on the same runs.

## The semantics, decided and stated

**What happens when `--lock-name` names a lock another process holds.** The run waits for it, bounded by `--lock-timeout` (empty waits indefinitely, which is compat's existing `--lock-timeout` semantics). An elapsed timeout fails the run before anything is applied. Live-verified against PostgreSQL 16 with a competing session holding `pg_advisory_lock(fnv32a("atlas_migrate_execute"))`:

```
$ ptah-compat schema apply --url postgres://… --to file://schema.sql --auto-approve \
    --lock-name atlas_migrate_execute --lock-timeout 2s
Error: acquire schema apply lock: timed out acquiring advisory lock "atlas_migrate_execute" on postgres after 2s
exit=1

$ ptah-compat migrate apply --url postgres://… --dir file://migrations \
    --lock-name atlas_migrate_execute --lock-timeout 2s
Error: error applying migrations: failed to acquire migration lock for migrate up: timed out acquiring migration lock "atlas_migrate_execute" for postgres after 2s
exit=1
```

**What `--skip-lock` does to that path.** It removes it. No lock is requested, so there is nothing to wait on and the held lock is irrelevant. Same competing session still holding the same lock:

```
$ ptah-compat schema apply … --skip-lock
Schema apply completed successfully.
exit=0                        # and the table exists afterwards

$ ptah-compat migrate apply … --skip-lock
Migration complete. Current version: 20260101000001
exit=0
```

That is the point of the flag, and it is why it must not be possible to pass it and still get a lock — or to pass `--lock-name` and silently get none.

**Two inputs are refused rather than interpreted.** Both are the silent-failure shape this family exists to avoid:

- `--lock-name ""` (explicitly blank) → `--lock-name must not be empty`. Passing it through would fall back to the default lock, so a caller who meant to coordinate on a named lock would coordinate on a different one without being told.
- `--lock-name X --skip-lock` → `--lock-name and --skip-lock cannot be used together: --skip-lock takes no lock, so there is no lock to name`. The published reference documents no resolution order for the pair; honouring either would drop the other silently. This is a deliberate, documented divergence for an input Atlas defines no behavior for.

**Defaults are unchanged, on purpose.** Compat still defaults to `ptah_migrate` / `ptah_schema_apply`, not to Atlas's `atlas_migrate_execute`. Moving the default would de-serialize a fleet mid-upgrade: an older ptah-compat holding `ptah_migrate` and a newer one holding `atlas_migrate_execute` do not see each other. `--lock-name atlas_migrate_execute` is the explicit spelling for coordinating with Atlas, which is precisely why the flag has to exist. Whether the compat default should eventually move is a separate decision with its own upgrade story — flagged below, not taken here.

**Unsupported dialects.** SQLite, ClickHouse, CockroachDB and Spanner have no advisory locks. An explicit `--lock-name` there prints a stderr note naming the lock that was not acquired, so a flag that cannot do its job says so instead of reading as serialization. `--skip-lock` prints nothing — a caller who asked for no lock does not need to be told the dialect has none. Output for every invocation that passes neither flag is byte-identical to before.

## What each test prints if the change is reverted

Each was verified by actually applying the mutation, running the test, and reverting.

| Test | Mutation | What it prints reverted |
| --- | --- | --- |
| `migration/migrator` `TestMigrateUpLockRequest/skipped_lock_requests_nothing` | drop `\|\| m.migrationLockSkipped` from `withMigrationLock` | `acquired=true name="ptah_migrate" spans=[ptah.migrate.up ptah.lock.acquire …]` — got `true`, want `false` |
| `internal/atlasmigrate` `TestPrepareApply_LockRequestReachesMigrator/skip_lock` | same mutation | `acquired=true name="ptah_migrate"` — got `true`, want `false` |
| `internal/atlasmigrate` `…/lock_name` | drop `WithMigrationLockName(opts.migrationLockName)` from `newApplyMigrator` | lock name is `ptah_migrate`, want `atlas_migrate_execute` |
| `cmd/atlas` `TestMigrateApplyNamedLockReachesMigrator/named_lock` | same | prints `the advisory lock "ptah_migrate" is not acquired`, want `"atlas_migrate_execute"` |
| `cmd/atlas` `TestSchemaApplyNamedLockReachesLockMachinery/skip_lock_silences_the_timeout_note` | make `--skip-lock` acquire the lock anyway | the run emits `note: schema apply locking is not supported for dialect "sqlite"; --lock-timeout is ignored …`, proving a lock was taken |
| `internal/atlasschema` `TestAcquireApplyLock_RecordsRequestedName` (3 rows) + `cmd/atlas` `…/named_lock` | stop recording the name on `dblock`'s no-op path | `lock.Name()` is `""` on every row |
| `cmd/atlas` `TestCompatLockFlagContradictionsRefused/*_blank_name` | remove the blank-name refusal | the run proceeds to `open migrations directory: … no such file or directory` / `load --to schema: schema file does not exist` instead of refusing |
| `cmd/atlas` `TestCompatLockFlagContradictionsRefused/*_name_with_skip` | remove the mutual-exclusion refusal | both rows fail: the contradiction is accepted |
| `cmd/atlas` `TestCompatLockFlagRegistration/migrate_apply_*` | unregister both flags on `migrate apply` | both rows fail, and `TestCompatCommand_AdvertisesEssentialAtlasFlags/migrate_apply` fails with them |
| `cmd/atlas` `TestCompatLockFlagRegistration/migrate_diff_lock_name` | register `--lock-name` on `migrate diff` | fails — this row is what keeps the three declined spellings declined |

Registration is measured in the test the same way as on the command line: by running the spelling and reading the error, with a positive and a negative control on every row. No help grepping.

Two live PostgreSQL tests ship env-gated (`POSTGRES_TEST_DSN` / `TEST_DATABASE_URL`), matching the existing lock live tests: `TestAcquireApplyLock_NamedLockContendsLive` (same name contends and times out; releasing the holder unblocks it) and `TestAcquireApplyLock_DistinctNamesDoNotContendLive` (a different name does not contend at all). Both were run and passed against a throwaway `postgres:16-alpine`, along with the three pre-existing live lock tests.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | pass |
| `go vet ./...` | pass |
| `go test ./... -count=1` | pass, no failures |
| `golangci-lint run ./...` | `0 issues.` |
| `scripts/check-test-style.sh` | `teststyle: OK (175 conditional groups, 45 white-box files)` |
| `scripts/check-public-api.sh` | pass |
| `scripts/check-public-api-snapshot.sh` | pass (snapshot regenerated for the three new `Migrator` methods) |
| `docs/site` `check-style.mjs` | `OK (100 documentation files)` |
| `docs/site` `build-feature-matrix.mjs --check` | `OK (159 rows)` |

## Public API delta

`migration/migrator` gains three methods, snapshot updated:

- `WithoutMigrationLock() *Migrator` — the capability `--skip-lock` needs.
- `MigrationLockName() string` and `MigrationLockSkipped() bool` — so a command can report the lock the machinery resolved rather than echoing its own flag value. The `migrate apply` stderr note reads its lock name from here, which is what makes that note a real observation of the machinery.

`internal/atlasschema.AcquireApplyLock` gains a `name` parameter (internal package; the native `ptah schema apply` call sites pass `""` and keep the default).

## One thing this PR does NOT decide, flagged for #951

**The conformance `cli-surface` tier will go RED until its allowance table is updated**, in the separate conformance checkout. `compareFlags` measures "extra" against the CE flag set plus a per-command `proSurfaceFlags()` allowance, and that table currently has an entry only for `schema inspect`. It needs:

```go
"migrate apply": {"--lock-name", "--skip-lock"},
"schema apply":  {"--lock-name", "--skip-lock"},
```

I did not make that change — it is a different repository and outside this worktree. Without it the tier reports `flag mismatch: extra --lock-name, --skip-lock` on both verbs. Worth pairing with this PR rather than discovering after merge.

Two smaller notes:

- A `migrate apply --dry-run` takes no lock at all (`withMigrationLock` short-circuits on dry-run), so `--lock-name` is inert there. That is pre-existing and applies equally to `--lock-timeout`; a dry run mutates nothing, so there is nothing to serialize.
- Whether compat's *default* lock name should eventually become `atlas_migrate_execute` is a real interop question this PR leaves open, with the upgrade hazard described above. It needs its own decision.
