### PR TITLE
compat: migrate-side Pro flags — apply --to-version, test --revisions-schema, checkpoint --schema/--qualifier/--lock-timeout/--edit

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -215,6 +215,22 @@ func atlasMigrateForwardVerbs() []atlasVerb {
 				// directory format is still rejected loudly (see
 				// docs/site/src/content/docs/reference/atlas-commands.md).
 				atlasCheckpointDirFormatFlag(),
+				// Atlas's published CLI reference registers these five on
+				// `migrate checkpoint`; the pinned community binary registers
+				// none of its own flags on this verb (every spelling answers
+				// `unknown flag`), so the reference is the oracle here.
+				//
+				// --lock-name is deliberately absent: the named-lock family is
+				// one feature across five verbs and lands as its own change.
+				atlasargs.NativeStringArray("schema", "s", "Schema names the checkpoint covers", "schemas"),
+				atlasargs.String("qualifier", "", "Qualify tables with a custom qualifier when working on a single schema"),
+				atlasargs.NativeString(
+					"lock-timeout",
+					"",
+					"How long to wait for the dev database's migration lock during the replay",
+					"migration-lock-timeout",
+				),
+				atlasargs.Bool("edit", "", "Edit the generated checkpoint file(s)"),
 			},
 		},
 		atlasMigrateEditVerb(),
@@ -438,6 +454,17 @@ func atlasMigrateTestVerb() atlasVerb {
 			atlasMigrateDirFormatFlag("dir-format"),
 			atlasargs.NativeString("dev-url", "", "Dev database URL the test cases run against", "db-url"),
 			atlasargs.String("run", "", "Run only test cases matching a Go regular expression"),
+			// Atlas's published CLI reference registers --revisions-schema on
+			// `migrate test` ("name of the schema the revisions table resides
+			// in"), the same spelling it carries on apply, status and set. It
+			// maps onto the native --migrations-schema, which places the
+			// revision table a migrate_to step writes.
+			atlasargs.NativeString(
+				"revisions-schema",
+				"",
+				"Schema the revision table written by a migrate_to step resides in",
+				"migrations-schema",
+			),
 		},
 	}
 }
@@ -769,6 +796,11 @@ func registerAtlasFlags(cmd *cobra.Command, flags []atlasargs.Flag) {
 			cmd.Flags().BoolP(flag.Name, flag.Shorthand, false, flag.Usage)
 		case atlasargs.UintFlag:
 			cmd.Flags().UintP(flag.Name, flag.Shorthand, 0, flag.Usage)
+		case atlasargs.StringArrayFlag:
+			// StringSlice, not StringArray: Atlas prints these as `strings`
+			// and splits a comma-separated value, which is the behavior a
+			// pipeline passing `--schema a,b` expects.
+			cmd.Flags().StringSliceP(flag.Name, flag.Shorthand, nil, flag.Usage)
 		}
 		if !flag.EnvDisabled {
 			continue

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -242,8 +242,13 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 				"--revisions-schema",
 				"--lock-timeout",
 				"--format",
+				// Atlas's published CLI reference registers --to-version on
+				// this verb; the pinned community binary does not, which is
+				// what makes it a Pro-surface addition rather than a CE parity
+				// row (stokaro/ptah#951).
+				"--to-version",
 			},
