### PR TITLE
Make every code the compat linter prints suppressible by that code

### DIFF
--- a/cmd/migrateup/lint_internal_test.go
+++ b/cmd/migrateup/lint_internal_test.go
@@ -37,6 +37,54 @@ func TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression(t *testing.T) {
 	c.Assert(findings[0].Rule, qt.Equals, "DS101")
 }
 
+// TestLintPendingDestructive_SuppressionSpellingsAtTheApplyGate records which
+// directives reopen the apply-time destructive gate, because resolving Atlas
+// analyzer names on the native surface changed one of these rows.
+//
+// The gate has always honored a statement-local directive an author wrote above
+// the statement: on a binary built from master, `-- ptah:nolint DS101` and
+// `-- atlas:nolint DS101` above `DROP TABLE users;` both take
+// `ptah migrations up` from exit 2 to exit 0. `-- atlas:nolint destructive`
+// did not, because the analyzer name resolved to nothing natively; it now does,
+// which is the row this change moves. The whole-file header keeps blocking, and
+// keeps blocking for the same reason as before: the header form is
+// compatibility-scoped, and a blank line detaches it from the statement below.
+//
+// Reverting the change prints []string{"DS101"} for the "Atlas analyzer name"
+// row instead of an empty slice.
+func TestLintPendingDestructive_SuppressionSpellingsAtTheApplyGate(t *testing.T) {
+	tests := []struct {
+		name string
+		up   string
+		want []string
+	}{
+		{name: "no directive", up: "DROP TABLE users;\n", want: []string{"DS101"}},
+		{name: "native code", up: "-- ptah:nolint DS101\nDROP TABLE users;\n", want: []string{}},
+		{name: "Atlas code spelling", up: "-- atlas:nolint DS101\nDROP TABLE users;\n", want: []string{}},
+		{name: "Atlas analyzer name", up: "-- atlas:nolint destructive\nDROP TABLE users;\n", want: []string{}},
+		{name: "Atlas file header", up: "-- atlas:nolint destructive\n\nDROP TABLE users;\n", want: []string{"DS101"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			fsys := fstest.MapFS{
+				"0000000001_drop.up.sql":   {Data: []byte(test.up)},
+				"0000000001_drop.down.sql": {Data: []byte("CREATE TABLE users (id INTEGER);\n")},
+			}
+
+			findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite", "")
+
+			c.Assert(err, qt.IsNil)
+			codes := make([]string, 0, len(findings))
+			for _, finding := range findings {
+				codes = append(codes, finding.Rule)
+			}
+			c.Assert(codes, qt.DeepEquals, test.want)
+		})
+	}
+}
+
 func TestLintPendingDestructive_HonorsDirectoryPrefixedExclusion(t *testing.T) {
 	c := qt.New(t)
 	fsys := fstest.MapFS{

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -857,11 +857,11 @@
   {
     "area": "Lint policy and suppression",
     "feature": "Inline nolint suppression",
-    "ptah": "partial",
+    "ptah": "yes",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored.",
-    "evidence": "internal/atlaslint/rules.go:41 NativeSuppressionTargets maps 5 analyzer names + ds102/ds103/mf103 only, default returns nil. Reproduced: `ptah-compat migrate lint` reports `[PG101]` yet `-- atlas:nolint PG101` leaves the diagnostic. CE side: PARITY.md:420 records the imported Atlas fixtures asserting `-- atlas:nolint` suppression for `atlas migrate lint`; gaps.md:814 runs cli-migrate-lint-ignore.txtar with 57 assertions. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter — a plan-tier claim in tension with the measured CE fixtures asserting `-- atlas:nolint` suppression; the measured yes stands. `-- atlas:nolint <CODE>` and analyzer-name spellings both suppress; matching is exact, not blanket (measured; observation study, scenario, lint-test-pro)"
+    "note": "Every code the compat surface prints is silenced by that code; analyzer names work on both surfaces; a blank line detaches a directive. Unknown selectors accepted silently, matching CE.",
+    "evidence": "internal/atlaslint/rules.go NativeSuppressionTargets is the inverse of RuleForNativeCode, so all 40 distinct codes the compat profile prints are suppressed by that code — 1 of 40 before (37 resolved to nothing, DS103 and MF103 to one of their two producers each), pinned by TestRules_EveryCompatibilityCodeIsSuppressibleByThatCode over lint.Rules(). Reproduced: `-- atlas:nolint PG101` above CREATE INDEX left `[PG101]` reported by `ptah-compat migrate lint` and now suppresses it; `-- atlas:nolint concurrent_index` now suppresses on `ptah migrations lint` too. Code selectors match exactly, measured against the pinned community binary on `ALTER TABLE t DROP COLUMN legacy;`: `-- atlas:nolint DS`, `-- atlas:nolint D` and `-- atlas:nolint totally_bogus_selector` all leave DS103 reported at exit 1 there, the last with no warning about the selector, so unknown selectors stay silently accepted. Same binary: a blank line between the directive and its statement leaves DS103 reported at exit 1, which Ptah suppressed. CE side: PARITY.md:420 records the imported Atlas fixtures asserting `-- atlas:nolint` suppression for `atlas migrate lint`; gaps.md:814 runs cli-migrate-lint-ignore.txtar with 57 assertions. Atlas pricing page (atlasgo.io/pricing), retrieved 2026-08-01: 'Migration linting' is unchecked on Starter — a plan-tier claim in tension with the measured CE fixtures asserting `-- atlas:nolint` suppression; the measured yes stands."
   },
   {
     "area": "Lint policy and suppression",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -76,13 +76,13 @@ Across the 163 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 89 |
-| Ptah supports it with a stated limitation | 49 |
+| Ptah supports it fully | 90 |
+| Ptah supports it with a stated limitation | 48 |
 | Ptah does not implement it | 25 |
-| Ptah and Atlas CE both support it | 21 |
+| Ptah and Atlas CE both support it | 22 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
 | Ptah has it and neither Atlas edition does | 20 |
-| Atlas CE has it and Ptah does not, or only in part | 26 |
+| Atlas CE has it and Ptah does not, or only in part | 25 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
@@ -205,7 +205,7 @@ seven of them as open capabilities regardless.
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
 | Generation-time destructive-change gate | ✅ | ❌ | ❌ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
-| Inline nolint suppression | 🟡 | ✅ | ✅ | Analyzer-name selectors suppress, but only codes DS102/DS103/MF103 map; atlas:nolint PG101 and unknown selectors are silently ignored. |
+| Inline nolint suppression | ✅ | ✅ | ✅ | Every code the compat surface prints is silenced by that code; analyzer names work on both surfaces; a blank line detaches a directive. Unknown selectors accepted silently, matching CE. |
 | Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |
 | Per-rule severity policy | 🟡 | ❌ | 🟡 | Severity vocabulary is warning\|error only (info errors out). The community binary carries no severity attribute: it accepts one and ignores it, exactly as it treats an invented attribute. |
 | Pre-migration assertion checks | 🟡 | ❌ | ✅ | Scalar SELECTs; txtar checks.sql and checks/*.sql support all-of/oneof groups. CE ignores checks. Compat bypass is PTAH_SKIP_CHECKS. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -772,19 +772,41 @@ For a code-by-code audit of the analyzer checks Atlas marks as Pro against
 Ptah's native lint rules, see
 [Comparison: Atlas Pro analyzer coverage](../comparison/#atlas-pro-analyzer-coverage).
 
-Atlas-compatible lint directives are enabled only under the `ptah-compat
-migrate lint` compatibility profile. A statement-local `-- atlas:nolint
-<selector>` suppresses the following statement. A first nonempty `--
-atlas:nolint <selector>` header followed by a blank line applies to the whole
-file.
+A statement-local `-- atlas:nolint <selector>` suppresses the statement
+directly below it. A blank line between the directive and the statement
+detaches the two: the directive then suppresses nothing, exactly as the
+community binary treats it.
 
-A bare file header ignores the file completely, so it is absent from `.Files`
-and per-file analysis steps. Supported analyzer selectors are `destructive`,
-`data_depend`, `concurrent_index`, `incompatible`, and `nestedtx`; supported
-Atlas diagnostic aliases are `DS102`, `DS103`, and `MF103`.
+The whole-file header form — a first nonempty `-- atlas:nolint <selector>`
+line followed by a blank line — is enabled only under the `ptah-compat migrate
+lint` compatibility profile. A bare file header ignores the file completely, so
+it is absent from `.Files` and per-file analysis steps.
 
-Native lint and migrate-up safety keep their native directive semantics unless
-the Atlas compatibility profile is selected explicitly.
+Supported analyzer selectors are `destructive`, `data_depend`,
+`concurrent_index`, `incompatible`, and `nestedtx`. They name rule families, so
+they mean the same thing on both surfaces.
+
+A code selector names the code the running surface prints: every code
+`ptah-compat migrate lint` emits is suppressed by that code, and every code
+`ptah migrations lint` emits is suppressed by that code. The three codes the
+compatibility surface renames are the only place the two differ — a column drop
+prints `DS102` natively and `DS103` on the compatibility surface, so `--
+atlas:nolint DS103` silences it there and `-- atlas:nolint DS102` silences it
+natively. Where two native rules share one printed code, the selector reaches
+both: `-- atlas:nolint DS103` silences a `DROP COLUMN` and a column type change
+alike.
+
+A code selector matches one code exactly and never widens into a family, on
+both surfaces: `-- atlas:nolint DS` and `-- atlas:nolint D` suppress nothing,
+while the native `-- ptah:nolint DS` still silences the whole family. An
+unrecognized
+selector is accepted and suppresses nothing, without a warning — the pinned
+community binary behaves the same way, and matching it was chosen over
+diagnosing the typo. Ptah's own `.ptah-lint.yaml` `disabled-rules` remains
+strict and rejects a selector matching no registered rule.
+
+Migrate-up safety keeps its native directive semantics: the whole-file Atlas
+header never reopens the apply-time destructive gate.
 
 ## Metadata commands and directory formats
 

--- a/docs/site/src/content/docs/extend/components.md
+++ b/docs/site/src/content/docs/extend/components.md
@@ -420,8 +420,11 @@ _ = m
 `VersionSelection.Restricted` distinguishes no selector from an explicitly
 empty changeset. Native Ptah callers should keep the zero-value
 `CompatibilityProfileNative`; `CompatibilityProfileAtlas` exists for
-Atlas-compatible command adapters and enables Atlas-specific `nolint` aliases
-and file-header semantics without changing native safety behavior.
+Atlas-compatible command adapters. It switches the `atlas:nolint` code
+namespace to the codes that profile prints and enables the file-header form,
+without changing native safety behavior. Atlas analyzer-name selectors resolve
+under both profiles, because they name rule families rather than printed
+codes.
 
 Each finding context identifies its zero-based statement index. Structured
 subjects preserve the executable identifier spelling: table subjects use

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -501,14 +501,29 @@ everywhere else, put a `ptah:nolint` comment directly above it:
 ALTER TABLE users DROP COLUMN archived_note;
 ```
 
-The directive suppresses only the named rules, and only for the next
-statement. List several codes separated by spaces or commas, name a family
-(`DS`), or write a bare `-- ptah:nolint` to silence every rule for that one
-statement. `-- atlas:nolint DS102` is accepted as an alias with the same
+The directive suppresses only the named rules, and only for the statement
+directly below it — a blank line between the comment and the statement
+detaches the two. List several codes separated by spaces or commas, name a
+family (`DS`), or write a bare `-- ptah:nolint` to silence every rule for
+that one statement.
+
+`-- atlas:nolint DS102` is accepted as an alias with the same
 statement-scoped behavior, so a directory shared with Atlas tooling keeps
-one set of directives. Atlas analyzer-name selectors (such as
-`destructive`) and whole-file `atlas:nolint` headers take effect only on
-the Atlas-compatible surface — see
+one set of directives. Atlas analyzer-name selectors (`destructive`,
+`data_depend`, `concurrent_index`, `incompatible`, `nestedtx`) name rule
+families and work here too. A code selector always names the code the
+command you ran printed, so on this surface it is the native code:
+`ptah migrations lint` reports `DS102` for a dropped column and
+`-- atlas:nolint DS102` silences it, while `ptah-compat migrate lint`
+prints the same finding as `DS103`.
+
+The `atlas:` spelling follows Atlas's matching rule rather than Ptah's, so a
+code selector there matches one code exactly: `-- ptah:nolint DS` silences
+the data-safety family and `-- atlas:nolint DS` silences nothing. An
+unrecognized `atlas:nolint` selector is accepted and silences nothing,
+without a warning; `.ptah-lint.yaml` `disabled-rules` stays strict and
+rejects a selector matching no registered rule. Whole-file `atlas:nolint`
+headers take effect only on the Atlas-compatible surface — see
 [Atlas migrate commands](../../atlas/migrate-commands/).
 
 ## The destructive-change gate

--- a/internal/atlaslint/rules.go
+++ b/internal/atlaslint/rules.go
@@ -19,45 +19,125 @@ type Rule struct {
 	Code     string
 }
 
+// Target is one resolved nolint selector.
+//
+// A target with Family set suppresses every native rule code that starts with
+// Value, which is how analyzer names work: "destructive" owns the whole DS and
+// CD families. A target without it suppresses exactly the rule whose code
+// equals Value, which is how code selectors work: the community binary silences
+// nothing for `-- atlas:nolint DS` or `-- atlas:nolint D`, so a code selector
+// must never widen into a family (measured against atlas community version
+// v1.3.0; both leave the DS103 diagnostic reported and exit 1).
+type Target struct {
+	Value  string
+	Family bool
+}
+
+// CodeTarget suppresses exactly one native rule code.
+func CodeTarget(code string) Target { return Target{Value: code} }
+
+// FamilyTarget suppresses every native rule code starting with prefix. The
+// empty prefix is every rule, which is what a bare nolint directive means.
+func FamilyTarget(prefix string) Target { return Target{Value: prefix, Family: true} }
+
+// Matches reports whether this target suppresses the given native rule code.
+func (t Target) Matches(code string) bool {
+	if t.Family {
+		return strings.HasPrefix(code, t.Value)
+	}
+	return code == t.Value
+}
+
+// MatchesEveryRule reports whether this target suppresses every rule, the
+// meaning of a nolint directive written without a selector.
+func (t Target) MatchesEveryRule() bool {
+	return t.Family && t.Value == ""
+}
+
+// atlasIdentities lists every native rule whose printed code differs from its
+// native code on the compatibility surface. It is the single source of truth
+// for both directions: RuleForNativeCode reads it forward and
+// NativeSuppressionTargets reads it backward, so a selector can never resolve
+// to a rule that prints under a different code.
+//
+// Declared as an ordered slice rather than a map so resolution order is
+// deterministic.
+var atlasIdentities = []struct {
+	NativeCode string
+	Rule       Rule
+}{
+	{NativeCode: "DS101", Rule: Rule{Analyzer: AnalyzerDestructive, Code: "DS102"}},
+	{NativeCode: "DS102", Rule: Rule{Analyzer: AnalyzerDestructive, Code: "DS103"}},
+	{NativeCode: "DD101", Rule: Rule{Analyzer: AnalyzerDataDependent, Code: "MF103"}},
+}
+
 // RuleForNativeCode returns the Atlas-compatible identity for a native Ptah
 // rule. Rules without a proven Atlas identity remain Ptah diagnostics so
 // overlapping code spaces cannot silently change their meaning.
 func RuleForNativeCode(code string) Rule {
-	switch code {
-	case "DS101":
-		return Rule{Analyzer: AnalyzerDestructive, Code: "DS102"}
-	case "DS102":
-		return Rule{Analyzer: AnalyzerDestructive, Code: "DS103"}
-	case "DD101":
-		return Rule{Analyzer: AnalyzerDataDependent, Code: "MF103"}
-	default:
-		return Rule{Analyzer: AnalyzerPtah, Code: code}
+	for _, identity := range atlasIdentities {
+		if identity.NativeCode == code {
+			return identity.Rule
+		}
 	}
+	return Rule{Analyzer: AnalyzerPtah, Code: code}
+}
+
+// AnalyzerSuppressionTargets translates one Atlas analyzer name into the native
+// Ptah rule families that analyzer owns. Analyzer names mean the same thing on
+// both command surfaces because they name families, not printed codes.
+func AnalyzerSuppressionTargets(selector string) ([]Target, bool) {
+	switch strings.ToLower(strings.TrimSpace(selector)) {
+	case AnalyzerDestructive:
+		return []Target{FamilyTarget("DS"), FamilyTarget("CD")}, true
+	case AnalyzerDataDependent:
+		return []Target{FamilyTarget("DD")}, true
+	case AnalyzerConcurrentIndex:
+		return []Target{CodeTarget("PG101"), CodeTarget("PG103")}, true
+	case AnalyzerIncompatible:
+		return []Target{FamilyTarget("BC")}, true
+	case AnalyzerNestedTX:
+		return []Target{CodeTarget("TX201")}, true
+	}
+	return nil, false
 }
 
 // NativeSuppressionTargets translates one Atlas nolint selector into native
-// Ptah rule codes or families. Unknown Atlas diagnostic codes intentionally do
-// not fall through to same-named Ptah rules because the two code spaces overlap
-// with different meanings.
-func NativeSuppressionTargets(selector string) []string {
-	switch strings.ToLower(strings.TrimSpace(selector)) {
-	case AnalyzerDestructive:
-		return []string{"DS", "CD"}
-	case AnalyzerDataDependent:
-		return []string{"DD"}
-	case AnalyzerConcurrentIndex:
-		return []string{"PG101", "PG103"}
-	case AnalyzerIncompatible:
-		return []string{"BC"}
-	case AnalyzerNestedTX:
-		return []string{"TX201"}
-	case "ds102":
-		return []string{"DS101"}
-	case "ds103":
-		return []string{"DS102"}
-	case "mf103":
-		return []string{"DD101"}
-	default:
+// Ptah suppression targets for the Atlas-compatible surface.
+//
+// A code selector names the code that surface prints, so it resolves to every
+// native rule whose Atlas identity is that code — both producers of a shared
+// printed code, never one of them. Selectors naming a code the surface cannot
+// print (an Atlas code Ptah remaps away from, such as DS101) resolve to
+// nothing rather than falling through to the same-named Ptah rule, because the
+// two code spaces overlap with different meanings.
+//
+// Unknown selectors resolve to a target that matches no rule and are otherwise
+// silent, matching atlas community version v1.3.0: `-- atlas:nolint
+// totally_bogus_selector` above a DROP COLUMN leaves DS103 reported and exits 1
+// there without printing anything about the selector.
+func NativeSuppressionTargets(selector string) []Target {
+	if targets, ok := AnalyzerSuppressionTargets(selector); ok {
+		return targets
+	}
+	code := strings.ToUpper(strings.TrimSpace(selector))
+	if code == "" {
 		return nil
 	}
+	var targets []Target
+	remapped := false
+	for _, identity := range atlasIdentities {
+		if identity.Rule.Code == code {
+			targets = append(targets, CodeTarget(identity.NativeCode))
+		}
+		if identity.NativeCode == code {
+			// The native rule with this code prints under another one, so the
+			// compatibility surface never emits this code for it.
+			remapped = true
+		}
+	}
+	if !remapped {
+		targets = append(targets, CodeTarget(code))
+	}
+	return targets
 }

--- a/internal/atlaslint/rules_test.go
+++ b/internal/atlaslint/rules_test.go
@@ -46,64 +46,206 @@ func TestRuleForNativeCode(t *testing.T) {
 	}
 }
 
+// TestNativeSuppressionTargets pins the resolution of one Atlas nolint selector
+// into native rule targets.
+//
+// The two collision rows are the point of the table. Native DS102 and native
+// DS103 both print as DS103 on the compatibility surface, and native DD101 and
+// native MF103 both print as MF103; a selector naming a printed code has to
+// reach every producer of that code, not the first one. Reverting the change
+// drops the second target from each of those rows, which is what let
+// `-- atlas:nolint DS103` silence a DROP COLUMN while leaving an
+// ALTER COLUMN ... TYPE on the very next line reported.
+//
+// The "DS" and "D" rows pin exactness against the pinned community binary
+// (atlas community version v1.3.0): with `-- atlas:nolint DS` or
+// `-- atlas:nolint D` above `ALTER TABLE t DROP COLUMN legacy;` it reports
+// DS103 and exits 1, so a code selector must never widen into a family. Give
+// the code fallback Family:true and both rows silence the whole DS family,
+// which is exit 0 where the community binary exits 1.
 func TestNativeSuppressionTargets(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
 		name     string
 		selector string
-		want     []string
+		want     []atlaslint.Target
 	}{
 		{
 			name:     "destructive analyzer",
 			selector: "destructive",
-			want:     []string{"DS", "CD"},
+			want:     []atlaslint.Target{atlaslint.FamilyTarget("DS"), atlaslint.FamilyTarget("CD")},
 		},
 		{
 			name:     "data dependent analyzer",
 			selector: "data_depend",
-			want:     []string{"DD"},
+			want:     []atlaslint.Target{atlaslint.FamilyTarget("DD")},
 		},
 		{
 			name:     "concurrent index analyzer",
 			selector: "concurrent_index",
-			want:     []string{"PG101", "PG103"},
+			want:     []atlaslint.Target{atlaslint.CodeTarget("PG101"), atlaslint.CodeTarget("PG103")},
 		},
 		{
 			name:     "incompatible analyzer",
 			selector: "incompatible",
-			want:     []string{"BC"},
+			want:     []atlaslint.Target{atlaslint.FamilyTarget("BC")},
 		},
 		{
 			name:     "nested transaction analyzer",
 			selector: "nestedtx",
-			want:     []string{"TX201"},
+			want:     []atlaslint.Target{atlaslint.CodeTarget("TX201")},
 		},
 		{
 			name:     "Atlas table drop",
 			selector: "DS102",
-			want:     []string{"DS101"},
+			want:     []atlaslint.Target{atlaslint.CodeTarget("DS101")},
 		},
 		{
-			name:     "Atlas column drop",
+			name:     "Atlas column drop reaches both producers",
 			selector: "DS103",
-			want:     []string{"DS102"},
+			want:     []atlaslint.Target{atlaslint.CodeTarget("DS102"), atlaslint.CodeTarget("DS103")},
 		},
 		{
-			name:     "Atlas data dependent",
+			name:     "Atlas data dependent reaches both producers",
 			selector: "MF103",
-			want:     []string{"DD101"},
+			want:     []atlaslint.Target{atlaslint.CodeTarget("DD101"), atlaslint.CodeTarget("MF103")},
 		},
 		{
-			name:     "overlapping unknown code",
+			name:     "code the compatibility surface prints unchanged",
+			selector: "PG101",
+			want:     []atlaslint.Target{atlaslint.CodeTarget("PG101")},
+		},
+		{
+			name:     "code remapped away is never printed",
 			selector: "DS101",
 			want:     nil,
+		},
+		{
+			name:     "native code remapped away is never printed",
+			selector: "DD101",
+			want:     nil,
+		},
+		{
+			name:     "family prefix is not a code",
+			selector: "DS",
+			want:     []atlaslint.Target{atlaslint.CodeTarget("DS")},
+		},
+		{
+			name:     "single letter is not a code",
+			selector: "D",
+			want:     []atlaslint.Target{atlaslint.CodeTarget("D")},
+		},
+		{
+			name:     "unknown selector resolves to a target matching nothing",
+			selector: "totally_bogus_selector",
+			want:     []atlaslint.Target{atlaslint.CodeTarget("TOTALLY_BOGUS_SELECTOR")},
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
 			got := atlaslint.NativeSuppressionTargets(tt.selector)
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+// TestTargetMatches pins the difference the Target type exists to carry: a
+// family target widens to every code sharing its prefix, an exact target does
+// not. Collapse the two and `-- atlas:nolint DS` starts silencing DS101.
+func TestTargetMatches(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		target atlaslint.Target
+		code   string
+		want   bool
+	}{
+		{name: "family covers its prefix", target: atlaslint.FamilyTarget("DS"), code: "DS101", want: true},
+		{name: "family stops at its prefix", target: atlaslint.FamilyTarget("DS"), code: "DD101", want: false},
+		{name: "empty family covers everything", target: atlaslint.FamilyTarget(""), code: "PG101", want: true},
+		{name: "exact code matches itself", target: atlaslint.CodeTarget("DS101"), code: "DS101", want: true},
+		{name: "exact code does not widen", target: atlaslint.CodeTarget("DS"), code: "DS101", want: false},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.target.Matches(tt.code), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestTargetMatchesEveryRule pins which target the bare directive produces:
+// only the empty family means "every rule". A code target that happens to be
+// empty must not, or a directive whose selector parsed to nothing would mark a
+// whole file ignored.
+func TestTargetMatchesEveryRule(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		target atlaslint.Target
+		want   bool
+	}{
+		{name: "empty family", target: atlaslint.FamilyTarget(""), want: true},
+		{name: "named family", target: atlaslint.FamilyTarget("DS"), want: false},
+		{name: "empty code", target: atlaslint.CodeTarget(""), want: false},
+		{name: "named code", target: atlaslint.CodeTarget("DS101"), want: false},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(tt.target.MatchesEveryRule(), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestAnalyzerSuppressionTargets pins which selectors are analyzer names. The
+// ok flag is what lets the native surface resolve an Atlas analyzer name while
+// still reading a code selector in its own namespace; drop it and
+// `-- atlas:nolint concurrent_index` stops silencing PG101 on
+// `ptah migrations lint`.
+func TestAnalyzerSuppressionTargets(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		selector string
+		want     []atlaslint.Target
+		wantOK   bool
+	}{
+		{
+			name:     "analyzer name",
+			selector: "concurrent_index",
+			want:     []atlaslint.Target{atlaslint.CodeTarget("PG101"), atlaslint.CodeTarget("PG103")},
+			wantOK:   true,
+		},
+		{
+			name:     "analyzer name uppercased by the directive parser",
+			selector: "DESTRUCTIVE",
+			want:     []atlaslint.Target{atlaslint.FamilyTarget("DS"), atlaslint.FamilyTarget("CD")},
+			wantOK:   true,
+		},
+		{
+			name:     "diagnostic code is not an analyzer name",
+			selector: "DS103",
+			want:     nil,
+			wantOK:   false,
+		},
+		{
+			name:     "unknown selector is not an analyzer name",
+			selector: "totally_bogus_selector",
+			want:     nil,
+			wantOK:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got, ok := atlaslint.AnalyzerSuppressionTargets(tt.selector)
+			c.Assert(ok, qt.Equals, tt.wantOK)
 			c.Assert(got, qt.DeepEquals, tt.want)
 		})
 	}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strings"
 
+	"go.5x5.cz/ptah/internal/atlaslint"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -93,7 +94,7 @@ type Statement struct {
 	// Line is the 1-based line number of the statement's first token.
 	Line            int
 	sourceWords     []string
-	suppressedRules []string
+	suppressedRules []atlaslint.Target
 }
 
 // File is one migration file prepared for linting.
@@ -154,7 +155,7 @@ type File struct {
 	// statement count. Ordered by statement, then by the order changes appear
 	// within each statement.
 	Changes         []SchemaChange
-	suppressedRules []string
+	suppressedRules []atlaslint.Target
 	// compatibility is the profile this run was started with. A rule reads it
 	// when the two command surfaces model the same statement differently; see
 	// [renamedNames] for the one construct where they do.

--- a/migration/lint/analysis_test.go
+++ b/migration/lint/analysis_test.go
@@ -536,15 +536,35 @@ ALTER TABLE accounts DROP COLUMN legacy;
 	c.Assert(atlas.Findings(), qt.HasLen, 0)
 }
 
-// TestAnalyzeFS_AtlasAnalyzerSuppressionsAreCompatibilityScoped checks that an
-// Atlas analyzer name silences the native rules that analyzer owns.
+// TestAnalyzeFS_AtlasAnalyzerSuppressionsApplyOnBothSurfaces checks that an
+// Atlas analyzer name silences the native rules that analyzer owns, on the
+// native surface as well as the compatibility one.
 //
-// The rename is suppressed with `destructive`, not `incompatible`: measured
-// against the pinned community binary, `-- atlas:nolint destructive` above a
-// column rename silences it while `-- atlas:nolint incompatible` above the same
-// rename leaves DS103 reported. The per-selector behavior itself is pinned in
+// This fixture previously asserted the opposite for the native column: the
+// three analyzer names were compatibility-scoped, so `-- atlas:nolint
+// concurrent_index` silenced PG101 under `ptah-compat migrate lint` and did
+// nothing under `ptah migrations lint`, while `-- atlas:nolint PG101` did the
+// reverse. Each selector worked on exactly one of the two commands and they
+// disagreed about which. Analyzer names name rule families rather than printed
+// codes, so they mean the same thing on both surfaces; the code namespace is
+// what stays surface-specific, and TestAnalyzeFS_AtlasNoLintSelectorsAgree
+// pins the pair together.
+//
+// The rename is the one row that still differs, and it differs for a reason
+// that is not about selectors: the two surfaces classify a rename under
+// different families. `destructive` owns DS and CD on both surfaces, and the
+// compatibility surface calls a rename DS102 while the native surface calls it
+// BC101 (#1120, measured against the pinned community binary — `-- atlas:nolint
+// destructive` above a column rename silences it there and `-- atlas:nolint
+// incompatible` above the same rename leaves DS103 reported). The rename row is
+// therefore also the non-interference control that resolving analyzer names
+// natively did not widen `destructive` past DS and CD into BC. The per-selector
+// behavior itself is pinned in
 // TestAnalyzeFS_RenameIsSuppressedByTheDestructiveSelectorOnly.
-func TestAnalyzeFS_AtlasAnalyzerSuppressionsAreCompatibilityScoped(t *testing.T) {
+//
+// Reverting the change prints the native column as
+// []string{"PG101", "BC101", "DS101", "TX201"} instead of []string{"BC101"}.
+func TestAnalyzeFS_AtlasAnalyzerSuppressionsApplyOnBothSurfaces(t *testing.T) {
 	c := qt.New(t)
 	fsys := fixture(map[string]string{
 		"1_index.sql": `-- atlas:nolint concurrent_index
@@ -553,7 +573,10 @@ CREATE INDEX idx_users_id ON users (id);
 		"2_rename.sql": `-- atlas:nolint destructive
 ALTER TABLE users RENAME COLUMN old_name TO new_name;
 `,
-		"3_transaction.sql": `-- atlas:nolint nestedtx
+		"3_drop.sql": `-- atlas:nolint destructive
+DROP TABLE legacy_users;
+`,
+		"4_transaction.sql": `-- atlas:nolint nestedtx
 BEGIN;
 `,
 	})
@@ -563,7 +586,7 @@ BEGIN;
 		Dialect:   "postgres",
 	})
 	c.Assert(err, qt.IsNil)
-	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"PG101", "BC101", "TX201"})
+	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"BC101"})
 
 	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
 		Compatibility: lint.CompatibilityProfileAtlas,
@@ -598,6 +621,17 @@ BEGIN;
 	c.Assert(analysis.Findings(), qt.HasLen, 0)
 }
 
+// TestAnalyzeFS_BareAtlasHeaderMarksOnlyCompatibilityFileIgnored checks that
+// the whole-file Atlas header form applies to the compatibility surface only.
+//
+// The native column asserted zero findings before this change, which
+// contradicted the test's own name: the file was not marked Ignored, but the
+// header line was still being read a second time as a statement-local
+// directive for the statement below it, so nothing was reported anyway.
+// A suppression directive separated from a statement by a blank line no
+// longer attaches to it, so the native surface now reports the DROP TABLE the
+// header does not cover. Reverting the change prints an empty findings slice
+// here.
 func TestAnalyzeFS_BareAtlasHeaderMarksOnlyCompatibilityFileIgnored(t *testing.T) {
 	c := qt.New(t)
 	fsys := fixture(map[string]string{
@@ -614,7 +648,7 @@ DROP TABLE users;
 	nativeFiles := native.Files()
 	c.Assert(nativeFiles, qt.HasLen, 1)
 	c.Assert(nativeFiles[0].Ignored, qt.IsFalse)
-	c.Assert(native.Findings(), qt.HasLen, 0)
+	c.Assert(rulesOf(native.Findings()), qt.DeepEquals, []string{"DS101"})
 
 	atlas, err := lint.AnalyzeFS(fsys, lint.Options{
 		Compatibility: lint.CompatibilityProfileAtlas,

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -223,13 +223,10 @@ func fileSuppressesRule(file *File, code string) bool {
 	return suppressesRule(file.suppressedRules, code)
 }
 
-func suppressesRule(entries []string, code string) bool {
-	for _, entry := range entries {
-		if entry == "*" || strings.HasPrefix(code, entry) {
-			return true
-		}
-	}
-	return false
+func suppressesRule(entries []atlaslint.Target, code string) bool {
+	return slices.ContainsFunc(entries, func(entry atlaslint.Target) bool {
+		return entry.Matches(code)
+	})
 }
 
 func statementFindingContext(index int, subjects ...Subject) *FindingContext {
@@ -350,7 +347,7 @@ type rawStatement struct {
 	line            int
 	start           int
 	end             int
-	suppressedRules []string
+	suppressedRules []atlaslint.Target
 }
 
 // splitStatementsWithLines splits SQL into statements using the dialect-aware
@@ -367,8 +364,8 @@ func splitStatementsWithLines(
 	end := 0
 	startLine := 0
 	lastStatementEndLine := 0
-	var pendingSuppressions []string
-	var activeSuppressions []string
+	var pendingSuppressions []atlaslint.Target
+	var activeSuppressions []atlaslint.Target
 	for _, tok := range scanSQL(raw, mode) {
 		switch tok.kind {
 		case tokSemicolon:
@@ -387,6 +384,19 @@ func splitStatementsWithLines(
 		case tokWhitespace:
 			// Never starts a statement; keep end untouched so trailing
 			// comments/whitespace are not included in the statement text.
+			//
+			// A blank line detaches a pending directive from whatever comes
+			// next: a statement-local nolint has to sit directly above its
+			// statement. Measured against atlas community version v1.3.0 on
+			// `-- atlas:nolint DS103`, a blank line, then a DROP COLUMN — it
+			// reports DS103 and exits 1, while the same two lines with no
+			// blank line between them exit 0. A directive on the file's first
+			// line followed by a blank line is the file-wide header form,
+			// handled by [parseAtlasFileNoLint] on the compatibility surface
+			// only.
+			if start < 0 && strings.Count(tok.text, "\n") > 1 {
+				pendingSuppressions = nil
+			}
 		case tokComment:
 			if start < 0 && tok.line != lastStatementEndLine {
 				pendingSuppressions = append(
@@ -398,7 +408,7 @@ func splitStatementsWithLines(
 			if start < 0 {
 				start = tok.start
 				startLine = tok.line
-				activeSuppressions = append([]string(nil), pendingSuppressions...)
+				activeSuppressions = slices.Clone(pendingSuppressions)
 				pendingSuppressions = nil
 			}
 			end = tok.end
@@ -419,7 +429,7 @@ func splitStatementsWithLines(
 func parseNoLintDirective(
 	comment string,
 	compatibility CompatibilityProfile,
-) []string {
+) []atlaslint.Target {
 	trimmed := strings.TrimSpace(comment)
 	if !strings.HasPrefix(trimmed, "--") && !strings.HasPrefix(trimmed, "#") {
 		return nil
@@ -427,15 +437,32 @@ func parseNoLintDirective(
 	if rules, ok := parseNoLintMarker(comment, "ptah:nolint", nativeNoLintTargets); ok {
 		return rules
 	}
-	targets := nativeNoLintTargets
-	if compatibility == CompatibilityProfileAtlas {
-		targets = atlaslint.NativeSuppressionTargets
-	}
-	rules, _ := parseNoLintMarker(comment, "atlas:nolint", targets)
+	rules, _ := parseNoLintMarker(comment, "atlas:nolint", atlasNoLintTargets(compatibility))
 	return rules
 }
 
-func parseAtlasFileNoLint(sql string) ([]string, bool) {
+// atlasNoLintTargets resolves one `atlas:nolint` selector for the surface that
+// is running. The selector vocabulary is Atlas's on both surfaces: analyzer
+// names name rule families, and a code selector matches one code exactly rather
+// than widening into a family the way `ptah:nolint DS` does. Only the code
+// namespace is surface-specific — a selector names the code the running surface
+// prints, which is the native code natively and the Atlas identity under the
+// compatibility profile.
+func atlasNoLintTargets(compatibility CompatibilityProfile) func(string) []atlaslint.Target {
+	if compatibility == CompatibilityProfileAtlas {
+		return atlaslint.NativeSuppressionTargets
+	}
+	return nativeAtlasNoLintTargets
+}
+
+func nativeAtlasNoLintTargets(entry string) []atlaslint.Target {
+	if targets, ok := atlaslint.AnalyzerSuppressionTargets(entry); ok {
+		return targets
+	}
+	return []atlaslint.Target{atlaslint.CodeTarget(entry)}
+}
+
+func parseAtlasFileNoLint(sql string) ([]atlaslint.Target, bool) {
 	lines := strings.Split(sql, "\n")
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(strings.TrimPrefix(line, "\uFEFF"))
@@ -449,7 +476,7 @@ func parseAtlasFileNoLint(sql string) ([]string, bool) {
 		for _, following := range lines[i+1:] {
 			trimmedFollowing := strings.TrimSpace(following)
 			if trimmedFollowing == "" {
-				return rules, suppressesRule(rules, "*")
+				return rules, slices.ContainsFunc(rules, atlaslint.Target.MatchesEveryRule)
 			}
 			if strings.HasPrefix(trimmedFollowing, "--") {
 				continue
@@ -461,7 +488,7 @@ func parseAtlasFileNoLint(sql string) ([]string, bool) {
 	return nil, false
 }
 
-func parseAtlasNoLintLine(line string) ([]string, bool) {
+func parseAtlasNoLintLine(line string) ([]atlaslint.Target, bool) {
 	comment, ok := strings.CutPrefix(strings.TrimSpace(line), "--")
 	if !ok {
 		return nil, false
@@ -481,8 +508,8 @@ func parseAtlasNoLintLine(line string) ([]string, bool) {
 func parseNoLintMarker(
 	comment string,
 	marker string,
-	targets func(string) []string,
-) ([]string, bool) {
+	targets func(string) []atlaslint.Target,
+) ([]atlaslint.Target, bool) {
 	idx := strings.Index(strings.ToLower(comment), marker)
 	if idx < 0 {
 		return nil, false
@@ -494,13 +521,13 @@ func parseNoLintMarker(
 	return parseNoLintRules(rest, targets), true
 }
 
-func parseNoLintRules(rest string, targets func(string) []string) []string {
+func parseNoLintRules(rest string, targets func(string) []atlaslint.Target) []atlaslint.Target {
 	rest = strings.TrimSpace(rest)
 	if rest == "" {
-		return []string{"*"}
+		return []atlaslint.Target{atlaslint.FamilyTarget("")}
 	}
 	parts := strings.FieldsFunc(rest, isNoLintSeparator)
-	rules := make([]string, 0, len(parts))
+	rules := make([]atlaslint.Target, 0, len(parts))
 	for _, part := range parts {
 		part = strings.ToUpper(strings.TrimSpace(part))
 		if part == "" {
@@ -511,8 +538,11 @@ func parseNoLintRules(rest string, targets func(string) []string) []string {
 	return rules
 }
 
-func nativeNoLintTargets(entry string) []string {
-	return []string{entry}
+// nativeNoLintTargets resolves a selector against the native code namespace,
+// where a code prefix names its family: `ptah:nolint DS` silences every
+// data-safety rule and `ptah:nolint DS102` silences one.
+func nativeNoLintTargets(entry string) []atlaslint.Target {
+	return []atlaslint.Target{atlaslint.FamilyTarget(entry)}
 }
 
 func isNoLintSeparator(r rune) bool {

--- a/migration/lint/suppression_test.go
+++ b/migration/lint/suppression_test.go
@@ -1,0 +1,307 @@
+package lint_test
+
+import (
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlaslint"
+	"go.5x5.cz/ptah/migration/lint"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestRules_EveryCompatibilityCodeIsSuppressibleByThatCode is the coverage
+// gate: every code `ptah-compat migrate lint` can print must be silenced by
+// `-- atlas:nolint <that code>`.
+//
+// Before this change 1 of the 40 distinct printed codes passed (DS102); 37
+// resolved to no target at all and 2 (DS103, MF103) resolved to one of the two
+// native rules that print them. Reverting the change turns this into 39 failing
+// subtests, each named for its rule code and printing "value is not true" with
+// the comment "native rule PG101 prints as PG101, which resolves to []".
+func TestRules_EveryCompatibilityCodeIsSuppressibleByThatCode(t *testing.T) {
+	c := qt.New(t)
+
+	for _, rule := range lint.Rules() {
+		c.Run(rule.Code, func(c *qt.C) {
+			printed := atlaslint.RuleForNativeCode(rule.Code).Code
+			targets := atlaslint.NativeSuppressionTargets(printed)
+			suppressed := slices.ContainsFunc(targets, func(target atlaslint.Target) bool {
+				return target.Matches(rule.Code)
+			})
+			c.Assert(suppressed, qt.IsTrue, qt.Commentf(
+				"native rule %s prints as %s, which resolves to %v",
+				rule.Code, printed, targets,
+			))
+		})
+	}
+}
+
+// TestAnalyzeFS_AtlasCodeSelectorReachesBothProducersOfAPrintedCode is the
+// collision fixture. Native DS102 (DROP COLUMN) and native DS103 (column type
+// change) both print as DS103 on the compatibility surface, so one directive
+// has to reach both.
+//
+// Before this change the same `-- atlas:nolint DS103` on two adjacent
+// statements had opposite outcomes: the DROP COLUMN was silenced and the
+// ALTER COLUMN ... TYPE on the next line still reported DS103. Reverting the
+// change prints []string{"DS102", "DS103"} on the "silences the type change"
+// row and []string{"DS103"} on the "silences both when repeated" row.
+func TestAnalyzeFS_AtlasCodeSelectorReachesBothProducersOfAPrintedCode(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "no directive reports both producers",
+			sql: `ALTER TABLE accounts DROP COLUMN legacy;
+ALTER TABLE accounts ALTER COLUMN note TYPE varchar(10);
+`,
+			want: []string{"DS102", "DS103"},
+		},
+		{
+			name: "the printed code silences the column drop",
+			sql: `-- atlas:nolint DS103
+ALTER TABLE accounts DROP COLUMN legacy;
+ALTER TABLE accounts ALTER COLUMN note TYPE varchar(10);
+`,
+			want: []string{"DS103"},
+		},
+		{
+			name: "the printed code silences the type change",
+			sql: `ALTER TABLE accounts DROP COLUMN legacy;
+-- atlas:nolint DS103
+ALTER TABLE accounts ALTER COLUMN note TYPE varchar(10);
+`,
+			want: []string{"DS102"},
+		},
+		{
+			name: "the printed code silences both when repeated",
+			sql: `-- atlas:nolint DS103
+ALTER TABLE accounts DROP COLUMN legacy;
+-- atlas:nolint DS103
+ALTER TABLE accounts ALTER COLUMN note TYPE varchar(10);
+`,
+			want: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+				"1_collision.sql": test.sql,
+			}), lint.Options{
+				Compatibility: lint.CompatibilityProfileAtlas,
+				DirFormat:     migrator.MigrationDirFormatAtlas,
+				Dialect:       "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_AtlasMF103SelectorReachesBothProducers is the second collision:
+// native DD101 (a NOT NULL column added to a populated table) and native MF103
+// (a file name the migrator will not pick up) both print as MF103.
+//
+// MF103 is a file-form rule with no statement to sit under, so the fixture uses
+// the whole-file header form, which is the only directive that reaches it.
+// Reverting the change leaves MF103 in the suppressed row, printing
+// []string{"MF101", "MF103"} instead of []string{"MF101"}.
+func TestAnalyzeFS_AtlasMF103SelectorReachesBothProducers(t *testing.T) {
+	tests := []struct {
+		name   string
+		header string
+		want   []string
+	}{
+		{
+			name:   "no directive reports both producers",
+			header: "",
+			want:   []string{"MF101", "MF103", "DD101"},
+		},
+		{
+			name:   "the printed code silences both",
+			header: "-- atlas:nolint MF103\n\n",
+			want:   []string{"MF101"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+				"weird_name.up.sql": test.header +
+					"ALTER TABLE accounts ADD COLUMN tenant_id INTEGER NOT NULL;\n",
+			}), lint.Options{
+				Compatibility: lint.CompatibilityProfileAtlas,
+				DirFormat:     migrator.MigrationDirFormatPtah,
+				Dialect:       "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_AtlasNoLintSelectorsAgreeAcrossSurfaces closes the four cells
+// of the cross-binary table in #936: each selector must have the same effect on
+// `ptah migrations lint` and on `ptah-compat migrate lint`.
+//
+// Before this change `-- atlas:nolint PG101` silenced PG101 natively and did
+// nothing under the compatibility profile, while `-- atlas:nolint
+// concurrent_index` did the reverse — each selector worked on exactly one of
+// the two commands, and they disagreed about which. The family-prefix row is
+// the third disagreement: `atlas:nolint PG` resolved through the native
+// identity and silenced the whole PG family on `ptah migrations lint` while
+// the pinned community binary silences nothing for a prefix.
+//
+// Reverting the native half (resolve `atlas:nolint` through the native
+// identity again) prints the native column as []string{"PG101"} on the
+// analyzer-name row and []string{} on the family-prefix row. Reverting the
+// compatibility half (a code selector resolving to nothing) prints the atlas
+// column as []string{"PG101"} on the printed-code row.
+func TestAnalyzeFS_AtlasNoLintSelectorsAgreeAcrossSurfaces(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		want      []string
+	}{
+		{name: "no directive", directive: "", want: []string{"PG101"}},
+		{name: "printed code", directive: "-- atlas:nolint PG101\n", want: []string{}},
+		{name: "analyzer name", directive: "-- atlas:nolint concurrent_index\n", want: []string{}},
+		{name: "family prefix", directive: "-- atlas:nolint PG\n", want: []string{"PG101"}},
+		{name: "unknown selector", directive: "-- atlas:nolint totally_bogus\n", want: []string{"PG101"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			fsys := fixture(map[string]string{
+				"1_index.sql": test.directive + "CREATE INDEX idx_users_id ON users (id);\n",
+			})
+
+			native, err := lint.AnalyzeFS(fsys, lint.Options{
+				DirFormat: migrator.MigrationDirFormatAtlas,
+				Dialect:   "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(native.Findings()), qt.DeepEquals, test.want)
+
+			atlas, err := lint.AnalyzeFS(fsys, lint.Options{
+				Compatibility: lint.CompatibilityProfileAtlas,
+				DirFormat:     migrator.MigrationDirFormatAtlas,
+				Dialect:       "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(atlas.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_AtlasSelectorsMatchTheCommunityBinaryOnADroppedColumn is the
+// regression guard for the selector behavior that already matched the pinned
+// community binary and has to keep matching it.
+//
+// Every row was run against the pinned community binary (atlas community
+// version v1.3.0) on `ALTER TABLE t DROP COLUMN legacy;` replayed on a sqlite
+// dev database. It reports DS103 and exits 1 with no directive (negative
+// control), exits 0 for `DS103` and for `destructive` (positive controls), and
+// exits 1 for `DS102`, for `DS`, for `D` and for `totally_bogus_selector` —
+// printing nothing about the selector in the last case.
+//
+// Every row here also held before the change, which is the point: this is a
+// guard, not a demonstration, so reverting the change leaves it green. It was
+// validated with the inverse mutant instead — give the code fallback in
+// [atlaslint.NativeSuppressionTargets] Family:true and the "family prefix" and
+// "single letter" rows print []string{} instead of []string{"DS102"}, which is
+// exit 0 where the community binary exits 1.
+func TestAnalyzeFS_AtlasSelectorsMatchTheCommunityBinaryOnADroppedColumn(t *testing.T) {
+	tests := []struct {
+		name      string
+		directive string
+		want      []string
+	}{
+		{name: "no directive", directive: "", want: []string{"DS102"}},
+		{name: "printed code", directive: "-- atlas:nolint DS103\n", want: []string{}},
+		{name: "analyzer name", directive: "-- atlas:nolint destructive\n", want: []string{}},
+		{name: "the other Atlas code", directive: "-- atlas:nolint DS102\n", want: []string{"DS102"}},
+		{name: "family prefix", directive: "-- atlas:nolint DS\n", want: []string{"DS102"}},
+		{name: "single letter", directive: "-- atlas:nolint D\n", want: []string{"DS102"}},
+		{name: "unknown selector", directive: "-- atlas:nolint totally_bogus_selector\n", want: []string{"DS102"}},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+				"1_drop.sql": test.directive + "ALTER TABLE t DROP COLUMN legacy;\n",
+			}), lint.Options{
+				Compatibility: lint.CompatibilityProfileAtlas,
+				DirFormat:     migrator.MigrationDirFormatAtlas,
+				Dialect:       "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_BlankLineDetachesANoLintDirective pins statement-local
+// adjacency, measured against the pinned community binary (atlas community
+// version v1.3.0) on a two-migration sqlite fixture: with `-- atlas:nolint
+// DS103`, a blank line, then `ALTER TABLE t DROP COLUMN legacy;` it reports
+// DS103 at L5 and exits 1, and with the blank line removed it exits 0 with no
+// diagnostics. Ptah silenced both, which is exit 0 where the community binary
+// exits 1.
+//
+// The same rule is what keeps a whole-file `atlas:nolint` header from doubling
+// as a statement-local directive for the first statement of the file; see
+// TestAnalyzeFS_AtlasFileSuppressionIsCompatibilityScoped and
+// TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression.
+//
+// Reverting the change prints []string{} for the detached row.
+func TestAnalyzeFS_BlankLineDetachesANoLintDirective(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []string
+	}{
+		{
+			name: "directive above its statement",
+			sql: `CREATE TABLE u2 (id integer);
+-- atlas:nolint DS103
+ALTER TABLE t DROP COLUMN legacy;
+`,
+			want: []string{},
+		},
+		{
+			name: "directive detached by a blank line",
+			sql: `CREATE TABLE u2 (id integer);
+
+-- atlas:nolint DS103
+
+ALTER TABLE t DROP COLUMN legacy;
+`,
+			want: []string{"DS102"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+				"1_gap.sql": test.sql,
+			}), lint.Options{
+				Compatibility: lint.CompatibilityProfileAtlas,
+				DirFormat:     migrator.MigrationDirFormatAtlas,
+				Dialect:       "postgres",
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}


### PR DESCRIPTION
Workstream A of #936 — "make every code the compat linter prints suppressible by that code". Workstream B (`.ptah-lint.yaml` outside `ptah.sum`) is untouched here; see "What I deliberately left open".

Measured on this worktree at `22e00b56`, branched from `origin/master` `ef3368fa`, with `ptah` and `ptah-compat` built from that tree and the pinned community binary (`atlas community version v1.3.0`, absolute path). Every row below was run; none was inferred from an adjacent one.

## Reproduction, before and after

Fixture (Atlas-format directory, `20240101000000_base.sql` creates `t (id integer, legacy varchar(20))`, `20240101000001_case.sql` holds the case).

### 1. A printed code does not silence its own diagnostic

```text
# 20240101000001_case.sql
-- atlas:nolint PG101
CREATE INDEX idx_t ON t (id);
```

| | before | after |
|---|---|---|
| `ptah-compat migrate lint --dir file://… --latest 1` | `-- L2 [PG101]: CREATE INDEX without CONCURRENTLY …` | `-- no diagnostics found` |

### 2. The DS103 collision — one directive, two outcomes

Two native rules print as `DS103` on the compatibility surface: native `DS102`
(DROP COLUMN) and native `DS103` (column type change).

```text
-- atlas:nolint DS103
ALTER TABLE t DROP COLUMN legacy;              # before: suppressed   after: suppressed

-- atlas:nolint DS103
ALTER TABLE t ALTER COLUMN legacy TYPE varchar(10);
                                               # before: -- L2 [DS103]: changing a column type …
                                               # after:  -- no diagnostics found
```

`MF103` has the identical shape (native `DD101` and native `MF103` both print
`MF103`); the whole-file header form is the only directive that reaches the
file-form rule, and it now silences both producers.

### 3. The two surfaces disagreed about which selector works

Same fixture, `CREATE INDEX idx_t ON t (id);`:

| directive | `ptah migrations lint` before / after | `ptah-compat migrate lint` before / after |
|---|---|---|
| *(none)* | PG101 / PG101 | PG101 / PG101 |
| `-- atlas:nolint PG101` | suppressed / suppressed | reported / **suppressed** |
| `-- atlas:nolint concurrent_index` | reported / **suppressed** | suppressed / suppressed |
| `-- atlas:nolint PG` | **suppressed** / reported | reported / reported |

All four cells of the issue's table now agree. The third row is new evidence
not in the issue: `atlas:nolint PG` resolved through the native identity and
silenced the whole PG family on the native surface, while the pinned binary
silences nothing for a prefix.

### 4. Regression guard against the pinned community binary

`ALTER TABLE t DROP COLUMN legacy;`, replayed on `sqlite://file?mode=memory`.
Exit codes captured immediately, not through a pipe.

| directive | pinned CE | ptah-compat before | ptah-compat after |
|---|---|---|---|
| *(none, negative control)* | DS103, exit 1 | DS103, exit 1 | DS103, exit 1 |
| `DS103` (positive control) | suppressed, exit 0 | suppressed, exit 0 | suppressed, exit 0 |
| `destructive` (positive control) | suppressed, exit 0 | suppressed, exit 0 | suppressed, exit 0 |
| `DS102` (wrong code) | DS103, exit 1 | DS103, exit 1 | DS103, exit 1 |
| `DS` | DS103, exit 1 | DS103, exit 1 | DS103, exit 1 |
| `D` | DS103, exit 1 | DS103, exit 1 | DS103, exit 1 |
| `totally_bogus_selector` | DS103, exit 1, no selector warning | DS103, exit 1 | DS103, exit 1 |

The `DS` and `D` rows are why a code selector resolves to an **exact** target
rather than a prefix. Had the fallback been a family prefix — the obvious
one-line shape — `ptah-compat` would exit 0 where the pinned binary exits 1,
which is exactly the direction parity rule (a) forbids.

### 5. Blank-line adjacency — an (a)-class divergence found while measuring

Not in the issue. Same mechanism, so it is fixed here.

```text
CREATE TABLE u2 (id integer);

-- atlas:nolint DS103

ALTER TABLE t DROP COLUMN legacy;
```

| | pinned CE | ptah-compat before | ptah-compat after |
|---|---|---|---|
| directive detached by a blank line | `-- L5: Dropping non-virtual column "legacy"`, exit 1 | `-- no diagnostics found`, exit 0 | `-- L5 …`, exit 1 |
| directive directly above the statement | suppressed, exit 0 | suppressed, exit 0 | suppressed, exit 0 |

Ptah was silent where the pinned binary reported and exited 1. This is also
what keeps a whole-file `atlas:nolint` header from doubling as a
statement-local directive for the file's first statement.

### 6. Coverage count

Enumerating `lint.Rules()` through `RuleForNativeCode` and back through
`NativeSuppressionTargets`:

| | before | after |
|---|---|---|
| registered native rules | 42 | 42 |
| distinct codes the compat profile prints | 40 | 40 |
| printed codes suppressible by their own code selector | **1** (`DS102`) | **40** |
| printed codes resolving to nothing | 37 | 0 |
| printed codes resolving to the wrong native rule | 2 (`DS103`, `MF103`) | 0 |

## The unknown-selector decision (completion criterion 5)

**Chosen: match the community binary's silence.** An unrecognized
`atlas:nolint` selector is accepted, suppresses nothing, and produces no
warning.

The measurement that frames it is row 4 above: `-- atlas:nolint
totally_bogus_selector` on the pinned binary leaves DS103 reported and exits
1, printing nothing about the selector. Rejecting unknown selectors in
`ptah-compat` would therefore be a *divergence* from the binary it stands in
for, not a parity fix — the issue title reads the other way round.

Recorded in `docs/site/src/content/docs/atlas/migrate-commands.md` and
`versioned/integrity-and-safety.md`, both of which also state that
`.ptah-lint.yaml` `disabled-rules` stays strict (exit 2, "rule selector … does
not match any registered rule", from #993). Because this matches rather than
diverges, nothing was added to `comparison.md`; the feature-matrix row moves
🟡 → ✅.

## What each test prints if the change is reverted

Every claim below was produced by building and running the stated mutant, not
by reasoning about it.

**Revert mutant A** — `NativeSuppressionTargets` back to the explicit
`ds102`/`ds103`/`mf103` switch with `default: return nil`:

- `TestRules_EveryCompatibilityCodeIsSuppressibleByThatCode` — 39 failing
  subtests, one per rule code, each printing `value is not true` with the
  comment `native rule PG101 prints as PG101, which resolves to []`.
- `TestAnalyzeFS_AtlasCodeSelectorReachesBothProducersOfAPrintedCode` —
  `[]string{"DS102", "DS103"}` on the "silences the type change" row and
  `[]string{"DS103"}` on the "silences both when repeated" row.
- `TestAnalyzeFS_AtlasMF103SelectorReachesBothProducers` —
  `[]string{"MF101", "MF103"}` instead of `[]string{"MF101"}`.
- `TestAnalyzeFS_AtlasNoLintSelectorsAgreeAcrossSurfaces` — atlas column prints
  `[]string{"PG101"}` on the printed-code row.
- `TestNativeSuppressionTargets` (atlaslint) — the two "reaches both producers"
  rows lose their second target.

**Revert mutant B** — `atlas:nolint` resolved through the native identity again
on the native surface:

- `TestAnalyzeFS_AtlasAnalyzerSuppressionsApplyOnBothSurfaces` — native column
  prints `[]string{"PG101", "BC101", "DS101", "TX201"}` instead of
  `[]string{"BC101"}`.
- `TestAnalyzeFS_AtlasNoLintSelectorsAgreeAcrossSurfaces` — native column
  prints `[]string{"PG101"}` on the analyzer-name row and `[]string{}` on the
  family-prefix row.
- `TestLintPendingDestructive_SuppressionSpellingsAtTheApplyGate` —
  `[]string{"DS101"}` instead of `[]string{}` on the "Atlas analyzer name" row.

**Revert mutant C** — drop the blank-line clause in
`splitStatementsWithLines`:

- `TestAnalyzeFS_BlankLineDetachesANoLintDirective` — `[]string{}` instead of
  `[]string{"DS102"}` on the detached row.
- `TestAnalyzeFS_BareAtlasHeaderMarksOnlyCompatibilityFileIgnored` —
  `[]string{}` instead of `[]string{"DS101"}`.
- `TestAnalyzeFS_AtlasFileSuppressionIsCompatibilityScoped` (pre-existing) —
  `[]string{"DS102"}` instead of `[]string{"DS101", "DS102"}`.
- `TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression`
  (pre-existing) and the "Atlas file header" row of the new gate table both
  go red.

**Inverse mutant** — give the code fallback in `NativeSuppressionTargets`
`Family: true`. `TestAnalyzeFS_AtlasSelectorsMatchTheCommunityBinaryOnADroppedColumn`
prints `[]string{}` instead of `[]string{"DS102"}` on the "family prefix" and
"single letter" rows. That test is a pure regression guard — every row already
held on master — so a revert leaves it green and only the inverse mutant
reddens it. Said in the test comment too.

## Fixtures I changed rather than weakened the gate

Two existing tests asserted states this change makes wrong. I changed the
fixtures; here is why each was wrong.

- `TestAnalyzeFS_AtlasAnalyzerSuppressionsAreCompatibilityScoped` →
  `…ApplyOnBothSurfaces`. It pinned the disagreement completion criterion 3
  asks to remove: analyzer names silenced on the compatibility surface and did
  nothing natively. The rename row keeps reporting `BC101` natively and is now
  labelled as the non-interference control that `destructive` was not widened
  past DS and CD into BC — #1120's family-keyed reasoning is intact.
- `TestAnalyzeFS_BareAtlasHeaderMarksOnlyCompatibilityFileIgnored`. It asserted
  zero native findings while asserting `Ignored == false`, which contradicts
  its own name: the header was being read a second time as a statement-local
  directive, so nothing was reported anyway. It now reports `DS101` natively,
  which is what "the header applies only on the compatibility surface" means.

`TestAnalyzeFS_AtlasFileSuppressionIsCompatibilityScoped` and
`TestLintPendingDestructive_DoesNotApplyAtlasFileSuppression` were briefly red
mid-change and are green again unmodified, because the blank-line rule
restores exactly what they guard.

## One safety-relevant behavior change, stated plainly

`ptah migrations up` gate, `DROP TABLE users;` as the pending migration,
sqlite, exit code captured directly:

| directive above the statement | master | this branch |
|---|---|---|
| *(none)* | exit 2, blocked | exit 2, blocked |
| `-- ptah:nolint DS101` | exit 0 | exit 0 |
| `-- atlas:nolint DS101` | exit 0 | exit 0 |
| `-- atlas:nolint destructive` | exit 2, blocked | **exit 0** |
| `-- atlas:nolint destructive` + blank line (file header) | exit 2, blocked | exit 2, blocked |

The gate has always honored a statement-local directive an author wrote above
the statement; the analyzer-name spelling now joins the two code spellings that
already did. The whole-file header still never reopens it. Both are pinned by
`TestLintPendingDestructive_SuppressionSpellingsAtTheApplyGate`, which is new
in this PR precisely so this row cannot move again unnoticed.

## What I deliberately left open

- **Workstream B is not touched.** `.ptah-lint.yaml` living inside the
  directory `ptah.sum` covers is a native design decision with no Atlas oracle
  (the pinned binary's `atlas.sum` also hashes only `.sql`, and it keeps its
  lint config in `atlas.hcl` outside the directory). The framing comment asks
  for it as a separate issue; this PR does not file it.
- **`ptah:nolint` keeps native family-prefix matching.** `-- ptah:nolint DS`
  still silences the whole data-safety family, as documented. Only the
  `atlas:` spelling adopts Atlas's exact matching, on both surfaces. That
  asymmetry is intentional and now documented in
  `versioned/integrity-and-safety.md`.
- **The three remapped codes still mean different things per surface.** A
  dropped column prints `DS102` natively and `DS103` under the compatibility
  profile, so `-- atlas:nolint DS103` silences it there and `-- atlas:nolint
  DS102` silences it natively. This is inherent to printing Atlas identities,
  not a residue of the bug: a selector names the code the command you ran
  printed. Documented in both pages.
- **`--dir-format ptah` under the compatibility profile** is the only way to
  reach the native-`MF103` half of the MF103 collision from the CLI, because an
  Atlas-format directory makes every file name well formed. The unit test
  covers both producers; no CLI fixture was added for that path.

## Gates

Run on this branch at `22e00b56`:

- `go build ./...` and `go vet ./...` — clean
- `go test ./... -count=1` — one full run green end to end (`GOTEST_EXIT=0`,
  no `FAIL` lines). Two later full runs on this loaded machine reported
  `cmd/ptah-ls` and `cmd/viz` red, and once `cmd/atlas` with `panic: test timed
  out after 10m0s`. Every one of those failures is a wall-clock symptom —
  `context deadline exceeded` against a 20s per-command budget, `signal:
  killed`, and `render SVG with Graphviz dot: signal: killed` instead of the
  stub's `graphviz exploded` — with 23 concurrent `go test` processes on the
  box. Both packages pass in isolation on this branch
  (`go test ./cmd/ptah-ls/ ./cmd/viz/ -count=1` → `ok`, 15.8s and 11.5s), and
  neither imports `migration/lint` or `internal/atlaslint`. Calling them
  contention flakes rather than regressions, and saying so rather than
  reporting a clean sweep.
- `go tool qtlint ./...` — exit 0
- `golangci-lint run ./...` — `0 issues.`
- `scripts/check-test-style.sh` — `teststyle: OK (175 conditional groups, 45 white-box files)`
- `scripts/check-public-api.sh` and `scripts/check-public-api-snapshot.sh` — exit 0
- `gofmt -l` over `./cmd ./internal ./migration` — silent. (`gofmt -l .` names
  `internal/goannotationexport/testdata/cleanup/models.go`, which is testdata
  last touched by #988 and is not in this diff.)
- docs touched, so all 12 `check:*` scripts in `docs/site/package.json` plus
  their selftests and `gen-versions --selftest`, after `npm ci` and
  `npm run build` in this worktree — all exit 0, including `check:responsive`
  (60 routes × 2 viewports) which needs a built `dist`
- `node scripts/build-feature-matrix.mjs --check` — `OK (163 rows)`; the page is
  generated, so the row was edited in `feature-matrix-rows.json` and the page
  regenerated

Closes #936
