### PR TITLE
Give every protobuf export limitation an owner or a reason

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -73,11 +73,16 @@ jobs:
           node-version: '24'
 
       # check-style.mjs has no npm dependencies, so this needs no install step.
+      # check-limitations.mjs has none either, and it governs a page under
+      # docs/site, so it runs here rather than in the site build: the fast job
+      # is the one that sees every documentation change.
       - name: Check documentation style
         run: |
           set -euo pipefail
           node docs/site/scripts/check-style.mjs --selftest
           node docs/site/scripts/check-style.mjs
+          node docs/site/scripts/check-limitations.mjs --selftest
+          node docs/site/scripts/check-limitations.mjs
           node docs/site/scripts/build-feature-matrix.mjs --check
 
   build:
@@ -122,8 +127,6 @@ jobs:
           npm run check:exit-codes
           npm run check:style:selftest
           npm run check:style
-          npm run check:limitations:selftest
-          npm run check:limitations
           npx playwright install --with-deps chromium
           npm run check:responsive:selftest
           npm run build
@@ -157,10 +160,6 @@ jobs:
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style:selftest
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style
-            if [ -f scripts/check-limitations.mjs ]; then
-              DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:limitations:selftest
-              DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:limitations
-            fi
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build
           )
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -122,6 +122,8 @@ jobs:
           npm run check:exit-codes
           npm run check:style:selftest
           npm run check:style
+          npm run check:limitations:selftest
+          npm run check:limitations
           npx playwright install --with-deps chromium
           npm run check:responsive:selftest
           npm run build
@@ -155,6 +157,10 @@ jobs:
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:exit-codes
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style:selftest
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:style
+            if [ -f scripts/check-limitations.mjs ]; then
+              DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:limitations:selftest
+              DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run check:limitations
+            fi
             DOCS_VERSION=edge ASTRO_TELEMETRY_DISABLED=1 npm run build
           )
           mkdir -p "$GITHUB_WORKSPACE/_site/edge"

--- a/docs/site/package.json
+++ b/docs/site/package.json
@@ -20,6 +20,8 @@
     "check:redirects:selftest": "node scripts/check-redirects.mjs --selftest",
     "check:style": "node scripts/check-style.mjs",
     "check:style:selftest": "node scripts/check-style.mjs --selftest",
+    "check:limitations": "node scripts/check-limitations.mjs",
+    "check:limitations:selftest": "node scripts/check-limitations.mjs --selftest",
     "check:responsive": "node scripts/check-responsive.mjs",
     "check:responsive:selftest": "node scripts/check-responsive.mjs --selftest",
     "versions:selftest": "node scripts/gen-versions.mjs --selftest"

