### PR TITLE
Refuse a converted Flyway apply over another implementation's revisions

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -310,6 +310,16 @@ func runAtlasMigrateApply(
 		return err
 	}
 
+	// The same question one implementation over: Atlas CE records a converted
+	// Flyway migration under its SOURCE version token, so a revision table it
+	// wrote also matches no file here and reads as entirely pending
+	// (stokaro/ptah#1100). The Ptah-encoding check above runs first because it
+	// is the more specific claim about who wrote the row, and its repair is a
+	// different one.
+	if err := checkForeignFlywayRevisions(captured, resolvedDirFormat, plan); err != nil {
+		return err
+	}
+
 	// The exemption above only stops the linear guard from reading the
 	// baseline's band position as "authored earlier". Whether a baseline may
 	// run against a database that already has history is a separate question,

--- a/cmd/atlas/migrate_apply_foreign_flyway.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway.go
@@ -263,12 +263,18 @@ func foreignFlywaySetRoute(
 	}
 	unrun := foreignFlywayUnrunBelowHead(head, covered, stale, applied)
 	if len(removed) == 0 && len(unrun) == 0 {
+		// The count of listed migrations is deliberately NOT reported as the
+		// size of what `migrate set` writes: a database that recorded some of
+		// this directory under this build's own versions and the rest under the
+		// source tool's has more rows landing in than the refusal listed, and
+		// both kinds have run. What every one of them has in common is having
+		// executed, and that is what the sentence claims.
 		return fmt.Sprintf("  - adopt the versions this build uses: `migrate set %d`, with the same --dir "+
 			"and --url, records every migration up to and including that version as applied under those "+
-			"versions. On this database that set is exactly the %d migration(s) listed above, which it has "+
-			"already run, so nothing is recorded that did not execute. It is a one-way switch: the revision "+
-			"table then carries both spellings, and the implementation that wrote it refuses a migration "+
-			"added afterwards as out of order.\n", head, len(stale))
+			"versions. On this database every migration it would record has already run here, so nothing "+
+			"is recorded that did not execute. It is a one-way switch: the revision table then carries "+
+			"both spellings, and the implementation that wrote it refuses a migration added afterwards "+
+			"as out of order.\n", head)
 	}
 
 	var b strings.Builder

--- a/cmd/atlas/migrate_apply_foreign_flyway.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway.go
@@ -1,0 +1,251 @@
+package atlas
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// foreignFlywayRevision is one migration this database has already run, but
+// recorded under the source tool's version token instead of the Atlas version
+// this build executes it under.
+type foreignFlywayRevision struct {
+	// source is the Flyway file name, relative to the migration directory.
+	source string
+	// recorded is the version in the revision table: the source token, read
+	// the same way the revision reader reads it.
+	recorded int64
+	// current is the Atlas version this build would execute the file under.
+	current int64
+}
+
+// checkForeignFlywayRevisions refuses an apply that would re-run migrations
+// another Atlas implementation has already applied through the same converted
+// directory (stokaro/ptah#1100).
+//
+// A `?format=flyway` directory is converted to Atlas single-file migrations
+// before it is executed, and the two implementations do not agree on the
+// version the converted migration is then recorded under. Atlas CE identifies a
+// Flyway migration by its opaque version STRING and records that string
+// verbatim; Ptah's migrator identifies a migration by an int64, so converting
+// projects the token onto the band-and-slot encoding documented above
+// flywayComponentSlot. Measured on the pinned community binary v1.3.0 with
+// V1__a.sql and V2__b.sql: it records `1` and `2`, this build records
+// `4611686018427469511` and `4611686018427510315`.
+//
+// The projection is not a different spelling of one version, it makes the two
+// revision tables mutually unreadable, and in one direction that means
+// re-execution. Reading a table this build wrote is benign — the community
+// binary sees versions above everything it has and executes nothing — but
+// reading a table the community binary wrote, every converted file matches no
+// row and the whole directory reads as pending. Measured, both halves:
+//
+//	CREATE TABLE t1 (id int)                 -> `table t1 already exists`, exit 1,
+//	                                            and a dirty revision left behind
+//	CREATE TABLE IF NOT EXISTS + INSERT       -> exit 0, and the seed row inserted twice
+//
+// The second is why this is a refusal and not a diagnostic. Nothing in the exit
+// code, stdout or `migrate status` said the data had been duplicated.
+//
+// WHY REFUSE RATHER THAN MATCH. The community binary exits 0 on that database
+// having executed nothing, so refusing exits 1 where it exits 0. That is the
+// deliberate half (b) choice: the alternatives are to reproduce its version
+// space (which changes migration identity in the migrator, far past this issue)
+// or to record the token alongside the version and match on it (which is the
+// same change seen from the other end, since the revision table would still be
+// keyed on the int64). Refusing removes the data-safety edge without touching
+// the projection, and the parity rule allows being stricter, never looser.
+//
+// THE RULE, and what separates it from the plausible looser one. "A recorded
+// version no converted file produces" would refuse an ordinary baseline squash,
+// which retires applied migrations by design. The rule is narrower: a file's
+// SOURCE TOKEN is recorded AND the version that file converts to is not. A
+// database this build wrote fails the first clause; a database an operator has
+// already migrated forward fails the second.
+//
+// The token is compared as an int64 read by strconv.ParseInt, because that is
+// exactly what the revision reader does with the recorded string
+// (parseAtlasRevisionVersion), so "01" and "1" meet in the same place they meet
+// there. A token the reader cannot parse — "1.5", or a repeatable's empty
+// string — is skipped, and needs no branch here: such a row makes the read
+// itself fail first, with `Atlas revision version "1.5" is not a numeric Ptah
+// migration version`, which is already a refusal before anything executes.
+//
+// ONLY FLYWAY, measured rather than assumed. Of the five converted layouts,
+// only Flyway re-executes. Applying the same two-migration directory with each
+// implementation into its own database and reading each with the other: goose
+// records `00001`/`00002` against this build's `1`/`2`, which meet under
+// ParseInt, so nothing is pending; golang-migrate, dbmate and liquibase record
+// identical versions on both. Those three still refuse cross-tool, with
+// `checksum mismatch: stored <base64>, current <hex>` — the two implementations
+// also disagree about the checksum ENCODING — but that is a refusal, not a
+// re-execution, and it is not this issue. Extending this guard to them would be
+// unreachable code, since their tokens ARE the versions they convert to.
+//
+// There is exactly ONE layout gate, and it is inside
+// [atlasmigrateimport.FlywayCoveredSourceVersions], which reports nothing for
+// any other layout. Repeating it here would make each copy individually
+// unkillable — either alone still suppresses the check — and a rule two
+// redundant guards hold is a rule no test can hold.
+func checkForeignFlywayRevisions(
+	captured fs.FS,
+	format atlasmigrateimport.Format,
+	plan atlasmigrate.ApplyPlan,
+) error {
+	if plan.Status == nil {
+		return nil
+	}
+	applied := plan.Status.AppliedMigrations
+	if len(applied) == 0 {
+		return nil
+	}
+	covered, err := atlasmigrateimport.FlywayCoveredSourceVersions(captured, format)
+	if err != nil {
+		// The conversion error this would report is the one the caller already
+		// surfaces on its own path; nothing to add here.
+		return nil //nolint:nilerr // conversion failures are reported by the apply path itself.
+	}
+	stale := foreignFlywayRevisions(covered, applied)
+	if len(stale) == 0 {
+		return nil
+	}
+	return errors.New(foreignFlywayRefusal(stale, applied))
+}
+
+// foreignFlywayRevisions selects the migrations this database recorded under
+// the source token.
+//
+// The third clause is the one that keeps the detector from inventing a
+// refusal. A converted version and a source token live in the same int64 space,
+// and a baseline converts into the LOW band — B10__base.sql becomes 448844 —
+// so a directory that also holds V448844__x.sql has a token equal to a version
+// this very directory produces. Recording it says nothing about which
+// implementation wrote the row, so that pairing is dropped rather than read as
+// foreign history. Measured without it, `migrate apply 1` on exactly that
+// directory (which runs the baseline alone, since the baseline band sorts
+// first) makes the next apply refuse a database this build had just written
+// itself, blaming another implementation for a row it did not write.
+//
+// The cost is stated rather than hidden: on that same pathological directory
+// the clause also declines to flag the genuine cross-tool case, because the
+// evidence really is ambiguous. That input then behaves exactly as it did
+// before this check existed, so it is a detection this does not add rather than
+// one it takes away.
+func foreignFlywayRevisions(
+	covered []atlasmigrateimport.FlywayCoveredSourceVersion,
+	applied []int64,
+) []foreignFlywayRevision {
+	ours := make([]int64, 0, len(covered))
+	for _, migration := range covered {
+		ours = append(ours, migration.Version)
+	}
+
+	var stale []foreignFlywayRevision
+	for _, migration := range covered {
+		recorded, err := strconv.ParseInt(strings.TrimSpace(migration.Token), 10, 64)
+		if err != nil {
+			continue
+		}
+		if !slices.Contains(applied, recorded) || slices.Contains(applied, migration.Version) {
+			continue
+		}
+		if slices.Contains(ours, recorded) {
+			continue
+		}
+		stale = append(stale, foreignFlywayRevision{
+			source:   migration.Source,
+			recorded: recorded,
+			current:  migration.Version,
+		})
+	}
+	return stale
+}
+
+// foreignFlywayRefusal renders the refusal and the two routes measured to work.
+//
+// The hand-written UPDATE the pre-#982 refusal prints is deliberately NOT
+// offered here, and the last paragraph says why. That repair moves a row
+// between two encodings of ONE implementation, so the recorded hash still
+// covers the same converted body. Across implementations it does not: measured,
+// rewriting `1` to `4611686018427469511` by hand on a community-binary-written
+// table gets `migration 4611686018427469511 checksum mismatch: stored
+// 9mRxDpig5tZbhHslnEoWdaeiT7fFPnkxapig7dheO1w=, current
+// ca5446be32fd97a6194819f463b3321c799f9acd0fb138f62dca0cc48164dfa8` on the next
+// apply — the two implementations record the checksum in different encodings.
+// `migrate set` writes whole revision rows, so it settles both at once.
+//
+// Both routes are measured on the fixture in the reproduction, not inferred:
+// `migrate set <head>` reports `(2 set)` and removes nothing, the next
+// `migrate apply` prints `No migration files to execute.` with the seed row
+// still inserted once, and the community binary afterwards prints
+// `No migration files to execute` at exit 0 — so adopting this build's versions
+// does not take the database away from the implementation that wrote it.
+func foreignFlywayRefusal(stale []foreignFlywayRevision, applied []int64) string {
+	var b strings.Builder
+	fmt.Fprintf(&b, "this database records converted Flyway migrations under their SOURCE version token, "+
+		"which is how another Atlas implementation identifies them; Ptah's migrator identifies a migration "+
+		"by the int64 that token projects to, so %d already-applied migration(s) read as pending here and "+
+		"would run a second time. Nothing has been applied", len(stale))
+
+	b.WriteString("\n\nrecorded version -> version this build uses:\n")
+	head := int64(0)
+	for _, revision := range stale {
+		fmt.Fprintf(&b, "  %-20d -> %-20d %s\n", revision.recorded, revision.current, revision.source)
+		head = max(head, revision.current)
+	}
+
+	b.WriteString("\nways forward:\n")
+	b.WriteString("  - keep applying this database with the implementation that wrote the table: it reads " +
+		"its own versions and is unaffected\n")
+	b.WriteString(foreignFlywaySetRoute(head, applied))
+
+	b.WriteString("\nrewriting the version column by hand is not enough: the two implementations also record " +
+		"the migration checksum differently, so an apply after a bare version rewrite refuses with a " +
+		"checksum mismatch. `migrate set` writes the whole revision row.\n")
+	return b.String()
+}
+
+// foreignFlywaySetRoute renders the second way forward, or says there is none.
+//
+// `migrate set V` moves the database to EXACTLY V: it records everything up to
+// V as applied and REMOVES every revision above it. Offering it unconditionally
+// would print a command that deletes real history on one measurable shape.
+// Converted baselines sit in the low band — B2__base.sql becomes 122412 — and a
+// baseline squashes files whose token sorts at or below its own AS A STRING, so
+// `V1000000__z.sql` (token "1000000" < "2", value 1000000) is squashed out of
+// the covered set while its revision row sits above the head. Recommending
+// `migrate set 122412` there would retire the migration the database actually
+// ran.
+//
+// So the route is offered only when it removes nothing, and named as unsafe
+// with the rows it would delete otherwise — the same choice
+// [flywayBaselineRefusal] makes for the same verb, and for the same reason: a
+// refusal that prints a command which quietly makes it worse is not a way
+// forward.
+func foreignFlywaySetRoute(head int64, applied []int64) string {
+	var removed []int64
+	for _, version := range applied {
+		if version > head {
+			removed = append(removed, version)
+		}
+	}
+	if len(removed) == 0 {
+		return fmt.Sprintf("  - adopt the versions this build uses: `migrate set %d`, with the same --dir "+
+			"and --url, records every migration up to and including that version as applied under those "+
+			"versions. The other implementation still reads the result as up to date.\n", head)
+	}
+
+	labels := make([]string, 0, len(removed))
+	for _, version := range removed {
+		labels = append(labels, strconv.FormatInt(version, 10))
+	}
+	return fmt.Sprintf("\nadopting the versions this build uses has no safe route here: `migrate set %d` "+
+		"would move the database to exactly that version and remove the revision(s) above it — %s — which "+
+		"is history this database really ran.\n", head, strings.Join(labels, ", "))
+}

