### PR TITLE
Emit SQLite table-rebuild plans for unsupported ALTERs

### DIFF
--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -148,7 +148,7 @@ seven of them as open capabilities regardless.
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | `--include`/`--exclude` narrow the cleanup, and a narrowed run executes only what it printed. Plan and `--dry-run` list every object kind destroyed, except the revision table outside SQLite. |
-| schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
+| schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite rebuilds the table for column modify, NOT NULL, default, constraint and enum CHECK changes. Adding a column that carries UNIQUE still refuses. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
 | Schema-qualified exclude globs for enums and functions | 🟡 | 🟡 | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. The community binary matches `app.mood`; it reports no functions. |
@@ -257,7 +257,7 @@ seven of them as open capabilities regardless.
 | Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
 | SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
-| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
+| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops, type, nullability, default and constraint changes all emit a full rebuild with backfill. Rebuilding a table with inbound FKs still refuses. PG-only objects error one at a time. |
 | Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
 | Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -148,7 +148,7 @@ seven of them as open capabilities regardless.
 | Local pre-approved plan files | ✅ | ❌ | ✅ | `schema plan` writes Atlas `.plan.hcl` by default (`.json` keeps the native plan); `apply --plan` reads both, Atlas-authored included, verified by replay against `--to` plus an end-state check. |
 | schema apply against a live database | ✅ | ✅ | ✅ | Diffs `--url` against the `--to` desired state, prints the SQL plan, applies after confirmation. Verified end to end on SQLite. |
 | schema clean | 🟡 | ✅ | ✅ | `--include`/`--exclude` narrow the cleanup, and a narrowed run executes only what it printed. Plan and `--dry-run` list every object kind destroyed, except the revision table outside SQLite. |
-| schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite rebuilds the table for column modify, NOT NULL, default, constraint and enum CHECK changes. Adding a column that carries UNIQUE still refuses. |
+| schema diff between two schema states | 🟡 | ✅ | ✅ | SQLite refuses any change needing a table rebuild: column modify, NOT NULL change, constraint add/remove, enum CHECK change. Same on apply. |
 | schema fmt (HCL canonical layout) | ✅ | ✅ | ✅ | Formats .hcl paths recursively and prints only changed files. Native `ptah schema fmt --check` adds a no-write CI gate. |
 | schema inspect to HCL, SQL, or JSON | ✅ | ✅ | ✅ | Default HCL; `--format` sql\|json\|template. Native twin `ptah schema inspect` adds `--out-dir` and `--split` file export. |
 | Schema-qualified exclude globs for enums and functions | 🟡 | 🟡 | ❔ | Tables, views and extensions match schema-qualified exclude globs; enum and function filters compare the bare name only. The community binary matches `app.mood`; it reports no functions. |
@@ -257,7 +257,7 @@ seven of them as open capabilities regardless.
 | Roles, grants, and row-level security | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits CREATE ROLE on YugabyteDB. SQL files read ROLE, GRANT, POLICY, ENABLE RLS. Atlas prices this as Pro; CE no-ops a `role` block silently. |
 | Spanner PostgreSQL interface (spanner) | 🟡 | ❌ | ✅ | Enums and FKs render as skip comments, SERIAL hard-errors, no dedicated driver (uses the PostgreSQL pgx path), and no live container or live test exists. |
 | SQL Server and Azure SQL (sqlserver, mssql, tsql) | 🟡 | ❌ | ✅ | The mssql and tsql aliases silently drop views and triggers that sqlserver emits; render's default dialect list and `--dialect` help omit SQL Server; no sequences, RLS, roles/grants or matviews. |
-| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops, type, nullability, default and constraint changes all emit a full rebuild with backfill. Rebuilding a table with inbound FKs still refuses. PG-only objects error one at a time. |
+| SQLite (sqlite, sqlite3) | 🟡 | ✅ | ✅ | Column drops do emit a full rebuild; type, nullability, default and uniqueness changes fail with "modifying columns ... requires a table rebuild plan". PG-only objects error one at a time. |
 | Standalone sequences | 🟡 | ❌ | ✅ | PostgreSQL only in `schema render`; `schema apply` emits it on YugabyteDB too. SQL schema files read CREATE SEQUENCE. |
 | TiDB and LibSQL | ❌ | ✅ | ✅ | Both names fail dialect normalization: "unsupported database dialect: tidb" / "...: libsql". No renderer, planner or driver entry. |
 | Triggers | 🟡 | ❌ | ✅ | `--dialect mssql`/`tsql` drop them while `sqlserver` renders them; MySQL forces FOR EACH ROW; SQL Server rewrites BEFORE to AFTER silently. |

--- a/docs/site/src/content/docs/databases/sqlite.md
+++ b/docs/site/src/content/docs/databases/sqlite.md
@@ -42,9 +42,15 @@ The SQLite renderer and planner support:
 - `CREATE INDEX`, including unique and partial indexes, and
   `DROP INDEX IF EXISTS` / `DROP TABLE IF EXISTS`.
 - `ALTER TABLE ... ADD COLUMN`, `RENAME COLUMN`, and `RENAME TO`.
-- Simple column drops through a generated table-rebuild plan: create a
-  rebuilt table, copy retained columns, swap it in, and recreate retained
-  indexes and triggers when their metadata round-trips safely.
+- Column and constraint changes ALTER TABLE cannot express, through a
+  generated table-rebuild plan: create a rebuilt table in its desired shape,
+  copy the retained columns, swap it in, and recreate the desired indexes and
+  triggers when their metadata round-trips safely. One rebuild covers column
+  drops, column type, nullability, default and generated-expression changes,
+  added and removed table constraints (including enum-backed `CHECK`
+  constraints), and a column drop combined with a column addition. A column the
+  desired schema makes `NOT NULL` with a default is backfilled in the copy with
+  `IFNULL(<column>, <default>)`, so rows already holding `NULL` survive.
 - Views without `WITH CHECK OPTION`, and row-level triggers (SQLite has no
   statement-level triggers).
 
@@ -53,23 +59,22 @@ and Ptah's own revision table.
 
 ## Rebuild-required changes
 
-SQLite cannot add, drop, or modify table constraints in place, and many column
-changes can only be expressed by rebuilding the table. Ptah's rebuild planning
-is intentionally conservative: outside the supported shapes above, it reports
-an explicit rebuild-required error instead of emitting unsafe or partial SQL.
-Changes that report as rebuild-required include:
+Ptah's rebuild planning is intentionally conservative: where it cannot prove
+the rebuild is safe, it reports an explicit rebuild-required error instead of
+emitting unsafe or partial SQL. Changes that still report as rebuild-required
+are:
 
-- Modifying a column's type, nullability, default, primary key, unique, or
-  generated-column shape.
-- Adding or removing table constraints on an existing table, including
-  enum-backed `CHECK` constraints.
-- Adding a column in a shape SQLite cannot apply in place — a primary key,
-  unique, or `AUTOINCREMENT` column, a `NOT NULL` column without a non-NULL
-  literal default, an expression or parenthesized default, or a `STORED`
-  generated column.
-- Dropping columns combined with other table changes in one diff, from tables
-  referenced by inbound foreign keys, or from tables whose retained triggers
-  use syntax Ptah cannot round-trip.
+- Adding a column, without any other change to the same table, in a shape
+  SQLite cannot apply in place — a primary key, unique, or `AUTOINCREMENT`
+  column, a `NOT NULL` column without a non-NULL literal default, an expression
+  or parenthesized default, or a `STORED` generated column.
+- Adding a `NOT NULL` column without a default as part of a rebuild: the copy
+  step leaves the column out of the `INSERT`, so the first row would violate it.
+- Rebuilding a table referenced by an inbound foreign key, whose retained
+  triggers use syntax Ptah cannot round-trip, or whose rebuild scaffolding name
+  `__ptah_rebuild_<table>` is already taken.
+- A constraint change the diff cannot attribute to a table, so there is no
+  table to rebuild.
 
 Model such changes as a manual migration that performs the rebuild — see
 [Generate migrations](../../versioned/generate/) for hand-written pairs.

