### PR TITLE
Prove the oci://repo:tag@sha256:D digest is enforced, not just parsed

### DIFF
--- a/cmd/atlas/migrate_hash_oci_dir_test.go
+++ b/cmd/atlas/migrate_hash_oci_dir_test.go
@@ -1,0 +1,69 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+const compatHashDigest = "sha256:" +
+	"c1eb0d4d1a1d6a48d5f3c6f2b7a9e0c4d8b2f6a1e3c5079b4d8e2a6c0f4b8d2e"
+
+// TestCompatMigrateHash_RefusesOCIDirAtTheURLGate guards the boundary
+// stokaro/ptah#1094 created. `atlas migrate hash` reuses the native
+// `ptah migrations hash` command, and that command now refuses an oci://
+// directory with a sentence about immutable artifacts. On the compatibility
+// surface the refusal must still come from the file:// URL gate instead, at
+// exit 1, because that is where every other compat verb refuses a remote
+// directory and it is the outcome the pinned community binary produces
+// (`unsupported driver "oci"`, exit 1, measured 2026-08-03 through
+// ptah-atlas-conformance/bin/atlas).
+//
+// Discriminator: if the native message ever reached this surface, the
+// qt.Not(qt.Contains) row below goes red rather than silently exporting native
+// wording into the compat namespace.
+func TestCompatMigrateHash_RefusesOCIDirAtTheURLGate(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{name: "tag and digest", dir: "oci://registry.example:5000/team/app:release@" + compatHashDigest},
+		{name: "bare digest", dir: "oci://registry.example:5000/team/app@" + compatHashDigest},
+		{name: "tag", dir: "oci://registry.example:5000/team/app:release"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, _, err := runCompat("migrate", "hash", "--dir", tt.dir)
+
+			c.Assert(err, qt.ErrorMatches,
+				`atlas migrate hash --dir: only local file:// migration directories are supported`)
+			c.Assert(err.Error(), qt.Not(qt.Contains), "an OCI artifact is immutable")
+		})
+	}
+}
+
+// TestCompatMigrateHash_LocalDirStillHashes is the non-interference control for
+// the rows above: a compat surface that refused every --dir would satisfy them
+// all. This one has to keep working, and it is the same call the rest of the
+// compat suite builds its fixtures with.
+func TestCompatMigrateHash_LocalDirStillHashes(t *testing.T) {
+	c := qt.New(t)
+	dir := filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o750), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "20240101000000_init.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+
+	_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir)
+
+	c.Assert(err, qt.IsNil)
+	_, statErr := os.Stat(filepath.Join(dir, "atlas.sum"))
+	c.Assert(statErr, qt.IsNil)
+}

--- a/cmd/migratehash/migratehash.go
+++ b/cmd/migratehash/migratehash.go
@@ -4,11 +4,13 @@ package migratehash
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/ociartifact"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -39,7 +41,31 @@ an already-committed migration.`,
 	return cmd
 }
 