--- a/cmd/atlas/migrate_apply_foreign_flyway.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway.go
@@ -115,7 +115,7 @@ func checkForeignFlywayRevisions(
 	if len(stale) == 0 {
 		return nil
 	}
-	return errors.New(foreignFlywayRefusal(stale, applied))
+	return errors.New(foreignFlywayRefusal(covered, stale, applied))
 }
 
 // foreignFlywayRevisions selects the migrations this database recorded under
@@ -167,7 +167,7 @@ func foreignFlywayRevisions(
 	return stale
 }
 
-// foreignFlywayRefusal renders the refusal and the two routes measured to work.
+// foreignFlywayRefusal renders the refusal and the ways forward.
 //
 // The hand-written UPDATE the pre-#982 refusal prints is deliberately NOT
 // offered here, and the last paragraph says why. That repair moves a row
@@ -179,14 +179,11 @@ func foreignFlywayRevisions(
 // ca5446be32fd97a6194819f463b3321c799f9acd0fb138f62dca0cc48164dfa8` on the next
 // apply — the two implementations record the checksum in different encodings.
 // `migrate set` writes whole revision rows, so it settles both at once.
-//
-// Both routes are measured on the fixture in the reproduction, not inferred:
-// `migrate set <head>` reports `(2 set)` and removes nothing, the next
-// `migrate apply` prints `No migration files to execute.` with the seed row
-// still inserted once, and the community binary afterwards prints
-// `No migration files to execute` at exit 0 — so adopting this build's versions
-// does not take the database away from the implementation that wrote it.
-func foreignFlywayRefusal(stale []foreignFlywayRevision, applied []int64) string {
+func foreignFlywayRefusal(
+	covered []atlasmigrateimport.FlywayCoveredSourceVersion,
+	stale []foreignFlywayRevision,
+	applied []int64,
+) string {
 	var b strings.Builder
 	fmt.Fprintf(&b, "this database records converted Flyway migrations under their SOURCE version token, "+
 		"which is how another Atlas implementation identifies them; Ptah's migrator identifies a migration "+
@@ -203,7 +200,7 @@ func foreignFlywayRefusal(stale []foreignFlywayRevision, applied []int64) string
 	b.WriteString("\nways forward:\n")
 	b.WriteString("  - keep applying this database with the implementation that wrote the table: it reads " +
 		"its own versions and is unaffected\n")
-	b.WriteString(foreignFlywaySetRoute(head, applied))
+	b.WriteString(foreignFlywaySetRoute(head, covered, stale, applied))
 
 	b.WriteString("\nrewriting the version column by hand is not enough: the two implementations also record " +
 		"the migration checksum differently, so an apply after a bare version rewrite refuses with a " +
@@ -213,39 +210,123 @@ func foreignFlywayRefusal(stale []foreignFlywayRevision, applied []int64) string
 
 // foreignFlywaySetRoute renders the second way forward, or says there is none.
 //
-// `migrate set V` moves the database to EXACTLY V: it records everything up to
-// V as applied and REMOVES every revision above it. Offering it unconditionally
-// would print a command that deletes real history on one measurable shape.
-// Converted baselines sit in the low band — B2__base.sql becomes 122412 — and a
-// baseline squashes files whose token sorts at or below its own AS A STRING, so
-// `V1000000__z.sql` (token "1000000" < "2", value 1000000) is squashed out of
-// the covered set while its revision row sits above the head. Recommending
-// `migrate set 122412` there would retire the migration the database actually
-// ran.
+// `migrate set V` moves the database to EXACTLY V. It writes a revision row for
+// EVERY covered migration up to and including V — whether or not that migration
+// ran — and REMOVES every revision above it. Both halves of that verb can lose
+// something, so the route is offered only when this database is a shape where
+// it loses neither, and withdrawn by name, with the rows it would touch, on
+// every other. That is the same choice [flywayBaselineRefusal] makes for the
+// same verb, and for the same reason: a refusal that prints a command which
+// quietly makes it worse is not a way forward.
 //
-// So the route is offered only when it removes nothing, and named as unsafe
-// with the rows it would delete otherwise — the same choice
-// [flywayBaselineRefusal] makes for the same verb, and for the same reason: a
-// refusal that prints a command which quietly makes it worse is not a way
-// forward.
-func foreignFlywaySetRoute(head int64, applied []int64) string {
+// REMOVES ABOVE THE HEAD. Converted baselines sit in the low band —
+// B2__base.sql becomes 122412 — and a baseline squashes files whose token sorts
+// at or below its own AS A STRING, so `V1000000__z.sql` (token "1000000" < "2",
+// value 1000000) is squashed out of the covered set while its revision row sits
+// above the head. Recommending `migrate set 122412` there would retire the
+// migration the database actually ran.
+//
+// RECORDS BELOW THE HEAD WITHOUT RUNNING. The head is the largest version among
+// the migrations this database HAS run under the source tool's token, and the
+// covered migrations below it need not all be among them. Measured on
+// V1__g1.sql and V3__g3.sql recorded by the other implementation as `1` and `3`
+// with V2__g2.sql added afterwards: the head is V3's 4611686018427551119, and
+// `migrate set 4611686018427551119` reports `(3 set)` — g1, g2 and g3 — so the
+// next `migrate apply` prints `No migration files to execute.` at exit 0 with
+// table g2 never created and now unreachable, because its version is recorded.
+// The operator followed the printed instruction and lost a migration; the
+// refusal said nothing about it. That is the shape this clause withdraws on,
+// naming the file and the version it would assert.
+//
+// WHY THE OFFER SAYS THE SWITCH IS ONE WAY. `migrate set` adds this build's
+// versions and does not remove the source tool's, so the revision table ends up
+// carrying both spellings. Measured on V1__a.sql and V2__b.sql recorded as `1`
+// and `2`: after the route the pinned community binary v1.3.0 prints
+// `No migration files to execute` at exit 0, but once V3__c.sql is added it
+// prints `migration file V3__c.sql was added out of order` at exit 1, while
+// this build applies it at exit 0. The controls separate that from the file:
+// the same three-file directory on a fresh database, and on a database carrying
+// only the source tool's `1`,`2`, both apply at exit 0 on that binary. So the
+// two ways forward are alternatives, not steps — taking the second closes the
+// first — and the offer says so instead of calling the result up to date.
+func foreignFlywaySetRoute(
+	head int64,
+	covered []atlasmigrateimport.FlywayCoveredSourceVersion,
+	stale []foreignFlywayRevision,
+	applied []int64,
+) string {
 	var removed []int64
 	for _, version := range applied {
 		if version > head {
 			removed = append(removed, version)
 		}
 	}
-	if len(removed) == 0 {
+	unrun := foreignFlywayUnrunBelowHead(head, covered, stale, applied)
+	if len(removed) == 0 && len(unrun) == 0 {
 		return fmt.Sprintf("  - adopt the versions this build uses: `migrate set %d`, with the same --dir "+
 			"and --url, records every migration up to and including that version as applied under those "+
-			"versions. The other implementation still reads the result as up to date.\n", head)
+			"versions. On this database that set is exactly the %d migration(s) listed above, which it has "+
+			"already run, so nothing is recorded that did not execute. It is a one-way switch: the revision "+
+			"table then carries both spellings, and the implementation that wrote it refuses a migration "+
+			"added afterwards as out of order.\n", head, len(stale))
 	}
 
-	labels := make([]string, 0, len(removed))
-	for _, version := range removed {
-		labels = append(labels, strconv.FormatInt(version, 10))
+	var b strings.Builder
+	fmt.Fprintf(&b, "\nadopting the versions this build uses has no safe route here: `migrate set %d` would "+
+		"move the database to exactly that version, and on this database that is not a no-op:\n", head)
+	if len(unrun) > 0 {
+		labels := make([]string, 0, len(unrun))
+		for _, migration := range unrun {
+			labels = append(labels, fmt.Sprintf("%s (%d)", migration.Source, migration.Version))
+		}
+		fmt.Fprintf(&b, "  - it would record %d migration(s) as applied WITHOUT running them — %s — so that "+
+			"SQL would never execute here and nothing afterwards would report it missing\n",
+			len(unrun), strings.Join(labels, ", "))
 	}
-	return fmt.Sprintf("\nadopting the versions this build uses has no safe route here: `migrate set %d` "+
-		"would move the database to exactly that version and remove the revision(s) above it — %s — which "+
-		"is history this database really ran.\n", head, strings.Join(labels, ", "))
+	if len(removed) > 0 {
+		labels := make([]string, 0, len(removed))
+		for _, version := range removed {
+			labels = append(labels, strconv.FormatInt(version, 10))
+		}
+		fmt.Fprintf(&b, "  - it would remove the revision(s) above it — %s — which is history this database "+
+			"really ran\n", strings.Join(labels, ", "))
+	}
+	return b.String()
+}
+
+// foreignFlywayUnrunBelowHead reports the covered migrations `migrate set head`
+// would record as applied although this database has not executed them.
+//
+// A covered migration at or below the head has run if this build recorded it —
+// its converted version is in the applied set — or if the other implementation
+// did, which is exactly what putting it in stale claims. Anything else is a
+// migration whose SQL has never touched this database, and recording it is the
+// silent loss.
+//
+// A covered migration the detector DECLINED to claim as foreign history — the
+// collision clause in [foreignFlywayRevisions] — lands here as unrun, which
+// withdraws the route on evidence that is merely ambiguous. That is the
+// conservative direction for a message that tells an operator what to type.
+func foreignFlywayUnrunBelowHead(
+	head int64,
+	covered []atlasmigrateimport.FlywayCoveredSourceVersion,
+	stale []foreignFlywayRevision,
+	applied []int64,
+) []atlasmigrateimport.FlywayCoveredSourceVersion {
+	ran := make([]int64, 0, len(stale))
+	for _, revision := range stale {
+		ran = append(ran, revision.current)
+	}
+
+	var unrun []atlasmigrateimport.FlywayCoveredSourceVersion
+	for _, migration := range covered {
+		if migration.Version > head {
+			continue
+		}
+		if slices.Contains(applied, migration.Version) || slices.Contains(ran, migration.Version) {
+			continue
+		}
+		unrun = append(unrun, migration)
+	}
+	return unrun
 }

--- a/cmd/atlas/migrate_apply_foreign_flyway_test.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway_test.go
@@ -66,6 +66,28 @@ func recordForeignFlywayVersions(c *qt.C, dbPath string, tokens []string) {
 	c.Assert(revisionVersionsByOrder(c, db), qt.DeepEquals, tokens)
 }
 
+// renameForeignFlywayVersion rewrites ONE revision into the other spelling,
+// leaving the rest on this build's own encoding.
+//
+// That is the mixed database: some migrations recorded here, some by the tool
+// that wrote the source directory.
+func renameForeignFlywayVersion(c *qt.C, dbPath, from, to string) {
+	c.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	result, err := db.Exec(
+		`UPDATE atlas_schema_revisions SET version = ?, hash = ? WHERE version = ?`,
+		to, foreignFlywayHash, from,
+	)
+	c.Assert(err, qt.IsNil)
+	affected, err := result.RowsAffected()
+	c.Assert(err, qt.IsNil)
+	// A fixture that rewrote nothing would leave the database entirely on this
+	// build's encoding and make every assertion below vacuous.
+	c.Assert(affected, qt.Equals, int64(1))
+}
+
 func revisionVersionsByOrder(c *qt.C, db *sql.DB) []string {
 	c.Helper()
 	rows, err := db.Query(`SELECT version FROM atlas_schema_revisions ORDER BY CAST(version AS INTEGER)`)
@@ -163,6 +185,18 @@ var migrateSetVersion = regexp.MustCompile("`migrate set ([0-9]+)`")
 // because the two also record the checksum differently. `migrate set` writes
 // whole rows, which is why it is the route offered.
 //
+// WHAT THIS TEST DELIBERATELY NO LONGER ASSERTS. It used to end by adding
+// `V3__more.sql` and requiring the apply to succeed, under the heading "the
+// directory keeps working". That state is one the pinned community binary
+// v1.3.0 REFUSES: measured, on the revision table this route leaves behind —
+// `1`, `2`, 4611686018427469511, 4611686018427510315 — it prints `migration
+// file V3__c.sql was added out of order` at exit 1 while this build applies at
+// exit 0. Controls separate that from the added file itself: the same
+// three-file directory on a fresh database, and on a database carrying only
+// `1`,`2`, both apply at exit 0 on that binary. Pinning the old assertion
+// pinned ptah-compat exiting 0 where the binary exits 1 as the desired result,
+// so it is gone and the message says the switch is one way instead.
+//
 // Reverting the change makes the first apply succeed, so no message is produced
 // and the regexp finds nothing: the test fails on the `qt.IsNotNil` above it.
 func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing.T) {
@@ -181,6 +215,11 @@ func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing
 	// wordings have to be pinned or one can silently become the other.
 	c.Assert(message, qt.Contains, "adopt the versions this build uses:")
 	c.Assert(message, qt.Not(qt.Contains), "has no safe route here")
+	// The two claims the offer now makes, both measured: it records only what
+	// this database already ran, and it closes the other way forward.
+	c.Assert(message, qt.Contains, "nothing is recorded that did not execute")
+	c.Assert(message, qt.Contains, "one-way switch")
+	c.Assert(message, qt.Not(qt.Contains), "still reads the result as up to date")
 
 	stdout, stderr, err := runCompat(
 		"migrate", "set", match[1],
@@ -188,19 +227,166 @@ func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing
 		"--dir", "file://"+dir+"?format=flyway",
 	)
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	// Every version the route records is one of the two the refusal listed, so
+	// "nothing is recorded that did not execute" is checked against what the
+	// command actually wrote rather than against the sentence.
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals,
+		[]string{"1", "2", foreignFlywayV1, foreignFlywayV2})
 
 	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
 	c.Assert(stdout, qt.Contains, "No migration files to execute.")
 	// The seed did not run a second time.
 	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
+}
 
-	// And the directory keeps working: a migration added afterwards applies.
-	writeAtlasApplyProjectMigration(c, dir, "V3__more.sql", "INSERT INTO seeded (id) VALUES (3);")
+// TestCompatMigrateApply_ForeignFlywaySetRouteWithdrawnWhenItWouldRecordUnrunMigrations
+// is the input that separates a route which records only what ran from one
+// that records whatever sits below the head.
+//
+// `migrate set V` writes a revision row for EVERY covered migration up to V,
+// run or not. The head is the largest version among the migrations the other
+// implementation DID run, and nothing makes the covered migrations below it a
+// subset of those: `V1__g1.sql` and `V3__g3.sql` recorded as `1` and `3`, with
+// `V2__g2.sql` added afterwards, puts an unapplied file underneath.
+//
+// Measured with the route still offered there: `migrate set 4611686018427551119`
+// reports `(3 set)` — `+ 4611686018427510315 (g2)` among them — the next
+// `migrate apply` prints `No migration files to execute.` at exit 0, and table
+// g2 is absent with its version recorded, so it can never run again. Following
+// the printed instruction lost a migration and the refusal said nothing.
+//
+// The database is also worse off for the other implementation afterwards: on
+// that five-row table the pinned community binary v1.3.0 prints `migration file
+// V2__g2.sql was added out of order` at exit 1.
+//
+// Reverting the unrun clause prints `- adopt the versions this build uses:
+// `migrate set 4611686018427551119“ as a way forward, which is the command
+// that retires g2 unrun.
+func TestCompatMigrateApply_ForeignFlywaySetRouteWithdrawnWhenItWouldRecordUnrunMigrations(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "gap.db")
+	writeAtlasApplyProjectMigration(c, dir, "V1__g1.sql", "CREATE TABLE g1 (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V3__g3.sql", "CREATE TABLE g3 (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	recordForeignFlywayVersions(c, dbPath, []string{"1", "3"})
+
+	// The gap: a migration between the two the other implementation ran.
+	writeAtlasApplyProjectMigration(c, dir, "V2__g2.sql", "CREATE TABLE g2 (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "has no safe route here")
+	c.Assert(message, qt.Not(qt.Contains), "adopt the versions this build uses:")
+	// The row it would have asserted is named — file and version — so the
+	// operator can see what the command would claim rather than being told it
+	// is safe.
+	c.Assert(message, qt.Contains, "WITHOUT running them")
+	c.Assert(message, qt.Contains, "V2__g2.sql ("+foreignFlywayV2+")")
+	// Nothing ran and nothing was recorded: the database is exactly where the
+	// other implementation left it.
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"g1", "g3"})
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals, []string{"1", "3"})
+}
+
+// TestCompatMigrateApply_ForeignFlywaySetRouteOfferedWithPendingAboveTheHead is
+// the input that separates "records something that never ran" from "the
+// directory has anything unapplied in it at all".
+//
+// `migrate set <head>` writes rows up to the head and no further, so a
+// migration ABOVE the head is untouched by it and stays pending — which is the
+// ordinary shape of an operator who switched tools with new work in flight.
+// Withdrawing the route there would strand every such directory.
+//
+// Dropping the `migration.Version > head` skip in foreignFlywayUnrunBelowHead
+// prints `adopting the versions this build uses has no safe route here ... it
+// would record 1 migration(s) as applied WITHOUT running them — V3__c.sql
+// (4611686018427551119)`, on a database `migrate set` would not touch.
+func TestCompatMigrateApply_ForeignFlywaySetRouteOfferedWithPendingAboveTheHead(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "pending.db")
+	writeAtlasApplyProjectMigration(c, dir, "V1__a.sql", "CREATE TABLE pa (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V2__b.sql", "CREATE TABLE pb (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	recordForeignFlywayVersions(c, dbPath, []string{"1", "2"})
+
+	// New work, above everything the other implementation ran.
+	writeAtlasApplyProjectMigration(c, dir, "V3__c.sql", "CREATE TABLE pc (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "adopt the versions this build uses:")
+	c.Assert(message, qt.Not(qt.Contains), "has no safe route here")
+
+	match := migrateSetVersion.FindStringSubmatch(message)
+	c.Assert(match, qt.HasLen, 2)
+	c.Assert(match[1], qt.Equals, foreignFlywayV2)
+	stdout, stderr, err = runCompat(
+		"migrate", "set", match[1],
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+dir+"?format=flyway",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	// V3 is neither recorded nor run: the route asserted only the two
+	// migrations the refusal listed, and left the pending one pending.
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals,
+		[]string{"1", "2", foreignFlywayV1, foreignFlywayV2})
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"pa", "pb"})
+}
+
+// TestCompatMigrateApply_ForeignFlywaySetRouteCountsThisBuildsOwnRowsAsRun is
+// the mixed database: some migrations recorded here, one recorded by the tool
+// that wrote the directory.
+//
+// A migration this build already recorded HAS run, so `migrate set` writing its
+// row again asserts nothing new. Reading only the foreign half as evidence of
+// execution would withdraw the route on a database where it loses nothing.
+//
+// Dropping the `slices.Contains(applied, migration.Version)` half of the skip
+// prints `it would record 1 migration(s) as applied WITHOUT running them —
+// V1__m.sql (4611686018427469511)` for a migration this build ran itself and
+// whose revision row is right there.
+func TestCompatMigrateApply_ForeignFlywaySetRouteCountsThisBuildsOwnRowsAsRun(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "mixed.db")
+	writeAtlasApplyProjectMigration(c, dir, "V1__m.sql", "CREATE TABLE m1 (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+
+	writeAtlasApplyProjectMigration(c, dir, "V2__n.sql", "CREATE TABLE m2 (id INTEGER PRIMARY KEY);")
 	hashConvertedApplyDir(c, dir, "flyway")
 	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 2)
+	// Only the second row moves to the other spelling, so V1 stays recorded
+	// under the version this build uses.
+	renameForeignFlywayVersion(c, dbPath, foreignFlywayV2, "2")
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals, []string{"2", foreignFlywayV1})
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "V2__n.sql")
+	c.Assert(message, qt.Contains, "adopt the versions this build uses:")
+	c.Assert(message, qt.Not(qt.Contains), "WITHOUT running them")
+	c.Assert(message, qt.Not(qt.Contains), "has no safe route here")
 }
 
 // TestCompatMigrateApply_ForeignFlywayTokenWithLeadingSpace is the input that