-			forbidden: []string{"--to-version", "--lock-name"},
+			forbidden: []string{"--lock-name"},
 		},
 		{
 			name: "migrate_down",
@@ -263,9 +268,10 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 			},
 		},
 		{
-			name:  "migrate_checkpoint",
-			path:  []string{"migrate", "checkpoint"},
-			flags: []string{"--dir", "--dev-url", "--dir-format"},
+			name:      "migrate_checkpoint",
+			path:      []string{"migrate", "checkpoint"},
+			flags:     []string{"--dir", "--dev-url", "--dir-format", "--schema", "--qualifier", "--lock-timeout", "--edit"},
+			forbidden: []string{"--editor"},
 		},
 		{
 			name:  "migrate_lint",
@@ -290,7 +296,7 @@ func TestCompatCommand_AdvertisesEssentialAtlasFlags(t *testing.T) {
 		{
 			name:  "migrate_test",
 			path:  []string{"migrate", "test"},
-			flags: []string{"--dir", "--dir-format", "--dev-url", "--run"},
+			flags: []string{"--dir", "--dir-format", "--dev-url", "--run", "--revisions-schema"},
 		},
 		{
 			name:  "schema_test",
@@ -3075,20 +3081,15 @@ func TestCompatCommand_MigrateApplyWritesFormatOnApplyError(t *testing.T) {
 	assertSQLiteTableMissing(c, dbPath, "error_before")
 }
 
+// TestCompatCommand_MigrateApplyRejectsNonAtlasFlags keeps the spellings this
+// verb must NOT answer to.
+//
+// --to-version used to be one of them and no longer is: Atlas's published CLI
+// reference registers it on `migrate apply`, so refusing it broke a Pro
+// pipeline for no parity gain (stokaro/ptah#951). Its behavior is pinned in
+// migrate_apply_to_version_test.go instead.
 func TestCompatCommand_MigrateApplyRejectsNonAtlasFlags(t *testing.T) {
 	c := qt.New(t)
-
-	c.Run("to_version", func(c *qt.C) {
-		cmd := NewCompatCommand("atlas")
-		var out bytes.Buffer
-		cmd.SetOut(&out)
-		cmd.SetErr(&out)
-		cmd.SetArgs([]string{"migrate", "apply", "--to-version", "1"})
-
-		err := cmd.Execute()
-
-		c.Assert(err, qt.ErrorMatches, `unknown flag: --to-version`)
-	})
 
 	c.Run("lock_name", func(c *qt.C) {
 		cmd := NewCompatCommand("atlas")

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -35,6 +35,7 @@ type atlasMigrateApplyOptions struct {
 	execOrder       string
 	allowDirty      bool
 	baseline        string
+	toVersion       string
 	revisionsSchema string
 	lockTimeout     string
 	format          string
@@ -68,6 +69,12 @@ Native Ptah equivalent: ptah migrations up.`,
 	flags.StringVar(&opts.execOrder, "exec-order", opts.execOrder, "Execution order: linear, linear-skip, or non-linear")
 	flags.BoolVar(&opts.allowDirty, "allow-dirty", false, "Allow applying migrations when the revision table is dirty")
 	flags.StringVar(&opts.baseline, "baseline", "", "Baseline version to mark applied before running pending migrations")
+	// Atlas registers --to-version on `migrate apply` as a string
+	// ("migrate to this version, if set"), so the value is carried as text and
+	// parsed like --baseline instead of as a typed integer flag: a
+	// non-numeric value must fail with Ptah's version diagnostic, not with
+	// pflag's "invalid argument" for an int flag.
+	flags.StringVar(&opts.toVersion, "to-version", "", "Migrate to this version, if set")
 	flags.StringVar(&opts.revisionsSchema, "revisions-schema", "", "Schema for the Atlas revisions table")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring the migration lock, such as 10s or 2m")
 	flags.StringVar(&opts.format, "format", "", "Atlas Go template output format")
@@ -187,6 +194,10 @@ func runAtlasMigrateApply(
 	if err != nil {
 		return err
 	}
+	toVersion, err := atlasmigrate.ParseMigrationVersionFlag("to-version", opts.toVersion)
+	if err != nil {
+		return err
+	}
 	txMode, err := migrator.ParseMigrationTxMode(opts.txMode)
 	if err != nil {
 		return err
@@ -284,6 +295,7 @@ func runAtlasMigrateApply(
 		RevisionsSchema:      opts.revisionsSchema,
 		MigrationLockTimeout: migrationLockTimeout,
 		Amount:               amount,
+		ToVersion:            toVersion,
 		AllowDirty:           opts.allowDirty,
 		BaselineVersion:      baselineVersion,
 		SkipChecks:           skipChecks,

--- a/cmd/atlas/migrate_apply_to_version_test.go
+++ b/cmd/atlas/migrate_apply_to_version_test.go
@@ -1,0 +1,206 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// The three versions the fixture below carries. They are named so a test can
+// say which one it bounds the apply at without repeating the literal.
+const (
+	toVersionOne   = "20240101000001"
+	toVersionTwo   = "20240101000002"
+	toVersionThree = "20240101000003"
+)
+
+// writeToVersionFixture writes an Atlas-format directory of three independent
+// migrations, hashed, so the apply integrity gate lets it through. Each
+// migration creates its own table, which is what makes "exactly two ran"
+// observable in the database rather than only in the revision table.
+func writeToVersionFixture(c *qt.C) (migrationsDir, dbPath string) {
+	c.Helper()
+	root := c.TempDir()
+	migrationsDir = filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	files := map[string]string{
+		toVersionOne + "_one.sql":     "CREATE TABLE tv_one (id INTEGER PRIMARY KEY);\n",
+		toVersionTwo + "_two.sql":     "CREATE TABLE tv_two (id INTEGER PRIMARY KEY);\n",
+		toVersionThree + "_three.sql": "CREATE TABLE tv_three (id INTEGER PRIMARY KEY);\n",
+	}
+	for name, body := range files {
+		c.Assert(os.WriteFile(filepath.Join(migrationsDir, name), []byte(body), 0o600), qt.IsNil)
+	}
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return migrationsDir, filepath.Join(root, "live.db")
+}
+
+// runCompatStreams runs one compat invocation with stdout and stderr captured
+// separately, because some assertions below are about which stream a line
+// landed on.
+func runCompatStreams(c *qt.C, args ...string) (stdout, stderr string, err error) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return out.String(), errOut.String(), err
+}
+
+func compatTableNames(c *qt.C, dbPath string) []string {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(schema.Tables))
+	for _, table := range schema.Tables {
+		names = append(names, table.Name)
+	}
+	return names
+}
+
+// TestCompatCommand_MigrateApplyToVersionAppliesBoundedPrefix is the headline
+// contract of stokaro/ptah#951's `migrate apply --to-version`: the bound
+// selects a prefix of the pending migrations, the rest stays pending, and the
+// verb that reports state agrees with the verb that changed it.
+//
+// Reverted, this test does not fail on a count — it fails with
+// `unknown flag: --to-version`, because the compat surface refuses the spelling
+// outright.
+func TestCompatCommand_MigrateApplyToVersionAppliesBoundedPrefix(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeToVersionFixture(c)
+
+	stdout, _, err := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+		"--to-version", toVersionTwo,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Migrating to version "+toVersionTwo+" from 2 pending migrations.")
+	c.Assert(stdout, qt.Contains, "Migration complete. Current version: "+toVersionTwo)
+	// Exactly two of the three ran: the third migration's table is absent.
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "tv_one")
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "tv_two")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "tv_three")
+	c.Assert(sqliteAtlasRevisionVersions(c, dbPath), qt.DeepEquals, []string{toVersionOne, toVersionTwo})
+
+	// The following status must agree that one migration is still pending.
+	statusOut, _, statusErr := runCompatStreams(c,
+		"migrate", "status",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(statusErr, qt.IsNil)
+	c.Assert(statusOut, qt.Contains, "Current Version: "+toVersionTwo)
+	c.Assert(statusOut, qt.Contains, "Applied Migrations: 2")
+	c.Assert(statusOut, qt.Contains, "Pending Migrations: 1")
+	c.Assert(statusOut, qt.Contains, "Status: Pending migrations available")
+
+	// A second bounded apply finishes the directory, so the bound is a bound
+	// and not a permanent ceiling.
+	finishOut, _, finishErr := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+		"--to-version", toVersionThree,
+	)
+	c.Assert(finishErr, qt.IsNil)
+	c.Assert(finishOut, qt.Contains, "Migration complete. Current version: "+toVersionThree)
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "tv_three")
+}
+
+// TestCompatCommand_MigrateApplyToVersionDryRunPreviewsTheSamePrefix pins the
+// preview: a dry run must count the bounded prefix, not the whole pending set,
+// and must leave the database untouched. A preview that ignored the bound would
+// promise three migrations and then apply two.
+func TestCompatCommand_MigrateApplyToVersionDryRunPreviewsTheSamePrefix(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeToVersionFixture(c)
+
+	stdout, _, err := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+		"--to-version", toVersionTwo,
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Dry run mode: no changes will be made.")
+	c.Assert(stdout, qt.Contains, "Would have applied 2 migrations.")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "tv_one")
+}
+
+// TestCompatCommand_MigrateApplyToVersionRefusals covers the three ways the
+// bound can be wrong. Each row states what the invocation asks for and the
+// diagnostic it must get; none of them may apply anything.
+func TestCompatCommand_MigrateApplyToVersionRefusals(t *testing.T) {
+	tests := []struct {
+		name      string
+		extraArgs func(migrationsDir string) []string
+		wantErr   string
+	}{
+		{
+			name: "non-numeric value",
+			extraArgs: func(string) []string {
+				return []string{"--to-version", "not-a-version"}
+			},
+			wantErr: `--to-version "not-a-version" is not a valid migration version.*`,
+		},
+		{
+			name: "zero is not a version",
+			extraArgs: func(string) []string {
+				return []string{"--to-version", "0"}
+			},
+			wantErr: `--to-version must be greater than zero`,
+		},
+		{
+			name: "bound and amount together",
+			extraArgs: func(string) []string {
+				return []string{"--to-version", toVersionThree, "1"}
+			},
+			wantErr: `--to-version and the amount argument cannot both be set`,
+		},
+		{
+			name: "version the directory does not carry",
+			extraArgs: func(string) []string {
+				return []string{"--to-version", "19990101000000"}
+			},
+			wantErr: `.*target version 19990101000000 was not found in the migration provider`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			migrationsDir, dbPath := writeToVersionFixture(c)
+			args := append([]string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + migrationsDir,
+			}, test.extraArgs(migrationsDir)...)
+
+			_, _, err := runCompatStreams(c, args...)
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "tv_one")
+		})
+	}
+}

--- a/cmd/atlas/migrate_checkpoint_flags_test.go
+++ b/cmd/atlas/migrate_checkpoint_flags_test.go
@@ -1,0 +1,304 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// checkpointFlagFixture writes a hashed two-migration Atlas directory and
+// returns it together with a fresh shadow database URL.
+func checkpointFlagFixture(c *qt.C) (migrationsDir, devURL string) {
+	c.Helper()
+	root := c.TempDir()
+	migrationsDir = filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "20240101000001_init.sql"),
+		[]byte("CREATE TABLE ck_users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "20240101000002_orders.sql"),
+		[]byte("CREATE TABLE ck_orders (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return migrationsDir, "sqlite://" + filepath.Join(root, "shadow.db")
+}
+
+// writeAppendingEditor writes an editor command that appends a marker to every
+// file it is handed and exits, which is the non-interactive editor the opt-out
+// environment variable exists for.
+func writeAppendingEditor(c *qt.C, marker string) string {
+	c.Helper()
+	path := filepath.Join(c.TempDir(), "editor.sh")
+	script := "#!/bin/sh\nfor f in \"$@\"; do\n  printf '%s\\n' \"" + marker + "\" >> \"$f\"\ndone\n"
+	c.Assert(os.WriteFile(path, []byte(script), 0o700), qt.IsNil) //nolint:gosec // the test editor must be executable
+	return path
+}
+
+func checkpointFileNames(c *qt.C, migrationsDir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(migrationsDir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func checkpointBody(c *qt.C, migrationsDir string) string {
+	c.Helper()
+	written, err := filepath.Glob(filepath.Join(migrationsDir, "*_checkpoint.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(written, qt.HasLen, 1)
+	body, err := os.ReadFile(written[0])
+	c.Assert(err, qt.IsNil)
+	return string(body)
+}
+
+// TestCompatCommand_MigrateCheckpointEditRefusesWhatItCannotFinish pins the two
+// deterministic refusals of --edit. Neither may write a checkpoint: a directory
+// left with a file nobody could edit is the outcome the up-front check exists
+// to prevent, and a run that blocks on an editor with no terminal is worse than
+// either.
+func TestCompatCommand_MigrateCheckpointEditRefusesWhatItCannotFinish(t *testing.T) {
+	tests := []struct {
+		name    string
+		env     func(c *qt.C)
+		wantErr string
+	}{
+		{
+			name: "no editor is configured",
+			env: func(c *qt.C) {
+				c.Setenv("VISUAL", "")
+				c.Setenv("EDITOR", "")
+			},
+			wantErr: `no editor configured: set \$EDITOR or \$VISUAL, or pass --editor`,
+		},
+		{
+			name: "an editor is configured but there is no terminal",
+			env: func(c *qt.C) {
+				c.Setenv("VISUAL", "")
+				c.Setenv("EDITOR", writeAppendingEditor(c, "-- edited"))
+			},
+			wantErr: `standard input is not a terminal.*set PTAH_ALLOW_NONINTERACTIVE_EDIT=1.*`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Setenv("PTAH_ALLOW_NONINTERACTIVE_EDIT", "")
+			test.env(c)
+			migrationsDir, devURL := checkpointFlagFixture(c)
+
+			_, _, err := runCompatStreams(c,
+				"migrate", "checkpoint",
+				"--dir", "file://"+migrationsDir,
+				"--dev-url", devURL,
+				"--edit",
+			)
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(checkpointFileNames(c, migrationsDir), qt.HasLen, 3)
+		})
+	}
+}
+
+// TestCompatCommand_MigrateCheckpointEditRewritesAndRehashes is the --edit
+// happy path: the written checkpoint carries the editor's change, and the
+// directory's atlas.sum covers the EDITED bytes. The second half is the one
+// that matters — a refresh that did not happen would leave a directory that
+// every integrity check refuses, including Atlas's own.
+func TestCompatCommand_MigrateCheckpointEditRewritesAndRehashes(t *testing.T) {
+	c := qt.New(t)
+	c.Setenv("VISUAL", "")
+	c.Setenv("EDITOR", writeAppendingEditor(c, "-- edited by the test"))
+	c.Setenv("PTAH_ALLOW_NONINTERACTIVE_EDIT", "1")
+	migrationsDir, devURL := checkpointFlagFixture(c)
+
+	stdout, _, err := runCompatStreams(c,
+		"migrate", "checkpoint",
+		"--dir", "file://"+migrationsDir,
+		"--dev-url", devURL,
+		"--edit",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Wrote checkpoint version")
+	c.Assert(checkpointBody(c, migrationsDir), qt.Contains, "-- edited by the test")
+	// The first line must still be the checkpoint directive: the editor appends.
+	c.Assert(strings.HasPrefix(checkpointBody(c, migrationsDir), "-- atlas:checkpoint\n"), qt.IsTrue)
+
+	_, _, validateErr := runCompatStreams(c,
+		"migrate", "validate",
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(validateErr, qt.IsNil)
+}
+
+// TestCompatCommand_MigrateCheckpointDeclaredFlagSurface pins what this verb
+// advertises, because that is the surface the conformance CLI tier compares.
+//
+// Atlas's published reference registers --dev-url, --dir, --dir-format,
+// -s/--schema, --lock-timeout, --format, --qualifier, --edit and --lock-name on
+// `migrate checkpoint`. Everything declared here is on that list, and the
+// native-only editor selection (--editor) is deliberately NOT declared: it has
+// no Atlas spelling, so it must not appear on this help surface.
+//
+// --format and --lock-name are absent on purpose too: --lock-name belongs to
+// the named-lock family landing separately, and --format needs the compat
+// Go-template report path this change does not build.
+func TestCompatCommand_MigrateCheckpointDeclaredFlagSurface(t *testing.T) {
+	tests := []struct {
+		name   string
+		flag   string
+		assert func(c *qt.C, help, flag string)
+	}{
+		{name: "edit is declared", flag: "--edit", assert: assertHelpDeclaresFlag},
+		{name: "qualifier is declared", flag: "--qualifier", assert: assertHelpDeclaresFlag},
+		{name: "lock-timeout is declared", flag: "--lock-timeout", assert: assertHelpDeclaresFlag},
+		{name: "schema is declared", flag: "--schema", assert: assertHelpDeclaresFlag},
+		{name: "dir-format is still declared", flag: "--dir-format", assert: assertHelpDeclaresFlag},
+		{name: "editor is native-only", flag: "--editor", assert: assertHelpOmitsFlag},
+		{name: "format is not declared", flag: "--format", assert: assertHelpOmitsFlag},
+		{name: "lock-name is not declared", flag: "--lock-name", assert: assertHelpOmitsFlag},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			stdout, _, err := runCompatStreams(c, "migrate", "checkpoint", "--help")
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, stdout, test.flag)
+		})
+	}
+}
+
+func assertHelpDeclaresFlag(c *qt.C, help, flag string) {
+	c.Helper()
+	c.Assert(help, qt.Contains, flag+" ")
+}
+
+func assertHelpOmitsFlag(c *qt.C, help, flag string) {
+	c.Helper()
+	c.Assert(help, qt.Not(qt.Contains), flag+" ")
+}
+
+// TestCompatCommand_MigrateCheckpointLockTimeout covers both halves of the
+// flag: a value that cannot be a duration stops the run, and a value that can
+// says so when the dev database's dialect implements no advisory locking, so a
+// bound that cannot bind is never silently accepted.
+func TestCompatCommand_MigrateCheckpointLockTimeout(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		assert func(c *qt.C, stdout, stderr string, err error)
+	}{
+		{
+			name:  "a value that is not a duration",
+			value: "not-a-duration",
+			assert: func(c *qt.C, _, _ string, err error) {
+				c.Assert(err, qt.ErrorMatches, `invalid migration lock timeout: .*`)
+			},
+		},
+		{
+			name:  "a valid value on a dialect with no advisory lock",
+			value: "10s",
+			assert: func(c *qt.C, stdout, stderr string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(stderr, qt.Contains,
+					`note: migration locking is not supported for dialect "sqlite"; --migration-lock-timeout is ignored`)
+				// The note goes to stderr so it cannot contaminate the SQL a
+				// dry run writes to stdout.
+				c.Assert(stdout, qt.Not(qt.Contains), "note: migration locking")
+				c.Assert(stdout, qt.Contains, "CREATE TABLE")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			migrationsDir, devURL := checkpointFlagFixture(c)
+
+			stdout, stderr, err := runCompatStreams(c,
+				"migrate", "checkpoint",
+				"--dir", "file://"+migrationsDir,
+				"--dev-url", devURL,
+				"--lock-timeout", test.value,
+				"--dry-run",
+			)
+
+			test.assert(c, stdout, stderr, err)
+		})
+	}
+}
+
+// TestCompatCommand_MigrateCheckpointLockTimeoutStaysQuietWhenUnset is the
+// control for the note above: it must be a consequence of the flag, not
+// something every SQLite checkpoint prints.
+func TestCompatCommand_MigrateCheckpointLockTimeoutStaysQuietWhenUnset(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, devURL := checkpointFlagFixture(c)
+
+	_, stderr, err := runCompatStreams(c,
+		"migrate", "checkpoint",
+		"--dir", "file://"+migrationsDir,
+		"--dev-url", devURL,
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stderr, qt.Not(qt.Contains), "migration locking is not supported")
+}
+
+// TestCompatCommand_MigrateCheckpointQualifierReachesThePlan proves the
+// qualifier value is carried into plan qualification rather than parsed and
+// dropped: SQLite cannot qualify, and the refusal it raises is produced deep in
+// the qualifier engine, which is only reached when a qualifier is set.
+func TestCompatCommand_MigrateCheckpointQualifierReachesThePlan(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, devURL := checkpointFlagFixture(c)
+
+	_, _, err := runCompatStreams(c,
+		"migrate", "checkpoint",
+		"--dir", "file://"+migrationsDir,
+		"--dev-url", devURL,
+		"--qualifier", "app",
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.ErrorMatches, `.*--qualifier is not supported for dialect "sqlite"`)
+}
+
+// TestCompatCommand_MigrateCheckpointQualifierUnsetPlansCleanly is the control
+// for the refusal above: without the flag the same fixture plans and prints a
+// checkpoint, so the refusal is attributable to the qualifier and not to the
+// fixture.
+func TestCompatCommand_MigrateCheckpointQualifierUnsetPlansCleanly(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, devURL := checkpointFlagFixture(c)
+
+	stdout, _, err := runCompatStreams(c,
+		"migrate", "checkpoint",
+		"--dir", "file://"+migrationsDir,
+		"--dev-url", devURL,
+		"--dry-run",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, `CREATE TABLE "ck_users"`)
+}

--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -318,6 +318,8 @@ func checkAtlasMigrateSourceArgs(cmd *cobra.Command, verb atlasVerb, args []stri
 			flagSet.UintP(flag.Name, flag.Shorthand, 0, flag.Usage)
 		case atlasargs.StringFlag:
 			flagSet.StringP(flag.Name, flag.Shorthand, flag.Default, flag.Usage)
+		case atlasargs.StringArrayFlag:
+			flagSet.StringSliceP(flag.Name, flag.Shorthand, nil, flag.Usage)
 		}
 	}
 	if err := flagSet.Parse(args); err != nil {

--- a/cmd/atlas/migrate_test_revisions_schema_test.go
+++ b/cmd/atlas/migrate_test_revisions_schema_test.go
@@ -1,0 +1,107 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// writeMigrateTestRevisionsFixture writes a hashed one-migration Atlas directory plus a
+// test case that proves WHERE the revision table landed.
+//
+// The case attaches a second SQLite database under the name the run is asked to
+// put revisions in, so "a named schema" is expressible on the ephemeral SQLite
+// database the test runner provisions, with no server involved. It then asserts
+// both halves: the revision row is in the named schema, and the connection's
+// default schema has no revision table at all. Asserting only the first half
+// would pass on an implementation that wrote revisions to both.
+func writeMigrateTestRevisionsFixture(c *qt.C) (migrationsDir, casesDir string) {
+	c.Helper()
+	root := c.TempDir()
+	migrationsDir = filepath.Join(root, "migrations")
+	casesDir = filepath.Join(root, "tests")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(casesDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "20240101000001_init.sql"),
+		[]byte("CREATE TABLE rs_users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+
+	attached := filepath.Join(root, "attached.db")
+	cases := `cases:
+  - name: revisions land in the named schema
+    steps:
+      - name: attach the schema
+        exec: "ATTACH DATABASE '` + attached + `' AS alt"
+      - name: migrate to latest
+        migrate_to: latest
+      - name: the revision row is in alt
+        assert:
+          query: "SELECT count(*) FROM alt.schema_migrations"
+          scalar: "1"
+      - name: the default schema has no revision table
+        assert:
+          query: "SELECT count(*) FROM sqlite_master WHERE type='table' AND name='schema_migrations'"
+          scalar: "0"
+`
+	c.Assert(os.WriteFile(filepath.Join(casesDir, "revisions.yaml"), []byte(cases), 0o600), qt.IsNil)
+	return migrationsDir, casesDir
+}
+
+// TestCompatCommand_MigrateTestRevisionsSchema is a discriminating pair rather
+// than a single assertion: the same fixture must PASS with the flag and FAIL
+// without it. Without the pair, a test runner that ignored --revisions-schema
+// and wrote revisions everywhere would look correct.
+//
+// Reverted, the passing row does not merely fail its assertion — the run stops
+// with `unknown flag: --revisions-schema`.
+func TestCompatCommand_MigrateTestRevisionsSchema(t *testing.T) {
+	tests := []struct {
+		name     string
+		flagArgs func() []string
+		wantOut  string
+		wantErr  func(c *qt.C, err error)
+	}{
+		{
+			name:     "with the flag the revision table moves",
+			flagArgs: func() []string { return []string{"--revisions-schema", "alt"} },
+			wantOut:  "1 cases, 1 passed, 0 failed",
+			wantErr: func(c *qt.C, err error) {
+				c.Assert(err, qt.IsNil)
+			},
+		},
+		{
+			name:     "without the flag the same case fails",
+			flagArgs: func() []string { return nil },
+			wantOut:  "1 cases, 0 passed, 1 failed",
+			wantErr: func(c *qt.C, err error) {
+				c.Assert(err, qt.ErrorMatches, "migration tests failed")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			migrationsDir, casesDir := writeMigrateTestRevisionsFixture(c)
+			args := append([]string{
+				"migrate", "test",
+				"--dir", "file://" + migrationsDir,
+			}, test.flagArgs()...)
+			args = append(args, casesDir)
+
+			stdout, _, err := runCompatStreams(c, args...)
+
+			test.wantErr(c, err)
+			c.Assert(stdout, qt.Contains, test.wantOut)
+		})
+	}
+}

--- a/cmd/internal/editor/editor.go
+++ b/cmd/internal/editor/editor.go
@@ -8,16 +8,103 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 
 	"github.com/google/shlex"
+	"github.com/mattn/go-isatty"
 )
 
 // ErrNoEditor reports that no editor command could be resolved. Callers may
 // decorate it with the command-specific flags that would supply one.
 var ErrNoEditor = errors.New("no editor configured: set $EDITOR or $VISUAL")
+
+// ErrNotInteractive reports that an editor session was requested on a stream
+// that is not a terminal, so the editor would have nothing to read from.
+var ErrNotInteractive = errors.New("standard input is not a terminal, so an editor session cannot be opened")
+
+// AllowNonInteractiveEnvVar names the environment variable that declares the
+// configured editor to be non-interactive (a script such as `sed -i`), which
+// makes an editor session legitimate without a terminal.
+//
+// It is an environment variable rather than a flag on purpose: the Atlas
+// surface registers no flag for it, and the compat surface must not grow flags
+// Atlas does not have. The same reasoning applies on the native side, where the
+// variable keeps one spelling across both binaries.
+const AllowNonInteractiveEnvVar = "PTAH_ALLOW_NONINTERACTIVE_EDIT"
+
+// Resolve returns the editor command [Open] would launch: an explicit
+// editorCmd, then $VISUAL, then $EDITOR. It reports [ErrNoEditor] when none
+// resolves, so a caller can refuse before doing expensive work it would have to
+// throw away.
+func Resolve(editorCmd string) (string, error) {
+	if editorCmd == "" {
+		editorCmd = firstNonEmpty(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
+	}
+	if strings.TrimSpace(editorCmd) == "" {
+		return "", ErrNoEditor
+	}
+	return editorCmd, nil
+}
+
+// RequireInteractive reports whether an editor session may be opened against
+// in, which is the command's standard input.
+//
+// A terminal is required because an interactive editor started without one
+// does not fail — it blocks, and a pipeline that waits forever is worse than
+// one that stops. The refusal is therefore deterministic: no terminal and no
+// declared non-interactive editor means the command stops before launching
+// anything.
+//
+// The escape hatch is [AllowNonInteractiveEnvVar], for the scripted-editor
+// workflow ($EDITOR set to something that edits and exits on its own).
+func RequireInteractive(in io.Reader) error {
+	allowed, err := nonInteractiveAllowed()
+	if err != nil {
+		return err
+	}
+	if allowed || isTerminal(in) {
+		return nil
+	}
+	return fmt.Errorf("%w; set %s=1 when the configured editor edits non-interactively", ErrNotInteractive, AllowNonInteractiveEnvVar)
+}
+
+// nonInteractiveAllowed reads the opt-out. An unparsable value is an error
+// rather than a silent false: an operator who believes the gate is lifted must
+// not get a refusal from a typo, and one who believes it is closed must not get
+// an editor launched by one.
+func nonInteractiveAllowed() (bool, error) {
+	value, ok := os.LookupEnv(AllowNonInteractiveEnvVar)
+	if !ok || value == "" {
+		return false, nil
+	}
+	allowed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean value %q for %s", value, AllowNonInteractiveEnvVar)
+	}
+	return allowed, nil
+}
+
+// isTerminal reports whether in is an open terminal device. A stream that is
+// not an *os.File at all (a test buffer, a captured pipe) is never one, which
+// is also what makes the refusal reachable in a test.
+//
+// The check is an ioctl, not a `ModeCharDevice` bit test, and the difference
+// decides whether the guard works at all: /dev/null IS a character device, and
+// it is exactly what CI hands a process as standard input. A mode test
+// therefore calls the most common non-interactive environment interactive and
+// lets an editor launch into it.
+func isTerminal(in io.Reader) bool {
+	file, ok := in.(*os.File)
+	if !ok || file == nil {
+		return false
+	}
+	fd := file.Fd()
+	return isatty.IsTerminal(fd) || isatty.IsCygwinTerminal(fd)
+}
 
 // Open launches the resolved editor on the given file paths, wired to the
 // current terminal for interactive editing. An empty editorCmd falls back to
@@ -25,11 +112,9 @@ var ErrNoEditor = errors.New("no editor configured: set $EDITOR or $VISUAL")
 // without invoking a shell, so commands such as `code --wait` and quoted
 // executable paths work without exposing the edited paths to shell expansion.
 func Open(ctx context.Context, editorCmd string, paths ...string) error {
-	if editorCmd == "" {
-		editorCmd = firstNonEmpty(os.Getenv("VISUAL"), os.Getenv("EDITOR"))
-	}
-	if strings.TrimSpace(editorCmd) == "" {
-		return ErrNoEditor
+	editorCmd, err := Resolve(editorCmd)
+	if err != nil {
+		return err
 	}
 	fields, err := shlex.Split(editorCmd)
 	if err != nil {

--- a/cmd/migratecheckpoint/migratecheckpoint.go
+++ b/cmd/migratecheckpoint/migratecheckpoint.go
@@ -14,31 +14,43 @@ import (
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/dbcli"
+	"go.5x5.cz/ptah/cmd/internal/editor"
+	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/internal/dblock"
+	"go.5x5.cz/ptah/internal/migrateops"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/generator"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
 const (
-	migrationsFlag  = "migrations-dir"
-	shadowDBFlag    = "shadow-db"
-	dialectFlag     = "dialect"
-	descriptionFlag = "description"
-	versionFlag     = "version"
-	dryRunFlag      = "dry-run"
-	dirFormatFlag   = "dir-format"
+	migrationsFlag           = "migrations-dir"
+	shadowDBFlag             = "shadow-db"
+	dialectFlag              = "dialect"
+	descriptionFlag          = "description"
+	versionFlag              = "version"
+	dryRunFlag               = "dry-run"
+	dirFormatFlag            = "dir-format"
+	qualifierFlag            = "qualifier"
+	editFlag                 = "edit"
+	editorFlag               = "editor"
+	migrationLockTimeoutFlag = "migration-lock-timeout"
 )
 
 type options struct {
-	migrationsDir  string
-	shadowDB       string
-	dialect        string
-	description    string
-	version        string
-	dryRun         bool
-	dirFormat      string
-	schemas        string
-	connectTimeout string
+	migrationsDir        string
+	shadowDB             string
+	dialect              string
+	description          string
+	version              string
+	dryRun               bool
+	dirFormat            string
+	schemas              string
+	connectTimeout       string
+	qualifier            string
+	edit                 bool
+	editor               string
+	migrationLockTimeout string
 }
 
 // NewMigrateCheckpointCommand returns the `checkpoint` command.
@@ -79,6 +91,10 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.StringVar(&opts.version, versionFlag, "", "Checkpoint version; defaults to one above the newest migration")
 	flags.BoolVar(&opts.dryRun, dryRunFlag, false, "Print the checkpoint SQL instead of writing files")
 	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format")
+	flags.StringVar(&opts.qualifier, qualifierFlag, "", "Qualify every object in the checkpoint with a custom schema qualifier (single-schema checkpoints only)")
+	flags.BoolVar(&opts.edit, editFlag, false, "Open the written checkpoint files in an editor before reporting them (the directory checksum is refreshed afterwards)")
+	flags.StringVar(&opts.editor, editorFlag, "", "Editor command used with --edit (defaults to $VISUAL, then $EDITOR)")
+	flags.StringVar(&opts.migrationLockTimeout, migrationLockTimeoutFlag, "", "Maximum time to wait for the shadow database's migration advisory lock during the replay (for example 10s). Empty waits indefinitely.")
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 }
@@ -120,18 +136,32 @@ func migrateCheckpointCommand(cmd *cobra.Command, _ []string, opts *options) err
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	migrationLockTimeout, err := migrator.ParseMigrationLockTimeout(opts.migrationLockTimeout)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	warnUnlockableShadowDialect(cmd, opts)
+	// Both edit preconditions are checked before the replay, not after the
+	// files are written: the replay drops and rebuilds the shadow database, and
+	// a run that is going to refuse must not pay for that or leave a checkpoint
+	// behind that nobody could edit.
+	if err := checkEditPreconditions(cmd, opts); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	version, err := resolveCheckpointVersion(opts.version, opts.migrationsDir, dirFormat)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 
 	upSQL, downSQL, err := generator.GenerateCheckpointFromShadow(ctx, generator.CheckpointFromShadowOptions{
-		ShadowDatabaseURL: opts.shadowDB,
-		MigrationsDir:     opts.migrationsDir,
-		Dialect:           opts.dialect,
-		Schemas:           dbcli.ParseSchemas(opts.schemas),
-		ProviderOptions:   []migrator.FSProviderOption{migrator.WithMigrationDirFormat(dirFormat)},
-		ConnectTimeout:    connectTimeout,
+		ShadowDatabaseURL:    opts.shadowDB,
+		MigrationsDir:        opts.migrationsDir,
+		Dialect:              opts.dialect,
+		Schemas:              dbcli.ParseSchemas(opts.schemas),
+		ProviderOptions:      []migrator.FSProviderOption{migrator.WithMigrationDirFormat(dirFormat)},
+		ConnectTimeout:       connectTimeout,
+		MigrationLockTimeout: migrationLockTimeout,
+		SchemaQualifier:      opts.qualifier,
 	})
 	if err != nil {
 		return err
@@ -153,8 +183,100 @@ func migrateCheckpointCommand(cmd *cobra.Command, _ []string, opts *options) err
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	if err := editWrittenCheckpoint(cmd, opts, dirFormat, upPath, downPath); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	fmt.Fprintf(out, "Wrote checkpoint version %d:\n  %s\n  %s\n", version, upPath, downPath)
 	return nil
+}
+
+// warnUnlockableShadowDialect says so when a lock timeout was asked for on a
+// shadow database whose dialect implements no advisory locking (SQLite, and
+// ClickHouse), where the replay takes no lock and the timeout therefore bounds
+// nothing.
+//
+// Silence would be the worse answer: an operator who set a bound would believe
+// concurrent replays against one shadow database are serialized. The same
+// disclosure exists on `schema apply` for the same reason.
+//
+// It is emitted only when the flag was set explicitly, so an ordinary SQLite
+// checkpoint stays quiet, and on stderr, so it never contaminates the
+// checkpoint SQL a --dry-run writes to stdout.
+func warnUnlockableShadowDialect(cmd *cobra.Command, opts *options) {
+	if !cmd.Flags().Changed(migrationLockTimeoutFlag) {
+		return
+	}
+	dialect := opts.dialect
+	if dialect == "" {
+		// A URL Ptah cannot classify is not evidence either way, so an error
+		// here means no claim is made rather than a wrong one.
+		dialect, _ = atlasurl.DialectFromURL(opts.shadowDB)
+	}
+	if dialect == "" || dblock.Supported(dialect) {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(),
+		"note: migration locking is not supported for dialect %q; --%s is ignored and the checkpoint replay proceeds without a lock\n",
+		dialect, migrationLockTimeoutFlag,
+	)
+}
+
+// checkEditPreconditions refuses an --edit run that could not finish, before
+// any database work happens.
+//
+// Two things can make an editor session impossible, and both are silent
+// failures if left to the editor itself: no editor is configured (the run would
+// write a checkpoint and then stop), and no terminal is attached (an
+// interactive editor started without one blocks forever, which in CI is
+// indistinguishable from a hang). Refusing up front turns both into an exit
+// code and a message.
+//
+// The sibling `ptah migrations create --edit` deliberately keeps its existing
+// behavior; changing it is a separate change with its own blast radius.
+func checkEditPreconditions(cmd *cobra.Command, opts *options) error {
+	if !opts.edit {
+		if opts.editor != "" {
+			return fmt.Errorf("--%s requires --%s", editorFlag, editFlag)
+		}
+		return nil
+	}
+	if _, err := editor.Resolve(opts.editor); err != nil {
+		if errors.Is(err, editor.ErrNoEditor) {
+			return fmt.Errorf("%w, or pass --%s", err, editorFlag)
+		}
+		return err
+	}
+	return editor.RequireInteractive(cmd.InOrStdin())
+}
+
+// editWrittenCheckpoint opens the checkpoint files just written and refreshes
+// the directory's integrity file, because editing changes bytes the write path
+// already hashed. Both conventions maintain a sum (ptah.sum, atlas.sum), so the
+// refresh is unconditional here, unlike on `migrations create`, where the ptah
+// path maintains none.
+func editWrittenCheckpoint(
+	cmd *cobra.Command,
+	opts *options,
+	dirFormat migrator.MigrationDirFormat,
+	paths ...string,
+) error {
+	if !opts.edit {
+		return nil
+	}
+	if err := editor.Open(cmd.Context(), opts.editor, paths...); err != nil {
+		return err
+	}
+	if _, err := migrateops.Rehash(opts.migrationsDir, dirFormat); err != nil {
+		return fmt.Errorf("refresh %s after editing: %w", integrityFileName(dirFormat), err)
+	}
+	return nil
+}
+
+func integrityFileName(dirFormat migrator.MigrationDirFormat) string {
+	if dirFormat == migrator.MigrationDirFormatAtlas {
+		return migratesum.AtlasFileName
+	}
+	return migratesum.FileName
 }
 
 // writeAtlasCheckpoint emits the Atlas single-file checkpoint convention. The
@@ -170,6 +292,9 @@ func writeAtlasCheckpoint(cmd *cobra.Command, out io.Writer, opts *options, vers
 
 	path, err := generator.WriteAtlasCheckpointFile(opts.migrationsDir, version, opts.description, upSQL)
 	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	if err := editWrittenCheckpoint(cmd, opts, migrator.MigrationDirFormatAtlas, path); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
 	fmt.Fprintf(out, "Wrote checkpoint version %d:\n  %s\n", version, path)

--- a/cmd/migrationstest/migrationstest.go
+++ b/cmd/migrationstest/migrationstest.go
@@ -12,6 +12,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
+	"go.5x5.cz/ptah/cmd/internal/dbcli"
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
 	"go.5x5.cz/ptah/migration/dbtest"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -34,14 +35,15 @@ const (
 var reportFormats = []string{"text", "json", "html"}
 
 type options struct {
-	dir           string
-	migrationsDir string
-	rootDir       string
-	seedDir       string
-	dbURL         string
-	dirFormat     string
-	report        string
-	runPattern    string
+	dir              string
+	migrationsDir    string
+	rootDir          string
+	seedDir          string
+	dbURL            string
+	dirFormat        string
+	report           string
+	runPattern       string
+	migrationsSchema string
 }
 
 // NewMigrationsTestCommand returns the "test" command for the migrations
@@ -87,6 +89,7 @@ The command exits non-zero if any case fails.`,
 	flags.StringVar(&opts.dirFormat, dirFormatFlag, string(migrator.MigrationDirFormatPtah), "Migration directory format: auto, ptah, or atlas")
 	flags.StringVar(&opts.report, reportFlag, reportFormatText, "Report format: text, json, or html")
 	flags.StringVar(&opts.runPattern, runFlag, "", "Run only case names matching this Go regular expression")
+	dbcli.RegisterMigrationsSchemaFlag(flags, &opts.migrationsSchema)
 
 	cmdutil.ConfigureCommand(cmd)
 	return cmd
@@ -118,12 +121,13 @@ func run(ctx context.Context, out io.Writer, opts options) error {
 	}
 
 	report, err := dbtest.RunMigrationTest(ctx, dbtest.Options{
-		Cases:         cases,
-		MigrationsDir: opts.migrationsDir,
-		RootDir:       opts.rootDir,
-		SeedDir:       opts.seedDir,
-		DBURL:         opts.dbURL,
-		DirFormat:     dirFormat,
+		Cases:           cases,
+		MigrationsDir:   opts.migrationsDir,
+		RootDir:         opts.rootDir,
+		SeedDir:         opts.seedDir,
+		DBURL:           opts.dbURL,
+		DirFormat:       dirFormat,
+		RevisionsSchema: opts.migrationsSchema,
 	})
 	if err != nil {
 		return err

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5777,6 +5777,12 @@ type Options struct {
     // the Ptah directory format (not the migrator's own "auto" default), so a
     // direct caller that wants format auto-detection must set it explicitly.
     DirFormat migrator.MigrationDirFormat
+    // RevisionsSchema places the revision table a migrate_to step writes in a
+    // named schema instead of the connection's default one. It matters when the
+    // throwaway database already holds a revision table the run must not touch,
+    // or when the tests exist to prove that a deployment's revision schema is
+    // the one the migrations expect. Empty keeps the connection default.
+    RevisionsSchema string
 }
     Options configures a single RunMigrationTest invocation.
 
@@ -6007,6 +6013,16 @@ type CheckpointFromShadowOptions struct {
     ProviderOptions []migrator.FSProviderOption
     // ConnectTimeout bounds the shadow database connection attempt.
     ConnectTimeout time.Duration
+    // MigrationLockTimeout bounds how long the replay waits for the shadow
+    // database's migration advisory lock. Zero waits indefinitely, which is the
+    // migrator's own default. It only has an effect on dialects that implement
+    // advisory locking.
+    MigrationLockTimeout time.Duration
+    // SchemaQualifier, when non-empty, prefixes every object the checkpoint
+    // creates with a schema qualifier, exactly as the same-named option does on
+    // a generated migration. It applies to a single-schema checkpoint only, and
+    // an unqualifiable statement kind is refused rather than emitted unqualified.
+    SchemaQualifier string
 }
     CheckpointFromShadowOptions configures GenerateCheckpointFromShadow.
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -71,8 +71,21 @@ golang-migrate down file and a Flyway undo file are not covered, and a layout
 that carries no `atlas.sum` and whose covered set is empty is not a checksum
 error. What executes is what the verified checksum covers, for every layout.
 
-**Rejected on this verb, matching Atlas OSS:** `--dir-format`, `--to-version`,
-and `--lock-name`.
+**Rejected on this verb, matching Atlas OSS:** `--dir-format` and `--lock-name`.
+
+`--to-version` bounds the run at a migration version: every pending migration up
+to and including it runs, and nothing above it does. The bound is enforced where
+the apply plan is built, inside the migration lock, so a concurrent writer
+cannot turn it into a different set of migrations; a version the directory does
+not carry is refused rather than rounded to a neighbor, and the bound cannot be
+combined with the amount argument, because the two select different prefixes and
+neither outranks the other. The pinned community binary does not register the
+flag — Atlas's published CLI reference does, which is what makes this a
+Pro-surface addition rather than a CE parity row.
+
+```bash
+ptah-compat migrate apply --url "$DB" --dir file://migrations --to-version 20240101000002
+```
 
 Pre-migration checks — `-- +ptah check` directives and Atlas txtar
 `checks.sql` / `checks/*.sql` sections — are enforced here as they are natively.
@@ -298,6 +311,30 @@ the `--dev-url` dev database and writing a cumulative-schema checkpoint.
 | Positional name (optional) | The checkpoint description, used as the file-name stem. |
 | `--dir-format=atlas` | Writes the Atlas single-file checkpoint (default). |
 | `--dir-format=ptah` | Writes the ptah reversible checkpoint pair. |
+| `-s, --schema` | The native `--schemas` allow-list; repeat the flag or pass one comma-separated value. |
+| `--qualifier` | The native `--qualifier`: prefixes every object the checkpoint creates with a schema qualifier. |
+| `--lock-timeout` | The native `--migration-lock-timeout`, bounding the wait for the dev database's migration lock during the replay. |
+| `--edit` | The native `--edit`: opens the written checkpoint files in `$VISUAL`, then `$EDITOR`, and refreshes the directory checksum afterwards. |
+
+`--edit` refuses before it replays anything when the session could not finish:
+with no editor configured, and when standard input is not a terminal. The second
+refusal is the one that matters in CI, where an interactive editor launched
+without a terminal does not fail but waits. Set
+`PTAH_ALLOW_NONINTERACTIVE_EDIT=1` when `$EDITOR` is a script that edits and
+exits on its own; that is an environment variable rather than a flag because
+Atlas registers no flag for it. The native `--editor` selects a specific editor
+command and is deliberately not part of this verb's Atlas flag surface.
+
+`--lock-timeout` bounds a lock only on dialects that implement advisory locking.
+On one that does not — SQLite, ClickHouse — the run says so on stderr rather than
+accepting a bound that binds nothing.
+
+`--qualifier` is refused on a dialect Ptah cannot qualify, so a checkpoint is
+never written half-qualified.
+
+Not registered here: `--format`, whose Go-template report needs the compat
+formatting path this verb does not have yet, and `--lock-name`, which belongs to
+the named-lock family.
 
 `--dir-format` selects the checkpoint convention, and **on this verb it
 defaults to `atlas`**, matching the default Atlas registers and every other
@@ -360,6 +397,7 @@ Forwards to `ptah migrations test`.
 | `--dir` | The native migration directory, Atlas-format by default via `--dir-format`. |
 | `--dev-url` | The native throwaway database; an ephemeral SQLite database when omitted. |
 | `--run` | The native case-name filter. |
+| `--revisions-schema` | The native `--migrations-schema`: the schema a `migrate_to` step records revisions in. |
 | Positional path (optional) | The directory of Ptah-native YAML test cases, default `./tests`. |
 
 Exit codes match the native runner: 0 when all cases pass, 1 on test failure.

--- a/docs/site/src/content/docs/reference/native-commands.md
+++ b/docs/site/src/content/docs/reference/native-commands.md
@@ -50,11 +50,11 @@ review artifact, not one executable SQL script.
 | `ptah migrations hash` | Write or update migration-directory integrity. |
 | `ptah migrations validate` | Validate migration-directory integrity and, optionally, SQL execution by cleaning and replaying migrations on `--dev-url`. |
 | `ptah migrations lint` | Lint migration files and, with `--dev-url`, clean and replay migrations on a directly connectable dev database before static reporting. |
-| `ptah migrations test` | Run declarative YAML cases with migrate/apply-schema/seed/SQL/assert steps against a throwaway database, exiting non-zero on any failure. |
+| `ptah migrations test` | Run declarative YAML cases with migrate/apply-schema/seed/SQL/assert steps against a throwaway database, exiting non-zero on any failure; `--migrations-schema` places the revision table a `migrate_to` step writes. |
 | `ptah migrations edit` | Edit a migration's SQL (via `$EDITOR` or `--up-file`/`--down-file`) and rewrite the integrity file, refusing already-applied migrations unless `--force`. |
 | `ptah migrations rebase` | Move a migration to the end of history by re-timestamping it, and rewrite the integrity file, refusing already-applied migrations unless `--force`. |
 | `ptah migrations rm` | Delete a migration's up/down pair and rewrite the integrity file, refusing already-applied migrations unless `--force`. |
-| `ptah migrations checkpoint` | Squash migration history into a cumulative-schema checkpoint by replaying the directory on a `--shadow-db`; `--dir-format` selects the ptah pair (default) or the Atlas single-file convention. |
+| `ptah migrations checkpoint` | Squash migration history into a cumulative-schema checkpoint by replaying the directory on a `--shadow-db`; `--dir-format` selects the ptah pair (default) or the Atlas single-file convention, and `--qualifier`, `--migration-lock-timeout` and `--edit` shape the replay and the written files. |
 | `ptah migrations data` | Generate a reversible data migration from declarative reference-data drift against a live database. |
 | `ptah migrations push` | Publish a migration directory to an OCI registry. |
 | `ptah migrations pull` | Pull and reconstruct a migration directory from an OCI registry. |

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/google/shlex v0.0.0-20191202100458-e7afc7fbc510
 	github.com/hashicorp/hcl/v2 v2.24.0
 	github.com/jackc/pgx/v5 v5.10.0
+	github.com/mattn/go-isatty v0.0.24
 	github.com/microsoft/go-mssqldb v1.10.0
 	github.com/opencontainers/go-digest v1.0.0
 	github.com/opencontainers/image-spec v1.1.1
@@ -59,7 +60,6 @@ require (
 	github.com/klauspost/compress v1.19.1 // indirect
 	github.com/kr/pretty v0.3.1 // indirect
 	github.com/kr/text v0.2.0 // indirect
-	github.com/mattn/go-isatty v0.0.24 // indirect
 	github.com/mitchellh/go-wordwrap v1.0.1 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/paulmach/orb v0.13.0 // indirect

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -27,6 +27,14 @@ const (
 	BoolFlag
 	// UintFlag describes an Atlas unsigned integer flag.
 	UintFlag
+	// StringArrayFlag describes a repeatable Atlas string flag (pflag prints
+	// these as `strings`). Every occurrence contributes a value, and the whole
+	// set is forwarded to the native flag as one comma-separated value.
+	//
+	// It exists because forwarding each occurrence separately would silently
+	// drop all but the last one against a native flag that takes a single
+	// string, which is the failure shape a repeatable Atlas flag must not have.
+	StringArrayFlag
 )
 
 // Flag describes one Atlas-compatible CLI flag and how it maps to Ptah.
@@ -82,6 +90,14 @@ func NativeString(name, shorthand, usage, nativeName string) Flag {
 func NativeStringDefault(name, shorthand, usage, nativeName, defaultValue string) Flag {
 	flag := NativeString(name, shorthand, usage, nativeName)
 	flag.Default = defaultValue
+	return flag
+}
+
+// NativeStringArray creates a repeatable Atlas string flag that forwards every
+// occurrence to a single native Ptah flag as one comma-separated value.
+func NativeStringArray(name, shorthand, usage, nativeName string) Flag {
+	flag := Flag{Name: name, Shorthand: shorthand, Usage: usage, Kind: StringArrayFlag}
+	flag.NativeName = nativeName
 	return flag
 }
 
@@ -234,61 +250,177 @@ func Map(group, use string, flags []Flag, args []string) ([]string, error) {
 	}
 	args = appendDefaultArgs(flags, args)
 	out := make([]string, 0, len(args))
+	// Repeatable flags are accumulated instead of emitted in place: their
+	// native counterpart takes one value, so the occurrences have to be joined
+	// rather than forwarded one by one.
+	arrays := newStringArrayValues(flags)
 	for i := 0; i < len(args); i++ {
-		arg := args[i]
-		if arg == "--" {
+		if args[i] == "--" {
 			out = append(out, args[i:]...)
 			break
 		}
-		parsed := splitFlag(arg)
-		if !parsed.ok {
-			out = append(out, arg)
+		emitted, consumed, err := mapOneArg(group, use, flags, arrays, args, i)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, emitted...)
+		i += consumed - 1
+	}
+	return arrays.appendTo(out), nil
+}
+
+// mapOneArg translates the argument at index and reports how many arguments it
+// consumed (1 for a flag carrying its value inline or none, 2 when the value is
+// the following argument). A repeatable flag emits nothing here: its value is
+// recorded in arrays and joined once at the end.
+func mapOneArg(
+	group, use string,
+	flags []Flag,
+	arrays *stringArrayValues,
+	args []string,
+	index int,
+) (emitted []string, consumed int, err error) {
+	arg := args[index]
+	parsed := splitFlag(arg)
+	if !parsed.ok {
+		return []string{arg}, 1, nil
+	}
+	flag, found := findFlag(flags, parsed.name)
+	if !found {
+		return []string{arg}, 1, nil
+	}
+	displayName := "--" + flag.Name
+	if len(parsed.name) == 1 {
+		displayName = "-" + parsed.name
+	}
+	if flag.Unsupported {
+		return nil, 0, UnsupportedFlagError(group, use, flag, displayName)
+	}
+	nativeFlag := "--" + nativeFlagName(flag)
+	emitted, consumed, err = mapFlagOccurrence(flag, parsed, arrays, nativeFlag, args, index)
+	if err != nil {
+		return nil, 0, fmt.Errorf("atlas %s %s %s: %w", group, use, displayName, err)
+	}
+	return emitted, consumed, nil
+}
+
+// mapFlagOccurrence emits the native spelling of one recognized flag.
+func mapFlagOccurrence(
+	flag Flag,
+	parsed parsedFlag,
+	arrays *stringArrayValues,
+	nativeFlag string,
+	args []string,
+	index int,
+) (emitted []string, consumed int, err error) {
+	switch {
+	case flag.Kind == StringArrayFlag:
+		consumed, err = collectStringArrayValue(arrays, flag, parsed, args, index)
+		if err != nil {
+			return nil, 0, err
+		}
+		if consumed == 0 {
+			// A trailing occurrence with no value: forward it unchanged and let
+			// the native command report the missing value.
+			return []string{nativeFlag}, 1, nil
+		}
+		return nil, consumed, nil
+	case flag.Kind == BoolFlag && parsed.hasValue:
+		return []string{nativeFlag + "=" + parsed.value}, 1, nil
+	case flag.Kind == BoolFlag:
+		return []string{nativeFlag}, 1, nil
+	case parsed.hasValue:
+		value, err := mapFlagValue(flag, parsed.value)
+		if err != nil {
+			return nil, 0, err
+		}
+		return []string{nativeFlag + "=" + value}, 1, nil
+	case index+1 >= len(args):
+		return []string{nativeFlag}, 1, nil
+	default:
+		value, err := mapFlagValue(flag, args[index+1])
+		if err != nil {
+			return nil, 0, err
+		}
+		return []string{nativeFlag, value}, 2, nil
+	}
+}
+
+func nativeFlagName(flag Flag) string {
+	if flag.NativeName != "" {
+		return flag.NativeName
+	}
+	return flag.Name
+}
+
+// collectStringArrayValue records one occurrence of a repeatable flag and
+// reports how many args it consumed: 1 for an inline `--flag=value`, 2 when the
+// value is the next arg, and 0 when the occurrence is trailing and has no value
+// at all, which the caller forwards unchanged so the native command produces
+// the diagnostic.
+func collectStringArrayValue(
+	arrays *stringArrayValues,
+	flag Flag,
+	parsed parsedFlag,
+	args []string,
+	index int,
+) (consumed int, err error) {
+	value := parsed.value
+	consumed = 1
+	if !parsed.hasValue {
+		if index+1 >= len(args) {
+			return 0, nil
+		}
+		value = args[index+1]
+		consumed = 2
+	}
+	mapped, err := mapFlagValue(flag, value)
+	if err != nil {
+		return 0, err
+	}
+	arrays.add(flag.Name, mapped)
+	return consumed, nil
+}
+
+// stringArrayValues accumulates the values of repeatable flags in flag
+// declaration order, so the forwarded args are deterministic whatever order the
+// occurrences arrived in.
+type stringArrayValues struct {
+	order  []Flag
+	values map[string][]string
+}
+
+func newStringArrayValues(flags []Flag) *stringArrayValues {
+	acc := &stringArrayValues{values: map[string][]string{}}
+	for _, flag := range flags {
+		if flag.Kind == StringArrayFlag {
+			acc.order = append(acc.order, flag)
+		}
+	}
+	return acc
+}
+
+func (a *stringArrayValues) add(name, value string) {
+	a.values[name] = append(a.values[name], value)
+}
+
+// appendTo emits one native flag per repeatable flag that was used, carrying
+// every occurrence's value. Empty values are dropped rather than forwarded as
+// empty list members, matching what the native comma-separated parsers do with
+// them.
+func (a *stringArrayValues) appendTo(out []string) []string {
+	for _, flag := range a.order {
+		values := a.values[flag.Name]
+		if len(values) == 0 {
 			continue
-		}
-		flag, found := findFlag(flags, parsed.name)
-		if !found {
-			out = append(out, arg)
-			continue
-		}
-		displayName := "--" + flag.Name
-		if len(parsed.name) == 1 {
-			displayName = "-" + parsed.name
-		}
-		if flag.Unsupported {
-			return nil, UnsupportedFlagError(group, use, flag, displayName)
 		}
 		nativeName := flag.Name
 		if flag.NativeName != "" {
 			nativeName = flag.NativeName
 		}
-		nativeFlag := "--" + nativeName
-		if flag.Kind == BoolFlag {
-			if parsed.hasValue {
-				out = append(out, nativeFlag+"="+parsed.value)
-			} else {
-				out = append(out, nativeFlag)
-			}
-			continue
-		}
-		if parsed.hasValue {
-			value, err := mapFlagValue(flag, parsed.value)
-			if err != nil {
-				return nil, fmt.Errorf("atlas %s %s %s: %w", group, use, displayName, err)
-			}
-			out = append(out, nativeFlag+"="+value)
-			continue
-		}
-		out = append(out, nativeFlag)
-		if i+1 < len(args) {
-			i++
-			value, err := mapFlagValue(flag, args[i])
-			if err != nil {
-				return nil, fmt.Errorf("atlas %s %s %s: %w", group, use, displayName, err)
-			}
-			out = append(out, value)
-		}
+		out = append(out, "--"+nativeName+"="+strings.Join(values, ","))
 	}
-	return out, nil
+	return out
 }
 
 func appendDefaultArgs(flags []Flag, args []string) []string {

--- a/internal/atlasargs/string_array_test.go
+++ b/internal/atlasargs/string_array_test.go
@@ -1,0 +1,86 @@
+package atlasargs_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasargs"
+)
+
+// checkpointSchemaFlags is the repeatable-flag half of `migrate checkpoint`:
+// Atlas declares `-s, --schema strings`, Ptah takes one comma-separated
+// --schemas.
+func checkpointSchemaFlags() []atlasargs.Flag {
+	return []atlasargs.Flag{
+		atlasargs.NativeStringArray("schema", "s", "Schema names", "schemas"),
+		atlasargs.NativeString("dev-url", "", "Dev database URL", "shadow-db"),
+	}
+}
+
+// TestMap_RepeatableFlagJoinsEveryOccurrence is the test that exists because of
+// how this can fail silently. A repeatable Atlas flag forwarded occurrence by
+// occurrence lands on a native flag that holds one string, so the last value
+// wins and every earlier one disappears without an error — a checkpoint that
+// covers one schema when the caller named three.
+//
+// Each row therefore asserts the WHOLE mapped argument list, not just that the
+// last value survived.
+func TestMap_RepeatableFlagJoinsEveryOccurrence(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want []string
+	}{
+		{
+			name: "repeated long form",
+			args: []string{"--schema", "public", "--schema", "billing"},
+			want: []string{"--schemas=public,billing"},
+		},
+		{
+			name: "repeated inline form",
+			args: []string{"--schema=public", "--schema=billing"},
+			want: []string{"--schemas=public,billing"},
+		},
+		{
+			name: "shorthand form",
+			args: []string{"-s", "public", "-s", "billing"},
+			want: []string{"--schemas=public,billing"},
+		},
+		{
+			name: "one comma-separated value passes through whole",
+			args: []string{"--schema", "public,billing"},
+			want: []string{"--schemas=public,billing"},
+		},
+		{
+			name: "a single occurrence still maps",
+			args: []string{"--schema", "public"},
+			want: []string{"--schemas=public"},
+		},
+		{
+			name: "absent means absent, not an empty list",
+			args: []string{"--dev-url", "sqlite://dev.db"},
+			want: []string{"--shadow-db", "sqlite://dev.db"},
+		},
+		{
+			name: "occurrences are collected past other flags",
+			args: []string{"--schema", "public", "--dev-url=sqlite://dev.db", "--schema", "billing"},
+			want: []string{"--shadow-db=sqlite://dev.db", "--schemas=public,billing"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Setenv("PTAH_SCHEMA", "")
+			c.Setenv("PTAH_SCHEMAS", "")
+			c.Setenv("PTAH_DEV_URL", "")
+			c.Setenv("PTAH_SHADOW_DB", "")
+
+			got, err := atlasargs.Map("migrate", "checkpoint", checkpointSchemaFlags(), test.args)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.DeepEquals, test.want)
+		})
+	}
+}

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -32,8 +32,15 @@ type ApplyOptions struct {
 	RevisionsSchema      string
 	MigrationLockTimeout time.Duration
 	Amount               uint64
-	AllowDirty           bool
-	BaselineVersion      int64
+	// ToVersion bounds the apply at a migration version: every pending
+	// migration up to and including it runs, and nothing above it does. Zero
+	// means unbounded. It is the version bound Atlas spells --to-version, and
+	// it is enforced by the migrator inside the migration lock rather than by
+	// the preview below, so a run that races another writer applies the
+	// versions the bound names rather than a count computed before the lock.
+	ToVersion       int64
+	AllowDirty      bool
+	BaselineVersion int64
 	// SkipChecks bypasses pre-migration check evaluation. Atlas registers no
 	// flag for this on `migrate apply` (measured on CE v1.2.0 and on
 	// Atlas's own help surface), so the compat command resolves it from
@@ -122,7 +129,7 @@ func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts A
 	return ApplyPlan{
 		Status:                 status,
 		Migrations:             mig.MigrationProvider().Migrations(),
-		SelectedVersions:       selectedApplyVersions(pending, opts.Amount),
+		SelectedVersions:       selectedApplyVersions(pending, opts.Amount, opts.ToVersion),
 		CurrentVersion:         plannedCurrentVersion,
 		DryRun:                 opts.DryRun,
 		StartedAt:              startedAt,
@@ -166,6 +173,7 @@ func (p ApplyPlan) execute(ctx context.Context, hook migrator.PreMigrationHook) 
 	lockedPlanObserved := false
 	err := p.mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
 		Amount:                 p.opts.Amount,
+		TargetVersion:          p.opts.ToVersion,
 		AllowDirty:             p.opts.AllowDirty,
 		AssumedAppliedVersions: p.assumedAppliedVersions,
 		PlanObserver: func(_ context.Context, plan migrator.MigrationPlan) {
@@ -279,6 +287,16 @@ func validateApplyOptions(conn *dbschema.DatabaseConnection, opts ApplyOptions) 
 	if opts.BaselineVersion < 0 {
 		return errors.New("migrate apply baseline version must be greater than or equal to zero")
 	}
+	if opts.ToVersion < 0 {
+		return errors.New("migrate apply target version must be greater than or equal to zero")
+	}
+	// Refused here rather than left to the migrator, which raises the same
+	// conflict only once it holds the migration lock. The two bounds select
+	// different prefixes and there is no defensible precedence between them, so
+	// the run must not start.
+	if opts.ToVersion > 0 && opts.Amount > 0 {
+		return errors.New("--to-version and the amount argument cannot both be set")
+	}
 	return nil
 }
 
@@ -345,9 +363,20 @@ func pendingAfterAssumedApplied(pending []int64, assumedApplied []int64) []int64
 	return filtered
 }
 
-func selectedApplyVersions(pending []int64, amount uint64) []int64 {
+// selectedApplyVersions previews the versions an apply will run, before the
+// migration lock is taken.
+//
+// The toVersion bound skips over a version above the bound rather than
+// stopping at it, because that is what the migrator does inside the lock
+// (migrationsToApply continues past an out-of-bound version). Stopping instead
+// would make the preview disagree with the execution on a directory whose
+// pending versions are not monotonically ordered.
+func selectedApplyVersions(pending []int64, amount uint64, toVersion int64) []int64 {
 	selected := make([]int64, 0, len(pending))
 	for _, version := range pending {
+		if toVersion > 0 && version > toVersion {
+			continue
+		}
 		selected = append(selected, version)
 		if amount > 0 && uint64(len(selected)) == amount {
 			break

--- a/migration/dbtest/engine.go
+++ b/migration/dbtest/engine.go
@@ -41,6 +41,12 @@ type Options struct {
 	// the Ptah directory format (not the migrator's own "auto" default), so a
 	// direct caller that wants format auto-detection must set it explicitly.
 	DirFormat migrator.MigrationDirFormat
+	// RevisionsSchema places the revision table a migrate_to step writes in a
+	// named schema instead of the connection's default one. It matters when the
+	// throwaway database already holds a revision table the run must not touch,
+	// or when the tests exist to prove that a deployment's revision schema is
+	// the one the migrations expect. Empty keeps the connection default.
+	RevisionsSchema string
 }
 
 // Report is the outcome of a [RunMigrationTest] or [RunSchemaTest] run.
@@ -264,11 +270,12 @@ func RunMigrationTest(ctx context.Context, opts Options) (*Report, error) {
 
 	run := func(ctx context.Context, conn *dbschema.DatabaseConnection, c Case) (CaseResult, error) {
 		r := &runner{
-			conn:          conn,
-			migrationsDir: opts.MigrationsDir,
-			dirFormat:     dirFormat,
-			desiredSchema: desiredSchema,
-			seedDir:       opts.SeedDir,
+			conn:            conn,
+			migrationsDir:   opts.MigrationsDir,
+			dirFormat:       dirFormat,
+			desiredSchema:   desiredSchema,
+			seedDir:         opts.SeedDir,
+			revisionsSchema: opts.RevisionsSchema,
 		}
 		r.migrateTo = r.runMigrateTo
 		r.applySchema = r.runApplySchema
@@ -399,6 +406,9 @@ type runner struct {
 	dirFormat     migrator.MigrationDirFormat
 	desiredSchema *goschema.Database
 	seedDir       string
+	// revisionsSchema is the schema the migrate_to migrator records revisions
+	// in. Empty keeps the connection default.
+	revisionsSchema string
 	// migrateTo handles a migrate_to step. Migration tests wire it to
 	// [runner.runMigrateTo]; schema tests wire it to a rejection because a schema
 	// test applies a desired schema directly and has no migrations to move
@@ -501,7 +511,14 @@ func (r *runner) newMigrator() (*migrator.Migrator, error) {
 	if err != nil {
 		return nil, err
 	}
-	return migrator.NewMigrator(r.conn, provider).WithLogger(slog.New(slog.DiscardHandler)), nil
+	m := migrator.NewMigrator(r.conn, provider).WithLogger(slog.New(slog.DiscardHandler))
+	if r.revisionsSchema != "" {
+		// The table name stays the revision format's own default; only the
+		// schema moves, which is the single axis Atlas's --revisions-schema
+		// names.
+		m = m.WithMigrationsTable(r.revisionsSchema, "")
+	}
+	return m, nil
 }
 
 func (r *runner) runExec(ctx context.Context, sql string) (passed bool, detail string) {

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -13,6 +13,7 @@ import (
 	"go.5x5.cz/ptah/core/platform/capability"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/convert/dbschematogo"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -53,7 +54,7 @@ func GenerateCheckpointWithDatabaseInfo(
 	if err != nil {
 		return "", "", fmt.Errorf("generate checkpoint: %w", err)
 	}
-	return generateCheckpointFromDiff(schema, empty, info, diff)
+	return generateCheckpointFromDiff(schema, empty, info, diff, "")
 }
 
 // GenerateCheckpointWithDatabase renders a checkpoint after resolving the
@@ -63,6 +64,18 @@ func GenerateCheckpointWithDatabase(
 	conn *dbschema.DatabaseConnection,
 	schema *goschema.Database,
 ) (upSQL, downSQL string, err error) {
+	return generateCheckpointWithDatabaseQualified(ctx, conn, schema, "")
+}
+
+// generateCheckpointWithDatabaseQualified is GenerateCheckpointWithDatabase
+// with the schema qualifier the shadow-replay entry point carries. The public
+// signature above stays qualifier-free so existing callers are unaffected.
+func generateCheckpointWithDatabaseQualified(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	schema *goschema.Database,
+	qualifier string,
+) (upSQL, downSQL string, err error) {
 	if schema == nil {
 		return "", "", fmt.Errorf("checkpoint schema is required")
 	}
@@ -71,7 +84,7 @@ func GenerateCheckpointWithDatabase(
 	if err != nil {
 		return "", "", fmt.Errorf("generate checkpoint: %w", err)
 	}
-	return generateCheckpointFromDiff(schema, empty, conn.Info(), diff)
+	return generateCheckpointFromDiff(schema, empty, conn.Info(), diff, qualifier)
 }
 
 func generateCheckpointFromDiff(
@@ -79,10 +92,15 @@ func generateCheckpointFromDiff(
 	empty *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	diff *schemadifftypes.SchemaDiff,
+	qualifierValue string,
 ) (upSQL, downSQL string, err error) {
 	capabilities := info.Capabilities
 	if capabilities == nil {
 		capabilities = capability.ForDialect(info.Dialect)
+	}
+	qualifier, err := atlasmigrate.ParseQualifier(qualifierValue)
+	if err != nil {
+		return "", "", err
 	}
 	spec, _, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
 		Diff:         diff,
@@ -90,6 +108,7 @@ func generateCheckpointFromDiff(
 		DBSchema:     empty,
 		Dialect:      info.Dialect,
 		Capabilities: capabilities,
+		Qualifier:    qualifier,
 	})
 	if err != nil {
 		return "", "", fmt.Errorf("generate checkpoint: %w", err)
@@ -222,6 +241,16 @@ type CheckpointFromShadowOptions struct {
 	ProviderOptions []migrator.FSProviderOption
 	// ConnectTimeout bounds the shadow database connection attempt.
 	ConnectTimeout time.Duration
+	// MigrationLockTimeout bounds how long the replay waits for the shadow
+	// database's migration advisory lock. Zero waits indefinitely, which is the
+	// migrator's own default. It only has an effect on dialects that implement
+	// advisory locking.
+	MigrationLockTimeout time.Duration
+	// SchemaQualifier, when non-empty, prefixes every object the checkpoint
+	// creates with a schema qualifier, exactly as the same-named option does on
+	// a generated migration. It applies to a single-schema checkpoint only, and
+	// an unqualifiable statement kind is refused rather than emitted unqualified.
+	SchemaQualifier string
 }
 
 // GenerateCheckpointFromShadow replays the entire migration directory on a fresh
@@ -269,7 +298,8 @@ func generateCheckpointFromConn(ctx context.Context, shadowConn *dbschema.Databa
 		return "", "", fmt.Errorf("checkpoint generation failed: no migrations found in %s", opts.MigrationsDir)
 	}
 
-	mig := migrator.NewMigrator(shadowConn, migrator.NewRegisteredMigrationProvider(migrations...))
+	mig := migrator.NewMigrator(shadowConn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationLockTimeout(opts.MigrationLockTimeout)
 	if err := mig.MigrateUp(ctx); err != nil {
 		if description := describeReplayError(err); description != "" {
 			return "", "", fmt.Errorf("checkpoint generation failed: %s", description)
@@ -284,9 +314,10 @@ func generateCheckpointFromConn(ctx context.Context, shadowConn *dbschema.Databa
 	if err != nil {
 		return "", "", fmt.Errorf("checkpoint generation failed: read shadow schema: %w", err)
 	}
-	return GenerateCheckpointWithDatabase(
+	return generateCheckpointWithDatabaseQualified(
 		ctx,
 		shadowConn,
 		dbschematogo.ConvertDBSchemaToGoSchema(shadowSchema),
+		opts.SchemaQualifier,
 	)
 }


### PR DESCRIPTION
Batch 2 of the #951 grouping: the migrate-side flags. Six added, two declined with evidence, `--lock-name` untouched everywhere (it belongs to the named-lock family landing separately).

## Atlas-side source for every flag

The pinned community binary v1.3.0 registers **none** of these. Measured, with both controls on every verb:

```
$ atlas migrate apply --to-version=2          -> Error: unknown flag: --to-version
$ atlas migrate status --allow-dirty=true     -> Error: unknown flag: --allow-dirty
$ atlas migrate test --run=x                  -> Error: unknown flag: --run        (verb registers no flags of its own)
$ atlas migrate checkpoint --dir-format=atlas -> Error: unknown flag: --dir-format (same)
$ atlas migrate apply --dry-run=true          -> Error: sql/migrate: stat migrations: ...   (positive control: present)
$ atlas migrate <verb> --frobnicate-nonsense=x-> Error: unknown flag: --frobnicate-nonsense (negative control)
$ atlas migrate frobnicate                    -> group help, exit 0                         (nonsense-verb control)
```

So the oracle is Atlas's public CLI reference (atlasgo.io/cli-reference), fetched over HTTP: 301397 bytes, non-empty, positive control `atlas migrate apply` present 10×, `--dry-run` present 9×, negative control `--frobnicate-nonsense` present 0×. It publishes:

| Verb | Flag as documented | Added |
| --- | --- | --- |
| `migrate apply` | `--to-version string` — "migrate to this version, if set" | yes |
| `migrate test` | `--revisions-schema string` — "name of the schema the revisions table resides in" | yes |
| `migrate checkpoint` | `-s, --schema strings` — "set schema names" | yes |
| `migrate checkpoint` | `--qualifier string` — "qualify tables with custom qualifier when working on a single schema" | yes |
| `migrate checkpoint` | `--lock-timeout duration` — "set how long to wait for the database lock" | yes |
| `migrate checkpoint` | `--edit` — "edit the generated migration file(s)" | yes |
| `migrate checkpoint` | `--format string` — "Go template to use to format the output" | **no** — see below |
| `migrate status` | `--allow-dirty` — "allow start working on a non-clean database" | **no** — see below |

Spelling, type and default follow that source: `--to-version` is a string (a non-numeric value must fail with Ptah's version diagnostic, not pflag's int parser), `--schema` is repeatable with the `-s` shorthand, `--edit` is a bool, `--lock-timeout` takes a duration literal.

## Measurement, before and after

Same probe, run against `ptah-compat` built from this branch's parent and from its head. Never `--help | grep`: on several verbs `--help` short-circuits before flag validation, and `--foo` appears inside `unknown flag: --foo`.

```
                                            before      after
migrate apply      --dry-run=true           present     present    (positive control)
migrate apply      --frobnicate-nonsense=x  MISSING     MISSING    (negative control)
migrate apply      --to-version=2           MISSING     present
migrate status     --format=x               present     present    (positive control)
migrate status     --frobnicate-nonsense=x  MISSING     MISSING    (negative control)
migrate status     --allow-dirty=true       MISSING     MISSING    (declined)
migrate test       --run=x                  present     present    (positive control)
migrate test       --frobnicate-nonsense=x  MISSING     MISSING    (negative control)
migrate test       --revisions-schema=s     MISSING     present
migrate checkpoint --dir-format=atlas       present     present    (positive control, #1011)
migrate checkpoint --frobnicate-nonsense=x  MISSING     MISSING    (negative control)
migrate checkpoint --edit=true              MISSING     present
migrate checkpoint --format=x               MISSING     MISSING    (declined)
migrate checkpoint --qualifier=q            MISSING     present
migrate checkpoint --schema=s               MISSING     present
migrate checkpoint --lock-timeout=10s       MISSING     present
```

`--dir-format` on checkpoint stayed `present` throughout, which is the positive control the issue asked for on that verb.

### End-to-end, three migrations

```
$ ptah-compat migrate apply --url sqlite://live.db --dir file://migrations --to-version 20240101000002
Migrating to version 20240101000002 from 2 pending migrations.
Migration complete. Current version: 20240101000002
tables: ['atlas_schema_revisions', 't1', 't2']        # t3 absent
revisions: ['20240101000001', '20240101000002']

$ ptah-compat migrate status --url sqlite://live.db --dir file://migrations
Current Version: 20240101000002 / Applied: 2 / Pending: 1 / Status: Pending migrations available

$ atlas migrate status --url sqlite://live.db --dir file://migrations     # pinned community binary, same database
Migration Status: PENDING
  -- Current Version: 20240101000002
  -- Executed Files:  2
  -- Pending Files:   1
```

Both readers agree, including the independent one. Follow-up refusals on the same fixture: a version the directory does not carry → `target version 19990101000000 was not found in the migration provider`; bound plus amount → `--to-version and the amount argument cannot both be set`; `--to-version abc` → `--to-version "abc" is not a valid migration version`.

## What each flag actually changes

- **`--to-version`** sets `MigrateUpOptions.TargetVersion`, which the migrator applies **inside** the migration lock where the plan is built. The pre-lock preview is filtered the same way and skips past an out-of-bound version rather than stopping at one, matching `migrationsToApply`, so preview and execution cannot disagree on a directory whose pending versions are not monotonic. A count computed before the lock would have been the silent failure here.
- **`--revisions-schema`** needed the capability, not just the spelling: the migration test runner had no way to move the revision table. `dbtest.Options.RevisionsSchema` now reaches `runner.newMigrator()`, and native `ptah migrations test --migrations-schema` exposes it.
- **`--qualifier`** carries into `buildGeneratedMigrationSpec`'s plan qualification, the same engine `migrate diff --qualifier` uses. A dialect that cannot qualify is refused rather than emitting an unqualified checkpoint.
- **`--lock-timeout`** bounds the advisory lock the replay already takes on the dev database (`Migrator.WithMigrationLockTimeout`). On a dialect with no advisory locking (SQLite, ClickHouse) it says so on stderr instead of accepting a bound that binds nothing — the same disclosure `schema apply` already makes.
- **`--schema`** maps onto the native `--schemas` allow-list. Its downstream effect is that flag's documented, PostgreSQL-family contract; what is new here is the mapping, and it needed a new mapping kind (below).
- **`--edit`** opens the written checkpoint files in `$VISUAL`, then `$EDITOR`, then refreshes the directory's integrity file — the edited bytes are the ones `atlas.sum` covers. Verified with the pinned community binary: after an edited checkpoint, `atlas migrate validate` exits 0 on the directory.

### Repeatable flags could have failed silently

`-s/--schema` is Atlas's only repeatable flag in this batch, and Ptah's `--schemas` holds one string. Forwarding each occurrence separately would have produced `--schemas=public --schemas=billing`, where the last value silently wins — the exact failure shape this issue flagged for `schema test -u`. `atlasargs.StringArrayFlag` collects occurrences and forwards one comma-joined value.

### `--edit` cannot hang

Both preconditions are checked before the replay, so a refusal costs nothing and leaves no checkpoint nobody could edit:

```
$ EDITOR= VISUAL= ptah-compat migrate checkpoint --dir file://m --dev-url sqlite://s.db --edit
Error: no editor configured: set $EDITOR or $VISUAL, or pass --editor          (exit 1, nothing written)

$ EDITOR=./ed.sh ptah-compat migrate checkpoint --dir file://m --dev-url sqlite://s.db --edit
Error: standard input is not a terminal, so an editor session cannot be opened;
       set PTAH_ALLOW_NONINTERACTIVE_EDIT=1 when the configured editor edits
       non-interactively                                                       (exit 1, nothing written)

$ EDITOR=./ed.sh PTAH_ALLOW_NONINTERACTIVE_EDIT=1 ptah-compat migrate checkpoint ... --edit
Wrote checkpoint version 20260803123027: migrations/20260803123027_checkpoint.sql   (edited, atlas.sum refreshed)
```

The terminal test is an ioctl, not an `os.ModeCharDevice` mode test. That distinction decides whether the guard works: /dev/null **is** a character device and is what CI hands a process as standard input, so a mode test calls the most common non-interactive environment interactive and lets an editor launch into it. The first draft did exactly that and the "no terminal" case silently succeeded; `github.com/mattn/go-isatty` (already in the module graph via modernc.org/sqlite) moves from indirect to direct for it.

The opt-out is a `PTAH_*` environment variable, not a flag, per this issue's standing constraint. Native `--editor` is deliberately not on the compat help surface: Atlas registers no editor-selection flag.

## Declined, with evidence

**`migrate status --allow-dirty`.** The source exists, but nothing on this verb would change. ptah-compat's `migrate status` refuses nothing — not a non-clean database, not a dirty revision row — so the flag would parse and do nothing, which this issue's constraint calls worse than absence. Measured on the pinned community binary, its `migrate status` does not refuse either, at any table count:

```
0 / 1 / 2 / 3 pre-existing tables, no revision table -> "Migration Status: PENDING", exit 0 in all four
dirty revision row                                   -> reports the partial apply, exit 0
```

There is one state where CE's status does refuse — revision table present, empty, and other objects in the database: `Error: sql/migrate: connected database is not clean: found multiple tables: 2. baseline version or allow-dirty is required`, exit 1. That refusal is what `--allow-dirty` would lift, and Ptah has no clean-check machinery at all (no `CheckClean` equivalent anywhere in the tree). Building a cross-dialect one is a default-behavior change with its own blast radius and belongs in its own issue; this batch would otherwise ship a flag with nothing to gate. Note the CE message names an escape CE itself does not register, which is consistent with the flag being Pro-only.

**`migrate checkpoint --format`.** Documented by Atlas, and its Go-template report needs the compat formatting path (`migrate down --format` shape: intercept the adapter, re-resolve atlas.hcl on a second code path). Wiring it as a native flag instead would collide with the native `--format` enum convention (`schema diff`, `sql`, `lint`, `drift`, `oci`, `viz` all use it for a format name). Adding the flag without either would be parse-and-ignore, so it is left off the declared surface and named in the docs as absent.

**`--lock-name`, every verb including checkpoint.** Owned by the named-lock family; not touched here.

## What each test prints if the change is reverted

Every one was checked by actually reverting the line and running it.

| Test | Reverted output |
| --- | --- |
| `MigrateApplyToVersionAppliesBoundedPrefix`, `...DryRunPreviews...`, `...Refusals` (4 rows) | `unknown flag: --to-version` — all six |
| `MigrateTestRevisionsSchema/with the flag...` (mapping removed) | fails: the case that must pass fails, `unknown flag: --revisions-schema` |
| `MigrateTestRevisionsSchema/with the flag...` (engine wiring removed, flag kept) | fails: `no such table: alt.schema_migrations` — the flag parses and does nothing, which is what the paired row exists to catch |
| `MigrateCheckpointEditRefusesWhatItCannotFinish` (2 rows) | fails: the run writes a checkpoint and exits 0 instead of refusing |
| `MigrateCheckpointLockTimeout/a valid value...` | fails: no note on stderr |
| `MigrateCheckpointQualifierReachesThePlan` | fails: the run succeeds, the qualifier never reaches plan qualification |
| `Map_RepeatableFlagJoinsEveryOccurrence` (4 of 7 rows) | fails: `--schemas=billing` instead of `--schemas=public,billing` — the silent-loss shape |

The `--revisions-schema` and `--qualifier` tests are paired with controls that hold the fixture fixed and remove only the flag, so a failure is attributable to the flag and not to the fixture.

## Gates

| Gate | Result |
| --- | --- |
| `go build ./...` | exit 0 |
| `go vet ./...` | exit 0 |
| `go test ./... -count=1` | exit 0, 0 FAIL lines |
| `golangci-lint run ./...` | `0 issues.` (`Map`'s cognitive complexity went 30 → 42 with the new branch; it was refactored into `mapOneArg`/`mapFlagOccurrence` rather than waived) |
| `scripts/check-test-style.sh` | `teststyle: OK (175 conditional groups, 45 white-box files)` |
| `scripts/check-public-api.sh` | exit 0 |
| `scripts/check-public-api-snapshot.sh` | exit 0 after `--update` (two additive struct fields: `dbtest.Options.RevisionsSchema`, `generator.CheckpointFromShadowOptions.MigrationLockTimeout`/`.SchemaQualifier`). It first reported RED — its exit code has to be read directly, since a trailing `| tail` reports the pipe's status and reads as green. |
| `node docs/site/scripts/check-style.mjs` | `OK (100 documentation files)` |
| `node docs/site/scripts/build-feature-matrix.mjs --check` | `OK (159 rows)` |

None skipped.

## Pinned behavior that changed

`TestCompatCommand_MigrateApplyRejectsNonAtlasFlags/to_version` asserted `--to-version` is refused on apply. It is deleted, with the reason recorded on the surviving test; `--lock-name` keeps its row. `TestCompatCommand_AdvertisesEssentialAtlasFlags` moves `--to-version` from apply's forbidden list to its flag list and gains the new checkpoint and test flags, plus `--editor` as forbidden.

Refs #951
