### PR TITLE
Render query-builder DML for Spanner and pin every dialect cell

### DIFF
--- a/core/renderer/dml.go
+++ b/core/renderer/dml.go
@@ -254,6 +254,15 @@ func (r *selectRenderer) renderDelete(stmt *ast.DeleteStatement) error {
 // INSERT and DELETE, not UPDATE — so, to keep one rule across all three write
 // statements, both MySQL and MariaDB are treated as unsupported and a non-empty
 // RETURNING is rejected there rather than emitted as SQL the engine cannot run.
+//
+// "The PostgreSQL family" includes Cloud Spanner's PostgreSQL interface, which
+// is what Ptah targets when the dialect is spanner: RETURNING is emitted there
+// exactly as it is for PostgreSQL, rather than singled out for a refusal that
+// would make this the one place in the repository where Spanner is not
+// PostgreSQL. Spanner has no live coverage in this repository (stokaro/ptah#942)
+// and the databases support matrix already asks callers to review generated
+// Spanner SQL before relying on it; that caveat covers the whole statement, not
+// this clause in particular.
 func (r *selectRenderer) renderReturning(cols []ast.ColumnRef) error {
 	if len(cols) == 0 {
 		return nil
@@ -279,11 +288,10 @@ func (r *selectRenderer) renderReturning(cols []ast.ColumnRef) error {
 
 // supportsReturning reports whether the renderer's dialect can execute a
 // RETURNING clause. See renderReturning for the per-dialect rationale.
+//
+// Family membership is asked of platform.IsPostgresFamily rather than spelled
+// out, for the same reason as in selectPlaceholderStyle: a list of names here is
+// a list that drifts, and it had already drifted — it omitted Spanner.
 func (r *selectRenderer) supportsReturning() bool {
-	switch r.dialect {
-	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.SQLite:
-		return true
-	default:
-		return false
-	}
+	return platform.IsPostgresFamily(r.dialect) || r.dialect == platform.SQLite
 }

--- a/core/renderer/dml_dialect_matrix_test.go
+++ b/core/renderer/dml_dialect_matrix_test.go
@@ -1,0 +1,389 @@
+package renderer_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/core/sqlutil"
+	"go.5x5.cz/ptah/internal/sqlident"
+)
+
+// This file is the dialect-coverage guard for the query builder's four render
+// entry points. It exists because the previous shape of the suite let the
+// builder acquire a dialect silently: only three cells anywhere pinned a
+// refusal, all three on ClickHouse, so adding a dialect to
+// selectPlaceholderStyle and deleting those three cells produced a green suite
+// and SQL nobody had ever looked at.
+//
+// Two independent things are pinned here:
+//
+//  1. TestDMLDialectMatrix walks renderer.SupportedDialects() x the four render
+//     functions and pins every one of the 48 cells to an exact SQL string with
+//     exact args, or to an exact error string. The table must list exactly the
+//     names SupportedDialects() returns, so a new dialect name cannot enter the
+//     builder without a row being written for it.
+//  2. TestDMLGenericRefusalCensus observes which cells still answer with the
+//     generic "rendering is not supported for dialect" refusal and pins that
+//     observed set against a hand-written quarantine list. The census reads
+//     behavior, not the table above, so the two cannot be edited into agreement
+//     one at a time.
+//
+// A third test, TestDMLPlaceholderAgreesWithRebind, pins the DML renderer's
+// placeholder for the first bound value against sqlutil.Rebind for the same
+// dialect. The expectation is derived from Rebind rather than written out, so
+// the two placeholder tables in this repository cannot drift apart.
+
+// genericRefusalMarker is the substring newSelectRenderer and newWriteRenderer
+// emit for a dialect that has no entry in selectPlaceholderStyle. A cell that
+// still carries it is a dialect the builder has never been taught, as opposed to
+// one it refuses for a stated engine reason.
+const genericRefusalMarker = "rendering is not supported for dialect"
+
+// dmlCell is the pinned outcome of one (dialect, verb) cell: either sql plus
+// args, or err. The two are mutually exclusive — a refusing render returns an
+// empty string and nil args, which is what the zero values here express.
+type dmlCell struct {
+	sql  string
+	args []any
+	err  string
+}
+
+// dmlVerb is one of the four render entry points, bound to the fixture this
+// guard renders through it. Every verb uses the same table, the same column
+// names, and the same single bound id, so the cells differ only where the
+// dialects differ.
+type dmlVerb struct {
+	name   string
+	render func(dialect string) (string, []any, error)
+}
+
+func dmlVerbs() []dmlVerb {
+	return []dmlVerb{
+		{
+			name: "SELECT",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderSelect(&ast.SelectStatement{
+					Columns: []ast.ResultColumn{{Name: "id"}, {Name: "name"}},
+					From:    "users",
+					Where:   matrixWhereID(),
+					Limit:   matrixInt64(10),
+				}, dialect)
+			},
+		},
+		{
+			name: "INSERT",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderInsert(&ast.InsertStatement{
+					Table:   "users",
+					Columns: []string{"id", "name"},
+					Rows:    [][]ast.Expression{{&ast.BoundValue{Value: int64(1)}, &ast.BoundValue{Value: "a"}}},
+				}, dialect)
+			},
+		},
+		{
+			name: "UPDATE",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderUpdate(&ast.UpdateStatement{
+					Table: "users",
+					Set:   []ast.Assignment{{Column: "name", Value: &ast.BoundValue{Value: "a"}}},
+					Where: matrixWhereID(),
+				}, dialect)
+			},
+		},
+		{
+			name: "DELETE",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderDelete(&ast.DeleteStatement{
+					Table: "users",
+					Where: matrixWhereID(),
+				}, dialect)
+			},
+		},
+	}
+}
+
+func matrixWhereID() ast.Expression {
+	return &ast.Comparison{
+		Left:     &ast.ColumnRef{Name: "id"},
+		Operator: ast.OpEqual,
+		Right:    &ast.BoundValue{Value: int64(1)},
+	}
+}
+
+func matrixInt64(v int64) *int64 { return new(v) }
+
+// dmlMatrixRow pins all four cells for one dialect name. The cells are listed in
+// the order dmlVerbs() returns.
+type dmlMatrixRow struct {
+	dialect string
+	sel     dmlCell
+	ins     dmlCell
+	upd     dmlCell
+	del     dmlCell
+}
+
+func (r dmlMatrixRow) cells() []dmlCell { return []dmlCell{r.sel, r.ins, r.upd, r.del} }
+
+// dollarCells is the pinned rendering for a PostgreSQL-family dialect: double
+// quoted identifiers and $n placeholders numbered left to right.
+func dollarCells(dialect string) dmlMatrixRow {
+	return dmlMatrixRow{
+		dialect: dialect,
+		sel:     dmlCell{sql: `SELECT "id", "name" FROM "users" WHERE "id" = $1 LIMIT $2`, args: []any{int64(1), int64(10)}},
+		ins:     dmlCell{sql: `INSERT INTO "users" ("id", "name") VALUES ($1, $2)`, args: []any{int64(1), "a"}},
+		upd:     dmlCell{sql: `UPDATE "users" SET "name" = $1 WHERE "id" = $2`, args: []any{"a", int64(1)}},
+		del:     dmlCell{sql: `DELETE FROM "users" WHERE "id" = $1`, args: []any{int64(1)}},
+	}
+}
+
+// backtickQuestionCells is the pinned rendering for MySQL and MariaDB.
+func backtickQuestionCells(dialect string) dmlMatrixRow {
+	return dmlMatrixRow{
+		dialect: dialect,
+		sel:     dmlCell{sql: "SELECT `id`, `name` FROM `users` WHERE `id` = ? LIMIT ?", args: []any{int64(1), int64(10)}},
+		ins:     dmlCell{sql: "INSERT INTO `users` (`id`, `name`) VALUES (?, ?)", args: []any{int64(1), "a"}},
+		upd:     dmlCell{sql: "UPDATE `users` SET `name` = ? WHERE `id` = ?", args: []any{"a", int64(1)}},
+		del:     dmlCell{sql: "DELETE FROM `users` WHERE `id` = ?", args: []any{int64(1)}},
+	}
+}
+
+// quotedQuestionCells is the pinned rendering for SQLite: PostgreSQL-style
+// identifier quoting with ? placeholders.
+func quotedQuestionCells(dialect string) dmlMatrixRow {
+	return dmlMatrixRow{
+		dialect: dialect,
+		sel:     dmlCell{sql: `SELECT "id", "name" FROM "users" WHERE "id" = ? LIMIT ?`, args: []any{int64(1), int64(10)}},
+		ins:     dmlCell{sql: `INSERT INTO "users" ("id", "name") VALUES (?, ?)`, args: []any{int64(1), "a"}},
+		upd:     dmlCell{sql: `UPDATE "users" SET "name" = ? WHERE "id" = ?`, args: []any{"a", int64(1)}},
+		del:     dmlCell{sql: `DELETE FROM "users" WHERE "id" = ?`, args: []any{int64(1)}},
+	}
+}
+
+// genericRefusalCells is the row for a dialect the builder has not been taught:
+// all four verbs answer with the generic unsupported-dialect error, quoting the
+// caller's spelling of the dialect rather than the normalized name.
+func genericRefusalCells(dialect string) dmlMatrixRow {
+	refusal := func(verb string) dmlCell {
+		return dmlCell{err: fmt.Sprintf("renderer: %s %s %q", verb, genericRefusalMarker, dialect)}
+	}
+	return dmlMatrixRow{
+		dialect: dialect,
+		sel:     refusal("SELECT"),
+		ins:     refusal("INSERT"),
+		upd:     refusal("UPDATE"),
+		del:     refusal("DELETE"),
+	}
+}
+
+// dmlMatrixRows lists one row per name in renderer.SupportedDialects(), in the
+// same order. TestDMLDialectMatrix compares the two lists, so this table cannot
+// fall behind the set of names the renderer accepts.
+func dmlMatrixRows() []dmlMatrixRow {
+	return []dmlMatrixRow{
+		dollarCells("postgresql"),
+		dollarCells("postgres"),
+		backtickQuestionCells("mysql"),
+		backtickQuestionCells("mariadb"),
+		genericRefusalCells("clickhouse"),
+		quotedQuestionCells("sqlite"),
+		quotedQuestionCells("sqlite3"),
+		genericRefusalCells("sqlserver"),
+		genericRefusalCells("mssql"),
+		dollarCells("cockroachdb"),
+		dollarCells("yugabytedb"),
+		dollarCells("spanner"),
+	}
+}
+
+// dmlGenericRefusalQuarantine is the hand-written list of cells that still
+// answer with the generic unsupported-dialect refusal. Every entry is a dialect
+// the query builder has never been taught, tracked on stokaro/ptah#941:
+// SQL Server (workstream W2) and ClickHouse (workstream W3).
+//
+// Adding a dialect to selectPlaceholderStyle without editing this list makes
+// TestDMLGenericRefusalCensus red, and the list is compared against observed
+// behavior rather than against dmlMatrixRows, so shrinking it without also
+// teaching the renderer is red too.
+func dmlGenericRefusalQuarantine() []string {
+	return []string{
+		"clickhouse/SELECT", "clickhouse/INSERT", "clickhouse/UPDATE", "clickhouse/DELETE",
+		"sqlserver/SELECT", "sqlserver/INSERT", "sqlserver/UPDATE", "sqlserver/DELETE",
+		"mssql/SELECT", "mssql/INSERT", "mssql/UPDATE", "mssql/DELETE",
+	}
+}
+
+// TestDMLDialectMatrix pins all 48 (dialect, verb) cells.
+//
+// Revert the Spanner placeholder entry and the four spanner cells stop at the
+// first line of the cell check, printing
+//
+//	got:  `renderer: SELECT rendering is not supported for dialect "spanner"`
+//	want: ""
+//
+// Change a rendering instead of removing one — a quote style, a placeholder, a
+// keyword — and the cell reaches the second line and prints the two SQL strings.
+//
+// Drop a name from renderer.SupportedDialects(), or add one, and the
+// "table covers exactly SupportedDialects" subtest prints the two lists side by
+// side with the difference marked.
+func TestDMLDialectMatrix(t *testing.T) {
+	c := qt.New(t)
+	rows := dmlMatrixRows()
+	verbs := dmlVerbs()
+
+	c.Run("table covers exactly SupportedDialects", func(c *qt.C) {
+		names := make([]string, 0, len(rows))
+		for _, row := range rows {
+			names = append(names, row.dialect)
+		}
+		c.Assert(names, qt.DeepEquals, renderer.SupportedDialects())
+	})
+
+	for _, row := range rows {
+		cells := row.cells()
+		for i, verb := range verbs {
+			c.Run(row.dialect+"/"+verb.name, func(c *qt.C) {
+				sql, args, err := verb.render(row.dialect)
+				want := cells[i]
+				c.Assert(errorText(err), qt.Equals, want.err)
+				c.Assert(sql, qt.Equals, want.sql)
+				c.Assert(args, qt.DeepEquals, want.args)
+			})
+		}
+	}
+}
+
+// TestDMLGenericRefusalCensus pins which cells are still untaught dialects
+// rather than deliberate refusals.
+//
+// Revert the Spanner placeholder entry and this prints the observed list with
+// the four spanner entries back in it, against a want list without them —
+// quicktest marks the four extra elements. Teach the renderer a dialect without
+// striking it from dmlGenericRefusalQuarantine and the diff runs the other way:
+// its cells are marked missing from the observed list, one per verb.
+func TestDMLGenericRefusalCensus(t *testing.T) {
+	c := qt.New(t)
+
+	var observed []string
+	for _, dialect := range renderer.SupportedDialects() {
+		for _, verb := range dmlVerbs() {
+			_, _, err := verb.render(dialect)
+			observed = append(observed, genericRefusalLabel(dialect, verb.name, err)...)
+		}
+	}
+
+	c.Assert(observed, qt.DeepEquals, dmlGenericRefusalQuarantine())
+}
+
+// genericRefusalLabel returns a one-element slice naming the cell when err is
+// the generic unsupported-dialect refusal, and an empty slice otherwise.
+func genericRefusalLabel(dialect, verb string, err error) []string {
+	if err == nil || !strings.Contains(err.Error(), genericRefusalMarker) {
+		return nil
+	}
+	return []string{dialect + "/" + verb}
+}
+
+func errorText(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}
+
+// placeholderRow pins how one dialect names its first bound parameter. The check
+// is a func field rather than a flag so the two outcomes — renders, or refuses —
+// each state their own expectation.
+type placeholderRow struct {
+	dialect string
+	check   func(c *qt.C, dialect string)
+}
+
+// onePlaceholderInsert is the smallest statement with exactly one bound value,
+// so the placeholder it renders is unambiguously the first one.
+func onePlaceholderInsert() *ast.InsertStatement {
+	return &ast.InsertStatement{
+		Table:   "users",
+		Columns: []string{"id"},
+		Rows:    [][]ast.Expression{{&ast.BoundValue{Value: int64(1)}}},
+	}
+}
+
+// agreesWithRebind renders the one-placeholder INSERT and compares it against a
+// string built from sqlutil.Rebind for the same dialect. The expectation is
+// derived, not written out: there is no constant here to edit into agreement, so
+// a placeholder style added to selectPlaceholderStyle that disagrees with Rebind
+// fails on this line.
+func agreesWithRebind(c *qt.C, dialect string) {
+	sql, args, err := renderer.RenderInsert(onePlaceholderInsert(), dialect)
+	c.Assert(err, qt.IsNil)
+	c.Assert(args, qt.DeepEquals, []any{int64(1)})
+	c.Assert(sql, qt.Equals, fmt.Sprintf(
+		"INSERT INTO %s (%s) VALUES (%s)",
+		sqlident.Quote(dialect, "users"),
+		sqlident.Quote(dialect, "id"),
+		sqlutil.Rebind(dialect, "?"),
+	))
+}
+
+// refusesButRebindKnows pins the pair for a dialect the builder has not been
+// taught: the render refuses, while sqlutil.Rebind already has an answer for the
+// same name. wantRebind records that answer so whoever teaches the renderer this
+// dialect has the placeholder style in front of them; for SQL Server it is @p1,
+// not the ? a naive entry in selectPlaceholderStyle would emit.
+func refusesButRebindKnows(wantRebind string) func(c *qt.C, dialect string) {
+	return func(c *qt.C, dialect string) {
+		_, _, err := renderer.RenderInsert(onePlaceholderInsert(), dialect)
+		c.Assert(errorText(err), qt.Equals,
+			fmt.Sprintf("renderer: INSERT %s %q", genericRefusalMarker, dialect))
+		c.Assert(sqlutil.Rebind(dialect, "?"), qt.Equals, wantRebind)
+	}
+}
+
+// TestDMLPlaceholderAgreesWithRebind pins the DML renderer's placeholder for the
+// first bound value against sqlutil.Rebind, the repository's other per-dialect
+// placeholder table.
+//
+// Revert the Spanner placeholder entry and the spanner row prints
+//
+//	error: got non-nil error, want nil
+//	error message: renderer: INSERT rendering is not supported for dialect "spanner"
+//
+// Give a dialect the wrong style — sqlserver with ?, say — and its row prints the
+// rendered SQL against the Rebind-derived string, `VALUES (?)` against
+// `VALUES (@p1)`.
+func TestDMLPlaceholderAgreesWithRebind(t *testing.T) {
+	c := qt.New(t)
+
+	rows := []placeholderRow{
+		{dialect: "postgresql", check: agreesWithRebind},
+		{dialect: "postgres", check: agreesWithRebind},
+		{dialect: "mysql", check: agreesWithRebind},
+		{dialect: "mariadb", check: agreesWithRebind},
+		{dialect: "clickhouse", check: refusesButRebindKnows("?")},
+		{dialect: "sqlite", check: agreesWithRebind},
+		{dialect: "sqlite3", check: agreesWithRebind},
+		{dialect: "sqlserver", check: refusesButRebindKnows("@p1")},
+		{dialect: "mssql", check: refusesButRebindKnows("@p1")},
+		{dialect: "cockroachdb", check: agreesWithRebind},
+		{dialect: "yugabytedb", check: agreesWithRebind},
+		{dialect: "spanner", check: agreesWithRebind},
+	}
+
+	names := make([]string, 0, len(rows))
+	for _, row := range rows {
+		names = append(names, row.dialect)
+	}
+	c.Assert(names, qt.DeepEquals, renderer.SupportedDialects())
+
+	for _, row := range rows {
+		c.Run(row.dialect, func(c *qt.C) {
+			row.check(c, row.dialect)
+		})
+	}
+}

