### PR TITLE
Refuse a `column` attribute that cannot name a column (#1106)

### DIFF
--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -988,7 +988,10 @@ func (p *parser) parseIndexParts(onBlocks []*hclsyntax.Block) ([]string, []gosch
 		operator := p.optionalSQLExpression(nested.Body.Attributes["ops"])
 		prefix := p.optionalRawExpr(nested.Body.Attributes["prefix"])
 		if columnAttr != nil {
-			column := p.columnNameFromExpr(columnAttr)
+			column, err := p.columnNameFromExpr(nested, "index on", columnAttr)
+			if err != nil {
+				return nil, nil, err
+			}
 			columns = append(columns, column)
 			parts = append(parts, goschema.IndexPart{Name: column, Operator: operator, Prefix: prefix, Desc: desc})
 			continue
@@ -1111,7 +1114,11 @@ func (p *parser) parsePartitionParts(block *hclsyntax.Block, byBlocks []*hclsynt
 			return nil, p.blockError(nested, "partition by block cannot set both column and expr")
 		}
 		if columnAttr != nil {
-			parts = append(parts, goschema.PartitionPart{Name: p.columnNameFromExpr(columnAttr)})
+			name, err := p.columnNameFromExpr(nested, "partition by", columnAttr)
+			if err != nil {
+				return nil, err
+			}
+			parts = append(parts, goschema.PartitionPart{Name: name})
 			continue
 		}
 		parts = append(parts, goschema.PartitionPart{Expr: p.exprString(exprAttr)})
@@ -1159,8 +1166,12 @@ func (p *parser) parsePrimaryKeyParts(block *hclsyntax.Block) ([]goschema.Primar
 		if attr == nil {
 			return nil, p.blockError(nested, "primary_key on block requires column")
 		}
+		name, err := p.columnNameFromExpr(nested, "primary_key on", attr)
+		if err != nil {
+			return nil, err
+		}
 		parts = append(parts, goschema.PrimaryKeyPart{
-			Name:   p.columnNameFromExpr(attr),
+			Name:   name,
 			Prefix: p.optionalRawExpr(nested.Body.Attributes["prefix"]),
 			Desc:   p.optionalBool(nested.Body.Attributes["desc"], false),
 		})
@@ -1796,8 +1807,34 @@ func (p *parser) stringListAttr(block *hclsyntax.Block, attrName string) ([]stri
 	return values, nil
 }
 
-func (p *parser) columnNameFromExpr(attr *hclsyntax.Attribute) string {
-	return columnNameFromRef(p.rawExpr(attr))
+// columnNameFromExpr reads a `column` attribute as a column reference and
+// refuses a value that cannot name a column at all.
+//
+// This is the apply-time half of issue #1106. Reducing Atlas HCL's sql() escape
+// hatch to the SQL text it carries fixed every position that reads a plain
+// STRING, but a `column` attribute reads a REFERENCE, and SQL text is not one.
+// Ptah swallowed the mismatch: columnNameFromRef yields "" for any value it
+// cannot resolve, and the empty name went straight into DDL. Measured before
+// this refusal existed, `index "u" { unique = true, on { column = sql("n") } }`
+// planned AND applied `CREATE UNIQUE INDEX "u" ON "t" ("")` at exit 0, leaving a
+// table that accepts exactly one row -- sqlite indexes every row on the same
+// constant, so the second INSERT fails on a uniqueness rule the schema never
+// asked for. The primary_key form dropped the key without a word. The pinned
+// Atlas community binary v1.3.0 refuses all of it: `expected value to be a
+// *Ref, got: *schemahcl.RawExpr`.
+//
+// The refusal is narrower than the blanket one rejected when sql() reduction
+// landed. It fires only where Ptah has no column name to render, so every value
+// Ptah could already name is untouched -- a reference, or the quoted-string
+// spelling Ptah accepts and that binary does not. Raw SQL in an index part has
+// its own attribute, `expr`, which takes it and renders it.
+func (p *parser) columnNameFromExpr(block *hclsyntax.Block, label string, attr *hclsyntax.Attribute) (string, error) {
+	raw := p.rawExpr(attr)
+	name := columnNameFromRef(raw)
+	if name == "" {
+		return "", p.blockError(block, "%s column contains unsupported reference %q", label, raw)
+	}
+	return name, nil
 }
 
 func (p *parser) rawExpr(attr *hclsyntax.Attribute) string {

--- a/internal/atlashcl/column_ref_test.go
+++ b/internal/atlashcl/column_ref_test.go
@@ -1,0 +1,243 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// A `column` attribute holds a column REFERENCE, and Atlas HCL's sql() escape
+// hatch produces SQL TEXT. Reducing the call to its text -- the answer issue
+// #1106 took for every position that reads a plain string -- still leaves text
+// where a reference belongs, so these positions needed their own answer: refuse.
+//
+// Reverted, every row below parses with a nil error and an EMPTY column name
+// reaches the renderer. Measured on the reverted build: the index rows plan
+// `CREATE UNIQUE INDEX IF NOT EXISTS "main"."u" ON "t" ("")`, the primary_key
+// row plans `CREATE TABLE "main"."t" ("n" int NOT NULL)` with the key silently
+// gone, and the partition row is the only one another layer catches -- the
+// postgres renderer rejects it with `postgres partition key cannot be empty`,
+// at render time and without naming the attribute. The pinned Atlas community
+// binary v1.3.0 exits 1 on all five.
+func TestParseRefusesAColumnAttributeThatCannotNameAColumn(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		hcl   string
+		match string
+	}{
+		{
+			name: "index on sql call",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = sql("n") }
+  }
+}
+`,
+			match: `.*index on column contains unsupported reference "sql\(\\"n\\"\)"`,
+		},
+		{
+			name: "index on number",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = 42 }
+  }
+}
+`,
+			match: `.*index on column contains unsupported reference "42"`,
+		},
+		{
+			// The quoted-string spelling is accepted for a NON-empty name (see
+			// the control test below), so this row pins that the acceptance is
+			// "unquoted to something", not "unquoting succeeded".
+			name: "index on empty string",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = "" }
+  }
+}
+`,
+			match: `.*index on column contains unsupported reference "\\"\\""`,
+		},
+		{
+			name: "primary key on sql call",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  primary_key {
+    on { column = sql("n") }
+  }
+}
+`,
+			match: `.*primary_key on column contains unsupported reference "sql\(\\"n\\"\)"`,
+		},
+		{
+			name: "partition by sql call",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  partition {
+    type = RANGE
+    by { column = sql("n") }
+  }
+}
+`,
+			match: `.*partition by column contains unsupported reference "sql\(\\"n\\"\)"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
+}
+
+// The non-interference control for the refusal above. Every value Ptah could
+// already turn into a column name still parses and still names the same column.
+// The last row is the one that earns its keep: the quoted-string spelling is a
+// Ptah-only extension -- the pinned Atlas community binary v1.3.0 exits 1 on it
+// with `missing type in reference "n"` -- and tightening `column` to references
+// only would have taken it away from anyone relying on it.
+//
+// Reverted, this still passes: it pins the boundary of the refusal, not the
+// refusal. It goes red under the INVERSE mutant -- making the refusal fire for
+// every value -- which is the only way a guard's non-interference is provable.
+// Measured under that mutant: all five rows fail on `err` being non-nil.
+func TestParseKeepsColumnAttributesThatNameAColumn(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		hcl    string
+		assert func(c *qt.C, db *goschema.Database)
+	}{
+		{
+			name: "index on column reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = column.n }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts[0].Name, qt.Equals, "n")
+			},
+		},
+		{
+			name: "index on qualified table reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = table.t.column.n }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts[0].Name, qt.Equals, "n")
+			},
+		},
+		{
+			name: "primary key on column reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  primary_key {
+    on { column = column.n }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{{Name: "n"}})
+			},
+		},
+		{
+			name: "partition by column reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  partition {
+    type = RANGE
+    by { column = column.n }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].Partition, qt.DeepEquals, &goschema.PartitionSpec{
+					Type:  "RANGE",
+					Parts: []goschema.PartitionPart{{Name: "n"}},
+				})
+			},
+		},
+		{
+			name: "index on quoted string",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = "n" }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Parts[0].Name, qt.Equals, "n")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			test.assert(c, db)
+		})
+	}
+}
+
+// Raw SQL in an index part is not lost by the refusal -- it has its own
+// attribute. This is the row that makes the refusal a redirection rather than a
+// removal: `on { expr = sql("n * 2") }` still plans
+// `CREATE INDEX IF NOT EXISTS "main"."idx_n" ON "t" (n * 2)` at exit 0.
+//
+// Reverted, this still passes; it exists so a future widening of the refusal to
+// the `expr` attribute is a deliberate edit with a failing test.
+func TestParseKeepsRawSQLInTheIndexExprAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { expr = sql("n * 2") }
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Indexes, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+	c.Assert(db.Indexes[0].Parts[0].Expr, qt.Equals, "n * 2")
+	c.Assert(db.Indexes[0].Parts[0].Name, qt.Equals, "")
+}