+// refuseOCIDir refuses an oci:// migration directory by name.
+//
+// Every read verb resolves oci:// references, including the digest-pinned
+// oci://registry/repository:tag@sha256:D form (stokaro/ptah#1094). hash is the
+// one verb that cannot: it writes the integrity file into the directory it
+// hashed, and a registry artifact is immutable content addressed by its own
+// digest, so the result has nowhere to go. Falling through to os.Stat reported
+// "no such file or directory" for a reference that was never a path, which
+// reads as "this tool does not know oci://" rather than "this verb writes".
+func refuseOCIDir(dir string) error {
+	if !strings.HasPrefix(dir, ociartifact.Scheme) {
+		return nil
+	}
+	return fmt.Errorf(
+		"cannot hash %s: an OCI artifact is immutable, so there is nowhere to write the integrity "+
+			"file; hash the local migration directory instead and publish the result with "+
+			"'ptah migrations push'",
+		dir,
+	)
+}
+
 func runHash(cmd *cobra.Command, dir, dirFormatValue string) error {
+	if err := refuseOCIDir(dir); err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	if err := cmdutil.StatDir(dir); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/migratehash/oci_dir_refusal_test.go
+++ b/cmd/migratehash/oci_dir_refusal_test.go
@@ -3,7 +3,6 @@ package migratehash_test
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -92,7 +91,7 @@ func TestHash_OCIRefusalLeavesLocalDirectoriesAlone(t *testing.T) {
 
 			c.Assert(err, qt.IsNil, qt.Commentf("%s", stdout))
 			c.Assert(stdout, qt.Contains, "1 migration file(s) hashed")
-			c.Assert(strings.Contains(stdout, "immutable"), qt.IsFalse)
+			c.Assert(stdout, qt.Not(qt.Contains), "immutable")
 			result, err := migratesum.VerifyDir(dir)
 			c.Assert(err, qt.IsNil)
 			c.Assert(result.OK(), qt.IsTrue)

--- a/cmd/migratehash/oci_dir_refusal_test.go
+++ b/cmd/migratehash/oci_dir_refusal_test.go
@@ -1,0 +1,101 @@
+package migratehash_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/exitcode"
+	"go.5x5.cz/ptah/internal/migratesum"
+)
+
+const refusalDigest = "sha256:" +
+	"c1eb0d4d1a1d6a48d5f3c6f2b7a9e0c4d8b2f6a1e3c5079b4d8e2a6c0f4b8d2e"
+
+// TestHash_RefusesOCIDirectoryByName pins the fourth verb stokaro/ptah#1094
+// names. up, status and down resolve oci://registry/repository:tag@sha256:D by
+// its digest; hash cannot, because it writes the integrity file back into the
+// directory it hashed. Before this change every row below failed as
+// "stat oci://...: no such file or directory", which names a file that was
+// never a path and reads as "oci:// is not a thing here" -- the opposite of
+// what the other verbs do. The refusal must say the artifact is immutable and
+// point at the workflow that does work.
+func TestHash_RefusesOCIDirectoryByName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		dir  string
+	}{
+		{
+			name: "tag and digest",
+			dir:  "oci://registry.example:5000/team/app:release@" + refusalDigest,
+		},
+		{
+			name: "bare digest",
+			dir:  "oci://registry.example:5000/team/app@" + refusalDigest,
+		},
+		{
+			name: "tag",
+			dir:  "oci://registry.example:5000/team/app:release",
+		},
+		{
+			name: "no selector",
+			dir:  "oci://registry.example:5000/team/app",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stdout, err := execute("--dir", tt.dir)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Contains, "cannot hash "+tt.dir)
+			c.Assert(err.Error(), qt.Contains, "an OCI artifact is immutable")
+			c.Assert(err.Error(), qt.Contains, "ptah migrations push")
+			c.Assert(err.Error(), qt.Not(qt.Contains), "no such file or directory")
+			// Unchanged from the stat failure this replaces: the refusal is a
+			// clearer sentence, not a new outcome.
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stdout, qt.Not(qt.Contains), "hashed")
+		})
+	}
+}
+
+// TestHash_OCIRefusalLeavesLocalDirectoriesAlone is the non-interference
+// control. A guard that fired on every directory would still make every row of
+// the test above pass, so the refusal has to be measured against a path that
+// must still be hashed -- including one whose name merely contains "oci".
+func TestHash_OCIRefusalLeavesLocalDirectoriesAlone(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		base string
+	}{
+		{name: "ordinary directory", base: "migrations"},
+		{name: "directory named after the scheme", base: "oci"},
+		{name: "directory whose name embeds the scheme", base: "oci--registry.example"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dir := filepath.Join(c.TempDir(), tt.base)
+			c.Assert(os.MkdirAll(dir, 0o750), qt.IsNil)
+			c.Assert(os.WriteFile(filepath.Join(dir, "0000000001_init.up.sql"),
+				[]byte("CREATE TABLE t (id INT);\n"), 0o600), qt.IsNil)
+
+			stdout, err := execute("--dir", dir)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", stdout))
+			c.Assert(stdout, qt.Contains, "1 migration file(s) hashed")
+			c.Assert(strings.Contains(stdout, "immutable"), qt.IsFalse)
+			result, err := migratesum.VerifyDir(dir)
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.OK(), qt.IsTrue)
+		})
+	}
+}

