### PR TITLE
Make every configuration diagnostic name the thing the user must change

### DIFF
--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -135,11 +135,16 @@ func registerAtlasProjectFlags(flags *pflag.FlagSet, target *atlasProjectFlagVal
 	if flags.Lookup(atlasConfigFlagName) == nil {
 		flags.StringVarP(&target.configPath, atlasConfigFlagName, "c", "file://"+projectconfig.AtlasFileName, "select config (project) file using URL format")
 	}
-	if flags.Lookup(dbcli.EnvFlagName) == nil {
-		dbcli.RegisterEnvFlag(flags, &target.envName)
-	}
+	// --var is registered before --env, and the order is load-bearing:
+	// dbcli.RegisterEnvFlag also registers --var (idempotently), so letting it
+	// run first would leave this surface with the native flag — unbound to
+	// target.vars and carrying the native help text where Atlas's belongs.
+	// TestCompatVarFlagKeepsAtlasUsage fails if this order is swapped.
 	if flags.Lookup(atlasVarFlagName) == nil {
 		flags.StringArrayVar(&target.vars, atlasVarFlagName, nil, "input variables")
+	}
+	if flags.Lookup(dbcli.EnvFlagName) == nil {
+		dbcli.RegisterEnvFlag(flags, &target.envName)
 	}
 }
 

--- a/cmd/atlas/project_var_usage_test.go
+++ b/cmd/atlas/project_var_usage_test.go
@@ -1,0 +1,50 @@
+package atlas_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// TestCompatVarFlagKeepsAtlasUsage pins the Atlas-compatible spelling of --var
+// on the command groups that carry it.
+//
+// The native --env registration also registers --var, idempotently, so
+// whichever surface registers first owns the flag's help text. This surface
+// must own it: its --help is compared against Atlas's, and "Value for an
+// atlas.hcl variable with no default…" is not what Atlas prints. Without this
+// test, swapping the two registrations in registerAtlasProjectFlags is a
+// silent change to published help.
+func TestCompatVarFlagKeepsAtlasUsage(t *testing.T) {
+	c := qt.New(t)
+
+	root := atlas.NewCompatCommand("ptah-compat")
+	for _, group := range []string{"schema", "migrate"} {
+		cmd := childCommand(c, root, group)
+		flag := cmd.PersistentFlags().Lookup("var")
+		c.Assert(flag, qt.IsNotNil, qt.Commentf("%s must carry --var", group))
+		// A prefix, not equality: the env-binding pass appends
+		// " [env: PTAH_VAR]" to every registered flag's help text, and that
+		// suffix is not what this test is about.
+		c.Assert(strings.HasPrefix(flag.Usage, "input variables"), qt.IsTrue, qt.Commentf(
+			"%s --var help is %q, not Atlas's wording", group, flag.Usage,
+		))
+		c.Assert(flag.Usage, qt.Not(qt.Contains), "atlas.hcl variable with no default")
+		c.Assert(flag.Value.Type(), qt.Equals, "stringArray")
+		c.Assert(flag.Hidden, qt.IsFalse)
+	}
+}
+
+func childCommand(c *qt.C, parent *cobra.Command, name string) *cobra.Command {
+	for _, child := range parent.Commands() {
+		if child.Name() == name {
+			return child
+		}
+	}
+	c.Fatalf("command %q not found", name)
+	return nil
+}

--- a/cmd/compare/compare.go
+++ b/cmd/compare/compare.go
@@ -72,7 +72,7 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.BoolVar(&opts.exitOnDiff, exitCodeFlag, false, "Exit with 1 when the schema diff is non-empty")
 	flags.BoolVar(&opts.plainHTTP, plainHTTPFlag, false, "Use plain HTTP for OCI registry access")
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
-	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	dbcli.RegisterProjectEnvFlag(flags)
 	dbcli.RegisterExternalSchemaOptInFlag(flags)
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)

--- a/cmd/drift/drift.go
+++ b/cmd/drift/drift.go
@@ -90,7 +90,7 @@ func NewDriftCommand() *cobra.Command {
 		"Maximum time to wait when establishing the initial database connection (for example 5s or 1m). Use 0 to disable the timeout.",
 	)
 	cmd.Flags().StringVar(&configPath, dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
-	cmd.Flags().String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	dbcli.RegisterProjectEnvFlag(cmd.Flags())
 	cmd.Flags().BoolVar(&plainHTTP, "plain-http", false, "Use plain HTTP for OCI registry access")
 	dbcli.RegisterExternalSchemaOptInFlag(cmd.Flags())
 

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -17,6 +17,13 @@ import (
 const (
 	// EnvFlagName selects an env block from project config.
 	EnvFlagName = "env"
+	// ProjectVarFlagName supplies a value for an atlas.hcl variable block that
+	// declares no default. It is the flag the evaluator's diagnostic names, so
+	// it is registered wherever EnvFlagName is: an atlas.hcl reached through
+	// --env can require a variable on any of those commands, and a command
+	// that can print the advice but cannot honor it is the defect this flag
+	// exists to close.
+	ProjectVarFlagName = "var"
 	// AllowExternalSchemaFlagName explicitly permits executing the
 	// external_schema program loaded from ptah.yaml or from an atlas.hcl
 	// data.external_schema source.
@@ -29,6 +36,16 @@ const (
 	AtlasProjectVarFlagName = "atlas-project-var"
 	schemaCommandFlagName   = "schema-cmd"
 )
+
+// ProjectConfigEnvAnnotation marks the --env flag that selects a ptah.yaml or
+// atlas.hcl env block. The flag name alone does not identify it: `ptah seed`
+// registers an unrelated --env naming the seed environment to apply, reads no
+// project config, and must not grow a --var it would never honor. The
+// annotation is what lets a test tell the two apart from the assembled command
+// tree instead of from a hand-kept list of packages.
+const ProjectConfigEnvAnnotation = "ptah_project_config_env"
+
+const projectEnvFlagUsage = "Project env name to read from ptah.yaml or atlas.hcl"
 
 type projectConfigContextKey struct{}
 
@@ -47,9 +64,47 @@ func WithProjectConfig(ctx context.Context, config projectconfig.Config) context
 	})
 }
 
-// RegisterEnvFlag registers the shared project env selection flag.
+// RegisterEnvFlag registers the shared project env selection flag, bound to
+// target, together with the variable-override flag its evaluator advises. The
+// two are registered by one call because every command that can select an env
+// can also hit an atlas.hcl variable with no default, and registering them
+// separately is how eleven of the fourteen commands came to advise a flag they
+// rejected.
 func RegisterEnvFlag(flags *pflag.FlagSet, target *string) {
-	flags.StringVar(target, EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	flags.StringVar(target, EnvFlagName, "", projectEnvFlagUsage)
+	markProjectEnvFlag(flags)
+}
+
+// RegisterProjectEnvFlag registers the same pair as [RegisterEnvFlag] without
+// binding --env to a variable, for commands that read the value back off the
+// flag set. It exists so no command has to spell EnvFlagName inline: five did,
+// which is why a search for the helper found nine of the fourteen commands
+// that can reach the variable diagnostic.
+func RegisterProjectEnvFlag(flags *pflag.FlagSet) {
+	flags.String(EnvFlagName, "", projectEnvFlagUsage)
+	markProjectEnvFlag(flags)
+}
+
+func markProjectEnvFlag(flags *pflag.FlagSet) {
+	RegisterProjectVarFlag(flags)
+	if err := flags.SetAnnotation(EnvFlagName, ProjectConfigEnvAnnotation, []string{"true"}); err != nil {
+		panic(err)
+	}
+}
+
+// RegisterProjectVarFlag registers the atlas.hcl variable override flag. It is
+// idempotent so a command that already carries the flag — from
+// [RegisterEnvFlag] or from an Atlas-compatible surface that spells it the
+// same way — keeps the binding it already has.
+func RegisterProjectVarFlag(flags *pflag.FlagSet) {
+	if flags.Lookup(ProjectVarFlagName) != nil {
+		return
+	}
+	flags.StringArray(
+		ProjectVarFlagName,
+		nil,
+		"Value for an atlas.hcl variable with no default, as name=value (repeatable)",
+	)
 }
 
 // RegisterExternalSchemaOptInFlag registers the safety gate for executing an
@@ -98,7 +153,7 @@ func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig
 	if err != nil {
 		return projectconfig.Config{}, err
 	}
-	atlasVars, err := stringArrayFlag(cmd, AtlasProjectVarFlagName)
+	atlasVars, err := projectVars(cmd)
 	if err != nil {
 		return projectconfig.Config{}, err
 	}
@@ -108,6 +163,26 @@ func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig
 		EnvName:   envName,
 		AtlasVars: atlasVars,
 	})