### PR DESCRIPTION
Refs #1106. One part of the issue survives on purpose and needs a decision rather than code — see **What survives** at the bottom.

Measured in my own worktree, branched from `origin/master` at `f22107bd`, against the pinned Atlas community binary at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (`atlas community version v1.3.0`), by absolute path.

## Re-measuring #1106 first: most of it is already closed

| part of the issue | state at `f22107bd` | closed by |
| --- | --- | --- |
| `check.expr` plans `CHECK (sql("n > 0"))` | **fixed** — plans `CHECK (n > 0)` | #1131 |
| `index.where` plans `WHERE sql("n > 5")` | **fixed** — plans `WHERE n > 5` | #1131 |
| the choice between refusing and evaluating, reasoned in code | **done** — `internal/atlashcl/sqlrawexpr.go` header | #1131 |
| "check the other attributes that accept `sql()` — the list is a lower bound" | **partly done** — #1131 fixed the four *value* readers; the *reference* readers were left | this PR |
| count 2: `ptah-compat` exits 0 where that binary exits 1 | **survives** | — |

Confirmed at `f22107bd` before touching anything, both spellings from the issue:

```
$ ptah-compat schema diff --from sqlite://empty.db --to file://check.hcl --dev-url sqlite://dev.db
CREATE TABLE "main"."t" ("n" int NOT NULL, CONSTRAINT "n_positive" CHECK (n > 0));   rc=0
$ ptah-compat schema diff ... --to file://where.hcl ...
CREATE INDEX IF NOT EXISTS "main"."idx_n" ON "t" ("n") WHERE n > 5;                  rc=0
```