--- a/cmd/migrateup/oci_digest_pin_internal_test.go
+++ b/cmd/migrateup/oci_digest_pin_internal_test.go
@@ -1,0 +1,242 @@
+package migrateup
+
+// White-box testing required: these tests reuse the in-process OCI registry
+// harness this package already builds for stokaro/ptah#944 (ociMemoryStore,
+// startOCITestRegistry, pushProvenanceArtifact, writeHashedProvenanceDir,
+// runUpInternal). No exported seam lets a test repoint a registry tag between
+// two resolutions of the same reference, and no exported seam lets a test serve
+// one manifest under another manifest's digest, which is the registry behavior
+// a digest pin exists to defend against (stokaro/ptah#1094).
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestMigrateUp_OCITagAndDigestResolvesByDigest is the fixture stokaro/ptah#1094
+// asks for. Both artifacts are pushed to the same :release tag, so the tag is
+// repointed after the digest was captured and the two candidate behaviors --
+// honor the digest, or quietly follow the tag -- create differently named
+// tables. The bare-tag row is the control: without it the digest rows would
+// pass even in a build that ignored the digest, because a tag that never moved
+// resolves to the pinned bytes anyway.
+func TestMigrateUp_OCITagAndDigestResolvesByDigest(t *testing.T) {
+	c := qt.New(t)
+	const repository = "ptah/pinned"
+	store := newOCIMemoryStore()
+	host := startOCITestRegistry(c, store, repository)
+	reviewed := pushProvenanceArtifact(c, store, writeHashedProvenanceDir(c, "reviewed"), "release")
+	swapped := pushProvenanceArtifact(c, store, writeHashedProvenanceDir(c, "swapped"), "release")
+	c.Assert(swapped, qt.Not(qt.Equals), reviewed,
+		qt.Commentf("the two artifacts must differ, or no row can tell the tag from the digest"))
+	base := "oci://" + host + "/" + repository
+
+	tests := []struct {
+		name        string
+		reference   string
+		wantTable   string
+		absentTable string
+		verify      func(c *qt.C, out string)
+	}{
+		{
+			name:        "bare tag follows the repoint",
+			reference:   base + ":release",
+			wantTable:   "swapped",
+			absentTable: "reviewed",
+			verify: func(c *qt.C, out string) {
+				c.Assert(out, qt.Contains, "is a movable tag")
+			},
+		},
+		{
+			name:        "tag and digest resolves by the digest",
+			reference:   base + ":release@" + reviewed,
+			wantTable:   "reviewed",
+			absentTable: "swapped",
+			verify: func(c *qt.C, out string) {
+				// #1094 definition of done: the readable pin counts as a digest
+				// reference for the #1093 warning, because a digest was pinned.
+				c.Assert(out, qt.Not(qt.Contains), "movable tag")
+				c.Assert(out, qt.Not(qt.Contains), "Warning:")
+			},
+		},
+		{
+			name:        "bare digest resolves the same bytes",
+			reference:   base + "@" + reviewed,
+			wantTable:   "reviewed",
+			absentTable: "swapped",
+			verify: func(c *qt.C, out string) {
+				c.Assert(out, qt.Not(qt.Contains), "Warning:")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			dbURL := "sqlite://" + filepath.Join(c.TempDir(), "pinned.db")
+
+			out, err := runUpInternal(
+				"--db-url", dbURL,
+				"--migrations-dir", tt.reference,
+				"--verify-sum",
+				"--plain-http",
+				"--skip-report",
+				"--verbose",
+			)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
+			c.Assert(out, qt.Contains, "ptah.sum verified: migrations directory is intact")
+			c.Assert(sqliteMigrateUpTableExists(c, dbURL, tt.wantTable), qt.IsTrue,
+				qt.Commentf("%s", out))
+			c.Assert(sqliteMigrateUpTableExists(c, dbURL, tt.absentTable), qt.IsFalse,
+				qt.Commentf("%s", out))
+			tt.verify(c, out)
+		})
+	}
+}
+
+// TestMigrateUp_OCIDigestNotInRegistryIsRefused pins that a digest this registry
+// never held fails instead of falling back to the tag written beside it. A
+// fallback would make the pin decoration: the reference would run whatever
+// :release points at today, which is the outcome #1093 warns about and #1094
+// asks operators to escape.
+func TestMigrateUp_OCIDigestNotInRegistryIsRefused(t *testing.T) {
+	c := qt.New(t)
+	const repository = "ptah/unserved"
+	store := newOCIMemoryStore()
+	host := startOCITestRegistry(c, store, repository)
+	pushProvenanceArtifact(c, store, writeHashedProvenanceDir(c, "swapped"), "release")
+	// Minted in a registry of its own: a well-formed artifact digest that the
+	// registry under test has never served.
+	elsewhere := pushProvenanceArtifact(c, newOCIMemoryStore(), writeHashedProvenanceDir(c, "reviewed"), "release")
+	dbURL := "sqlite://" + filepath.Join(c.TempDir(), "unserved.db")
+
+	out, err := runUpInternal(
+		"--db-url", dbURL,
+		"--migrations-dir", "oci://"+host+"/"+repository+":release@"+elsewhere,
+		"--verify-sum",
+		"--plain-http",
+		"--skip-report",
+		"--verbose",
+	)
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf("%s", out))
+	c.Assert(err.Error(), qt.Contains, elsewhere,
+		qt.Commentf("the refusal must name the digest that was asked for"))
+	c.Assert(err.Error(), qt.Contains, "not found")
+	c.Assert(sqliteMigrateUpTableExists(c, dbURL, "swapped"), qt.IsFalse,
+		qt.Commentf("the tag must not stand in for the digest: %s", out))
+	c.Assert(sqliteMigrateUpTableExists(c, dbURL, "reviewed"), qt.IsFalse)
+}
+
+// TestMigrateUp_OCISubstitutedManifestIsRefused answers the question a parse
+// test cannot: is the digest enforced, or merely carried? This registry answers
+// every manifest request with the bytes :release resolves to, whatever digest
+// the client asked for -- a compromised or simply wrong registry. Both rows must
+// refuse before any DDL runs; the second row also lies in the
+// Docker-Content-Digest header, so only hashing the body catches it.
+func TestMigrateUp_OCISubstitutedManifestIsRefused(t *testing.T) {
+	c := qt.New(t)
+	const repository = "ptah/substituted"
+
+	tests := []struct {
+		name   string
+		header func(served, requested string) string
+	}{
+		{
+			name:   "registry advertises the bytes it actually served",
+			header: func(served, _ string) string { return served },
+		},
+		{
+			name:   "registry echoes the digest that was asked for",
+			header: func(_, requested string) string { return requested },
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			store := newOCIMemoryStore()
+			host := startSubstitutingOCITestRegistry(c, store, repository, tt.header)
+			pushProvenanceArtifact(c, store, writeHashedProvenanceDir(c, "swapped"), "release")
+			reviewed := pushProvenanceArtifact(
+				c,
+				newOCIMemoryStore(),
+				writeHashedProvenanceDir(c, "reviewed"),
+				"release",
+			)
+			dbURL := "sqlite://" + filepath.Join(c.TempDir(), "substituted.db")
+
+			out, err := runUpInternal(
+				"--db-url", dbURL,
+				"--migrations-dir", "oci://"+host+"/"+repository+":release@"+reviewed,
+				"--verify-sum",
+				"--plain-http",
+				"--skip-report",
+				"--verbose",
+			)
+
+			c.Assert(err, qt.IsNotNil, qt.Commentf("%s", out))
+			c.Assert(err.Error(), qt.Contains, "mismatch",
+				qt.Commentf("the refusal must be a digest mismatch, not an unrelated failure"))
+			c.Assert(sqliteMigrateUpTableExists(c, dbURL, "swapped"), qt.IsFalse,
+				qt.Commentf("substituted bytes must never reach the database: %s", out))
+			c.Assert(sqliteMigrateUpTableExists(c, dbURL, "reviewed"), qt.IsFalse)
+		})
+	}
+}
+
+// serveSubstitutedManifest answers every manifest request with the bytes tag
+// currently resolves to, ignoring the digest in the request path. header picks
+// the digest the response advertises, so a registry that lies only in the body
+// and a registry that also lies in the header are both measurable.
+func (s *ociMemoryStore) serveSubstitutedManifest(
+	tag string,
+	header func(served, requested string) string,
+) http.HandlerFunc {
+	return func(writer http.ResponseWriter, request *http.Request) {
+		descriptor, err := s.Resolve(request.Context(), tag)
+		if err != nil {
+			http.Error(writer, "manifest unknown", http.StatusNotFound)
+			return
+		}
+		s.mu.Lock()
+		blob := s.blobs[descriptor.Digest]
+		s.mu.Unlock()
+		writer.Header().Set("Content-Type", descriptor.MediaType)
+		writer.Header().Set(
+			"Docker-Content-Digest",
+			header(descriptor.Digest.String(), request.PathValue("reference")),
+		)
+		writer.Header().Set("Content-Length", strconv.Itoa(len(blob.data)))
+		writer.WriteHeader(http.StatusOK)
+		_, _ = writer.Write(blob.data)
+	}
+}
+
+// startSubstitutingOCITestRegistry serves store over the read half of the OCI
+// distribution API with the substituting manifest handler in place. Blobs are
+// served honestly, so a refusal can only come from the manifest the pin names.
+func startSubstitutingOCITestRegistry(
+	c *qt.C,
+	store *ociMemoryStore,
+	repository string,
+	header func(served, requested string) string,
+) string {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/v2/", func(writer http.ResponseWriter, _ *http.Request) {
+		writer.WriteHeader(http.StatusOK)
+	})
+	mux.HandleFunc(
+		"/v2/"+repository+"/manifests/{reference}",
+		store.serveSubstitutedManifest("release", header),
+	)
+	mux.HandleFunc("/v2/"+repository+"/blobs/{digest}", store.serveBlob)
+	server := httptest.NewServer(mux)
+	c.Cleanup(server.Close)
+	return strings.TrimPrefix(server.URL, "http://")
+}