--- a/core/renderer/dml_spanner_test.go
+++ b/core/renderer/dml_spanner_test.go
@@ -1,0 +1,211 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+// Ptah routes Cloud Spanner's PostgreSQL interface through the PostgreSQL
+// implementation everywhere: platform.IsPostgresFamily says so, the DDL renderer
+// hands spanner to the PostgreSQL visitor, dbschema reads it over pgx, and
+// sqlutil.Rebind numbers its parameters $1, $2, … The query builder was the one
+// subsystem that did not, so it refused spanner outright.
+//
+// These cases pin the contract that closes that gap: for the whole DML surface,
+// spanner renders byte-identically to postgres. Byte-identity alone would be
+// satisfied by both sides regressing together, so every case also pins the
+// literal SQL and args — a postgres regression fails the literal, a spanner-only
+// regression fails the comparison, and each failure names which.
+//
+// Spanner has no live coverage in this repository (stokaro/ptah#942), so nothing
+// here executes: these are rendering contracts, not execution evidence.
+
+type spannerParityCase struct {
+	name     string
+	render   func(dialect string) (string, []any, error)
+	wantSQL  string
+	wantArgs []any
+}
+
+func spannerParityCases() []spannerParityCase {
+	whereID := func() ast.Expression {
+		return &ast.Comparison{
+			Left:     &ast.ColumnRef{Name: "id"},
+			Operator: ast.OpEqual,
+			Right:    &ast.BoundValue{Value: int64(7)},
+		}
+	}
+	limit := int64(10)
+	offset := int64(5)
+
+	return []spannerParityCase{
+		{
+			name: "select with full outer join, limit and offset",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderSelect(&ast.SelectStatement{
+					Columns:   []ast.ResultColumn{{Qualifier: "u", Name: "id"}, {Qualifier: "o", Name: "total"}},
+					From:      "users",
+					FromAlias: "u",
+					Joins: []ast.JoinClause{{
+						Type:  ast.JoinFull,
+						Table: "orders",
+						Alias: "o",
+						On: &ast.Comparison{
+							Left:     &ast.ColumnRef{Qualifier: "u", Name: "id"},
+							Operator: ast.OpEqual,
+							Right:    &ast.ColumnRef{Qualifier: "o", Name: "user_id"},
+						},
+					}},
+					Where: &ast.Comparison{
+						Left:     &ast.ColumnRef{Qualifier: "u", Name: "status"},
+						Operator: ast.OpEqual,
+						Right:    &ast.BoundValue{Value: "paid"},
+					},
+					Limit:  &limit,
+					Offset: &offset,
+				}, dialect)
+			},
+			wantSQL: `SELECT "u"."id", "o"."total" FROM "users" "u" FULL OUTER JOIN "orders" "o" ` +
+				`ON "u"."id" = "o"."user_id" WHERE "u"."status" = $1 LIMIT $2 OFFSET $3`,
+			wantArgs: []any{"paid", int64(10), int64(5)},
+		},
+		{
+			name: "select with offset and no limit emits a bare OFFSET",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderSelect(&ast.SelectStatement{
+					Columns: []ast.ResultColumn{{Name: "id"}},
+					From:    "users",
+					Offset:  &offset,
+				}, dialect)
+			},
+			wantSQL:  `SELECT "id" FROM "users" OFFSET $1`,
+			wantArgs: []any{int64(5)},
+		},
+		{
+			name: "insert with returning",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderInsert(&ast.InsertStatement{
+					Table:     "users",
+					Columns:   []string{"id", "name"},
+					Rows:      [][]ast.Expression{{&ast.BoundValue{Value: int64(1)}, &ast.BoundValue{Value: "alice"}}},
+					Returning: []ast.ColumnRef{{Name: "id"}},
+				}, dialect)
+			},
+			wantSQL:  `INSERT INTO "users" ("id", "name") VALUES ($1, $2) RETURNING "id"`,
+			wantArgs: []any{int64(1), "alice"},
+		},
+		{
+			name: "update with returning",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderUpdate(&ast.UpdateStatement{
+					Table:     "users",
+					Set:       []ast.Assignment{{Column: "name", Value: &ast.BoundValue{Value: "bob"}}},
+					Where:     whereID(),
+					Returning: []ast.ColumnRef{{Name: "id"}, {Name: "name"}},
+				}, dialect)
+			},
+			wantSQL:  `UPDATE "users" SET "name" = $1 WHERE "id" = $2 RETURNING "id", "name"`,
+			wantArgs: []any{"bob", int64(7)},
+		},
+		{
+			name: "delete with returning",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderDelete(&ast.DeleteStatement{
+					Table:     "users",
+					Where:     whereID(),
+					Returning: []ast.ColumnRef{{Name: "id"}},
+				}, dialect)
+			},
+			wantSQL:  `DELETE FROM "users" WHERE "id" = $1 RETURNING "id"`,
+			wantArgs: []any{int64(7)},
+		},
+	}
+}
+
+// TestSpannerRendersIdenticallyToPostgres pins the Spanner rendering of the whole
+// DML surface against the PostgreSQL rendering of the same statement.
+//
+// Revert the Spanner entry in selectPlaceholderStyle and every case prints
+//
+//	error: got non-nil error, want nil
+//	error message: renderer: SELECT rendering is not supported for dialect "spanner"
+//
+// Revert only the Spanner half of supportsReturning and the three RETURNING
+// cases print `renderer: spanner does not support RETURNING` where the postgres
+// side rendered the clause, and the star-column case below prints that same
+// message where it wants the star refusal — four subtests, measured. The two
+// SELECT cases stay green, which is what separates the placeholder change from
+// the RETURNING change.
+func TestSpannerRendersIdenticallyToPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	for _, tc := range spannerParityCases() {
+		c.Run(tc.name, func(c *qt.C) {
+			gotSQL, gotArgs, gotErr := tc.render(platform.Spanner)
+			refSQL, refArgs, refErr := tc.render(platform.Postgres)
+
+			c.Assert(refErr, qt.IsNil)
+			c.Assert(gotErr, qt.IsNil)
+			c.Assert(gotSQL, qt.Equals, refSQL)
+			c.Assert(gotArgs, qt.DeepEquals, refArgs)
+			c.Assert(gotSQL, qt.Equals, tc.wantSQL)
+			c.Assert(gotArgs, qt.DeepEquals, tc.wantArgs)
+		})
+	}
+}
+
+// TestSpannerRejectsTheSameStatementsAsPostgres pins the refusals, so "spanner
+// renders like postgres" cannot be read as "spanner renders anything". A
+// WHERE-less UPDATE and a star RETURNING are rejected on both, with the same
+// message; the dialect name in the first message is the normalized one.
+//
+// Delete the Unconditional guard and the first case prints
+// `got "" want "renderer: update without a WHERE clause must be marked
+// unconditional"`; teach RETURNING a star column and the second prints the
+// rendered `RETURNING *` against the same want.
+func TestSpannerRejectsTheSameStatementsAsPostgres(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		render  func(dialect string) (string, []any, error)
+		wantErr string
+	}{
+		{
+			name: "update without a where clause",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderUpdate(&ast.UpdateStatement{
+					Table: "users",
+					Set:   []ast.Assignment{{Column: "name", Value: &ast.BoundValue{Value: "bob"}}},
+				}, dialect)
+			},
+			wantErr: "renderer: update without a WHERE clause must be marked unconditional",
+		},
+		{
+			name: "returning a star column",
+			render: func(dialect string) (string, []any, error) {
+				return renderer.RenderDelete(&ast.DeleteStatement{
+					Table:         "users",
+					Unconditional: true,
+					Returning:     []ast.ColumnRef{{Name: "*"}},
+				}, dialect)
+			},
+			wantErr: "renderer: RETURNING does not support a star column",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, _, spannerErr := tt.render(platform.Spanner)
+			_, _, postgresErr := tt.render(platform.Postgres)
+
+			c.Assert(errorText(spannerErr), qt.Equals, tt.wantErr)
+			c.Assert(errorText(postgresErr), qt.Equals, tt.wantErr)
+		})
+	}
+}