So the "DDL no engine can execute" half is gone for those two. It is **not** gone everywhere.

## The reproduction this PR fixes, before

#1131 reduced `sql()` at the four helpers that read an attribute as a plain **string**. A `column` attribute is not a string — it is a **reference**, read by `columnNameFromExpr`, which returns `""` for any value it cannot resolve. Nothing consumed that `""` as an error; it went into DDL.

`uniq.hcl`:

```hcl
schema "main" {
}
table "t" {
  schema = schema.main
  column "n" { type = int }
  index "u" {
    unique = true
    on { column = sql("n") }
  }
}
```

```
$ atlas schema diff --from sqlite://empty.db --to file://uniq.hcl --dev-url sqlite://dev.db
Error: schemahcl: failed reading spec as *sqlite.doc: set field "column":
  schemahcl: expected value to be a *Ref, got: *schemahcl.RawExpr
rc=1

$ ptah-compat schema diff --from sqlite://empty.db --to file://uniq.hcl --dev-url sqlite://dev.db
CREATE TABLE "main"."t" ("n" int NOT NULL);
CREATE UNIQUE INDEX IF NOT EXISTS "main"."u" ON "t" ("");
rc=0
```

This one does not even fail at apply time, which is what makes it worse than the shape the issue filed. It applies:

```
$ ptah-compat schema apply --url sqlite://live.db --dev-url sqlite://devx.db --to file://uniq.hcl --auto-approve
Schema apply completed successfully.                          rc=0
$ sqlite3 live.db "SELECT sql FROM sqlite_master WHERE name='u';"
CREATE UNIQUE INDEX "u" ON "t" ("")
$ sqlite3 live.db "INSERT INTO t VALUES (1);"                 rc=0
$ sqlite3 live.db "INSERT INTO t VALUES (2);"
Error: stepping, UNIQUE constraint failed: index 'u' (19)     rc=19
```

`PRAGMA index_info('u')` returns column id `-2` — an *expression*, not a column. SQLite reads `""` as a string constant, so every row indexes the same value and the table the user asked to be unique on `n` holds exactly one row, forever, silently.

`primary_key.on` is the quiet version of the same thing — `on { column = sql("n") }` planned `CREATE TABLE "main"."t" ("n" int NOT NULL)` at rc=0 with the key simply absent, against rc=1 from that binary.

## The reproduction, after

```
$ ptah-compat schema diff ... --to file://uniq.hcl ...
Error: load --to schema: parse HCL schema at uniq.hcl:10,5-7:
  index on column contains unsupported reference "sql(\"n\")"
rc=1

$ ptah-compat schema apply ... --to file://uniq.hcl --auto-approve
Error: load --to schema: parse HCL schema at uniq.hcl:10,5-7: ...
rc=1     (no table created; the INSERTs that followed fail with "no such table: t")
```

