### PR TITLE
security: root migrate-diff publication and recovery to retained directory handles

### DIFF
--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -503,6 +503,18 @@ directory; the next lock holder compares the checksum commit marker and either
 finalizes the committed batch or removes only the hard-linked files owned by
 the interrupted batch.
 
+Publication and recovery are rooted. Ptah opens the migration directory and the
+directory that holds its journal once, before the snapshot the run verifies is
+captured, and addresses every later staged file, migration file, journal,
+commit marker, `atlas.sum`, rollback quarantine and cleanup entry by name
+relative to those two retained handles. Replacing the directory's pathname
+afterwards — a rename, a symlink, or a fresh directory moved into place —
+cannot redirect a write: the handles keep referring to the filesystem objects
+that were validated, wherever those objects are moved to
+([#895](https://github.com/stokaro/ptah/issues/895)). The boundary is the
+retained directory, so recovery can never act on a replacement and cleanup can
+never remove a file that a replacement contributed.
+
 ```bash
 ptah-compat migrate diff add_users \
   --dir file://migrations \

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -581,6 +581,19 @@ project directory handle opened for config evaluation until capture completes;
 replacing the project pathname does not retarget it. Parent-relative project
 directories are external compatibility paths and do not inherit that root.
 
+Commands that *write* the directory — `migrate diff` and native migration
+generation — extend the same binding to publication. The migration directory
+and the directory holding its publication journal are opened once, before the
+snapshot the run verifies is captured, and every staged file, migration file,
+journal, commit marker, `atlas.sum`, rollback quarantine and cleanup entry is
+addressed by name relative to those retained handles. A directory replaced
+after validation therefore receives nothing, and recovery resolves an
+interrupted publication on the objects that were validated rather than on
+whatever the pathname resolves to when recovery runs
+([#895](https://github.com/stokaro/ptah/issues/895)). This closes the
+observation window that the two-capture check cannot: a replacement is no
+longer a difference to notice, it is a directory the writes never reach.
+
 ## Pre-migration checks
 
 Guard a migration on a data-state precondition with a `-- +ptah check`

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -144,13 +144,17 @@ func generateDiff(
 	if err != nil {
 		return DiffResult{}, err
 	}
-	if err := os.MkdirAll(opts.Dir, 0755); err != nil {
-		return DiffResult{}, fmt.Errorf("create migration directory: %w", err)
+	pub, err := createAndRetainMigrationDir(opts.Dir)
+	if err != nil {
+		return DiffResult{}, err
 	}
-	if err := recoverPendingPublication(opts.Dir); err != nil {
+	defer func() {
+		err = errors.Join(err, pub.close())
+	}()
+	if err := recoverPendingPublication(pub); err != nil {
 		return DiffResult{}, fmt.Errorf("recover migration artifact publication: %w", err)
 	}
-	migrationSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(opts.Dir))
+	migrationSnapshot, err := migrationsnapshot.CaptureStable(pub.fsys())
 	if err != nil {
 		return DiffResult{}, fmt.Errorf("capture migration directory: %w", err)
 	}
@@ -200,7 +204,7 @@ func generateDiff(
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
 	}
-	if err := verifyMigrationDirUnchanged(opts.Dir, migrationSnapshot); err != nil {
+	if err := verifyMigrationDirUnchanged(pub, migrationSnapshot); err != nil {
 		return DiffResult{}, err
 	}
 	if opts.DryRun {
@@ -208,12 +212,27 @@ func generateDiff(
 	}
 	return writeDiffArtifacts(
 		ctx,
-		opts.Dir,
+		pub,
 		opts.Name,
 		contents,
 		migrationSnapshot,
 		opts.PreparePublication,
 	)
+}
+
+// createAndRetainMigrationDir creates the migration directory if it is missing
+// and retains it, together with the directory that holds its publication
+// journal, as rooted handles.
+//
+// Everything after this point -- recovery, the snapshot this run verifies
+// against, planning, and publication -- acts on the filesystem objects opened
+// here, so replacing the pathname afterwards cannot redirect a write
+// (stokaro/ptah#895). The caller owns the returned handle.
+func createAndRetainMigrationDir(dir string) (*publicationDir, error) {
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return nil, fmt.Errorf("create migration directory: %w", err)
+	}
+	return openPublicationDir(dir)
 }
 
 func prepareDiff(
@@ -363,8 +382,8 @@ func verifyDirSum(fsys fs.FS) error {
 	return nil
 }
 
-func verifyMigrationDirUnchanged(dir string, expected fsnapshot.Snapshot) error {
-	current, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+func verifyMigrationDirUnchanged(pub *publicationDir, expected fsnapshot.Snapshot) error {
+	current, err := migrationsnapshot.CaptureStable(pub.fsys())
 	if err != nil {
 		return fmt.Errorf("recapture migration directory: %w", err)
 	}

--- a/internal/atlasmigrate/diff_directory_swap_nonwindows_internal_test.go
+++ b/internal/atlasmigrate/diff_directory_swap_nonwindows_internal_test.go
@@ -1,0 +1,197 @@
+//go:build !windows
+
+package atlasmigrate
+
+// White-box testing required: the window this exercises opens after
+// GenerateDiff has already locked, recovered and snapshotted the migration
+// directory, so it cannot be reached from the exported API. PreparePublication
+// is the same internal seam diff_prepare_nonwindows_internal_test.go uses, and
+// recoverPendingPublication is only reachable from inside the package.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/migrationreplay"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// swappedDirectories names the two directories a swap leaves behind: the
+// object that was validated, which every write must still reach, and the
+// pathname that now resolves to the replacement, which must receive nothing.
+type swappedDirectories struct {
+	retained    string
+	replacement string
+}
+
+// replaceMigrationDirectory moves dir aside, copies its contents into a
+// replacement, and installs the replacement on dir's pathname through install.
+// Callers pass os.Symlink or a rename to choose which shape of replacement the
+// pathname resolves to afterwards; either way the pathname is what reads of
+// swappedDirectories.replacement go through.
+func replaceMigrationDirectory(
+	c *qt.C,
+	dir string,
+	install func(replacement, pathname string) error,
+) swappedDirectories {
+	c.Helper()
+	swap := swappedDirectories{retained: dir + ".retained", replacement: dir}
+	staging := filepath.Join(filepath.Dir(dir), "replacement")
+	c.Assert(os.CopyFS(staging, os.DirFS(dir)), qt.IsNil)
+	c.Assert(os.Rename(dir, swap.retained), qt.IsNil)
+	c.Assert(install(staging, dir), qt.IsNil)
+	return swap
+}
+
+func migrationFileNames(c *qt.C, dir string) []string {
+	c.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(matches))
+	for _, match := range matches {
+		names = append(names, filepath.Base(match))
+	}
+	return names
+}
+
+func readSumFile(c *qt.C, dir string) string {
+	c.Helper()
+	contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	return string(contents)
+}
+
+// TestGenerateDiff_PublishesIntoTheValidatedDirectory pins that the migration
+// file and atlas.sum land in the directory this run validated even after the
+// directory's pathname is made to resolve somewhere else, and that the
+// replacement receives nothing (stokaro/ptah#895).
+func TestGenerateDiff_PublishesIntoTheValidatedDirectory(t *testing.T) {
+	tests := []struct {
+		name    string
+		install func(replacement, pathname string) error
+	}{
+		{
+			name:    "pathname becomes a symlink to the replacement",
+			install: os.Symlink,
+		},
+		{
+			name: "pathname becomes the replacement directory",
+			install: func(replacement, pathname string) error {
+				return os.Rename(replacement, pathname)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			conn, opts := prepareGenerateDiffFaultTest(c)
+			previousSum := readSumFile(c, opts.Dir)
+			var swap swappedDirectories
+			opts.PreparePublication = func([]string) error {
+				swap = replaceMigrationDirectory(c, opts.Dir, test.install)
+				return nil
+			}
+
+			result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+				readDevSchema:        readScopedDevSchema,
+				withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(result.MigrationPaths, qt.HasLen, 1)
+			// The validated directory received the migration and the refreshed
+			// checksum, and still verifies against them.
+			c.Assert(migrationFileNames(c, swap.retained), qt.HasLen, 2)
+			c.Assert(readSumFile(c, swap.retained), qt.Not(qt.Equals), previousSum)
+			verification, verifyErr := migratesum.VerifyWithFormat(
+				os.DirFS(swap.retained),
+				migrator.MigrationDirFormatAtlas,
+			)
+			c.Assert(verifyErr, qt.IsNil)
+			c.Assert(verification.OK(), qt.IsTrue)
+			// The directory that took over the pathname received nothing.
+			c.Assert(migrationFileNames(c, swap.replacement), qt.DeepEquals, []string{"1_init.sql"})
+			c.Assert(readSumFile(c, swap.replacement), qt.Equals, previousSum)
+			assertSQLiteCleanupObjectCount(c, conn, 0)
+		})
+	}
+}
+
+// TestGenerateDiff_PublishesIntoUnswappedDirectory is the control for the swap
+// fixture above: with no swap the same reads observe the migration and the
+// refreshed checksum in the same directory, which is what makes "the
+// replacement stayed empty" evidence rather than an artifact of looking in the
+// wrong place.
+func TestGenerateDiff_PublishesIntoUnswappedDirectory(t *testing.T) {
+	c := qt.New(t)
+	conn, opts := prepareGenerateDiffFaultTest(c)
+	previousSum := readSumFile(c, opts.Dir)
+
+	result, err := generateDiff(t.Context(), conn, opts, diffRuntime{
+		readDevSchema:        readScopedDevSchema,
+		withReplayedSnapshot: migrationreplay.WithReplayedSnapshotLocked,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.MigrationPaths, qt.HasLen, 1)
+	c.Assert(migrationFileNames(c, opts.Dir), qt.HasLen, 2)
+	c.Assert(readSumFile(c, opts.Dir), qt.Not(qt.Equals), previousSum)
+}
+
+// TestRecoverPendingPublication_RollsBackInTheRetainedDirectory pins that
+// recovery undoes the interrupted batch in the directory the handle was opened
+// on, and leaves an identically named file in the replacement untouched.
+func TestRecoverPendingPublication_RollsBackInTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	pub := openTestPublicationDir(c, dir)
+	batch, err := stageMigrationBatchAt(
+		pub,
+		"interrupted",
+		1,
+		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	_, _ = beginTestPublication(c, pub, batch, []MigrationFileContent{{SQL: "SELECT 1;"}})
+	published, err := publishMigrationBatch(pub, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	migrationName := filepath.Base(batch.paths(pub)[0])
+	swap := replaceMigrationDirectory(c, dir, os.Symlink)
+
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
+
+	_, err = os.Stat(filepath.Join(swap.retained, migrationName))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	replaced, err := os.ReadFile(filepath.Join(swap.replacement, migrationName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(replaced), qt.Equals, "SELECT 1;")
+}
+
+// TestRecoverPendingPublication_CleansUpInTheRetainedDirectory pins that orphan
+// staging cleanup removes the temporary file inside the directory the handle
+// was opened on and cannot reach an identically named file in a directory that
+// took over the pathname.
+func TestRecoverPendingPublication_CleansUpInTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	pub := openTestPublicationDir(c, dir)
+	stagedName, err := stageMigrationFile(pub, "SELECT 1;")
+	c.Assert(err, qt.IsNil)
+	swap := replaceMigrationDirectory(c, dir, os.Symlink)
+
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
+
+	_, err = os.Stat(filepath.Join(swap.retained, stagedName))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	orphan, err := os.ReadFile(filepath.Join(swap.replacement, stagedName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(orphan), qt.Equals, "SELECT 1;")
+}

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -22,16 +22,17 @@ import (
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/atlasurl"
-	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
+	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
 func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	// A non-cooperating writer claimed version 2 after this run allocated 1..2.
 	// Publishing the stale plan must fail instead of silently moving it above
 	// a migration that was never replayed.
@@ -41,13 +42,13 @@ func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 		{NameSuffix: "_concurrent_indexes", SQL: "SELECT 2;", NoTransaction: true},
 	}
 
-	batch, err := stageMigrationBatchAt(dir, "add_email", 1, contents)
+	batch, err := stageMigrationBatchAt(pub, "add_email", 1, contents)
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 
 	c.Assert(err, qt.ErrorMatches, `migration directory changed during publication: .*2_add_email_concurrent_indexes\.sql already exists`)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(pub, batch, published), qt.IsNil)
 	// The colliding file kept its content and no version-1 leftover remains
 	// from the aborted attempt.
 	taken, readErr := os.ReadFile(filepath.Join(dir, "2_add_email_concurrent_indexes.sql"))
@@ -60,21 +61,22 @@ func TestWriteMigrationFilesAt_CollisionRejectsStalePlan(t *testing.T) {
 func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	// The second file's name exceeds the filesystem's name limit, so its
 	// create fails with a non-collision error after the first file was
 	// already written; the batch rolls back completely.
 	oversizedSuffix := "_" + strings.Repeat("x", 512)
 
-	batch, err := stageMigrationBatch(dir, "add_email", []MigrationFileContent{
+	batch, err := stageMigrationBatch(pub, "add_email", []MigrationFileContent{
 		{NameSuffix: "_transactional", SQL: "SELECT 1;"},
 		{NameSuffix: oversizedSuffix, SQL: "SELECT 2;", NoTransaction: true},
 	})
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 
 	c.Assert(err, qt.ErrorMatches, `publish migration file: .*`)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(pub, batch, published), qt.IsNil)
 	_, leftoverErr := os.Stat(filepath.Join(dir, "1_add_email_transactional.sql"))
 	c.Assert(leftoverErr, qt.ErrorIs, os.ErrNotExist)
 }
@@ -82,8 +84,9 @@ func TestWriteMigrationFiles_FailedWriteRollsBackEarlierFiles(t *testing.T) {
 func TestPublishMigrationBatch_ExclusiveCopyMode(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"copy",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -91,26 +94,27 @@ func TestPublishMigrationBatch_ExclusiveCopyMode(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	batch.mode = publicationModeCopy
 
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	stagedInfo, err := os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
-	finalInfo, err := os.Stat(batch.paths[0])
+	finalInfo, err := os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
-	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	stagedContents, err := os.ReadFile(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
-	finalContents, err := os.ReadFile(batch.paths[0])
+	finalContents, err := os.ReadFile(batch.paths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(finalContents, qt.DeepEquals, stagedContents)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(pub, batch, published), qt.IsNil)
 }
 
 func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeAtlasSum,
@@ -124,7 +128,7 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	}
 
 	err := writePublicationJournalWithLink(
-		dir,
+		pub,
 		journal,
 		func(string, string) error {
 			return syscall.ENOTSUP
@@ -132,24 +136,24 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	)
 
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
-	got, err := readPublicationJournal(journalPath)
+	journalPath := pub.journalPath()
+	got, err := readPublicationJournal(pub)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.DeepEquals, journal)
 	backups, err := filepath.Glob(journalPath + ".*.tmp")
 	c.Assert(err, qt.IsNil)
 	c.Assert(backups, qt.HasLen, 1)
 	c.Assert(os.WriteFile(journalPath, []byte("{"), 0o600), qt.IsNil)
-	got, err = readPublicationJournal(journalPath)
+	got, err = readPublicationJournal(pub)
 	c.Assert(err, qt.IsNil)
 	c.Assert(got, qt.DeepEquals, journal)
-	c.Assert(removePublicationJournal(journalPath), qt.IsNil)
+	c.Assert(removePublicationJournal(pub), qt.IsNil)
 }
 
 func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 
 	paths, err := PublishArtifactsLocked(
 		t.Context(),
@@ -176,17 +180,17 @@ func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	report, err := os.ReadFile(paths[2])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(report), qt.Equals, "{}\n")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	_, err = os.Stat(journalPath + publicationCommitMarkerSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
 func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	existingPath := filepath.Join(dir, "1_change.down.sql")
 	c.Assert(os.WriteFile(existingPath, []byte("existing\n"), 0o600), qt.IsNil)
 
@@ -209,8 +213,7 @@ func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
 	staged, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
 	c.Assert(err, qt.IsNil)
 	c.Assert(staged, qt.HasLen, 0)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
@@ -218,15 +221,17 @@ func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
 func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 
 	batch, err := stageMigrationBatchAtWithModeDetector(
-		dir,
+		pub,
 		"copy",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
-		func(stagedPath string) (publicationMode, error) {
+		func(root *pathguard.OpenedDirectory, stagedName string) (publicationMode, error) {
 			return detectPublicationModeWithLink(
-				stagedPath,
+				root,
+				stagedName,
 				func(string, string) error {
 					return syscall.ENOTSUP
 				},
@@ -236,27 +241,28 @@ func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(batch.mode, qt.Equals, publicationModeCopy)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	stagedInfo, err := os.Stat(batch.stagedPaths[0])
+	stagedInfo, err := os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
-	finalInfo, err := os.Stat(batch.paths[0])
+	finalInfo, err := os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(os.SameFile(stagedInfo, finalInfo), qt.IsFalse)
-	c.Assert(rollBackUnjournaledBatch(dir, batch, published), qt.IsNil)
+	c.Assert(rollBackUnjournaledBatch(pub, batch, published), qt.IsNil)
 }
 
 func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	c.Assert(os.Mkdir(filepath.Join(dir, "atlas.sum"), 0o700), qt.IsNil)
 	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
 	c.Assert(err, qt.IsNil)
 
 	result, err := writeDiffArtifacts(
 		t.Context(),
-		dir,
+		pub,
 		"add_email",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
@@ -275,12 +281,13 @@ func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	initialPath := filepath.Join(dir, "1_initial.sql")
 	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
 	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"interrupted",
 		2,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
@@ -288,22 +295,21 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
@@ -314,12 +320,13 @@ func TestRecoverPendingPublication_RollsBackInterruptedBatch(t *testing.T) {
 func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	initialPath := filepath.Join(dir, "1_initial.sql")
 	c.Assert(os.WriteFile(initialPath, []byte("SELECT 1;"), 0o600), qt.IsNil)
 	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
 	c.Assert(err, qt.IsNil)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"interrupted_copy",
 		2,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
@@ -328,19 +335,19 @@ func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 	batch.mode = publicationModeCopy
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 2;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(
 		os.DirFS(dir),
@@ -353,8 +360,9 @@ func TestRecoverPendingPublication_RollsBackInterruptedCopyBatch(t *testing.T) {
 func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"interrupted_move",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -363,22 +371,21 @@ func TestRecoverPendingPublication_RollsBackInterruptedMoveBatch(t *testing.T) {
 	batch.mode = publicationModeWriteThroughMove
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
@@ -397,8 +404,9 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
 			dir := c.TempDir()
+			pub := openTestPublicationDir(c, dir)
 			batch, err := stageMigrationBatchAt(
-				dir,
+				pub,
 				"interrupted",
 				1,
 				[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -407,31 +415,26 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 			batch.mode = test.mode
 			_, _ = beginTestPublication(
 				c,
-				dir,
+				pub,
 				batch,
 				[]MigrationFileContent{{SQL: "SELECT 1;"}},
 			)
-			published, err := publishMigrationBatch(dir, batch)
+			published, err := publishMigrationBatch(pub, batch)
 			c.Assert(err, qt.IsNil)
 			c.Assert(published, qt.Equals, 1)
-			quarantineDir := batch.stagedPaths[0] + ".rollback"
-			quarantinePath := filepath.Join(quarantineDir, "published")
-			c.Assert(os.Mkdir(quarantineDir, 0o700), qt.IsNil)
-			c.Assert(os.Rename(batch.paths[0], quarantinePath), qt.IsNil)
-			c.Assert(removeFiles(batch.stagedPaths), qt.IsNil)
+			quarantinePath := batch.stagedPaths(pub)[0] + rollbackQuarantineSuffix
+			c.Assert(os.Rename(batch.paths(pub)[0], quarantinePath), qt.IsNil)
+			c.Assert(removeNames(pub.dir, batch.stagedNames), qt.IsNil)
 
-			c.Assert(recoverPendingPublication(dir), qt.IsNil)
+			c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-			_, err = os.Stat(batch.paths[0])
+			_, err = os.Stat(batch.paths(pub)[0])
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			_, err = os.Stat(batch.stagedPaths[0])
+			_, err = os.Stat(batch.stagedPaths(pub)[0])
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 			_, err = os.Stat(quarantinePath)
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			_, err = os.Stat(quarantineDir)
-			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-			journalPath, err := publicationJournalPath(dir)
-			c.Assert(err, qt.IsNil)
+			journalPath := pub.journalPath()
 			_, err = os.Stat(journalPath)
 			c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 		})
@@ -441,14 +444,15 @@ func TestRecoverPendingPublication_CleansQuarantineOnlyStateForEveryMode(t *test
 func TestRemovePublicationJournal_RetireFailurePreservesCommitMarker(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
-	journalPath := filepath.Join(dir, "publication.pending")
-	markerPath := publicationCommitMarkerPath(journalPath)
+	pub := openTestPublicationDir(c, dir)
+	journalPath := pub.journalPath()
+	markerPath := journalPath + publicationCommitMarkerSuffix
 	c.Assert(os.WriteFile(journalPath, []byte("{}"), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile(markerPath, []byte("committed"), 0o600), qt.IsNil)
 	retireErr := errors.New("injected journal retirement failure")
 
 	err := removePublicationJournalWithRetirer(
-		journalPath,
+		pub,
 		func(string, string) error {
 			return retireErr
 		},
@@ -464,34 +468,34 @@ func TestRemovePublicationJournal_RetireFailurePreservesCommitMarker(t *testing.
 func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageArtifactBatch(
-		dir,
+		pub,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.safety.json", Contents: []byte("{}\n")},
 		},
 	)
 	c.Assert(err, qt.IsNil)
-	journal, err := beginMarkerPublication(dir, batch)
+	journal, err := beginMarkerPublication(pub, batch)
 	c.Assert(err, qt.IsNil)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 2)
-	c.Assert(writePublicationCommitMarker(dir, journal), qt.IsNil)
+	c.Assert(writePublicationCommitMarker(pub, journal), qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	up, err := os.ReadFile(batch.paths[0])
+	up, err := os.ReadFile(batch.paths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(up), qt.Equals, "SELECT 1;\n")
-	report, err := os.ReadFile(batch.paths[1])
+	report, err := os.ReadFile(batch.paths(pub)[1])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(report), qt.Equals, "{}\n")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	_, err = os.Stat(publicationCommitMarkerPath(journalPath))
+	_, err = os.Stat(journalPath + publicationCommitMarkerSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	_, err = os.Stat(journalPath + publicationCleanupSuffix)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
@@ -500,8 +504,9 @@ func TestRecoverPendingPublication_FinalizesMarkerCommittedBatch(t *testing.T) {
 func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"committed",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -509,28 +514,27 @@ func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	journal, sum := beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	_, err = writeDirSum(dir, sum)
+	_, err = writeDirSum(pub, sum)
 	c.Assert(err, qt.IsNil)
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(pub, journal)
 	c.Assert(err, qt.IsNil)
 	c.Assert(committed, qt.IsTrue)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	contents, err := os.ReadFile(batch.paths[0])
+	contents, err := os.ReadFile(batch.paths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "SELECT 1;")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	result, err := migratesum.VerifyWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
@@ -541,8 +545,9 @@ func TestRecoverPendingPublication_FinalizesCommittedBatch(t *testing.T) {
 func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"collision",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -550,24 +555,23 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(batch.paths(pub)[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = recoverPendingPublication(dir)
+	err = recoverPendingPublication(pub)
 
 	c.Assert(err, qt.ErrorMatches, `cannot safely recover migration publication: .* content changed; preserved at .*`)
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(batch.stagedPaths(pub)[0] + rollbackQuarantineSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
 }
@@ -575,8 +579,9 @@ func TestRecoverPendingPublication_RejectsForeignCollision(t *testing.T) {
 func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"collision",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -584,28 +589,27 @@ func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(os.Remove(batch.paths[0]), qt.IsNil)
-	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+	c.Assert(os.Remove(batch.paths(pub)[0]), qt.IsNil)
+	c.Assert(os.WriteFile(batch.paths(pub)[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = abortPendingPublication(dir, batch, published)
+	err = abortPendingPublication(pub, batch, published)
 
 	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: .* content changed; preserved at .*`)
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(batch.stagedPaths(pub)[0] + rollbackQuarantineSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	_, err = os.Stat(batch.stagedPaths[0])
+	_, err = os.Stat(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
 }
@@ -613,8 +617,9 @@ func TestAbortPendingPublication_RejectsForeignReplacement(t *testing.T) {
 func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	batch, err := stageMigrationBatchAt(
-		dir,
+		pub,
 		"mutated",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
@@ -623,28 +628,27 @@ func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
 	batch.mode = publicationModeHardLink
 	_, _ = beginTestPublication(
 		c,
-		dir,
+		pub,
 		batch,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 	)
-	published, err := publishMigrationBatch(dir, batch)
+	published, err := publishMigrationBatch(pub, batch)
 	c.Assert(err, qt.IsNil)
 	c.Assert(published, qt.Equals, 1)
-	c.Assert(os.WriteFile(batch.paths[0], []byte("foreign"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(batch.paths(pub)[0], []byte("foreign"), 0o600), qt.IsNil)
 
-	err = abortPendingPublication(dir, batch, published)
+	err = abortPendingPublication(pub, batch, published)
 
 	c.Assert(err, qt.ErrorMatches, `roll back published migration files: cannot safely recover migration publication: staging file content changed; preserved .*`)
-	_, err = os.Stat(batch.paths[0])
+	_, err = os.Stat(batch.paths(pub)[0])
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
-	contents, err := os.ReadFile(filepath.Join(batch.stagedPaths[0]+".rollback", "published"))
+	contents, err := os.ReadFile(batch.stagedPaths(pub)[0] + rollbackQuarantineSuffix)
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(contents), qt.Equals, "foreign")
-	stagedContents, err := os.ReadFile(batch.stagedPaths[0])
+	stagedContents, err := os.ReadFile(batch.stagedPaths(pub)[0])
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(stagedContents), qt.Equals, "foreign")
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
 }
@@ -652,18 +656,19 @@ func TestAbortPendingPublication_RejectsInPlaceHardLinkMutation(t *testing.T) {
 func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
 	c.Assert(err, qt.IsNil)
 
 	result, err := writeDiffArtifactsWithSumWriter(
 		t.Context(),
-		dir,
+		pub,
 		"uncertain",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
 		nil,
-		func(dir string, sum *migratesum.SumFile) (string, error) {
-			path, writeErr := writeDirSum(dir, sum)
+		func(pub *publicationDir, sum *migratesum.SumFile) (string, error) {
+			path, writeErr := writeDirSum(pub, sum)
 			c.Assert(writeErr, qt.IsNil)
 			return path, &migratesum.CommitUncertainError{
 				Err: errors.New("injected directory sync failure"),
@@ -679,12 +684,11 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 	stagedFiles, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
 	c.Assert(err, qt.IsNil)
 	c.Assert(stagedFiles, qt.HasLen, 1)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 	sqlFiles, err = filepath.Glob(filepath.Join(dir, "*_uncertain.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(sqlFiles, qt.HasLen, 1)
@@ -704,6 +708,7 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
 	c.Assert(err, qt.IsNil)
 	foreignPath := filepath.Join(dir, "99_foreign.sql")
@@ -711,7 +716,7 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 
 	result, err := writeDiffArtifacts(
 		t.Context(),
-		dir,
+		pub,
 		"planned",
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
@@ -726,24 +731,33 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 	plannedFiles, err := filepath.Glob(filepath.Join(dir, "*_planned.sql"))
 	c.Assert(err, qt.IsNil)
 	c.Assert(plannedFiles, qt.HasLen, 0)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	_, err = os.Stat(journalPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
+func openTestPublicationDir(c *qt.C, dir string) *publicationDir {
+	c.Helper()
+	pub, err := openPublicationDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(pub.close(), qt.IsNil)
+	})
+	return pub
+}
+
 func beginTestPublication(
 	c *qt.C,
-	dir string,
+	pub *publicationDir,
 	batch migrationBatch,
 	contents []MigrationFileContent,
 ) (publicationJournal, *migratesum.SumFile) {
 	c.Helper()
-	baseSnapshot, err := migrationsnapshot.CaptureStable(os.DirFS(dir))
+	baseSnapshot, err := migrationsnapshot.CaptureStable(pub.fsys())
 	c.Assert(err, qt.IsNil)
 	_, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
 	c.Assert(err, qt.IsNil)
-	journal, err := beginPublication(dir, batch, sum.Bytes())
+	journal, err := beginPublication(pub, batch, sum.Bytes())
 	c.Assert(err, qt.IsNil)
 	return journal, sum
 }
@@ -751,10 +765,10 @@ func beginTestPublication(
 func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
-	stagedPath, err := stageMigrationFile(dir, "SELECT 1;")
+	pub := openTestPublicationDir(c, dir)
+	stagedName, err := stageMigrationFile(pub, "SELECT 1;")
 	c.Assert(err, qt.IsNil)
-	journalPath, err := publicationJournalPath(dir)
-	c.Assert(err, qt.IsNil)
+	journalPath := pub.journalPath()
 	journalTemp, err := os.CreateTemp(
 		filepath.Dir(journalPath),
 		filepath.Base(journalPath)+".*.tmp",
@@ -763,9 +777,9 @@ func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 	journalTempPath := journalTemp.Name()
 	c.Assert(journalTemp.Close(), qt.IsNil)
 
-	c.Assert(recoverPendingPublication(dir), qt.IsNil)
+	c.Assert(recoverPendingPublication(pub), qt.IsNil)
 
-	_, err = os.Stat(stagedPath)
+	_, err = os.Stat(pub.path(stagedName))
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 	_, err = os.Stat(journalTempPath)
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
@@ -774,29 +788,30 @@ func TestRecoverPendingPublication_RemovesOrphanTemps(t *testing.T) {
 func TestWriteMigrationFiles_EmptySQLIsRejected(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	pub := openTestPublicationDir(c, dir)
 
-	batch, err := stageMigrationBatch(dir, "noop", []MigrationFileContent{{SQL: "   \n"}})
+	batch, err := stageMigrationBatch(pub, "noop", []MigrationFileContent{{SQL: "   \n"}})
 
 	c.Assert(err, qt.ErrorMatches, `migration SQL is empty`)
-	c.Assert(batch.paths, qt.HasLen, 0)
+	c.Assert(batch.names, qt.HasLen, 0)
 }
 
-func publishMigrationBatch(dir string, batch migrationBatch) (int, error) {
-	return publishMigrationBatchContext(context.Background(), dir, batch)
+func publishMigrationBatch(pub *publicationDir, batch migrationBatch) (int, error) {
+	return publishMigrationBatchContext(context.Background(), pub, batch)
 }
 
 func rollBackUnjournaledBatch(
-	dir string,
+	pub *publicationDir,
 	batch migrationBatch,
 	published int,
 ) error {
-	if err := removeFiles(batch.paths[:published]); err != nil {
+	if err := removeNames(pub.dir, batch.names[:published]); err != nil {
 		return fmt.Errorf("roll back published migration files: %w", err)
 	}
-	if err := removeFiles(batch.stagedPaths); err != nil {
+	if err := removeNames(pub.dir, batch.stagedNames); err != nil {
 		return fmt.Errorf("remove rolled back migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
 	return nil

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -16,9 +16,9 @@ import (
 	"slices"
 	"strings"
 
-	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -27,7 +27,15 @@ const (
 	publicationJournalSuffix      = ".ptah-migrate-diff.pending"
 	publicationCommitMarkerSuffix = ".committed"
 	publicationCleanupSuffix      = ".cleanup"
-	stagedMigrationPattern        = ".ptah-migrate-diff-*.tmp"
+	stagedMigrationPrefix         = ".ptah-migrate-diff-"
+	stagedMigrationSuffix         = ".tmp"
+	stagedMigrationPattern        = stagedMigrationPrefix + "*" + stagedMigrationSuffix
+	// rollbackQuarantineSuffix names the file a rollback moves an already
+	// published migration aside to. It is a direct child of the migration
+	// directory so that creating, moving and removing it all run through the one
+	// retained handle; a nested quarantine would need a second handle whose own
+	// open is the race this package exists to close.
+	rollbackQuarantineSuffix = ".rollback"
 
 	publicationCommitModeAtlasSum = "atlas-sum"
 	publicationCommitModeMarker   = "journal-marker"
@@ -61,11 +69,30 @@ type PublicationArtifact struct {
 	Contents []byte
 }
 
+// migrationBatch names one publication batch relative to the retained migration
+// directory handle. Names are what the rooted operations act on; paths are
+// rendered from them for reporting and error messages only.
 type migrationBatch struct {
-	paths       []string
-	stagedPaths []string
+	names       []string
+	stagedNames []string
 	digests     []string
 	mode        publicationMode
+}
+
+func (b migrationBatch) paths(pub *publicationDir) []string {
+	paths := make([]string, 0, len(b.names))
+	for _, name := range b.names {
+		paths = append(paths, pub.path(name))
+	}
+	return paths
+}
+
+func (b migrationBatch) stagedPaths(pub *publicationDir) []string {
+	paths := make([]string, 0, len(b.stagedNames))
+	for _, name := range b.stagedNames {
+		paths = append(paths, pub.path(name))
+	}
+	return paths
 }
 
 // writeDiffArtifacts durably publishes one batch of migration files and then
@@ -73,14 +100,15 @@ type migrationBatch struct {
 // publication recoverable by the next lock holder.
 func writeDiffArtifacts(
 	ctx context.Context,
-	dir, name string,
+	pub *publicationDir,
+	name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
 ) (DiffResult, error) {
 	return writeDiffArtifactsWithSumWriter(
 		ctx,
-		dir,
+		pub,
 		name,
 		contents,
 		baseSnapshot,
@@ -91,32 +119,33 @@ func writeDiffArtifacts(
 
 func writeDiffArtifactsWithSumWriter(
 	ctx context.Context,
-	dir, name string,
+	pub *publicationDir,
+	name string,
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
-	writeSum func(string, *migratesum.SumFile) (string, error),
+	writeSum func(*publicationDir, *migratesum.SumFile) (string, error),
 ) (DiffResult, error) {
 	if err := ctx.Err(); err != nil {
 		return DiffResult{}, err
 	}
-	if err := recoverPendingPublication(dir); err != nil {
+	if err := recoverPendingPublication(pub); err != nil {
 		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
 	}
 	version, err := nextMigrationVersionFS(baseSnapshot)
 	if err != nil {
 		return DiffResult{}, err
 	}
-	batch, err := stageMigrationBatchAt(dir, name, version, contents)
+	batch, err := stageMigrationBatchAt(pub, name, version, contents)
 	if err != nil {
 		return DiffResult{}, err
 	}
-	if err := prepareStagedMigrationBatch(ctx, batch, prepare); err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	if err := prepareStagedMigrationBatch(ctx, pub, batch, prepare); err != nil {
+		return DiffResult{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
-	stagedContents, err := readStagedMigrationContents(&batch)
+	stagedContents, err := readStagedMigrationContents(pub, &batch)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
 	publishedSnapshot, sum, err := preparePublicationSnapshot(
 		baseSnapshot,
@@ -124,23 +153,23 @@ func writeDiffArtifactsWithSumWriter(
 		stagedContents,
 	)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
-	journal, err := beginPublication(dir, batch, sum.Bytes())
+	journal, err := beginPublication(pub, batch, sum.Bytes())
 	if err != nil {
-		return DiffResult{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return DiffResult{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
-	published, err := publishMigrationBatchContext(ctx, dir, batch)
+	published, err := publishMigrationBatchContext(ctx, pub, batch)
 	if err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
-	if err := verifyMigrationDirUnchanged(dir, publishedSnapshot); err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+	if err := verifyMigrationDirUnchanged(pub, publishedSnapshot); err != nil {
+		return DiffResult{}, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
 	if err := ctx.Err(); err != nil {
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
-	sumPath, err := writeSum(dir, sum)
+	sumPath, err := writeSum(pub, sum)
 	if err != nil {
 		if migratesum.IsCommitUncertain(err) {
 			return DiffResult{}, fmt.Errorf(
@@ -148,131 +177,151 @@ func writeDiffArtifactsWithSumWriter(
 				err,
 			)
 		}
-		return DiffResult{}, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return DiffResult{}, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
-	result := DiffResult{MigrationPaths: batch.paths, SumPath: sumPath}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return result, err
-	}
-	committed, err := publicationCommitted(dir, journal)
+	result := DiffResult{MigrationPaths: batch.paths(pub), SumPath: sumPath}
+	committed, err := publicationCommitted(pub, journal)
 	if err != nil {
 		return result, fmt.Errorf("verify migration publication commit marker: %w", err)
 	}
 	if !committed {
 		return result, errors.New("atlas.sum does not match the journaled migration publication")
 	}
-	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
+	if err := finalizeCommittedPublication(pub, journal); err != nil {
 		return result, fmt.Errorf("finalize migration artifact publication: %w", err)
 	}
 	return result, nil
 }
 
 // PublishArtifactsLocked durably publishes all artifacts as one batch. The
-// caller must hold the migration-directory lock for dir.
+// caller must hold the migration-directory lock for dir. The directory is
+// opened once and every write in the batch is addressed through that retained
+// handle.
 func PublishArtifactsLocked(
 	ctx context.Context,
 	dir string,
 	artifacts []PublicationArtifact,
-) ([]string, error) {
+) (paths []string, resultErr error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := recoverPendingPublication(dir); err != nil {
+	pub, err := openPublicationDir(dir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, pub.close())
+	}()
+	return publishArtifactsIn(ctx, pub, artifacts)
+}
+
+func publishArtifactsIn(
+	ctx context.Context,
+	pub *publicationDir,
+	artifacts []PublicationArtifact,
+) ([]string, error) {
+	if err := recoverPendingPublication(pub); err != nil {
 		return nil, fmt.Errorf("recover previous artifact publication: %w", err)
 	}
-	batch, err := stageArtifactBatch(dir, artifacts)
+	batch, err := stageArtifactBatch(pub, artifacts)
 	if err != nil {
 		return nil, err
 	}
-	journal, err := beginMarkerPublication(dir, batch)
+	journal, err := beginMarkerPublication(pub, batch)
 	if err != nil {
-		return nil, errors.Join(err, removeFiles(batch.stagedPaths))
+		return nil, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
-	published, err := publishMigrationBatchContext(ctx, dir, batch)
+	published, err := publishMigrationBatchContext(ctx, pub, batch)
 	if err != nil {
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
-	if err := writePublicationCommitMarker(dir, journal); err != nil {
-		committed, commitErr := publicationCommitted(dir, journal)
+	if err := writePublicationCommitMarker(pub, journal); err != nil {
+		committed, commitErr := publicationCommitted(pub, journal)
 		if committed && commitErr == nil {
 			return nil, fmt.Errorf(
 				"write artifact publication commit marker; journal retained for recovery: %w",
 				err,
 			)
 		}
-		return nil, errors.Join(err, abortPendingPublication(dir, batch, published))
+		return nil, errors.Join(err, abortPendingPublication(pub, batch, published))
 	}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return nil, err
-	}
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(pub, journal)
 	if err != nil {
 		return nil, fmt.Errorf("verify artifact publication commit marker: %w", err)
 	}
 	if !committed {
 		return nil, errors.New("artifact publication commit marker does not match its journal")
 	}
-	if err := finalizeCommittedPublication(dir, journalPath, journal); err != nil {
-		return slices.Clone(batch.paths), fmt.Errorf("finalize artifact publication: %w", err)
+	if err := finalizeCommittedPublication(pub, journal); err != nil {
+		return batch.paths(pub), fmt.Errorf("finalize artifact publication: %w", err)
 	}
-	return slices.Clone(batch.paths), nil
+	return batch.paths(pub), nil
 }
 
 func prepareStagedMigrationBatch(
 	ctx context.Context,
+	pub *publicationDir,
 	batch migrationBatch,
 	prepare func([]string) error,
 ) error {
 	if prepare != nil {
-		if err := prepare(slices.Clone(batch.stagedPaths)); err != nil {
+		if err := prepare(batch.stagedPaths(pub)); err != nil {
 			return fmt.Errorf("prepare migration files for publication: %w", err)
 		}
 	}
 	if err := ctx.Err(); err != nil {
 		return err
 	}
-	for _, path := range batch.stagedPaths {
-		info, err := os.Lstat(path)
-		if err != nil {
-			return fmt.Errorf("inspect staged migration file after preparation: %w", err)
-		}
-		if !info.Mode().IsRegular() {
-			return fmt.Errorf("staged migration file is not a regular file: %s", path)
-		}
-		file, err := os.OpenFile(path, os.O_RDWR, 0)
-		if err != nil {
-			return fmt.Errorf("open staged migration file after preparation: %w", err)
-		}
-		openedInfo, err := file.Stat()
-		if err != nil {
-			return errors.Join(
-				fmt.Errorf("inspect opened staged migration file: %w", err),
-				file.Close(),
-			)
-		}
-		if !os.SameFile(info, openedInfo) {
-			return errors.Join(
-				fmt.Errorf("staged migration file changed while being opened: %s", path),
-				file.Close(),
-			)
-		}
-		if err := errors.Join(file.Sync(), file.Close()); err != nil {
-			return fmt.Errorf("sync staged migration file after preparation: %w", err)
+	for _, name := range batch.stagedNames {
+		if err := syncPreparedStagedFile(pub, name); err != nil {
+			return err
 		}
 	}
 	return nil
 }
 
-func readStagedMigrationContents(batch *migrationBatch) ([]MigrationFileContent, error) {
-	contents := make([]MigrationFileContent, len(batch.stagedPaths))
-	batch.digests = make([]string, len(batch.stagedPaths))
-	for i, path := range batch.stagedPaths {
-		data, err := os.ReadFile(path)
+func syncPreparedStagedFile(pub *publicationDir, name string) error {
+	info, err := pub.dir.Lstat(name)
+	if err != nil {
+		return fmt.Errorf("inspect staged migration file after preparation: %w", err)
+	}
+	if !info.Mode().IsRegular() {
+		return fmt.Errorf("staged migration file is not a regular file: %s", pub.path(name))
+	}
+	file, err := pub.dir.OpenFile(name, os.O_RDWR, 0)
+	if err != nil {
+		return fmt.Errorf("open staged migration file after preparation: %w", err)
+	}
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return errors.Join(
+			fmt.Errorf("inspect opened staged migration file: %w", err),
+			file.Close(),
+		)
+	}
+	if !os.SameFile(info, openedInfo) {
+		return errors.Join(
+			fmt.Errorf("staged migration file changed while being opened: %s", pub.path(name)),
+			file.Close(),
+		)
+	}
+	if err := errors.Join(file.Sync(), file.Close()); err != nil {
+		return fmt.Errorf("sync staged migration file after preparation: %w", err)
+	}
+	return nil
+}
+
+func readStagedMigrationContents(
+	pub *publicationDir,
+	batch *migrationBatch,
+) ([]MigrationFileContent, error) {
+	contents := make([]MigrationFileContent, len(batch.stagedNames))
+	batch.digests = make([]string, len(batch.stagedNames))
+	for i, name := range batch.stagedNames {
+		data, err := pub.dir.ReadFile(name)
 		if err != nil {
 			return nil, fmt.Errorf("read staged migration file after preparation: %w", err)
 		}
@@ -292,9 +341,9 @@ func preparePublicationSnapshot(
 	batch migrationBatch,
 	contents []MigrationFileContent,
 ) (fsnapshot.Snapshot, *migratesum.SumFile, error) {
-	files := make(map[string][]byte, len(batch.paths))
-	for i, path := range batch.paths {
-		files[filepath.Base(path)] = []byte(contents[i].SQL)
+	files := make(map[string][]byte, len(batch.names))
+	for i, name := range batch.names {
+		files[name] = []byte(contents[i].SQL)
 	}
 	publishedSnapshot, err := baseSnapshot.WithFiles(files)
 	if err != nil {
@@ -311,114 +360,113 @@ func preparePublicationSnapshot(
 }
 
 func beginPublication(
-	dir string,
+	pub *publicationDir,
 	batch migrationBatch,
 	sum []byte,
 ) (publicationJournal, error) {
 	// Persist the staging directory entries before making the journal durable.
 	// Once the journal exists, recovery relies on the staging links to prove
 	// ownership of any published final paths.
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return publicationJournal{}, fmt.Errorf("sync staged migration files: %w", err)
 	}
 
-	entries := make([]publicationEntry, len(batch.paths))
-	for i := range batch.paths {
-		entries[i] = publicationEntry{
-			Staged: filepath.Base(batch.stagedPaths[i]),
-			Final:  filepath.Base(batch.paths[i]),
-			Mode:   string(batch.mode),
-			Digest: batch.digests[i],
-		}
-	}
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeAtlasSum,
-		Entries:    entries,
+		Entries:    publicationEntries(batch),
 		Sum:        slices.Clone(sum),
 	}
-	if err := writePublicationJournal(dir, journal); err != nil {
+	if err := writePublicationJournal(pub, journal); err != nil {
 		return publicationJournal{}, fmt.Errorf("write migration publication journal: %w", err)
 	}
 	return journal, nil
 }
 
 func beginMarkerPublication(
-	dir string,
+	pub *publicationDir,
 	batch migrationBatch,
 ) (publicationJournal, error) {
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return publicationJournal{}, fmt.Errorf("sync staged artifact files: %w", err)
-	}
-	entries := make([]publicationEntry, len(batch.paths))
-	for i := range batch.paths {
-		entries[i] = publicationEntry{
-			Staged: filepath.Base(batch.stagedPaths[i]),
-			Final:  filepath.Base(batch.paths[i]),
-			Mode:   string(batch.mode),
-			Digest: batch.digests[i],
-		}
 	}
 	journal := publicationJournal{
 		Version:    publicationJournalVersion,
 		CommitMode: publicationCommitModeMarker,
-		Entries:    entries,
+		Entries:    publicationEntries(batch),
 	}
-	if err := writePublicationJournal(dir, journal); err != nil {
+	if err := writePublicationJournal(pub, journal); err != nil {
 		return publicationJournal{}, fmt.Errorf("write artifact publication journal: %w", err)
 	}
 	return journal, nil
 }
 
+func publicationEntries(batch migrationBatch) []publicationEntry {
+	entries := make([]publicationEntry, len(batch.names))
+	for i := range batch.names {
+		entries[i] = publicationEntry{
+			Staged: batch.stagedNames[i],
+			Final:  batch.names[i],
+			Mode:   string(batch.mode),
+			Digest: batch.digests[i],
+		}
+	}
+	return entries
+}
+
 func publishMigrationBatchContext(
 	ctx context.Context,
-	dir string,
+	pub *publicationDir,
 	batch migrationBatch,
 ) (int, error) {
-	for i, stagedPath := range batch.stagedPaths {
+	for i, stagedName := range batch.stagedNames {
 		if err := ctx.Err(); err != nil {
 			return i, err
 		}
-		err := publishStagedFile(stagedPath, batch.paths[i], batch.mode)
+		err := publishStagedFile(pub.dir, stagedName, batch.names[i], batch.mode)
 		if err != nil {
 			if errors.Is(err, os.ErrExist) {
 				return i, fmt.Errorf(
 					"migration directory changed during publication: %s already exists",
-					batch.paths[i],
+					pub.path(batch.names[i]),
 				)
 			}
 			return i, fmt.Errorf("publish migration file: %w", err)
 		}
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
-		return len(batch.paths), fmt.Errorf("sync published migration files: %w", err)
+	if err := pub.dir.Sync(); err != nil {
+		return len(batch.names), fmt.Errorf("sync published migration files: %w", err)
 	}
-	return len(batch.paths), nil
+	return len(batch.names), nil
 }
 
 func publishStagedFile(
-	stagedPath, finalPath string,
+	root *pathguard.OpenedDirectory,
+	stagedName, finalName string,
 	mode publicationMode,
 ) error {
 	switch mode {
 	case publicationModeHardLink:
-		return os.Link(stagedPath, finalPath)
+		return root.Link(stagedName, finalName)
 	case publicationModeCopy:
-		return copyFileExclusive(stagedPath, finalPath)
+		return copyFileExclusive(root, stagedName, finalName)
 	case publicationModeWriteThroughMove:
-		return fsdurable.MoveFileNoReplace(stagedPath, finalPath)
+		return root.MoveFileNoReplace(stagedName, finalName)
 	default:
 		return fmt.Errorf("unsupported migration publication mode %q", mode)
 	}
 }
 
-func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
-	contents, err := os.ReadFile(sourcePath)
+func copyFileExclusive(
+	root *pathguard.OpenedDirectory,
+	sourceName, destinationName string,
+) (resultErr error) {
+	contents, err := root.ReadFile(sourceName)
 	if err != nil {
 		return err
 	}
-	destination, err := os.OpenFile(
-		destinationPath,
+	destination, err := root.OpenFile(
+		destinationName,
 		os.O_WRONLY|os.O_CREATE|os.O_EXCL,
 		0o644,
 	)
@@ -431,7 +479,7 @@ func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
 			resultErr = errors.Join(
 				resultErr,
 				destination.Close(),
-				removeFiles([]string{destinationPath}),
+				removeNames(root, []string{destinationName}),
 			)
 		}
 	}()
@@ -448,55 +496,62 @@ func copyFileExclusive(sourcePath, destinationPath string) (resultErr error) {
 	return nil
 }
 
-func abortPendingPublication(dir string, batch migrationBatch, published int) error {
+func abortPendingPublication(pub *publicationDir, batch migrationBatch, published int) error {
 	for i := range published {
 		if err := rollBackPublicationEntry(
-			batch.stagedPaths[i],
-			batch.paths[i],
+			pub,
+			batch.stagedNames[i],
+			batch.names[i],
 			batch.digests[i],
 		); err != nil {
 			return fmt.Errorf("roll back published migration files: %w", err)
 		}
 	}
-	if err := removeFiles(batch.stagedPaths[published:]); err != nil {
+	if err := removeNames(pub.dir, batch.stagedNames[published:]); err != nil {
 		return fmt.Errorf("remove rolled back migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(pub)
 }
 
-func recoverPendingPublication(dir string) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
-	journal, err := readPublicationJournal(journalPath)
+func recoverPendingPublication(pub *publicationDir) error {
+	journal, err := readPublicationJournal(pub)
 	if errors.Is(err, os.ErrNotExist) {
-		return removeOrphanPublicationTemps(dir, journalPath)
+		return removeOrphanPublicationTemps(pub)
 	}
 	if err != nil {
 		return err
 	}
-	committed, err := publicationCommitted(dir, journal)
+	committed, err := publicationCommitted(pub, journal)
 	if err != nil {
 		return err
 	}
 	if committed {
-		return finalizeCommittedPublication(dir, journalPath, journal)
+		return finalizeCommittedPublication(pub, journal)
 	}
-	return rollBackPendingPublication(dir, journalPath, journal)
+	return rollBackPendingPublication(pub, journal)
 }
 
 // RecoverPendingPublicationLocked resolves an interrupted artifact publication.
 // The caller must hold the migration-directory lock for dir.
-func RecoverPendingPublicationLocked(dir string) error {
-	return recoverPendingPublication(dir)
+func RecoverPendingPublicationLocked(dir string) (resultErr error) {
+	pub, err := openPublicationDir(dir)
+	if errors.Is(err, os.ErrNotExist) {
+		// A directory that does not exist holds neither staged files nor
+		// published ones, so there is nothing to recover. Any journal left in
+		// the parent is resolved by the next run that creates the directory,
+		// which is also the first run able to act on the entries it names.
+		return nil
+	}
+	if err != nil {
+		return err
+	}
+	defer func() {
+		resultErr = errors.Join(resultErr, pub.close())
+	}()
+	return recoverPendingPublication(pub)
 }
 
 // RecoverPendingPublication resolves an interrupted artifact publication,
@@ -508,17 +563,17 @@ func RecoverPendingPublication(ctx context.Context, dir string) error {
 		return fmt.Errorf("resolve migration directory lock path: %w", err)
 	}
 	if held {
-		return recoverPendingPublication(dir)
+		return RecoverPendingPublicationLocked(dir)
 	}
 	return WithMigrationDirectoryLock(ctx, dir, 0, func(context.Context) error {
-		return recoverPendingPublication(dir)
+		return RecoverPendingPublicationLocked(dir)
 	})
 }
 
-func publicationCommitted(dir string, journal publicationJournal) (bool, error) {
+func publicationCommitted(pub *publicationDir, journal publicationJournal) (bool, error) {
 	switch journal.CommitMode {
 	case publicationCommitModeAtlasSum:
-		contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+		contents, err := pub.dir.ReadFile(migratesum.AtlasFileName)
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
@@ -527,11 +582,7 @@ func publicationCommitted(dir string, journal publicationJournal) (bool, error) 
 		}
 		return bytes.Equal(contents, journal.Sum), nil
 	case publicationCommitModeMarker:
-		journalPath, err := publicationJournalPath(dir)
-		if err != nil {
-			return false, err
-		}
-		contents, err := os.ReadFile(publicationCommitMarkerPath(journalPath))
+		contents, err := pub.parent.ReadFile(pub.commitMarkerName())
 		if errors.Is(err, os.ErrNotExist) {
 			return false, nil
 		}
@@ -552,56 +603,53 @@ func publicationCommitted(dir string, journal publicationJournal) (bool, error) 
 }
 
 func finalizeCommittedPublication(
-	dir, journalPath string,
+	pub *publicationDir,
 	journal publicationJournal,
 ) error {
-	stagedPaths := publicationStagedPaths(dir, journal)
-	if err := removeFiles(stagedPaths); err != nil {
+	if err := removeNames(pub.dir, publicationStagedNames(journal)); err != nil {
 		return fmt.Errorf("remove committed migration staging files: %w", err)
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return fmt.Errorf("sync committed migration directory: %w", err)
 	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(pub)
 }
 
 func rollBackPendingPublication(
-	dir, journalPath string,
+	pub *publicationDir,
 	journal publicationJournal,
 ) error {
 	for _, entry := range journal.Entries {
-		stagedPath := filepath.Join(dir, entry.Staged)
-		finalPath := filepath.Join(dir, entry.Final)
 		if err := rollBackPublicationEntry(
-			stagedPath,
-			finalPath,
+			pub,
+			entry.Staged,
+			entry.Final,
 			entry.Digest,
 		); err != nil {
 			return err
 		}
 	}
-	if err := fsdurable.SyncDir(dir); err != nil {
+	if err := pub.dir.Sync(); err != nil {
 		return fmt.Errorf("sync rolled back migration directory: %w", err)
 	}
-	return removePublicationJournal(journalPath)
+	return removePublicationJournal(pub)
 }
 
 func rollBackPublicationEntry(
-	stagedPath, finalPath, expectedDigest string,
+	pub *publicationDir,
+	stagedName, finalName, expectedDigest string,
 ) error {
-	quarantineDir := stagedPath + ".rollback"
-	quarantinePath := filepath.Join(quarantineDir, "published")
+	quarantineName := stagedName + rollbackQuarantineSuffix
 
-	if err := quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath); err != nil {
+	if err := quarantinePublishedMigration(pub, finalName, quarantineName); err != nil {
 		return err
 	}
-	stagedDigest, stagedErr := fileDigest(stagedPath)
-	quarantinedDigest, quarantineErr := fileDigest(quarantinePath)
-	return reconcileRollbackFiles(rollbackFileState{
-		stagedPath:        stagedPath,
-		finalPath:         finalPath,
-		quarantineDir:     quarantineDir,
-		quarantinePath:    quarantinePath,
+	stagedDigest, stagedErr := fileDigest(pub, stagedName)
+	quarantinedDigest, quarantineErr := fileDigest(pub, quarantineName)
+	return reconcileRollbackFiles(pub, rollbackFileState{
+		stagedName:        stagedName,
+		finalName:         finalName,
+		quarantineName:    quarantineName,
 		expectedDigest:    expectedDigest,
 		stagedDigest:      stagedDigest,
 		stagedErr:         stagedErr,
@@ -610,20 +658,17 @@ func rollBackPublicationEntry(
 	})
 }
 
-func quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath string) error {
-	if err := os.Mkdir(quarantineDir, 0700); err != nil && !errors.Is(err, os.ErrExist) {
-		return fmt.Errorf("create migration rollback quarantine: %w", err)
-	}
-	if err := fsdurable.SyncDir(filepath.Dir(quarantineDir)); err != nil {
-		return fmt.Errorf("sync migration rollback quarantine directory: %w", err)
-	}
-	if _, err := os.Stat(quarantinePath); errors.Is(err, os.ErrNotExist) {
-		if moveErr := fsdurable.MoveFileNoReplace(finalPath, quarantinePath); moveErr != nil {
-			if !errors.Is(moveErr, os.ErrNotExist) {
-				return fmt.Errorf("quarantine published migration file: %w", moveErr)
+func quarantinePublishedMigration(pub *publicationDir, finalName, quarantineName string) error {
+	if _, err := pub.dir.Stat(quarantineName); errors.Is(err, os.ErrNotExist) {
+		moveErr := pub.dir.MoveFileNoReplace(finalName, quarantineName)
+		switch {
+		case moveErr == nil:
+			if err := pub.dir.Sync(); err != nil {
+				return fmt.Errorf("sync migration directory after quarantine move: %w", err)
 			}
-		} else if err := syncQuarantineMove(finalPath, quarantineDir); err != nil {
-			return err
+		case errors.Is(moveErr, os.ErrNotExist):
+		default:
+			return fmt.Errorf("quarantine published migration file: %w", moveErr)
 		}
 	} else if err != nil {
 		return fmt.Errorf("inspect quarantined migration file: %w", err)
@@ -632,10 +677,9 @@ func quarantinePublishedMigration(finalPath, quarantineDir, quarantinePath strin
 }
 
 type rollbackFileState struct {
-	stagedPath        string
-	finalPath         string
-	quarantineDir     string
-	quarantinePath    string
+	stagedName        string
+	finalName         string
+	quarantineName    string
 	expectedDigest    string
 	stagedDigest      string
 	stagedErr         error
@@ -643,28 +687,28 @@ type rollbackFileState struct {
 	quarantineErr     error
 }
 
-func reconcileRollbackFiles(state rollbackFileState) error {
+func reconcileRollbackFiles(pub *publicationDir, state rollbackFileState) error {
 	switch {
 	case errors.Is(state.stagedErr, os.ErrNotExist) && errors.Is(state.quarantineErr, os.ErrNotExist):
-		return removeEmptyQuarantineDir(state.quarantineDir)
+		return nil
 	case state.stagedErr == nil && errors.Is(state.quarantineErr, os.ErrNotExist):
 		if state.stagedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: staging file content changed; preserved %s",
-				state.stagedPath,
+				pub.path(state.stagedName),
 			)
 		}
-		return removeRollbackFiles(state.quarantineDir, state.stagedPath)
+		return removeNames(pub.dir, []string{state.stagedName})
 	case errors.Is(state.stagedErr, os.ErrNotExist) &&
 		state.quarantineErr == nil:
 		if state.quarantinedDigest != state.expectedDigest {
 			return fmt.Errorf(
 				"cannot safely recover migration publication: %s content changed; preserved at %s",
-				state.finalPath,
-				state.quarantinePath,
+				pub.path(state.finalName),
+				pub.path(state.quarantineName),
 			)
 		}
-		return removeRollbackFiles(state.quarantineDir, state.quarantinePath)
+		return removeNames(pub.dir, []string{state.quarantineName})
 	case state.stagedErr != nil:
 		return fmt.Errorf("inspect staged migration file: %w", state.stagedErr)
 	case state.quarantineErr != nil:
@@ -672,126 +716,93 @@ func reconcileRollbackFiles(state rollbackFileState) error {
 	case state.stagedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: staging file content changed; preserved %s and %s",
-			state.stagedPath,
-			state.quarantinePath,
+			pub.path(state.stagedName),
+			pub.path(state.quarantineName),
 		)
 	case state.quarantinedDigest != state.expectedDigest:
 		return fmt.Errorf(
 			"cannot safely recover migration publication: %s content changed; preserved at %s",
-			state.finalPath,
-			state.quarantinePath,
+			pub.path(state.finalName),
+			pub.path(state.quarantineName),
 		)
 	default:
-		return removeRollbackFiles(state.quarantineDir, state.quarantinePath, state.stagedPath)
+		return removeNames(pub.dir, []string{state.quarantineName, state.stagedName})
 	}
 }
 
-func syncQuarantineMove(finalPath, quarantineDir string) error {
-	if err := fsdurable.SyncDir(filepath.Dir(finalPath)); err != nil {
-		return fmt.Errorf("sync migration directory after quarantine move: %w", err)
-	}
-	if err := fsdurable.SyncDir(quarantineDir); err != nil {
-		return fmt.Errorf("sync migration rollback quarantine: %w", err)
-	}
-	return nil
-}
-
-func removeRollbackFiles(quarantineDir string, paths ...string) error {
-	for _, path := range paths {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			return fmt.Errorf("remove %s: %w", path, err)
-		}
-	}
-	return removeEmptyQuarantineDir(quarantineDir)
-}
-
-func fileDigest(path string) (string, error) {
-	contents, err := os.ReadFile(path)
+func fileDigest(pub *publicationDir, name string) (string, error) {
+	contents, err := pub.dir.ReadFile(name)
 	if err != nil {
 		return "", err
 	}
 	return contentDigest(contents), nil
 }
 
-func removeEmptyQuarantineDir(path string) error {
-	err := os.Remove(path)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	return err
-}
-
-func removePublicationJournal(journalPath string) error {
-	return removePublicationJournalWithRetirer(journalPath, retirePublicationJournal)
+func removePublicationJournal(pub *publicationDir) error {
+	return removePublicationJournalWithRetirer(pub, func(journalName, cleanupName string) error {
+		if _, err := pub.parent.Lstat(journalName); errors.Is(err, os.ErrNotExist) {
+			return nil
+		} else if err != nil {
+			return err
+		}
+		return pub.parent.ReplaceFile(journalName, cleanupName)
+	})
 }
 
 func removePublicationJournalWithRetirer(
-	journalPath string,
+	pub *publicationDir,
 	retire func(string, string) error,
 ) error {
-	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+	journalTemps, err := listNames(pub.parent, pub.journalName+".", stagedMigrationSuffix)
 	if err != nil {
 		return fmt.Errorf("find migration publication journal backups: %w", err)
 	}
-	cleanupPath := journalPath + publicationCleanupSuffix
-	if err := retire(journalPath, cleanupPath); err != nil {
+	cleanupName := pub.journalCleanupName()
+	if err := retire(pub.journalName, cleanupName); err != nil {
 		return fmt.Errorf("retire migration publication journal: %w", err)
 	}
-	parent := filepath.Dir(journalPath)
-	if err := fsdurable.SyncDir(parent); err != nil {
+	if err := pub.parent.Sync(); err != nil {
 		return fmt.Errorf("sync retired migration publication journal: %w", err)
 	}
-	paths := append(
-		[]string{publicationCommitMarkerPath(journalPath), cleanupPath},
+	names := append(
+		[]string{pub.commitMarkerName(), cleanupName},
 		journalTemps...,
 	)
-	if err := removeFiles(paths); err != nil {
+	if err := removeNames(pub.parent, names); err != nil {
 		return fmt.Errorf("remove retired migration publication metadata: %w", err)
 	}
-	if err := fsdurable.SyncDir(parent); err != nil {
+	if err := pub.parent.Sync(); err != nil {
 		return fmt.Errorf("sync migration publication journal directory: %w", err)
 	}
 	return nil
 }
 
-func retirePublicationJournal(journalPath, cleanupPath string) error {
-	_, err := os.Stat(journalPath)
-	if errors.Is(err, os.ErrNotExist) {
-		return nil
-	}
-	if err != nil {
-		return err
-	}
-	return fsdurable.ReplaceFile(journalPath, cleanupPath)
-}
-
-func removeOrphanPublicationTemps(dir, journalPath string) error {
-	stagedPaths, err := filepath.Glob(filepath.Join(dir, stagedMigrationPattern))
+func removeOrphanPublicationTemps(pub *publicationDir) error {
+	stagedNames, err := listNames(pub.dir, stagedMigrationPrefix, stagedMigrationSuffix)
 	if err != nil {
 		return fmt.Errorf("find orphan migration staging files: %w", err)
 	}
-	journalTemps, err := filepath.Glob(journalPath + ".*.tmp")
+	journalTemps, err := listNames(pub.parent, pub.journalName+".", stagedMigrationSuffix)
 	if err != nil {
 		return fmt.Errorf("find orphan migration publication journals: %w", err)
 	}
-	orphanPaths := slices.Concat(
-		stagedPaths,
+	orphanJournalNames := slices.Concat(
 		journalTemps,
-		[]string{
-			publicationCommitMarkerPath(journalPath),
-			journalPath + publicationCleanupSuffix,
-		},
+		[]string{pub.commitMarkerName(), pub.journalCleanupName()},
 	)
-	if err := removeFiles(orphanPaths); err != nil {
+	if err := errors.Join(
+		removeNames(pub.dir, stagedNames),
+		removeNames(pub.parent, orphanJournalNames),
+	); err != nil {
 		return fmt.Errorf("remove orphan migration publication files: %w", err)
 	}
-	if len(stagedPaths) > 0 {
-		if err := fsdurable.SyncDir(dir); err != nil {
+	if len(stagedNames) > 0 {
+		if err := pub.dir.Sync(); err != nil {
 			return fmt.Errorf("sync migration directory after orphan cleanup: %w", err)
 		}
 	}
 	if len(journalTemps) > 0 {
-		if err := fsdurable.SyncDir(filepath.Dir(journalPath)); err != nil {
+		if err := pub.parent.Sync(); err != nil {
 			return fmt.Errorf("sync publication journal directory after orphan cleanup: %w", err)
 		}
 	}
@@ -799,49 +810,31 @@ func removeOrphanPublicationTemps(dir, journalPath string) error {
 }
 
 func writePublicationCommitMarker(
-	dir string,
+	pub *publicationDir,
 	journal publicationJournal,
 ) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
 	contents, err := publicationJournalDigest(journal)
 	if err != nil {
 		return err
 	}
-	markerPath := publicationCommitMarkerPath(journalPath)
-	parent := filepath.Dir(markerPath)
-	temp, err := os.CreateTemp(parent, filepath.Base(markerPath)+".*.tmp")
+	markerName := pub.commitMarkerName()
+	tempName, err := stageMetadataFile(pub.parent, markerName, contents)
 	if err != nil {
 		return err
 	}
-	tempPath := temp.Name()
-	if err := temp.Chmod(0600); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if _, err := temp.Write(contents); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := temp.Sync(); err != nil {
-		return errors.Join(err, temp.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := temp.Close(); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	mode, err := detectPublicationMode(tempPath)
+	mode, err := detectPublicationMode(pub.parent, tempName)
 	if err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
+		return errors.Join(err, removeNames(pub.parent, []string{tempName}))
 	}
-	if err := publishStagedFile(tempPath, markerPath, mode); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
+	if err := publishStagedFile(pub.parent, tempName, markerName, mode); err != nil {
+		return errors.Join(err, removeNames(pub.parent, []string{tempName}))
 	}
 	if mode != publicationModeWriteThroughMove {
-		if err := removeFiles([]string{tempPath}); err != nil {
+		if err := removeNames(pub.parent, []string{tempName}); err != nil {
 			return err
 		}
 	}
-	return fsdurable.SyncDir(parent)
+	return pub.parent.Sync()
 }
 
 func publicationJournalDigest(journal publicationJournal) ([]byte, error) {
@@ -853,35 +846,31 @@ func publicationJournalDigest(journal publicationJournal) ([]byte, error) {
 	return sum[:], nil
 }
 
-func publicationCommitMarkerPath(journalPath string) string {
-	return journalPath + publicationCommitMarkerSuffix
-}
-
-func writePublicationJournal(dir string, journal publicationJournal) error {
+func writePublicationJournal(pub *publicationDir, journal publicationJournal) error {
 	return writePublicationJournalWithPublisher(
-		dir,
+		pub,
 		journal,
-		func(tempPath, journalPath string) error {
-			mode, err := detectPublicationMode(tempPath)
+		func(tempName, journalName string) error {
+			mode, err := detectPublicationMode(pub.parent, tempName)
 			if err != nil {
 				return err
 			}
-			return publishStagedFile(tempPath, journalPath, mode)
+			return publishStagedFile(pub.parent, tempName, journalName, mode)
 		},
 	)
 }
 
 func writePublicationJournalWithLink(
-	dir string,
+	pub *publicationDir,
 	journal publicationJournal,
 	link func(string, string) error,
 ) error {
 	return writePublicationJournalWithPublisher(
-		dir,
+		pub,
 		journal,
-		func(tempPath, journalPath string) error {
-			if err := link(tempPath, journalPath); err != nil {
-				if copyErr := copyFileExclusive(tempPath, journalPath); copyErr != nil {
+		func(tempName, journalName string) error {
+			if err := link(tempName, journalName); err != nil {
+				if copyErr := copyFileExclusive(pub.parent, tempName, journalName); copyErr != nil {
 					return errors.Join(err, copyErr)
 				}
 			}
@@ -891,44 +880,52 @@ func writePublicationJournalWithLink(
 }
 
 func writePublicationJournalWithPublisher(
-	dir string,
+	pub *publicationDir,
 	journal publicationJournal,
 	publish func(string, string) error,
 ) error {
-	journalPath, err := publicationJournalPath(dir)
-	if err != nil {
-		return err
-	}
 	contents, err := json.Marshal(journal)
 	if err != nil {
 		return err
 	}
-	parent := filepath.Dir(journalPath)
-	file, err := os.CreateTemp(parent, filepath.Base(journalPath)+".*.tmp")
+	tempName, err := stageMetadataFile(pub.parent, pub.journalName, contents)
 	if err != nil {
 		return err
 	}
-	tempPath := file.Name()
-	if err := file.Chmod(0600); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
+	if err := publish(tempName, pub.journalName); err != nil {
+		return errors.Join(err, removeNames(pub.parent, []string{tempName}))
 	}
-	if _, err := file.Write(contents); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := file.Sync(); err != nil {
-		return errors.Join(err, file.Close(), removeFiles([]string{tempPath}))
-	}
-	if err := file.Close(); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	if err := publish(tempPath, journalPath); err != nil {
-		return errors.Join(err, removeFiles([]string{tempPath}))
-	}
-	return fsdurable.SyncDir(parent)
+	return pub.parent.Sync()
 }
 
-func readPublicationJournal(path string) (publicationJournal, error) {
-	contents, err := os.ReadFile(path)
+// stageMetadataFile writes contents to a private temporary sibling of name and
+// returns the staged name inside root.
+func stageMetadataFile(
+	root *pathguard.OpenedDirectory,
+	name string,
+	contents []byte,
+) (string, error) {
+	file, tempName, err := root.CreateTemp(name + ".*" + stagedMigrationSuffix)
+	if err != nil {
+		return "", err
+	}
+	if err := file.Chmod(0600); err != nil {
+		return "", errors.Join(err, file.Close(), removeNames(root, []string{tempName}))
+	}
+	if _, err := file.Write(contents); err != nil {
+		return "", errors.Join(err, file.Close(), removeNames(root, []string{tempName}))
+	}
+	if err := file.Sync(); err != nil {
+		return "", errors.Join(err, file.Close(), removeNames(root, []string{tempName}))
+	}
+	if err := file.Close(); err != nil {
+		return "", errors.Join(err, removeNames(root, []string{tempName}))
+	}
+	return tempName, nil
+}
+
+func readPublicationJournal(pub *publicationDir) (publicationJournal, error) {
+	contents, err := pub.parent.ReadFile(pub.journalName)
 	if err != nil {
 		return publicationJournal{}, err
 	}
@@ -936,12 +933,12 @@ func readPublicationJournal(path string) (publicationJournal, error) {
 	if decodeErr == nil {
 		return journal, nil
 	}
-	backups, globErr := filepath.Glob(path + ".*.tmp")
-	if globErr != nil {
-		return publicationJournal{}, errors.Join(decodeErr, globErr)
+	backups, listErr := listNames(pub.parent, pub.journalName+".", stagedMigrationSuffix)
+	if listErr != nil {
+		return publicationJournal{}, errors.Join(decodeErr, listErr)
 	}
 	for _, backup := range backups {
-		contents, err := os.ReadFile(backup)
+		contents, err := pub.parent.ReadFile(backup)
 		if err != nil {
 			continue
 		}
@@ -1027,8 +1024,8 @@ func validatePublicationCommit(journal publicationJournal) error {
 
 func validatePublicationEntry(entry publicationEntry) error {
 	if filepath.Base(entry.Staged) != entry.Staged ||
-		!strings.HasPrefix(entry.Staged, ".ptah-migrate-diff-") ||
-		!strings.HasSuffix(entry.Staged, ".tmp") {
+		!strings.HasPrefix(entry.Staged, stagedMigrationPrefix) ||
+		!strings.HasSuffix(entry.Staged, stagedMigrationSuffix) {
 		return fmt.Errorf("invalid staged migration publication path: %q", entry.Staged)
 	}
 	if filepath.Base(entry.Final) != entry.Final ||
@@ -1048,95 +1045,85 @@ func validatePublicationEntry(entry publicationEntry) error {
 	return nil
 }
 
-func publicationJournalPath(dir string) (string, error) {
-	canonicalDir, err := canonicalMigrationDir(dir)
-	if err != nil {
-		return "", fmt.Errorf("resolve migration publication journal path: %w", err)
-	}
-	return filepath.Join(
-		filepath.Dir(canonicalDir),
-		"."+filepath.Base(canonicalDir)+publicationJournalSuffix,
-	), nil
-}
-
-func publicationStagedPaths(dir string, journal publicationJournal) []string {
-	paths := make([]string, 0, len(journal.Entries))
+func publicationStagedNames(journal publicationJournal) []string {
+	names := make([]string, 0, len(journal.Entries))
 	for _, entry := range journal.Entries {
-		paths = append(paths, filepath.Join(dir, entry.Staged))
+		names = append(names, entry.Staged)
 	}
-	return paths
+	return names
 }
 
 // writeDirSum atomically refreshes atlas.sum after every complete migration
 // file has been published. The sum is the commit marker for the batch.
-func writeDirSum(dir string, sum *migratesum.SumFile) (string, error) {
-	sumPath := filepath.Join(dir, migratesum.AtlasFileName)
-	if err := migratesum.WritePrecomputedWithFormat(
-		dir,
+func writeDirSum(pub *publicationDir, sum *migratesum.SumFile) (string, error) {
+	if err := migratesum.WritePrecomputedWithFormatIn(
+		pub.dir,
 		migrator.MigrationDirFormatAtlas,
 		sum,
 	); err != nil {
 		return "", fmt.Errorf("write atlas.sum: %w", err)
 	}
-	return sumPath, nil
+	return pub.path(migratesum.AtlasFileName), nil
 }
 
-func removeFiles(paths []string) error {
+func removeNames(root *pathguard.OpenedDirectory, names []string) error {
 	var resultErr error
-	for _, path := range paths {
-		if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-			resultErr = errors.Join(resultErr, fmt.Errorf("remove %s: %w", path, err))
+	for _, name := range names {
+		if err := root.Remove(name); err != nil && !errors.Is(err, os.ErrNotExist) {
+			resultErr = errors.Join(resultErr, fmt.Errorf("remove %s: %w", name, err))
 		}
 	}
 	return resultErr
 }
 
 func stageArtifactBatch(
-	dir string,
+	pub *publicationDir,
 	artifacts []PublicationArtifact,
 ) (migrationBatch, error) {
 	if len(artifacts) == 0 {
 		return migrationBatch{}, errors.New("artifact publication batch is empty")
 	}
 	batch := migrationBatch{
-		paths:       make([]string, 0, len(artifacts)),
-		stagedPaths: make([]string, 0, len(artifacts)),
+		names:       make([]string, 0, len(artifacts)),
+		stagedNames: make([]string, 0, len(artifacts)),
 		digests:     make([]string, 0, len(artifacts)),
 	}
-	names := make([]string, 0, len(artifacts))
 	for _, artifact := range artifacts {
 		if filepath.Base(artifact.Name) != artifact.Name ||
 			artifact.Name == "." ||
 			artifact.Name == "" {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("invalid artifact publication name %q", artifact.Name),
-				removeFiles(batch.stagedPaths),
+				removeNames(pub.dir, batch.stagedNames),
 			)
 		}
-		if slices.Contains(names, artifact.Name) {
+		if slices.Contains(batch.names, artifact.Name) {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("duplicate artifact publication name %q", artifact.Name),
-				removeFiles(batch.stagedPaths),
+				removeNames(pub.dir, batch.stagedNames),
 			)
 		}
-		stagedPath, err := stageArtifactFile(dir, artifact.Contents)
+		stagedName, err := stageArtifactFile(pub, artifact.Contents)
 		if err != nil {
-			return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+			return migrationBatch{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 		}
-		names = append(names, artifact.Name)
-		batch.paths = append(batch.paths, filepath.Join(dir, artifact.Name))
-		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+		batch.names = append(batch.names, artifact.Name)
+		batch.stagedNames = append(batch.stagedNames, stagedName)
 		batch.digests = append(batch.digests, contentDigest(artifact.Contents))
 	}
-	mode, err := detectPublicationMode(batch.stagedPaths[0])
+	mode, err := detectPublicationMode(pub.dir, batch.stagedNames[0])
 	if err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return migrationBatch{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
 	batch.mode = mode
 	return batch, nil
 }
 
-func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (migrationBatch, error) {
+func stageMigrationBatch(
+	pub *publicationDir,
+	name string,
+	contents []MigrationFileContent,
+) (migrationBatch, error) {
 	if len(contents) == 0 {
 		return migrationBatch{}, errors.New("migration SQL is empty")
 	}
@@ -1145,20 +1132,21 @@ func stageMigrationBatch(dir, name string, contents []MigrationFileContent) (mig
 			return migrationBatch{}, errors.New("migration SQL is empty")
 		}
 	}
-	version, err := nextMigrationVersion(dir)
+	version, err := nextMigrationVersionFS(pub.fsys())
 	if err != nil {
 		return migrationBatch{}, err
 	}
-	return stageMigrationBatchAt(dir, name, version, contents)
+	return stageMigrationBatchAt(pub, name, version, contents)
 }
 
 func stageMigrationBatchAt(
-	dir, name string,
+	pub *publicationDir,
+	name string,
 	version int64,
 	contents []MigrationFileContent,
 ) (migrationBatch, error) {
 	return stageMigrationBatchAtWithModeDetector(
-		dir,
+		pub,
 		name,
 		version,
 		contents,
@@ -1167,85 +1155,84 @@ func stageMigrationBatchAt(
 }
 
 func stageMigrationBatchAtWithModeDetector(
-	dir, name string,
+	pub *publicationDir,
+	name string,
 	version int64,
 	contents []MigrationFileContent,
-	detectMode func(string) (publicationMode, error),
+	detectMode func(*pathguard.OpenedDirectory, string) (publicationMode, error),
 ) (migrationBatch, error) {
 	batch := migrationBatch{
-		paths:       make([]string, 0, len(contents)),
-		stagedPaths: make([]string, 0, len(contents)),
+		names:       make([]string, 0, len(contents)),
+		stagedNames: make([]string, 0, len(contents)),
 	}
 	for i, content := range contents {
 		fileVersion := version + int64(i)
 		slug := migrationSlug(name + content.NameSuffix)
-		path := filepath.Join(dir, fmt.Sprintf("%d_%s.sql", fileVersion, slug))
-		stagedPath, err := stageMigrationFile(dir, content.SQL)
+		stagedName, err := stageMigrationFile(pub, content.SQL)
 		if err != nil {
 			return migrationBatch{}, errors.Join(
 				fmt.Errorf("stage migration file: %w", err),
-				removeFiles(batch.stagedPaths),
+				removeNames(pub.dir, batch.stagedNames),
 			)
 		}
-		batch.paths = append(batch.paths, path)
-		batch.stagedPaths = append(batch.stagedPaths, stagedPath)
+		batch.names = append(batch.names, fmt.Sprintf("%d_%s.sql", fileVersion, slug))
+		batch.stagedNames = append(batch.stagedNames, stagedName)
 	}
-	mode, err := detectMode(batch.stagedPaths[0])
+	mode, err := detectMode(pub.dir, batch.stagedNames[0])
 	if err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+		return migrationBatch{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
 	batch.mode = mode
-	if _, err := readStagedMigrationContents(&batch); err != nil {
-		return migrationBatch{}, errors.Join(err, removeFiles(batch.stagedPaths))
+	if _, err := readStagedMigrationContents(pub, &batch); err != nil {
+		return migrationBatch{}, errors.Join(err, removeNames(pub.dir, batch.stagedNames))
 	}
 	return batch, nil
 }
 
-func detectPublicationMode(stagedPath string) (publicationMode, error) {
-	return platformPublicationMode(stagedPath)
+func detectPublicationMode(
+	root *pathguard.OpenedDirectory,
+	stagedName string,
+) (publicationMode, error) {
+	return platformPublicationMode(root, stagedName)
 }
 
 func detectPublicationModeWithLink(
-	stagedPath string,
+	root *pathguard.OpenedDirectory,
+	stagedName string,
 	link func(string, string) error,
 ) (publicationMode, error) {
-	probePath := stagedPath + ".link-probe"
-	if err := link(stagedPath, probePath); err != nil {
+	probeName := stagedName + ".link-probe"
+	if err := link(stagedName, probeName); err != nil {
 		return publicationModeCopy, nil
 	}
-	if err := os.Remove(probePath); err != nil {
+	if err := root.Remove(probeName); err != nil {
 		return "", fmt.Errorf("remove migration publication link probe: %w", err)
 	}
 	return publicationModeHardLink, nil
 }
 
-func stageMigrationFile(dir, migrationSQL string) (string, error) {
-	return stageArtifactFile(dir, []byte(migrationSQL))
+func stageMigrationFile(pub *publicationDir, migrationSQL string) (string, error) {
+	return stageArtifactFile(pub, []byte(migrationSQL))
 }
 
-func stageArtifactFile(dir string, contents []byte) (string, error) {
-	file, err := os.CreateTemp(dir, stagedMigrationPattern)
+func stageArtifactFile(pub *publicationDir, contents []byte) (string, error) {
+	file, name, err := pub.dir.CreateTemp(stagedMigrationPattern)
 	if err != nil {
 		return "", err
 	}
-	path := file.Name()
 	if err := file.Chmod(0644); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+		return "", errors.Join(err, file.Close(), removeNames(pub.dir, []string{name}))
 	}
 	if _, err := file.Write(contents); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+		return "", errors.Join(err, file.Close(), removeNames(pub.dir, []string{name}))
 	}
 	if err := file.Sync(); err != nil {
-		return "", errors.Join(err, file.Close(), removeFiles([]string{path}))
+		return "", errors.Join(err, file.Close(), removeNames(pub.dir, []string{name}))
 	}
 	if err := file.Close(); err != nil {
-		return "", errors.Join(err, removeFiles([]string{path}))
+		return "", errors.Join(err, removeNames(pub.dir, []string{name}))
 	}
-	return path, nil
-}
-
-func nextMigrationVersion(dir string) (int64, error) {
-	return nextMigrationVersionFS(os.DirFS(dir))
+	return name, nil
 }
 
 func nextMigrationVersionFS(fsys fs.FS) (int64, error) {

--- a/internal/atlasmigrate/publication_mode_nonwindows.go
+++ b/internal/atlasmigrate/publication_mode_nonwindows.go
@@ -2,8 +2,11 @@
 
 package atlasmigrate
 
-import "os"
+import "go.5x5.cz/ptah/internal/pathguard"
 
-func platformPublicationMode(stagedPath string) (publicationMode, error) {
-	return detectPublicationModeWithLink(stagedPath, os.Link)
+func platformPublicationMode(
+	root *pathguard.OpenedDirectory,
+	stagedName string,
+) (publicationMode, error) {
+	return detectPublicationModeWithLink(root, stagedName, root.Link)
 }

--- a/internal/atlasmigrate/publication_mode_windows.go
+++ b/internal/atlasmigrate/publication_mode_windows.go
@@ -2,6 +2,11 @@
 
 package atlasmigrate
 
-func platformPublicationMode(string) (publicationMode, error) {
+import "go.5x5.cz/ptah/internal/pathguard"
+
+func platformPublicationMode(
+	*pathguard.OpenedDirectory,
+	string,
+) (publicationMode, error) {
 	return publicationModeWriteThroughMove, nil
 }

--- a/internal/atlasmigrate/publicationdir.go
+++ b/internal/atlasmigrate/publicationdir.go
@@ -1,0 +1,120 @@
+package atlasmigrate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// publicationDir is the retained rooted view of one migration directory and of
+// the directory that holds its publication journal.
+//
+// Every staged, published, journal, commit-marker, checksum, rollback and
+// cleanup operation in this package is addressed by a name relative to one of
+// these two handles. Both handles are opened once, before the directory is
+// snapshotted, so replacing either pathname afterwards -- with a rename, a
+// symlink or a fresh directory -- cannot redirect a later write: os.Root keeps
+// referencing the filesystem object it was opened on, wherever that object is
+// moved to (stokaro/ptah#895).
+//
+// The journal deliberately lives in the parent directory, which is why the
+// parent needs its own retained handle rather than being reached through
+// filepath.Dir of a pathname that may since have been replaced.
+type publicationDir struct {
+	dir    *pathguard.OpenedDirectory
+	parent *pathguard.OpenedDirectory
+	// displayPath is the migration directory as the caller named it. It is used
+	// for reported paths and error messages only; it is never reopened.
+	displayPath string
+	// journalDir is the display path of the directory holding the journal.
+	journalDir string
+	// journalName is the journal's name inside parent.
+	journalName string
+}
+
+// openPublicationDir binds the parent of dir first and then opens dir only
+// through that handle, so neither open can be redirected by replacing the
+// other's pathname. The caller owns the result and must close it.
+func openPublicationDir(dir string) (*publicationDir, error) {
+	if strings.TrimSpace(dir) == "" {
+		return nil, errors.New("migration directory is required")
+	}
+	canonical, err := canonicalMigrationDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve migration directory: %w", err)
+	}
+	journalDir := filepath.Dir(canonical)
+	base := filepath.Base(canonical)
+	parent, err := pathguard.OpenDirectory(journalDir)
+	if err != nil {
+		return nil, fmt.Errorf("open migration directory parent: %w", err)
+	}
+	opened, err := parent.OpenDirectory(base)
+	if err != nil {
+		return nil, errors.Join(
+			fmt.Errorf("open migration directory: %w", err),
+			parent.Close(),
+		)
+	}
+	return &publicationDir{
+		dir:         opened,
+		parent:      parent,
+		displayPath: filepath.Clean(dir),
+		journalDir:  journalDir,
+		journalName: "." + base + publicationJournalSuffix,
+	}, nil
+}
+
+func (p *publicationDir) close() error {
+	return errors.Join(p.dir.Close(), p.parent.Close())
+}
+
+// fsys returns an escape-resistant view of the retained migration directory.
+func (p *publicationDir) fsys() fs.FS {
+	return p.dir.FS()
+}
+
+// path renders a name inside the migration directory for display. The result is
+// never reopened; rooted operations always take the bare name.
+func (p *publicationDir) path(name string) string {
+	return filepath.Join(p.displayPath, name)
+}
+
+// journalPath renders the publication journal's pathname for display.
+func (p *publicationDir) journalPath() string {
+	return filepath.Join(p.journalDir, p.journalName)
+}
+
+// commitMarkerName is the journal's commit marker, a sibling of the journal.
+func (p *publicationDir) commitMarkerName() string {
+	return p.journalName + publicationCommitMarkerSuffix
+}
+
+func (p *publicationDir) journalCleanupName() string {
+	return p.journalName + publicationCleanupSuffix
+}
+
+// listNames returns the names directly inside root that carry prefix and
+// suffix. It replaces filepath.Glob, which resolves a pathname the caller may
+// no longer own.
+func listNames(root *pathguard.OpenedDirectory, prefix, suffix string) ([]string, error) {
+	entries, err := root.ReadDir()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		name := entry.Name()
+		if len(name) < len(prefix)+len(suffix) {
+			continue
+		}
+		if strings.HasPrefix(name, prefix) && strings.HasSuffix(name, suffix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}

--- a/internal/fsdurable/move_root_nonwindows.go
+++ b/internal/fsdurable/move_root_nonwindows.go
@@ -1,0 +1,27 @@
+//go:build !windows
+
+package fsdurable
+
+import (
+	"errors"
+	"os"
+)
+
+// MoveFileNoReplaceAt publishes oldName at newName inside root without
+// replacing an existing entry. Both names are resolved through the retained
+// root, so replacing the directory's pathname cannot redirect the move.
+// Callers must sync root afterwards.
+//
+// It uses the same link-then-unlink sequence as the pathname-based
+// MoveFileNoReplace: link fails with fs.ErrExist when the destination is taken,
+// which is exactly the no-replace guarantee, and it does not depend on a
+// conditional rename primitive the filesystem may not implement.
+func MoveFileNoReplaceAt(root *os.Root, oldName, newName string) error {
+	if err := root.Link(oldName, newName); err != nil {
+		return err
+	}
+	if err := root.Remove(oldName); err != nil {
+		return errors.Join(err, root.Remove(newName))
+	}
+	return nil
+}

--- a/internal/fsdurable/move_root_test.go
+++ b/internal/fsdurable/move_root_test.go
@@ -1,0 +1,79 @@
+package fsdurable_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/fsdurable"
+)
+
+func openTestRoot(c *qt.C, dir string) *os.Root {
+	c.Helper()
+	root, err := os.OpenRoot(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(root.Close(), qt.IsNil)
+	})
+	return root
+}
+
+func TestMoveFileNoReplaceAt_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("contents"), 0o600), qt.IsNil)
+	root := openTestRoot(c, dir)
+
+	err := fsdurable.MoveFileNoReplaceAt(root, "staged", "published")
+
+	c.Assert(err, qt.IsNil)
+	_, err = os.Stat(filepath.Join(dir, "staged"))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+	contents, err := os.ReadFile(filepath.Join(dir, "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "contents")
+}
+
+func TestMoveFileNoReplaceAt_RefusesExistingDestination(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("new"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "published"), []byte("existing"), 0o600), qt.IsNil)
+	root := openTestRoot(c, dir)
+
+	err := fsdurable.MoveFileNoReplaceAt(root, "staged", "published")
+
+	c.Assert(err, qt.ErrorIs, os.ErrExist)
+	staged, readErr := os.ReadFile(filepath.Join(dir, "staged"))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(staged), qt.Equals, "new")
+	published, readErr := os.ReadFile(filepath.Join(dir, "published"))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(string(published), qt.Equals, "existing")
+}
+
+// TestMoveFileNoReplaceAt_FollowsTheRetainedDirectory pins the property the
+// rooted variant exists for: after the directory is renamed away from the
+// pathname it was opened on, the move still lands inside the directory the
+// handle refers to.
+func TestMoveFileNoReplaceAt_FollowsTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	parent := c.TempDir()
+	dir := filepath.Join(parent, "retained")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("contents"), 0o600), qt.IsNil)
+	root := openTestRoot(c, dir)
+	moved := filepath.Join(parent, "moved")
+	c.Assert(os.Rename(dir, moved), qt.IsNil)
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+
+	c.Assert(fsdurable.MoveFileNoReplaceAt(root, "staged", "published"), qt.IsNil)
+
+	contents, err := os.ReadFile(filepath.Join(moved, "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "contents")
+	_, err = os.Stat(filepath.Join(dir, "published"))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}

--- a/internal/fsdurable/move_root_windows.go
+++ b/internal/fsdurable/move_root_windows.go
@@ -1,0 +1,35 @@
+package fsdurable
+
+import (
+	"errors"
+	"fmt"
+	"os"
+)
+
+// MoveFileNoReplaceAt publishes oldName at newName inside root without
+// replacing an existing entry and flushes the published file before returning.
+// Both names must identify direct children of root.
+//
+// Windows has no rooted MoveFileEx, so the move runs through the same
+// rename-by-handle primitive the rooted publication uses, which never requests
+// replacement. MOVEFILE_WRITE_THROUGH has no equivalent there either, so
+// durability is supplied by flushing the moved file afterwards. Errors raised
+// after the rename took effect wrap ErrReplacementCommitted.
+func MoveFileNoReplaceAt(root *os.Root, oldName, newName string) error {
+	if err := validateDirectChildName("moveat", oldName); err != nil {
+		return err
+	}
+	if err := validateDirectChildName("moveat", newName); err != nil {
+		return err
+	}
+	if err := rootRenameNoReplace(root, oldName, newName); err != nil {
+		return err
+	}
+	published, err := openPublicationFile(root, newName)
+	if err != nil {
+		return replacementCommittedError(
+			fmt.Errorf("open published file after rooted move %s: %w", newName, err),
+		)
+	}
+	return replacementCommittedError(errors.Join(published.Sync(), published.Close()))
+}

--- a/internal/migratesum/io.go
+++ b/internal/migratesum/io.go
@@ -54,6 +54,78 @@ func WritePrecomputedWithFormat(
 	return nil
 }
 
+// RootedDir is the retained rooted directory handle a durable checksum write
+// needs. It is satisfied by pathguard.OpenedDirectory, which this package
+// cannot name without depending on it.
+type RootedDir interface {
+	CreateTemp(pattern string) (*os.File, string, error)
+	ReplaceFile(oldName, newName string) error
+	Remove(name string) error
+	Sync() error
+}
+
+// WritePrecomputedWithFormatIn writes sum to the integrity file selected by
+// format through a retained rooted directory handle. A directory whose pathname
+// is replaced after the caller validated it therefore cannot receive the
+// checksum: every name is resolved through the handle that was opened once.
+func WritePrecomputedWithFormatIn(
+	dir RootedDir,
+	format migrator.MigrationDirFormat,
+	sum *SumFile,
+) error {
+	if sum == nil {
+		return errors.New("migration checksum must not be nil")
+	}
+	name, err := FileNameForFormat(format)
+	if err != nil {
+		return err
+	}
+	if err := writeAtomicSumFileIn(dir, name, sum.Bytes()); err != nil {
+		return fmt.Errorf("failed to write %s: %w", name, err)
+	}
+	return nil
+}
+
+func writeAtomicSumFileIn(dir RootedDir, name string, contents []byte) error {
+	file, tempName, err := dir.CreateTemp("." + name + ".*.tmp")
+	if err != nil {
+		return err
+	}
+
+	// The sum file is committed alongside migrations and checked in, so it
+	// uses the same 0644 permissions as generated migration files.
+	if err := file.Chmod(0644); err != nil {
+		return errors.Join(err, file.Close(), removeRootedFile(dir, tempName))
+	}
+	if _, err := file.Write(contents); err != nil {
+		return errors.Join(err, file.Close(), removeRootedFile(dir, tempName))
+	}
+	if err := file.Sync(); err != nil {
+		return errors.Join(err, file.Close(), removeRootedFile(dir, tempName))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(err, removeRootedFile(dir, tempName))
+	}
+	if err := dir.ReplaceFile(tempName, name); err != nil {
+		if errors.Is(err, fsdurable.ErrReplacementCommitted) {
+			return &CommitUncertainError{Err: err}
+		}
+		return errors.Join(err, removeRootedFile(dir, tempName))
+	}
+	if err := dir.Sync(); err != nil {
+		return &CommitUncertainError{Err: err}
+	}
+	return nil
+}
+
+func removeRootedFile(dir RootedDir, name string) error {
+	err := dir.Remove(name)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
 // CommitUncertainError reports that the checksum file was atomically replaced
 // but syncing the containing directory failed. The visible checksum may be the
 // old or new commit marker after a crash, so callers must retain recovery state.

--- a/internal/migratesum/io_root_test.go
+++ b/internal/migratesum/io_root_test.go
@@ -1,0 +1,92 @@
+package migratesum_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+func openSumDirectory(c *qt.C, dir string) *pathguard.OpenedDirectory {
+	c.Helper()
+	opened, err := pathguard.OpenDirectory(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	return opened
+}
+
+func TestWritePrecomputedWithFormatIn_WritesAtlasSum(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_init.sql"), []byte("SELECT 1;"), 0o600), qt.IsNil)
+	sum, err := migratesum.ComputeWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	opened := openSumDirectory(c, dir)
+
+	writeErr := migratesum.WritePrecomputedWithFormatIn(
+		opened,
+		migrator.MigrationDirFormatAtlas,
+		sum,
+	)
+
+	c.Assert(writeErr, qt.IsNil)
+	contents, err := os.ReadFile(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(contents, qt.DeepEquals, sum.Bytes())
+	result, err := migratesum.VerifyDirWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.OK(), qt.IsTrue)
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 2)
+}
+
+func TestWritePrecomputedWithFormatIn_RejectsNilSum(t *testing.T) {
+	c := qt.New(t)
+	opened := openSumDirectory(c, c.TempDir())
+
+	err := migratesum.WritePrecomputedWithFormatIn(
+		opened,
+		migrator.MigrationDirFormatAtlas,
+		nil,
+	)
+
+	c.Assert(err, qt.ErrorMatches, `migration checksum must not be nil`)
+}
+
+// TestWritePrecomputedWithFormatIn_WritesIntoTheRetainedDirectory pins that the
+// checksum lands in the directory the handle was opened on even when a
+// replacement has taken over its pathname.
+func TestWritePrecomputedWithFormatIn_WritesIntoTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	parent := c.TempDir()
+	dir := filepath.Join(parent, "retained")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_init.sql"), []byte("SELECT 1;"), 0o600), qt.IsNil)
+	sum, err := migratesum.ComputeWithFormat(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	opened := openSumDirectory(c, dir)
+	moved := filepath.Join(parent, "moved")
+	c.Assert(os.Rename(dir, moved), qt.IsNil)
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+
+	writeErr := migratesum.WritePrecomputedWithFormatIn(
+		opened,
+		migrator.MigrationDirFormatAtlas,
+		sum,
+	)
+
+	c.Assert(writeErr, qt.IsNil)
+	contents, err := os.ReadFile(filepath.Join(moved, migratesum.AtlasFileName))
+	c.Assert(err, qt.IsNil)
+	c.Assert(contents, qt.DeepEquals, sum.Bytes())
+	_, err = os.Stat(filepath.Join(dir, migratesum.AtlasFileName))
+	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
+}

--- a/internal/pathguard/opened_directory_ops.go
+++ b/internal/pathguard/opened_directory_ops.go
@@ -19,6 +19,31 @@ func (d *OpenedDirectory) Open(name string) (*os.File, error) {
 	return d.root.Open(name)
 }
 
+// OpenFile opens name with the supplied flags through the rooted directory
+// handle. The caller owns the returned file and must close it.
+func (d *OpenedDirectory) OpenFile(name string, flag int, perm fs.FileMode) (*os.File, error) {
+	return d.root.OpenFile(name, flag, perm)
+}
+
+// Link creates newName as a hard link to oldName through the rooted directory
+// handle. It fails with fs.ErrExist when newName already exists, so callers get
+// no-replace publication semantics.
+func (d *OpenedDirectory) Link(oldName, newName string) error {
+	return d.root.Link(oldName, newName)
+}
+
+// MoveFileNoReplace publishes oldName at newName through the rooted directory
+// handle without replacing an existing entry. Callers must follow a successful
+// move with Sync.
+func (d *OpenedDirectory) MoveFileNoReplace(oldName, newName string) error {
+	return fsdurable.MoveFileNoReplaceAt(d.root, oldName, newName)
+}
+
+// ReadDir lists the opened directory's own entries through the rooted handle.
+func (d *OpenedDirectory) ReadDir() ([]fs.DirEntry, error) {
+	return fs.ReadDir(d.root.FS(), ".")
+}
+
 // Lstat returns information about name without following its final symlink.
 func (d *OpenedDirectory) Lstat(name string) (fs.FileInfo, error) {
 	return d.root.Lstat(name)

--- a/internal/pathguard/opened_directory_publication_test.go
+++ b/internal/pathguard/opened_directory_publication_test.go
@@ -1,0 +1,81 @@
+package pathguard_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+func openTestDirectory(c *qt.C, dir string) *pathguard.OpenedDirectory {
+	c.Helper()
+	opened, err := pathguard.OpenDirectory(dir)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		c.Check(opened.Close(), qt.IsNil)
+	})
+	return opened
+}
+
+// TestOpenedDirectoryPublicationOperations_HappyPath covers the rooted
+// operations a journaled publication needs beyond replace-and-sync: opening a
+// staged file for writing, hard-linking it into place, moving it without
+// replacing, and listing the directory's own entries.
+func TestOpenedDirectoryPublicationOperations_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("contents"), 0o600), qt.IsNil)
+	opened := openTestDirectory(c, dir)
+
+	file, err := opened.OpenFile("staged", os.O_RDWR, 0)
+	c.Assert(err, qt.IsNil)
+	c.Assert(file.Sync(), qt.IsNil)
+	c.Assert(file.Close(), qt.IsNil)
+
+	c.Assert(opened.Link("staged", "linked"), qt.IsNil)
+	c.Assert(opened.Link("staged", "linked"), qt.ErrorIs, os.ErrExist)
+	c.Assert(opened.MoveFileNoReplace("staged", "moved"), qt.IsNil)
+	c.Assert(opened.Sync(), qt.IsNil)
+
+	entries, err := opened.ReadDir()
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	c.Assert(names, qt.DeepEquals, []string{"linked", "moved"})
+	contents, err := opened.ReadFile("moved")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "contents")
+}
+
+// TestOpenedDirectoryPublicationOperations_FollowTheRetainedDirectory pins that
+// the publication operations keep acting on the directory the handle was opened
+// on after a replacement takes over its pathname.
+func TestOpenedDirectoryPublicationOperations_FollowTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	parent := c.TempDir()
+	dir := filepath.Join(parent, "retained")
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "staged"), []byte("contents"), 0o600), qt.IsNil)
+	opened := openTestDirectory(c, dir)
+	moved := filepath.Join(parent, "moved")
+	c.Assert(os.Rename(dir, moved), qt.IsNil)
+	c.Assert(os.Mkdir(dir, 0o700), qt.IsNil)
+
+	c.Assert(opened.Link("staged", "linked"), qt.IsNil)
+	c.Assert(opened.MoveFileNoReplace("staged", "published"), qt.IsNil)
+
+	entries, err := opened.ReadDir()
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 2)
+	replacementEntries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(replacementEntries, qt.HasLen, 0)
+	contents, err := os.ReadFile(filepath.Join(moved, "published"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Equals, "contents")
+}


### PR DESCRIPTION
## The hole

`internal/atlasmigrate` published by pathname from end to end. `diff.go:203`
verified `opts.Dir` and `diff.go:209` then wrote through the same string;
`publication.go` carried 19 `dir string` parameters across ~30 functions and
contained no reference to `os.Root` or `pathguard`. A directory replaced after
validation therefore received everything the run produced, and the post-publish
guard did not catch it because it re-stats the pathname, which by then resolves
to the replacement.

## Reproduction

Probe run in this worktree at `f22107bd` (master), dropped into
`internal/atlasmigrate` as a `_test.go` file. It swaps the directory inside
`PreparePublication` — after the directory is locked, recovered, snapshotted and
verified, and after the batch is staged: copy the contents to `attacker/`,
rename `migrations` to `migrations.retained`, symlink `migrations` → `attacker`.

**Before** — `go test ./internal/atlasmigrate/ -run TestIssue895 -v`, exit 1:

```
--- PASS: TestIssue895_Control_NoSwap
    control: sql files in validated dir = [1786000387_fault_injection.sql 1_init.sql]
--- FAIL: TestIssue895_DirectorySwapAfterValidation
    generateDiff err = <nil>
    MigrationPaths = [.../001/migrations/1786000387_fault_injection.sql]
    SumPath        = .../001/migrations/atlas.sum
    sql in ATTACKER dir .../001/attacker            = [1786000387_fault_injection.sql 1_init.sql]
    sql in RETAINED dir .../001/migrations.retained = [1_init.sql]
    migration write was redirected into the replacement directory
    validated directory did not receive the migration
```

**After** — same probe, same fixture, exit 0:

```
--- PASS: TestIssue895_DirectorySwapAfterValidation
    generateDiff err = <nil>
    sql in ATTACKER dir .../001/attacker            = [1_init.sql]
    sql in RETAINED dir .../001/migrations.retained = [1786001201_fault_injection.sql 1_init.sql]
```

The probe is not in the diff; it is superseded by
`internal/atlasmigrate/diff_directory_swap_nonwindows_internal_test.go`, which
covers the same window plus the rename shape, `atlas.sum`, checksum
verification, rollback and cleanup.

## The change

`publicationDir` (`internal/atlasmigrate/publicationdir.go`) binds the parent of
the canonical migration directory first and opens the migration directory only
through that handle. Both are retained for the life of the run. Every staged
file, published migration, journal, commit marker, `atlas.sum`, rollback
quarantine and cleanup entry is now addressed by a **name** relative to one of
those two handles; pathnames survive only for reported paths and error text.
`filepath.Glob` is replaced by a rooted `ReadDir` + prefix/suffix filter, and
`os.DirFS(dir)` by the handle's own `FS()`.

The journal deliberately lives in the parent directory, which is why the parent
gets its own retained handle rather than being reached through `filepath.Dir` of
a pathname that may since have been replaced. Its name is still derived from the
canonical directory, so journals written by earlier versions are still found.

New primitives:

- `fsdurable.MoveFileNoReplaceAt` — link-then-unlink on Unix (the exact sequence
  the pathname version already used, so no new "this filesystem cannot do
  conditional renames" failure mode), rename-by-handle plus a flush on Windows,
  where there is no rooted `MoveFileEx`.
- `pathguard.OpenedDirectory`: `OpenFile`, `Link`, `MoveFileNoReplace`,
  `ReadDir`.
- `migratesum.WritePrecomputedWithFormatIn` — the same atomic
  create/chmod/write/sync/replace/sync as `writeAtomicSumFile`, through a
  retained handle. It also maps a post-rename `ErrReplacementCommitted` onto
  `CommitUncertainError`, which is what the caller already treats as "journal
  retained for recovery".

The **rollback quarantine changes shape**: it was a directory
`<staged>.rollback/` holding a file `published`; it is now the direct-child file
`<staged>.rollback`. Rooted publication addresses direct children of a retained
handle, and a nested quarantine would need a second retained handle whose own
open is exactly the race this PR closes. A side effect is that the rollback path
now creates and removes no directory at all, so "rooted cleanup cannot remove a
replacement directory" holds by construction rather than by a check.

`RecoverPendingPublicationLocked` returns `nil` for a migration directory that
does not exist yet. Master reached the same outcome by globbing a missing
directory; opening one now fails, and `migration/generator` calls it before the
directory is created. Measured: without this, `TestMigrateGenerateJSONReportWritesSiblingSafetyArtifact`
fails with `recover migration publication before planning: open migration
directory: openat migrations: no such file or directory`.

## What each test prints if the change is reverted

Measured with inverse mutants — each function re-resolves `pub.displayPath` and
uses the fresh handle, which is precisely what master did — not by reverting.

| Test | Mutant | Output |
| --- | --- | --- |
| `TestGenerateDiff_PublishesIntoTheValidatedDirectory` (both rows) | `publishMigrationBatchContext`, `writeDirSum`, `verifyMigrationDirUnchanged`, `publicationCommitted`, `finalizeCommittedPublication` re-resolve | `unexpected length / len(got): int(1) / got: []string{"1_init.sql"} / want length: int(2)` at `migrationFileNames(c, swap.retained)` — i.e. `generateDiff` returns `nil` and the validated directory received nothing. With only `publishMigrationBatchContext` mutated it instead fails earlier with `migration directory changed during migrate diff planning`; with the sum writer added, `atlas.sum does not match the journaled migration publication`. |
| `TestGenerateDiff_PublishesIntoUnswappedDirectory` | same mutant | stays green — this is the non-interference control that makes "the replacement stayed empty" evidence rather than an artifact of reading the wrong directory. |
| `TestRecoverPendingPublication_RollsBackInTheRetainedDirectory` | `recoverPendingPublication` re-resolves | `got nil error but want non-nil / want: e"file does not exist"` — the rollback removed the replacement's copy and left the retained one. |
| `TestRecoverPendingPublication_CleansUpInTheRetainedDirectory` | same | same shape, on the orphan staging file. |
| `TestMoveFileNoReplaceAt_FollowsTheRetainedDirectory` | `MoveFileNoReplaceAt` joins `root.Name()` | `link .../retained/staged .../retained/published: no such file or directory` |
| `TestOpenedDirectoryPublicationOperations_FollowTheRetainedDirectory` | same | `link .../retained/staged .../retained/published: no such file or directory` |
| `TestWritePrecomputedWithFormatIn_WritesIntoTheRetainedDirectory` | `WritePrecomputedWithFormatIn` writes `filepath.Join(dir.Path(), name)` | `open .../moved/atlas.sum: no such file or directory` |
| `TestMoveFileNoReplaceAt_HappyPath` / `_RefusesExistingDestination`, `TestOpenedDirectoryPublicationOperations_HappyPath`, `TestWritePrecomputedWithFormatIn_WritesAtlasSum` / `_RejectsNilSum` | same mutants | stay green — the swap rows are what discriminates, not the primitives' existence. |

The ~50 converted call sites in `diff_internal_test.go` are the existing
coverage for hard-link, exclusive-copy and write-through-move publication,
interrupted publication, commit uncertainty and foreign-collision refusal; they
pass unchanged in meaning, with `dir` replaced by the retained handle and the
quarantine assertions following the flat layout.

## Gates

All run in this worktree, exit codes captured immediately:

```
build 0 · vet 0 · test 0 (0 FAIL lines in the full log) · qtlint 0
golangci-lint 0 (0 issues) · check-test-style 0 (175 conditional groups, 45 white-box files)
check-public-api 0 · check-public-api-snapshot 0
gofmt -l: only internal/goannotationexport/testdata/cleanup/models.go, a
  pre-existing fixture from #988 that is not in this diff
GOOS=windows go build ./... 0 · GOOS=windows go vet ./internal/... ./cmd/... ./migration/... 0
```

`docs/` is touched, so all 15 scripts in `docs/site/package.json` ran, each
exit 0 — including `check:responsive`, which needs `npm run build` first and
otherwise reports `dist not found` without checking anything.

## Deliberately left open

- **The command layer still passes a pathname.** `cmd/atlas/migrate_diff.go`
  resolves `--dir` and hands `atlasmigrate` a string, which reopens it. The
  window between those two resolutions is *before* this run validates anything —
  the directory that gets opened is the directory that gets verified — so
  acceptance criterion 1 ("after planning") is met. Threading a handle from the
  CLI is the input-side half that `40eeeb12` stripped out of `135aeac4`; it is
  worth relanding but it is a separate change to `cmd/atlas`,
  `cmd/internal/migrationsource` and `pathguard`, and it closes a different
  window.
- **The directory lock is still keyed by pathname.** `acquireDirLock` /
  `migrationDirLockPath` create the lock file next to the canonical directory
  before any handle exists. That is a cooperative mutual-exclusion mechanism
  between Ptah processes, not a boundary against a hostile writer, and rooting it
  would change the lock identity that other verbs already agree on.
- **`PublishArtifactsLocked` and `RecoverPendingPublication*` still take a
  string.** They now open the directory once at entry and route the whole batch
  through that handle, which covers the native `ptah migrate generate` surface,
  but a swap strictly before the call still selects which directory is used.
  Giving them handle-taking variants belongs with the command-layer item above.
- **`DiffOptions.PreparePublication` still receives absolute staged paths.** The
  `--edit` callback hands them to an external editor, which cannot take a
  handle. The paths are re-validated through the rooted handle afterwards —
  `Lstat` for regularity, open-then-`SameFile`, digest — which is what the
  existing symlink-replacement test pins.

Closes #895