--- a/docs/oci_registry.md
+++ b/docs/oci_registry.md
@@ -38,6 +38,7 @@ Ptah accepts these forms:
 oci://registry.example/team/repository
 oci://registry.example/team/repository:tag
 oci://registry.example/team/repository@sha256:<64-lowercase-hex-characters>
+oci://registry.example/team/repository:tag@sha256:<64-lowercase-hex-characters>
 ```
 
 An unqualified reference resolves to `:latest`:
@@ -69,6 +70,18 @@ client when the two disagree. The tag is carried for readability and is echoed
 back in the canonical form; it never selects content and never softens the pin.
 Because the reference is digest-pinned, pushing to it is rejected exactly as
 pushing to a bare `@sha256:` reference.
+
+The pin is enforced, not merely recorded. Ptah asks the registry for the
+manifest by digest and verifies the bytes it receives against that digest
+before anything is read out of the artifact, so a repointed tag cannot smuggle
+other content in behind a reference that names one. A digest the registry does
+not serve fails; it never falls back to the tag written beside it.
+
+`migrations up`, `migrations status`, `migrations down`, `migrations pull`, and
+`lint` accept every form above. `migrations hash` does not accept any `oci://`
+reference: it writes the integrity file back into the directory it hashed, and
+a registry artifact is immutable content addressed by its own digest. Hash the
+local directory and publish the result.
 
 A sum file carries different weight depending on which of those you applied. A
 sum verifies a directory against the sum stored beside it; for an OCI artifact

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -246,6 +246,20 @@ prints that qualification, along with the digest the tag resolved to and the
 reference that pins it, whenever a sum verifies over a tag-resolved artifact.
 The run still succeeds; a digest reference gets no such line.
 