--- a/cmd/atlas/migrate_apply_foreign_flyway_test.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway_test.go
@@ -1,0 +1,520 @@
+package atlas_test
+
+import (
+	"database/sql"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "modernc.org/sqlite"
+)
+
+// These tests cover the refusal that stops a converted Flyway directory from
+// re-running migrations another Atlas implementation has already applied
+// through it (stokaro/ptah#1100).
+//
+// Atlas CE records a converted Flyway migration under its SOURCE version token
+// — measured on the pinned community binary v1.3.0, `1` and `2` for V1__a.sql
+// and V2__b.sql — while Ptah's migrator records the int64 that token projects
+// to. Each revision table is therefore unreadable to the other implementation,
+// and in the direction where Ptah reads CE's table every file matches no row
+// and the whole directory reads as pending.
+//
+// A foreign revision table is simulated by applying with THIS build and then
+// rewriting each row into the other spelling, which keeps the fixture honest
+// without needing a second binary on PATH.
+const (
+	foreignFlywayV1 = "4611686018427469511"
+	foreignFlywayV2 = "4611686018427510315"
+	// foreignFlywayHash is a checksum in the encoding the OTHER implementation
+	// writes: measured, it records a base64 h1 digest where Ptah records hex
+	// sha256. The fixture rewrites the hash as well as the version so that no
+	// assertion below can pass because a checksum happened to match Ptah's own.
+	foreignFlywayHash = "9mRxDpig5tZbhHslnEoWdaeiT7fFPnkxapig7dheO1w="
+)
+
+// recordForeignFlywayVersions rewrites the revision rows this build just wrote
+// into the spelling the other implementation uses.
+//
+// Rows are paired with tokens by position. That is sound for these fixtures
+// because a converted Flyway directory executes in the order the source tool
+// executes it — that ordering is what flywayOrderingKey reproduces and it is
+// measured against the pinned community binary — so the nth recorded revision
+// is the nth token.
+func recordForeignFlywayVersions(c *qt.C, dbPath string, tokens []string) {
+	c.Helper()
+	db, err := sql.Open("sqlite", dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+
+	current := revisionVersionsByOrder(c, db)
+	// A fixture that rewrote a different number of rows than it meant to would
+	// leave the database on Ptah's own encoding and make every assertion below
+	// vacuous.
+	c.Assert(current, qt.HasLen, len(tokens))
+	for i, from := range current {
+		result, err := db.Exec(
+			`UPDATE atlas_schema_revisions SET version = ?, hash = ? WHERE version = ?`,
+			tokens[i], foreignFlywayHash, from,
+		)
+		c.Assert(err, qt.IsNil)
+		affected, err := result.RowsAffected()
+		c.Assert(err, qt.IsNil)
+		c.Assert(affected, qt.Equals, int64(1))
+	}
+	c.Assert(revisionVersionsByOrder(c, db), qt.DeepEquals, tokens)
+}
+
+func revisionVersionsByOrder(c *qt.C, db *sql.DB) []string {
+	c.Helper()
+	rows, err := db.Query(`SELECT version FROM atlas_schema_revisions ORDER BY CAST(version AS INTEGER)`)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Check(rows.Close(), qt.IsNil) }()
+	var out []string
+	for rows.Next() {
+		var version string
+		c.Assert(rows.Scan(&version), qt.IsNil)
+		out = append(out, version)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return out
+}
+
+// foreignFlywayFixture builds a hashed Flyway directory, applies it, and then
+// rewrites both revisions into the other implementation's spelling.
+//
+// The bodies are deliberately replayable. That is the shape the refusal exists
+// for: measured, a CREATE TABLE re-run fails loudly and strands a dirty
+// revision, but this pair re-runs at exit 0 and inserts the seed row a second
+// time with nothing in the exit status, stdout or `migrate status` saying so.
+func foreignFlywayFixture(c *qt.C) (dir, dbPath string) {
+	c.Helper()
+	root := c.TempDir()
+	dir = filepath.Join(root, "migrations")
+	dbPath = filepath.Join(root, "foreign.db")
+	writeAtlasApplyProjectMigration(c, dir, "V1__init.sql", "CREATE TABLE IF NOT EXISTS seeded (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V2__seed.sql", "INSERT INTO seeded (id) VALUES (1);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
+
+	recordForeignFlywayVersions(c, dbPath, []string{"1", "2"})
+	return dir, dbPath
+}
+
+// TestCompatMigrateApply_ForeignFlywayRevisionsRefused is the reproduction.
+//
+// Reverting the change prints `Migrating to version 4611686018427510315 from 2
+// pending migrations.` followed by `Migration complete.` at exit 0, and leaves
+// two rows in `seeded` where there was one.
+func TestCompatMigrateApply_ForeignFlywayRevisionsRefused(t *testing.T) {
+	c := qt.New(t)
+	dir, dbPath := foreignFlywayFixture(c)
+
+	_, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "another Atlas implementation")
+	// The mapping is printed per file, because the int64 appears in no file
+	// name and in no Atlas output: on its own it says nothing an operator can
+	// act on.
+	c.Assert(message, qt.Contains, foreignFlywayV1)
+	c.Assert(message, qt.Contains, foreignFlywayV2)
+	c.Assert(message, qt.Contains, "V1__init.sql")
+	c.Assert(message, qt.Contains, "V2__seed.sql")
+	// Nothing ran: the seed did not insert a second row, and the recorded
+	// versions are untouched, so there is no dirty revision to clear either.
+	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals, []string{"1", "2"})
+}
+
+// TestCompatMigrateApply_ForeignFlywayDryRunRefused covers the preview, which
+// was not merely uninformative but wrong.
+//
+// Reverting the change prints `Dry run mode: no changes will be made.` and
+// `Would have applied 2 migrations.` at exit 0 — a preview of work the database
+// has already done.
+func TestCompatMigrateApply_ForeignFlywayDryRunRefused(t *testing.T) {
+	c := qt.New(t)
+	dir, dbPath := foreignFlywayFixture(c)
+
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath, "--dry-run")
+
+	c.Assert(err, qt.IsNotNil, qt.Commentf("stdout:\n%s", stdout))
+	c.Assert(errorText(err)+stderr, qt.Contains, "another Atlas implementation")
+	c.Assert(stdout, qt.Not(qt.Contains), "Would have applied")
+}
+
+// migrateSetVersion pulls the version out of the route the refusal prints, so
+// a change to what is printed and a change to what works cannot drift apart.
+var migrateSetVersion = regexp.MustCompile("`migrate set ([0-9]+)`")
+
+// TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery runs the
+// route the refusal prints, verbatim, and then applies again.
+//
+// A refusal offering a repair nobody executed is the failure mode here, and the
+// hand-written UPDATE the pre-#982 refusal prints does NOT work across
+// implementations — measured, a bare version rewrite then fails with `migration
+// 4611686018427469511 checksum mismatch: stored <base64>, current <hex>`,
+// because the two also record the checksum differently. `migrate set` writes
+// whole rows, which is why it is the route offered.
+//
+// Reverting the change makes the first apply succeed, so no message is produced
+// and the regexp finds nothing: the test fails on the `qt.IsNotNil` above it.
+func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing.T) {
+	c := qt.New(t)
+	dir, dbPath := foreignFlywayFixture(c)
+
+	_, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNotNil)
+
+	message := errorText(err) + stderr
+	match := migrateSetVersion.FindStringSubmatch(message)
+	c.Assert(match, qt.HasLen, 2)
+	c.Assert(match[1], qt.Equals, foreignFlywayV2)
+	// The version alone does not say the route was OFFERED: the withdrawal
+	// names the same command while telling the reader not to run it. Both
+	// wordings have to be pinned or one can silently become the other.
+	c.Assert(message, qt.Contains, "adopt the versions this build uses:")
+	c.Assert(message, qt.Not(qt.Contains), "has no safe route here")
+
+	stdout, stderr, err := runCompat(
+		"migrate", "set", match[1],
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+dir+"?format=flyway",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+
+	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	// The seed did not run a second time.
+	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
+
+	// And the directory keeps working: a migration added afterwards applies.
+	writeAtlasApplyProjectMigration(c, dir, "V3__more.sql", "INSERT INTO seeded (id) VALUES (3);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 2)
+}
+
+// TestCompatMigrateApply_ForeignFlywayTokenWithLeadingSpace is the input that
+// separates reading the token the way the revision reader reads a recorded
+// version from reading it raw.
+//
+// `V 1__x.sql` is an ordinary migration to Atlas CE: measured, it prints
+// `-- migrating version  1` and records the version `[ 1]`, leading space and
+// all. Ptah's parseAtlasRevisionVersion trims before parsing, so that row comes
+// back as 1, and a comparison that did not trim the token would match nothing
+// and let the file run a second time.
+//
+// Reverting the strings.TrimSpace prints `Migrating to version
+// 4611686018427469511 from 2 pending migrations.` at exit 0 and inserts the
+// seed row twice.
+func TestCompatMigrateApply_ForeignFlywayTokenWithLeadingSpace(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "space.db")
+	writeAtlasApplyProjectMigration(c, dir, "V 1__init.sql", "CREATE TABLE IF NOT EXISTS spaced (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V 2__seed.sql", "INSERT INTO spaced (id) VALUES (1);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	recordForeignFlywayVersions(c, dbPath, []string{" 1", " 2"})
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(errorText(err)+stderr, qt.Contains, "another Atlas implementation")
+	c.Assert(countRows(c, dbPath, "spaced"), qt.Equals, 1)
+}
+
+// TestCompatMigrateApply_ForeignFlywayBaselineOverForeignHistory covers a cell
+// stokaro/ptah#1100 did not name and this change also closes.
+//
+// A baseline added to a directory another implementation has already applied is
+// not a re-run of the SAME file, it is a squash executed on top of the history
+// it squashes. Measured on the pinned community binary v1.3.0 with V1 and V2
+// recorded as `1` and `2` and B2__base.sql added: the binary prints `No
+// migration files to execute` at exit 0 and never creates the table, while
+// master ptah-compat prints `Migrating to version 122412 from 1 pending
+// migrations.` at exit 0 and creates it.
+//
+// The existing baseline refusal (stokaro/ptah#1003) does not reach this: it
+// looks for the CONVERTED version of a same-token migration in the applied set,
+// and on a foreign revision table that version is not there. The token
+// comparison is what sees it.
+//
+// Reverting the change prints `Migrating to version 122412 from 1 pending
+// migrations.` at exit 0 and leaves table base beside p and q.
+func TestCompatMigrateApply_ForeignFlywayBaselineOverForeignHistory(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "baseline.db")
+	writeAtlasApplyProjectMigration(c, dir, "V1__p.sql", "CREATE TABLE p (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V2__q.sql", "CREATE TABLE q (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	recordForeignFlywayVersions(c, dbPath, []string{"1", "2"})
+
+	writeAtlasApplyProjectMigration(c, dir, "B2__base.sql", "CREATE TABLE base (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "B2__base.sql")
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"p", "q"})
+
+	// The route the refusal prints settles this shape too: it removes nothing,
+	// and the baseline the community binary skips is recorded rather than run.
+	match := migrateSetVersion.FindStringSubmatch(message)
+	c.Assert(match, qt.HasLen, 2)
+	stdout, stderr, err = runCompat(
+		"migrate", "set", match[1],
+		"--url", "sqlite://"+dbPath,
+		"--dir", "file://"+dir+"?format=flyway",
+	)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"p", "q"})
+}
+
+// TestCompatMigrateApply_ForeignFlywaySetRouteWithdrawnWhenUnsafe is the input
+// that separates offering the route from offering it unconditionally.
+//
+// `migrate set V` moves the database to EXACTLY V and removes every revision
+// above it. A converted baseline sits in the LOW band — B2__base.sql becomes
+// 122412 — and a baseline squashes files whose token sorts at or below its own
+// AS A STRING, so `V1000000__z.sql` ("1000000" < "2") is squashed out of the
+// covered set while its revision row, 1000000, sits far above the head. Printing
+// `migrate set 122412` there would delete the migration the database ran.
+//
+// Reverting the withdrawal prints `- adopt the versions this build uses:
+// `migrate set 122412` ... records every migration up to and including that
+// version as applied`, which is a command that retires revision 1000000.
+func TestCompatMigrateApply_ForeignFlywaySetRouteWithdrawnWhenUnsafe(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "unsafe.db")
+	writeAtlasApplyProjectMigration(c, dir, "V2__q.sql", "CREATE TABLE q (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V1000000__z.sql", "CREATE TABLE z (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	recordForeignFlywayVersions(c, dbPath, []string{"2", "1000000"})
+
+	writeAtlasApplyProjectMigration(c, dir, "B2__base.sql", "CREATE TABLE base (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "has no safe route here")
+	// The row it would have deleted is named, so the claim can be checked.
+	c.Assert(message, qt.Contains, "1000000")
+	c.Assert(message, qt.Not(qt.Contains), "adopt the versions this build uses:")
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"q", "z"})
+}
+
+// TestCompatMigrateApply_ForeignFlywayTokenIsAlsoAConvertedVersion is the input
+// that separates the rule that shipped from the looser one it could have been.
+//
+// A source token and a converted version share the int64 space, and a baseline
+// converts into the LOW band: B10__base.sql becomes 448844. A directory that
+// also holds V448844__x.sql therefore has a token equal to a version this same
+// directory produces, so recording 448844 says nothing about which
+// implementation wrote the row — and here THIS build wrote it, by applying the
+// baseline alone.
+//
+// Reverting the third clause prints `this database records converted Flyway
+// migrations under their SOURCE version token ... 448844 ->
+// 4611686036742059283  V448844__x.sql` at exit 1 on a database ptah-compat had
+// just written itself, and leaves table cv uncreated.
+func TestCompatMigrateApply_ForeignFlywayTokenIsAlsoAConvertedVersion(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "collide.db")
+	writeAtlasApplyProjectMigration(c, dir, "B10__base.sql", "CREATE TABLE cb (id INTEGER PRIMARY KEY);")
+	writeAtlasApplyProjectMigration(c, dir, "V448844__x.sql", "CREATE TABLE cv (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	// The baseline sorts first, so one migration is exactly the baseline.
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath, "1")
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(revisionVersions(c, dbPath), qt.DeepEquals, []string{"448844"})
+
+	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"cb", "cv"})
+}
+
+// TestCompatMigrateApply_ForeignFlywayRepeatableCarriesNoToken is the input
+// that separates reporting Atlas CE's version for a file from reporting the
+// file's own token.
+//
+// Every repeatable is version "" to Atlas CE whatever its name, so `R2__r.sql`
+// is not a migration CE ever records as `2`. Reporting its own token instead
+// pairs it with any revision row that happens to be `2` and refuses a database
+// on the strength of a file that cannot have written that row.
+//
+// The database here carries BOTH spellings of `V2__q.sql` — the shape an
+// operator who inserted the new row instead of moving the old one leaves behind
+// — so V2 itself is settled and the stray `2` is the only thing left to blame.
+// The repeatable is then added, unapplied, so only the token decides.
+//
+// A repeatable added beside an applied `V2` IS refused, by the out-of-order
+// guard, and that is the refusal Atlas CE reports for the same directory: its
+// empty version sorts below the mark it compares against (stokaro/ptah#1098).
+// So the assertion is on WHICH refusal speaks, not on whether one does.
+//
+// Reverting flywayCEVersion to file.version reports `this database records
+// converted Flyway migrations under their SOURCE version token ... 2 ->
+// 9223372036854775807  R2__r.sql` instead, blaming a file that cannot have
+// written the row `2` and hiding the diagnosis CE agrees with.
+func TestCompatMigrateApply_ForeignFlywayRepeatableCarriesNoToken(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	dbPath := filepath.Join(root, "repeatable.db")
+	writeAtlasApplyProjectMigration(c, dir, "V2__q.sql", "CREATE TABLE rq (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+	stdout, stderr, err := compatApplyConverted(dir, "flyway", dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+
+	// The row the other implementation would have written for V2, left beside
+	// the one this build wrote rather than replacing it.
+	copyRevisionRow(c, dbPath, foreignFlywayV2, "2")
+	writeAtlasApplyProjectMigration(c, dir, "R2__r.sql", "CREATE TABLE rr (id INTEGER PRIMARY KEY);")
+	hashConvertedApplyDir(c, dir, "flyway")
+
+	_, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	message := errorText(err) + stderr
+	c.Assert(message, qt.Contains, "out-of-order pending migrations")
+	c.Assert(message, qt.Not(qt.Contains), "SOURCE version token")
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"rq"})
+}
+
+// foreignFlywayCase is one database that must keep applying.
+type foreignFlywayCase struct {
+	name   string
+	format string
+	// seed leaves the database and directory in the state under test.
+	seed func(c *qt.C, dir, dbPath string)
+	// added is written after the seed, then the directory is re-hashed.
+	added []flywayMigration
+	// tables is the full set of user tables expected afterwards.
+	tables []string
+}
+
+// TestCompatMigrateApply_ForeignFlywayDetectorDoesNotOverRefuse covers the
+// databases that must keep working. The detector keys on a file's SOURCE token
+// being recorded while the version that file converts to is NOT, so a database
+// this build wrote, a fresh one, and an ordinary baseline squash all pass
+// through it.
+//
+// Every row here passes on master too — that is the point of a non-interference
+// control. What each row would print under a BROKEN version of the check is
+// stated on the row.
+func TestCompatMigrateApply_ForeignFlywayDetectorDoesNotOverRefuse(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []foreignFlywayCase{{
+		// Dropping the `slices.Contains(applied, migration.Version)` clause
+		// refuses this one: `1 already-applied migration(s) read as pending`.
+		name:   "a database migrated only by this build",
+		format: "flyway",
+		seed: seedFlyway(
+			flywayMigration{"V1__one.sql", "CREATE TABLE h1 (id INTEGER PRIMARY KEY);"},
+		),
+		added:  []flywayMigration{{"V2__two.sql", "CREATE TABLE h2 (id INTEGER PRIMARY KEY);"}},
+		tables: []string{"h1", "h2"},
+	}, {
+		// Dropping the `len(applied) == 0` early return leaves this unchanged,
+		// so this row is a control rather than a discriminator: a fresh install
+		// of a converted directory has to keep working at all.
+		name:   "a fresh database",
+		format: "flyway",
+		seed:   seedNothing,
+		added: []flywayMigration{
+			{"V1__one.sql", "CREATE TABLE f1 (id INTEGER PRIMARY KEY);"},
+			{"V2__two.sql", "CREATE TABLE f2 (id INTEGER PRIMARY KEY);"},
+		},
+		tables: []string{"f1", "f2"},
+	}, {
+		// The ordinary Flyway squash. B3 retires V2 from the covered set, so the
+		// only recorded version belongs to no covered file at all. A rule phrased
+		// as "a recorded version no converted file produces" — the shape the
+		// issue sketched — refuses this, and Atlas CE executes it.
+		name:   "a baseline that retires the applied history",
+		format: "flyway",
+		seed: seedFlyway(
+			flywayMigration{"V2__s2.sql", "CREATE TABLE b2 (id INTEGER PRIMARY KEY);"},
+		),
+		added:  []flywayMigration{{"B3__base.sql", "CREATE TABLE bbase (id INTEGER PRIMARY KEY);"}},
+		tables: []string{"b2", "bbase"},
+	}, {
+		// The layout gate. A goose directory is hashed over every .sql it holds
+		// — measured, the pinned community binary covers both files below — but
+		// goose executes only 1_a.sql, recording version 1. Removing the
+		// FormatFlyway guard inside FlywayCoveredSourceVersions makes V1__x.sql
+		// report token "1" against converted version 4611686018427469511, and
+		// this apply refuses with `1 already-applied migration(s) read as
+		// pending` on a goose database that has nothing to do with Flyway.
+		name:   "a goose directory holding a Flyway-shaped file",
+		format: "goose",
+		seed: seedGoose(
+			flywayMigration{"1_a.sql", "-- +goose Up\nCREATE TABLE ga (id INTEGER PRIMARY KEY);"},
+			flywayMigration{"V1__x.sql", "CREATE TABLE gv (id INTEGER PRIMARY KEY);"},
+		),
+		added:  []flywayMigration{{"2_b.sql", "-- +goose Up\nCREATE TABLE gb (id INTEGER PRIMARY KEY);"}},
+		tables: []string{"ga", "gb"},
+	}}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			dir := filepath.Join(root, "migrations")
+			dbPath := filepath.Join(root, "keep.db")
+			test.seed(c, dir, dbPath)
+			writeFlywayMigrations(c, dir, test.added)
+			hashConvertedApplyDir(c, dir, test.format)
+
+			stdout, stderr, err := compatApplyConverted(dir, test.format, dbPath)
+
+			c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+			c.Assert(userTables(c, dbPath), qt.DeepEquals, test.tables)
+		})
+	}
+}
+
+// seedGoose applies goose files first, leaving recorded migration history.
+func seedGoose(files ...flywayMigration) func(c *qt.C, dir, dbPath string) {
+	return func(c *qt.C, dir, dbPath string) {
+		c.Helper()
+		writeFlywayMigrations(c, dir, files)
+		hashConvertedApplyDir(c, dir, "goose")
+		stdout, stderr, err := compatApplyConverted(dir, "goose", dbPath)
+		c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+		// A seed that recorded nothing would make the row vacuous: the check
+		// under test returns early on a database with no history.
+		c.Assert(revisionVersions(c, dbPath), qt.Not(qt.HasLen), 0)
+	}
+}

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -359,14 +359,86 @@ Run them against the schema `--revisions-schema` selects, then re-run the
 apply. Rewriting the version column is enough on its own: the recorded hash
 covers the converted SQL body, which this change does not touch.
 
