### PR TITLE
Reduce Atlas HCL sql() to its SQL instead of rendering the call

### DIFF
--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -58,6 +58,13 @@ func Parse(data []byte, filename string) (*goschema.Database, error) {
 	if err := classifyProjectFile(body, filename); err != nil {
 		return nil, err
 	}
+	// Refuse malformed sql() calls before the body walk, not during it. Every
+	// value helper below falls back to an attribute's source text when the
+	// expression will not evaluate, so a call this guard let through would be
+	// rendered into DDL verbatim -- issue #1106.
+	if err := p.rejectMalformedSQLRawExprs(body); err != nil {
+		return nil, err
+	}
 	if err := p.parseBody(body); err != nil {
 		return nil, err
 	}
@@ -1468,6 +1475,9 @@ func (p *parser) optionalRefName(attr *hclsyntax.Attribute) string {
 	if attr == nil {
 		return ""
 	}
+	if value, ok := p.sqlRawExprValue(attr.Expr); ok {
+		return value
+	}
 	return refName(p.rawExpr(attr))
 }
 
@@ -1542,6 +1552,9 @@ func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {
 	if attr == nil {
 		return ""
 	}
+	if value, ok := p.sqlRawExprValue(attr.Expr); ok {
+		return value
+	}
 	return p.rawExpr(attr)
 }
 
@@ -1555,19 +1568,26 @@ func (p *parser) optionalSQLExpression(attr *hclsyntax.Attribute) string {
 	return p.exprString(attr)
 }
 
+// sqlExpression reports whether the attribute is Atlas's sql() raw expression,
+// and reduces it to the SQL it carries. Callers that branch on ok distinguish a
+// SQL expression from a literal value -- a column default, for instance.
+//
+// The match is structural, on the parsed call. It used to be textual, on the
+// attribute's source: a `sql(` prefix and a `)` suffix. That accepted anything
+// those two bytes bracketed, so `default = sql("1") + sql("2")` was read as the
+// SQL text `"1") + sql("2` and planned as `DEFAULT "1") + sql("2"`.
 func (p *parser) sqlExpression(attr *hclsyntax.Attribute) (string, bool) {
-	raw := p.rawExpr(attr)
-	if value, ok := strings.CutPrefix(raw, "sql("); ok && strings.HasSuffix(value, ")") {
-		value = strings.TrimSuffix(value, ")")
-		if unquoted, err := strconv.Unquote(value); err == nil {
-			return unquoted, true
-		}
-		return value, true
-	}
-	return "", false
+	return p.sqlRawExprValue(attr.Expr)
 }
 
 func (p *parser) exprString(attr *hclsyntax.Attribute) string {
+	// sql() lands here from every attribute Ptah reads as a plain string, which
+	// is most of the grammar. Reduce it: the fallback below hands the
+	// attribute's SOURCE TEXT to the renderer, and that is what put
+	// `CHECK (sql("n > 0"))` into a plan -- issue #1106.
+	if value, ok := p.sqlRawExprValue(attr.Expr); ok {
+		return value
+	}
 	value, diags := attr.Expr.Value(nil)
 	if !diags.HasErrors() && value.Type() == cty.String {
 		return value.AsString()

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -91,7 +91,11 @@ func (p *parser) parseFunctionArgs(block *hclsyntax.Block) ([]string, error) {
 		if len(nested.Labels) != 1 {
 			return nil, p.blockError(nested, "function arg requires exactly one name label")
 		}
-		args = append(args, nested.Labels[0]+" "+p.rawExpr(typeAttr))
+		// optionalRawExpr, not rawExpr: an argument type is written as a bare
+		// keyword (`type = bigint`) so it has no string value to evaluate, but
+		// it can also be written with Atlas's sql() escape hatch, and the raw
+		// source of that call is not a type -- issue #1106.
+		args = append(args, nested.Labels[0]+" "+p.optionalRawExpr(typeAttr))
 	}
 	return args, nil
 }

--- a/internal/atlashcl/sqlrawexpr.go
+++ b/internal/atlashcl/sqlrawexpr.go
@@ -1,0 +1,196 @@
+package atlashcl
+
+import (
+	"fmt"
+	"slices"
+	"strconv"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// sqlFuncName is Atlas HCL's raw-expression escape hatch. `sql("X")` marks X as
+// SQL text that is handed to the engine unchanged.
+const sqlFuncName = "sql"
+
+// Ptah reduces `sql("X")` to X in every position it reads a value from, instead
+// of refusing the call the way the pinned Atlas community binary v1.3.0 does in
+// the positions Atlas declares as plain strings. Issue #1106 offered both
+// answers; this is the reasoning for the one taken, and both sides were
+// measured against that binary before choosing.
+//
+// Refusing cannot be applied uniformly. The community binary ACCEPTS sql() in
+// several of the same positions Ptah leaked it from -- `type = sql("varchar(10)")`
+// plans as `varchar`, and files whose view.as, materialized.as or composite
+// field type carry a sql() call are planned without complaint. A blanket
+// refusal would make ptah-compat exit 1 on files that binary plans fine, which
+// is a drop-in break in the direction that costs a user their working schema.
+// Refusing only where that binary refuses means carrying a hand-copied table of
+// Atlas's per-attribute hclspec types, re-measured attribute by attribute, and
+// a wrong row in that table breaks drop-in silently.
+//
+// Reducing cannot smuggle anything past the renderer. `sql("X")` reduces to the
+// string X, which is exactly the value the literal spelling `= "X"` already
+// produces in the same position -- a spelling Ptah and that binary both accept
+// today. After the reduction the two spellings are indistinguishable everywhere
+// downstream, so the renderer is handed nothing it could not already be handed.
+//
+// What the choice costs: ptah-compat still exits 0 for check.expr and
+// index.where where that binary exits 1. That is the same richer-surface
+// direction this project already takes for the sequence, function, domain,
+// policy and trigger blocks. The defect issue #1106 named is the DDL -- a plan
+// that reports success and cannot run -- and the DDL is valid again.
+// rejectMalformedSQLRawExprs is what keeps the remaining looseness honest: no
+// spelling of sql() reaches the renderer unreduced, valid or not.
+
+// sqlRawExprValue reduces a sql() call to the SQL text it carries.
+//
+// ok is false when expr is not a sql() call at all, and also for a call that
+// cannot be reduced -- but no parse path can observe the second case, because
+// rejectMalformedSQLRawExprs refuses the whole file first.
+func (p *parser) sqlRawExprValue(expr hclsyntax.Expression) (string, bool) {
+	call, ok := expr.(*hclsyntax.FunctionCallExpr)
+	if !ok || call.Name != sqlFuncName {
+		return "", false
+	}
+	value, err := p.sqlCallText(call)
+	if err != nil {
+		return "", false
+	}
+	return value, true
+}
+
+// sqlCallText returns the SQL text a sql() call carries, or the reason the call
+// cannot be reduced to text.
+func (p *parser) sqlCallText(call *hclsyntax.FunctionCallExpr) (string, error) {
+	if call.ExpandFinal {
+		return "", fmt.Errorf("sql() does not take an expanded argument list")
+	}
+	if len(call.Args) != 1 {
+		return "", fmt.Errorf("sql() takes exactly one string argument, got %d", len(call.Args))
+	}
+
+	arg := call.Args[0]
+	value, diags := arg.Value(nil)
+	if !diags.HasErrors() && value.IsKnown() && !value.IsNull() && value.Type() == cty.String {
+		return value.AsString(), nil
+	}
+
+	// A quoted string Ptah cannot evaluate is a string carrying an
+	// interpolation, and Ptah has no schema-file variable evaluation yet
+	// (issue #926). Handing back the template source keeps that gap exactly
+	// where it already is -- `default = "${var.x}"` renders its own source text
+	// today -- instead of turning #926 into a refusal in this one spot.
+	//
+	// The distinction is not cosmetic: measured against the pinned community
+	// binary, `default = sql("${var.floor} + 1")` is planned successfully, so
+	// refusing it here would be a NEW stricter break on a file that binary
+	// supports. The DDL Ptah renders for it stays wrong until #926 lands, but
+	// it no longer carries the literal token sql( into the plan.
+	if _, ok := arg.(*hclsyntax.TemplateExpr); ok {
+		return unquotedSource(p.rawExprNode(arg)), nil
+	}
+
+	return "", fmt.Errorf("sql() takes a string argument")
+}
+
+// unquotedSource strips the quoting from an expression's source text. A heredoc
+// is not quoted that way and is returned unchanged.
+func unquotedSource(raw string) string {
+	if unquoted, err := strconv.Unquote(raw); err == nil {
+		return unquoted
+	}
+	return raw
+}
+
+// sqlRawExprRefusal is one malformed sql() call and why it was refused.
+type sqlRawExprRefusal struct {
+	rng      hcl.Range
+	attrName string
+	reason   string
+}
+
+// rejectMalformedSQLRawExprs refuses every sql() call in the file that Ptah
+// cannot reduce to SQL text, before the body walk can put one in front of the
+// renderer.
+//
+// This is the half of the #1106 decision that keeps reducing sql() honest.
+// Every value helper in this package falls back to the attribute's SOURCE TEXT
+// when an expression will not evaluate, which is how `CHECK (sql("n > 0"))`
+// reached a plan in the first place. The same fallback is worse for a call that
+// is only part of an expression: `default = sql("1") + sql("2")` planned as
+// `DEFAULT "1") + sql("2"` before this guard existed.
+//
+// Two shapes are refused:
+//
+//   - a sql() call Ptah cannot reduce: wrong arity, an expanded argument list,
+//     or an argument that is not a string
+//   - a sql() call that is not the whole attribute value
+//
+// The pinned Atlas community binary v1.3.0 refuses every one of these too, so
+// the guard opens no position where ptah-compat is stricter than that binary.
+func (p *parser) rejectMalformedSQLRawExprs(body *hclsyntax.Body) error {
+	var refusals []sqlRawExprRefusal
+	p.collectSQLRawExprRefusals(body, &refusals)
+	if len(refusals) == 0 {
+		return nil
+	}
+	// Attributes hang off a map, so report the one that comes first in the
+	// file rather than whichever the map iteration reached first.
+	first := slices.MinFunc(refusals, func(a, b sqlRawExprRefusal) int {
+		return a.rng.Start.Byte - b.rng.Start.Byte
+	})
+	return fmt.Errorf(
+		"parse HCL schema at %s: attribute %q: %s",
+		first.rng.String(), first.attrName, first.reason,
+	)
+}
+
+func (p *parser) collectSQLRawExprRefusals(body *hclsyntax.Body, out *[]sqlRawExprRefusal) {
+	for _, attr := range body.Attributes {
+		p.collectAttrSQLRawExprRefusals(attr, out)
+	}
+	for _, block := range body.Blocks {
+		p.collectSQLRawExprRefusals(block.Body, out)
+	}
+}
+
+func (p *parser) collectAttrSQLRawExprRefusals(attr *hclsyntax.Attribute, out *[]sqlRawExprRefusal) {
+	if call, ok := attr.Expr.(*hclsyntax.FunctionCallExpr); ok && call.Name == sqlFuncName {
+		if _, err := p.sqlCallText(call); err != nil {
+			*out = append(*out, sqlRawExprRefusal{rng: call.Range(), attrName: attr.Name, reason: err.Error()})
+		}
+		// A nested sql() inside a call Ptah already refused is the same
+		// mistake reported twice; the outer refusal names the position.
+		return
+	}
+	for _, call := range nestedSQLCalls(attr.Expr) {
+		*out = append(*out, sqlRawExprRefusal{
+			rng:      call.Range(),
+			attrName: attr.Name,
+			reason:   "sql() must be the whole attribute value, not part of a larger expression",
+		})
+	}
+}
+
+// nestedSQLCalls returns every sql() call inside expr. Callers reach it only
+// when expr itself is not a sql() call, so everything it finds is nested.
+func nestedSQLCalls(expr hclsyntax.Expression) []*hclsyntax.FunctionCallExpr {
+	var collector sqlCallCollector
+	hclsyntax.Walk(expr, &collector) //nolint:errcheck // the walker never reports diagnostics
+	return collector.calls
+}
+
+type sqlCallCollector struct {
+	calls []*hclsyntax.FunctionCallExpr
+}
+
+func (c *sqlCallCollector) Enter(node hclsyntax.Node) hcl.Diagnostics {
+	if call, ok := node.(*hclsyntax.FunctionCallExpr); ok && call.Name == sqlFuncName {
+		c.calls = append(c.calls, call)
+	}
+	return nil
+}
+
+func (c *sqlCallCollector) Exit(hclsyntax.Node) hcl.Diagnostics { return nil }

--- a/internal/atlashcl/sqlrawexpr_test.go
+++ b/internal/atlashcl/sqlrawexpr_test.go
@@ -1,0 +1,505 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// Atlas's sql("X") escape hatch must reach the IR as X. Before issue #1106 the
+// value helpers fell back to the attribute's SOURCE TEXT for every position the
+// grammar reads as a plain string, so the IR carried the literal `sql("X")` and
+// the renderer emitted DDL no engine accepts -- `CHECK (sql("n > 0"))`.
+//
+// Reverted, every row below fails on the same shape: the field holds
+// `sql("...")` where the row asserts the SQL inside it.
+func TestParseReducesSQLRawExpressionToItsSQL(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		hcl    string
+		assert func(c *qt.C, db *goschema.Database)
+	}{
+		{
+			name: "table check expr",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "n_positive" { expr = sql("n > 0") }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Constraints, qt.HasLen, 1)
+				c.Assert(db.Constraints[0].CheckExpression, qt.Equals, "n > 0")
+			},
+		},
+		{
+			name: "index where",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    columns = [column.n]
+    where   = sql("n > 5")
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Condition, qt.Equals, "n > 5")
+			},
+		},
+		{
+			name: "index part expr",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { expr = sql("n + 1") }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts[0].Expr, qt.Equals, "n + 1")
+			},
+		},
+		{
+			name: "index part prefix",
+			hcl: `
+table "t" {
+  column "n" { type = text }
+  index "idx_n" {
+    on {
+      column = column.n
+      prefix = sql("4")
+    }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts[0].Prefix, qt.Equals, "4")
+			},
+		},
+		{
+			name: "index comment",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    columns = [column.n]
+    comment = sql("hello")
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Comment, qt.Equals, "hello")
+			},
+		},
+		{
+			name: "generated column as attribute",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  column "g" {
+    type = int
+    as   = sql("n * 2")
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 2)
+				c.Assert(db.Fields[1].GeneratedExpression, qt.Equals, "n * 2")
+			},
+		},
+		{
+			name: "generated column as block expr",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  column "g" {
+    type = int
+    as {
+      expr = sql("n * 2")
+      type = VIRTUAL
+    }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 2)
+				c.Assert(db.Fields[1].GeneratedExpression, qt.Equals, "n * 2")
+			},
+		},
+		{
+			name: "column type",
+			hcl: `
+table "t" {
+  column "n" { type = sql("varchar(10)") }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 1)
+				c.Assert(db.Fields[0].Type, qt.Equals, "varchar(10)")
+			},
+		},
+		{
+			name: "column comment",
+			hcl: `
+table "t" {
+  column "n" {
+    type    = int
+    comment = sql("hello")
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 1)
+				c.Assert(db.Fields[0].Comment, qt.Equals, "hello")
+			},
+		},
+		{
+			name: "table comment",
+			hcl: `
+table "t" {
+  comment = sql("hello")
+  column "n" { type = int }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].Comment, qt.Equals, "hello")
+			},
+		},
+		{
+			name: "view body",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+}
+view "v" {
+  as = sql("SELECT n FROM t")
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Views, qt.HasLen, 1)
+				c.Assert(db.Views[0].Body, qt.Equals, "SELECT n FROM t")
+			},
+		},
+		{
+			name: "function body",
+			hcl: `
+function "f" {
+  lang   = SQL
+  return = sql("text")
+  as     = sql("SELECT 'x'")
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Functions, qt.HasLen, 1)
+				c.Assert(db.Functions[0].Body, qt.Equals, "SELECT 'x'")
+				c.Assert(db.Functions[0].Returns, qt.Equals, "text")
+			},
+		},
+		{
+			name: "column default keeps its expression role",
+			hcl: `
+table "t" {
+  column "n" {
+    type    = int
+    default = sql("now()")
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 1)
+				// A sql() default is an EXPRESSION, not a literal. The
+				// structural match has to keep that branch alive: a default
+				// landing in Default instead would be rendered quoted.
+				c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "now()")
+				c.Assert(db.Fields[0].Default, qt.Equals, "")
+			},
+		},
+		{
+			// The call is matched on the parsed expression, not on the source
+			// text. The textual match this replaced looked for a `sql(` prefix
+			// and a `)` suffix and unquoted whatever sat between them, so a
+			// single space inside the parentheses defeated the unquoting and
+			// the DEFAULT reached the renderer as ` "now()" ` -- quotes,
+			// padding and all.
+			name: "argument padded inside the parentheses",
+			hcl: `
+table "t" {
+  column "n" {
+    type    = int
+    default = sql( "now()" )
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 1)
+				c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "now()")
+			},
+		},
+		{
+			name: "function argument type",
+			hcl: `
+function "f" {
+  arg "user_id" { type = sql("bigint") }
+  lang   = SQL
+  return = text
+  as     = "SELECT 'x'"
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Functions, qt.HasLen, 1)
+				c.Assert(db.Functions[0].Parameters, qt.Equals, "user_id bigint")
+			},
+		},
+		{
+			// Reference-shaped attributes read the attribute's source text by
+			// design -- `schema = schema.app` has no string value to evaluate.
+			// That path has to reduce sql() too, or the schema name becomes the
+			// literal `sql("app")` and every qualified identifier built from it
+			// is unusable.
+			name: "table schema reference",
+			hcl: `
+table "t" {
+  schema = sql("app")
+  column "n" { type = int }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].Schema, qt.Equals, "app")
+			},
+		},
+		{
+			// A heredoc is a string to HCL and to the community binary, and it
+			// carries no quotes for a textual match to strip.
+			name: "heredoc argument",
+			hcl: `
+table "t" {
+  column "n" {
+    type    = int
+    default = sql(<<-SQL
+now()
+SQL
+    )
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields, qt.HasLen, 1)
+				c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "now()\n")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			test.assert(c, db)
+		})
+	}
+}
+
+// A sql() call Ptah cannot reduce to SQL text is refused outright rather than
+// rendered from its source. This is the guard that keeps the #1106 decision
+// honest: reducing sql() is only safe if no other sql() spelling can reach the
+// renderer. The pinned Atlas community binary v1.3.0 refuses every shape below
+// too, so refusing them costs no drop-in compatibility.
+//
+// Reverted, each row parses without error and the file plans: `sql(1)` reaches
+// DDL as the literal text `sql(1)`, and the "default split across two calls"
+// row plans as `DEFAULT "1") + sql("2"` -- the old textual `sql(` prefix match
+// handing back the bytes between the first `sql(` and the last `)`.
+func TestParseRefusesMalformedSQLRawExpression(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		hcl   string
+		match string
+	}{
+		{
+			name: "no arguments",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql() }
+}
+`,
+			match: `.*attribute "expr": sql\(\) takes exactly one string argument, got 0`,
+		},
+		{
+			name: "two arguments",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql("n > 0", "x") }
+}
+`,
+			match: `.*attribute "expr": sql\(\) takes exactly one string argument, got 2`,
+		},
+		{
+			name: "number argument",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql(1) }
+}
+`,
+			match: `.*attribute "expr": sql\(\) takes a string argument`,
+		},
+		{
+			name: "nested call argument",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql(sql("n > 0")) }
+}
+`,
+			match: `.*attribute "expr": sql\(\) takes a string argument`,
+		},
+		{
+			name: "expanded argument list",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql(["n > 0"]...) }
+}
+`,
+			match: `.*attribute "expr": sql\(\) does not take an expanded argument list`,
+		},
+		{
+			name: "part of a larger expression",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sql("n > 0") + sql("1") }
+}
+`,
+			match: `.*attribute "expr": sql\(\) must be the whole attribute value, not part of a larger expression`,
+		},
+		{
+			name: "default split across two calls",
+			hcl: `
+table "t" {
+  column "n" {
+    type    = int
+    default = sql("1") + sql("2")
+  }
+}
+`,
+			match: `.*attribute "default": sql\(\) must be the whole attribute value, not part of a larger expression`,
+		},
+		{
+			name: "inside a list",
+			hcl: `
+table "t" {
+  checks = [sql("n > 0")]
+  column "n" { type = int }
+}
+`,
+			match: `.*attribute "checks": sql\(\) must be the whole attribute value, not part of a larger expression`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
+}
+
+// The refusal names the offender that comes FIRST in the file. Attributes hang
+// off a Go map, so without the explicit ordering the reported position is
+// whichever key the runtime happened to visit first and the message flips
+// between runs.
+//
+// Reverted, this test fails intermittently -- the second table's `expr` is
+// reported roughly half the time.
+func TestParseRefusesTheFirstMalformedSQLRawExpressionInTheFile(t *testing.T) {
+	c := qt.New(t)
+
+	// Both offenders sit in the SAME body, which is what puts them in one Go
+	// map. Two offenders in two different table blocks would be visited in
+	// slice order and would not discriminate.
+	source := `
+table "t" {
+  comment = sql(1)
+  charset = sql(2)
+  column "n" { type = int }
+}
+`
+
+	for range 64 {
+		_, err := atlashcl.Parse([]byte(source), "schema.hcl")
+		c.Assert(err, qt.ErrorMatches, `parse HCL schema at schema.hcl:3,13-19: attribute "comment": .*`)
+	}
+}
+
+// Ptah does not evaluate schema-file variables yet (issue #926), so a sql()
+// argument carrying an interpolation cannot be reduced to a value. It must NOT
+// be refused: measured against the pinned Atlas community binary v1.3.0,
+// `default = sql("${var.floor} + 1")` is planned successfully there, so
+// refusing it would break drop-in on a file that binary supports. Ptah keeps
+// #926's existing behavior -- the template source, rendered as-is -- while
+// still stripping the sql() wrapper the renderer must never see.
+//
+// Reverted to a refusal, this test fails on the nil-error assertion. Reverted
+// to the pre-#1106 source-text fallback, DefaultExpr holds
+// `sql("${var.floor} + 1")` instead.
+func TestParseKeepsSQLRawExpressionInterpolationSource(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+variable "floor" {
+  type    = number
+  default = 5
+}
+table "t" {
+  column "n" {
+    type    = int
+    default = sql("${var.floor} + 1")
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Fields, qt.HasLen, 1)
+	c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "${var.floor} + 1")
+}
+
+// A function call that is not sql() is out of scope here and keeps its existing
+// behavior, tracked separately in issue #926. The row exists so a future widening
+// of the guard to every unknown call is a deliberate edit with a failing test,
+// not a silent side effect.
+//
+// Reverted, this still passes -- it pins the boundary of the change rather than
+// the change itself.
+func TestParseLeavesNonSQLFunctionCallsAlone(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "n" { type = int }
+  check "c" { expr = sqlx("n > 0") }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Constraints, qt.HasLen, 1)
+	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, `sqlx("n > 0")`)
+}