--- a/core/renderer/select.go
+++ b/core/renderer/select.go
@@ -31,8 +31,11 @@ import (
 // A function name (COUNT, SUM, …) is a keyword emitted verbatim, never quoted;
 // the renderer rejects a name that is not a simple identifier rather than emit it.
 //
-// Supported dialects are PostgreSQL (including CockroachDB and YugabyteDB),
-// MySQL, MariaDB, and SQLite. Any other dialect returns an error, as does a nil
+// Supported dialects are the PostgreSQL family (PostgreSQL itself, CockroachDB,
+// YugabyteDB, and Cloud Spanner's PostgreSQL interface — the set
+// platform.IsPostgresFamily reports), plus MySQL, MariaDB, and SQLite. SQL
+// Server and ClickHouse are not supported yet and are refused by name; see
+// selectPlaceholderStyle. Any other dialect returns an error, as does a nil
 // statement, a statement without a FROM table, an empty IN list, a malformed
 // operator, a function call with an invalid name or a bad argument shape, a GROUP
 // BY term with an empty column, a join without a table or ON condition, or a
@@ -79,10 +82,28 @@ func newSelectRenderer(dialect string) (*selectRenderer, error) {
 	return &selectRenderer{dialect: normalized, placeholder: style}, nil
 }
 
+// selectPlaceholderStyle reports how a dialect numbers bound parameters, and
+// whether the query builder renders for it at all.
+//
+// The PostgreSQL family is resolved through platform.IsPostgresFamily rather
+// than by listing member names, so this table cannot disagree with the rest of
+// the repository about who is in that family. It used to list Postgres,
+// CockroachDB and YugabyteDB by name and so omitted Spanner, which every other
+// subsystem already treats as PostgreSQL: platform.IsPostgresFamily("spanner")
+// is true, sqlutil.Rebind gives it $n, NewRendererWithCapabilities routes its
+// DDL through the PostgreSQL renderer, and dbschema reads it over pgx.
+//
+// SQL Server and ClickHouse are deliberately absent. Neither is a missing map
+// entry: SQL Server needs a third placeholder style (@p1, @p2, … — what
+// sqlutil.Rebind already emits for it), T-SQL pagination in place of LIMIT, and
+// an OUTPUT-versus-RETURNING decision; ClickHouse needs a decided statement
+// shape for UPDATE and DELETE, whose mutation forms are not the portable
+// statements this renderer emits. Both are tracked on stokaro/ptah#941.
 func selectPlaceholderStyle(normalized string) (placeholderStyle, bool) {
-	switch normalized {
-	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB:
+	if platform.IsPostgresFamily(normalized) {
 		return placeholderDollar, true
+	}
+	switch normalized {
 	case platform.MySQL, platform.MariaDB, platform.SQLite:
 		return placeholderQuestion, true
 	default:

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -167,8 +167,8 @@
     "ptah": "partial",
     "atlas_oss": "na",
     "atlas_pro": "na",
-    "note": "Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error.",
-    "evidence": "core/query/query.go (InnerJoin/LeftJoin/RightJoin/FullJoin, Distinct, GroupBy, Having) and core/query/write.go (InsertInto/Update/DeleteFrom, Returning); core/ast/select.go:17-18 records arithmetic, LIKE, subqueries and window functions as follow-ups; core/ast/write.go:13-16 records upsert, INSERT..SELECT, CTEs and multi-table UPDATE/DELETE as out of scope; core/renderer/select.go:84-89 maps placeholders for postgres/cockroachdb/yugabytedb/mysql/mariadb/sqlite only; executed probe over renderer.RenderInsert confirms sqlserver, mssql, clickhouse and spanner return \"renderer: INSERT rendering is not supported for dialect ...\""
+    "note": "Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server and ClickHouse error.",
+    "evidence": "core/query/query.go (InnerJoin/LeftJoin/RightJoin/FullJoin, Distinct, GroupBy, Having) and core/query/write.go (InsertInto/Update/DeleteFrom, Returning); core/ast/select.go:17-18 records arithmetic, LIKE, subqueries and window functions as follow-ups; core/ast/write.go:13-16 records upsert, INSERT..SELECT, CTEs and multi-table UPDATE/DELETE as out of scope; core/renderer/select.go selectPlaceholderStyle admits the platform.IsPostgresFamily set (postgres, cockroachdb, yugabytedb, spanner) plus mysql/mariadb/sqlite; core/renderer/dml_dialect_matrix_test.go walks renderer.SupportedDialects() x SELECT/INSERT/UPDATE/DELETE and pins all 48 cells, with 12 of them - sqlserver, mssql and clickhouse - still answering \"renderer: INSERT rendering is not supported for dialect ...\""
   },
   {
     "area": "Schema visualization",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -275,7 +275,7 @@ seven of them as open capabilities regardless.
 | Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
 | ptah-ls annotation language server | ✅ | ➖ | ➖ | stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax. |
 | Public API compatibility gate | ✅ | ➖ | ➖ | check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line. |
-| Query builder for parameterized SQL | 🟡 | ➖ | ➖ | Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server, ClickHouse, Spanner error. |
+| Query builder for parameterized SQL | 🟡 | ➖ | ➖ | Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server and ClickHouse error. |
 | Reusable Go packages (embedder API) | ✅ | ➖ | ➖ | Documented embedder packages cover parse, diff, plan, render, migrate, lint and seed. CE conformance measures CLI commands, not Go APIs. |
 | Schema visualization (ERD diagrams) | ✅ | ❌ | ✅ | Mermaid, DOT or SVG ERD from Go annotations only; SVG shells out to Graphviz dot. Atlas ERD lives in the hosted service (any plan per its pricing page); the CE binary rejects `--web`. |
 | Statement observer and validator hooks (Go API) | ✅ | ➖ | ➖ | migrator.WithStatementObserver runs a read-only callback per executed statement; WithStatementValidator gates all statements pre-execution; both compose with StatementInterceptor. |

--- a/docs/site/src/content/docs/extend/query-builder.md
+++ b/docs/site/src/content/docs/extend/query-builder.md
@@ -6,7 +6,9 @@ description: Build parameterized, dialect-aware SELECT statements with the core/
 Ptah's `core/query` package is a fluent builder for parameterized `SELECT`
 statements. It is the DML counterpart to the DDL AST: a builder produces an
 `*ast.SelectStatement`, and `renderer.RenderSelect` turns that into a SQL string
-plus its positional arguments for PostgreSQL, MySQL, MariaDB, and SQLite.
+plus its positional arguments for the PostgreSQL family, MySQL, MariaDB, and
+SQLite. See [Dialect coverage](#dialect-coverage) for the exact set and for the
+dialects that are refused.
 
 This is a bounded slice of the DML work in issue
 [`#98`](https://github.com/stokaro/ptah/issues/98). It exists so callers can stop
@@ -35,6 +37,35 @@ Implemented so far:
 Not yet implemented (follow-up phases): non-aggregate function calls, arithmetic,
 `LIKE`, subqueries, window functions, `ON CONFLICT` / upsert, `INSERT … SELECT`,
 and common table expressions.
+
+## Dialect coverage
+
+`RenderSelect`, `RenderInsert`, `RenderUpdate`, and `RenderDelete` render for the
+PostgreSQL family — PostgreSQL, CockroachDB, YugabyteDB, and Cloud Spanner's
+PostgreSQL interface, which all take `$1`, `$2`, … placeholders — and for MySQL,
+MariaDB, and SQLite, which take `?`. Spanner renders byte-identically to
+PostgreSQL, including `RETURNING`; it has no live coverage in this repository, so
+the [support matrix](../../databases/support-matrix/) caveat applies — review the
+generated SQL before relying on it.
+
+SQL Server (`sqlserver`, `mssql`) and ClickHouse are Ptah dialects for DDL and
+introspection, but the query builder refuses them:
+
+```text
+renderer: INSERT rendering is not supported for dialect "sqlserver"
+```
+
+Neither is a one-line addition. SQL Server needs a third placeholder style
+(`@p1`, `@p2`, …, which `sqlutil.Rebind` already emits for it), T-SQL pagination
+in place of `LIMIT`, and an `OUTPUT`-versus-`RETURNING` decision; ClickHouse needs
+a decided statement shape for `UPDATE` and `DELETE`, whose mutation forms are not
+the portable statements this renderer emits. Both are tracked on
+[`#941`](https://github.com/stokaro/ptah/issues/941).
+
+Every dialect name `renderer.SupportedDialects()` returns is pinned against all
+four render functions — 48 cells, each pinned to an exact SQL string or an exact
+error — in `core/renderer/dml_dialect_matrix_test.go`, so the builder cannot
+acquire or lose a dialect without that table saying so.
 
 ## Safety model
 
@@ -183,8 +214,8 @@ that fails at execution time against the database.
 - **MySQL and MariaDB** have no `FULL [OUTER] JOIN` in any version — it must be
   emulated with a `UNION` of a `LEFT` and a `RIGHT` join — so `FULL` is rejected
   (`renderer: mysql does not support FULL OUTER JOIN`). `RIGHT` renders normally.
-- The **PostgreSQL family** (including CockroachDB and YugabyteDB) supports all
-  four.
+- The **PostgreSQL family** (including CockroachDB, YugabyteDB, and Spanner)
+  supports all four.
 
 ## Aggregates, GROUP BY, and HAVING
 
@@ -363,7 +394,7 @@ that cannot execute it, rather than emit SQL that fails at execution time.
 
 | Dialect | `RETURNING` |
 | --- | --- |
-| PostgreSQL family (incl. CockroachDB, YugabyteDB) | yes |
+| PostgreSQL family (incl. CockroachDB, YugabyteDB, Spanner) | yes |
 | SQLite | yes (since 3.35, 2021) |
 | MySQL | no |
 | MariaDB | no (see note) |


### PR DESCRIPTION
Refs #941.

The query builder refused `spanner` outright — `RenderSelect`, `RenderInsert`, `RenderUpdate` and `RenderDelete` all answered `rendering is not supported for dialect`. That made the DML renderer the only subsystem in the repository that does not treat Spanner as PostgreSQL:

- `platform.IsPostgresFamily` says it is;
- `sqlutil.Rebind` numbers its parameters `$1, $2, …`;
- the DDL renderer hands it to the PostgreSQL visitor;
- `dbschema` reads it over pgx.

`selectPlaceholderStyle` and `supportsReturning` now ask `platform.IsPostgresFamily` instead of listing three of that family's four members, so the two tables cannot drift from the rest of the repository again.

## What is pinned, and what is not

Spanner renders byte-identically to PostgreSQL across all four statements, including `RETURNING`. **Nothing is executed against a Spanner server**, because this repository has none — that is #942 — so what this change pins is *rendering*, not execution. Saying so in the commit rather than leaving the reader to assume coverage.

## Why the test is a 48-cell table rather than four new rows

The suite pinned only three refusals before this change, and all three were ClickHouse. So teaching the renderer one more dialect and deleting those three cells would have produced a **green suite and unreviewed SQL** — the change would have been indistinguishable from a change that got the SQL wrong.

Three tests now stand in for that:

1. A table walks `renderer.SupportedDialects()` across the four render functions and pins all **48 cells** to an exact SQL string with exact args, or to an exact error.
2. A census pins which cells still carry the generic unsupported-dialect refusal — **12**, on `sqlserver`, `mssql` and `clickhouse` — measured against observed behavior rather than read off the table it is supposed to check.
3. A third test derives the expected placeholder from `sqlutil.Rebind`, so the two placeholder tables cannot disagree silently.

## Deliberately unchanged

SQL Server and ClickHouse are still refused, and neither is a missing map entry:

- **SQL Server** needs a third placeholder style, T-SQL pagination and a decision about `OUTPUT`.
- **ClickHouse** needs a decided shape for its mutation forms.

Both are design decisions rather than wiring, so they stay refused and stay counted by the census above.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all green. docs/ is touched, so every `check:*` script in `docs/site/package.json` was run: style, exit-codes, core-doc-links, page-health and feature-matrix all OK.

Rebased onto current master cleanly before opening.