-The statements have to be run by hand because `migrate set` and `migrate
-status` do not yet accept `?format=`
-([#1002](https://github.com/stokaro/ptah/issues/1002)), and `--baseline`
-refuses once the revision table is non-empty.
+`--baseline` refuses once the revision table is non-empty, so the rewrite is the
+route for this case. Both encodings are Ptah's own, which is what makes moving
+the version column sufficient.
 
 Without the refusal this is not reliably loud: re-running a `CREATE TABLE`
 fails and leaves a dirty revision, but re-running a backfill or a seed
 succeeds, exits 0, and duplicates the rows.
+:::
+
+:::danger[A revision table written by another Atlas implementation]
+The two implementations record a **converted** Flyway migration under different
+versions. Atlas CE identifies a migration by an opaque version string and stores
+the Flyway token verbatim; Ptah's migrator identifies one by an `int64`, so the
+importer projects the token onto a number. Measured on Atlas CE v1.3.0 against
+sqlite, on a directory holding `V1__a.sql` and `V2__b.sql`:
+
+| Applied by | Versions recorded in `atlas_schema_revisions` |
+| --- | --- |
+| Atlas CE | `1`, `2` |
+| `ptah-compat` | `4611686018427469511`, `4611686018427510315` |
+
+One direction is harmless. Atlas CE reads a table `ptah-compat` wrote as already
+ahead of the directory and prints `No migration files to execute` at exit 0. The
+other is not: every converted file matches no row, the whole directory reads as
+pending, and the migrations run a second time.
+
+That second run is not reliably loud either. A `CREATE TABLE` fails and strands
+a dirty revision, but `CREATE TABLE IF NOT EXISTS` followed by a seed re-runs at
+exit 0 and inserts the row twice, with nothing in the exit status, on stdout, or
+in `migrate status` saying so.
+
+`migrate apply` — and `--dry-run`, which previewed the same re-run — refuses that
+database before executing anything
+([#1100](https://github.com/stokaro/ptah/issues/1100)):
+
+```text
+error: this database records converted Flyway migrations under their SOURCE
+version token, which is how another Atlas implementation identifies them ...
+2 already-applied migration(s) read as pending here and would run a second
+time. Nothing has been applied
+
+recorded version -> version this build uses:
+  1                    -> 4611686018427469511  V1__init.sql
+  2                    -> 4611686018427510315  V2__seed.sql
+```
+
+Two ways forward, both measured:
+
+- Keep applying that database with the implementation that wrote its revision
+  table. It reads its own versions and is unaffected.
+- Adopt the versions this build uses. The refusal prints
+  `migrate set <head version>`; run it with the same `--dir` and `--url`, and
+  Atlas CE still reads the result as up to date afterwards.
+
+The second route is withdrawn, by name, on the one shape where it would destroy
+history. `migrate set` moves the database to exactly the version given and
+removes the revisions above it, and a converted baseline lands in a low band, so
+a directory whose head is a baseline can have real revisions above it. The
+refusal then says there is no safe route and names the rows the command would
+have deleted.
+
+A baseline added to a directory another implementation has already applied is
+covered by the same refusal, and it is not the same defect: nothing re-runs, a
+squashed schema executes on top of the history it squashes. Measured, Atlas CE
+prints `No migration files to execute` there while `ptah-compat` created the
+table.
+
+Rewriting the version column by hand is **not** enough here, unlike the upgrade
+above. The two implementations also record the migration checksum differently —
+a base64 `h1` digest against a hex SHA-256 — so a bare version rewrite fails the
+next apply with `checksum mismatch`. `migrate set` writes the whole revision row.
+
+`migrate status` is deliberately left alone. Its counts run over three different
+sets on a mismatched revision table, so they can sum above the total, and
+measured, Atlas CE reports the equivalent input the same way.
+
+Only Flyway is affected, measured across all five converted layouts. Goose
+records `00001` where Ptah records `1`, and those meet when the revision reader
+parses them; golang-migrate, dbmate and liquibase record identical versions on
+both tools.
 :::
 
 ## Replay on a dev database

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -405,20 +405,41 @@ recorded version -> version this build uses:
   2                    -> 4611686018427510315  V2__seed.sql
 ```
 
-Two ways forward, both measured:
+Two ways forward, both measured. They are **alternatives, not steps** — taking
+the second closes the first:
 
 - Keep applying that database with the implementation that wrote its revision
   table. It reads its own versions and is unaffected.
 - Adopt the versions this build uses. The refusal prints
-  `migrate set <head version>`; run it with the same `--dir` and `--url`, and
-  Atlas CE still reads the result as up to date afterwards.
+  `migrate set <head version>`; run it with the same `--dir` and `--url`.
 
-The second route is withdrawn, by name, on the one shape where it would destroy
-history. `migrate set` moves the database to exactly the version given and
-removes the revisions above it, and a converted baseline lands in a low band, so
-a directory whose head is a baseline can have real revisions above it. The
-refusal then says there is no safe route and names the rows the command would
-have deleted.
+`migrate set` records this build's versions and does **not** remove the source
+tool's, so the revision table then carries both spellings. Measured on
+`V1__a.sql` and `V2__b.sql` recorded by Atlas CE as `1` and `2`: right after the
+route, Atlas CE v1.3.0 still prints `No migration files to execute` at exit 0 —
+but add `V3__c.sql` and it prints
+`migration file V3__c.sql was added out of order` at exit 1, while `ptah-compat`
+applies it at exit 0. The controls separate that from the added file: the same
+three-file directory on a fresh database, and on a database carrying only CE's
+`1`,`2`, both apply at exit 0 on Atlas CE. So the switch is one way, and the
+refusal says so rather than calling the result up to date.
+
+The second route is withdrawn, by name, on the two shapes where `migrate set`
+is not a no-op. It moves the database to exactly the version given, which both
+**removes** the revisions above it and **records** every covered migration below
+it, run or not:
+
+- A converted baseline lands in a low band, so a directory whose head is a
+  baseline can have real revisions above it. The refusal names the rows the
+  command would have deleted.
+- The head is the largest version among the migrations the other implementation
+  *ran*, and the covered migrations below it need not all be among them.
+  Measured on `V1__g1.sql` and `V3__g3.sql` recorded as `1` and `3` with
+  `V2__g2.sql` added afterwards: `migrate set 4611686018427551119` reports
+  `(3 set)`, the next apply prints `No migration files to execute.` at exit 0,
+  and table `g2` is absent with its version recorded — it can never run again.
+  The refusal names that file and the version the command would assert, so
+  nothing is lost by following the printed instruction.
 
 A baseline added to a directory another implementation has already applied is
 covered by the same refusal, and it is not the same defect: nothing re-runs, a

--- a/internal/atlasmigrateimport/importer.go
+++ b/internal/atlasmigrateimport/importer.go
@@ -1057,6 +1057,62 @@ func FlywaySourceVersions(fsys fs.FS, format Format) (map[int64]string, error) {
 	return sources, nil
 }
 
+// FlywayCoveredSourceVersion carries both spellings one executed Flyway
+// migration has: the version token the source tool identifies it by, and the
+// int64 Ptah's migrator executes and records it under.
+//
+// It is a list entry rather than a map key because the file name is the third
+// operand and the only one an operator can find in their directory —
+// 4611686018427510315 appears in no file name and in no Atlas output.
+type FlywayCoveredSourceVersion struct {
+	// Source is the file name, relative to the migration directory.
+	Source string
+	// Token is Atlas CE's version string for the file: "10" for B10__base.sql,
+	// "02" for V02__q.sql, and "" for every repeatable. See [flywayCEVersion].
+	Token string
+	// Version is the Atlas version the converted entry executes and is
+	// recorded under.
+	Version int64
+}
+
+// FlywayCoveredSourceVersions reports both spellings for every Flyway migration
+// this directory would execute, in execution order. It returns nil for every
+// other layout.
+//
+// [FlywaySourceVersions] answers the same question keyed the other way round
+// and cannot be substituted here for two reasons. It is keyed BY the converted
+// version, so it cannot name the file a token belongs to; and it deliberately
+// also carries the tokens of migrations a surviving baseline has SQUASHED out
+// of this directory, which is right for the linear guard (a squashed row still
+// sets the high-water mark) and wrong for a caller asking which of the
+// migrations it is about to RUN a database has already run under another name.
+//
+// Both share flywayCoveredFiles and flywayConvertedVersions with the importer,
+// so the token reported for a version belongs to the entry actually executed
+// under it.
+func FlywayCoveredSourceVersions(fsys fs.FS, format Format) ([]FlywayCoveredSourceVersion, error) {
+	if format != FormatFlyway {
+		return nil, nil
+	}
+	covered, err := flywayCoveredFiles(fsys)
+	if err != nil {
+		return nil, err
+	}
+	versions, err := flywayConvertedVersions(covered)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]FlywayCoveredSourceVersion, len(covered))
+	for i, file := range covered {
+		out[i] = FlywayCoveredSourceVersion{
+			Source:  file.name,
+			Token:   flywayCEVersion(file),
+			Version: versions[i],
+		}
+	}
+	return out, nil
+}
+
 // flywaySquashedSourceVersions reports the tokens of the migrations a surviving
 // baseline has retired from this directory's covered set, keyed by the Atlas
 // version a database that ran them recorded.

--- a/scripts/mutations/foreign-flyway-revisions.json
+++ b/scripts/mutations/foreign-flyway-revisions.json
@@ -91,8 +91,8 @@
     {
       "name": "the offer still calls the result up to date instead of one way",
       "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
-      "old": "\"already run, so nothing is recorded that did not execute. It is a one-way switch: the revision \"+\n\t\t\t\"table then carries both spellings, and the implementation that wrote it refuses a migration \"+\n\t\t\t\"added afterwards as out of order.\\n\", head, len(stale))",
-      "new": "\"already run. The other implementation still reads the result as up to date.\\n\", head, len(stale))"
+      "old": "\"versions. On this database every migration it would record has already run here, so nothing \"+\n\t\t\t\"is recorded that did not execute. It is a one-way switch: the revision table then carries \"+\n\t\t\t\"both spellings, and the implementation that wrote it refuses a migration added afterwards \"+\n\t\t\t\"as out of order.\\n\", head)",
+      "new": "\"versions. The other implementation still reads the result as up to date.\\n\", head)"
     },
     {
       "name": "every converted layout is checked, not only Flyway",

--- a/scripts/mutations/foreign-flyway-revisions.json
+++ b/scripts/mutations/foreign-flyway-revisions.json
@@ -49,14 +49,50 @@
     {
       "name": "the destructive migrate set is printed anyway",
       "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
-      "old": "\tif len(removed) == 0 {\n\t\treturn fmt.Sprintf(",
-      "new": "\tif true {\n\t\t_ = removed\n\t\treturn fmt.Sprintf("
+      "old": "\tif len(removed) == 0 && len(unrun) == 0 {",
+      "new": "\tif len(unrun) == 0 {\n\t\t_ = removed"
+    },
+    {
+      "name": "the lossy migrate set is printed anyway",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\tif len(removed) == 0 && len(unrun) == 0 {",
+      "new": "\tif len(removed) == 0 {\n\t\t_ = unrun"
     },
     {
       "name": "INVERSE: the migrate set route is never offered",
       "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
-      "old": "\tif len(removed) == 0 {\n\t\treturn fmt.Sprintf(",
-      "new": "\tif false {\n\t\treturn fmt.Sprintf("
+      "old": "\tif len(removed) == 0 && len(unrun) == 0 {",
+      "new": "\tif false {\n\t\t_, _ = removed, unrun"
+    },
+    {
+      "name": "the migrations the route would assert unrun are never named",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\t\tlabels = append(labels, fmt.Sprintf(\"%s (%d)\", migration.Source, migration.Version))",
+      "new": "\t\t\tlabels = append(labels, \"a migration\")\n\t\t\t_ = migration"
+    },
+    {
+      "name": "a migration above the head is counted as one the route would record",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif migration.Version > head {\n\t\t\tcontinue\n\t\t}\n",
+      "new": ""
+    },
+    {
+      "name": "only the other implementation's rows count as executed",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif slices.Contains(applied, migration.Version) || slices.Contains(ran, migration.Version) {",
+      "new": "\t\tif slices.Contains(ran, migration.Version) {"
+    },
+    {
+      "name": "only this build's own rows count as executed",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif slices.Contains(applied, migration.Version) || slices.Contains(ran, migration.Version) {",
+      "new": "\t\tif slices.Contains(applied, migration.Version) {\n\t\t\t_ = ran"
+    },
+    {
+      "name": "the offer still calls the result up to date instead of one way",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\"already run, so nothing is recorded that did not execute. It is a one-way switch: the revision \"+\n\t\t\t\"table then carries both spellings, and the implementation that wrote it refuses a migration \"+\n\t\t\t\"added afterwards as out of order.\\n\", head, len(stale))",
+      "new": "\"already run. The other implementation still reads the result as up to date.\\n\", head, len(stale))"
     },
     {
       "name": "every converted layout is checked, not only Flyway",

--- a/scripts/mutations/foreign-flyway-revisions.json
+++ b/scripts/mutations/foreign-flyway-revisions.json
@@ -1,0 +1,74 @@
+{
+  "packages": [
+    "./cmd/atlas/",
+    "./internal/atlasmigrateimport/"
+  ],
+  "mutations": [
+    {
+      "name": "the refusal is never reached",
+      "file": "cmd/atlas/migrate_apply.go",
+      "old": "\tif err := checkForeignFlywayRevisions(captured, resolvedDirFormat, plan); err != nil {\n\t\treturn err\n\t}",
+      "new": "\t_ = checkForeignFlywayRevisions"
+    },
+    {
+      "name": "a database already migrated forward is flagged again",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif !slices.Contains(applied, recorded) || slices.Contains(applied, migration.Version) {",
+      "new": "\t\tif !slices.Contains(applied, recorded) {"
+    },
+    {
+      "name": "a source token nobody recorded is treated as foreign history",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif !slices.Contains(applied, recorded) || slices.Contains(applied, migration.Version) {",
+      "new": "\t\tif slices.Contains(applied, migration.Version) {"
+    },
+    {
+      "name": "INVERSE: a token that is also a converted version is read as foreign history",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\tif slices.Contains(ours, recorded) {\n\t\t\tcontinue\n\t\t}\n",
+      "new": ""
+    },
+    {
+      "name": "the token is read raw instead of the way the revision reader reads it",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\trecorded, err := strconv.ParseInt(strings.TrimSpace(migration.Token), 10, 64)",
+      "new": "\t\trecorded, err := strconv.ParseInt(migration.Token, 10, 64)"
+    },
+    {
+      "name": "the refused file is never named",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\t\tsource:   migration.Source,",
+      "new": "\t\t\tsource:   \"\","
+    },
+    {
+      "name": "the route names the first stale version instead of the head",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\t\thead = max(head, revision.current)",
+      "new": "\t\tif head == 0 {\n\t\t\thead = revision.current\n\t\t}"
+    },
+    {
+      "name": "the destructive migrate set is printed anyway",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\tif len(removed) == 0 {\n\t\treturn fmt.Sprintf(",
+      "new": "\tif true {\n\t\t_ = removed\n\t\treturn fmt.Sprintf("
+    },
+    {
+      "name": "INVERSE: the migrate set route is never offered",
+      "file": "cmd/atlas/migrate_apply_foreign_flyway.go",
+      "old": "\tif len(removed) == 0 {\n\t\treturn fmt.Sprintf(",
+      "new": "\tif false {\n\t\treturn fmt.Sprintf("
+    },
+    {
+      "name": "every converted layout is checked, not only Flyway",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "func FlywayCoveredSourceVersions(fsys fs.FS, format Format) ([]FlywayCoveredSourceVersion, error) {\n\tif format != FormatFlyway {\n\t\treturn nil, nil\n\t}",
+      "new": "func FlywayCoveredSourceVersions(fsys fs.FS, format Format) ([]FlywayCoveredSourceVersion, error) {\n\t_ = format"
+    },
+    {
+      "name": "a repeatable reports its own token instead of Atlas CE's empty version",
+      "file": "internal/atlasmigrateimport/importer.go",
+      "old": "\t\t\tToken:   flywayCEVersion(file),",
+      "new": "\t\t\tToken:   file.version,"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #1100.

The issue offered three shapes and asked for an argument. This is **shape 1, refuse rather than re-run**, and the argument is below along with the two cells the issue did not measure.

## The reproduction, before

Re-measured on `f22107bd` (the commit this work started from; the branch is now rebased onto `028ac05d`, whose delta is unrelated compat/lint work) against the pinned community build `v1.3.0` by absolute path, sqlite, every cell in its own database so no cell can be polluted by the one before it.

```
d/V1__a.sql   CREATE TABLE t1 (id int);
d/V2__b.sql   CREATE TABLE t2 (id int);
atlas migrate hash --dir 'file://d?format=flyway'
```

| | recorded versions |
|---|---|
| applied by the community binary | `1`, `2` |
| applied by `ptah-compat` | `4611686018427469511`, `4611686018427510315` |

```
$ ptah-compat migrate apply --dir 'file://d?format=flyway' --url sqlite://ce.db
Migrating to version 4611686018427510315 from 2 pending migrations.
Error: error applying migrations: failed to apply migration 4611686018427469511: failed to
execute migration SQL: sqlite: SQL execution failed: SQL logic error: table t1 already exists (1)
exit=1

$ atlas migrate apply --dir 'file://d?format=flyway' --url sqlite://ce.db
No migration files to execute
exit=0
```

**The loud half is the lucky half.** With bodies that replay, the same cell exits 0 and duplicates data:

```
d/V1__t.sql   CREATE TABLE IF NOT EXISTS seed (id int);
d/V2__s.sql   INSERT INTO seed (id) VALUES (7);

community binary applies -> rows in seed: 1
$ ptah-compat migrate apply --dir 'file://d?format=flyway' --url sqlite://x.db
Migrating to version 4611686018427510315 from 2 pending migrations.
Migration complete. Current version: 4611686018427510315
exit=0
rows in seed: 2
```

Controls, all clean: the community binary re-reading its own database, `ptah-compat` re-reading its own, and the community binary reading a `ptah-compat`-written table all print `No migration files to execute` at exit 0 with the seed row still at 1. A native (non-`?format=`) Atlas directory is unaffected in both directions. `--dry-run` printed `Would have applied 2 migrations.` at exit 0 — a preview of work the database had already done.

## Two cells the issue did not name

**A baseline over a foreign revision table.** Nothing re-runs here; a squashed schema executes on top of the history it squashes. `V1`,`V2` applied by the community binary, then `B2__base.sql` added:

| | exit | tables after |
|---|---|---|
| pinned community binary | 0, `No migration files to execute` | `p`, `q` |
| `ptah-compat` on base | 0, `Migrating to version 122412 from 1 pending migrations.` | `p`, `q`, **`base`** |

The existing #1003 baseline refusal does not reach this: it looks for the CONVERTED version of a same-token migration in the applied set, and on a foreign table that version is not there. The token comparison is what sees it.

**The other four converted layouts.** The issue asked; measured, only Flyway re-executes.

| format | community binary records | `ptah-compat` records | `ptah-compat` on the community database |
|---|---|---|---|
| flyway | `1`, `2` | `4611686018427469511`, … | **re-executes** |
| goose | `00001`, `00002` | `1`, `2` | exit 0, nothing to execute |
| golang-migrate | `1`, `2` | `1`, `2` | exit 1, `checksum mismatch` |
| dbmate | `20240101000001`, … | identical | exit 1, `checksum mismatch` |
| liquibase | `1`, `2` | `1`, `2` | exit 1, `checksum mismatch` |

The three `checksum mismatch` rows are a **second, independent divergence** — the two implementations record the digest in different encodings (`stored 9mRxDpig…=`, `current ca5446be…`). It is a refusal, not a re-execution, so it is out of scope here and named in "left open" below.

## The reproduction, after

```
$ ptah-compat migrate apply --dir 'file://d?format=flyway' --url sqlite://ce.db
Error: this database records converted Flyway migrations under their SOURCE version token, which
is how another Atlas implementation identifies them; Ptah's migrator identifies a migration by the
int64 that token projects to, so 2 already-applied migration(s) read as pending here and would run
a second time. Nothing has been applied

recorded version -> version this build uses:
  1                    -> 4611686018427469511  V1__a.sql
  2                    -> 4611686018427510315  V2__b.sql

ways forward:
  - keep applying this database with the implementation that wrote the table: it reads its own
    versions and is unaffected
  - adopt the versions this build uses: `migrate set 4611686018427510315`, with the same --dir and
    --url, records every migration up to and including that version as applied under those
    versions. On this database every migration it would record has already run here, so nothing
    is recorded that did not execute. It is a one-way switch: the revision table then carries
    both spellings, and the implementation that wrote it refuses a migration added afterwards
    as out of order.

rewriting the version column by hand is not enough: the two implementations also record the
migration checksum differently, so an apply after a bare version rewrite refuses with a checksum
mismatch. `migrate set` writes the whole revision row.
exit=1
```

Every control above still prints what it printed before. `--dry-run` refuses instead of previewing. The seed row stays at 1.

## The route the refusal prints, re-measured

Two blocking findings were raised against the **recovery advice**, not the refusal. Both are real, both were reproduced here, and both are fixed.

**It dropped a migration.** `migrate set V` does not only remove revisions above `V`; it writes a revision row for **every covered migration up to `V`**, run or not. The head is the largest version among the migrations the other implementation *ran*, and the covered migrations below it need not all be among them. `V1__g1.sql` and `V3__g3.sql` recorded as `1`,`3` with `V2__g2.sql` added afterwards, following the printed route verbatim:

```
before      revisions: [1 3]      tables: [g1 g3]
$ ptah-compat migrate set 4611686018427551119 --dir 'file://d?format=flyway' --url sqlite://gap.db
Current version is 4611686018427551119 (3 set):
  + 4611686018427469511 (g1)
  + 4611686018427510315 (g2)
  + 4611686018427551119 (g3)
$ ptah-compat migrate apply --dir 'file://d?format=flyway' --url sqlite://gap.db
No migration files to execute.
exit=0
after       revisions: [1 3 4611686018427469511 4611686018427510315 4611686018427551119]
            tables: [g1 g3]
```

`g2` is absent and its version is recorded, so it can never run. The refusal said nothing. On that five-row table the pinned community binary also exits 1: `migration file V2__g2.sql was added out of order`.

The route is now offered only when it removes nothing **and** records nothing that did not execute, and withdrawn otherwise with the rows named:

```
adopting the versions this build uses has no safe route here: `migrate set 4611686018427551119`
would move the database to exactly that version, and on this database that is not a no-op:
  - it would record 1 migration(s) as applied WITHOUT running them — V2__g2.sql
    (4611686018427510315) — so that SQL would never execute here and nothing afterwards would
    report it missing
```

Nothing runs and nothing is recorded: `revisions [1 3]`, `tables [g1 g3]`, exactly where the other implementation left it.

**"The other implementation still reads the result as up to date" was false.** Measured on `V1__a.sql`,`V2__b.sql` recorded as `1`,`2`, after taking the route (`revisions [1 2 4611686018427469511 4611686018427510315]`):

```
$ atlas migrate apply --dir 'file://d?format=flyway'  --url sqlite://after-route.db
No migration files to execute
exit=0
$ atlas migrate apply --dir 'file://d3?format=flyway' --url sqlite://after-route.db   # + V3__c.sql
Error: migration file V3__c.sql was added out of order.
exit=1
$ ptah-compat migrate apply --dir 'file://d3?format=flyway' --url sqlite://after-route.db
Migrating to version 4611686018427551119 from 1 pending migrations.
Migration complete. Current version: 4611686018427551119
exit=0
```

Controls, both clean, separating that from the added file itself: the same three-file directory on a **fresh** database applies at exit 0 on the pinned binary, and on a database carrying only `1`,`2` it applies `V3` at exit 0. So the refusal now says the switch is **one way** and the two ways forward are alternatives, not steps.

That state is **not created by this change**. With the refusal call removed from `migrate_apply.go`, a plain apply over the same foreign table lands on the identical four-row set:

```
BASE before: [1 2]
BASE apply : Migrating to version 4611686018427510315 from 2 pending migrations. / Migration complete.
BASE after : [1 2 4611686018427469511 4611686018427510315]
```

So base reaches it by accident on every apply; this branch removes the accidental path and leaves a deliberate, disclosed one. `TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery` no longer ends by adding a migration and asserting it applies — that assertion pinned `ptah-compat` exiting 0 where the pinned binary exits 1 as the desired result.

## Why shape 1, and what it costs

**Chosen: (b) over matching, and it is stated rather than buried.** The community binary exits 0 on that database, so refusing exits **1 where the pinned binary exits 0**. That is the allowed direction — half (a) is untouched, because nothing here makes `ptah-compat` exit 0 where the binary exits 1. Shapes 2 and 3 are the same change seen from two ends: the revision table is keyed on the int64 either way, so "record the token alongside" still needs the migrator's identity model to consult it. Shape 1 closes the data-safety edge without touching the projection.

**The rule, and the looser one it is not.** "A recorded version no converted file produces" — the phrasing the issue sketched — refuses an ordinary baseline squash, which retires applied migrations by design. The rule that shipped is narrower: a file's SOURCE token is recorded **and** the version that file converts to is not.

**The issue's stated cost is milder than it assumed, but only just.** It expected shape 1 to leave "an operator who switches tools with a directory neither can move forward". Measured, there is a route on the databases where it costs nothing: `migrate set <head>` records the history under this build's versions. It is a **one-way** switch, not a bridge — see the section above — and it is withdrawn entirely on the shapes where it loses something. So the refusal is a stop with a way out on most databases and a plain stop on the rest, which is closer to the issue's expectation than the first draft of this branch claimed.

**The route is measured, not inferred.** Running `migrate set <head>` on the reproduction: `(2 set)`, nothing removed, nothing recorded that did not execute, the next apply prints `No migration files to execute.` with the seed row still at 1, and the pinned community binary afterwards prints `No migration files to execute` at exit 0. A test runs the route verbatim and then asserts the resulting revision set, so "nothing is recorded that did not execute" is checked against what the command wrote rather than against the sentence. The hand-written `UPDATE` the pre-#982 refusal prints is deliberately **not** offered: measured, a bare version rewrite then fails with `migration 4611686018427469511 checksum mismatch`.

**The route is withdrawn on both shapes where `migrate set` is not a no-op.** It *removes* the revisions above the version given and *records* every covered migration below it:

- **Removes.** A converted baseline lands in a low band. On `V2` + `V1000000__z.sql` recorded by the community binary with `B2__base.sql` added, the head is `122412` and `1000000` sits above it; the refusal names the row the command would have deleted.
- **Records unrun.** `V1__g1.sql`,`V3__g3.sql` recorded as `1`,`3` with `V2__g2.sql` added; the refusal names `V2__g2.sql (4611686018427510315)` as a migration the command would assert without running.

Two inputs keep that from over-refusing: a migration **above** the head stays pending and is untouched by `migrate set`, and a migration this build recorded **itself** has run even though the foreign half of the table does not say so. Both are separate tests and separate mutants.

## What each test prints if the change is reverted

| test | on revert |
|---|---|
| `…_ForeignFlywayRevisionsRefused` | `Migrating to version 4611686018427510315 from 2 pending migrations.` then `Migration complete.` at exit 0, and two rows in `seeded` where there was one |
| `…_ForeignFlywayDryRunRefused` | `Dry run mode: no changes will be made.` and `Would have applied 2 migrations.` at exit 0 |
| `…_ForeignFlywayRefusalPrintsWorkingRecovery` | the first apply succeeds, so no message exists and the `migrate set` version cannot be extracted |
| `…_ForeignFlywaySetRouteWithdrawnWhenItWouldRecordUnrunMigrations` (revert the unrun clause) | prints `- adopt the versions this build uses: `migrate set 4611686018427551119`` — the command that records `g2` unrun |
| `…_ForeignFlywaySetRouteOfferedWithPendingAboveTheHead` (drop the `> head` skip) | `has no safe route here … WITHOUT running them — V3__c.sql (4611686018427551119)`, on a migration `migrate set` would not touch |
| `…_ForeignFlywaySetRouteCountsThisBuildsOwnRowsAsRun` (drop the `applied` half) | `WITHOUT running them — V1__m.sql (4611686018427469511)` for a migration this build ran itself |
| `…_ForeignFlywayTokenWithLeadingSpace` (revert the `TrimSpace`) | `Migrating to version 4611686018427469511 from 2 pending migrations.` at exit 0, seed row inserted twice |
| `…_ForeignFlywayBaselineOverForeignHistory` | `Migrating to version 122412 from 1 pending migrations.` at exit 0, table `base` created beside `p` and `q` |
| `…_ForeignFlywaySetRouteWithdrawnWhenUnsafe` (revert the withdrawal) | prints `migrate set 122412` as a way forward — a command that retires revision `1000000` |
| `…_ForeignFlywayTokenIsAlsoAConvertedVersion` (revert the third clause) | exit 1 refusing a database `ptah-compat` had just written itself, table `cv` never created |
| `…_DetectorDoesNotOverRefuse/a database migrated only by this build` | with the second clause dropped: `1 already-applied migration(s) read as pending` |
| `…_DetectorDoesNotOverRefuse/a baseline that retires the applied history` | with the issue's looser phrasing: refuses a squash both tools apply |
| `…_DetectorDoesNotOverRefuse/a goose directory holding a Flyway-shaped file` | with the layout gate removed: `1 already-applied migration(s) read as pending` on a goose database |
| `…_DetectorDoesNotOverRefuse/a fresh database` | non-interference control; passes on base too |
| `…_ForeignFlywayRepeatableCarriesNoToken` | with a repeatable reporting its own token: `2 -> 9223372036854775807  R2__r.sql` at exit 1, hiding the out-of-order diagnosis the community binary agrees with |

`scripts/mutations/foreign-flyway-revisions.json` is added: **17/17 killed**, tree clean after restore. It includes an **inverse mutant** for each conservative clause — dropping the collision clause makes the check fire on a database this build wrote, and forcing the `migrate set` route off removes a route measured to work. The route's two new guards each have both directions: `the lossy migrate set is printed anyway` / `the destructive migrate set is printed anyway` against `INVERSE: the migrate set route is never offered`, and the two over-refusal clauses against `a migration above the head is counted as one the route would record` and `only the other implementation's rows count as executed`.

## Gates

```
go build ./...                                              exit 0
go vet ./...                                                exit 0
go test ./... -count=1                                      exit 0, 176 packages ok, 0 failures
go tool qtlint ./...                                        exit 0
golangci-lint run ./...                                     exit 0, "0 issues."
scripts/check-test-style.sh                                 OK (175 conditional groups, 45 white-box files)
scripts/check-public-api.sh                                 exit 0
scripts/check-public-api-snapshot.sh                        exit 0
scripts/mutation-check.py scripts/mutations/foreign-flyway-revisions.json
                                                            17/17 killed, tree clean after restore
```

`qtlint` prints nothing on success, so it was proved live rather than assumed: rewriting one assertion as `c.Assert(len(userTables(…)), qt.Equals, 2)` makes it print `qtlint: use qt.HasLen instead of len(x), qt.Equals` at that line. `golangci-lint` first reported 89 issues from files under paths that no longer exist — a poisoned shared cache, with `can't read file …: no such file or directory` in the warnings; run against a private `GOLANGCI_LINT_CACHE` it reports `0 issues.`

`docs/` is touched, so every `check:*`/selftest script in `docs/site/package.json` was run, plus `versions:selftest` and `node docs/site/scripts/build-feature-matrix.mjs --check`: all green, including `check-exit-codes.mjs: OK (60 reference rows)`, `check-links.mjs: OK (60 pages, 60 routes, 571 heading anchors)`, `check-style.mjs: OK (100 documentation files)` and `build-feature-matrix.mjs --check: OK (163 rows)`. `check:responsive` needed `npm ci` and `npm run build` first — without them it reports `dist not found` and exits 1. Both really ran: `OK (60 routes x 2 viewports, cells within 8 lines)` and `OK (overflow, wide-table, tall-cell, and unstyled-page guards verified)`.

`gofmt -l` on the touched trees prints nothing; the positive control (a deliberately misformatted file dropped into `cmd/atlas`) does print its name, so the silence is a pass and not a broken probe.

## Deliberately left open

- **The checksum encoding.** `ptah-compat` stores a hex SHA-256 where the community binary stores a base64 `h1` digest, so golang-migrate, dbmate and liquibase directories refuse cross-tool with `checksum mismatch` even though their versions agree. That is a refusal, not a re-execution, and it is the reason a bare version rewrite is not a repair here. Not this issue; worth its own.
- **`migrate status`.** Still prints `Current Version: 2 / Applied: 2 / Pending: 2` on a mismatched table. The issue parks the count arithmetic explicitly ("Not this issue"), and the counts run over three different sets on the community binary too.
- **One pathological input the collision clause declines to flag.** A directory whose baseline converts to a number another file in the same directory carries as its token (`B10__base.sql` beside `V448844__x.sql`) is ambiguous evidence, so no claim is made about who wrote the row. That input behaves exactly as it does on base — a detection not added, not one taken away. The clause exists because without it `migrate apply 1` on that same directory makes the next apply blame another implementation for a row `ptah-compat` had just written.
- **Shapes 2 and 3 from the issue.** The version projection is untouched, so the two revision tables are still mutually unreadable; an operator who switches tools with a directory in flight still has to pick a side. That trade is what the issue named as the actual decision, and it is taken here knowingly.
- **A revision table carrying both spellings.** Once `1`,`2` and `4611686018427469511`,`4611686018427510315` sit side by side, a migration added afterwards is out of order to the pinned community binary (exit 1) and ordinary to `ptah-compat` (exit 0). That is a half-(a) gap, and it is **pre-existing**: measured with the refusal call removed, a plain apply over a foreign table produces that exact four-row set, so base reaches it on every such apply. This branch removes the accidental path to it; the remaining path is the printed route, which now says in the message that it is one way. Closing the gap itself means closing the version projection — shapes 2 and 3 above.