### PR DESCRIPTION
Refs #1106. Part of the issue survives on purpose — see **The decision** below.

All measurements were taken on this branch's worktree against the pinned Atlas
community binary v1.3.0 at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`,
by absolute path, on 2026-08-03. Branched from `origin/master` at `979a92c4`.

## Reproduction, before

Reproduced on master before touching anything, exactly as filed.

`s.hcl`:

```hcl
schema "main" {}
table "t" {
  schema = schema.main
  column "n" { type = int }
  check "n_positive" { expr = sql("n > 0") }
}
```

```
$ atlas schema diff --from sqlite://empty.db --to file://s.hcl --dev-url sqlite://dev.db
Error: schemahcl: failed reading spec as *sqlite.doc: value of attr "expr" cannot be read as string: incorrect type raw
exit=1

$ ptah-compat schema diff --from sqlite://empty.db --to file://s.hcl --dev-url sqlite://dev.db
CREATE TABLE "main"."t" (
  "n" int NOT NULL,
  CONSTRAINT "n_positive" CHECK (sql("n > 0"))
);
exit=0
```

`index.where` the same way:

```
CREATE INDEX IF NOT EXISTS "main"."idx_n" ON "t" ("n") WHERE sql("n > 5");
exit=0
```

Control on the same runs: the literal spelling `expr = "n > 0"` is planned by
both binaries as `CHECK (n > 0)`, exit 0 each. Missing-control: `sqlx("n > 0")`
makes the community binary exit 1 with `There is no function named "sqlx"`.

## Reproduction, after

```
$ ptah-compat schema diff --from sqlite://empty.db --to file://s.hcl --dev-url sqlite://dev.db
CREATE TABLE "main"."t" (
  "n" int NOT NULL,
  CONSTRAINT "n_positive" CHECK (n > 0)
);
exit=0