+}
+
+// projectVars resolves the atlas.hcl variable overrides for a command. The
+// public --var wins when the user passed it; otherwise the hidden adapter-only
+// flag supplies whatever a forwarding command already routed. The two are not
+// concatenated: a repeated --var for one name is how a list(string) variable
+// is built, so merging both sources would turn a scalar override into a
+// two-element list.
+func projectVars(cmd *cobra.Command) ([]string, error) {
+	if flagChanged(cmd, ProjectVarFlagName) {
+		return cmd.Flags().GetStringArray(ProjectVarFlagName)
+	}
+	adapterVars, err := stringArrayFlag(cmd, AtlasProjectVarFlagName)
+	if err != nil {
+		return nil, err
+	}
+	if len(adapterVars) > 0 {
+		return adapterVars, nil
+	}
+	return stringArrayFlag(cmd, ProjectVarFlagName)
 }
 
 func projectConfigFromContext(ctx context.Context) (projectconfig.Config, bool) {

--- a/cmd/internal/dbcli/project_var_test.go
+++ b/cmd/internal/dbcli/project_var_test.go
@@ -1,0 +1,150 @@
+package dbcli_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/cmd/internal/dbcli"
+)
+
+// atlasHCLRequiringVar is a project config whose env cannot be evaluated
+// without a value for the variable, which is what makes the evaluator print
+// its "requires a default or --var name=value" advice.
+const atlasHCLRequiringVar = `variable "dburl" {}
+
+env "local" {
+  url = var.dburl
+}
+`
+
+func chdirTemp(c *qt.C, files map[string]string) string {
+	dir := c.TempDir()
+	for name, content := range files {
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	original, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	c.Cleanup(func() {
+		c.Assert(os.Chdir(original), qt.IsNil)
+	})
+	return dir
+}
+
+func envVarCommand(c *qt.C) *cobra.Command {
+	cmd := &cobra.Command{Use: "test"}
+	var envName string
+	dbcli.RegisterEnvFlag(cmd.Flags(), &envName)
+	return cmd
+}
+
+// TestLoadProjectConfigHonorsPublicVarFlag is the positive half of the item-2
+// fix: the flag the diagnostic names actually supplies the value.
+func TestLoadProjectConfigHonorsPublicVarFlag(t *testing.T) {
+	c := qt.New(t)
+	chdirTemp(c, map[string]string{"atlas.hcl": atlasHCLRequiringVar})
+
+	cmd := envVarCommand(c)
+	c.Assert(cmd.Flags().Set(dbcli.EnvFlagName, "local"), qt.IsNil)
+	c.Assert(cmd.Flags().Set(dbcli.ProjectVarFlagName, "dburl=sqlite://file.db"), qt.IsNil)
+
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://file.db")
+}
+
+// TestLoadProjectConfigWithoutVarAdvisesTheFlagItAccepts is the negative half:
+// the advice still fires when nothing was passed, and the flag it names is one
+// the command registers.
+func TestLoadProjectConfigWithoutVarAdvisesTheFlagItAccepts(t *testing.T) {
+	c := qt.New(t)
+	chdirTemp(c, map[string]string{"atlas.hcl": atlasHCLRequiringVar})
+
+	cmd := envVarCommand(c)
+	c.Assert(cmd.Flags().Set(dbcli.EnvFlagName, "local"), qt.IsNil)
+
+	_, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.ErrorMatches, `atlas\.hcl variable "dburl" requires a default or --var dburl=value`)
+	c.Assert(cmd.Flags().Lookup(dbcli.ProjectVarFlagName), qt.IsNotNil)
+}
+
+// TestLoadProjectConfigPublicVarWinsOverAdapterVar pins the precedence rule.
+// The two sources are not concatenated: a repeated --var for one name builds a
+// list(string), so merging them would turn a scalar override into a list.
+func TestLoadProjectConfigPublicVarWinsOverAdapterVar(t *testing.T) {
+	c := qt.New(t)
+	chdirTemp(c, map[string]string{"atlas.hcl": atlasHCLRequiringVar})
+
+	cmd := envVarCommand(c)
+	dbcli.RegisterAtlasProjectInternalFlags(cmd.Flags())
+	c.Assert(cmd.Flags().Set(dbcli.EnvFlagName, "local"), qt.IsNil)
+	c.Assert(cmd.Flags().Set(dbcli.AtlasProjectVarFlagName, "dburl=sqlite://adapter.db"), qt.IsNil)
+	c.Assert(cmd.Flags().Set(dbcli.ProjectVarFlagName, "dburl=sqlite://public.db"), qt.IsNil)
+
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://public.db")
+}
+
+// TestLoadProjectConfigStillHonorsAdapterVar is the non-interference control
+// for the precedence rule above: the hidden forwarding flag keeps working when
+// the public one is absent.
+func TestLoadProjectConfigStillHonorsAdapterVar(t *testing.T) {
+	c := qt.New(t)
+	chdirTemp(c, map[string]string{"atlas.hcl": atlasHCLRequiringVar})
+
+	cmd := envVarCommand(c)
+	dbcli.RegisterAtlasProjectInternalFlags(cmd.Flags())
+	c.Assert(cmd.Flags().Set(dbcli.EnvFlagName, "local"), qt.IsNil)
+	c.Assert(cmd.Flags().Set(dbcli.AtlasProjectVarFlagName, "dburl=sqlite://adapter.db"), qt.IsNil)
+
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://adapter.db")
+}
+
+// TestRegisterEnvFlagAnnotatesTheProjectEnvFlag pins the marker that lets the
+// command-tree gate tell a project env from `ptah seed --env`.
+func TestRegisterEnvFlagAnnotatesTheProjectEnvFlag(t *testing.T) {
+	c := qt.New(t)
+
+	bound := envVarCommand(c)
+	c.Assert(
+		bound.Flags().Lookup(dbcli.EnvFlagName).Annotations[dbcli.ProjectConfigEnvAnnotation],
+		qt.DeepEquals,
+		[]string{"true"},
+	)
+
+	unbound := &cobra.Command{Use: "test"}
+	dbcli.RegisterProjectEnvFlag(unbound.Flags())
+	c.Assert(
+		unbound.Flags().Lookup(dbcli.EnvFlagName).Annotations[dbcli.ProjectConfigEnvAnnotation],
+		qt.DeepEquals,
+		[]string{"true"},
+	)
+	c.Assert(unbound.Flags().Lookup(dbcli.ProjectVarFlagName), qt.IsNotNil)
+}
+
+// TestExplicitConfigOverHCLNamesTheConfigFlag holds the ptah.yaml diagnostic's
+// spelling of the flag to the flag this package actually registers. The
+// projectconfig package cannot import this one, so it spells "config" itself;
+// this is what stops the two from drifting apart.
+func TestExplicitConfigOverHCLNamesTheConfigFlag(t *testing.T) {
+	c := qt.New(t)
+	chdirTemp(c, map[string]string{"atlas.hcl": atlasHCLRequiringVar})
+
+	cmd := envVarCommand(c)
+	_, err := dbcli.LoadProjectConfig(cmd, "atlas.hcl")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "--"+dbcli.ConfigFlagName)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
+}

