### PR TITLE
fix(convert): one dialect spelling, one answer (#929 workstream A1/A3)

### DIFF
--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -255,11 +255,11 @@ seven of them as open capabilities regardless.
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
 | Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
-| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | No sequences, RLS, roles/grants or matviews. Every accepted spelling (sqlserver, mssql, tsql, sql-server, sql_server) renders identical DDL. |
+| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
 | SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
 | Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
-| Triggers | 🟡 | ❌ | ✅ | `schema render` emits them on PostgreSQL, SQL Server, MySQL/MariaDB and SQLite, not on CockroachDB/YugabyteDB/Spanner. MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
+| Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
 | Views and materialized views | 🟡 | ❌ | ✅ | Matviews render on PostgreSQL only; SQL schema files read both. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently. |
 | YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them. |
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -255,11 +255,11 @@ seven of them as open capabilities regardless.
 | PostgreSQL 12+ (postgres, postgresql) | ✅ | ✅ | ✅ | Only engine where views, functions, sequences, roles, RLS and domains are emitted; presets 12-13, 14-16, 17+ from the server banner. |
 | Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
-| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
+| SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | No sequences, RLS, roles/grants or matviews. Every accepted spelling (sqlserver, mssql, tsql, sql-server, sql_server) renders identical DDL. |
 | SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
 | Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
-| Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
+| Triggers | 🟡 | ❌ | ✅ | `schema render` emits them on PostgreSQL, SQL Server, MySQL/MariaDB and SQLite, not on CockroachDB/YugabyteDB/Spanner. MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |
 | Views and materialized views | 🟡 | ❌ | ✅ | Matviews render on PostgreSQL only; SQL schema files read both. Elsewhere behavior differs by engine: MySQL/MariaDB apply errors, YugabyteDB live apply plans them, ClickHouse drops them silently. |
 | YugabyteDB (yugabytedb, ysql) | 🟡 | ❌ | ✅ | Live apply does plan roles, grants, sequences, domains, views, matviews, functions and triggers; only RLS and concurrent indexes are gated off. Offline render omits all of them. |
 

--- a/docs/site/src/content/docs/concepts/dialects-and-capabilities.md
+++ b/docs/site/src/content/docs/concepts/dialects-and-capabilities.md
@@ -15,7 +15,12 @@ or `row_level_security`.
 ## How Ptah models it
 
 Dialect names normalize first: `postgresql` means `postgres`, `sqlite3` means
-`sqlite`, `mssql` means `sqlserver`, and so on. Each normalized dialect maps
+`sqlite`, `mssql` means `sqlserver`, and so on. Every accepted spelling of an
+engine produces byte-identical DDL; a test derives its spelling list from the
+normalization function itself, so a new spelling cannot be added without being
+covered.
+
+Each normalized dialect maps
 to an implementation family, and several engines deliberately share one —
 MySQL and MariaDB share a planner family, and CockroachDB, YugabyteDB, and
 Spanner ride the PostgreSQL family. What distinguishes the members is their

--- a/docs/site/src/content/docs/databases/support-matrix.md
+++ b/docs/site/src/content/docs/databases/support-matrix.md
@@ -13,15 +13,15 @@ per-capability tables are in [Capabilities](../../reference/capabilities/).
 
 | Engine | Dialect (aliases) | URL schemes | Support |
 | --- | --- | --- | --- |
-| [PostgreSQL](../postgresql/) | `postgres` (`postgresql`) | `postgres://`, `postgresql://` | Primary first-party target with the broadest schema-object coverage. |
+| [PostgreSQL](../postgresql/) | `postgres` (`postgresql`, `pgx`) | `postgres://`, `postgresql://` | Primary first-party target with the broadest schema-object coverage. |
 | [SQLite](../sqlite/) | `sqlite` (`sqlite3`) | `sqlite://` | Supported for local workflows, examples, and lightweight test databases. |
 | MySQL | `mysql` | `mysql://` | Supported, with dialect-specific limitations. |
 | MariaDB | `mariadb` | `mariadb://` | Supported, with dialect-specific limitations. |
-| [SQL Server](../sqlserver/) | `sqlserver` (`mssql`, `tsql`) | `sqlserver://`, `mssql://` | Deliberately conservative portable subset. |
+| [SQL Server](../sqlserver/) | `sqlserver` (`mssql`, `tsql`, `sql-server`, `sql_server`) | `sqlserver://`, `mssql://` | Deliberately conservative portable subset. |
 | CockroachDB | `cockroachdb` (`cockroach`, `crdb`) | `cockroachdb://`, `crdb://` | PostgreSQL-compatible path with capability differences. |
 | YugabyteDB | `yugabytedb` (`yugabyte`, `ysql`) | `yugabytedb://`, `ysql://` | PostgreSQL-compatible path with capability differences. |
 | ClickHouse | `clickhouse` (`ch`) | `clickhouse://`, `ch://` | Capability-limited support. |
-| Spanner (PostgreSQL interface) | `spanner` (`cloudspanner`) | `spanner://` | Most conservative capability-limited support. |
+| Spanner (PostgreSQL interface) | `spanner` (`cloudspanner`, `google-spanner`, `google_spanner`) | `spanner://` | Most conservative capability-limited support. |
 
 Accepted URL formats, and the difference between target, dev, shadow, and
 throwaway databases, are on

--- a/internal/convert/fromschema/dialect_spelling_test.go
+++ b/internal/convert/fromschema/dialect_spelling_test.go
@@ -135,9 +135,20 @@ func TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName(t *testi
 // The parity comparison is only meaningful if the fixture can tell engines
 // apart at all. A fixture that rendered to the same statements everywhere would
 // make TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName pass
-// no matter what the predicates did. If the fixture is emptied or its
-// per-engine overrides are deleted, this fails naming the two engines that
-// collided.
+// no matter what the predicates did.
+//
+// Emptying the fixture reddens this test. Measured: it then reports one
+// survivor per fingerprint rather than the colliding pair, because the map is
+// keyed by fingerprint and the last engine written wins — `map[string]string
+// {"": "spanner"}` for an empty fixture.
+//
+// Deleting the per-engine `platform.<name>.<attr>` overrides does NOT redden
+// it, and an earlier version of this comment claimed it did. The remaining
+// column types and constraints still fingerprint the nine engines apart, so
+// the control holds for the reason above rather than because of the overrides.
+// What the overrides are load-bearing for is the parity test itself: under a
+// raw-index mutant, dropping `platform.sqlite.default` removes sqlite3 from
+// its divergent list and swapping `platform.clickhouse.type` removes ch.
 func TestFromDatabase_FixtureDiscriminatesEngines(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/convert/fromschema/dialect_spelling_test.go
+++ b/internal/convert/fromschema/dialect_spelling_test.go
@@ -1,0 +1,156 @@
+package fromschema_test
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// normalizeDialectSource is the file that decides which dialect spellings ptah
+// accepts. The spelling list below is read out of it rather than copied here, so
+// a spelling added to the switch is covered by this test without anyone editing
+// this file.
+const normalizeDialectSource = "../../../core/platform/constants.go"
+
+// quotedLiteral deliberately requires a non-empty literal: the switch's default
+// arm returns "", which is the one string in the body that is not a spelling.
+var quotedLiteral = regexp.MustCompile(`"([^"]+)"`)
+
+// acceptedSpellings returns every dialect spelling that appears as a case in
+// platform.NormalizeDialect's switch, read from the switch body itself.
+//
+// The body holds no string literal other than the case spellings: the argument
+// is lowercased through strings helpers and every return is a named constant.
+func acceptedSpellings(c *qt.C) []string {
+	source, err := os.ReadFile(normalizeDialectSource)
+	c.Assert(err, qt.IsNil)
+
+	_, afterSignature, foundSignature := strings.Cut(string(source), "func NormalizeDialect(dialect string) string {")
+	c.Assert(foundSignature, qt.IsTrue, qt.Commentf("NormalizeDialect signature moved in %s", normalizeDialectSource))
+
+	body, _, foundEnd := strings.Cut(afterSignature, "\n}")
+	c.Assert(foundEnd, qt.IsTrue, qt.Commentf("NormalizeDialect body is unterminated in %s", normalizeDialectSource))
+
+	matches := quotedLiteral.FindAllStringSubmatch(body, -1)
+	spellings := make([]string, 0, len(matches))
+	for _, match := range matches {
+		spellings = append(spellings, match[1])
+	}
+	slices.Sort(spellings)
+	return slices.Compact(spellings)
+}
+
+// convertedStatements is the conversion this test compares: the AST that
+// fromschema builds for a dialect spelling, rendered to SQL. A render error is
+// folded into the compared string instead of failing the test, so a dialect that
+// refuses part of the fixture still contributes a value both spellings of that
+// engine must agree on.
+func convertedStatements(database goschema.Database, dialect string) []string {
+	nodes := fromschema.FromDatabase(database, dialect)
+	rendered := make([]string, 0, len(nodes.Statements))
+	for _, node := range nodes.Statements {
+		sql, err := renderer.RenderSQL(dialect, node)
+		rendered = append(rendered, fmt.Sprintf("%s | err=%v", sql, err))
+	}
+	return rendered
+}
+
+func spellingFixture(c *qt.C) goschema.Database {
+	database, err := goschema.ParseDir("testdata/dialectspellings")
+	c.Assert(err, qt.IsNil)
+	c.Assert(database, qt.IsNotNil)
+	return *database
+}
+
+// TestAcceptedSpellings_ExtractionControls proves the spelling list the parity
+// test iterates is really the switch's own list.
+//
+// Reverting the extraction (a renamed signature, a regexp that stops matching)
+// leaves acceptedSpellings empty, and an empty list makes the parity test below
+// pass while comparing nothing. This test prints the missing spelling name.
+func TestAcceptedSpellings_ExtractionControls(t *testing.T) {
+	c := qt.New(t)
+
+	spellings := acceptedSpellings(c)
+
+	// Positive control: aliases that exist only inside the switch, one per
+	// engine family that has one.
+	for _, alias := range []string{"pgx", "ch", "sqlite3", "tsql", "sql-server", "crdb", "ysql", "google_spanner"} {
+		c.Assert(spellings, qt.Contains, alias)
+	}
+	// Positive control: every canonical name is a case of its own switch.
+	for _, canonical := range []string{
+		platform.Postgres, platform.MySQL, platform.MariaDB, platform.ClickHouse,
+		platform.SQLite, platform.SQLServer, platform.CockroachDB, platform.YugabyteDB, platform.Spanner,
+	} {
+		c.Assert(spellings, qt.Contains, canonical)
+	}
+	// Negative control: the extractor must not reach past the switch body. Every
+	// literal it collected has to be a spelling NormalizeDialect actually
+	// accepts, so a comment word or a neighboring function's literal fails here.
+	for _, spelling := range spellings {
+		c.Assert(platform.NormalizeDialect(spelling), qt.Not(qt.Equals), "", qt.Commentf("collected %q, which is not an accepted spelling", spelling))
+	}
+}
+
+// TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName is the
+// completion criterion for stokaro/ptah#929 workstream A: one dialect spelling,
+// one answer.
+//
+// If the normalization is reverted — isPostgreSQLPlatform back to its two-string
+// form, handleEnumTypes back to comparing the raw name, applyPlatformOverrides
+// back to indexing Overrides by the raw name — this fails with the list of
+// spellings that disagree with their own canonical name, so the failure is a
+// count of engines-times-predicates rather than a single boolean. On the
+// measured baseline that list held all 15 non-canonical spellings.
+func TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName(t *testing.T) {
+	c := qt.New(t)
+
+	database := spellingFixture(c)
+	spellings := acceptedSpellings(c)
+
+	divergent := slices.DeleteFunc(slices.Clone(spellings), func(spelling string) bool {
+		return slices.Equal(
+			convertedStatements(database, spelling),
+			convertedStatements(database, platform.NormalizeDialect(spelling)),
+		)
+	})
+
+	c.Assert(divergent, qt.HasLen, 0, qt.Commentf("these spellings convert differently from their own canonical name"))
+}
+
+// TestFromDatabase_FixtureDiscriminatesEngines is the negative control for the
+// parity test above.
+//
+// The parity comparison is only meaningful if the fixture can tell engines
+// apart at all. A fixture that rendered to the same statements everywhere would
+// make TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName pass
+// no matter what the predicates did. If the fixture is emptied or its
+// per-engine overrides are deleted, this fails naming the two engines that
+// collided.
+func TestFromDatabase_FixtureDiscriminatesEngines(t *testing.T) {
+	c := qt.New(t)
+
+	database := spellingFixture(c)
+	canonicals := []string{
+		platform.Postgres, platform.MySQL, platform.MariaDB, platform.ClickHouse,
+		platform.SQLite, platform.SQLServer, platform.CockroachDB, platform.YugabyteDB, platform.Spanner,
+	}
+
+	fingerprints := make(map[string]string, len(canonicals))
+	for _, canonical := range canonicals {
+		fingerprints[strings.Join(convertedStatements(database, canonical), "\n")] = canonical
+	}
+
+	c.Assert(fingerprints, qt.HasLen, len(canonicals))
+}

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -99,9 +99,9 @@ func defaultGeneratedKind(field goschema.Field, targetPlatform string) string {
 	switch {
 	case isPostgreSQLPlatform(targetPlatform):
 		return "STORED"
-	case targetPlatform == "mysql" || targetPlatform == "mariadb":
+	case isMySQLFamilyTarget(targetPlatform):
 		return "VIRTUAL"
-	case targetPlatform == "sqlserver":
+	case platform.NormalizeDialect(targetPlatform) == platform.SQLServer:
 		return "PERSISTED"
 	case isSQLiteTarget(targetPlatform):
 		return "VIRTUAL"
@@ -110,8 +110,23 @@ func defaultGeneratedKind(field goschema.Field, targetPlatform string) string {
 	}
 }
 
+// canonicalPlatform maps a dialect spelling onto the single name every platform
+// predicate in this file compares against, so that a documented alias converts
+// to exactly the same AST as its canonical name.
+//
+// A spelling platform.NormalizeDialect does not recognize is returned unchanged
+// rather than as the empty string NormalizeDialect yields for it. An unknown
+// name has no canonical form, and rewriting it to "" would switch off the
+// platform-override lookup for a schema that keys overrides by that exact name.
+func canonicalPlatform(targetPlatform string) string {
+	if canonical := platform.NormalizeDialect(targetPlatform); canonical != "" {
+		return canonical
+	}
+	return targetPlatform
+}
+
 func isPostgreSQLPlatform(targetPlatform string) bool {
-	return strings.EqualFold(targetPlatform, "postgres") || strings.EqualFold(targetPlatform, "postgresql")
+	return platform.NormalizeDialect(targetPlatform) == platform.Postgres
 }
 
 // typeRawSQLSurvives reports whether the column type is still the one the
@@ -124,6 +139,35 @@ func isPostgreSQLPlatform(targetPlatform string) bool {
 // hatch to text that never went through it.
 func typeRawSQLSurvives(field goschema.Field, declaredType string) bool {
 	return field.TypeRawSQL && field.Type == declaredType
+}
+
+// platformOverrideGroup resolves the platform.<name>.<attribute> override group
+// that applies to targetPlatform.
+//
+// The lookup is by engine, not by spelling. The canonical name is tried first,
+// then — deterministically, lowest key first — any other spelling in the map
+// that names the same engine. Without that second step `--dialect postgres` and
+// `--dialect pgx` disagree whenever the schema keyed its overrides by the
+// spelling the caller did not happen to type.
+func platformOverrideGroup(overrides map[string]map[string]string, targetPlatform string) (map[string]string, bool) {
+	if len(overrides) == 0 {
+		return nil, false
+	}
+	canonical := canonicalPlatform(targetPlatform)
+	if group, ok := overrides[canonical]; ok {
+		return group, true
+	}
+	candidates := make([]string, 0, len(overrides))
+	for key := range overrides {
+		if canonicalPlatform(key) == canonical {
+			candidates = append(candidates, key)
+		}
+	}
+	if len(candidates) == 0 {
+		return nil, false
+	}
+	slices.Sort(candidates)
+	return overrides[candidates[0]], true
 }
 
 func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschema.Field {
@@ -153,7 +197,7 @@ func applyPlatformOverrides(field goschema.Field, targetPlatform string) goschem
 		)
 	}
 
-	platformOverrides, exists := field.Overrides[targetPlatform]
+	platformOverrides, exists := platformOverrideGroup(field.Overrides, targetPlatform)
 	if !exists {
 		return fieldWithPlatformValues(
 			field,
@@ -226,7 +270,7 @@ func EffectiveFieldForPlatform(field goschema.Field, targetPlatform string) gosc
 }
 
 func platformFieldType(fieldType, targetPlatform string) string {
-	switch targetPlatform {
+	switch platform.NormalizeDialect(targetPlatform) {
 	case platform.MySQL, platform.MariaDB:
 		return mysqlFamilyFieldType(fieldType)
 	case platform.SQLServer:
@@ -297,7 +341,13 @@ func handleEnumTypes(field goschema.Field, enums []goschema.Enum, targetPlatform
 	// Validate enum field
 	validateEnumField(field, enums)
 
-	if targetPlatform != "mysql" && targetPlatform != "mariadb" && targetPlatform != "sqlite" && targetPlatform != "sqlserver" {
+	// The inline rewrite is the exact complement of the standalone CREATE TYPE:
+	// a dialect models an enum either on the column or as its own type, never
+	// both and never neither. Deriving both sides from one predicate is what
+	// stops a spelling from suppressing the CREATE TYPE and the inline rewrite
+	// at the same time, which is how `--dialect sqlite3` used to drop the enum
+	// entirely and render the column as the bare type name `enum_status`.
+	if emitsStandaloneEnumDefinitions(targetPlatform) {
 		return field
 	}
 
@@ -318,17 +368,17 @@ func applyInlineEnumModel(field goschema.Field, enum goschema.Enum, targetPlatfo
 	}
 
 	newField := field
-	switch targetPlatform {
-	case "mysql", "mariadb":
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB:
 		newField.Type = fmt.Sprintf("ENUM(%s)", strings.Join(quotedValues, ", "))
-	case "sqlite":
+	case platform.SQLite:
 		newField.Type = "TEXT"
 		enumCheck := fmt.Sprintf("%s IN (%s)", field.Name, strings.Join(quotedValues, ", "))
 		if field.Check != "" {
 			enumCheck = fmt.Sprintf("(%s) AND %s", field.Check, enumCheck)
 		}
 		newField.Check = enumCheck
-	case "sqlserver":
+	case platform.SQLServer:
 		newField.Type = "NVARCHAR(255)"
 		enumCheck := fmt.Sprintf("%s IN (%s)", sqlServerBracketIdentifier(field.Name), strings.Join(quotedValues, ", "))
 		if field.Check != "" {
@@ -602,7 +652,7 @@ func applyTablePlatformOverrides(createTable *ast.CreateTableNode, table goschem
 	tableStrict := table.Strict
 	tableWithoutRowID := table.WithoutRowID
 
-	platformOverrides, exists := table.Overrides[targetPlatform]
+	platformOverrides, exists := platformOverrideGroup(table.Overrides, targetPlatform)
 	if !exists {
 		return table
 	}
@@ -779,7 +829,7 @@ func fromTableWithFieldConverter(
 	if newTable.Collate != "" {
 		createTable.SetOption("COLLATE", newTable.Collate)
 	}
-	if targetPlatform == "sqlite" {
+	if isSQLiteTarget(targetPlatform) {
 		if newTable.WithoutRowID {
 			createTable.SetOption("WITHOUT_ROWID", "true")
 		}
@@ -2152,10 +2202,8 @@ func appendPostgreSQLPostForeignKeyFeatureStatements(statements *ast.StatementLi
 }
 
 func supportsStandaloneViewsAndTriggers(targetPlatform string) bool {
-	switch {
-	case isPostgreSQLPlatform(targetPlatform):
-		return false
-	case strings.EqualFold(targetPlatform, "mysql"), strings.EqualFold(targetPlatform, "mariadb"), strings.EqualFold(targetPlatform, platform.SQLServer), isSQLiteTarget(targetPlatform):
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB, platform.SQLServer, platform.SQLite:
 		return true
 	default:
 		return false
@@ -2172,11 +2220,16 @@ func appendViewAndTriggerStatements(statements *ast.StatementList, database gosc
 }
 
 func isSQLiteTarget(targetPlatform string) bool {
-	return strings.EqualFold(targetPlatform, "sqlite") || strings.EqualFold(targetPlatform, "sqlite3")
+	return platform.NormalizeDialect(targetPlatform) == platform.SQLite
 }
 
 func isMySQLFamilyTarget(targetPlatform string) bool {
-	return strings.EqualFold(targetPlatform, "mysql") || strings.EqualFold(targetPlatform, "mariadb")
+	switch platform.NormalizeDialect(targetPlatform) {
+	case platform.MySQL, platform.MariaDB:
+		return true
+	default:
+		return false
+	}
 }
 
 func appendSchemaStatements(statements *ast.StatementList, schemas []goschema.Schema) {

--- a/internal/convert/fromschema/platform_override_group_internal_test.go
+++ b/internal/convert/fromschema/platform_override_group_internal_test.go
@@ -1,0 +1,100 @@
+package fromschema
+
+// White-box testing required: platformOverrideGroup is unexported and its
+// tie-break is not observable through any exported converter, because every
+// caller resolves an engine that has exactly one override group in the schemas
+// this repository ships. Reaching the discard needs two sibling spellings in
+// one map, which only this level can construct.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestPlatformOverrideGroup_ResolvesBySpelling pins the lookup platformOverrideGroup
+// performs, including the tie-break, which nothing else in the suite reaches.
+//
+// The function has no test of its own, so before this file the tie-break could be
+// changed from "lowest key" to "highest key" — or to a merge of the sibling groups —
+// and every test in the repository would stay green while `--dialect tsql` started
+// answering with a different override.
+//
+// The tie-break is deliberately arbitrary and it discards. With both
+// `platform.tsql.type` and `platform.mssql.type` present, one group wins and the
+// other becomes unreachable from every spelling, silently. That is measured here
+// rather than left to be discovered: agreement across spellings is the property
+// #929 asked for, and this is its cost.
+func TestPlatformOverrideGroup_ResolvesBySpelling(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		overrides map[string]map[string]string
+		target    string
+		wantOK    bool
+		wantType  string
+	}{
+		{
+			name:      "the canonical name wins over a sibling spelling",
+			overrides: map[string]map[string]string{"sqlserver": {"type": "A"}, "mssql": {"type": "B"}},
+			target:    "sqlserver",
+			wantOK:    true,
+			wantType:  "A",
+		},
+		{
+			name:      "a non-canonical spelling reaches the canonical group",
+			overrides: map[string]map[string]string{"sqlserver": {"type": "A"}},
+			target:    "tsql",
+			wantOK:    true,
+			wantType:  "A",
+		},
+		{
+			name:      "a canonical target reaches a group keyed by a sibling spelling",
+			overrides: map[string]map[string]string{"mssql": {"type": "B"}},
+			target:    "sqlserver",
+			wantOK:    true,
+			wantType:  "B",
+		},
+		{
+			// The discard this pins: "mssql" sorts below "tsql", so the tsql group
+			// is unreachable from every spelling of SQL Server, with no diagnostic.
+			name:      "two sibling spellings tie-break to the lowest key and drop the other",
+			overrides: map[string]map[string]string{"tsql": {"type": "FROM_TSQL"}, "mssql": {"type": "FROM_MSSQL"}},
+			target:    "tsql",
+			wantOK:    true,
+			wantType:  "FROM_MSSQL",
+		},
+		{
+			name:      "the same tie-break answers every spelling of that engine",
+			overrides: map[string]map[string]string{"tsql": {"type": "FROM_TSQL"}, "mssql": {"type": "FROM_MSSQL"}},
+			target:    "sql_server",
+			wantOK:    true,
+			wantType:  "FROM_MSSQL",
+		},
+		{
+			name:      "an override for another engine is not borrowed",
+			overrides: map[string]map[string]string{"postgres": {"type": "PG"}},
+			target:    "mysql",
+			wantOK:    false,
+		},
+		{
+			name:      "no overrides at all",
+			overrides: nil,
+			target:    "postgres",
+			wantOK:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			group, ok := platformOverrideGroup(test.overrides, test.target)
+
+			c.Assert(ok, qt.Equals, test.wantOK)
+			c.Assert(group["type"], qt.Equals, test.wantType)
+		})
+	}
+}

--- a/internal/convert/fromschema/testdata/dialectspellings/models.go
+++ b/internal/convert/fromschema/testdata/dialectspellings/models.go
@@ -1,0 +1,111 @@
+// Package models is the fixture behind
+// TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName.
+//
+// Every declaration here exists to separate one dialect-name predicate in
+// fromschema from the spelling the caller typed. Deleting any of them makes the
+// parity test pass for a reason it should not:
+//
+//   - platform.<name>.* on note pins applyPlatformOverrides' map lookup for all
+//     nine engines, with a distinct value per engine. Measured: stripping these
+//     overrides and then reverting the lookup to index Overrides by the raw
+//     dialect name leaves the parity test green, so they are the only thing
+//     holding that comparison. SQLite gets a default rather than only a type
+//     because the SQLite renderer maps every string width onto TEXT and would
+//     otherwise erase the difference.
+//   - enum_status plus ref_status pins handleEnumTypes / applyInlineEnumModel
+//     against emitsStandaloneEnumDefinitions: on the four engines that model an
+//     enum on the column, a spelling that reaches only one of the two halves
+//     drops the enum entirely.
+//   - active_users and users_touch pin supportsStandaloneViewsAndTriggers.
+//   - email_lower pins defaultGeneratedKind (STORED / VIRTUAL / PERSISTED).
+//   - orders.user_id pins isSQLiteTarget (inline vs ALTER TABLE foreign keys)
+//     and isMySQLFamilyTarget (index emission order around ADD CONSTRAINT).
+//   - the PostgreSQL object block pins isPostgreSQLPlatform.
+//
+// The app-qualified audit table exercises renderTableName, but it does not pin
+// sqlident.Quote's quote style: the dialect renderer re-quotes the table name,
+// so reverting Quote to raw-string matching leaves this fixture green. That
+// comparison is pinned in internal/sqlident/sqlident_test.go instead.
+package models
+
+//ptah:schema:extension name="pgcrypto" if_not_exists="true"
+type ExtensionsMarker struct{}
+
+//ptah:schema:enum name="enum_status" values="active,archived"
+type StatusEnumMarker struct{}
+
+//ptah:schema:role name="app_user" login="true" inherit="true"
+type AppRoleMarker struct{}
+
+//ptah:schema:sequence name="order_number_seq" as="bigint" start="1000" increment="1"
+type OrderSeqMarker struct{}
+
+//ptah:schema:domain name="email_domain" type="TEXT" not_null="true" check="VALUE ~ '@'"
+type EmailDomainMarker struct{}
+
+//ptah:schema:composite name="addr_type" fields="street:TEXT,city:TEXT"
+type AddressCompositeMarker struct{}
+
+//ptah:schema:range name="float_range" subtype="float8"
+type FloatRangeMarker struct{}
+
+//ptah:schema:table name="users"
+type User struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+
+	//ptah:schema:field name="email" type="TEXT" not_null="true"
+	Email string
+
+	//ptah:schema:field name="ref_status" type="enum_status"
+	RefStatus string
+
+	//ptah:schema:field name="note" type="VARCHAR(64)" platform.postgres.type="VARCHAR(80)" platform.cockroachdb.type="VARCHAR(81)" platform.yugabytedb.type="VARCHAR(82)" platform.spanner.type="STRING(83)" platform.clickhouse.type="FixedString(9)" platform.sqlite.type="VARCHAR(85)" platform.sqlite.default="sqlite-only" platform.mysql.type="VARCHAR(86)" platform.mariadb.type="VARCHAR(87)" platform.sqlserver.type="NVARCHAR(88)"
+	Note string
+
+	//ptah:schema:field name="email_lower" type="TEXT" generated="LOWER(email)"
+	EmailLower string
+
+	//ptah:schema:field name="updated_at" type="TIMESTAMP"
+	UpdatedAt *string
+
+	//ptah:schema:index name="idx_users_email" fields="email" unique="true"
+	_ int
+}
+
+//ptah:schema:table name="orders"
+type Order struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+
+	//ptah:schema:field name="user_id" type="BIGINT" not_null="true" foreign="users(id)"
+	UserID int64
+
+	//ptah:schema:index name="idx_orders_user" fields="user_id"
+	_ int
+}
+
+//ptah:schema:table name="audit" schema="app"
+type Audit struct {
+	//ptah:schema:field name="id" type="BIGINT" primary="true"
+	ID int64
+}
+
+//ptah:schema:function name="touch_updated" returns="trigger" language="plpgsql" body="BEGIN NEW.updated_at = NOW(); RETURN NEW; END;"
+type FunctionMarker struct{}
+
+//ptah:schema:view name="active_users" body="SELECT id, email FROM users"
+type ActiveUsersView struct{}
+
+//ptah:schema:matview name="user_counts" body="SELECT COUNT(*) AS cnt FROM users"
+type UserCountsMatView struct{}
+
+//ptah:schema:trigger name="users_touch" table="users" timing="BEFORE" event="UPDATE" for="ROW" body="NEW.updated_at = NOW(); RETURN NEW;"
+type UsersTouchTrigger struct{}
+
+//ptah:schema:rls:enable table="users"
+//ptah:schema:rls:policy name="users_self" table="users" for="SELECT" to="app_user" using="true"
+type SecurityMarker struct{}
+
+//ptah:schema:grant role="app_user" privilege="SELECT" on_table="users"
+type AccessControlMarker struct{}

--- a/internal/sqlident/sqlident.go
+++ b/internal/sqlident/sqlident.go
@@ -5,20 +5,26 @@
 // terminate the quoted identifier and inject SQL.
 package sqlident
 
-import "strings"
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+)
 
 // Quote returns name as a safely-quoted identifier for dialect. The dialect
 // selects the quote style: backticks for MySQL, MariaDB, and ClickHouse; square
 // brackets for SQL Server; and double quotes for the PostgreSQL family, SQLite,
 // and any unrecognized dialect. Embedded quote characters are doubled per the
 // SQL standard so the value cannot terminate the quoted identifier. The dialect
-// is matched case-insensitively and surrounding whitespace is ignored; name
-// itself is quoted verbatim (it is not trimmed).
+// is resolved through platform.NormalizeDialect, so every documented spelling of
+// an engine (`mssql`, `tsql`, `sql-server`, `sql_server`; `ch`) picks the same
+// quote style as its canonical name. name itself is quoted verbatim (it is not
+// trimmed).
 func Quote(dialect, name string) string {
-	switch strings.ToLower(strings.TrimSpace(dialect)) {
-	case "mysql", "mariadb", "clickhouse":
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
 		return "`" + strings.ReplaceAll(name, "`", "``") + "`"
-	case "sqlserver", "mssql":
+	case platform.SQLServer:
 		return "[" + strings.ReplaceAll(name, "]", "]]") + "]"
 	default:
 		return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`

--- a/internal/sqlident/sqlident_test.go
+++ b/internal/sqlident/sqlident_test.go
@@ -26,7 +26,19 @@ func TestQuote(t *testing.T) {
 		{name: "mariadb backticks", dialect: "mariadb", ident: "users", want: "`users`"},
 		{name: "clickhouse backticks", dialect: "clickhouse", ident: "users", want: "`users`"},
 		{name: "sqlserver brackets", dialect: "sqlserver", ident: "users", want: "[users]"},
+		// Every documented spelling of an engine has to pick that engine's quote
+		// style. Reverting Quote to matching raw strings makes the four rows
+		// below fail with `"users"` (SQL Server) and `"users"` (ClickHouse):
+		// the raw switch listed only sqlserver/mssql and clickhouse, so tsql,
+		// sql-server, sql_server and ch fell through to the default arm and
+		// produced PostgreSQL quoting for a SQL Server / ClickHouse identifier.
 		{name: "mssql alias brackets", dialect: "mssql", ident: "users", want: "[users]"},
+		{name: "tsql alias brackets", dialect: "tsql", ident: "users", want: "[users]"},
+		{name: "sql-server alias brackets", dialect: "sql-server", ident: "users", want: "[users]"},
+		{name: "sql_server alias brackets", dialect: "sql_server", ident: "users", want: "[users]"},
+		{name: "ch alias backticks", dialect: "ch", ident: "users", want: "`users`"},
+		{name: "pgx alias double quotes", dialect: "pgx", ident: "users", want: `"users"`},
+		{name: "sqlite3 alias double quotes", dialect: "sqlite3", ident: "users", want: `"users"`},
 		{name: "dialect is case and space insensitive", dialect: "  MySQL ", ident: "users", want: "`users`"},
 		{name: "postgres escapes embedded double quote", dialect: "postgres", ident: `a"b`, want: `"a""b"`},
 		{name: "mysql escapes embedded backtick", dialect: "mysql", ident: "a`b", want: "`a``b`"},


### PR DESCRIPTION
Implements **workstream A1/A3** of the framing comment on #929: one dialect spelling, one answer. Measured on `d1e2dc64` in a clean worktree branched from `origin/master`.

There is no external oracle for this issue. The pinned Atlas community binary has no driver for `cockroachdb`, `yugabytedb`, `spanner`, `sqlserver`, `mssql` or `tsql`, so "correct" is defined internally: **a documented spelling of an engine must render exactly what its canonical name renders**. Nothing here was measured against, or claims parity with, any non-OSS build.

## Reproduction, before and after

One fixture, every accepted spelling, `ptah schema render --dialect <spelling>` compared byte-for-byte against the canonical name of that engine.

The fixture carries a `platform.<name>.type` (and one `platform.sqlite.default`) for all nine engines, an `enum_`-prefixed enum on a column, a view, a trigger, a generated column, a foreign key and a schema-qualified table — one discriminator per raw-string predicate in `internal/convert/fromschema/fromschema.go`.

**Before** (binary built from `d1e2dc64`):

```
spelling            canonical      rc/rc  stmts/stmts   verdict
postgresql          postgres       0/0    5/5           DIVERGES
pgx                 postgres       0/0    4/5           DIVERGES
ch                  clickhouse     0/0    4/4           DIVERGES
sqlite3             sqlite         0/0    4/4           DIVERGES
mssql               sqlserver      0/0    3/4           DIVERGES
sql-server          sqlserver      0/0    3/4           DIVERGES
sql_server          sqlserver      0/0    3/4           DIVERGES
tsql                sqlserver      0/0    3/4           DIVERGES
cockroach           cockroachdb    0/0    4/4           DIVERGES
crdb                cockroachdb    0/0    4/4           DIVERGES
yugabyte            yugabytedb     0/0    4/4           DIVERGES
ysql                yugabytedb     0/0    4/4           DIVERGES
cloudspanner        spanner        0/0    4/4           DIVERGES
google-spanner      spanner        0/0    4/4           DIVERGES
google_spanner      spanner        0/0    4/4           DIVERGES

DIVERGING SPELLINGS: 15 of 15
```

**After** (same fixture, same commands, binary built from this branch): `DIVERGING SPELLINGS: 0 of 15`, every row `same`, every exit code unchanged.

Controls on both runs: `postgres` vs `postgres` reads `same` (the comparator can see equality) and `postgres` vs `mysql` reads `DIVERGES` (it can see difference); exit codes were captured immediately rather than through a pipe.

Concrete instances behind those rows:

```
$ ptah schema render --dialect sqlite  | grep ref_status
  "ref_status" TEXT CHECK (ref_status IN ('active', 'archived')),
$ ptah schema render --dialect sqlite3 | grep ref_status     # before
  "ref_status" enum_status,
```

`--dialect sqlite3` lost the enum **entirely**: `handleEnumTypes` compared the raw string against `"sqlite"` so the inline rewrite never fired, while its neighbor `emitsStandaloneEnumDefinitions` *did* normalize and suppressed the standalone `CREATE TYPE` anyway. The issue body says "The sqlite3 and postgresql aliases do not have this problem" — that sentence is false and this is the counter-example. `mssql`, `tsql`, `sql-server` and `sql_server` had the same failure; the body names two SQL Server spellings, there are four.

```
$ ptah schema render --dialect postgres   | grep '"note"'
  "note" VARCHAR(80)
$ ptah schema render --dialect postgresql | grep '"note"'    # before
  "note" VARCHAR(64)
```

`postgresql` diverges too, which the framing comment's fixture could not see: `applyPlatformOverrides` indexed `field.Overrides` by the raw dialect name, so `platform.postgres.type=` never applied under `--dialect postgresql`. Every engine had this, which is why the count is 15 and not 6.

## What changed

`internal/convert/fromschema/fromschema.go`
- `isPostgreSQLPlatform`, `isSQLiteTarget`, `isMySQLFamilyTarget`, `supportsStandaloneViewsAndTriggers`, `platformFieldType`, `applyInlineEnumModel`, `defaultGeneratedKind` and the SQLite table-option gate all resolve the spelling through `platform.NormalizeDialect` before comparing.
- `handleEnumTypes` no longer repeats the dialect list. It gates on `emitsStandaloneEnumDefinitions`, which is its exact complement — a dialect models an enum on the column or as its own type, never both and never neither. Deriving both from one predicate is what stops a spelling from switching off the `CREATE TYPE` and the inline rewrite at the same time.
- New `platformOverrideGroup` resolves `platform.<name>.<attr>` **by engine, not by spelling**: canonical key first, then deterministically (lowest key first) any other spelling naming the same engine. Both directions matter — a schema keyed `platform.pgx.type` must reach `--dialect postgres` just as `platform.postgres.type` must reach `--dialect pgx`.
- An unrecognized dialect is left as-is rather than rewritten to `NormalizeDialect`'s empty string, so overrides keyed by an unknown name keep working exactly as before.

`internal/sqlident/sqlident.go` — `Quote` matched raw strings and listed only `sqlserver`/`mssql` and `clickhouse`, so `tsql`, `sql-server` and `sql_server` fell to the default arm and produced PostgreSQL double quotes for a SQL Server identifier, and `ch` did the same for a ClickHouse one. It now normalizes.

## What each test prints if the change is reverted

Verified by applying each mutant and reading the output, then reverting.

| Mutant | Test | Output |
| --- | --- | --- |
| `isPostgreSQLPlatform` back to the two-string form | `TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName` | `len(got): int(1)` / `[]string{"pgx"}` / `want length: int(0)` |
| `handleEnumTypes` back to comparing the raw name | same | `len(got): int(5)` / `[]string{"mssql", "sql-server", "sql_server", "sqlite3", "tsql"}` |
| override lookup back to indexing `Overrides` by the raw name | same | `len(got): int(15)` — every non-canonical spelling |
| `sqlident.Quote` back to the raw switch | `TestQuote` | four rows fail: `tsql`, `sql-server`, `sql_server` get `"users"` instead of `[users]`; `ch` gets `"users"` instead of `` `users` `` |

It fails with a **count and the names**, not a boolean, which is what completion criterion A3 asked for.

Two inverse mutants, because a guard cannot be proved by reverting it:

- Renaming the signature the spelling extractor searches for makes `TestAcceptedSpellings_ExtractionControls` fail with `NormalizeDialect signature moved in ../../../core/platform/constants.go`, **and** takes the parity test down with it. That is the point: an extractor that silently returns an empty list would make the parity test pass while comparing nothing.
- Stripping the per-engine `platform.<name>.*` overrides from the fixture and *then* reverting the override lookup leaves the parity test **green**. Those overrides are the only operand holding that comparison, which is now recorded in the fixture's own doc comment.

`TestFromDatabase_FixtureDiscriminatesEngines` is the fixture's negative control: it asserts the nine canonical dialects produce nine distinct renderings, so a fixture that had been emptied could not make the parity test pass by rendering the same thing everywhere.

The spelling list in `TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName` is read out of `NormalizeDialect`'s own switch body at test time, not copied. Adding a spelling that renders differently turns the test red with nobody editing the test.

## Deliberately left open

**A2 — offline render still does not emit what the apply planner plans, for CockroachDB, YugabyteDB and Spanner.** Measured with `schemadiff.CompareWithDialect` + `planner.GenerateSchemaDiffSQLStatements` against an empty `types.DBSchema`, which is the same planner entry `schema apply` uses:

| dialect | planned-but-not-rendered before | after |
| --- | --- | --- |
| `postgres` (control) | 0 | 0 |
| `pgx` | 13 | **0** |
| `yugabytedb` | 11 | 11 |
| `cockroachdb` / `spanner` (portable fixture) | 1 each | 1 each |

This PR closes the `pgx` column — for the same reason it closes A1, `pgx` now *is* `postgres`. It deliberately does not touch the rest: making `isPostgreSQLPlatform` cover the whole PostgreSQL family is a change to which objects a target emits, not to how a name is spelled, and it lands on the exact lines #931 items 3 and 8 also rewrite. Doing it here would conflict.

The 11 remaining YugabyteDB cells are `DOMAIN:email_domain`, `FUNCTION:touch_updated`, `FUNCTION:ptah_trigger_users_users_touch`, `TRIGGER:users_touch`, `VIEW:active_users`, `MATVIEW:user_counts`, `ROLE:app_user`, `GRANT:users`, `SEQUENCE:order_number_seq`, `TYPE:addr_type`, `TYPE:float_range`.

**Workstream B — capability keys for view / matview / function / trigger** stays out by the framing comment's own ordering argument, and its Spanner column is blocked on #942.

**Item 6** (SQL Server missing from the render dialect list and `--dialect` help) was already closed by #1007 (`2456f26c`); the stale half-sentence it left in `feature-matrix.md` is deleted here.

**Not measured:** a live `schema apply --dry-run` round trip against a real CockroachDB / YugabyteDB / Spanner endpoint. No such server was reachable, and no number above depends on one.

## Docs

Three claims the matrix carried are now false and are corrected rather than left to a later measurement pass: the SQL Server row's "the mssql and tsql aliases silently drop views and triggers", the same row's stale "render's default dialect list and `--dialect` help omit SQL Server", and the Triggers row's `--dialect mssql`/`tsql` clause. `pgx`, `sql-server`, `sql_server`, `google-spanner` and `google_spanner` were accepted but undocumented; now that they render identically to their canonical names they are listed in the support matrix.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1` (176 packages `ok`, exit 0), `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh` (OK, 175 conditional groups), `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all green.

Because docs/ changed, **all 14** `check:*` scripts in `docs/site/package.json` were run, not only the four functional ones: exit-codes, core-doc-links, page-health, links, redirects, style, limitations, responsive, plus each of the five `:selftest` controls. All 14 green.

Read the output before trusting it: `check:responsive` first exited 1 with `dist not found; run "npm run build" first` — it would have reported nothing at all had that been read as a pass. It was re-run green after `npm run build`. `check:style` caught the docs paragraph this PR added going over the 900-character limit; the paragraph was split rather than the rule relaxed.

`gofmt -l` names one file, `internal/goannotationexport/testdata/cleanup/models.go`, which is not in this diff and was last touched by #988.

Refs #929