+To keep the readable name and the pin together, write both:
+
+```bash
+ptah migrations up \
+  --db-url "$DATABASE_URL" \
+  --migrations-dir oci://ghcr.io/acme/app-migrations:release@sha256:<digest> \
+  --verify-sum
+```
+
+The digest selects the bytes and is verified against what the registry returns;
+the tag is a label. Repointing `:release` afterwards changes nothing about what
+this command runs, and this reference counts as a digest pin, so it gets no
+movable-tag qualification.
+
 See [OCI registry artifacts](../../operate/oci-registry/) for
 authentication, tag and digest semantics, referrer reports, and CI wiring.
 

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -122,7 +122,9 @@ pin these exact bytes.
 ```
 
 The run still succeeds — the check did what it claims. A digest reference and
-a local directory produce no such line.
+a local directory produce no such line, and
+`oci://ghcr.io/acme/app-migrations:release@sha256:<digest>` is a digest
+reference: the digest selects and is verified, the tag is only a label.
 
 **`ptah-compat migrate apply`, `migrate status` and `migrate set` refuse an
 unhashed directory.** Atlas treats a missing `atlas.sum` as a checksum error, so


### PR DESCRIPTION
Closes #1094.

## What I found before changing anything

I re-ran the issue's reproduction on `master` at `979a92c4`. **The headline
refusal no longer reproduces.** The `a reference cannot contain both a tag and
a digest` restriction was dropped by #1093, which landed nine minutes after
this issue was filed.