--- a/internal/planner/dialects/sqlite/sqlite.go
+++ b/internal/planner/dialects/sqlite/sqlite.go
@@ -148,7 +148,24 @@ func planTableRebuilds(diff *types.SchemaDiff) (tableRebuilds, error) {
 		return tableRebuilds{}, err
 	}
 	for _, tableName := range constrained {
-		add(tableName, nil)
+		// The columns this table gains in the SAME diff have to travel with it.
+		// A table reaches this loop when its constraint change arrived at schema
+		// level (ConstraintsAddedWithTables) rather than on the TableDiff, so
+		// tableDiffNeedsRebuild answered false and the loop above skipped it --
+		// even though the diff also adds columns to it.
+		//
+		// Passing nil here made rebuildCopiedColumns copy the new column out of
+		// the old table, where it does not exist. SQLite reads an unknown
+		// double-quoted identifier as a STRING LITERAL, so every row received
+		// the column's own name instead of NULL and `schema apply` exited 0
+		// saying it succeeded (#930).
+		//
+		// A table the loop above already added arrives here carrying the same
+		// names a second time. That is inert, not a bug worth a branch:
+		// rebuildCopiedColumns turns addedColumns into a set before using it, so
+		// a repeat cannot change the plan, and a guard against it would be a
+		// branch no fixture could redden.
+		add(tableName, addedColumnsFor(diff, tableName))
 	}
 	return rebuilds, nil
 }
@@ -861,4 +878,19 @@ func unsupportedFeaturef(format string, args ...any) error {
 		Err:     ptaherr.ErrUnsupportedFeature,
 		Message: message,
 	}
+}
+
+// addedColumnsFor returns the columns tableName gains in this diff, or nil.
+//
+// planTableRebuilds needs it for a table whose constraint change is recorded at
+// schema level: such a table is in TablesModified with its ColumnsAdded, but
+// tableDiffNeedsRebuild does not select it, so the rebuild would otherwise be
+// planned without knowing which columns are new.
+func addedColumnsFor(diff *types.SchemaDiff, tableName string) []string {
+	for _, table := range diff.TablesModified {
+		if table.TableName == tableName {
+			return table.ColumnsAdded
+		}
+	}
+	return nil
 }

