### PR TITLE
Keep the atlas.hcl file() sandbox, and make it one

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -84,6 +84,32 @@ jobs:
           # mode this job exists to prevent, so a skip fails the job.
           ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-schema-hcl-run"
 
+      # The atlas.hcl file() sandbox (stokaro/ptah#1042) is a deliberate
+      # divergence, so the community side of it has to stay measured: if a later
+      # build starts refusing these reads, the divergence is over and this run
+      # is what says so. Listed before it is run, for the same reason as above.
+      - name: Verify atlas.hcl file() conformance selection
+        run: |
+          GOWORK=off go test -list '^TestOracle' \
+            ./config/projectconfig > "$RUNNER_TEMP/atlas-file-sandbox-tests"
+          cat "$RUNNER_TEMP/atlas-file-sandbox-tests"
+          grep -Fx 'TestOracleReadsFilesOutsideTheAtlasHCLDirectory' "$RUNNER_TEMP/atlas-file-sandbox-tests"
+          grep -Fx 'TestOracleEvaluatesTheFileCallItIsGiven' "$RUNNER_TEMP/atlas-file-sandbox-tests"
+          grep -Fx 'TestOraclePlacesOutsideFileContentsWhereTheCallerCanSeeThem' "$RUNNER_TEMP/atlas-file-sandbox-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-file-sandbox-tests")" -eq 3
+
+      - name: Run atlas.hcl file() conformance tests
+        run: |
+          GOWORK=off go test -count=1 -v -run '^TestOracle' ./config/projectconfig \
+            > "$RUNNER_TEMP/atlas-file-sandbox-run" 2>&1 || {
+              cat "$RUNNER_TEMP/atlas-file-sandbox-run"
+              exit 1
+            }
+          cat "$RUNNER_TEMP/atlas-file-sandbox-run"
+          # A missing oracle skips these silently. That is the exact failure
+          # mode this job exists to prevent, so a skip fails the job.
+          ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-file-sandbox-run"
+
       - name: Regenerate Atlas CE corpus
         run: >-
           internal/atlasmigrateimport/testdata/ce-sums/regenerate.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,26 @@ grounds that it matched. That traded a place where Ptah was better for a place
 where it was merely identical, and it was reverted. The directive is honored in
 both forms, and the divergence is documented rather than hidden.
 
+### A second worked example
+
+`file()` in an `atlas.hcl` inlines a file's contents into a config value.
+Measured on the pinned community v1.3.0 build:
+
+| argument | community binary | Ptah |
+| --- | --- | --- |
+| `file("local.txt")` | reads it, exit 0 | reads it, exit 0 |
+| `file("/etc/passwd")` | **reads it, exit 0** | refused, exit 1 |
+| `file("../../../../etc/passwd")` | **reads it, exit 0** | refused, exit 1 |
+| `file("link.txt")`, a link out of the directory | **reads it, exit 0** | refused, exit 1 |
+
+An `atlas.hcl` is repository-controlled and evaluated before anything is
+applied, and the value lands somewhere observable: put the read in `env.url` and
+the file's contents come back in `Error: sql/sqlclient: unknown driver "..."`.
+Matching would turn config authorship into an arbitrary-file read on the machine
+running the migration, which is the second half of the policy, not the first.
+Ptah keeps the confinement on both binaries and names the rule in the refusal.
+See [`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042).
+
 ### Deciding which you are doing
 
 Before matching a measured behavior, ask what it costs the user. If the answer

--- a/cmd/atlas/atlas_file_sandbox_test.go
+++ b/cmd/atlas/atlas_file_sandbox_test.go
@@ -1,0 +1,134 @@
+// One of the three escape shapes here is a symbolic link, and creating one on
+// Windows needs a privilege an ordinary CI account does not have.
+//go:build !windows
+
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// The compat surface half of the atlas.hcl file() sandbox (stokaro/ptah#1042).
+//
+// `ptah-compat` is the surface a CI pipeline runs, and it builds the sandbox's
+// filesystem in its own place -- cmd/atlas/project_config.go opens the config
+// directory through pathguard, not through the loader in config/projectconfig.
+// A fix proven only at the library would leave this branch unmeasured, which is
+// how the same class of gap has shipped here before.
+//
+// The community binary reads all three of these and exits 0; that half is
+// pinned by TestOracleReadsFilesOutsideTheAtlasHCLDirectory in
+// config/projectconfig.
+
+const compatOutsideMarker = "PTAH-1042-COMPAT-SECRET"
+
+func TestCompatCommand_AtlasHCLFileSandbox(t *testing.T) {
+	tests := []struct {
+		name     string
+		argument func(c *qt.C, dir, outside string) string
+		err      string
+	}{
+		{
+			name:     "absolute path",
+			argument: compatAbsoluteArgument,
+			err:      `.*absolute paths are not supported: .*compat-secret\.txt: atlas\.hcl file\(\) and fileset\(\) read only inside the directory holding atlas\.hcl; pass a value from outside it through getenv\(\).*`,
+		},
+		{
+			name:     "parent traversal",
+			argument: compatTraversalArgument,
+			err:      `.*path escapes atlas\.hcl directory: \.\./compat-secret\.txt: atlas\.hcl file\(\) and fileset\(\).*`,
+		},
+		{
+			name:     "symbolic link out of the directory",
+			argument: compatSymlinkArgument,
+			err:      `.*path escapes atlas\.hcl directory: secret\.link: secret\.link is a symbolic link pointing outside it.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			base := t.TempDir()
+			dir := filepath.Join(base, "project")
+			c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+			outside := filepath.Join(base, "compat-secret.txt")
+			c.Assert(os.WriteFile(outside, []byte(compatOutsideMarker), 0o600), qt.IsNil)
+			writeCompatSandboxConfig(c, dir, tt.argument(c, dir, outside))
+			t.Chdir(dir)
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"migrate", "status", "--env", "local"})
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, tt.err)
+			c.Assert(err.Error(), qt.Not(qt.Contains), compatOutsideMarker)
+			c.Assert(out.String(), qt.Not(qt.Contains), compatOutsideMarker)
+		})
+	}
+}
+
+// The control: the same command, the same shape, a file that lives inside the
+// config directory. It reads, so the rows above measure where the path goes
+// rather than whether `migrate status --env local` runs at all.
+func TestCompatCommand_AtlasHCLFileReadsInsideTheConfigDirectory(t *testing.T) {
+	c := qt.New(t)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "project")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(base, "compat-secret.txt"), []byte(compatOutsideMarker), 0o600), qt.IsNil)
+	dbPath := filepath.Join(dir, "sandbox.db")
+	c.Assert(os.WriteFile(filepath.Join(dir, "url.txt"), []byte("sqlite://"+dbPath), 0o600), qt.IsNil)
+	writeCompatSandboxConfig(c, dir, "url.txt")
+	t.Chdir(dir)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "status", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Contains, "MIGRATION STATUS")
+}
+
+func writeCompatSandboxConfig(c *qt.C, dir, argument string) {
+	c.Helper()
+
+	body := "env \"local\" {\n  url = file(\"" + argument + "\")\n  migration {\n    dir = \"file://migrations\"\n  }\n}\n"
+	c.Assert(os.MkdirAll(filepath.Join(dir, "migrations"), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(body), 0o600), qt.IsNil)
+}
+
+func compatAbsoluteArgument(c *qt.C, _, outside string) string {
+	c.Helper()
+
+	return outside
+}
+
+func compatTraversalArgument(c *qt.C, _, outside string) string {
+	c.Helper()
+
+	return "../" + filepath.Base(outside)
+}
+
+func compatSymlinkArgument(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	c.Assert(os.Symlink(outside, filepath.Join(dir, "secret.link")), qt.IsNil)
+	return "secret.link"
+}

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -78,16 +78,49 @@ func ParseAtlas(data []byte, filename, envName string) (Config, error) {
 
 // ParseAtlasWithOptions parses the supported subset of an Atlas project config
 // file with Atlas-compatible evaluation options.
+//
+// file() and fileset() resolve through a rooted handle on the directory that
+// holds filename, so a symbolic link inside that directory cannot be used to
+// read a file outside it. os.DirFS is deliberately not used here: it follows
+// such a link out of the directory and hands back the target's contents.
 func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error) {
 	if filename == "" {
 		filename = AtlasFileName
 	}
-	return ParseAtlasFSWithOptions(data, filename, os.DirFS(filepath.Dir(filename)), opts)
+	root, err := os.OpenRoot(filepath.Dir(filename))
+	if err != nil {
+		// The directory is only reached by file() and fileset(). A config that
+		// calls neither parses from an unreadable directory exactly as it did
+		// before the sandbox was rooted, so the failure is reported by the
+		// first read instead of by the parse.
+		return ParseAtlasFSWithOptions(data, filename, unreadableFS{err: err}, opts)
+	}
+	// Closed here rather than in a defer, so the exported signature keeps its
+	// unnamed results and the public API snapshot stays byte-identical.
+	cfg, parseErr := ParseAtlasFSWithOptions(data, filename, root.FS(), opts)
+	return cfg, errors.Join(parseErr, root.Close())
+}
+
+// unreadableFS reports the same error from every open. It stands in for a
+// directory that could not be opened, so the error surfaces at the read that
+// needs it rather than at the parse that may never read anything.
+type unreadableFS struct {
+	err error
+}
+
+func (f unreadableFS) Open(name string) (fs.File, error) {
+	return nil, &fs.PathError{Op: "open", Path: name, Err: f.err}
 }
 
 // ParseAtlasFSWithOptions parses an Atlas project config while resolving
 // file() and fileset() through fsys. fsys must be rooted at the directory that
 // contains filename.