--- a/cmd/internal/schemaload/env_reference_test.go
+++ b/cmd/internal/schemaload/env_reference_test.go
@@ -1,0 +1,90 @@
+package schemaload_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/schemaload"
+)
+
+// An env:// --schema-file used to be handed to filepath.Abs, so it failed on
+// its empty extension: the message named neither env:// nor the attribute, and
+// a valid attribute and a misspelled one produced byte-identical output. These
+// tests hold each half of that split.
+
+func TestLoad_EnvReferenceWithSupportedAttributeNamesEnvScheme(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{"env://src"}})
+
+	c.Assert(err, qt.ErrorMatches, `--schema-file "env://src": env:// references are not resolved by ptah; pass the schema file itself, or use ptah-compat, whose --to and --from accept env://src`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), `unsupported schema file extension`)
+}
+
+func TestLoad_EnvReferenceWithUnknownAttributeNamesTheAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{"env://bogus"}})
+
+	c.Assert(err, qt.ErrorMatches, `--schema-file "env://bogus": unsupported env:// attribute "bogus": supported attributes are src, schema.src, url, dev, migration, and migration.dir`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), `unsupported schema file extension`)
+}
+
+// TestLoad_EnvReferencesDifferByAttributeValidity is the point of the split:
+// the two messages must not be interchangeable, because the actions they call
+// for are different.
+func TestLoad_EnvReferencesDifferByAttributeValidity(t *testing.T) {
+	c := qt.New(t)
+
+	_, supported := schemaload.Load(schemaload.Options{SchemaFiles: []string{"env://src"}})
+	_, unknown := schemaload.Load(schemaload.Options{SchemaFiles: []string{"env://bogus"}})
+
+	c.Assert(supported, qt.IsNotNil)
+	c.Assert(unknown, qt.IsNotNil)
+	c.Assert(supported.Error(), qt.Not(qt.Equals), unknown.Error())
+	// Differing only by the attribute echoed back would satisfy the line above
+	// while still telling a user with a typo to go and use another binary, so
+	// each message is also held to the phrase the other must not carry.
+	c.Assert(supported.Error(), qt.Not(qt.Contains), "unsupported env:// attribute")
+	c.Assert(unknown.Error(), qt.Not(qt.Contains), "are not resolved by ptah")
+}
+
+func TestLoad_EnvReferenceWithoutAttributeIsNamed(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{"env://"}})
+
+	c.Assert(err, qt.ErrorMatches, `--schema-file "env://": env:// desired-state reference is missing the env attribute \(for example env://src\)`)
+}
+
+// TestLoad_UnsupportedExtensionSurvivesEnvRejection is the negative control:
+// the extension error must still fire for a real extension problem. Without
+// it, deleting the extension check entirely would pass the tests above.
+func TestLoad_UnsupportedExtensionSurvivesEnvRejection(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.txt")
+	c.Assert(os.WriteFile(path, []byte("CREATE TABLE t (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+	_, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+
+	c.Assert(err, qt.ErrorMatches, `unsupported schema file extension "\.txt": only \.yaml, \.yml, \.hcl, and \.sql are supported`)
+}
+
+// TestLoad_PlainFileNamedLikeEnvIsStillAFile is the other negative control: the
+// rejection keys on the env:// scheme, not on the substring "env", so an
+// ordinary file whose name contains it still loads.
+func TestLoad_PlainFileNamedLikeEnvIsStillAFile(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "env-src.sql")
+	c.Assert(os.WriteFile(path, []byte("CREATE TABLE t (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.Tables, qt.HasLen, 1)
+}

--- a/cmd/internal/schemaload/schemaload.go
+++ b/cmd/internal/schemaload/schemaload.go
@@ -16,6 +16,7 @@ import (
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/schemasource"
+	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/ociartifact"
 	"go.5x5.cz/ptah/internal/schemaartifact"
 	"go.5x5.cz/ptah/internal/schemafile"
@@ -245,6 +246,9 @@ func (o Options) loadSchemaFile(ctx context.Context, schemaFile string) (*gosche
 	if strings.HasPrefix(schemaFile, ociartifact.Scheme) {
 		return o.loadOCI(ctx, schemaFile)
 	}
+	if err := rejectEnvReference(schemaFile); err != nil {
+		return nil, err
+	}
 	absPath, err := filepath.Abs(schemaFile)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving schema file: %w", err)
@@ -266,6 +270,46 @@ func (o Options) loadSchemaFile(ctx context.Context, schemaFile string) (*gosche
 		return nil, fmt.Errorf("error parsing schema file: %w", err)
 	}
 	return result, nil
+}
+
+// envScheme is the desired-state reference scheme that reads an attribute out
+// of the selected atlas.hcl env.
+const envScheme = "env://"
+
+// rejectEnvReference refuses an env:// --schema-file value with a diagnostic
+// that names env://.
+//
+// The native binary resolves no env:// reference: it has no route from the
+// selected atlas.hcl env to a desired-state source, so a value that reached
+// [filepath.Abs] was treated as a relative path and failed on its (empty)
+// extension. That message named neither env:// nor the attribute, and was
+// byte-identical for a valid attribute and a misspelled one.
+//
+// The two cases are separated here because they need different actions: a
+// misspelled attribute is fixed by spelling it correctly, while a correctly
+// spelled one is fixed by naming the file or by switching binaries. The
+// attribute vocabulary comes from atlassource so the two surfaces cannot
+// advertise different lists.
+func rejectEnvReference(schemaFile string) error {
+	trimmed := strings.TrimSpace(schemaFile)
+	if !strings.HasPrefix(strings.ToLower(trimmed), envScheme) {
+		return nil
+	}
+	source, err := atlassource.Classify(trimmed)
+	if err != nil {
+		return fmt.Errorf("--schema-file %q: %w", schemaFile, err)
+	}
+	if err := atlassource.ValidateEnvAttr(source.EnvAttr); err != nil {
+		return fmt.Errorf("--schema-file %q: %w", schemaFile, err)
+	}
+	return fmt.Errorf(
+		"--schema-file %q: %s references are not resolved by ptah; pass the schema file itself, "+
+			"or use ptah-compat, whose --to and --from accept %s%s",
+		schemaFile,
+		envScheme,
+		envScheme,
+		source.EnvAttr,
+	)
 }
 
 func (o Options) loadOCI(ctx context.Context, raw string) (*goschema.Database, error) {

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -99,7 +99,7 @@ Rules can be disabled per code or family via --disable or .ptah-lint.yaml.`,
 	cmd.Flags().StringVar(&format, "format", formatText, "Output format: text, json, github-actions, sarif")
 	cmd.Flags().StringVar(&configPath, "config", "", "Path to a lint config file (default: <dir>/"+migrationlint.ConfigFileName+" when present)")
 	cmd.Flags().StringVar(&atlasEnv, "atlas-env", "", "Value exposed as .Env when rendering Atlas SQL template migrations")
-	cmd.Flags().StringVar(&envName, dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	dbcli.RegisterEnvFlag(cmd.Flags(), &envName)
 	dbcli.RegisterAtlasProjectInternalFlags(cmd.Flags())
 	cmd.Flags().StringVar(&devURL, "dev-url", "", "Dev database URL used to clean and replay migrations and infer the lint dialect")
 	cmd.Flags().StringVar(&gitBase, gitBaseFlag, "", "Run analysis against the base Git branch")

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -76,7 +76,7 @@ repository alone.`,
 	flags.String(generateReportFormatFlag, "", `Safety report format next to the migration files: "", html, or json`)
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
 	flags.String(dbcli.ConnectTimeoutFlagName, dbcli.DefaultConnectTimeout.String(), "Initial database connection timeout")
-	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	dbcli.RegisterProjectEnvFlag(flags)
 	flags.String(dbcli.SchemasFlagName, "", "Comma-separated schemas to introspect when supported")
 	dbcli.RegisterExternalSchemaOptInFlag(flags)
 

--- a/cmd/migrate/migrate.go
+++ b/cmd/migrate/migrate.go
@@ -85,7 +85,7 @@ func registerFlags(cmd *cobra.Command, opts *options) {
 	flags.BoolVar(&opts.attach, attachFlag, false, "Attach the migration plan to the exact OCI schema artifact digest")
 	flags.BoolVar(&opts.plainHTTP, plainHTTPFlag, false, "Allow an unencrypted HTTP connection to a local OCI registry")
 	flags.String(dbcli.ConfigFlagName, "", "Path to a ptah.yaml config file (default: ./ptah.yaml when present)")
-	flags.String(dbcli.EnvFlagName, "", "Project env name to read from ptah.yaml or atlas.hcl")
+	dbcli.RegisterProjectEnvFlag(flags)
 	dbcli.RegisterExternalSchemaOptInFlag(flags)
 	dbcli.RegisterConnectTimeoutFlag(flags, &opts.connectTimeout)
 	dbcli.RegisterSchemasFlag(flags, &opts.schemas)

--- a/cmd/root/project_var_flag_test.go
+++ b/cmd/root/project_var_flag_test.go
@@ -1,0 +1,126 @@
+package root_test
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/cmd/internal/dbcli"
+	"go.5x5.cz/ptah/cmd/root"
+)
+
+// projectEnvCommandPaths lists every native command that selects a project env
+// and can therefore reach the atlas.hcl evaluator's
+// `requires a default or --var name=value` diagnostic.
+//
+// The set is pinned rather than merely counted because the defect this test
+// guards was per-command: eleven of the fourteen printed advice naming a flag
+// they rejected, so a test exercising only the command in the bug report would
+// have passed with thirteen still broken. A new entry here is a new command
+// that must also answer --var.
+var projectEnvCommandPaths = []string{
+	"ptah migrations down",
+	"ptah migrations generate",
+	"ptah migrations lint",
+	"ptah migrations plan",
+	"ptah migrations set",
+	"ptah migrations status",
+	"ptah migrations up",
+	"ptah schema apply",
+	"ptah schema compare",
+	"ptah schema diff",
+	"ptah schema drift",
+	"ptah schema inspect",
+	"ptah schema plan",
+	"ptah schema render",
+}
+
+// TestEveryProjectEnvCommandAcceptsVar holds every project-env command to the
+// rule that it also accepts the flag its own diagnostic advises.
+func TestEveryProjectEnvCommandAcceptsVar(t *testing.T) {
+	c := qt.New(t)
+
+	found := projectEnvCommands(root.NewRootCommand())
+	paths := make([]string, 0, len(found))
+	for path := range found {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	// Reported before the per-command assertions so an added or removed
+	// command is named rather than hidden behind a count.
+	c.Assert(paths, qt.DeepEquals, projectEnvCommandPaths)
+
+	for _, path := range paths {
+		cmd := found[path]
+		flag := cmd.Flags().Lookup(dbcli.ProjectVarFlagName)
+		c.Assert(flag, qt.IsNotNil, qt.Commentf(
+			"%s selects a project env but does not register --%s", path, dbcli.ProjectVarFlagName,
+		))
+		c.Assert(flag.Hidden, qt.IsFalse, qt.Commentf(
+			"%s hides --%s, so --help does not list the flag the diagnostic advises", path, dbcli.ProjectVarFlagName,
+		))
+		c.Assert(flag.Value.Type(), qt.Equals, "stringArray", qt.Commentf(
+			"%s must accept a repeatable --%s", path, dbcli.ProjectVarFlagName,
+		))
+	}
+}
+
+// TestSeedEnvIsNotAProjectEnv is the negative control for the rule above.
+// `ptah seed --env` names the seed environment to apply, reads no project
+// config, and can never print the variable diagnostic — so it must stay out of
+// the annotated set and must not grow a --var it would ignore. Without this the
+// rule could be satisfied by annotating every flag spelled --env.
+func TestSeedEnvIsNotAProjectEnv(t *testing.T) {
+	c := qt.New(t)
+
+	seed := findCommand(root.NewRootCommand(), "ptah seed")
+	c.Assert(seed, qt.IsNotNil)
+
+	envFlag := seed.Flags().Lookup(dbcli.EnvFlagName)
+	c.Assert(envFlag, qt.IsNotNil)
+	c.Assert(envFlag.Annotations[dbcli.ProjectConfigEnvAnnotation], qt.IsNil)
+	c.Assert(seed.Flags().Lookup(dbcli.ProjectVarFlagName), qt.IsNil)
+}
+
+// projectEnvCommands maps the full path of every command whose --env selects a
+// project env to the command itself.
+func projectEnvCommands(rootCmd *cobra.Command) map[string]*cobra.Command {
+	found := make(map[string]*cobra.Command)
+	walkCommands(rootCmd, func(cmd *cobra.Command) {
+		flag := cmd.Flags().Lookup(dbcli.EnvFlagName)
+		if flag == nil || flag.Annotations[dbcli.ProjectConfigEnvAnnotation] == nil {
+			return
+		}
+		found[commandPath(cmd)] = cmd
+	})
+	return found
+}
+
+func findCommand(rootCmd *cobra.Command, path string) *cobra.Command {
+	var match *cobra.Command
+	walkCommands(rootCmd, func(cmd *cobra.Command) {
+		if commandPath(cmd) == path {
+			match = cmd
+		}
+	})
+	return match
+}
+
+func walkCommands(cmd *cobra.Command, visit func(*cobra.Command)) {
+	visit(cmd)
+	for _, child := range cmd.Commands() {
+		walkCommands(child, visit)
+	}
+}
+
+func commandPath(cmd *cobra.Command) string {
+	var parts []string
+	for current := cmd; current != nil; current = current.Parent() {
+		parts = append([]string{strings.Fields(current.Use)[0]}, parts...)
+	}
+	return strings.Join(parts, " ")
+}

--- a/config/projectconfig/load.go
+++ b/config/projectconfig/load.go
@@ -22,7 +22,12 @@ func Load(opts LoadOptions) (Config, error) {
 		atlasPath = AtlasFileName
 	}
 
-	ptah, err := loadPtahFile(ptahPath, opts.EnvName, opts.PtahPath != "")
+	ptahSource := discoveredPtahConfig
+	if opts.PtahPath != "" {
+		ptahSource = explicitPtahConfig
+	}
+
+	ptah, err := loadPtahFile(ptahPath, opts.EnvName, ptahSource)
 	if err != nil {
 		return Config{}, err
 	}

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -95,23 +95,30 @@ type yamlMigrateGenerateConfig struct {
 // LoadPtahFile loads Ptah's project config file. A missing file returns an
 // empty config.
 func LoadPtahFile(path, envName string) (Config, error) {
-	return loadPtahFile(path, envName, false)
+	return loadPtahFile(path, envName, discoveredPtahConfig)
 }
 
-func loadPtahFile(path, envName string, required bool) (Config, error) {
+// loadPtahFile reads the config file at path. source carries how the path was
+// chosen: an explicit --config path must exist, and is the only case in which a
+// diagnostic may blame that flag; a discovered ./ptah.yaml is optional.
+func loadPtahFile(path, envName string, source ptahConfigSource) (Config, error) {
 	raw, err := os.ReadFile(path)
 	switch {
-	case errors.Is(err, fs.ErrNotExist) && !required:
+	case errors.Is(err, fs.ErrNotExist) && source == discoveredPtahConfig:
 		return Config{}, nil
 	case err != nil:
 		return Config{}, fmt.Errorf("failed to read ptah config %s: %w", path, err)
 	}
 
-	return ParsePtah(raw, path, envName)
+	return parsePtah(raw, path, envName, source)
 }
 
 // ParsePtah parses Ptah's strict YAML project config.
 func ParsePtah(data []byte, filename, envName string) (Config, error) {
+	return parsePtah(data, filename, envName, discoveredPtahConfig)
+}
+
+func parsePtah(data []byte, filename, envName string, source ptahConfigSource) (Config, error) {
 	if filename == "" {
 		filename = PtahFileName
 	}
@@ -119,7 +126,7 @@ func ParsePtah(data []byte, filename, envName string) (Config, error) {
 	decoder := yaml.NewDecoder(bytes.NewReader(data))
 	decoder.KnownFields(true)
 	if err := decoder.Decode(&doc); err != nil {
-		return Config{}, fmt.Errorf("failed to parse ptah config %s: %w", filename, err)
+		return Config{}, translatePtahYAMLError(err, filename, source)
 	}
 	cfg, err := selectPtahEnv(doc, envName)
 	if err != nil {

--- a/config/projectconfig/yaml_test.go
+++ b/config/projectconfig/yaml_test.go
@@ -93,7 +93,11 @@ func TestParsePtahProjectConfigRejectsUnknownKeys(t *testing.T) {
 urll: postgres://typo/db
 `), "ptah.yaml", "")
 
-	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: yaml: unmarshal errors:\n  line 2: field urll not found in type projectconfig\.yamlDocument`)
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 2: unknown ptah\.yaml key "urll"; supported keys are url, dev, schemas, exclude, migration, lint, migrate, online_ddl, diff, external_schema, env`)
+	// The decoder reports rejected keys against the Go type it decodes into.
+	// That name is not a thing the user can look up or act on, so no
+	// diagnostic may carry it.
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
 }
 
 func TestParsePtahProjectConfigRejectsUnknownOnlineDDLKeys(t *testing.T) {
@@ -102,14 +106,16 @@ func TestParsePtahProjectConfigRejectsUnknownOnlineDDLKeys(t *testing.T) {
 	_, err := projectconfig.ParsePtah([]byte(`online_ddl:
   threshhold_rows: 100
 `), "ptah.yaml", "")
-	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field threshhold_rows not found.*`)
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 2: unknown ptah\.yaml key "threshhold_rows" under online_ddl; supported keys are tool, threshold_rows, args, fallback`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
 
 	_, err = projectconfig.ParsePtah([]byte(`env:
   prod:
     online_ddl:
       tooll: ghost
 `), "ptah.yaml", "prod")
-	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field tooll not found.*`)
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 4: unknown ptah\.yaml key "tooll" under online_ddl; supported keys are tool, threshold_rows, args, fallback`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
 }
 
 func TestParsePtahProjectConfigRejectsUnknownMigrationPreflightKeys(t *testing.T) {
@@ -119,7 +125,8 @@ func TestParsePtahProjectConfigRejectsUnknownMigrationPreflightKeys(t *testing.T
   pg_dumpto: ./backups
 `), "ptah.yaml", "")
 
-	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: .*field pg_dumpto not found.*`)
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 2: unknown ptah\.yaml key "pg_dumpto" under migration; supported keys are dir, format, revisions_schema, revisions_table, revision_format, lock_timeout, statement_timeout, connect_timeout, migration_lock_timeout, exec_order, tx_mode, pre_up_hook, pre_down_hook, pg_dump_to, mysqldump_to, webhook`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
 }
 
 func TestParsePtahProjectConfigAllowsOnlineDDLSection(t *testing.T) {

--- a/config/projectconfig/yamlerror.go
+++ b/config/projectconfig/yamlerror.go
@@ -1,0 +1,258 @@
+package projectconfig
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// ptahConfigFlagName is the CLI flag that selects an explicit ptah.yaml path.
+// It is spelled here rather than imported because cmd/internal/dbcli, which
+// registers it, depends on this package. TestPtahConfigFlagNameMatchesCLI in
+// cmd/internal/dbcli holds the two spellings together.
+const ptahConfigFlagName = "config"
+
+// The go-yaml strict decoder reports rejected input against the Go type it was
+// decoding into: `field src not found in type projectconfig.yamlDocument`. That
+// names a symbol the user cannot act on and cannot even find, so every decoder
+// error is translated here into the ptah.yaml vocabulary before it reaches
+// stderr. The translation is derived from the struct tags by reflection rather
+// than from a hand-written table, so adding a ptah.yaml key updates the
+// "supported keys are ..." list without a second edit.
+
+var (
+	// yamlFieldNotFoundPattern matches go-yaml's strict-mode unknown-key error.
+	yamlFieldNotFoundPattern = regexp.MustCompile(`^line (\d+): field (\S+) not found in type (\S+)$`)
+	// yamlCannotUnmarshalPattern matches go-yaml's type-mismatch error. The
+	// middle group is the optional excerpt of the offending scalar.
+	yamlCannotUnmarshalPattern = regexp.MustCompile(`^line (\d+): cannot unmarshal (\S+)(?: .*?)? into (\S+)$`)
+	// yamlGoTypePattern is the fail-safe: any residual Go type name from this
+	// package is replaced even when no specific rule above matched, so an
+	// unanticipated decoder message cannot leak one.
+	yamlGoTypePattern = regexp.MustCompile(`projectconfig\.[A-Za-z0-9_]+`)
+)
+
+// ptahYAMLSection describes where one ptah.yaml struct type sits in the
+// document and which keys it accepts.
+type ptahYAMLSection struct {
+	// path is the dotted ptah.yaml path at which the type appears, empty for
+	// the document root.
+	path string
+	// keys are the accepted YAML keys in declaration order.
+	keys []string
+}
+
+// ptahYAMLSections maps a Go type name to its ptah.yaml position and keys.
+var ptahYAMLSections = buildPtahYAMLSections()
+
+// ptahDocumentTypeName is the Go type the whole document decodes into. A
+// type-mismatch reported against it means the file is not a YAML mapping at
+// all, which is what pointing --config at an atlas.hcl looks like.
+var ptahDocumentTypeName = reflect.TypeFor[yamlDocument]().String()
+
+func buildPtahYAMLSections() map[string]ptahYAMLSection {
+	sections := make(map[string]ptahYAMLSection)
+	visitPtahYAMLType(reflect.TypeFor[yamlDocument](), "", sections)
+	return sections
+}
+
+func visitPtahYAMLType(typ reflect.Type, path string, sections map[string]ptahYAMLSection) {
+	structType := ptahYAMLStructType(typ)
+	if structType == nil {
+		return
+	}
+	name := structType.String()
+	if _, seen := sections[name]; seen {
+		return
+	}
+	sections[name] = ptahYAMLSection{path: path, keys: ptahYAMLKeys(structType)}
+	for field := range structType.Fields() {
+		key, opts := splitYAMLTag(field.Tag.Get("yaml"))
+		if strings.Contains(opts, "inline") {
+			// An inline struct contributes its keys at the parent's level, so
+			// it shares the parent's path.
+			visitPtahYAMLType(field.Type, path, sections)
+			continue
+		}
+		if key == "" || key == "-" {
+			continue
+		}
+		visitPtahYAMLType(field.Type, joinYAMLPath(path, key), sections)
+	}
+}
+
+// ptahYAMLKeys lists the YAML keys a struct accepts, expanding inline structs
+// so the reported list matches what the strict decoder actually allows.
+func ptahYAMLKeys(structType reflect.Type) []string {
+	var keys []string
+	for field := range structType.Fields() {
+		key, opts := splitYAMLTag(field.Tag.Get("yaml"))
+		if strings.Contains(opts, "inline") {
+			if inlined := ptahYAMLStructType(field.Type); inlined != nil {
+				keys = append(keys, ptahYAMLKeys(inlined)...)
+			}
+			continue
+		}
+		if key == "" || key == "-" {
+			continue
+		}
+		keys = append(keys, key)
+	}
+	return keys
+}
+
+// ptahYAMLStructType unwraps pointers, slices, and maps down to a struct type,
+// returning nil for anything that is not one.
+func ptahYAMLStructType(typ reflect.Type) reflect.Type {
+	for typ.Kind() == reflect.Pointer || typ.Kind() == reflect.Slice || typ.Kind() == reflect.Map {
+		typ = typ.Elem()
+	}
+	if typ.Kind() != reflect.Struct {
+		return nil
+	}
+	return typ
+}
+
+func splitYAMLTag(tag string) (key, opts string) {
+	key, opts, _ = strings.Cut(tag, ",")
+	return key, opts
+}
+
+func joinYAMLPath(path, key string) string {
+	if path == "" {
+		return key
+	}
+	return path + "." + key
+}
+
+// ptahYAMLSectionLabel names a section the way the user spells it in
+// ptah.yaml.
+func ptahYAMLSectionLabel(typeName string) string {
+	section, ok := ptahYAMLSections[typeName]
+	if !ok || section.path == "" {
+		return "the " + PtahFileName + " document"
+	}
+	return "the " + PtahFileName + " " + section.path + " block"
+}
+
+// ptahConfigSource says how the config file was selected, which decides
+// whether a diagnostic can point at the --config flag.
+type ptahConfigSource int
+
+const (
+	// discoveredPtahConfig is the conventional ./ptah.yaml path.
+	discoveredPtahConfig ptahConfigSource = iota
+	// explicitPtahConfig is a path the user passed with --config.
+	explicitPtahConfig
+)
+
+// translatePtahYAMLError rewrites a go-yaml decoder error into ptah.yaml terms.
+// It never returns a message containing a Go type name from this package.
+func translatePtahYAMLError(err error, filename string, source ptahConfigSource) error {
+	lines := ptahYAMLErrorLines(err)
+
+	// A type mismatch against the document type means the file is not a YAML
+	// mapping. When the path came from --config, the actionable fact is what
+	// --config accepts, not which YAML node kind was found.
+	if found, line, ok := ptahYAMLRootMismatch(lines); ok {
+		if source == explicitPtahConfig {
+			return fmt.Errorf(
+				"--%s takes a %s file, and %s is not a YAML mapping (line %s: found %s); an Atlas project config is discovered as ./%s and selected with --env",
+				ptahConfigFlagName,
+				PtahFileName,
+				filename,
+				line,
+				found,
+				AtlasFileName,
+			)
+		}
+		return fmt.Errorf(
+			"failed to parse ptah config %s: line %s: expected a YAML mapping of %s keys, found %s",
+			filename,
+			line,
+			PtahFileName,
+			found,
+		)
+	}
+
+	translated := make([]string, 0, len(lines))
+	for _, line := range lines {
+		translated = append(translated, translatePtahYAMLLine(line))
+	}
+	if len(translated) == 1 {
+		return fmt.Errorf("failed to parse ptah config %s: %s", filename, translated[0])
+	}
+	return fmt.Errorf(
+		"failed to parse ptah config %s:\n  %s",
+		filename,
+		strings.Join(translated, "\n  "),
+	)
+}
+
+// ptahYAMLErrorLines splits a decoder error into its individual complaints.
+func ptahYAMLErrorLines(err error) []string {
+	var typeErr *yaml.TypeError
+	if errors.As(err, &typeErr) && len(typeErr.Errors) > 0 {
+		return typeErr.Errors
+	}
+	return []string{scrubPtahYAMLGoTypes(err.Error())}
+}
+
+// ptahYAMLRootMismatch reports the node kind and line of a type mismatch
+// against the document type, which is what a non-mapping file produces.
+func ptahYAMLRootMismatch(lines []string) (found, line string, ok bool) {
+	for _, raw := range lines {
+		match := yamlCannotUnmarshalPattern.FindStringSubmatch(raw)
+		if match != nil && match[3] == ptahDocumentTypeName {
+			return match[2], match[1], true
+		}
+	}
+	return "", "", false
+}
+
+func translatePtahYAMLLine(raw string) string {
+	if match := yamlFieldNotFoundPattern.FindStringSubmatch(raw); match != nil {
+		return ptahYAMLUnknownKey(match[1], match[2], match[3])
+	}
+	if match := yamlCannotUnmarshalPattern.FindStringSubmatch(raw); match != nil {
+		if _, known := ptahYAMLSections[match[3]]; known {
+			return fmt.Sprintf(
+				"line %s: cannot read %s as %s",
+				match[1],
+				match[2],
+				ptahYAMLSectionLabel(match[3]),
+			)
+		}
+	}
+	return scrubPtahYAMLGoTypes(raw)
+}
+
+func ptahYAMLUnknownKey(line, key, typeName string) string {
+	section, known := ptahYAMLSections[typeName]
+	if !known {
+		return fmt.Sprintf("line %s: unknown %s key %q", line, PtahFileName, key)
+	}
+	where := ""
+	if section.path != "" {
+		where = " under " + section.path
+	}
+	return fmt.Sprintf(
+		"line %s: unknown %s key %q%s; supported keys are %s",
+		line,
+		PtahFileName,
+		key,
+		where,
+		strings.Join(section.keys, ", "),
+	)
+}
+
+// scrubPtahYAMLGoTypes is the last line of defence for a decoder message no
+// rule above recognized: it replaces any Go type name from this package with
+// the ptah.yaml section it stands for.
+func scrubPtahYAMLGoTypes(raw string) string {
+	return yamlGoTypePattern.ReplaceAllStringFunc(raw, ptahYAMLSectionLabel)
+}

--- a/config/projectconfig/yamlerror_test.go
+++ b/config/projectconfig/yamlerror_test.go
@@ -1,0 +1,104 @@
+package projectconfig_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+// The go-yaml strict decoder reports failures against the Go type it decodes
+// into. These tests hold every ptah.yaml diagnostic to the rule that it names
+// something the user wrote, never a symbol from this package.
+
+func chdirWith(c *qt.C, files map[string]string) {
+	dir := c.TempDir()
+	for name, content := range files {
+		c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600), qt.IsNil)
+	}
+	original, err := os.Getwd()
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.Chdir(dir), qt.IsNil)
+	c.Cleanup(func() {
+		c.Assert(os.Chdir(original), qt.IsNil)
+	})
+}
+
+// TestLoadExplicitConfigOverHCLBlamesTheFlag covers pointing --config at an
+// atlas.hcl. The real problem is what --config accepts, not which YAML node
+// kind the decoder found.
+func TestLoadExplicitConfigOverHCLBlamesTheFlag(t *testing.T) {
+	c := qt.New(t)
+	chdirWith(c, map[string]string{"atlas.hcl": "env \"local\" {\n  url = \"sqlite://file.db\"\n}\n"})
+
+	_, err := projectconfig.Load(projectconfig.LoadOptions{PtahPath: "atlas.hcl", EnvName: "local"})
+
+	c.Assert(err, qt.ErrorMatches, `--config takes a ptah\.yaml file, and atlas\.hcl is not a YAML mapping \(line 1: found !!str\); an Atlas project config is discovered as \./atlas\.hcl and selected with --env`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "unmarshal")
+}
+
+// TestLoadDiscoveredPtahFileDoesNotBlameTheFlag is the control for the case
+// above: a conventional ./ptah.yaml that is not a mapping was not selected by
+// --config, so the diagnostic must not blame it.
+func TestLoadDiscoveredPtahFileDoesNotBlameTheFlag(t *testing.T) {
+	c := qt.New(t)
+	chdirWith(c, map[string]string{projectconfig.PtahFileName: "- not-a-mapping\n"})
+
+	_, err := projectconfig.Load(projectconfig.LoadOptions{})
+
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 1: expected a YAML mapping of ptah\.yaml keys, found !!seq`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "--config")
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
+}
+
+// TestLoadExplicitValidConfigStillLoads is the positive control: the
+// explicit-path branch above must not have made --config refuse real files.
+func TestLoadExplicitValidConfigStillLoads(t *testing.T) {
+	c := qt.New(t)
+	chdirWith(c, map[string]string{"custom.yaml": "url: \"sqlite://file.db\"\n"})
+
+	cfg, err := projectconfig.Load(projectconfig.LoadOptions{PtahPath: "custom.yaml"})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://file.db")
+}
+
+// TestParsePtahTypeMismatchNamesTheBlock covers a mismatch reported against a
+// nested type rather than the document type.
+func TestParsePtahTypeMismatchNamesTheBlock(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte("migration: not-a-block\n"), "ptah.yaml", "")
+
+	c.Assert(err, qt.ErrorMatches, `failed to parse ptah config ptah\.yaml: line 1: cannot read !!str as the ptah\.yaml migration block`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
+}
+
+// TestParsePtahReportsEveryUnknownKey pins the multi-error rendering: a file
+// with two mistakes reports both, each naming its own key and line.
+func TestParsePtahReportsEveryUnknownKey(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte("urll: a\nsrc: [b]\n"), "ptah.yaml", "")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `line 1: unknown ptah.yaml key "urll"`)
+	c.Assert(err.Error(), qt.Contains, `line 2: unknown ptah.yaml key "src"`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "projectconfig")
+}
+
+// TestParsePtahSyntaxErrorSurvivesTranslation is the non-interference control:
+// a plain YAML syntax error carries no Go type name and must reach the user
+// unchanged rather than being rewritten into an unknown-key report.
+func TestParsePtahSyntaxErrorSurvivesTranslation(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := projectconfig.ParsePtah([]byte("url: \"unterminated\n"), "ptah.yaml", "")
+
+	c.Assert(err, qt.ErrorMatches, `(?s)failed to parse ptah config ptah\.yaml: yaml: .*`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "unknown ptah.yaml key")
+}

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -95,8 +95,8 @@
     "ptah": "yes",
     "atlas_oss": "na",
     "atlas_pro": "na",
-    "note": "Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail.",
-    "evidence": "config/projectconfig/yaml.go:17-92 (typed key set; the desired-source key is `schemas`, not `src`). Repro: `src: [\"s.sql\"]` in ptah.yaml -> `error: failed to parse ptah config ptah.yaml: yaml: unmarshal errors: line 2: field src not found in type projectconfig.yamlDocument`"
+    "note": "Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. An unknown key fails, naming the key, its line, and the accepted keys.",
+    "evidence": "config/projectconfig/yaml.go:17-92 (typed key set; the desired-source key is `schemas`, not `src`), config/projectconfig/yamlerror.go (the decoder's Go type names are translated into ptah.yaml sections by reflection over the same struct tags, so the reported key list cannot drift from the accepted one). Repro: `src: [\"s.sql\"]` in ptah.yaml -> `error: failed to parse ptah config ptah.yaml: line 2: unknown ptah.yaml key \"src\"; supported keys are url, dev, schemas, exclude, migration, lint, migrate, online_ddl, diff, external_schema, env`"
   },
   {
     "area": "Project config",
@@ -131,8 +131,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently.",
-    "evidence": "internal/atlassource/atlassource.go:266-282 expandEnv attribute allowlist; env:// classification is reached only from --to/--from ClassifySet. Reproduced: `--exclude env://exclude` with env.exclude=[\"users\"] still emitted the users table"
+    "note": "Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; native `--schema-file` refuses it by name; elsewhere (`--exclude`) the literal string is used silently.",
+    "evidence": "internal/atlassource/atlassource.go EnvAttrs/ValidateEnvAttr is the one attribute allowlist, shared by expandEnv and by the native --schema-file refusal in cmd/internal/schemaload/schemaload.go rejectEnvReference; env:// expansion is still reached only from --to/--from ClassifySet. Reproduced: `--exclude env://exclude` with env.exclude=[\"users\"] still emitted the users table. Native repro: `ptah schema compare --env local --schema-file env://src` -> `--schema-file \"env://src\": env:// references are not resolved by ptah`, while `--schema-file env://bogus` -> `unsupported env:// attribute \"bogus\"`; the two were byte-identical extension errors before"
   },
   {
     "area": "Project config",
@@ -1238,8 +1238,8 @@
     "ptah": "partial",
     "atlas_oss": "na",
     "atlas_pro": "na",
-    "note": "ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved.",
-    "evidence": "cmd/internal/dbcli/project_config.go:66-80 (the atlas.hcl path and --var forwarding flags are hidden adapter-only), config/projectconfig/load.go:20-24 (AtlasPath defaults to AtlasFileName in the working directory). Repro: `ptah schema compare --env local --schema-file s.sql --var dburl=sqlite://file.db` -> `error: unknown flag: --var`; `ptah schema compare --config atlas.hcl --env local` -> `error: failed to parse ptah config atlas.hcl: yaml: unmarshal errors`"
+    "note": "ptah `--env` reads ./atlas.hcl in the working directory; `--var name=value` supplies a variable with no default on every env-aware verb; `--config` still takes ptah.yaml only.",
+    "evidence": "cmd/internal/dbcli/project_config.go RegisterEnvFlag/RegisterProjectEnvFlag register --var alongside --env, and LoadProjectConfig prefers it over the hidden adapter flag; config/projectconfig/load.go:20-24 (AtlasPath defaults to AtlasFileName in the working directory). cmd/root/project_var_flag_test.go pins the fourteen commands carrying the project env flag against the assembled command tree, with `ptah seed --env` as the negative control. Repro: `ptah schema compare --env local --schema-file s.sql` -> `error: atlas.hcl variable \"dburl\" requires a default or --var dburl=value`, and re-running with `--var dburl=sqlite://file.db` exits 0; `ptah schema compare --config atlas.hcl --env local` -> `error: --config takes a ptah.yaml file, and atlas.hcl is not a YAML mapping`"
   },
   {
     "area": "Schema inspection filters",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -231,11 +231,11 @@ seven of them as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema. |
 | atlas.hcl file() and fileset() path confinement | ✅ | ❌ | ❌ | Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today. |
-| atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl only: no `--var` flag, and `--config` takes ptah.yaml, so a variable without a default cannot be resolved. |
+| atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl in the working directory; `--var name=value` supplies a variable with no default on every env-aware verb; `--config` still takes ptah.yaml only. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input, absolute paths, and any non-file:// value are rejected. |
 | Docker dev databases (`docker://` `--dev-url`) | ❌ | ✅ | ✅ | migrate diff, lint and validate refuse docker:// and require a directly connectable dev database URL. |
-| env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; elsewhere (`--exclude`) the literal string is used silently. |
-| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. Unknown keys fail. |
+| env:// desired-state references | 🟡 | ✅ | ✅ | Resolves only on `--to`/`--from` and only src, schema.src, url, dev, migration.dir; native `--schema-file` refuses it by name; elsewhere (`--exclude`) the literal string is used silently. |
+| Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. An unknown key fails, naming the key, its line, and the accepted keys. |
 | PTAH_* environment-variable flag equivalents | ✅ | ❌ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
 | Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected. |

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -254,12 +254,13 @@ held through simulation, confirmation, and execution, and released on every
 exit path including cancellation.
 
 An empty value waits indefinitely; an elapsed timeout fails the apply before
-the target is inspected. PostgreSQL (`pg_advisory_lock`), MySQL and MariaDB
-(`GET_LOCK`), and SQL Server (`sp_getapplock`) use real database locks.
+the target is inspected. PostgreSQL and YugabyteDB (`pg_advisory_lock`), MySQL
+and MariaDB (`GET_LOCK`), and SQL Server (`sp_getapplock`) use real database
+locks.
 
-SQLite, ClickHouse, CockroachDB, YugabyteDB, and Spanner have no advisory-lock
-semantics: the apply proceeds without a lock, and an explicitly passed
-`--lock-timeout` prints a note on stderr.
+SQLite, ClickHouse, CockroachDB, and Spanner have no advisory-lock semantics:
+the apply proceeds without a lock, and an explicitly passed `--lock-timeout`
+prints a note on stderr.
 
 `--lock-name` replaces the lock name for the run. Two runs serialize only when
 they name the same lock, so this is how a Ptah apply coordinates with another

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -635,8 +635,9 @@ serializes concurrent schema applies against one target. The lock is acquired
 before target inspection and planning, held through simulation, confirmation,
 and execution, and released on every exit path. Empty waits indefinitely, an
 elapsed timeout fails before the target is inspected, and dialects without
-advisory locks (SQLite, ClickHouse, CockroachDB, YugabyteDB, Spanner) proceed
-unlocked with a stderr note.
+advisory locks (SQLite, ClickHouse, CockroachDB, Spanner) proceed unlocked with
+a stderr note. PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server take a
+real lock.
 
 **`--lock-name`** replaces the lock name for the run (`ptah_schema_apply` by
 default). Runs serialize only against other runs naming the same lock, which is

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -50,6 +50,26 @@ configuration once and map supported values to explicit native command
 arguments. An explicit `--config` path must exist; the conventional
 `./ptah.yaml` is optional.
 
+`--config` takes a `ptah.yaml` file. Pointing it at an `atlas.hcl` is refused by
+name rather than reported as a YAML parse failure: the Atlas project config is
+discovered as `./atlas.hcl` and selected with `--env`.
+
+Every native command that accepts `--env` also accepts `--var name=value`, which
+supplies a value for an `atlas.hcl` `variable` block that declares no default.
+The flag is repeatable, and repeating one name builds a `list(string)`. This is
+the flag the evaluator names when a variable cannot be resolved:
+
+```text
+$ ptah schema compare --env local --schema-file schema.sql
+error: atlas.hcl variable "dburl" requires a default or --var dburl=value
+$ ptah schema compare --env local --schema-file schema.sql --var dburl=sqlite://app.db
+```
+
+`env://` references resolve on the `ptah-compat` `--to` and `--from` flags. The
+native `--schema-file` does not resolve them and says so, naming `env://` and,
+for an attribute outside `src`, `schema.src`, `url`, `dev`, `migration`, and
+`migration.dir`, naming the attribute.
+
 For Atlas-compatible commands, plain local schema paths, relative `file://`
 schema URLs, and relative `migration.dir` values declared in `atlas.hcl` resolve
 relative to the directory containing that `atlas.hcl` file. Explicit CLI path
@@ -149,5 +169,5 @@ Continue with [Atlas project config](../../atlas/project-config/) for the suppor
 `atlas.hcl` subset.
 
 :::note
-Ptah config parsing is intentionally strict. Unknown `ptah.yaml` keys and unsupported `atlas.hcl` constructs fail instead of being ignored.
+Ptah config parsing is intentionally strict. Unknown `ptah.yaml` keys and unsupported `atlas.hcl` constructs fail instead of being ignored. A rejected `ptah.yaml` key is reported by name, with its line and the keys that section accepts — never by the Go type the decoder was filling.
 :::

--- a/internal/atlasschema/lock.go
+++ b/internal/atlasschema/lock.go
@@ -83,9 +83,14 @@ func EffectiveApplyLockName(name string) string {
 	return ApplyLockName
 }
 
-// Supported reports whether the lock is backed by a real database lock. It is
-// false on dialects without advisory-lock semantics (SQLite, ClickHouse,
-// CockroachDB, YugabyteDB, and Spanner), where the apply proceeds unlocked.
+// Supported reports whether the lock is backed by a real database lock. It
+// answers with [dblock.Supported], which is the single source of truth for the
+// list: PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server take a real
+// session advisory lock, and every other dialect (SQLite, ClickHouse,
+// CockroachDB, and Spanner) proceeds unlocked. Restating the list here rather
+// than deferring to that function is how it drifted before, so any change to
+// dblock.Supported must be repeated in this comment and in the two reference
+// pages that carry the same list.
 func (l *ApplyLock) Supported() bool {
 	return l != nil && l.lock.Supported()
 }

--- a/internal/atlassource/atlassource.go
+++ b/internal/atlassource/atlassource.go
@@ -299,9 +299,39 @@ func classifyLocal(rawURL string) (Source, error) {
 	return Source{Raw: rawURL, Kind: KindLocalFile, Path: resolved}, nil
 }
 
+// EnvAttrs are the env:// attributes an env reference may name, in the order
+// they are listed to the user. It is the single source of truth for both the
+// expansion switch below and the native binary's refusal, so a surface that
+// grows an attribute cannot leave the other advertising the old list.
+var EnvAttrs = []string{"src", "schema.src", "url", "dev", "migration", "migration.dir"}
+
+// ValidateEnvAttr reports whether attr names a supported env:// attribute,
+// returning the shared diagnostic when it does not.
+func ValidateEnvAttr(attr string) error {
+	if slices.Contains(EnvAttrs, attr) {
+		return nil
+	}
+	return fmt.Errorf(
+		"unsupported env:// attribute %q: supported attributes are %s",
+		attr,
+		joinEnvAttrs(),
+	)
+}
+
+// joinEnvAttrs renders the attribute list as prose: "a, b, and c".
+func joinEnvAttrs() string {
+	if len(EnvAttrs) < 2 {
+		return strings.Join(EnvAttrs, "")
+	}
+	return strings.Join(EnvAttrs[:len(EnvAttrs)-1], ", ") + ", and " + EnvAttrs[len(EnvAttrs)-1]
+}
+
 func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 	if !env.Loaded {
 		return nil, errors.New("env:// desired-state references require an evaluated atlas.hcl project configuration; pass --config and --env to select one")
+	}
+	if err := ValidateEnvAttr(source.EnvAttr); err != nil {
+		return nil, err
 	}
 	switch source.EnvAttr {
 	case "src", "schema.src":
@@ -313,7 +343,10 @@ func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 	case "migration", "migration.dir":
 		return expandEnvMigrationDir(env)
 	default:
-		return nil, fmt.Errorf("unsupported env:// attribute %q: supported attributes are src, schema.src, url, dev, migration, and migration.dir", source.EnvAttr)
+		// Unreachable while EnvAttrs and this switch agree; ValidateEnvAttr has
+		// already rejected everything else. Kept fail-closed so an attribute
+		// added to EnvAttrs alone cannot silently expand to nothing.
+		return nil, ValidateEnvAttr(source.EnvAttr)
 	}
 }
 


### PR DESCRIPTION
Refs #935 — items 1, 2, 3 and 5 are done here; item 4 is not, so the issue
stays open.

Item 4 split in two. **4a** (an unsupported atlas.hcl function reported by the
enclosing attribute name) was already fixed by #1039 before this branch started
and no longer reproduces — its paragraph in the issue body is stale and should
be struck. **4b** (an absolute `data.hcl_schema` path reported as `unsupported
atlas.hcl construct "path"`) still reproduces on this branch and is left alone:
#1042 is deciding whether that refusal survives on this surface at all, so
pinning its wording now would pin a message whose underlying rule may be
removed. It belongs on #1042 as a rider, or refiled once #1042 lands.

Both halves measured on this branch, not assumed:

```text
$ ptah-compat schema inspect --env local     # env dev = urlsetpath("sqlite://file.db","x")
Error: cannot evaluate atlas.hcl "dev" at atlas.hcl:2: atlas.hcl:2,9-19: Call to unknown function; There is no function named "urlsetpath".
exit=1                                       # 4a: names the function — fixed, does not reproduce

$ ptah-compat schema inspect --env local     # data "hcl_schema" "s" { path = "/etc/absolute.hcl" }
Error: unsupported atlas.hcl construct "path" at atlas.hcl:2
exit=1                                       # 4b: reproduces verbatim
```

Measured on a worktree branched from `origin/master` =
`d29a44f4538cb8787ce4b74f5d6e25587478a399`, with `ptah` and `ptah-compat` built
from that tree. **No claim here is a comparison against Atlas** — every item is
Ptah against Ptah or Ptah against its own documentation — so no Atlas binary was
involved in any measurement. Exit codes were read from unpiped invocations.
Each fixture is its own directory holding only the files shown.

## Reproduction before the change

All four items still reproduced on `d29a44f4`, unchanged from the framing
comment's measurement on `bd7d3c66`:

```text
$ ptah schema compare --env local --schema-file s.sql            # c2a
error: atlas.hcl variable "dburl" requires a default or --var dburl=value      exit=2
$ ptah schema compare --env local --schema-file s.sql --var dburl=sqlite://file.db
error: unknown flag: --var                                                     exit=2

$ ptah schema compare --env local --schema-file env://src        # c3
error: unsupported schema file extension "": only .yaml, .yml, .hcl, and .sql are supported   exit=2
$ ptah schema compare --env local --schema-file env://bogus      # byte-identical
error: unsupported schema file extension "": only .yaml, .yml, .hcl, and .sql are supported   exit=2

$ ptah schema compare --schema-file s.sql                        # c5
error: failed to parse ptah config ptah.yaml: yaml: unmarshal errors:
  line 2: field src not found in type projectconfig.yamlDocument               exit=2
$ ptah schema compare --config atlas.hcl --env local --schema-file s.sql
error: failed to parse ptah config atlas.hcl: yaml: unmarshal errors:
  line 1: cannot unmarshal !!str `env "lo...` into projectconfig.yamlDocument   exit=2

$ grep -n "YugabyteDB" internal/atlasschema/lock.go
88:// CockroachDB, YugabyteDB, and Spanner), where the apply proceeds unlocked.
```

One correction to the framing comment, found by building the gate from the
assembled command tree rather than from a package list: **fifteen** commands
carry a flag named `--env`, not fourteen. The fifteenth is `ptah seed`, whose
`--env` names a *seed* environment, reads no project config, and can never
print the variable advice. It is excluded by name in a test, not silently.

## Completion criteria

### C1 — the unlocked list matches `dblock.Supported`, in all three places

```text
$ grep -rn "YugabyteDB" internal/atlasschema/lock.go \
    docs/site/src/content/docs/atlas/schema-commands.md \
    docs/site/src/content/docs/reference/atlas-commands.md
internal/atlasschema/lock.go:88:// list: PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server take a real
docs/.../atlas/schema-commands.md:257:the target is inspected. PostgreSQL and YugabyteDB (`pg_advisory_lock`), MySQL
docs/.../reference/atlas-commands.md:287:- PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server use session advisory
docs/.../reference/atlas-commands.md:619:a stderr note. PostgreSQL, YugabyteDB, MySQL, MariaDB, and SQL Server take a
```

Every remaining mention places YugabyteDB among the real-lock dialects. No line
in those three files puts it among dialects that lack advisory locks, run
unlocked, or print a stderr note.

```text
$ go test ./internal/dblock/ -run TestSupported -v -count=1 | grep -c '^=== RUN   TestSupported/'
11
$ sed -n '139p' docs/site/src/content/docs/atlas/feature-matrix.md
| Apply advisory lock, ... | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; ... |
```

Row 139 is unchanged, as the framing said it should be. Control, on a dialect
that genuinely runs unlocked:

```text
$ ptah schema apply --db-url sqlite://lock.db --schema-file s.sql --lock-timeout 5s --auto-approve
note: schema apply locking is not supported for dialect "sqlite"; --lock-timeout is ignored and the apply proceeds without a database lock
...
exit=0
```

**Unmeasured:** no apply was run against a live YugabyteDB. The absence of the
note there is inferred from `dblock.Supported("yugabytedb") == true` plus the two
call sites that print it, not observed.

### C2 — no command advises a flag it rejects, on every command that can print the advice

`--var name=value` is now public and repeatable, registered wherever the project
`--env` is. The table below is one row per command, run against fixture `c2a`
(`atlas.hcl` with `variable "dburl" {}` and `env "local" { url = var.dburl }`,
plus `s.sql`), and `c2b` (the same with `default = "sqlite://file.db"`).

Row 1 is mechanical: every `--[a-z-]+` token extracted from the message is
checked against that command's own `--help`.

| Command | 1: advised flag in `--help` | 2: `--var` clears the variable error | 3: `c2b` default not a variable failure |
| --- | --- | --- | --- |
| `ptah migrations down` | yes | yes → `migrations directory is required` | yes (2, same) |
| `ptah migrations generate` | yes | yes → `migrations directory is required` | yes (2, same) |
| `ptah migrations lint` | yes | yes → `migrations directory ./migrations: ... no such file` | yes (2, same) |
| `ptah migrations plan` | yes | yes → exit 0 | yes (0) |
| `ptah migrations set` | yes | yes → `migrations directory is required` | yes (2, same) |
| `ptah migrations status` | yes | yes → `migrations directory is required` | yes (2, same) |
| `ptah migrations up` | yes | yes → `migrations directory is required` | yes (2, same) |
| `ptah schema apply` | yes | yes → `a desired schema source is required` | yes (2, same) |
| `ptah schema compare` | yes | yes → exit 0 | yes (0) |
| `ptah schema diff` | yes | yes → `--from is required` | yes (2, same) |
| `ptah schema drift` | yes | yes → exit 0 | yes (0) |
| `ptah schema inspect` | yes | yes → exit 0 | yes (0) |
| `ptah schema plan` | yes | yes → `a desired schema source is required` | yes (2, same) |
| `ptah schema render` | yes | yes → exit 0 | yes (0) |

All fourteen print the same advice with no `--var` and clear it with one. Every
row-2 remainder is about something other than the variable, and row 3 matches
row 2 exactly on every command.

Recorded decision, since the framing asked for one: **a public `--var`**, not a
promoted `--atlas-project-var` and not a per-command reworded message. It makes
the existing message true everywhere, matches the spelling `ptah-compat` already
uses, and is the only option that satisfies row 2 without inventing a second
vocabulary for the same thing. `--atlas-project-var` stays, hidden, for the
adapters that already route through it; the public flag wins when both are set,
and the two are never concatenated (a repeated `--var` for one name is how a
`list(string)` is built, so merging would turn a scalar into a list).

Controls:

```text
$ ptah-compat schema inspect --env local --var dburl=sqlite://file.db    exit=0     # compat --var still binds
$ ptah schema compare --env local --var malformed
error: atlas variable overrides must use name=value, got "malformed"      exit=2
```

The gate is `cmd/root/project_var_flag_test.go`, which walks the assembled
command tree, pins the exact set of project-env commands, and asserts each has a
non-hidden, repeatable `--var`. `TestSeedEnvIsNotAProjectEnv` is its negative
control: without it the rule could be satisfied by annotating every flag spelled
`--env`.

### C3 — `env://` failures on native `ptah` say `env://`, and say different things

```text
$ ptah schema compare --env local --schema-file env://src            # c3
error: --schema-file "env://src": env:// references are not resolved by ptah; pass the schema file itself, or use ptah-compat, whose --to and --from accept env://src
exit=2
$ ptah schema compare --env local --schema-file env://bogus
error: --schema-file "env://bogus": unsupported env:// attribute "bogus": supported attributes are src, schema.src, url, dev, migration, and migration.dir
exit=2
```

Both contain `env://`; neither contains `unsupported schema file extension ""`;
they differ. The unknown-attribute wording is `atlassource`'s own, and the
attribute list is now a single exported value shared by the resolver and the
refusal, so the two surfaces cannot drift apart. Controls:

```text
$ ptah schema compare --env local --schema-file s.txt
error: unsupported schema file extension ".txt": only .yaml, .yml, .hcl, and .sql are supported   exit=2
$ ptah schema compare --env local --schema-file s.sql                                             exit=0
$ ptah schema compare --env local --schema-file env://
error: --schema-file "env://": env:// desired-state reference is missing the env attribute (for example env://src)   exit=2
```

This is a refusal, not a resolution — see "left open".

### C4 — no Go type name reaches a `ptah.yaml` diagnostic

```text
$ ptah schema compare --schema-file s.sql                             # c5
error: failed to parse ptah config ptah.yaml: line 2: unknown ptah.yaml key "src"; supported keys are url, dev, schemas, exclude, migration, lint, migrate, online_ddl, diff, external_schema, env
exit=2
$ ptah schema compare --config atlas.hcl --env local --schema-file s.sql
error: --config takes a ptah.yaml file, and atlas.hcl is not a YAML mapping (line 1: found !!str); an Atlas project config is discovered as ./atlas.hcl and selected with --env
exit=2
$ cd ../c5b && ptah schema compare --schema-file s.sql                                            exit=0
```

Zero matches for `projectconfig` in either combined output; both still exit 2;
the control exits 0. The first names the rejected key and its line; the second
states what `--config` takes. The advice in the second is measured, not
guessed: in a directory with only an `atlas.hcl`, `ptah schema compare --env
local --schema-file s.sql` exits 0.

The key lists are derived by reflection over the same struct tags the decoder
reads, so they cannot drift from what is accepted — nested sections included:

```text
$ printf 'migration:\n  pg_dumpto: ./backups\n' > ptah.yaml && ptah schema compare
error: failed to parse ptah config ptah.yaml: line 2: unknown ptah.yaml key "pg_dumpto" under migration; supported keys are dir, format, revisions_schema, ...
```

A regex fail-safe replaces any residual `projectconfig.<Type>` even in a decoder
message no rule anticipated.

### C5 — the matrix rows for items 2, 3 and 5 state the new behavior

`docs/site/scripts/data/feature-matrix-rows.json` is the source; `feature-matrix.md`
is regenerated from it. Rows changed:

- *atlas.hcl from the native ptah binary* — no longer says "no `--var` flag …
  a variable without a default cannot be resolved". Stays 🟡: `--config` still
  takes `ptah.yaml` only.
- *env:// desired-state references* — adds that the native `--schema-file`
  refuses it by name.
- *Native project config (ptah.yaml)* — "Unknown keys fail" → "An unknown key
  fails, naming the key, its line, and the accepted keys."

No row was left reading `partial` for a capability these criteria made specific;
the two that remain 🟡 do so for limitations these criteria did not cover, named
in the note. `feature-matrix.md:139` is untouched.

## What each test prints if the change is reverted

Each was verified by running the inverse mutant, not by reverting the diff.

| Mutant | Test that goes red | What it prints |
| --- | --- | --- |
| M1: drop `RegisterProjectVarFlag` from `markProjectEnvFlag` | `TestEveryProjectEnvCommandAcceptsVar`, and 4 in `cmd/internal/dbcli` | `ptah migrations down selects a project env but does not register --var` |
| M2 (inverse): annotate `ptah seed --env` as a project env | `TestSeedEnvIsNotAProjectEnv` **and** `TestEveryProjectEnvCommandAcceptsVar` | list diff `+ "ptah seed"` |
| M3: collapse the two `env://` branches into one message | `TestLoad_EnvReferenceWithUnknownAttributeNamesTheAttribute`, `TestLoad_EnvReferencesDifferByAttributeValidity` | error does not match `unsupported env:// attribute "bogus"` |
| M4: return the raw decoder error instead of translating | 7 tests in `config/projectconfig` | got `field pg_dumpto not found in type projectconfig.yamlMigration` |
| M5: swap `--var`/`--env` registration order in `registerAtlasProjectFlags` | `TestCompatVarFlagKeepsAtlasUsage` | `schema --var help is "Value for an atlas.hcl variable with no default…", not Atlas's wording` |

M5 is worth calling out: the first version of that guard **survived** the
mutant, because the compat surface reads `--var` by flag name rather than
through the bound target, so swapping the order only changed the published help
text. The test was rewritten to pin the help text — which is the thing that
actually differs — and only then did the mutant go red. The comment in
`registerAtlasProjectFlags` names that test.

M3 also survived its first guard: the "the two messages differ" assertion was
satisfied trivially because both echo the attribute back. It now also asserts
each message lacks the other's distinguishing phrase.

## Gates

All run in this worktree at `4fe89183`.

```text
go build ./... && go vet ./... && go test ./... -count=1     no failures
go tool qtlint ./...                                          no output
golangci-lint run ./...                                       0 issues.
scripts/check-test-style.sh                                   teststyle: OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh && scripts/check-public-api-snapshot.sh    exit 0
```

`docs/` is touched, so all 12 `check:*` scripts in `docs/site/package.json` were
run (`npm run build` first, which `check:responsive` requires):

```text
check:exit-codes            OK (60 reference rows)
check:exit-codes:selftest   OK
check:core-doc-links        OK (7 protected core references)
check:page-health           OK (59 sidebar entries)
check:links                 OK (60 pages, 60 routes, 565 heading anchors)
check:links:selftest        OK
check:redirects             OK (30 redirects)
check:redirects:selftest    OK
check:style                 OK (100 documentation files)
check:style:selftest        OK (16 rule assertions via analyze())
check:responsive            OK (60 routes x 2 viewports, cells within 8 lines)
check:responsive:selftest   OK
```

Parity rule: nothing here changes an exit code from 1 to 0 relative to any
oracle. Every behavior change either replaces one exit-2 message with a better
exit-2 message, or turns an exit-2 `unknown flag` into a working invocation. No
defect was reproduced for the sake of matching anything.

## Deliberately left open

- **Item 4b** (`data.hcl_schema` absolute path reported as `unsupported
  atlas.hcl construct "path"`) is not here. It is blocked on #1042, which is
  deciding whether that refusal survives on this surface at all; pinning its
  wording now would pin a message whose rule may be removed. It still
  reproduces on this branch.
- **`env://` on the native `--schema-file` is refused, not resolved.** This is
  what the issue asked for, and it is the honest state: native `ptah` has no
  route from the selected env to a desired-state source at all. Measured in
  fixture `c3`, whose `atlas.hcl` sets `src = "s.sql"`:
  `ptah schema compare --env local` (no `--schema-file`) prints
  `Comparing schema from ./` and scans the working directory for Go entities —
  the env's `src` is ignored entirely. Wiring that is #843's territory and would
  touch every command that builds a `schemaload.Options`, so it is not folded in
  here.
- **`--config` still takes `ptah.yaml` only.** The diagnostic now says so, and
  the matrix row still reads 🟡 for exactly that reason. Giving native `ptah` a
  public flag for an explicit `atlas.hcl` path is a surface decision, not a
  diagnostics fix.
- **C1 has no new automated guard.** `TestSupported` pins `dblock.Supported`,
  and the doc comment now defers to it in prose rather than restating the list
  independently, but nothing fails if a future edit reintroduces a wrong list
  into either reference page. The check is the `grep` above.
- **Eleven of the fourteen C2 commands were previously enumerated from
  registration sites rather than run.** All fourteen are now run, in the table
  above. Live-database commands were exercised against SQLite only.