Before (on unmodified `979a92c4`, built from this worktree):

```
$ ptah migrations up --db-url sqlite://a.db \
    --migrations-dir oci://localhost:15944/ptah/m944:release@sha256:ea…aa \
    --plain-http --skip-report
error: resolve migrations artifact: pull oci://localhost:15944/ptah/m944:release@sha256:ea…aa:
  fetch OCI manifest: Get "http://localhost:15944/v2/ptah/m944/manifests/sha256:ea…aa":
  dial tcp [::1]:15944: connect: connection refused
[exit 2]
```

The reference parses and the request goes to `…/manifests/sha256:ea…aa` — by
digest, never by the tag. `status`, `down` and `pull` behave identically.
`push` still exits 2 with `cannot push to a digest reference` for both
`@sha256:` and `:tag@sha256:`, and `mutableTagSumWarning` already keys on
`PinnedByDigest`, so the readable pin gets no movable-tag warning.

Both probe controls behaved: a bare `@sha256:` reference answered present the
same way, and `--frobnicate-nonsense` answered `unknown flag`, exit 2.

So three of the four definition-of-done bullets were already met. **What was
missing is the fourth, and it is the one the issue calls the point of the whole
area:** nothing proved the digest *decides*. Every existing fixture is either a
`ParseRef` assertion or a pre-network push refusal, and a parse assertion passes
whether the implementation honors the digest or silently follows the tag written
beside it.

## After

Same command, unchanged — the acceptance was never the problem. What changed is
that the enforcement is now measured, and the fourth verb the issue names now
refuses honestly:

```
$ ptah migrations hash --dir oci://localhost:15944/ptah/m944:release@sha256:ea…aa
error: cannot hash oci://localhost:15944/ptah/m944:release@sha256:ea…aa: an OCI
  artifact is immutable, so there is nowhere to write the integrity file; hash the
  local migration directory instead and publish the result with 'ptah migrations push'
[exit 2]

$ ptah migrations hash --dir ./mdir          # control
Wrote ./mdir/ptah.sum
2 migration file(s) hashed
[exit 0]
```

Previously that first command said `stat oci://…: no such file or directory` —
naming a file that was never a path, and reading as "this tool does not know
`oci://`", which is the opposite of what every read verb does. Exit status is
unchanged at 2; only the sentence is.

## The fixture the issue asks for

`cmd/migrateup/oci_digest_pin_internal_test.go` pushes **two different** migration
directories to the **same `:release` tag** through the in-process OCI registry this
package already builds for #944, so the tag is repointed after the digest was
captured. The two candidate behaviors then create differently named tables:

| row | reference | asserts |
|---|---|---|
| bare tag follows the repoint | `…:release` | creates `swapped`; **control** |
| tag and digest resolves by the digest | `…:release@<reviewed>` | creates `reviewed`, no `Warning:` |
| bare digest agrees | `…@<reviewed>` | creates `reviewed` |
| unserved digest | `…:release@<minted elsewhere>` | refused, no table, no tag fallback |
| substituting registry ×2 | `…:release@<reviewed>` | refused before any DDL |

The **bare-tag row is load-bearing**: without it the digest rows would pass even
in a build that ignored the digest entirely, because a tag that never moved
resolves to the pinned bytes anyway.

The last two rows are the supply-chain control the issue is actually about. That
registry answers *every* manifest request with whatever `:release` points at,
which is what a compromised or simply wrong registry does. One row advertises the
digest it really served (caught by the descriptor comparison); the other echoes
back the digest that was asked for, so only hashing the response body catches it.

## What each test prints if the change is reverted

Measured, not asserted from reading:

- **Mutant: `Client.Pull` selects `ref.Tag()` when a tag is present** (the silent
  follow-the-tag defect). `tag and digest resolves by the digest` fails with
  `Applying migration … description="Create Swapped"` and exit 0 — the pinned
  reference runs the swapped bytes. `…DigestNotInRegistryIsRefused` fails with
  `got nil value but want non-nil` and applies `Create Swapped`. Both
  substituting-registry rows fail the same way. The bare-tag and bare-digest
  control rows stay green, which is correct.