+//
+// fsys is the outer boundary of the file() sandbox: pass an escape-resistant
+// filesystem such as os.Root.FS(). The sandbox refuses absolute paths, parent
+// traversal, and the symbolic-link escapes it can resolve itself, but only the
+// filesystem can refuse the rest -- a link chain it cannot follow, or a path
+// swapped for a link between the check and the read.
 func ParseAtlasFSWithOptions(
 	data []byte,
 	filename string,
@@ -1996,7 +2029,8 @@ func atlasFileFunc(fsys fs.FS) function.Function {
 		},
 		Type: function.StaticReturnType(cty.String),
 		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
-			path, err := atlasLocalFSPath(args[0].AsString())
+			value := args[0].AsString()
+			path, err := atlasSandboxedFSPath(fsys, value)
 			if err != nil {
 				return cty.NilVal, err
 			}
@@ -2045,6 +2079,9 @@ func atlasFileset(fsys fs.FS, pattern string) ([]string, error) {
 	}
 	values := make([]string, 0, len(matches))
 	for _, match := range matches {
+		if err := atlasCheckSandboxedFSPath(fsys, match); err != nil {
+			return nil, err
+		}
 		info, err := fs.Stat(fsys, match)
 		if err != nil {
 			return nil, err
@@ -2077,6 +2114,9 @@ func atlasRecursiveFileset(fsys fs.FS, pattern string) ([]string, error) {
 			return err
 		}
 		if matched {
+			if err := atlasCheckSandboxedFSPath(fsys, name); err != nil {
+				return err
+			}
 			if _, err := fs.Stat(fsys, name); err != nil {
 				return err
 			}
@@ -2119,6 +2159,117 @@ func atlasMatchSegments(patternParts, nameParts []string) (bool, error) {
 	return atlasMatchSegments(patternParts[1:], nameParts[1:])
 }
 
+// atlasFileSandboxHint names what to do instead, so a refusal is a redirection
+// rather than a dead end. A value that genuinely lives outside the config
+// directory -- a mounted secret, a shared CA bundle -- reaches atlas.hcl
+// through the environment, which is what getenv() is for.
+const atlasFileSandboxHint = "atlas.hcl file() and fileset() read only inside the directory holding atlas.hcl; " +
+	"pass a value from outside it through getenv()"
+
+// atlasSymlinkHopLimit is where this walk stops resolving and leaves the rest
+// to the filesystem. A config argument that needs more than a few chained links
+// to resolve is not something an author writes, and following further buys
+// nothing: a rooted filesystem still refuses whatever leaves it, and a caller
+// that supplied a filesystem without that protection has already chosen who
+// enforces the boundary.
+const atlasSymlinkHopLimit = 4
+
+// atlasSandboxedFSPath resolves an atlas.hcl file()/fileset() argument to a
+// path inside fsys, refusing every shape that reads outside the directory that
+// holds atlas.hcl: an absolute path, parent traversal, and a symbolic link
+// whose target leaves the directory.
+func atlasSandboxedFSPath(fsys fs.FS, value string) (string, error) {
+	path, err := atlasLocalFSPath(value)
+	if err != nil {
+		return "", err
+	}
+	if err := atlasCheckSandboxedFSPath(fsys, path); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+// atlasCheckSandboxedFSPath refuses name when a symbolic link on the way to it
+// points out of fsys.
+//
+// A rooted filesystem (os.Root.FS()) refuses these reads on its own, and it,
+// not this walk, is what makes the refusal reliable: it resolves each component
+// in the kernel, so nothing can be swapped for a link between this check and
+// the read. This walk exists for two other reasons -- it names the offending
+// link and the sandbox rule in the error instead of leaving an "openat: path
+// escapes from parent" for the user to interpret, and it holds the line for a
+// caller that passes ParseAtlasFSWithOptions a filesystem with no such
+// protection. Whatever it cannot resolve it leaves alone: the read that follows
+// reports the real error.
+func atlasCheckSandboxedFSPath(fsys fs.FS, name string) error {
+	links, ok := fsys.(fs.ReadLinkFS)
+	if !ok {
+		return nil
+	}
+	pending := atlasPathComponents(name)
+	resolved := "."
+	via := ""
+	for hops := 0; len(pending) > 0; {
+		next := pathpkg.Join(resolved, pending[0])
+		if next == ".." || strings.HasPrefix(next, "../") {
+			return atlasSymlinkEscapeError(name, via)
+		}
+		info, err := links.Lstat(next)
+		if err != nil {
+			return nil
+		}
+		if info.Mode()&fs.ModeSymlink == 0 {
+			resolved, pending = next, pending[1:]
+			continue
+		}
+		hops++
+		if hops > atlasSymlinkHopLimit {
+			return nil
+		}
+		target, err := links.ReadLink(next)
+		if err != nil {
+			return nil
+		}
+		if atlasTargetIsAbsolute(target) {
+			return atlasSymlinkEscapeError(name, next)
+		}
+		resolved, via = pathpkg.Dir(next), next
+		pending = append(atlasPathComponents(target), pending[1:]...)
+	}
+	return nil
+}
+
+// atlasPathComponents splits a slash path into the components a resolution walk
+// consumes one at a time. Targets read back from a link may be spelled with
+// either separator on Windows, so both are honored.
+func atlasPathComponents(name string) []string {
+	parts := strings.FieldsFunc(filepath.ToSlash(name), func(r rune) bool { return r == '/' })
+	components := make([]string, 0, len(parts))
+	for _, part := range parts {
+		if part == "." {
+			continue
+		}
+		components = append(components, part)
+	}
+	return components
+}
+
+// atlasTargetIsAbsolute reports whether a link target names a location from the
+// filesystem root rather than from the link's own directory. A rooted
+// filesystem refuses an absolute target outright -- even one that points back
+// inside the root -- so this agrees with it rather than second-guessing it.
+func atlasTargetIsAbsolute(target string) bool {
+	return filepath.IsAbs(target) || strings.HasPrefix(filepath.ToSlash(target), "/")
+}
+
+func atlasSymlinkEscapeError(name, via string) error {
+	if via == "" {
+		return fmt.Errorf("path escapes atlas.hcl directory: %s: %s", name, atlasFileSandboxHint)
+	}
+	return fmt.Errorf("path escapes atlas.hcl directory: %s: %s is a symbolic link pointing outside it: %s",
+		name, via, atlasFileSandboxHint)
+}
+
 func atlasLocalFSPath(value string) (string, error) {
 	if err := validateAtlasLocalPathValue(value); err != nil {
 		return "", err
@@ -2126,7 +2277,7 @@ func atlasLocalFSPath(value string) (string, error) {
 	rawPath := strings.TrimPrefix(value, "file://")
 	localPath := filepath.Clean(filepath.FromSlash(rawPath))
 	if localPath == ".." || strings.HasPrefix(localPath, ".."+string(filepath.Separator)) {
-		return "", fmt.Errorf("path escapes atlas.hcl directory: %s", value)
+		return "", fmt.Errorf("path escapes atlas.hcl directory: %s: %s", value, atlasFileSandboxHint)
 	}
 	return filepath.ToSlash(localPath), nil
 }
@@ -2134,7 +2285,7 @@ func atlasLocalFSPath(value string) (string, error) {
 func validateAtlasLocalPathValue(value string) error {
 	switch {
 	case filepath.IsAbs(strings.TrimPrefix(value, "file://")):
-		return fmt.Errorf("absolute paths are not supported: %s", value)
+		return fmt.Errorf("absolute paths are not supported: %s: %s", value, atlasFileSandboxHint)
 	case strings.Contains(value, "://") && !strings.HasPrefix(value, "file://"):
 		return fmt.Errorf("unsupported URL scheme: %s", value)
 	default:

--- a/config/projectconfig/atlas_file_sandbox_oracle_test.go
+++ b/config/projectconfig/atlas_file_sandbox_oracle_test.go
@@ -1,0 +1,251 @@
+// Unix-only for the same reason as atlas_file_sandbox_test.go, whose escape
+// fixtures this run reuses: two of them are symbolic links.
+//go:build !windows
+
+package projectconfig_test
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+// The community half of the stokaro/ptah#1042 divergence, measured rather than
+// remembered.
+//
+// The decision recorded in that issue is to keep Ptah's file() sandbox on both
+// surfaces, which leaves `ptah-compat` stricter than the community binary in
+// exactly one respect. A divergence nobody re-measures rots: if a later
+// community build starts refusing these reads, the divergence is gone and the
+// sandbox is plain parity -- and nothing here would have said so. So this run
+// pins the community behavior itself, and asserts Ptah's refusal of the same
+// fixture beside it.
+//
+// It runs only with PTAH_ATLAS_ORACLE set, and the Atlas CE Oracle workflow
+// fails if it skips.
+
+const fileOracleEnv = "PTAH_ATLAS_ORACLE"
+
+// fileOracleVersion is the only build these verdicts describe. Comparing
+// against another build would report version drift as divergence.
+const fileOracleVersion = "atlas community version v1.3.0"
+
+// fileOracleProbeURL is planted outside the config directory. It is a URL scheme
+// so the value can be traced into the binary's own error text: the leak this
+// sandbox exists to prevent is the content landing somewhere observable, not
+// merely being opened.
+const fileOracleProbeURL = "ptahsecret1042://x"
+
+func TestOracleReadsFilesOutsideTheAtlasHCLDirectory(t *testing.T) {
+	oracle := requireFileOracle(t)
+
+	tests := []struct {
+		name string
+		// argument is the file() argument, planted relative to the config
+		// directory in dir, aimed at the file outside.
+		argument func(c *qt.C, dir, outside string) string
+		// ptahErr is what Ptah says about the identical config.
+		ptahErr string
+	}{
+		{
+			name:     "absolute path",
+			argument: escapeAbsolutePath,
+			ptahErr:  `.*absolute paths are not supported.*`,
+		},
+		{
+			name:     "parent traversal",
+			argument: escapeParentTraversal,
+			ptahErr:  `.*path escapes atlas\.hcl directory.*`,
+		},
+		{
+			name:     "symbolic link out of the directory",
+			argument: escapeSymlinkedFile,
+			ptahErr:  `.*path escapes atlas\.hcl directory.*symbolic link.*`,
+		},
+		{
+			name:     "symbolic link to a directory outside",
+			argument: escapeSymlinkedDirectory,
+			ptahErr:  `.*path escapes atlas\.hcl directory.*symbolic link.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			base := t.TempDir()
+			dir := filepath.Join(base, "project")
+			c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+			outside := plantOracleSecret(c, base)
+			path := writeOracleFileConfig(c, dir, tt.argument(c, dir, outside))
+
+			out, code := runFileOracle(c, oracle, dir)
+
+			// The community binary reads it. Exit 0 on a config whose only
+			// unusual content is the file() call is the whole claim.
+			c.Assert(code, qt.Equals, 0, qt.Commentf("oracle output: %s", out))
+
+			_, err := projectconfig.LoadAtlasFile(path, "local")
+
+			c.Assert(err, qt.ErrorMatches, tt.ptahErr)
+		})
+	}
+}
+
+// The control the exit codes above depend on. A missing file makes the same
+// position fail, so `exit 0` up there means the community binary read the file
+// -- not that it never evaluated the expression.
+func TestOracleEvaluatesTheFileCallItIsGiven(t *testing.T) {
+	oracle := requireFileOracle(t)
+	c := qt.New(t)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "project")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	path := writeOracleFileConfig(c, dir, "no-such-file.txt")
+
+	out, code := runFileOracle(c, oracle, dir)
+
+	c.Assert(code, qt.Equals, 1, qt.Commentf("oracle output: %s", out))
+	c.Assert(out, qt.Contains, "no-such-file.txt")
+
+	_, err := projectconfig.LoadAtlasFile(path, "local")
+
+	// Ptah fails the same config for the same reason, so the missing-file
+	// control is not itself a divergence.
+	c.Assert(err, qt.ErrorMatches, `.*no-such-file\.txt.*`)
+}
+
+// The consequence, stated as a measurement: the contents of a file outside the
+// config directory reach a place the caller can see. This is what the sandbox
+// costs a user and what removing it would buy an attacker who can commit an
+// atlas.hcl.
+func TestOraclePlacesOutsideFileContentsWhereTheCallerCanSeeThem(t *testing.T) {
+	oracle := requireFileOracle(t)
+	c := qt.New(t)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "project")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	outside := plantOracleSecret(c, base)
+	path := writeOracleURLConfig(c, dir, outside)
+
+	out, code := runFileOracle(c, oracle, dir)
+
+	c.Assert(code, qt.Equals, 1, qt.Commentf("oracle output: %s", out))
+	// The binary lowercases the scheme before reporting it, so the comparison
+	// is on the lowercased output rather than on a rewritten expectation.
+	c.Assert(strings.ToLower(out), qt.Contains, "ptahsecret1042")
+
+	_, err := projectconfig.LoadAtlasFile(path, "local")
+
+	c.Assert(err, qt.ErrorMatches, `.*absolute paths are not supported.*`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "ptahsecret1042")
+}
+
+func plantOracleSecret(c *qt.C, base string) string {
+	c.Helper()
+
+	path := filepath.Join(base, "secret.txt")
+	c.Assert(os.WriteFile(path, []byte(fileOracleProbeURL), 0o600), qt.IsNil)
+	return path
+}
+
+// writeOracleFileConfig puts the file() call in a position whose value is
+// discarded: an unknown top-level attribute, which both the community binary
+// and Ptah evaluate and then ignore. That isolates the read from everything a
+// URL would then do with the value.
+func writeOracleFileConfig(c *qt.C, dir, argument string) string {
+	c.Helper()
+
+	path := filepath.Join(dir, "atlas.hcl")
+	body := "probe_value = file(" + quoteHCL(argument) + ")\n\n" +
+		"env \"local\" {\n  url = \"sqlite://file?mode=memory\"\n  migration {\n    dir = \"file://migrations\"\n  }\n}\n"
+	c.Assert(os.MkdirAll(filepath.Join(dir, "migrations"), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+// writeOracleURLConfig puts the same read in the env URL, where the value is
+// used and therefore visible.
+func writeOracleURLConfig(c *qt.C, dir, argument string) string {
+	c.Helper()
+
+	path := filepath.Join(dir, "atlas.hcl")
+	body := "env \"local\" {\n  url = file(" + quoteHCL(argument) + ")\n" +
+		"  migration {\n    dir = \"file://migrations\"\n  }\n}\n"
+	c.Assert(os.MkdirAll(filepath.Join(dir, "migrations"), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+// runFileOracle runs `migrate status --env local` in dir and returns its
+// combined output and exit code. The verb needs no database of its own beyond
+// the in-memory SQLite the config names, so the whole measurement is local.
+func runFileOracle(c *qt.C, oracle, dir string) (string, int) {
+	c.Helper()
+
+	warmUpFileOracle(c, oracle)
+
+	cmd := exec.Command(oracle, "migrate", "status", "--env", "local")
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	var exitErr *exec.ExitError
+	c.Assert(err == nil || asExitError(err, &exitErr), qt.IsTrue, qt.Commentf("running the oracle failed: %v", err))
+	return string(out), cmd.ProcessState.ExitCode()
+}
+
+func asExitError(err error, target **exec.ExitError) bool {
+	exitErr, ok := err.(*exec.ExitError) //nolint:errorlint // the run either exited or never started; nothing wraps it here
+	if ok {
+		*target = exitErr
+	}
+	return ok
+}
+
+// fileOracleWarmup absorbs the once-per-environment edition notice, which
+// otherwise attaches itself to whichever measurement happens to run first.
+var fileOracleWarmup sync.Once
+
+func warmUpFileOracle(c *qt.C, oracle string) {
+	c.Helper()
+
+	fileOracleWarmup.Do(func() {
+		dir := c.TempDir()
+		//nolint:errcheck // best effort: a failed write still runs the oracle, which is all the warm-up needs
+		_ = os.WriteFile(filepath.Join(dir, "atlas.hcl"),
+			[]byte("env \"local\" {\n  url = \"sqlite://file?mode=memory\"\n}\n"), 0o600)
+		cmd := exec.Command(oracle, "migrate", "status", "--env", "local")
+		cmd.Dir = dir
+		//nolint:errcheck // output and status are both discarded; this run exists only to spend the notice
+		_, _ = cmd.CombinedOutput()
+	})
+}
+
+func requireFileOracle(t *testing.T) string {
+	t.Helper()
+
+	oracle := os.Getenv(fileOracleEnv)
+	if oracle == "" {
+		t.Skipf("SKIPPED: set %s to the pinned Atlas CE binary (%s) to run the atlas.hcl file() conformance run",
+			fileOracleEnv, fileOracleVersion)
+	}
+
+	out, err := exec.Command(oracle, "version").Output() //nolint:gosec // the oracle path is operator-provided via PTAH_ATLAS_ORACLE
+	if err != nil {
+		t.Fatalf("%s=%s is not runnable: %v", fileOracleEnv, oracle, err)
+	}
+	got, _, _ := strings.Cut(string(out), "\n")
+	if strings.TrimSpace(got) != fileOracleVersion {
+		t.Fatalf("%s=%s reports %q, want %q; a different build may have changed the rules under test",
+			fileOracleEnv, oracle, strings.TrimSpace(got), fileOracleVersion)
+	}
+	return oracle
+}

--- a/config/projectconfig/atlas_file_sandbox_test.go
+++ b/config/projectconfig/atlas_file_sandbox_test.go
@@ -1,0 +1,453 @@
+// Symbolic links are half of what this file measures, and creating one on
+// Windows needs a privilege an ordinary CI account does not have. The build tag
+// follows atlas_root_unix_test.go, which is unix-only for the same reason.
+//go:build !windows
+
+package projectconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+// The atlas.hcl file() sandbox, pinned. See stokaro/ptah#1042.
+//
+// file() inlines the contents of a file into a config value -- a database URL,
+// an error message, anything the config can name. The pinned community binary
+// resolves that argument against the whole filesystem: an absolute path, a
+// parent-traversal path, and a symbolic link out of the config directory all
+// read the target and exit 0. Ptah confines it to the directory holding
+// atlas.hcl.
+//
+// That divergence is deliberate and it is measured, not remembered: the
+// community half of it is pinned by TestOracleReadsFilesOutsideTheAtlasHCLDirectory
+// in atlas_file_sandbox_oracle_test.go, which runs the binary. This file pins
+// the Ptah half.
+//
+// The refusals below are checked through both loaders that reach a real
+// directory, because the two build the filesystem the sandbox rests on
+// separately, and only one of them was ever symlink-safe: ParseAtlas used
+// os.DirFS, which follows a link straight out of the directory.
+
+// outsideFileMarker is the content of every file planted outside the config
+// directory. Every refusal is asserted not to contain it, so a message that
+// quotes the file it refused to read cannot pass as a refusal.
+const outsideFileMarker = "PTAH-1042-SECRET-OUTSIDE-THE-CONFIG-DIRECTORY"
+
+// insideFileMarker is the content of files that legitimately live inside the config
+// directory, so a control can assert the value was actually read.
+const insideFileMarker = "PTAH-1042-INSIDE-THE-CONFIG-DIRECTORY"
+
+// atlasFileLoader is one way to reach the file() sandbox with a config that
+// lives on disk.
+type atlasFileLoader struct {
+	name string
+	load func(c *qt.C, path string) (projectconfig.Config, error)
+}
+
+func atlasFileLoaders() []atlasFileLoader {
+	return []atlasFileLoader{
+		{
+			name: "LoadAtlasFile",
+			load: func(_ *qt.C, path string) (projectconfig.Config, error) {
+				return projectconfig.LoadAtlasFile(path, "local")
+			},
+		},
+		{
+			name: "ParseAtlas",
+			load: func(c *qt.C, path string) (projectconfig.Config, error) {
+				raw, err := os.ReadFile(path)
+				c.Assert(err, qt.IsNil)
+				return projectconfig.ParseAtlas(raw, path, "local")
+			},
+		},
+	}
+}
+
+// writeAtlasFileConfig writes an atlas.hcl whose env URL is the contents of the
+// named file, and returns its path. The value lands in a field the caller can
+// read back, so a successful read is provable rather than merely not an error.
+func writeAtlasFileConfig(c *qt.C, dir, argument string) string {
+	c.Helper()
+
+	path := filepath.Join(dir, "atlas.hcl")
+	body := "env \"local\" {\n  url = file(" + quoteHCL(argument) + ")\n}\n"
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+func quoteHCL(value string) string {
+	return "\"" + value + "\""
+}
+
+// plantOutsideSecret writes the out-of-directory file every escape below aims
+// at, one level above the config directory, and returns its absolute path.
+func plantOutsideSecret(c *qt.C, base string) string {
+	c.Helper()
+
+	path := filepath.Join(base, "secret.txt")
+	c.Assert(os.WriteFile(path, []byte(outsideFileMarker), 0o600), qt.IsNil)
+	return path
+}
+
+func symlink(c *qt.C, target, link string) {
+	c.Helper()
+
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+}
+
+// The escape shapes. Each returns the argument to hand file(), after planting
+// whatever the shape needs in the config directory.
+
+func escapeAbsolutePath(c *qt.C, _, outside string) string {
+	c.Helper()
+
+	return outside
+}
+
+func escapeParentTraversal(c *qt.C, _, outside string) string {
+	c.Helper()
+
+	return "../" + filepath.Base(outside)
+}
+
+func escapeSymlinkedFile(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	symlink(c, outside, filepath.Join(dir, "link.txt"))
+	return "link.txt"
+}
+
+func escapeSymlinkedRelativeFile(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	symlink(c, filepath.Join("..", filepath.Base(outside)), filepath.Join(dir, "relative.link"))
+	return "relative.link"
+}
+
+func escapeSymlinkedDirectory(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	symlink(c, filepath.Dir(outside), filepath.Join(dir, "outdir"))
+	return "outdir/" + filepath.Base(outside)
+}
+
+func escapeSymlinkChain(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	symlink(c, filepath.Join("..", filepath.Base(outside)), filepath.Join(dir, "second.link"))
+	symlink(c, "second.link", filepath.Join(dir, "first.link"))
+	return "first.link"
+}
+
+// escapeLongSymlinkChain builds hop0 -> hop1 -> ... -> the outside file, longer
+// than the sandbox's own resolution and well short of any operating system's
+// limit on chained links, so the read is attempted rather than refused as a
+// loop.
+func escapeLongSymlinkChain(c *qt.C, dir, outside string) string {
+	c.Helper()
+
+	const hops = 6
+	for hop := range hops - 1 {
+		symlink(c, hopLinkName(hop+1), filepath.Join(dir, hopLinkName(hop)))
+	}
+	symlink(c, filepath.Join("..", filepath.Base(outside)), filepath.Join(dir, hopLinkName(hops-1)))
+	return hopLinkName(0)
+}
+
+func hopLinkName(hop int) string {
+	return "hop" + strconv.Itoa(hop) + ".link"
+}
+
+// escapeSymlinkReentry leaves the directory and comes back to a file inside it.
+// It reads nothing an author could not have named directly, and it is refused
+// anyway: the rule is about where the path goes, not about what it ends up on,
+// and a rooted filesystem refuses it for exactly the same reason.
+func escapeSymlinkReentry(c *qt.C, dir, _ string) string {
+	c.Helper()
+
+	inside := filepath.Join(dir, "inside.txt")
+	c.Assert(os.WriteFile(inside, []byte(insideFileMarker), 0o600), qt.IsNil)
+	symlink(c, filepath.Join("..", filepath.Base(dir), "inside.txt"), filepath.Join(dir, "reentry.link"))
+	return "reentry.link"
+}
+
+func TestAtlasFileSandboxRefusesReadsOutsideTheConfigDirectory(t *testing.T) {
+	tests := []struct {
+		name  string
+		plant func(c *qt.C, dir, outside string) string
+		err   string
+	}{
+		{
+			name:  "absolute path",
+			plant: escapeAbsolutePath,
+			err:   `.*absolute paths are not supported: .*secret\.txt: atlas\.hcl file\(\) and fileset\(\) read only inside the directory holding atlas\.hcl; pass a value from outside it through getenv\(\).*`,
+		},
+		{
+			name:  "parent traversal",
+			plant: escapeParentTraversal,
+			err:   `.*path escapes atlas\.hcl directory: \.\./secret\.txt: atlas\.hcl file\(\) and fileset\(\) read only inside the directory holding atlas\.hcl.*`,
+		},
+		{
+			name:  "symbolic link to an absolute path outside",
+			plant: escapeSymlinkedFile,
+			err:   `.*path escapes atlas\.hcl directory: link\.txt: link\.txt is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "symbolic link to a relative path outside",
+			plant: escapeSymlinkedRelativeFile,
+			err:   `.*path escapes atlas\.hcl directory: relative\.link: relative\.link is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "symbolic link to a directory outside",
+			plant: escapeSymlinkedDirectory,
+			err:   `.*path escapes atlas\.hcl directory: outdir/secret\.txt: outdir is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "chain of symbolic links leaving the directory",
+			plant: escapeSymlinkChain,
+			err:   `.*path escapes atlas\.hcl directory: first\.link: second\.link is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "symbolic link that leaves and re-enters",
+			plant: escapeSymlinkReentry,
+			err:   `.*path escapes atlas\.hcl directory: reentry\.link: reentry\.link is a symbolic link pointing outside it.*`,
+		},
+		{
+			// The row that measures the filesystem rather than the walk. The
+			// chain is longer than the sandbox resolves, so the named refusal
+			// above is not reached and the only thing left standing is the
+			// rooted filesystem the loader opened -- which is why its wording
+			// is the operating system's. Hand either loader an os.DirFS instead
+			// and this reads the file.
+			name:  "chain longer than the sandbox resolves",
+			plant: escapeLongSymlinkChain,
+			err:   `.*openat hop0\.link: path escapes from parent.*`,
+		},
+	}
+
+	for _, loader := range atlasFileLoaders() {
+		for _, tt := range tests {
+			t.Run(loader.name+"/"+tt.name, func(t *testing.T) {
+				c := qt.New(t)
+
+				base := t.TempDir()
+				dir := filepath.Join(base, "project")
+				c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+				outside := plantOutsideSecret(c, base)
+				path := writeAtlasFileConfig(c, dir, tt.plant(c, dir, outside))
+
+				cfg, err := loader.load(c, path)
+
+				c.Assert(err, qt.ErrorMatches, tt.err)
+				c.Assert(cfg.DatabaseURL, qt.Equals, "")
+				// A refusal that quotes the file it refused to read would be a
+				// smaller version of the same leak.
+				c.Assert(err.Error(), qt.Not(qt.Contains), outsideFileMarker)
+			})
+		}
+	}
+}
+
+// The other half of the guard: everything inside the directory still reads,
+// including symbolic links that stay inside it. Without this, "refuse
+// everything" would pass the table above.
+func TestAtlasFileSandboxReadsInsideTheConfigDirectory(t *testing.T) {
+	tests := []struct {
+		name  string
+		plant func(c *qt.C, dir string) string
+	}{
+		{
+			name:  "plain file",
+			plant: insidePlainFile,
+		},
+		{
+			name:  "file in a subdirectory",
+			plant: insideSubdirectoryFile,
+		},
+		{
+			name:  "symbolic link to a sibling",
+			plant: insideSiblingSymlink,
+		},
+		{
+			name:  "symbolic link in a subdirectory pointing up to a sibling",
+			plant: insideUpwardSymlink,
+		},
+		{
+			name:  "explicit ./ prefix",
+			plant: insideDotSlashFile,
+		},
+	}
+
+	for _, loader := range atlasFileLoaders() {
+		for _, tt := range tests {
+			t.Run(loader.name+"/"+tt.name, func(t *testing.T) {
+				c := qt.New(t)
+
+				base := t.TempDir()
+				dir := filepath.Join(base, "project")
+				c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+				plantOutsideSecret(c, base)
+				path := writeAtlasFileConfig(c, dir, tt.plant(c, dir))
+
+				cfg, err := loader.load(c, path)
+
+				c.Assert(err, qt.IsNil)
+				c.Assert(cfg.DatabaseURL, qt.Equals, insideFileMarker)
+			})
+		}
+	}
+}
+
+func insidePlainFile(c *qt.C, dir string) string {
+	c.Helper()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "url.txt"), []byte(insideFileMarker), 0o600), qt.IsNil)
+	return "url.txt"
+}
+
+func insideDotSlashFile(c *qt.C, dir string) string {
+	c.Helper()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "url.txt"), []byte(insideFileMarker), 0o600), qt.IsNil)
+	return "./url.txt"
+}
+
+func insideSubdirectoryFile(c *qt.C, dir string) string {
+	c.Helper()
+
+	c.Assert(os.Mkdir(filepath.Join(dir, "conf"), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "conf", "url.txt"), []byte(insideFileMarker), 0o600), qt.IsNil)
+	return "conf/url.txt"
+}
+
+func insideSiblingSymlink(c *qt.C, dir string) string {
+	c.Helper()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "url.txt"), []byte(insideFileMarker), 0o600), qt.IsNil)
+	symlink(c, "url.txt", filepath.Join(dir, "url.link"))
+	return "url.link"
+}
+
+func insideUpwardSymlink(c *qt.C, dir string) string {
+	c.Helper()
+
+	c.Assert(os.WriteFile(filepath.Join(dir, "url.txt"), []byte(insideFileMarker), 0o600), qt.IsNil)
+	c.Assert(os.Mkdir(filepath.Join(dir, "conf"), 0o700), qt.IsNil)
+	symlink(c, filepath.Join("..", "url.txt"), filepath.Join(dir, "conf", "url.link"))
+	return "conf/url.link"
+}
+
+// writeAtlasFilesetConfig writes an atlas.hcl whose schema sources are a
+// fileset() glob, so the resolved list is readable from the parsed config.
+func writeAtlasFilesetConfig(c *qt.C, dir, glob string) string {
+	c.Helper()
+
+	path := filepath.Join(dir, "atlas.hcl")
+	body := "data \"hcl_schema\" \"app\" {\n  paths = fileset(" + quoteHCL(glob) + ")\n}\n\n" +
+		"env \"local\" {\n  src = data.hcl_schema.app.url\n}\n"
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+// fileset() walks the same sandbox. An entry that leaves the directory fails
+// the whole call rather than being quietly dropped from the list: the returned
+// paths become schema-source URLs that another reader opens, and silently
+// shortening a list the author wrote is how a schema goes missing without
+// anyone being told.
+func TestAtlasFilesetSandboxRefusesEscapingEntries(t *testing.T) {
+	tests := []struct {
+		name  string
+		glob  string
+		plant func(c *qt.C, dir, outside string)
+		err   string
+	}{
+		{
+			name:  "glob matching a link out of the directory",
+			glob:  "*.hcl",
+			plant: plantEscapingFilesetEntry,
+			err:   `.*path escapes atlas\.hcl directory: leaked\.hcl: leaked\.hcl is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "recursive glob matching a link out of the directory",
+			glob:  "**/*.hcl",
+			plant: plantEscapingNestedFilesetEntry,
+			err:   `.*path escapes atlas\.hcl directory: nested/leaked\.hcl: nested/leaked\.hcl is a symbolic link pointing outside it.*`,
+		},
+		{
+			name:  "parent traversal glob",
+			glob:  "../*.hcl",
+			plant: plantSiblingSchema,
+			err:   `.*path escapes atlas\.hcl directory: \.\./\*\.hcl: atlas\.hcl file\(\) and fileset\(\) read only inside the directory holding atlas\.hcl.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			base := t.TempDir()
+			dir := filepath.Join(base, "project")
+			c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+			outside := plantOutsideSchema(c, base)
+			tt.plant(c, dir, outside)
+			path := writeAtlasFilesetConfig(c, dir, tt.glob)
+
+			cfg, err := projectconfig.LoadAtlasFile(path, "local")
+
+			c.Assert(err, qt.ErrorMatches, tt.err)
+			c.Assert(cfg.SchemaSources, qt.HasLen, 0)
+		})
+	}
+}
+
+// The fileset() control: a glob that stays inside the directory still resolves,
+// links included.
+func TestAtlasFilesetResolvesEntriesInsideTheConfigDirectory(t *testing.T) {
+	c := qt.New(t)
+
+	base := t.TempDir()
+	dir := filepath.Join(base, "project")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	plantOutsideSchema(c, base)
+	c.Assert(os.Mkdir(filepath.Join(dir, "schema"), 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema", "a.hcl"), []byte("schema \"main\" {\n}\n"), 0o600), qt.IsNil)
+	symlink(c, "a.hcl", filepath.Join(dir, "schema", "b.hcl"))
+	path := writeAtlasFilesetConfig(c, dir, "schema/*.hcl")
+
+	cfg, err := projectconfig.LoadAtlasFile(path, "local")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.SchemaSources, qt.DeepEquals, []string{"file://schema/a.hcl", "file://schema/b.hcl"})
+}
+
+func plantOutsideSchema(c *qt.C, base string) string {
+	c.Helper()
+
+	path := filepath.Join(base, "leaked.hcl")
+	c.Assert(os.WriteFile(path, []byte("schema \"main\" {\n}\n"), 0o600), qt.IsNil)
+	return path
+}
+
+func plantEscapingFilesetEntry(c *qt.C, dir, outside string) {
+	c.Helper()
+
+	symlink(c, outside, filepath.Join(dir, "leaked.hcl"))
+}
+
+func plantEscapingNestedFilesetEntry(c *qt.C, dir, outside string) {
+	c.Helper()
+
+	c.Assert(os.Mkdir(filepath.Join(dir, "nested"), 0o700), qt.IsNil)
+	symlink(c, outside, filepath.Join(dir, "nested", "leaked.hcl"))
+}
+
+func plantSiblingSchema(c *qt.C, _, _ string) {
+	c.Helper()
+}

--- a/config/projectconfig/atlas_root_unix_test.go
+++ b/config/projectconfig/atlas_root_unix_test.go
@@ -35,7 +35,16 @@ func TestParseAtlasFSWithOptionsRejectsFileSymlinkEscape(t *testing.T) {
 		projectconfig.AtlasLoadOptions{EnvName: "local"},
 	)
 
-	c.Assert(err, qt.ErrorMatches, `cannot evaluate atlas\.hcl "url" at atlas\.hcl:2: .*path escapes from parent.*`)
+	// The refusal is the same one this test was written for. Its wording moved
+	// from the filesystem's ("openat database-url.txt: path escapes from
+	// parent") to the sandbox's own, which names the link and the rule --
+	// stokaro/ptah#1042. The rooted filesystem still refuses whatever the
+	// sandbox cannot resolve for itself; that path is pinned by the
+	// "chain longer than the sandbox resolves" row in
+	// TestAtlasFileSandboxRefusesReadsOutsideTheConfigDirectory.
+	c.Assert(err, qt.ErrorMatches,
+		`cannot evaluate atlas\.hcl "url" at atlas\.hcl:2: .*path escapes atlas\.hcl directory: database-url\.txt: `+
+			`database-url\.txt is a symbolic link pointing outside it.*`)
 }
 
 func TestParseAtlasFSWithOptionsRejectsFilesetSymlinkEscape(t *testing.T) {

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -328,6 +328,32 @@ and a list of `file://...` URLs when `paths` is used. `fileset` returns stable
 slash-separated relative paths sorted lexicographically and supports recursive
 `**` path segments.
 
+### The file() and fileset() sandbox
+
+Both functions are confined to the directory holding `atlas.hcl`. An absolute
+path, a parent-traversal path, and a symbolic link whose target leaves the
+directory are refused, and the error names the rule and points at `getenv()`
+for a value that lives elsewhere. A `fileset` glob whose match leaves the
+directory fails the whole call rather than dropping the entry, because the
+returned paths become schema-source URLs that another reader opens. A symbolic
+link that stays inside the directory is read normally.
+
+The refusal is enforced twice on purpose. The loader resolves what it can
+itself, so the message names the offending link instead of leaving an
+`openat: path escapes from parent` to interpret; the directory is also opened
+through a rooted handle, which is what catches a link chain the resolver stops
+following and a path swapped for a link between the check and the read.
+`ParseAtlasFSWithOptions` takes the filesystem from its caller, so a caller that
+supplies one without that protection has chosen a weaker boundary; the loaders
+in this package and in `cmd/atlas` supply a rooted one.
+
+This is deliberately stricter than Atlas. The pinned community v1.3.0 binary
+reads all three shapes and exits 0, and the contents land somewhere observable,
+so matching it would give any author of a repository-controlled `atlas.hcl` an
+arbitrary-file read wherever the tool runs. The divergence is measured by the
+`TestOracle*` runs in `config/projectconfig` under the Atlas CE Oracle
+workflow. See [`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042).
+
 Atlas-compatible commands under `ptah-compat schema ...` and
 `ptah-compat migrate ...` accept Atlas project flags:
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -109,6 +109,15 @@
   },
   {
     "area": "Project config",
+    "feature": "atlas.hcl file() and fileset() path confinement",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today.",
+    "evidence": "config/projectconfig/atlas.go atlasSandboxedFSPath/atlasCheckSandboxedFSPath. Measured against the pinned community v1.3.0 binary: an atlas.hcl with `probe_value = file(\"<abs>/secret.txt\")` plus `atlas migrate status --env local` -> exit 0; the same read in env.url puts the file's contents in `Error: sql/sqlclient: unknown driver \"...\"`; `../../secret.txt` and a symlink out of the directory behave identically. ptah-compat exits 1 naming the rule. Pinned by TestOracleReadsFilesOutsideTheAtlasHCLDirectory and TestAtlasFileSandboxRefusesReadsOutsideTheConfigDirectory (config/projectconfig), TestCompatCommand_AtlasHCLFileSandbox (cmd/atlas)"
+  },
+  {
+    "area": "Project config",
     "feature": "data \"hcl_schema\" reference",
     "ptah": "partial",
     "atlas_oss": "yes",

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -513,7 +513,22 @@ Unsupported constructs fail explicitly rather than being silently ignored.
 
 **Atlas Commercial / Cloud.** Pro data sources and policy features include composite schema, blob directory, custom lint rules, and review workflows.
 
-**Evidence.** [HCL schema](../../reference/hcl-schema/), [Atlas project config](../project-config/), [Atlas feature availability](https://atlasgo.io/features), [`stokaro/ptah#582`](https://github.com/stokaro/ptah/issues/582), [`stokaro/ptah#511`](https://github.com/stokaro/ptah/issues/511)
+**Retained divergence on `file()` paths.** The community binary resolves a
+`file()` or `fileset()` argument against the whole filesystem. Measured on the
+pinned v1.3.0 build: `file("/etc/passwd")` and `file("../../../../etc/passwd")`
+in an `atlas.hcl` both exit `0` with the file read, and the contents reach an
+observable place — a database URL, an error message on standard error.
+
+Ptah confines both functions to the directory holding `atlas.hcl` on both
+binaries, and refuses an absolute path, parent traversal, or a symbolic link
+leaving that directory by name. An `atlas.hcl` is repository-controlled and
+evaluated before anything is applied, so matching here would turn config
+authorship into an arbitrary-file read on whatever machine runs the migration.
+The exit code is `1` either way today, so no working configuration changes; the
+refusal now names its reason and points at `getenv()`. See
+[`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042).
+
+**Evidence.** [HCL schema](../../reference/hcl-schema/), [Atlas project config](../project-config/), [Atlas feature availability](https://atlasgo.io/features), [`stokaro/ptah#582`](https://github.com/stokaro/ptah/issues/582), [`stokaro/ptah#511`](https://github.com/stokaro/ptah/issues/511), [`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042)
 
 
 ### Conformance status

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -72,16 +72,16 @@ row for a migration decision.
 
 ## At a glance
 
-Across the 162 capabilities below:
+Across the 163 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 88 |
+| Ptah supports it fully | 89 |
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 25 |
 | Ptah and Atlas CE both support it | 21 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
-| Ptah has it and neither Atlas edition does | 19 |
+| Ptah has it and neither Atlas edition does | 20 |
 | Atlas CE has it and Ptah does not, or only in part | 26 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
@@ -230,6 +230,7 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema. |
+| atlas.hcl file() and fileset() path confinement | ✅ | ❌ | ❌ | Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today. |
 | atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected. |
 | Docker dev databases (`docker://` `--dev-url`) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -193,6 +193,48 @@ external schema program. `env://url` and `env://dev` resolve the corresponding
 database URL; `env://migration.dir` resolves the configured local migration
 directory. Nested `env://` references fail explicitly.
 
+## Reading files with file() and fileset()
+
+`file("path")` inlines a file's contents into a config value, and
+`fileset("glob")` expands to a list of paths. Both resolve relative to the
+directory holding `atlas.hcl`, and both are confined to it. These are refused,
+with the reason named:
+
+| Argument | Refused because |
+| --- | --- |
+| `file("/run/secrets/db")` | absolute path |
+| `file("../secrets/db")` | parent traversal |
+| `file("link.txt")` where `link.txt` points outside the directory | symbolic link leaving the directory |
+| `fileset("*.hcl")` where one match points outside the directory | the whole call fails; escaping entries are never dropped silently |
+
+A symbolic link that stays inside the directory is read normally, including one
+that walks up and back down inside it. The rule is about where the path goes,
+not about links.
+
+Pass a value that genuinely lives elsewhere through the environment instead:
+
+```hcl
+env "local" {
+  url = getenv("DATABASE_URL")
+}
+```
+
+This is stricter than the community binary, deliberately. Measured against the
+pinned community v1.3.0 build: an `atlas.hcl` calling `file("/etc/passwd")` or
+`file("../../../../etc/passwd")` exits 0 there with the file read, and the
+contents reach an observable place — a database URL, an error message on
+standard error. An `atlas.hcl` is repository-controlled and evaluated before
+anything is applied, so matching that would hand any config author an
+arbitrary-file read on the machine running the migration. The exit code is 1
+either way today, so no working configuration changes; what changes is that the
+refusal now names its reason. See
+[`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042).
+
+The confinement covers what `file()` and `fileset()` read. It is not a claim
+that `atlas.hcl` cannot name a path outside its directory at all: a schema
+source such as `src = "../shared/schema.hcl"` is a path the author points the
+tool at deliberately, and it still resolves.
+
 ## External schema data source
 
 `data "external_schema"` declares a program whose standard output is the


### PR DESCRIPTION
Refs #1042 — not "closes", because one item of its definition of done survives:
the `ce-gating` scenario belongs in `stokaro/ptah-atlas-conformance` and needs a
PR there. Everything else lands here, including an equivalent conformance run
that executes in this repository's CI. Detail under
[Deliberately left open](#deliberately-left-open).

## The decision, where the issue offered a choice

**Option 1: keep the sandbox on both surfaces.** `file()` and `fileset()` stay
confined to the directory holding `atlas.hcl`, on `ptah-compat` and on native
`ptah`, and the divergence is recorded in the feature matrix, the comparison
page, and a conformance run that re-measures the community side on every CI
build.

I argued the other way first, because the usability case is real: a config that
reads `/run/secrets/db_password` — the path a Docker or Kubernetes secret mount
actually has — is refused here and works on the community binary, and moving
onto `ptah-compat` means editing that config. That is a genuine cost, and the
alternative I would hand a user (`getenv()`) is now named in the error text
rather than left for them to find.

It does not outweigh what relaxing buys an attacker. `atlas.hcl` is
repository-controlled, `file()` evaluates before anything is applied, and the
value lands somewhere observable. The exfiltration is measured, not assumed:
with the read in `env.url`, the community binary returns the file's contents in
its own error text (`TestOraclePlacesOutsideFileContentsWhereTheCallerCanSeeThem`,
below). Removing the sandbox turns "can open a pull request" into "can read any
file the migration process can read, and see the result in the CI log". The
policy in `AGENTS.md` covers exactly this case — matching is the floor, and we
do not copy a defect — so the two halves of the rule do not pull apart here.

Option 3 (an env-var opt-in) was rejected on threat model rather than taste:
anyone who can commit an `atlas.hcl` can usually set a CI environment variable
too, so the gate stands beside the capability instead of in front of it, and it
would ship a documented bypass in every build.

**Parity rule (a) is not engaged.** Nothing here makes `ptah-compat` exit 0
where the community binary exits 1; every change only adds a refusal. The
divergence is entirely in the permitted direction, and the exit code is 1 on
both sides for all four shapes today, so no working configuration breaks.

## What the sandbox still refuses, and why that set

Refused, each with the rule named and `getenv()` offered:

| Argument | Why |
| --- | --- |
| `file("/run/secrets/db")` | absolute path |
| `file("../secrets/db")` | parent traversal |
| `file("link.txt")` where the link leaves the directory | symbolic-link escape, including chains and a link that leaves and re-enters |
| `fileset("*.hcl")` with one match leaving the directory | the whole call fails; escaping entries are never dropped silently |

Allowed: anything inside the directory, symbolic links included — a link to a
sibling, and a link in a subdirectory pointing up to a file that is still
inside. The rule is about where the path goes, not about links. That is the
line that makes this a sandbox rather than a ban, and it is pinned by its own
tests (see the inverse mutant below).

A sandbox that reads any absolute path is not a sandbox — and neither is one
that follows a symlink out of its root. That was the state of one branch here
before this PR.

## Reproduction, before

Fixtures: `atlas.hcl` with `probe_value = file(<argument>)` (a discarded
position) plus an `env "local"` on in-memory SQLite; `secret.txt` planted one
directory above. Command: `<binary> migrate status --env local`, run in the
fixture directory. Community binary: the pinned build at
`ptah-atlas-conformance/bin/atlas`, `atlas community version v1.3.0`.
`ptah-compat` built from `bd7d3c66` (master at the time).

| fixture | community binary | ptah-compat |
| --- | --- | --- |
| `file("local.txt")` | 0 | 0 |
| `file("<abs>/secret.txt")` | **0** | 1 `absolute paths are not supported` |
| `file("../../outside/secret.txt")` | **0** | 1 `path escapes atlas.hcl directory` |
| `file("link.txt")` → outside | **0** | 1 `openat link.txt: path escapes from parent` |
| `file("linkdir/secret.txt")`, linked dir | **0** | 1 `openat linkdir/secret.txt: path escapes from parent` |
| `getenv("HOME")` | 0 | 0 |
| `file("no-such-file.txt")` | 1 | 1 |

Controls carried by that run: the missing-file row exits 1 on both, so the
community binary's `0`s mean it read the file rather than never evaluating the
expression; `--frobnicate-nonsense` is `unknown flag` on both, so the probe was
reaching the flag parser it looks like it was reaching.

The issue still reproduces on master, so there was work to do.

Leak measurement, same fixtures with the read moved into `env.url` and the file
containing `SECRETTOKEN1042://x`:

```
CE          exit=1  Error: sql/sqlclient: unknown driver "secrettoken1042". See: https://atlasgo.io/url
ptah-compat exit=1  Error: ... Call to function "file" failed: absolute paths are not supported: <abs>/oneline.txt
```

The contents of a file outside the config directory reach standard error. That
is the cost of matching, stated as a measurement.

## Reproduction, after

Same fixtures and command, `ptah-compat` built from this branch:

| fixture | community binary | ptah-compat |
| --- | --- | --- |
| `file("local.txt")` | 0 | 0 |
| `file("<abs>/secret.txt")` | 0 | 1 `absolute paths are not supported: <path>: atlas.hcl file() and fileset() read only inside the directory holding atlas.hcl; pass a value from outside it through getenv()` |
| `file("../../outside/secret.txt")` | 0 | 1 `path escapes atlas.hcl directory: ../../outside/secret.txt: ` + the same hint |
| `file("link.txt")` → outside | 0 | 1 `path escapes atlas.hcl directory: link.txt: link.txt is a symbolic link pointing outside it: ` + the same hint |
| `file("linkdir/secret.txt")` | 0 | 1 `path escapes atlas.hcl directory: linkdir/secret.txt: linkdir is a symbolic link pointing outside it: ` + the same hint |
| `getenv("HOME")` | 0 | 0 |
| `file("no-such-file.txt")` | 1 | 1 |

Native `ptah migrations status --env local` on the same symlink fixture exits 1
with the identical message, and on the `inside` fixture prints the status — both
surfaces, both directions.

## What changed

- **`config/projectconfig/atlas.go`.** `ParseAtlasWithOptions` resolved
  `file()` through `os.DirFS`, which follows a link straight out of the
  directory (measured: `DirFS` returns the outside file's contents where
  `os.Root.FS()` returns `path escapes from parent`). It now opens the
  directory as a rooted handle, matching `LoadAtlasFileWithOptions` and
  `cmd/atlas`, which were already rooted. A directory that cannot be opened
  yields a filesystem that reports that error from the first read, so a config
  that never calls `file()` parses exactly as before.
- **The refusal is now the sandbox's own.** A component-by-component walk over
  `fs.ReadLinkFS` names the offending link and the rule instead of leaving an
  `openat: path escapes from parent` to interpret, and it holds the line for a
  caller that hands `ParseAtlasFSWithOptions` a filesystem with no protection of
  its own. The rooted filesystem stays the enforcement of record: it resolves in
  the kernel, so nothing can be swapped for a link between the check and the
  read, and it catches the shapes the walk stops following. Both facts are
  pinned (below).
- **Every refusal names `getenv()`**, which is what a value outside the config
  directory should travel through.
- **Docs**: a `file()`/`fileset()` section on the project-config page, a
  retained-divergence paragraph in the comparison page's HCL and config
  section, the repo-level `docs/atlas_project_config.md`, and a second worked
  example in `AGENTS.md` beside the `atlas:txmode` one.
- **Feature matrix**: a new row, `atlas.hcl file() and fileset() path
  confinement` — Ptah ✅, CE ❌, Pro ❌ — regenerated through
  `build-feature-matrix.mjs`.

## What each test prints if the change is reverted

Every mutation below was run; these are transcripts, not predictions.

**Mutant 1 — `ParseAtlasWithOptions` back on `os.DirFS`.**
`TestAtlasFileSandboxRefusesReadsOutsideTheConfigDirectory/ParseAtlas/chain_longer_than_the_sandbox_resolves`
fails with `got nil error but want non-nil` for
`.*openat hop0\.link: path escapes from parent.*` — the six-link chain resolves
and the outside file is read. That row exists precisely to measure the
filesystem rather than the walk: it is longer than the sandbox resolves, so the
rooted handle is the only thing left standing. Every other row stays green under
this mutant, which is the honest reading — the walk covers the rest.

**Mutant 2 — the symlink walk returns `nil` unconditionally.** Thirteen rows
fail: five symlink rows under each of the two loaders, both `fileset` escape
rows, and `TestCompatCommand_AtlasHCLFileSandbox/symbolic_link_out_of_the_directory`.
Each prints the filesystem's `openat …: path escapes from parent` where the
pinned message names the link and the rule. The refusal survives on the rooted
paths; the reason does not.

**Mutant 3 — the `getenv()` hint emptied.** Seven rows fail: the absolute-path
and parent-traversal rows under both loaders, the parent-traversal `fileset`
row, and both non-symlink rows of the compat test, each printing the message
without its second half.

**Mutant 4 — the inverse, refusing every symbolic link.** This is the
non-interference proof, and it cannot be obtained by reverting anything:
removing a guard never makes a control fire. Five control rows go red —
`symbolic_link_to_a_sibling` and
`symbolic_link_in_a_subdirectory_pointing_up_to_a_sibling` under both loaders,
plus `TestAtlasFilesetResolvesEntriesInsideTheConfigDirectory` — each printing
the refusal where the file's contents were expected. The controls discriminate;
they are not passing because nothing refuses.

**The oracle run** cannot go vacuously green either:
`TestOracleEvaluatesTheFileCallItIsGiven` is its control. If the community
binary stopped evaluating the expression, that test fails (`exit 1` and the
filename in the output are both asserted), and the `exit 0`s in
`TestOracleReadsFilesOutsideTheAtlasHCLDirectory` would no longer mean "it read
the file". If a future community build starts refusing these reads, that test
goes red and says the divergence is over.

`config/projectconfig/atlas_root_unix_test.go` is the one existing pin whose
expectation moved: same refusal, wording now the sandbox's rather than the
filesystem's. Its comment says so and points at the row that still covers the
filesystem's own message.

## Gates

Green: `go build ./...`, `go vet ./...`, `go test ./... -count=1`,
`go tool qtlint ./...`, `golangci-lint run ./...`,
`scripts/check-test-style.sh`, `scripts/check-public-api.sh`,
`scripts/check-public-api-snapshot.sh`. Docs touched, so all twelve
`docs/site` `check:*` scripts were run: `check:exit-codes`,
`check:exit-codes:selftest`, `check:core-doc-links`, `check:page-health`,
`check:links`, `check:links:selftest`, `check:redirects`,
`check:redirects:selftest`, `check:style`, `check:style:selftest`,
`versions:selftest` — all OK.

Two honest qualifications:

- **`check:responsive` SKIPPED locally**, because playwright is not installed
  here; the site built cleanly (61 pages) and the check refuses to report
  success without a browser, so this is a skip and not a pass. The CI job
  installs the browser. In its place I measured what it looks for: the new
  matrix cell is 196 characters, tenth longest of 163 and under the 200-char
  cap, and the widest cell in the new project-config table is 88 characters
  against that page's existing 136-character maximum, so neither table widens
  anything.
- **`cmd/viz`'s `TestSVGReportsGraphvizStderrOnFailure` failed in the full-suite
  run** with `signal: killed`, the documented machine-load failure. It passes on
  its own (`go test ./cmd/viz -run TestSVGReportsGraphvizStderrOnFailure` → ok),
  and `go list -deps ./cmd/viz` contains no package this PR touches.

`ParseAtlasWithOptions` keeps unnamed results on purpose: a named-result form
changed the public API snapshot text, and the snapshot is a baseline with its
own approval path.

## Deliberately left open

- **Schema-source paths are not confined, and this PR does not change that.**
  `env.src`, `env.schema.src`, and `data "hcl_schema"` paths still resolve
  outside the config directory: measured on this branch,
  `ptah-compat schema diff --env local --from env://url --to env://src` with
  `path = "link.hcl"` pointing outside prints
  `CREATE TABLE "main"."leaked_from_outside"`, and `src = "../shared/schema.hcl"`
  is an ordinary monorepo layout that must keep working. Those are paths an
  author points the tool at, and their content is parsed as a schema rather than
  inlined into a config value, so the two are not the same question — but
  "atlas.hcl cannot reach outside its directory" is not a true sentence, and the
  docs say so rather than implying otherwise. Absolute paths there are already
  refused while parent traversal is not, which is worth its own issue.
- **The conformance repository's `ce-gating.md` scenario.** The issue's
  definition of done names one; it lives in `stokaro/ptah-atlas-conformance` and
  needs its own PR there. What landed here is the equivalent that runs in this
  repository's CI — three `TestOracle*` runs wired into the Atlas CE Oracle
  workflow, listed before they are run and failing the job on `SKIPPED`, so the
  community side is re-measured on every build rather than remembered.
- **The walk stops after four chained links**, leaving longer chains, link
  cycles, and any check-to-read race to the rooted filesystem. That is a
  deliberate split of responsibility, pinned by the long-chain row; a caller who
  passes `ParseAtlasFSWithOptions` an unrooted filesystem takes those shapes on
  itself, which the doc comment states.
- **The absolute-symlink case is stricter than strictly necessary.** A link
  whose target is an absolute path pointing back inside the directory is
  refused. A rooted filesystem refuses it too, so the walk agrees with the layer
  below rather than second-guessing it; loosening one without the other would
  produce two answers to one question.
