### PR TITLE
Write a sql() column type back as the call instead of a bare identifier (#1138)

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -221,6 +221,13 @@ type ColumnNode struct {
 	Name string
 	// Type is the column data type (e.g., "INTEGER", "VARCHAR(255)", "TIMESTAMP")
 	Type string
+	// TypeRawSQL records that Type came from Atlas HCL's sql() raw expression
+	// -- `type = sql("USER_DEFINED")` -- rather than from a type the Atlas HCL
+	// grammar names. Type always holds the reduced SQL text, so SQL renderers
+	// need not consult this; it exists so a writer emitting Atlas HCL can put
+	// the call back instead of a bare identifier the Atlas community binary
+	// refuses.
+	TypeRawSQL bool
 	// Nullable indicates whether the column allows NULL values (default: true)
 	Nullable bool
 	// Primary indicates whether this column is part of the primary key

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -144,9 +144,16 @@ type Field struct {
 	FieldName  string // Name of the Go struct field
 	Name       string // Database column name
 	Type       string // Database column type (e.g., "VARCHAR(255)", "INTEGER")
-	Nullable   bool   // Whether the column allows NULL values
-	Primary    bool   // Whether this is a primary key column
-	AutoInc    bool   // Whether this column auto-increments
+	// TypeRawSQL records that Type was written with Atlas HCL's sql() raw
+	// expression -- `type = sql("USER_DEFINED")` -- rather than as a type the
+	// grammar names. Type still holds the reduced SQL text so rendered DDL is
+	// valid, but a writer that emits Atlas HCL must put the call back: the
+	// pinned Atlas community binary v1.3.0 refuses the bare identifier
+	// (`There is no type named "USER_DEFINED"`) and accepts only the call.
+	TypeRawSQL bool
+	Nullable   bool // Whether the column allows NULL values
+	Primary    bool // Whether this is a primary key column
+	AutoInc    bool // Whether this column auto-increments
 	// IdentityGeneration stores PostgreSQL identity generation mode: ALWAYS or BY_DEFAULT.
 	IdentityGeneration string
 	// IdentityStart stores the optional PostgreSQL identity START WITH value.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1072,6 +1072,13 @@ type ColumnNode struct {
     Name string
     // Type is the column data type (e.g., "INTEGER", "VARCHAR(255)", "TIMESTAMP")
     Type string
+    // TypeRawSQL records that Type came from Atlas HCL's sql() raw expression
+    // -- `type = sql("USER_DEFINED")` -- rather than from a type the Atlas HCL
+    // grammar names. Type always holds the reduced SQL text, so SQL renderers
+    // need not consult this; it exists so a writer emitting Atlas HCL can put
+    // the call back instead of a bare identifier the Atlas community binary
+    // refuses.
+    TypeRawSQL bool
     // Nullable indicates whether the column allows NULL values (default: true)
     Nullable bool
     // Primary indicates whether this column is part of the primary key
@@ -3830,9 +3837,16 @@ type Field struct {
     FieldName  string // Name of the Go struct field
     Name       string // Database column name
     Type       string // Database column type (e.g., "VARCHAR(255)", "INTEGER")
-    Nullable   bool   // Whether the column allows NULL values
-    Primary    bool   // Whether this is a primary key column
-    AutoInc    bool   // Whether this column auto-increments
+    // TypeRawSQL records that Type was written with Atlas HCL's sql() raw
+    // expression -- `type = sql("USER_DEFINED")` -- rather than as a type the
+    // grammar names. Type still holds the reduced SQL text so rendered DDL is
+    // valid, but a writer that emits Atlas HCL must put the call back: the
+    // pinned Atlas community binary v1.3.0 refuses the bare identifier
+    // (`There is no type named "USER_DEFINED"`) and accepts only the call.
+    TypeRawSQL bool
+    Nullable   bool // Whether the column allows NULL values
+    Primary    bool // Whether this is a primary key column
+    AutoInc    bool // Whether this column auto-increments
     // IdentityGeneration stores PostgreSQL identity generation mode: ALWAYS or BY_DEFAULT.
     IdentityGeneration string
     // IdentityStart stores the optional PostgreSQL identity START WITH value.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -502,11 +502,14 @@ func (p *parser) parseColumn(structName string, block *hclsyntax.Block) (goschem
 		return goschema.Field{}, err
 	}
 
+	columnType, typeRawSQL := p.columnTypeName(block, typeAttr)
+
 	field := goschema.Field{
 		StructName:          structName,
 		FieldName:           name,
 		Name:                name,
-		Type:                p.columnTypeName(block, typeAttr),
+		Type:                columnType,
+		TypeRawSQL:          typeRawSQL,
 		Nullable:            p.optionalBool(block.Body.Attributes["null"], false),
 		AutoInc:             p.optionalBool(block.Body.Attributes["auto_increment"], false) || identity.generation != "",
 		IdentityGeneration:  identity.generation,
@@ -1747,16 +1750,28 @@ func (p *parser) exprString(attr *hclsyntax.Attribute) string {
 	return p.rawExpr(attr)
 }
 
-func (p *parser) columnTypeName(block *hclsyntax.Block, attr *hclsyntax.Attribute) string {
+// columnTypeName returns the column's type and whether it was written with
+// Atlas's sql() escape hatch.
+//
+// The type itself is always the reduced SQL text, so the DDL Ptah renders stays
+// valid -- issue #1106. The second result is what a writer needs to put the
+// call back: `sql("USER_DEFINED")` is the only spelling of an engine type Atlas
+// does not model that the pinned Atlas community binary v1.3.0 accepts, and it
+// refuses the bare identifier Ptah would otherwise write back
+// ("Unknown column.type; There is no type named \"USER_DEFINED\"").
+func (p *parser) columnTypeName(block *hclsyntax.Block, attr *hclsyntax.Attribute) (string, bool) {
 	rawType := p.rawExpr(attr)
 	if enumName, ok := strings.CutPrefix(rawType, "enum."); ok {
-		return enumName
+		return enumName, false
 	}
+	_, rawSQL := p.sqlRawExprValue(attr.Expr)
 	typ := p.exprString(attr)
 	if p.optionalBool(block.Body.Attributes["unsigned"], false) && !strings.Contains(strings.ToLower(typ), "unsigned") {
-		return typ + " unsigned"
+		// `unsigned = true` is a Ptah-side edit to the type, so the source call
+		// no longer spells what the column holds and must not be written back.
+		return typ + " unsigned", false
 	}
-	return typ
+	return typ, rawSQL
 }
 
 func (p *parser) stringListAttr(block *hclsyntax.Block, attrName string) ([]string, error) {

--- a/internal/atlashcl/column_raw_sql_type_test.go
+++ b/internal/atlashcl/column_raw_sql_type_test.go
@@ -1,0 +1,148 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// A column type written with Atlas's sql() escape hatch reduces to its SQL text
+// -- issue #1106 -- but the reduction must not erase the fact that the hatch was
+// used, because writing the type back bare is not a spelling Atlas accepts.
+//
+// Measured on the pinned Atlas community binary v1.3.0:
+//
+//	type = sql("USER_DEFINED")  -> plans CREATE TABLE `t` (`c` USER_DEFINED NULL), exit 0
+//	type = USER_DEFINED         -> Error: Unknown column.type; There is no type
+//	                               named "USER_DEFINED", exit 1
+//
+// So Type carries the SQL and TypeRawSQL carries the spelling obligation.
+//
+// With TypeRawSQL removed from the parser, the first row below fails on
+// TypeRawSQL being false while Type stays correct -- the exact split that made
+// issue #1138 look like a rendering bug rather than a parsing one.
+func TestParseMarksSQLRawExpressionColumnTypes(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		hcl        string
+		wantType   string
+		wantRawSQL bool
+	}{
+		{
+			name: "sql call around a type the dialect does not model",
+			hcl: `
+table "t" {
+  column "c" { type = sql("USER_DEFINED") }
+}
+`,
+			wantType:   "USER_DEFINED",
+			wantRawSQL: true,
+		},
+		{
+			// The argument's case is carried through untouched. The community
+			// binary preserves it too: sql("user_defined") plans
+			// `c user_defined` and inspects back as sql("user_defined").
+			name: "sql call keeps the argument's case",
+			hcl: `
+table "t" {
+  column "c" { type = sql("user_defined") }
+}
+`,
+			wantType:   "user_defined",
+			wantRawSQL: true,
+		},
+		{
+			name: "sql call around a type the dialect does model",
+			hcl: `
+table "t" {
+  column "c" { type = sql("varchar(10)") }
+}
+`,
+			wantType:   "varchar(10)",
+			wantRawSQL: true,
+		},
+		{
+			// Negative control: the ordinary spelling must not acquire the
+			// marker, or every rendered type becomes a sql() call.
+			name: "bare type keyword",
+			hcl: `
+table "t" {
+  column "c" { type = text }
+}
+`,
+			wantType:   "text",
+			wantRawSQL: false,
+		},
+		{
+			// Negative control: a parameterized type is a call expression to
+			// HCL, so a marker keyed on "is a function call" rather than on the
+			// function's NAME would fire here.
+			name: "parameterized type keyword",
+			hcl: `
+table "t" {
+  column "c" { type = varchar(10) }
+}
+`,
+			wantType:   "varchar(10)",
+			wantRawSQL: false,
+		},
+		{
+			// Negative control: a quoted type is already a string, so nothing
+			// is reduced and nothing is marked.
+			name: "quoted type",
+			hcl: `
+table "t" {
+  column "c" { type = "USER_DEFINED" }
+}
+`,
+			wantType:   "USER_DEFINED",
+			wantRawSQL: false,
+		},
+		{
+			// Negative control: an enum reference is resolved to the enum name,
+			// which is not the sql() argument and must not be written back
+			// through the hatch.
+			name: "enum reference",
+			hcl: `
+enum "status" {
+  values = ["a"]
+}
+table "t" {
+  column "c" { type = enum.status }
+}
+`,
+			wantType:   "status",
+			wantRawSQL: false,
+		},
+		{
+			// `unsigned = true` edits the type after the call is reduced, so
+			// the sql() argument no longer spells what the column holds and
+			// writing it back would drop the "unsigned".
+			name: "unsigned rewrites the type and drops the marker",
+			hcl: `
+table "t" {
+  column "c" {
+    type     = sql("bigint")
+    unsigned = true
+  }
+}
+`,
+			wantType:   "bigint unsigned",
+			wantRawSQL: false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.Fields, qt.HasLen, 1)
+			c.Assert(db.Fields[0].Type, qt.Equals, test.wantType)
+			c.Assert(db.Fields[0].TypeRawSQL, qt.Equals, test.wantRawSQL)
+		})
+	}
+}

--- a/internal/atlashclrender/raw_sql_type_test.go
+++ b/internal/atlashclrender/raw_sql_type_test.go
@@ -1,0 +1,158 @@
+package atlashclrender_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// This is the round trip issue #1138 reported: an Atlas HCL schema whose column
+// type is written with the sql() escape hatch has to come back out of Ptah
+// spelled the same way.
+//
+// The reduction issue #1106 introduced is a READ-side reduction, so the DDL Ptah
+// renders is `c USER_DEFINED` rather than `c sql("USER_DEFINED")`. Writing the
+// reduced text back out bare is a different loss: measured on the pinned Atlas
+// community binary v1.3.0, `type = USER_DEFINED` is refused with `Unknown
+// column.type; There is no type named "USER_DEFINED"` (exit 1) while
+// `type = sql("USER_DEFINED")` plans at exit 0. A round trip through Ptah must
+// not turn a file that binary plans into one it refuses.
+//
+// Without the fix each row renders `type = USER_DEFINED` -- the assertion on the
+// call fails and the "still parses to the same type" assertion still passes,
+// which is why the loss was invisible to the existing round-trip tests.
+func TestRenderWritesSQLRawExpressionColumnTypeBackAsTheCall(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		source   string
+		wantType string
+	}{
+		{
+			name: "type the dialect does not model",
+			source: `
+table "t" {
+  column "c" {
+    null = true
+    type = sql("USER_DEFINED")
+  }
+}
+`,
+			wantType: `type = sql("USER_DEFINED")`,
+		},
+		{
+			// The case of the argument survives; the community binary does not
+			// canonicalize it either.
+			name: "lower-case argument",
+			source: `
+table "t" {
+  column "c" {
+    null = true
+    type = sql("user_defined")
+  }
+}
+`,
+			wantType: `type = sql("user_defined")`,
+		},
+		{
+			name: "argument carrying parentheses",
+			source: `
+table "t" {
+  column "c" {
+    null = true
+    type = sql("varchar(10)")
+  }
+}
+`,
+			wantType: `type = sql("varchar(10)")`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			parsed, err := atlashcl.Parse([]byte(test.source), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+
+			rendered, err := atlashclrender.Render(parsed)
+			c.Assert(err, qt.IsNil)
+			c.Assert(rendered.Diagnostics, qt.HasLen, 0)
+			c.Assert(string(rendered.Data), qt.Contains, test.wantType)
+
+			// Re-parsing has to land on the same IR, or the round trip is
+			// stable in text and lossy in meaning.
+			reparsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			c.Assert(reparsed.Fields, qt.HasLen, 1)
+			c.Assert(reparsed.Fields[0].Type, qt.Equals, parsed.Fields[0].Type)
+			c.Assert(reparsed.Fields[0].TypeRawSQL, qt.IsTrue)
+		})
+	}
+}
+
+// The two write-backs disagree on purpose, and this is the test that pins the
+// disagreement: the SQL side gets the reduced text, the HCL side gets the call.
+//
+// It is what rules out the other candidate fix for issue #1138 -- carrying
+// `sql("USER_DEFINED")` in the type itself, the way Ptah did before issue #1106.
+// That spelling makes the HCL round trip correct too, but it was measured to
+// render `CREATE TABLE "main"."t" ("c" sql("USER_DEFINED"))`, which sqlite
+// rejects: `ptah-compat schema apply` then exits 1 where the pinned Atlas
+// community binary v1.3.0 exits 0. Under that fix the DDL assertion here fails.
+func TestSQLRawExpressionColumnTypeRendersReducedInDDL(t *testing.T) {
+	c := qt.New(t)
+
+	parsed, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "c" {
+    null = true
+    type = sql("USER_DEFINED")
+  }
+}
+`), "schema.hcl")
+	c.Assert(err, qt.IsNil)
+
+	sql, err := renderer.RenderSQL(platform.SQLite, fromschema.FromDatabase(*parsed, platform.SQLite))
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains, "USER_DEFINED")
+	c.Assert(sql, qt.Not(qt.Contains), "sql(")
+
+	rendered, err := atlashclrender.Render(parsed)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(rendered.Data), qt.Contains, `type = sql("USER_DEFINED")`)
+}
+
+// Negative control for the test above: a column type that never went through
+// the escape hatch must keep rendering as the bare type. A renderer that wrapped
+// every type in sql() would pass the round-trip test above and fail here, and it
+// would also make every Ptah-authored schema unreadable as a plain type.
+func TestRenderKeepsOrdinaryColumnTypesBare(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "plain", Type: "text"},
+			{StructName: "T", Name: "sized", Type: "varchar(10)"},
+			{StructName: "T", Name: "hatched", Type: "USER_DEFINED", TypeRawSQL: true},
+		},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered.Diagnostics, qt.HasLen, 0)
+
+	out := string(rendered.Data)
+	c.Assert(out, qt.Contains, "type = text")
+	c.Assert(out, qt.Contains, "type = varchar(10)")
+	c.Assert(out, qt.Contains, `type = sql("USER_DEFINED")`)
+	c.Assert(strings.Count(out, "sql("), qt.Equals, 1)
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -198,7 +198,7 @@ func (r *renderer) renderTable(
 
 func (r *renderer) renderColumn(field goschema.Field) {
 	r.linef(`  column %s {`, quote(field.Name))
-	r.rawAttr(2, "type", typeExpr(field.Type))
+	r.rawAttr(2, "type", columnTypeExpr(field))
 	if field.Nullable {
 		r.rawAttr(2, "null", "true")
 	}
@@ -746,6 +746,23 @@ func parseForeignReference(value string) (string, []string) {
 		}
 	}
 	return table, columns
+}
+
+// columnTypeExpr renders a column's `type` attribute.
+//
+// A type the schema author reached the sql() escape hatch for is written back
+// through it. The reduction issue #1106 introduced is a READ-side reduction:
+// Ptah's IR carries the SQL text so the DDL it renders is valid. Writing that
+// text back bare loses the only spelling of an engine type Atlas does not model
+// that the pinned Atlas community binary v1.3.0 accepts -- it refuses
+// `type = USER_DEFINED` with `Unknown column.type; There is no type named
+// "USER_DEFINED"` and accepts `type = sql("USER_DEFINED")`. Measured on that
+// binary, an HCL file it plans must survive a Ptah round trip still planning.
+func columnTypeExpr(field goschema.Field) string {
+	if field.TypeRawSQL && strings.TrimSpace(field.Type) != "" {
+		return sqlCall(field.Type)
+	}
+	return typeExpr(field.Type)
 }
 
 func typeExpr(value string) string {

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -114,6 +114,18 @@ func isPostgreSQLPlatform(targetPlatform string) bool {
 	return strings.EqualFold(targetPlatform, "postgres") || strings.EqualFold(targetPlatform, "postgresql")
 }
 
+// typeRawSQLSurvives reports whether the column type is still the one the
+// schema author wrote with Atlas HCL's sql() escape hatch.
+//
+// A platform override or an inlined enum model replaces the type with a
+// spelling the author never wrote, and the sql() call that produced the
+// original no longer describes it. Carrying the marker across such a rewrite
+// would make a writer emit `sql("<the override>")`, attributing the escape
+// hatch to text that never went through it.
+func typeRawSQLSurvives(field goschema.Field, declaredType string) bool {
+	return field.TypeRawSQL && field.Type == declaredType
+}
+
 func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschema.Field {
 	fieldType := platformFieldType(field.Type, targetPlatform)
 	checkConstraint := field.Check
@@ -418,10 +430,12 @@ func emitsStandaloneEnumDefinitions(targetPlatform string) bool {
 // The returned node contains all the attributes specified in the input field, with platform-specific
 // overrides applied when a matching platform is specified.
 func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.ColumnNode {
+	declaredType := field.Type
 	field = applyPlatformOverrides(field, targetPlatform)
 	field = handleEnumTypes(field, enums, targetPlatform)
 
 	column := ast.NewColumn(field.Name, field.Type)
+	column.TypeRawSQL = typeRawSQLSurvives(field, declaredType)
 
 	// Set nullable - only override default if explicitly set to false
 	// The default behavior should be nullable=true (which ast.NewColumn already sets)
@@ -502,11 +516,13 @@ func FromField(field goschema.Field, enums []goschema.Enum, targetPlatform strin
 //   - *ast.ColumnNode: Column definition without foreign key constraints
 func FromFieldWithoutForeignKeys(field goschema.Field, enums []goschema.Enum, targetPlatform string) *ast.ColumnNode {
 	// Apply platform-specific overrides if available
+	declaredType := field.Type
 	field = applyPlatformOverrides(field, targetPlatform)
 	field = handleEnumTypes(field, enums, targetPlatform)
 
 	// Create column with basic properties
 	column := ast.NewColumn(field.Name, field.Type)
+	column.TypeRawSQL = typeRawSQLSurvives(field, declaredType)
 
 	// Set nullable (default is true, so only set if false)
 	if !field.Nullable {

--- a/internal/convert/fromschema/raw_sql_type_test.go
+++ b/internal/convert/fromschema/raw_sql_type_test.go
@@ -1,0 +1,88 @@
+package fromschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// The AST has to carry the sql() marker, not just the reduced type.
+//
+// ColumnNode.Type stays the reduced SQL text so every dialect renderer keeps
+// emitting valid DDL -- putting `sql("USER_DEFINED")` in Type instead was
+// measured and produces `CREATE TABLE "main"."t" ("c" sql("USER_DEFINED"))`,
+// which sqlite rejects and which makes `ptah-compat schema apply` exit 1 on a
+// file the pinned Atlas community binary v1.3.0 applies at exit 0. The marker is
+// how a consumer that writes Atlas HCL back out (issue #1138) tells the two
+// spellings apart without the IR carrying HCL syntax.
+//
+// Without the fix, wantRawSQL is false on every row.
+func TestFromFieldCarriesTheSQLRawExpressionTypeMarker(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		field      goschema.Field
+		platform   string
+		wantType   string
+		wantRawSQL bool
+	}{
+		{
+			name:       "marked type",
+			field:      goschema.Field{Name: "c", Type: "USER_DEFINED", TypeRawSQL: true},
+			wantType:   "USER_DEFINED",
+			wantRawSQL: true,
+		},
+		{
+			// Negative control: an ordinary type must not acquire the marker.
+			name:       "unmarked type",
+			field:      goschema.Field{Name: "c", Type: "USER_DEFINED"},
+			wantType:   "USER_DEFINED",
+			wantRawSQL: false,
+		},
+		{
+			// A platform override replaces the type with a spelling the sql()
+			// call never carried, so the marker must not survive: writing it
+			// back would attribute the escape hatch to the override's text.
+			name: "platform override replaces the type",
+			field: goschema.Field{
+				Name:       "c",
+				Type:       "USER_DEFINED",
+				TypeRawSQL: true,
+				Overrides:  map[string]map[string]string{"mysql": {"type": "JSON"}},
+			},
+			platform:   "mysql",
+			wantType:   "JSON",
+			wantRawSQL: false,
+		},
+		{
+			// An override that does not touch the type leaves the marker
+			// alone -- otherwise any override at all would silently drop it.
+			name: "platform override leaves the type alone",
+			field: goschema.Field{
+				Name:       "c",
+				Type:       "USER_DEFINED",
+				TypeRawSQL: true,
+				Overrides:  map[string]map[string]string{"mysql": {"comment": "hello"}},
+			},
+			platform:   "mysql",
+			wantType:   "USER_DEFINED",
+			wantRawSQL: true,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			column := fromschema.FromField(test.field, nil, test.platform)
+			c.Assert(column.Type, qt.Equals, test.wantType)
+			c.Assert(column.TypeRawSQL, qt.Equals, test.wantRawSQL)
+
+			withoutFK := fromschema.FromFieldWithoutForeignKeys(test.field, nil, test.platform)
+			c.Assert(withoutFK.Type, qt.Equals, test.wantType)
+			c.Assert(withoutFK.TypeRawSQL, qt.Equals, test.wantRawSQL)
+		})
+	}
+}


### PR DESCRIPTION
Refs #1138. Cluster A only. It does not close the issue, and the reason is measured, not assumed — see "What survives" below.

## The direction in the issue is backwards

The issue says we emit `sql("USER_DEFINED")` and the fixture wants `user_defined`. Both halves are the wrong way round, and the trap is inside the harness's own message. `internal/probe/txtar_script.go:10307` formats a `cmp` failure as

```go
fmt.Sprintf("cmp %s %s did not match: got %q want %q", left, rights[0], oneLine(l), oneLine(files[rights[0]]))
```

where `left` is the FIRST argument of `cmp schema.v1.hcl.inspected got` — the fixture file — and `rights[0]` is the file literally named `got`, which is where the run's own output was redirected. So the label `got` holds the fixture and the label `want` holds ours. The neighboring rows in the same report use the opposite convention: `cmphcl` (line 5296) and `cmpshow` (line 5389) format `got` as the actual. Cluster A came from `cmp`, cluster B from `cmphcl`/`cmpshow`, which is why one cluster read backwards and the other did not.

Reading the fixture settles it — `third_party/atlas/upstream/internal/integration/testdata/sqlite/column-user-defined.txtar`, section `schema.v1.hcl.inspected`, is `type = sql("USER_DEFINED")`.

## What the pinned community binary actually does

All five probes against `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (`atlas community version v1.3.0`), each with a control:

| probe | command | result |
| --- | --- | --- |
| apply + inspect the fixture | `schema apply --to file://schema.v1.hcl` then `schema inspect --url sqlite://file.db` | plans ``CREATE TABLE `t` (`c` USER_DEFINED NULL)``, inspects back **`type = sql("USER_DEFINED")`**, exit 0 |
| sql() around a type sqlite DOES model | `type = sql("varchar(10)")` | inspects back as bare **`varchar`** — the call is reserved for types the dialect does not model |
| negative control for the row above | `type = varchar(10)` written plainly | identical output, so the call is not what produced it |
| Ptah's current output fed back in | `type = USER_DEFINED` | **`Error: bare.hcl:5,12-24: Unknown column.type; There is no type named "USER_DEFINED".` exit 1** |
| positive control for the row above | `type = sql("USER_DEFINED")` | exit 0 |
| case | `type = sql("user_defined")` | plans `c user_defined`, inspects back `sql("user_defined")` — the argument's case is preserved, never canonicalized |

So the "fixture wants lower case, the CLI produces upper" framing dissolves: that binary preserves whatever the source wrote. The fixture's `USER_DEFINED` is upper because its source is; the harness's `user_defined` is lower because `atlasColumnType` calls `strings.ToLower` on any type without a `sql(` prefix. Neither is a canonicalization Ptah should copy.

The fourth row is the actual user-facing defect: **`ptah-compat schema inspect` emits HCL the community binary refuses.** `{{ hcl . }}` could not be used as the oracle for any of this — it is not available in the community build (`'atlas schema inspect' with 'hcl' function is not supported by the community version of Atlas`, exit 1).

## The change

`goschema.Field.TypeRawSQL` and `ast.ColumnNode.TypeRawSQL` record that a column type came through `sql()`. `Type` still holds the reduced SQL text, so every DDL path is untouched; only the HCL writer consults the marker and puts the call back. The marker is dropped when `unsigned = true`, a platform override, or an inlined enum model replaces the type, because the original call no longer spells what the column holds.

The alternative — put `sql("USER_DEFINED")` in `Type`, which is what Ptah did before #1131 — was measured, not argued away. It makes every one of the 10 harness rows green, and it makes `ptah-compat schema apply` plan `CREATE TABLE "main"."t" ("c" sql("USER_DEFINED"))` and exit 1 with `SQL logic error: near ""USER_DEFINED""` on the file the community binary applies at exit 0. That is parity rule (a) inverted, so it is not the fix. `TestSQLRawExpressionColumnTypeRendersReducedInDDL` exists to fail under it, and does.

## Completion criteria and the command that proves each

| criterion | command | result |
| --- | --- | --- |
| a `sql("X")` column type is recorded as such, and ordinary types are not | `go test ./internal/atlashcl/ -run TestParseMarksSQLRawExpressionColumnTypes -count=1` | ok — 3 marked rows, 5 unmarked controls incl. `varchar(10)`, `"USER_DEFINED"`, `enum.status` |
| an Atlas HCL file with `type = sql("X")` round-trips through Ptah spelled the same way | `go test ./internal/atlashclrender/ -run TestRenderWritesSQLRawExpressionColumnTypeBackAsTheCall -count=1` | ok — renders the call, re-parses to the same IR |
| the DDL for that column stays reduced | `go test ./internal/atlashclrender/ -run TestSQLRawExpressionColumnTypeRendersReducedInDDL -count=1` | ok — SQL contains `USER_DEFINED`, contains no `sql(` |
| ordinary types keep rendering bare | `go test ./internal/atlashclrender/ -run TestRenderKeepsOrdinaryColumnTypesBare -count=1` | ok — exactly one `sql(` in the output |
| the AST carries the marker, and drops it on a type rewrite | `go test ./internal/convert/fromschema/ -run TestFromFieldCarriesTheSQLRawExpressionTypeMarker -count=1` | ok — 4 rows incl. an override that replaces the type and one that does not |
| `ptah-compat schema apply` on the fixture still exits 0 with valid DDL | `ptah-compat schema apply --url "sqlite://file.db?_fk=1" --dev-url "sqlite://dev?mode=memory" --to file://schema.v1.hcl --auto-approve` | `CREATE TABLE "main"."t" ("c" USER_DEFINED)`, exit 0; re-run says `Schema is synced` |

## What each test prints if the change is reverted

Byte-snapshot mutants, restored from a file copy rather than `git checkout` — the fix is uncommitted, so a git restore silently reverts the fix and every later mutant measures a full revert instead of itself. Baseline and post-restore controls both green.

| mutant | goes red |
| --- | --- |
| parser never sets the marker | `TestParseMarksSQLRawExpressionColumnTypes` (3 marked rows), all 3 `…WritesSQLRawExpressionColumnTypeBackAsTheCall` rows, `…RendersReducedInDDL` |
| parser marks every type (inverse) | `TestParseMarksSQLRawExpressionColumnTypes` (exactly the 3 negative controls: bare keyword, parameterized, quoted) |
| HCL writer ignores the marker | all 3 round-trip rows, `…RendersReducedInDDL`, `TestRenderKeepsOrdinaryColumnTypesBare` |
| HCL writer wraps every type (inverse) | `TestRenderKeepsOrdinaryColumnTypesBare` only — the round-trip rows still pass, which is exactly why that control has to exist |
| marker never reaches the AST | `TestFromFieldCarriesTheSQLRawExpressionTypeMarker` (marked type, override-leaves-type-alone) |
| marker survives a type rewrite | `TestFromFieldCarriesTheSQLRawExpressionTypeMarker` (override-replaces-the-type) only |
| the rejected design: `Type` carries the call | `TestSQLRawExpressionColumnTypeRendersReducedInDDL` only — the HCL round trip passes under it |

## What survives, and why this is Refs and not Closes

**`sqlite/column-user-defined.txtar` is still red, and no Ptah-only change can turn it green.** Offline tier run from a throwaway copy of the harness with `go.5x5.cz/ptah` replaced by this branch (nothing written to that repo):

- this branch alone: `175 fixtures, 819 observations, 10 non-OK` — unchanged from master
- this branch plus a 15-line shim in the harness that re-spells `sql("X")` from `ColumnNode.TypeRawSQL` before its renderer runs: `175 fixtures, 813 observations, 0 non-OK`, byte-identical to the report produced by the full pre-#1131 revert

The harness renders HCL itself and reads only `ast.ColumnNode.Type`; `atlasColumnType` (line 10065) passes a string through untouched if and only if it starts with `sql(`, and lowercases everything else. There are 8 `atlasSQLRawType(column.Type)` call sites built on that convention. That convention is Ptah's pre-#1131 leak: the only way to satisfy it from Ptah is to put HCL syntax back into the type, which is the rejected design above. So the remaining move is on the conformance side — read `TypeRawSQL`, which this PR adds to the AST for exactly that purpose — and until then the pin cannot advance on these rows. No fixture was rewritten, no waiver added, no budget raised.

**Cluster B moved, and I did not touch it.** The instruction was to leave it alone, and no line of this diff is about arrays or domains. But the measurement above establishes its attribution as a side effect, which the issue asked for and marked unknown: reverting the column-type reduction alone turns all 8 cluster-B rows green together with the 2 cluster-A rows, and the branch-plus-shim run reproduces that byte for byte. Cluster B is the same defect — a `sql()`-spelled type (`sql("varchar(100)[10][]")`, `sql("status[]")`, `sql("script_column_domain.positive_int")`) losing its wrapper — reaching the harness through the same field. It needs no separate bisect, and it needs no separate Ptah fix: it is already fixed on this branch, and is blocked on the same harness-side read.

**Left open deliberately:**

- `ptah-compat schema inspect --url sqlite://…` still prints `type = USER_DEFINED`, which the community binary refuses. That path materializes on the dev database and introspects back, so no marker exists to carry; matching the community binary there needs the introspector to classify a type the dialect does not model, which is a per-dialect type table and a separate change. This PR fixes the HCL→IR→HCL half only.
- A pre-existing parity rule (a) survivor, unrelated to this change and present on master: step 2 of the same fixture, `schema apply` onto an existing table, exits 1 with `sqlite: modifying columns on table main.t requires a table rebuild plan` where the community binary exits 0 after a rebuild.
- The `cmp`/`cmphcl` got-want inversion in the harness message is the reason this issue was filed with the direction reversed. Worth fixing there; out of scope here.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh` (175 conditional groups, 45 white-box files), `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all green. The snapshot is regenerated for the two new struct fields.

`docs/public_api.snapshot` lives under `docs/`, so all 12 `check:*` scripts in `docs/site/package.json` were run: 11 pass as-is; `check:responsive` needed `npm ci` and `npm run build` first (it exits 1 with `dist not found` on a fresh checkout regardless of the diff), and passes after that — `OK (60 routes x 2 viewports, cells within 8 lines)`.