### PR TITLE
SQL schema files: read back the PostgreSQL objects Ptah renders

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1533,8 +1533,15 @@ type CreateTriggerNode struct {
 	ForEach      string
 	Body         string
 	FunctionName string
-	Replace      bool
-	Comment      string
+	// ExternalFunction reports that FunctionName refers to a function that
+	// already exists rather than one rendered from Body. PostgreSQL keeps
+	// trigger code in a function, so renderers normally emit that function
+	// alongside the trigger; when this is set they must not, because
+	// redefining a function they were only asked to reference would discard
+	// its body.
+	ExternalFunction bool
+	Replace          bool
+	Comment          string
 }
 
 func NewCreateTrigger(name, table string) *CreateTriggerNode {
@@ -1563,6 +1570,13 @@ func (n *CreateTriggerNode) SetBody(body string) *CreateTriggerNode {
 
 func (n *CreateTriggerNode) SetFunctionName(functionName string) *CreateTriggerNode {
 	n.FunctionName = functionName
+	return n
+}
+
+// SetExternalFunction marks FunctionName as an already-existing function that
+// the renderer must reference without defining.
+func (n *CreateTriggerNode) SetExternalFunction() *CreateTriggerNode {
+	n.ExternalFunction = true
 	return n
 }
 

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -791,6 +791,15 @@ type Trigger struct {
 	ForEach    string // ROW or STATEMENT
 	Body       string // Trigger body
 	Comment    string // Optional comment for documentation
+
+	// ExecuteFunction names an already-existing function the trigger executes
+	// instead of a body Ptah owns. It is set when a SQL schema file spells
+	// EXECUTE FUNCTION with a name that is not this trigger's own
+	// FunctionName(), so reading such SQL back does not silently rebind the
+	// trigger to a Ptah-generated function. Body and ExecuteFunction are
+	// alternatives: when ExecuteFunction is set, Ptah does not render a
+	// function definition for the trigger.
+	ExecuteFunction string
 }
 
 // Canonicalize fills in trigger defaults and case-folds attributes reported in
@@ -799,6 +808,7 @@ func (t *Trigger) Canonicalize() {
 	t.Timing = strings.ToUpper(strings.TrimSpace(t.Timing))
 	t.Event = strings.ToUpper(strings.TrimSpace(t.Event))
 	t.ForEach = strings.ToUpper(strings.TrimSpace(t.ForEach))
+	t.ExecuteFunction = strings.TrimSpace(t.ExecuteFunction)
 	if t.ForEach == "" {
 		t.ForEach = "ROW"
 	}

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -1585,10 +1585,14 @@ func (r *Renderer) VisitCreateTrigger(node *ast.CreateTriggerNode) error {
 		functionName = postgresTriggerFunctionName(node.Table, node.Name)
 	}
 
-	r.w.WriteLinef("CREATE OR REPLACE FUNCTION %s()", r.escapeQualifiedIdentifier(functionName))
-	r.w.WriteLine("RETURNS trigger AS $$")
-	r.w.WriteLine(renderPostgreSQLTriggerFunctionBody(node.Body))
-	r.w.WriteLine("$$ LANGUAGE plpgsql;")
+	// An external function is referenced, never defined: emitting a body for it
+	// would overwrite whatever it already contains.
+	if !node.ExternalFunction {
+		r.w.WriteLinef("CREATE OR REPLACE FUNCTION %s()", r.escapeQualifiedIdentifier(functionName))
+		r.w.WriteLine("RETURNS trigger AS $$")
+		r.w.WriteLine(renderPostgreSQLTriggerFunctionBody(node.Body))
+		r.w.WriteLine("$$ LANGUAGE plpgsql;")
+	}
 
 	if node.Replace && !r.capabilities().Has(capability.CreateOrReplaceTrigger) {
 		r.w.WriteLinef("DROP TRIGGER IF EXISTS %s ON %s;", r.escapeIdentifier(node.Name), r.escapeQualifiedIdentifier(node.Table))

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1599,8 +1599,15 @@ type CreateTriggerNode struct {
     ForEach      string
     Body         string
     FunctionName string
-    Replace      bool
-    Comment      string
+    // ExternalFunction reports that FunctionName refers to a function that
+    // already exists rather than one rendered from Body. PostgreSQL keeps
+    // trigger code in a function, so renderers normally emit that function
+    // alongside the trigger; when this is set they must not, because
+    // redefining a function they were only asked to reference would discard
+    // its body.
+    ExternalFunction bool
+    Replace          bool
+    Comment          string
 }
     CreateTriggerNode represents a CREATE TRIGGER statement.
 
@@ -1609,6 +1616,7 @@ func (n *CreateTriggerNode) Accept(visitor Visitor) error
 func (n *CreateTriggerNode) SetBody(body string) *CreateTriggerNode
 func (n *CreateTriggerNode) SetComment(comment string) *CreateTriggerNode
 func (n *CreateTriggerNode) SetEvent(event string) *CreateTriggerNode
+func (n *CreateTriggerNode) SetExternalFunction() *CreateTriggerNode
 func (n *CreateTriggerNode) SetForEach(forEach string) *CreateTriggerNode
 func (n *CreateTriggerNode) SetFunctionName(functionName string) *CreateTriggerNode
 func (n *CreateTriggerNode) SetReplace() *CreateTriggerNode
@@ -4540,6 +4548,15 @@ type Trigger struct {
     ForEach    string // ROW or STATEMENT
     Body       string // Trigger body
     Comment    string // Optional comment for documentation
+
+    // ExecuteFunction names an already-existing function the trigger executes
+    // instead of a body Ptah owns. It is set when a SQL schema file spells
+    // EXECUTE FUNCTION with a name that is not this trigger's own
+    // FunctionName(), so reading such SQL back does not silently rebind the
+    // trigger to a Ptah-generated function. Body and ExecuteFunction are
+    // alternatives: when ExecuteFunction is set, Ptah does not render a
+    // function definition for the trigger.
+    ExecuteFunction string
 }
     Trigger represents a database trigger definition parsed from Go annotations.
 

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -23,8 +23,8 @@
     "ptah": "yes",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped.",
-    "evidence": "ptah schema render --help; ptah-compat schema diff --help (.sql accepted on --from/--to); docs/site/src/content/docs/atlas/docs-coverage.md:202 (Atlas: 'Open sources include SQL, HCL, and external schema')"
+    "note": "Accepted by native `--schema-file` and compat `--to`/`--from`. Reads back every object kind Ptah renders; DO blocks, COMMENT ON and raw routine bodies still parse and are dropped.",
+    "evidence": "ptah schema render --help; ptah-compat schema diff --help (.sql accepted on --from/--to). Round-trip measured by internal/schemafile.TestLoadAll_RenderedPostgresSQLReadsBackAsAFixedPoint: the 16 statements rendered from the docs/atlas_hcl_schema.md PostgreSQL-objects example load again and re-render identically apart from object comments emitted as bare `--` lines. Silent drops that remain: ast.RawSQLNode and ast.CommentNode (other than COMMENT ON ROLE) have no case in internal/convert/toschema.appendStatement. docs/site/src/content/docs/atlas/docs-coverage.md:202 (Atlas: 'Open sources include SQL, HCL, and external schema')"
   },
   {
     "area": "Schema sources",
@@ -1022,8 +1022,8 @@
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently.",
-    "evidence": "internal/convert/fromschema/fromschema.go:1758-1764 appends only Views (never MaterializedViews) for the non-PostgreSQL path; `ptah schema render --dialect mysql` emitted no matview statement, while `ptah schema apply` against live MySQL 9.7 failed with \"materialized views are not supported by MySQL or MariaDB\""
+    "note": "Matviews render on PostgreSQL only; SQL schema files read both. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1758-1764 appends only Views (never MaterializedViews) for the non-PostgreSQL path; `ptah schema render --dialect mysql` emitted no matview statement, while `ptah schema apply` against live MySQL 9.7 failed with \"materialized views are not supported by MySQL or MariaDB\". SQL schema files: CREATE VIEW used to parse and then vanish and CREATE MATERIALIZED VIEW was refused outright; both now render back (issue #932; internal/schemafile.TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles/view and /materialized_view)"
   },
   {
     "area": "Schema object kinds",
@@ -1049,8 +1049,8 @@
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported.",
-    "evidence": "internal/convert/fromschema/fromschema.go:1593 gates CREATE SEQUENCE on isPostgreSQLPlatform; live YugabyteDB apply planned CREATE SEQUENCE \"yb_seq\" START WITH 1; SQL source: \"unsupported CREATE target: SEQUENCE\". Atlas columns from PARITY.md Pro-gated-object sentence"
+    "note": "PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1593 gates CREATE SEQUENCE on isPostgreSQLPlatform; live YugabyteDB apply planned CREATE SEQUENCE \"yb_seq\" START WITH 1. SQL source: `CREATE SEQUENCE s1 START WITH 1;` in a --schema-file exits 0 and renders `CREATE SEQUENCE \"s1\" START WITH 1;` (issue #932; internal/schemafile.TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles/sequence). Atlas columns from PARITY.md Pro-gated-object sentence"
   },
   {
     "area": "Schema object kinds",
@@ -1067,8 +1067,8 @@
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently.",
-    "evidence": "internal/convert/fromschema/fromschema.go:1710-1745 (roles/grants/RLS behind isPostgreSQLPlatform); live YugabyteDB apply planned CREATE ROLE \"yb_role\"; `ptah schema render --schema-file` rejects CREATE ROLE / GRANT / CREATE POLICY / ALTER TABLE ... ENABLE ROW LEVEL SECURITY. Measured 2026-08-01, CE v1.2.0 (scratch env): `schema apply` with `role \"app\" { }` on sqlite -> exit 0 'Schema is synced, no changes to be made' (silent no-op). Atlas pricing page (atlasgo.io/pricing, retrieved 2026-08-01): 'Database Security as Code' is Pro, not Starter"
+    "note": "PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently.",
+    "evidence": "internal/convert/fromschema/fromschema.go:1710-1745 (roles/grants/RLS behind isPostgreSQLPlatform); live YugabyteDB apply planned CREATE ROLE \"yb_role\"; `ptah schema render --schema-file` reads CREATE ROLE / GRANT / CREATE POLICY / ALTER TABLE ... ENABLE ROW LEVEL SECURITY and renders each back (issue #932; internal/schemafile.TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles). Measured 2026-08-01, CE v1.2.0 (scratch env): `schema apply` with `role \"app\" { }` on sqlite -> exit 0 'Schema is synced, no changes to be made' (silent no-op). Atlas pricing page (atlasgo.io/pricing, retrieved 2026-08-01): 'Database Security as Code' is Pro, not Starter"
   },
   {
     "area": "Schema object kinds",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -122,7 +122,7 @@ seven of them as open capabilities regardless.
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
 | Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |
 | Ptah-only HCL schema extensions | ✅ | ➖ | ➖ | platform/override per dialect, EXCLUDE constraint block, column enum, table checks/custom, index ops, ClickHouse granularity, seed data block. |
-| SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and by `ptah-compat schema apply`/diff `--to`/`--from`; unsupported DDL fails instead of being skipped. |
+| SQL DDL schema files | ✅ | ✅ | ✅ | Accepted by native `--schema-file` and compat `--to`/`--from`. Reads back every object kind Ptah renders; DO blocks, COMMENT ON and raw routine bodies still parse and are dropped. |
 | YAML schema files | ✅ | ❌ | ❌ | Strict parser; unknown keys fail. Repo docs list Atlas OSS data sources as SQL, HCL, external schema, and remote/template dirs. |
 
 ## Declarative and direct schema changes
@@ -252,14 +252,14 @@ seven of them as open capabilities regardless.
 | MySQL and MariaDB | 🟡 | ✅ | ✅ | Matviews are an explicit error; extensions, functions, domains, roles/grants, RLS and MariaDB SEQUENCE objects are dropped silently. DDL auto-commit blocks rollback. |
 | Oracle, Snowflake, Redshift, Databricks | ❌ | ❌ | ✅ | No dialect entry; the names fail normalization the same way TiDB does. Listed as Atlas Pro drivers. |
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
-| Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files reject ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
+| Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
 | SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
 | SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
-| Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files reject CREATE SEQUENCE as unsupported. |
+| Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
 | Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
-| Views and materialized views | 🟡 | ❌ | ✅ | Matviews render on PostgreSQL only. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently. |
+| Views and materialized views | 🟡 | ❌ | ✅ | Matviews render on PostgreSQL only; SQL schema files read both. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently. |
 | YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them. |
 
 ## Go embedding and developer tooling

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -1689,13 +1689,24 @@ func appendTableForeignKeyConstraintStatements(
 // FromTrigger converts a goschema.Trigger to an ast.CreateTriggerNode.
 func FromTrigger(trigger goschema.Trigger) *ast.CreateTriggerNode {
 	trigger.Canonicalize()
+	// A trigger that names an existing function keeps that name; the renderer
+	// then emits only the CREATE TRIGGER, because the function is not Ptah's to
+	// define. Otherwise the deterministic Ptah function name is used and the
+	// renderer emits the function alongside the trigger.
+	functionName := trigger.FunctionName()
+	if trigger.ExecuteFunction != "" {
+		functionName = trigger.ExecuteFunction
+	}
 	triggerNode := ast.NewCreateTrigger(trigger.Name, trigger.Table).
 		SetTiming(trigger.Timing).
 		SetEvent(trigger.Event).
 		SetForEach(trigger.ForEach).
 		SetBody(trigger.Body).
-		SetFunctionName(trigger.FunctionName()).
+		SetFunctionName(functionName).
 		SetComment(trigger.Comment)
+	if trigger.ExecuteFunction != "" {
+		triggerNode.SetExternalFunction()
+	}
 	return triggerNode
 }
 

--- a/internal/convert/toschema/postgres_objects.go
+++ b/internal/convert/toschema/postgres_objects.go
@@ -1,0 +1,312 @@
+package toschema
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// This file converts the schema objects beyond tables, indexes and enums that
+// the SQL frontend parses. Before issue #932 every one of these nodes fell off
+// the end of ToDatabase's switch, so a CREATE VIEW in a --schema-file parsed
+// cleanly and then vanished from the rendered schema.
+
+func toSequence(node *ast.CreateSequenceNode) goschema.Sequence {
+	return goschema.Sequence{
+		Name:        normalizeSQLIdentifier(node.Name),
+		Schema:      normalizeSQLIdentifier(node.Schema),
+		AsType:      normalizeSQLIdentifier(node.AsType),
+		Start:       node.Start,
+		Increment:   node.Increment,
+		MinValue:    node.MinValue,
+		MaxValue:    node.MaxValue,
+		Cache:       node.Cache,
+		Cycle:       node.Cycle,
+		OwnedBy:     normalizeSQLTableReference(node.OwnedBy),
+		IfNotExists: node.IfNotExists,
+		Comment:     node.Comment,
+	}
+}
+
+func toRole(node *ast.CreateRoleNode) goschema.Role {
+	return goschema.Role{
+		Name:        normalizeSQLIdentifier(node.Name),
+		Login:       node.Login,
+		Password:    node.Password,
+		Superuser:   node.Superuser,
+		CreateDB:    node.CreateDB,
+		CreateRole:  node.CreateRole,
+		Inherit:     node.Inherit,
+		Replication: node.Replication,
+		Comment:     node.Comment,
+	}
+}
+
+func toGrant(node *ast.GrantPrivilegeNode) goschema.Grant {
+	grant := goschema.Grant{
+		Role:       normalizeSQLIdentifier(node.Role),
+		Privileges: node.Privileges,
+		WithOption: node.WithOption,
+		Comment:    node.Comment,
+	}
+	target := normalizeSQLTableReference(node.ObjectName)
+	switch strings.ToUpper(node.ObjectType) {
+	case "SCHEMA":
+		grant.OnSchema = normalizeSQLIdentifier(node.ObjectName)
+	case "SEQUENCE":
+		grant.OnSequence = target
+	default:
+		grant.OnTable = target
+	}
+	grant.Canonicalize()
+	return grant
+}
+
+func toRLSPolicy(node *ast.CreatePolicyNode) goschema.RLSPolicy {
+	return goschema.RLSPolicy{
+		Name:                normalizeSQLIdentifier(node.Name),
+		Table:               normalizeSQLTableReference(node.Table),
+		PolicyFor:           node.PolicyFor,
+		ToRoles:             normalizeRoleList(node.ToRoles),
+		UsingExpression:     node.UsingExpression,
+		WithCheckExpression: node.WithCheckExpression,
+		Comment:             node.Comment,
+	}
+}
+
+// normalizeRoleList unquotes each role in a policy's TO list while keeping the
+// separator the renderer expects.
+func normalizeRoleList(roles string) string {
+	if strings.TrimSpace(roles) == "" {
+		return ""
+	}
+	parts := strings.Split(roles, ",")
+	for index, part := range parts {
+		parts[index] = normalizeSQLIdentifier(strings.TrimSpace(part))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func toRLSEnabledTable(node *ast.AlterTableEnableRLSNode) goschema.RLSEnabledTable {
+	return goschema.RLSEnabledTable{
+		Table:   normalizeSQLTableReference(node.Table),
+		Comment: node.Comment,
+	}
+}
+
+func toView(node *ast.CreateViewNode) goschema.View {
+	return goschema.View{
+		Name:      normalizeSQLTableReference(node.Name),
+		Body:      strings.TrimSpace(node.Body),
+		WithCheck: node.WithCheck,
+		Comment:   node.Comment,
+	}
+}
+
+func toMaterializedView(node *ast.CreateMaterializedViewNode) goschema.MaterializedView {
+	view := goschema.MaterializedView{
+		Name:            normalizeSQLTableReference(node.Name),
+		Body:            strings.TrimSpace(node.Body),
+		RefreshStrategy: node.RefreshStrategy,
+		Comment:         node.Comment,
+	}
+	view.Canonicalize()
+	return view
+}
+
+func toFunction(node *ast.CreateFunctionNode) goschema.Function {
+	function := goschema.Function{
+		Name:       normalizeSQLTableReference(node.Name),
+		Parameters: node.Parameters,
+		Returns:    node.Returns,
+		Language:   node.Language,
+		Security:   node.Security,
+		Volatility: node.Volatility,
+		Body:       strings.TrimSpace(node.Body),
+		Comment:    node.Comment,
+	}
+	function.Canonicalize()
+	return function
+}
+
+func toTrigger(node *ast.CreateTriggerNode) goschema.Trigger {
+	trigger := goschema.Trigger{
+		Name:    normalizeSQLIdentifier(node.Name),
+		Table:   normalizeSQLTableReference(node.Table),
+		Timing:  node.Timing,
+		Event:   node.Event,
+		ForEach: node.ForEach,
+		Body:    strings.TrimSpace(node.Body),
+		Comment: node.Comment,
+	}
+	trigger.Canonicalize()
+	if node.ExternalFunction && node.FunctionName != "" {
+		trigger.ExecuteFunction = normalizeSQLTableReference(node.FunctionName)
+	}
+	return trigger
+}
+
+// appendCreateType routes a CREATE TYPE node to the bucket its type definition
+// belongs in. CREATE DOMAIN also arrives here, as a DomainTypeDef.
+func appendCreateType(database *goschema.Database, node *ast.CreateTypeNode) {
+	schema, name := normalizeSQLTableIdentifier(node.Name)
+	switch definition := node.TypeDef.(type) {
+	case *ast.EnumTypeDef:
+		database.Enums = append(database.Enums, goschema.Enum{
+			Name:   goschema.QualifyTableName(schema, name),
+			Values: definition.Values,
+		})
+	case *ast.CompositeTypeDef:
+		database.CompositeTypes = append(database.CompositeTypes, toCompositeType(schema, name, node, definition))
+	case *ast.RangeTypeDef:
+		database.Ranges = append(database.Ranges, toRange(schema, name, node, definition))
+	case *ast.DomainTypeDef:
+		database.Domains = append(database.Domains, toDomain(schema, name, node, definition))
+	}
+}
+
+func toCompositeType(schema, name string, node *ast.CreateTypeNode, definition *ast.CompositeTypeDef) goschema.CompositeType {
+	fields := make([]goschema.CompositeTypeField, 0, len(definition.Fields))
+	for _, field := range definition.Fields {
+		fields = append(fields, goschema.CompositeTypeField{
+			Name: normalizeSQLIdentifier(field.Name),
+			Type: field.Type,
+		})
+	}
+	composite := goschema.CompositeType{
+		Name:    name,
+		Schema:  schema,
+		Fields:  fields,
+		Comment: node.Comment,
+	}
+	composite.Canonicalize()
+	return composite
+}
+
+func toRange(schema, name string, node *ast.CreateTypeNode, definition *ast.RangeTypeDef) goschema.Range {
+	rangeType := goschema.Range{
+		Name:           name,
+		Schema:         schema,
+		Subtype:        definition.Subtype,
+		SubtypeOpClass: definition.SubtypeOpClass,
+		Collation:      definition.Collation,
+		Canonical:      definition.Canonical,
+		SubtypeDiff:    definition.SubtypeDiff,
+		Comment:        node.Comment,
+	}
+	rangeType.Canonicalize()
+	return rangeType
+}
+
+func toDomain(schema, name string, node *ast.CreateTypeNode, definition *ast.DomainTypeDef) goschema.Domain {
+	domain := goschema.Domain{
+		Name:     name,
+		Schema:   schema,
+		BaseType: definition.BaseType,
+		NotNull:  !definition.Nullable,
+		Check:    definition.Check,
+		Comment:  node.Comment,
+	}
+	if definition.Default != nil {
+		domain.Default = definition.Default.Value
+		domain.DefaultExpr = definition.Default.Expression
+	}
+	domain.Canonicalize()
+	return domain
+}
+
+// applyRoleComment attaches a COMMENT ON ROLE statement to the role it names.
+// PostgreSQL has no inline role comment, so Ptah's renderer emits the comment
+// as a second statement; reading it back is what keeps the pair round-tripping.
+func applyRoleComment(database *goschema.Database, node *ast.CommentNode) {
+	name, comment, ok := parseRoleComment(node.Text)
+	if !ok {
+		return
+	}
+	for index := range database.Roles {
+		if database.Roles[index].Name == name {
+			database.Roles[index].Comment = comment
+			return
+		}
+	}
+}
+
+// parseRoleComment recognizes the COMMENT ON ROLE text that
+// Parser.parseCommentStatement builds. The shape is fixed by that function, so
+// this reads a known format rather than arbitrary SQL.
+func parseRoleComment(text string) (name, comment string, ok bool) {
+	const prefix = "COMMENT ON ROLE "
+	if !strings.HasPrefix(text, prefix) {
+		return "", "", false
+	}
+	rest := text[len(prefix):]
+	separator := strings.LastIndex(rest, " IS ")
+	if separator < 0 {
+		return "", "", false
+	}
+	name = normalizeSQLIdentifier(strings.TrimSpace(rest[:separator]))
+	comment = strings.TrimSpace(rest[separator+len(" IS "):])
+	return name, unquoteSQLStringLiteral(comment), true
+}
+
+func unquoteSQLStringLiteral(value string) string {
+	if len(value) < 2 || value[0] != '\'' || value[len(value)-1] != '\'' {
+		return value
+	}
+	return strings.ReplaceAll(value[1:len(value)-1], "''", "'")
+}
+
+// adoptTriggerFunctions folds each Ptah-owned trigger function back into the
+// trigger that owns it. Rendering a trigger for PostgreSQL emits a
+// CREATE FUNCTION plus a CREATE TRIGGER pair, so reading that SQL back has to
+// recombine the two or the next render would emit the function twice.
+func adoptTriggerFunctions(database *goschema.Database) {
+	if len(database.Triggers) == 0 || len(database.Functions) == 0 {
+		return
+	}
+	bodies := make(map[string]string, len(database.Functions))
+	for _, function := range database.Functions {
+		bodies[function.Name] = function.Body
+	}
+
+	owned := make(map[string]bool, len(database.Triggers))
+	for index := range database.Triggers {
+		trigger := &database.Triggers[index]
+		if trigger.ExecuteFunction == "" || trigger.ExecuteFunction != trigger.FunctionName() {
+			continue
+		}
+		body, exists := bodies[trigger.ExecuteFunction]
+		if !exists {
+			continue
+		}
+		trigger.Body = trimTriggerFunctionWrapper(body)
+		trigger.ExecuteFunction = ""
+		owned[trigger.FunctionName()] = true
+	}
+	if len(owned) == 0 {
+		return
+	}
+
+	functions := make([]goschema.Function, 0, len(database.Functions))
+	for _, function := range database.Functions {
+		if !owned[function.Name] {
+			functions = append(functions, function)
+		}
+	}
+	database.Functions = functions
+}
+
+// trimTriggerFunctionWrapper removes the BEGIN / END; envelope the PostgreSQL
+// renderer wraps a trigger body in, so the recovered body renders identically.
+func trimTriggerFunctionWrapper(body string) string {
+	trimmed := strings.TrimSpace(body)
+	if !strings.HasPrefix(strings.ToUpper(trimmed), "BEGIN") {
+		return trimmed
+	}
+	inner := strings.TrimSpace(trimmed[len("BEGIN"):])
+	if !strings.HasSuffix(strings.ToUpper(inner), "END;") {
+		return trimmed
+	}
+	return strings.TrimSpace(inner[:len(inner)-len("END;")])
+}

--- a/internal/convert/toschema/toschema.go
+++ b/internal/convert/toschema/toschema.go
@@ -608,77 +608,114 @@ func ToDatabase(statements *ast.StatementList) goschema.Database {
 
 	// Process all statements and categorize them
 	for _, stmt := range statements.Statements {
-		switch node := stmt.(type) {
-		case *ast.CreateSchemaNode:
-			database.Schemas = append(database.Schemas, goschema.Schema{
-				Name:    normalizeSQLIdentifier(node.Name),
-				Comment: node.Comment,
-				Charset: node.Charset,
-				Collate: node.Collate,
-			})
-
-		case *ast.EnumNode:
-			// Convert enum definitions
-			enumSchema := ToEnum(node)
-			database.Enums = append(database.Enums, enumSchema)
-
-		case *ast.CreateTableNode:
-			// Convert table definition
-			tableSchema := ToTable(node, "")
-			database.Tables = append(database.Tables, tableSchema)
-
-			// Extract fields from table columns
-			fieldsStart := len(database.Fields)
-			for _, column := range node.Columns {
-				fieldSchema := ToField(column, tableSchema.StructName, "")
-				database.Fields = append(database.Fields, fieldSchema)
-			}
-			// A single-column table-level PRIMARY KEY (col) renders inline on the
-			// column, matching how it is expressed as an inline primary key and how
-			// the HCL loader treats it; a composite key stays on Table.PrimaryKey and
-			// renders as a table constraint.
-			markPrimaryFields(database.Fields[fieldsStart:], tableSchema.PrimaryKey)
-			for _, constraint := range node.Constraints {
-				constraintSchema, ok := ToConstraint(
-					constraint,
-					tableSchema.StructName,
-					tableSchema.QualifiedName(),
-				)
-				if ok {
-					database.Constraints = append(database.Constraints, constraintSchema)
-				}
-			}
-
-		case *ast.IndexNode:
-			// Convert index definitions
-			indexSchema := ToIndex(node)
-			database.Indexes = append(database.Indexes, indexSchema)
-
-		case *ast.AlterTableNode:
-			// Capture constraints added by ALTER TABLE ... ADD CONSTRAINT, such
-			// as the foreign keys ORM schema exporters emit as separate
-			// statements after the CREATE TABLEs.
-			tableSchemaName, tableName := normalizeSQLTableIdentifier(node.Name)
-			qualifiedTableName := goschema.QualifyTableName(tableSchemaName, tableName)
-			structName := tableStructName(node.Name)
-			for _, op := range node.Operations {
-				add, ok := op.(*ast.AddConstraintOperation)
-				if !ok || add.Constraint == nil {
-					continue
-				}
-				constraintSchema, ok := ToConstraint(
-					add.Constraint,
-					structName,
-					qualifiedTableName,
-				)
-				if ok {
-					database.Constraints = append(database.Constraints, constraintSchema)
-				}
-			}
-		}
+		appendStatement(&database, stmt)
 	}
 
+	// A PostgreSQL trigger renders as a function plus a trigger; recombine the
+	// pair so the function is not also carried as a standalone object.
+	adoptTriggerFunctions(&database)
+
 	return database
+}
+
+// appendStatement folds one parsed statement into the database being built.
+//
+// Every AST node kind the SQL frontend can produce for a schema object needs a
+// case here: a node with no case is accepted by the parser and then silently
+// dropped, which is what issue #932 reported for views, domains, composite and
+// range types, extensions, functions and triggers.
+func appendStatement(database *goschema.Database, stmt ast.Node) {
+	switch node := stmt.(type) {
+	case *ast.CreateSchemaNode:
+		database.Schemas = append(database.Schemas, goschema.Schema{
+			Name:    normalizeSQLIdentifier(node.Name),
+			Comment: node.Comment,
+			Charset: node.Charset,
+			Collate: node.Collate,
+		})
+	case *ast.EnumNode:
+		database.Enums = append(database.Enums, ToEnum(node))
+	case *ast.CreateTableNode:
+		appendCreateTable(database, node)
+	case *ast.IndexNode:
+		database.Indexes = append(database.Indexes, ToIndex(node))
+	case *ast.AlterTableNode:
+		appendAlterTableConstraints(database, node)
+	case *ast.CreateTypeNode:
+		appendCreateType(database, node)
+	case *ast.ExtensionNode:
+		database.Extensions = append(database.Extensions, ToExtension(node))
+	case *ast.CreateViewNode:
+		database.Views = append(database.Views, toView(node))
+	case *ast.CreateMaterializedViewNode:
+		database.MaterializedViews = append(database.MaterializedViews, toMaterializedView(node))
+	case *ast.CreateFunctionNode:
+		database.Functions = append(database.Functions, toFunction(node))
+	case *ast.CreateTriggerNode:
+		database.Triggers = append(database.Triggers, toTrigger(node))
+	case *ast.CreateSequenceNode:
+		database.Sequences = append(database.Sequences, toSequence(node))
+	case *ast.CreateRoleNode:
+		database.Roles = append(database.Roles, toRole(node))
+	case *ast.GrantPrivilegeNode:
+		database.Grants = append(database.Grants, toGrant(node))
+	case *ast.CreatePolicyNode:
+		database.RLSPolicies = append(database.RLSPolicies, toRLSPolicy(node))
+	case *ast.AlterTableEnableRLSNode:
+		database.RLSEnabledTables = append(database.RLSEnabledTables, toRLSEnabledTable(node))
+	case *ast.CommentNode:
+		applyRoleComment(database, node)
+	}
+}
+
+func appendCreateTable(database *goschema.Database, node *ast.CreateTableNode) {
+	tableSchema := ToTable(node, "")
+	database.Tables = append(database.Tables, tableSchema)
+
+	// Extract fields from table columns
+	fieldsStart := len(database.Fields)
+	for _, column := range node.Columns {
+		fieldSchema := ToField(column, tableSchema.StructName, "")
+		database.Fields = append(database.Fields, fieldSchema)
+	}
+	// A single-column table-level PRIMARY KEY (col) renders inline on the
+	// column, matching how it is expressed as an inline primary key and how
+	// the HCL loader treats it; a composite key stays on Table.PrimaryKey and
+	// renders as a table constraint.
+	markPrimaryFields(database.Fields[fieldsStart:], tableSchema.PrimaryKey)
+	for _, constraint := range node.Constraints {
+		constraintSchema, ok := ToConstraint(
+			constraint,
+			tableSchema.StructName,
+			tableSchema.QualifiedName(),
+		)
+		if ok {
+			database.Constraints = append(database.Constraints, constraintSchema)
+		}
+	}
+}
+
+// appendAlterTableConstraints captures constraints added by
+// ALTER TABLE ... ADD CONSTRAINT, such as the foreign keys ORM schema exporters
+// emit as separate statements after the CREATE TABLEs.
+func appendAlterTableConstraints(database *goschema.Database, node *ast.AlterTableNode) {
+	tableSchemaName, tableName := normalizeSQLTableIdentifier(node.Name)
+	qualifiedTableName := goschema.QualifyTableName(tableSchemaName, tableName)
+	structName := tableStructName(node.Name)
+	for _, op := range node.Operations {
+		add, ok := op.(*ast.AddConstraintOperation)
+		if !ok || add.Constraint == nil {
+			continue
+		}
+		constraintSchema, ok := ToConstraint(
+			add.Constraint,
+			structName,
+			qualifiedTableName,
+		)
+		if ok {
+			database.Constraints = append(database.Constraints, constraintSchema)
+		}
+	}
 }
 
 // markPrimaryFields marks the field backing a single-column table-level primary

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -121,6 +121,8 @@ func (p *Parser) parseStatement() (ast.Node, error) {
 		return p.parseCommentStatement()
 	case "DROP":
 		return p.parseDropStatement()
+	case "GRANT":
+		return p.parseGrantStatement()
 	case "DO":
 		return p.parseDoStatement()
 	case "GO":
@@ -176,7 +178,8 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 	p.skipWhitespace()
 
 	if p.current.Type != lexer.TokenIdentifier {
-		return nil, fmt.Errorf("expected CREATE target (TABLE, VIEW, FUNCTION, PROCEDURE, PROC, TRIGGER, INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION), got %s at position %d", p.current.Type, p.current.Start)
+		return nil, fmt.Errorf("expected CREATE target (%s), got %s at position %d",
+			createTargetList, p.current.Type, p.current.Start)
 	}
 
 	target := strings.ToUpper(p.current.Value)
@@ -222,6 +225,27 @@ func (p *Parser) parseCreateStatement() (ast.Node, error) {
 		return p.parseCreateType()
 	case "DOMAIN":
 		return p.parseCreateDomain()
+	default:
+		return p.parseCreateSchemaObject(target)
+	}
+}
+
+// createTargetList names the CREATE targets the grammar recognizes.
+const createTargetList = "TABLE, VIEW, MATERIALIZED VIEW, FUNCTION, PROCEDURE, PROC, TRIGGER, " +
+	"INDEX, TYPE, DOMAIN, SCHEMA, DATABASE, EXTENSION, SEQUENCE, ROLE, POLICY"
+
+// parseCreateSchemaObject parses the CREATE targets for standalone PostgreSQL
+// schema objects, which Ptah renders and, since issue #932, reads back.
+func (p *Parser) parseCreateSchemaObject(target string) (ast.Node, error) {
+	switch target {
+	case "SEQUENCE":
+		return p.parseCreateSequence()
+	case "ROLE":
+		return p.parseCreateRole()
+	case "POLICY":
+		return p.parseCreatePolicy()
+	case "MATERIALIZED":
+		return p.parseCreateMaterializedView()
 	default:
 		return nil, fmt.Errorf("unsupported CREATE target: %s at position %d", target, p.current.Start)
 	}
@@ -1145,24 +1169,59 @@ func (p *Parser) parseCreateTrigger(statementStart int) (ast.Node, error) {
 	}
 	p.skipWhitespace()
 
+	trigger := ast.NewCreateTrigger(triggerName, tableName).
+		SetTiming(timing).
+		SetEvent(event).
+		SetForEach(forEach)
+
 	if p.current.MatchIdentifierValue("EXECUTE") {
-		sql, err := p.collectRawStatement(statementStart, "CREATE TRIGGER statement")
-		if err != nil {
-			return nil, err
-		}
-		return ast.NewRawSQL(sql), nil
+		return p.parseTriggerExecuteClause(trigger, statementStart)
 	}
 
 	body, err := p.collectTriggerBody()
 	if err != nil {
 		return nil, err
 	}
+	return trigger.SetBody(body), nil
+}
 
-	return ast.NewCreateTrigger(triggerName, tableName).
-		SetTiming(timing).
-		SetEvent(event).
-		SetForEach(forEach).
-		SetBody(body), nil
+// parseTriggerExecuteClause reads the PostgreSQL
+// EXECUTE FUNCTION|PROCEDURE name() tail of a CREATE TRIGGER.
+//
+// A call with no arguments becomes a CreateTriggerNode that references the
+// named function, which is what lets Ptah read back the trigger it renders
+// (issue #932). A call that passes arguments stays raw SQL: CreateTriggerNode
+// has nowhere to keep them, and dropping them would change what the trigger
+// does.
+func (p *Parser) parseTriggerExecuteClause(trigger *ast.CreateTriggerNode, statementStart int) (ast.Node, error) {
+	p.advance()
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("FUNCTION") && !p.current.MatchIdentifierValue("PROCEDURE") {
+		return nil, fmt.Errorf("expected FUNCTION or PROCEDURE after EXECUTE at position %d", p.current.Start)
+	}
+	p.advance()
+	p.skipWhitespace()
+
+	functionName, err := p.parseQualifiedIdentifier("trigger function name")
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if !p.current.MatchOperatorValue("(") {
+		return nil, fmt.Errorf("expected '(' after trigger function name at position %d", p.current.Start)
+	}
+	p.advance()
+	p.skipWhitespace()
+	if !p.current.MatchOperatorValue(")") {
+		sql, err := p.collectRawStatement(statementStart, "CREATE TRIGGER statement")
+		if err != nil {
+			return nil, err
+		}
+		return ast.NewRawSQL(sql), nil
+	}
+	p.advance()
+
+	return trigger.SetFunctionName(functionName).SetExternalFunction(), nil
 }
 
 func (p *Parser) parseTriggerIfNotExists() error {
@@ -3479,8 +3538,10 @@ func (p *Parser) parsePostgreSQLWithClause(table *ast.CreateTableNode) error {
 	return nil
 }
 
-// parseAlterStatement parses ALTER TABLE statements.
-func (p *Parser) parseAlterStatement() (*ast.AlterTableNode, error) {
+// parseAlterStatement parses ALTER TABLE statements. Most tails become an
+// AlterTableNode carrying operations; ENABLE ROW LEVEL SECURITY is its own
+// node kind, so the return type is the Node interface.
+func (p *Parser) parseAlterStatement() (ast.Node, error) {
 	if err := p.expect(lexer.TokenIdentifier, "ALTER"); err != nil {
 		return nil, err
 	}
@@ -3502,6 +3563,10 @@ func (p *Parser) parseAlterStatement() (*ast.AlterTableNode, error) {
 	tableName, err := p.parseQualifiedIdentifier("table name")
 	if err != nil {
 		return nil, err
+	}
+
+	if rlsNode, handled, err := p.parseAlterTableRowSecurity(tableName); handled {
+		return rlsNode, err
 	}
 
 	alterNode := &ast.AlterTableNode{
@@ -4098,10 +4163,12 @@ func (p *Parser) parseCreateType() (ast.Node, error) {
 
 	p.skipWhitespace()
 
-	// Get type name
-	typeName, err := p.expectIdentifier()
+	// Get type name. A schema-qualified spelling is what Ptah's own renderer
+	// emits whenever a schema is declared, so it has to parse here exactly as
+	// it already does for CREATE DOMAIN and CREATE TABLE (issue #932).
+	typeName, err := p.parseQualifiedIdentifier("type name")
 	if err != nil {
-		return nil, fmt.Errorf("expected type name: %w", err)
+		return nil, err
 	}
 
 	p.skipWhitespace()
@@ -4409,11 +4476,12 @@ func (p *Parser) parseCommentStatement() (*ast.CommentNode, error) {
 
 	p.skipWhitespace()
 
-	// Parse the object name (could be table.column for columns)
-	var objectName strings.Builder
-	for p.current.Type == lexer.TokenIdentifier || p.current.MatchOperatorValue(".") {
-		objectName.WriteString(p.current.Value)
-		p.advance()
+	// Parse the object name (could be table.column for columns). Quoted
+	// identifiers have to be accepted here because that is how Ptah's own
+	// renderer spells the role in COMMENT ON ROLE.
+	objectName, err := p.parseQualifiedIdentifier("comment object name")
+	if err != nil {
+		return nil, err
 	}
 
 	p.skipWhitespace()
@@ -4430,7 +4498,7 @@ func (p *Parser) parseCommentStatement() (*ast.CommentNode, error) {
 	}
 
 	commentText := fmt.Sprintf("COMMENT ON %s %s IS %s",
-		strings.ToUpper(objectType), objectName.String(), p.current.Value)
+		strings.ToUpper(objectType), objectName, p.current.Value)
 	p.advance()
 
 	return ast.NewComment(commentText), nil

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -1009,9 +1009,19 @@ EXECUTE FUNCTION public.touch_updated_at();`
 		ast.PostgresRoutineStatementReturn,
 	})
 
-	rawTrigger, ok := statements.Statements[1].(*ast.RawSQLNode)
+	// An argument-free EXECUTE FUNCTION is a trigger node that references the
+	// named function, so the SQL frontend can read back the trigger Ptah
+	// renders (issue #932). The function is external: the renderer must not
+	// redefine it.
+	trigger, ok := statements.Statements[1].(*ast.CreateTriggerNode)
 	c.Assert(ok, qt.IsTrue)
-	c.Assert(rawTrigger.SQL, qt.Contains, "EXECUTE FUNCTION public.touch_updated_at()")
+	c.Assert(trigger.Name, qt.Equals, "set_updated_at")
+	c.Assert(trigger.Table, qt.Equals, "users")
+	c.Assert(trigger.Timing, qt.Equals, "BEFORE")
+	c.Assert(trigger.Event, qt.Equals, "UPDATE")
+	c.Assert(trigger.FunctionName, qt.Equals, "public.touch_updated_at")
+	c.Assert(trigger.ExternalFunction, qt.IsTrue)
+	c.Assert(trigger.Body, qt.Equals, "")
 }
 
 func TestParser_ParsePostgresDialectProcedureRoutineBodyMetadata(t *testing.T) {

--- a/internal/parser/postgres_objects.go
+++ b/internal/parser/postgres_objects.go
@@ -1,0 +1,644 @@
+package parser
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/internal/lexer"
+)
+
+// This file holds the statement grammar for the PostgreSQL schema objects that
+// Ptah's own renderer emits but its SQL frontend used to refuse: sequences,
+// roles, grants, policies, ALTER TABLE ... ENABLE ROW LEVEL SECURITY and
+// materialized views. Refusing them made `ptah schema render` unable to read
+// back the SQL it had just written (issue #932).
+
+// parseCreateSequence parses CREATE SEQUENCE [IF NOT EXISTS] name [options].
+func (p *Parser) parseCreateSequence() (*ast.CreateSequenceNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "SEQUENCE"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	ifNotExists, err := p.parseOptionalIfNotExists()
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	schema, name, err := p.parseSchemaQualifiedName("sequence name")
+	if err != nil {
+		return nil, err
+	}
+
+	sequence := ast.NewCreateSequence(name).SetSchema(schema)
+	if ifNotExists {
+		sequence.SetIfNotExists()
+	}
+	if err := p.parseSequenceOptions(sequence); err != nil {
+		return nil, err
+	}
+	return sequence, nil
+}
+
+// parseSequenceOptions consumes the option list that follows a sequence name.
+func (p *Parser) parseSequenceOptions(sequence *ast.CreateSequenceNode) error {
+	for {
+		p.skipWhitespace()
+		if p.isAtEnd() || p.current.Type == lexer.TokenSemicolon {
+			return nil
+		}
+		if p.current.Type != lexer.TokenIdentifier {
+			return fmt.Errorf("unsupported CREATE SEQUENCE option at position %d", p.current.Start)
+		}
+		keyword := strings.ToUpper(p.current.Value)
+		p.advance()
+		if err := p.applySequenceOption(sequence, keyword); err != nil {
+			return err
+		}
+	}
+}
+
+// applySequenceOption applies one CREATE SEQUENCE option keyword.
+func (p *Parser) applySequenceOption(sequence *ast.CreateSequenceNode, keyword string) error {
+	switch keyword {
+	case "AS":
+		return p.applySequenceAs(sequence)
+	case "INCREMENT", "START", "MINVALUE", "MAXVALUE", "CACHE":
+		return p.applySequenceNumericOption(sequence, keyword)
+	case "CYCLE":
+		sequence.SetCycle(true)
+		return nil
+	case "NO":
+		return p.applySequenceNoOption(sequence)
+	case "OWNED":
+		return p.applySequenceOwnedBy(sequence)
+	default:
+		return fmt.Errorf("unsupported CREATE SEQUENCE option: %s at position %d", keyword, p.current.Start)
+	}
+}
+
+func (p *Parser) applySequenceAs(sequence *ast.CreateSequenceNode) error {
+	p.skipWhitespace()
+	asType, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected type after AS in CREATE SEQUENCE: %w", err)
+	}
+	sequence.SetAs(asType)
+	return nil
+}
+
+// applySequenceNumericOption handles the options that take a single integer,
+// including the optional BY / WITH filler word PostgreSQL allows.
+func (p *Parser) applySequenceNumericOption(sequence *ast.CreateSequenceNode, keyword string) error {
+	p.skipWhitespace()
+	if p.current.MatchIdentifierValue("BY") || p.current.MatchIdentifierValue("WITH") {
+		p.advance()
+		p.skipWhitespace()
+	}
+	value, err := p.parseSignedInteger()
+	if err != nil {
+		return fmt.Errorf("expected integer after %s in CREATE SEQUENCE: %w", keyword, err)
+	}
+	switch keyword {
+	case "INCREMENT":
+		sequence.SetIncrement(value)
+	case "START":
+		sequence.SetStart(value)
+	case "MINVALUE":
+		sequence.SetMinValue(value)
+	case "MAXVALUE":
+		sequence.SetMaxValue(value)
+	case "CACHE":
+		sequence.SetCache(value)
+	}
+	return nil
+}
+
+// applySequenceNoOption handles NO MINVALUE / NO MAXVALUE / NO CYCLE, all of
+// which restate a PostgreSQL default and so leave the node unset.
+func (p *Parser) applySequenceNoOption(sequence *ast.CreateSequenceNode) error {
+	p.skipWhitespace()
+	keyword, err := p.expectIdentifier()
+	if err != nil {
+		return fmt.Errorf("expected MINVALUE, MAXVALUE or CYCLE after NO: %w", err)
+	}
+	switch strings.ToUpper(keyword) {
+	case "MINVALUE", "MAXVALUE":
+		return nil
+	case "CYCLE":
+		sequence.SetCycle(false)
+		return nil
+	default:
+		return fmt.Errorf("unsupported CREATE SEQUENCE option: NO %s at position %d", keyword, p.current.Start)
+	}
+}
+
+func (p *Parser) applySequenceOwnedBy(sequence *ast.CreateSequenceNode) error {
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "BY"); err != nil {
+		return fmt.Errorf("expected BY after OWNED: %w", err)
+	}
+	p.skipWhitespace()
+	owner, err := p.parseQualifiedIdentifier("OWNED BY target")
+	if err != nil {
+		return err
+	}
+	if !strings.EqualFold(owner, "NONE") {
+		sequence.SetOwnedBy(owner)
+	}
+	return nil
+}
+
+// parseSignedInteger reads an optionally signed integer literal. The lexer
+// emits numbers as identifiers and a leading '-' as an operator, so the sign
+// has to be reassembled here.
+func (p *Parser) parseSignedInteger() (int64, error) {
+	sign := int64(1)
+	if p.current.MatchOperatorValue("-") {
+		sign = -1
+		p.advance()
+	} else if p.current.MatchOperatorValue("+") {
+		p.advance()
+	}
+	if p.current.Type != lexer.TokenIdentifier {
+		return 0, fmt.Errorf("expected integer, got %s at position %d", p.current.Type, p.current.Start)
+	}
+	value, err := strconv.ParseInt(p.current.Value, 10, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid integer %q at position %d", p.current.Value, p.current.Start)
+	}
+	p.advance()
+	return sign * value, nil
+}
+
+// parseCreateRole parses CREATE ROLE name [WITH] [attribute ...].
+func (p *Parser) parseCreateRole() (*ast.CreateRoleNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "ROLE"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected role name: %w", err)
+	}
+
+	// ast.NewCreateRole defaults Inherit to true, matching PostgreSQL. A
+	// rendered role always spells every attribute out, so the loop below
+	// restates the default rather than relying on it.
+	role := ast.NewCreateRole(name)
+	if err := p.parseRoleOptions(role); err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+func (p *Parser) parseRoleOptions(role *ast.CreateRoleNode) error {
+	for {
+		p.skipWhitespace()
+		if p.isAtEnd() || p.current.Type == lexer.TokenSemicolon {
+			return nil
+		}
+		if p.current.Type != lexer.TokenIdentifier {
+			return fmt.Errorf("unsupported CREATE ROLE option at position %d", p.current.Start)
+		}
+		keyword := strings.ToUpper(p.current.Value)
+		p.advance()
+		if err := p.applyRoleOption(role, keyword); err != nil {
+			return err
+		}
+	}
+}
+
+func (p *Parser) applyRoleOption(role *ast.CreateRoleNode, keyword string) error {
+	if applyRoleFlag(role, keyword) {
+		return nil
+	}
+	switch keyword {
+	case "WITH":
+		return nil
+	case "ENCRYPTED", "UNENCRYPTED":
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "PASSWORD"); err != nil {
+			return fmt.Errorf("expected PASSWORD after %s: %w", keyword, err)
+		}
+		return p.applyRolePassword(role)
+	case "PASSWORD":
+		return p.applyRolePassword(role)
+	default:
+		return fmt.Errorf("unsupported CREATE ROLE option: %s at position %d", keyword, p.current.Start)
+	}
+}
+
+// applyRoleFlag sets the boolean role attributes, whose negative spellings are
+// the NO-prefixed keywords PostgreSQL and Ptah's renderer both use.
+func applyRoleFlag(role *ast.CreateRoleNode, keyword string) bool {
+	switch keyword {
+	case "LOGIN":
+		role.SetLogin(true)
+	case "NOLOGIN":
+		role.SetLogin(false)
+	case "SUPERUSER":
+		role.SetSuperuser(true)
+	case "NOSUPERUSER":
+		role.SetSuperuser(false)
+	case "CREATEDB":
+		role.SetCreateDB(true)
+	case "NOCREATEDB":
+		role.SetCreateDB(false)
+	case "CREATEROLE":
+		role.SetCreateRole(true)
+	case "NOCREATEROLE":
+		role.SetCreateRole(false)
+	case "INHERIT":
+		role.SetInherit(true)
+	case "NOINHERIT":
+		role.SetInherit(false)
+	case "REPLICATION":
+		role.SetReplication(true)
+	case "NOREPLICATION":
+		role.SetReplication(false)
+	default:
+		return false
+	}
+	return true
+}
+
+func (p *Parser) applyRolePassword(role *ast.CreateRoleNode) error {
+	p.skipWhitespace()
+	if p.current.Type != lexer.TokenString {
+		return fmt.Errorf("expected password literal at position %d", p.current.Start)
+	}
+	role.SetPassword(trimSQLStringLiteral(p.current.Value))
+	p.advance()
+	return nil
+}
+
+// parseGrantStatement parses GRANT priv[, ...] ON [objtype] name TO role
+// [WITH GRANT OPTION].
+func (p *Parser) parseGrantStatement() (*ast.GrantPrivilegeNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "GRANT"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	privileges, err := p.parseGrantPrivileges()
+	if err != nil {
+		return nil, err
+	}
+
+	objectType, objectName, err := p.parseGrantTarget()
+	if err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "TO"); err != nil {
+		return nil, fmt.Errorf("expected TO after GRANT target: %w", err)
+	}
+	p.skipWhitespace()
+	role, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected grantee role: %w", err)
+	}
+
+	grant := ast.NewGrantPrivilege(role, objectType, objectName, privileges)
+	withOption, err := p.parseGrantOptionSuffix()
+	if err != nil {
+		return nil, err
+	}
+	return grant.SetWithOption(withOption), nil
+}
+
+func (p *Parser) parseGrantPrivileges() ([]string, error) {
+	var privileges []string
+	for {
+		p.skipWhitespace()
+		privilege, err := p.expectIdentifier()
+		if err != nil {
+			return nil, fmt.Errorf("expected privilege name: %w", err)
+		}
+		privileges = append(privileges, strings.ToUpper(privilege))
+		p.skipWhitespace()
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			continue
+		}
+		if p.current.MatchIdentifierValue("ON") {
+			p.advance()
+			return privileges, nil
+		}
+		return nil, fmt.Errorf("expected ',' or ON in GRANT privileges at position %d", p.current.Start)
+	}
+}
+
+// grantObjectTypes are the GRANT target kinds Ptah models. A GRANT that omits
+// the keyword entirely targets a table, which is PostgreSQL's own default.
+var grantObjectTypes = map[string]bool{"TABLE": true, "SCHEMA": true, "SEQUENCE": true}
+
+func (p *Parser) parseGrantTarget() (objectType, objectName string, err error) {
+	p.skipWhitespace()
+	objectType = "TABLE"
+	if p.current.Type == lexer.TokenIdentifier {
+		keyword := strings.ToUpper(p.current.Value)
+		if grantObjectTypes[keyword] {
+			objectType = keyword
+			p.advance()
+			p.skipWhitespace()
+		}
+	}
+	objectName, err = p.parseQualifiedIdentifier("GRANT object name")
+	if err != nil {
+		return "", "", err
+	}
+	return objectType, objectName, nil
+}
+
+func (p *Parser) parseGrantOptionSuffix() (bool, error) {
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("WITH") {
+		return false, nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "GRANT"); err != nil {
+		return false, fmt.Errorf("expected GRANT after WITH: %w", err)
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "OPTION"); err != nil {
+		return false, fmt.Errorf("expected OPTION after WITH GRANT: %w", err)
+	}
+	return true, nil
+}
+
+// parseCreatePolicy parses CREATE POLICY name ON table [AS kind] [FOR command]
+// [TO roles] [USING (expr)] [WITH CHECK (expr)].
+func (p *Parser) parseCreatePolicy() (*ast.CreatePolicyNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "POLICY"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	name, err := p.expectIdentifier()
+	if err != nil {
+		return nil, fmt.Errorf("expected policy name: %w", err)
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "ON"); err != nil {
+		return nil, fmt.Errorf("expected ON after policy name: %w", err)
+	}
+	p.skipWhitespace()
+	table, err := p.parseQualifiedIdentifier("policy table name")
+	if err != nil {
+		return nil, err
+	}
+
+	policy := ast.NewCreatePolicy(name, table)
+	if err := p.parsePolicyClauses(policy); err != nil {
+		return nil, err
+	}
+	return policy, nil
+}
+
+func (p *Parser) parsePolicyClauses(policy *ast.CreatePolicyNode) error {
+	for {
+		p.skipWhitespace()
+		if p.isAtEnd() || p.current.Type == lexer.TokenSemicolon {
+			return nil
+		}
+		if p.current.Type != lexer.TokenIdentifier {
+			return fmt.Errorf("unsupported CREATE POLICY clause at position %d", p.current.Start)
+		}
+		keyword := strings.ToUpper(p.current.Value)
+		p.advance()
+		if err := p.applyPolicyClause(policy, keyword); err != nil {
+			return err
+		}
+	}
+}
+
+func (p *Parser) applyPolicyClause(policy *ast.CreatePolicyNode, keyword string) error {
+	switch keyword {
+	case "AS":
+		// PERMISSIVE / RESTRICTIVE has no place in Ptah's IR, and Ptah's HCL
+		// frontend rejects policy `as` for the same reason. Refuse rather than
+		// accept and drop a clause that inverts what the policy means.
+		p.skipWhitespace()
+		kind, err := p.expectIdentifier()
+		if err != nil {
+			return fmt.Errorf("expected PERMISSIVE or RESTRICTIVE after AS: %w", err)
+		}
+		return fmt.Errorf("unsupported CREATE POLICY clause: AS %s at position %d", strings.ToUpper(kind), p.current.Start)
+	case "FOR":
+		p.skipWhitespace()
+		command, err := p.expectIdentifier()
+		if err != nil {
+			return fmt.Errorf("expected command after FOR: %w", err)
+		}
+		policy.SetPolicyFor(strings.ToUpper(command))
+		return nil
+	case "TO":
+		return p.applyPolicyRoles(policy)
+	case "USING":
+		expression, err := p.parseParenthesizedExpression("USING")
+		if err != nil {
+			return err
+		}
+		policy.SetUsingExpression(expression)
+		return nil
+	case "WITH":
+		return p.applyPolicyWithCheck(policy)
+	default:
+		return fmt.Errorf("unsupported CREATE POLICY clause: %s at position %d", keyword, p.current.Start)
+	}
+}
+
+func (p *Parser) applyPolicyRoles(policy *ast.CreatePolicyNode) error {
+	var roles []string
+	for {
+		p.skipWhitespace()
+		role, err := p.expectIdentifier()
+		if err != nil {
+			return fmt.Errorf("expected role after TO: %w", err)
+		}
+		roles = append(roles, role)
+		p.skipWhitespace()
+		if p.current.MatchOperatorValue(",") {
+			p.advance()
+			continue
+		}
+		policy.SetToRoles(strings.Join(roles, ", "))
+		return nil
+	}
+}
+
+func (p *Parser) applyPolicyWithCheck(policy *ast.CreatePolicyNode) error {
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "CHECK"); err != nil {
+		return fmt.Errorf("expected CHECK after WITH: %w", err)
+	}
+	expression, err := p.parseParenthesizedExpression("WITH CHECK")
+	if err != nil {
+		return err
+	}
+	policy.SetWithCheckExpression(expression)
+	return nil
+}
+
+// parseParenthesizedExpression collects the text inside a balanced paren pair,
+// which is how policy USING / WITH CHECK expressions are rendered.
+func (p *Parser) parseParenthesizedExpression(label string) (string, error) {
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenOperator, "("); err != nil {
+		return "", fmt.Errorf("expected '(' after %s: %w", label, err)
+	}
+	var body strings.Builder
+	depth := 1
+	for {
+		if p.current.Type == lexer.TokenEOF {
+			return "", fmt.Errorf("unterminated %s expression", label)
+		}
+		if err := p.checkTimeout(); err != nil {
+			return "", err
+		}
+		if p.current.MatchOperatorValue("(") {
+			depth++
+		} else if p.current.MatchOperatorValue(")") {
+			depth--
+			if depth == 0 {
+				p.advance()
+				return strings.TrimSpace(body.String()), nil
+			}
+		}
+		body.WriteString(p.current.Value)
+		p.advance()
+	}
+}
+
+// parseCreateMaterializedView parses
+// CREATE MATERIALIZED VIEW [IF NOT EXISTS] name AS <query>.
+func (p *Parser) parseCreateMaterializedView() (*ast.CreateMaterializedViewNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "MATERIALIZED"); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "VIEW"); err != nil {
+		return nil, fmt.Errorf("expected VIEW after MATERIALIZED: %w", err)
+	}
+	p.skipWhitespace()
+	if _, err := p.parseOptionalIfNotExists(); err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+
+	name, err := p.parseQualifiedIdentifier("materialized view name")
+	if err != nil {
+		return nil, err
+	}
+	p.skipWhitespace()
+	if err := p.expect(lexer.TokenIdentifier, "AS"); err != nil {
+		return nil, fmt.Errorf("expected AS after materialized view name: %w", err)
+	}
+
+	body := p.collectStatementBody()
+	if strings.TrimSpace(body) == "" {
+		return nil, fmt.Errorf("expected materialized view body after AS at position %d", p.current.Start)
+	}
+	return ast.NewCreateMaterializedView(name).SetBody(body), nil
+}
+
+// parseAlterTableRowLevelSecurity parses the ROW LEVEL SECURITY tail of an
+// ALTER TABLE ... ENABLE / DISABLE statement, with the ENABLE or DISABLE
+// keyword already consumed. DISABLE has no IR representation, so it is refused
+// rather than read as its opposite.
+func (p *Parser) parseAlterTableRowLevelSecurity(table, keyword string, start int) (*ast.AlterTableEnableRLSNode, error) {
+	for _, word := range []string{"ROW", "LEVEL", "SECURITY"} {
+		if err := p.expect(lexer.TokenIdentifier, word); err != nil {
+			return nil, fmt.Errorf("expected %s in ALTER TABLE ... %s ROW LEVEL SECURITY: %w", word, keyword, err)
+		}
+	}
+	if keyword != "ENABLE" {
+		return nil, fmt.Errorf("unsupported ALTER operation: %s ROW LEVEL SECURITY at position %d", keyword, start)
+	}
+	return ast.NewAlterTableEnableRLS(table), nil
+}
+
+// parseAlterTableRowSecurity handles an ALTER TABLE tail that begins with
+// ENABLE or DISABLE. The second result reports whether the tail was consumed;
+// when it was not, the caller falls through to the operation list. Anything
+// after ENABLE / DISABLE other than ROW keeps the "unsupported ALTER
+// operation" error it had before, so ALTER TABLE ... ENABLE TRIGGER is
+// unaffected.
+func (p *Parser) parseAlterTableRowSecurity(table string) (ast.Node, bool, error) {
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("ENABLE") && !p.current.MatchIdentifierValue("DISABLE") {
+		return nil, false, nil
+	}
+	keyword := strings.ToUpper(p.current.Value)
+	start := p.current.Start
+	p.advance()
+	p.skipWhitespace()
+	if !p.current.MatchIdentifierValue("ROW") {
+		return nil, true, fmt.Errorf("unsupported ALTER operation: %s at position %d", keyword, start)
+	}
+	node, err := p.parseAlterTableRowLevelSecurity(table, keyword, start)
+	if err != nil {
+		return nil, true, err
+	}
+	return node, true, nil
+}
+
+// parseSchemaQualifiedName splits a possibly qualified name into its schema
+// prefix and its final part, for the nodes that keep the two apart.
+func (p *Parser) parseSchemaQualifiedName(label string) (schema, name string, err error) {
+	qualified, err := p.parseQualifiedIdentifier(label)
+	if err != nil {
+		return "", "", err
+	}
+	parts := splitQualifiedIdentifier(qualified)
+	if len(parts) == 1 {
+		return "", parts[0], nil
+	}
+	return strings.Join(parts[:len(parts)-1], "."), parts[len(parts)-1], nil
+}
+
+// splitQualifiedIdentifier splits on the dots that separate name parts while
+// leaving dots inside a double-quoted part alone. A doubled quote is SQL's
+// escape for a literal quote and does not end the quoted part.
+func splitQualifiedIdentifier(value string) []string {
+	var parts []string
+	start := 0
+	quoted := false
+	for index := 0; index < len(value); index++ {
+		switch {
+		case value[index] == '"' && quoted && index+1 < len(value) && value[index+1] == '"':
+			index++
+		case value[index] == '"':
+			quoted = !quoted
+		case value[index] == '.' && !quoted:
+			parts = append(parts, value[start:index])
+			start = index + 1
+		}
+	}
+	return append(parts, value[start:])
+}
+
+// trimSQLStringLiteral removes the surrounding quotes from a lexed string
+// literal and collapses the doubled quotes SQL uses for escaping.
+func trimSQLStringLiteral(value string) string {
+	if len(value) < 2 {
+		return value
+	}
+	quote := value[0]
+	if quote != '\'' && quote != '"' {
+		return value
+	}
+	if value[len(value)-1] != quote {
+		return value
+	}
+	inner := value[1 : len(value)-1]
+	return strings.ReplaceAll(inner, string([]byte{quote, quote}), string(quote))
+}

--- a/internal/schemafile/sql_object_kinds_test.go
+++ b/internal/schemafile/sql_object_kinds_test.go
@@ -1,0 +1,157 @@
+package schemafile_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/schemafile"
+)
+
+// The fixtures below are the object kinds a PostgreSQL SQL schema file could
+// not express before issue #932. Each one is loaded after a CREATE TABLE
+// anchor and must both load without error and reach the rendered SQL: an
+// exit-code assertion on its own passes for a statement that parses and is
+// then dropped, which is exactly how five of these used to behave.
+func loadRenderedPostgresSQL(c *qt.C, body string) string {
+	dir := c.TempDir()
+	path := writeSchemaFile(c, dir, "schema.sql", "CREATE TABLE t1 (id BIGINT PRIMARY KEY);\n"+body+"\n")
+	db, err := schemafile.LoadAll([]string{path}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+	return strings.Join(renderPostgres(c, db), "\n")
+}
+
+func TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      string
+	}{{
+		name:      "materialized view",
+		statement: `CREATE MATERIALIZED VIEW mv1 AS SELECT id FROM t1;`,
+		want:      `CREATE MATERIALIZED VIEW "mv1" AS`,
+	}, {
+		name:      "sequence",
+		statement: `CREATE SEQUENCE s1 START WITH 1;`,
+		want:      `CREATE SEQUENCE "s1" START WITH 1;`,
+	}, {
+		name:      "role",
+		statement: `CREATE ROLE r_x;`,
+		want:      `CREATE ROLE "r_x" WITH NOLOGIN`,
+	}, {
+		name:      "grant",
+		statement: `GRANT SELECT ON TABLE t1 TO r_x;`,
+		want:      `GRANT SELECT ON TABLE "t1" TO "r_x";`,
+	}, {
+		name:      "policy",
+		statement: `CREATE POLICY p1 ON t1 FOR SELECT USING (true);`,
+		want:      `CREATE POLICY "p1" ON "t1" FOR SELECT`,
+	}, {
+		name:      "row level security",
+		statement: `ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;`,
+		want:      `ALTER TABLE "t1" ENABLE ROW LEVEL SECURITY;`,
+	}, {
+		name:      "schema qualified composite type",
+		statement: `CREATE TYPE "public"."address" AS ("street" text);`,
+		want:      `CREATE TYPE "public"."address" AS ("street" text);`,
+	}, {
+		name:      "schema qualified range type",
+		statement: `CREATE TYPE "public"."floatrange" AS RANGE (SUBTYPE = float8);`,
+		want:      `CREATE TYPE "public"."floatrange" AS RANGE (SUBTYPE = float8);`,
+	}, {
+		name:      "schema qualified enum type",
+		statement: `CREATE TYPE "public"."e1" AS ENUM ('a');`,
+		want:      `CREATE TYPE "public"."e1" AS ENUM ('a');`,
+	}, {
+		name:      "view",
+		statement: `CREATE VIEW v1 AS SELECT id FROM t1;`,
+		want:      `CREATE VIEW "v1" AS`,
+	}, {
+		name:      "domain",
+		statement: `CREATE DOMAIN d1 AS TEXT;`,
+		want:      `CREATE DOMAIN "d1" AS TEXT;`,
+	}, {
+		name:      "extension",
+		statement: `CREATE EXTENSION IF NOT EXISTS pgcrypto;`,
+		want:      `CREATE EXTENSION IF NOT EXISTS "pgcrypto";`,
+	}, {
+		name:      "function",
+		statement: `CREATE FUNCTION f1() RETURNS INT AS $$ SELECT 1 $$ LANGUAGE SQL;`,
+		want:      `CREATE OR REPLACE FUNCTION "f1"() RETURNS int AS $$`,
+	}, {
+		name:      "trigger executing an existing function",
+		statement: `CREATE TRIGGER tg1 AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f1();`,
+		want:      `CREATE TRIGGER "tg1" AFTER INSERT ON "t1" FOR EACH ROW EXECUTE FUNCTION "f1"();`,
+	}, {
+		name:      "index control",
+		statement: `CREATE INDEX ix1 ON t1 (id);`,
+		want:      `CREATE INDEX IF NOT EXISTS "ix1" ON "t1" ("id");`,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(loadRenderedPostgresSQL(c, tc.statement), qt.Contains, tc.want)
+		})
+	}
+}
+
+// TestLoadAll_TriggerOnAnExistingFunctionDoesNotRedefineIt pins the half of the
+// trigger case that a "the object appears" assertion would miss. A trigger that
+// executes a function it did not define must reference that function, never
+// emit a body for it: rendering CREATE OR REPLACE FUNCTION "f1"() with an empty
+// body would erase whatever f1 actually contains.
+func TestLoadAll_TriggerOnAnExistingFunctionDoesNotRedefineIt(t *testing.T) {
+	c := qt.New(t)
+
+	sql := loadRenderedPostgresSQL(c, `CREATE TRIGGER tg1 AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f1();`)
+
+	c.Assert(sql, qt.Contains, `EXECUTE FUNCTION "f1"();`)
+	c.Assert(sql, qt.Not(qt.Contains), `CREATE OR REPLACE FUNCTION "f1"()`)
+	c.Assert(sql, qt.Not(qt.Contains), "ptah_trigger_t1_tg1")
+}
+
+// TestLoadAll_SQLSchemaFileStillRefusesStatementsOutsideTheGrammar is the
+// negative control for the fixtures above: widening the grammar must not turn
+// the loader into one that accepts anything.
+func TestLoadAll_SQLSchemaFileStillRefusesStatementsOutsideTheGrammar(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		wantError string
+	}{{
+		name:      "not sql at all",
+		statement: `DEFINITELY NOT SQL;`,
+		wantError: `unsupported SQL statement: DEFINITELY`,
+	}, {
+		name:      "unmodelled create target",
+		statement: `CREATE PUBLICATION p FOR ALL TABLES;`,
+		wantError: `unsupported CREATE target: PUBLICATION`,
+	}, {
+		name:      "alter table operation that is not row level security",
+		statement: `ALTER TABLE t1 ENABLE TRIGGER tg1;`,
+		wantError: `unsupported ALTER operation: ENABLE`,
+	}, {
+		name:      "disable row level security has no representation",
+		statement: `ALTER TABLE t1 DISABLE ROW LEVEL SECURITY;`,
+		wantError: `unsupported ALTER operation: DISABLE ROW LEVEL SECURITY`,
+	}, {
+		name:      "restrictive policy changes what the policy means",
+		statement: `CREATE POLICY p1 ON t1 AS RESTRICTIVE FOR SELECT USING (true);`,
+		wantError: `unsupported CREATE POLICY clause: AS RESTRICTIVE`,
+	}}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			path := writeSchemaFile(c, dir, "schema.sql", "CREATE TABLE t1 (id BIGINT PRIMARY KEY);\n"+tc.statement+"\n")
+
+			_, err := schemafile.LoadAll([]string{path}, schemafile.Options{Dialect: platform.Postgres})
+
+			c.Assert(err, qt.ErrorMatches, ".*"+tc.wantError+".*")
+		})
+	}
+}

--- a/internal/schemafile/sql_roundtrip_test.go
+++ b/internal/schemafile/sql_roundtrip_test.go
@@ -1,0 +1,237 @@
+package schemafile_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/schemafile"
+)
+
+// postgresObjectsHCL is the "PostgreSQL Schema Objects" example from
+// docs/atlas_hcl_schema.md, verbatim. Every block in it is one Ptah's HCL
+// frontend fully supports, so whatever it renders is SQL that Ptah itself
+// produced for a schema it can represent.
+const postgresObjectsHCL = `schema "public" {}
+
+extension "pg_trgm" {
+  if_not_exists = true
+  version       = "1.6"
+  comment       = "trigram search"
+}
+
+sequence "order_number_seq" {
+  schema    = schema.public
+  type      = bigint
+  start     = 1000
+  increment = 1
+  cache     = 10
+  cycle     = false
+}
+
+domain "email" {
+  schema = schema.public
+  type   = text
+  null   = false
+  check  = "VALUE ~ '@'"
+}
+
+composite "address" {
+  schema = schema.public
+  field "street" {
+    type = text
+  }
+  field "zip" {
+    type = integer
+  }
+}
+
+range "floatrange" {
+  schema       = schema.public
+  subtype      = float8
+  subtype_diff = float8mi
+}
+
+role "app_user" {
+  login   = true
+  inherit = true
+  comment = "application role"
+}
+
+table "users" {
+  schema = schema.public
+
+  column "id" {
+    type = int
+  }
+
+  row_security {
+    enabled = true
+    comment = "tenant isolation"
+  }
+}
+
+function "get_current_tenant" {
+  schema     = schema.public
+  lang       = SQL
+  return     = text
+  security   = INVOKER
+  volatility = STABLE
+  as         = "SELECT current_setting('app.tenant_id', true)"
+}
+
+view "active_users" {
+  schema  = schema.public
+  as      = "SELECT id FROM users WHERE deleted_at IS NULL"
+  comment = "active users"
+}
+
+materialized "user_stats" {
+  schema           = schema.public
+  as               = "SELECT count(*) FROM users"
+  refresh_strategy = "concurrently"
+}
+
+trigger "users_set_updated_at" {
+  on = table.users
+  before {
+    update = true
+  }
+  for = ROW
+  as  = "NEW.updated_at = now(); RETURN NEW;"
+}
+
+policy "users_tenant_policy" {
+  on    = table.users
+  for   = SELECT
+  to    = [role.app_user, PUBLIC]
+  using = "get_current_tenant() IS NOT NULL"
+}
+
+permission {
+  to         = role.app_user
+  for        = table.users
+  privileges = [SELECT, INSERT]
+  grantable  = true
+}
+
+permission {
+  to         = PUBLIC
+  for        = schema.public
+  privileges = [USAGE]
+}
+`
+
+func writeSchemaFile(c *qt.C, dir, name, body string) string {
+	path := filepath.Join(dir, name)
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+func renderPostgres(c *qt.C, db *goschema.Database) []string {
+	statements, err := renderer.GetOrderedCreateStatements(db, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+	return statements
+}
+
+// dropLeadingComments removes the leading `-- text` lines a statement carries.
+// Ptah renders an object's comment as a SQL line comment, and a SQL line
+// comment belongs to no object when it is read back, so those lines are the one
+// thing a rendered schema loses on its first trip through the SQL frontend.
+func dropLeadingComments(statements []string) []string {
+	stripped := make([]string, 0, len(statements))
+	for _, statement := range statements {
+		lines := strings.Split(statement, "\n")
+		for len(lines) > 0 && strings.HasPrefix(strings.TrimSpace(lines[0]), "--") {
+			lines = lines[1:]
+		}
+		stripped = append(stripped, strings.Join(lines, "\n"))
+	}
+	return stripped
+}
+
+// TestLoadAll_RenderedPostgresSQLReadsBackAsAFixedPoint is the acceptance check
+// for issue #932: Ptah must be able to read back the SQL it renders.
+//
+// Before the fix, feeding the rendered SQL back exited 2 at
+// "unsupported CREATE target: SEQUENCE", and of the 16 statements only
+// CREATE SCHEMA and CREATE TABLE survived: 8 were refused outright and 5 more
+// parsed and were then dropped on the floor by the AST-to-IR converter.
+func TestLoadAll_RenderedPostgresSQLReadsBackAsAFixedPoint(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	hclPath := writeSchemaFile(c, dir, "schema.hcl", postgresObjectsHCL)
+	fromHCL, err := schemafile.LoadAll([]string{hclPath}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+	first := renderPostgres(c, fromHCL)
+	c.Assert(first, qt.HasLen, 16)
+
+	sqlPath := writeSchemaFile(c, dir, "first.sql", strings.Join(first, ";\n")+";\n")
+	fromSQL, err := schemafile.LoadAll([]string{sqlPath}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+	second := renderPostgres(c, fromSQL)
+	c.Assert(second, qt.HasLen, 16)
+
+	// Every statement comes back identical apart from the object comments that
+	// were rendered as bare `--` lines.
+	c.Assert(dropLeadingComments(second), qt.DeepEquals, dropLeadingComments(first))
+
+	// From the second render on, the SQL is a true fixed point: reading it and
+	// rendering it again reproduces it byte for byte.
+	secondPath := writeSchemaFile(c, dir, "second.sql", strings.Join(second, ";\n")+";\n")
+	fromSecondSQL, err := schemafile.LoadAll([]string{secondPath}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+	c.Assert(renderPostgres(c, fromSecondSQL), qt.DeepEquals, second)
+}
+
+// TestLoadAll_RenderedPostgresSQLKeepsEveryObjectKind names the objects the
+// fixed-point check above depends on, so a regression says which kind was lost
+// rather than only that a statement count moved.
+func TestLoadAll_RenderedPostgresSQLKeepsEveryObjectKind(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	hclPath := writeSchemaFile(c, dir, "schema.hcl", postgresObjectsHCL)
+	fromHCL, err := schemafile.LoadAll([]string{hclPath}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+	rendered := renderPostgres(c, fromHCL)
+
+	sqlPath := writeSchemaFile(c, dir, "schema.sql", strings.Join(rendered, ";\n")+";\n")
+	got, err := schemafile.LoadAll([]string{sqlPath}, schemafile.Options{Dialect: platform.Postgres})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(got.Schemas, qt.HasLen, 1)
+	c.Assert(got.Tables, qt.HasLen, 1)
+	c.Assert(got.Extensions, qt.HasLen, 1)
+	c.Assert(got.Sequences, qt.HasLen, 1)
+	c.Assert(got.Domains, qt.HasLen, 1)
+	c.Assert(got.CompositeTypes, qt.HasLen, 1)
+	c.Assert(got.Ranges, qt.HasLen, 1)
+	c.Assert(got.Roles, qt.HasLen, 1)
+	c.Assert(got.Views, qt.HasLen, 1)
+	c.Assert(got.MaterializedViews, qt.HasLen, 1)
+	c.Assert(got.Triggers, qt.HasLen, 1)
+	c.Assert(got.RLSPolicies, qt.HasLen, 1)
+	c.Assert(got.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(got.Grants, qt.HasLen, 2)
+
+	// The role comment survives because PostgreSQL spells it as a separate
+	// COMMENT ON ROLE statement, which is real SQL rather than a line comment.
+	c.Assert(got.Roles[0].Name, qt.Equals, "app_user")
+	c.Assert(got.Roles[0].Comment, qt.Equals, "application role")
+
+	// A trigger renders as a function plus a trigger; reading it back folds the
+	// function into the trigger instead of leaving both, so the only function
+	// left is the standalone one the schema declared.
+	c.Assert(got.Functions, qt.HasLen, 1)
+	c.Assert(got.Functions[0].Name, qt.Equals, "public.get_current_tenant")
+	c.Assert(got.Triggers[0].Body, qt.Equals, "NEW.updated_at = now(); RETURN NEW;")
+	c.Assert(got.Triggers[0].ExecuteFunction, qt.Equals, "")
+}

--- a/internal/sqllint/lint_test.go
+++ b/internal/sqllint/lint_test.go
@@ -84,9 +84,12 @@ func TestLintSource_UnsupportedStatementLocationSkipsLeadingComments(t *testing.
 func TestLintSource_UnsupportedParserErrorIsExplicit(t *testing.T) {
 	c := qt.New(t)
 
+	// CREATE POLICY stood here while the parser refused it; it parses now
+	// (issue #932), so the unsupported-statement path needs a statement the
+	// grammar still has no rule for.
 	findings, err := LintSource(Source{
-		Name: "policy.sql",
-		SQL:  "CREATE POLICY p ON users USING (true);",
+		Name: "publication.sql",
+		SQL:  "CREATE PUBLICATION p FOR ALL TABLES;",
 	}, Options{Dialect: platform.Postgres})
 
 	c.Assert(err, qt.IsNil)
@@ -94,6 +97,18 @@ func TestLintSource_UnsupportedParserErrorIsExplicit(t *testing.T) {
 	c.Assert(findings[0].Rule, qt.Equals, RuleUnsupportedStatement)
 	c.Assert(findings[0].Severity, qt.Equals, SeverityError)
 	c.Assert(findings[0].Title, qt.Equals, "Unsupported SQL statement")
+}
+
+func TestLintSource_CreatePolicyIsSupported(t *testing.T) {
+	c := qt.New(t)
+
+	findings, err := LintSource(Source{
+		Name: "policy.sql",
+		SQL:  "CREATE POLICY p ON users USING (true);",
+	}, Options{Dialect: platform.Postgres})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0)
 }
 
 func TestLintSource_RawSQLNodesAreExplicitUnsupportedFindings(t *testing.T) {
@@ -183,7 +198,7 @@ func TestLintSource_UnsupportedStatementDoesNotMaskLaterDDL(t *testing.T) {
 
 	findings, err := LintSource(Source{
 		Name: "mixed.sql",
-		SQL: `CREATE POLICY p ON users USING (true);
+		SQL: `CREATE PUBLICATION p FOR ALL TABLES;
 CREATE TABLE audit_log (message TEXT NOT NULL);`,
 	}, Options{Dialect: platform.Postgres})
 

--- a/migration/lint/changes_test.go
+++ b/migration/lint/changes_test.go
@@ -105,9 +105,18 @@ func TestAnalyzeFS_SchemaChangeCardinality(t *testing.T) {
 			want: []changeProjection{},
 		},
 		{
+			// GRANT used to sit here, as a statement the parser refused. It
+			// parses now (issue #932) and counts as the one change it is, so
+			// the "outside the grammar" case needs a statement that is still
+			// outside it.
 			name: "statement outside the DDL grammar is zero changes",
-			sql:  "GRANT SELECT ON users TO app;",
+			sql:  "CLUSTER users USING idx_users_id;",
 			want: []changeProjection{},
+		},
+		{
+			name: "grant is one change",
+			sql:  "GRANT SELECT ON users TO app;",
+			want: []changeProjection{{lint.SchemaChangeAdd, "users"}},
 		},
 	}
 	for _, tc := range tests {


### PR DESCRIPTION
Closes #932.

`ptah schema render --schema-file` could not read back the SQL `ptah schema render` had just written. Rendering the PostgreSQL-objects example from `docs/atlas_hcl_schema.md` produces **16** statements (the framing comment says 15; measured on `d29a44f4`, it is 16 — `CREATE ROLE` and its `COMMENT ON ROLE` share one block, as do the trigger's function and the trigger). Feeding those 16 back exited 2 at `unsupported CREATE target: SEQUENCE`, and only 2 of the 16 survived.

Two fix sites, as the framing scoped them: `internal/parser/` for the refused statement forms, `internal/convert/toschema/` for the silent drops.

---

## Completion criteria

Every command below was run in this worktree at `16b0cb67`. The "before" column is from the same fixtures run against a binary built from `d29a44f4` (`origin/master`) at the start of this work.

### C1 — the round-trip is a fixed point

```
ptah schema render --schema-file full.hcl --dialect postgres   # 16 statements
ptah schema render --schema-file r1.sql  --dialect postgres    # 16 statements
ptah schema render --schema-file r2.sql  --dialect postgres    # 16 statements
diff r2.sql r3.sql                                             # empty
```

Before: the second command exited 2, `error parsing schema file: parse SQL schema file: unsupported CREATE target: SEQUENCE at position 91`. **16 of 16 now round-trip** (framing said 2 of 15; the count is 16, and it is now 16 of 16).

Test: `go test ./internal/schemafile/ -run TestLoadAll_RenderedPostgresSQLReadsBackAsAFixedPoint -count=1`

`diff r1.sql r2.sql` is **not** empty. It differs by exactly three lines and no more:

```
3d2
< -- trigram search
27d25
< -- active users
36d33
< -- tenant isolation
```

Those are the extension, view and RLS-enable comments, which the renderer emits as bare `--` lines. A SQL line comment belongs to no object once it is read back, and inferring one would mean claiming `-- POSTGRES TABLE: public.users --` is the users table's comment. The test asserts `dropLeadingComments(second) == dropLeadingComments(first)` plus a byte-exact `render(parse(render(parse(sql)))) == render(parse(sql))`, so any object that goes missing still fails it. See "Deliberately left open".

The role comment does survive, because PostgreSQL spells it as a real `COMMENT ON ROLE` statement rather than a line comment.

### C2 — the eight rejections become exit 0 and appear in the output

`go test ./internal/schemafile/ -run TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles -count=1`

Each row is one statement after `CREATE TABLE t1 (id BIGINT PRIMARY KEY);`, rendered with `--dialect postgres`.

| Fixture | Before | Now renders |
| --- | --- | --- |
| `CREATE MATERIALIZED VIEW mv1 AS SELECT id FROM t1;` | exit 2, `unsupported CREATE target: MATERIALIZED` | `CREATE MATERIALIZED VIEW "mv1" AS` |
| `CREATE SEQUENCE s1 START WITH 1;` | exit 2, `unsupported CREATE target: SEQUENCE` | `CREATE SEQUENCE "s1" START WITH 1;` |
| `CREATE ROLE r_x;` | exit 2, `unsupported CREATE target: ROLE` | `CREATE ROLE "r_x" WITH NOLOGIN …` |
| `GRANT SELECT ON TABLE t1 TO r_x;` | exit 2, `unsupported SQL statement: GRANT` | `GRANT SELECT ON TABLE "t1" TO "r_x";` |
| `CREATE POLICY p1 ON t1 FOR SELECT USING (true);` | exit 2, `unsupported CREATE target: POLICY` | `CREATE POLICY "p1" ON "t1" FOR SELECT` |
| `ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;` | exit 2, `unsupported ALTER operation: ENABLE` | `ALTER TABLE "t1" ENABLE ROW LEVEL SECURITY;` |
| `CREATE TYPE "public"."address" AS ("street" text);` | exit 2, `expected AS after type name … got Operator` | same text back |
| `CREATE TYPE "public"."floatrange" AS RANGE (SUBTYPE = float8);` | exit 2, same error | same text back |

One correction to the framing: the two `CREATE TYPE` errors were reported `at position 20`. Measured with the `CREATE TABLE t1` anchor the framing itself prescribes, the position is 61. The error text is otherwise verbatim.

### C3 — the five silent drops render back

Same test, same command. Each of these already exited 0 before; none of them appeared in the output.

| Fixture | Now renders |
| --- | --- |
| `CREATE VIEW v1 AS SELECT id FROM t1;` | `CREATE VIEW "v1" AS` |
| `CREATE DOMAIN d1 AS TEXT;` | `CREATE DOMAIN "d1" AS TEXT;` |
| `CREATE EXTENSION IF NOT EXISTS pgcrypto;` | `CREATE EXTENSION IF NOT EXISTS "pgcrypto";` |
| `CREATE FUNCTION f1() RETURNS INT AS $$ SELECT 1 $$ LANGUAGE SQL;` | `CREATE OR REPLACE FUNCTION "f1"() RETURNS int AS $$` |
| `CREATE TRIGGER tg1 AFTER INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f1();` | `CREATE TRIGGER "tg1" AFTER INSERT ON "t1" FOR EACH ROW EXECUTE FUNCTION "f1"();` |

The trigger needed more than a conversion case. `goschema.Trigger` had nowhere to keep the name of a function it did not define, so the trigger would have been rebound to a Ptah-generated `ptah_trigger_t1_tg1()` — and the renderer would have emitted `CREATE OR REPLACE FUNCTION "f1"()` with an empty body, erasing `f1`. `goschema.Trigger.ExecuteFunction` and `ast.CreateTriggerNode.ExternalFunction` are new for that; `TestLoadAll_TriggerOnAnExistingFunctionDoesNotRedefineIt` pins it.

### C4 — qualified and unqualified `CREATE TYPE` agree

`CREATE TYPE "public"."e1" AS ENUM ('a');` was exit 2; it now renders `CREATE TYPE "public"."e1" AS ENUM ('a');`, matching the unqualified form that already worked. Subtest `…/schema_qualified_enum_type`.

### C5 — the compat divergence closes

Measured against a throwaway PostgreSQL 16 container, since torn down. `ptah-compat schema diff --from file://from.sql --to file://to.sql --dev-url <pg>`:

| Fixture | Before | Now |
| --- | --- | --- |
| all six C2 statements | exit 1, `load --to schema: parse SQL schema file: …` | **exit 0** |
| `CREATE VIEW v1 …` (the silent-drop half) | exit 0, "Schemas are synced" | exit 0, plans `CREATE VIEW "v1" AS` |
| `CREATE INDEX ix1 ON t1 (id);` — positive control | exit 0, plans the index | exit 0, plans the index |
| `DEFINITELY NOT SQL;` — negative control | exit 1 | **exit 1** |

Same fixtures against the pinned community binary at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (which reports `atlas community version v1.3.0`, not the 1.2.0 the matrix preamble names — flagging, not resolving): all six exit 0 with "Schemas are synced, no changes to be made"; the index control plans the index; `DEFINITELY NOT SQL;` exits 1 with `pq: syntax error`. Both controls behave, so the probe is sound.

**Parity rule.** Clause (a) is satisfied in the direction that matters: Ptah no longer exits 1 where the community binary exits 0, and it still exits 1 where the community binary does. The two now differ in plan content, not exit code — the community binary drops these objects, Ptah plans them. That is the ceiling, not the floor: accept-and-drop was the #1016 precedent, and reproducing it here would have meant re-introducing the silent loss this issue is about.

One measured caveat: `ALTER TABLE t1 ENABLE ROW LEVEL SECURITY` exits 0 but reports "Schemas are synced". That is **not** this change — the file-to-file diff never compares `RLSEnabledTables`. Control: the same diff with two HCL files differing only by `row_security { enabled = true }` also reports "Schemas are synced". Pre-existing, out of scope, stated below.

### C6 — the matrix stops contradicting the binary

Edited in `docs/site/scripts/data/feature-matrix-rows.json` and regenerated with `node scripts/build-feature-matrix.mjs`:

- **SQL DDL schema files** (was line 125). The difference column read "unsupported DDL fails instead of being skipped", which was false for five object kinds. It now reads what is measured, *including* what is still dropped: "Reads back every object kind Ptah renders; DO blocks, COMMENT ON and raw routine bodies still parse and are dropped." The symbol stays ✅ because it was never about these rows. I did not silently make the old sentence true by claiming universal refusal — `ast.RawSQLNode` and `ast.CommentNode` (other than `COMMENT ON ROLE`) still have no case in `appendStatement`.
- **Roles, grants, and row-level security** (line 255): "SQL files reject ROLE, GRANT, POLICY, ENABLE RLS" → "SQL files read …".
- **Standalone sequences** (line 259): "SQL schema files reject CREATE SEQUENCE as unsupported" → "SQL schema files read CREATE SEQUENCE".
- **Views and materialized views** (line 262): C6 asked this row to gain the SQL-schema-file limitation lines 255 and 259 carried. That limitation no longer exists, so the row states the fact instead: "SQL schema files read both." Flagging the deviation from the criterion as written.

Every evidence field now names the test that measures it.

---

## What each test prints if the change is reverted

Measured by mutating the tree, not by reading the code.

**Drop `case *ast.CreateViewNode:` from `appendStatement`** — three tests fail:

```
--- FAIL: TestLoadAll_PostgresObjectKindsSurviveSQLSchemaFiles/view
    no substring match found
    container: "-- POSTGRES TABLE: t1 --\nCREATE TABLE \"t1\" (…);\n\n"
    want: `CREATE VIEW "v1" AS`
--- FAIL: TestLoadAll_RenderedPostgresSQLReadsBackAsAFixedPoint
    unexpected length  len(got): 15  want length: 16
--- FAIL: TestLoadAll_RenderedPostgresSQLKeepsEveryObjectKind
    len(got): 0  got: []goschema.View{}  want length: 1
```

**Replace the renderer's `if !node.ExternalFunction` with `if true`** — the destructive output the guard exists to stop:

```
--- FAIL: TestLoadAll_TriggerOnAnExistingFunctionDoesNotRedefineIt
    unexpected success
    container: "…CREATE OR REPLACE FUNCTION \"f1\"()\nRETURNS trigger AS $$\nBEGIN\n\nEND;\n$$ LANGUAGE plpgsql;\nCREATE TRIGGER \"tg1\" …"
    want: `CREATE OR REPLACE FUNCTION "f1"()`
```

**Inverse mutant for the DISABLE guard** — not a revert: delete the `keyword != "ENABLE"` check so `DISABLE ROW LEVEL SECURITY` yields an *enable* node. The negative control catches it:

```
--- FAIL: …/disable_row_level_security_has_no_representation
    got nil error but want non-nil
    regexp: ".*unsupported ALTER operation: DISABLE ROW LEVEL SECURITY.*"
```

The negative-control test also pins `DEFINITELY NOT SQL;`, `CREATE PUBLICATION`, `ALTER TABLE … ENABLE TRIGGER` (which keeps its old `unsupported ALTER operation: ENABLE` error verbatim) and `CREATE POLICY … AS RESTRICTIVE`.

## Existing tests this changes, and why

Three tests used a now-supported statement as their example of an unsupported one. Each keeps its property and gets a fixture that is still outside the grammar; a positive counterpart was added where the new behavior deserved its own assertion.

- `internal/parser` `TestParser_ParsePostgresDialectTriggerFunctionBodyAndReference` — `EXECUTE FUNCTION public.touch_updated_at()` was asserted to be `*ast.RawSQLNode`; it is now a `*ast.CreateTriggerNode` with `ExternalFunction` set. The sibling test with `touch_updated_at('updated_at')` still asserts raw SQL: a call with arguments has nowhere to keep them.
- `internal/sqllint` `TestLintSource_UnsupportedParserErrorIsExplicit` and `…DoesNotMaskLaterDDL` — `CREATE POLICY` → `CREATE PUBLICATION`. Added `TestLintSource_CreatePolicyIsSupported`.
- `migration/lint` `TestAnalyzeFS_SchemaChangeCardinality/statement_outside_the_DDL_grammar_is_zero_changes` — `GRANT` → `CLUSTER`. Added `grant is one change`, since `migration/lint/changes.go` already had a `*ast.GrantPrivilegeNode` case waiting for a parser that would produce one. Note the behavior change: a migration file containing `GRANT` now counts as a schema change.

## Deliberately left open

- **Object comments rendered as `--` lines are not recovered.** The three-line `r1`/`r2` diff above. Recovering them needs the parser to attribute a preceding line comment to the following statement, which would make any `-- ticket 123` above a `CREATE VIEW` into that view's comment and feed it into schema comparison as drift. The safer default is to lose it; the fixed-point property holds from the second render on either way.
- **`ExecuteFunction` is not compared by `schemadiff`.** `types.DBTrigger` does not report the function a live trigger executes, so there is nothing to compare it against. Two triggers differing only in `ExecuteFunction` compare equal. Wiring it needs introspection work.
- **The compat file-to-file diff does not plan RLS enablement.** Measured above with an HCL-only control, so it is not this change. Separate issue.
- **`ast.RawSQLNode` and `ast.CommentNode` are still dropped by `ToDatabase`.** `DO` blocks, dialect routine bodies, triggers with function arguments, and every `COMMENT ON` other than `COMMENT ON ROLE`. The matrix row now says so rather than claiming they fail.
- **`ManagedData`** — out of the round-trip criterion, as the framing scoped it.
- **#927 (HCL) and #940 item 3 (directory sources)** are untouched.

## Gates

```
go build ./...                       exit 0
go vet ./...                         exit 0
go test ./... -count=1               exit 0
go tool qtlint ./...                 exit 0
golangci-lint run ./...              exit 0   (0 issues)
scripts/check-test-style.sh          exit 0   (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh          exit 0
scripts/check-public-api-snapshot.sh exit 0   (snapshot regenerated for the two added fields)
scripts/check-public-api-released.sh exit 0
```

`docs/` is touched, so all 12 `check:*` scripts in `docs/site/package.json` were run after `npm ci && npm run build`: `check:exit-codes`, `check:exit-codes:selftest`, `check:core-doc-links`, `check:page-health`, `check:links`, `check:links:selftest`, `check:redirects`, `check:redirects:selftest`, `check:style`, `check:style:selftest`, `check:responsive`, `check:responsive:selftest` — all pass. Plus `node scripts/build-feature-matrix.mjs --check`: OK (162 rows).

Exit codes were captured directly, not through a pipe. `check-public-api-snapshot.sh` was verified to actually fail before the snapshot was regenerated (exit 1, showing the two added fields), so it is not a gate that passes without running.
