### PR TITLE
Decide Flyway linearity on the version token, not the ordering key (#1098)

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -276,34 +276,7 @@ func runAtlasMigrateApply(
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	// A surviving Flyway baseline is converted into the band BELOW every
-	// survivor, because Atlas CE emits and executes it first whatever its own
-	// version — measured, and measured to hold across runs, not only within one
-	// conversion. On a database that already has migrations recorded it
-	// therefore sorts below all of them, which the linear guard would read as
-	// "authored earlier". It is not: the position encodes sum order, not
-	// chronology. Exempting exactly that one version keeps every other
-	// out-of-order migration refused, which is what Atlas CE does too.
-	flywayBaseline, err := atlasmigrateimport.FlywaySurvivingBaseline(captured, resolvedDirFormat)
-	if err != nil {
-		return fmt.Errorf("atlas migrate apply --dir: %w", err)
-	}
-	var outOfOrderExempt []int64
-	if flywayBaseline != nil {
-		outOfOrderExempt = []int64{flywayBaseline.AtlasVersion}
-	}
-
-	// The linear guard's other operand (#1098). A converted Flyway directory is
-	// ORDERED numerically — V2 executes before V10, which is what the int64
-	// version encodes and what atlas.sum is written against — but the tool it
-	// came from decides whether a file "was added out of order" by comparing
-	// the version TOKEN as a string, where "10" sorts below "2". Carrying the
-	// token alongside the executed version lets the guard ask that question the
-	// way the source tool asks it, without renumbering anything already
-	// recorded. The comparison itself happens inside the migration lock, on the
-	// applied set the migrator reads there, so a concurrent writer cannot move
-	// the mark between the check and the run.
-	sourceVersions, err := atlasmigrateimport.FlywaySourceVersions(captured, resolvedDirFormat)
+	linearity, err := flywayLinearityOperands(captured, resolvedDirFormat)
 	if err != nil {
 		return fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
@@ -313,8 +286,8 @@ func runAtlasMigrateApply(
 		FS:                   migrationFS,
 		DryRun:               opts.dryRun,
 		ExecOrder:            execOrder,
-		OutOfOrderExempt:     outOfOrderExempt,
-		SourceVersions:       sourceVersions,
+		OutOfOrderExempt:     linearity.outOfOrderExempt,
+		SourceVersions:       linearity.sourceVersions,
 		TxMode:               txMode,
 		RevisionsSchema:      opts.revisionsSchema,
 		MigrationLockTimeout: migrationLockTimeout,
@@ -343,7 +316,7 @@ func runAtlasMigrateApply(
 	// baseline's band position as "authored earlier". Whether a baseline may
 	// run against a database that already has history is a separate question,
 	// and one Atlas CE answers three incompatible ways (stokaro/ptah#1003).
-	if err := checkFlywayBaselineHistory(flywayBaseline, execOrder, plan); err != nil {
+	if err := checkFlywayBaselineHistory(linearity.baseline, execOrder, plan); err != nil {
 		return err
 	}
 
@@ -653,4 +626,58 @@ func writeAtlasMigrateApplyFormat(
 		URL:    opts.url,
 		Result: result,
 	})
+}
+
+// flywayLinearityOperands returns everything the linear guard needs from a
+// converted Flyway directory: the surviving baseline, the versions whose
+// position below the current high-water mark is an artifact of the layout
+// projection rather than a claim about authoring order, and the source version
+// token each converted version came from.
+//
+// They are resolved together because they answer one question between them —
+// "was this file authored out of order?" — and it must be answered on the
+// operands the source tool decides it with.
+//
+// A surviving baseline is converted into the band BELOW every survivor, because
+// Atlas CE emits and executes it first whatever its own version — measured, and
+// measured to hold across runs, not only within one conversion. On a database
+// that already has migrations recorded it therefore sorts below all of them,
+// which the linear guard would read as "authored earlier". It is not: the
+// position encodes sum order, not chronology. Exempting exactly that one
+// version keeps every other out-of-order migration refused, which is what Atlas
+// CE does too.
+//
+// The tokens are the guard's other operand (#1098). A converted Flyway
+// directory is ORDERED numerically — V2 executes before V10, which is what the
+// int64 version encodes and what atlas.sum is written against — but the tool it
+// came from decides whether a file "was added out of order" by comparing the
+// version TOKEN as a string, where "10" sorts below "2". Carrying the token
+// alongside the executed version lets the guard ask that question the way the
+// source tool asks it, without renumbering anything already recorded. The
+// comparison itself happens inside the migration lock, on the applied set the
+// migrator reads there, so a concurrent writer cannot move the mark between the
+// check and the run.
+type flywayLinearity struct {
+	baseline         *atlasmigrateimport.FlywayBaseline
+	outOfOrderExempt []int64
+	sourceVersions   map[int64]string
+}
+
+func flywayLinearityOperands(
+	captured fs.FS,
+	format atlasmigrateimport.Format,
+) (flywayLinearity, error) {
+	baseline, err := atlasmigrateimport.FlywaySurvivingBaseline(captured, format)
+	if err != nil {
+		return flywayLinearity{}, err
+	}
+	operands := flywayLinearity{baseline: baseline}
+	if baseline != nil {
+		operands.outOfOrderExempt = []int64{baseline.AtlasVersion}
+	}
+	operands.sourceVersions, err = atlasmigrateimport.FlywaySourceVersions(captured, format)
+	if err != nil {
+		return flywayLinearity{}, err
+	}
+	return operands, nil
 }

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -293,12 +293,28 @@ func runAtlasMigrateApply(
 		outOfOrderExempt = []int64{flywayBaseline.AtlasVersion}
 	}
 
+	// The linear guard's other operand (#1098). A converted Flyway directory is
+	// ORDERED numerically — V2 executes before V10, which is what the int64
+	// version encodes and what atlas.sum is written against — but the tool it
+	// came from decides whether a file "was added out of order" by comparing
+	// the version TOKEN as a string, where "10" sorts below "2". Carrying the
+	// token alongside the executed version lets the guard ask that question the
+	// way the source tool asks it, without renumbering anything already
+	// recorded. The comparison itself happens inside the migration lock, on the
+	// applied set the migrator reads there, so a concurrent writer cannot move
+	// the mark between the check and the run.
+	sourceVersions, err := atlasmigrateimport.FlywaySourceVersions(captured, resolvedDirFormat)
+	if err != nil {
+		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+	}
+
 	plan, err := atlasmigrate.PrepareApply(cmd.Context(), conn, atlasmigrate.ApplyOptions{
 		Dir:                  dir,
 		FS:                   migrationFS,
 		DryRun:               opts.dryRun,
 		ExecOrder:            execOrder,
 		OutOfOrderExempt:     outOfOrderExempt,
+		SourceVersions:       sourceVersions,
 		TxMode:               txMode,
 		RevisionsSchema:      opts.revisionsSchema,
 		MigrationLockTimeout: migrationLockTimeout,

--- a/cmd/atlas/migrate_apply_flyway_source_order_test.go
+++ b/cmd/atlas/migrate_apply_flyway_source_order_test.go
@@ -1,0 +1,312 @@
+package atlas_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// These rows cover stokaro/ptah#1098: a converted Flyway directory is ORDERED
+// numerically and made LINEAR textually, and `migrate apply` used to answer both
+// questions with the numeric key.
+//
+// Measured on the pinned community binary, which reports
+// `atlas community version v1.3.0`, sqlite, `--dir file://m?format=flyway`,
+// atlas.sum written by each tool for its own run, exit codes captured
+// immediately. Every row's expectation is that binary's answer unless the
+// comment says otherwise:
+//
+//	applied      added            pinned v1.3.0                       here
+//	V2           V10              1, "was added out of order"         refused
+//	V9           V10              1, "was added out of order"         refused
+//	V2           V100             1, "was added out of order"         refused
+//	V2           R__r             1, "was added out of order"         refused
+//	V2           R9__r            1, "was added out of order"         refused
+//	V2, V10      V15              1, "was added out of order"         refused
+//	V2, V10      V3               1, "was added out of order"         refused
+//	V2           V3               0, executed                         executed
+//	V2           V20              0, executed                         executed
+//	V2, V10      V20              0, executed                         executed
+//	V10          V11              0, executed                         executed
+//	V01          V2               0, executed                         executed
+//	V2, V10      (none)           0, no pending files                 no-op
+//
+// Every refusing row above exited 0 here before the change and executed the
+// file — that is the defect, and it is what those rows print if the change is
+// reverted. The executing rows are green either way: their job is to fail if
+// the new comparison starts refusing ordinary sequences.
+
+type flywaySourceOrderOutput struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func (o flywaySourceOrderOutput) text() string {
+	return errorText(o.err) + o.stdout + o.stderr
+}
+
+type flywaySourceOrderRow struct {
+	name string
+	// applied are written, hashed and applied first; the row's second apply
+	// runs against the history they leave behind. Empty means no history,
+	// which is the shape with nothing for the source comparison to compare
+	// against.
+	applied []string
+	// added are written next, and the directory is re-hashed before the second
+	// apply.
+	added []string
+	// args are appended to the second `migrate apply` invocation.
+	args []string
+	// assert is the per-row wiring: refusing rows and executing rows do not
+	// share an assertion, and branching inside one body would hide which of the
+	// two a row is.
+	assert func(c *qt.C, dbPath string, out flywaySourceOrderOutput)
+}
+
+func TestCompatMigrateApplyFlywaySourceVersionOrder(t *testing.T) {
+	// refused asserts the refusal names both the mark it compared against and
+	// the migration it refused, by SOURCE version, and that the listed tables
+	// are exactly the ones the first apply left — nothing ran, because the
+	// refusal is raised while the migration set is selected.
+	refused := func(tables []string, sourceVersions ...string) func(*qt.C, string, flywaySourceOrderOutput) {
+		return func(c *qt.C, dbPath string, out flywaySourceOrderOutput) {
+			c.Assert(out.err, qt.IsNotNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", out.stdout, out.stderr))
+			c.Assert(out.text(), qt.Contains, "out-of-order pending migrations for current version")
+			for _, source := range sourceVersions {
+				c.Assert(out.text(), qt.Contains, `(source version "`+source+`")`)
+			}
+			c.Assert(userTables(c, dbPath), qt.DeepEquals, tables)
+		}
+	}
+	executed := func(tables ...string) func(*qt.C, string, flywaySourceOrderOutput) {
+		return func(c *qt.C, dbPath string, out flywaySourceOrderOutput) {
+			c.Assert(out.err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", out.stdout, out.stderr))
+			c.Assert(userTables(c, dbPath), qt.DeepEquals, tables)
+		}
+	}
+
+	tests := []flywaySourceOrderRow{
+		{
+			// The issue's shape. Reverted: exit 0, "Migrating to version
+			// 4611686018427836747 from 1 pending migrations.", tables sq2 and
+			// sq10 — the migration the oracle refuses, executed.
+			name:    "a tenth migration added under an applied second",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V10__sq10.sql"},
+			assert:  refused([]string{"sq2"}, "2", "10"),
+		},
+		{
+			// Reverted: exit 0, tables sq2 and sq10. Separates "two digits" from
+			// "numerically far above the mark": 10 > 9 numerically, and "10" <
+			// "9" textually, so only the textual comparison refuses it.
+			name:    "a tenth migration added under an applied ninth",
+			applied: []string{"V9__sq2.sql"},
+			added:   []string{"V10__sq10.sql"},
+			assert:  refused([]string{"sq2"}, "9", "10"),
+		},
+		{
+			// Reverted: exit 0, tables sq2 and sq100. Three digits reach the
+			// same rule, so the refusal is not a two-digit special case.
+			name:    "a hundredth migration added under an applied second",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V100__sq100.sql"},
+			assert:  refused([]string{"sq2"}, "2", "100"),
+		},
+		{
+			// Atlas CE gives every repeatable the empty version string, which
+			// sorts below every token, so it refuses a repeatable added to a
+			// database with any history. Reverted: exit 0, tables sq2 and sqr —
+			// the repeatable runs, because its reserved int64 slot is the
+			// highest there is and the numeric comparison sees nothing wrong.
+			name:    "a repeatable added to recorded history",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"R__sqr.sql"},
+			assert:  refused([]string{"sq2"}, "2", ""),
+		},
+		{
+			// The token is Atlas CE's version STRING for the file, not the
+			// file's own token. Every repeatable is version "" to CE whatever it
+			// is called, and CE refuses all of R__r.sql, R1__r.sql, R9__r.sql
+			// and Rfoo__r.sql added over an applied V2 — measured. Reading the
+			// file's own token instead would let this one through, because "9"
+			// sorts above the applied "2". Reverted: exit 0, tables sq2 and sqr.
+			name:    "a repeatable whose own token sorts high is still refused",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"R9__sqr.sql"},
+			assert:  refused([]string{"sq2"}, "2", ""),
+		},
+		{
+			// The mark is the highest applied TOKEN, not the token of the
+			// highest applied version, and this is the input that separates
+			// them: the applied tokens are "2" and "10", whose maxima disagree.
+			// "15" sorts below "2" and above "10". Comparing against "10" would
+			// pass it, and the numeric comparison passes it too (15 > 10), so
+			// only the right operand refuses it. Reverted: exit 0, tables sq10,
+			// sq15 and sq2.
+			name:    "a fifteenth migration under applied second and tenth",
+			applied: []string{"V2__sq2.sql", "V10__sq10.sql"},
+			added:   []string{"V15__sq15.sql"},
+			assert:  refused([]string{"sq10", "sq2"}, "10", "15"),
+		},
+		{
+			// The control for the row above: same applied pair, and "20" sorts
+			// above both applied tokens, so it runs. Without it, "refuse
+			// everything two-digit added to this history" would pass too.
+			name:    "a twentieth migration still applies over applied second and tenth",
+			applied: []string{"V2__sq2.sql", "V10__sq10.sql"},
+			added:   []string{"V20__sq20.sql"},
+			assert:  executed("sq10", "sq2", "sq20"),
+		},
+		{
+			// The union's other half. "3" sorts ABOVE the highest applied token
+			// "2", so the source comparison passes it; the numeric one refuses
+			// it because it lands under the applied V10. Reverted to a source-
+			// only comparison: exit 0, tables sq2, sq3 and sq10.
+			name:    "an ordinary migration under an applied two-digit version",
+			applied: []string{"V2__sq2.sql", "V10__sq10.sql"},
+			added:   []string{"V3__sq3.sql"},
+			assert: func(c *qt.C, dbPath string, out flywaySourceOrderOutput) {
+				c.Assert(out.err, qt.IsNotNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", out.stdout, out.stderr))
+				c.Assert(out.text(), qt.Contains, `(source version "3")`)
+				c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"sq10", "sq2"})
+			},
+		},
+		{
+			// Control. Reverted: green, unchanged — its job is to fail if the
+			// new comparison refuses an ordinary sequence.
+			name:    "the next single-digit migration still applies",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V3__sq3.sql"},
+			assert:  executed("sq2", "sq3"),
+		},
+		{
+			// Control, and the one that pins the comparison as textual rather
+			// than "refuse anything with more digits": "20" sorts above "2".
+			name:    "a twentieth migration still applies over an applied second",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V20__sq20.sql"},
+			assert:  executed("sq2", "sq20"),
+		},
+		{
+			// Control: two two-digit versions in their own order.
+			name:    "an eleventh migration still applies over an applied tenth",
+			applied: []string{"V10__sq2.sql"},
+			added:   []string{"V11__sq11.sql"},
+			assert:  executed("sq11", "sq2"),
+		},
+		{
+			// Control: zero padding, standard Flyway practice. "2" sorts above
+			// "01", and the pinned binary applies it, printing
+			// `Migrating to version 2 from 01`.
+			name:    "an unpadded second migration still applies over an applied zero-padded first",
+			applied: []string{"V01__sq2.sql"},
+			added:   []string{"V2__sq3.sql"},
+			assert:  executed("sq2", "sq3"),
+		},
+		{
+			// Two controls in one row. The first apply runs against no history
+			// at all, so the source comparison has no applied token to compare
+			// against and must not manufacture one — it goes red if the
+			// highest-applied-token lookup falls back to a zero value instead
+			// of reporting "none". The second apply then runs against history
+			// holding both, where V10's own token "10" sorts below the highest
+			// applied token "2": it must not be flagged, because it is applied,
+			// not pending. Feeding the comparison the full version list instead
+			// of the pending one turns this row red.
+			name:    "a settled directory holding both versions is not refused afterwards",
+			applied: []string{"V2__sq2.sql", "V10__sq10.sql"},
+			added:   nil,
+			assert:  executed("sq10", "sq2"),
+		},
+		{
+			// linear-skip leaves out-of-order migrations unapplied rather than
+			// refusing, and the pinned binary answers this exact input with
+			// "No migration files to execute" and an unchanged database.
+			// Reverted: exit 0 as well, but tables sq2 AND sq10 — the skip
+			// silently executed what it claims to skip.
+			name:    "linear-skip leaves the tenth migration unapplied",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V10__sq10.sql"},
+			args:    []string{"--exec-order=linear-skip"},
+			assert: func(c *qt.C, dbPath string, out flywaySourceOrderOutput) {
+				c.Assert(out.err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", out.stdout, out.stderr))
+				c.Assert(out.stdout, qt.Contains, "No migration files to execute")
+				c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"sq2"})
+			},
+		},
+		{
+			// The escape hatch the refusal names has to work, or the refusal is
+			// a dead end. The pinned binary runs it too.
+			name:    "non-linear runs the tenth migration the refusal names",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V10__sq10.sql"},
+			args:    []string{"--exec-order=non-linear"},
+			assert:  executed("sq10", "sq2"),
+		},
+		{
+			// A preview must not report work a real apply refuses. The pinned
+			// binary refuses the dry run too. Reverted: exit 0 and
+			// "Would have applied 1 migrations."
+			name:    "a dry run refuses rather than previewing the refused migration",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"V10__sq10.sql"},
+			args:    []string{"--dry-run"},
+			assert:  refused([]string{"sq2"}, "2", "10"),
+		},
+		{
+			// NON-INTERFERENCE with the surviving-baseline exemption. B10's
+			// token sorts below the applied "2" exactly like V10's does, so a
+			// source comparison applied outside the exemption would refuse a
+			// baseline this build runs. This row is green before and after the
+			// change; it goes red if the exemption is applied to only one half
+			// of the union. It is NOT a claim about the pinned binary, which
+			// skips this baseline silently — that divergence is stokaro/ptah#1003
+			// and is not decided here.
+			name:    "a surviving baseline below the mark stays exempt",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"B10__sqbase.sql"},
+			assert:  executed("sq2", "sqbase"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := c.TempDir()
+			dir := filepath.Join(root, "migrations")
+			dbPath := filepath.Join(root, "order.db")
+
+			for _, name := range tt.applied {
+				writeAtlasApplyProjectMigration(c, dir, name, flywaySourceOrderSQL(name))
+			}
+			hashConvertedApplyDir(c, dir, "flyway")
+			_, _, err := runCompat("migrate", "apply", "--url", "sqlite://"+dbPath, "--dir", "file://"+dir+"?format=flyway")
+			c.Assert(err, qt.IsNil)
+
+			for _, name := range tt.added {
+				writeAtlasApplyProjectMigration(c, dir, name, flywaySourceOrderSQL(name))
+			}
+			hashConvertedApplyDir(c, dir, "flyway")
+			args := append([]string{
+				"migrate", "apply",
+				"--url", "sqlite://" + dbPath,
+				"--dir", "file://" + dir + "?format=flyway",
+			}, tt.args...)
+			stdout, stderr, err := runCompat(args...)
+
+			tt.assert(c, dbPath, flywaySourceOrderOutput{stdout: stdout, stderr: stderr, err: err})
+		})
+	}
+}
+
+// flywaySourceOrderSQL derives each fixture's table from its own description,
+// so a row's expected table list names the files that ran rather than a
+// separately maintained mapping.
+func flywaySourceOrderSQL(name string) string {
+	base := strings.TrimSuffix(name, ".sql")
+	_, description, _ := strings.Cut(base, "__")
+	return "CREATE TABLE " + description + " (id INTEGER PRIMARY KEY);"
+}

--- a/cmd/atlas/migrate_apply_flyway_source_order_test.go
+++ b/cmd/atlas/migrate_apply_flyway_source_order_test.go
@@ -37,6 +37,17 @@ import (
 // file — that is the defect, and it is what those rows print if the change is
 // reverted. The executing rows are green either way: their job is to fail if
 // the new comparison starts refusing ordinary sequences.
+//
+// The last two rows are the surviving-baseline pair, and they are the one place
+// this file diverges from the pinned binary rather than matching it:
+//
+//	applied      added            pinned v1.3.0                       here
+//	V2           B10              0, skipped silently                 refused (#1003)
+//	V2           B10 (skip)       0, skipped silently                 executed (#1003)
+//
+// Both are stokaro/ptah#1003's decisions, measured again for this change and
+// unchanged by it. Neither is a parity-rule violation: the first is stricter
+// than the oracle, and the second exits 0 as the oracle does.
 
 type flywaySourceOrderOutput struct {
 	stdout string
@@ -257,17 +268,96 @@ func TestCompatMigrateApplyFlywaySourceVersionOrder(t *testing.T) {
 			assert:  refused([]string{"sq2"}, "2", "10"),
 		},
 		{
-			// NON-INTERFERENCE with the surviving-baseline exemption. B10's
-			// token sorts below the applied "2" exactly like V10's does, so a
-			// source comparison applied outside the exemption would refuse a
-			// baseline this build runs. This row is green before and after the
-			// change; it goes red if the exemption is applied to only one half
-			// of the union. It is NOT a claim about the pinned binary, which
-			// skips this baseline silently — that divergence is stokaro/ptah#1003
-			// and is not decided here.
-			name:    "a surviving baseline below the mark stays exempt",
+			// THE MARK SURVIVES THE SQUASH. B3 retires V2__sq2.sql from the
+			// covered set, and with it the only token any applied version had.
+			// The comparison then has no mark at all and passes everything —
+			// which is how this exact input exited 0 here while the pinned
+			// binary exits 1 with `migration files B3__sqb3.sql, R__sqr.sql
+			// were added out of order`. Nine such cells were measured across
+			// baseline-plus-repeatable shapes, all of them compat looser than
+			// the oracle.
+			//
+			// Reverted (the recovery removed): exit 0, "Migrating to version
+			// 9223372036854775807 from 2 pending migrations.", tables sq2,
+			// sqb3 and sqr.
+			//
+			// The pinned binary names both added files; this names only the
+			// repeatable, because B3 is a surviving baseline and exempt. Exit
+			// code and executed set match; the named set is narrower.
+			name:    "a repeatable added beside a baseline that squashes the applied migration",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"B3__sqb3.sql", "R__sqr.sql"},
+			assert:  refused([]string{"sq2"}, "2", ""),
+		},
+		{
+			// The control for the row above, and the one that keeps the
+			// recovery from becoming a blanket refusal: same squash, and the
+			// added migration's token "4" sorts above the recovered mark "2",
+			// so it runs. The pinned binary runs both files here too. Green
+			// before and after; it goes red if the recovered mark is the
+			// BASELINE's token rather than the squashed file's.
+			name:    "a forward migration beside a baseline that squashes the applied migration",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"B3__sqb3.sql", "V4__sq4.sql"},
+			assert:  executed("sq2", "sq4", "sqb3"),
+		},
+		{
+			// WHICH GUARD SPEAKS. B10's token sorts below the applied "2"
+			// exactly like V10's does, so the source comparison would refuse it
+			// — but a surviving baseline is exempt from the union, and the
+			// refusal that answers this shape is #1003's, which fires first and
+			// names the file, the squash and the way out. That is not an
+			// accident of ordering: for a directory whose applied files are all
+			// still present, a surviving baseline whose token sorts at or below
+			// the highest applied token ALWAYS trips #1003's guard, because an
+			// applied file with a token above the baseline's survives into
+			// Covered and one carrying the baseline's own token lands in
+			// SameVersion. The exemption therefore never grants a baseline
+			// permission to run; it only keeps the linear guard from answering
+			// with the worse message.
+			//
+			// Reverted — that is, with #1003's refusal removed for this shape —
+			// this row prints exit 0, "Migrating to version 4611686018427469511
+			// from 1 pending migrations." and tables sq2 AND sqbase: the squash
+			// executed on top of the history it squashes. That was this row's
+			// expectation before the rebase, and #1003 decided against it.
+			//
+			// The pinned binary answers this input with "No migration files to
+			// execute" at exit 0, running nothing. Refusing is the strict
+			// direction and is stokaro/ptah#1003's decision, not this one.
+			name:    "a surviving baseline below the mark is refused as a baseline, not as out of order",
 			applied: []string{"V2__sq2.sql"},
 			added:   []string{"B10__sqbase.sql"},
+			assert: func(c *qt.C, dbPath string, out flywaySourceOrderOutput) {
+				c.Assert(out.err, qt.IsNotNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", out.stdout, out.stderr))
+				c.Assert(out.text(), qt.Contains, "is a Flyway baseline and this database already has migration history")
+				c.Assert(out.text(), qt.Not(qt.Contains), "out-of-order pending migrations")
+				c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"sq2"})
+			},
+		},
+		{
+			// NON-INTERFERENCE with the surviving-baseline exemption, and the
+			// only shape where the exemption is observable at all now that
+			// #1003's guard answers the linear case. Under linear-skip that
+			// guard deliberately abstains — the operator has made the decision
+			// explicitly — so the linear verdict is the only thing left, and the
+			// exempt baseline runs.
+			//
+			// It goes red if the exemption is applied to only the numeric half
+			// of the union: the source half would then flag the baseline, and
+			// linear-skip, which now leaves unapplied exactly what the linear
+			// verdict names, would print exit 0 with tables sq2 alone — the
+			// baseline silently dropped.
+			//
+			// "linear-skip leaves unapplied what linear refuses" is a statement
+			// about the LINEAR GUARD's verdict, not about every refusal in the
+			// apply path. The pinned binary skips this baseline here; compat
+			// runs it. Both exit 0, so no parity rule is broken, and the
+			// divergence belongs to stokaro/ptah#1003's abstention list.
+			name:    "linear-skip runs the exempt baseline rather than skipping it",
+			applied: []string{"V2__sq2.sql"},
+			added:   []string{"B10__sqbase.sql"},
+			args:    []string{"--exec-order=linear-skip"},
 			assert:  executed("sq2", "sqbase"),
 		},
 	}

