### PR TITLE
Bind the migrate diff writer to the directory it opened (refs #1118)

### DIFF
--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -199,7 +199,15 @@ func runAtlasMigrateDiff(
 		}
 	}
 	diffResult, err := atlasmigrate.GenerateDiff(cmd.Context(), conn, atlasmigrate.DiffOptions{
-		Dir:                  migrationsDir,
+		Dir: migrationsDir,
+		// The same handle the preflight gate captured through. Handing it to the
+		// writer is what keeps the publication bound to the project root the
+		// directory was validated inside: without it the writer would carry only
+		// migrationsDir and reopen it by pathname for locking, staging,
+		// publication, the atlas.sum commit and recovery, so a directory or
+		// ancestor replaced after resolution could take the write somewhere the
+		// gate never looked (stokaro/ptah#1118).
+		Root:                 migrateDiffWriterRoot(project, localDir),
 		Desired:              desired,
 		SourceConnectTimeout: dbcli.DefaultConnectTimeout,
 		Name:                 name,
@@ -264,6 +272,20 @@ func resolveMigrateDiffDirectory(dir atlasargs.LocalDir) (string, error) {
 		return pathguard.ResolveWithinRoot(dir.Path, dir.AllowedRoot)
 	}
 	return pathguard.ResolveCLIPath(dir.Path)
+}
+
+// migrateDiffWriterRoot returns the opened root the writer must stay inside, or
+// nil when the operator named the directory directly.
+//
+// It reads the same two conditions [atlasProject.localOptions] uses for the
+// reading half, deliberately: "did this directory come from the project file"
+// is one question, and answering it differently for the gate and for the writer
+// is how the two end up bound to different filesystem objects.
+func migrateDiffWriterRoot(
+	project atlasProject,
+	dir atlasargs.LocalDir,
+) *pathguard.OpenedDirectory {
+	return project.localOptions(dir).Root
 }
 
 func needsAtlasMigrateDiffConfig(cmd *cobra.Command) bool {

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -6,8 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -21,6 +19,7 @@ import (
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
+	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/internal/schemascope"
 	"go.5x5.cz/ptah/migration/migrator"
 	"go.5x5.cz/ptah/migration/planner"
@@ -34,7 +33,17 @@ const (
 )
 
 type DiffOptions struct {
-	Dir                  string
+	Dir string
+	// Root, when set, is the opened project root the migration directory must
+	// stay inside. The writer binds Dir through it once and runs every later
+	// step -- staging, publication, checksum commit, rollback and recovery --
+	// through that handle, so replacing the directory or one of its ancestors
+	// after Dir was resolved cannot redirect a write out of the root
+	// (stokaro/ptah#1118). The caller retains ownership of the handle.
+	//
+	// Leave it nil for direct CLI semantics, where an explicit absolute --dir is
+	// the operator's own choice of destination and is bound as its own root.
+	Root                 *pathguard.OpenedDirectory
 	Desired              atlassource.Set
 	SourceConnectTimeout time.Duration
 	Name                 string
@@ -123,8 +132,8 @@ func generateDiff(
 	schemas := prepared.schemas
 	format := prepared.format
 
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(opts.Dir)), 0755); err != nil {
-		return DiffResult{}, fmt.Errorf("create migration directory parent: %w", err)
+	if err := ensureMigrationDirParent(opts.Root, opts.Dir); err != nil {
+		return DiffResult{}, err
 	}
 	dirLock, err := acquireDirLock(ctx, opts.Dir, opts.LockTimeout)
 	if err != nil {
@@ -144,19 +153,18 @@ func generateDiff(
 	if err != nil {
 		return DiffResult{}, err
 	}
-	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
-		return DiffResult{}, fmt.Errorf("create migration directory: %w", err)
-	}
-	if err := recoverPendingPublication(opts.Dir); err != nil {
-		return DiffResult{}, fmt.Errorf("recover migration artifact publication: %w", err)
-	}
-	migrationSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(opts.Dir))
+	// From here on the migration directory is a rooted capability, not a
+	// pathname. Everything that reads or writes it -- the capture, the checksum
+	// recheck, staging, publication, the atlas.sum commit, rollback and recovery
+	// -- goes through this handle, so a directory or ancestor replaced after this
+	// point cannot redirect the transaction (stokaro/ptah#1118).
+	writer, migrationSnapshot, err := openVerifiedMigrationDir(opts)
 	if err != nil {
-		return DiffResult{}, fmt.Errorf("capture migration directory: %w", err)
-	}
-	if err := opts.verifyDir(migrationSnapshot); err != nil {
 		return DiffResult{}, err
 	}
+	defer func() {
+		err = errors.Join(err, writer.Close())
+	}()
 
 	info := conn.Info()
 	devDefaultSchema := info.Schema
@@ -200,7 +208,7 @@ func generateDiff(
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
 	}
-	if err := verifyMigrationDirUnchanged(opts.Dir, migrationSnapshot); err != nil {
+	if err := verifyMigrationDirUnchanged(writer, migrationSnapshot); err != nil {
 		return DiffResult{}, err
 	}
 	if opts.DryRun {
@@ -208,12 +216,51 @@ func generateDiff(
 	}
 	return writeDiffArtifacts(
 		ctx,
-		opts.Dir,
+		writer,
 		opts.Name,
 		contents,
 		migrationSnapshot,
 		opts.PreparePublication,
 	)
+}
+
+// openVerifiedMigrationDir binds the migration directory once and returns it
+// together with the snapshot the rest of the run is planned against. Both come
+// from the same handle deliberately: verifying one filesystem object and
+// planning against another is the defect this ordering closes.
+func openVerifiedMigrationDir(
+	opts DiffOptions,
+) (*migrationWriterDir, fsnapshot.Snapshot, error) {
+	writer, err := createMigrationWriterDir(opts.Root, opts.Dir)
+	if err != nil {
+		return nil, fsnapshot.Snapshot{}, err
+	}
+	snapshot, err := captureVerifiedMigrationDir(writer, opts)
+	if err != nil {
+		return nil, fsnapshot.Snapshot{}, errors.Join(err, writer.Close())
+	}
+	return writer, snapshot, nil
+}
+
+func captureVerifiedMigrationDir(
+	w *migrationWriterDir,
+	opts DiffOptions,
+) (fsnapshot.Snapshot, error) {
+	if err := recoverPendingPublication(w); err != nil {
+		return fsnapshot.Snapshot{}, fmt.Errorf("recover migration artifact publication: %w", err)
+	}
+	fsys, err := w.FS()
+	if err != nil {
+		return fsnapshot.Snapshot{}, err
+	}
+	snapshot, err := migrationsnapshot.CaptureStable(fsys)
+	if err != nil {
+		return fsnapshot.Snapshot{}, fmt.Errorf("capture migration directory: %w", err)
+	}
+	if err := opts.verifyDir(snapshot); err != nil {
+		return fsnapshot.Snapshot{}, err
+	}
+	return snapshot, nil
 }
 
 func prepareDiff(
@@ -363,8 +410,12 @@ func verifyDirSum(fsys fs.FS) error {
 	return nil
 }
 
-func verifyMigrationDirUnchanged(dir string, expected fsnapshot.Snapshot) error {
-	current, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+func verifyMigrationDirUnchanged(w *migrationWriterDir, expected fsnapshot.Snapshot) error {
+	fsys, err := w.FS()
+	if err != nil {
+		return err
+	}
+	current, err := migrationsnapshot.CaptureStable(fsys)
 	if err != nil {
 		return fmt.Errorf("recapture migration directory: %w", err)
 	}

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -22,10 +22,10 @@ import (
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/atlasurl"
-	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
+	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -40,14 +40,15 @@ func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 		{NameSuffix: "_transactional", SQL: "SELECT 1;"},
 		{NameSuffix: "_concurrent_indexes", SQL: "SELECT 2;", NoTransaction: true},
 	}
+	writer := openTestWriter(c, dir)
 
-	batch, err := stageMigrationBatchAt(dir, "add_email", 1, contents)
+	batch, err := stageMigrationBatchAt(writer, "add_email", 1, contents)
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 
 	c.Assert(err, qt.ErrorMatches, `migration directory changed during publication: .*2_add_email_concurrent_indexes\.sql already exists`)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(writer, batch, published), qt.IsNil)
 	// The colliding file kept its content and no version-1 leftover remains
 	// from the aborted attempt.
 	taken, readErr := os.ReadFile(filepath.Join(dir, "2_add_email_concurrent_indexes.sql"))
@@ -64,17 +65,18 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 	// create fails with a non-collision error after the first file was
 	// already written; the batch rolls back completely.
 	oversizedSuffix := "_" + strings.Repeat("x", 512)
+	writer := openTestWriter(c, dir)
 
-	batch, err := stageMigrationBatch(dir, "add_email", []MigrationFileContent{
+	batch, err := stageMigrationBatch(writer, "add_email", []MigrationFileContent{
 		{NameSuffix: "_transactional", SQL: "SELECT 1;"},
 		{NameSuffix: oversizedSuffix, SQL: "SELECT 2;", NoTransaction: true},
 	})
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 
 	c.Assert(err, qt.ErrorMatches, `publish migration file: .*`)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(writer, batch, published), qt.IsNil)
 	_, leftoverErr := os.Stat(filepath.Join(dir, "1_add_email_transactional.sql"))
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
 }
@@ -82,8 +84,9 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 func TestPublishMigrationBatch_ExclusiveCopyMode(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"copy",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -91,26 +94,27 @@ func TestPublishMigrationBatch_ExclusiveCopyMode(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	batch.mode = publicationModeCopy
 
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	stagedInfo, err := os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
 	finalInfo, err := os.Stat(batch.paths[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
-	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	stagedContents, err := os.ReadFile(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
 	finalContents, err := os.ReadFile(batch.paths[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(finalContents, qt.DeepEquals, stagedContents)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(writer, batch, published), qt.IsNil)
 }
 
 func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeAtlasSum,
@@ -124,7 +128,7 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	}
 
 	err := writePublicationJournalWithLink(
-		dir,
+		writer,
 		journal,
 		func(string, string) error {
 			return syscall.ENOTSUP
@@ -132,19 +136,18 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	got, err := readPublicationJournal(journalPath)
+	journalPath := testJournalPath(writer)
+	got, err := readPublicationJournal(writer)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.DeepEquals, journal)
 	backups, err := filepath.Glob(journalPath + ".*.tmp")
 	c.Assert(err, qt.IsNil)
 	c.Assert(backups, qt.HasLen, 1)
 	c.Assert(os.WriteFile(journalPath, []byte("{"), 0o600), qt.IsNil)
-	got, err = readPublicationJournal(journalPath)
+	got, err = readPublicationJournal(writer)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.DeepEquals, journal)
-	c.Assert(removePublicationJournal(journalPath), qt.IsNil)
+	c.Assert(removePublicationJournal(writer), qt.IsNil)
 }
 
 func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
@@ -162,11 +165,7 @@ func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(paths, qt.DeepEquals, []string{
-		filepath.Join(dir, "1_change.up.sql"),
-		filepath.Join(dir, "1_change.down.sql"),
-		filepath.Join(dir, "1_change.safety.json"),
-	})
+	c.Assert(paths, qt.HasLen, 3)
 	up, err := os.ReadFile(paths[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(up), qt.Equals, "SELECT 1;\n")
@@ -176,11 +175,11 @@ func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	report, err := os.ReadFile(paths[2])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(report), qt.Equals, "{}\n")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
+	journalPath := testJournalPath(writer)
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	_, err = os.Stat(journalPath + publicationCommitMarkerSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
@@ -209,24 +208,25 @@ func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
 	staged, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
 	c.Assert(err, qt.IsNil)
 	c.Assert(staged, qt.HasLen, 0)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	writer := openTestWriter(c, dir)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 
 	batch, err := stageMigrationBatchAtWithModeDetector(
-		dir,
+		writer,
 		"copy",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
-		func(stagedPath string) (publicationMode, error) {
+		func(d *pathguard.OpenedDirectory, stagedName string) (publicationMode, error) {
 			return detectPublicationModeWithLink(
-				stagedPath,
+				d,
+				stagedName,
 				func(string, string) error {
 					return syscall.ENOTSUP
 				},
@@ -236,15 +236,15 @@ func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(batch.mode, qt.Equals, publicationModeCopy)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	stagedInfo, err := os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
 	finalInfo, err := os.Stat(batch.paths[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(writer, batch, published), qt.IsNil)
 }
 
 func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
@@ -253,10 +253,11 @@ func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 	c.Assert(os.Mkdir(filepath.Join(dir, "atlas.sum"), 0o700), qt.IsNil)
 	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
 	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
 
 	result, err := writeDiffArtifacts(
 		t.Context(),
-		dir,
+		writer,
 		"add_email",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
@@ -279,8 +280,9 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
 	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"interrupted",
 		2,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
@@ -288,23 +290,21 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
@@ -318,8 +318,9 @@ func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
 	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"interrupted_copy",
 		2,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
@@ -328,19 +329,19 @@ func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 	batch.mode = publicationModeCopy
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(
 		os.DirFS(dir),
@@ -353,8 +354,9 @@ func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"interrupted_move",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -363,23 +365,21 @@ func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
 	batch.mode = publicationModeWriteThroughMove
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
@@ -397,8 +397,9 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
 			dir := c.TempDir()
+			writer := openTestWriter(c, dir)
 			batch, err := stageMigrationBatchAt(
-				dir,
+				writer,
 				"interrupted",
 				1,
 				[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -407,32 +408,26 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 			batch.mode = test.mode
 			_, _ = beginTestPublication(
 				c,
-				dir,
+				writer,
 				batch,
 				[]MigrationFileContent{{SQL: "SELECT 1;"}},
 			)
-			published, err := publishMigrationBatch(dir, batch)
+			published, err := publishMigrationBatch(writer, batch)
 			c.Assert(err, qt.IsNil)
 			c.Assert(published, qt.Equals, 1)
-			quarantineDir := batch.stagedPaths[0] + ".rollback"
-			quarantinePath := filepath.Join(quarantineDir, "published")
-			c.Assert(os.Mkdir(quarantineDir, 0o700), qt.IsNil)
+			quarantinePath := stagedPath(writer, batch, 0) + publicationRollbackSuffix
 			c.Assert(os.Rename(batch.paths[0], quarantinePath), qt.IsNil)
-			c.Assert(removeFiles(batch.stagedPaths), qt.IsNil)
+			c.Assert(removeRootedFiles(writer.dir, batch.stagedNames), qt.IsNil)
 
-			c.Assert(recoverPendingPublication(dir), qt.IsNil)
+			c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 			_, err = os.Stat(batch.paths[0])
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			_, err = os.Stat(batch.stagedPaths[0])
+			_, err = os.Stat(stagedPath(writer, batch, 0))
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 			_, err = os.Stat(quarantinePath)
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			_, err = os.Stat(quarantineDir)
-			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			journalPath, err := publicationJournalPath(dir)
-			c.Assert(err, qt.IsNil)
-			_, err = os.Stat(journalPath)
+			_, err = os.Stat(testJournalPath(writer))
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 		})
 	}
@@ -441,15 +436,16 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 func TestRemovePublicationJournal_RetireFailurePreservesCommitMarker(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
-	journalPath := filepath.Join(dir, "publication.pending")
-	markerPath := publicationCommitMarkerPath(journalPath)
+	writer := openTestWriter(c, dir)
+	journalPath := testJournalPath(writer)
+	markerPath := journalPath + publicationCommitMarkerSuffix
 	c.Assert(os.WriteFile(journalPath, []byte("{}"), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(markerPath, []byte("committed"), 0o600), qt.IsNil)
 	retireErr := errors.New("injected journal retirement failure")
 
 	err := removePublicationJournalWithRetirer(
-		journalPath,
-		func(string, string) error {
+		writer,
+		func(*pathguard.OpenedDirectory, string, string) error {
 			return retireErr
 		},
 	)
@@ -464,22 +460,23 @@ func TestRemovePublicationJournal_RetireFailurePreservesCommitMarker(t *testing.
 func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageArtifactBatch(
-		dir,
+		writer,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.safety.json", Contents: []byte("{}\n")},
 		},
 	)
 	c.Assert(err, qt.IsNil)
-	journal, err := beginMarkerPublication(dir, batch)
+	journal, err := beginMarkerPublication(writer, batch)
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 2)
-	c.Assert(writePublicationCommitMarker(dir, journal), qt.IsNil)
+	c.Assert(writePublicationCommitMarker(writer, journal), qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 	up, err := os.ReadFile(batch.paths[0])
 	c.Assert(err, qt.IsNil)
@@ -487,11 +484,10 @@ func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 	report, err := os.ReadFile(batch.paths[1])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(report), qt.Equals, "{}\n")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := testJournalPath(writer)
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	_, err = os.Stat(journalPath + publicationCommitMarkerSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	_, err = os.Stat(journalPath + publicationCleanupSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
@@ -500,8 +496,9 @@ func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"committed",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -509,29 +506,27 @@ func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	journal, sum := beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	_, err = writeDirSum(dir, sum)
+	_, err = publishDirSum(writer, sum)
 	c.Assert(err, qt.IsNil)
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(writer, journal)
 	c.Assert(err, qt.IsNil)
 	c.Assert(committed, qt.IsTrue)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
 	contents, err := os.ReadFile(batch.paths[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "SELECT 1;")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
@@ -541,8 +536,9 @@ func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"collision",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -550,33 +546,32 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
 	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = recoverPendingPublication(dir)
+	err = recoverPendingPublication(writer)
 
 	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* content changed; preserved at .*`)
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(stagedPath(writer, batch, 0) + publicationRollbackSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.IsNil)
 }
 
 func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"collision",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -584,37 +579,36 @@ func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 	c.Assert(os.Remove(batch.paths[0]), qt.IsNil)
 	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = abortPendingPublication(dir, batch, published)
+	err = abortPendingPublication(writer, batch, published)
 
 	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: .* content changed; preserved at .*`)
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(stagedPath(writer, batch, 0) + publicationRollbackSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.IsNil)
 }
 
 func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		writer,
 		"mutated",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -623,29 +617,27 @@ func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
 	batch.mode = publicationModeHardLink
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		writer,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(writer, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = abortPendingPublication(dir, batch, published)
+	err = abortPendingPublication(writer, batch, published)
 
 	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: staging file content changed; preserved .*`)
 	_, err = os.Stat(batch.paths[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(stagedPath(writer, batch, 0) + publicationRollbackSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	stagedContents, err := os.ReadFile(stagedPath(writer, batch, 0))
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(stagedContents), qt.Equals, "foreign")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.IsNil)
 }
 
@@ -654,16 +646,17 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 	dir := c.TempDir()
 	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
 	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
 
 	result, err := writeDiffArtifactsWithSumWriter(
 		t.Context(),
-		dir,
+		writer,
 		"uncertain",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
 		nil,
-		func(dir string, sum *migratesum.SumFile) (string, error) {
-			path, writeErr := writeDirSum(dir, sum)
+		func(w *migrationWriterDir, sum *migratesum.SumFile) (string, error) {
+			path, writeErr := publishDirSum(w, sum)
 			c.Assert(writeErr, qt.IsNil)
 			return path, &migratesum.CommitUncertainError{
 				Err: errors.New("injected directory sync failure"),
@@ -679,12 +672,11 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 	stagedFiles, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
 	c.Assert(err, qt.IsNil)
 	c.Assert(stagedFiles, qt.HasLen, 1)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := testJournalPath(writer)
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 	sqlFiles, err = filepath.Glob(filepath.Join(dir, "*_uncertain.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(sqlFiles, qt.HasLen, 1)
@@ -708,10 +700,11 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	foreignPath := filepath.Join(dir, "99_foreign.sql")
 	c.Assert(os.WriteFile(foreignPath, []byte("SELECT 99;"), 0o600), qt.IsNil)
+	writer := openTestWriter(c, dir)
 
 	result, err := writeDiffArtifacts(
 		t.Context(),
-		dir,
+		writer,
 		"planned",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
@@ -726,24 +719,24 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 	plannedFiles, err := filepath.Glob(filepath.Join(dir, "*_planned.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(plannedFiles, qt.HasLen, 0)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	_, err = os.Stat(journalPath)
+	_, err = os.Stat(testJournalPath(writer))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func beginTestPublication(
 	c *qt.C,
-	dir string,
+	writer *migrationWriterDir,
 	batch migrationBatch,
 	contents []MigrationFileContent,
 ) (publicationJournal, *migratesum.SumFile) {
 	c.Helper()
-	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	fsys, err := writer.FS()
+	c.Assert(err, qt.IsNil)
+	baseSnapshot, err := migrationsnapshot.CaptureStable(fsys)
 	c.Assert(err, qt.IsNil)
 	_, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
 	c.Assert(err, qt.IsNil)
-	journal, err := beginPublication(dir, batch, sum.Bytes())
+	journal, err := beginPublication(writer, batch, sum.Bytes())
 	c.Assert(err, qt.IsNil)
 	return journal, sum
 }
@@ -751,10 +744,15 @@ func beginTestPublication(
 func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
-	stagedPath, err := stageMigrationFile(dir, "SELECT 1;")
+	writer := openTestWriter(c, dir)
+	stagedName, err := stageRootedFile(
+		writer.dir,
+		stagedMigrationPattern,
+		[]byte("SELECT 1;"),
+		publishedFileMode,
+	)
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := testJournalPath(writer)
 	journalTemp, err := os.CreateTemp(
 		filepath.Dir(journalPath),
 		filepath.Base(journalPath)+".*.tmp",
@@ -763,9 +761,9 @@ func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 	journalTempPath := journalTemp.Name()
 	c.Assert(journalTemp.Close(), qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
 
-	_, err = os.Stat(stagedPath)
+	_, err = os.Stat(filepath.Join(dir, stagedName))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	_, err = os.Stat(journalTempPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
@@ -774,29 +772,53 @@ func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 func TestWriteMigrationFiles_EmptySQLIsRejected(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	writer := openTestWriter(c, dir)
 
-	batch, err := stageMigrationBatch(dir, "noop", []MigrationFileContent{{SQL: "   \n"}})
+	batch, err := stageMigrationBatch(writer, "noop", []MigrationFileContent{{SQL: "   \n"}})
 
 	c.Assert(err, qt.ErrorMatches, `migration SQL is empty`)
 	c.Assert(batch.paths, qt.HasLen, 0)
 }
 
-func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
-	return publishMigrationBatchContext(context.Background(), dir, batch)
+// openTestWriter binds dir the way the writer does in production: one rooted
+// handle for the migration directory and one for its parent.
+func openTestWriter(c *qt.C, dir string) *migrationWriterDir {
+	c.Helper()
+	writer, err := createMigrationWriterDir(nil, dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(writer.Close(), qt.IsNil)
+	})
+	return writer
+}
+
+// testJournalPath spells the journal's pathname for assertions only. The writer
+// itself never resolves it; it names the journal as a direct child of the
+// opened parent handle.
+func testJournalPath(writer *migrationWriterDir) string {
+	return filepath.Join(writer.parent.Path(), publicationJournalName(writer))
+}
+
+func stagedPath(writer *migrationWriterDir, batch migrationBatch, index int) string {
+	return filepath.Join(writer.path, batch.stagedNames[index])
+}
+
+func publishMigrationBatch(writer *migrationWriterDir, batch migrationBatch) (int, error) {
+	return publishMigrationBatchContext(context.Background(), writer, batch)
 }
 
 func rollBackUnjournaledBatch(
-	dir string,
+	writer *migrationWriterDir,
 	batch migrationBatch,
 	published int,
 ) error {
-	if err := removeFiles(batch.paths[:published]); err != nil {
+	if err := removeRootedFiles(writer.dir, batch.names[:published]); err != nil {
 		return fmt.Errorf("roll back published migration files: %w", err)
 	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
+	if err := removeRootedFiles(writer.dir, batch.stagedNames); err != nil {
 		return fmt.Errorf("remove rolled back migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := writer.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
 	return nil

--- a/internal/atlasmigrate/diff_root_unix_test.go
+++ b/internal/atlasmigrate/diff_root_unix_test.go
@@ -1,0 +1,258 @@
+//go:build !windows
+
+package atlasmigrate_test
+
+import (
+	"context"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// These tests replace the migration directory, or one of its ancestors, after
+// the run has captured and verified it and before anything is published. The
+// swap is the exact shape stokaro/ptah#1118 describes: the writer used to carry
+// a string path and resolve it again for staging, publication, the atlas.sum
+// commit and recovery, so a pathname that pointed at one directory when it was
+// validated could point at another by the time it was written.
+//
+// Every row asserts BOTH halves: the artifacts appear inside the directory the
+// run opened, and the replacement directory is left completely untouched. The
+// second half is the one that fails when the rooted handle is removed --
+// without it a run that merely errors out would look the same as one that
+// stayed inside the root.
+
+// swapMigrationSymlink replaces link so it points at target. It is the hostile
+// step every row below performs from inside a callback the run invokes while
+// holding the migration-directory lock.
+func swapMigrationSymlink(c *qt.C, link, target string) {
+	c.Helper()
+	c.Assert(os.Remove(link), qt.IsNil)
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+}
+
+func dirEntryNames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func writeDiffDesiredSchema(c *qt.C, path string) {
+	c.Helper()
+	c.Assert(os.WriteFile(path, []byte(`
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  email TEXT NOT NULL DEFAULT ''
+);
+`), 0o600), qt.IsNil)
+}
+
+func openDiffProjectRoot(c *qt.C, root string) *pathguard.OpenedDirectory {
+	c.Helper()
+	opened, err := pathguard.OpenDirectory(root)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	return opened
+}
+
+// diffSwapCase is one hostile replacement staged through a callback the diff
+// run makes while it holds the lock.
+type diffSwapCase struct {
+	name string
+	// stage builds the directory layout and returns the --dir value, the
+	// directory the handles must stay bound to, and the decoy the swap points
+	// at. Both directories start empty, so a run that follows the swapped
+	// pathname passes the planning recheck and publishes into the decoy.
+	stage func(c *qt.C, root, decoy string) (dirFlag, bound string)
+	// swap performs the replacement.
+	swap func(c *qt.C, root, decoy string)
+	// hook selects which callback performs the swap.
+	hook func(opts *atlasmigrate.DiffOptions, swap func())
+	// projectRoot selects the boundary the run is given: the opened project root
+	// for a directory that came from atlas.hcl, or none for a --dir the operator
+	// named directly. Both must stay bound to the object they opened; only the
+	// containment rule differs between them.
+	projectRoot func(c *qt.C, root string) *pathguard.OpenedDirectory
+}
+
+func noProjectRoot(*qt.C, string) *pathguard.OpenedDirectory {
+	return nil
+}
+
+func verifyDirHook(opts *atlasmigrate.DiffOptions, swap func()) {
+	opts.VerifyDir = func(fs.FS) error {
+		swap()
+		return nil
+	}
+}
+
+func preparePublicationHook(opts *atlasmigrate.DiffOptions, swap func()) {
+	opts.PreparePublication = func([]string) error {
+		swap()
+		return nil
+	}
+}
+
+func TestGenerateDiff_ReplacedDirectoryCannotRedirectPublication(t *testing.T) {
+	c := qt.New(t)
+	tests := []diffSwapCase{
+		{
+			name: "migration directory symlink swapped before planning",
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "real")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				link := filepath.Join(root, "migrations")
+				c.Assert(os.Symlink(bound, link), qt.IsNil)
+				return link, bound
+			},
+			swap: func(c *qt.C, root, decoy string) {
+				swapMigrationSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			hook:        verifyDirHook,
+			projectRoot: openDiffProjectRoot,
+		},
+		{
+			name: "migration directory symlink swapped with no project root",
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "real")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				link := filepath.Join(root, "migrations")
+				c.Assert(os.Symlink(bound, link), qt.IsNil)
+				return link, bound
+			},
+			swap: func(c *qt.C, root, decoy string) {
+				swapMigrationSymlink(c, filepath.Join(root, "migrations"), filepath.Join(decoy, "migrations"))
+			},
+			hook:        verifyDirHook,
+			projectRoot: noProjectRoot,
+		},
+		{
+			name: "ancestor symlink swapped before planning",
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "realnest", "migrations")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				c.Assert(os.Symlink(filepath.Join(root, "realnest"), filepath.Join(root, "nest")), qt.IsNil)
+				return filepath.Join(root, "nest", "migrations"), bound
+			},
+			swap: func(c *qt.C, root, decoy string) {
+				swapMigrationSymlink(c, filepath.Join(root, "nest"), decoy)
+			},
+			hook:        verifyDirHook,
+			projectRoot: openDiffProjectRoot,
+		},
+		{
+			name: "migration directory symlink swapped during editor preparation",
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "real")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				link := filepath.Join(root, "migrations")
+				c.Assert(os.Symlink(bound, link), qt.IsNil)
+				return link, bound
+			},
+			swap: func(c *qt.C, root, decoy string) {
+				swapMigrationSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			hook:        preparePublicationHook,
+			projectRoot: openDiffProjectRoot,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			decoy := c.TempDir()
+			c.Assert(os.MkdirAll(filepath.Join(decoy, "migrations"), 0o755), qt.IsNil)
+			dirFlag, bound := test.stage(c, root, decoy)
+			schemaPath := filepath.Join(root, "schema.sql")
+			writeDiffDesiredSchema(c, schemaPath)
+			conn := connectSQLite(c, filepath.Join(root, "dev.db"))
+			defer dbschema.CloseAndWarn(conn)
+
+			opts := atlasmigrate.DiffOptions{
+				Dir:         dirFlag,
+				Root:        test.projectRoot(c, root),
+				Desired:     localDesiredSet(c, "file://"+schemaPath),
+				Name:        "add_email",
+				LockTimeout: time.Second,
+			}
+			test.hook(&opts, func() { test.swap(c, root, decoy) })
+
+			result, err := atlasmigrate.GenerateDiff(context.Background(), conn, opts)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.MigrationPaths, qt.HasLen, 1)
+			// The run published into the object it opened, not into whatever the
+			// pathname selects now.
+			c.Assert(atlasSQLFiles(c, bound), qt.HasLen, 1)
+			c.Assert(fileExists(filepath.Join(bound, "atlas.sum")), qt.IsTrue)
+			// No migration file, checksum, journal, staging or recovery artifact
+			// reached the replacement.
+			c.Assert(dirEntryNames(c, decoy), qt.DeepEquals, []string{"migrations"})
+			c.Assert(dirEntryNames(c, filepath.Join(decoy, "migrations")), qt.HasLen, 0)
+		})
+	}
+}
+
+func TestGenerateDiff_CreatesMissingMigrationDirectoryInsideOpenedRoot(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	schemaPath := filepath.Join(root, "schema.sql")
+	writeDiffDesiredSchema(c, schemaPath)
+	conn := connectSQLite(c, filepath.Join(root, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+	// Neither the migration directory nor its parent exists yet, so both are
+	// materialized through the opened root rather than through a pathname.
+	migrationsDir := filepath.Join(root, "nest", "migrations")
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         migrationsDir,
+		Root:        openDiffProjectRoot(c, root),
+		Desired:     localDesiredSet(c, "file://"+schemaPath),
+		Name:        "add_email",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.MigrationPaths, qt.HasLen, 1)
+	c.Assert(atlasSQLFiles(c, migrationsDir), qt.HasLen, 1)
+	c.Assert(result.SumPath, qt.Equals, filepath.Join(migrationsDir, "atlas.sum"))
+	c.Assert(fileExists(result.SumPath), qt.IsTrue)
+}
+
+func TestGenerateDiff_RefusesMigrationDirectoryOutsideOpenedRoot(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	outside := c.TempDir()
+	c.Assert(os.Symlink(outside, filepath.Join(root, "migrations")), qt.IsNil)
+	schemaPath := filepath.Join(root, "schema.sql")
+	writeDiffDesiredSchema(c, schemaPath)
+	conn := connectSQLite(c, filepath.Join(root, "dev.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+		Dir:         filepath.Join(root, "migrations"),
+		Root:        openDiffProjectRoot(c, root),
+		Desired:     localDesiredSet(c, "file://"+schemaPath),
+		Name:        "add_email",
+		LockTimeout: time.Second,
+	})
+
+	c.Assert(err, qt.ErrorIs, pathguard.ErrOutsideRoot)
+	c.Assert(result.MigrationPaths, qt.HasLen, 0)
+	c.Assert(dirEntryNames(c, outside), qt.HasLen, 0)
+}

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -19,6 +19,7 @@ import (
 	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -27,10 +28,15 @@ const (
 	publicationJournalSuffix      = ".ptah-migrate-diff.pending"
 	publicationCommitMarkerSuffix = ".committed"
 	publicationCleanupSuffix      = ".cleanup"
+	publicationRollbackSuffix     = ".rollback"
 	stagedMigrationPattern        = ".ptah-migrate-diff-*.tmp"
+	stagedMigrationPrefix         = ".ptah-migrate-diff-"
+	stagedMigrationSuffix         = ".tmp"
 
 	publicationCommitModeAtlasSum = "atlas-sum"
 	publicationCommitModeMarker   = "journal-marker"
+
+	publishedFileMode fs.FileMode = 0o644
 )
 
 type publicationMode string
@@ -61,62 +67,69 @@ type PublicationArtifact struct {
 	Contents []byte
 }
 
+// migrationBatch names the files of one publication batch as direct children of
+// the rooted migration directory. Paths are display data derived from the
+// handle's lexical path; no publication step resolves them again.
 type migrationBatch struct {
 	paths       []string
-	stagedPaths []string
+	names       []string
+	stagedNames []string
 	digests     []string
 	mode        publicationMode
 }
 
 // writeDiffArtifacts durably publishes one batch of migration files and then
-// atlas.sum. A journal next to the migration directory makes an interrupted
-// publication recoverable by the next lock holder.
+// atlas.sum, entirely through the rooted migration-directory handle. A journal
+// beside the migration directory makes an interrupted publication recoverable
+// by the next lock holder.
 func writeDiffArtifacts(
 	ctx context.Context,
-	dir, name string,
+	w *migrationWriterDir,
+	name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
 ) (DiffResult, error) {
 	return writeDiffArtifactsWithSumWriter(
 		ctx,
-		dir,
+		w,
 		name,
 		contents,
 		baseSnapshot,
 		prepare,
-		writeDirSum,
+		publishDirSum,
 	)
 }
 
 func writeDiffArtifactsWithSumWriter(
 	ctx context.Context,
-	dir, name string,
+	w *migrationWriterDir,
+	name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
-	writeSum func(string, *migratesum.SumFile) (string, error),
+	writeSum func(*migrationWriterDir, *migratesum.SumFile) (string, error),
 ) (DiffResult, error) {
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
 	}
-	if err := recoverPendingPublication(dir); err != nil {
+	if err := recoverPendingPublication(w); err != nil {
 		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
 	}
 	version, err := nextMigrationVersionFS(baseSnapshot)
 	if err != nil {
 		return DiffResult{}, err
 	}
-	batch, err := stageMigrationBatchAt(dir, name, version, contents)
+	batch, err := stageMigrationBatchAt(w, name, version, contents)
 	if err != nil {
 		return DiffResult{}, err
 	}
-	if err := prepareStagedMigrationBatch(ctx, batch, prepare); err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	if err := prepareStagedMigrationBatch(ctx, w, batch, prepare); err != nil {
+		return DiffResult{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
-	stagedContents, err := readStagedMigrationContents(&batch)
+	stagedContents, err := readStagedMigrationContents(w, &batch)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
 	publishedSnapshot, sum, err := preparePublicationSnapshot(
 		baseSnapshot,
@@ -124,23 +137,23 @@ func writeDiffArtifactsWithSumWriter(
 		stagedContents,
 	)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
-	journal, err := beginPublication(dir, batch, sum.Bytes())
+	journal, err := beginPublication(w, batch, sum.Bytes())
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
-	published, err := publishMigrationBatchContext(ctx, dir, batch)
+	published, err := publishMigrationBatchContext(ctx, w, batch)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
-	if err := verifyMigrationDirUnchanged(dir, publishedSnapshot); err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	if err := verifyMigrationDirUnchanged(w, publishedSnapshot); err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
 	if err := ctx.Err(); err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
-	sumPath, err := writeSum(dir, sum)
+	sumPath, err := writeSum(w, sum)
 	if err != nil {
 		if migratesum.IsCommitUncertain(err) {
 			return DiffResult{}, fmt.Errorf(
@@ -148,21 +161,17 @@ func writeDiffArtifactsWithSumWriter(
 				err,
 			)
 		}
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
 	result := DiffResult{MigrationPaths: batch.paths, SumPath: sumPath}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return result, err
-	}
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(w, journal)
 	if err != nil {
 		return result, fmt.Errorf("verify migration publication commit marker: %w", err)
 	}
 	if !committed {
 		return result, errors.New("atlas.sum does not match the journaled migration publication")
 	}
-	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
+	if err := finalizeCommittedPublication(w, journal); err != nil {
 		return result, fmt.Errorf("finalize migration artifact publication: %w", err)
 	}
 	return result, nil
@@ -178,101 +187,138 @@ func PublishArtifactsLocked(
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := recoverPendingPublication(dir); err != nil {
-		return nil, fmt.Errorf("recover previous artifact publication: %w", err)
-	}
-	batch, err := stageArtifactBatch(dir, artifacts)
+	w, err := createMigrationWriterDir(nil, dir)
 	if err != nil {
 		return nil, err
 	}
-	journal, err := beginMarkerPublication(dir, batch)
-	if err != nil {
-		return nil, errors.Join(err, removeFiles(batch.stagedPaths))
+	paths, publishErr := publishArtifactsLocked(ctx, w, artifacts)
+	return paths, errors.Join(publishErr, w.Close())
+}
+
+func publishArtifactsLocked(
+	ctx context.Context,
+	w *migrationWriterDir,
+	artifacts []PublicationArtifact,
+) ([]string, error) {
+	if err := recoverPendingPublication(w); err != nil {
+		return nil, fmt.Errorf("recover previous artifact publication: %w", err)
 	}
-	published, err := publishMigrationBatchContext(ctx, dir, batch)
+	batch, err := stageArtifactBatch(w, artifacts)
 	if err != nil {
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, err
+	}
+	journal, err := beginMarkerPublication(w, batch)
+	if err != nil {
+		return nil, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
+	}
+	published, err := publishMigrationBatchContext(ctx, w, batch)
+	if err != nil {
+		return nil, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
-	if err := writePublicationCommitMarker(dir, journal); err != nil {
-		committed, commitErr := publicationCommitted(dir, journal)
+	if err := writePublicationCommitMarker(w, journal); err != nil {
+		committed, commitErr := publicationCommitted(w, journal)
 		if committed && commitErr == nil {
 			return nil, fmt.Errorf(
 				"write artifact publication commit marker; journal retained for recovery: %w",
 				err,
 			)
 		}
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, errors.Join(err, abortPendingPublication(w, batch, published))
 	}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return nil, err
-	}
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(w, journal)
 	if err != nil {
 		return nil, fmt.Errorf("verify artifact publication commit marker: %w", err)
 	}
 	if !committed {
 		return nil, errors.New("artifact publication commit marker does not match its journal")
 	}
-	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
+	if err := finalizeCommittedPublication(w, journal); err != nil {
 		return slices.Clone(batch.paths), fmt.Errorf("finalize artifact publication: %w", err)
 	}
 	return slices.Clone(batch.paths), nil
 }
 
+// prepareStagedMigrationBatch runs the caller's editor hook over the staged
+// files and then re-validates each one through the rooted handle.
+//
+// The editor is an external program, so the hook has to receive pathnames.
+// Everything after it goes back through the handle and re-establishes the
+// staged file's identity there, so an editor that replaced the directory under
+// itself cannot hand a foreign file to the publication step.
 func prepareStagedMigrationBatch(
 	ctx context.Context,
+	w *migrationWriterDir,
 	batch migrationBatch,
 	prepare func([]string) error,
 ) error {
 	if prepare != nil {
-		if err := prepare(slices.Clone(batch.stagedPaths)); err != nil {
+		stagedPaths := make([]string, 0, len(batch.stagedNames))
+		for _, name := range batch.stagedNames {
+			stagedPaths = append(stagedPaths, filepath.Join(w.path, name))
+		}
+		if err := prepare(stagedPaths); err != nil {
 			return fmt.Errorf("prepare migration files for publication: %w", err)
 		}
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	for _, path := range batch.stagedPaths {
-		info, err := os.Lstat(path)
-		if err != nil {
-			return fmt.Errorf("inspect staged migration file after preparation: %w", err)
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("staged migration file is not a regular file: %s", path)
-		}
-		file, err := os.OpenFile(path, os.O_RDWR, 0)
-		if err != nil {
-			return fmt.Errorf("open staged migration file after preparation: %w", err)
-		}
-		openedInfo, err := file.Stat()
-		if err != nil {
-			return errors.Join(
-				fmt.Errorf("inspect opened staged migration file: %w", err),
-				file.Close(),
-			)
-		}
-		if !os.SameFile(info, openedInfo) {
-			return errors.Join(
-				fmt.Errorf("staged migration file changed while being opened: %s", path),
-				file.Close(),
-			)
-		}
-		if err := errors.Join(file.Sync(), file.Close()); err != nil {
-			return fmt.Errorf("sync staged migration file after preparation: %w", err)
+	for _, name := range batch.stagedNames {
+		if err := syncPreparedStagedFile(w, name); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func readStagedMigrationContents(batch *migrationBatch) ([]MigrationFileContent, error) {
-	contents := make([]MigrationFileContent, len(batch.stagedPaths))
-	batch.digests = make([]string, len(batch.stagedPaths))
-	for i, path := range batch.stagedPaths {
-		data, err := os.ReadFile(path)
+func syncPreparedStagedFile(w *migrationWriterDir, name string) error {
+	info, err := w.dir.Lstat(name)
+	if err != nil {
+		return fmt.Errorf("inspect staged migration file after preparation: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf(
+			"staged migration file is not a regular file: %s",
+			filepath.Join(w.path, name),
+		)
+	}
+	file, err := w.dir.OpenFile(name, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open staged migration file after preparation: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return errors.Join(
+			fmt.Errorf("inspect opened staged migration file: %w", err),
+			file.Close(),
+		)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return errors.Join(
+			fmt.Errorf(
+				"staged migration file changed while being opened: %s",
+				filepath.Join(w.path, name),
+			),
+			file.Close(),
+		)
+	}
+	if err := errors.Join(file.Sync(), file.Close()); err != nil {
+		return fmt.Errorf("sync staged migration file after preparation: %w", err)
+	}
+	return nil
+}
+
+func readStagedMigrationContents(
+	w *migrationWriterDir,
+	batch *migrationBatch,
+) ([]MigrationFileContent, error) {
+	contents := make([]MigrationFileContent, len(batch.stagedNames))
+	batch.digests = make([]string, len(batch.stagedNames))
+	for i, name := range batch.stagedNames {
+		data, err := w.dir.ReadFile(name)
 		if err != nil {
 			return nil, fmt.Errorf("read staged migration file after preparation: %w", err)
 		}
@@ -292,9 +338,9 @@ func preparePublicationSnapshot(
 	batch migrationBatch,
 	contents []MigrationFileContent,
 ) (fsnapshot.Snapshot, *migratesum.SumFile, error) {
-	files := make(map[string][]byte, len(batch.paths))
-	for i, path := range batch.paths {
-		files[filepath.Base(path)] = []byte(contents[i].SQL)
+	files := make(map[string][]byte, len(batch.names))
+	for i, name := range batch.names {
+		files[name] = []byte(contents[i].SQL)
 	}
 	publishedSnapshot, err := baseSnapshot.WithFiles(files)
 	if err != nil {
@@ -311,77 +357,71 @@ func preparePublicationSnapshot(
 }
 
 func beginPublication(
-	dir string,
+	w *migrationWriterDir,
 	batch migrationBatch,
 	sum []byte,
 ) (publicationJournal, error) {
 	// Persist the staging directory entries before making the journal durable.
 	// Once the journal exists, recovery relies on the staging links to prove
 	// ownership of any published final paths.
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := w.dir.Sync(); err != nil {
 		return publicationJournal{}, fmt.Errorf("sync staged migration files: %w", err)
-	}
-
-	entries := make([]publicationEntry, len(batch.paths))
-	for i := range batch.paths {
-		entries[i] = publicationEntry{
-			Staged: filepath.Base(batch.stagedPaths[i]),
-			Final:  filepath.Base(batch.paths[i]),
-			Mode:   string(batch.mode),
-			Digest: batch.digests[i],
-		}
 	}
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeAtlasSum,
-		Entries:    entries,
+		Entries:    publicationEntries(batch),
 		Sum:        slices.Clone(sum),
 	}
-	if err := writePublicationJournal(dir, journal); err != nil {
+	if err := writePublicationJournal(w, journal); err != nil {
 		return publicationJournal{}, fmt.Errorf("write migration publication journal: %w", err)
 	}
 	return journal, nil
 }
 
 func beginMarkerPublication(
-	dir string,
+	w *migrationWriterDir,
 	batch migrationBatch,
 ) (publicationJournal, error) {
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := w.dir.Sync(); err != nil {
 		return publicationJournal{}, fmt.Errorf("sync staged artifact files: %w", err)
-	}
-	entries := make([]publicationEntry, len(batch.paths))
-	for i := range batch.paths {
-		entries[i] = publicationEntry{
-			Staged: filepath.Base(batch.stagedPaths[i]),
-			Final:  filepath.Base(batch.paths[i]),
-			Mode:   string(batch.mode),
-			Digest: batch.digests[i],
-		}
 	}
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeMarker,
-		Entries:    entries,
+		Entries:    publicationEntries(batch),
 	}
-	if err := writePublicationJournal(dir, journal); err != nil {
+	if err := writePublicationJournal(w, journal); err != nil {
 		return publicationJournal{}, fmt.Errorf("write artifact publication journal: %w", err)
 	}
 	return journal, nil
 }
 
+func publicationEntries(batch migrationBatch) []publicationEntry {
+	entries := make([]publicationEntry, len(batch.names))
+	for i := range batch.names {
+		entries[i] = publicationEntry{
+			Staged: batch.stagedNames[i],
+			Final:  batch.names[i],
+			Mode:   string(batch.mode),
+			Digest: batch.digests[i],
+		}
+	}
+	return entries
+}
+
 func publishMigrationBatchContext(
 	ctx context.Context,
-	dir string,
+	w *migrationWriterDir,
 	batch migrationBatch,
 ) (int, error) {
-	for i, stagedPath := range batch.stagedPaths {
+	for i, stagedName := range batch.stagedNames {
 		if err := ctx.Err(); err != nil {
 			return i, err
 		}
-		err := publishStagedFile(stagedPath, batch.paths[i], batch.mode)
+		err := publishStagedFile(w.dir, stagedName, batch.names[i], batch.mode)
 		if err != nil {
-			if errors.Is(err, os.ErrExist) {
+			if errors.Is(err, fs.ErrExist) {
 				return i, fmt.Errorf(
 					"migration directory changed during publication: %s already exists",
 					batch.paths[i],
@@ -390,37 +430,56 @@ func publishMigrationBatchContext(
 			return i, fmt.Errorf("publish migration file: %w", err)
 		}
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
-		return len(batch.paths), fmt.Errorf("sync published migration files: %w", err)
+	if err := w.dir.Sync(); err != nil {
+		return len(batch.names), fmt.Errorf("sync published migration files: %w", err)
 	}
-	return len(batch.paths), nil
+	return len(batch.names), nil
 }
 
+// publishStagedFile commits one staged entry at its final name through the
+// rooted handle. Every mode is conditional on the destination being absent: a
+// hard link and an exclusive create both fail with fs.ErrExist, and the move
+// mode states the expectation to the rooted commit primitive. None of them can
+// overwrite a file that appeared after the caller looked.
 func publishStagedFile(
-	stagedPath, finalPath string,
+	d *pathguard.OpenedDirectory,
+	stagedName, finalName string,
 	mode publicationMode,
 ) error {
 	switch mode {
 	case publicationModeHardLink:
-		return os.Link(stagedPath, finalPath)
+		return d.Link(stagedName, finalName)
 	case publicationModeCopy:
-		return copyFileExclusive(stagedPath, finalPath)
+		return copyFileExclusive(d, stagedName, finalName)
 	case publicationModeWriteThroughMove:
-		return fsdurable.MoveFileNoReplace(stagedPath, finalPath)
+		info, err := d.Lstat(stagedName)
+		if err != nil {
+			return err
+		}
+		return d.PublishFile(
+			stagedName,
+			finalName,
+			info,
+			publishedFileMode,
+			fsdurable.ExpectAbsent(),
+		)
 	default:
 		return fmt.Errorf("unsupported migration publication mode %q", mode)
 	}
 }
 
-func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
-	contents, err := os.ReadFile(sourcePath)
+func copyFileExclusive(
+	d *pathguard.OpenedDirectory,
+	sourceName, destinationName string,
+) (resultErr error) {
+	contents, err := d.ReadFile(sourceName)
 	if err != nil {
 		return err
 	}
-	destination, err := os.OpenFile(
-		destinationPath,
+	destination, err := d.OpenFile(
+		destinationName,
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
-		0o644,
+		publishedFileMode,
 	)
 	if err != nil {
 		return err
@@ -431,11 +490,14 @@ func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
 			resultErr = errors.Join(
 				resultErr,
 				destination.Close(),
-				removeFiles([]string{destinationPath}),
+				removeRootedFiles(d, []string{destinationName}),
 			)
 		}
 	}()
 	if _, err := destination.Write(contents); err != nil {
+		return err
+	}
+	if err := destination.Chmod(publishedFileMode); err != nil {
 		return err
 	}
 	if err := destination.Sync(); err != nil {
@@ -448,55 +510,58 @@ func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
 	return nil
 }
 
-func abortPendingPublication(dir string, batch migrationBatch, published int) error {
+func abortPendingPublication(w *migrationWriterDir, batch migrationBatch, published int) error {
 	for i := range published {
 		if err := rollBackPublicationEntry(
-			batch.stagedPaths[i],
-			batch.paths[i],
+			w,
+			batch.stagedNames[i],
+			batch.names[i],
 			batch.digests[i],
 		); err != nil {
 			return fmt.Errorf("roll back published migration files: %w", err)
 		}
 	}
-	if err := removeFiles(batch.stagedPaths[published:]); err != nil {
+	if err := removeStagedFiles(w, batch.stagedNames[published:]); err != nil {
 		return fmt.Errorf("remove rolled back migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := w.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(w)
 }
 
-func recoverPendingPublication(dir string) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
-	journal, err := readPublicationJournal(journalPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return removeOrphanPublicationTemps(dir, journalPath)
+func recoverPendingPublication(w *migrationWriterDir) error {
+	journal, err := readPublicationJournal(w)
+	if errors.Is(err, fs.ErrNotExist) {
+		return removeOrphanPublicationTemps(w)
 	}
 	if err != nil {
 		return err
 	}
-	committed, err := publicationCommitted(dir, journal)
+	if !w.Exists() {
+		return fmt.Errorf(
+			"cannot recover migration publication: %w",
+			w.missingDirError(),
+		)
+	}
+	committed, err := publicationCommitted(w, journal)
 	if err != nil {
 		return err
 	}
 	if committed {
-		return finalizeCommittedPublication(dir, journalPath, journal)
+		return finalizeCommittedPublication(w, journal)
 	}
-	return rollBackPendingPublication(dir, journalPath, journal)
+	return rollBackPendingPublication(w, journal)
 }
 
 // RecoverPendingPublicationLocked resolves an interrupted artifact publication.
 // The caller must hold the migration-directory lock for dir.
 func RecoverPendingPublicationLocked(dir string) error {
-	return recoverPendingPublication(dir)
+	w, err := openMigrationWriterDir(nil, dir)
+	if err != nil {
+		return err
+	}
+	return errors.Join(recoverPendingPublication(w), w.Close())
 }
 
 // RecoverPendingPublication resolves an interrupted artifact publication,
@@ -508,18 +573,21 @@ func RecoverPendingPublication(ctx context.Context, dir string) error {
 		return fmt.Errorf("resolve migration directory lock path: %w", err)
 	}
 	if held {
-		return recoverPendingPublication(dir)
+		return RecoverPendingPublicationLocked(dir)
 	}
 	return WithMigrationDirectoryLock(ctx, dir, 0, func(context.Context) error {
-		return recoverPendingPublication(dir)
+		return RecoverPendingPublicationLocked(dir)
 	})
 }
 
-func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
+func publicationCommitted(w *migrationWriterDir, journal publicationJournal) (bool, error) {
 	switch journal.CommitMode {
 	case publicationCommitModeAtlasSum:
-		contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
-		if errors.Is(err, os.ErrNotExist) {
+		if !w.Exists() {
+			return false, w.missingDirError()
+		}
+		contents, err := w.dir.ReadFile(migratesum.AtlasFileName)
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		if err != nil {
@@ -527,12 +595,8 @@ func publicationCommitted(dir string, journal publicationJournal) (bool, error) 
 		}
 		return bytes.Equal(contents, journal.Sum), nil
 	case publicationCommitModeMarker:
-		journalPath, err := publicationJournalPath(dir)
-		if err != nil {
-			return false, err
-		}
-		contents, err := os.ReadFile(publicationCommitMarkerPath(journalPath))
-		if errors.Is(err, os.ErrNotExist) {
+		contents, err := w.parent.ReadFile(publicationCommitMarkerName(w))
+		if errors.Is(err, fs.ErrNotExist) {
 			return false, nil
 		}
 		if err != nil {
@@ -552,56 +616,57 @@ func publicationCommitted(dir string, journal publicationJournal) (bool, error) 
 }
 
 func finalizeCommittedPublication(
-	dir, journalPath string,
+	w *migrationWriterDir,
 	journal publicationJournal,
 ) error {
-	stagedPaths := publicationStagedPaths(dir, journal)
-	if err := removeFiles(stagedPaths); err != nil {
+	if err := removeStagedFiles(w, publicationStagedNames(journal)); err != nil {
 		return fmt.Errorf("remove committed migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := w.dir.Sync(); err != nil {
 		return fmt.Errorf("sync committed migration directory: %w", err)
 	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(w)
 }
 
 func rollBackPendingPublication(
-	dir, journalPath string,
+	w *migrationWriterDir,
 	journal publicationJournal,
 ) error {
 	for _, entry := range journal.Entries {
-		stagedPath := filepath.Join(dir, entry.Staged)
-		finalPath := filepath.Join(dir, entry.Final)
 		if err := rollBackPublicationEntry(
-			stagedPath,
-			finalPath,
+			w,
+			entry.Staged,
+			entry.Final,
 			entry.Digest,
 		); err != nil {
 			return err
 		}
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := w.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(w)
 }
 
+// rollBackPublicationEntry withdraws one published entry through the rooted
+// handle. The published file is first moved aside under a name only this
+// transaction knows, conditionally on that name being free, so the content
+// check that follows reads bytes nobody else can still reach by the final name.
 func rollBackPublicationEntry(
-	stagedPath, finalPath, expectedDigest string,
+	w *migrationWriterDir,
+	stagedName, finalName, expectedDigest string,
 ) error {
-	quarantineDir := stagedPath + ".rollback"
-	quarantinePath := filepath.Join(quarantineDir, "published")
-
-	if err := quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath); err != nil {
+	quarantineName := stagedName + publicationRollbackSuffix
+	if err := quarantinePublishedMigration(w, finalName, quarantineName); err != nil {
 		return err
 	}
-	stagedDigest, stagedErr := fileDigest(stagedPath)
-	quarantinedDigest, quarantineErr := fileDigest(quarantinePath)
+	stagedDigest, stagedErr := rootedFileDigest(w.dir, stagedName)
+	quarantinedDigest, quarantineErr := rootedFileDigest(w.dir, quarantineName)
 	return reconcileRollbackFiles(rollbackFileState{
-		stagedPath:        stagedPath,
-		finalPath:         finalPath,
-		quarantineDir:     quarantineDir,
-		quarantinePath:    quarantinePath,
+		writer:            w,
+		stagedName:        stagedName,
+		finalName:         finalName,
+		quarantineName:    quarantineName,
 		expectedDigest:    expectedDigest,
 		stagedDigest:      stagedDigest,
 		stagedErr:         stagedErr,
@@ -610,32 +675,39 @@ func rollBackPublicationEntry(
 	})
 }
 
-func quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath string) error {
-	if err := os.Mkdir(quarantineDir, 0700); err != nil && !errors.Is(err, os.ErrExist) {
-		return fmt.Errorf("create migration rollback quarantine: %w", err)
-	}
-	if err := fsdurable.SyncDir(filepath.Dir(quarantineDir)); err != nil {
-		return fmt.Errorf("sync migration rollback quarantine directory: %w", err)
-	}
-	if _, err := os.Stat(quarantinePath); errors.Is(err, os.ErrNotExist) {
-		if moveErr := fsdurable.MoveFileNoReplace(finalPath, quarantinePath); moveErr != nil {
-			if !errors.Is(moveErr, os.ErrNotExist) {
-				return fmt.Errorf("quarantine published migration file: %w", moveErr)
-			}
-		} else if err := syncQuarantineMove(finalPath, quarantineDir); err != nil {
-			return err
-		}
-	} else if err != nil {
+func quarantinePublishedMigration(
+	w *migrationWriterDir,
+	finalName, quarantineName string,
+) error {
+	if _, err := w.dir.Lstat(quarantineName); err == nil {
+		return nil
+	} else if !errors.Is(err, fs.ErrNotExist) {
 		return fmt.Errorf("inspect quarantined migration file: %w", err)
 	}
-	return nil
+	info, err := w.dir.Lstat(finalName)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("inspect published migration file: %w", err)
+	}
+	if err := w.dir.PublishFile(
+		finalName,
+		quarantineName,
+		info,
+		info.Mode().Perm(),
+		fsdurable.ExpectAbsent(),
+	); err != nil {
+		return fmt.Errorf("quarantine published migration file: %w", err)
+	}
+	return w.dir.Sync()
 }
 
 type rollbackFileState struct {
-	stagedPath        string
-	finalPath         string
-	quarantineDir     string
-	quarantinePath    string
+	writer            *migrationWriterDir
+	stagedName        string
+	finalName         string
+	quarantineName    string
 	expectedDigest    string
 	stagedDigest      string
 	stagedErr         error
@@ -643,28 +715,32 @@ type rollbackFileState struct {
 	quarantineErr     error
 }
 
+func (s rollbackFileState) display(name string) string {
+	return filepath.Join(s.writer.path, name)
+}
+
 func reconcileRollbackFiles(state rollbackFileState) error {
 	switch {
-	case errors.Is(state.stagedErr, os.ErrNotExist) && errors.Is(state.quarantineErr, os.ErrNotExist):
-		return removeEmptyQuarantineDir(state.quarantineDir)
-	case state.stagedErr == nil && errors.Is(state.quarantineErr, os.ErrNotExist):
+	case errors.Is(state.stagedErr, fs.ErrNotExist) && errors.Is(state.quarantineErr, fs.ErrNotExist):
+		return nil
+	case state.stagedErr == nil && errors.Is(state.quarantineErr, fs.ErrNotExist):
 		if state.stagedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: staging file content changed; preserved %s",
-				state.stagedPath,
+				state.display(state.stagedName),
 			)
 		}
-		return removeRollbackFiles(state.quarantineDir, state.stagedPath)
-	case errors.Is(state.stagedErr, os.ErrNotExist) &&
+		return removeRootedFiles(state.writer.dir, []string{state.stagedName})
+	case errors.Is(state.stagedErr, fs.ErrNotExist) &&
 		state.quarantineErr == nil:
 		if state.quarantinedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: %s content changed; preserved at %s",
-				state.finalPath,
-				state.quarantinePath,
+				state.display(state.finalName),
+				state.display(state.quarantineName),
 			)
 		}
-		return removeRollbackFiles(state.quarantineDir, state.quarantinePath)
+		return removeRootedFiles(state.writer.dir, []string{state.quarantineName})
 	case state.stagedErr != nil:
 		return fmt.Errorf("inspect staged migration file: %w", state.stagedErr)
 	case state.quarantineErr != nil:
@@ -672,176 +748,149 @@ func reconcileRollbackFiles(state rollbackFileState) error {
 	case state.stagedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: staging file content changed; preserved %s and %s",
-			state.stagedPath,
-			state.quarantinePath,
+			state.display(state.stagedName),
+			state.display(state.quarantineName),
 		)
 	case state.quarantinedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: %s content changed; preserved at %s",
-			state.finalPath,
-			state.quarantinePath,
+			state.display(state.finalName),
+			state.display(state.quarantineName),
 		)
 	default:
-		return removeRollbackFiles(state.quarantineDir, state.quarantinePath, state.stagedPath)
+		return removeRootedFiles(
+			state.writer.dir,
+			[]string{state.quarantineName, state.stagedName},
+		)
 	}
 }
 
-func syncQuarantineMove(finalPath, quarantineDir string) error {
-	if err := fsdurable.SyncDir(filepath.Dir(finalPath)); err != nil {
-		return fmt.Errorf("sync migration directory after quarantine move: %w", err)
-	}
-	if err := fsdurable.SyncDir(quarantineDir); err != nil {
-		return fmt.Errorf("sync migration rollback quarantine: %w", err)
-	}
-	return nil
-}
-
-func removeRollbackFiles(quarantineDir string, paths ...string) error {
-	for _, path := range paths {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove %s: %w", path, err)
-		}
-	}
-	return removeEmptyQuarantineDir(quarantineDir)
-}
-
-func fileDigest(path string) (string, error) {
-	contents, err := os.ReadFile(path)
+func rootedFileDigest(d *pathguard.OpenedDirectory, name string) (string, error) {
+	contents, err := d.ReadFile(name)
 	if err != nil {
 		return "", err
 	}
 	return contentDigest(contents), nil
 }
 
-func removeEmptyQuarantineDir(path string) error {
-	err := os.Remove(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
-}
-
-func removePublicationJournal(journalPath string) error {
-	return removePublicationJournalWithRetirer(journalPath, retirePublicationJournal)
+func removePublicationJournal(w *migrationWriterDir) error {
+	return removePublicationJournalWithRetirer(w, retirePublicationJournal)
 }
 
 func removePublicationJournalWithRetirer(
-	journalPath string,
-	retire func(string, string) error,
+	w *migrationWriterDir,
+	retire func(*pathguard.OpenedDirectory, string, string) error,
 ) error {
-	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+	journalName := publicationJournalName(w)
+	journalTemps, err := rootedGlob(w.parent, journalName+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("find migration publication journal backups: %w", err)
 	}
-	cleanupPath := journalPath + publicationCleanupSuffix
-	if err := retire(journalPath, cleanupPath); err != nil {
+	cleanupName := journalName + publicationCleanupSuffix
+	if err := retire(w.parent, journalName, cleanupName); err != nil {
 		return fmt.Errorf("retire migration publication journal: %w", err)
 	}
-	parent := filepath.Dir(journalPath)
-	if err := fsdurable.SyncDir(parent); err != nil {
+	if err := w.parent.Sync(); err != nil {
 		return fmt.Errorf("sync retired migration publication journal: %w", err)
 	}
-	paths := append(
-		[]string{publicationCommitMarkerPath(journalPath), cleanupPath},
+	names := append(
+		[]string{publicationCommitMarkerName(w), cleanupName},
 		journalTemps...,
 	)
-	if err := removeFiles(paths); err != nil {
+	if err := removeRootedFiles(w.parent, names); err != nil {
 		return fmt.Errorf("remove retired migration publication metadata: %w", err)
 	}
-	if err := fsdurable.SyncDir(parent); err != nil {
+	if err := w.parent.Sync(); err != nil {
 		return fmt.Errorf("sync migration publication journal directory: %w", err)
 	}
 	return nil
 }
 
-func retirePublicationJournal(journalPath, cleanupPath string) error {
-	_, err := os.Stat(journalPath)
-	if errors.Is(err, os.ErrNotExist) {
+func retirePublicationJournal(
+	d *pathguard.OpenedDirectory,
+	journalName, cleanupName string,
+) error {
+	info, err := d.Lstat(journalName)
+	if errors.Is(err, fs.ErrNotExist) {
 		return nil
 	}
 	if err != nil {
 		return err
 	}
-	return fsdurable.ReplaceFile(journalPath, cleanupPath)
+	return d.PublishFile(
+		journalName,
+		cleanupName,
+		info,
+		info.Mode().Perm(),
+		fsdurable.ExpectAbsent(),
+	)
 }
 
-func removeOrphanPublicationTemps(dir, journalPath string) error {
-	stagedPaths, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
-	if err != nil {
-		return fmt.Errorf("find orphan migration staging files: %w", err)
-	}
-	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+func removeOrphanPublicationTemps(w *migrationWriterDir) error {
+	journalName := publicationJournalName(w)
+	journalTemps, err := rootedGlob(w.parent, journalName+".*.tmp")
 	if err != nil {
 		return fmt.Errorf("find orphan migration publication journals: %w", err)
 	}
-	orphanPaths := slices.Concat(
-		stagedPaths,
+	orphanNames := slices.Concat(
 		journalTemps,
 		[]string{
-			publicationCommitMarkerPath(journalPath),
-			journalPath + publicationCleanupSuffix,
+			publicationCommitMarkerName(w),
+			journalName + publicationCleanupSuffix,
 		},
 	)
-	if err := removeFiles(orphanPaths); err != nil {
+	if err := removeRootedFiles(w.parent, orphanNames); err != nil {
 		return fmt.Errorf("remove orphan migration publication files: %w", err)
 	}
-	if len(stagedPaths) > 0 {
-		if err := fsdurable.SyncDir(dir); err != nil {
-			return fmt.Errorf("sync migration directory after orphan cleanup: %w", err)
+	if len(journalTemps) > 0 {
+		if err := w.parent.Sync(); err != nil {
+			return fmt.Errorf("sync publication journal directory after orphan cleanup: %w", err)
 		}
 	}
-	if len(journalTemps) > 0 {
-		if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
-			return fmt.Errorf("sync publication journal directory after orphan cleanup: %w", err)
+	if !w.Exists() {
+		return nil
+	}
+	stagedNames, err := rootedGlob(w.dir, stagedMigrationPattern)
+	if err != nil {
+		return fmt.Errorf("find orphan migration staging files: %w", err)
+	}
+	if err := removeRootedFiles(w.dir, stagedNames); err != nil {
+		return fmt.Errorf("remove orphan migration publication files: %w", err)
+	}
+	if len(stagedNames) > 0 {
+		if err := w.dir.Sync(); err != nil {
+			return fmt.Errorf("sync migration directory after orphan cleanup: %w", err)
 		}
 	}
 	return nil
 }
 
 func writePublicationCommitMarker(
-	dir string,
+	w *migrationWriterDir,
 	journal publicationJournal,
 ) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
 	contents, err := publicationJournalDigest(journal)
 	if err != nil {
 		return err
 	}
-	markerPath := publicationCommitMarkerPath(journalPath)
-	parent := filepath.Dir(markerPath)
-	temp, err := os.CreateTemp(parent, filepath.Base(markerPath)+".*.tmp")
+	markerName := publicationCommitMarkerName(w)
+	tempName, err := stageRootedFile(w.parent, markerName+".*.tmp", contents, 0o600)
 	if err != nil {
 		return err
 	}
-	tempPath := temp.Name()
-	if err := temp.Chmod(0600); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if _, err := temp.Write(contents); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := temp.Sync(); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := temp.Close(); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	mode, err := detectPublicationMode(tempPath)
+	mode, err := detectPublicationMode(w.parent, tempName)
 	if err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
+		return errors.Join(err, removeRootedFiles(w.parent, []string{tempName}))
 	}
-	if err := publishStagedFile(tempPath, markerPath, mode); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
+	if err := publishStagedFile(w.parent, tempName, markerName, mode); err != nil {
+		return errors.Join(err, removeRootedFiles(w.parent, []string{tempName}))
 	}
 	if mode != publicationModeWriteThroughMove {
-		if err := removeFiles([]string{tempPath}); err != nil {
+		if err := removeRootedFiles(w.parent, []string{tempName}); err != nil {
 			return err
 		}
 	}
-	return fsdurable.SyncDir(parent)
+	return w.parent.Sync()
 }
 
 func publicationJournalDigest(journal publicationJournal) ([]byte, error) {
@@ -853,35 +902,39 @@ func publicationJournalDigest(journal publicationJournal) ([]byte, error) {
 	return sum[:], nil
 }
 
-func publicationCommitMarkerPath(journalPath string) string {
-	return journalPath + publicationCommitMarkerSuffix
+func publicationJournalName(w *migrationWriterDir) string {
+	return "." + w.name + publicationJournalSuffix
 }
 
-func writePublicationJournal(dir string, journal publicationJournal) error {
+func publicationCommitMarkerName(w *migrationWriterDir) string {
+	return publicationJournalName(w) + publicationCommitMarkerSuffix
+}
+
+func writePublicationJournal(w *migrationWriterDir, journal publicationJournal) error {
 	return writePublicationJournalWithPublisher(
-		dir,
+		w,
 		journal,
-		func(tempPath, journalPath string) error {
-			mode, err := detectPublicationMode(tempPath)
+		func(tempName, journalName string) error {
+			mode, err := detectPublicationMode(w.parent, tempName)
 			if err != nil {
 				return err
 			}
-			return publishStagedFile(tempPath, journalPath, mode)
+			return publishStagedFile(w.parent, tempName, journalName, mode)
 		},
 	)
 }
 
 func writePublicationJournalWithLink(
-	dir string,
+	w *migrationWriterDir,
 	journal publicationJournal,
 	link func(string, string) error,
 ) error {
 	return writePublicationJournalWithPublisher(
-		dir,
+		w,
 		journal,
-		func(tempPath, journalPath string) error {
-			if err := link(tempPath, journalPath); err != nil {
-				if copyErr := copyFileExclusive(tempPath, journalPath); copyErr != nil {
+		func(tempName, journalName string) error {
+			if err := link(tempName, journalName); err != nil {
+				if copyErr := copyFileExclusive(w.parent, tempName, journalName); copyErr != nil {
 					return errors.Join(err, copyErr)
 				}
 			}
@@ -891,44 +944,28 @@ func writePublicationJournalWithLink(
 }
 
 func writePublicationJournalWithPublisher(
-	dir string,
+	w *migrationWriterDir,
 	journal publicationJournal,
 	publish func(string, string) error,
 ) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
 	contents, err := json.Marshal(journal)
 	if err != nil {
 		return err
 	}
-	parent := filepath.Dir(journalPath)
-	file, err := os.CreateTemp(parent, filepath.Base(journalPath)+".*.tmp")
+	journalName := publicationJournalName(w)
+	tempName, err := stageRootedFile(w.parent, journalName+".*.tmp", contents, 0o600)
 	if err != nil {
 		return err
 	}
-	tempPath := file.Name()
-	if err := file.Chmod(0600); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
+	if err := publish(tempName, journalName); err != nil {
+		return errors.Join(err, removeRootedFiles(w.parent, []string{tempName}))
 	}
-	if _, err := file.Write(contents); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := file.Sync(); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := file.Close(); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	if err := publish(tempPath, journalPath); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	return fsdurable.SyncDir(parent)
+	return w.parent.Sync()
 }
 
-func readPublicationJournal(path string) (publicationJournal, error) {
-	contents, err := os.ReadFile(path)
+func readPublicationJournal(w *migrationWriterDir) (publicationJournal, error) {
+	journalName := publicationJournalName(w)
+	contents, err := w.parent.ReadFile(journalName)
 	if err != nil {
 		return publicationJournal{}, err
 	}
@@ -936,12 +973,12 @@ func readPublicationJournal(path string) (publicationJournal, error) {
 	if decodeErr == nil {
 		return journal, nil
 	}
-	backups, globErr := filepath.Glob(path + ".*.tmp")
+	backups, globErr := rootedGlob(w.parent, journalName+".*.tmp")
 	if globErr != nil {
 		return publicationJournal{}, errors.Join(decodeErr, globErr)
 	}
 	for _, backup := range backups {
-		contents, err := os.ReadFile(backup)
+		contents, err := w.parent.ReadFile(backup)
 		if err != nil {
 			continue
 		}
@@ -1027,8 +1064,8 @@ func validatePublicationCommit(journal publicationJournal) error {
 
 func validatePublicationEntry(entry publicationEntry) error {
 	if filepath.Base(entry.Staged) != entry.Staged ||
-		!strings.HasPrefix(entry.Staged, ".ptah-migrate-diff-") ||
-		!strings.HasSuffix(entry.Staged, ".tmp") {
+		!strings.HasPrefix(entry.Staged, stagedMigrationPrefix) ||
+		!strings.HasSuffix(entry.Staged, stagedMigrationSuffix) {
 		return fmt.Errorf("invalid staged migration publication path: %q", entry.Staged)
 	}
 	if filepath.Base(entry.Final) != entry.Final ||
@@ -1048,51 +1085,131 @@ func validatePublicationEntry(entry publicationEntry) error {
 	return nil
 }
 
-func publicationJournalPath(dir string) (string, error) {
-	canonicalDir, err := canonicalMigrationDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolve migration publication journal path: %w", err)
-	}
-	return filepath.Join(
-		filepath.Dir(canonicalDir),
-		"."+filepath.Base(canonicalDir)+publicationJournalSuffix,
-	), nil
-}
-
-func publicationStagedPaths(dir string, journal publicationJournal) []string {
-	paths := make([]string, 0, len(journal.Entries))
+func publicationStagedNames(journal publicationJournal) []string {
+	names := make([]string, 0, len(journal.Entries))
 	for _, entry := range journal.Entries {
-		paths = append(paths, filepath.Join(dir, entry.Staged))
+		names = append(names, entry.Staged)
 	}
-	return paths
+	return names
 }
 
-// writeDirSum atomically refreshes atlas.sum after every complete migration
-// file has been published. The sum is the commit marker for the batch.
-func writeDirSum(dir string, sum *migratesum.SumFile) (string, error) {
-	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
-	if err := migratesum.WritePrecomputedWithFormat(
-		dir,
-		migrator.MigrationDirFormatAtlas,
-		sum,
-	); err != nil {
-		return "", fmt.Errorf("write atlas.sum: %w", err)
+// publishDirSum commits atlas.sum through the same rooted handle that published
+// the migration files, conditionally on the checksum state the transaction
+// observed. A concurrent writer that replaced atlas.sum after the migration
+// snapshot was verified is reported instead of overwritten.
+func publishDirSum(w *migrationWriterDir, sum *migratesum.SumFile) (string, error) {
+	if sum == nil {
+		return "", errors.New("migration checksum must not be nil")
 	}
-	return sumPath, nil
+	sumPath := filepath.Join(w.path, migratesum.AtlasFileName)
+	destination, err := expectedSumDestination(w)
+	if err != nil {
+		return "", fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err)
+	}
+	tempName, err := stageRootedFile(
+		w.dir,
+		"."+migratesum.AtlasFileName+".*.tmp",
+		sum.Bytes(),
+		publishedFileMode,
+	)
+	if err != nil {
+		return "", fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err)
+	}
+	info, err := w.dir.Lstat(tempName)
+	if err != nil {
+		return "", errors.Join(
+			fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err),
+			removeRootedFiles(w.dir, []string{tempName}),
+		)
+	}
+	publishErr := w.dir.PublishFile(
+		tempName,
+		migratesum.AtlasFileName,
+		info,
+		publishedFileMode,
+		destination,
+	)
+	if publishErr == nil {
+		return sumPath, nil
+	}
+	if errors.Is(publishErr, fsdurable.ErrReplacementCommitted) {
+		// The rename took effect; only the durability barrier after it failed.
+		// That is exactly the commit-uncertain contract the checksum writer has
+		// always reported, so the journal is retained for recovery.
+		return "", &migratesum.CommitUncertainError{
+			Err: fmt.Errorf("write %s: %w", migratesum.AtlasFileName, publishErr),
+		}
+	}
+	return "", errors.Join(
+		fmt.Errorf("write %s: %w", migratesum.AtlasFileName, publishErr),
+		removeRootedFiles(w.dir, []string{tempName}),
+	)
 }
 
-func removeFiles(paths []string) error {
+// expectedSumDestination captures the checksum state this commit replaces. It
+// is read through the rooted handle immediately before the staged sum is
+// published, so the window between the two is closed by the conditional commit
+// rather than by trusting the read.
+func expectedSumDestination(w *migrationWriterDir) (fsdurable.Destination, error) {
+	info, err := w.dir.Lstat(migratesum.AtlasFileName)
+	if errors.Is(err, fs.ErrNotExist) {
+		return fsdurable.ExpectAbsent(), nil
+	}
+	if err != nil {
+		return fsdurable.Destination{}, err
+	}
+	if !info.Mode().IsRegular() {
+		return fsdurable.Destination{}, fmt.Errorf(
+			"%s is not a regular file",
+			filepath.Join(w.path, migratesum.AtlasFileName),
+		)
+	}
+	return fsdurable.ExpectFile(info), nil
+}
+
+func removeStagedFiles(w *migrationWriterDir, names []string) error {
+	if !w.Exists() {
+		return nil
+	}
+	return removeRootedFiles(w.dir, names)
+}
+
+func removeRootedFiles(d *pathguard.OpenedDirectory, names []string) error {
 	var resultErr error
-	for _, path := range paths {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			resultErr = errors.Join(resultErr, fmt.Errorf("remove %s: %w", path, err))
+	for _, name := range names {
+		if err := d.Remove(name); err != nil && !errors.Is(err, fs.ErrNotExist) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("remove %s: %w", name, err))
 		}
 	}
 	return resultErr
 }
 
+// rootedGlob lists the direct children of d whose names match pattern. It
+// replaces filepath.Glob so the scan cannot follow a replaced pathname out of
+// the opened directory.
+func rootedGlob(d *pathguard.OpenedDirectory, pattern string) ([]string, error) {
+	entries, err := d.ReadDir(".")
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var matched []string
+	for _, entry := range entries {
+		ok, err := filepath.Match(pattern, entry.Name())
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			matched = append(matched, entry.Name())
+		}
+	}
+	return matched, nil
+}
+
 func stageArtifactBatch(
-	dir string,
+	w *migrationWriterDir,
 	artifacts []PublicationArtifact,
 ) (migrationBatch, error) {
 	if len(artifacts) == 0 {
@@ -1100,43 +1217,52 @@ func stageArtifactBatch(
 	}
 	batch := migrationBatch{
 		paths:       make([]string, 0, len(artifacts)),
-		stagedPaths: make([]string, 0, len(artifacts)),
+		names:       make([]string, 0, len(artifacts)),
+		stagedNames: make([]string, 0, len(artifacts)),
 		digests:     make([]string, 0, len(artifacts)),
 	}
-	names := make([]string, 0, len(artifacts))
 	for _, artifact := range artifacts {
 		if filepath.Base(artifact.Name) != artifact.Name ||
 			artifact.Name == "." ||
 			artifact.Name == "" {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("invalid artifact publication name %q", artifact.Name),
-				removeFiles(batch.stagedPaths),
+				removeStagedFiles(w, batch.stagedNames),
 			)
 		}
-		if slices.Contains(names, artifact.Name) {
+		if slices.Contains(batch.names, artifact.Name) {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("duplicate artifact publication name %q", artifact.Name),
-				removeFiles(batch.stagedPaths),
+				removeStagedFiles(w, batch.stagedNames),
 			)
 		}
-		stagedPath, err := stageArtifactFile(dir, artifact.Contents)
+		stagedName, err := stageRootedFile(
+			w.dir,
+			stagedMigrationPattern,
+			artifact.Contents,
+			publishedFileMode,
+		)
 		if err != nil {
-			return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+			return migrationBatch{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 		}
-		names = append(names, artifact.Name)
-		batch.paths = append(batch.paths, filepath.Join(dir, artifact.Name))
-		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+		batch.paths = append(batch.paths, filepath.Join(w.path, artifact.Name))
+		batch.names = append(batch.names, artifact.Name)
+		batch.stagedNames = append(batch.stagedNames, stagedName)
 		batch.digests = append(batch.digests, contentDigest(artifact.Contents))
 	}
-	mode, err := detectPublicationMode(batch.stagedPaths[0])
+	mode, err := detectPublicationMode(w.dir, batch.stagedNames[0])
 	if err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return migrationBatch{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
 	batch.mode = mode
 	return batch, nil
 }
 
-func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (migrationBatch, error) {
+func stageMigrationBatch(
+	w *migrationWriterDir,
+	name string,
+	contents []MigrationFileContent,
+) (migrationBatch, error) {
 	if len(contents) == 0 {
 		return migrationBatch{}, errors.New("migration SQL is empty")
 	}
@@ -1145,20 +1271,25 @@ func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (mig
 			return migrationBatch{}, errors.New("migration SQL is empty")
 		}
 	}
-	version, err := nextMigrationVersion(dir)
+	fsys, err := w.FS()
 	if err != nil {
 		return migrationBatch{}, err
 	}
-	return stageMigrationBatchAt(dir, name, version, contents)
+	version, err := nextMigrationVersionFS(fsys)
+	if err != nil {
+		return migrationBatch{}, err
+	}
+	return stageMigrationBatchAt(w, name, version, contents)
 }
 
 func stageMigrationBatchAt(
-	dir, name string,
+	w *migrationWriterDir,
+	name string,
 	version int64,
 	contents []MigrationFileContent,
 ) (migrationBatch, error) {
 	return stageMigrationBatchAtWithModeDetector(
-		dir,
+		w,
 		name,
 		version,
 		contents,
@@ -1167,85 +1298,100 @@ func stageMigrationBatchAt(
 }
 
 func stageMigrationBatchAtWithModeDetector(
-	dir, name string,
+	w *migrationWriterDir,
+	name string,
 	version int64,
 	contents []MigrationFileContent,
-	detectMode func(string) (publicationMode, error),
+	detectMode func(*pathguard.OpenedDirectory, string) (publicationMode, error),
 ) (migrationBatch, error) {
+	if !w.Exists() {
+		return migrationBatch{}, w.missingDirError()
+	}
 	batch := migrationBatch{
 		paths:       make([]string, 0, len(contents)),
-		stagedPaths: make([]string, 0, len(contents)),
+		names:       make([]string, 0, len(contents)),
+		stagedNames: make([]string, 0, len(contents)),
 	}
 	for i, content := range contents {
 		fileVersion := version + int64(i)
 		slug := migrationSlug(name + content.NameSuffix)
-		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", fileVersion, slug))
-		stagedPath, err := stageMigrationFile(dir, content.SQL)
+		fileName := fmt.Sprintf("%d_%s.sql", fileVersion, slug)
+		stagedName, err := stageRootedFile(
+			w.dir,
+			stagedMigrationPattern,
+			[]byte(content.SQL),
+			publishedFileMode,
+		)
 		if err != nil {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("stage migration file: %w", err),
-				removeFiles(batch.stagedPaths),
+				removeStagedFiles(w, batch.stagedNames),
 			)
 		}
-		batch.paths = append(batch.paths, path)
-		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+		batch.paths = append(batch.paths, filepath.Join(w.path, fileName))
+		batch.names = append(batch.names, fileName)
+		batch.stagedNames = append(batch.stagedNames, stagedName)
 	}
-	mode, err := detectMode(batch.stagedPaths[0])
+	mode, err := detectMode(w.dir, batch.stagedNames[0])
 	if err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return migrationBatch{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
 	batch.mode = mode
-	if _, err := readStagedMigrationContents(&batch); err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	if _, err := readStagedMigrationContents(w, &batch); err != nil {
+		return migrationBatch{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
 	}
 	return batch, nil
 }
 
-func detectPublicationMode(stagedPath string) (publicationMode, error) {
-	return platformPublicationMode(stagedPath)
+func detectPublicationMode(
+	d *pathguard.OpenedDirectory,
+	stagedName string,
+) (publicationMode, error) {
+	return platformPublicationMode(d, stagedName)
 }
 
 func detectPublicationModeWithLink(
-	stagedPath string,
+	d *pathguard.OpenedDirectory,
+	stagedName string,
 	link func(string, string) error,
 ) (publicationMode, error) {
-	probePath := stagedPath + ".link-probe"
-	if err := link(stagedPath, probePath); err != nil {
+	probeName := stagedName + ".link-probe"
+	if err := link(stagedName, probeName); err != nil {
 		return publicationModeCopy, nil
 	}
-	if err := os.Remove(probePath); err != nil {
+	if err := d.Remove(probeName); err != nil {
 		return "", fmt.Errorf("remove migration publication link probe: %w", err)
 	}
 	return publicationModeHardLink, nil
 }
 
-func stageMigrationFile(dir, migrationSQL string) (string, error) {
-	return stageArtifactFile(dir, []byte(migrationSQL))
-}
-
-func stageArtifactFile(dir string, contents []byte) (string, error) {
-	file, err := os.CreateTemp(dir, stagedMigrationPattern)
+// stageRootedFile writes contents into a new exclusively owned file inside the
+// opened directory and returns its name. Every staged file is created through
+// the handle, so no staging step can land outside the directory the caller
+// opened.
+func stageRootedFile(
+	d *pathguard.OpenedDirectory,
+	pattern string,
+	contents []byte,
+	mode fs.FileMode,
+) (string, error) {
+	file, name, err := d.CreateTemp(pattern)
 	if err != nil {
 		return "", err
 	}
-	path := file.Name()
-	if err := file.Chmod(0644); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+	if err := file.Chmod(mode); err != nil {
+		return "", errors.Join(err, file.Close(), removeRootedFiles(d, []string{name}))
 	}
 	if _, err := file.Write(contents); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+		return "", errors.Join(err, file.Close(), removeRootedFiles(d, []string{name}))
 	}
 	if err := file.Sync(); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+		return "", errors.Join(err, file.Close(), removeRootedFiles(d, []string{name}))
 	}
 	if err := file.Close(); err != nil {
-		return "", errors.Join(err, removeFiles([]string{path}))
+		return "", errors.Join(err, removeRootedFiles(d, []string{name}))
 	}
-	return path, nil
-}
-
-func nextMigrationVersion(dir string) (int64, error) {
-	return nextMigrationVersionFS(os.DirFS(dir))
+	return name, nil
 }
 
 func nextMigrationVersionFS(fsys fs.FS) (int64, error) {

--- a/internal/atlasmigrate/publication_mode_nonwindows.go
+++ b/internal/atlasmigrate/publication_mode_nonwindows.go
@@ -2,8 +2,11 @@
 
 package atlasmigrate
 
-import "os"
+import "go.5x5.cz/ptah/internal/pathguard"
 
-func platformPublicationMode(stagedPath string) (publicationMode, error) {
-	return detectPublicationModeWithLink(stagedPath, os.Link)
+func platformPublicationMode(
+	d *pathguard.OpenedDirectory,
+	stagedName string,
+) (publicationMode, error) {
+	return detectPublicationModeWithLink(d, stagedName, d.Link)
 }

--- a/internal/atlasmigrate/publication_mode_windows.go
+++ b/internal/atlasmigrate/publication_mode_windows.go
@@ -2,6 +2,8 @@
 
 package atlasmigrate
 
-func platformPublicationMode(string) (publicationMode, error) {
+import "go.5x5.cz/ptah/internal/pathguard"
+
+func platformPublicationMode(*pathguard.OpenedDirectory, string) (publicationMode, error) {
 	return publicationModeWriteThroughMove, nil
 }

--- a/internal/atlasmigrate/writerdir.go
+++ b/internal/atlasmigrate/writerdir.go
@@ -1,0 +1,212 @@
+package atlasmigrate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// migrationWriterDir is the rooted migration-directory capability one
+// publication transaction runs through, from the snapshot it verifies to the
+// atlas.sum it commits.
+//
+// It holds two handles rather than one because the transaction touches two
+// directories. The migration directory owns the staged files, the published
+// migrations and atlas.sum; its parent owns the publication journal and the
+// commit marker, which deliberately sit beside the directory so an interrupted
+// run stays recoverable even when the directory itself was left half-built.
+//
+// Both are opened once, before anything is staged, and every later step names
+// a direct child of one of them. That is the whole point: a pathname resolved
+// again after validation can select a different filesystem object, so once
+// these handles exist no write or verification step may reopen the directory by
+// pathname (stokaro/ptah#1118).
+//
+// When root is supplied the two opens go through it, so a project-config
+// relative migration directory cannot leave the opened project root even if the
+// directory or one of its ancestors is replaced by a symlink pointing out of it
+// after the path was resolved. A nil root keeps the direct-CLI behavior, where
+// an explicit absolute --dir is the operator's own choice of destination.
+type migrationWriterDir struct {
+	parent *pathguard.OpenedDirectory
+	// dir is nil when the migration directory does not exist. Recovery runs on
+	// that shape, because the journal lives beside the directory and outlives it.
+	dir *pathguard.OpenedDirectory
+	// name is the migration directory's entry name inside parent, resolved the
+	// same way the cross-process lock resolves it so both name the same object.
+	name string
+	// path is the pathname the caller selected, kept verbatim for the paths this
+	// run reports back. Nothing resolves it again.
+	path string
+}
+
+// Path returns the stable lexical path selected for the migration directory.
+// It is display and result data only; no write step resolves it again.
+func (w *migrationWriterDir) Path() string {
+	return w.path
+}
+
+// FS returns the escape-resistant filesystem rooted at the migration directory.
+func (w *migrationWriterDir) FS() (fs.FS, error) {
+	if w.dir == nil {
+		return nil, w.missingDirError()
+	}
+	return w.dir.FS(), nil
+}
+
+// Exists reports whether the migration directory was present when the handles
+// were bound.
+func (w *migrationWriterDir) Exists() bool {
+	return w.dir != nil
+}
+
+func (w *migrationWriterDir) missingDirError() error {
+	return fmt.Errorf("migration directory %s: %w", w.path, fs.ErrNotExist)
+}
+
+// Close releases both handles.
+func (w *migrationWriterDir) Close() error {
+	if w == nil {
+		return nil
+	}
+	var dirErr error
+	if w.dir != nil {
+		dirErr = w.dir.Close()
+	}
+	return errors.Join(dirErr, w.parent.Close())
+}
+
+// writerDirBinding selects whether binding the migration directory may create
+// it. It is a named type rather than a bool so the two call sites read as the
+// operations they are at the call site instead of as a naked true/false.
+type writerDirBinding int
+
+const (
+	// bindExistingWriterDir opens what is already there and reports a missing
+	// migration directory through migrationWriterDir.Exists.
+	bindExistingWriterDir writerDirBinding = iota
+	// createWriterDir materializes a missing migration directory and its parents
+	// through the selected root.
+	createWriterDir
+)
+
+func (b writerDirBinding) creates() bool {
+	return b == createWriterDir
+}
+
+// openMigrationWriterDir binds the migration directory and its parent without
+// creating either. A migration directory that does not exist yields a handle
+// whose Exists reports false rather than an error, because recovery has to run
+// on a directory an interrupted run never finished creating.
+func openMigrationWriterDir(
+	root *pathguard.OpenedDirectory,
+	dir string,
+) (*migrationWriterDir, error) {
+	return bindMigrationWriterDir(root, dir, bindExistingWriterDir)
+}
+
+// createMigrationWriterDir binds the migration directory and its parent,
+// creating the directory through the parent handle when it is missing. The
+// creation goes through the same rooted boundary as every later write, so a
+// missing directory is materialized inside the opened root rather than wherever
+// the pathname happens to point.
+func createMigrationWriterDir(
+	root *pathguard.OpenedDirectory,
+	dir string,
+) (*migrationWriterDir, error) {
+	return bindMigrationWriterDir(root, dir, createWriterDir)
+}
+
+func bindMigrationWriterDir(
+	root *pathguard.OpenedDirectory,
+	dir string,
+	binding writerDirBinding,
+) (*migrationWriterDir, error) {
+	display, err := filepath.Abs(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve migration directory: %w", err)
+	}
+	canonical, err := canonicalMigrationDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve migration directory: %w", err)
+	}
+	parent, err := openMigrationWriterParent(root, filepath.Dir(canonical), binding)
+	if err != nil {
+		return nil, err
+	}
+	name := filepath.Base(canonical)
+	writer := &migrationWriterDir{parent: parent, name: name, path: filepath.Clean(display)}
+	if binding.creates() {
+		if err := parent.Mkdir(name, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+			return nil, errors.Join(fmt.Errorf("create migration directory: %w", err), parent.Close())
+		}
+	}
+	opened, err := parent.OpenDirectory(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return writer, nil
+	}
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("open migration directory: %w", err), parent.Close())
+	}
+	writer.dir = opened
+	return writer, nil
+}
+
+func openMigrationWriterParent(
+	root *pathguard.OpenedDirectory,
+	parentPath string,
+	binding writerDirBinding,
+) (*pathguard.OpenedDirectory, error) {
+	if root == nil {
+		if binding.creates() {
+			if err := os.MkdirAll(parentPath, 0o755); err != nil {
+				return nil, fmt.Errorf("create migration directory parent: %w", err)
+			}
+		}
+		opened, err := pathguard.OpenDirectory(parentPath)
+		if err != nil {
+			return nil, fmt.Errorf("open migration directory parent: %w", err)
+		}
+		return opened, nil
+	}
+	if binding.creates() {
+		if err := rootMkdirAll(root, parentPath); err != nil {
+			return nil, err
+		}
+	}
+	opened, err := root.OpenDirectory(parentPath)
+	if err != nil {
+		return nil, fmt.Errorf("open migration directory parent: %w", err)
+	}
+	return opened, nil
+}
+
+// ensureMigrationDirParent creates the migration directory's parent through the
+// selected root before the cross-process lock file is created beside it.
+func ensureMigrationDirParent(root *pathguard.OpenedDirectory, dir string) error {
+	parentPath := filepath.Dir(filepath.Clean(dir))
+	if root == nil {
+		if err := os.MkdirAll(parentPath, 0o755); err != nil {
+			return fmt.Errorf("create migration directory parent: %w", err)
+		}
+		return nil
+	}
+	return rootMkdirAll(root, parentPath)
+}
+
+// rootMkdirAll creates path inside root, treating an entry that already resolves
+// to a directory as success. os.Root.MkdirAll reports fs.ErrExist for a path
+// component that is a symlink to a directory, where the unrooted os.MkdirAll
+// this replaced followed it and returned nil; the containment guarantee comes
+// from the rooted open that follows, not from the create.
+func rootMkdirAll(root *pathguard.OpenedDirectory, path string) error {
+	err := root.MkdirAll(path, 0o755)
+	if err == nil || errors.Is(err, fs.ErrExist) {
+		return nil
+	}
+	return fmt.Errorf("create migration directory parent: %w", err)
+}

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -34,6 +34,44 @@ func (d *OpenedDirectory) Remove(name string) error {
 	return d.root.Remove(name)
 }
 
+// ReadDir lists name through the rooted directory handle. Pass "." for the
+// opened directory itself.
+func (d *OpenedDirectory) ReadDir(name string) ([]fs.DirEntry, error) {
+	return fs.ReadDir(d.root.FS(), name)
+}
+
+// OpenFile opens name through the rooted directory handle with the supplied
+// flags. The caller owns the returned file and must close it.
+func (d *OpenedDirectory) OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
+	return d.root.OpenFile(name, flag, perm)
+}
+
+// Link creates newName as a hard link to oldName through the rooted directory
+// handle. An existing newName is reported through fs.ErrExist, so the link is
+// already conditional on the destination being absent.
+func (d *OpenedDirectory) Link(oldName, newName string) error {
+	return d.root.Link(oldName, newName)
+}
+
+// Mkdir creates name as a directory inside the opened directory. An entry that
+// already exists is reported through fs.ErrExist.
+func (d *OpenedDirectory) Mkdir(name string, perm fs.FileMode) error {
+	return d.root.Mkdir(name, perm)
+}
+
+// MkdirAll creates path and every missing parent inside the opened directory.
+// Path may be spelled absolutely as long as it stays within the handle.
+func (d *OpenedDirectory) MkdirAll(path string, perm fs.FileMode) error {
+	target, err := rootedRelativePath(path, d.path)
+	if err != nil {
+		return err
+	}
+	if target.relative == "." {
+		return nil
+	}
+	return d.root.MkdirAll(target.relative, perm)
+}
+
 // CreateTemp creates a new exclusively owned file directly in the opened
 // directory. Pattern may contain one or more asterisks; the last is replaced
 // with random text. A pattern without an asterisk receives a random suffix.


### PR DESCRIPTION
Refs #1118. The `migrate diff` half is done; `migrate new` is not, and the reason is stated at the bottom rather than implied.

## The reproduction, before

The escape #1118 describes needs no exotic timing — only a replacement between the moment the directory is validated and the moment it is written. `DiffOptions.VerifyDir` is exactly that window: it is the callback the compat surface already passes in, it runs under the migration-directory lock, after the snapshot capture and before anything is staged.

The probe below points `--dir` at `<root>/migrations`, a symlink to `<root>/real`, and swaps it to an equally empty decoy from inside `VerifyDir` (both empty, so the planning recheck still passes):

```go
result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
    Dir:     link,                                   // <root>/migrations -> <root>/real
    Desired: localDesiredSet(c, "file://"+schemaPath),
    Name:    "add_email",
    VerifyDir: func(fs.FS) error {
        os.Remove(link)
        os.Symlink(filepath.Join(decoy, "migrations"), link)
        return nil
    },
})
```

Run against `f22107bd` (master at the time of writing), in a clean worktree of that commit:

```text
=== RUN   TestProbe1118_DirectorySymlinkSwap
    PROBE bound dir entries: []
    PROBE decoy migrations entries: [1786002629_add_email.sql atlas.sum]
--- FAIL: TestProbe1118_DirectorySymlinkSwap (0.29s)
```

The run returned a nil error. The migration file and `atlas.sum` were written into the decoy; the directory the run had opened, captured and verified was left empty.

## The reproduction, after

The identical probe file, unchanged, on this branch:

```text
=== RUN   TestProbe1118_DirectorySymlinkSwap
    PROBE bound dir entries: [1786002658_add_email.sql atlas.sum]
    PROBE decoy migrations entries: []
--- PASS: TestProbe1118_DirectorySymlinkSwap (0.61s)
```

Note the probe sets no `Root` at all. The binding is not a project-config feature bolted on top; it is how the writer addresses its directory now, so a plain `--dir` gets it too.

## What changed

`internal/atlasmigrate/writerdir.go` introduces `migrationWriterDir`: one rooted handle on the migration directory (staging, published migrations, `atlas.sum`) and one on its parent (publication journal, commit marker — they sit beside the directory so an interrupted run stays recoverable when the directory itself was left half-built). Both are opened once, before anything is staged, and every later step names a direct child of one of them.

`publication.go` was rewritten onto that pair. `os.CreateTemp`, `os.ReadFile`, `os.Remove`, `os.Link`, `os.OpenFile`, `filepath.Glob` and `fsdurable.SyncDir` on a pathname are gone from the write path; the corresponding rooted operations replace them, with `rootedGlob` reading the opened directory instead of resolving a pattern.

`DiffOptions.Root` carries the opened project root when `--dir` came from `atlas.hcl` — read off `atlasProject.localOptions`, the same predicate the reading half already uses, so the gate and the writer cannot end up bound to different objects. A `--dir` the operator named directly passes `nil` and is bound as its own root, keeping the explicit absolute-path behavior the issue asks to preserve.

Points worth calling out:

- **Conditional publication.** Migration files keep the three modes, and each is already conditional on the destination being absent: a hard link and an `O_EXCL` create both fail with `fs.ErrExist`, and the move mode states `fsdurable.ExpectAbsent()` to the rooted commit primitive from #948. `atlas.sum` was the one unconditional write — `fsdurable.ReplaceFile` — and is now `PublishFile` with `ExpectFile`/`ExpectAbsent` captured through the handle immediately before the commit. A rename that took effect but whose durability barrier failed is still reported as `migratesum.CommitUncertainError`, so the commit-uncertain contract and the journal retention are unchanged.
- **Rollback.** A published file is moved aside to `<staged>.rollback` conditionally on that name being free, and only then are its bytes compared; the check reads content nobody can still reach by the final name. This replaces the `<staged>.rollback/published` subdirectory, which needed a rooted no-replace move into a nested path that the direct-child commit primitive does not accept.
- **Missing directories.** The migration directory and its missing parents are created through the selected root. `os.Root.MkdirAll` reports `fs.ErrExist` for a component that is a symlink to a directory where the unrooted `os.MkdirAll` it replaced followed it, so that case is tolerated and containment comes from the rooted open that follows, not from the create.
- **The lock is untouched.** `canonicalMigrationDir` still decides the lock and journal location, so two Ptah processes reaching one directory by different pathnames still exclude each other, and `TestCanonicalMigrationDirResolvesSymlinkAlias` still pins it. The issue is about the writer's pathname lookups, not about the lock.
- **The journal format is untouched** (version 5), so a journal written by the previous binary is still recovered by this one.

## What each test prints if the change is reverted

Measured, not predicted. Three inverse mutants were built and run; each restores exactly one pathname re-resolution the change removed.

`internal/atlasmigrate/diff_root_unix_test.go`:

- `TestGenerateDiff_ReplacedDirectoryCannotRedirectPublication` — four rows: the directory symlink swapped before planning (with a project root, and again with none), an ancestor symlink swapped before planning, and the directory symlink swapped from inside the editor-preparation callback. Every row asserts both halves: the artifacts are in the opened directory, and the replacement is left with nothing in it.
  - Mutant "stage through `pathguard.OpenDirectory(w.path)`" (the pre-change staging): rows 1–3 print `unexpected length ... len(got): int(0) ... want length: int(1)` at `atlasSQLFiles(c, bound)`. Row 4 stays green, correctly — its swap happens after staging.
  - Mutant "publish through `pathguard.OpenDirectory(w.path)`": all four rows red.
  - Mutant "commit `atlas.sum` through `pathguard.OpenDirectory(w.path)`": all four rows red.
- `TestGenerateDiff_RefusesMigrationDirectoryOutsideOpenedRoot` — a `--dir` symlink pointing out of the project root. Mutant "ignore `Root` when binding the parent": prints `got non-nil error ... want ... nil` inverted — the assertion `qt.ErrorIs pathguard.ErrOutsideRoot` fails because the run succeeds and writes outside. This is the row the other three mutants leave green, which is what separates "bound to the object" from "confined to the root".
- `TestGenerateDiff_CreatesMissingMigrationDirectoryInsideOpenedRoot` — `--dir` naming a directory whose parent does not exist either. Revert the rooted `MkdirAll` to the unrooted one and it still passes; it is a non-interference control for the create path, not a security assertion, and is labelled as such by what it asserts (the migration and `atlas.sum` exist at the reported paths).

Existing coverage that moved rather than disappeared: the publication-mode, journal-fallback, orphan-temp, quarantine, foreign-collision, foreign-replacement, in-place-mutation, commit-uncertain and unreplayed-concurrent-migration tests in `diff_internal_test.go` were re-expressed against the rooted handle. None were deleted; each still asserts the same outcome. Reverting the rooted publication makes them fail to compile rather than fail an assertion, which is why the four tests above carry the behavioral proof.

## Gates

All green on this branch, on darwin/arm64:

```text
go build ./... && go vet ./...        # clean
go test ./cmd/... ./migration/... ./internal/... -count=1   # exit=0
go tool qtlint ./...                  # exit 0
golangci-lint run ./...               # 0 issues
scripts/check-test-style.sh           # OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh           # exit 0
scripts/check-public-api-snapshot.sh  # exit 0
```

`gocyclo` and `revive`'s `flag-parameter` both fired on the first draft and were fixed rather than suppressed: the capture-and-verify block moved into `openVerifiedMigrationDir`, and the `create bool` parameter became a named `writerDirBinding`.

The public API snapshot is unchanged — every type this adds is under `internal/`, and `migration/generator`'s signatures are untouched.

## Deliberately left open

- **`migrate new` is not fixed.** The forwarded verb writes through `migration/generator.GenerateEmptyMigration`, a different writer with its own `OutputDir string` and its own `migratesum.WriteWithFormat` call, plus a `--edit` rehash through `migrateops.Rehash`. Rooting it means adding a rooted boundary to an exported option struct and threading the handle from the compat surface through `ptah migrations create` — a public-API change with its own snapshot update. Bundling a half-done version of that into this PR would have made the diff harder to review and the guarantee harder to state. `#1118` therefore stays open under Refs for that half specifically; nothing else in the issue's required design is outstanding for `migrate diff`.
- **`PublishArtifactsLocked` and `RecoverPendingPublication*` gained the rooted transaction but not a root parameter.** They open the directory with direct-CLI semantics, which is what their only caller (`migration/generator`) has. Giving them an explicit boundary belongs with the `migrate new` work above.
- **No documentation change.** `docs/site/.../migrate-commands.md` describes the staging, the atomic `atlas.sum` replacement and the journal, and all three statements remain true. Nothing about the rooted contract is externally visible in the public API, so there is no generator or public-API doc to update. The docs checks were not run because nothing under `docs/` changed.
- **The reported path is still the pathname the caller gave.** In the hostile scenario the tests stage, `DiffResult.MigrationPaths` therefore names a path that, after the swap, resolves somewhere else — the file is written correctly, the string printed afterwards is stale. Reporting the canonicalized path instead was tried and rejected: it changes `Created migration file:` output for every ordinary run under a symlinked path (on macOS, every run under `/var/...`), which is a worse trade for a line that is only misleading when someone is actively attacking the directory.