## The answer, and why it is not the blanket refusal #1131 rejected

#1131 argued against refusing `sql()` positionally: it needs a hand-copied table of Atlas's per-attribute hclspec types, and one wrong row breaks drop-in silently. That argument holds and this change does not contradict it.

The refusal here is not positional and not about `sql()`. It fires when **Ptah has no column name to render** — from any value, `sql("n")` or `42` or `""`. There is no table to keep in sync: the condition is Ptah's own inability to produce output, which is exactly the condition under which Ptah must not produce output. `parseColumnRefsAttr` two hundred lines away already refuses on the identical condition (`%s contains unsupported reference %q`) for the list-shaped `columns` / `ref_columns`; the single-attribute readers were the ones that swallowed it. The reason is in the code, on `columnNameFromExpr`.

Users who want raw SQL in an index part are not losing anything: `on { expr = sql("n * 2") }` still plans `ON "t" (n * 2)` at rc=0, and has a test row pinning that.

### Exit-code ledger — every rc this change moves

| file | attribute value | pinned binary | before | after |
| --- | --- | --- | --- | --- |
| `oncol.hcl` | `index.on.column = sql("n")` | 1 | 0, `ON "t" ("")` | **1** |
| `uniq.hcl` | same, `unique = true` | 1 | 0, applies a one-row table | **1** |
| `pkon.hcl` | `primary_key.on.column = sql("n")` | 1 | 0, key silently dropped | **1** |
| `oncol_num.hcl` | `index.on.column = 42` | 1 | 0, `ON "t" ("")` | **1** |

**Four positions get stricter (0 → 1), and the pinned binary exits 1 on all four**, so all four are same-rc after. **Zero positions where `ptah-compat` becomes stricter than that binary** — no row in the sweep has ptah=1 against binary=0.

Negative controls, unmoved, same DDL before and after:

| file | value | binary | ptah |
| --- | --- | --- | --- |
| `oncol_ctrl.hcl` | `column = column.n` | 0 | 0, `ON "t" ("n")` |
| `oncol_tblref.hcl` | `column = table.t.column.n` | 0 | 0, `ON "t" ("n")` |
| `pkon_ctrl.hcl` | `primary_key.on.column = column.n` | 0 | 0, `"n" int PRIMARY KEY` |
| `oncol_str.hcl` | `column = "n"` | **1** | 0, `ON "t" ("n")` |
| `onexpr.hcl` | `index.on.expr = sql("n * 2")` | 1 | 0, `ON "t" (n * 2)` |
| `check.hcl` / `where.hcl` | the filed spellings | 1 | 0, valid DDL (#1131) |
| `ctrl_literal.hcl` | `expr = "n > 0"` | 0 | 0, identical DDL |

`oncol_str.hcl` is the row that shaped the condition. The quoted-string spelling is a Ptah-only extension — that binary refuses it with `missing type in reference "n"` — and it renders correctly. Tightening `column` to references only would have deleted a working feature to fix a broken one, so the refusal keys on the empty result rather than on the value's syntax.

## What each test prints if the change is reverted

Byte-snapshot mutants restored from a file copy, not a git restore. Baseline green before, and green again after each restore.

| mutant | goes red |
| --- | --- |
| refusal removed (`columnNameFromExpr` returns the empty name) | `TestParseRefusesAColumnAttributeThatCannotNameAColumn`, all 5 rows. Both control tests stay green. |
| refusal fires unconditionally (**inverse**) | `TestParseKeepsColumnAttributesThatNameAColumn`, exactly its 5 rows. The refusal test stays green, and so does `TestParseKeepsRawSQLInTheIndexExprAttribute` — which is why the control test has to exist: removing the guard can never over-refuse, so removal proves nothing about non-interference. |

Per-test, in words:

- **`TestParseRefusesAColumnAttributeThatCannotNameAColumn`** — reverted, every row parses with a nil error and an empty column name reaches the renderer. Measured on the reverted build: the index rows plan `CREATE UNIQUE INDEX IF NOT EXISTS "main"."u" ON "t" ("")`, the primary_key row plans `CREATE TABLE "main"."t" ("n" int NOT NULL)` with the key gone, and the partition row is the one case another layer catches — the postgres renderer says `postgres partition key cannot be empty`, at render time and without naming the attribute. The `index on empty string` row (`column = ""`) discriminates "unquoted to something" from "unquoting succeeded"; a mutant that accepts any successful unquote passes the other four rows and fails only that one.
- **`TestParseKeepsColumnAttributesThatNameAColumn`** — reverted, still passes. It pins the boundary, not the change. Stated so nobody cites it as a discriminator for the fix.
- **`TestParseKeepsRawSQLInTheIndexExprAttribute`** — reverted, still passes. It exists so a future widening of the refusal to `expr` is a deliberate edit with a failing test.

## What survives, and why this is Refs

**Count 2 of #1106 is unfixed and is a decision, not code.** `ptah-compat` still exits 0 for `check.expr`, `index.where` and `index.on.expr` where the pinned binary exits 1. That is parity rule (a) surviving, stated plainly. Nothing in this PR moves it, and nothing should move it by accident: #1131 chose to evaluate `sql()` rather than refuse it, argued the choice from measurement, and wrote "Refs, not Closes, so the author decides whether that trade closes it." The issue has no comments, so that has not been answered.

The choice, precisely, and the measurement that frames it:

- **Accept the trade → #1106 can be closed.** Both spellings plan *correct* DDL, which is the "same or better" side the issue itself describes for this option. Cost: `ptah-compat` accepts three files the community binary rejects.
- **Reject the trade → a follow-up refuses `sql()` in `check.expr`, `index.where` and `index.on.expr`.** That is a 3-row table of Atlas's per-attribute hclspec types, re-measured per attribute, and it partially reverts #1131 — which landed three days ago with its reasoning in the code. Cost: an escape hatch users can reasonably want, removed from positions where it currently works.

I did not make that call in this PR. It removes working functionality either way, it was already escalated once, and it is not the defect this PR is about.

**Also deliberately left open:**

- **`column = column.nope`** — a reference to a column that does not exist plans `ON "t" ("nope")` at rc=0 against rc=1 from that binary (`Unsupported attribute; This object does not have an attribute named "nope"`). The name *is* read, it just resolves to nothing; the DDL is well-formed, merely wrong. That is name resolution, not the reference/text mismatch this PR fixes, and it wants its own measurement pass.
- **`column = "n"`** — kept accepted at rc=0 where that binary exits 1, on purpose. Argued in the ledger above.
- **`partition.by` has no CLI reproduction here.** `partition` is PostgreSQL-only, so demonstrating it end-to-end needs a live server; it is covered at the parser layer instead, in both the refusal test and the control test, and the reverted-build behavior quoted above was measured through the postgres renderer rather than through `ptah-compat`.

## Gates

Every one run in this worktree, exit codes captured directly:

```
go build ./...                     rc=0
go vet ./...                       rc=0
go test ./... -count=1             rc=0   (251 ok/no-test-files lines, zero FAIL)
go tool qtlint ./...               rc=0
golangci-lint run ./...            rc=0   (0 issues)
scripts/check-test-style.sh        rc=0   (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh        rc=0
scripts/check-public-api-snapshot.sh rc=0
```

`check-test-style.sh` was proven live on the new file rather than trusted: adding one `if` inside a test body turns it red with `internal/atlashcl/column_ref_test.go TestParseKeepsRawSQLInTheIndexExprAttribute if 1`. Removed again, green.

**`go test ./...` silently skips the oracle conformance gate** — `TestOracleAcceptsAndDropsUnknownSchemaHCLNames`, `TestOracleRefusesUnevaluableDroppedBodies`, `TestOracleAcceptsReferencesPtahRefuses` and `TestOraclePartitionIsDialectSplit` all report SKIP without `PTAH_ATLAS_ORACLE`, and `TestOracleAcceptsReferencesPtahRefuses` is directly about the code this PR changes. Re-run against the pinned binary by absolute path, together with the other two oracle-gated packages:

```
PTAH_ATLAS_ORACLE=/Users/buster/.../bin/atlas go test ./internal/atlashcl/ -run TestOracle   rc=0
PTAH_ATLAS_ORACLE=... go test ./config/projectconfig/ ./internal/atlasmigrateimport/         rc=0
```

No exported API change, so the snapshot gate is green on an unchanged baseline.

Nothing under `docs/` is touched or made false — `docs/atlas_hcl_schema.md` documents `on { column = ..., prefix = ... }` and `on { expr = "..." }`, and never documents `sql()` in a `column` attribute — so the twelve `check:*` scripts in `docs/site/package.json` do not apply to this diff.