--- a/docs/site/scripts/check-limitations.mjs
+++ b/docs/site/scripts/check-limitations.mjs
@@ -1,0 +1,215 @@
+#!/usr/bin/env node
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const scriptDir = dirname(fileURLToPath(import.meta.url));
+const siteRoot = join(scriptDir, '..');
+const docsRoot = join(siteRoot, 'src', 'content', 'docs');
+
+// Pages whose "Limitations" list is a disposition record rather than prose: a
+// reader must be able to tell, per bullet, whether somebody owns the gap or
+// whether it is a decision that will not change. A page is opted in by being
+// listed here; a listed page that disappears is an error rather than a silent
+// pass, because a checker that governs zero files reports OK forever.
+const governedPages = ['schema/protobuf.md'];
+
+// A tracking link in the spelling the documentation already uses elsewhere,
+// for example [#904](https://github.com/stokaro/ptah/issues/904). The label and
+// the target are captured separately so a bullet cannot cite one issue and link
+// another.
+const trackingLink = /\[#(\d+)\]\(https:\/\/github\.com\/stokaro\/ptah\/issues\/(\d+)\)/;
+
+// The permanence clause. "Permanent" alone is too weak to accept: a bullet has
+// to say why, because that reason is what a later reader argues with.
+const permanenceClause = /\bis permanent because\b/;
+
+// sectionLines returns the lines of the "## Limitations" section, each with its
+// 1-based line number in the file, or null when the page has no such section.
+function sectionLines(source) {
+  const lines = source.split('\n');
+  const start = lines.findIndex((line) => /^##\s+Limitations\s*$/.test(line));
+  if (start === -1) return null;
+
+  const collected = [];
+  for (let index = start + 1; index < lines.length; index += 1) {
+    if (/^##\s/.test(lines[index])) break;
+    collected.push({ line: index + 1, text: lines[index] });
+  }
+  return collected;
+}
+
+// bullets groups the section into top-level list items. A nested bullet or an
+// indented continuation belongs to the item above it, so a bullet is measured
+// as the reader sees it rather than one source line at a time.
+function bullets(section) {
+  const found = [];
+  for (const { line, text } of section) {
+    if (/^[-*]\s/.test(text)) {
+      found.push({ line, parts: [text.replace(/^[-*]\s+/, '')] });
+      continue;
+    }
+    if (text.trim() === '') continue;
+    if (found.length > 0 && /^\s+\S/.test(text)) {
+      found[found.length - 1].parts.push(text.trim());
+    }
+  }
+  return found.map((bullet) => ({ line: bullet.line, text: bullet.parts.join(' ') }));
+}
+
+// lastSentence returns the closing sentence of a bullet. The disposition has to
+// close the bullet: an issue number mentioned halfway through describes the
+// gap, while the last sentence is what a reader takes away as its status.
+function lastSentence(text) {
+  const sentences = text
+    .trim()
+    .split(/(?<=[.!?])\s+/)
+    .map((sentence) => sentence.trim())
+    .filter((sentence) => sentence !== '');
+  return sentences.length === 0 ? '' : sentences[sentences.length - 1];
+}
+
+// analyze is the single implementation of the rule. checkFile and the self-test
+// both call it, so a rule that stops firing here fails the self-test rather
+// than passing every page in silence.
+export function analyze(source) {
+  const section = sectionLines(source);
+  if (section === null) {
+    return [{ line: 1, message: 'governed page has no "## Limitations" section' }];
+  }
+
+  const items = bullets(section);
+  if (items.length === 0) {
+    return [{ line: 1, message: '"## Limitations" section has no bullets' }];
+  }
+
+  const findings = [];
+  for (const item of items) {
+    const closing = lastSentence(item.text);
+    const link = trackingLink.exec(closing);
+    if (link) {
+      if (link[1] !== link[2]) {
+        findings.push({
+          line: item.line,
+          message: `limitation bullet cites #${link[1]} but links issue ${link[2]}`,
+        });
+      }
+      continue;
+    }
+    if (permanenceClause.test(closing)) continue;
+    findings.push({
+      line: item.line,
+      message:
+        'limitation bullet has no disposition; close it with a tracking link ' +
+        '[#N](https://github.com/stokaro/ptah/issues/N) or with a sentence saying ' +
+        'why it is permanent because …',
+    });
+  }
+  return findings;
+}
+
+function checkFile(page) {
+  const path = join(docsRoot, page);
+  if (!existsSync(path)) {
+    return [`docs/site/src/content/docs/${page}: governed page is missing; update governedPages`];
+  }
+  return analyze(readFileSync(path, 'utf8')).map(
+    (finding) => `docs/site/src/content/docs/${page}:${finding.line}: ${finding.message}`,
+  );
+}
+
+// selftest drives the production analyze() over fixtures that pin each branch:
+// a missing disposition, a mismatched citation, a disposition that is not the
+// closing sentence, a missing section, an empty section, and clean prose.
+function selftest() {
+  const failures = [];
+
+  const clean = [
+    '## Limitations',
+    '',
+    '- The source is Go annotations only. Tracked by',
+    '  [#1144](https://github.com/stokaro/ptah/issues/1144).',
+    '- RLS policies are not emitted. This is permanent because a policy is',
+    '  evaluated against a session and a file has none.',
+    '',
+    '## Next steps',
+    '',
+    '- Unrelated bullet with no disposition at all.',
+  ].join('\n');
+
+  for (const finding of analyze(clean)) {
+    failures.push(`clean fixture produced a finding at line ${finding.line}: ${finding.message}`);
+  }
+
+  const violating = [
+    '## Limitations',
+    '',
+    '- One file per run, and nothing tracks that.',
+    '- Numbers come from the previous file.',
+    '  Tracked by [#904](https://github.com/stokaro/ptah/issues/905).',
+    '- Comments are copied, see [#1145](https://github.com/stokaro/ptah/issues/1145).',
+    '  Review them before publishing the file.',
+    '',
+  ].join('\n');
+
+  const expected = [
+    { line: 3, needle: 'no disposition' },
+    { line: 4, needle: 'cites #904 but links issue 905' },
+    { line: 6, needle: 'no disposition' },
+  ];
+  const actual = analyze(violating);
+  for (const [index, want] of expected.entries()) {
+    const got = actual[index];
+    if (!got) {
+      failures.push(`missing finding at line ${want.line} (${want.needle})`);
+      continue;
+    }
+    if (got.line !== want.line || !got.message.includes(want.needle)) {
+      failures.push(
+        `finding ${index} was ${got.line}: ${got.message}; wanted ${want.line} containing "${want.needle}"`,
+      );
+    }
+  }
+  if (actual.length !== expected.length) {
+    failures.push(`violating fixture produced ${actual.length} findings, wanted ${expected.length}`);
+  }
+
+  const noSection = analyze('# Page\n\nProse only.\n');
+  if (noSection.length !== 1 || !noSection[0].message.includes('no "## Limitations" section')) {
+    failures.push('a governed page without a Limitations section was not reported');
+  }
+
+  const emptySection = analyze('## Limitations\n\nProse, no bullets.\n\n## Next steps\n');
+  if (emptySection.length !== 1 || !emptySection[0].message.includes('no bullets')) {
+    failures.push('an empty Limitations section was not reported');
+  }
+
+  if (failures.length > 0) {
+    console.error('check-limitations.mjs --selftest: FAILED');
+    for (const failure of failures) console.error(`- ${failure}`);
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-limitations.mjs --selftest: OK (${expected.length + 3} assertions via analyze())`);
+}
+
+function main() {
+  if (process.argv[2] === '--selftest') {
+    selftest();
+    return;
+  }
+
+  const errors = governedPages.flatMap(checkFile);
+  if (errors.length > 0) {
+    console.error('Limitation disposition check failed:');
+    for (const error of errors) console.error(`- ${error}`);
+    console.error(
+      '\nEvery bullet in a governed "Limitations" list must close with the issue that tracks it or with the reason it is permanent.',
+    );
+    process.exitCode = 1;
+    return;
+  }
+  console.log(`check-limitations.mjs: OK (${governedPages.length} governed page(s))`);
+}
+
+main();

--- a/docs/site/scripts/check-limitations.mjs
+++ b/docs/site/scripts/check-limitations.mjs
@@ -39,20 +39,37 @@ function sectionLines(source) {
   return collected;
 }
 
-// bullets groups the section into top-level list items. A nested bullet or an
-// indented continuation belongs to the item above it, so a bullet is measured
-// as the reader sees it rather than one source line at a time.
+// bullets groups the section into top-level list items. A nested bullet, an
+// indented continuation, and a lazy continuation — an unindented line directly
+// under a bullet, which Markdown folds into it — all belong to the item above,
+// so a bullet is measured as the reader sees it rather than one source line at
+// a time. A blank line followed by unindented prose ends the list instead:
+// attributing a trailing paragraph to the last bullet would let one page-level
+// sentence excuse a bullet that says nothing about its own status.
 function bullets(section) {
   const found = [];
+  let open = false;
+  let blankSeen = false;
+
   for (const { line, text } of section) {
-    if (/^[-*]\s/.test(text)) {
-      found.push({ line, parts: [text.replace(/^[-*]\s+/, '')] });
+    if (text.trim() === '') {
+      blankSeen = true;
       continue;
     }
-    if (text.trim() === '') continue;
-    if (found.length > 0 && /^\s+\S/.test(text)) {
-      found[found.length - 1].parts.push(text.trim());
+    if (/^[-*]\s/.test(text)) {
+      found.push({ line, parts: [text.replace(/^[-*]\s+/, '')] });
+      open = true;
+      blankSeen = false;
+      continue;
     }
+    const indented = /^\s+\S/.test(text);
+    if (open && (indented || !blankSeen)) {
+      found[found.length - 1].parts.push(text.trim());
+      blankSeen = false;
+      continue;
+    }
+    if (!indented) open = false;
+    blankSeen = false;
   }
   return found.map((bullet) => ({ line: bullet.line, text: bullet.parts.join(' ') }));
 }
@@ -127,10 +144,16 @@ function selftest() {
   const clean = [
     '## Limitations',
     '',
+    'Intro prose above the list is not a bullet and carries no disposition.',
+    '',
     '- The source is Go annotations only. Tracked by',
     '  [#1144](https://github.com/stokaro/ptah/issues/1144).',
     '- RLS policies are not emitted. This is permanent because a policy is',
     '  evaluated against a session and a file has none.',
+    // A lazy continuation: Markdown folds this into the bullet above, so the
+    // disposition on it counts.
+    '- One file per run.',
+    'Tracked by [#1146](https://github.com/stokaro/ptah/issues/1146).',
     '',
     '## Next steps',
     '',
@@ -149,6 +172,11 @@ function selftest() {
     '  Tracked by [#904](https://github.com/stokaro/ptah/issues/905).',
     '- Comments are copied, see [#1145](https://github.com/stokaro/ptah/issues/1145).',
     '  Review them before publishing the file.',
+    // A page-level sentence after a blank line is not this bullet's
+    // disposition, however many issues it names.
+    '- A bullet whose status is only stated for the page as a whole.',
+    '',
+    'Everything here is tracked by [#904](https://github.com/stokaro/ptah/issues/904).',
     '',
   ].join('\n');
 
@@ -156,6 +184,7 @@ function selftest() {
     { line: 3, needle: 'no disposition' },
     { line: 4, needle: 'cites #904 but links issue 905' },
     { line: 6, needle: 'no disposition' },
+    { line: 8, needle: 'no disposition' },
   ];
   const actual = analyze(violating);
   for (const [index, want] of expected.entries()) {

--- a/docs/site/src/content/docs/schema/protobuf.md
+++ b/docs/site/src/content/docs/schema/protobuf.md
@@ -461,41 +461,64 @@ Every check below runs before anything is written, and each exits with code
 
 ## Limitations
 
+Every bullet below ends with either the issue that tracks it or the reason it is
+permanent, so nothing on this list is an unowned gap.
+
 - The source is Go annotations only. There is no `--schema-file` or database
   URL for this target; run [`ptah introspect`](../../start/adopt-an-existing-database/)
-  first to generate annotated models from an existing database.
+  first to generate annotated models from an existing database. Tracked by
+  [#1144](https://github.com/stokaro/ptah/issues/1144).
 - Table selection is the narrowest available projection. There are no
   field-level allowlists, read/write visibility rules, sensitive-field markers,
   or API-specific aliases. Use a curated annotation source or wrapper messages
-  when a public contract must expose only part of a table.
+  when a public contract must expose only part of a table. Tracked by
+  [#904](https://github.com/stokaro/ptah/issues/904).
 - Database identifiers determine generated API identifiers after Protobuf name
   normalization. Renaming a table or column can therefore rename a public
-  symbol even when its wire number remains stable.
+  symbol even when its wire number remains stable. A column rename is the quiet
+  one: the export exits `0` with no diagnostic, reserves the old number and the
+  old name, and allocates a new number for the new name. Tracked by
+  [#905](https://github.com/stokaro/ptah/issues/905).
 - Additive compatibility is not the same as intentional exposure. Adding a
   column to a selected table adds a field on the next export unless the whole
-  table is excluded.
+  table is excluded. Tracked by
+  [#904](https://github.com/stokaro/ptah/issues/904).
 - The generated definition contains no authorization or tenant-isolation
   semantics. RLS policies are not emitted, and their presence in the database
-  does not define who may use a message field.
-- Table and field comments are copied into the generated definition. Review them
-  for internal implementation details or sensitive operational information
-  before publishing the file.
+  does not define who may use a message field. Inferring API authorization from
+  row-level security is an explicit non-goal of
+  [#904](https://github.com/stokaro/ptah/issues/904). This is permanent because
+  a policy is evaluated by the database against a session, and a published
+  `.proto` has no session to evaluate it against.
+- Table and field comments are copied into the generated definition, and from
+  there into whatever `protoc-gen-go` produces. Review them for internal
+  implementation details or sensitive operational information before publishing
+  the file. Tracked by [#1145](https://github.com/stokaro/ptah/issues/1145).
 - One file per run. Ptah writes a single compilation unit, so splitting a
   schema across `.proto` files means several exports with disjoint
-  `--include-tables` sets and separate packages.
+  `--include-tables` sets and separate packages. Tracked by
+  [#1146](https://github.com/stokaro/ptah/issues/1146).
 - Two tables that map to the same message name fail the export naming both.
-  Give one a distinct `schema=` or exclude it; Ptah will not disambiguate with
-  a numeric suffix, because the result would depend on table order. A table and
-  an enum that produce the same name fail the same way.
+  Give one a distinct `schema=` or exclude it. A table and an enum that produce
+  the same name fail the same way. The refusal is permanent because any
+  automatic disambiguation, a numeric suffix included, would depend on table
+  order; a declarative alias that spares you renaming a database object is
+  tracked by [#905](https://github.com/stokaro/ptah/issues/905).
 - A table with no exportable columns is skipped with
   `table has no exportable columns; message omitted`. Protobuf has no way to
   tell an empty message apart from a type retained only for its reservations.
+  This is permanent because writing the empty message instead would make the
+  next run read it as a type that left the schema: a previous file carrying
+  `message AuditMarker {}` for a table still present in the source is refused
+  with `types removed from the source schema: AuditMarker`.
 - A previous type whose `reserved` ranges expand past 1,048,576 individual
   numbers is refused instead of being loaded partially. Partial loading could
   reallocate a number that remains reserved in the published wire contract.
+  Tracked by [#1147](https://github.com/stokaro/ptah/issues/1147).
 - The three header comment lines are copied into whatever `protoc-gen-go`
   generates, so the content digest appears at the top of the `.pb.go` files
-  too. It changes only when the schema changes.
+  too. It changes only when the schema changes. Tracked by
+  [#1148](https://github.com/stokaro/ptah/issues/1148).
 
 ## Next steps
 


### PR DESCRIPTION
Closes #923.

The issue asked which of the eleven documented protobuf-export limitations can be resolved, and its framing comment set the bar: the Limitations list must end each bullet with either a tracking link or a resolution. I re-measured all eleven on master `feb6af19` with a `ptah` built from it, then annotated the list and filed the five workstreams that had no owner. No behavior changes here — the diff contains no Go file.

## Re-measurement first: nothing here was closed by merged work

Only two commits have ever touched `internal/protobufrender`: `0ac3aa4f` (#897, which implemented the target and wrote this list) and `371c172d` (#1022, the `github.com/stokaro/ptah` → `go.5x5.cz/ptah` import-path move). `git log bd7d3c66..feb6af19 -- internal/protobufrender cmd/schema/export_protobuf.go docs/site/src/content/docs/schema/protobuf.md` is empty. I did not rely on that: every row below was run against a binary built from `feb6af19`.

| # | Bullet | Measured on `feb6af19` | Disposition |
| --- | --- | --- | --- |
| 1 | Go annotations are the only source | `--from hcl/sql/yaml/db` exit 2 `unsupported --from "hcl": expected go`; `--schema-file`, `--db-url`, `--from-db` exit 2 `unknown flag`; same on `--to openapi-v3` and `--to graphql` | #1144 |
| 2 | No field-level projection | `password_hash` is exported with no opt-in; `--include-columns`, `--exclude-columns`, `--include-fields`, `--exclude-fields`, `--projection`, `--read-only-fields`, `--write-only-fields` all exit 2 `unknown flag` | #904 |
| 3 | Database names decide API names | table `users`→`accounts` refused by default, tombstoned under `--proto-type-removal=tombstone` with `id`/`email` keeping 1 and 2; column `email`→`email_address` exits **0 with no diagnostic**, reserves number 2 and the name `email`, allocates 3 | #905 |
| 4 | Additive exposure | adding `internal_fraud_score` to an already-exported `users` writes `int32 internal_fraud_score = 4;`, exit 0, zero diagnostics | #904 |
| 5 | No authorization or RLS | a models directory with `//ptah:schema:rls:enable` and `//ptah:schema:rls:policy` exports a `.proto` with 0 mentions of either; positive control on the same directory: `ptah schema render --dialect postgres` emits 2 RLS statements | permanent |
| 6 | Comments are copied | `Internal: sharded by tenant_id; see runbook RB-42` and `bcrypt hash, never expose` reach the `.proto` **and** the `.pb.go`; `--no-comments`, `--strip-comments`, `--omit-comments` exit 2 `unknown flag` | #1145 |
| 7 | One file per run | one run over a two-table schema writes 1 file; `--out-dir`, `--split-by-schema`, `--file-per-table` exit 2 `unknown flag`; two runs with disjoint `--include-tables` and separate packages both exit 0 and write 2 files | #1146 |
| 8 | Name collisions fail the export | `users`+`user` → exit 2, nothing written, `tables map to the same protobuf message name: User: user (struct LegacyUser), users (struct User); …`; `schema="audit"` on one exits 0 and yields `AuditUser` + `User`. Table `account_statuses` + enum on `accounts.status` → exit 2, nothing written | permanent refusal; declarative remedy on #905 |
| 9 | Empty table skipped | `warning: audit_marker: table has no exportable columns; message omitted`, exit 0 | permanent |
| 10 | Reserved ranges capped | see the discriminating pair below | #1147 |
| 11 | Header reaches `.pb.go` | see the control below | #1148 |

Every probe carried controls. Positive: the same command without the probed flag exits 0. Negative: `--definitely-not-a-flag` exits 2 with `unknown flag`, and `ptah definitely-not-a-command` reports `unknown command`. No flag was declared absent by reading `--help`.

### Bullet 10, the discriminating pair

Two hand-built baselines, identical except for the width of one range, each re-stamped with a valid `ptah:content-sha256`:

| Previous baseline | Individual numbers | Result |
| --- | --- | --- |
| `reserved 20000 to 20005;` | 6 | exit 0, range preserved |
| `reserved 20000 to 1030000;` | 1,010,001 | exit 0, rewritten with the range intact |
| `reserved 20000 to 2100000;` | 2,080,001 | exit 2, `reserved ranges expand to more than 1048576 numbers; refusing to truncate compatibility state` |

Negative controls on the same fixture: a file Ptah did not write is refused as `output file was not generated by ptah`; the 6-number baseline widened by one without re-stamping is refused as `output file was modified since it was generated`. So the pair separates the range width from every other reason a baseline can be rejected.

### Bullet 11, the control that isolates the cause

With `protoc` 35.1 and `protoc-gen-go` v1.36.11, lines 1-3 of the generated `.pb.go` are the three ptah header lines, above protoc-gen-go's own marker. The **same** `.proto` with those three lines moved to the end produces a `.pb.go` with **0** occurrences of `ptah:content-sha256` (control: header at the top, 1 occurrence), while the table and column comments still propagate in both variants. So the header travels because it is the file's leading detached comment, and comment propagation is a separate matter — which is why they are two issues, #1148 and #1145, not one.

### Bullet 9, why permanent is a measurement and not a shrug

Writing an empty message instead of omitting one is worse than the omission. A previous file carrying `message AuditMarker {}` for a table that is **still in the source** is read on the next run as a type that left the schema:

```text
error: types removed from the source schema: AuditMarker; protobuf cannot reserve a top-level type name, so choose --proto-type-removal=tombstone …
```

The docs bullet now says that, with the diagnostic.

## Reproduction, before and after

Before, on `feb6af19`:

```console
$ node docs/site/scripts/check-limitations.mjs
Error: Cannot find module '…/docs/site/scripts/check-limitations.mjs'
```

and the eleven bullets end in plain prose — a reader cannot tell which are gaps with owners, which are decisions, and which are neither.

After:

```console
$ npm run check:limitations
check-limitations.mjs: OK (1 governed page(s))
```

with 11 bullets and 11 dispositions: 5 tracked on new issues, 3 on #904/#905 (one bullet cites #905 twice: once for the identity half, once for the remedy), 3 permanent with a stated reason.

## What the tests print if the change is reverted

`check-limitations.mjs` is the test. Six mutants, each applied to a copy of the page and then restored (the tree was verified byte-identical afterwards):

| Mutant | Exit | Output |
| --- | --- | --- |
| **Revert mutant**: drop `Tracked by [#1146](…)` from the one-file-per-run bullet | 1 | `protobuf.md:497: limitation bullet has no disposition; close it with a tracking link [#N](https://github.com/stokaro/ptah/issues/N) or with a sentence saying why it is permanent because …` |
| Cite `#1147`, link issue `1148` | 1 | `protobuf.md:514: limitation bullet cites #1147 but links issue 1148` |
| Keep the link but move it out of the closing sentence | 1 | `protobuf.md:493: limitation bullet has no disposition; …` |
| Replace the empty-table reason with a bare `This is permanent.` | 1 | `protobuf.md:507: limitation bullet has no disposition; …` |
| **Inverse mutant**: add a *new* bullet ending in a valid tracking link | 0 | `check-limitations.mjs: OK (1 governed page(s))` |
| **Inverse mutant**: add a *new* bullet ending in a permanence clause | 0 | `check-limitations.mjs: OK (1 governed page(s))` |

The two inverse mutants are what prove the guard is a rule and not a hash of today's eleven bullets: reverting my edit can only show that the checker fires, never that it leaves valid new content alone.

A seventh mutant covers the way this kind of checker usually dies — governing nothing. Renaming `schema/protobuf.md` in `governedPages` prints:

```text
docs/site/src/content/docs/schema/protobuf-renamed.md: governed page is missing; update governedPages
```

exit 1, rather than a cheerful `OK (0 governed pages)`.

`check-limitations.mjs --selftest` drives the production `analyze()` over fixtures for every branch (missing disposition, mismatched citation, non-closing disposition, a disposition stated only for the page after a blank line, missing section, empty section, and clean prose including a lazy continuation), so a rule that stops firing fails the self-test instead of passing every page in silence.

In CI it runs in the **Documentation style** job, next to `check-style.mjs`: neither has npm dependencies, and that job sees every change under `docs/**` on every pull request, while the site build only runs when `docs/site/**` changes. `check:limitations` and `check:limitations:selftest` are in `docs/site/package.json` for local runs.

## Gates

- `go build ./...`, `go vet ./...`, `go test ./... -count=1` — 0, 0, 0 (176 packages ok, 0 FAIL)
- `go tool qtlint ./...` — 0; `golangci-lint run ./...` — 0 (`0 issues.`)
- `scripts/check-test-style.sh` — 0 (`175 conditional groups, 45 white-box files`)
- `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — 0 and 0; both print only on failure, so silence is their pass
- All 12 pre-existing `check:*` scripts in `docs/site/package.json` plus the 2 added here, each run individually with its own exit code, plus `npm run build` (61 pages) and `check:responsive` after it — all 0
- `gofmt -l .` prints `internal/goannotationexport/testdata/cleanup/models.go`, which is not in this diff; it is an unformatted-by-design test fixture on master

## What I deliberately left open

- **No behavior change lands here.** Bullets 1, 6, 7, 10 and 11 are resolvable, and each now has its own issue with acceptance criteria stated as a test that fails today. #1147 is the smallest (`maxReservedNumbers = 1 << 20` in `internal/protobufrender/model.go`, plus a range-preserving loader) and #1146 the largest (N baselines, and a rule for a table moving between files). Doing any of them inside a docs PR would put a compatibility-state change under a `docs(...)` commit.
- **#904 and #905 keep their acceptance criteria.** This PR does not restate or re-derive them; bullets 2, 3, 4 and 8 point at them instead. #906 is adjacent but touches none of these eleven bullets.
- **The silent column rename is stated but not fixed.** `email` → `email_address` exits 0 with no diagnostic while retiring one field number and allocating another. Every other compatibility-relevant event in this exporter either warns or is gated by a `--proto-on-*` policy. The docs now say so, and whether it should warn belongs to #905; I have said so there rather than deciding it here.
- **The checker governs one page.** Five other pages have a `## Limitations` section (`databases/sqlserver.md`, `direct/apply.md`, `start/adopt-an-existing-database.md`, `operate/seed-data.md`, `schema/visualize.md`). Opting them in is a per-page editorial decision with a real cost, so `governedPages` starts at the page #923 is about; adding a page is a one-line change.
