### PR TITLE
fix(migrator): resume the retry after a failed migration body (refs #966)

### DIFF
--- a/cmd/atlas/migrate_apply_txtar_checks_test.go
+++ b/cmd/atlas/migrate_apply_txtar_checks_test.go
@@ -74,10 +74,10 @@ func TestMigrateApplyTxtarFailingChecksAbortBeforeBody(t *testing.T) {
 
 // TestMigrateApplyTxtarRetryAfterFixingDataSucceeds is the recovery half of the
 // gate on the surface that needs it most: `ptah-compat migrate apply` registers
-// no --skip-checks (Atlas has none either), and its --allow-dirty cannot clear
-// a dirty row because the retry fails on the revision re-insert (#966). A
-// failed check must therefore leave no dirty row behind, or the drop-in
-// workflow is wedged with no working in-band recovery.
+// no --skip-checks (Atlas has none either), so a check failure that left a dirty
+// row would force every later apply through --allow-dirty. Since #966 that flag
+// does recover, but a failed check must still leave no dirty row behind, or the
+// drop-in workflow needs a flag Atlas users never had to pass.
 func TestMigrateApplyTxtarRetryAfterFixingDataSucceeds(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()

--- a/cmd/atlas/migrate_dirty_retry_test.go
+++ b/cmd/atlas/migrate_dirty_retry_test.go
@@ -1,0 +1,188 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// The compat surface half of stokaro/ptah#966: `migrate apply` registers
+// --allow-dirty (and no --skip-checks, matching Atlas), but after a migration
+// body failed the flag could not be used — the retry re-inserted the same
+// version and died on the revision table's UNIQUE constraint — and `migrate
+// status` reported the half-applied version as Current Version with no sign
+// that anything was wrong.
+
+const dirtyRetryVersionOne = "20240301000001"
+const dirtyRetryVersionTwo = "20240301000002"
+
+// writeDirtyRetryFixture writes a two-migration Atlas directory whose second
+// migration's body fails on its second statement, hashed so the apply integrity
+// gate lets it through.
+func writeDirtyRetryFixture(c *qt.C, secondBody string) (migrationsDir, dbPath string) {
+	c.Helper()
+	root := c.TempDir()
+	migrationsDir = filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	writeDirtyRetrySecond(c, migrationsDir, secondBody)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, dirtyRetryVersionOne+"_one.sql"),
+		[]byte("CREATE TABLE dr_one (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return migrationsDir, filepath.Join(root, "dirty.db")
+}
+
+// writeDirtyRetrySecond rewrites the second migration and re-hashes the
+// directory, modeling the operator fixing the migration between runs.
+func writeDirtyRetrySecond(c *qt.C, migrationsDir, body string) {
+	c.Helper()
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, dirtyRetryVersionTwo+"_two.sql"),
+		[]byte(body),
+		0o600,
+	), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+}
+
+const dirtyRetryFailingBody = `CREATE TABLE dr_two (id INTEGER PRIMARY KEY);
+THIS IS A FAILING STATEMENT;
+`
+
+const dirtyRetryFixedBody = `CREATE TABLE dr_two (id INTEGER PRIMARY KEY);
+CREATE TABLE dr_three (id INTEGER PRIMARY KEY);
+`
+
+// TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure is the
+// compat-surface reproduction from #966, end to end through the CLI.
+//
+// Reverted, the final apply fails with "failed to record pending migration
+// 20240301000002: ... UNIQUE constraint failed: atlas_schema_revisions.version"
+// and dr_three is never created.
+func TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeDirtyRetryFixture(c, dirtyRetryFailingBody)
+
+	_, _, err := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "failed to apply migration "+dirtyRetryVersionTwo)
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "dr_two")
+
+	// Without the flag the dirty guard still refuses, so --allow-dirty is doing
+	// the work rather than the guard having quietly disappeared.
+	writeDirtyRetrySecond(c, migrationsDir, dirtyRetryFixedBody)
+	_, _, guardErr := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(guardErr, qt.IsNotNil)
+	c.Assert(guardErr.Error(), qt.Contains, "is dirty")
+
+	stdout, _, retryErr := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+		"--allow-dirty",
+	)
+	c.Assert(retryErr, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Migration complete. Current version: "+dirtyRetryVersionTwo)
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "dr_two")
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "dr_three")
+	// One row per version: the retry reused the dirty row instead of adding one.
+	c.Assert(
+		sqliteAtlasRevisionVersions(c, dbPath),
+		qt.DeepEquals,
+		[]string{dirtyRetryVersionOne, dirtyRetryVersionTwo},
+	)
+
+	statusOut, _, statusErr := runCompatStreams(c,
+		"migrate", "status",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(statusErr, qt.IsNil)
+	c.Assert(statusOut, qt.Contains, "Status: Database is up to date")
+	c.Assert(statusOut, qt.Not(qt.Contains), "Dirty Migration:")
+}
+
+// TestCompatCommand_DirtyGuardRefusalLeavesTheDatabaseWritable isolates the
+// connection leak the recovery path used to walk into: the dirty guard's own
+// query left an unscanned *sql.Row on the Atlas revision layout, pinning its
+// connection and its SQLite read lock for the rest of the process.
+//
+// Reverted, `migrate set` after the refusal fails with "failed to commit Atlas
+// revision set transaction: database is locked (5) (SQLITE_BUSY)" — and so does
+// every other write, including the --allow-dirty retry this issue is about.
+func TestCompatCommand_DirtyGuardRefusalLeavesTheDatabaseWritable(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeDirtyRetryFixture(c, dirtyRetryFailingBody)
+
+	_, _, err := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(err, qt.IsNotNil)
+
+	// The refusal itself: this is the run that leaked.
+	_, _, guardErr := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(guardErr, qt.IsNotNil)
+	c.Assert(guardErr.Error(), qt.Contains, "is dirty")
+
+	// Any write afterwards, in the same process, must still go through.
+	_, _, setErr := runCompatStreams(c,
+		"migrate", "set", dirtyRetryVersionOne,
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(setErr, qt.IsNil)
+	c.Assert(sqliteAtlasRevisionVersions(c, dbPath), qt.DeepEquals, []string{dirtyRetryVersionOne})
+}
+
+// TestCompatCommand_MigrateStatusReportsTheDirtyMigration covers the reporting
+// half: while a version is half-applied, status has to say so.
+//
+// Reverted, the output is Current Version / Total / Applied / Pending followed
+// straight by "Status: Pending migrations available", naming the failed version
+// as the current one with no dirty marker, no failing statement and no error —
+// the three Contains assertions below are what go red.
+func TestCompatCommand_MigrateStatusReportsTheDirtyMigration(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeDirtyRetryFixture(c, dirtyRetryFailingBody)
+
+	_, _, err := runCompatStreams(c,
+		"migrate", "apply",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+	c.Assert(err, qt.IsNotNil)
+
+	statusOut, _, statusErr := runCompatStreams(c,
+		"migrate", "status",
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+migrationsDir,
+	)
+
+	c.Assert(statusErr, qt.IsNil)
+	c.Assert(statusOut, qt.Contains, "Current Version: "+dirtyRetryVersionTwo)
+	c.Assert(statusOut, qt.Contains, "Dirty Migration: version="+dirtyRetryVersionTwo+" applied=0/2")
+	c.Assert(statusOut, qt.Contains, "Error Statement: THIS IS A FAILING STATEMENT")
+	c.Assert(statusOut, qt.Contains, "Error: failed to execute migration SQL")
+}

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -2,6 +2,7 @@ package atlas
 
 import (
 	"fmt"
+	"io"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -13,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/atlasreport"
+	"go.5x5.cz/ptah/migration/migrator"
 )
 
 type atlasMigrateStatusOptions struct {
@@ -232,11 +234,41 @@ func writeAtlasMigrateStatusDefault(cmd *cobra.Command, result atlasmigrate.Stat
 	fmt.Fprintf(out, "Total Migrations: %d\n", status.TotalMigrations)
 	fmt.Fprintf(out, "Applied Migrations: %d\n", len(status.AppliedMigrations))
 	fmt.Fprintf(out, "Pending Migrations: %d\n", len(status.PendingMigrations))
+	writeAtlasMigrateStatusDirty(out, status.DirtyRevision)
 	if status.HasPendingChanges {
 		fmt.Fprintln(out, "Status: Pending migrations available")
 		return
 	}
 	fmt.Fprintln(out, "Status: Database is up to date")
+}
+
+// writeAtlasMigrateStatusDirty reports a half-applied migration.
+//
+// Current Version above is the highest recorded version, which includes a
+// version whose body failed part-way; without this block the output named that
+// version and then said only "Pending migrations available", so a wedged
+// database was indistinguishable from a healthy one with work outstanding
+// (#966). The community Atlas binary annotates the same state on its own
+// Current Version line and prints the failing statement afterwards; this keeps
+// ptah-compat's own status layout and adds the same facts rather than
+// restructuring the block.
+func writeAtlasMigrateStatusDirty(out io.Writer, revision *migrator.MigrationRevision) {
+	if revision == nil {
+		return
+	}
+	fmt.Fprintf(
+		out,
+		"Dirty Migration: version=%d applied=%d/%d\n",
+		revision.Version,
+		revision.Applied,
+		revision.Total,
+	)
+	if revision.ErrorStatement != "" {
+		fmt.Fprintf(out, "Error Statement: %s\n", revision.ErrorStatement)
+	}
+	if revision.Error != "" {
+		fmt.Fprintf(out, "Error: %s\n", revision.Error)
+	}
 }
 
 func atlasStatusDirURL(raw string) string {

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -118,6 +118,39 @@ Pending Migrations: 0
 Status: Database is up to date
 ```
 
+## Recovering from a migration body that failed part-way
+
+Unlike Atlas, Ptah records a revision row for a migration whose body failed, so
+the failure survives the run that caused it. `migrate status` names that row
+explicitly, because `Current Version` counts it:
+
+```text
+=== MIGRATION STATUS ===
+Current Version: 20260721120100
+Total Migrations: 2
+Applied Migrations: 1
+Pending Migrations: 1
+Dirty Migration: version=20260721120100 applied=1/2
+Error Statement: ALTER TABLE users ADD COLUMN email TEXT
+Error: failed to execute migration SQL: ...
+Status: Pending migrations available
+```
+
+Fix the migration, rerun `ptah-compat migrate hash`, and rerun the apply with
+`--allow-dirty`. The retry reuses the dirty row instead of recording a second
+one and skips the statements the earlier attempt committed — under
+`--tx-mode none` above, statement 1 — so it resumes rather than repeating SQL.
+Atlas needs no flag here; `--allow-dirty` stays required so a half-applied
+migration is never resumed by accident.
+
+Two cases refuse to resume automatically and say so, naming
+`ptah migrations repair --version <v>`: a run interrupted mid-statement, whose
+last statement's outcome was never observed, and an edit that changed the
+migration's statement count, after which the recorded progress no longer indexes
+into the file.
+
+## Rolling back
+
 Roll back using the `down.sql` section. A bare `ptah-compat migrate down` reads
 the Atlas revision rows `migrate apply` wrote and starts the rollback without
 reading stdin:

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -180,8 +180,14 @@ people and pipelines share a directory:
 - **Batch limit** (`--limit`): apply only the first N pending migrations —
   useful for staged rollouts and verifying one step at a time. `--allow-dirty`
   is the explicit recovery escape hatch that proceeds past a dirty revision
-  row (for example one left by a crashed migration whose file was later
-  rebased); prefer `ptah migrations repair` for the dirty row itself.
+  row. When the dirty row belongs to a migration that is still pending — the
+  usual case, a body that failed part-way — the retry reuses that row rather
+  than recording a second one, and skips the statements the earlier attempt
+  committed, so fixing the migration and rerunning with `--allow-dirty` is the
+  recovery. Use `ptah migrations repair` when the row cannot be resumed
+  automatically: an interrupted process whose last statement has an unknown
+  outcome, an edit that changed the file's statement count, or a dirty row for
+  a migration whose file was rebased away.
 - **Execution order** (`--exec-order`): `linear` (default) fails when a merge
   landed a pending migration below the current version; `linear-skip` warns
   and leaves it pending; `non-linear` applies it. Status reports such

--- a/migration/migrator/atlas_tx_mode_matrix_test.go
+++ b/migration/migrator/atlas_tx_mode_matrix_test.go
@@ -126,9 +126,14 @@ func assertAtlasTxModeRejectedBeforeWrites(
 
 func TestAtlasTxModeMatrix_BodyFailurePath(t *testing.T) {
 	c := qt.New(t)
-	// Per-file transaction failures currently retain applied=1/2 even though
-	// SQLite rolls back the body (#887). This matrix pins effective mode
-	// selection for #998, not Atlas revision-bookkeeping parity.
+	// This matrix pins effective mode selection for #998.
+	//
+	// wantApplied and wantTable now agree in every row, and that agreement is
+	// the point: the first statement creates the table, so applied is 1 exactly
+	// when the table survived the failure and 0 when the body was rolled back.
+	// Before #966 the four rolled-back rows still recorded applied=1, which a
+	// retry would have read as "statement 1 is committed, resume at 2" and so
+	// skipped a CREATE TABLE that never ran.
 	tests := []struct {
 		name        string
 		globalMode  migrator.MigrationTxMode
@@ -139,13 +144,13 @@ func TestAtlasTxModeMatrix_BodyFailurePath(t *testing.T) {
 		{
 			name:        "global file directive absent",
 			globalMode:  migrator.MigrationTxModeFile,
-			wantApplied: 1,
+			wantApplied: 0,
 		},
 		{
 			name:        "global file directive file",
 			globalMode:  migrator.MigrationTxModeFile,
 			directive:   "-- atlas:txmode file\n\n",
-			wantApplied: 1,
+			wantApplied: 0,
 		},
 		{
 			name:        "global file directive none",
@@ -158,7 +163,7 @@ func TestAtlasTxModeMatrix_BodyFailurePath(t *testing.T) {
 			name:        "global file misplaced directive is ignored",
 			globalMode:  migrator.MigrationTxModeFile,
 			directive:   "-- generated migration\n\n-- atlas:txmode none\n",
-			wantApplied: 1,
+			wantApplied: 0,
 		},
 		{
 			name:       "global all directive absent",
@@ -174,7 +179,7 @@ func TestAtlasTxModeMatrix_BodyFailurePath(t *testing.T) {
 			name:        "global none directive file",
 			globalMode:  migrator.MigrationTxModeNone,
 			directive:   "-- atlas:txmode file\n\n",
-			wantApplied: 1,
+			wantApplied: 0,
 		},
 		{
 			name:        "global none directive none",

--- a/migration/migrator/dirty_retry_test.go
+++ b/migration/migrator/dirty_retry_test.go
@@ -264,6 +264,43 @@ func TestMigrateUp_AllowDirtyRefusesToResumeAnUnknownStatementOutcome(t *testing
 	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
 }
 
+// TestMigrateUp_TxModeAllAllowDirtyRetryReusesTheDirtyRevisionRow covers the
+// third transaction mode, whose bookkeeping goes through its own callers
+// (recordRolledBackBatchFailure and recordAppliedMigrationOn) rather than the
+// per-file path the tests above exercise.
+//
+// Reverted, the retry fails with "failed to record pending migration 2: ...
+// UNIQUE constraint failed: schema_migrations.version" exactly as the per-file
+// path did.
+func TestMigrateUp_TxModeAllAllowDirtyRetryReusesTheDirtyRevisionRow(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "txall.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeAll, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	// The batch rolled back whole: version 1 has no row, version 2 has a dirty
+	// one recording that nothing was applied.
+	revisions, err := m.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 1)
+	c.Assert(revisions[0].Version, qt.Equals, int64(2))
+	c.Assert(revisions[0].Applied, qt.Equals, 0)
+	c.Assert(dirtyRetryTableExists(c, conn, "users"), qt.IsFalse)
+
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeAll, migrator.RevisionTableFormatPtah)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+
+	after, err := fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(after, qt.HasLen, 2)
+	c.Assert(after[1].Version, qt.Equals, int64(2))
+	c.Assert(after[1].Dirty, qt.IsFalse)
+	c.Assert(after[1].Applied, qt.Equals, 2)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+}
+
 // newRegisteredDirtyRetryMigrator builds a migrator over programmatically
 // registered SQL, which executes through [executeSQLStatements] rather than the
 // file provider's loop. The two loops are separate gates: a resume floor

--- a/migration/migrator/dirty_retry_test.go
+++ b/migration/migrator/dirty_retry_test.go
@@ -1,0 +1,358 @@
+package migrator_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// Recovery after a failed migration body (#966).
+//
+// A body that fails part-way records a dirty revision row. Every retry then had
+// to insert that same version again and died on the revision table's UNIQUE
+// constraint, including the retry the operator asked for with --allow-dirty
+// after fixing the migration; `migrations repair` was the only way out. These
+// tests fail a real migration's body, fix it, and require the retry to run.
+//
+// The fixture discriminates: the same fixed migration set applies cleanly to an
+// empty database, so only the dirty-row retry path is under test.
+
+const dirtyRetryFirstUp = "CREATE TABLE users (id INTEGER PRIMARY KEY);\n"
+
+// dirtyRetryFailingUp fails on its second statement. Under a per-file
+// transaction the whole body is rolled back; under no-transaction the INSERT is
+// already committed when the retry starts, which is what makes the audit row
+// count a resume detector rather than an idempotence accident.
+const dirtyRetryFailingUp = `INSERT INTO users (id) VALUES (1);
+THIS IS A FAILING STATEMENT;
+`
+
+const dirtyRetryFixedUp = `INSERT INTO users (id) VALUES (1);
+CREATE TABLE pets (id INTEGER PRIMARY KEY);
+`
+
+// newDirtyRetryMigrator builds a migrator over a two-migration directory whose
+// second file is secondUp, sharing dbPath so a later call models a second run of
+// the tool against the database the first one left behind.
+func newDirtyRetryMigrator(
+	c *qt.C,
+	dbPath string,
+	secondUp string,
+	txMode migrator.MigrationTxMode,
+	revisionFormat migrator.RevisionTableFormat,
+) (*dbschema.DatabaseConnection, *migrator.Migrator) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { _ = conn.Close() })
+
+	m, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"0000000001_users.up.sql":   &fstest.MapFile{Data: []byte(dirtyRetryFirstUp)},
+		"0000000001_users.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE users;\n")},
+		"0000000002_seed.up.sql":    &fstest.MapFile{Data: []byte(secondUp)},
+		"0000000002_seed.down.sql":  &fstest.MapFile{Data: []byte("DROP TABLE pets;\n")},
+	})
+	c.Assert(err, qt.IsNil)
+	return conn, m.WithTransactionMode(txMode).WithRevisionTableFormat(revisionFormat)
+}
+
+func dirtyRetryUserCount(c *qt.C, conn *dbschema.DatabaseConnection) int {
+	c.Helper()
+	var count int
+	c.Assert(conn.QueryRowContext(c.Context(), "SELECT count(*) FROM users").Scan(&count), qt.IsNil)
+	return count
+}
+
+func dirtyRetryTableExists(c *qt.C, conn *dbschema.DatabaseConnection, table string) bool {
+	c.Helper()
+	var count int
+	c.Assert(
+		conn.QueryRowContext(
+			c.Context(),
+			"SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = ?",
+			table,
+		).Scan(&count),
+		qt.IsNil,
+	)
+	return count == 1
+}
+
+// TestMigrateUp_AllowDirtyRetryReusesTheDirtyRevisionRow is the core #966
+// contract on the native surface under the default per-file transaction mode.
+//
+// Reverted (the up path inserts unconditionally again), the retry fails with
+// "failed to record pending migration 2: ... UNIQUE constraint failed:
+// schema_migrations.version" and version 2 stays dirty forever.
+func TestMigrateUp_AllowDirtyRetryReusesTheDirtyRevisionRow(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "retry.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	// The per-file transaction rolled the body back, so nothing was applied and
+	// the counter says so.
+	revisions, err := m.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[1].Version, qt.Equals, int64(2))
+	c.Assert(revisions[1].Dirty, qt.IsTrue)
+	c.Assert(revisions[1].Applied, qt.Equals, 0)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 0)
+
+	// The operator fixes the migration and reruns with the escape hatch.
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+
+	// One row per version, and version 2 is applied rather than duplicated.
+	after, err := fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(after, qt.HasLen, 2)
+	c.Assert(after[1].Version, qt.Equals, int64(2))
+	c.Assert(after[1].Dirty, qt.IsFalse)
+	c.Assert(after[1].Applied, qt.Equals, 2)
+	c.Assert(after[1].Total, qt.Equals, 2)
+	// The rolled-back body ran in full, exactly once.
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+
+	status, err := fixed.GetMigrationStatus(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(2))
+}
+
+// TestMigrateUp_AllowDirtyRetryResumesAfterCommittedStatements covers the
+// no-transaction case, where the earlier attempt's first statement is already
+// committed when the retry starts.
+//
+// Reverted to a plain row reuse with no resume, the retry re-runs the committed
+// INSERT and users holds 2 rows instead of 1; reverted entirely, the retry fails
+// with "UNIQUE constraint failed: schema_migrations.version" as above.
+func TestMigrateUp_AllowDirtyRetryResumesAfterCommittedStatements(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "resume.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	// Statement 1 committed outside any transaction, and the counter says so.
+	revisions, err := m.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[1].Applied, qt.Equals, 1)
+	c.Assert(revisions[1].Total, qt.Equals, 2)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+
+	// The committed INSERT was skipped, not repeated: one user, not two. The
+	// primary key would have rejected a repeat, so this also proves the retry
+	// did not merely swallow an error.
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+
+	after, err := fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(after, qt.HasLen, 2)
+	c.Assert(after[1].Dirty, qt.IsFalse)
+	c.Assert(after[1].Applied, qt.Equals, 2)
+}
+
+// TestMigrateUp_AtlasFormatAllowDirtyRetryReusesTheDirtyRevisionRow is the same
+// contract on the Atlas-shaped revision table that `ptah-compat migrate apply`
+// writes, which registers --allow-dirty and no --skip-checks.
+//
+// Reverted, the retry fails with "UNIQUE constraint failed:
+// atlas_schema_revisions.version".
+func TestMigrateUp_AtlasFormatAllowDirtyRetryReusesTheDirtyRevisionRow(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "atlas-retry.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatAtlas)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatAtlas)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+
+	var rows int
+	c.Assert(
+		conn.QueryRowContext(c.Context(), "SELECT count(*) FROM atlas_schema_revisions WHERE version = '2'").Scan(&rows),
+		qt.IsNil,
+	)
+	c.Assert(rows, qt.Equals, 1)
+
+	after, err := fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(after, qt.HasLen, 2)
+	c.Assert(after[1].Dirty, qt.IsFalse)
+	c.Assert(after[1].Applied, qt.Equals, 2)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+}
+
+// TestMigrateUp_AllowDirtyRefusesToResumeIntoARestructuredFile pins the one
+// place this deliberately does not match the community Atlas binary, which
+// resumes at applied+1 by index whatever the file now contains. Once the
+// statement count has changed, that index no longer names the same statement,
+// so ptah refuses and names the repair command instead of applying the wrong
+// SQL.
+//
+// Reverted, the retry resumes at statement 2 of the restructured file, creates
+// pets, marks version 2 applied, and the skipped statement never runs: the
+// assertion that pets does not exist is what goes red.
+func TestMigrateUp_AllowDirtyRefusesToResumeIntoARestructuredFile(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "restructured.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	// The operator restructures the file: three statements now, so the recorded
+	// "1 of 2 applied" no longer indexes into it.
+	restructured := `CREATE TABLE audit (id INTEGER PRIMARY KEY);
+INSERT INTO users (id) VALUES (1);
+CREATE TABLE pets (id INTEGER PRIMARY KEY);
+`
+	_, retried := newDirtyRetryMigrator(c, dbPath, restructured, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	err := retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "migration 2 cannot resume automatically")
+	c.Assert(err.Error(), qt.Contains, "applied 1 of 2 statements but the file now has 3")
+	c.Assert(err.Error(), qt.Contains, "ptah migrations repair --version 2")
+	// Nothing from the restructured file ran.
+	c.Assert(dirtyRetryTableExists(c, conn, "audit"), qt.IsFalse)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
+// TestMigrateUp_AllowDirtyRefusesToResumeAnUnknownStatementOutcome covers the
+// interrupted-process row, where the recorded error says the last statement's
+// fate is unknown. RepairMigration already refuses --resume-from on such a row;
+// the automatic resume has to refuse for the same reason.
+//
+// Reverted, the retry silently resumes at statement 2 and reports success, so
+// the assertion on the error goes red with a nil error.
+func TestMigrateUp_AllowDirtyRefusesToResumeAnUnknownStatementOutcome(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "unknown.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	// Model a process killed mid-statement: the row keeps its progress but the
+	// error records that the statement's outcome was never observed.
+	_, err := conn.ExecContext(
+		c.Context(),
+		"UPDATE schema_migrations SET error = ? WHERE version = 2",
+		"statement execution outcome is unknown after process interruption",
+	)
+	c.Assert(err, qt.IsNil)
+
+	_, retried := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatPtah)
+	err = retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "migration 2 cannot resume automatically")
+	c.Assert(err.Error(), qt.Contains, "the outcome of statement 2 is unknown")
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
+// newRegisteredDirtyRetryMigrator builds a migrator over programmatically
+// registered SQL, which executes through [executeSQLStatements] rather than the
+// file provider's loop. The two loops are separate gates: a resume floor
+// honored by only one of them looks fixed from every file-based test.
+func newRegisteredDirtyRetryMigrator(
+	c *qt.C,
+	dbPath string,
+	secondUp string,
+) (*dbschema.DatabaseConnection, *migrator.Migrator) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { _ = conn.Close() })
+
+	m := migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(
+		migrator.CreateMigrationFromSQL(1, "users", dirtyRetryFirstUp, "DROP TABLE users;\n"),
+		migrator.CreateMigrationFromSQL(2, "seed", secondUp, "DROP TABLE pets;\n"),
+	)).WithTransactionMode(migrator.MigrationTxModeNone)
+	c.Assert(m.Initialize(c.Context()), qt.IsNil)
+	return conn, m
+}
+
+// TestMigrateUp_RegisteredMigrationAllowDirtyRetryResumes is the same resume
+// contract on the registered-migration path.
+//
+// Reverted only in [executeSQLStatements] — the mutation every file-based test
+// above survives — the committed INSERT runs a second time and the primary key
+// rejects it, so the retry fails with "UNIQUE constraint failed: users.id".
+func TestMigrateUp_RegisteredMigrationAllowDirtyRetryResumes(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "registered.db")
+
+	conn, m := newRegisteredDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+
+	_, fixed := newRegisteredDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+}
+
+// TestMigrateUp_FirstAttemptRecordsOneRowPerVersion is the non-interference
+// control for the reuse path, and it cannot be proved by reverting the change:
+// removing a reuse branch never makes a first attempt stop inserting. It is
+// aimed at the INVERSE mutant, "always rewrite instead of inserting", under
+// which a first attempt updates zero rows, the revision table stays empty, and
+// the assertions on the recorded revisions and the reported current version go
+// red while the schema itself still looks right.
+func TestMigrateUp_FirstAttemptRecordsOneRowPerVersion(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "first.db")
+
+	conn, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNil)
+
+	revisions, err := m.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[0].Version, qt.Equals, int64(1))
+	c.Assert(revisions[1].Version, qt.Equals, int64(2))
+	c.Assert(revisions[1].Applied, qt.Equals, 2)
+	c.Assert(revisions[1].Dirty, qt.IsFalse)
+
+	status, err := m.GetMigrationStatus(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.CurrentVersion, qt.Equals, int64(2))
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+}
+
+// TestMigrateUp_DirtyGuardStillRefusesWithoutAllowDirty keeps the escape hatch
+// an escape hatch: reusing the row is what --allow-dirty now does, not what
+// every run does.
+//
+// Reverted, this test passes unchanged — it is here so a later change that
+// makes the retry automatic has to say so out loud.
+func TestMigrateUp_DirtyGuardStillRefusesWithoutAllowDirty(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "guard.db")
+
+	_, m := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	c.Assert(m.MigrateUp(c.Context()), qt.IsNotNil)
+
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	err := fixed.MigrateUp(context.Background())
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -143,6 +143,33 @@ type statementProgressHooks struct {
 
 type statementProgressRecorderContextKey struct{}
 
+type migrationResumeContextKey struct{}
+
+// withMigrationResume declares that statements before resumeFrom (1-based) were
+// already committed by an earlier attempt at the same migration, so this attempt
+// must skip them rather than execute them a second time.
+//
+// The floor travels in the context rather than as an execution-path parameter
+// because the two statement loops that need it, [executeSQLStatements] and
+// [executeMigrationFileSQL], are reached through the caller-supplied
+// sqlMigrationFunc indirection, which has no room for a new argument.
+//
+// resumeFrom <= 1 means "run everything", which is the value every first attempt
+// installs, so an absent key and a fresh run behave identically.
+func withMigrationResume(ctx context.Context, resumeFrom int) context.Context {
+	if resumeFrom <= 1 {
+		return ctx
+	}
+	return context.WithValue(ctx, migrationResumeContextKey{}, resumeFrom)
+}
+
+// migrationStatementAlreadyApplied reports whether the 1-based statement index
+// was committed by an earlier attempt and must not run again.
+func migrationStatementAlreadyApplied(ctx context.Context, index int) bool {
+	resumeFrom, _ := ctx.Value(migrationResumeContextKey{}).(int)
+	return index < resumeFrom
+}
+
 type statementProgressError struct {
 	err     error
 	event   StatementEvent
@@ -785,6 +812,9 @@ func executeSQLStatements(ctx context.Context, conn *dbschema.DatabaseConnection
 			Index:     i + 1,
 			Total:     len(statements),
 		}
+		if migrationStatementAlreadyApplied(ctx, event.Index) {
+			continue
+		}
 		if err := recordStatementProgressBefore(ctx, event); err != nil {
 			return err
 		}
@@ -842,6 +872,9 @@ func executeMigrationFileSQL(
 			Index:      i + 1,
 			Total:      len(statements),
 			Directives: maps.Clone(fileDirectives),
+		}
+		if migrationStatementAlreadyApplied(ctx, event.Index) {
+			continue
 		}
 		if err := recordStatementProgressBefore(ctx, event); err != nil {
 			return err

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1675,6 +1675,18 @@ func (m *Migrator) applyUpMigrationsInSingleTransaction(ctx context.Context, mig
 		return nil, err
 	}
 
+	// Every revision row this batch touches is decided before the transaction
+	// opens: once it holds the only connection of a single-connection pool, a
+	// read would deadlock. See [Migrator.planUpRetry].
+	plans := make(map[int64]upRetryPlan, len(migrations))
+	for _, migration := range migrations {
+		plan, err := m.planUpRetry(ctx, migration)
+		if err != nil {
+			return nil, err
+		}
+		plans[migration.Version] = plan
+	}
+
 	tx, err := m.conn.SchemaWriter().BeginTransaction(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin tx-mode all transaction: %w", err)
@@ -1683,11 +1695,13 @@ func (m *Migrator) applyUpMigrationsInSingleTransaction(ctx context.Context, mig
 	startedAt := make(map[int64]time.Time, len(migrations))
 	for _, migration := range migrations {
 		startedAt[migration.Version] = time.Now()
-		if err := m.applyUpMigrationInExistingTransaction(ctx, txConn, migration, startedAt[migration.Version]); err != nil {
+		plan := plans[migration.Version]
+		migrationCtx := withMigrationResume(ctx, plan.resumeFrom)
+		if err := m.applyUpMigrationInExistingTransaction(migrationCtx, txConn, migration, startedAt[migration.Version]); err != nil {
 			_ = tx.Rollback()
-			return nil, m.recordRolledBackBatchFailure(ctx, migration, startedAt[migration.Version], err)
+			return nil, m.recordRolledBackBatchFailure(ctx, migration, startedAt[migration.Version], err, plan)
 		}
-		if err := m.recordAppliedMigrationOn(ctx, txConn, migration, startedAt[migration.Version]); err != nil {
+		if err := m.recordAppliedMigrationOn(ctx, txConn, migration, startedAt[migration.Version], plan); err != nil {
 			_ = tx.Rollback()
 			return nil, fmt.Errorf("failed to record migration %d in tx-mode all transaction: %w", migration.Version, err)
 		}
@@ -1804,9 +1818,21 @@ func (m *Migrator) applyUpMigrationObserved(
 	if err != nil {
 		return false, err
 	}
-	if err := m.beginMigrationRevision(ctx, migration, startedAt); err != nil {
+	plan, err := m.planUpRetry(ctx, migration)
+	if err != nil {
+		return false, err
+	}
+	if err := m.recordPendingMigrationRevisionOn(ctx, m.conn, migration, startedAt, plan); err != nil {
 		return false, fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
 	}
+	if plan.resumeFrom > 1 {
+		m.logger.Info(
+			"Resuming migration after a partially applied attempt",
+			"version", migration.Version,
+			"resumeFromStatement", plan.resumeFrom,
+		)
+	}
+	ctx = withMigrationResume(ctx, plan.resumeFrom)
 	if txMode == MigrationTxModeNone {
 		return checksDeferred, m.applyUpMigrationNoTransaction(ctx, migration, startedAt)
 	}
@@ -1821,13 +1847,14 @@ func (m *Migrator) applyUpMigrationObserved(
 // pre-migration state, so running them before the pending-revision insert means
 // a failed check leaves the revision table byte-identical: the migration was
 // never started, rather than started and marked dirty. Recording the failure
-// instead would wedge the Atlas-compatible surface: `ptah-compat migrate apply`
-// registers no --skip-checks (Atlas has none either), and while it does
-// register --allow-dirty, that flag currently fails on the re-insert with a
-// UNIQUE violation on the revision table (#966, measured on both surfaces), so
-// after fixing the data that tripped the check every later apply aborted on the
-// dirty row with no working in-band recovery. Atlas itself writes no row when
-// its checks fail, and the retry simply works (#956).
+// instead would still cost the Atlas-compatible surface a flag it does not
+// have: `ptah-compat migrate apply` registers no --skip-checks (Atlas has none
+// either), so a check failure that recorded a dirty row would force every
+// subsequent apply through --allow-dirty even after the data that tripped the
+// check was fixed. (It would no longer wedge outright — since #966 that flag
+// reuses the dirty row instead of failing on a re-insert — but a gate that
+// leaves nothing behind needs no recovery at all.) Atlas itself writes no row
+// when its checks fail, and the retry simply works (#956).
 // observesApplyState says whether this migration observes the state a real
 // apply would evaluate its assertions against — true for the first migration
 // executed in the run, and always true outside a dry run. When it is false the
@@ -1886,8 +1913,9 @@ func (m *Migrator) recordRolledBackBatchFailure(
 	migration *Migration,
 	startedAt time.Time,
 	failure error,
+	plan upRetryPlan,
 ) error {
-	if beginErr := m.beginMigrationRevision(ctx, migration, startedAt); beginErr != nil {
+	if beginErr := m.recordPendingMigrationRevisionOn(ctx, m.conn, migration, startedAt, plan); beginErr != nil {
 		return fmt.Errorf("%w; additionally failed to record pending migration %d after tx-mode all rollback: %v", failure, migration.Version, beginErr)
 	}
 	return m.failMigrationWithDirtyStateWithMode(
@@ -1906,8 +1934,9 @@ func (m *Migrator) recordAppliedMigrationOn(
 	conn *dbschema.DatabaseConnection,
 	migration *Migration,
 	startedAt time.Time,
+	plan upRetryPlan,
 ) error {
-	if err := m.beginMigrationRevisionOn(ctx, conn, migration, startedAt); err != nil {
+	if err := m.recordPendingMigrationRevisionOn(ctx, conn, migration, startedAt, plan); err != nil {
 		return fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
 	}
 	if err := m.completeMigrationRevisionOn(ctx, conn, migration, startedAt); err != nil {

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -168,8 +168,14 @@ func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMod
 
 	total = execErr.Total
 	applied = execErr.StatementIndex - 1
-	if txMode == MigrationTxModeAll ||
-		(txMode == MigrationTxModeFile && (dialect == "postgres" || dialect == "cockroachdb" || dialect == "yugabytedb")) {
+	// The recorded counter is not decoration: a retry resumes at applied+1, so
+	// overstating it skips a statement that never ran. Whether the earlier
+	// statements survived the failure is a property of the transaction mode and
+	// the dialect, which is what migrationProgressRolledBack answers — this
+	// branch used to carry its own shorter, unnormalized list that omitted SQLite
+	// and SQL Server and so recorded applied=1 for a file whose transaction had
+	// rolled the whole body back (#966).
+	if migrationProgressRolledBack(dialect, txMode) {
 		applied = 0
 	}
 	if applied < 0 {
@@ -310,6 +316,31 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
 	}
 	return fmt.Sprintf(`INSERT INTO %s (version, description, applied_at, state, applied, total, error, error_stmt, execution_time_ms, checksum)
 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`, m.qualifiedMigrationsTable())
+}
+
+// restartMigrationSQL rewrites an existing revision row so a retry of the same
+// version reuses it instead of inserting a second one.
+//
+// beginMigrationSQL is a bare INSERT, and the up path used to run it
+// unconditionally. Once a failed body had recorded a dirty row, every retry —
+// including the one the operator asked for with --allow-dirty after fixing the
+// migration — died on `UNIQUE constraint failed` on the version column instead
+// of running, with `migrations repair` the only way out (#966). This is the
+// up-direction counterpart of beginRollbackSQL, which has always rewritten the
+// row in place for the down direction.
+func (m *Migrator) restartMigrationSQL() string {
+	if m.revisionTableFormat.isAtlas() {
+		return revisionUpdateSQL(
+			m.connectionDialect(),
+			m.qualifiedMigrationsTable(),
+			"description = ?, type = ?, applied = ?, total = ?, executed_at = ?, execution_time = ?, error = '', error_stmt = '', hash = ?, partial_hashes = ?, operator_version = ?",
+		)
+	}
+	return revisionUpdateSQL(
+		m.connectionDialect(),
+		m.qualifiedMigrationsTable(),
+		"description = ?, applied_at = ?, state = ?, applied = ?, total = ?, error = NULL, error_stmt = NULL, execution_time_ms = ?, checksum = ?",
+	)
 }
 
 func (m *Migrator) completeMigrationSQL() string {
@@ -662,13 +693,24 @@ checksum = VALUES(checksum)`
 	}
 }
 
+// dirtyRevision reads the lowest revision row that is not cleanly applied.
+//
+// Only the ptah layout's predicate takes an argument; the Atlas layout compares
+// applied against total and needs none. This used to issue the ptah query first
+// and then overwrite the result for the Atlas layout, which left a *sql.Row that
+// nothing ever scanned — and an unscanned Row keeps its connection, and its open
+// read cursor, checked out for the life of the process. On SQLite that read lock
+// blocks the next write against the same file, so a dirty-guard refusal poisoned
+// every later write in the same process with `database is locked (SQLITE_BUSY)`:
+// exactly the recovery run this guard exists to send the operator towards
+// (#966).
 func (m *Migrator) dirtyRevision(ctx context.Context) (*MigrationRevision, error) {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.getDirtyRevisionSQL())
-	row := m.conn.QueryRowContext(ctx, query, migrationStateApplied)
+	args := []any{migrationStateApplied}
 	if m.revisionTableFormat.isAtlas() {
-		row = m.conn.QueryRowContext(ctx, query)
+		args = nil
 	}
-	revision, err := m.scanRevisionRow(row)
+	revision, err := m.scanRevisionRow(m.conn.QueryRowContext(ctx, query, args...))
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -813,12 +855,154 @@ func (m *Migrator) failIfDirty(ctx context.Context) error {
 	return nil
 }
 
-func (m *Migrator) beginMigrationRevision(
+// upRetryPlan says how an up attempt relates to an earlier attempt at the same
+// version. The zero value is not usable: build it with [Migrator.planUpRetry],
+// which always sets resumeFrom to at least 1.
+type upRetryPlan struct {
+	// reuseRevision says a dirty revision row for this version already exists,
+	// so the attempt must rewrite that row instead of inserting a second one.
+	reuseRevision bool
+	// resumeFrom is the 1-based index of the first statement this attempt runs.
+	// Everything below it was committed by the earlier attempt.
+	resumeFrom int
+}
+
+// planUpRetry reads the revision row for migration, if any, and decides whether
+// this attempt reuses it and where in the body it restarts.
+//
+// The read has to happen here — before the caller opens the migration's
+// transaction — because on a single-connection pool a query issued while the
+// transaction holds the only connection deadlocks. See the note in
+// [Migrator.applyUpMigrationTransactional].
+func (m *Migrator) planUpRetry(ctx context.Context, migration *Migration) (upRetryPlan, error) {
+	plan := upRetryPlan{resumeFrom: 1}
+	if m.conn.Writer().IsDryRun() || !m.metadataAvailable || m.legacyRevisionTable {
+		return plan, nil
+	}
+	revision, err := m.getRevision(ctx, migration.Version)
+	if err != nil {
+		return upRetryPlan{}, err
+	}
+	// A row that is present and clean means an applied migration is being
+	// applied again, which no up path should have selected. Leave it to the
+	// INSERT so the contradiction surfaces instead of being overwritten.
+	if revision == nil || !revision.Dirty {
+		return plan, nil
+	}
+	resumeFrom, err := resumeStatementFor(*revision, m.migrationStatementCount(migration.UpSQL))
+	if err != nil {
+		return upRetryPlan{}, err
+	}
+	return upRetryPlan{reuseRevision: true, resumeFrom: resumeFrom}, nil
+}
+
+// resumeStatementFor returns the 1-based statement index a retry restarts at,
+// given the dirty row the previous attempt left and the statement count the
+// migration file has now.
+//
+// It refuses rather than guesses in the two cases where the recorded counter
+// cannot be trusted to index into the current file. Refusing costs a retry that
+// the community Atlas binary would have run — it resumes at applied+1 by index
+// with no such check — but resuming by a stale index executes the wrong
+// statements, so this is one place where matching would mean reproducing a
+// defect.
+func resumeStatementFor(revision MigrationRevision, total int) (int, error) {
+	if revision.Applied <= 0 {
+		return 1, nil
+	}
+	if revision.Error == unknownStatementOutcomeError {
+		return 0, fmt.Errorf(
+			"migration %d cannot resume automatically: the outcome of statement %d is unknown after an interrupted run; inspect the database, then use 'ptah migrations repair --version %d'",
+			revision.Version,
+			revision.Applied+1,
+			revision.Version,
+		)
+	}
+	if revision.Total != total {
+		return 0, fmt.Errorf(
+			"migration %d cannot resume automatically: the previous attempt applied %d of %d statements but the file now has %d; inspect the database, then use 'ptah migrations repair --version %d'",
+			revision.Version,
+			revision.Applied,
+			revision.Total,
+			total,
+			revision.Version,
+		)
+	}
+	return revision.Applied + 1, nil
+}
+
+// recordPendingMigrationRevisionOn writes the row that says "this version is
+// being applied right now", inserting it or reusing the dirty row a previous
+// attempt left, as plan says.
+func (m *Migrator) recordPendingMigrationRevisionOn(
 	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
 	migration *Migration,
 	startedAt time.Time,
+	plan upRetryPlan,
 ) error {
-	return m.beginMigrationRevisionOn(ctx, m.conn, migration, startedAt)
+	if plan.reuseRevision {
+		return m.restartMigrationRevisionOn(ctx, conn, migration, startedAt, plan.resumeFrom-1)
+	}
+	return m.beginMigrationRevisionOn(ctx, conn, migration, startedAt)
+}
+
+// restartMigrationRevisionOn rewrites an existing revision row back to pending
+// for a fresh attempt, recording alreadyApplied as the progress this attempt
+// starts from so an interruption before the first executed statement does not
+// understate what is committed.
+func (m *Migrator) restartMigrationRevisionOn(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migration *Migration,
+	startedAt time.Time,
+	alreadyApplied int,
+) error {
+	if m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	if m.revisionTableFormat.isAtlas() {
+		return m.restartAtlasMigrationRevisionOn(ctx, conn, migration, startedAt, alreadyApplied)
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.restartMigrationSQL())
+	return executeSQLOn(
+		ctx,
+		conn,
+		query,
+		migration.Description,
+		startedAt,
+		migrationStatePending,
+		alreadyApplied,
+		m.migrationStatementCount(migration.UpSQL),
+		0,
+		migrationRevisionHash(migration),
+		migration.Version,
+	)
+}
+
+func (m *Migrator) restartAtlasMigrationRevisionOn(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migration *Migration,
+	startedAt time.Time,
+	alreadyApplied int,
+) error {
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.restartMigrationSQL())
+	return executeSQLOn(
+		ctx,
+		conn,
+		query,
+		migration.atlasFilenameDescription(),
+		int64(AtlasRevisionTypeApplied),
+		alreadyApplied,
+		m.migrationStatementCount(migration.UpSQL),
+		m.atlasRevisionTimestamp(startedAt),
+		int64(0),
+		migrationRevisionHash(migration),
+		m.atlasNullJSONValue(),
+		ptahOperatorVersion,
+		strconv.FormatInt(migration.Version, 10),
+	)
 }
 
 func (m *Migrator) beginMigrationRevisionOn(

--- a/migration/migrator/txtar_checks_test.go
+++ b/migration/migrator/txtar_checks_test.go
@@ -375,9 +375,9 @@ func revisionVersions(t *testing.T, conn *dbschema.DatabaseConnection) []string 
 // TestMigrateUp_TxtarFailingCheckWritesNoRevisionRow pins the recovery contract
 // behind the check gate: because checks run before any bookkeeping write, a
 // failed check leaves the revision table exactly as it was. Recording the
-// failure instead would strand the Atlas-compatible surface, which has neither
-// --skip-checks, and whose --allow-dirty cannot clear the row because it fails
-// on the re-insert (#966), to recover (#956).
+// failure instead would push the Atlas-compatible surface, which registers no
+// --skip-checks, through --allow-dirty on every later apply — recoverable since
+// #966, but a gate that writes nothing needs no recovery at all (#956).
 func TestMigrateUp_TxtarFailingCheckWritesNoRevisionRow(t *testing.T) {
 	c := qt.New(t)
 	ctx := context.Background()


### PR DESCRIPTION
Refs #966 — deliberately not `Closes`. **The issue's own title is now wrong**: the trigger it names no longer reproduces, having been closed by #964. This PR fixes the half that survives, and reports the other half as measured-and-gone rather than fixing it twice. One divergence from the community binary also survives on purpose and is named below, which is the second reason for `Refs`. See "What the title says vs what reproduces".

Measured on branch `agent/966-dirty-retry-resume` in a private worktree. Originally cut from `origin/master` at `bd7d3c66` — every "before" measurement below is from that commit — then rebased onto `d29a44f4` (#1132) once it landed, because the two branches overlap in `migration/migrator/migrator.go` and `docs/site/src/content/docs/atlas/migrate-commands.md` and `MERGEABLE` only says the auto-merge produces no conflict markers. Verified afterwards that both sides survived: `WithSourceVersions` is present in `migrator.go` and #1132's Flyway-linearity section is present in the docs page, alongside this PR's additions. Every gate re-ran on the rebased tree.

Comparison binary: `atlas community version v1.3.0`, run by absolute path. Local SQLite throughout.

---

## What the title says vs what reproduces

The title names a **pre-migration check** as the trigger. That trigger is gone, closed by #964, which moved `runPreMigrationChecks` ahead of `beginMigrationRevision`. Re-measured on master at `bd7d3c66` before touching anything:

```
$ ptah migrations up --db-url sqlite://probe.db --migrations-dir migrations
error: pre-migration check users_empty for migration 2 was not satisfied (assert: SELECT count(*) = 0 FROM users)
rerun with --skip-checks to bypass this pre-migration check after review
exit=2

$ sqlite3 probe.db "SELECT version, state, applied, total FROM schema_migrations;"
1|applied|2|2                      <- no row for version 2: nothing to be dirty

$ ptah migrations up ... --skip-checks
exit=0    "Database is now at version: 2"
```

`--allow-dirty` is not needed on that path at all. **That half of #966 closed itself**, and this PR does not re-fix it.

What survives, on both surfaces, is the **recovery path itself**: a failed migration *body* writes a dirty row, and the retry re-INSERTs that version. That is what this PR fixes. Suggested retitle: *"A failed migration body wedges the retry: `--allow-dirty` re-inserts the dirty revision row instead of resuming"*.

---

## Reproduction, before

Fixture: `0000000001` creates `users`; `0000000002` is `CREATE TABLE pets (...);` followed by `THIS IS A FAILING STATEMENT;`. Then the body is fixed to `CREATE TABLE pets; CREATE TABLE toys;` and the run is repeated.

**Native, default `--tx-mode file`, master `bd7d3c66`:**

```
$ ptah migrations up ...                                  exit=2
  schema_migrations: 1|applied|1/1
                     2|failed|1/2|failed to execute migration SQL: ... near "THIS"
  .tables: schema_migrations users        <- pets absent: the body rolled back,
                                             yet applied=1 was recorded

$ (body fixed) ptah migrations up ...                     exit=2  "migration 2 is dirty"
$ (body fixed) ptah migrations up ... --allow-dirty       exit=2
  error: failed to record pending migration 2:
    UNIQUE constraint failed: schema_migrations.version (1555)
    SQL: INSERT INTO "schema_migrations" (version, description, applied_at, state, ...)
```

**Compat, default `--tx-mode file`, master `bd7d3c66`:**

```
$ ptah-compat migrate apply --url sqlite://probe.db --dir file://migrations     exit=1
  atlas_schema_revisions: 20260801000001|1/1
                          20260801000002|1/2|failed to execute migration SQL: ...

$ ptah-compat migrate status ...                                               exit=0
  === MIGRATION STATUS ===
  Current Version: 20260801000002      <- the FAILED version
  Applied Migrations: 1
  Pending Migrations: 1
  Status: Pending migrations available <- no dirty indication anywhere

$ (body fixed, re-hashed) ptah-compat migrate apply ... --allow-dirty           exit=1
  Error: failed to record pending migration 20260801000002:
    UNIQUE constraint failed: atlas_schema_revisions.version (1555)
```

Under `--tx-mode none` the same collision occurs, and there `pets` really is committed, so even a working INSERT→UPDATE would then fail with "table pets already exists": the fix has to resume, not just reuse.

## Reproduction, after

**Native, `--tx-mode file`:**

```
$ ptah migrations up ...                                  exit=2
  schema_migrations: 2|failed|0/2                <- 0, not 1: the body rolled back
$ (body fixed) ptah migrations up ...                     exit=2  "migration 2 is dirty"
$ (body fixed) ptah migrations up ... --allow-dirty       exit=0
  "Database is now at version: 2"
  schema_migrations: 1|applied|1/1  2|applied|2/2         <- one row, reused
  .tables: pets schema_migrations toys users
```

**Native, `--tx-mode none`** (statement 1 already committed):

```
$ ptah migrations up ... --tx-mode none                   exit=2
  schema_migrations: 2|failed|1/2 ; .tables includes pets
$ (body fixed) ptah migrations up ... --tx-mode none --allow-dirty   exit=0
  INFO Resuming migration after a partially applied attempt version=2 resumeFromStatement=2
  schema_migrations: 2|applied|2/2 ; toys created, pets NOT recreated
```

**Compat, `--tx-mode file`:**

```
$ ptah-compat migrate apply ...                                    exit=1
$ ptah-compat migrate status ...                                   exit=0
  Current Version: 20260801000002
  Applied Migrations: 1
  Pending Migrations: 1
  Dirty Migration: version=20260801000002 applied=0/2
  Error Statement: THIS IS A FAILING STATEMENT
  Error: failed to execute migration SQL: ...
  Status: Pending migrations available
$ (body fixed, re-hashed) ptah-compat migrate apply ...            exit=1  "is dirty"
$ (body fixed, re-hashed) ptah-compat migrate apply ... --allow-dirty   exit=0
  "Migration complete. Current version: 20260801000002"
  atlas_schema_revisions: 20260801000001|1/1  20260801000002|2/2
$ ptah-compat migrate status ...                                   exit=0
  Status: Database is up to date        (no Dirty Migration line)
```

`--tx-mode none` on the compat surface behaves the same, resuming at statement 2.

**`--tx-mode all`, both surfaces** — the third branch, and the one where the plan has to be built before the batch transaction opens, because a read on a single-connection pool while that transaction holds it deadlocks:

```
$ ptah migrations up ... --tx-mode all                            exit=2
  schema_migrations: 2|failed|0/2      (version 1's row rolled back with the batch)
  .tables: schema_migrations
$ (body fixed) ptah migrations up ... --tx-mode all --allow-dirty exit=0
  schema_migrations: 1|applied|1/1  2|applied|2/2 ; pets, toys, users all present

$ ptah-compat migrate apply ... --tx-mode all                     exit=1
  atlas_schema_revisions: 20260801000002|0/2
$ (fixed, re-hashed) ptah-compat migrate apply ... --tx-mode all --allow-dirty   exit=0
  atlas_schema_revisions: 20260801000001|1/1  20260801000002|2/2
```

Before this PR, `--tx-mode all` collided on the same UNIQUE constraint: `recordRolledBackBatchFailure` and `recordAppliedMigrationOn` both went through the same unconditional INSERT.

**The fixture discriminates.** The identical fixed migration set applies to an empty database with `exit=0` and no flag, so only the dirty-row retry path is under test.

---

## What the comparison binary does on the same fixtures

| | `--tx-mode file` (default) | `--tx-mode none` |
|---|---|---|
| **atlas v1.3.0**, failed apply | exit 1, **no revision row for the failed version** (it rolls back with the body); status: `Current Version: 20260801000001`, `Pending Files: 1` | exit 1, row `...\|1\|2\|near "THIS": syntax error`; status: `Current Version: 20260801000002 (1 statements applied)`, `Executed Files: 2 (last one partially)`, plus a `Last migration attempt had errors:` block |
| **atlas v1.3.0**, retry after fixing | **exit 0, no flag** | **exit 0, no flag**; resumes at statement 2 and UPDATEs the row to 2/2 |
| **ptah-compat**, after this PR | exit 1 leaving a dirty row; status names it | exit 1 leaving a dirty row; status names it |
| **ptah-compat** retry after fixing | exit 0 **with `--allow-dirty`** | exit 0 **with `--allow-dirty`**, resuming at statement 2 |

Parity rule (a) is not at issue anywhere here: there is no case where ptah-compat exits 0 and the community binary exits 1. Both remaining differences are ptah being stricter or louder.

---

## Decisions where the issue offered a choice

**1. `--allow-dirty` stays required; I did not make the retry automatic.**
The community binary needs no flag: under `--tx-mode file` it writes no row to trip over, and under `--tx-mode none` it resumes silently. Ptah keeps recording dirty state (a documented native advantage that feeds `status`, `repair`, and now resume), so its guard has something to refuse. Making the guard stand down whenever the resume looks safe would change native `ptah migrations up` semantics for every user, not just compat ones, and it removes the operator's chance to look at a half-applied database before more SQL runs. The issue's own stated expectation is "the retry path **under `--allow-dirty`** should update the existing dirty row rather than re-insert it", which is what this implements. The cost is one flag on a drop-in path; it is measured in the table above and left open below.

**2. I refuse to resume where the community binary would, in two cases.**
It resumes at `applied+1` by index with no check on what the file now contains. Once the recorded counter cannot be trusted to index into the current file, resuming executes the wrong statements — a data-corruption defect, so under parity rule (b) I decline to match it:

- an interrupted run whose last statement's outcome was never observed (`RepairMigration` already refuses `--resume-from` on exactly this row; the automatic path now agrees);
- an edit that changed the file's statement count.

Both refuse with a message naming `ptah migrations repair --version <v>`, replacing what was previously a `UNIQUE constraint` error anyway.

**3. `migrate status` gained a dirty block rather than Atlas's line shape.**
The earlier comment on the issue proposed filtering `getVersionSQL`'s Atlas branch on `applied = total AND error = ''`. That would **diverge** — the community binary also reports the partially-applied version as Current Version. I kept `Current Version` as it is and added the facts underneath (`Dirty Migration: version=… applied=N/M`, `Error Statement:`, `Error:`), matching ptah-compat's own existing status layout rather than restructuring it into Atlas's `Migration Status: PENDING` block, which ptah-compat has never emitted.

---

## Found on the way: a connection leak on this exact path

`dirtyRevision` issued the ptah-layout query first and then overwrote the result for the Atlas layout, leaving a `*sql.Row` that nothing ever scanned. An unscanned `Row` keeps its connection — and its open SQLite read cursor — checked out for the life of the process, so **every write after a dirty-guard refusal failed with `database is locked (5) (SQLITE_BUSY)`**. Pre-existing, and not only on the retry: a probe showed `ptah-compat migrate set` failing the same way after a refusal.

```
failed to commit Atlas revision set transaction: database is locked (5) (SQLITE_BUSY)
```

Invisible to the CLI end-to-end (each invocation is a fresh process that exits) and to every existing test, because nothing wrote after a refusal in one process. It is fixed here because the recovery this PR enables runs straight into it in any embedded/library caller.

---

## Tests, and what each prints if the change is reverted

New `migration/migrator/dirty_retry_test.go`:

| Test | Reverted, it prints |
|---|---|
| `TestMigrateUp_AllowDirtyRetryReusesTheDirtyRevisionRow` | `failed to record pending migration 2: ... UNIQUE constraint failed: schema_migrations.version`; also `Applied: 1 != 0` if only the counter fix is reverted |
| `TestMigrateUp_AllowDirtyRetryResumesAfterCommittedStatements` | the committed `INSERT` runs again — `users` holds 2 rows, not 1 (or `UNIQUE constraint failed: users.id`); with the whole change reverted, the revision `UNIQUE` error above |
| `TestMigrateUp_AtlasFormatAllowDirtyRetryReusesTheDirtyRevisionRow` | `UNIQUE constraint failed: atlas_schema_revisions.version` |
| `TestMigrateUp_TxModeAllAllowDirtyRetryReusesTheDirtyRevisionRow` | the same `UNIQUE constraint failed: schema_migrations.version`. `--tx-mode all` writes its pending row through its own callers (`recordRolledBackBatchFailure`, `recordAppliedMigrationOn`), not the per-file path the rows above exercise |
| `TestMigrateUp_RegisteredMigrationAllowDirtyRetryResumes` | covers the **second** statement loop (`executeSQLStatements`, the registered-migration path). Reverted only there — a mutation every file-based test above survives — the committed `INSERT` repeats and the primary key rejects it |
| `TestMigrateUp_AllowDirtyRefusesToResumeIntoARestructuredFile` | no error at all: it resumes at statement 2 of the restructured file, creates `pets`, marks version 2 applied, and the skipped statement never runs |
| `TestMigrateUp_AllowDirtyRefusesToResumeAnUnknownStatementOutcome` | no error: the interrupted row is silently resumed and reported successful |
| `TestMigrateUp_FirstAttemptRecordsOneRowPerVersion` | **passes** — it is the non-interference control, aimed at the INVERSE mutant (always rewrite, never insert), under which a first attempt updates zero rows, the revision table stays empty, and `CurrentVersion` reads 0 while the schema still looks right |
| `TestMigrateUp_DirtyGuardStillRefusesWithoutAllowDirty` | **passes** — it is here so a later change that makes the retry automatic has to say so out loud |

New `cmd/atlas/migrate_dirty_retry_test.go`:

| Test | Reverted, it prints |
|---|---|
| `TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure` | `error applying migrations: failed to record pending migration 20240301000002: ... UNIQUE constraint failed: atlas_schema_revisions.version`, and `dr_three` is never created |
| `TestCompatCommand_DirtyGuardRefusalLeavesTheDatabaseWritable` | `failed to commit Atlas revision set transaction: database is locked (5) (SQLITE_BUSY)` |
| `TestCompatCommand_MigrateStatusReportsTheDirtyMigration` | the output ends `Pending Migrations: 1` / `Status: Pending migrations available` with no dirty marker, no failing statement and no error — the three `Contains` assertions go red |

Updated `migration/migrator/atlas_tx_mode_matrix_test.go`: four rows moved from `wantApplied: 1` to `0`, and the stale comment claiming per-file failures "currently retain applied=1/2" is replaced. `wantApplied` and `wantTable` now agree in every row, which is the invariant: the first statement creates the table, so `applied` is 1 exactly when the table survived. Reverting the counter fix turns those four subtests red.

**Mutation results** (each mutant built and the suite rerun):

| Mutant | Killed by |
|---|---|
| reuse branch disabled (pre-#966 unconditional INSERT) | 3 tests |
| `resumeStatementFor` always returns 1 | 2 tests |
| **inverse**: always rewrite, never insert | all 8 targeted tests incl. the non-interference control |
| pre-#966 progress-counter list restored | tx-mode matrix + 1 |
| both resume-skip sites removed | 2 tests |
| resume-skip removed in `executeSQLStatements` only | `RegisteredMigrationAllowDirtyRetryResumes` only |
| resume-skip removed in `executeMigrationFileSQL` only | the 2 file-based resume tests only |
| both resume refusals disabled | the 2 refusal tests |
| pre-fix `dirtyRevision` (discarded `*sql.Row`) | 2 compat tests |

No survivors. The two skip sites are separately gated on purpose — a resume floor honored by only one of them looks fixed from every file-based test.

---

## Gates

All green on this branch:

```
go build ./... && go vet ./... && go test ./... -count=1     OK
go tool qtlint ./...                                          exit 0
golangci-lint run ./...                                       0 issues
scripts/check-test-style.sh                       OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh                                   exit 0
scripts/check-public-api-snapshot.sh                          exit 0
```

docs/ was touched, so all 12 `check:*` scripts in `docs/site/package.json` ran, plus the two generators:

```
check:exit-codes 0   check:exit-codes:selftest 0   check:core-doc-links 0   check:page-health 0
check:links 0        check:links:selftest 0        check:redirects 0        check:redirects:selftest 0
check:style 0        check:style:selftest 0        check:responsive 0       check:responsive:selftest 0
build-feature-matrix.mjs --check: OK (162 rows)    gen-versions.mjs --selftest: OK
```

`check:responsive` needs `dist`, so `npm ci && npm run build` ran first; it reports exit 0 with no `dist` and would have passed without running.

---

## Deliberately left open

1. **The flag itself.** The community binary retries with no flag; ptah-compat still needs `--allow-dirty`. This is over-refusal on a drop-in path, not a rule (a) violation, and it is a deliberate design choice (decision 1). Worth its own issue if drop-in fidelity should win over the guard.
2. **Ptah still records a dirty row where the community binary records none** (`--tx-mode file`, rolled-back body). This is the same deliberate surface split #964 established for the down direction: ptah's dirty-state metadata feeds `status`, `repair`, and now resume. Not changed, and no feature-matrix row added for it.
3. **Atlas's status annotations are not reproduced.** `Current Version: <v> (N statements applied)`, `Executed Files: N (last one partially)`, and the trailing `Last migration attempt had errors:` block are Atlas's line shape; ptah-compat's status has never used that layout, so I added the facts to ptah-compat's own block instead (decision 3).
4. **`partial_hashes` is still written as NULL.** Atlas uses it to detect that already-applied statements changed under a resume. The statement-count check here is a coarser guard covering the common restructure; a hash-level check would catch an in-place edit of an already-committed statement. Untouched.
5. **A dry run does not evaluate the retry plan.** `planUpRetry` short-circuits under `--dry-run`, so a dry run over a dirty row behaves exactly as it did before this PR — including not surfacing a resume refusal that the real run would raise. Dry runs have never modelled dirty-row mechanics; making them do so is a separate change.
6. **One extra point read per migration per run.** `planUpRetry` issues a `SELECT … WHERE version = ?` for every migration it is about to apply. It could be skipped whenever `failIfDirty` already passed, since that proves no dirty row exists anywhere — but that couples the planner to which entry point ran the guard, and `migrateUpTo` is a second entry point. Left as the simpler, obviously-correct form.
7. **Not measured on PostgreSQL, MySQL, MariaDB, SQL Server or ClickHouse.** All measurements above are SQLite. The counter fix now routes MySQL/MariaDB through `migrationProgressRolledBack`, which correctly answers "not rolled back" for them, so a per-file failure there records real progress and the retry resumes — that is a behavior improvement I have reasoned about but not executed against a live server.
