### PR TITLE
Represent DROP INDEX CONCURRENTLY (refs #997)

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -15,7 +15,9 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"go.5x5.cz/ptah/config/projectconfig"
 	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/testutils"
 	migrationlint "go.5x5.cz/ptah/migration/lint"
@@ -2315,15 +2317,24 @@ table "old_users" {
 	c.Assert(out.String(), qt.Equals, "synced")
 }
 
-func TestCompatCommand_SchemaDiffRejectsUnsupportedAtlasProjectDiffPolicy(t *testing.T) {
+// TestCompatCommand_SchemaDiffAcceptsConcurrentIndexDropPolicy pins that
+// diff.concurrent_index.drop is decoded and carried into planning instead of
+// aborting the run. Reverting the policy wiring prints
+// `Error: atlas.hcl diff.concurrent_index.drop is not supported yet` and the
+// command exits non-zero, which is what the pinned community binary does not do
+// with the same file.
+func TestCompatCommand_SchemaDiffAcceptsConcurrentIndexDropPolicy(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 	t.Chdir(dir)
+	from := filepath.Join(dir, "from.hcl")
+	to := filepath.Join(dir, "to.hcl")
+	c.Assert(os.WriteFile(from, []byte(`schema "main" {}
+`), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(to, []byte(`schema "main" {}
+`), 0o600), qt.IsNil)
 	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
   dev = "sqlite://dev.db"
-  schema {
-    src = "file://to.hcl"
-  }
   diff {
     concurrent_index {
       drop = true
@@ -2340,12 +2351,60 @@ func TestCompatCommand_SchemaDiffRejectsUnsupportedAtlasProjectDiffPolicy(t *tes
 		"schema", "diff",
 		"--env", "local",
 		"--from", "file://from.hcl",
+		"--to", "file://to.hcl",
 	})
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, `atlas\.hcl diff\.concurrent_index\.drop is not supported yet`)
-	c.Assert(out.String(), qt.Contains, `Error: atlas.hcl diff.concurrent_index.drop is not supported yet`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(out.String(), qt.Not(qt.Contains), "not supported yet")
+}
+
+// TestAtlasDiffPolicy_CarriesConcurrentIndexDrop is the unit-level half: the
+// decoded config must reach the planning policy, not just avoid an error.
+// Reverting the wiring prints "values are not equal: true != false" for the
+// ConcurrentIndexDrop field.
+func TestAtlasDiffPolicy_CarriesConcurrentIndexDrop(t *testing.T) {
+	tests := []struct {
+		name   string
+		config func() projectconfig.Config
+		want   atlasschema.DiffPolicy
+	}{
+		{
+			name: "drop requested",
+			config: func() projectconfig.Config {
+				var cfg projectconfig.Config
+				cfg.Diff.ConcurrentIndex.Drop = projectconfig.ConfigBool{Value: true, Set: true}
+				return cfg
+			},
+			want: atlasschema.DiffPolicy{ConcurrentIndexDrop: true},
+		},
+		{
+			name: "drop explicitly declined",
+			config: func() projectconfig.Config {
+				var cfg projectconfig.Config
+				cfg.Diff.ConcurrentIndex.Drop = projectconfig.ConfigBool{Value: false, Set: true}
+				return cfg
+			},
+			want: atlasschema.DiffPolicy{},
+		},
+		{
+			name:   "drop unset",
+			config: func() projectconfig.Config { return projectconfig.Config{} },
+			want:   atlasschema.DiffPolicy{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := atlasDiffPolicy(tt.config())
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
 }
 
 func TestCompatCommand_SchemaDiffRejectsInvalidFormatBeforeLoadingFiles(t *testing.T) {

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -876,11 +876,9 @@ func effectiveAtlasExclude(cmd *cobra.Command, flagValues []string, cfg projectc
 }
 
 func atlasDiffPolicy(cfg projectconfig.Config) (atlasschema.DiffPolicy, error) {
-	if cfg.Diff.ConcurrentIndex.Drop.Set && cfg.Diff.ConcurrentIndex.Drop.Value {
-		return atlasschema.DiffPolicy{}, fmt.Errorf("atlas.hcl diff.concurrent_index.drop is not supported yet")
-	}
 	return atlasschema.DiffPolicy{
 		SkipDropTable:         cfg.Diff.Skip.DropTable.Set && cfg.Diff.Skip.DropTable.Value,
-		ConcurrentIndexCreate: cfg.Diff.ConcurrentIndex.Create.Set && cfg.Diff.ConcurrentIndex.Create.Value,
+		ConcurrentIndexCreate: cfg.Diff.ConcurrentIndexCreate(),
+		ConcurrentIndexDrop:   cfg.Diff.ConcurrentIndexDrop(),
 	}, nil
 }

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -778,11 +778,31 @@ func validateAtlasSchemaApplyDiffPolicy(
 		return nil
 	}
 	for _, statement := range statements {
-		if strings.Contains(strings.ToUpper(statement), "CREATE INDEX CONCURRENTLY") {
-			return fmt.Errorf("atlas.hcl diff.concurrent_index.create requires --tx-mode none for schema apply")
+		if setting := concurrentIndexPolicySetting(statement); setting != "" {
+			return fmt.Errorf("atlas.hcl %s requires --tx-mode none for schema apply", setting)
 		}
 	}
 	return nil
+}
+
+// concurrentIndexPolicySetting names the diff policy that produced a statement
+// PostgreSQL refuses to run inside a transaction block, or "" when the
+// statement is safe to wrap.
+//
+// The UNIQUE spelling is listed explicitly: a unique index renders as
+// CREATE UNIQUE INDEX CONCURRENTLY, which a substring test for
+// "CREATE INDEX CONCURRENTLY" does not see.
+func concurrentIndexPolicySetting(statement string) string {
+	upper := strings.ToUpper(statement)
+	switch {
+	case strings.Contains(upper, "CREATE INDEX CONCURRENTLY"),
+		strings.Contains(upper, "CREATE UNIQUE INDEX CONCURRENTLY"):
+		return "diff.concurrent_index.create"
+	case strings.Contains(upper, "DROP INDEX CONCURRENTLY"):
+		return "diff.concurrent_index.drop"
+	default:
+		return ""
+	}
 }
 
 // editAtlasSchemaApplySQL round-trips the planned SQL through the operator's

--- a/cmd/atlas/schema_apply_concurrent_index_txmode_internal_test.go
+++ b/cmd/atlas/schema_apply_concurrent_index_txmode_internal_test.go
@@ -1,0 +1,73 @@
+package atlas
+
+// White-box testing required: concurrentIndexPolicySetting is the internal
+// classifier behind the schema-apply transaction-mode guard, and its whole
+// value is in the spellings it recognizes.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestConcurrentIndexPolicySetting pins which planned statements force
+// --tx-mode none on schema apply. PostgreSQL rejects every CONCURRENTLY index
+// form inside a transaction block, so a statement the classifier misses is one
+// Ptah would wrap and then watch fail at execution.
+//
+// Reverting the classifier to a bare "CREATE INDEX CONCURRENTLY" substring test
+// prints `values are not equal: "" != "diff.concurrent_index.create"` for the
+// unique row and `"" != "diff.concurrent_index.drop"` for the drop row. The
+// blocking rows keep returning "" either way, which is what makes the pair
+// discriminating rather than a rule that fires on everything.
+func TestConcurrentIndexPolicySetting(t *testing.T) {
+	tests := []struct {
+		name      string
+		statement string
+		want      string
+	}{
+		{
+			name:      "concurrent build",
+			statement: `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");`,
+			want:      "diff.concurrent_index.create",
+		},
+		{
+			name:      "concurrent unique build",
+			statement: `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");`,
+			want:      "diff.concurrent_index.create",
+		},
+		{
+			name:      "concurrent drop",
+			statement: `DROP INDEX CONCURRENTLY IF EXISTS "idx_members_email";`,
+			want:      "diff.concurrent_index.drop",
+		},
+		{
+			name:      "blocking build",
+			statement: `CREATE INDEX IF NOT EXISTS "idx_members_email" ON "members" ("email");`,
+			want:      "",
+		},
+		{
+			name:      "blocking unique build",
+			statement: `CREATE UNIQUE INDEX IF NOT EXISTS "idx_members_email" ON "members" ("email");`,
+			want:      "",
+		},
+		{
+			name:      "blocking drop",
+			statement: `DROP INDEX IF EXISTS "idx_members_email";`,
+			want:      "",
+		},
+		{
+			name:      "lowercase concurrent drop",
+			statement: `drop index concurrently if exists "idx_members_email";`,
+			want:      "diff.concurrent_index.drop",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(concurrentIndexPolicySetting(tt.statement), qt.Equals, tt.want)
+		})
+	}
+}

--- a/cmd/migrate/generate.go
+++ b/cmd/migrate/generate.go
@@ -283,8 +283,9 @@ func migrateGenerateCommand(cmd *cobra.Command, _ []string) error {
 		ShadowDatabaseURL: shadowDB,
 		SchemaQualifier:   qualifierValue,
 		DiffPolicy: generator.DiffPolicy{
-			SkipChangeKinds: projectCfg.Diff.SkipChangeKinds(),
-			ConcurrentIndex: projectCfg.Diff.ConcurrentIndexCreate(),
+			SkipChangeKinds:     projectCfg.Diff.SkipChangeKinds(),
+			ConcurrentIndex:     projectCfg.Diff.ConcurrentIndexCreate(),
+			ConcurrentIndexDrop: projectCfg.Diff.ConcurrentIndexDrop(),
 		},
 	}
 	var files *generator.MigrationFiles

--- a/cmd/schema/apply.go
+++ b/cmd/schema/apply.go
@@ -128,6 +128,7 @@ func nativeDiffPolicy(cfg projectconfig.Config) atlasschema.DiffPolicy {
 	return atlasschema.DiffPolicy{
 		SkipDropTable:         slices.Contains(cfg.Diff.SkipChangeKinds(), diffpolicy.DropTable),
 		ConcurrentIndexCreate: cfg.Diff.ConcurrentIndexCreate(),
+		ConcurrentIndexDrop:   cfg.Diff.ConcurrentIndexDrop(),
 	}
 }
 

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -653,6 +653,12 @@ func (c DiffConfig) ConcurrentIndexCreate() bool {
 	return c.ConcurrentIndex.Create.Value
 }
 
+// ConcurrentIndexDrop reports whether the policy requests
+// DROP INDEX CONCURRENTLY for removed indexes.
+func (c DiffConfig) ConcurrentIndexDrop() bool {
+	return c.ConcurrentIndex.Drop.Value
+}
+
 // DiffConcurrentIndexConfig holds Atlas diff.concurrent_index policy.
 type DiffConcurrentIndexConfig struct {
 	Create ConfigBool

--- a/config/projectconfig/yaml.go
+++ b/config/projectconfig/yaml.go
@@ -45,11 +45,14 @@ type yamlExternalSchema struct {
 
 // yamlDiff is the ptah.yaml diff policy block. skip lists destructive change
 // kinds to omit from generated migrations; concurrent_index requests
-// CREATE INDEX CONCURRENTLY for newly added indexes. concurrent_index is a
-// pointer so an explicit false is distinguishable from an unset value.
+// CREATE INDEX CONCURRENTLY for newly added indexes and
+// concurrent_index_drop requests DROP INDEX CONCURRENTLY for standalone index
+// removals. Both are pointers so an explicit false is distinguishable from an
+// unset value.
 type yamlDiff struct {
-	Skip            *[]string `yaml:"skip"`
-	ConcurrentIndex *bool     `yaml:"concurrent_index"`
+	Skip                *[]string `yaml:"skip"`
+	ConcurrentIndex     *bool     `yaml:"concurrent_index"`
+	ConcurrentIndexDrop *bool     `yaml:"concurrent_index_drop"`
 }
 
 type yamlMigration struct {
@@ -375,6 +378,9 @@ func (d yamlDiff) diffConfig() (DiffConfig, error) {
 	}
 	if d.ConcurrentIndex != nil {
 		cfg.ConcurrentIndex.Create = ConfigBool{Value: *d.ConcurrentIndex, Set: true}
+	}
+	if d.ConcurrentIndexDrop != nil {
+		cfg.ConcurrentIndex.Drop = ConfigBool{Value: *d.ConcurrentIndexDrop, Set: true}
 	}
 	return cfg, nil
 }

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1056,6 +1056,14 @@ type DropIndexNode struct {
 	Table string
 	// IfExists indicates whether to use IF EXISTS clause
 	IfExists bool
+	// Concurrently requests DROP INDEX CONCURRENTLY, PostgreSQL's non-blocking
+	// index removal. Renderers emit the keyword only when the target's
+	// capability set includes capability.DropIndexConcurrently; every other
+	// dialect ignores the flag. PostgreSQL rejects CONCURRENTLY inside a
+	// transaction block and rejects it for an index that backs a constraint, so
+	// planners set it only for standalone index drops the caller routes into a
+	// no_transaction migration.
+	Concurrently bool
 	// Comment is an optional comment for the drop operation
 	Comment string
 }
@@ -1099,6 +1107,20 @@ func (n *DropIndexNode) SetTable(table string) *DropIndexNode {
 //	dropIndex.SetIfExists()
 func (n *DropIndexNode) SetIfExists() *DropIndexNode {
 	n.IfExists = true
+	return n
+}
+
+// SetConcurrently requests DROP INDEX CONCURRENTLY for the statement.
+//
+// The keyword only reaches the SQL when the renderer's capability set has
+// capability.DropIndexConcurrently. Callers must place the statement in a
+// migration that runs outside a transaction.
+//
+// Example:
+//
+//	dropIndex.SetConcurrently()
+func (n *DropIndexNode) SetConcurrently() *DropIndexNode {
+	n.Concurrently = true
 	return n
 }
 

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -106,6 +106,15 @@ const (
 	// changes behavior (issue #171).
 	CreateIndexConcurrently Capability = "create_index_concurrently"
 
+	// DropIndexConcurrently marks support for PostgreSQL's non-locking
+	// DROP INDEX CONCURRENTLY. It is deliberately a separate flag from
+	// CreateIndexConcurrently with no implication edge between them: a caller
+	// composing a set with .With(CreateIndexConcurrently, false) is restricting
+	// index builds, not asserting anything about drops, and Validate must not
+	// turn that composition into an error. The PostgreSQL-compatible presets
+	// that already decline CREATE INDEX CONCURRENTLY decline this too.
+	DropIndexConcurrently Capability = "drop_index_concurrently"
+
 	// CreateOrReplaceTrigger marks support for replacing triggers in one
 	// statement (PostgreSQL 14+ and MariaDB 10.1.4+ use
 	// CREATE OR REPLACE TRIGGER; SQL Server uses CREATE OR ALTER TRIGGER;
@@ -206,6 +215,9 @@ var registry = map[Capability]spec{
 	},
 	CreateIndexConcurrently: {
 		doc: "CREATE [UNIQUE] INDEX CONCURRENTLY (PostgreSQL; a compatibility no-op on CockroachDB)",
+	},
+	DropIndexConcurrently: {
+		doc: "DROP INDEX CONCURRENTLY (PostgreSQL; disabled on the PostgreSQL-compatible presets that do not emit CONCURRENTLY)",
 	},
 	CreateOrReplaceTrigger: {
 		doc: "single-statement trigger replacement (PostgreSQL/MariaDB CREATE OR REPLACE, SQL Server CREATE OR ALTER; not MySQL)",
@@ -373,6 +385,7 @@ func MySQL84() Capabilities {
 		EnumInlineColumn:                   true,
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
+		DropIndexConcurrently:              false,
 		CreateOrReplaceTrigger:             false,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   false,
@@ -424,6 +437,7 @@ func MariaDB1011() Capabilities {
 		EnumInlineColumn:                   true,
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
+		DropIndexConcurrently:              false,
 		CreateOrReplaceTrigger:             true,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   false,
@@ -463,6 +477,7 @@ func Postgres16() Capabilities {
 		EnumInlineColumn:                   false,
 		EnumCustomType:                     true,
 		CreateIndexConcurrently:            true,
+		DropIndexConcurrently:              true,
 		CreateOrReplaceTrigger:             true,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   true,
@@ -502,6 +517,7 @@ func ClickHouse24() Capabilities {
 		EnumInlineColumn:                   true,
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
+		DropIndexConcurrently:              false,
 		CreateOrReplaceTrigger:             false,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   false,
@@ -530,6 +546,7 @@ func SQLite3() Capabilities {
 		EnumInlineColumn:                   false,
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
+		DropIndexConcurrently:              false,
 		CreateOrReplaceTrigger:             false,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   false,
@@ -559,6 +576,7 @@ func SQLServer2022() Capabilities {
 		EnumInlineColumn:                   false,
 		EnumCustomType:                     false,
 		CreateIndexConcurrently:            false,
+		DropIndexConcurrently:              false,
 		CreateOrReplaceTrigger:             true,
 		AlterGeneratedColumnExpression:     false,
 		RowLevelSecurity:                   false,
@@ -581,6 +599,7 @@ func SQLServer2022() Capabilities {
 func CockroachDB23() Capabilities {
 	return Postgres16().
 		With(CreateIndexConcurrently, false).
+		With(DropIndexConcurrently, false).
 		With(XMLType, false).
 		With(AdvisoryLocks, false).
 		With(RowLevelSecurity, false).
@@ -595,6 +614,7 @@ func CockroachDB23() Capabilities {
 func YugabyteDB25() Capabilities {
 	return Postgres16().
 		With(CreateIndexConcurrently, false).
+		With(DropIndexConcurrently, false).
 		With(AdvisoryLocks, false).
 		With(RowLevelSecurity, false)
 }
@@ -612,6 +632,7 @@ func SpannerPostgres() Capabilities {
 		With(CheckConstraintsEnforced, false).
 		With(EnumCustomType, false).
 		With(CreateIndexConcurrently, false).
+		With(DropIndexConcurrently, false).
 		With(CreateOrReplaceTrigger, false).
 		With(RowLevelSecurity, false).
 		With(RoleManagement, false).

--- a/core/renderer/internal/dialects/postgres/drop_index_concurrently_test.go
+++ b/core/renderer/internal/dialects/postgres/drop_index_concurrently_test.go
@@ -1,0 +1,105 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/core/renderer/internal/dialects/postgres"
+)
+
+// TestPostgreSQLRenderer_DropIndexConcurrently pins the rendered spelling of a
+// non-blocking index drop and its capability gate.
+//
+// If the renderer change is reverted, every row prints the same string as the
+// "capability withheld" row — the subject rows print
+// `DROP INDEX IF EXISTS "idx_users_email";` where they want
+// `DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";` — so the gate rows can
+// no longer be told apart from the enabled rows.
+func TestPostgreSQLRenderer_DropIndexConcurrently(t *testing.T) {
+	tests := []struct {
+		name    string
+		caps    capability.Capabilities
+		dialect string
+		node    func() *ast.DropIndexNode
+		want    string
+	}{
+		{
+			name:    "concurrently with the guard",
+			caps:    capability.Postgres16(),
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetIfExists().SetConcurrently()
+			},
+			want: "DROP INDEX CONCURRENTLY IF EXISTS \"idx_users_email\";\n",
+		},
+		{
+			name:    "concurrently without the guard",
+			caps:    capability.Postgres16().With(capability.DropIndexIfExists, false),
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetIfExists().SetConcurrently()
+			},
+			want: "DROP INDEX CONCURRENTLY \"idx_users_email\";\n",
+		},
+		{
+			name:    "capability withheld drops the keyword",
+			caps:    capability.Postgres16().With(capability.DropIndexConcurrently, false),
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetIfExists().SetConcurrently()
+			},
+			want: "DROP INDEX IF EXISTS \"idx_users_email\";\n",
+		},
+		{
+			name:    "cockroachdb preset withholds the keyword",
+			caps:    capability.CockroachDB23(),
+			dialect: platform.CockroachDB,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetIfExists().SetConcurrently()
+			},
+			want: "DROP INDEX IF EXISTS \"users\"@\"idx_users_email\";\n",
+		},
+		{
+			name:    "nil capability set is conservative",
+			caps:    nil,
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetConcurrently()
+			},
+			want: "DROP INDEX \"idx_users_email\";\n",
+		},
+		{
+			name:    "unmarked drop is unchanged",
+			caps:    capability.Postgres16(),
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_users_email").SetTable("users").SetIfExists()
+			},
+			want: "DROP INDEX IF EXISTS \"idx_users_email\";\n",
+		},
+		{
+			name:    "schema-qualified target keeps the namespace",
+			caps:    capability.Postgres16(),
+			dialect: platform.Postgres,
+			node: func() *ast.DropIndexNode {
+				return ast.NewDropIndex("idx_user_order").SetTable("audit.orders").SetIfExists().SetConcurrently()
+			},
+			want: "DROP INDEX CONCURRENTLY IF EXISTS \"audit\".\"idx_user_order\";\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			sql, err := postgres.NewWithCapabilities(tt.caps, tt.dialect).Render(tt.node())
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, tt.want)
+		})
+	}
+}

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -36,6 +36,12 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	var parts []string
 	parts = append(parts, "DROP INDEX")
 
+	// CONCURRENTLY precedes IF EXISTS in PostgreSQL's grammar:
+	// DROP INDEX CONCURRENTLY [ IF EXISTS ] name.
+	if node.Concurrently && r.capabilities().Has(capability.DropIndexConcurrently) {
+		parts = append(parts, "CONCURRENTLY")
+	}
+
 	if node.IfExists && r.capabilities().Has(capability.DropIndexIfExists) {
 		parts = append(parts, "IF EXISTS")
 	}

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -114,6 +114,7 @@ The supported attributes map to Ptah settings as follows:
 | `diff.skip.drop_table` | Drop-table suppression for local schema diff/apply planning |
 | `diff.skip.drop_schema` | Accepted and type-checked; Ptah's planner emits no schema drop for it to suppress |
 | `diff.concurrent_index.create` | PostgreSQL concurrent index creation where the command can execute without a surrounding transaction |
+| `diff.concurrent_index.drop` | PostgreSQL concurrent index removal for standalone index drops, capability-gated |
 | `env.schema.repo.name` | Accepted and type-checked; no local behavior, matching the community binary |
 
 `env.src` and `env.schema.src` accept either one string or a list of strings.
@@ -226,8 +227,18 @@ plans that actually emit `CREATE INDEX CONCURRENTLY`, Ptah requires
 `--tx-mode none` because PostgreSQL does not allow concurrent index creation
 inside a transaction. `ptah-compat migrate diff` splits mixed plans and tags
 concurrent-index files with `-- atlas:txmode none`, so replay executes those
-files outside a transaction. `diff.concurrent_index.drop` is rejected until
-Ptah implements matching concurrent drop semantics.
+files outside a transaction.
+
+`diff.concurrent_index.drop = true` maps to `DROP INDEX CONCURRENTLY` for
+standalone index removals, gated on the target's `drop_index_concurrently`
+capability. An index that is dropped and recreated under the same identity is a
+redefinition, not a standalone removal, and keeps the blocking drop the planner
+pairs with the rebuild. The setting governs the up direction only: the rollback
+of a concurrent index build is always emitted concurrently where the target
+supports it, because a blocking drop there would take the very write lock the
+build avoided. A non-dry-run PostgreSQL `schema apply` plan that emits
+`DROP INDEX CONCURRENTLY` requires `--tx-mode none` for the same reason the
+create side does.
 
 `lint.latest` and `lint.git` configure the migration changeset selected by
 `migrations lint` and `ptah-compat migrate lint`. These selectors are mutually

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -89,6 +89,7 @@ so typos fail fast. Current registry:
 | `enum_inline_column` | Enums are inline column types (MySQL/MariaDB `ENUM`, ClickHouse `Enum8/16`) |
 | `enum_custom_type` | Enums are separate named types (PostgreSQL `CREATE TYPE … AS ENUM`) |
 | `create_index_concurrently` | `CREATE [UNIQUE] INDEX CONCURRENTLY` (PostgreSQL; a compatibility no-op on CockroachDB) |
+| `drop_index_concurrently` | `DROP INDEX CONCURRENTLY` (PostgreSQL; disabled on the PostgreSQL-compatible presets that do not emit `CONCURRENTLY`) |
 | `create_or_replace_trigger` | Single-statement trigger replacement: `CREATE OR REPLACE TRIGGER` on PostgreSQL 14+/MariaDB and `CREATE OR ALTER TRIGGER` on SQL Server. Not available on MySQL |
 | `alter_generated_column_expression` | In-place `ALTER COLUMN SET EXPRESSION` for generated columns (PostgreSQL 17+) |
 | `row_level_security` | Row-level security policies (PostgreSQL) |
@@ -132,6 +133,7 @@ composed sets yourself.
 | `enum_inline_column` | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `enum_custom_type` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ❌ |
 | `create_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
+| `drop_index_concurrently` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `create_or_replace_trigger` | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ | ✅ | ❌ |
 | `alter_generated_column_expression` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |
 | `row_level_security` | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ | ✅ | ✅ | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | ❌ |

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -118,6 +118,7 @@ env:
 | `online_ddl.fallback` | Routing fallback policy: `error` or `plain` |
 | `diff.skip` | Destructive change kinds the planner omits from generated migrations (`drop_table`, `drop_column`, `drop_index`, `drop_enum`) |
 | `diff.concurrent_index` | Emit `CREATE INDEX CONCURRENTLY` for newly added indexes (PostgreSQL, capability-gated) |
+| `diff.concurrent_index_drop` | Emit `DROP INDEX CONCURRENTLY` for standalone index removals (PostgreSQL, capability-gated) |
 
 `migrate.generate.shadow_db` is also accepted as the older spelling for `dev`.
 When both are present, `dev` wins.
@@ -194,6 +195,7 @@ concurrent_index { ... } }` policy.
 diff:
   skip: [drop_table, drop_column, drop_index, drop_enum]
   concurrent_index: true
+  concurrent_index_drop: true
 ```
 
 **`diff.skip`** lists destructive change kinds to omit from the plan. A skipped
@@ -235,6 +237,17 @@ the target's capabilities: a PostgreSQL-compatible engine without concurrent
 index support keeps plain `CREATE INDEX`. Concurrent index builds cannot run
 inside a transaction, so the affected statements are split into a
 `+ptah no_transaction` migration file automatically.
+
+**`diff.concurrent_index_drop: true`** requests `DROP INDEX CONCURRENTLY` for
+standalone index removals, under the same capability gate and the same
+`+ptah no_transaction` split. An index that is dropped and recreated under the
+same identity is a redefinition rather than a standalone removal, and keeps the
+blocking drop the planner pairs with the rebuild.
+
+The setting governs the up direction only. The rollback of a concurrent index
+build is always emitted as `DROP INDEX CONCURRENTLY` where the target supports
+it, whatever this setting says: a blocking drop on rollback would take the very
+write lock the build was written to avoid.
 
 ## Precedence
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -284,6 +284,7 @@ type DiffConfig struct {
     DiffConfig holds Atlas diff policy blocks.
 
 func (c DiffConfig) ConcurrentIndexCreate() bool
+func (c DiffConfig) ConcurrentIndexDrop() bool
 func (c DiffConfig) SkipChangeKinds() []diffpolicy.ChangeKind
 
 ### go.5x5.cz/ptah/config/projectconfig.DiffSkipConfig
@@ -1874,6 +1875,14 @@ type DropIndexNode struct {
     Table string
     // IfExists indicates whether to use IF EXISTS clause
     IfExists bool
+    // Concurrently requests DROP INDEX CONCURRENTLY, PostgreSQL's non-blocking
+    // index removal. Renderers emit the keyword only when the target's
+    // capability set includes capability.DropIndexConcurrently; every other
+    // dialect ignores the flag. PostgreSQL rejects CONCURRENTLY inside a
+    // transaction block and rejects it for an index that backs a constraint, so
+    // planners set it only for standalone index drops the caller routes into a
+    // no_transaction migration.
+    Concurrently bool
     // Comment is an optional comment for the drop operation
     Comment string
 }
@@ -1886,6 +1895,7 @@ type DropIndexNode struct {
 func NewDropIndex(name string) *DropIndexNode
 func (n *DropIndexNode) Accept(visitor Visitor) error
 func (n *DropIndexNode) SetComment(comment string) *DropIndexNode
+func (n *DropIndexNode) SetConcurrently() *DropIndexNode
 func (n *DropIndexNode) SetIfExists() *DropIndexNode
 func (n *DropIndexNode) SetTable(table string) *DropIndexNode
 
@@ -6113,6 +6123,17 @@ type DiffPolicy struct {
     // index, superseding the populated-table heuristic. It remains gated on the
     // target's CreateIndexConcurrently capability.
     ConcurrentIndex bool
+    // ConcurrentIndexDrop requests DROP INDEX CONCURRENTLY for every standalone
+    // index removal, gated on the target's DropIndexConcurrently capability. An
+    // index that is dropped and recreated under the same identity is a
+    // redefinition, not a standalone removal, and keeps the blocking drop the
+    // planner already pairs with the rebuild.
+    //
+    // It does NOT govern the down direction: the rollback of a concurrent index
+    // build is always emitted concurrently where the target supports it,
+    // because a blocking drop there would undo the whole point of having built
+    // the index without a lock.
+    ConcurrentIndexDrop bool
 }
     DiffPolicy is the generator-level view of the project diff policy.
 
@@ -7778,6 +7799,14 @@ type Options struct {
     // exactly these table-qualified newly added indexes when the target
     // supports it.
     ConcurrentIndexRefs []types.IndexRef
+    // ConcurrentIndexDrops requests PostgreSQL DROP INDEX CONCURRENTLY for all
+    // standalone index removals when the target supports it. It is separate
+    // from ConcurrentIndexes so enabling concurrent index builds never silently
+    // rewrites a drop the caller did not ask for.
+    ConcurrentIndexDrops bool
+    // ConcurrentIndexDropRefs requests PostgreSQL DROP INDEX CONCURRENTLY for
+    // exactly these table-qualified removed indexes when the target supports it.
+    ConcurrentIndexDropRefs []types.IndexRef
     // SkipChangeKinds lists destructive change kinds the planner must omit from
     // the plan (emitting a clearly-marked comment in their place) instead of
     // deferring to the coarse destructive gate. Currently honored by the

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -120,6 +120,7 @@ env "local" {
 | `format.migrate.status` | Default `migrate status --format`. |
 | `diff.skip.drop_table` | Suppresses table drops in supported local diff/apply plans. |
 | `diff.concurrent_index.create` | Requests PostgreSQL concurrent index creation where transaction mode allows it. |
+| `diff.concurrent_index.drop` | Requests PostgreSQL `DROP INDEX CONCURRENTLY` for standalone index removals. |
 
 `migration.tx_mode` accepts `file`, `all`, or `none`. A migration's leading
 `atlas:txmode file` or `atlas:txmode none` header overrides global `file` or

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -283,9 +283,11 @@ objects are ignored rather than dropped.
 Disabled `schema.mode` values are mapped to the same resource-exclusion system
 for object kinds represented in Ptah's schema IR. `diff.skip.drop_table = true`
 removes table drops from supported local plans. For non-dry-run PostgreSQL
-`schema apply` plans that actually emit `CREATE INDEX CONCURRENTLY`,
-`diff.concurrent_index.create = true` requires `--tx-mode none`;
-`diff.concurrent_index.drop` fails explicitly. `diff.skip.drop_schema` is
+`schema apply` plans that actually emit a `CONCURRENTLY` index statement,
+`--tx-mode none` is required: `diff.concurrent_index.create = true` for
+`CREATE [UNIQUE] INDEX CONCURRENTLY`, and `diff.concurrent_index.drop = true`
+for `DROP INDEX CONCURRENTLY`. PostgreSQL rejects either inside a transaction
+block. `diff.skip.drop_schema` is
 accepted and type-checked, but changes no plan: Ptah's schema diff has no
 removed-schema list, so there is no `DROP SCHEMA` for the suppression to omit.
 

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -138,6 +138,20 @@ in `atlas.hcl` tags such files with the Atlas `-- atlas:txmode none` directive
 instead ([Atlas migrate commands](../../atlas/migrate-commands/)); the
 migrator honors both directives.
 
+## Concurrent index removal
+
+`DROP INDEX CONCURRENTLY` is the matching non-blocking removal, and it carries
+the same restriction: it cannot run inside a transaction block.
+
+The rollback of a concurrent index build always uses it where the target
+supports it, so the down file undoes a non-blocking build without taking the
+write lock the build avoided. For the up direction it is opt-in:
+`diff.concurrent_index_drop: true` in `ptah.yaml`, or
+`diff.concurrent_index.drop = true` in `atlas.hcl`, requests it for standalone
+index removals. An index that is dropped and recreated under the same identity
+is a redefinition rather than a standalone removal and keeps the blocking drop
+the planner pairs with the rebuild.
+
 ## Migration locking
 
 Migration runs serialize through a session-level advisory lock

--- a/docs/site/src/content/docs/reference/capabilities.md
+++ b/docs/site/src/content/docs/reference/capabilities.md
@@ -21,7 +21,7 @@ Capabilities answer questions that a dialect name alone cannot answer:
 - Are enums inline column types or standalone custom types?
   `enum_inline_column`, `enum_custom_type`
 - Can PostgreSQL-style concurrent indexes be emitted?
-  `create_index_concurrently`
+  `create_index_concurrently`, `drop_index_concurrently`
 - Does the target support roles, RLS, XML, or advisory locks?
   `role_management`, `row_level_security`, `xml_type`, `advisory_locks`
 - Does the target support foreign keys, and how is the referenced key backed?

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -115,16 +115,18 @@ the shadow rehearsal that `migrations down` performs before touching its target.
 | Safety and operations | `migration.pre_up_hook`, `migration.pg_dump_to`, `migration.webhook`, `migration.exec_order`, `migration.tx_mode` |
 | Lint defaults and policy | `lint.dialect`, `lint.disabled-rules`, `lint.latest`, `lint.git.base`, `lint.destructive.error`, `lint.concurrent_index.error` |
 | Online DDL | `online_ddl.tool`, `online_ddl.threshold_rows`, `online_ddl.args`, `online_ddl.fallback` |
-| Diff policy (native `migrations generate`) | `diff.skip: [drop_table, drop_column, drop_index, drop_enum]`, `diff.concurrent_index` |
+| Diff policy (native `migrations generate`) | `diff.skip: [drop_table, drop_column, drop_index, drop_enum]`, `diff.concurrent_index`, `diff.concurrent_index_drop` |
 | Atlas-compatible output | `format.schema.inspect`, `format.schema.apply`, `format.schema.clean`, `format.schema.diff`, `format.migrate.apply`, `format.migrate.diff`, `format.migrate.lint`, `format.migrate.status` |
-| Atlas-compatible diff policy | `diff.skip.drop_table`, `diff.concurrent_index.create` |
+| Atlas-compatible diff policy | `diff.skip.drop_table`, `diff.concurrent_index.create`, `diff.concurrent_index.drop` |
 
 The native `diff` block shapes what `ptah migrations generate` emits: `diff.skip`
 lists destructive change kinds (`drop_table`, `drop_column`, `drop_index`,
 `drop_enum`) to omit — a `-- SKIP: ...` comment is written in their place — and
 `diff.concurrent_index: true` requests `CREATE INDEX CONCURRENTLY` for new
-indexes (PostgreSQL, capability-gated). A skipped change is never emitted, so it
-never trips the `--check-destructive` gate. A selected environment's
+indexes (PostgreSQL, capability-gated), while
+`diff.concurrent_index_drop: true` requests `DROP INDEX CONCURRENTLY` for
+standalone index removals under the same gate. A skipped change is never
+emitted, so it never trips the `--check-destructive` gate. A selected environment's
 `diff.skip` replaces the top-level list; an explicit empty list clears all
 inherited skip kinds.
 

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -283,8 +283,9 @@ func planDiffFileContents(
 	opts DiffOptions,
 ) ([]MigrationFileContent, error) {
 	upNodes, err := planner.GenerateSchemaDiffASTWithOptions(diff, desired, info.Dialect, planner.Options{
-		Capabilities:      info.Capabilities,
-		ConcurrentIndexes: opts.Policy.ConcurrentIndexCreate,
+		Capabilities:         info.Capabilities,
+		ConcurrentIndexes:    opts.Policy.ConcurrentIndexCreate,
+		ConcurrentIndexDrops: opts.Policy.ConcurrentIndexDrop,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("generate migration SQL: %w", err)

--- a/internal/atlasmigrate/filecontent.go
+++ b/internal/atlasmigrate/filecontent.go
@@ -148,8 +148,16 @@ func splitNoTransactionPlanNodes(dialect string, nodes []ast.Node) (transactiona
 
 func nodesAreConcurrentIndexes(nodes []ast.Node) bool {
 	for _, node := range nodes {
-		index, ok := node.(*ast.IndexNode)
-		if !ok || !index.Concurrently {
+		switch typed := node.(type) {
+		case *ast.IndexNode:
+			if !typed.Concurrently {
+				return false
+			}
+		case *ast.DropIndexNode:
+			if !typed.Concurrently {
+				return false
+			}
+		default:
 			return false
 		}
 	}

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -179,8 +179,9 @@ func computeApplyPlan(
 	}
 
 	computation.statements, err = planner.GenerateSchemaDiffSQLStatementsWithOptions(diff, desired, info.Dialect, planner.Options{
-		Capabilities:      info.Capabilities,
-		ConcurrentIndexes: opts.Policy.ConcurrentIndexCreate,
+		Capabilities:         info.Capabilities,
+		ConcurrentIndexes:    opts.Policy.ConcurrentIndexCreate,
+		ConcurrentIndexDrops: opts.Policy.ConcurrentIndexDrop,
 	})
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("generate schema apply SQL: %w", err)

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -124,7 +124,8 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 	var statements []string
 	if diff.HasChanges() {
 		statements, err = planner.GenerateSchemaDiffSQLStatementsWithOptions(diff, to, dialect, planner.Options{
-			ConcurrentIndexes: opts.Policy.ConcurrentIndexCreate,
+			ConcurrentIndexes:    opts.Policy.ConcurrentIndexCreate,
+			ConcurrentIndexDrops: opts.Policy.ConcurrentIndexDrop,
 		})
 		if err != nil {
 			return atlasreport.SchemaDiff{}, fmt.Errorf("generate schema diff SQL: %w", err)

--- a/internal/atlasschema/diff_policy.go
+++ b/internal/atlasschema/diff_policy.go
@@ -12,6 +12,7 @@ import (
 type DiffPolicy struct {
 	SkipDropTable         bool
 	ConcurrentIndexCreate bool
+	ConcurrentIndexDrop   bool
 }
 
 // ApplyDiffPolicy returns a shallow copy of diff with supported Atlas diff

--- a/internal/planner/dialects/postgres/concurrent_index_drop_test.go
+++ b/internal/planner/dialects/postgres/concurrent_index_drop_test.go
@@ -1,0 +1,122 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+func indexRemovalFixture() (*types.SchemaDiff, *goschema.Database) {
+	diff := &types.SchemaDiff{IndexesRemoved: []types.IndexRef{
+		{Name: "idx_users_email", TableName: "users"},
+	}}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+	}
+	return diff, generated
+}
+
+// indexRedefinitionFixture drops and rebuilds the same index identity. The
+// planner pairs that drop with the rebuild, so it is not a standalone removal
+// and must never become concurrent: PostgreSQL would then need the pair split
+// across a transactional and a non-transactional file.
+func indexRedefinitionFixture() (*types.SchemaDiff, *goschema.Database) {
+	diff := &types.SchemaDiff{
+		IndexesAdded:   []types.IndexRef{{Name: "idx_users_email", TableName: "users"}},
+		IndexesRemoved: []types.IndexRef{{Name: "idx_users_email", TableName: "users"}},
+	}
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Indexes: []goschema.Index{
+			{Name: "idx_users_email", StructName: "User", Fields: []string{"email", "tenant"}},
+		},
+	}
+	return diff, generated
+}
+
+// TestPlanner_ConcurrentIndexDrops pins that DROP INDEX CONCURRENTLY needs BOTH
+// an explicit per-plan request AND capability.DropIndexConcurrently, and that
+// requesting concurrent BUILDS never rewrites a drop.
+//
+// If the planner change is reverted, every row prints
+// "DROP INDEX IF EXISTS idx_users_email;" and the three rows that want
+// CONCURRENTLY fail with `no substring match found`; the negative rows keep
+// passing, which is what makes the pair discriminating.
+func TestPlanner_ConcurrentIndexDrops(t *testing.T) {
+	removalRef := types.IndexRef{Name: "idx_users_email", TableName: "users"}
+
+	tests := []struct {
+		name    string
+		fixture func() (*types.SchemaDiff, *goschema.Database)
+		planner func() *postgres.Planner
+		want    string
+	}{
+		{
+			name:    "default policy stays blocking",
+			fixture: indexRemovalFixture,
+			planner: postgres.New,
+			want:    "DROP INDEX IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "blanket drop policy emits CONCURRENTLY",
+			fixture: indexRemovalFixture,
+			planner: func() *postgres.Planner { return postgres.New().WithConcurrentIndexDrops() },
+			want:    "DROP INDEX CONCURRENTLY IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "listed ref emits CONCURRENTLY",
+			fixture: indexRemovalFixture,
+			planner: func() *postgres.Planner { return postgres.New().WithConcurrentIndexDropRefs(removalRef) },
+			want:    "DROP INDEX CONCURRENTLY IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "unlisted ref stays blocking",
+			fixture: indexRemovalFixture,
+			planner: func() *postgres.Planner {
+				return postgres.New().WithConcurrentIndexDropRefs(types.IndexRef{Name: "idx_users_email", TableName: "orders"})
+			},
+			want: "DROP INDEX IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "concurrent builds do not rewrite drops",
+			fixture: indexRemovalFixture,
+			planner: func() *postgres.Planner { return postgres.New().WithConcurrentIndexes() },
+			want:    "DROP INDEX IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "capability withheld keeps the blocking drop",
+			fixture: indexRemovalFixture,
+			planner: func() *postgres.Planner {
+				caps := capability.Postgres16().With(capability.DropIndexConcurrently, false)
+				return postgres.NewWithCapabilities(caps).WithConcurrentIndexDrops()
+			},
+			want: "DROP INDEX IF EXISTS idx_users_email;",
+		},
+		{
+			name:    "redefinition keeps its paired blocking drop",
+			fixture: indexRedefinitionFixture,
+			planner: func() *postgres.Planner { return postgres.New().WithConcurrentIndexDrops() },
+			want:    "DROP INDEX IF EXISTS idx_users_email;",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff, generated := tt.fixture()
+
+			nodes, err := tt.planner().GenerateMigrationASTChecked(diff, generated)
+			c.Assert(err, qt.IsNil)
+			sql, err := renderer.RenderSQL("postgres", nodes...)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(legacyRenderedSQL(sql), qt.Contains, tt.want, qt.Commentf("got:\n%s", sql))
+		})
+	}
+}

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -85,6 +85,17 @@ type Planner struct {
 	// listed newly added indexes. Table-qualified identity lets the generator
 	// target one of two same-named indexes in different schemas.
 	concurrentIndexRefs map[types.IndexRef]struct{}
+	// concurrentIndexDrops requests DROP INDEX CONCURRENTLY for every standalone
+	// index removal. Like concurrentIndexes it is a POLICY choice and is gated
+	// on capability.DropIndexConcurrently.
+	concurrentIndexDrops bool
+	// concurrentIndexDropRefs requests DROP INDEX CONCURRENTLY only for the
+	// listed removed indexes. It is a SEPARATE set from concurrentIndexRefs on
+	// purpose: the two directions are chosen by different callers (a down file
+	// reverses a concurrent build; an up file honors an explicit drop policy),
+	// and folding them together would make a concurrent build silently rewrite
+	// unrelated drops in the same plan.
+	concurrentIndexDropRefs map[types.IndexRef]struct{}
 	// skip lists destructive change kinds this planner omits from the plan,
 	// emitting a clearly-marked comment in their place. See diffpolicy.
 	skip diffpolicy.SkipSet
@@ -164,6 +175,37 @@ func (p *Planner) WithConcurrentIndexRefs(indexRefs ...types.IndexRef) *Planner 
 	return &cp
 }
 
+// WithConcurrentIndexDrops returns a copy of the planner that emits
+// DROP INDEX CONCURRENTLY for every standalone index removal, provided the
+// target capability set includes capability.DropIndexConcurrently. The receiver
+// is not modified. An index that is dropped and recreated under the same
+// identity is a redefinition, not a standalone removal, and keeps the blocking
+// drop the planner pairs with the rebuild.
+func (p *Planner) WithConcurrentIndexDrops() *Planner {
+	cp := *p
+	cp.concurrentIndexDrops = true
+	return &cp
+}
+
+// WithConcurrentIndexDropRefs returns a copy of the planner that emits
+// DROP INDEX CONCURRENTLY only for the listed removed indexes, provided the
+// target capability set includes capability.DropIndexConcurrently. Concurrent
+// drops cannot run inside a transaction block; callers must arrange
+// no_transaction execution for such statements.
+func (p *Planner) WithConcurrentIndexDropRefs(indexRefs ...types.IndexRef) *Planner {
+	cp := *p
+	cp.concurrentIndexDropRefs = maps.Clone(p.concurrentIndexDropRefs)
+	if cp.concurrentIndexDropRefs == nil {
+		cp.concurrentIndexDropRefs = make(map[types.IndexRef]struct{}, len(indexRefs))
+	}
+	for _, ref := range indexRefs {
+		if strings.TrimSpace(ref.Name) != "" && strings.TrimSpace(ref.TableName) != "" {
+			cp.concurrentIndexDropRefs[ref] = struct{}{}
+		}
+	}
+	return &cp
+}
+
 // WithSkipChangeKinds returns a copy of the planner that omits the listed
 // destructive change kinds from the plan, emitting a clearly-marked comment in
 // their place instead of the DDL. The receiver is not modified. Passing no
@@ -186,6 +228,18 @@ func (p *Planner) usesConcurrentIndex(ref types.IndexRef) bool {
 		return true
 	}
 	_, ok := p.concurrentIndexRefs[ref]
+	return ok
+}
+
+// usesConcurrentIndexDrop reports whether this index removal should be emitted
+// as DROP INDEX CONCURRENTLY. The drop side has its own policy flag and its own
+// ref set, so turning on concurrent index BUILDS never rewrites a drop the
+// caller did not ask for.
+func (p *Planner) usesConcurrentIndexDrop(ref types.IndexRef) bool {
+	if p.concurrentIndexDrops {
+		return true
+	}
+	_, ok := p.concurrentIndexDropRefs[ref]
 	return ok
 }
 
@@ -906,6 +960,15 @@ func (p *Planner) removeIndexes(
 			SetTable(ref.TableName)
 		if guarded {
 			dropIndexNode.SetIfExists()
+		}
+		// CONCURRENTLY on a drop is opt-in policy AND capability-gated, exactly
+		// like the build side. A redefinition never reaches here (it is skipped
+		// above as an addition conflict), so a concurrent drop is always a
+		// standalone index removal — never the drop half of a rebuild and never
+		// an index backing a constraint, both of which PostgreSQL refuses to
+		// drop concurrently.
+		if p.usesConcurrentIndexDrop(ref) && p.capabilities().Has(capability.DropIndexConcurrently) {
+			dropIndexNode.SetConcurrently()
 		}
 		result = append(result, dropIndexNode)
 	}

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -37,7 +37,10 @@ func TestPlanGeneratedMigrationSpecs_ConcurrentIndexForPopulatedPostgresTable(t 
 	c.Assert(specs[0].UpSQL, qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
 	c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "+ptah lock_timeout")
 	c.Assert(specs[0].DownSQL, qt.Contains, "-- +ptah no_transaction")
-	c.Assert(specs[0].DownSQL, qt.Contains, `DROP INDEX IF EXISTS "idx_users_email";`)
+	// Reverting the concurrent-drop wiring prints
+	// `DROP INDEX IF EXISTS "idx_users_email";` here: the rollback of a
+	// non-blocking build would take the very write lock the build avoided.
+	c.Assert(specs[0].DownSQL, qt.Contains, `DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";`)
 }
 
 func TestPlanGeneratedMigrationSpecs_ConcurrentIndexRequiresPopulatedCapablePostgres(t *testing.T) {
@@ -126,7 +129,9 @@ func TestPlanGeneratedMigrationSpecs_SplitsTransactionalAndConcurrentIndex(t *te
 	c.Assert(specs[1].NoTransaction, qt.IsTrue)
 	c.Assert(specs[1].UpSQL, qt.Contains, "-- +ptah no_transaction")
 	c.Assert(specs[1].UpSQL, qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`)
-	c.Assert(specs[1].DownSQL, qt.Contains, `DROP INDEX IF EXISTS "idx_users_email";`)
+	// Reverting the concurrent-drop wiring prints
+	// `DROP INDEX IF EXISTS "idx_users_email";` here.
+	c.Assert(specs[1].DownSQL, qt.Contains, `DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";`)
 }
 
 func TestPlanGeneratedMigrationSpecs_SplitsPopulatedAndEmptyTableIndexes(t *testing.T) {
@@ -213,6 +218,148 @@ func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
 	c.Assert(files.Files[0].Version < files.Files[1].Version, qt.IsTrue)
 	c.Assert(strings.HasSuffix(files.Files[0].UpFile, "100_transactional.up.sql"), qt.IsTrue)
 	c.Assert(strings.HasSuffix(files.Files[1].UpFile, "101_concurrent_indexes.up.sql"), qt.IsTrue)
+}
+
+// TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropPolicy pins the UP
+// direction of the drop policy: a standalone index removal becomes
+// non-blocking only when the project asks for it, and the resulting statement
+// is routed into its own no_transaction migration because PostgreSQL rejects
+// DROP INDEX CONCURRENTLY inside a transaction block.
+//
+// With the change reverted the "policy on" row prints
+// `DROP INDEX IF EXISTS "idx_users_email";` with NoTransaction false, so it
+// becomes indistinguishable from the "policy off" row.
+func TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropPolicy(t *testing.T) {
+	tests := []struct {
+		name              string
+		policy            DiffPolicy
+		info              dbschematypes.DBInfo
+		wantNoTransaction bool
+		wantUpSQL         string
+		wantDownSQL       string
+	}{
+		{
+			name:              "policy off keeps the blocking drop",
+			policy:            DiffPolicy{},
+			info:              postgresInfo(capability.Postgres16()),
+			wantNoTransaction: false,
+			wantUpSQL:         `DROP INDEX IF EXISTS "idx_users_email";`,
+			wantDownSQL:       `CREATE INDEX IF NOT EXISTS "idx_users_email" ON "users" ("email");`,
+		},
+		{
+			name:              "policy on drops concurrently and rebuilds concurrently",
+			policy:            DiffPolicy{ConcurrentIndexDrop: true},
+			info:              postgresInfo(capability.Postgres16()),
+			wantNoTransaction: true,
+			wantUpSQL:         `DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";`,
+			wantDownSQL:       `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_users_email" ON "users" ("email");`,
+		},
+		{
+			name:              "capability withheld keeps the blocking drop",
+			policy:            DiffPolicy{ConcurrentIndexDrop: true},
+			info:              postgresInfo(capability.Postgres16().With(capability.DropIndexConcurrently, false)),
+			wantNoTransaction: false,
+			wantUpSQL:         `DROP INDEX IF EXISTS "idx_users_email";`,
+			wantDownSQL:       `CREATE INDEX IF NOT EXISTS "idx_users_email" ON "users" ("email");`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			specs, _, err := planGeneratedMigrationSpecs(
+				indexRemovalOnlyDiff(),
+				indexOnlyGeneratedSchema(),
+				indexRemovalDBSchema(),
+				tt.info,
+				100,
+				"drop_user_email_index",
+				tt.policy,
+				atlasmigrate.Qualifier{},
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(specs, qt.HasLen, 1)
+			c.Assert(specs[0].NoTransaction, qt.Equals, tt.wantNoTransaction)
+			c.Assert(specs[0].UpSQL, qt.Contains, tt.wantUpSQL)
+			c.Assert(specs[0].DownSQL, qt.Contains, tt.wantDownSQL)
+		})
+	}
+}
+
+// TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropSplitsFromTransactional
+// pins the file split: a concurrent drop cannot share a file with a statement
+// that needs the transaction, so it gets its own migration.
+//
+// With the change reverted this test fails at the first assertion with
+// "specs has len 1, want 2" — the drop stays blocking and everything fits in a
+// single transactional migration.
+func TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropSplitsFromTransactional(t *testing.T) {
+	c := qt.New(t)
+
+	diff := indexRemovalOnlyDiff()
+	diff.TablesAdded = []string{"posts"}
+	generated := indexOnlyGeneratedSchema()
+	generated.Tables = append(generated.Tables, goschema.Table{StructName: "Post", Name: "posts"})
+	generated.Fields = append(generated.Fields, goschema.Field{
+		StructName: "Post",
+		Name:       "id",
+		Type:       "SERIAL",
+		Primary:    true,
+		AutoInc:    true,
+	})
+
+	specs, _, err := planGeneratedMigrationSpecs(
+		diff,
+		generated,
+		indexRemovalDBSchema(),
+		postgresInfo(capability.Postgres16()),
+		100,
+		"add_posts_drop_index",
+		DiffPolicy{ConcurrentIndexDrop: true},
+		atlasmigrate.Qualifier{},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(specs, qt.HasLen, 2)
+	c.Assert(specs[0].Name, qt.Equals, "add_posts_drop_index_transactional")
+	c.Assert(specs[0].NoTransaction, qt.IsFalse)
+	c.Assert(specs[0].UpSQL, qt.Contains, `CREATE TABLE "posts"`)
+	c.Assert(specs[0].UpSQL, qt.Not(qt.Contains), "idx_users_email")
+
+	c.Assert(specs[1].Name, qt.Equals, "add_posts_drop_index_concurrent_indexes")
+	c.Assert(specs[1].NoTransaction, qt.IsTrue)
+	c.Assert(specs[1].UpSQL, qt.Contains, "-- +ptah no_transaction")
+	c.Assert(specs[1].UpSQL, qt.Contains, `DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";`)
+	c.Assert(specs[1].UpSQL, qt.Not(qt.Contains), `CREATE TABLE "posts"`)
+}
+
+// indexRemovalDBSchema is the pre-change database state a removal is planned
+// against: the index the migration drops still exists, so the down direction
+// can rebuild it.
+func indexRemovalDBSchema() *dbschematypes.DBSchema {
+	return &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name:          "users",
+			Type:          "BASE TABLE",
+			EstimatedRows: 10,
+			Columns: []dbschematypes.DBColumn{
+				{Name: "email", DataType: "text", UDTName: "text", IsNullable: "YES", OrdinalPosition: 1},
+			},
+		}},
+		Indexes: []dbschematypes.DBIndex{{
+			Name:      "idx_users_email",
+			TableName: "users",
+			Columns:   []string{"email"},
+		}},
+	}
+}
+
+func indexRemovalOnlyDiff() *types.SchemaDiff {
+	return &types.SchemaDiff{IndexesRemoved: []types.IndexRef{
+		{Name: "idx_users_email", TableName: "users"},
+	}}
 }
 
 func indexOnlyDiff() *types.SchemaDiff {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -30,6 +30,7 @@ import (
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/fsnapshot"
+	"go.5x5.cz/ptah/internal/indexscope"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/internal/pathguard"
@@ -115,6 +116,17 @@ type DiffPolicy struct {
 	// index, superseding the populated-table heuristic. It remains gated on the
 	// target's CreateIndexConcurrently capability.
 	ConcurrentIndex bool
+	// ConcurrentIndexDrop requests DROP INDEX CONCURRENTLY for every standalone
+	// index removal, gated on the target's DropIndexConcurrently capability. An
+	// index that is dropped and recreated under the same identity is a
+	// redefinition, not a standalone removal, and keeps the blocking drop the
+	// planner already pairs with the rebuild.
+	//
+	// It does NOT govern the down direction: the rollback of a concurrent index
+	// build is always emitted concurrently where the target supports it,
+	// because a blocking drop there would undo the whole point of having built
+	// the index without a lock.
+	ConcurrentIndexDrop bool
 }
 
 // MigrationFilePair represents one generated up/down migration file pair.
@@ -599,9 +611,11 @@ func planGeneratedMigrationSpecs(
 	}
 
 	concurrentIndexRefs := concurrentIndexRefsForPolicy(diff, dbSchema, info, policy)
+	concurrentIndexDropRefs := concurrentIndexDropRefsForPolicy(diff, info, policy)
 	plannerOpts := planner.Options{
-		Capabilities:        info.Capabilities,
-		ConcurrentIndexRefs: concurrentIndexRefs,
+		Capabilities:            info.Capabilities,
+		ConcurrentIndexRefs:     concurrentIndexRefs,
+		ConcurrentIndexDropRefs: concurrentIndexDropRefs,
 	}
 	upNodes, err := planner.GenerateSchemaDiffASTWithOptions(diff, generated, info.Dialect, plannerOpts)
 	if err != nil {
@@ -631,16 +645,17 @@ func planGeneratedMigrationSpecs(
 	nodeGroups := splitNoTransactionNodes(info.Dialect, upNodes)
 	if len(nodeGroups.transactional) == 0 {
 		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
-			Diff:                diff,
-			Qualifier:           qualifier,
-			Generated:           generated,
-			DBSchema:            dbSchema,
-			Dialect:             info.Dialect,
-			Capabilities:        info.Capabilities,
-			Version:             version,
-			Name:                migrationName,
-			ConcurrentIndexRefs: concurrentIndexRefs,
-			NoTransaction:       true,
+			Diff:                    diff,
+			Qualifier:               qualifier,
+			Generated:               generated,
+			DBSchema:                dbSchema,
+			Dialect:                 info.Dialect,
+			Capabilities:            info.Capabilities,
+			Version:                 version,
+			Name:                    migrationName,
+			ConcurrentIndexRefs:     concurrentIndexRefs,
+			ConcurrentIndexDropRefs: concurrentIndexDropRefs,
+			NoTransaction:           true,
 		})
 		if err != nil || spec.UpSQL == "" {
 			return nil, assessments, err
@@ -651,7 +666,7 @@ func planGeneratedMigrationSpecs(
 		return nil, nil, fmt.Errorf("generated migration mixes transactional statements with non-transactional statements that cannot be split automatically")
 	}
 
-	diffGroups := splitConcurrentIndexDiff(diff, concurrentIndexRefs)
+	diffGroups := splitConcurrentIndexDiff(diff, concurrentIndexRefs, concurrentIndexDropRefs)
 	specs := make([]generatedMigrationSpec, 0, 2)
 	allAssessments := make([]safety.StatementAssessment, 0)
 	if diffGroups.transactional.HasChanges() {
@@ -676,16 +691,17 @@ func planGeneratedMigrationSpecs(
 	}
 	if diffGroups.noTransaction.HasChanges() {
 		spec, assessments, err := buildGeneratedMigrationSpec(generatedMigrationSpecOptions{
-			Diff:                diffGroups.noTransaction,
-			Qualifier:           qualifier,
-			Generated:           generated,
-			DBSchema:            dbSchema,
-			Dialect:             info.Dialect,
-			Capabilities:        info.Capabilities,
-			Version:             version,
-			Name:                migrationName + "_concurrent_indexes",
-			ConcurrentIndexRefs: concurrentIndexRefs,
-			NoTransaction:       true,
+			Diff:                    diffGroups.noTransaction,
+			Qualifier:               qualifier,
+			Generated:               generated,
+			DBSchema:                dbSchema,
+			Dialect:                 info.Dialect,
+			Capabilities:            info.Capabilities,
+			Version:                 version,
+			Name:                    migrationName + "_concurrent_indexes",
+			ConcurrentIndexRefs:     concurrentIndexRefs,
+			ConcurrentIndexDropRefs: concurrentIndexDropRefs,
+			NoTransaction:           true,
 		})
 		if err != nil {
 			return nil, nil, err
@@ -717,22 +733,24 @@ func withSkipComments(specs []generatedMigrationSpec, skipped []diffpolicy.Skipp
 }
 
 type generatedMigrationSpecOptions struct {
-	Diff                *types.SchemaDiff
-	Generated           *goschema.Database
-	DBSchema            *dbschematypes.DBSchema
-	Dialect             string
-	Capabilities        capability.Capabilities
-	Version             int64
-	Name                string
-	ConcurrentIndexRefs []types.IndexRef
-	NoTransaction       bool
-	Qualifier           atlasmigrate.Qualifier
+	Diff                    *types.SchemaDiff
+	Generated               *goschema.Database
+	DBSchema                *dbschematypes.DBSchema
+	Dialect                 string
+	Capabilities            capability.Capabilities
+	Version                 int64
+	Name                    string
+	ConcurrentIndexRefs     []types.IndexRef
+	ConcurrentIndexDropRefs []types.IndexRef
+	NoTransaction           bool
+	Qualifier               atlasmigrate.Qualifier
 }
 
 func buildGeneratedMigrationSpec(opts generatedMigrationSpecOptions) (generatedMigrationSpec, []safety.StatementAssessment, error) {
 	plannerOpts := planner.Options{
-		Capabilities:        opts.Capabilities,
-		ConcurrentIndexRefs: opts.ConcurrentIndexRefs,
+		Capabilities:            opts.Capabilities,
+		ConcurrentIndexRefs:     opts.ConcurrentIndexRefs,
+		ConcurrentIndexDropRefs: opts.ConcurrentIndexDropRefs,
 	}
 	upNodes, err := planner.GenerateSchemaDiffASTWithOptions(opts.Diff, opts.Generated, opts.Dialect, plannerOpts)
 	if err != nil {
@@ -761,7 +779,18 @@ func buildGeneratedMigrationSpec(opts generatedMigrationSpecOptions) (generatedM
 	// so the down migration reverses only what the up migration actually did: a
 	// skipped destructive change is absent from the diff, so its inverse (e.g. a
 	// CREATE TABLE that would collide with the kept table) is never emitted.
-	downSQL, err := generateDownMigrationSQLQualified(opts.Diff, opts.Generated, opts.DBSchema, opts.Dialect, directiveOpts, opts.Qualifier, opts.Capabilities)
+	// The rollback of a concurrent build must itself be non-blocking, so the
+	// two ref sets swap with the direction: an index the up file BUILT
+	// concurrently is DROPPED concurrently by the down file, and an index the
+	// up file DROPPED concurrently is REBUILT concurrently.
+	downOpts := downMigrationOptions{
+		directives:              directiveOpts,
+		qualifier:               opts.Qualifier,
+		capabilities:            opts.Capabilities,
+		concurrentIndexRefs:     opts.ConcurrentIndexDropRefs,
+		concurrentIndexDropRefs: opts.ConcurrentIndexRefs,
+	}
+	downSQL, err := generateDownMigrationSQLQualified(opts.Diff, opts.Generated, opts.DBSchema, opts.Dialect, downOpts)
 	if err != nil {
 		return generatedMigrationSpec{}, nil, fmt.Errorf("error generating down migration SQL: %w", err)
 	}
@@ -819,12 +848,25 @@ func splitNoTransactionNodes(dialect string, nodes []ast.Node) splitMigrationNod
 
 func allNoTransactionNodesAreConcurrentIndexes(nodes []ast.Node) bool {
 	for _, node := range nodes {
-		index, ok := node.(*ast.IndexNode)
-		if !ok || !index.Concurrently {
+		if !isConcurrentIndexNode(node) {
 			return false
 		}
 	}
 	return true
+}
+
+// isConcurrentIndexNode reports whether a node is one of the two concurrent
+// index statements the generator knows how to split into its own
+// no_transaction migration.
+func isConcurrentIndexNode(node ast.Node) bool {
+	switch typed := node.(type) {
+	case *ast.IndexNode:
+		return typed.Concurrently
+	case *ast.DropIndexNode:
+		return typed.Concurrently
+	default:
+		return false
+	}
 }
 
 // concurrentIndexRefsForPolicy resolves which newly added indexes are built
@@ -844,6 +886,43 @@ func concurrentIndexRefsForPolicy(
 		return nil
 	}
 	return diff.IndexAdditions()
+}
+
+// concurrentIndexDropRefsForPolicy resolves which index removals are dropped
+// concurrently in the UP direction. Unlike builds there is no populated-table
+// heuristic: a concurrent drop happens only when the project asks for one, so
+// the default output is byte-identical to before this policy existed.
+//
+// A removal that is also an addition under the same identity is a redefinition
+// whose drop the planner pairs with the rebuild; it is excluded here so the
+// pair is never split across a transactional and a non-transactional file.
+func concurrentIndexDropRefsForPolicy(
+	diff *types.SchemaDiff,
+	info dbschematypes.DBInfo,
+	policy DiffPolicy,
+) []types.IndexRef {
+	if !policy.ConcurrentIndexDrop {
+		return nil
+	}
+	if !platform.IsPostgresFamily(info.Dialect) || !info.Capabilities.Has(capability.DropIndexConcurrently) {
+		return nil
+	}
+	// Match the planner's own redefinition test (indexscope conflict semantics),
+	// not plain struct equality: two refs differing only in identifier case are
+	// the same index on a case-insensitive target, and treating them as distinct
+	// here would route a rebuild's drop into the wrong migration file.
+	additions := indexscope.NewConflictSetWithSemantics(
+		diff.EffectiveIdentifierSemantics(info.Dialect),
+		diff.IndexAdditions(),
+	)
+	var refs []types.IndexRef
+	for _, ref := range diff.IndexRemovals() {
+		if additions.Contains(ref) {
+			continue
+		}
+		refs = append(refs, ref)
+	}
+	return refs
 }
 
 func concurrentIndexRefsForPopulatedTables(
@@ -889,24 +968,40 @@ type splitSchemaDiffs struct {
 func splitConcurrentIndexDiff(
 	diff *types.SchemaDiff,
 	concurrentIndexRefs []types.IndexRef,
+	concurrentIndexDropRefs []types.IndexRef,
 ) splitSchemaDiffs {
-	concurrent := indexRefSet(concurrentIndexRefs)
 	txDiff := cloneSchemaDiff(diff)
 	noTxDiff := &types.SchemaDiff{
 		IdentifierSemantics: cloneIdentifierSemantics(diff.IdentifierSemantics),
 	}
-	var transactionalRefs []types.IndexRef
-	var noTransactionRefs []types.IndexRef
-	for _, resolved := range diff.IndexAdditions() {
-		if _, ok := concurrent[resolved]; ok {
-			noTransactionRefs = append(noTransactionRefs, resolved)
+	addTx, addNoTx := partitionIndexRefs(diff.IndexAdditions(), concurrentIndexRefs)
+	txDiff.SetIndexAdditions(addTx)
+	noTxDiff.SetIndexAdditions(addNoTx)
+
+	// Only rewrite the removal lists when something actually moves. SetIndexRemovals
+	// re-sorts, so calling it unconditionally would reorder the drops in every
+	// existing split migration for no reason.
+	if len(concurrentIndexDropRefs) > 0 {
+		dropTx, dropNoTx := partitionIndexRefs(diff.IndexRemovals(), concurrentIndexDropRefs)
+		txDiff.SetIndexRemovals(dropTx)
+		noTxDiff.SetIndexRemovals(dropNoTx)
+	}
+	return splitSchemaDiffs{transactional: txDiff, noTransaction: noTxDiff}
+}
+
+// partitionIndexRefs splits refs into the ones that stay in the transactional
+// migration and the ones that move to the no_transaction migration, preserving
+// the input order within each group so file contents stay deterministic.
+func partitionIndexRefs(refs, selected []types.IndexRef) (transactional, noTransaction []types.IndexRef) {
+	set := indexRefSet(selected)
+	for _, ref := range refs {
+		if _, ok := set[ref]; ok {
+			noTransaction = append(noTransaction, ref)
 			continue
 		}
-		transactionalRefs = append(transactionalRefs, resolved)
+		transactional = append(transactional, ref)
 	}
-	txDiff.SetIndexAdditions(transactionalRefs)
-	noTxDiff.SetIndexAdditions(noTransactionRefs)
-	return splitSchemaDiffs{transactional: txDiff, noTransaction: noTxDiff}
+	return transactional, noTransaction
 }
 
 func indexRefSet(values []types.IndexRef) map[types.IndexRef]struct{} {
@@ -1087,7 +1182,24 @@ func generateDownMigrationSQLWithOptions(
 	directiveOpts generatedDirectiveOptions,
 	capsOverride ...capability.Capabilities,
 ) (string, error) {
-	return generateDownMigrationSQLQualified(diff, generated, dbSchema, dialect, directiveOpts, atlasmigrate.Qualifier{}, capsOverride...)
+	opts := downMigrationOptions{directives: directiveOpts}
+	if len(capsOverride) > 0 {
+		opts.capabilities = capsOverride[0]
+	}
+	return generateDownMigrationSQLQualified(diff, generated, dbSchema, dialect, opts)
+}
+
+// downMigrationOptions carries the down-direction planning inputs that vary per
+// caller. A nil capabilities set means "the dialect default preset".
+type downMigrationOptions struct {
+	directives   generatedDirectiveOptions
+	qualifier    atlasmigrate.Qualifier
+	capabilities capability.Capabilities
+	// concurrentIndexRefs and concurrentIndexDropRefs are expressed in DOWN
+	// direction terms: they name indexes the down file builds and drops, which
+	// are the mirror image of the up file's own two sets.
+	concurrentIndexRefs     []types.IndexRef
+	concurrentIndexDropRefs []types.IndexRef
 }
 
 func generateDownMigrationSQLQualified(
@@ -1095,10 +1207,9 @@ func generateDownMigrationSQLQualified(
 	generated *goschema.Database,
 	dbSchema *dbschematypes.DBSchema,
 	dialect string,
-	directiveOpts generatedDirectiveOptions,
-	qualifier atlasmigrate.Qualifier,
-	capsOverride ...capability.Capabilities,
+	opts downMigrationOptions,
 ) (string, error) {
+	directiveOpts := opts.directives
 	// For down migrations, we need to use the current database schema as the "generated" schema
 	// since we're reverting back to the current state
 	dbAsGoSchema := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
@@ -1111,11 +1222,12 @@ func generateDownMigrationSQLQualified(
 	reverseDiff := reverseSchemaDiffWithSchema(diff, generated, dbSchema)
 	addMySQLFamilyForeignKeyBackingIndexRemovals(reverseDiff, diff, dbSchema, dialect)
 
-	caps := capability.ForDialect(dialect)
-	if len(capsOverride) > 0 {
-		caps = capsOverride[0]
+	plannerOpts := planner.Options{
+		Capabilities:            opts.capabilities,
+		ConcurrentIndexRefs:     opts.concurrentIndexRefs,
+		ConcurrentIndexDropRefs: opts.concurrentIndexDropRefs,
 	}
-	statements, err := planDownMigrationStatements(reverseDiff, dbAsGoSchema, dialect, caps, qualifier)
+	statements, err := planDownMigrationStatements(reverseDiff, dbAsGoSchema, dialect, plannerOpts, opts.qualifier)
 	if err != nil {
 		return "", err
 	}
@@ -1142,24 +1254,24 @@ func planDownMigrationStatements(
 	reverseDiff *types.SchemaDiff,
 	dbAsGoSchema *goschema.Database,
 	dialect string,
-	caps capability.Capabilities,
+	plannerOpts planner.Options,
 	qualifier atlasmigrate.Qualifier,
 ) ([]string, error) {
 	if qualifier.IsZero() {
-		statements, err := planner.GenerateSchemaDiffSQLStatementsWithCapabilities(reverseDiff, dbAsGoSchema, dialect, caps)
+		statements, err := planner.GenerateSchemaDiffSQLStatementsWithOptions(reverseDiff, dbAsGoSchema, dialect, plannerOpts)
 		if err != nil {
 			return nil, fmt.Errorf("error generating down migration SQL: %w", err)
 		}
 		return statements, nil
 	}
-	nodes, err := planner.GenerateSchemaDiffASTWithOptions(reverseDiff, dbAsGoSchema, dialect, planner.Options{Capabilities: caps})
+	nodes, err := planner.GenerateSchemaDiffASTWithOptions(reverseDiff, dbAsGoSchema, dialect, plannerOpts)
 	if err != nil {
 		return nil, fmt.Errorf("error generating down migration SQL: %w", err)
 	}
 	if err := qualifier.ApplyToPlan(dialect, dbAsGoSchema, nodes); err != nil {
 		return nil, err
 	}
-	output, err := renderer.RenderSQLWithCapabilities(dialect, caps, nodes...)
+	output, err := renderer.RenderSQLWithCapabilities(dialect, plannerOpts.CapabilitiesFor(dialect), nodes...)
 	if err != nil {
 		return nil, fmt.Errorf("error generating down migration SQL: %w", err)
 	}

--- a/migration/generator/index_refs_internal_test.go
+++ b/migration/generator/index_refs_internal_test.go
@@ -29,7 +29,7 @@ func TestSplitConcurrentIndexDiff_PreservesTableQualifiedIdentity(t *testing.T) 
 	})
 	got := splitConcurrentIndexDiff(diff, []types.IndexRef{
 		{Name: "idx_shared", TableName: "users"},
-	})
+	}, nil)
 
 	c.Assert(got.transactional.IndexAdditions(), qt.DeepEquals, []types.IndexRef{
 		{Name: "idx_shared", TableName: "orders"},
@@ -180,7 +180,7 @@ func TestIndexTransforms_PreserveIdentifierSemantics(t *testing.T) {
 
 	cloned := cloneSchemaDiff(diff)
 	reversed := reverseSchemaDiffWithSchema(diff, nil, nil)
-	split := splitConcurrentIndexDiff(diff, diff.IndexAdditions())
+	split := splitConcurrentIndexDiff(diff, diff.IndexAdditions(), nil)
 
 	c.Assert(cloned.IdentifierSemantics, qt.DeepEquals, &semantics)
 	c.Assert(reversed.IdentifierSemantics, qt.DeepEquals, &semantics)

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -368,6 +368,13 @@ func TestLintFS_AtlasAnalyzerCatalogHazards(t *testing.T) {
 		{"add non-nullable column without default", "postgres", "ALTER TABLE t ADD COLUMN c INT NOT NULL;", []string{"DD101"}},
 		{"add unique constraint", "postgres", "ALTER TABLE t ADD CONSTRAINT u UNIQUE (email);", []string{"PG105"}},
 		{"drop index without concurrently", "postgres", "DROP INDEX idx;", []string{"PG106"}},
+		// The discriminating partner for the row above: PG106 must stay silent
+		// on the spelling Ptah now generates for a concurrent-index rollback.
+		// Without this row a rule that fired on every DROP INDEX would still
+		// pass the table. PG103 is the correct residual finding — this fixture
+		// has no no_transaction directive, and CONCURRENTLY cannot run inside
+		// the migration transaction.
+		{"drop index concurrently", "postgres", "DROP INDEX CONCURRENTLY idx;", []string{"PG103"}},
 		{"add primary key", "postgres", "ALTER TABLE t ADD PRIMARY KEY (id);", []string{"PG104"}},
 		{"volatile default", "postgres", "ALTER TABLE t ADD COLUMN c UUID DEFAULT gen_random_uuid();", []string{"PG302"}},
 		{"set not null", "postgres", "ALTER TABLE t ALTER COLUMN c SET NOT NULL;", []string{"PG303"}},

--- a/migration/planner/planner.go
+++ b/migration/planner/planner.go
@@ -165,6 +165,14 @@ type Options struct {
 	// exactly these table-qualified newly added indexes when the target
 	// supports it.
 	ConcurrentIndexRefs []types.IndexRef
+	// ConcurrentIndexDrops requests PostgreSQL DROP INDEX CONCURRENTLY for all
+	// standalone index removals when the target supports it. It is separate
+	// from ConcurrentIndexes so enabling concurrent index builds never silently
+	// rewrites a drop the caller did not ask for.
+	ConcurrentIndexDrops bool
+	// ConcurrentIndexDropRefs requests PostgreSQL DROP INDEX CONCURRENTLY for
+	// exactly these table-qualified removed indexes when the target supports it.
+	ConcurrentIndexDropRefs []types.IndexRef
 	// SkipChangeKinds lists destructive change kinds the planner must omit from
 	// the plan (emitting a clearly-marked comment in their place) instead of
 	// deferring to the coarse destructive gate. Currently honored by the
@@ -334,9 +342,13 @@ func registerPostgresFamilyPlanner(dialect string) error {
 	return registerPlannerFactory(dialect, func(opts Options) Planner {
 		plan := postgres.NewForDialect(dialect, opts.CapabilitiesFor(dialect)).
 			WithConcurrentIndexRefs(opts.ConcurrentIndexRefs...).
+			WithConcurrentIndexDropRefs(opts.ConcurrentIndexDropRefs...).
 			WithSkipChangeKinds(opts.SkipChangeKinds...)
 		if opts.ConcurrentIndexes {
-			return plan.WithConcurrentIndexes()
+			plan = plan.WithConcurrentIndexes()
+		}
+		if opts.ConcurrentIndexDrops {
+			plan = plan.WithConcurrentIndexDrops()
 		}
 		return plan
 	})
@@ -513,6 +525,12 @@ func NodeRequiresNoTransaction(dialect string, node ast.Node) bool {
 	}
 	if index, ok := node.(*ast.IndexNode); ok {
 		return index.Concurrently
+	}
+	// DROP INDEX CONCURRENTLY is rejected inside a transaction block exactly as
+	// CREATE INDEX CONCURRENTLY is, so it must reach the same no_transaction
+	// routing rather than being wrapped and failing at execution time.
+	if dropIndex, ok := node.(*ast.DropIndexNode); ok {
+		return dropIndex.Concurrently
 	}
 	alterType, ok := node.(*ast.AlterTypeNode)
 	if !ok {

--- a/migration/planner/planner_test.go
+++ b/migration/planner/planner_test.go
@@ -207,6 +207,48 @@ func TestRequiresNoTransaction(t *testing.T) {
 	c.Assert(planner.RequiresNoTransaction(platform.Postgres, []ast.Node{ast.NewComment("noop")}), qt.IsFalse)
 }
 
+// TestRequiresNoTransaction_ConcurrentIndexDrop pins that a concurrent index
+// DROP is routed out of the per-migration transaction, exactly as a concurrent
+// index BUILD already is. Reverting the classifier change prints
+// "values are not equal: false != true" for the concurrent postgres row, and
+// the migrator would then wrap a statement PostgreSQL refuses to run in a
+// transaction block.
+func TestRequiresNoTransaction_ConcurrentIndexDrop(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		node    func() ast.Node
+		want    bool
+	}{
+		{
+			name:    "concurrent drop on postgres",
+			dialect: platform.Postgres,
+			node:    func() ast.Node { return ast.NewDropIndex("idx").SetTable("users").SetConcurrently() },
+			want:    true,
+		},
+		{
+			name:    "blocking drop on postgres",
+			dialect: platform.Postgres,
+			node:    func() ast.Node { return ast.NewDropIndex("idx").SetTable("users") },
+			want:    false,
+		},
+		{
+			name:    "concurrent drop outside the postgres family",
+			dialect: platform.MySQL,
+			node:    func() ast.Node { return ast.NewDropIndex("idx").SetTable("users").SetConcurrently() },
+			want:    false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(planner.RequiresNoTransaction(tt.dialect, []ast.Node{tt.node()}), qt.Equals, tt.want)
+		})
+	}
+}
+
 type externalPlanner struct {
 	caps capability.Capabilities
 }


### PR DESCRIPTION
Refs #997 — workstream 1 of the five that #997 retained after #1101 was split out and fixed by #1104.

`DROP INDEX CONCURRENTLY` had no representation anywhere in Ptah: not in the AST, not in the capability registry, not in any renderer. Two things followed from that. The down file of a concurrent index build took the write lock the build was written to avoid, and `atlas.hcl diff.concurrent_index.drop` was refused outright.

## Reproduction

### Live, postgres:16-alpine, own container on port 55997 (removed afterwards)

`members(id serial, email text)`, 5000 rows, `ANALYZE`d, model adds `idx_members_email`, then `ptah migrations generate` → `up` → `down`.

**Before** (`f22107bd`, the branch point):

```
1786003811_add_email_index.up.sql
  -- +ptah no_transaction
  CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");
1786003811_add_email_index.down.sql
  -- +ptah no_transaction
  DROP INDEX IF EXISTS "idx_members_email";        <-- blocking
```

**After:**

```
1786003793_add_email_index.up.sql
  -- +ptah no_transaction
  CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");
1786003793_add_email_index.down.sql
  -- +ptah no_transaction
  DROP INDEX CONCURRENTLY IF EXISTS "idx_members_email";
```

`migrations up` exit=0, index built and `indisvalid = t`; `migrations down --confirm` exit=0, logged as `Rolled back non-transactional migration`, index gone.

Positive control, same script, same run, table left **empty**: both directions stay blocking and the file carries no `no_transaction` directive, before and after. Without that control the probe would only be showing that Ptah prints `CONCURRENTLY` unconditionally.

### `atlas.hcl diff.concurrent_index.drop`

One `atlas.hcl`, three envs, `ptah-compat schema diff`:

| env | before | after |
| --- | --- | --- |
| `drop = true` | exit 1, `Error: atlas.hcl diff.concurrent_index.drop is not supported yet` | exit 1 on the database connection, same as the control |
| `drop` absent (control) | exit 1 on the database connection | unchanged |

The pinned community build at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (community version v1.3.0) reads the same file and reaches the same connection error in both envs — it never refuses the setting. Before this change Ptah exited 1 where that binary proceeds.

Live, against the same postgres, dropping an index the database has and the desired schema does not:

```
env droptrue   -> DROP INDEX CONCURRENTLY IF EXISTS "idx_members_email";
env dropfalse  -> DROP INDEX IF EXISTS "idx_members_email";
```

Same file, one attribute apart.

## What this adds

- `ast.DropIndexNode.Concurrently` + `SetConcurrently()`.
- `capability.DropIndexConcurrently` (`drop_index_concurrently`), enabled on the PostgreSQL presets and disabled on every preset that already declines `CREATE INDEX CONCURRENTLY`. Deliberately **no** implication edge to `CreateIndexConcurrently`: `Postgres16().With(CreateIndexConcurrently, false)` is a caller restricting index builds, and `Validate` must not turn that into an error about drops. The matrix row in `docs/capabilities.md` was generated from the presets, not hand-typed; the same generator reproduced the existing `create_index_concurrently` row byte-for-byte first.
- PostgreSQL renderer: `DROP INDEX CONCURRENTLY [IF EXISTS] …`, keyword before the guard, capability-gated.
- Planner: `WithConcurrentIndexDrops()` (policy) and `WithConcurrentIndexDropRefs()` (per index). Separate from the build-side flag and ref set, so turning on concurrent builds never rewrites a drop the caller did not ask for.
- `NodeRequiresNoTransaction` classifies a concurrent drop, and the generator's file split moves the matching removal into the `_concurrent_indexes` migration.
- Config: `diff.concurrent_index.drop` (atlas.hcl) and `diff.concurrent_index_drop` (ptah.yaml), honored by `ptah migrations generate`, `ptah schema apply`, `ptah-compat schema diff/apply` and `ptah-compat migrate diff`.
- The `schema apply` transaction-mode guard now also names the drop policy — and, while there, stops missing `CREATE UNIQUE INDEX CONCURRENTLY`, which the old `strings.Contains(upper, "CREATE INDEX CONCURRENTLY")` test could not see. That is strictly a refusal Ptah already intended to make; it never turns an exit 0 into an exit 1 relative to the pinned binary, which requires the same transaction mode for either statement.

The down direction is **not** governed by the config. Rolling back a non-blocking build with a blocking drop defeats the build; where the target supports it, the rollback is concurrent regardless.

## Tests, and what each prints if the change is reverted

| Test | Reverted output |
| --- | --- |
| `TestPlanGeneratedMigrationSpecs_ConcurrentIndexForPopulatedPostgresTable` (edited) | `no substring match found … want: DROP INDEX CONCURRENTLY IF EXISTS "idx_users_email";` against a container holding `DROP INDEX IF EXISTS …` |
| `TestPlanGeneratedMigrationSpecs_SplitsTransactionalAndConcurrentIndex` (edited) | same, on `specs[1].DownSQL` |
| `TestPostgreSQLRenderer_DropIndexConcurrently` (new, 7 rows) | the three subject rows print `DROP INDEX IF EXISTS "idx_users_email";` where they want the `CONCURRENTLY` form, so they become indistinguishable from the capability-withheld rows |
| `TestPlanner_ConcurrentIndexDrops` (new, 7 rows) | the three rows that want `DROP INDEX CONCURRENTLY IF EXISTS idx_users_email;` fail with `no substring match found`; the four negative rows keep passing, which is what makes the pair discriminating |
| `TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropPolicy` (new, 3 rows) | the "policy on" row prints `DROP INDEX IF EXISTS …` with `NoTransaction` false, becoming indistinguishable from the "policy off" row |
| `TestPlanGeneratedMigrationSpecs_ConcurrentIndexDropSplitsFromTransactional` (new) | `specs has len 1, want 2` — with a blocking drop everything fits in one transactional migration |
| `TestRequiresNoTransaction_ConcurrentIndexDrop` (new, 3 rows) | `values are not equal: false != true` on the concurrent postgres row |
| `TestConcurrentIndexPolicySetting` (new, 7 rows) | `"" != "diff.concurrent_index.create"` for the unique row and `"" != "diff.concurrent_index.drop"` for the drop row; the blocking rows return `""` either way |
| `TestCompatCommand_SchemaDiffAcceptsConcurrentIndexDropPolicy` (replaces the refusal test) | `Error: atlas.hcl diff.concurrent_index.drop is not supported yet`, exit non-zero |
| `TestAtlasDiffPolicy_CarriesConcurrentIndexDrop` (new, 3 rows) | `values are not equal: true != false` on `ConcurrentIndexDrop` |
| `TestLintFS_AtlasAnalyzerCatalogHazards` new row | with a PG106 that ignored `CONCURRENTLY`, the row would report `["PG103","PG106"]` instead of `["PG103"]`; the existing `DROP INDEX idx;` row is its discriminating partner |

`TestCompatCommand_SchemaDiffRejectsUnsupportedAtlasProjectDiffPolicy` was **replaced, not deleted**. It asserted a state neither Ptah nor the pinned binary should be in, and its fixture never wrote the `from.hcl`/`to.hcl` it pointed at — with the refusal gone it failed on a missing file rather than on the behavior. The replacement writes both files and asserts the run gets past the policy step.

## Deliberately left open

Four of the five workstreams #997 retained. All measured on this branch, live, so the issue keeps an accurate record rather than a re-derivation.

**2. Partitioned-parent awareness — still broken, needs a public-API decision.** `internal/dbschema/postgres/reader.go` selects from `information_schema.tables`, which flattens `relkind = 'p'` to `BASE TABLE`, and `DBTable` has no field to carry the distinction. Measured: a partitioned `members` (relkind `p`, reltuples 5000) still gets

```
CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");
```

and PostgreSQL 16 answers `ERROR: cannot create index on partitioned table "members" concurrently`, while the same statement on a plain table succeeds and builds the index. The fix needs `relkind` on `DBTable`, which is in the pinned baseline at `docs/public_api.snapshot`, so it is a public-API approval step. It also needs a call between "downgrade to a plain `CREATE INDEX`, which PostgreSQL does accept on a parent" and "refuse before publication with a diagnostic" — the acceptance box allows either, and they are not the same product decision.

**3. Fail-safe statistics — needs a decision on the default.** Measured: `members` with 5000 real rows, statistics discarded (`pg_stat_reset()`, no `ANALYZE`) reports `reltuples = -1`, `n_live_tup = 0`, and Ptah plans a **blocking** `CREATE INDEX` on a populated table. The detection is not the hard part — PostgreSQL 14+ already distinguishes "never analyzed" as `reltuples = -1`, and the reader's `COALESCE(GREATEST(c.reltuples::bigint, st.n_live_tup, 0), 0)` is what erases it. The decision is what unknown should mean by default, and flipping it to "assume populated" changes behavior for every existing user and invalidates the pinned `missing table stats stays transactional` row in `concurrent_index_test.go`.

Worth recording alongside it: the plainer version of that box already holds. 5000 rows inserted with no `ANALYZE` at all reports `reltuples = -1, n_live_tup = 5000` and Ptah correctly plans `CREATE INDEX CONCURRENTLY`, because the reader reads `pg_stat_all_tables` and not only `reltuples`. Only genuinely absent statistics fail.

**4. Down-file lint coverage — needs a decision, and the naive version is measurably wrong.** `migration/lint/analysis.go` still confines statement rules to up files. The specific hole #997 named is closed at the source — Ptah's own concurrent-index down file is now `DROP INDEX CONCURRENTLY`, which PG106 already ignores, and the new lint row pins that. The blind spot for hand-written down files survives. I measured the wholesale fix by flipping the `file.IsUp` guard: three existing tests go red immediately, and `TestLintFS_DollarQuotedBodiesDoNotSplitStatements` shows why — DS107 `database object dropped` fires on a down file for dropping the function its up file created. A down file's whole job is to undo, so an undirected rule set flags essentially every down file in every repository. Extending coverage requires per-rule direction awareness, which is a design decision, not a one-line guard change.

**5. Live test matrix.** Still outstanding, and mostly downstream of 2 and 3.

Also left alone on purpose: an index dropped and recreated under one identity keeps its blocking drop even under `drop = true`. The planner pairs that drop with the rebuild in one statement group, and making it concurrent would move half the pair into a different migration file. #997 asks explicitly to preserve deterministic file splitting, so the redefinition path is unchanged and pinned by a test row.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — each exit 0, captured per step.

`docs/public_api.snapshot` is regenerated: additive only (four new exported fields, one new method, one new fluent setter). `scripts/check-public-api-released.sh` exits 0 on the pre-existing approved `migration/migrator` entry.

`docs/` changed, so all 14 `check:*` scripts in `docs/site/package.json` ran after `npm run build` — 14 passed, 0 failed.