--- a/cmd/atlas/migrate_apply_flyway_source_order_test.go
+++ b/cmd/atlas/migrate_apply_flyway_source_order_test.go
@@ -317,8 +317,9 @@ func TestCompatMigrateApplyFlywaySourceVersionOrder(t *testing.T) {
 			// with the worse message.
 			//
 			// Reverted — that is, with #1003's refusal removed for this shape —
-			// this row prints exit 0, "Migrating to version 4611686018427469511
-			// from 1 pending migrations." and tables sq2 AND sqbase: the squash
+			// this row prints exit 0, "Migrating to version 448844 from 1
+			// pending migrations." / "Migration complete. Current version:
+			// 4611686018427510315", and tables sq2 AND sqbase: the squash
 			// executed on top of the history it squashes. That was this row's
 			// expectation before the rebase, and #1003 decided against it.
 			//

--- a/cmd/atlas/migrate_apply_legacy_flyway_test.go
+++ b/cmd/atlas/migrate_apply_legacy_flyway_test.go
@@ -383,7 +383,11 @@ func TestCompatMigrateApply_FlywayOutOfOrderStillRefused(t *testing.T) {
 		_, stderr, err := runCompat("migrate", "apply", "--url", "sqlite://"+dbPath, "--dir", "file://"+dir+"?format=flyway")
 
 		c.Assert(err, qt.IsNotNil)
-		c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations below current version")
+		// The refusal names the source token, not only the projected int64:
+		// 4611686018427510315 appears in no file name and in no Atlas output,
+		// so on its own it does not say which file to move (#1098).
+		c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations for current version")
+		c.Assert(errorText(err)+stderr, qt.Contains, `(source version "2")`)
 		c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"oa", "oc"})
 	})
 