--- a/internal/planner/dialects/sqlite/sqlite.go
+++ b/internal/planner/dialects/sqlite/sqlite.go
@@ -3,6 +3,7 @@ package sqlite
 
 import (
 	"fmt"
+	"maps"
 	"slices"
 	"strings"
 
@@ -40,7 +41,11 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	if err := rejectUnsupportedChanges(diff); err != nil {
 		return nil, err
 	}
-	if err := validateAddedColumns(diff, generated); err != nil {
+	rebuilds, err := planTableRebuilds(diff)
+	if err != nil {
+		return nil, err
+	}
+	if err := validateAddedColumns(diff, generated, rebuilds); err != nil {
 		return nil, err
 	}
 
@@ -50,21 +55,21 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 		return nil, err
 	}
 	result = append(result, addedTables...)
-	modifiedTables, err := p.modifyTables(diff, generated)
+	modifiedTables, err := p.modifyTables(diff, generated, rebuilds)
 	if err != nil {
 		return nil, err
 	}
 	result = append(result, modifiedTables...)
 	result = append(result, p.addViews(diff, generated)...)
 	result = append(result, p.modifyViews(diff, generated)...)
-	result = append(result, p.addTriggers(diff, generated)...)
-	result = append(result, p.modifyTriggers(diff, generated)...)
-	addedIndexes, err := p.addIndexes(diff, indexes)
+	result = append(result, p.addTriggers(diff, generated, rebuilds)...)
+	result = append(result, p.modifyTriggers(diff, generated, rebuilds)...)
+	addedIndexes, err := p.addIndexes(diff, indexes, rebuilds)
 	if err != nil {
 		return nil, err
 	}
 	result = append(result, addedIndexes...)
-	result = append(result, p.removeIndexes(diff)...)
+	result = append(result, p.removeIndexes(diff, rebuilds)...)
 	result = append(result, p.removeTriggers(diff)...)
 	result = append(result, p.removeViews(diff)...)
 	result = append(result, p.removeTables(diff)...)
@@ -72,9 +77,6 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 }
 
 func rejectUnsupportedChanges(diff *types.SchemaDiff) error {
-	if err := rejectUnsupportedTableChanges(diff); err != nil {
-		return err
-	}
 	if err := rejectUnsupportedSchemaObjects(diff); err != nil {
 		return err
 	}
@@ -84,62 +86,107 @@ func rejectUnsupportedChanges(diff *types.SchemaDiff) error {
 	return nil
 }
 
-func rejectUnsupportedTableChanges(diff *types.SchemaDiff) error {
+// tableRebuilds is the set of existing tables whose diff cannot be expressed
+// with SQLite's narrow ALTER TABLE grammar and is therefore executed as a
+// create-new / copy-rows / drop-old / rename sequence.
+//
+// The order field keeps emission deterministic: tables reached through
+// [types.SchemaDiff.TablesModified] keep that slice's order, and tables reached
+// only through a constraint change follow, sorted by name.
+type tableRebuilds struct {
+	order   []string
+	targets map[string]rebuildTarget
+}
+
+// rebuildTarget records what a single table's rebuild has to account for.
+type rebuildTarget struct {
+	// tableName is the table's qualified name, as the diff spells it.
+	tableName string
+	// addedColumns are columns that exist only in the desired schema, so the
+	// copy step must leave them out of the INSERT ... SELECT.
+	addedColumns []string
+}
+
+func (r tableRebuilds) target(tableName string) (rebuildTarget, bool) {
+	target, ok := r.targets[tableName]
+	return target, ok
+}
+
+func (r tableRebuilds) contains(tableName string) bool {
+	_, ok := r.targets[tableName]
+	return ok
+}
+
+// planTableRebuilds decides which existing tables need a rebuild.
+//
+// SQLite's ALTER TABLE can only rename a table, rename a column, add a column,
+// or drop a column. Every other shape — a column's type, nullability, default
+// or generated expression, and any table constraint — has to be rewritten
+// through a new table. A constraint change that cannot be attributed to a table
+// is still refused, because there is nothing to rebuild.
+func planTableRebuilds(diff *types.SchemaDiff) (tableRebuilds, error) {
+	rebuilds := tableRebuilds{targets: map[string]rebuildTarget{}}
+	add := func(tableName string, addedColumns []string) {
+		target, seen := rebuilds.targets[tableName]
+		if !seen {
+			target = rebuildTarget{tableName: tableName}
+			rebuilds.order = append(rebuilds.order, tableName)
+		}
+		target.addedColumns = append(target.addedColumns, addedColumns...)
+		rebuilds.targets[tableName] = target
+	}
+
 	for _, table := range diff.TablesModified {
-		switch {
-		case len(table.ColumnsModified) > 0:
-			return unsupportedFeaturef("modifying columns on table %s requires a table rebuild plan", table.TableName)
-		case len(table.ColumnsRemoved) > 0 && (len(table.ColumnsAdded) > 0 ||
-			len(table.ConstraintsAdded) > 0 || len(table.ConstraintsRemoved) > 0):
-			return unsupportedFeaturef("combining dropped columns with other table changes on %s requires a manual rebuild plan", table.TableName)
-		case len(table.ConstraintsAdded) > 0 || len(table.ConstraintsRemoved) > 0:
-			return unsupportedFeaturef("changing constraints on table %s requires a table rebuild plan", table.TableName)
+		if !tableDiffNeedsRebuild(table) {
+			continue
 		}
+		add(table.TableName, table.ColumnsAdded)
 	}
-	if hasExistingTableConstraintChanges(diff) {
-		return unsupportedFeaturef("changing constraints on existing tables requires a table rebuild plan")
+
+	constrained, err := existingTablesWithConstraintChanges(diff)
+	if err != nil {
+		return tableRebuilds{}, err
 	}
-	if len(diff.EnumsModified) > 0 || len(diff.EnumsRemoved) > 0 {
-		return unsupportedFeaturef("changing enum-backed CHECK constraints requires a table rebuild plan")
+	for _, tableName := range constrained {
+		add(tableName, nil)
 	}
-	return nil
+	return rebuilds, nil
 }
 
-func hasExistingTableConstraintChanges(diff *types.SchemaDiff) bool {
-	return !constraintAdditionsBelongToAddedTables(diff) ||
-		!constraintRemovalsBelongToRemovedTables(diff)
+func tableDiffNeedsRebuild(table types.TableDiff) bool {
+	return len(table.ColumnsModified) > 0 ||
+		len(table.ColumnsRemoved) > 0 ||
+		len(table.ConstraintsAdded) > 0 ||
+		len(table.ConstraintsRemoved) > 0
 }
 
-func constraintAdditionsBelongToAddedTables(diff *types.SchemaDiff) bool {
-	if len(diff.ConstraintsAdded) == 0 {
-		return true
-	}
-	seen := make(map[string]bool, len(diff.ConstraintsAddedWithTables))
+// existingTablesWithConstraintChanges returns the sorted names of tables that
+// keep existing across the diff while gaining or losing a constraint. Adding
+// and dropping a table already carries its constraints inline, so those are
+// skipped.
+func existingTablesWithConstraintChanges(diff *types.SchemaDiff) ([]string, error) {
+	tables := map[string]bool{}
+	named := make(map[string]bool, len(diff.ConstraintsAddedWithTables)+len(diff.ConstraintsRemovedWithTables))
 	for _, constraint := range diff.ConstraintsAddedWithTables {
+		named[constraint.Name] = true
 		if !slices.Contains(diff.TablesAdded, constraint.TableName) {
-			return false
+			tables[constraint.TableName] = true
 		}
-		seen[constraint.Name] = true
 	}
-	return !slices.ContainsFunc(diff.ConstraintsAdded, func(name string) bool {
-		return !seen[name]
-	})
-}
-
-func constraintRemovalsBelongToRemovedTables(diff *types.SchemaDiff) bool {
-	if len(diff.ConstraintsRemoved) == 0 {
-		return true
-	}
-	seen := make(map[string]bool, len(diff.ConstraintsRemovedWithTables))
 	for _, constraint := range diff.ConstraintsRemovedWithTables {
+		named[constraint.Name] = true
 		if !slices.Contains(diff.TablesRemoved, constraint.TableName) {
-			return false
+			tables[constraint.TableName] = true
 		}
-		seen[constraint.Name] = true
 	}
-	return !slices.ContainsFunc(diff.ConstraintsRemoved, func(name string) bool {
-		return !seen[name]
-	})
+	unattributed := slices.ContainsFunc(diff.ConstraintsAdded, func(name string) bool { return !named[name] }) ||
+		slices.ContainsFunc(diff.ConstraintsRemoved, func(name string) bool { return !named[name] })
+	if unattributed {
+		return nil, unsupportedFeaturef("changing constraints on existing tables requires a table rebuild plan")
+	}
+	names := slices.Collect(maps.Keys(tables))
+	slices.Sort(names)
+	return names, nil
 }
 
 func rejectUnsupportedSchemaObjects(diff *types.SchemaDiff) error {
@@ -236,15 +283,21 @@ func withDefaultForeignKeyName(tableName string, constraint goschema.Constraint)
 	return constraint
 }
 
-func (p *Planner) modifyTables(diff *types.SchemaDiff, generated *goschema.Database) ([]ast.Node, error) {
+func (p *Planner) modifyTables(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	rebuilds tableRebuilds,
+) ([]ast.Node, error) {
 	var result []ast.Node
+	emitted := make(map[string]bool, len(rebuilds.order))
 	for _, tableDiff := range diff.TablesModified {
-		if len(tableDiff.ColumnsRemoved) > 0 {
-			nodes, err := p.rebuildTableWithoutColumns(tableDiff, diff, generated)
+		if target, ok := rebuilds.target(tableDiff.TableName); ok {
+			nodes, err := p.rebuildTable(target, diff, generated)
 			if err != nil {
 				return nil, err
 			}
 			result = append(result, nodes...)
+			emitted[tableDiff.TableName] = true
 			continue
 		}
 		for _, columnName := range tableDiff.ColumnsAdded {
@@ -256,17 +309,34 @@ func (p *Planner) modifyTables(diff *types.SchemaDiff, generated *goschema.Datab
 			}
 		}
 	}
+	// Tables reached only through a constraint change never appear in
+	// TablesModified, so they are emitted after the column-driven ones.
+	for _, tableName := range rebuilds.order {
+		if emitted[tableName] {
+			continue
+		}
+		nodes, err := p.rebuildTable(rebuilds.targets[tableName], diff, generated)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, nodes...)
+	}
 	return result, nil
 }
 
-func (p *Planner) rebuildTableWithoutColumns(
-	tableDiff types.TableDiff,
+// rebuildTable emits the create-new / copy-rows / drop-old / rename sequence
+// that stands in for the ALTER TABLE forms SQLite does not have. The new table
+// is rendered from the desired definition, so one rebuild covers column type,
+// nullability, default, generated-expression and constraint changes at once,
+// as well as dropped and added columns.
+func (p *Planner) rebuildTable(
+	target rebuildTarget,
 	diff *types.SchemaDiff,
 	generated *goschema.Database,
 ) ([]ast.Node, error) {
-	table := findTable(generated.Tables, tableDiff.TableName)
+	table := findTable(generated.Tables, target.tableName)
 	if table == nil {
-		return nil, unsupportedFeaturef("rebuilding table %s requires the retained table definition", tableDiff.TableName)
+		return nil, unsupportedFeaturef("rebuilding table %s requires the retained table definition", target.tableName)
 	}
 	if err := validateRebuildTablePreconditions(*table, diff, generated); err != nil {
 		return nil, err
@@ -280,16 +350,19 @@ func (p *Planner) rebuildTableWithoutColumns(
 	}
 	createNode.Name = qualifyLikeTable(*table, tempName)
 
-	columns := rebuildColumnNames(*table, generated.Fields)
+	columns, err := rebuildCopiedColumns(*table, generated.Fields, target.addedColumns)
+	if err != nil {
+		return nil, err
+	}
 	if len(columns) == 0 {
 		return nil, unsupportedFeaturef("rebuilding table %s without retained columns is not supported", table.QualifiedName())
 	}
 
 	nodes := []ast.Node{
-		ast.NewComment("SQLite table rebuild to remove unsupported columns from " + table.QualifiedName()),
+		ast.NewComment("SQLite table rebuild for changes ALTER TABLE cannot express on " + table.QualifiedName()),
 		createNode,
 		ast.NewRawSQL("INSERT INTO " + quoteQualifiedIdentifier(createNode.Name) +
-			" (" + quoteIdentifierList(columns) + ") SELECT " + quoteIdentifierList(columns) +
+			" (" + quoteIdentifierList(copiedColumnNames(columns)) + ") SELECT " + copiedColumnSelectList(columns) +
 			" FROM " + quoteQualifiedIdentifier(table.QualifiedName()) + ";"),
 		ast.NewDropTable(table.QualifiedName()),
 		ast.NewRawSQL("ALTER TABLE " + quoteQualifiedIdentifier(createNode.Name) +
@@ -351,14 +424,106 @@ func qualifyLikeTable(table goschema.Table, name string) string {
 	return goschema.QualifyTableName(table.Schema, name)
 }
 
-func rebuildColumnNames(table goschema.Table, fields []goschema.Field) []string {
-	var columns []string
-	for _, field := range fields {
-		if field.StructName == table.StructName {
-			columns = append(columns, field.Name)
-		}
+// copiedColumn is one column of the rebuilt table that carries data over from
+// the old table.
+type copiedColumn struct {
+	// name is the column name on both the old and the new table.
+	name string
+	// selectExpr is the expression read from the old table. It is the bare
+	// quoted column name unless the desired definition needs a backfill.
+	selectExpr string
+}
+
+func copiedColumnNames(columns []copiedColumn) []string {
+	names := make([]string, len(columns))
+	for i, column := range columns {
+		names[i] = column.name
 	}
-	return columns
+	return names
+}
+
+func copiedColumnSelectList(columns []copiedColumn) string {
+	parts := make([]string, len(columns))
+	for i, column := range columns {
+		parts[i] = column.selectExpr
+	}
+	return strings.Join(parts, ", ")
+}
+
+// rebuildCopiedColumns lists the columns the rebuild copies over. Columns the
+// diff adds exist only in the desired schema, so they are left out of the copy
+// and take their declared default in the new table; a NOT NULL addition with no
+// default would violate the new table on the very first row, so it is refused
+// rather than emitted.
+func rebuildCopiedColumns(
+	table goschema.Table,
+	fields []goschema.Field,
+	addedColumns []string,
+) ([]copiedColumn, error) {
+	added := make(map[string]bool, len(addedColumns))
+	for _, name := range addedColumns {
+		added[name] = true
+	}
+
+	var columns []copiedColumn
+	for _, field := range fields {
+		if field.StructName != table.StructName {
+			continue
+		}
+		if added[field.Name] {
+			if err := validateRebuiltAddedColumn(table, field); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		columns = append(columns, copiedColumn{
+			name:       field.Name,
+			selectExpr: rebuildSelectExpression(field),
+		})
+	}
+	return columns, nil
+}
+
+// rebuildSelectExpression backfills a column that the desired schema makes NOT
+// NULL while giving it a default. Rows already holding NULL would otherwise
+// abort the copy, so the default is substituted in flight.
+func rebuildSelectExpression(field goschema.Field) string {
+	quoted := quoteIdentifier(field.Name)
+	if field.Nullable || field.Primary {
+		return quoted
+	}
+	backfill := rebuildBackfillValue(field)
+	if backfill == "" {
+		return quoted
+	}
+	return "IFNULL(" + quoted + ", " + backfill + ") AS " + quoted
+}
+
+func rebuildBackfillValue(field goschema.Field) string {
+	if value := strings.TrimSpace(field.Default); value != "" && !isNullLiteral(value) {
+		return value
+	}
+	if value := strings.TrimSpace(field.DefaultExpr); value != "" && !isNullLiteral(value) {
+		return value
+	}
+	return ""
+}
+
+func validateRebuiltAddedColumn(table goschema.Table, field goschema.Field) error {
+	if field.Nullable || field.Primary || field.AutoInc {
+		return nil
+	}
+	if strings.TrimSpace(field.GeneratedExpression) != "" {
+		return nil
+	}
+	if rebuildBackfillValue(field) != "" {
+		return nil
+	}
+	return unsupportedFeaturef(
+		"rebuilding table %s cannot add NOT NULL column %s without a default",
+		table.QualifiedName(),
+		field.Name,
+	)
 }
 
 func (p *Planner) recreateTableIndexes(table goschema.Table, generated *goschema.Database) []ast.Node {
@@ -451,8 +616,15 @@ func quoteIdentifier(name string) string {
 	return `"` + strings.ReplaceAll(name, `"`, `""`) + `"`
 }
 
-func validateAddedColumns(diff *types.SchemaDiff, generated *goschema.Database) error {
+// validateAddedColumns gates the ALTER TABLE ... ADD COLUMN path, whose
+// accepted shapes SQLite restricts far below what CREATE TABLE accepts. Tables
+// that are being rebuilt go through CREATE TABLE instead, so they are excluded
+// here and checked by [validateRebuiltAddedColumn].
+func validateAddedColumns(diff *types.SchemaDiff, generated *goschema.Database, rebuilds tableRebuilds) error {
 	for _, tableDiff := range diff.TablesModified {
+		if rebuilds.contains(tableDiff.TableName) {
+			continue
+		}
 		for _, columnName := range tableDiff.ColumnsAdded {
 			column := findColumn(generated, tableDiff.TableName, columnName)
 			if column == nil {
@@ -537,6 +709,7 @@ func findColumn(generated *goschema.Database, tableName, columnName string) *ast
 func (p *Planner) addIndexes(
 	diff *types.SchemaDiff,
 	indexes *indexscope.Resolver,
+	rebuilds tableRebuilds,
 ) ([]ast.Node, error) {
 	var result []ast.Node
 	indexRemovals := indexscope.NewConflictSetWithSemantics(
@@ -544,6 +717,12 @@ func (p *Planner) addIndexes(
 		diff.IndexRemovals(),
 	)
 	for _, ref := range diff.IndexAdditions() {
+		// A rebuilt table drops every index with the old table and recreates
+		// the desired set from scratch, so repeating them here would emit the
+		// same CREATE INDEX twice.
+		if rebuilds.contains(ref.TableName) {
+			continue
+		}
 		index, err := indexes.Resolve(ref)
 		if err != nil {
 			return nil, err
@@ -557,7 +736,7 @@ func (p *Planner) addIndexes(
 	return result, nil
 }
 
-func (p *Planner) removeIndexes(diff *types.SchemaDiff) []ast.Node {
+func (p *Planner) removeIndexes(diff *types.SchemaDiff, rebuilds tableRebuilds) []ast.Node {
 	var result []ast.Node
 	indexAdditions := indexscope.NewConflictSetWithSemantics(
 		diff.EffectiveIdentifierSemantics(platform.SQLite),
@@ -565,6 +744,10 @@ func (p *Planner) removeIndexes(diff *types.SchemaDiff) []ast.Node {
 	)
 	for _, ref := range diff.IndexRemovals() {
 		if indexAdditions.Contains(ref) {
+			continue
+		}
+		// DROP TABLE already took this index with it.
+		if rebuilds.contains(ref.TableName) {
 			continue
 		}
 		result = append(result, ast.NewDropIndex(ref.Name).SetTable(ref.TableName).SetIfExists())
@@ -617,9 +800,18 @@ func findView(views []goschema.View, name string) *goschema.View {
 	return nil
 }
 
-func (p *Planner) addTriggers(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+func (p *Planner) addTriggers(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	rebuilds tableRebuilds,
+) []ast.Node {
 	var result []ast.Node
 	for _, ref := range diff.TriggersAdded {
+		// A rebuilt table recreates every desired trigger already; CREATE
+		// TRIGGER carries no IF NOT EXISTS here, so a second copy would fail.
+		if rebuilds.contains(ref.TableName) {
+			continue
+		}
 		if trigger := findTrigger(generated.Triggers, ref.TableName, ref.TriggerName); trigger != nil {
 			result = append(result, fromschema.FromTrigger(*trigger))
 		}
@@ -627,9 +819,16 @@ func (p *Planner) addTriggers(diff *types.SchemaDiff, generated *goschema.Databa
 	return result
 }
 
-func (p *Planner) modifyTriggers(diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+func (p *Planner) modifyTriggers(
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	rebuilds tableRebuilds,
+) []ast.Node {
 	var result []ast.Node
 	for _, triggerDiff := range diff.TriggersModified {
+		if rebuilds.contains(triggerDiff.TableName) {
+			continue
+		}
 		if trigger := findTrigger(generated.Triggers, triggerDiff.TableName, triggerDiff.TriggerName); trigger != nil {
 			result = append(result, fromschema.FromTrigger(*trigger).SetReplace())
 		}

--- a/internal/planner/dialects/sqlite/sqlite_test.go
+++ b/internal/planner/dialects/sqlite/sqlite_test.go
@@ -733,3 +733,53 @@ func TestPlannerRejectsSQLiteExcludeConstraint(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
 	c.Assert(err, qt.ErrorMatches, "sqlite: EXCLUDE constraints are not supported")
 }
+
+// TestPlannerRebuildExcludesColumnsAddedBesideAConstraintChange pins the
+// intersection that corrupted data: one diff that BOTH adds a column and changes
+// a table-level constraint on the same existing table.
+//
+// The added column must not appear in the rebuild's SELECT, because it does not
+// exist in the old table. SQLite reads an unknown double-quoted identifier as a
+// STRING LITERAL rather than refusing it, so copying `"note"` out of a table
+// without that column writes the text `note` into every row — and `schema apply`
+// exits 0 reporting success. Measured on a seeded database before the fix:
+// (1,'alpha','note'), (2,'beta','note'), typeof text.
+//
+// Reverted, the INSERT reads `("id", "name", "note") SELECT "id", "name", "note"`
+// and this row fails on the first assertion. The suite covers each half of the
+// shape separately — a column added alone, a constraint changed alone — and
+// neither reaches the bad SELECT, which is why the branch was green.
+func TestPlannerRebuildExcludesColumnsAddedBesideAConstraintChange(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+			{Name: "name", Type: "TEXT", StructName: "User", Nullable: false},
+			{Name: "note", Type: "TEXT", StructName: "User", Nullable: true},
+		},
+	}
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{{
+			TableName:    "users",
+			ColumnsAdded: []string{"note"},
+		}},
+		ConstraintsAdded: []string{"uq_users_name"},
+		ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+			Name:      "uq_users_name",
+			TableName: "users",
+			Type:      "UNIQUE",
+			Columns:   []string{"name"},
+		}},
+	}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.SQLite)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(sql, qt.Contains,
+		`INSERT INTO "__ptah_rebuild_users" ("id", "name") SELECT "id", "name" FROM "users";`)
+	c.Assert(sql, qt.Not(qt.Contains), `SELECT "id", "name", "note"`)
+	c.Assert(sql, qt.Contains, `CREATE TABLE "__ptah_rebuild_users"`)
+	c.Assert(sql, qt.Contains, `"note" TEXT`)
+}

--- a/internal/planner/dialects/sqlite/sqlite_test.go
+++ b/internal/planner/dialects/sqlite/sqlite_test.go
@@ -1,6 +1,7 @@
 package sqlite_test
 
 import (
+	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -388,30 +389,177 @@ func TestPlannerDropsIndexesAndTables(t *testing.T) {
 	c.Assert(sql, qt.Contains, `DROP TABLE IF EXISTS "old_users"`)
 }
 
-func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
+// usersRebuildSchema is the desired shape the rebuild tests converge on: a
+// two-column table whose definition the caller adjusts per case.
+func usersRebuildSchema(fields []goschema.Field, constraints []goschema.Constraint) *goschema.Database {
+	return &goschema.Database{
+		Tables:      []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields:      fields,
+		Constraints: constraints,
+	}
+}
+
+func usersNameField(name goschema.Field) []goschema.Field {
+	return []goschema.Field{
+		{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+		name,
+	}
+}
+
+// TestPlannerRebuildsTableForChangesAlterTableCannotExpress pins one rebuild per
+// diff shape that SQLite's ALTER TABLE grammar cannot carry. Each row asserts
+// the create/copy/drop/rename sequence plus the shape-specific detail. Before
+// the rebuild generalization every row returned an unsupported-feature error
+// instead: "sqlite: modifying columns on table users requires a table rebuild
+// plan" for the three column rows, "sqlite: changing constraints on table users
+// requires a table rebuild plan" for the table-level constraint row, and
+// "sqlite: changing constraints on existing tables requires a table rebuild
+// plan" for the schema-level constraint and enum rows.
+func TestPlannerRebuildsTableForChangesAlterTableCannotExpress(t *testing.T) {
 	tests := []struct {
-		name string
-		diff *types.SchemaDiff
-		want string
+		name      string
+		generated *goschema.Database
+		diff      *types.SchemaDiff
+		assert    func(c *qt.C, sql string)
 	}{
 		{
-			name: "modify column",
-			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{
-				{TableName: "users", ColumnsModified: []types.ColumnDiff{{ColumnName: "name"}}},
-			}},
-			want: "sqlite: modifying columns on table users requires a table rebuild plan",
+			name: "column type change",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "name", Type: "INTEGER", StructName: "User"}),
+				nil,
+			),
+			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{{
+				TableName:       "users",
+				ColumnsModified: []types.ColumnDiff{{ColumnName: "name", Changes: map[string]string{"type": "text -> integer"}}},
+			}}},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `"name" INTEGER NOT NULL`)
+				c.Assert(sql, qt.Contains, `SELECT "id", "name" FROM "users";`)
+			},
 		},
 		{
-			name: "change constraints",
-			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{
-				{TableName: "users", ConstraintsAdded: []string{"users_name_key"}},
-			}},
-			want: "sqlite: changing constraints on table users requires a table rebuild plan",
+			name: "column nullability change",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "name", Type: "TEXT", StructName: "User", Nullable: true}),
+				nil,
+			),
+			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{{
+				TableName:       "users",
+				ColumnsModified: []types.ColumnDiff{{ColumnName: "name", Changes: map[string]string{"nullable": "false -> true"}}},
+			}}},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `"name" TEXT`)
+				c.Assert(sql, qt.Not(qt.Contains), `"name" TEXT NOT NULL`)
+			},
 		},
 		{
-			name: "enum check drift",
-			diff: &types.SchemaDiff{EnumsModified: []types.EnumDiff{{EnumName: "enum_users_status"}}},
-			want: "sqlite: changing enum-backed CHECK constraints requires a table rebuild plan",
+			name: "not null default addition backfills the copy",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "name", Type: "TEXT", StructName: "User", Default: "'x'"}),
+				nil,
+			),
+			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{{
+				TableName: "users",
+				ColumnsModified: []types.ColumnDiff{{
+					ColumnName: "name",
+					Changes:    map[string]string{"nullable": "true -> false", "default": " -> 'x'"},
+				}},
+			}}},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `SELECT "id", IFNULL("name", 'x') AS "name" FROM "users";`)
+			},
+		},
+		{
+			name: "table-level constraint change",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "name", Type: "TEXT", StructName: "User"}),
+				[]goschema.Constraint{{
+					Name:            "users_name_check",
+					Type:            "CHECK",
+					StructName:      "User",
+					CheckExpression: "length(name) > 2",
+				}},
+			),
+			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{{
+				TableName:        "users",
+				ConstraintsAdded: []string{"users_name_check"},
+			}}},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `CONSTRAINT "users_name_check" CHECK (length(name) > 2)`)
+			},
+		},
+		{
+			name: "schema-level constraint change on an existing table",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "name", Type: "TEXT", StructName: "User"}),
+				[]goschema.Constraint{{
+					Name:            "users_name_check",
+					Type:            "CHECK",
+					StructName:      "User",
+					CheckExpression: "length(name) > 2",
+				}},
+			),
+			diff: &types.SchemaDiff{
+				ConstraintsAdded: []string{"users_name_check"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:            "users_name_check",
+					TableName:       "users",
+					Type:            "CHECK",
+					CheckExpression: "length(name) > 2",
+				}},
+			},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `CONSTRAINT "users_name_check" CHECK (length(name) > 2)`)
+			},
+		},
+		{
+			name: "enum-backed check constraint change",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{
+					Name:       "status",
+					Type:       "TEXT",
+					StructName: "User",
+					Check:      "status IN ('draft', 'published')",
+					CheckName:  "users_status_check",
+				}),
+				nil,
+			),
+			diff: &types.SchemaDiff{
+				EnumsModified:      []types.EnumDiff{{EnumName: "enum_users_status", ValuesRemoved: []string{"archived"}}},
+				ConstraintsAdded:   []string{"users_status_check"},
+				ConstraintsRemoved: []string{"users_status_check"},
+				ConstraintsAddedWithTables: []types.ConstraintAdditionInfo{{
+					Name:            "users_status_check",
+					TableName:       "users",
+					Type:            "CHECK",
+					CheckExpression: "status IN ('draft', 'published')",
+				}},
+				ConstraintsRemovedWithTables: []types.ConstraintRemovalInfo{{
+					Name:      "users_status_check",
+					TableName: "users",
+					Type:      "CHECK",
+				}},
+			},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `CHECK (status IN ('draft', 'published'))`)
+				c.Assert(sql, qt.Not(qt.Contains), "archived")
+			},
+		},
+		{
+			name: "dropped column combined with an added column",
+			generated: usersRebuildSchema(
+				usersNameField(goschema.Field{Name: "nickname", Type: "TEXT", StructName: "User", Nullable: true}),
+				nil,
+			),
+			diff: &types.SchemaDiff{TablesModified: []types.TableDiff{{
+				TableName:      "users",
+				ColumnsAdded:   []string{"nickname"},
+				ColumnsRemoved: []string{"email"},
+			}}},
+			assert: func(c *qt.C, sql string) {
+				c.Assert(sql, qt.Contains, `"nickname" TEXT`)
+				c.Assert(sql, qt.Contains, `INSERT INTO "__ptah_rebuild_users" ("id") SELECT "id" FROM "users";`)
+			},
 		},
 	}
 
