### PR TITLE
Match schema-qualified --exclude globs against the default schema

### DIFF
--- a/cmd/atlas/schema_clean_scope.go
+++ b/cmd/atlas/schema_clean_scope.go
@@ -49,7 +49,7 @@ func scopeAtlasSchemaCleanPlan(
 			return schemaclean.Plan{}, fmt.Errorf("apply --include to the cleanup plan: %w", err)
 		}
 	} else {
-		projected, err = atlasfilter.ExcludeDatabase(synthetic, scope.Exclude)
+		projected, err = atlasfilter.ExcludeDatabaseWithDefaultSchema(synthetic, scope.Exclude, scope.DefaultSchema)
 		if err != nil {
 			return schemaclean.Plan{}, fmt.Errorf("apply --exclude to the cleanup plan: %w", err)
 		}

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -545,8 +545,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums.",
-    "evidence": "internal/atlasfilter/filter.go:341-346 (filterFunctions matches function.Name only) and :298-302 (filterEnums matches value.Name only); dbschema/types/types.go:358-367 DBFunction and :106-109 DBEnum carry no Schema field; internal/tableref/tableref.go:14-21 Canonical returns the bare name when schema is empty; live PostgreSQL 16 repro with the built ptah-compat binary; Atlas CE side from conformance cli-surface.md line 43/45/47 (--exclude registered on schema apply, diff, inspect)"
+    "note": "Resource globs plus one final-segment [type=...]; qualified globs now reach default-schema tables, views and their children, but enum and function filters still compare the bare name.",
+    "evidence": "internal/atlasfilter/filter.go ExcludeDatabaseWithDefaultSchema and exclusionState.effectiveSchema resolve a blank object schema to the connection default, so `--exclude public.users` matches the same table `--exclude users` does; filterEnums and filterFunctions still pass the bare name only; live PostgreSQL 16 repro with the built ptah-compat binary (`schema inspect -u $PG -s public -s app --exclude public.users` keeps table \"orders\" and drops table \"users\"); Atlas CE side from conformance cli-surface.md line 43/45/47 (--exclude registered on schema apply, diff, inspect)"
   },
   {
     "area": "Declarative / direct schema workflow",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -130,7 +130,7 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | `--dry-run`, `--auto-approve`, and `--edit` | ✅ | ✅ | ✅ | All three registered and functional; `--edit` opens $VISUAL/$EDITOR and the edited SQL is what gets planned, rehearsed, and applied. |
-| `--exclude` glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; schema-qualified globs never match default-schema tables, functions or enums. |
+| `--exclude` glob and type selectors | 🟡 | ✅ | ✅ | Resource globs plus one final-segment [type=...]; qualified globs now reach default-schema tables, views and their children, but enum and function filters still compare the bare name. |
 | `--include` resource selectors | ✅ | ❌ | ✅ | CE registers `--include` on apply/diff but aborts it as non-community, and registers none on inspect. Ptah has all three, with union semantics and cross-scope dependency diagnostics. |
 | `--schema` / -s scoping of both sides | ✅ | ✅ | ✅ | Names define the schema universe for apply and diff; repeated and comma-separated values union deterministically. |
 | `schema diff --export` | ❌ | ❌ | ✅ | Registered and refused by name. The flag selects an exporter declared by an atlas.hcl `exporter` block, and Ptah evaluates no such block, so there is nothing to select. |

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -105,6 +105,21 @@ and enum filters remain limited by Ptah's current introspection model, which
 does not retain schema names for those resource types yet. Exporter blocks
 remain an explicit gap.
 
+A pattern matches an object under either spelling: its bare name, or its name
+qualified by the schema that owns it. Introspection reports an object in the
+connection's own schema with no schema of its own, so the connection default
+supplies the qualified spelling — `--exclude public.users` and
+`--exclude users` remove the same table on a PostgreSQL database URL, and both
+subtract it from every side of a comparison, so an excluded object is neither
+created nor dropped.
+
+Accepting both spellings is looser than the pinned Atlas community binary,
+deliberately. That binary reads a pattern relative to the URL scope: on a
+database URL only `public.users` matches, and on a schema-bound URL
+(`?search_path=public`) only `users` does. Ptah honors both in both scopes.
+The extra matches only ever remove more objects from a plan, so the looser
+rule cannot turn a protected object into a dropped one.
+
 ### Select what is inspected with `--include`
 
 `--include` positively selects which top-level resources survive inspection,

--- a/internal/atlasfilter/filter.go
+++ b/internal/atlasfilter/filter.go
@@ -13,8 +13,27 @@ import (
 )
 
 // ExcludeDatabase returns a shallow copy of schema with resources matching
-// Atlas-style exclude globs removed.
+// Atlas-style exclude globs removed. Objects that carry no schema are treated
+// as unqualified; use [ExcludeDatabaseWithDefaultSchema] when the connection
+// names the schema those objects live in.
 func ExcludeDatabase(schema *dbschematypes.DBSchema, patterns []string) (*dbschematypes.DBSchema, error) {
+	return ExcludeDatabaseWithDefaultSchema(schema, patterns, "")
+}
+
+// ExcludeDatabaseWithDefaultSchema is [ExcludeDatabase] told which schema owns
+// the objects introspection left unqualified.
+//
+// Every reader blanks the schema of objects in the connection's own schema, so
+// without the default a table in it exposes only its bare name as a match
+// candidate and the schema-qualified spelling of the very same object matches
+// nothing. That miss is silent — exclude patterns have no match requirement —
+// and on `schema apply` and `schema diff` it reaches a DROP: the user writes
+// the qualified spelling to protect an object and the plan destroys it.
+func ExcludeDatabaseWithDefaultSchema(
+	schema *dbschematypes.DBSchema,
+	patterns []string,
+	defaultSchema string,
+) (*dbschematypes.DBSchema, error) {
 	filters, err := parsePatterns(patterns)
 	if err != nil {
 		return nil, err
@@ -23,7 +42,7 @@ func ExcludeDatabase(schema *dbschematypes.DBSchema, patterns []string) (*dbsche
 		return schema, nil
 	}
 
-	state := newExclusionState(filters)
+	state := newExclusionState(filters, defaultSchema)
 	filtered := cloneDatabase(schema)
 	filtered.Tables = state.filterTables(filtered.Tables)
 	filtered.Enums = state.filterEnums(filtered.Enums)
@@ -43,6 +62,20 @@ func ExcludeDatabase(schema *dbschematypes.DBSchema, patterns []string) (*dbsche
 // ExcludeGenerated returns a shallow copy of schema with generated-schema IR
 // resources matching Atlas-style exclude globs removed.
 func ExcludeGenerated(schema *goschema.Database, patterns []string) (*goschema.Database, error) {
+	return ExcludeGeneratedWithDefaultSchema(schema, patterns, "")
+}
+
+// ExcludeGeneratedWithDefaultSchema is [ExcludeGenerated] told which schema
+// owns the objects the generated IR left unqualified.
+//
+// Both sides of a comparison must subtract the same objects: a pattern that
+// removed a table from the introspected side but not from the desired side
+// would turn a filtered-out object into a CREATE.
+func ExcludeGeneratedWithDefaultSchema(
+	schema *goschema.Database,
+	patterns []string,
+	defaultSchema string,
+) (*goschema.Database, error) {
 	filters, err := parsePatterns(patterns)
 	if err != nil {
 		return nil, err
@@ -51,7 +84,7 @@ func ExcludeGenerated(schema *goschema.Database, patterns []string) (*goschema.D
 		return schema, nil
 	}
 
-	state := newExclusionState(filters)
+	state := newExclusionState(filters, defaultSchema)
 	filtered := cloneGenerated(schema)
 	filtered.Tables = state.filterGeneratedTables(filtered.Tables)
 	tableByStruct := generatedTableByStruct(filtered.Tables)
@@ -245,7 +278,12 @@ func selectorLikeSuffix(raw string) (selector string, ok bool) {
 }
 
 type exclusionState struct {
-	patterns        []resourcePattern
+	patterns []resourcePattern
+	// defaultSchema owns objects that carry no schema of their own. It is the
+	// connection's schema for introspected states and the dialect default for
+	// file-backed ones; empty means "no default", which restores the
+	// bare-name-only candidate set.
+	defaultSchema   string
 	excludedTables  map[tableIdentity]struct{}
 	excludedColumns map[columnIdentity]struct{}
 }
@@ -260,19 +298,53 @@ type columnIdentity struct {
 	column string
 }
 
-func newExclusionState(patterns []resourcePattern) *exclusionState {
+func newExclusionState(patterns []resourcePattern, defaultSchema string) *exclusionState {
 	return &exclusionState{
 		patterns:        patterns,
+		defaultSchema:   strings.TrimSpace(defaultSchema),
 		excludedTables:  map[tableIdentity]struct{}{},
 		excludedColumns: map[columnIdentity]struct{}{},
 	}
+}
+
+// effectiveSchema resolves the schema that owns an object. An object with no
+// schema of its own lives in the default schema, so it is the same object the
+// schema-qualified spelling names.
+func (s *exclusionState) effectiveSchema(schema string) string {
+	if trimmed := strings.TrimSpace(schema); trimmed != "" {
+		return trimmed
+	}
+	return s.defaultSchema
+}
+
+// nameCandidates returns the names an exclude pattern can match for a
+// top-level object: the bare name and the effective-schema-qualified name.
+// Both spellings name the same object, so both are offered — matching the
+// bare name is looser than the community binary on a database URL, and
+// looseness on an exclude subtracts rather than adds statements.
+func (s *exclusionState) nameCandidates(schema, name string) []string {
+	return qualifiedNameCandidates(s.effectiveSchema(schema), name)
+}
+
+// qualifiedNameCandidatesFor is [exclusionState.nameCandidates] for objects
+// whose only schema qualification is an optional "schema." prefix on the name,
+// mirroring how the include projection reads generated views.
+func (s *exclusionState) qualifiedNameCandidatesFor(name string) []string {
+	schema, bare := splitQualified(name)
+	return s.nameCandidates(schema, bare)
+}
+
+// childNameCandidates returns the names an exclude pattern can match for a
+// child of a table: "table.child" and "schema.table.child".
+func (s *exclusionState) childNameCandidates(schema, table, child string) []string {
+	return tableChildNameCandidates(s.effectiveSchema(schema), table, child)
 }
 
 func (s *exclusionState) filterTables(tables []dbschematypes.DBTable) []dbschematypes.DBTable {
 	result := make([]dbschematypes.DBTable, 0, len(tables))
 	for _, table := range tables {
 		table = cloneTable(table)
-		tableNames := tableNameCandidates(table.Schema, table.Name)
+		tableNames := s.nameCandidates(table.Schema, table.Name)
 		if s.matchesAny(tableResourceTypes(table), tableNames...) {
 			s.excludeTable(table.Schema, table.Name)
 			continue
@@ -286,7 +358,7 @@ func (s *exclusionState) filterTables(tables []dbschematypes.DBTable) []dbschema
 func (s *exclusionState) filterColumns(table dbschematypes.DBTable, columns []dbschematypes.DBColumn) []dbschematypes.DBColumn {
 	result := make([]dbschematypes.DBColumn, 0, len(columns))
 	for _, column := range columns {
-		columnNames := tableChildNameCandidates(table.Schema, table.Name, column.Name)
+		columnNames := s.childNameCandidates(table.Schema, table.Name, column.Name)
 		if s.matches("column", columnNames...) {
 			s.excludeColumn(table.Schema, table.Name, column.Name)
 			continue
@@ -307,7 +379,7 @@ func (s *exclusionState) filterIndexes(indexes []dbschematypes.DBIndex) []dbsche
 		if s.tableExcluded(index.Schema, index.TableName) || s.anyColumnExcluded(index.Schema, index.TableName, index.Columns) {
 			return false
 		}
-		return !s.matches("index", tableChildNameCandidates(index.Schema, index.TableName, index.Name)...)
+		return !s.matches("index", s.childNameCandidates(index.Schema, index.TableName, index.Name)...)
 	})
 }
 
@@ -320,14 +392,14 @@ func (s *exclusionState) filterConstraints(constraints []dbschematypes.DBConstra
 			s.anyColumnExcluded(foreignSchema, derefString(constraint.ForeignTable), constraint.ForeignColumnsOrDefault()) {
 			return false
 		}
-		return !s.matchesAny(constraintResourceTypes(constraint), tableChildNameCandidates(constraint.Schema, constraint.TableName, constraint.Name)...)
+		return !s.matchesAny(constraintResourceTypes(constraint), s.childNameCandidates(constraint.Schema, constraint.TableName, constraint.Name)...)
 	})
 }
 
 func (s *exclusionState) filterExtensions(extensions []dbschematypes.DBExtension) []dbschematypes.DBExtension {
 	result := make([]dbschematypes.DBExtension, 0, len(extensions))
 	for _, extension := range extensions {
-		names := qualifiedNameCandidates(extension.Schema, extension.Name)
+		names := s.nameCandidates(extension.Schema, extension.Name)
 		if s.matches("extension", names...) {
 			continue
 		}
@@ -347,7 +419,7 @@ func (s *exclusionState) filterFunctions(functions []dbschematypes.DBFunction) [
 
 func (s *exclusionState) filterViews(views []dbschematypes.DBView) []dbschematypes.DBView {
 	return keep(views, func(view dbschematypes.DBView) bool {
-		excluded := s.matches("view", qualifiedNameCandidates(view.Schema, view.Name)...)
+		excluded := s.matches("view", s.nameCandidates(view.Schema, view.Name)...)
 		if excluded {
 			s.excludeTable(view.Schema, view.Name)
 		}
@@ -357,7 +429,7 @@ func (s *exclusionState) filterViews(views []dbschematypes.DBView) []dbschematyp
 
 func (s *exclusionState) filterMatViews(views []dbschematypes.DBMatView) []dbschematypes.DBMatView {
 	return keep(views, func(view dbschematypes.DBMatView) bool {
-		excluded := s.matches("materialized_view", qualifiedNameCandidates(view.Schema, view.Name)...)
+		excluded := s.matches("materialized_view", s.nameCandidates(view.Schema, view.Name)...)
 		if excluded {
 			s.excludeTable(view.Schema, view.Name)
 		}
@@ -370,7 +442,7 @@ func (s *exclusionState) filterTriggers(triggers []dbschematypes.DBTrigger) []db
 		if s.tableExcluded(trigger.Schema, trigger.Table) {
 			return false
 		}
-		return !s.matches("trigger", tableChildNameCandidates(trigger.Schema, trigger.Table, trigger.Name)...)
+		return !s.matches("trigger", s.childNameCandidates(trigger.Schema, trigger.Table, trigger.Name)...)
 	})
 }
 
@@ -380,7 +452,7 @@ func (s *exclusionState) filterRLSPolicies(policies []dbschematypes.DBRLSPolicy)
 		if s.tableExcluded(schema, table) {
 			return false
 		}
-		return !s.matches("policy", tableChildNameCandidates(schema, table, policy.Name)...)
+		return !s.matches("policy", s.childNameCandidates(schema, table, policy.Name)...)
 	})
 }
 
@@ -401,7 +473,7 @@ func (s *exclusionState) filterGrants(grants []dbschematypes.DBGrant) []dbschema
 
 func (s *exclusionState) filterGeneratedTables(tables []goschema.Table) []goschema.Table {
 	return keep(tables, func(table goschema.Table) bool {
-		names := tableNameCandidates(table.Schema, table.Name)
+		names := s.nameCandidates(table.Schema, table.Name)
 		if s.matches("table", names...) {
 			s.excludeTable(table.Schema, table.Name)
 			return false
@@ -456,7 +528,7 @@ func (s *exclusionState) filterGeneratedIndexes(
 		if !ok || s.generatedAnyColumnExcluded(table, generatedIndexColumns(index)) {
 			return false
 		}
-		return !s.matches("index", tableChildNameCandidates(table.Schema, table.Name, index.Name)...)
+		return !s.matches("index", s.childNameCandidates(table.Schema, table.Name, index.Name)...)
 	})
 }
 
@@ -473,7 +545,7 @@ func (s *exclusionState) filterGeneratedConstraints(
 			s.generatedForeignColumnsExcluded(table.Schema, constraint.ForeignTable, constraint.ForeignColumnsOrDefault()) {
 			return false
 		}
-		return !s.matchesAny(generatedConstraintResourceTypes(constraint), tableChildNameCandidates(table.Schema, table.Name, constraint.Name)...)
+		return !s.matchesAny(generatedConstraintResourceTypes(constraint), s.childNameCandidates(table.Schema, table.Name, constraint.Name)...)
 	})
 }
 
@@ -528,9 +600,13 @@ func (s *exclusionState) filterGeneratedFunctions(functions []goschema.Function)
 	})
 }
 
+// filterGeneratedViews mirrors the introspected view exclusion. A generated
+// view carries its schema only as an optional "schema." prefix on its name, so
+// the candidates are resolved from that prefix and the default schema, keeping
+// both sides of a comparison subtracting the same views.
 func (s *exclusionState) filterGeneratedViews(views []goschema.View) []goschema.View {
 	return keep(views, func(view goschema.View) bool {
-		excluded := s.matches("view", view.Name)
+		excluded := s.matches("view", s.qualifiedNameCandidatesFor(view.Name)...)
 		if excluded {
 			s.excludeTable("", view.Name)
 		}
@@ -540,7 +616,7 @@ func (s *exclusionState) filterGeneratedViews(views []goschema.View) []goschema.
 
 func (s *exclusionState) filterGeneratedMaterializedViews(views []goschema.MaterializedView) []goschema.MaterializedView {
 	return keep(views, func(view goschema.MaterializedView) bool {
-		excluded := s.matches("materialized_view", view.Name)
+		excluded := s.matches("materialized_view", s.qualifiedNameCandidatesFor(view.Name)...)
 		if excluded {
 			s.excludeTable("", view.Name)
 		}
@@ -557,7 +633,7 @@ func (s *exclusionState) filterGeneratedTriggers(
 		if !ok {
 			return false
 		}
-		return !s.matches("trigger", tableChildNameCandidates(table.Schema, table.Name, trigger.Name)...)
+		return !s.matches("trigger", s.childNameCandidates(table.Schema, table.Name, trigger.Name)...)
 	})
 }
 
@@ -570,7 +646,7 @@ func (s *exclusionState) filterGeneratedRLSPolicies(
 		if !ok {
 			return false
 		}
-		return !s.matches("policy", tableChildNameCandidates(table.Schema, table.Name, policy.Name)...)
+		return !s.matches("policy", s.childNameCandidates(table.Schema, table.Name, policy.Name)...)
 	})
 }
 
@@ -659,7 +735,7 @@ func (s *exclusionState) anyColumnExcluded(schema, table string, columns []strin
 }
 
 func (s *exclusionState) generatedFieldExcluded(table goschema.Table, column string) bool {
-	return s.matches("column", tableChildNameCandidates(table.Schema, table.Name, column)...)
+	return s.matches("column", s.childNameCandidates(table.Schema, table.Name, column)...)
 }
 
 func (s *exclusionState) generatedColumnExcluded(table goschema.Table, column string) bool {
@@ -764,10 +840,6 @@ func keep[T any](values []T, keepValue func(T) bool) []T {
 		}
 	}
 	return result
-}
-
-func tableNameCandidates(schema, table string) []string {
-	return qualifiedNameCandidates(schema, table)
 }
 
 func tableChildNameCandidates(schema, table, child string) []string {

--- a/internal/atlasfilter/filter_default_schema_test.go
+++ b/internal/atlasfilter/filter_default_schema_test.go
@@ -1,0 +1,240 @@
+package atlasfilter_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasfilter"
+)
+
+// defaultSchemaFixture mirrors the PostgreSQL fixture the issue reproduces
+// against: objects in the connection's own schema come back from every reader
+// with an empty Schema field, objects in a second schema carry theirs.
+func defaultSchemaFixture() *dbschematypes.DBSchema {
+	return &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{Name: "users", Columns: []dbschematypes.DBColumn{{Name: "id"}, {Name: "name"}}},
+			{Schema: "app", Name: "orders", Columns: []dbschematypes.DBColumn{{Name: "id"}}},
+		},
+		Indexes: []dbschematypes.DBIndex{
+			{TableName: "users", Name: "users_name_idx", Columns: []string{"name"}},
+			{Schema: "app", TableName: "orders", Name: "orders_id_idx", Columns: []string{"id"}},
+		},
+		Views: []dbschematypes.DBView{
+			{Name: "v_users"},
+			{Schema: "app", Name: "v_orders"},
+		},
+		MatViews: []dbschematypes.DBMatView{
+			{Name: "mv_users"},
+			{Schema: "app", Name: "mv_orders"},
+		},
+		Extensions: []dbschematypes.DBExtension{
+			{Schema: "public", Name: "pgcrypto", Version: "1.3"},
+			{Schema: "public", Name: "plpgsql", Version: "1.0"},
+		},
+	}
+}
+
+func defaultSchemaMatViewNames(views []dbschematypes.DBMatView) []string {
+	names := make([]string, 0, len(views))
+	for _, view := range views {
+		names = append(names, view.QualifiedName())
+	}
+	return names
+}
+
+func defaultSchemaExtensionNames(extensions []dbschematypes.DBExtension) []string {
+	names := make([]string, 0, len(extensions))
+	for _, extension := range extensions {
+		names = append(names, extension.Name)
+	}
+	return names
+}
+
+// TestExcludeDatabaseWithDefaultSchema_QualifiedPatternsReachDefaultSchema is
+// the object-list form of the issue's completion criteria 1-4. Each row asserts
+// what survives the filter rather than an exit code: a silent no-op and a
+// correct filter both return a nil error here, so only the surviving objects
+// tell them apart.
+//
+// Reverting the default-schema candidate makes the "qualified, default schema"
+// rows fail with the excluded object still listed — exactly the reported bug —
+// while the bare-name and non-default-schema rows stay green, which is what
+// makes them controls rather than duplicates.
+func TestExcludeDatabaseWithDefaultSchema_QualifiedPatternsReachDefaultSchema(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		assert  func(*qt.C, *dbschematypes.DBSchema)
+	}{
+		{
+			name:    "qualified default-schema table",
+			pattern: "public.users",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"app.orders"})
+				c.Assert(indexNames(got.Indexes), qt.DeepEquals, []string{"orders_id_idx"})
+			},
+		},
+		{
+			name:    "bare default-schema table stays supported",
+			pattern: "users",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"app.orders"})
+			},
+		},
+		{
+			name:    "qualified non-default-schema table stays supported",
+			pattern: "app.orders",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users"})
+			},
+		},
+		{
+			name:    "qualified default-schema view",
+			pattern: "public.v_users",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(viewNames(got.Views), qt.DeepEquals, []string{"app.v_orders"})
+			},
+		},
+		{
+			name:    "qualified default-schema materialized view",
+			pattern: "public.mv_users",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(defaultSchemaMatViewNames(got.MatViews), qt.DeepEquals, []string{"app.mv_orders"})
+			},
+		},
+		{
+			name:    "qualified default-schema column",
+			pattern: "public.users.name",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users", "app.orders"})
+				c.Assert(columnNames(got.Tables[0].Columns), qt.DeepEquals, []string{"id"})
+				c.Assert(indexNames(got.Indexes), qt.DeepEquals, []string{"orders_id_idx"})
+			},
+		},
+		{
+			name:    "qualified extension stays supported",
+			pattern: "public.pgcrypto",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(defaultSchemaExtensionNames(got.Extensions), qt.DeepEquals, []string{"plpgsql"})
+			},
+		},
+		{
+			name:    "a different schema still matches nothing",
+			pattern: "nosuch.users",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users", "app.orders"})
+				c.Assert(viewNames(got.Views), qt.DeepEquals, []string{"v_users", "app.v_orders"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := atlasfilter.ExcludeDatabaseWithDefaultSchema(
+				defaultSchemaFixture(), []string{test.pattern}, "public")
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, got)
+		})
+	}
+}
+
+// TestExcludeDatabase_WithoutDefaultSchemaKeepsBareOnlyCandidates is the
+// inverse mutant of the test above: with no default schema the qualified
+// spelling must go back to matching nothing, and the bare one must still work.
+// Without this row, a candidate layer that qualified every object with a
+// hard-coded "public" would pass the table above and silently mis-filter every
+// non-PostgreSQL target.
+//
+// Reverting the fix leaves this test green; breaking the "empty default means
+// no default" rule turns the first assertion red with "users" already gone.
+func TestExcludeDatabase_WithoutDefaultSchemaKeepsBareOnlyCandidates(t *testing.T) {
+	c := qt.New(t)
+
+	qualified, err := atlasfilter.ExcludeDatabase(defaultSchemaFixture(), []string{"public.users"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableNames(qualified.Tables), qt.DeepEquals, []string{"users", "app.orders"})
+
+	bare, err := atlasfilter.ExcludeDatabase(defaultSchemaFixture(), []string{"users"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableNames(bare.Tables), qt.DeepEquals, []string{"app.orders"})
+}
+
+// TestExcludeGeneratedWithDefaultSchema_MatchesDatabaseSide pins the symmetry
+// the comparison depends on. A pattern that removed an object from the
+// introspected side but not from the desired side would turn the protected
+// object into a CREATE, which is the opposite failure of the one being fixed.
+//
+// Reverting the fix fails this with the table and the view still present in the
+// desired state, while the introspected side of the same pattern is empty.
+func TestExcludeGeneratedWithDefaultSchema_MatchesDatabaseSide(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		assert  func(*qt.C, *goschema.Database)
+	}{
+		{
+			name:    "qualified default-schema table",
+			pattern: "public.users",
+			assert: func(c *qt.C, got *goschema.Database) {
+				c.Assert(generatedTableNames(got.Tables), qt.DeepEquals, []string{"app.orders"})
+				c.Assert(generatedFieldNames(got.Fields), qt.DeepEquals, []string{"Order.id"})
+			},
+		},
+		{
+			name:    "qualified default-schema view",
+			pattern: "public.v_users",
+			assert: func(c *qt.C, got *goschema.Database) {
+				c.Assert(generatedViewNames(got.Views), qt.DeepEquals, []string{"app.v_orders"})
+			},
+		},
+		{
+			name:    "a different schema still matches nothing",
+			pattern: "nosuch.users",
+			assert: func(c *qt.C, got *goschema.Database) {
+				// goschema.Finalize sorts tables by name; views keep input order.
+				c.Assert(generatedTableNames(got.Tables), qt.DeepEquals, []string{"app.orders", "users"})
+				c.Assert(generatedViewNames(got.Views), qt.DeepEquals, []string{"v_users", "app.v_orders"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			schema := &goschema.Database{
+				Tables: []goschema.Table{
+					{StructName: "User", Name: "users"},
+					{StructName: "Order", Schema: "app", Name: "orders"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+					{StructName: "Order", Name: "id", Type: "INTEGER", Primary: true},
+				},
+				Views: []goschema.View{
+					{StructName: "VUsers", Name: "v_users", Body: "SELECT id FROM users"},
+					{StructName: "VOrders", Name: "app.v_orders", Body: "SELECT id FROM app.orders"},
+				},
+			}
+
+			got, err := atlasfilter.ExcludeGeneratedWithDefaultSchema(schema, []string{test.pattern}, "public")
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, got)
+		})
+	}
+}
+
+func generatedViewNames(views []goschema.View) []string {
+	names := make([]string, 0, len(views))
+	for _, view := range views {
+		names = append(names, view.Name)
+	}
+	return names
+}

--- a/internal/atlasfilter/scope.go
+++ b/internal/atlasfilter/scope.go
@@ -215,7 +215,7 @@ func validateIncludeSelectorTypes(raw string, types map[string]struct{}) error {
 // selection keep using it, and callers that refuse one have the error.
 func ScopeGenerated(db *goschema.Database, scope Scope) (*goschema.Database, error) {
 	if !scope.Positive() {
-		return ExcludeGenerated(db, scope.Exclude)
+		return ExcludeGeneratedWithDefaultSchema(db, scope.Exclude, scope.DefaultSchema)
 	}
 	selectors, err := parseIncludeSelectors(scope.Include)
 	if err != nil {
@@ -226,7 +226,7 @@ func ScopeGenerated(db *goschema.Database, scope Scope) (*goschema.Database, err
 	}
 	selection := newScopeSelection(scope, selectors)
 	selected := selection.projectGenerated(db)
-	final, err := ExcludeGenerated(selected, scope.Exclude)
+	final, err := ExcludeGeneratedWithDefaultSchema(selected, scope.Exclude, scope.DefaultSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -242,7 +242,7 @@ func ScopeGenerated(db *goschema.Database, scope Scope) (*goschema.Database, err
 // an empty include selection the same way [ScopeGenerated] does.
 func ScopeDatabase(db *dbschematypes.DBSchema, scope Scope) (*dbschematypes.DBSchema, error) {
 	if !scope.Positive() {
-		return ExcludeDatabase(db, scope.Exclude)
+		return ExcludeDatabaseWithDefaultSchema(db, scope.Exclude, scope.DefaultSchema)
 	}
 	selectors, err := parseIncludeSelectors(scope.Include)
 	if err != nil {
@@ -253,7 +253,7 @@ func ScopeDatabase(db *dbschematypes.DBSchema, scope Scope) (*dbschematypes.DBSc
 	}
 	selection := newScopeSelection(scope, selectors)
 	selected := selection.projectDatabase(db)
-	final, err := ExcludeDatabase(selected, scope.Exclude)
+	final, err := ExcludeDatabaseWithDefaultSchema(selected, scope.Exclude, scope.DefaultSchema)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -309,7 +309,10 @@ func VerifyPlanTarget(conn *dbschema.DatabaseConnection, plan PlanFile) error {
 	if err != nil {
 		return fmt.Errorf("read database schema: %w", err)
 	}
-	current, err = atlasfilter.ExcludeDatabase(current, plan.Exclude)
+	// The connection's default schema is the same one computeApplyPlan gave the
+	// exclusion when the plan was recorded. Passing a different one here would
+	// subtract a different set of objects and mis-report a fresh plan as stale.
+	current, err = atlasfilter.ExcludeDatabaseWithDefaultSchema(current, plan.Exclude, conn.Info().Schema)
 	if err != nil {
 		return fmt.Errorf("apply plan exclude patterns to current schema: %w", err)
 	}

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -109,7 +109,9 @@ func RehearsePlanStatements(
 	if err != nil {
 		return fmt.Errorf("read database schema: %w", err)
 	}
-	current, err = atlasfilter.ExcludeDatabase(current, opts.Exclude)
+	// Same default schema computeApplyPlan uses, so the rehearsal subtracts
+	// exactly the objects the plan was computed without.
+	current, err = atlasfilter.ExcludeDatabaseWithDefaultSchema(current, opts.Exclude, conn.Info().Schema)
 	if err != nil {
 		return fmt.Errorf("apply plan exclude patterns to current schema: %w", err)
 	}

--- a/internal/atlasschema/scope.go
+++ b/internal/atlasschema/scope.go
@@ -31,7 +31,7 @@ func scopeGeneratedSide(db *goschema.Database, scope atlasfilter.Scope, side str
 		}
 		return filtered, nil
 	}
-	filtered, err := atlasfilter.ExcludeGenerated(db, scope.Exclude)
+	filtered, err := atlasfilter.ExcludeGeneratedWithDefaultSchema(db, scope.Exclude, scope.DefaultSchema)
 	if err != nil {
 		return nil, fmt.Errorf("apply --exclude to %s: %w", side, err)
 	}
@@ -52,7 +52,7 @@ func scopeDatabaseSide(db *types.DBSchema, scope atlasfilter.Scope, side string)
 		}
 		return filtered, nil
 	}
-	filtered, err := atlasfilter.ExcludeDatabase(db, scope.Exclude)
+	filtered, err := atlasfilter.ExcludeDatabaseWithDefaultSchema(db, scope.Exclude, scope.DefaultSchema)
 	if err != nil {
 		return nil, fmt.Errorf("apply --exclude to %s: %w", side, err)
 	}


### PR DESCRIPTION
Implements **workstream A** of the split proposed in the framing comment on #933: *schema-qualified `--exclude` misses the default schema, and the miss reaches a DROP*. Items 2 and 3 of the issue body survive and are named at the bottom.

## The bug

Every reader blanks the schema of objects living in the connection's own schema (`internal/dbschema/postgres/reader.go` `outputSchema`, and the same shape in the MySQL, MSSQL, SQLite and ClickHouse readers). The exclusion filter built its match candidates from that blank schema, so a default-schema object exposed only its bare name. `--exclude public.users` matched nothing.

An exclude pattern has no match requirement, so the miss was silent — exit 0, no warning — and it did not stop at filtering. It reached a plan.

## Reproduction

Fixture: `postgres:16-alpine`, seeded with `public.users` (comment `a users comment`), `public.v_users`, `public.mood`, `public.fn_audit`, `pgcrypto`, `app.orders`, `app.v_orders`, `app.color`, `app.fn_app`. `$PG` is the database URL, `$DEV` an empty dev database, `empty.sql` a file holding only a comment. Binaries: `go build -o pc933 ./cmd/ptah-compat` at `d1e2dc64` (before) and at this branch's tip (after).

### `schema inspect -u $PG -s public -s app --exclude <selector>`

| selector | before | after |
| --- | --- | --- |
| `public.users` | exit 0, **`table "users"` still there** | exit 0, `users` gone, `orders` kept |
| `public.v_users` | exit 0, **`view "v_users"` still there** | exit 0, `v_users` gone, `v_orders` kept |
| `users` (control) | `users` gone | `users` gone |
| `app.orders` (control) | `orders` gone | `orders` gone |
| `public.pgcrypto` (control) | `pgcrypto` gone | `pgcrypto` gone |
| `nosuch.users` (negative control) | nothing removed | nothing removed |
| `public.mood`, `public.fn_audit`, `app.color`, `app.fn_app` | no-op | no-op (workstream B, unchanged) |

### It reaches a DROP

`schema apply -u $PG --to file://keep.sql --dev-url $DEV -s public --dry-run --exclude public.users,public.v_users`, where `keep.sql` holds only a comment:

```
before: DROP VIEW IF EXISTS "v_users"; DROP TABLE IF EXISTS "users";
        DROP FUNCTION IF EXISTS "fn_audit"(); DROP TYPE IF EXISTS "mood" CASCADE;   exit 0
after:  DROP FUNCTION IF EXISTS "fn_audit"(); DROP TYPE IF EXISTS "mood" CASCADE;   exit 0
```

The bare-name control `--exclude users,v_users` prints the "after" plan on both binaries. That is the whole defect: the qualified spelling silently destroyed what the bare spelling protected, and now the two are the same plan.

`schema diff --from $PG --to file://empty.sql --dev-url $DEV -s public --exclude public.users` completes criterion 3 the same way the bare spelling already did: exit 1 with `view "v_users" references "users", but "users" is not selected`, no `DROP TABLE IF EXISTS "users"` anywhere. Excluding the dependent view too (`--exclude public.users --exclude public.v_users`) gives exit 0 and a plan byte-identical to the bare spelling's.

### Not only PostgreSQL

The framing comment flagged the other readers as unmeasured. Measured on `mysql:8.0`, `schema inspect -u mysql://root:pw@localhost:PORT/auditdb`:

| selector | before | after |
| --- | --- | --- |
| `auditdb.users` | exit 0, table still there | exit 0, table gone |
| `users` (control) | table gone | table gone |
| `auditdb.v_users` (control — MySQL views already carry the db name) | view gone | view gone |
| `nosuchdb.users` (negative control) | nothing removed | nothing removed |

## The change

The fix is in the candidate layer, as the framing scoped it. `exclusionState` now carries a default schema and resolves a blank object schema through it, so a default-schema object offers both spellings of its own name:

- `ExcludeDatabaseWithDefaultSchema` / `ExcludeGeneratedWithDefaultSchema` are the new entry points; the old two-argument forms delegate with an empty default and keep their exact previous behavior.
- Every caller that already had a default schema passes it: `ScopeDatabase`/`ScopeGenerated`, `scopeDatabaseSide`/`scopeGeneratedSide`, `VerifyPlanTarget`, `RehearsePlanStatements`, and `schema clean`'s plan projection.
- The generated-IR side takes the same default deliberately. Filtering only the introspected side would remove a table from the current state but not from the desired state, turning a protected object into a `CREATE` — the opposite failure.
- `VerifyPlanTarget` and `RehearsePlanStatements` had to move together with `computeApplyPlan`: they fingerprint the excluded current schema, and a different default there would subtract a different object set and report a fresh plan as stale.

No IR change, no public-API change (`scripts/check-public-api.sh` and `scripts/check-public-api-snapshot.sh` are green without a new approval).

## Criterion 5: the bare-name divergence, stated

The issue's criterion 4 requires `--exclude users` to keep working on a database URL. The pinned Atlas community binary does not honor it there. **This PR keeps Ptah's looser behavior deliberately.** Re-measured on the fixture above, both binaries exiting 0 in every cell:

| | community v1.3.0 | Ptah after this PR |
| --- | --- | --- |
| database URL, `--exclude public.users` | protects `users` | protects (**fixed — was: dropped it**) |
| database URL, `--exclude users` | does not protect | protects (**looser, deliberate**) |
| schema-bound URL (`?search_path=public`), `--exclude users` | protects | protects (match) |
| schema-bound URL, `--exclude public.users` | does not protect | protects (**looser, new in this PR**) |
| MySQL database URL, `--exclude users` | protects | protects (match) |
| MySQL database URL, `--exclude auditdb.users` | does not protect | protects (**looser, new in this PR**) |

The community rule is "the pattern is relative to the URL scope". Ptah's rule after this PR is simpler and is a strict superset of it in both scopes: **a pattern matches an object under either its bare name or its effective-schema-qualified name**. The fourth and sixth rows are new looseness this PR introduces; the fourth row previously matched the community binary.

I chose the superset over the URL-scope rule for two reasons, in this order. First, criterion 4 forbids dropping the bare form, so the URL-scope rule is not reachable without a breaking change the issue rules out. Second, every extra match on an `--exclude` removes statements from a plan and never adds any, so the looseness can only under-change a database, never over-change one. Parity rule (a) is not engaged anywhere here: there is no cell where Ptah exits 0 and the pinned binary exits 1.

## What the tests print if the change is reverted

New file `internal/atlasfilter/filter_default_schema_test.go`. Both mutants below were run; the output quoted is what I actually saw.

**`TestExcludeDatabaseWithDefaultSchema_QualifiedPatternsReachDefaultSchema`** — one row per criteria 1-4, each asserting the surviving object list rather than the exit code, because a silent no-op and a correct filter both return a nil error here.

Revert mutant (`effectiveSchema` stops consulting the default) reddens exactly four subtests and no others:

```
--- FAIL: .../qualified_default-schema_table
--- FAIL: .../qualified_default-schema_view
--- FAIL: .../qualified_default-schema_materialized_view
--- FAIL: .../qualified_default-schema_column
```

with `got: []string{"users", "app.orders"}` against `want: []string{"app.orders"}` — the excluded table still present, which is the reported bug spelled out. The four control rows (`bare default-schema table`, `qualified non-default-schema table`, `qualified extension`, `a different schema still matches nothing`) stay green under the same mutant, which is what makes them controls and not duplicates.

**`TestExcludeGeneratedWithDefaultSchema_MatchesDatabaseSide`** — the two-sided symmetry. The same revert mutant reddens `qualified_default-schema_table` and `qualified_default-schema_view` with the table and view still present in the desired state while the introspected side of the same pattern is empty; the negative-control row stays green.

**`TestExcludeDatabase_WithoutDefaultSchemaKeepsBareOnlyCandidates`** — the guard that "empty default means no default". The revert mutant leaves it **green**, so it does not double-count the fix. Its own failure needs the *inverse* mutant: hard-coding `effectiveSchema` to return `"public"` when the default is empty. Run with that inverse mutant, it is the only test in the package that fails:

```
--- FAIL: TestExcludeDatabase_WithoutDefaultSchemaKeepsBareOnlyCandidates
```

reporting `users` already removed by `--exclude public.users` when no default schema was supplied. Without this test, a candidate layer that qualified every object with a hard-coded `"public"` would pass the whole table above and silently mis-filter every non-PostgreSQL target.

## Gates

All green on this branch:

```
go build ./...                       exit 0
go vet ./...                         exit 0
go test ./... -count=1               exit 0
go tool qtlint ./...                 exit 0
golangci-lint run ./...              exit 0   (0 issues)
scripts/check-test-style.sh          exit 0   (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh          exit 0
scripts/check-public-api-snapshot.sh exit 0
gofmt -l <touched dirs>              no output
```

`docs/` is touched, so every `check:*` script in `docs/site/package.json` was run plus `versions:selftest` — 15 scripts, all exit 0. `check:responsive` needs `npm run build` first (it exits 1 with `dist not found` otherwise); the Astro build ran green, 61 pages, and `check:responsive` then reported `OK (60 routes x 2 viewports, cells within 8 lines)`.

`feature-matrix.md:133` no longer contains *"schema-qualified globs never match default-schema tables"*; the row is regenerated from `docs/site/scripts/data/feature-matrix-rows.json` by `build-feature-matrix.mjs`, and the new `note` is 183 characters.

## Deliberately left open

- **Item 3 and the enum/function half of item 4 (framing's workstream B).** `--exclude public.mood`, `--exclude app.color`, `--exclude public.fn_audit` and `--exclude app.fn_app` are still silent no-ops after this PR — measured, not assumed. `dbschema/types.DBEnum` and `DBFunction` carry no `Schema` field at all, so there is nothing for the candidate layer to resolve; fixing it needs an IR change across every reader plus a public-API baseline approval. Out of scope here on purpose: it has a wider blast radius, no safety urgency, and only the enum half has a community oracle.
- **Item 2 (framing's workstream C).** The four `--exclude` spellings Ptah refuses and the community binary accepts are untouched. Pure grammar work with no database semantics.
- **Item 1.** Already closed by #1113; the framing comment recommends striking it from the body rather than reopening the exit-code question.
- **The row the issue's feature matrix keeps at 🟡.** `feature-matrix.md:154` (*Schema-qualified exclude globs for enums and functions*) is unchanged, and the `schema-commands.md` sentence about the introspection model not retaining schema names for enums and functions is still there and still true. Both belong to workstream B.
- **`atlas.hcl` `env.exclude`.** Only the CLI flag was exercised, as in the framing comment.
- **Generated-side extensions.** `filterGeneratedExtensions` still matches the bare extension name while the introspected side matches both spellings. It is not the default-schema defect — introspected extensions carry a real schema — and no criterion covers it, so I left it rather than widen the change.

Refs #933