@@ -405,7 +409,11 @@ func TestCompatMigrateApply_FlywayOutOfOrderStillRefused(t *testing.T) {
 		_, stderr, err := runCompat("migrate", "apply", "--url", "sqlite://"+dbPath, "--dir", "file://"+dir+"?format=flyway")
 
 		c.Assert(err, qt.IsNotNil)
-		c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations below current version")
+		c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations for current version")
+		// Atlas CE gives every repeatable the empty version string, so the
+		// current mark here has an empty source version and V2 is refused
+		// against it. Printing the reserved int64 alone would say nothing.
+		c.Assert(errorText(err)+stderr, qt.Contains, `(source version "")`)
 	})
 }
 
@@ -435,7 +443,8 @@ func TestCompatMigrateApply_FlywayExemptionIsOneVersion(t *testing.T) {
 
 	// V2 is still out of order; exempting it as well would apply it silently.
 	c.Assert(err, qt.IsNotNil)
-	c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations below current version")
+	c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations for current version")
+	c.Assert(errorText(err)+stderr, qt.Contains, `(source version "2")`)
 	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"ea", "ec"})
 }
 
@@ -465,7 +474,12 @@ func TestCompatMigrateApply_GooseKeepsTheOutOfOrderGuard(t *testing.T) {
 	_, stderr, err := runCompat("migrate", "apply", "--url", "sqlite://"+dbPath, "--dir", "file://"+dir+"?format=goose")
 
 	c.Assert(err, qt.IsNotNil)
+	// "below current version" is the NATIVE wording, and this row is the one
+	// that holds it. A goose directory carries no source version tokens, so the
+	// refusal keeps the message and the operand it always had; only a converted
+	// Flyway directory reports source versions (#1098).
 	c.Assert(errorText(err)+stderr, qt.Contains, "out-of-order pending migrations below current version")
+	c.Assert(errorText(err)+stderr, qt.Not(qt.Contains), "source version")
 	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"ga", "gc"})
 }
 