@@ -419,15 +567,131 @@ func TestPlannerRejectsRebuildOnlyTableChanges(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			nodes, err := planner.GenerateSchemaDiffAST(tt.diff, &goschema.Database{}, platform.SQLite)
-			c.Assert(nodes, qt.IsNil)
-			var planErr *ptaherr.PlanError
-			c.Assert(err, qt.ErrorAs, &planErr)
-			c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
-			c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
-			c.Assert(err, qt.ErrorMatches, tt.want)
+			sql, err := planner.GenerateSchemaDiffSQL(tt.diff, tt.generated, platform.SQLite)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Contains, `CREATE TABLE "__ptah_rebuild_users"`)
+			c.Assert(sql, qt.Contains, `INSERT INTO "__ptah_rebuild_users"`)
+			c.Assert(sql, qt.Contains, `DROP TABLE "users";`)
+			c.Assert(sql, qt.Contains, `ALTER TABLE "__ptah_rebuild_users" RENAME TO "users";`)
+			tt.assert(c, sql)
 		})
 	}
+}
+
+// TestPlannerRebuildRefusesAddedNotNullColumnWithoutDefault keeps the rebuild
+// from emitting a copy that cannot execute: the added column is absent from the
+// INSERT list, so SQLite would fill it with NULL and abort on the first row.
+// Reverting the guard prints a plan containing
+// `INSERT INTO "__ptah_rebuild_users" ("id") SELECT "id" FROM "users";` and a
+// nil error instead of the refusal.
+func TestPlannerRebuildRefusesAddedNotNullColumnWithoutDefault(t *testing.T) {
+	c := qt.New(t)
+
+	generated := usersRebuildSchema(
+		usersNameField(goschema.Field{Name: "email", Type: "TEXT", StructName: "User"}),
+		nil,
+	)
+	diff := &types.SchemaDiff{TablesModified: []types.TableDiff{{
+		TableName:      "users",
+		ColumnsAdded:   []string{"email"},
+		ColumnsRemoved: []string{"legacy"},
+	}}}
+
+	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, platform.SQLite)
+
+	c.Assert(nodes, qt.IsNil)
+	var planErr *ptaherr.PlanError
+	c.Assert(err, qt.ErrorAs, &planErr)
+	c.Assert(planErr.Dialect, qt.Equals, platform.SQLite)
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrUnsupportedFeature)
+	c.Assert(err, qt.ErrorMatches, `sqlite: rebuilding table users cannot add NOT NULL column email without a default`)
+}
+
+// TestPlannerRebuildEmitsIndexesAndTriggersOnce pins that a rebuilt table
+// recreates its desired indexes and triggers exactly once. The rebuild drops
+// the table, so the diff's own index and trigger additions must not be replayed
+// on top. Reverting the skip prints the CREATE INDEX line twice and the CREATE
+// TRIGGER statement twice.
+func TestPlannerRebuildEmitsIndexesAndTriggersOnce(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: "INTEGER", StructName: "User", Primary: true},
+			{Name: "name", Type: "INTEGER", StructName: "User"},
+		},
+		Indexes: []goschema.Index{{
+			Name:       "idx_users_name",
+			StructName: "User",
+			Fields:     []string{"name"},
+		}},
+		Triggers: []goschema.Trigger{{
+			Name:    "trg_users_name",
+			Table:   "users",
+			Timing:  "AFTER",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "BEGIN SELECT NEW.name; END",
+		}},
+	}
+	diff := &types.SchemaDiff{
+		TablesModified: []types.TableDiff{{
+			TableName:       "users",
+			ColumnsModified: []types.ColumnDiff{{ColumnName: "name", Changes: map[string]string{"type": "text -> integer"}}},
+		}},
+		IndexesAdded:  []types.IndexRef{{Name: "idx_users_name", TableName: "users"}},
+		TriggersAdded: []types.TriggerRef{{TriggerName: "trg_users_name", TableName: "users"}},
+	}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.SQLite)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Count(sql, `CREATE INDEX IF NOT EXISTS "idx_users_name"`), qt.Equals, 1)
+	c.Assert(strings.Count(sql, `CREATE TRIGGER "trg_users_name"`), qt.Equals, 1)
+}
+
+// TestPlannerEmitsTriggerChangesWithoutRebuild is the non-interference control
+// for the rebuild skip in addTriggers and modifyTriggers: a table that is not
+// being rebuilt must still get its added and replaced triggers. Inverting the
+// skip so that only rebuilt tables emit prints zero occurrences of both
+// statements and fails on the first count.
+func TestPlannerEmitsTriggerChangesWithoutRebuild(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{{Name: "id", Type: "INTEGER", StructName: "User", Primary: true}},
+		Triggers: []goschema.Trigger{
+			{
+				Name:    "trg_users_insert",
+				Table:   "users",
+				Timing:  "AFTER",
+				Event:   "INSERT",
+				ForEach: "ROW",
+				Body:    "BEGIN SELECT NEW.id; END",
+			},
+			{
+				Name:    "trg_users_update",
+				Table:   "users",
+				Timing:  "AFTER",
+				Event:   "UPDATE",
+				ForEach: "ROW",
+				Body:    "BEGIN SELECT NEW.id; END",
+			},
+		},
+	}
+	diff := &types.SchemaDiff{
+		TriggersAdded:    []types.TriggerRef{{TriggerName: "trg_users_insert", TableName: "users"}},
+		TriggersModified: []types.TriggerDiff{{TriggerName: "trg_users_update", TableName: "users"}},
+	}
+
+	sql, err := planner.GenerateSchemaDiffSQL(diff, generated, platform.SQLite)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Count(sql, `CREATE TRIGGER "trg_users_insert"`), qt.Equals, 1)
+	c.Assert(strings.Count(sql, `TRIGGER "trg_users_update"`), qt.Equals, 1)
 }
 
 func TestPlannerRejectsUnqualifiedExistingTableConstraintChanges(t *testing.T) {


### PR DESCRIPTION
Closes #930.

The SQLite planner rebuilt a table to drop a column, but every other shape that
ALTER TABLE cannot express returned an unsupported-feature error instead of
reusing that machinery. This generalizes the rebuild from "drop these columns"
to "reshape to the desired definition".

Measured on this branch against `origin/master` d1e2dc64, with `ptah-compat` and
`ptah` built from the branch, cross-checked against the pinned Atlas community
binary (`atlas community version v1.3.0`) at
`/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`.

## Reproduction, before and after

Fixtures, all SQLite, all diffs run as
`ptah-compat schema diff --from file://<a> --to file://<b> --dev-url sqlite://dev.db`:

```sql
-- base.sql
CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);
-- base3.sql
CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL, email TEXT);
-- c_type.sql      name INTEGER NOT NULL
-- c_nullable.sql  name TEXT
-- c_default.sql   name TEXT NOT NULL DEFAULT 'x'
-- c_colcheck.sql  name TEXT NOT NULL CHECK (length(name) > 2)
-- c_uq.sql        base3 + CONSTRAINT uq_users_email UNIQUE (email)
-- c_dropadd.sql   base3 with email dropped and nickname TEXT added
```

| # | Fixture | Before | After | Atlas CE v1.3.0 |
|---|---|---|---|---|
| 1 | `base → c_type` | exit 1 `sqlite: modifying columns on table users requires a table rebuild plan` | exit 0, rebuild | exit 0, rebuild |
| 2 | `base → c_nullable` | exit 1, same message | exit 0, rebuild | exit 0, rebuild |
| 3 | `base → c_default` | exit 1, same message | exit 0, rebuild with `IFNULL` | exit 0, rebuild with `IFNULL` |
| 4 | `base → c_colcheck` | exit 1 `sqlite: changing constraints on existing tables requires a table rebuild plan` | exit 0, rebuild | exit 0, rebuild |
| 5 | `base3 → c_dropadd` | exit 1 `sqlite: combining dropped columns with other table changes on users requires a manual rebuild plan` | exit 0, rebuild | exit 0, rebuild |
| 6 | enum shrink via Go entities | exit 2 `sqlite: changing constraints on existing tables requires a table rebuild plan` | exit 0, rebuild | no CE equivalent (Ptah annotations) |
| — | `base3 → c_uq` (extra) | exit 1, constraints message | exit 0, rebuild | exit 0, `CREATE UNIQUE INDEX` |

Controls, all unchanged by this branch: `base → base3` (nullable column
addition) exits 0 with `ALTER TABLE "users" ADD COLUMN "email" TEXT;` on both
binaries; `base3 → base` (column drop only) exits 0 with a rebuild on both;
`base → base` exits 0 with "Schemas are synced" on both.

The DEFAULT case, before and after:

```
$ pc schema diff --from file://base.sql --to file://c_default.sql --dev-url sqlite://dev.db
error: generate schema diff SQL: sqlite: modifying columns on table users requires a table rebuild plan   (exit 1)

$ pc schema diff --from file://base.sql --to file://c_default.sql --dev-url sqlite://dev.db
-- SQLite table rebuild for changes ALTER TABLE cannot express on users
CREATE TABLE "__ptah_rebuild_users" (
  "id" INTEGER PRIMARY KEY,
  "name" TEXT NOT NULL DEFAULT 'x'
);
INSERT INTO "__ptah_rebuild_users" ("id", "name") SELECT "id", IFNULL("name", 'x') AS "name" FROM "users";
DROP TABLE "users";
ALTER TABLE "__ptah_rebuild_users" RENAME TO "users";
(exit 0)
```

The enum case, `ptah migrations plan --root-dir <entities> --db-url sqlite://enum.db`,
shrinking `enum="draft,published,archived"` to `enum="draft,published"`:

```
before: error: error generating migration plan: sqlite: changing constraints on existing tables requires a table rebuild plan   (exit 2)
after:  -- SQLite table rebuild for changes ALTER TABLE cannot express on articles
        CREATE TABLE "__ptah_rebuild_articles" (
          "id" INTEGER PRIMARY KEY,
          "status" TEXT NOT NULL CHECK (status IN ('draft', 'published'))
        );
        INSERT INTO "__ptah_rebuild_articles" ("id", "status") SELECT "id", "status" FROM "articles";
        DROP TABLE "articles";
        ALTER TABLE "__ptah_rebuild_articles" RENAME TO "articles";
        (exit 0)
```

## Executed end to end, not only planned

Every case above was seeded into a real SQLite database with two rows, applied
with `ptah-compat schema apply --url sqlite://<db> --to file://<to> --dev-url
sqlite://<dev> --auto-approve`, and inspected afterwards. All six exit 0, all
six keep `count(*) = 2`, and `SELECT name FROM sqlite_schema WHERE name LIKE
'__ptah_rebuild_%'` returns zero rows in every case.

The DEFAULT case is the discriminating one: seeded `(1,'alpha'),(2,NULL)` on a
nullable column, applying `NOT NULL DEFAULT 'x'` leaves `1='alpha' / 2='x'`.
The enum case was applied the same way; afterwards
`INSERT INTO articles (id,status) VALUES (3,'archived')` fails with
`CHECK constraint failed: status IN ('draft', 'published')`, which is the
positive control that the rebuilt constraint is live rather than merely printed.

## What each test prints if the change is reverted

Every claim below was produced by actually running the mutant, not predicted.

- **`TestPlannerRebuildsTableForChangesAlterTableCannotExpress`** — seven rows,
  one per diff shape. Narrowing `tableDiffNeedsRebuild` back to
  `len(table.ColumnsRemoved) > 0` reddens exactly four rows (`column_type_change`,
  `column_nullability_change`, `not_null_default_addition_backfills_the_copy`,
  `table-level_constraint_change`) with the old unsupported-feature errors.
  Separately, dropping the constraint-attributed tables from `planTableRebuilds`
  reddens exactly the other two constraint rows
  (`schema-level_constraint_change_on_an_existing_table`,
  `enum-backed_check_constraint_change`). The two mutants redden disjoint sets,
  so each of the three former call sites is pinned by its own row rather than by
  one test standing in for all.
- **The backfill row** — making `rebuildSelectExpression` always return the bare
  quoted column reddens only that row, and the end-to-end apply then fails with
  `Error: apply schema changes: ... NOT NULL constraint failed: __ptah_rebuild_users.name (1299)`.
- **`TestPlannerRebuildRefusesAddedNotNullColumnWithoutDefault`** — removing the
  guard prints `got non-nil value` for the nil-nodes assertion, i.e. a plan is
  emitted where it must not be. The inverse mutant (refuse every added column in
  a rebuild) reddens `dropped_column_combined_with_an_added_column`, so the
  guard's condition discriminates rather than firing unconditionally.
- **`TestPlannerRebuildEmitsIndexesAndTriggersOnce`** — removing the rebuild skip
  in `addIndexes` prints `got: int(2) / want: int(1)` for
  `CREATE INDEX IF NOT EXISTS "idx_users_name"`.
- **`TestPlannerEmitsTriggerChangesWithoutRebuild`** — this is the
  non-interference control for the trigger skip, and it is new because the
  inverse mutant found nothing else in the repository catching it: inverting the
  skip in `addTriggers`/`modifyTriggers` so that only rebuilt tables emit turned
  the **entire** `go test ./...` red on one test only, my own duplicate-count
  test. With the control added, the inverse mutant reddens it with
  `strings.Count(sql, "TRIGGER \"trg_users_update\"") == 0`.
- **`TestPlannerAddsColumnsAndIndexes` and the six `TestPlanner_IndexRefs_*`
  tests** are the non-interference control for the index skip: inverting that
  guard (`!rebuilds.contains`) reddens all seven, proving the skip is scoped to
  rebuilt tables and does not suppress ordinary index emission.
- **`TestPlannerRejectsAddColumnShapesThatNeedRebuild`** (unchanged) is the
  non-interference control for excluding rebuilt tables from
  `validateAddedColumns`: inverting that exclusion reddens it, because pure
  column additions on a non-rebuilt table must still be validated.
- **`TestPlannerRejectsUnqualifiedExistingTableConstraintChanges`** (unchanged)
  still pins the one surviving `changing constraints on existing tables`
  refusal, for a constraint the diff cannot attribute to a table.

## Where I chose the ceiling over matching

Two shapes exit 1 here where the pinned community binary exits 0. Parity rule
(a) is about never exiting 0 where the pinned binary exits 1, so neither is a
rule-(a) violation; both are cases where I took rule (b), because the CE plan
does not execute:

```
$ sqlite3 seeded.db 'ALTER TABLE `users` ADD COLUMN `email` text NOT NULL;'
Error: stepping, Cannot add a NOT NULL column with default value NULL   (exit 1)

$ sqlite3 seeded.db 'CREATE TABLE `new_users` (`id` integer NULL, `name` integer NOT NULL, `email` text NOT NULL, PRIMARY KEY (`id`));
                     INSERT INTO `new_users` (`id`, `name`) SELECT `id`, `name` FROM `users`;'
Error: stepping, NOT NULL constraint failed: new_users.email (19)   (exit 19)
```

Both statement lists are verbatim CE output for `base → users(id, name, email
NOT NULL)` and `base → users(id, name INTEGER, email NOT NULL)`. The control
that these are genuine and not a fixture artifact: the same rebuild against an
**empty** table exits 0, which is why the plan looks fine until it meets data.
Ptah refuses at plan time instead, with
`sqlite: adding column email to table users requires a table rebuild plan` and
`sqlite: rebuilding table users cannot add NOT NULL column email without a default`.

## What I deliberately left open

- **Adding a column that carries UNIQUE.** `base → users(id, name, email TEXT
  UNIQUE)` still exits 1 with `sqlite: adding column email to table users
  requires a table rebuild plan`; CE exits 0 with `ALTER TABLE ... ADD COLUMN`
  plus `CREATE UNIQUE INDEX`. That is the index path, not the rebuild path — a
  different function (`validateAddedColumn`) and a different strategy, and
  rebuilding for it would emit a needlessly destructive plan for a case that
  needs an index. The framing comment on #930 scoped this as W3.
- **Rebuilding a table with inbound foreign keys.** Still refused at
  `validateRebuildTablePreconditions` with `sqlite: rebuilding table users with
  inbound foreign keys requires a manual rebuild plan`, and Ptah still emits no
  `PRAGMA foreign_keys` bracket. The framing comment scoped this as W2. It is
  independent of the six shapes here — none of them involves a foreign key — and
  the PRAGMA is a no-op inside a transaction, so adding it without settling how
  the rebuild is executed would be decoration rather than a fix.
- **Table-level `CHECK` in a `.sql` schema file is invisible to the diff.** The
  issue's `base → c_check` fixture, where `c_check.sql` carries
  `CONSTRAINT name_len CHECK (length(name) > 2)` as a table constraint, exits 0
  with "Schemas are synced" both before and after this branch — the constraint
  never reaches the planner. `ptah-compat schema inspect --url file://c_check.sql`
  prints the table without the CHECK, and CE emits a full rebuild for the same
  fixture. This is a SQL-schema-file source gap, not a planner gap, so the CHECK
  row is covered here by the equivalent column-level fixture
  (`name TEXT NOT NULL CHECK (length(name) > 2)`), which does reach the planner
  and now rebuilds. Adjacent to #932.
- **A `.yaml` schema file with an `ENUM` column does not self-diff clean.**
  `ptah schema diff --from file://y.yaml --to file://y.yaml --dev-url sqlite://dev.db`
  reports changes — my negative control caught this, which is why the enum case
  above is measured through the Go-entity route instead. The spurious drift is
  `id nullable "true -> false"` and `status type "enum_article_status -> text"`,
  both from `schemafile.ToDBSchema` not rendering the desired side for the
  dialect. Adjacent to #931/#932; untouched here.
- **Feature-matrix rows stay 🟡, not ✅.** The issue's completion criteria asked
  for ✅ on lines 151 and 259. Both notes are rewritten to state what the rebuild
  now covers, but the symbols stay 🟡 because the two cases above genuinely
  survive. Claiming ✅ would cost a later measurement pass to unwind.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1`, `go tool qtlint ./...`,
`golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`
(OK, 175 conditional groups), `scripts/check-public-api.sh`,
`scripts/check-public-api-snapshot.sh` — all green.

`docs/` is touched, so all 14 `check:*` scripts in `docs/site/package.json` ran,
all exit 0. `check:responsive` needs `npm run build` first — it exits 1 with
`dist not found` otherwise, so the site was built and the check re-run; it then
reports `OK (60 routes x 2 viewports, cells within 8 lines)` rather than
skipping.