$ ptah-compat schema diff ... --to file://where.hcl ...
CREATE INDEX IF NOT EXISTS "main"."idx_n" ON "t" ("n") WHERE n > 5;
exit=0
```

The community binary still exits 1 on both, unchanged.

## The list was a lower bound, and it was much lower than two

The issue said the two named positions were found by measurement rather than by
reading the grammar. Enumerating instead of guessing: **every** attribute value
in this front end is read through one of four helpers, and all four fall back to
the attribute's SOURCE TEXT when the expression will not evaluate — which
`sql(...)` never does under an empty context. So the leak was not two positions,
it was the grammar.

Measured, 36 sqlite fixtures + 17 postgres fixtures, before → after:

| sweep | fixtures rendering `sql(` into DDL, before | after |
| --- | --- | --- |
| sqlite | 19 | **0** |
| postgres | 13 | **0** |

The positions that leaked, beyond the two filed:

`index.on.expr`, `index.on.prefix`, `index.comment`, `column.as` (attribute
form), `column.as { expr }`, `column.as { type }`, `column.type`,
`column.comment`, `table.comment`, `table.schema` (and every block's schema
reference), `foreign_key.on_delete`, `identity.start`, `partition.by { expr }`,
`view.as`, `materialized.as`, `function.as`, `function.return`,
`function.arg.type`, `policy.using`, `trigger.as`, `composite` field `type`,
`range.subtype_diff`, `extension.version`.

Two of those are worth calling out because they are not parity-rule (a) at all —
the community binary plans them fine and Ptah was the one producing garbage:

- `type = sql("varchar(10)")` — that binary plans `varchar`; Ptah planned
  `"n" sql("varchar(10)") NOT NULL`, exit 0 both sides.
- `composite` field `type`, `view.as`, `materialized.as` — that binary exits 0
  (dropping the object); Ptah planned `AS ("street" sql("text"))` and
  `CREATE VIEW ... AS sql("SELECT n FROM t")`.

Because the fix is at the four readers rather than per attribute, the list is
now closed by construction rather than enumerated. `git grep 'p.rawExpr('`
was walked to confirm no direct raw-source reader survives: the one that did,
`function.arg.type` in objects.go, is fixed in this branch and has its own test
row.

## The decision, where the issue offered a choice

**Taken: evaluate `sql()` to its raw string.** Reasoning is in the code, at the
top of `internal/atlashcl/sqlrawexpr.go`, next to the implementation.

Why not refuse, in one line: **refusing cannot be applied uniformly, and the
non-uniform version is a measurement liability.** The community binary *accepts*
`sql()` in `column.type`, and accepts files whose `view.as`, `materialized.as`
or composite field type carry it. A blanket refusal makes `ptah-compat` exit 1
on files that binary plans fine — a drop-in break in the direction that costs a
user their working schema. A positional refusal means carrying a hand-copied
table of Atlas's per-attribute hclspec types and re-measuring it for every new
attribute; one wrong row breaks drop-in silently.

Why reducing does not smuggle: `sql("X")` reduces to the string `X`, which is
byte-identical to what the literal spelling `= "X"` already produces in the same
position — a spelling both binaries accept today. After the reduction the two
spellings are indistinguishable everywhere downstream, so the renderer is handed
nothing it could not already be handed. That is the whole anti-smuggling
argument, and it is why the *guard* below is the load-bearing half.

**What survives of #1106, stated plainly.** The issue listed two counts. Count 1
(the DDL cannot run) is fixed. Count 2 (`ptah-compat` exits 0 where the
community binary exits 1, for `check.expr` and `index.where`) is **not** fixed,
deliberately. That is the same richer-surface direction this project already
takes for the `sequence`, `function`, `domain`, `policy` and `trigger` blocks —
the issue says as much about #1053 — and the plan is now correct rather than
broken. `Refs`, not `Closes`, so the author decides whether that trade closes it.

### Exit-code ledger — every rc this change moves

Nothing is hidden here; this is the direction the house rule cares about.

**One position gets looser (1 → 0):** `foreign_key.on_delete = sql("CASCADE")`.
Before, Ptah exited 1 by accident, at the wrong layer — the renderer choked with
`sqlite does not support ON DELETE SQL("CASCADE")`. After, it plans
`ON DELETE CASCADE`, identical to the `on_delete = CASCADE` spelling. The
community binary exits 1 on it. Accepting this is forced by consistency: it is
the same trade as `check.expr`, and refusing it here while accepting it there
would need the per-attribute table this change exists to avoid.

**Seven positions get stricter (0 → 1), and the community binary refuses all
seven too**, so all seven are same-rc after: `sql()`, `sql("a","b")`, `sql(1)`,
`sql(sql("x"))`, `sql([...]...)`, `sql("a") + sql("b")`, and
`default = sql("1") + sql("2")`.

**Zero new positions where `ptah-compat` is stricter than that binary.** The one
that looked like a risk was measured and is why the interpolation branch exists
— see the test note below.

**Postgres sweep: zero rc changes at all**, 13 leaks → 0.

## The guard, and why it is not decorative

`rejectMalformedSQLRawExprs` runs before the body walk and refuses any `sql()`
call that is not a whole attribute value reducible to a single string. Without
it, "reduce sql()" would be a half-measure: the source-text fallback still ships
bytes to the renderer for every shape the reducer declines. The old textual
match (`sql(` prefix, `)` suffix, unquote whatever is between) read
`default = sql("1") + sql("2")` as the SQL text `"1") + sql("2` and planned
`DEFAULT "1") + sql("2"`. The match is structural now, on the parsed call.

Guard non-interference was validated with the **inverse mutant**, not by
removing it: making it fire unconditionally turns all 17 reduction rows plus the
interpolation and non-`sql()` controls RED. Removing a guard never makes it
fire, so removal proves nothing.

## What each test prints if the change is reverted

| test | reverted behavior |
| --- | --- |
| `TestParseReducesSQLRawExpressionToItsSQL` (17 rows) | The IR holds `sql("...")` where the row asserts the SQL inside it. Verified per mutant: dropping the `exprString` reduction reddens 11 rows; dropping `optionalRawExpr` reddens `index part prefix` and `function argument type`; dropping `optionalRefName` reddens `table schema reference`; restoring the textual `sqlExpression` reddens `argument padded inside the parentheses` (DefaultExpr becomes `` "now()" `` — quotes and padding) and `heredoc argument`. |
| `TestParseRefusesMalformedSQLRawExpression` (8 rows) | Parse returns nil error and the file plans: `sql(1)` reaches DDL as the literal `sql(1)`, and the two-call default plans `DEFAULT "1") + sql("2"`. Verified: disabling the guard reddens all 8. |
| `TestParseRefusesTheFirstMalformedSQLRawExpressionInTheFile` | The message flips between the two offending attributes across runs — they sit in one Go map. Verified: replacing `slices.MinFunc` with `refusals[0]` reddens it within 5 runs. (Two offenders in two *different* table blocks do NOT discriminate — blocks are visited in slice order. The fixture puts both in the same body for that reason.) |
| `TestParseKeepsSQLRawExpressionInterpolationSource` | Reverted to a refusal → fails on the nil-error assertion. Reverted to the pre-#1106 fallback → `DefaultExpr` holds `sql("${var.floor} + 1")`. Verified both. |
| `TestParseLeavesNonSQLFunctionCallsAlone` | Still passes. It pins the *boundary* of the change, not the change; a future widening of the guard to every unknown call has to edit it deliberately. Stated so nobody cites it as a discriminator. |

The interpolation test is the one that earns its keep. Ptah has no schema-file
variable evaluation yet (#926), so `sql("${var.floor} + 1")` cannot be reduced
to a value. Refusing it looked correct until it was measured: the community
binary plans that file successfully (`DEFAULT (5 + 1)`), so refusing would have
been a new stricter break on a file it supports. The branch keeps #926's
existing behavior for that shape while still stripping the wrapper.

## Gates

Every one green, first time, exit codes captured directly rather than through a
pipe:

```
go build ./...                     rc=0
go vet ./...                       rc=0
go test ./... -count=1             rc=0
golangci-lint run ./...            rc=0
check-test-style.sh                rc=0
check-public-api.sh                rc=0
check-public-api-snapshot.sh       rc=0
```

`check-test-style.sh` was proven live on the new file rather than trusted:
adding one `if` inside a test body turns it red with
`internal/atlashcl/sqlrawexpr_test.go TestParseKeepsSQLRawExpressionInterpolationSource if 1`.

No exported API change, so the snapshot gate is green on an unchanged baseline
rather than on a regenerated one.

## Deliberately left open

- **Count 2 of #1106** — `ptah-compat` still exits 0 for `check.expr` and
  `index.where` where the community binary exits 1. Argued above; this is the
  half of the issue that survives, and why this is `Refs`.
- **`foreign_key.on_delete`** — one position moved from exit 1 to exit 0. Listed
  in the ledger rather than buried.
- **Non-`sql()` unevaluable expressions** — `expr = sqlx("n > 0")` still plans
  `CHECK (sqlx("n > 0"))` at exit 0 while the community binary exits 1. Same
  source-text fallback, different trigger; widening the guard to every unknown
  function call is #1016's shape, not this one's, and would need its own
  measurement sweep.
- **`#926`** — `expr = "n > ${var.floor}"` still plans `CHECK ("n > ${var.floor}")`
  against `CHECK (n > 5)` from the community binary. Untouched here; this branch
  only stops the `sql()` wrapper from riding along.
- **`index.on { column = sql("n") }`** — plans `ON "t" ("")`, an empty
  identifier. Not a `sql(` leak (the wrapper is gone); it is the column-reference
  reader yielding empty for any non-reference value, which predates this change
  and wants its own fix.
- **docs/** — nothing in `docs/` is made false by this change
  (`docs/atlas_hcl_schema.md` already documents `default = sql("...")`, still
  true), and `docs/site/node_modules` is not installed here, so the site's twelve
  check scripts could not all be run. Not touching docs rather than touching them
  ungated.