--- a/cmd/atlas/migrate_apply_legacy_flyway_test.go
+++ b/cmd/atlas/migrate_apply_legacy_flyway_test.go
@@ -751,7 +751,13 @@ func TestCompatMigrateApply_FlywayBaselineAgainstRecordedHistory(t *testing.T) {
 		added: []flywayMigration{{"V1__base.sql", "CREATE TABLE base (id INTEGER PRIMARY KEY);"}},
 		assert: func(c *qt.C, run flywayBaselineRun) {
 			c.Assert(run.err, qt.IsNotNil, qt.Commentf("stdout:\n%s", run.stdout))
-			c.Assert(run.message(), qt.Contains, "out-of-order pending migrations below current version")
+			// A converted directory names the SOURCE tokens (#1098). The int64
+			// appears in no file name and in no Atlas output, so printing it
+			// alone does not say which file to move. Reverting #1098's message
+			// change prints "below current version" and no source version here.
+			c.Assert(run.message(), qt.Contains, "out-of-order pending migrations for current version")
+			c.Assert(run.message(), qt.Contains, `(source version "2")`)
+			c.Assert(run.message(), qt.Contains, `(source version "1")`)
 			c.Assert(userTables(c, run.dbPath), qt.DeepEquals, []string{"s2"})
 		},
 	}, {
@@ -769,7 +775,9 @@ func TestCompatMigrateApply_FlywayBaselineAgainstRecordedHistory(t *testing.T) {
 		},
 		assert: func(c *qt.C, run flywayBaselineRun) {
 			c.Assert(run.err, qt.IsNotNil, qt.Commentf("stdout:\n%s", run.stdout))
-			c.Assert(run.message(), qt.Contains, "out-of-order pending migrations below current version")
+			c.Assert(run.message(), qt.Contains, "out-of-order pending migrations for current version")
+			c.Assert(run.message(), qt.Contains, `(source version "3")`)
+			c.Assert(run.message(), qt.Contains, `(source version "2")`)
 			c.Assert(run.message(), qt.Not(qt.Contains), "Flyway baseline")
 			c.Assert(userTables(c, run.dbPath), qt.DeepEquals, []string{"ea", "ec"})
 		},

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6846,6 +6846,7 @@ type OnFail string
     const OnFailAbort OnFail = "abort"
 type OutOfOrderError struct{ ... }
     func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
+    func NewOutOfOrderSourceError(currentVersion int64, versions []int64, sourceVersions map[int64]string) *OutOfOrderError
 type ParsedMigrationUp struct{ ... }
     func ParseMigrationUp(filename, sql string) (ParsedMigrationUp, error)
     func ParseMigrationUpForAnalysis(filename, sql string) (ParsedMigrationUp, error)
@@ -7457,6 +7458,7 @@ func (m *Migrator) WithObserver(observer Observer) *Migrator
 func (m *Migrator) WithOutOfOrderExempt(versions []int64) *Migrator
 func (m *Migrator) WithRevisionTableFormat(format RevisionTableFormat) *Migrator
 func (m *Migrator) WithSkipChecks(skip bool) *Migrator
+func (m *Migrator) WithSourceVersions(sourceVersions map[int64]string) *Migrator
 func (m *Migrator) WithTransactionMode(mode MigrationTxMode) *Migrator
 func (m *Migrator) WithoutMigrationLock() *Migrator
 
@@ -7524,11 +7526,19 @@ package migrator // import "go.5x5.cz/ptah/migration/migrator"
 type OutOfOrderError struct {
     CurrentVersion int64
     Versions       []int64
+    // SourceVersions carries the source tool's own version token for the
+    // current version and for every version listed, for a directory read
+    // through a foreign layout. It is empty for a native Atlas directory.
+    //
+    // It is reported because the int64 is not a name anyone can look up: it
+    // appears in no file name and in no Atlas output, so a refusal that only
+    // prints 4611686018427836747 does not tell an operator which file to move.
+    SourceVersions map[int64]string
 }
-    OutOfOrderError reports pending migrations that are below the current
-    high-water mark while linear execution is required.
+    OutOfOrderError reports pending migrations that linear execution refuses.
 
 func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError
+func NewOutOfOrderSourceError(currentVersion int64, versions []int64, sourceVersions map[int64]string) *OutOfOrderError
 func (e *OutOfOrderError) Error() string
 
 ### go.5x5.cz/ptah/migration/migrator.ParsedMigrationUp

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -336,13 +336,35 @@ covers semantic and `yyyyMMddHHmmss` timestamp schemes. A version with more than
 three components, or a minor/patch of `100` or more, cannot be represented in an
 int64 and is rejected before the database is opened.
 
+That numeric order governs `atlas.sum` and execution, and it is **not** the
+comparison that decides whether a migration was added out of order. Flyway
+answers that on the version token as text, where `"10"` sorts below `"2"`, so a
+project's tenth migration added beside an already-applied `V2__x.sql` is refused
+rather than executed:
+
+```text
+Error: error applying migrations: out-of-order pending migrations for current
+version 4611686018427510315 (source version "2"): 4611686018427836747
+(source version "10") (use --exec-order=non-linear to apply or
+--exec-order=linear-skip to ignore)
+```
+
+The refusal names the **source version** because the int64 beside it appears in
+no file name. `--exec-order=non-linear` runs the migration, `--exec-order=linear-skip`
+leaves it pending, and a directory with no recorded history is unaffected —
+applying `V2__x.sql` and `V10__y.sql` together for the first time runs both, in
+that order. A repeatable (`R__`) is version `""` to Atlas, which sorts below
+every token, so one added to a database that already has history is refused by
+the same rule.
+
 Several inputs still fail before Ptah opens the target database rather than guess
 at semantics: unknown formats; goose files whose directives are out of order;
-dbmate files missing their up directive; Flyway repeatable (`R__`)
-migrations, which Ptah cannot yet execute as versioned migrations (matching how
-`ptah-compat migrate import` handles them); and two source files that resolve to
-the same version. See
-[`stokaro/ptah#742`](https://github.com/stokaro/ptah/issues/742).
+dbmate files missing their up directive; and two source files that resolve to the
+same version. Flyway repeatable migrations are **not** in that list — they are
+converted and executed, on a reserved version slot above every versioned
+migration, which is where Atlas emits them. See
+[`stokaro/ptah#742`](https://github.com/stokaro/ptah/issues/742) and
+[`stokaro/ptah#1098`](https://github.com/stokaro/ptah/issues/1098).
 
 ### Goose directive parsing
 

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -278,8 +278,20 @@ deliberately left open:
 - A database with **no recorded history** still runs the baseline. That is the
   fresh-install path a converted Flyway directory exists for.
 - `--exec-order=non-linear` executes the baseline against a database that does
-  have history, which is what the refusal points at. Atlas CE applies a
-  below-mark baseline under that flag too.
+  have history, which is what the refusal points at. So does
+  `--exec-order=linear-skip`: the refusal comes from the baseline check rather
+  than from the linear guard, and that check stands aside whenever the operator
+  has named an execution order explicitly.
+
+Atlas CE follows only halfway there. For a baseline it refuses as out of order
+it does the same thing — `B2.5__base.sql` on a database at `V1`, `V2`, `V3` is
+exit 1 without the flag and `Migrating to version 2.5 from 3` with it. For a
+baseline it *skips silently*, the first row of the table above, neither flag
+changes anything: `V2` plus `B10__base.sql` still prints
+`No migration files to execute` at exit 0 under `--exec-order=non-linear` and
+under `--exec-order=linear-skip`. `ptah-compat` runs the baseline in both, which
+is what makes the flag a way forward rather than a second dead end. Both tools
+exit 0 either way.
 
 A baseline that squashes away the whole recorded history still runs on both
 tools — `B3__base.sql` on a database at `V2`, `B2__base.sql` on one at `V10` —

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -27,7 +27,12 @@ type ApplyOptions struct {
 	// current high-water mark is an artifact of the layout projection rather
 	// than a claim about authoring order. Only the Flyway converted path sets
 	// it; see atlasmigrateimport.FlywaySurvivingBaseline.
-	OutOfOrderExempt     []int64
+	OutOfOrderExempt []int64
+	// SourceVersions maps each converted version to the source tool's own
+	// version token, so the linear guard can ask "was this added out of order"
+	// on the operand that tool decides it with. Only the Flyway converted path
+	// sets it; see atlasmigrateimport.FlywaySourceVersions.
+	SourceVersions       map[int64]string
 	TxMode               migrator.MigrationTxMode
 	RevisionsSchema      string
 	MigrationLockTimeout time.Duration
@@ -103,6 +108,7 @@ func PrepareApply(ctx context.Context, conn *dbschema.DatabaseConnection, opts A
 	mig, err := newApplyMigrator(conn, opts.FS, applyMigratorOptions{
 		execOrder:            opts.ExecOrder,
 		outOfOrderExempt:     opts.OutOfOrderExempt,
+		sourceVersions:       opts.SourceVersions,
 		txMode:               opts.TxMode,
 		revisionsSchema:      opts.RevisionsSchema,
 		migrationLockTimeout: opts.MigrationLockTimeout,
@@ -329,6 +335,7 @@ func validateApplyOptions(conn *dbschema.DatabaseConnection, opts ApplyOptions) 
 type applyMigratorOptions struct {
 	execOrder            migrator.ExecOrder
 	outOfOrderExempt     []int64
+	sourceVersions       map[int64]string
 	txMode               migrator.MigrationTxMode
 	revisionsSchema      string
 	migrationLockTimeout time.Duration
@@ -354,6 +361,7 @@ func newApplyMigrator(
 		WithMigrationsTable(opts.revisionsSchema, "").
 		WithExecOrder(opts.execOrder).
 		WithOutOfOrderExempt(opts.outOfOrderExempt).
+		WithSourceVersions(opts.sourceVersions).
 		WithTransactionMode(opts.txMode).
 		WithMigrationLockTimeout(opts.migrationLockTimeout).
 		WithMigrationLockName(opts.migrationLockName).

--- a/internal/atlasmigrateimport/flywayselection_test.go
+++ b/internal/atlasmigrateimport/flywayselection_test.go
@@ -3,6 +3,8 @@ package atlasmigrateimport_test
 import (
 	"fmt"
 	"io/fs"
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 	"testing/fstest"
@@ -497,4 +499,84 @@ func TestLoadFSFlywayDescriptionEndingInDown_KnownDivergence(t *testing.T) {
 		"4611686018427469511_a.down.sql",
 		"4611686018427836747_c.sql",
 	})
+}
+
+// TestFlywaySourceVersionsCarriesSquashedTokens covers the operand the linear
+// comparison compares AGAINST: the highest version token a database has
+// applied.
+//
+// A surviving baseline retires the files it squashes from the covered set, and
+// with them their tokens. The comparison then has no mark for any applied
+// version, reports "none", and passes every pending file — which is how
+// `V2__a.sql` applied plus `B3__base.sql` and `R__r.sql` added came to exit 0
+// here while the pinned community binary v1.3.0 exits 1 with `migration files
+// B3__base.sql, R__r.sql were added out of order`. The tokens of the squashed
+// files are therefore recovered from the directory as it stood before the
+// baseline, which is the only shape their revision rows can have come from.
+//
+// The assertion is on the token SET rather than on int64 keys, because the keys
+// are this build's projection and the tokens are Atlas CE's own strings; a row
+// spelling out both would only prove the fixture was written twice.
+func TestFlywaySourceVersionsCarriesSquashedTokens(t *testing.T) {
+	tests := []struct {
+		name   string
+		files  []string
+		tokens []string
+	}{{
+		// Reverted: ["3"] — the applied V2's token is gone with its file, so
+		// the comparison has no mark and lets everything through.
+		name:   "a baseline that squashes the only applied migration",
+		files:  []string{"V2__a.sql", "B3__base.sql"},
+		tokens: []string{"2", "3"},
+	}, {
+		// The shape the pinned binary refuses. Reverted: ["", "3"], and
+		// `migrate apply` exits 0 executing both added files.
+		name:   "a repeatable beside a baseline that squashes the applied migration",
+		files:  []string{"V2__a.sql", "B3__base.sql", "R__r.sql"},
+		tokens: []string{"", "2", "3"},
+	}, {
+		// The recovered token is the SQUASHED file's, not the baseline's: a
+		// fill keyed on the baseline would report ["1", "1", "3"] and make the
+		// mark "1", passing files an applied "02" outranks.
+		name:   "a zero-padded migration squashed by an unpadded baseline",
+		files:  []string{"V02__a.sql", "V3__c.sql", "B1__base.sql"},
+		tokens: []string{"02", "1", "3"},
+	}, {
+		// The executed mapping wins where the two selections land on the same
+		// slot. B02 squashes V02__b.sql and leaves V2__a.sql, which then takes
+		// the tie slot V02 held before it — so the recovered V02 entry and the
+		// executed V2 entry are the SAME key, carrying different tokens. Both
+		// "2"s are real: one is what this directory executes at that slot, the
+		// other is what a pre-baseline database recorded one slot up.
+		// Recovering by overwrite rather than by filling gaps prints
+		// ["02", "02", "2", "3"] and hands the comparison a mark of "02" for a
+		// migration whose token is "2".
+		name:   "a padded and an unpadded migration on one ordering slot",
+		files:  []string{"V2__a.sql", "V02__b.sql", "V3__c.sql", "B02__base.sql"},
+		tokens: []string{"02", "2", "2", "3"},
+	}, {
+		// Control: a baseline that squashes nothing adds nothing. Green either
+		// way; it goes red if the recovery starts inventing tokens.
+		name:   "a baseline below every applied migration",
+		files:  []string{"V2__a.sql", "B1__base.sql"},
+		tokens: []string{"1", "2"},
+	}, {
+		// Control: no baseline, so there is nothing to recover and the map is
+		// exactly the executed one. Green either way.
+		name:   "a directory with no baseline at all",
+		files:  []string{"V2__a.sql", "V10__b.sql"},
+		tokens: []string{"10", "2"},
+	}}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sources, err := atlasmigrateimport.FlywaySourceVersions(
+				flywaySource(test.files...), atlasmigrateimport.FormatFlyway)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(slices.Sorted(maps.Values(sources)), qt.DeepEquals, test.tokens)
+		})
+	}
 }

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -940,6 +940,11 @@ func flywayMigrationVersions(files []flywaySumFile, versions []int64) []FlywayMi
 // why it refuses an `R__r.sql` added to a database that has already applied
 // `V2__x.sql`, and reproducing the token faithfully reproduces that answer too.
 //
+// The map also carries the tokens of the migrations a surviving baseline has
+// SQUASHED out of this directory, because the caller's question is about a
+// database's recorded history and those rows are still in it. See
+// flywaySquashedSourceVersions.
+//
 // It shares flywayCoveredFiles and flywayConvertedVersions with the importer,
 // so the token reported for a version belongs to the entry actually executed
 // under it.
@@ -947,10 +952,11 @@ func FlywaySourceVersions(fsys fs.FS, format Format) (map[int64]string, error) {
 	if format != FormatFlyway {
 		return nil, nil
 	}
-	covered, err := flywayCoveredFiles(fsys)
+	names, err := treeNames(fsys, skipHiddenDir)
 	if err != nil {
 		return nil, err
 	}
+	covered := flywaySumFiles(names)
 	versions, err := flywayConvertedVersions(covered)
 	if err != nil {
 		return nil, err
@@ -959,7 +965,71 @@ func FlywaySourceVersions(fsys fs.FS, format Format) (map[int64]string, error) {
 	for i, file := range covered {
 		sources[versions[i]] = flywayCEVersion(file)
 	}
+	// The executed mapping is authoritative and is written first, so a version
+	// this directory still executes never takes a squashed file's token.
+	for version, source := range flywaySquashedSourceVersions(names, covered) {
+		if _, ok := sources[version]; !ok {
+			sources[version] = source
+		}
+	}
 	return sources, nil
+}
+
+// flywaySquashedSourceVersions reports the tokens of the migrations a surviving
+// baseline has retired from this directory's covered set, keyed by the Atlas
+// version a database that ran them recorded.
+//
+// Without them the linear comparison switches ITSELF off on exactly the
+// directories a baseline has just landed in. Its mark is the highest token
+// among the APPLIED versions, and once the baseline squashes their files out of
+// the covered set none of those versions has a token, so the lookup reports
+// "no mark" and every pending file passes. Measured on the pinned community
+// binary v1.3.0, sqlite: with `V2__a2.sql` applied and `B3__nb3.sql` plus
+// `R__nr.sql` added, the binary exits 1 with `migration files B3__nb3.sql,
+// R__nr.sql were added out of order` while compat exited 0 and executed both —
+// compat looser than the oracle, which is the one direction that is never
+// allowed. Nine such cells were measured across baseline-plus-repeatable
+// shapes; every one of them is a repeatable whose empty version token sorts
+// below the mark that the squash had hidden.
+//
+// The domain is this directory WITHOUT the surviving baseline, which is the
+// same domain and the same argument flywaySameVersionMigrations uses: it is the
+// only shape a revision row for a squashed file can have come from, and
+// re-running the selection with the baseline removed puts each file back at the
+// tie slot it was recorded under rather than assuming slot 0.
+//
+// It only ever FILLS GAPS, so it cannot change an answer the caller already
+// had. Adding a token can raise the mark and refuse more; it can never lower
+// the mark, because the mark is a maximum, and it can never clear one, because
+// the executed mapping is written first. Refusing more is the safe direction
+// here — a file whose token does not sort strictly above the highest APPLIED
+// token is one Atlas CE never executes.
+//
+// One removal, not a transitive reconstruction: a directory holding several
+// baselines yields the tokens of the files the SURVIVING one squashed, not
+// those a superseded baseline had squashed before it. That is the conservative
+// half again — it can only fail to flag.
+func flywaySquashedSourceVersions(names []string, covered []flywaySumFile) map[int64]string {
+	// flywaySumFiles emits at most one baseline, and always first.
+	if len(covered) == 0 || covered[0].kind != flywaySumBaseline {
+		return nil
+	}
+	baseline := covered[0]
+	before := flywaySumFiles(slices.DeleteFunc(slices.Clone(names), func(name string) bool {
+		return name == baseline.name
+	}))
+	versions, err := flywayConvertedVersions(before)
+	if err != nil {
+		// A pre-baseline directory this build cannot convert yields nothing,
+		// because no build could have applied it either, so no revision row of
+		// its making exists.
+		return nil
+	}
+	recorded := make(map[int64]string, len(before))
+	for i, file := range before {
+		recorded[versions[i]] = flywayCEVersion(file)
+	}
+	return recorded
 }
 
 // flywayEntryName renders the converted Atlas single-file name. A Flyway file

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -909,6 +909,59 @@ func flywayMigrationVersions(files []flywaySumFile, versions []int64) []FlywayMi
 	return out
 }
 
+// FlywaySourceVersions reports the Flyway version TOKEN every converted
+// migration was projected from, keyed by the int64 Atlas version it executes
+// and is recorded under. It returns nil for every other layout.
+//
+// It exists because two different comparisons decide two different questions
+// about the same directory, and Ptah answered both with the first
+// (stokaro/ptah#1098):
+//
+//   - ORDER, for atlas.sum and for execution, is NUMERIC on the version
+//     components: V2 runs before V10. [flywayOrderingKey] reproduces exactly
+//     that, and it is measured to match — a fresh apply of a directory holding
+//     V2__a.sql and V10__b.sql runs version 2 then version 10 on the pinned
+//     community binary v1.3.0.
+//   - LINEARITY, "was this file added after everything already applied", is
+//     decided on the version token as a STRING. `"10" < "2"`, so a V10 added
+//     beside an applied V2 is refused on the same binary with
+//     `migration file V10__y.sql was added out of order`.
+//
+// Keying the linear guard on the ordering int64 answers the second question
+// with the first one's answer, which is how a Flyway project's tenth migration
+// came to apply here at exit 0 where the oracle exits 1. The token is therefore
+// carried ALONGSIDE the executed version rather than replacing it: renumbering
+// would strand every revision row already recorded, which is a cost
+// [LegacyFlywayAtlasVersions] exists to document.
+//
+// The value is Atlas CE's version string for the file, so a repeatable reports
+// the empty string whatever its own token — see [flywayCEVersion]. That is not
+// a gap in the map: CE compares the empty string like any other token, which is
+// why it refuses an `R__r.sql` added to a database that has already applied
+// `V2__x.sql`, and reproducing the token faithfully reproduces that answer too.
+//
+// It shares flywayCoveredFiles and flywayConvertedVersions with the importer,
+// so the token reported for a version belongs to the entry actually executed
+// under it.
+func FlywaySourceVersions(fsys fs.FS, format Format) (map[int64]string, error) {
+	if format != FormatFlyway {
+		return nil, nil
+	}
+	covered, err := flywayCoveredFiles(fsys)
+	if err != nil {
+		return nil, err
+	}
+	versions, err := flywayConvertedVersions(covered)
+	if err != nil {
+		return nil, err
+	}
+	sources := make(map[int64]string, len(covered))
+	for i, file := range covered {
+		sources[versions[i]] = flywayCEVersion(file)
+	}
+	return sources, nil
+}
+
 // flywayEntryName renders the converted Atlas single-file name. A Flyway file
 // need not carry a description at all — V1.sql and Video.sql are both ordinary
 // migrations to Atlas CE — so the name degrades to the bare version rather than

--- a/migration/migrator/exec_order.go
+++ b/migration/migrator/exec_order.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"fmt"
 	"slices"
+	"strconv"
 	"strings"
 )
 
@@ -72,26 +73,156 @@ func outOfOrderExempt(versions, exempt []int64) []int64 {
 	return out
 }
 
-// OutOfOrderError reports pending migrations that are below the current
-// high-water mark while linear execution is required.
+// outOfOrderSourceVersions reports the pending versions a converted directory's
+// SOURCE tool considers out of order, which is a different question from the
+// numeric one above and has to be asked separately.
+//
+// A directory read through a foreign layout carries two orders, and they are
+// not the same order. Its int64 version is a projection of the source tool's
+// ORDER, which for Flyway is numeric on the version components — V2 executes
+// before V10. Whether a file "was added after everything already applied" is
+// decided by that tool on the version TOKEN as a string, and `"10" < "2"`. So a
+// V10 added beside an applied V2 is numerically above the mark and textually
+// below it, and only the second answer is the one the source tool gives
+// (stokaro/ptah#1098).
+//
+// The comparison is against the highest applied token, not against the token of
+// the highest applied version — the two differ exactly when the tokens disagree
+// with the ordering, which is the whole case this exists for.
+//
+// A version with no token is skipped rather than assumed. Tokens come from the
+// directory as it stands now, so an applied migration whose file a baseline has
+// since squashed away contributes none, and the numeric comparison is left to
+// answer for it alone. That is the conservative direction: it can only fail to
+// flag, never flag something the source tool would execute.
+func outOfOrderSourceVersions(pending, applied []int64, sourceVersions map[int64]string) []int64 {
+	if len(sourceVersions) == 0 {
+		return nil
+	}
+	highest, ok := highestAppliedSourceVersion(applied, sourceVersions)
+	if !ok {
+		return nil
+	}
+	out := make([]int64, 0, len(pending))
+	for _, version := range pending {
+		// A token that does not sort strictly above every applied token is one
+		// the source tool never executes: it either refuses it as out of order
+		// or drops it as already covered. Refusing is the safe half of that.
+		if source, found := sourceVersions[version]; found && source <= highest {
+			out = append(out, version)
+		}
+	}
+	return out
+}
+
+func highestAppliedSourceVersion(applied []int64, sourceVersions map[int64]string) (string, bool) {
+	var highest string
+	found := false
+	for _, version := range applied {
+		source, ok := sourceVersions[version]
+		if !ok {
+			continue
+		}
+		if !found || source > highest {
+			highest, found = source, true
+		}
+	}
+	return highest, found
+}
+
+// mergeOutOfOrderVersions unions the two comparisons' verdicts, keeping the
+// ascending order the callers' pending list already has.
+//
+// It is a union rather than a replacement, and both halves are load-bearing.
+// The numeric comparison catches an ordinary migration inserted below the mark
+// whose token still sorts above it (V3 added to an applied V2 and V10); the
+// source comparison catches a migration above the mark whose token sorts below
+// it (V10 added to an applied V2). Dropping either one reopens a shape the
+// pinned community binary refuses.
+func mergeOutOfOrderVersions(numeric, source []int64) []int64 {
+	if len(source) == 0 {
+		return numeric
+	}
+	merged := make([]int64, 0, len(numeric)+len(source))
+	merged = append(merged, numeric...)
+	merged = append(merged, source...)
+	slices.Sort(merged)
+	return slices.Compact(merged)
+}
+
+// OutOfOrderError reports pending migrations that linear execution refuses.
 type OutOfOrderError struct {
 	CurrentVersion int64
 	Versions       []int64
+	// SourceVersions carries the source tool's own version token for the
+	// current version and for every version listed, for a directory read
+	// through a foreign layout. It is empty for a native Atlas directory.
+	//
+	// It is reported because the int64 is not a name anyone can look up: it
+	// appears in no file name and in no Atlas output, so a refusal that only
+	// prints 4611686018427836747 does not tell an operator which file to move.
+	SourceVersions map[int64]string
 }
 
 func (e *OutOfOrderError) Error() string {
+	const escape = "(use --exec-order=non-linear to apply or --exec-order=linear-skip to ignore)"
+	if len(e.SourceVersions) == 0 {
+		return fmt.Sprintf(
+			"out-of-order pending migrations below current version %d: %v %s",
+			e.CurrentVersion,
+			e.Versions,
+			escape,
+		)
+	}
+	// "below" is dropped for a converted directory on purpose. A version can be
+	// refused here while sorting ABOVE the current one, because the source
+	// tool's own comparison put it below; claiming otherwise would describe the
+	// int64 order, which is not the order that decided this.
+	listed := make([]string, 0, len(e.Versions))
+	for _, version := range e.Versions {
+		listed = append(listed, e.describe(version))
+	}
 	return fmt.Sprintf(
-		"out-of-order pending migrations below current version %d: %v (use --exec-order=non-linear to apply or --exec-order=linear-skip to ignore)",
-		e.CurrentVersion,
-		e.Versions,
+		"out-of-order pending migrations for current version %s: %s %s",
+		e.describe(e.CurrentVersion),
+		strings.Join(listed, ", "),
+		escape,
 	)
 }
 
+func (e *OutOfOrderError) describe(version int64) string {
+	source, ok := e.SourceVersions[version]
+	if !ok {
+		return strconv.FormatInt(version, 10)
+	}
+	return fmt.Sprintf("%d (source version %q)", version, source)
+}
+
 // NewOutOfOrderError builds the typed error returned for linear execution when
-// lower-version pending migrations are present.
+// pending migrations the execution order refuses are present.
 func NewOutOfOrderError(currentVersion int64, versions []int64) *OutOfOrderError {
 	return &OutOfOrderError{
 		CurrentVersion: currentVersion,
 		Versions:       slices.Clone(versions),
 	}
+}
+
+// NewOutOfOrderSourceError builds the same error for a directory read through a
+// foreign layout, carrying the source version tokens needed to name the files
+// the refusal is about.
+func NewOutOfOrderSourceError(currentVersion int64, versions []int64, sourceVersions map[int64]string) *OutOfOrderError {
+	err := NewOutOfOrderError(currentVersion, versions)
+	if len(sourceVersions) == 0 {
+		return err
+	}
+	err.SourceVersions = make(map[int64]string, len(versions)+1)
+	for _, version := range append(slices.Clone(versions), currentVersion) {
+		if source, ok := sourceVersions[version]; ok {
+			err.SourceVersions[version] = source
+		}
+	}
+	if len(err.SourceVersions) == 0 {
+		err.SourceVersions = nil
+	}
+	return err
 }

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"maps"
 	"slices"
 	"sort"
 	"strconv"
@@ -110,6 +111,7 @@ type Migrator struct {
 	revisionTableFormat  RevisionTableFormat
 	execOrder            ExecOrder
 	outOfOrderExempt     []int64
+	sourceVersions       map[int64]string
 	txMode               MigrationTxMode
 	migrationLockName    string
 	migrationLockTimeout time.Duration
@@ -352,6 +354,43 @@ func (m *Migrator) WithExecOrder(execOrder ExecOrder) *Migrator {
 func (m *Migrator) WithOutOfOrderExempt(versions []int64) *Migrator {
 	tmp := *m
 	tmp.outOfOrderExempt = slices.Clone(versions)
+	return &tmp
+}
+
+// WithSourceVersions supplies, for a migration directory converted from another
+// tool's layout, the SOURCE version token each executed version was projected
+// from. It makes the linear execution guard stricter; it never makes it looser.
+//
+// WHY A SECOND KEY EXISTS AT ALL. The int64 version a converted directory
+// executes under is a projection of the source tool's ORDER. For Flyway that
+// order is numeric on the version components — V2 executes before V10 — and
+// reproducing it is what lets Ptah write the same atlas.sum and run the same
+// sequence as the tool it is standing in for. But "was this migration added
+// after everything already applied" is not an ordering question, and the source
+// tool does not answer it with the ordering: Flyway's version token is compared
+// as a STRING, where "10" sorts below "2". Supplying the token lets the guard
+// ask the linearity question on the operand that decides it, while execution
+// order, atlas.sum and every recorded revision keep the int64 they already have
+// (stokaro/ptah#1098).
+//
+// The two comparisons are unioned. A pending migration is refused under
+// [ExecOrderLinear], and left unapplied under [ExecOrderLinearSkip], when its
+// version sorts below the current one OR its token does not sort above every
+// applied token. Neither half subsumes the other: V3 added to a database
+// holding V2 and V10 is caught only by the first, and V10 added to a database
+// holding V2 only by the second.
+//
+// Passing tokens for a NATIVE Atlas directory would be a mistake rather than a
+// no-op: there the int64 is the version, not a projection of one, and comparing
+// its decimal spelling as text would refuse ordinary sequences. Only the
+// converted apply path sets this; see
+// atlasmigrateimport.FlywaySourceVersions.
+//
+// Versions absent from the map are governed by the numeric comparison alone, so
+// a partial map narrows what the guard can see rather than corrupting it.
+func (m *Migrator) WithSourceVersions(sourceVersions map[int64]string) *Migrator {
+	tmp := *m
+	tmp.sourceVersions = maps.Clone(sourceVersions)
 	return &tmp
 }
 
@@ -2263,14 +2302,23 @@ func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, t
 	bootstrap := checkpointBootstrap(migrations, applied, targetVersion)
 	floor := checkpointFloor(migrations, applied, bootstrap)
 	pendingVersions := pendingMigrationVersionsFloored(migrations, applied, bootstrap, floor)
+	// Two comparisons, one verdict. The numeric one asks whether a pending
+	// version sorts below the mark; the source one asks whether the tool this
+	// directory belongs to would call the same file out of order. They
+	// disagree on real directories, so both are asked and the exemption is
+	// applied to the union rather than to either half — see
+	// [Migrator.WithSourceVersions].
 	outOfOrderVersions := outOfOrderExempt(
-		outOfOrderMigrationVersions(pendingVersions, currentVersion),
+		mergeOutOfOrderVersions(
+			outOfOrderMigrationVersions(pendingVersions, currentVersion),
+			outOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),
+		),
 		m.outOfOrderExempt,
 	)
 	execOrder := normalizeExecOrder(m.execOrder)
 
 	if execOrder == ExecOrderLinear && len(outOfOrderVersions) > 0 {
-		return nil, NewOutOfOrderError(currentVersion, outOfOrderVersions)
+		return nil, NewOutOfOrderSourceError(currentVersion, outOfOrderVersions, m.sourceVersions)
 	}
 
 	appliedSet := versionSet(applied)
@@ -2285,8 +2333,12 @@ func (m *Migrator) migrationsToApply(migrations []*Migration, applied []int64, t
 		if targetVersion > 0 && migration.Version > targetVersion {
 			continue
 		}
-		if execOrder == ExecOrderLinearSkip && migration.Version < currentVersion &&
-			!slices.Contains(m.outOfOrderExempt, migration.Version) {
+		// linear-skip leaves unapplied exactly what linear refuses, so it reads
+		// the verdict computed above instead of re-deriving it. Re-deriving is
+		// what let a converted directory skip nothing under linear-skip while
+		// linear refused, and execute a migration the source tool leaves
+		// pending.
+		if execOrder == ExecOrderLinearSkip && slices.Contains(outOfOrderVersions, migration.Version) {
 			m.logger.Warn("Skipping out-of-order migration", "version", migration.Version, "currentVersion", currentVersion)
 			continue
 		}

--- a/scripts/mutations/flyway-source-version-order.json
+++ b/scripts/mutations/flyway-source-version-order.json
@@ -1,0 +1,64 @@
+{
+  "packages": [
+    "./internal/atlasmigrateimport/",
+    "./internal/atlasmigrate/",
+    "./migration/migrator/",
+    "./cmd/atlas/"
+  ],
+  "mutations": [
+    {
+      "name": "the source version tokens are never handed to the migrator",
+      "file": "cmd/atlas/migrate_apply.go",
+      "old": "\t\tSourceVersions:       sourceVersions,\n",
+      "new": ""
+    },
+    {
+      "name": "the source comparison replaces the numeric one instead of joining it",
+      "file": "migration/migrator/migrator.go",
+      "old": "\t\tmergeOutOfOrderVersions(\n\t\t\toutOfOrderMigrationVersions(pendingVersions, currentVersion),\n\t\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),\n\t\t),",
+      "new": "\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),"
+    },
+    {
+      "name": "the numeric comparison replaces the source one instead of joining it",
+      "file": "migration/migrator/migrator.go",
+      "old": "\t\tmergeOutOfOrderVersions(\n\t\t\toutOfOrderMigrationVersions(pendingVersions, currentVersion),\n\t\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),\n\t\t),",
+      "new": "\t\toutOfOrderMigrationVersions(pendingVersions, currentVersion),"
+    },
+    {
+      "name": "the out-of-order exemption reaches only the numeric half of the verdict",
+      "file": "migration/migrator/migrator.go",
+      "old": "\toutOfOrderVersions := outOfOrderExempt(\n\t\tmergeOutOfOrderVersions(\n\t\t\toutOfOrderMigrationVersions(pendingVersions, currentVersion),\n\t\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),\n\t\t),\n\t\tm.outOfOrderExempt,\n\t)",
+      "new": "\toutOfOrderVersions := mergeOutOfOrderVersions(\n\t\toutOfOrderExempt(outOfOrderMigrationVersions(pendingVersions, currentVersion), m.outOfOrderExempt),\n\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),\n\t)"
+    },
+    {
+      "name": "linear-skip re-derives the verdict from the numeric comparison alone",
+      "file": "migration/migrator/migrator.go",
+      "old": "\t\tif execOrder == ExecOrderLinearSkip && slices.Contains(outOfOrderVersions, migration.Version) {",
+      "new": "\t\tif execOrder == ExecOrderLinearSkip && migration.Version < currentVersion &&\n\t\t\t!slices.Contains(m.outOfOrderExempt, migration.Version) {"
+    },
+    {
+      "name": "the mark is the token of the highest applied version, not the highest applied token",
+      "file": "migration/migrator/exec_order.go",
+      "old": "\tvar highest string\n\tfound := false\n\tfor _, version := range applied {\n\t\tsource, ok := sourceVersions[version]\n\t\tif !ok {\n\t\t\tcontinue\n\t\t}\n\t\tif !found || source > highest {\n\t\t\thighest, found = source, true\n\t\t}\n\t}\n\treturn highest, found",
+      "new": "\tvar highest string\n\tvar highestVersion int64\n\tfound := false\n\tfor _, version := range applied {\n\t\tsource, ok := sourceVersions[version]\n\t\tif !ok {\n\t\t\tcontinue\n\t\t}\n\t\tif !found || version > highestVersion {\n\t\t\thighest, highestVersion, found = source, version, true\n\t\t}\n\t}\n\treturn highest, found"
+    },
+    {
+      "name": "the source comparison is asked of every version, not only the pending ones",
+      "file": "migration/migrator/migrator.go",
+      "old": "\t\t\toutOfOrderSourceVersions(pendingVersions, applied, m.sourceVersions),",
+      "new": "\t\t\toutOfOrderSourceVersions(append(slices.Clone(pendingVersions), applied...), applied, m.sourceVersions),"
+    },
+    {
+      "name": "the token map records the projected int64 instead of the source version",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\t\tsources[versions[i]] = flywayCEVersion(file)",
+      "new": "\t\tsources[versions[i]] = fmt.Sprint(versions[i])"
+    },
+    {
+      "name": "a repeatable reports its own token instead of Atlas CE's empty version",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\t\tsources[versions[i]] = flywayCEVersion(file)",
+      "new": "\t\tsources[versions[i]] = file.version"
+    }
+  ]
+}

--- a/scripts/mutations/flyway-source-version-order.json
+++ b/scripts/mutations/flyway-source-version-order.json
@@ -8,9 +8,9 @@
   "mutations": [
     {
       "name": "the source version tokens are never handed to the migrator",
-      "file": "cmd/atlas/migrate_apply.go",
-      "old": "\t\tSourceVersions:       sourceVersions,\n",
-      "new": ""
+      "file": "internal/atlasmigrate/apply.go",
+      "old": "\t\tWithSourceVersions(opts.sourceVersions).",
+      "new": "\t\tWithSourceVersions(nil)."
     },
     {
       "name": "the source comparison replaces the numeric one instead of joining it",
@@ -52,7 +52,7 @@
       "name": "the token map records the projected int64 instead of the source version",
       "file": "internal/atlasmigrateimport/importer.go",
       "old": "\t\tsources[versions[i]] = flywayCEVersion(file)",
-      "new": "\t\tsources[versions[i]] = fmt.Sprint(versions[i])"
+      "new": "\t\t_ = file\n\t\tsources[versions[i]] = fmt.Sprint(versions[i])"
     },
     {
       "name": "a repeatable reports its own token instead of Atlas CE's empty version",

--- a/scripts/mutations/flyway-source-version-order.json
+++ b/scripts/mutations/flyway-source-version-order.json
@@ -55,6 +55,12 @@
       "new": "\t\t_ = file\n\t\tsources[versions[i]] = fmt.Sprint(versions[i])"
     },
     {
+      "name": "INVERSE: the source comparison refuses every pending migration",
+      "file": "migration/migrator/exec_order.go",
+      "old": "\t\tif source, found := sourceVersions[version]; found && source <= highest {",
+      "new": "\t\t_ = highest\n\t\tif _, found := sourceVersions[version]; found {"
+    },
+    {
       "name": "a repeatable reports its own token instead of Atlas CE's empty version",
       "file": "internal/atlasmigrateimport/importer.go",
       "old": "\t\tsources[versions[i]] = flywayCEVersion(file)",

--- a/scripts/mutations/flyway-source-version-order.json
+++ b/scripts/mutations/flyway-source-version-order.json
@@ -65,6 +65,30 @@
       "file": "internal/atlasmigrateimport/importer.go",
       "old": "\t\tsources[versions[i]] = flywayCEVersion(file)",
       "new": "\t\tsources[versions[i]] = file.version"
+    },
+    {
+      "name": "the tokens a surviving baseline squashed away are not recovered",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\tfor version, source := range flywaySquashedSourceVersions(names, covered) {\n\t\tif _, ok := sources[version]; !ok {\n\t\t\tsources[version] = source\n\t\t}\n\t}",
+      "new": "\t_ = flywaySquashedSourceVersions"
+    },
+    {
+      "name": "the recovery overwrites the executed mapping instead of filling gaps",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\tfor version, source := range flywaySquashedSourceVersions(names, covered) {\n\t\tif _, ok := sources[version]; !ok {\n\t\t\tsources[version] = source\n\t\t}\n\t}",
+      "new": "\tfor version, source := range flywaySquashedSourceVersions(names, covered) {\n\t\tsources[version] = source\n\t}"
+    },
+    {
+      "name": "the recovered token is the baseline's own, not the squashed file's",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\t\trecorded[versions[i]] = flywayCEVersion(file)",
+      "new": "\t\t_ = file\n\t\trecorded[versions[i]] = baseline.version"
+    },
+    {
+      "name": "the surviving-baseline refusal is removed, leaving the exemption to decide",
+      "file": "cmd/atlas/migrate_apply.go",
+      "old": "\tif err := checkFlywayBaselineHistory(linearity.baseline, execOrder, plan); err != nil {\n\t\treturn err\n\t}",
+      "new": "\t_ = checkFlywayBaselineHistory"
     }
   ]
 }


### PR DESCRIPTION
Closes #1098.

A converted Flyway directory carries two orders and they are not the same order.
`ptah-compat migrate apply` had only one of them, so a Flyway project's tenth
migration applied at exit 0 where the pinned community binary exits 1.

Rebased onto master this branch met #1003, which landed while it waited. Both
changes answer the same question — "was this converted Flyway migration authored
out of order?" — in different places. That interaction is settled below, in
**The #1003 interaction** and **What the token comparison still buys**.

## The reproduction, before

Pinned community binary at `ptah-atlas-conformance/bin/atlas`, which reports
`atlas community version v1.3.0`. sqlite, `--dir file://m?format=flyway`,
`atlas.sum` written by each tool for its own run, exit codes captured
immediately, tables read back from `sqlite_master`. `ptah-compat` built from
`master`.

`V2__s2.sql` applied, then `V10__y.sql` added:

```
$ atlas migrate apply --url sqlite://ce.db --dir 'file://m?format=flyway'
Error: migration file V10__y.sql was added out of order. See: https://atlasgo.io/versioned/apply#non-linear-error
exit=1        tables: s2

$ ptah-compat migrate apply --url sqlite://ptah.db --dir 'file://m?format=flyway'
Migrating to version 4611686018427836747 from 1 pending migrations.
Migration complete. Current version: 4611686018427836747
exit=0        tables: s2,y        <- executed what the oracle refuses
```

## The reproduction, after

Same fixture, `ptah-compat` built from this branch:

```
$ ptah-compat migrate apply --url sqlite://ptah.db --dir 'file://m?format=flyway'
Error: error applying migrations: out-of-order pending migrations for current
version 4611686018427510315 (source version "2"): 4611686018427836747
(source version "10") (use --exec-order=non-linear to apply or
--exec-order=linear-skip to ignore)
exit=1        tables: s2
```

The mirror shape (`V10` applied, `V2__y.sql` added) already matched and still
does, and a fresh apply of a directory holding both still runs version 2 then
version 10 at exit 0 on both tools.

## Why

Two comparisons decide two different questions about the same directory:

- **ORDER**, for `atlas.sum` and for execution, is **numeric** on the version
  components. `flywayOrderingKey` reproduces exactly that, and it is measured to
  match — a fresh apply of `V2__a.sql` beside `V10__b.sql` runs version 2 then
  version 10 on the pinned binary. #982 converged on it and it is right.
- **LINEARITY** — "was this file added after everything already applied" — is
  decided on the version **token as a string**, where `"10"` sorts below `"2"`.

The apply path keyed pending-ness and the linear guard on the ordering int64,
which answers the second question with the first one's answer. This is the same
class of mistake PR #1123 had to fix inside #1003: ordering and identity are
different questions, and here ordering and linearity are too.

The rule is derived from the pinned binary by measurement alone — 20 probe
cells for the rule itself, then the grids below, every cell explained. Nothing
here rests on reading that binary's source.

## What changed

The token is carried **alongside** the executed version, never replacing it —
renumbering would strand every revision row already recorded, which is the cost
`checkLegacyFlywayRevisions` exists to document.

- `atlasmigrateimport.FlywaySourceVersions` maps each converted version to Atlas
  CE's version string for its file. Nil for every other layout.
- `Migrator.WithSourceVersions` hands that map to the linear guard, which now
  refuses a pending migration when its version sorts **below the current one**
  **OR** its token does not sort **above every applied token**.
- The comparison runs inside the migration lock, on the applied set the migrator
  reads there, so a concurrent writer cannot move the mark between the check and
  the run — the same reasoning `--to-version` was built on in #1117.

The two halves are unioned and neither subsumes the other: `V3` added to a
database holding `V2` and `V10` is caught only by the numeric one, `V10` added to
a database holding `V2` only by the textual one.

## The #1003 interaction

#1003 refuses a surviving baseline whose position the recorded history has
already passed. This branch teaches the linear guard to compare the source
token. Rebased, two of this branch's own rows went red, and one of them was the
decision: **`V2` applied, `B10__sqbase.sql` added** was asserted to stay exempt
and apply, and on master it is refused.

The whole space where the two guards can meet, re-measured for this PR against
three binaries — the pinned community build v1.3.0, a compat built from master
at `2a189a46`, and a compat built from this branch's head. Same protocol as
above; "answered by" names the guard that produces compat's verdict.

| applied | added | pinned v1.3.0 | compat @ master | compat @ head | answered by |
| --- | --- | --- | --- | --- | --- |
| `V2` | `B10` | 0, skipped silently | 1 | 1 | #1003 |
| `V2` | `B1` | 0, skipped silently | 1 | 1 | #1003 |
| `V2` | `B3` | 0, executed | 0, executed | 0, executed | — |
| `V1`,`V2`,`V3` | `B2` | 0, skipped silently | 1 | 1 | #1003 |
| `V1`,`V2` | `B2` | 0, skipped silently | 1 | 1 | #1003 |
| `V1`,`V2` | `B3` | 0, executed | 0, executed | 0, executed | — |
| `V02` | `B10` | 0, executed | 0, executed | 0, executed | — |
| `V2` | `B02` | 0, skipped silently | 1 | 1 | #1003 |
| `V01`,`V02` | `B2` | 0, executed | 0, executed | 0, executed | — |
| `V2`,`V10` | `B11` | 1, added out of order | 1 | 1 | #1003 |
| `V2` | `B10`, `V11` | 1, names `V11` | 1 | 1 | #1003 |
| `V9` | `B10` | 0, skipped silently | 1 | 1 | #1003 |
| `V2`,`V10` | `B3` | 0, executed | 0, executed | 0, executed | — |
| `V2`,`V10` | `B1` | 0, skipped silently | 1 | 1 | #1003 |
| `V10` | `B2` | 0, executed | 0, executed | 0, executed | — |
| `V2` | `B10`, `V1` | 0, skipped silently | 1 | 1 | #1003 |
| `V02`,`V03` | `B10` | 0, executed | 0, executed | 0, executed | — |
| `V2` | `B10` `--dry-run` | 0, skipped silently | 1 | 1 | #1003 |
| `V2` | `B10` `--exec-order=non-linear` | 0, skipped silently | 0, executed | 0, executed | — |
| `V2` | `B10` `--exec-order=linear-skip` | 0, skipped silently | 0, executed | 0, executed | — |
| `V2` | `V10` | 1, added out of order | **0, executed** | 1 | source token |
| `V2` | `R__r` | 1, added out of order | **0, executed** | 1 | source token |
| `V2` | `V1` | 0, skipped silently | 1 | 1 | numeric |
| `V2`,`V10` | `V3` | 1, added out of order | 1 | 1 | numeric |
| `V2` | `V3` | 0, executed | 0, executed | 0, executed | — |
| `V01` | `V2` | 0, executed | 0, executed | 0, executed | — |

### The decision

**The refusal is correct and this branch's test expectation was written against
a world that no longer exists.** The row now asserts the refusal.

The expectation matched **neither** tool. The pinned binary exits 0 having run
nothing; the row asserted exit 0 having *run the squash on top of the history it
squashes*. That is the third behavior #1003 examined and rejected.

The reason the token comparison does **not** subsume #1003's refusal is visible
in the grid and provable from the selection rule. Split the baseline rows by
whether the source comparison would flag the baseline at all — that is, whether
its token sorts at or below the highest applied token:

- **Token at or below the mark**: `V2`+`B10`, `V2`+`B1`, `V1,V2,V3`+`B2`,
  `V1,V2`+`B2`, `V2`+`B02`, `V2,V10`+`B11`, `V2`+`B10,V11`, `V9`+`B10`,
  `V2,V10`+`B1`, `V2`+`B10,V1`. **All ten are refused by #1003's guard**, on
  master and on this branch, and the message is #1003's in every one.
- **Token above the mark**: `V2`+`B3`, `V1,V2`+`B3`, `V02`+`B10`,
  `V01,V02`+`B2`, `V2,V10`+`B3`, `V10`+`B2`, `V02,V03`+`B10`. **All seven
  execute on all three binaries**, and the source comparison never flags them.

That is not a coincidence of the fixtures. Squashing compares the two version
tokens as strings, so a file whose token outranks the baseline's survives into
`Covered` and one carrying the baseline's own token lands in `SameVersion`; if
the baseline's token is at or below the highest applied token, the file holding
that mark must be in one of the two, and #1003's guard fires. So the source
comparison can never be the deciding refusal for a surviving baseline.
Narrowing #1003's guard would therefore have removed a refusal and replaced it
with nothing for those ten cells, and re-opened the shapes it was built for.

The exemption is still load-bearing — for the **numeric** half. A surviving
baseline is converted into the band below every survivor whatever its own token,
so without the exemption the seven executing rows above would be refused,
including the twelve zero-padded cells PR #1123 fixed.

## What the token comparison still buys

Every cell in the table below. None of them has a `B` file in it, and #1003's
guard returns nil for all of them — it requires a surviving baseline. The two
guards partition the space rather than overlapping it.

| applied | added | pinned v1.3.0 | compat before | compat now |
| --- | --- | --- | --- | --- |
| `V2` | `V10` | 1 | 0, executed | 1 |
| `V3` | `V10` | 1 | 0, executed | 1 |
| `V9` | `V10` | 1 | 0, executed | 1 |
| `V1`, `V2` | `V10` | 1 | 0, executed | 1 |
| `V2`, `V3` | `V10` | 1 | 0, executed | 1 |
| `V2`, `V10` | `V11` | 1 | 0, executed | 1 |
| `V2`, `V10` | `V15` | 1 | 0, executed | 1 |
| `V2` | `V100` | 1 | 0, executed | 1 |
| `V2` | `V10`, `V11` | 1 | 0, executed | 1 |
| `V2` | `V3`, `V10` | 1 | 0, executed | 1 |
| `V2` | `R__r` | 1 | 0, executed | 1 |
| `V2` | `R1__r` | 1 | 0, executed | 1 |
| `V2` | `R9__r` | 1 | 0, executed | 1 |
| `V2` | `Rfoo__r` | 1 | 0, executed | 1 |
| `V9` | `R2__r` | 1 | 0, executed | 1 |

Repeatables are the same defect wearing a different hat. Atlas gives every
repeatable the version string `""`, which sorts below every token, so it refuses
one added to a database with any history whatever the file is called. Ptah placed
them on a reserved slot above every versioned migration, where the numeric
comparison sees nothing wrong.

Cells that already matched and are unchanged: `V2`+`V3`, `V2`+`V20`, `V10`+`V11`,
`V01`+`V2`, `V1`+`V10`, `V0`+`V10`, `V1.1`+`V1.10`, `V10`+`V2`, `V2`,`V10`+`V3`,
`V10`,`V11`+`V9`, and every fresh-directory shape.

## Nine more cells, found by hunting for the direction that must never happen

The rule the whole branch exists to protect is one-sided: compat may be stricter
than the pinned binary, never looser. A sweep of 189 `(applied, added)` pairs
crossing nine applied sets with twenty-one added sets found nine cells where
compat exits 0 and the pinned binary exits 1 — all of them a **surviving
baseline plus a repeatable**:

| applied | added | pinned v1.3.0 | compat before | compat now |
| --- | --- | --- | --- | --- |
| `V1` | `B10`, `R__r` | 1 | 0, executed | 1 |
| `V1` | `B3`, `R__r` | 1 | 0, executed | 1 |
| `V2` | `B3`, `R__r` | 1 | 0, executed | 1 |
| `V10` | `B3`, `R__r` | 1 | 0, executed | 1 |
| `V2`,`V10` | `B3`, `R__r` | 1 | 0, executed | 1 |
| `V01`,`V02` | `B10`, `R__r` | 1 | 0, executed | 1 |
| `V01`,`V02` | `B3`, `R__r` | 1 | 0, executed | 1 |
| `V05`,`V06`,`V07` | `B10`, `R__r` | 1 | 0, executed | 1 |
| `V05`,`V06`,`V07` | `B3`, `R__r` | 1 | 0, executed | 1 |

```
$ atlas migrate apply --url sqlite://ce.db --dir 'file://m?format=flyway'
Error: migration files B3__nb3.sql, R__nr.sql were added out of order.
exit=1        tables: a2

$ ptah-compat migrate apply --url sqlite://ptah.db --dir 'file://m?format=flyway'
Migrating to version 9223372036854775807 from 2 pending migrations.
exit=0        tables: a2,nb3,nr
```

They are the same repeatable defect, hidden behind a squash. The source
comparison's mark is the highest token among the **applied** versions; a
surviving baseline retires the applied file from the covered set, its token goes
with it, the lookup reports "no mark at all" and every pending file passes. The
cells are equally loose on master, so this is not a regression the branch
introduced — but shipping while they stood would have shipped the claim that a
repeatable is refused "whatever the file is called" against a measurement that
says otherwise.

`FlywaySourceVersions` now also carries the tokens of the migrations the
surviving baseline squashed, keyed by the Atlas version a database that ran them
recorded. The domain is this directory **without** the baseline — the same
domain and the same argument `flywaySameVersionMigrations` uses in #1123: it is
the only shape such a revision row can have come from, and re-running the
selection with the baseline removed puts each file back at the tie slot it was
recorded under rather than assuming slot 0.

It only **fills gaps**. The executed mapping is written first, so a version this
directory still executes never takes a squashed file's token — which matters,
because the two selections do collide: `B02__base.sql` beside `V2__a.sql` and
`V02__b.sql` leaves `V2` holding the tie slot `V02` had. Filling gaps can only
add a token, which can only raise the mark, which can only refuse more; a file
whose token does not sort strictly above the highest applied token is one Atlas
CE never executes, so refusing more is the safe direction. One removal, not a
transitive reconstruction: a superseded baseline's squashes are not recovered,
which is the conservative half again.

After the fix the sweep reports **zero** cells where compat exits 0 and the
pinned binary exits 1, and the nine rows above are the **only** rows in it whose
answer changed.

## The message

`--exec-order` is unchanged, but the error drops the word "below" for a
converted directory, because a version can be refused while sorting **above**
the current one. It names the **source version** because the int64 appears in no
file name and in no Atlas output — PR #1123 corrected the same defect in the
#1003 refusal. The **native** wording is byte-for-byte unchanged, and
`TestCompatMigrateApply_GooseKeepsTheOutOfOrderGuard` holds it with both a
positive and a negative assertion.

`--exec-order=linear-skip` now leaves refused migrations unapplied instead of
executing them, which is what the pinned binary does with the same input. It
reads the verdict the linear branch computed rather than re-deriving it
numerically; re-deriving is how linear could refuse while linear-skip silently
ran the same file. A dry run refuses too, as the oracle does. Note that this is
a statement about the **linear guard's** verdict: #1003's baseline refusal
stands aside under both exec-order flags by design, so an exempt baseline still
runs under `linear-skip`, and a test row pins that.

## What each test prints if the change is reverted

`cmd/atlas/migrate_apply_flyway_source_order_test.go`, 20 rows. Every row states
this in a comment beside it.

Rows that go red on a revert of the token comparison:

- `a tenth migration added under an applied second` — exit 0, `Migrating to
  version 4611686018427836747 from 1 pending migrations.`, tables `sq2`, `sq10`.
- `a tenth migration added under an applied ninth` — exit 0, tables `sq2`, `sq10`.
- `a hundredth migration added under an applied second` — exit 0, tables `sq2`,
  `sq100`.
- `a repeatable added to recorded history` — exit 0, tables `sq2`, `sqr`.
- `a repeatable whose own token sorts high is still refused` — exit 0, tables
  `sq2`, `sqr`.
- `a fifteenth migration under applied second and tenth` — exit 0, tables `sq10`,
  `sq15`, `sq2`.
- `linear-skip leaves the tenth migration unapplied` — still exit 0, but tables
  `sq2` **and** `sq10`: the skip executed what it claims to skip.
- `a dry run refuses rather than previewing the refused migration` — exit 0,
  `Would have applied 1 migrations.`

Rows added by the two decisions in this update:

- `a repeatable added beside a baseline that squashes the applied migration` —
  with the token recovery removed: exit 0, `Migrating to version
  9223372036854775807 from 2 pending migrations.`, tables `sq2`, `sqb3`, `sqr`.
- `a forward migration beside a baseline that squashes the applied migration` —
  green either way; it goes red if the recovered mark is the **baseline's** token
  rather than the squashed file's.
- `a surviving baseline below the mark is refused as a baseline, not as out of
  order` — with #1003's refusal removed for this shape: exit 0, `Migrating to
  version 448844 from 1 pending migrations.` / `Migration complete. Current
  version: 4611686018427510315`, tables `sq2` **and** `sqbase`. It also asserts
  the absence of the out-of-order wording, so it holds *which* guard answers.
- `linear-skip runs the exempt baseline rather than skipping it` — with the
  exemption reaching only the numeric half of the union: exit 0 with tables
  `sq2` alone, the baseline silently dropped. This replaces the old row's job:
  the exemption is no longer observable under `linear`, because #1003's guard
  answers there whether or not the baseline is exempt.

Rows green either way, which is their job — they fail if the new comparison
starts refusing ordinary sequences: `the next single-digit migration still
applies`, `a twentieth migration still applies over an applied second`, `a
twentieth migration still applies over applied second and tenth`, `an eleventh
migration still applies over an applied tenth`, `an unpadded second migration
still applies over an applied zero-padded first`, `a settled directory holding
both versions is not refused afterwards`, `non-linear runs the tenth migration
the refusal names`.

`an ordinary migration under an applied two-digit version` is the union's other
half: reverting only the numeric comparison prints exit 0 with tables `sq2`,
`sq3` and `sq10`.

`internal/atlasmigrateimport/flywayselection_test.go`,
`TestFlywaySourceVersionsCarriesSquashedTokens`, 5 rows asserting the token
**set** — the int64 keys are this build's projection while the tokens are Atlas
CE's own strings, so a row spelling out both would only prove the fixture was
written twice. Removing the recovery reddens exactly three: `a baseline that
squashes the only applied migration` prints `["3"]`, `a repeatable beside a
baseline that squashes the applied migration` prints `["", "3"]`, `a zero-padded
migration squashed by an unpadded baseline` prints `["1", "3"]`. `a padded and
an unpadded migration on one ordering slot` is the collision row: recovering by
overwrite rather than by filling gaps prints `["02", "02", "2", "3"]`. `a
baseline below every applied migration` and `a directory with no baseline at
all` are the controls.

Five assertions in `migrate_apply_legacy_flyway_test.go` moved from `below
current version` to `for current version` and gained source-version assertions —
three in the first commit, two more here that #1123 added to master while this
branch waited. The goose row in the same file keeps `below current version` and
also asserts the message carries **no** `source version` — that is the
discriminator for "the native wording did not move".

## Non-interference, proved with the inverse mutant

A control that expects execution cannot be validated by deleting the guard —
deleting a guard never makes it fire. `scripts/mutations/flyway-source-version-order.json`
carries an inverse mutant that makes the source comparison refuse **every**
pending migration carrying a token. In `TestCompatMigrateApplyFlywaySourceVersionOrder`
it reddens exactly the six rows that expect execution:

```
--- FAIL: .../the_next_single-digit_migration_still_applies
--- FAIL: .../a_twentieth_migration_still_applies_over_an_applied_second
--- FAIL: .../a_twentieth_migration_still_applies_over_applied_second_and_tenth
--- FAIL: .../an_eleventh_migration_still_applies_over_an_applied_tenth
--- FAIL: .../an_unpadded_second_migration_still_applies_over_an_applied_zero-padded_first
--- FAIL: .../a_forward_migration_beside_a_baseline_that_squashes_the_applied_migration
```

The two baseline rows stay green under it, and that is the exemption doing its
job: the mutant flags the baseline like everything else, and the exemption
removes it from the union before the verdict is read. It also reddens
`TestCompatMigrateApply_FlywayBaselineAfterApply`,
`TestCompatMigrateApply_LegacyFlywayDetectorDoesNotOverRefuse` and
`TestCompatMigrateApply_LegacyFlywayRefusalPrintsWorkingRecovery`, which is the
same property being held from three other directions.

Mutation sweep: `scripts/mutations/flyway-source-version-order.json` **14/14
killed**, no BUILD-FAILED and no PATCH-FAILED. Four rules are new: the token
recovery, its gap-fill discipline, the identity of the token it recovers, and
"the surviving-baseline refusal is removed, leaving the exemption to decide" —
the last is the discriminator for the decision above, and it reddens five
subtests across `TestCompatMigrateApplyFlywaySourceVersionOrder` and
`TestCompatMigrateApply_FlywayBaselineAgainstRecordedHistory`.

Each new mutation was also run alone and its reddened subtests read by name
rather than by count: the half-exemption mutant reddens exactly `linear-skip
runs the exempt baseline rather than skipping it`, and the removed-refusal
mutant reddens exactly `a surviving baseline below the mark is refused as a
baseline, not as out of order`.

## Not touched, and measured to be a different shape

golang-migrate, goose, dbmate and native Atlas directories are listed in
file-**name** order, which is the same textual order the linear comparison uses,
so the two never disagree there. On "2 applied, add 10" the pinned binary answers
all four with `No migration files to execute` at exit 0 rather than a refusal,
and compat's answers for those layouts are byte-identical before and after this
change. Only Flyway is sorted numerically while being compared textually.

## Docs

`docs/site/src/content/docs/atlas/migrate-commands.md` gains the two-comparison
rule and the refusal it produces, and its claim that Flyway repeatables "cannot
yet be executed as versioned migrations" is corrected, because it is measurably
false.

`docs/site/src/content/docs/versioned/integrity-and-safety.md` — the note the
#1003 refusal sends readers to — carried a claim that measurement contradicts:
"Atlas CE applies a below-mark baseline under that flag too", of
`--exec-order=non-linear`. That holds only for a baseline Atlas CE refuses as
out of order, not for one it skips silently, which is the first row of the
note's own table:

| applied | added | flag | pinned v1.3.0 |
| --- | --- | --- | --- |
| `V1`,`V2`,`V3` | `B2.5__base.sql` | (none) | 1, `added out of order` |
| `V1`,`V2`,`V3` | `B2.5__base.sql` | `--exec-order=non-linear` | 0, `Migrating to version 2.5 from 3` |
| `V2` | `B10__base.sql` | `--exec-order=non-linear` | 0, `No migration files to execute` |
| `V2` | `B10__base.sql` | `--exec-order=linear-skip` | 0, `No migration files to execute` |

`ptah-compat` executes the baseline in all four. The note now says so, and adds
`--exec-order=linear-skip` to the list of flags that leave the baseline runnable,
which it had omitted.

## Deliberately left open

- **`V2` applied, `V1` added.** The pinned binary exits 0 and drops `V1` silently.
  Ptah refuses, as it already did. That is the #1003 footgun and this change does
  not import it. Strict direction, permitted.
- **`V2` applied, `V02` added.** The pinned binary drops it silently; Ptah exits 1
  on a checksum mismatch, because the tie slot `V2` was recorded under moves when
  `V02` joins the run. Unchanged here, and it belongs to the identity family PR
  #1123 works in, not to ordering.
- **A surviving baseline the pinned binary skips silently is refused here**
  (`V2`+`B10` and nine relatives). #1003's decision, re-measured for this PR and
  unchanged. Strict direction, permitted.
- **An exempt baseline runs under `--exec-order=linear-skip` where the pinned
  binary skips it.** Both exit 0, so no parity rule is broken. It is #1003's
  abstention: with an exec order named explicitly the operator has already made
  the decision. Now pinned by a test row and stated in the docs note rather than
  left implicit.
- **When a baseline and an out-of-order migration are both pending, the two tools
  name different files.** `V2` applied plus `B10` and `V11`: the pinned binary
  names `V11`, Ptah names `B10`. Exit code and executed set match. Same class as
  `V2` applied plus `V3` and `V10`, where the pinned binary names both files and
  Ptah names only `V10`.
- **`MigrationStatus.OutOfOrderMigrations` is still the numeric verdict alone.**
  The linear guard's verdict is the union; the status field is not, so
  `migrate status` under-reports for a converted Flyway directory. It cannot
  produce a looser apply — every version the status field lists is also in the
  union — but it is an inconsistency worth its own issue.
- **The refusal names the numerically highest applied version as "current",
  while the comparison uses the textually highest token.** With `V2` and `V10`
  applied the message reads `for current version ... (source version "10")`
  while the mark was `"2"`. Both operands are correct for their own question;
  the message could say which. Not changed here.
- **Subdirectory shapes.** Every grid cell is a flat directory. The
  backwards-reaching squash rule compares a survivor's full **path** against the
  baseline's token, so the subsumption argument above is measured for flat
  directories and reasoned, not measured, for nested ones.
- **Non-Flyway layouts executing what the oracle silently drops** (both exit 0, so
  no parity-rule violation). Same class as #1003 and not decided here.
- **The stale encoding prose** two sentences further down the migrate-commands
  paragraph — "a fixed-width `major.minor.patch` int64" and "depends only on the
  version, never on the other files in the directory" — predates #982's bands and
  tie budget. Correcting it needs its own measurement.

## Gates

- `go build ./...` — ok
- `go vet ./...` — ok
- `go test ./... -count=1` — ok, no failures
- `go tool qtlint ./...` — ok
- `golangci-lint run ./...` — `0 issues.`
- `scripts/check-test-style.sh` — `OK (175 conditional groups, 45 white-box files)`
- `scripts/check-public-api.sh` — ok
- `scripts/check-public-api-snapshot.sh` — ok, no snapshot movement in this
  update (`FlywaySourceVersions` keeps its signature)
- `scripts/check-public-api-released.sh` — ok (the reported incompatibilities are
  the pre-existing approved pre-v1 list, unchanged by this branch)

Docs (`docs/site`), every script `package.json` defines:

- `check:style` — `OK (100 documentation files)`
- `check:style:selftest` — `OK (16 rule assertions via analyze())`
- `check:exit-codes` — `OK (60 reference rows)`
- `check:exit-codes:selftest` — `OK`
- `check:core-doc-links` — `OK (7 protected core references)`
- `check:page-health` — `OK (59 sidebar entries)`
- `check:links` — `OK (60 pages, 60 routes, 565 heading anchors)`
- `check:links:selftest` — `OK`
- `check:redirects` — `OK (30 redirects)`
- `check:redirects:selftest` — `OK`
- `versions:selftest` — `OK`
- `build-feature-matrix.mjs --check` — `OK (162 rows)`
- `check:responsive:selftest` — `OK (overflow, wide-table, tall-cell, and
  unstyled-page guards verified)`
- `check:responsive` — **actually run this time**, after `npm ci`,
  `npx playwright install chromium` and `npm run build` (61 pages):
  `OK (60 routes x 2 viewports, cells within 8 lines)`. Without those three it
  prints `dist not found; run "npm run build" first` and exits **1**, so the
  earlier report that it exits 0 unrun was wrong on this tree.