- **Mutant: drop `PinnedByDigest` from `mutableTagSumWarning`.** Both digest rows
  fail on `"Warning:"` while still applying `Create Reviewed` — the resolution was
  right, only the qualification was wrong.
- **Revert the `hash` guard.** All four rows of
  `TestHash_RefusesOCIDirectoryByName` fail with
  `migrations directory oci://…: stat oci://…: no such file or directory`.
- **Inverse mutant: make the `hash` guard fire unconditionally.** This is the one
  that validates the non-interference control, because removing a guard can never
  make it fire. `TestHash_OCIRefusalLeavesLocalDirectoriesAlone` goes red on all
  three rows (including the directories literally named `oci` and
  `oci--registry.example`), and so do `TestHash_WritesSumFileForMigrations`,
  `TestHash_AtlasFormatWritesAtlasSum` and five `cmd/atlas` compat tests.
- **`TestCompatMigrateHash_RefusesOCIDirAtTheURLGate`** fails if the native
  wording ever reaches the compatibility surface.

## Parity

Nothing is loosened relative to the pinned community build. Measured 2026-08-03
through `ptah-atlas-conformance/bin/atlas`, by absolute path:

| command | ptah-compat | pinned community build |
|---|---|---|
| `migrate hash --dir oci://…:tag@sha256:D` | `only local file:// migration directories are supported`, exit 1 | `unsupported driver "oci"`, exit 1 |
| `migrate hash --dir file://<dir>` | exit 0 | exit 0 |
| `migrate hash --frobnicate-nonsense` | `unknown flag`, exit 1 | `unknown flag`, exit 1 |

`atlas migrate hash --dir` converts a `file://` URL to a local path and rejects
remote directories *before* the native command runs, so the new refusal is
unreachable from that surface. `oci://` is native-Ptah-only territory.
`cmd/atlas/migrate_hash_oci_dir_test.go` pins both halves of that, with a
local-directory row as its own non-interference control.

## The choice the issue offered

The issue lists `hash` alongside `up`, `status` and `down` as verbs that must
resolve `oci://repo:tag@sha256:D`. **I made `hash` refuse instead.** `migrations
hash` writes the integrity file back into the directory it hashed; a registry
artifact is immutable content addressed by its own digest, so there is nowhere
for the result to go. Making it appear to succeed while writing nowhere would be
strictly worse than the confusing `stat` error it replaces. The refusal names the
reason and points at the workflow that does work.

## Deliberately left open

- **`migrations validate` has the same shape and I did not touch it.** It refuses
  `oci://` with the same misleading stat error, but unlike `hash` it is read-only,
  so it *could* legitimately resolve an artifact and verify the sum inside it.
  That is a feature, not a message fix, and it deserves its own issue rather than
  being smuggled in here.
- **`migrationsource.OCI.Tag` is populated and never read** outside tests. It is a
  dead field today; #1093 added it for the warning, which ended up keying on
  `PinnedByDigest` instead. Removing it would be a public-shape change unrelated
  to this issue.
- **No live-registry integration coverage was added.** `integration/oci_registry_e2e_test.go`
  gained the tamper/repoint sequence in #1093; the repointed-tag-versus-digest and
  hostile-registry rows here live in the in-process harness, which needs no
  container and runs in the default `go test ./...`.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `golangci-lint run ./...`
(0 issues), `scripts/check-test-style.sh` (OK, 175 conditional groups, 45 white-box
files), `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all
green, all first time.

`docs/` is touched, so every script `docs/site/package.json` defines was run, not
just the obvious ones: `check:exit-codes` (60 rows) and its selftest,
`check:core-doc-links` (7 protected references), `check:page-health` (59 sidebar
entries), `check:links` (60 pages / 564 anchors) and its selftest,
`check:redirects` (30) and its selftest, `check:style` (100 files) and its
selftest, `versions:selftest`, and `check:responsive`. The last one needed
`npm ci`, an Astro build and Playwright's chromium to run at all — with those in
place it reports `OK (60 routes x 2 viewports, cells within 8 lines)`, and its
selftest confirms the overflow, wide-table, tall-cell and unstyled-page guards
actually fire. That mattered here: this PR adds a long inline
`oci://…:release@sha256:<digest>` code span to a paragraph in
`integrity-and-safety.md`, which is exactly the unbreakable-token shape that
overflows a 390px viewport.