### PR TITLE
fix(atlashcl): evaluate HCL schema-file expressions instead of copying their source

### DIFF
--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -198,6 +198,10 @@ func runAtlasMigrateDiff(
 			return editor.Open(cmd.Context(), "", stagedPaths...)
 		}
 	}
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	diffResult, err := atlasmigrate.GenerateDiff(cmd.Context(), conn, atlasmigrate.DiffOptions{
 		Dir: migrationsDir,
 		// The same handle the preflight gate captured through. Handing it to the
@@ -217,6 +221,7 @@ func runAtlasMigrateDiff(
 		Policy:               policy,
 		Qualifier:            qualifier,
 		DryRun:               opts.dryRun,
+		Vars:                 schemaVars,
 		PreparePublication:   preparePublication,
 		// The same predicate the preflight above already applied, re-applied to
 		// the locked snapshot. Passing it in is what keeps this verb from

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -341,15 +341,32 @@ func atlasProjectFlagsFromCommand(cmd *cobra.Command) (atlasProjectFlagValues, b
 		flags.envName = flag.Value.String()
 		changed = changed || flag.Changed
 	}
-	if flag := cmd.Flags().Lookup(atlasVarFlagName); flag != nil {
-		values, err := cmd.Flags().GetStringArray(atlasVarFlagName)
-		if err != nil {
-			return atlasProjectFlagValues{}, false, err
-		}
-		flags.vars = values
-		changed = changed || flag.Changed
+	// --var deliberately does NOT contribute to `changed`, which is what makes
+	// the project file REQUIRED. Measured on the pinned Atlas community binary
+	// v1.3.0 in a directory holding no atlas.hcl:
+	//
+	//	schema diff --from file://empty.hcl --to file://v.hcl --var status=live
+	//	  -> exit 0, DEFAULT 'live'
+	//
+	// Ptah answered `failed to read atlas config atlas.hcl: no such file or
+	// directory` at exit 1, because --var reached only config/projectconfig and
+	// dragged the project requirement along with it. The values are still
+	// carried below, so an atlas.hcl that IS present still gets them.
+	values, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return atlasProjectFlagValues{}, false, err
 	}
+	flags.vars = values
 	return flags, changed, nil
+}
+
+// atlasVarFlagValues reads --var, which the Atlas-compatible commands hand both
+// to the project config and to the HCL schema files they load.
+func atlasVarFlagValues(cmd *cobra.Command) ([]string, error) {
+	if cmd.Flags().Lookup(atlasVarFlagName) == nil {
+		return nil, nil
+	}
+	return cmd.Flags().GetStringArray(atlasVarFlagName)
 }
 
 func refreshAtlasProjectFlagEnvironment(cmd *cobra.Command) error {

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -239,6 +239,10 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 	defer releaseAtlasSchemaApplyLock(cmd, applyLock)
 	noteAtlasSchemaApplyLockUnsupported(cmd, opts.lockTimeout, opts.lock, applyLock, conn.Info().Dialect)
 
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	plan, err := atlasschema.PrepareApply(cmd.Context(), conn, atlasschema.ApplyRuntimeOptions{
 		DevURL:     opts.devURL,
 		ToURLs:     opts.toURLs,
@@ -253,6 +257,7 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		// Atlas-compatible surface: a schema file written for another tool
 		// must not be refused over a name this parser does not model.
 		IgnoreUnknownHCLNames: true,
+		Vars:                  schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -407,11 +412,16 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	}
 	defer dbschema.CloseAndWarn(conn)
 
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	var desired *goschema.Database
 	if len(opts.toURLs) > 0 {
 		desired, err = schemafile.LoadAll(opts.toURLs, schemafile.Options{
 			Dialect:               conn.Info().Dialect,
 			IgnoreUnknownHCLNames: true,
+			Vars:                  schemaVars,
 		})
 		if err != nil {
 			return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -131,6 +131,10 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 	if err := validateAtlasSchemaDiffOptions(cmd, opts, projectEnv); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 
 	report, err := atlasschema.Diff(cmd.Context(), atlasschema.DiffOptions{
 		FromURLs:    opts.fromURLs,
@@ -145,6 +149,7 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
 		IgnoreUnknownHCLNames: true,
+		Vars:                  schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_file_variable_test.go
+++ b/cmd/atlas/schema_file_variable_test.go
@@ -1,0 +1,99 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// schemaFileVariableHCL declares a variable with no default and reads it from a
+// COLUMN DEFAULT.
+//
+// The placement is load-bearing. Put the reference in a table comment instead
+// and the fixture proves nothing: Ptah drops table comments on SQLite whether
+// or not the reference resolved, so the control and the variant agree. A column
+// default is a position Ptah does render, which is what makes the byte
+// assertions below discriminate.
+const schemaFileVariableHCL = `variable "status" {
+  type = string
+}
+schema "main" {
+}
+table "t" {
+  schema = schema.main
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`
+
+const schemaFileEmptyHCL = "schema \"main\" {\n}\n"
+
+// writeSchemaFileVariableFixture writes the fixture pair into a directory that
+// deliberately holds NO atlas.hcl, and makes it the working directory. The
+// absence is the point: the pinned Atlas community binary v1.3.0 accepts --var
+// there, and Ptah used to demand a project file that binary never reads.
+func writeSchemaFileVariableFixture(t *testing.T) (from, to string) {
+	t.Helper()
+	c := qt.New(t)
+	dir := t.TempDir()
+	fromPath := filepath.Join(dir, "empty.hcl")
+	toPath := filepath.Join(dir, "schema.hcl")
+	c.Assert(os.WriteFile(fromPath, []byte(schemaFileEmptyHCL), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(toPath, []byte(schemaFileVariableHCL), 0o600), qt.IsNil)
+	t.Chdir(dir)
+	return "file://" + fromPath, "file://" + toPath
+}
+
+// TestSchemaDiffVarReachesTheSchemaFile is the acceptance test for the --var
+// half of issue #926.
+//
+// Measured on the pinned binary in a directory with no atlas.hcl:
+//
+//	schema diff --from file://empty.hcl --to file://schema.hcl --var status=live
+//	  -> exit 0, CREATE TABLE `t` (`state` text NOT NULL DEFAULT 'live');
+//
+// Ptah answered `failed to read atlas config atlas.hcl: openat atlas.hcl: no
+// such file or directory` at exit 1, because --var reached only
+// config/projectconfig and made the project file required on the way.
+//
+// Reverted, this test fails on the nil-error assertion and prints that
+// atlas-config message.
+func TestSchemaDiffVarReachesTheSchemaFile(t *testing.T) {
+	c := qt.New(t)
+	from, to := writeSchemaFileVariableFixture(t)
+
+	out, err := runCompatCommand(t,
+		"schema", "diff",
+		"--dev-url", "sqlite://file?mode=memory",
+		"--from", from,
+		"--to", to,
+		"--var", "status=live",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(out, qt.Contains, "DEFAULT 'live'")
+}
+
+// TestSchemaDiffWithoutVarNamesTheMissingVariable is the other half: with no
+// --var the same file is refused, byte-identically to the pinned binary's
+// `missing value for required variable "status"`.
+//
+// Reverted, this test fails on the non-nil-error assertion, and the command
+// instead succeeds printing the DDL literal DEFAULT 'var.status'.
+func TestSchemaDiffWithoutVarNamesTheMissingVariable(t *testing.T) {
+	c := qt.New(t)
+	from, to := writeSchemaFileVariableFixture(t)
+
+	_, err := runCompatCommand(t,
+		"schema", "diff",
+		"--dev-url", "sqlite://file?mode=memory",
+		"--from", from,
+		"--to", to,
+	)
+
+	c.Assert(err, qt.ErrorMatches, `.*missing value for required variable "status".*`)
+}

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -138,6 +138,10 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	if err := validateAtlasSchemaInspectOptions(opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 
 	rendered, err := atlasschema.InspectSource(cmd.Context(), atlasschema.InspectSourceOptions{
 		URL:            opts.url,
@@ -152,6 +156,7 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
 		IgnoreUnknownHCLNames: true,
+		Vars:                  schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_plan.go
+++ b/cmd/atlas/schema_plan.go
@@ -165,6 +165,10 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	plan, err := atlasschema.PreparePlanFile(cmd.Context(), conn, atlasschema.PlanFileOptions{
 		Name:    opts.name,
 		DevURL:  opts.devURL,
@@ -174,6 +178,7 @@ func runAtlasSchemaPlan(cmd *cobra.Command, opts atlasSchemaPlanOptions) error {
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
 		IgnoreUnknownHCLNames: true,
+		Vars:                  schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/cmd/atlas/schema_plan_validate.go
+++ b/cmd/atlas/schema_plan_validate.go
@@ -151,9 +151,14 @@ func runAtlasSchemaPlanValidate(cmd *cobra.Command, opts atlasSchemaPlanValidate
 	}
 	defer dbschema.CloseAndWarn(conn)
 
+	schemaVars, err := atlasVarFlagValues(cmd)
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{
 		Dialect:               conn.Info().Dialect,
 		IgnoreUnknownHCLNames: true,
+		Vars:                  schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("load --to schema: %w", err))

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1181,11 +1181,11 @@
   {
     "area": "Schema sources",
     "feature": "HCL variable blocks and var.* references",
-    "ptah": "no",
+    "ptah": "yes",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "`variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error.",
-    "evidence": "internal/atlashcl/atlashcl.go:107-110 and 1478-1484; conformance gaps.md atlas-hcl-parse row `schemahcl/testdata/variables.hcl` — \"only non-schema top-level blocks: variable\". `variable` + var.x inside a schema file substitutes in Atlas (measured; observation study, scenario, hcl-semantics)"
+    "note": "`variable` blocks bind `var.x`, `--var name=value` overrides them, and a typed variable with no value exits 1 with `missing value for required variable \"x\"` — the community binary's own text.",
+    "evidence": "internal/atlashcl/evalcontext.go (var./local. namespaces, --var overrides, variable type keywords) and internal/atlashcl/evalreject.go (refusal of what will not resolve); plumbed through internal/schemafile.Options.Vars to the compat schema and migrate groups. Measured 2026-08-06, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, `schema diff --dev-url \"sqlite://file?mode=memory\"`, fixture with the reference in a COLUMN DEFAULT — a table comment discriminates nothing because ptah drops table comments on SQLite either way. variable status { type = string, default = \"active\" } with `default = var.status`: both binaries exit 0 and render DEFAULT 'active'. Same file with no default and no --var: both exit 1 with `missing value for required variable \"status\"`. Same file with --var status=live: both exit 0 and render DEFAULT 'live'; ptah previously exited 1 demanding an atlas.hcl the community binary does not read. Control with a literal `default = \"active\"` renders identically on both before and after, so the fixture discriminates on the variable alone. `type = var.coltype` exits 1 on both — the community binary with 'set field \"type\": unexpected type string'."
   },
   {
     "area": "Schema sources",
@@ -1193,17 +1193,17 @@
     "ptah": "partial",
     "atlas_oss": "partial",
     "atlas_pro": "partial",
-    "note": "sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr and index.where it leaks into the DDL where the community binary refuses the file.",
-    "evidence": "internal/atlashcl/atlashcl.go:1466-1476 (textual `sql(` prefix match, 6 call sites) and 1486-1496. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. Column type: `type = sql(\"varchar(17)\")` -> community binary plans `\"s\" character varying(17)`, ptah-compat plans `\"s\" sql(\"varchar(17)\")`, which is not valid SQL. check.expr and index.where: `expr = sql(\"n > 0\")` with `where = sql(\"n > 5\")` -> community binary exits 1 with 'schemahcl: failed reading spec as *postgres.doc: value of attr \"expr\" cannot be read as string: incorrect type raw', ptah-compat exits 0 and emits CHECK (sql(\"n > 0\")) and WHERE sql(\"n > 5\"). Ptah accepting where the community binary refuses is the ordinary Pro-parity direction, but here it ships DDL no engine will execute; tracked as a follow-up, not fixed by this docs change."
+    "note": "sql() reduces to its SQL everywhere; other calls evaluate against a function set measured name by name on the community binary. yamldecode, yamlencode, uuid and print stay refused where it evaluates.",
+    "evidence": "internal/atlashcl/sqlrawexpr.go (structural sql() reduction, stokaro/ptah#1131 and #1140) and internal/atlashcl/evalcontext.go schemaFunctions. The function set is a measurement, not a guess: each candidate name was called with no arguments in a column default and run through the pinned community binary (reports \"atlas community version v1.3.0\") with `schema diff --dev-url \"sqlite://file?mode=memory\"`; \"There is no function named X\" means absent, an arity or type complaint means present. 68 present, 38 absent, and the negative control `nosuchfnxyz` came back absent, so the probe discriminates. `reverse` is the LIST reverse there and `strrev` the STRING reverse — go-cty spells them the other way round, so a name-for-name match swaps both. Four measured-present names are not implemented: yamldecode and yamlencode would add a module dependency, and uuid and print are a nondeterministic generator and a debug tap. Measured 2026-08-06, same command: `default = upper(\"abc\")` renders DEFAULT 'ABC' on both binaries where ptah-compat previously rendered the literal text upper(\"abc\") at exit 0; `default = now()` exits 1 on both. Remaining looseness, unchanged by this row: check.expr and index.where accept sql() here and are refused by the community binary ('incorrect type raw')."
   },
   {
     "area": "Schema sources",
     "feature": "HCL locals, lock, atlas, dynamic/for_each",
-    "ptah": "no",
+    "ptah": "partial",
     "atlas_oss": "partial",
     "atlas_pro": "partial",
-    "note": "Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block \"locals\"/\"lock\"/\"atlas\"; unsupported table block \"dynamic\". The community binary honors locals.",
-    "evidence": "internal/atlashcl/atlashcl.go:111-113 and 321-323; `ptah schema render --schema-file t_locals.hcl` prints each quoted error. Measured 2026-08-03, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, against PostgreSQL 16 in Docker. locals { dflt = 7 } referenced as `default = local.dflt`: community binary plans `\"n\" integer NOT NULL DEFAULT 7` - the literal 7 is the discriminator, it can only appear if the local resolved - while ptah-compat exits 1 'unsupported top-level block \"locals\"'. lock {} and atlas {} in a schema file: community binary exits 0 and plans the table, so the blocks are accepted and ignored rather than refused. dynamic \"index\" with for_each: community binary exits 0 and plans no index at all, so no expansion happens; the marker name idx_dynamic_marker never appears."
+    "note": "`locals` is evaluated and `local.x` resolves. Still rejected by name (`ptah-compat` exit 1, native `ptah` exit 2): top-level \"lock\"/\"atlas\"; table block \"dynamic\". The community binary ignores both.",
+    "evidence": "internal/atlashcl/evalcontext.go bindLocals (fixed-point evaluation, so locals may reference each other and the var. namespace in any order); lock/atlas/dynamic still reach the default arm of parseTopLevelBlock and `ptah schema render` prints each quoted error. Measured 2026-08-06, pinned community binary (reports \"atlas community version v1.3.0\") vs ptah-compat built from this branch, `schema diff --dev-url \"sqlite://file?mode=memory\"`. locals { d = \"abc\" } referenced as `default = local.d`: both binaries now exit 0 and render DEFAULT 'abc' - the literal abc is the discriminator, it can only appear if the local resolved - where ptah-compat previously exited 1 'unsupported top-level block \"locals\"'. Unchanged from the 2026-08-03 round: lock {} and atlas {} in a schema file are accepted and ignored by the community binary at exit 0, and dynamic \"index\" with for_each exits 0 there planning no index at all, so no expansion happens and the marker name idx_dynamic_marker never appears."
   },
   {
     "area": "Schema sources",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -76,13 +76,13 @@ Across the 164 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 90 |
-| Ptah supports it with a stated limitation | 48 |
-| Ptah does not implement it | 26 |
-| Ptah and Atlas CE both support it | 22 |
+| Ptah supports it fully | 91 |
+| Ptah supports it with a stated limitation | 49 |
+| Ptah does not implement it | 24 |
+| Ptah and Atlas CE both support it | 23 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
 | Ptah has it and neither Atlas edition does | 20 |
-| Atlas CE has it and Ptah does not, or only in part | 26 |
+| Atlas CE has it and Ptah does not, or only in part | 25 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
@@ -113,11 +113,11 @@ seven of them as open capabilities regardless.
 | External program / ORM loaders | ✅ | ✅ | ✅ | `--schema-cmd` or `ptah.yaml` external_schema (needs `--allow-external-schema`) runs a program without a shell emitting SQL, HCL, or YAML. |
 | Go struct annotations | ✅ | ❌ | ❌ | Ptah parses //ptah:schema:* comments into the desired schema. Atlas's route to Go models is an external ORM provider program. |
 | HCL foreign_key deferrable | ❌ | ❌ | ❌ | Errors: unsupported foreign_key attribute "deferrable". DEFERRABLE is absent from the whole Ptah IR, so YAML and Go annotations lack it too. The community binary plans no DEFERRABLE either. |
-| HCL function calls in schema files | 🟡 | 🟡 | 🟡 | sql() unwraps in column default/on_update/unique_expr/check, index ops, domain check only; in type, check.expr and index.where it leaks into the DDL where the community binary refuses the file. |
-| HCL locals, lock, atlas, dynamic/for_each | ❌ | 🟡 | 🟡 | Named rejections, rejected (`ptah-compat` exit 1, native `ptah` exit 2): unsupported top-level block "locals"/"lock"/"atlas"; unsupported table block "dynamic". The community binary honors locals. |
+| HCL function calls in schema files | 🟡 | 🟡 | 🟡 | sql() reduces to its SQL everywhere; other calls evaluate against a function set measured name by name on the community binary. yamldecode, yamlencode, uuid and print stay refused where it evaluates. |
+| HCL locals, lock, atlas, dynamic/for_each | 🟡 | 🟡 | 🟡 | `locals` is evaluated and `local.x` resolves. Still rejected by name (`ptah-compat` exit 1, native `ptah` exit 2): top-level "lock"/"atlas"; table block "dynamic". The community binary ignores both. |
 | HCL table and column child blocks | ✅ | 🟡 | ✅ | column, primary_key, index, unique, foreign_key, check, partition, row_security, constraint, platform; column nests as, identity, platform. The community binary drops row_security silently. |
 | HCL top-level blocks Ptah parses | ✅ | 🟡 | ✅ | schema, enum, table, extension, sequence, domain, composite, range, function, view, materialized, trigger, policy, role, permission, data. The community binary plans DDL for table and enum. |
-| HCL variable blocks and var.* references | ❌ | ✅ | ✅ | `variable` is parsed then discarded and `var.x` reaches DDL as the literal text `var.x`, exit 0 — no substitution and no error. |
+| HCL variable blocks and var.* references | ✅ | ✅ | ✅ | `variable` blocks bind `var.x`, `--var name=value` overrides them, and a typed variable with no value exits 1 with `missing value for required variable "x"` — the community binary's own text. |
 | Live database as desired state | ✅ | ✅ | ✅ | One connectable DB URL can be the desired side of compat schema apply/diff and migrate diff; `ptah db read` introspects natively. |
 | Live database to Go annotation source | ✅ | ❌ | ❌ | `ptah introspect` writes annotated Go models from a live DB; repo docs record Go annotations as a first-party Ptah workflow. |
 | Migration directory as a source | ✅ | ✅ | ✅ | Atlas-format directory with `atlas.sum`, replayed on a required `--dev-url`. Works on `ptah schema inspect` and compat apply/diff/migrate diff. |

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -84,6 +84,54 @@ Unsupported semantics fail explicitly. Ptah does not silently drop HCL objects
 that it cannot represent in the schema IR. The Ptah `ops` index attribute
 preserves a Go annotation operator class.
 
+## Variables, locals, and expressions
+
+A schema file may declare `variable` and `locals` blocks and read them back
+through the `var.` and `local.` namespaces:
+
+```hcl
+variable "status" {
+  type    = string
+  default = "active"
+}
+
+locals {
+  state_column = "state_${var.status}"
+}
+
+schema "app" {}
+
+table "t" {
+  schema = schema.app
+  column "state" {
+    type    = text
+    default = var.status
+    comment = local.state_column
+  }
+}
+```
+
+A `variable` block requires `type`, which is one of `bool`, `int`, `number`,
+`string`, or `list`, `map` or `set` of those. It accepts `default` and
+`description`. A variable with no `default` needs a value from `--var`:
+
+```bash
+ptah-compat schema diff --dev-url "sqlite://file?mode=memory" \
+  --from file://empty.hcl --to file://schema.hcl --var status=live
+```
+
+One `--var` occurrence carries comma-separated `name=value` assignments, and the
+flag may be repeated. A variable that ends with no value fails with
+`missing value for required variable "status"`. `--var` does not require an
+`atlas.hcl`; when one is present it also supplies that file's variables.
+
+Attribute values are evaluated. A function call resolves against the function
+set, a `var.` or `local.` reference resolves against the blocks above, and
+anything that will not resolve is an error rather than the expression's own
+source text. References that name schema objects — `schema.app`, `column.state`,
+`enum.status` — and type expressions such as `text` or `varchar(255)` are read
+as written and are not evaluated, so a `var.` reference in a `type` is rejected.
+
 ## Go annotation parity
 
 Every schema semantic accepted by Ptah's Go annotation parser has an HCL

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -13,6 +13,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/internal/tableref"
@@ -38,6 +39,16 @@ type Options struct {
 	// the order the parser reached them. Optional; nil discards them, which is
 	// what the community binary does.
 	RecordIgnored func(IgnoredName)
+
+	// Vars supplies values for the file's `variable` blocks, spelled the way
+	// `--var` spells them: one entry per flag occurrence, each entry a
+	// comma-separated list of name=value assignments.
+	//
+	// A name with no matching variable block is ignored, matching the pinned
+	// Atlas community binary v1.3.0: `--var nosuch=1` against a file declaring
+	// `variable "v"` still fails with `missing value for required variable
+	// "v"` rather than complaining about the unused override.
+	Vars []string
 }
 
 // ParseFile parses an HCL schema file into the same Database IR used by
@@ -94,11 +105,25 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 	if err := classifyProjectFile(body, filename); err != nil {
 		return nil, err
 	}
+	// The evaluation context is built from the file's own variable and locals
+	// blocks, so it has to exist before any attribute is read -- including the
+	// sql() arguments the next guard evaluates.
+	ctx, err := newEvalContext(body, opts.Vars)
+	if err != nil {
+		return nil, err
+	}
+	p.ctx = ctx
 	// Refuse malformed sql() calls before the body walk, not during it. Every
 	// value helper below falls back to an attribute's source text when the
 	// expression will not evaluate, so a call this guard let through would be
 	// rendered into DDL verbatim -- issue #1106.
 	if err := p.rejectMalformedSQLRawExprs(body); err != nil {
+		return nil, err
+	}
+	// Same reason, for the expressions the context above was built to resolve:
+	// an unresolved var. reference would otherwise reach DDL as its own source
+	// text -- issue #926.
+	if err := p.rejectUnresolvedExprs(body); err != nil {
 		return nil, err
 	}
 	if err := p.parseBody(body); err != nil {
@@ -165,6 +190,10 @@ type parser struct {
 	sourceDir string
 	db        *goschema.Database
 
+	// ctx carries the var. and local. namespaces and the function set every
+	// attribute is evaluated against. It is never nil once Parse has built it.
+	ctx *hcl.EvalContext
+
 	// tolerant enables the unknown-name policy described on Options.
 	tolerant bool
 	// recordIgnored receives the names dropped under that policy. Nil discards
@@ -224,14 +253,15 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		// returns the identical error so the message cannot drift between the
 		// two routes.
 		return projectFileError(p.filename, block)
-	case "variable":
-		// Left accepted on purpose; do not fold this into the env arm.
+	case variableBlockType, localsBlockType:
+		// Consumed already; do not fold either name into the env arm.
 		//
-		// `variable` is a genuine schema-file construct in Atlas: the community
-		// binary accepts it, EVALUATES var.X references against it, and fails
-		// with `missing value for required variable %q` only when a typed
-		// variable has neither a default nor a --var override. Measured on the
-		// pinned binary, a schema file whose column default is var.status:
+		// Both are genuine schema-file constructs in Atlas: the community
+		// binary accepts them, EVALUATES var.X and local.X references against
+		// them, and fails with `missing value for required variable %q` only
+		// when a typed variable has neither a default nor a --var override.
+		// Measured on the pinned binary, a schema file whose column default is
+		// var.status:
 		//
 		//   variable "status" { type = string, default = "active" }
 		//     -> exit 0, renders `default = "active"`
@@ -242,15 +272,9 @@ func (p *parser) parseTopLevelBlock(block *hclsyntax.Block) error {
 		// prevent. Quote the typed spelling or the measurement says the opposite
 		// of what it is cited for.
 		//
-		// Ptah has no schema-file variable evaluation, so accepting and ignoring
-		// is knowingly looser than that binary on BOTH spellings it refuses --
-		// a variable missing `type`, and a typed variable with no default and no
-		// --var -- and it renders var.X into DDL as literal text. Real defects,
-		// all three, and all of them predate this arm's split. Moving
-		// this name to the default arm would "fix" them by refusing files the
-		// community binary fully supports -- a new stricter break, not parity.
-		// The fix is evaluation plus --var plumbing, tracked in issue #926
-		// ("HCL schema files: expressions are not evaluated").
+		// newEvalContext read both block kinds before this walk started, which
+		// is where their validation and their `missing value` refusal live.
+		// Reaching them again here would parse a type constraint as a value.
 		return nil
 	default:
 		return p.rejectUnsupportedBlock(block, "top-level")
@@ -1662,7 +1686,7 @@ func (p *parser) stringAttr(block *hclsyntax.Block, name, label string) (string,
 	if attr == nil {
 		return "", nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || !value.IsKnown() || value.IsNull() || value.Type() != cty.String {
 		return "", p.blockError(block, "%s attribute %q must be a string", label, name)
 	}
@@ -1673,7 +1697,7 @@ func (p *parser) optionalBool(attr *hclsyntax.Attribute, fallback bool) bool {
 	if attr == nil {
 		return fallback
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return fallback
 	}
@@ -1685,7 +1709,7 @@ func (p *parser) optionalTableBool(block *hclsyntax.Block, name string, fallback
 	if attr == nil {
 		return fallback, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return false, p.blockError(block, "table attribute %q must be a bool", name)
 	}
@@ -1697,7 +1721,7 @@ func (p *parser) optionalIndexOnBool(block *hclsyntax.Block, name string, fallba
 	if attr == nil {
 		return fallback, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return false, p.blockError(block, "index on attribute %q must be a bool", name)
 	}
@@ -1709,7 +1733,7 @@ func (p *parser) optionalBlockBoolPtr(block *hclsyntax.Block, name, label string
 	if attr == nil {
 		return nil, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return nil, p.blockError(block, "%s attribute %q must be a bool", label, name)
 	}
@@ -1723,6 +1747,14 @@ func (p *parser) optionalRawExpr(attr *hclsyntax.Attribute) string {
 	}
 	if value, ok := p.sqlRawExprValue(attr.Expr); ok {
 		return value
+	}
+	// A var. or local. reference resolves here too. Everything else this helper
+	// reads -- `on = table.users`, `to = [role.app]`, a bare argument type --
+	// is a reference spelled as source text and stays one.
+	if mustEvaluate(attr.Expr) {
+		if text, ok := p.evaluatedText(attr.Expr); ok {
+			return text
+		}
 	}
 	return p.rawExpr(attr)
 }
@@ -1757,11 +1789,37 @@ func (p *parser) exprString(attr *hclsyntax.Attribute) string {
 	if value, ok := p.sqlRawExprValue(attr.Expr); ok {
 		return value
 	}
-	value, diags := attr.Expr.Value(nil)
-	if !diags.HasErrors() && value.Type() == cty.String {
-		return value.AsString()
+	if text, ok := p.evaluatedText(attr.Expr); ok {
+		return text
 	}
 	return p.rawExpr(attr)
+}
+
+// evaluatedText returns an expression's evaluated value as the text Ptah stores
+// in the schema IR.
+//
+// A string result is taken whatever the expression was, which is what the nil
+// evaluation context already did for a quoted literal. A number or bool result
+// is taken only for an expression [mustEvaluate] claims -- `var.n`, `max(1,2)`
+// -- because for a plain numeric literal the source text and the formatted
+// value can differ (`1.50` formats as `1.5`) and the source text is what every
+// existing schema was written against.
+func (p *parser) evaluatedText(expr hclsyntax.Expression) (string, bool) {
+	value, diags := expr.Value(p.ctx)
+	if diags.HasErrors() || value.IsNull() || !value.IsKnown() {
+		return "", false
+	}
+	if value.Type() == cty.String {
+		return value.AsString(), true
+	}
+	if !mustEvaluate(expr) {
+		return "", false
+	}
+	converted, err := convert.Convert(value, cty.String)
+	if err != nil {
+		return "", false
+	}
+	return converted.AsString(), true
 }
 
 // columnTypeName returns the column's type and whether it was written with
@@ -1793,7 +1851,7 @@ func (p *parser) stringListAttr(block *hclsyntax.Block, attrName string) ([]stri
 	if attr == nil {
 		return nil, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	valueType := value.Type()
 	if diags.HasErrors() || !valueType.IsTupleType() && !valueType.IsListType() {
 		return nil, p.blockError(block, "%s must be a list of strings", attrName)

--- a/internal/atlashcl/column_ref_expr_test.go
+++ b/internal/atlashcl/column_ref_expr_test.go
@@ -248,7 +248,7 @@ table "t" {
   }
 }
 `,
-			match: refusedConditional,
+			match: `.*variable\ "by_a"\ requires\ a\ type.*`,
 		},
 		{
 			name: "variable without a default",
@@ -264,7 +264,7 @@ table "t" {
   }
 }
 `,
-			match: refusedConditional,
+			match: `.*missing\ value\ for\ required\ variable\ "by_a".*`,
 		},
 		{
 			name: "variable typed by an unknown keyword",
@@ -281,7 +281,7 @@ table "t" {
   }
 }
 `,
-			match: refusedConditional,
+			match: `.*variable\ "by_a"\ type\ is\ not\ supported.*`,
 		},
 		{
 			name: "no variable of that name",
@@ -328,7 +328,7 @@ table "t" {
   }
 }
 `,
-			match: refusedConditional,
+			match: `.*variable\ "by_a":\ a\ bool\ is\ required.*`,
 		},
 		{
 			name: "declared type contradicts a default the condition can still compare",
@@ -345,7 +345,7 @@ table "t" {
   }
 }
 `,
-			match: `.*index on column contains unsupported reference "var.pick == \\"a\\" \? column.a : column.b"`,
+			match: `.*variable\ "pick":\ a\ number\ is\ required.*`,
 		},
 	}
 
@@ -357,6 +357,16 @@ table "t" {
 	}
 }
 
+// refusedConditional is the column resolver's own refusal. Only the two rows
+// whose variable declaration is well formed still reach it: "no variable of
+// that name" and "condition is not a boolean".
+//
+// The other five now fail earlier and more precisely. #926's evaluation pass
+// diagnoses the variable DECLARATION -- missing type, missing value, unsupported
+// type keyword, a default contradicting its type -- which is upstream of the
+// column reference and names what the author has to change. Every row still
+// refuses; what moved is which layer speaks first, not whether a conditional
+// column is resolved.
 const refusedConditional = `.*index on column contains unsupported reference "var.by_a \? column.a : column.b"`
 
 // A branch that is taken still has to name a column. This is what keeps the

--- a/internal/atlashcl/evalcontext.go
+++ b/internal/atlashcl/evalcontext.go
@@ -1,0 +1,483 @@
+package atlashcl
+
+import (
+	"encoding/csv"
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/ext/tryfunc"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+	"github.com/zclconf/go-cty/cty/convert"
+	"github.com/zclconf/go-cty/cty/function"
+	"github.com/zclconf/go-cty/cty/function/stdlib"
+)
+
+const (
+	variableBlockType = "variable"
+	localsBlockType   = "locals"
+)
+
+// varNamespace and localNamespace are the two root names an expression can use
+// to reach the evaluation context. Everything else a schema file writes as a
+// traversal -- schema.x, column.c, enum.status, a bare type keyword -- is a
+// reference this package resolves from source text, not a value.
+const (
+	varNamespace   = "var"
+	localNamespace = "local"
+)
+
+// newEvalContext builds the evaluation context an HCL schema file is parsed
+// against: the `var.` namespace from its `variable` blocks, the `local.`
+// namespace from its `locals` blocks, and the function set.
+//
+// Before this existed every attribute was evaluated against a nil context, so
+// `var.status` could not resolve and the raw source text "var.status" was
+// written into the schema IR and out as DDL -- issue #926.
+func newEvalContext(body *hclsyntax.Body, vars []string) (*hcl.EvalContext, error) {
+	overrides, err := parseVarOverrides(vars)
+	if err != nil {
+		return nil, err
+	}
+	ctx := &hcl.EvalContext{
+		Variables: map[string]cty.Value{},
+		Functions: schemaFunctions(),
+	}
+	if err := bindVariables(ctx, body, overrides); err != nil {
+		return nil, err
+	}
+	return bindLocals(ctx, body)
+}
+
+// parseVarOverrides turns --var values into the override map.
+//
+// One occurrence carries comma-separated assignments, matching the pinned Atlas
+// community binary v1.3.0: `--var a=1,b=2` sets both. Repeating the flag for one
+// name collects a list, which then fails the variable's declared scalar type the
+// way that binary fails it ("variable \"v\": string required").
+func parseVarOverrides(vars []string) (map[string]cty.Value, error) {
+	overrides := map[string]cty.Value{}
+	for _, raw := range vars {
+		values, err := csv.NewReader(strings.NewReader(raw)).Read()
+		if err != nil {
+			return nil, fmt.Errorf("parse --var %q: %w", raw, err)
+		}
+		for _, assignment := range values {
+			if err := applyVarOverride(overrides, assignment); err != nil {
+				return nil, err
+			}
+		}
+	}
+	return overrides, nil
+}
+
+func applyVarOverride(overrides map[string]cty.Value, assignment string) error {
+	name, text, ok := strings.Cut(assignment, "=")
+	if !ok {
+		return fmt.Errorf("--var must use name=value, got %q", assignment)
+	}
+	if strings.TrimSpace(name) == "" {
+		return fmt.Errorf("--var %q has an empty name", assignment)
+	}
+	value := cty.StringVal(text)
+	if existing, found := overrides[name]; found {
+		value = appendVarValue(existing, value)
+	}
+	overrides[name] = value
+	return nil
+}
+
+func appendVarValue(existing, value cty.Value) cty.Value {
+	if existing.Type().IsListType() {
+		return cty.ListVal(append(existing.AsValueSlice(), value))
+	}
+	return cty.ListVal([]cty.Value{existing, value})
+}
+
+// schemaVariable is one parsed top-level `variable` block.
+type schemaVariable struct {
+	name       string
+	typ        cty.Type
+	defValue   cty.Value
+	hasDefault bool
+}
+
+func bindVariables(ctx *hcl.EvalContext, body *hclsyntax.Body, overrides map[string]cty.Value) error {
+	values := map[string]cty.Value{}
+	for _, block := range body.Blocks {
+		if block.Type != variableBlockType {
+			continue
+		}
+		variable, err := parseVariableBlock(ctx, block)
+		if err != nil {
+			return err
+		}
+		value, err := variableValue(variable, overrides)
+		if err != nil {
+			return err
+		}
+		// Last declaration wins, with no duplicate diagnostic: measured on the
+		// pinned binary, two `variable "v"` blocks parse at exit 0 and the
+		// second block's default is the one that reaches the DDL.
+		values[variable.name] = value
+	}
+	if len(values) > 0 {
+		ctx.Variables[varNamespace] = cty.ObjectVal(values)
+	}
+	return nil
+}
+
+// variableAttrs are the attributes a schema-file `variable` block accepts.
+//
+// `sensitive` is deliberately absent. It is valid in an atlas.hcl PROJECT file
+// but the pinned binary refuses it in a schema file ("An argument named
+// \"sensitive\" is not expected here"), so accepting it here would be a
+// looser-than-oracle break in a spot no schema needs.
+var variableAttrs = []string{"default", "description", "type"}
+
+func parseVariableBlock(ctx *hcl.EvalContext, block *hclsyntax.Block) (schemaVariable, error) {
+	if len(block.Labels) != 1 {
+		return schemaVariable{}, fmt.Errorf(
+			"parse HCL schema at %s: variable block requires exactly one label",
+			block.TypeRange.String(),
+		)
+	}
+	if len(block.Body.Blocks) > 0 {
+		nested := block.Body.Blocks[0]
+		return schemaVariable{}, fmt.Errorf(
+			"parse HCL schema at %s: unsupported variable block %q",
+			nested.TypeRange.String(), nested.Type,
+		)
+	}
+	for _, name := range sortedAttrNames(block.Body.Attributes) {
+		if !slices.Contains(variableAttrs, name) {
+			return schemaVariable{}, fmt.Errorf(
+				"parse HCL schema at %s: unsupported variable attribute %q",
+				block.Body.Attributes[name].NameRange.String(), name,
+			)
+		}
+	}
+	return variableFromAttrs(ctx, block)
+}
+
+func variableFromAttrs(ctx *hcl.EvalContext, block *hclsyntax.Block) (schemaVariable, error) {
+	variable := schemaVariable{name: block.Labels[0]}
+	typeAttr, ok := block.Body.Attributes["type"]
+	if !ok {
+		// Measured: the pinned binary refuses a schema-file variable with no
+		// type ("The argument \"type\" is required"). Accepting one is how Ptah
+		// used to exit 0 on a file that binary refuses.
+		return schemaVariable{}, fmt.Errorf(
+			"parse HCL schema at %s: variable %q requires a type",
+			block.TypeRange.String(), variable.name,
+		)
+	}
+	typ, err := variableType(variable.name, typeAttr)
+	if err != nil {
+		return schemaVariable{}, err
+	}
+	variable.typ = typ
+
+	defaultAttr, ok := block.Body.Attributes["default"]
+	if !ok {
+		return variable, nil
+	}
+	value, diags := defaultAttr.Expr.Value(ctx)
+	if diags.HasErrors() {
+		return schemaVariable{}, fmt.Errorf(
+			"parse HCL schema: variable %q default: %s", variable.name, diags.Error(),
+		)
+	}
+	converted, err := convert.Convert(value, variable.typ)
+	if err != nil {
+		return schemaVariable{}, fmt.Errorf("variable %q: %s", variable.name, err)
+	}
+	variable.defValue = converted
+	variable.hasDefault = true
+	return variable, nil
+}
+
+func variableValue(variable schemaVariable, overrides map[string]cty.Value) (cty.Value, error) {
+	override, ok := overrides[variable.name]
+	if ok {
+		converted, err := convert.Convert(override, variable.typ)
+		if err != nil {
+			return cty.NilVal, fmt.Errorf("variable %q: %s", variable.name, err)
+		}
+		return converted, nil
+	}
+	if !variable.hasDefault {
+		// Byte-identical to the pinned binary's diagnostic, so a script that
+		// matches on it keeps working across the two.
+		return cty.NilVal, fmt.Errorf("missing value for required variable %q", variable.name)
+	}
+	return variable.defValue, nil
+}
+
+// variableTypeKeywords are the scalar type constraints a schema-file variable
+// block accepts, measured one keyword at a time against the pinned binary.
+// `float`, `any`, `integer`, `object` and `tuple` are NOT among them: that
+// binary reports "There is no variable named \"float\"" for each, and the
+// negative control `nosuchkeyword` reports the same, so the list is the
+// measured boundary rather than a guess.
+var variableTypeKeywords = map[string]cty.Type{
+	"bool":   cty.Bool,
+	"int":    cty.Number,
+	"number": cty.Number,
+	"string": cty.String,
+}
+
+// variableTypeConstructors are the collection constraints: list(T), set(T) and
+// map(T), each over one of the scalar keywords.
+var variableTypeConstructors = map[string]func(cty.Type) cty.Type{
+	"list": cty.List,
+	"map":  cty.Map,
+	"set":  cty.Set,
+}
+
+func variableType(name string, attr *hclsyntax.Attribute) (cty.Type, error) {
+	if typ, ok := scalarVariableType(attr.Expr); ok {
+		return typ, nil
+	}
+	if typ, ok := collectionVariableType(attr.Expr); ok {
+		return typ, nil
+	}
+	return cty.NilType, fmt.Errorf(
+		"parse HCL schema at %s: variable %q type is not supported: supported types are bool, int, number, string, and list, map or set of those",
+		attr.NameRange.String(), name,
+	)
+}
+
+func scalarVariableType(expr hclsyntax.Expression) (cty.Type, bool) {
+	name, ok := rootTraversalName(expr)
+	if !ok {
+		return cty.NilType, false
+	}
+	typ, ok := variableTypeKeywords[name]
+	return typ, ok
+}
+
+func collectionVariableType(expr hclsyntax.Expression) (cty.Type, bool) {
+	call, ok := expr.(*hclsyntax.FunctionCallExpr)
+	if !ok || len(call.Args) != 1 {
+		return cty.NilType, false
+	}
+	constructor, ok := variableTypeConstructors[call.Name]
+	if !ok {
+		return cty.NilType, false
+	}
+	element, ok := scalarVariableType(call.Args[0])
+	if !ok {
+		return cty.NilType, false
+	}
+	return constructor(element), true
+}
+
+// rootTraversalName returns the single-step traversal name an expression is,
+// such as `string` in `type = string`.
+func rootTraversalName(expr hclsyntax.Expression) (string, bool) {
+	scope, ok := expr.(*hclsyntax.ScopeTraversalExpr)
+	if !ok || len(scope.Traversal) != 1 {
+		return "", false
+	}
+	root, ok := scope.Traversal[0].(hcl.TraverseRoot)
+	if !ok {
+		return "", false
+	}
+	return root.Name, true
+}
+
+// bindLocals evaluates every `locals` attribute into the `local.` namespace.
+//
+// Locals may reference each other in any order, so evaluation runs to a fixed
+// point: each pass binds whatever now resolves, and the first pass that binds
+// nothing reports the attribute that is still stuck.
+func bindLocals(ctx *hcl.EvalContext, body *hclsyntax.Body) (*hcl.EvalContext, error) {
+	pending := hclsyntax.Attributes{}
+	for _, block := range body.Blocks {
+		if block.Type != localsBlockType {
+			continue
+		}
+		if err := collectLocals(block, pending); err != nil {
+			return nil, err
+		}
+	}
+	values := map[string]cty.Value{}
+	for len(pending) > 0 {
+		stuck := sortedAttrNames(pending)[0]
+		if !bindResolvableLocals(ctx, values, pending) {
+			attr := pending[stuck]
+			_, diags := attr.Expr.Value(ctx)
+			return nil, fmt.Errorf("parse HCL schema: local %q: %s", stuck, diags.Error())
+		}
+	}
+	return ctx, nil
+}
+
+func collectLocals(block *hclsyntax.Block, pending hclsyntax.Attributes) error {
+	if len(block.Labels) > 0 {
+		return fmt.Errorf(
+			"parse HCL schema at %s: locals block does not take a label",
+			block.TypeRange.String(),
+		)
+	}
+	if len(block.Body.Blocks) > 0 {
+		nested := block.Body.Blocks[0]
+		return fmt.Errorf(
+			"parse HCL schema at %s: unsupported locals block %q",
+			nested.TypeRange.String(), nested.Type,
+		)
+	}
+	maps.Copy(pending, block.Body.Attributes)
+	return nil
+}
+
+func bindResolvableLocals(ctx *hcl.EvalContext, values map[string]cty.Value, pending hclsyntax.Attributes) bool {
+	progress := false
+	for _, name := range sortedAttrNames(pending) {
+		value, diags := pending[name].Expr.Value(ctx)
+		if diags.HasErrors() {
+			continue
+		}
+		values[name] = value
+		ctx.Variables[localNamespace] = cty.ObjectVal(values)
+		delete(pending, name)
+		progress = true
+	}
+	return progress
+}
+
+func sortedAttrNames(attrs hclsyntax.Attributes) []string {
+	names := make([]string, 0, len(attrs))
+	for name := range attrs {
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
+}
+
+// schemaFunctions is the function set an HCL schema file is evaluated against.
+//
+// The names come from a measurement, not a guess: each candidate was called
+// with no arguments in a column default and run through the pinned Atlas
+// community binary v1.3.0. "There is no function named X" means absent;
+// anything else -- including an arity complaint -- means present. The negative
+// control `nosuchfnxyz` came back absent, so the probe discriminates.
+//
+// Four names measured PRESENT on that binary are deliberately not here:
+// `yamldecode` and `yamlencode` would add a module dependency for a spelling no
+// schema needs, and `uuid` and `print` are a nondeterministic generator and a
+// debug tap, neither of which belongs in a schema that has to diff stably. A
+// file using one of those four is refused here and planned there.
+func schemaFunctions() map[string]function.Function {
+	fns := map[string]function.Function{
+		"abs":       stdlib.AbsoluteFunc,
+		"can":       tryfunc.CanFunc,
+		"ceil":      stdlib.CeilFunc,
+		"chomp":     stdlib.ChompFunc,
+		"chunklist": stdlib.ChunklistFunc,
+		"compact":   stdlib.CompactFunc,
+		"concat":    stdlib.ConcatFunc,
+		"contains":  stdlib.ContainsFunc,
+		"csvdecode": stdlib.CSVDecodeFunc,
+		"distinct":  stdlib.DistinctFunc,
+		"element":   stdlib.ElementFunc,
+		"flatten":   stdlib.FlattenFunc,
+		"floor":     stdlib.FloorFunc,
+		"format":    stdlib.FormatFunc,
+		"indent":    stdlib.IndentFunc,
+		"index":     stdlib.IndexFunc,
+		"join":      stdlib.JoinFunc,
+		"keys":      stdlib.KeysFunc,
+		"length":    stdlib.LengthFunc,
+		"log":       stdlib.LogFunc,
+		"lower":     stdlib.LowerFunc,
+		"max":       stdlib.MaxFunc,
+		"merge":     stdlib.MergeFunc,
+		"min":       stdlib.MinFunc,
+		"parseint":  stdlib.ParseIntFunc,
+		"pow":       stdlib.PowFunc,
+		"range":     stdlib.RangeFunc,
+		"regex":     stdlib.RegexFunc,
+		"regexall":  stdlib.RegexAllFunc,
+		"replace":   stdlib.ReplaceFunc,
+		"reverse":   stdlib.ReverseListFunc,
+		"signum":    stdlib.SignumFunc,
+		"slice":     stdlib.SliceFunc,
+		"sort":      stdlib.SortFunc,
+		"split":     stdlib.SplitFunc,
+		"substr":    stdlib.SubstrFunc,
+		"timeadd":   stdlib.TimeAddFunc,
+		"title":     stdlib.TitleFunc,
+		"trim":      stdlib.TrimFunc,
+		"trimspace": stdlib.TrimSpaceFunc,
+		"try":       tryfunc.TryFunc,
+		"upper":     stdlib.UpperFunc,
+		"values":    stdlib.ValuesFunc,
+		"zipmap":    stdlib.ZipmapFunc,
+	}
+	maps.Copy(fns, schemaCollectionFunctions())
+	return fns
+}
+
+func schemaCollectionFunctions() map[string]function.Function {
+	return map[string]function.Function{
+		"alltrue":         allTrueFunc,
+		"coalescelist":    stdlib.CoalesceListFunc,
+		"endswith":        affixFunc(strings.HasSuffix),
+		"formatdate":      stdlib.FormatDateFunc,
+		"formatlist":      stdlib.FormatListFunc,
+		"jsondecode":      stdlib.JSONDecodeFunc,
+		"jsonencode":      stdlib.JSONEncodeFunc,
+		"setintersection": stdlib.SetIntersectionFunc,
+		"setproduct":      stdlib.SetProductFunc,
+		"setsubtract":     stdlib.SetSubtractFunc,
+		"setunion":        stdlib.SetUnionFunc,
+		"startswith":      affixFunc(strings.HasPrefix),
+		// reverse is the LIST reverse and strrev the STRING reverse, measured:
+		// `reverse("abc")` is refused ("can only reverse list or tuple values")
+		// while `strrev("abc")` renders "cba". go-cty spells them the other way
+		// round -- ReverseFunc is the string one -- so a mechanical name match
+		// here would have swapped both.
+		"strrev":     stdlib.ReverseFunc,
+		"tobool":     stdlib.MakeToFunc(cty.Bool),
+		"tolist":     stdlib.MakeToFunc(cty.List(cty.DynamicPseudoType)),
+		"tonumber":   stdlib.MakeToFunc(cty.Number),
+		"toset":      stdlib.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
+		"tostring":   stdlib.MakeToFunc(cty.String),
+		"trimprefix": stdlib.TrimPrefixFunc,
+		"trimsuffix": stdlib.TrimSuffixFunc,
+	}
+}
+
+// affixFunc builds startswith/endswith, which go-cty's stdlib does not export.
+func affixFunc(match func(string, string) bool) function.Function {
+	return function.New(&function.Spec{
+		Params: []function.Parameter{
+			{Name: "str", Type: cty.String},
+			{Name: "affix", Type: cty.String},
+		},
+		Type: function.StaticReturnType(cty.Bool),
+		Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+			return cty.BoolVal(match(args[0].AsString(), args[1].AsString())), nil
+		},
+	})
+}
+
+// allTrueFunc reports whether every element of a list of bools is true, which
+// go-cty's stdlib does not export either.
+var allTrueFunc = function.New(&function.Spec{
+	Params: []function.Parameter{{Name: "list", Type: cty.List(cty.Bool)}},
+	Type:   function.StaticReturnType(cty.Bool),
+	Impl: func(args []cty.Value, _ cty.Type) (cty.Value, error) {
+		for _, item := range args[0].AsValueSlice() {
+			if item.IsNull() || !item.True() {
+				return cty.False, nil
+			}
+		}
+		return cty.True, nil
+	},
+})

--- a/internal/atlashcl/evalcontext_test.go
+++ b/internal/atlashcl/evalcontext_test.go
@@ -1,0 +1,536 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// A schema file's `variable` and `locals` blocks bind values that var. and
+// local. references resolve to, instead of the reference's own source text
+// being copied into the IR -- issue #926.
+//
+// Every row puts the reference in a COLUMN DEFAULT, and that placement is the
+// whole point. A fixture that puts it in a table comment discriminates nothing:
+// Ptah drops table comments on SQLite whether or not the reference resolved, so
+// the control and the variant agree and the test passes over a broken parser.
+//
+// Reverted, every row prints the reference's own source text where it asserts
+// the value: `var.status` for the first, `prefix_${var.n}` (quotes included)
+// for the interpolation, `local.d` for the local, `upper("abc")` for the
+// function call. The literal control row passes either way, which is what makes
+// the others discriminate.
+func TestParseResolvesSchemaVariablesAndLocals(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		hcl  string
+		want string
+	}{
+		{
+			name: "literal default control",
+			hcl: `
+table "t" {
+  column "state" {
+    type    = text
+    default = "active"
+  }
+}
+`,
+			want: "active",
+		},
+		{
+			name: "variable default",
+			hcl: `
+variable "status" {
+  type    = string
+  default = "active"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			want: "active",
+		},
+		{
+			name: "interpolation in an attribute value",
+			hcl: `
+variable "n" {
+  type    = string
+  default = "users"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = "prefix_${var.n}"
+  }
+}
+`,
+			want: "prefix_users",
+		},
+		{
+			name: "locals block",
+			hcl: `
+locals {
+  d = "abc"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = local.d
+  }
+}
+`,
+			want: "abc",
+		},
+		{
+			name: "local built from a variable",
+			hcl: `
+variable "env" {
+  type    = string
+  default = "prod"
+}
+locals {
+  d = "${var.env}-default"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = local.d
+  }
+}
+`,
+			want: "prod-default",
+		},
+		{
+			name: "function call",
+			hcl: `
+table "t" {
+  column "state" {
+    type    = text
+    default = upper("abc")
+  }
+}
+`,
+			want: "ABC",
+		},
+		{
+			name: "numeric variable formats as its value",
+			hcl: `
+variable "n" {
+  type    = int
+  default = 7
+}
+table "t" {
+  column "state" {
+    type    = int
+    default = var.n
+  }
+}
+`,
+			want: "7",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(tt.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.Fields, qt.HasLen, 1)
+			c.Assert(db.Fields[0].Default, qt.Equals, tt.want)
+		})
+	}
+}
+
+// --var supplies a value for a variable that declares no default, and overrides
+// one that does.
+//
+// Reverted, the first row parses at exit 0 with the DEFAULT `var.status` and
+// this test fails on the value; the second row keeps the block's own default
+// and fails the same way.
+func TestParseAppliesVarOverrides(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		hcl  string
+		vars []string
+		want string
+	}{
+		{
+			name: "supplies a required variable",
+			hcl: `
+variable "status" {
+  type = string
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			vars: []string{"status=live"},
+			want: "live",
+		},
+		{
+			name: "overrides a declared default",
+			hcl: `
+variable "status" {
+  type    = string
+  default = "active"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			vars: []string{"status=live"},
+			want: "live",
+		},
+		{
+			name: "one occurrence carries comma-separated assignments",
+			hcl: `
+variable "a" {
+  type = string
+}
+variable "b" {
+  type = string
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = "${var.a}-${var.b}"
+  }
+}
+`,
+			vars: []string{"a=x,b=y"},
+			want: "x-y",
+		},
+		{
+			name: "an override for an undeclared name is ignored",
+			hcl: `
+variable "status" {
+  type    = string
+  default = "active"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			vars: []string{"nosuch=1"},
+			want: "active",
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			db, err := atlashcl.ParseWithOptions(
+				[]byte(tt.hcl), "schema.hcl", atlashcl.Options{Vars: tt.vars},
+			)
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.Fields, qt.HasLen, 1)
+			c.Assert(db.Fields[0].Default, qt.Equals, tt.want)
+		})
+	}
+}
+
+// Files the pinned Atlas community binary v1.3.0 exits 1 on now exit non-zero
+// here too, instead of exiting 0 with the unresolved source text in the DDL.
+//
+// Each row was run through that binary with `schema diff --dev-url
+// "sqlite://file?mode=memory"` and the diagnostic it printed is quoted on the
+// row. Reverted, every row parses at exit 0 and this test fails on the
+// non-nil-error assertion.
+func TestParseRefusesUnresolvableExpressions(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		hcl     string
+		wantErr string
+	}{
+		{
+			// Community binary: `missing value for required variable "status"`.
+			name: "typed variable with neither a default nor an override",
+			hcl: `
+variable "status" {
+  type = string
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			wantErr: `missing value for required variable "status"`,
+		},
+		{
+			// Community binary: `The argument "type" is required, but no
+			// definition was found.`
+			name: "variable with no type",
+			hcl: `
+variable "status" {
+  default = "active"
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			wantErr: `.*variable "status" requires a type`,
+		},
+		{
+			// Community binary: `Unsupported attribute; This object does not
+			// have an attribute named "missing".`
+			name: "reference to an undeclared variable",
+			hcl: `
+table "t" {
+  column "state" {
+    type    = text
+    default = var.missing
+  }
+}
+`,
+			wantErr: `.*unknown variable "var"`,
+		},
+		{
+			// Community binary: `Call to unknown function; There is no function
+			// named "now".`
+			name: "call to a function that is not in the set",
+			hcl: `
+table "t" {
+  column "state" {
+    type    = text
+    default = now()
+  }
+}
+`,
+			wantErr: `.*call to unknown function: There is no function named "now".*`,
+		},
+		{
+			// Community binary: `set field "type": unexpected type string`.
+			// Resolving it instead would exit 0 where that binary exits 1.
+			name: "variable reference in a column type",
+			hcl: `
+variable "coltype" {
+  type    = string
+  default = "varchar(255)"
+}
+table "t" {
+  column "state" {
+    type = var.coltype
+  }
+}
+`,
+			wantErr: `.*a variable reference is not supported in a type`,
+		},
+		{
+			// Community binary: `variable "n": a number is required`.
+			name: "default that does not match the declared type",
+			hcl: `
+variable "n" {
+  type    = int
+  default = "abc"
+}
+table "t" {
+  column "state" {
+    type    = int
+    default = var.n
+  }
+}
+`,
+			wantErr: `.*variable "n": .*`,
+		},
+		{
+			// Community binary: `An argument named "sensitive" is not expected
+			// here` -- sensitive is an atlas.hcl PROJECT variable attribute, not
+			// a schema-file one.
+			name: "sensitive is not a schema-file variable attribute",
+			hcl: `
+variable "status" {
+  type      = string
+  default   = "active"
+  sensitive = true
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.status
+  }
+}
+`,
+			wantErr: `.*unsupported variable attribute "sensitive"`,
+		},
+		{
+			// Community binary: `Unknown variable; There is no variable named
+			// "float"`. The keyword set is bool, int, number, string and
+			// list/map/set of those, measured one keyword at a time.
+			name: "variable type keyword outside the measured set",
+			hcl: `
+variable "n" {
+  type    = float
+  default = 1
+}
+table "t" {
+  column "state" {
+    type    = text
+    default = var.n
+  }
+}
+`,
+			wantErr: `.*variable "n" type is not supported.*`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			_, err := atlashcl.Parse([]byte(tt.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, tt.wantErr)
+		})
+	}
+}
+
+// The reference forms a schema file is full of are NOT values, and adding the
+// evaluation context must not start evaluating them.
+//
+// Every row here would fail to evaluate against any context -- `text` names no
+// variable, `varchar(255)` calls no function, `[column.n]` reaches a root that
+// does not exist -- and every one of them has to keep resolving from source
+// text. Reverted to evaluating them, each row fails with an "unknown variable"
+// or "call to unknown function" error that the assertion prints.
+func TestParseKeepsReferenceFormsUnevaluated(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		hcl    string
+		assert func(c *qt.C, db *goschema.Database)
+	}{
+		{
+			name: "bare type keyword",
+			hcl: `
+table "t" {
+  column "n" { type = text }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields[0].Type, qt.Equals, "text")
+			},
+		},
+		{
+			name: "parameterized type spelled as a call",
+			hcl: `
+table "t" {
+  column "n" { type = varchar(255) }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields[0].Type, qt.Equals, "varchar(255)")
+			},
+		},
+		{
+			name: "schema reference",
+			hcl: `
+schema "app" {
+}
+table "t" {
+  schema = schema.app
+  column "n" { type = int }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables[0].Schema, qt.Equals, "app")
+			},
+		},
+		{
+			name: "column reference inside an index list",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "i" {
+    columns = [column.n]
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Indexes, qt.HasLen, 1)
+				c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{"n"})
+			},
+		},
+		{
+			// function.return and range.subtype hold a type the same way
+			// column.type does. Reverted to checking only `type`, this row
+			// fails with `call to unknown function: There is no function named
+			// "varchar"`.
+			name: "parameterized type in a function return",
+			hcl: `
+function "f" {
+  lang   = SQL
+  return = varchar(255)
+  as     = "SELECT 'x'"
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Functions, qt.HasLen, 1)
+				c.Assert(db.Functions[0].Returns, qt.Equals, "varchar(255)")
+			},
+		},
+		{
+			name: "parameterized subtype in a range",
+			hcl: `
+schema "main" {
+}
+range "r" {
+  schema  = schema.main
+  subtype = numeric(10, 2)
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Ranges, qt.HasLen, 1)
+				c.Assert(db.Ranges[0].Subtype, qt.Equals, "numeric(10, 2)")
+			},
+		},
+		{
+			name: "enum reference as a column type",
+			hcl: `
+schema "main" {
+}
+enum "status" {
+  schema = schema.main
+  values = ["a", "b"]
+}
+table "t" {
+  schema = schema.main
+  column "n" { type = enum.status }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Fields[0].Type, qt.Equals, "status")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(tt.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			tt.assert(c, db)
+		})
+	}
+}

--- a/internal/atlashcl/evalreject.go
+++ b/internal/atlashcl/evalreject.go
@@ -1,0 +1,166 @@
+package atlashcl
+
+import (
+	"fmt"
+	"slices"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+)
+
+// typeAttrNames are the attributes whose value is a TYPE rather than a value.
+// Types are read from source text -- `varchar(255)` is a call Ptah must not
+// evaluate, `int` is a traversal that names no variable -- so the checks below
+// skip them. A var. reference is still refused there: measured, the pinned
+// Atlas community binary v1.3.0 refuses `type = var.x` too ("set field
+// \"type\": unexpected type string"), and resolving it would exit 0 where that
+// binary exits 1.
+//
+// The list is three names, not one. `column.type` is the obvious member;
+// `function.return` and `range.subtype` hold a type in exactly the same way and
+// are read through the same source-text path, so leaving them out would refuse
+// `return = varchar(255)` as a call to an unknown function.
+var typeAttrNames = []string{"return", "subtype", "type"}
+
+// rejectUnresolvedExprs refuses every expression the evaluation context was
+// supposed to resolve and could not.
+//
+// It runs before the body walk for the same reason rejectMalformedSQLRawExprs
+// does: every value helper in this package falls back to an attribute's SOURCE
+// TEXT when the expression will not evaluate, so an unresolved `var.status`
+// silently becomes the DDL literal 'var.status' -- issue #926, and the reason
+// docs/site/src/content/docs/reference/hcl-schema.md's "unsupported HCL
+// constructs return errors rather than partial output" was not true.
+//
+// Only two shapes are checked, and the narrowness is the point. A schema file
+// is full of traversals that are references rather than values -- schema.main,
+// column.c, enum.status, the bare keyword `text` -- and every one of them
+// still resolves from source text exactly as before.
+func (p *parser) rejectUnresolvedExprs(body *hclsyntax.Body) error {
+	refusals := p.collectUnresolvedExprs(body, nil)
+	if len(refusals) == 0 {
+		return nil
+	}
+	// Attributes hang off a map, so report the one that comes first in the
+	// file rather than whichever the map iteration reached first.
+	return slices.MinFunc(refusals, func(a, b unresolvedExpr) int {
+		return a.start - b.start
+	}).err
+}
+
+// unresolvedExpr is one expression that had to evaluate and did not, with the
+// source offset that orders it against the others.
+type unresolvedExpr struct {
+	start int
+	err   error
+}
+
+func (p *parser) collectUnresolvedExprs(body *hclsyntax.Body, out []unresolvedExpr) []unresolvedExpr {
+	for _, name := range sortedAttrNames(body.Attributes) {
+		out = p.appendUnresolvedExpr(name, body.Attributes[name], out)
+	}
+	for _, block := range body.Blocks {
+		// variable and locals bodies built the evaluation context; re-checking
+		// them here would evaluate a type constraint as if it were a value.
+		if block.Type == variableBlockType || block.Type == localsBlockType {
+			continue
+		}
+		out = p.collectUnresolvedExprs(block.Body, out)
+	}
+	return out
+}
+
+func (p *parser) appendUnresolvedExpr(name string, attr *hclsyntax.Attribute, out []unresolvedExpr) []unresolvedExpr {
+	target, wrapped := sqlCallArgument(attr.Expr)
+	if slices.Contains(typeAttrNames, name) {
+		if wrapped || !usesEvalNamespace(attr.Expr) {
+			return out
+		}
+		rng := attr.Expr.Range()
+		return append(out, unresolvedExpr{
+			start: rng.Start.Byte,
+			err: fmt.Errorf(
+				"parse HCL schema at %s: a variable reference is not supported in a type",
+				rng.String(),
+			),
+		})
+	}
+	if !mustEvaluate(target) {
+		return out
+	}
+	err := p.unresolvedExprError(target)
+	if err == nil {
+		return out
+	}
+	return append(out, unresolvedExpr{start: target.Range().Start.Byte, err: err})
+}
+
+// unresolvedExprError evaluates one expression and reports why it would not
+// resolve, or nil when it does.
+//
+// A namespace that is not in the context at all is reported by name and at the
+// root's own range, the way checkDroppedExpr reports one, because that is what
+// the community binary underlines -- `var.status` points at `var`. Everything
+// else is the HCL diagnostic, which already names the member or the operand.
+func (p *parser) unresolvedExprError(expr hclsyntax.Expression) error {
+	for _, traversal := range hclsyntax.Variables(expr) {
+		root, ok := traversal[0].(hcl.TraverseRoot)
+		if !ok || !isEvalNamespace(root.Name) {
+			continue
+		}
+		if _, bound := p.ctx.Variables[root.Name]; !bound {
+			return p.unknownVariableError(root.Name, root.SrcRange)
+		}
+	}
+	if _, diags := expr.Value(p.ctx); diags.HasErrors() {
+		return p.evaluationFailed(diags)
+	}
+	return nil
+}
+
+// sqlCallArgument unwraps `sql(X)` to X, reporting whether it unwrapped
+// anything. The wrapper itself is never evaluated -- `sql` is not a function in
+// the evaluation context -- but its argument is, so `sql("${var.floor} + 1")`
+// is checked on the template it carries.
+func sqlCallArgument(expr hclsyntax.Expression) (hclsyntax.Expression, bool) {
+	call, ok := expr.(*hclsyntax.FunctionCallExpr)
+	if !ok || call.Name != sqlFuncName || len(call.Args) != 1 {
+		return expr, false
+	}
+	return call.Args[0], true
+}
+
+// mustEvaluate reports whether an expression is one the evaluation context is
+// responsible for resolving, so that failing to resolve it is an error rather
+// than a fall-through to source text.
+//
+// Two shapes qualify:
+//
+//   - anything reaching the var. or local. namespace, at any depth, including
+//     inside a template: `var.status`, `"prefix_${var.n}"`, `local.d`
+//   - a function call spelled as the whole value: `upper("abc")`, `now()`
+//
+// Everything else keeps the source-text path: a bare traversal names a schema
+// object or a type keyword, and a tuple of traversals (`columns = [column.c]`)
+// names columns.
+func mustEvaluate(expr hclsyntax.Expression) bool {
+	if usesEvalNamespace(expr) {
+		return true
+	}
+	call, ok := expr.(*hclsyntax.FunctionCallExpr)
+	return ok && call.Name != sqlFuncName
+}
+
+// usesEvalNamespace reports whether expr reads var. or local. anywhere.
+func usesEvalNamespace(expr hclsyntax.Expression) bool {
+	for _, traversal := range hclsyntax.Variables(expr) {
+		if isEvalNamespace(traversal.RootName()) {
+			return true
+		}
+	}
+	return false
+}
+
+func isEvalNamespace(name string) bool {
+	return name == varNamespace || name == localNamespace
+}

--- a/internal/atlashcl/evalreject.go
+++ b/internal/atlashcl/evalreject.go
@@ -145,7 +145,18 @@ func sqlCallArgument(expr hclsyntax.Expression) (hclsyntax.Expression, bool) {
 // names columns.
 func mustEvaluate(expr hclsyntax.Expression) bool {
 	if usesEvalNamespace(expr) {
-		return true
+		// ...unless the same expression also reaches a namespace this context
+		// does not bind. `column = var.by_a ? column.a : column.b` mixes the two
+		// resolvers: `var` comes from here, `column` from the schema-object
+		// resolver in column_ref.go, which picks the branch and reads the
+		// column off it (stokaro/ptah#1182). Evaluating the whole expression
+		// here would fail on `column` and report `unknown variable: There is no
+		// variable named "column"` for a spelling the pinned community binary
+		// plans correctly.
+		//
+		// Ownership, not tolerance: an expression naming a schema object is the
+		// object resolver's, and it still refuses one that names nothing.
+		return !usesNonEvalTraversal(expr)
 	}
 	call, ok := expr.(*hclsyntax.FunctionCallExpr)
 	return ok && call.Name != sqlFuncName
@@ -163,4 +174,16 @@ func usesEvalNamespace(expr hclsyntax.Expression) bool {
 
 func isEvalNamespace(name string) bool {
 	return name == varNamespace || name == localNamespace
+}
+
+// usesNonEvalTraversal reports whether expr reads a traversal root the
+// evaluation context does not bind -- `column`, `table`, `enum`, `schema` and
+// the other schema-object namespaces.
+func usesNonEvalTraversal(expr hclsyntax.Expression) bool {
+	for _, traversal := range hclsyntax.Variables(expr) {
+		if !isEvalNamespace(traversal.RootName()) {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -662,7 +662,7 @@ func (p *parser) boolAttr(block *hclsyntax.Block, name, label string, fallback b
 	if attr == nil {
 		return fallback, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Bool {
 		return false, p.blockError(block, "%s attribute %q must be a bool", label, name)
 	}
@@ -1065,7 +1065,7 @@ func (p *parser) optionalInt64(block *hclsyntax.Block, name, label string) (*int
 	if attr == nil {
 		return nil, nil
 	}
-	value, diags := attr.Expr.Value(nil)
+	value, diags := attr.Expr.Value(p.ctx)
 	if diags.HasErrors() || value.Type() != cty.Number {
 		return nil, p.blockError(block, "%s attribute %q must be an integer", label, name)
 	}

--- a/internal/atlashcl/oracle_conformance_test.go
+++ b/internal/atlashcl/oracle_conformance_test.go
@@ -720,6 +720,20 @@ table "t" {
 // accepting one of these the row is no longer a divergence and should move, and
 // if Ptah starts accepting one the trade recorded here has been reversed
 // without being re-argued.
+//
+// The "declared variable" row was removed here rather than adjusted, and this
+// is that argument. `annotation "gql" { ref = var.v }` beside a declared
+// `variable "v"` was a divergence only because the dropped body's scope did not
+// bind `var`; #926 gives it the same evaluation context the rest of the file
+// uses, so the reference resolves. Measured on both, the row is no longer a
+// divergence in either direction:
+//
+//	oracle:      exit 0, table "t" with column "id"
+//	ptah-compat: exit 0, table "t" with column "id"
+//
+// The remaining rows keep the trade, and for the reason above: their roots are
+// `column` and `table`, which need a reference root built from the file's own
+// blocks — the thing every attempt so far has had to guess a member of.
 func TestOracleAcceptsReferencesPtahRefuses(t *testing.T) {
 	oracle := requireSchemaOracle(t)
 	c := qt.New(t)
@@ -728,25 +742,6 @@ func TestOracleAcceptsReferencesPtahRefuses(t *testing.T) {
 		name string
 		hcl  string
 	}{
-		{
-			name: "declared variable",
-			hcl: `variable "v" {
-  type    = string
-  default = "x"
-}
-schema "main" {
-}
-annotation "gql" {
-  ref = var.v
-}
-table "t" {
-  schema = schema.main
-  column "id" {
-    type = int
-  }
-}
-`,
-		},
 		{
 			name: "column root inside a table body",
 			hcl: `schema "main" {

--- a/internal/atlashcl/sqlrawexpr.go
+++ b/internal/atlashcl/sqlrawexpr.go
@@ -72,22 +72,21 @@ func (p *parser) sqlCallText(call *hclsyntax.FunctionCallExpr) (string, error) {
 	}
 
 	arg := call.Args[0]
-	value, diags := arg.Value(nil)
+	value, diags := arg.Value(p.ctx)
 	if !diags.HasErrors() && value.IsKnown() && !value.IsNull() && value.Type() == cty.String {
 		return value.AsString(), nil
 	}
 
-	// A quoted string Ptah cannot evaluate is a string carrying an
-	// interpolation, and Ptah has no schema-file variable evaluation yet
-	// (issue #926). Handing back the template source keeps that gap exactly
-	// where it already is -- `default = "${var.x}"` renders its own source text
-	// today -- instead of turning #926 into a refusal in this one spot.
+	// A quoted string that still will not evaluate against the file's own
+	// variables and locals is a template reaching something the evaluation
+	// context does not carry. Handing back the template source keeps this spot
+	// out of the refusal business: rejectUnresolvedExprs checks the same
+	// argument and reports the diagnostic with the position, so returning the
+	// source here only decides what a caller that skipped that guard sees.
 	//
-	// The distinction is not cosmetic: measured against the pinned community
-	// binary, `default = sql("${var.floor} + 1")` is planned successfully, so
-	// refusing it here would be a NEW stricter break on a file that binary
-	// supports. The DDL Ptah renders for it stays wrong until #926 lands, but
-	// it no longer carries the literal token sql( into the plan.
+	// Measured against the pinned community binary, `default = sql("${var.floor}
+	// + 1")` is planned successfully; with the evaluation context in place the
+	// branch above now returns "5 + 1" for it rather than the source text.
 	if _, ok := arg.(*hclsyntax.TemplateExpr); ok {
 		return unquotedSource(p.rawExprNode(arg)), nil
 	}

--- a/internal/atlashcl/sqlrawexpr_test.go
+++ b/internal/atlashcl/sqlrawexpr_test.go
@@ -450,18 +450,16 @@ table "t" {
 	}
 }
 
-// Ptah does not evaluate schema-file variables yet (issue #926), so a sql()
-// argument carrying an interpolation cannot be reduced to a value. It must NOT
-// be refused: measured against the pinned Atlas community binary v1.3.0,
-// `default = sql("${var.floor} + 1")` is planned successfully there, so
-// refusing it would break drop-in on a file that binary supports. Ptah keeps
-// #926's existing behavior -- the template source, rendered as-is -- while
-// still stripping the sql() wrapper the renderer must never see.
+// A sql() argument carrying an interpolation is reduced through the file's own
+// variables. Measured against the pinned Atlas community binary v1.3.0,
+// `default = sql("${var.floor} + 1")` is planned there as `5 + 1`, so it must
+// neither be refused nor pass its source text through -- both of which this
+// file did before issue #926 was fixed.
 //
-// Reverted to a refusal, this test fails on the nil-error assertion. Reverted
-// to the pre-#1106 source-text fallback, DefaultExpr holds
-// `sql("${var.floor} + 1")` instead.
-func TestParseKeepsSQLRawExpressionInterpolationSource(t *testing.T) {
+// Reverted, DefaultExpr holds the template source `${var.floor} + 1` and the
+// equality assertion fails printing that string. Reverted to a refusal
+// instead, the nil-error assertion fails.
+func TestParseReducesSQLRawExpressionInterpolation(t *testing.T) {
 	c := qt.New(t)
 
 	db, err := atlashcl.Parse([]byte(`
@@ -479,27 +477,29 @@ table "t" {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(db.Fields, qt.HasLen, 1)
-	c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "${var.floor} + 1")
+	c.Assert(db.Fields[0].DefaultExpr, qt.Equals, "5 + 1")
 }
 
-// A function call that is not sql() is out of scope here and keeps its existing
-// behavior, tracked separately in issue #926. The row exists so a future widening
-// of the guard to every unknown call is a deliberate edit with a failing test,
-// not a silent side effect.
+// A function call that is not sql() and is not in the evaluation context's
+// function set is refused rather than copied into the IR as source text.
 //
-// Reverted, this still passes -- it pins the boundary of the change rather than
-// the change itself.
-func TestParseLeavesNonSQLFunctionCallsAlone(t *testing.T) {
+// This is the position issue #926 left open and #1106 deliberately did not
+// widen into. Measured, the same file on the pinned binary exits 1 with
+// `Call to unknown function; There is no function named "sqlx".`, so refusing
+// here is what matches rather than what over-reaches.
+//
+// Reverted, this test fails on the non-nil-error assertion, and the parse
+// instead yields a check constraint whose expression is the literal text
+// `sqlx("n > 0")`.
+func TestParseRefusesUnknownFunctionCalls(t *testing.T) {
 	c := qt.New(t)
 
-	db, err := atlashcl.Parse([]byte(`
+	_, err := atlashcl.Parse([]byte(`
 table "t" {
   column "n" { type = int }
   check "c" { expr = sqlx("n > 0") }
 }
 `), "schema.hcl")
 
-	c.Assert(err, qt.IsNil)
-	c.Assert(db.Constraints, qt.HasLen, 1)
-	c.Assert(db.Constraints[0].CheckExpression, qt.Equals, `sqlx("n > 0")`)
+	c.Assert(err, qt.ErrorMatches, `.*call to unknown function: There is no function named "sqlx".*`)
 }

--- a/internal/atlashcl/unknown_names.go
+++ b/internal/atlashcl/unknown_names.go
@@ -108,12 +108,36 @@ var droppedBodyFunctions = map[string]function.Function{
 	"upper":      stdlib.UpperFunc,
 }
 
-// droppedBodyContext is the evaluation context every dropped expression sees.
-// It is built once and never mutated; HCL only reads it, and a for-expression
-// binds its iterator in a child context rather than in this one.
+// droppedBodyContext is the base evaluation context every dropped expression
+// sees. It is built once and never mutated; HCL only reads it, and a
+// for-expression binds its iterator in a child context rather than in this one.
 var droppedBodyContext = &hcl.EvalContext{
 	Variables: droppedBodyScope,
 	Functions: droppedBodyFunctions,
+}
+
+// droppedContext is droppedBodyContext plus whatever the file's own variable
+// and locals blocks actually declared.
+//
+// The scope above is closed because the earlier attempts to model the file
+// reached for wildcards; these two names need no wildcard. They carry the real
+// typed values newEvalContext resolved, so `ref = var.v` on a declared string
+// variable resolves exactly as it does on the community binary, while
+// `ref = var.v.nope` and `ref = 1 + var.v` fail there with that binary's own
+// member-access and operand diagnostics rather than with a blanket
+// "unknown variable". Nothing widens: a name with no block declaring it is
+// still absent, and the failure is still the closed-scope one.
+func (p *parser) droppedContext() *hcl.EvalContext {
+	if p.ctx == nil {
+		return droppedBodyContext
+	}
+	scope := maps.Clone(droppedBodyScope)
+	for _, name := range []string{varNamespace, localNamespace} {
+		if value, bound := p.ctx.Variables[name]; bound {
+			scope[name] = value
+		}
+	}
+	return &hcl.EvalContext{Variables: scope, Functions: droppedBodyFunctions}
 }
 
 // tolerateUnknownBlock accepts a block name this parser does not model.
@@ -208,6 +232,7 @@ func (p *parser) checkDroppedExpr(expr hclsyntax.Expression) error {
 	if expr == nil {
 		return nil
 	}
+	ctx := p.droppedContext()
 	for _, traversal := range expr.Variables() {
 		if len(traversal) == 0 {
 			continue
@@ -216,7 +241,7 @@ func (p *parser) checkDroppedExpr(expr hclsyntax.Expression) error {
 		if !ok {
 			continue
 		}
-		if _, inScope := droppedBodyScope[root.Name]; inScope {
+		if _, inScope := ctx.Variables[root.Name]; inScope {
 			continue
 		}
 		// The root's own range, not the whole traversal's: the community binary
@@ -224,7 +249,7 @@ func (p *parser) checkDroppedExpr(expr hclsyntax.Expression) error {
 		// at `column`.
 		return p.unknownVariableError(root.Name, root.SrcRange)
 	}
-	if _, diags := expr.Value(droppedBodyContext); diags.HasErrors() {
+	if _, diags := expr.Value(ctx); diags.HasErrors() {
 		return p.evaluationFailed(diags)
 	}
 	return nil

--- a/internal/atlashcl/unknown_names_test.go
+++ b/internal/atlashcl/unknown_names_test.go
@@ -676,6 +676,9 @@ table "t" {
 			wantErr: `parse HCL schema at schema\.hcl:12,11-22: unknown variable "primary_key"`,
 		},
 		{
+			// Since issue #926 the file's own variables are in scope here, so
+			// this fails on the member access rather than on the root -- the
+			// same diagnostic the community binary reports for it.
 			name: "attribute access on a declared string variable",
 			hcl: `variable "v" {
   type    = string
@@ -687,7 +690,7 @@ annotation "gql" {
   ref = var.v.nope
 }
 `,
-			wantErr: `parse HCL schema at schema\.hcl:8,9-12: unknown variable "var"`,
+			wantErr: `parse HCL schema at schema\.hcl:8,14-19: unsupported attribute: Can't access attributes on a primitive-typed value \(string\)\.`,
 		},
 		{
 			name: "arithmetic over a declared string variable",
@@ -701,7 +704,7 @@ annotation "gql" {
   ref = 1 + var.v
 }
 `,
-			wantErr: `parse HCL schema at schema\.hcl:8,13-16: unknown variable "var"`,
+			wantErr: `parse HCL schema at schema\.hcl:8,13-18: invalid operand: Unsuitable value for right operand: a number is required\.`,
 		},
 		{
 			name: "reference that stops on a block type rather than a block",
@@ -822,6 +825,25 @@ annotation "gql" {
 }
 `,
 		},
+		{
+			// Moved here from
+			// TestParseIgnoreUnknownNamesIsStricterThanTheOracleOnReferences by
+			// issue #926, which is the revisit that test's doc comment asked
+			// for: the file's own variable blocks now bind real typed values,
+			// so a dropped body reading one resolves it exactly as the
+			// community binary does instead of being refused.
+			name: "declared variable inside a dropped block",
+			hcl: `variable "v" {
+  type    = string
+  default = "x"
+}
+schema "main" {
+}
+annotation "gql" {
+  gql = var.v
+}
+`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -854,20 +876,6 @@ func TestParseIgnoreUnknownNamesIsStricterThanTheOracleOnReferences(t *testing.T
 		hcl     string
 		wantErr string
 	}{
-		{
-			name: "declared variable",
-			hcl: `variable "v" {
-  type    = string
-  default = "x"
-}
-schema "main" {
-}
-annotation "gql" {
-  gql = var.v
-}
-`,
-			wantErr: `.*unknown variable "var"`,
-		},
 		{
 			name: "column root inside a table body",
 			hcl: `schema "main" {

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -53,6 +53,9 @@ type DiffOptions struct {
 	Policy               atlasschema.DiffPolicy
 	Qualifier            Qualifier
 	DryRun               bool
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// PreparePublication may edit the staged migration files before they are
 	// durably published and included in atlas.sum. The callback runs while the
 	// migration-directory lock is held.
@@ -313,6 +316,7 @@ func resolveDesiredState(
 		// `migrate diff` is registered on the Atlas-compatible command tree
 		// only, so this surface always reads files written for another tool.
 		IgnoreUnknownHCLNames: true,
+		Vars:                  opts.Vars,
 	})
 	if err != nil {
 		return atlassource.State{}, fmt.Errorf("load --to schema: %w", err)

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -43,6 +43,9 @@ type ApplyOptions struct {
 	// roots and native schema files loaded through the shared desired-source
 	// loader. The Atlas-compatible callers never set it.
 	Desired *goschema.Database
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
 	IgnoreUnknownHCLNames bool
@@ -70,6 +73,9 @@ type ApplyRuntimeOptions struct {
 	// Desired supplies a pre-loaded desired schema model; see
 	// [ApplyOptions.Desired].
 	Desired *goschema.Database
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [ApplyOptions.IgnoreUnknownHCLNames].
 	IgnoreUnknownHCLNames bool
@@ -205,6 +211,7 @@ func loadDesiredApplySchema(
 		return schemafile.LoadAll(opts.ToURLs, schemafile.Options{
 			Dialect:               conn.Info().Dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			Vars:                  opts.Vars,
 		})
 	}
 	set, err := atlassource.ClassifySet("--to", opts.ToURLs, opts.ProjectEnv)
@@ -216,6 +223,7 @@ func loadDesiredApplySchema(
 		DialectFlag:           "--url",
 		DevURL:                opts.DevURL,
 		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		Vars:                  opts.Vars,
 	})
 	if err != nil {
 		return nil, err
@@ -248,6 +256,7 @@ func PrepareApply(
 		Desired:    opts.Desired,
 
 		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		Vars:                  opts.Vars,
 	})
 	if err != nil {
 		return ApplyRuntimePlan{}, err

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -38,6 +38,9 @@ type DiffOptions struct {
 	// that matched nothing on either side. It never receives plan output, so
 	// the bytes on standard output stay unchanged.
 	Diagnostics io.Writer
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
 	IgnoreUnknownHCLNames bool
@@ -83,6 +86,7 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 		Schemas:               opts.Schemas,
 		ConnectTimeout:        opts.ConnectTimeout,
 		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		Vars:                  opts.Vars,
 	}
 	fromState, err := fromSet.Resolve(ctx, resolveOpts)
 	if err != nil {

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -49,6 +49,9 @@ type InspectSourceOptions struct {
 	// ConnectTimeout bounds the initial database connection attempts. Zero
 	// disables the bound.
 	ConnectTimeout time.Duration
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
 	IgnoreUnknownHCLNames bool
@@ -127,6 +130,7 @@ func inspectOnDev(
 		desired, err = schemafile.LoadAll(sourceRawURLs(set), schemafile.Options{
 			Dialect:               dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			Vars:                  opts.Vars,
 		})
 		if err != nil {
 			return "", err

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -72,6 +72,9 @@ type PlanFileOptions struct {
 	// Desired supplies a pre-loaded desired schema model; see
 	// [ApplyOptions.Desired]. When set, ToURLs are ignored.
 	Desired *goschema.Database
+	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
+	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [ApplyOptions.IgnoreUnknownHCLNames].
 	IgnoreUnknownHCLNames bool
@@ -118,6 +121,7 @@ func PreparePlanFile(
 		Desired:        opts.Desired,
 
 		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+		Vars:                  opts.Vars,
 	})
 	if err != nil {
 		return PlanFile{}, err

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -65,6 +65,9 @@ type ResolveOptions struct {
 	// tool, and not to Ptah's own commands, where an unmodeled name is a typo
 	// worth naming. See [go.5x5.cz/ptah/internal/schemafile.Options].
 	IgnoreUnknownHCLNames bool
+	// Vars supplies values for the `variable` blocks of an HCL schema file, as
+	// `--var` spells them. See [go.5x5.cz/ptah/internal/schemafile.Options].
+	Vars []string
 }
 
 // State is one resolved desired-state. Resolution closes every connection it
@@ -96,6 +99,7 @@ func (s Set) Resolve(ctx context.Context, opts ResolveOptions) (State, error) {
 		schema, err := schemafile.LoadAll(s.rawURLs(), schemafile.Options{
 			Dialect:               opts.Dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			Vars:                  opts.Vars,
 		})
 		if err != nil {
 			return State{}, err

--- a/internal/schemafile/schemafile.go
+++ b/internal/schemafile/schemafile.go
@@ -45,6 +45,13 @@ type Options struct {
 	// consumes it, and a forwarding field with no producer is a field no test
 	// can hold to account.
 	IgnoreUnknownHCLNames bool
+
+	// Vars supplies values for the `variable` blocks of an HCL schema file, as
+	// `--var` spells them. See [atlashcl.Options.Vars].
+	//
+	// Other schema file formats ignore it: YAML and SQL have no variables, and
+	// silently accepting a value for one there would suggest they do.
+	Vars []string
 }
 
 // Load reads one local schema file from either a plain path or file:// URL.
@@ -78,6 +85,7 @@ func LoadPath(path string, opts Options) (*goschema.Database, error) {
 	case ".hcl":
 		return atlashcl.ParseFileWithOptions(resolved, atlashcl.Options{
 			IgnoreUnknownNames: opts.IgnoreUnknownHCLNames,
+			Vars:               opts.Vars,
 		})
 	case ".yaml", ".yml":
 		return yamlschema.ParseFile(resolved)


### PR DESCRIPTION
Closes #926.

Every attribute in an HCL schema file was evaluated against a nil
`hcl.EvalContext`, so anything that was not a literal degraded to its own source
text and was written into the schema IR and out as DDL at exit 0.

`internal/atlashcl` now builds an evaluation context from the file's own
`variable` and `locals` blocks plus a measured function set, refuses what still
will not resolve, and `--var` is plumbed from the Atlas-compatible `schema` and
`migrate` groups through `internal/schemafile` into the parser.

## What was already closed, and by what

Two of the issue's five items are closed by merged work, not by this PR:

- **Item 2 (unwrap `sql()` in column type, check expr, index where)** — closed by
  e371d323 ("write a sql() column type back as the call, not bare", #1140) and
  f97232d1 ("reduce sql() to its SQL instead of rendering the call", #1131). The
  issue's own `r2.hcl` now renders `"c" geometry(Point,4326)`,
  `CHECK (c IS NOT NULL)` and `WHERE c IS NOT NULL` at exit 0.
- **Item 4 (`sql()` raw column type reaching the database)** — closed by the same
  two. `type = sql("custom_type")` plans `"raw" custom_type NOT NULL` on
  ptah-compat and `` `raw` custom_type `` on the pinned binary, both exit 0.

The framing comment's `case "env", "variable"` split also landed already, as
e680cd88 (#1073 via #1107), so `projectFileBlocks` is on master and this PR
edits that arm rather than creating it.

Items 1, 3 and 5 reproduced verbatim on master d1e2dc64 and are what this PR
fixes.

## Reproduction, before and after

All rows: `ptah-compat schema diff --dev-url "sqlite://file?mode=memory" --from
file://empty.hcl --to file://X.hcl`, run in a directory holding **no**
`atlas.hcl`, exit codes captured immediately. "pinned" is the pinned Atlas
community binary v1.3.0 at
`/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`.

The reference is in a **column default** in every fixture. That placement is the
discriminator the framing comment asked for: a table-comment fixture proves
nothing, because ptah drops table comments on SQLite whether or not the
reference resolved, so control and variant agree.

| fixture | pinned | ptah before | ptah after |
| --- | --- | --- | --- |
| `variable "status" {type=string default="active"}`, `default = var.status` | 0, `DEFAULT 'active'` | 0, `DEFAULT 'var.status'` | 0, `DEFAULT 'active'` |
| **control**: same file, literal `default = "active"` | 0, `DEFAULT 'active'` | 0, `DEFAULT 'active'` | 0, `DEFAULT 'active'` |
| same variable with no default, no `--var` | 1, `missing value for required variable "status"` | 0, `DEFAULT 'var.status'` | 1, `missing value for required variable "status"` |
| same file `--var status=live` | 0, `DEFAULT 'live'` | 1, `failed to read atlas config atlas.hcl: openat atlas.hcl: no such file or directory` | 0, `DEFAULT 'live'` |
| `default = "prefix_${var.n}"` | 0, `DEFAULT 'prefix_users'` | 0, `DEFAULT '"prefix_${var.n}"'` | 0, `DEFAULT 'prefix_users'` |
| **control**: literal `default = "prefix_users"` | 0, `DEFAULT 'prefix_users'` | 0, `DEFAULT 'prefix_users'` | 0, `DEFAULT 'prefix_users'` |
| `locals { d = "abc" }`, `default = local.d` | 0, `DEFAULT 'abc'` | 0, `DEFAULT 'local.d'` (compat drops it; native `ptah` exit 2 `unsupported top-level block "locals"`) | 0, `DEFAULT 'abc'` |
| `variable "status" { default = "active" }` — no `type` | 1, `The argument "type" is required` | 0, `DEFAULT 'var.status'` | 1, `variable "status" requires a type` |
| `default = upper("abc")` | 0, `DEFAULT 'ABC'` | 0, `DEFAULT 'upper("abc")'` | 0, `DEFAULT 'ABC'` |
| `default = now()` | 1, `Call to unknown function` | 0, `DEFAULT 'now()'` | 1, `call to unknown function: There is no function named "now".` |
| `default = var.missing` (undeclared) | 1, `Unsupported attribute` | 0, `DEFAULT 'var.missing'` | 1, `unknown variable "var"` |
| `type = var.coltype` | 1, `set field "type": unexpected type string` | 0, `"c" var.coltype` | 1, `a variable reference is not supported in a type` |

The issue's own item-1 reproduction, `ptah schema render --schema-file r1.hcl
--dialect postgres`, went from exit 0 with `"email" var.coltype NOT NULL DEFAULT
'var.coltype'` to exit 2 naming the type position — `r1.hcl` puts `var.coltype`
in a `type`, which the pinned binary also refuses.

Non-interference control: with an `atlas.hcl` present, `--var` still reaches it
and the same command exits 0. Inverse mutant for the same edit: `--config
file://nope.hcl` still makes the project file required and exits 1 with `failed
to read atlas config nope.hcl`. Dropping `--var` from the required-project
trigger therefore moved only `--var`.

## What each test prints if the change is reverted

`internal/atlashcl/evalcontext_test.go`

- `TestParseResolvesSchemaVariablesAndLocals` — each row prints the reference's
  own source text where it asserts the value: `var.status`, `prefix_${var.n}`
  (quotes included), `local.d`, `upper("abc")`, `var.n`. The **literal default
  control** row passes either way, which is what makes the others discriminate.
  Verified by mutating `evaluatedText` to `expr.Value(nil)`: six rows red, the
  control green.
- `TestParseAppliesVarOverrides` — all four rows print the block's own default or
  `var.status` instead of the override.
- `TestParseRefusesUnresolvableExpressions` — every row fails "got nil error but
  want non-nil". Verified by short-circuiting `rejectUnresolvedExprs` to `return
  nil`: the undeclared-variable, unknown-function and type-position rows go red.
- `TestParseKeepsReferenceFormsUnevaluated` — this is the boundary test, and it
  goes red only if the change over-reaches. Verified by narrowing
  `typeAttrNames` back to `{"type"}`: the `function.return` and `range.subtype`
  rows fail with `call to unknown function: There is no function named
  "varchar"` / `"numeric"`. That mutant is how those two names were found.

`internal/atlashcl/sqlrawexpr_test.go`

- `TestParseReducesSQLRawExpressionInterpolation` (was
  `TestParseKeepsSQLRawExpressionInterpolationSource`) — reverted, `DefaultExpr`
  holds the template source `${var.floor} + 1` and the equality assertion prints
  it. The pinned binary plans that file as `5 + 1`, so the old assertion was
  pinning the gap.
- `TestParseRefusesUnknownFunctionCalls` (was
  `TestParseLeavesNonSQLFunctionCallsAlone`) — reverted, the parse succeeds and
  yields a check constraint whose expression is the literal text `sqlx("n > 0")`.
  The pinned binary exits 1 there.

`cmd/atlas/schema_file_variable_test.go`

- `TestSchemaDiffVarReachesTheSchemaFile` — reverted, fails on the nil-error
  assertion printing `failed to read atlas config atlas.hcl: openat atlas.hcl:
  no such file or directory`.
- `TestSchemaDiffWithoutVarNamesTheMissingVariable` — reverted, the command
  succeeds and prints `DEFAULT 'var.status'`.

## Fixtures that were asserting a state neither tool accepts

Four existing assertions changed. Every one was pinning the #926 gap, so the
fixture was fixed rather than the new gate weakened:

- The two `sqlrawexpr_test.go` tests above, renamed to say what they now pin.
- `TestParseIgnoreUnknownNamesStillEvaluatesTheBody`, rows "attribute access on a
  declared string variable" and "arithmetic over a declared string variable".
  Both expected a blanket `unknown variable "var"`; the file's own variables are
  now in scope inside a dropped body, so they fail on the member access and the
  operand instead — `Can't access attributes on a primitive-typed value (string)`
  and `Unsuitable value for right operand: a number is required`, which are the
  community binary's own diagnostics for those two files.
- `TestParseIgnoreUnknownNamesIsStricterThanTheOracleOnReferences`, row "declared
  variable", moved into
  `TestParseIgnoreUnknownNamesAcceptsEvaluableBodies`. That test's doc comment
  asks for exactly this: "If a later change makes any of these parse, this test
  is where the decision gets revisited rather than quietly reversed." `ref =
  var.v` on a declared variable now resolves, matching the pinned binary, and no
  wildcard was added to do it — `droppedContext` copies the real typed values.

## How the function set was decided

Not guessed. Each candidate name was called with no arguments in a column
default and run through the pinned binary: `There is no function named X` means
absent, anything else (including an arity complaint) means present. 68 present,
38 absent, and the negative control `nosuchfnxyz` came back absent, so the probe
discriminates.

One trap that measurement caught: `reverse` is the LIST reverse on that binary
and `strrev` the STRING reverse (`reverse("abc")` is refused with "can only
reverse list or tuple values"; `strrev("abc")` renders `cba`). go-cty spells
them the other way round — `stdlib.ReverseFunc` is the string one — so a
name-for-name match would have swapped both.

The variable type keywords were measured the same way: `bool`, `int`, `number`,
`string`, and `list`/`map`/`set` of those. `float`, `any`, `integer`, `object`
and `tuple` all come back `There is no variable named "…"`, the same as the
negative control `nosuchkeyword`.

## Deliberately left open

- **Four functions measured present on the pinned binary are not implemented**:
  `yamldecode` and `yamlencode` would add a module dependency, and `uuid` and
  `print` are a nondeterministic generator and a debug tap, neither of which
  belongs in a schema that has to diff stably. A file using one of the four is
  refused here and planned there — stricter, not looser.
- **`check.expr` and `index.where` still accept `sql()` where the pinned binary
  refuses it** (`incorrect type raw`, exit 1). That is a surviving parity-rule-(a)
  violation, and it is unfixed: it is the deliberate #1106 decision recorded in
  `internal/atlashcl/sqlrawexpr.go`, and reversing it belongs in its own change
  with its own measurement, not smuggled in here.
- **Native `ptah` still does not pass `--var` to schema files.** The flag exists
  on the native verbs but is documented and wired as an `atlas.hcl` project
  variable override, so `ptah schema render --schema-file v.hcl --var
  status=live` exits 2 with `missing value for required variable "status"`. The
  framing comment scoped the plumbing to the compat `schema`/`migrate` groups,
  which is the drop-in surface an oracle exists for; extending the native flag
  changes its published help text and should be its own decision.
- **A `var.` reference whose value is not a scalar still falls through to source
  text.** `variable "l" { type = list(string) }` read from a column default gives
  ptah exit 0 with `DEFAULT 'var.l'`; the pinned binary exits 1
  (`unsupported type for default value`). Pre-existing and unchanged.
- **`DEFAULT '7'` vs `DEFAULT 7` for numeric defaults.** `var.n` of type `int`
  renders quoted. The control settles it as a renderer question, not a variable
  one: a plain `default = 7` with no variable anywhere renders `DEFAULT '7'` too,
  before and after.
- **The dropped-body function table is still the narrow eight names**, not the
  measured 68. Widening it is safe in the accept direction but touches
  `TestParseIgnoreUnknownNamesAcceptsEvaluableBodies`'s boundary and belongs with
  its own measurement.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1` (run in package
groups), `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues),
`scripts/check-test-style.sh`, `scripts/check-public-api.sh`,
`scripts/check-public-api-snapshot.sh` — all clean.

`docs/` is touched, so every `check:*` script in `docs/site/package.json` ran:
all 14 pass. `check:responsive` needs `npm run build` first and was green after
it. The feature-matrix page is generated, so
`docs/site/scripts/data/feature-matrix-rows.json` was edited and
`node scripts/build-feature-matrix.mjs` re-ran; three rows moved, as the issue's
Notes section requires.

One test failure is **not** from this change: `cmd/viz`'s
`TestSVGReportsGraphvizStderrOnFailure` fails with `signal: killed` at ~10s when
the whole `./cmd/...` batch runs on a loaded machine, and passes on its own.
`go list -deps ./cmd/viz/` shows zero dependency on `internal/atlashcl`,
`internal/schemafile`, `internal/atlasschema`, `internal/atlassource` or
`internal/atlasmigrate`, so this change cannot reach it.
