### PR TITLE
fix(atlashcl): read a column reference from the parsed expression (#1182)

### DIFF
--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -83,6 +83,7 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 		db:            &goschema.Database{},
 		tolerant:      opts.IgnoreUnknownNames,
 		recordIgnored: opts.RecordIgnored,
+		refContext:    columnRefContext(body),
 	}
 	// Classify before validating the schema body. A file carrying a project-file
 	// marker is the wrong kind of file, and that verdict must not depend on
@@ -169,6 +170,9 @@ type parser struct {
 	// recordIgnored receives the names dropped under that policy. Nil discards
 	// them.
 	recordIgnored func(IgnoredName)
+	// refContext decides a conditional inside a column reference. Built once
+	// from the file's own `variable` blocks -- see columnRefContext.
+	refContext *hcl.EvalContext
 }
 
 func (p *parser) parseBody(body *hclsyntax.Body) error {
@@ -1357,10 +1361,9 @@ func (p *parser) parseColumnRefsAttr(block *hclsyntax.Block, attrName string) ([
 
 	var refs []columnRef
 	for _, expr := range exprs {
-		item := p.rawExprNode(expr)
-		table, column := tableColumnFromRef(item)
+		table, column := p.tableColumnFromExpr(expr)
 		if column == "" {
-			return nil, p.blockError(block, "%s contains unsupported reference %q", attrName, item)
+			return nil, p.blockError(block, "%s contains unsupported reference %q", attrName, p.rawExprNode(expr))
 		}
 		refs = append(refs, columnRef{table: table, column: column})
 	}
@@ -1828,11 +1831,16 @@ func (p *parser) stringListAttr(block *hclsyntax.Block, attrName string) ([]stri
 // Ptah could already name is untouched -- a reference, or the quoted-string
 // spelling Ptah accepts and that binary does not. Raw SQL in an index part has
 // its own attribute, `expr`, which takes it and renders it.
+//
+// What "has no column name" means is tableColumnFromExpr's business, and it is a
+// question about the PARSED EXPRESSION. Asking the attribute's source text
+// instead was issue #1182: it refused five spellings the pinned binary plans,
+// because text that is not a bare traversal reads the same whether it wraps a
+// column reference or carries no reference at all.
 func (p *parser) columnNameFromExpr(block *hclsyntax.Block, label string, attr *hclsyntax.Attribute) (string, error) {
-	raw := p.rawExpr(attr)
-	name := columnNameFromRef(raw)
+	_, name := p.tableColumnFromExpr(attr.Expr)
 	if name == "" {
-		return "", p.blockError(block, "%s column contains unsupported reference %q", label, raw)
+		return "", p.blockError(block, "%s column contains unsupported reference %q", label, p.rawExpr(attr))
 	}
 	return name, nil
 }
@@ -1874,51 +1882,4 @@ func normalizeIdentityGeneration(value string) string {
 	default:
 		return ""
 	}
-}
-
-func columnNameFromRef(raw string) string {
-	_, column := tableColumnFromRef(raw)
-	return column
-}
-
-func tableColumnFromRef(raw string) (table string, column string) {
-	raw = strings.TrimSpace(raw)
-	raw = strings.TrimSuffix(raw, ",")
-	if unquoted, err := strconv.Unquote(raw); err == nil {
-		return "", unquoted
-	}
-	expr, diags := hclsyntax.ParseExpression([]byte(raw), "column-reference.hcl", hcl.InitialPos)
-	if diags.HasErrors() {
-		return "", ""
-	}
-	traversal, diags := hcl.AbsTraversalForExpr(expr)
-	if diags.HasErrors() || len(traversal) < 2 {
-		return "", ""
-	}
-	root, ok := traversal[0].(hcl.TraverseRoot)
-	if !ok {
-		return "", ""
-	}
-	parts := make([]string, 0, len(traversal)-1)
-	for _, step := range traversal[1:] {
-		part, ok := traversalPart(step)
-		if !ok {
-			return "", ""
-		}
-		parts = append(parts, part)
-	}
-	if root.Name == "column" && len(parts) == 1 {
-		return "", parts[0]
-	}
-	if root.Name != "table" || len(parts) < 3 || parts[len(parts)-2] != "column" {
-		return "", ""
-	}
-	tableParts := parts[:len(parts)-2]
-	if len(tableParts) == 1 {
-		return tableref.Canonical("", tableParts[0]), parts[len(parts)-1]
-	}
-	if len(tableParts) == 2 {
-		return tableref.Canonical(tableParts[0], tableParts[1]), parts[len(parts)-1]
-	}
-	return "", ""
 }

--- a/internal/atlashcl/column_ref.go
+++ b/internal/atlashcl/column_ref.go
@@ -1,0 +1,235 @@
+package atlashcl
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+
+	"go.5x5.cz/ptah/internal/tableref"
+)
+
+// maxColumnRefDepth bounds how many wrappers a column reference may be buried
+// under. HCL's own parser already refuses deeply nested source, so no realistic
+// schema reaches this; it exists so a hand-built expression tree cannot turn the
+// unwrapping below into unbounded recursion.
+const maxColumnRefDepth = 64
+
+// tableColumnFromExpr reads a `column` value as a column reference by asking the
+// PARSED expression, and returns ("", "") when the expression cannot name a
+// column at all.
+//
+// This is issue #1182. The refusal added for #1106 keyed on the ATTRIBUTE'S
+// SOURCE TEXT: it sliced the attribute's bytes and re-parsed them, and
+// [hcl.AbsTraversalForExpr] answers no to anything that is not a bare traversal.
+// So five spellings that name a column perfectly well were refused while the
+// pinned Atlas community binary v1.3.0 planned them at exit 0 -- a parenthesised
+// reference in `index.on`, the same across newlines, the same in
+// `primary_key.on`, and both conditional forms. Measured before this function
+// existed, all five exited 1 with `column contains unsupported reference`.
+//
+// Two wrappers stand between the attribute and the traversal, and each needs its
+// own answer:
+//
+//   - Parentheses. [hclsyntax.ParenthesesExpr] embeds the hclsyntax.Expression
+//     INTERFACE, so it promotes only what that interface declares -- and
+//     `AsTraversal` is declared on the concrete traversal expressions, not on the
+//     interface. It has no `UnwrapExpression` either, so
+//     [hcl.UnwrapExpressionUntil] cannot see through it. Handing `attr.Expr`
+//     straight to [hcl.AbsTraversalForExpr] therefore fails on `(column.n)`
+//     exactly as the sliced text did; the unwrap has to be explicit.
+//
+//   - A conditional. Only one branch is taken, and which one is a question about
+//     VALUES, so the condition is evaluated. See conditionalBranch.
+//
+// What the refusal was for survives untouched: a value that resolves to no
+// column name still returns "" and the caller still refuses. `column = sql("n")`
+// is a function call, which is neither wrapper and is not a traversal, and
+// `column = 42` is a number that unquotes to nothing.
+func (p *parser) tableColumnFromExpr(expr hclsyntax.Expression) (table, column string) {
+	return p.tableColumnFromExprAt(expr, 0)
+}
+
+func (p *parser) tableColumnFromExprAt(expr hclsyntax.Expression, depth int) (table, column string) {
+	if expr == nil || depth > maxColumnRefDepth {
+		return "", ""
+	}
+	switch expr := expr.(type) {
+	case *hclsyntax.ParenthesesExpr:
+		return p.tableColumnFromExprAt(expr.Expression, depth+1)
+	case *hclsyntax.ConditionalExpr:
+		branch, ok := p.conditionalBranch(expr)
+		if !ok {
+			return "", ""
+		}
+		return p.tableColumnFromExprAt(branch, depth+1)
+	}
+	if traversal, diags := hcl.AbsTraversalForExpr(expr); !diags.HasErrors() {
+		return tableColumnFromTraversal(traversal)
+	}
+	// The quoted-string spelling, `column = "n"`. It is read from source text
+	// rather than evaluated so that this change is about WHICH expressions can be
+	// read and not about HOW a string is read: the accepted set for a literal is
+	// byte-for-byte what it was before.
+	return "", quotedColumnName(p.rawExprNode(expr))
+}
+
+// conditionalBranch picks the branch a conditional takes, or reports that the
+// condition cannot be decided.
+//
+// Refusing to guess is the whole point. When the condition does not evaluate to
+// a known boolean, this returns false and the caller refuses the attribute --
+// which is what the pinned binary does too, by failing the file outright on a
+// variable it cannot resolve. Taking a branch anyway would put a column name
+// into DDL that the schema never asked for, the same class of silent damage
+// #1106 was filed about.
+func (p *parser) conditionalBranch(expr *hclsyntax.ConditionalExpr) (hclsyntax.Expression, bool) {
+	value, diags := expr.Condition.Value(p.refContext)
+	if diags.HasErrors() || !value.IsKnown() || value.IsNull() || value.Type() != cty.Bool {
+		return nil, false
+	}
+	if value.True() {
+		return expr.TrueResult, true
+	}
+	return expr.FalseResult, true
+}
+
+// schemaVariableTypes maps an Atlas `variable` block's declared type to the cty
+// type its default has to carry.
+//
+// These three are the bare type keywords already measured to resolve on the
+// pinned community binary (see droppedBodyScope). A variable declared as
+// anything else stays out of scope, so a conditional that reads it is refused --
+// stricter than that binary, but not a new stricter position: every conditional
+// was refused before this file existed.
+var schemaVariableTypes = map[string]cty.Type{
+	"bool":   cty.Bool,
+	"int":    cty.Number,
+	"string": cty.String,
+}
+
+// columnRefContext is the evaluation context a conditional's condition is
+// decided in.
+//
+// It carries the file's own `variable` defaults under `var`, plus the same
+// function table a dropped body evaluates against. Ptah has no general
+// schema-file variable evaluation -- that is issue #926 -- and this does not add
+// one: nothing here reaches DDL. It decides which of two column references a
+// conditional selects, and both were written by the schema author.
+//
+// The admission rule for a variable is measured against the pinned binary, whose
+// exit code for the r4 fixture below moves with each part of it. All four
+// rejected shapes exit 1 there, so keeping them out of scope keeps Ptah from
+// planning a file that binary refuses:
+//
+//	variable "by_a" { type = bool, default = true }   -> 0, index on "a"
+//	variable "pick" { type = string, default = "a" }  -> 0, index on "a"
+//	variable "n"    { type = int, default = 1 }       -> 0, index on "a"
+//	variable "n"    { type = int, default = 1.5 }     -> 0, index on "b"
+//	variable "by_a" { default = true }                -> 1, `The argument "type" is required`
+//	variable "by_a" { type = bool }                   -> 1, `missing value for required variable`
+//	variable "by_a" { type = nonsense, default = true } -> 1, `There is no variable named "nonsense"`
+//	variable "by_a" { type = bool, default = "yes" }  -> 1, `a bool is required`
+//
+// The int rows are the pair that pins strict type EQUALITY as the rule rather
+// than an integer check: that binary accepts a fractional default under
+// `type = int` and lets `var.n == 1` come out false.
+func columnRefContext(body *hclsyntax.Body) *hcl.EvalContext {
+	return &hcl.EvalContext{
+		Variables: map[string]cty.Value{"var": cty.ObjectVal(schemaVariableDefaults(body))},
+		Functions: droppedBodyFunctions,
+	}
+}
+
+func schemaVariableDefaults(body *hclsyntax.Body) map[string]cty.Value {
+	values := map[string]cty.Value{}
+	for _, block := range body.Blocks {
+		name, value, ok := schemaVariableDefault(block)
+		if !ok {
+			continue
+		}
+		values[name] = value
+	}
+	return values
+}
+
+func schemaVariableDefault(block *hclsyntax.Block) (name string, value cty.Value, ok bool) {
+	if block.Type != "variable" || len(block.Labels) != 1 || block.Body == nil {
+		return "", cty.NilVal, false
+	}
+	typeAttr := block.Body.Attributes["type"]
+	defaultAttr := block.Body.Attributes["default"]
+	if typeAttr == nil || defaultAttr == nil {
+		return "", cty.NilVal, false
+	}
+	want, known := declaredVariableType(typeAttr.Expr)
+	if !known {
+		return "", cty.NilVal, false
+	}
+	value, diags := defaultAttr.Expr.Value(nil)
+	if diags.HasErrors() || !value.IsKnown() || value.IsNull() || !value.Type().Equals(want) {
+		return "", cty.NilVal, false
+	}
+	return block.Labels[0], value, true
+}
+
+func declaredVariableType(expr hclsyntax.Expression) (cty.Type, bool) {
+	traversal, diags := hcl.AbsTraversalForExpr(expr)
+	if diags.HasErrors() || len(traversal) != 1 {
+		return cty.NilType, false
+	}
+	root, isRoot := traversal[0].(hcl.TraverseRoot)
+	if !isRoot {
+		return cty.NilType, false
+	}
+	want, known := schemaVariableTypes[root.Name]
+	return want, known
+}
+
+func quotedColumnName(raw string) string {
+	raw = strings.TrimSpace(raw)
+	raw = strings.TrimSuffix(raw, ",")
+	unquoted, err := strconv.Unquote(raw)
+	if err != nil {
+		return ""
+	}
+	return unquoted
+}
+
+func tableColumnFromTraversal(traversal hcl.Traversal) (table, column string) {
+	if len(traversal) < 2 {
+		return "", ""
+	}
+	root, isRoot := traversal[0].(hcl.TraverseRoot)
+	if !isRoot {
+		return "", ""
+	}
+	parts := make([]string, 0, len(traversal)-1)
+	for _, step := range traversal[1:] {
+		part, named := traversalPart(step)
+		if !named {
+			return "", ""
+		}
+		parts = append(parts, part)
+	}
+	if root.Name == "column" && len(parts) == 1 {
+		return "", parts[0]
+	}
+	if root.Name != "table" || len(parts) < 3 || parts[len(parts)-2] != "column" {
+		return "", ""
+	}
+	return qualifiedTableColumn(parts)
+}
+
+func qualifiedTableColumn(parts []string) (table, column string) {
+	tableParts := parts[:len(parts)-2]
+	if len(tableParts) == 1 {
+		return tableref.Canonical("", tableParts[0]), parts[len(parts)-1]
+	}
+	if len(tableParts) == 2 {
+		return tableref.Canonical(tableParts[0], tableParts[1]), parts[len(parts)-1]
+	}
+	return "", ""
+}

--- a/internal/atlashcl/column_ref_expr_test.go
+++ b/internal/atlashcl/column_ref_expr_test.go
@@ -1,0 +1,415 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// A `column` value is read from the PARSED expression, so every spelling that
+// names a column names it -- not only the spellings whose source text happens to
+// be a bare traversal. This is issue #1182.
+//
+// Reverted to the source-text reader, every row here fails on `err` being
+// non-nil with `index on column contains unsupported reference "(column.n)"`
+// (and the row's own text for the others); the pinned Atlas community binary
+// v1.3.0 plans all of them at exit 0. The two `columns = [...]` rows were never
+// part of the #1182 regression -- the list reader has read source text since
+// before #1165 -- and they go red the same way, which is why they are here.
+//
+// Deleting only the ParenthesesExpr arm reddens the four parenthesised rows and
+// leaves the two conditional rows green; deleting only the ConditionalExpr arm
+// does the opposite. Neither mutation touches TestParseKeepsColumnAttributesThatNameAColumn.
+func TestParseReadsAColumnAttributeThroughTheParsedExpression(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		hcl    string
+		assert func(c *qt.C, db *goschema.Database)
+	}{
+		{
+			name: "index on parenthesised reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = (column.n) }
+  }
+}
+`,
+			assert: assertSoleIndexPart("n"),
+		},
+		{
+			name: "index on parenthesised reference across newlines",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on {
+      column = (
+        column.n
+      )
+    }
+  }
+}
+`,
+			assert: assertSoleIndexPart("n"),
+		},
+		{
+			name: "index on doubly parenthesised qualified reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = ((table.t.column.n)) }
+  }
+}
+`,
+			assert: assertSoleIndexPart("n"),
+		},
+		{
+			name: "index on conditional over a bool variable",
+			hcl: `
+variable "by_a" {
+  type    = bool
+  default = true
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			assert: assertSoleIndexPart("a"),
+		},
+		{
+			name: "index on conditional that takes the false branch",
+			hcl: `
+variable "by_a" {
+  type    = bool
+  default = false
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			assert: assertSoleIndexPart("b"),
+		},
+		{
+			name: "index on conditional over literals",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = "n" == "n" ? column.n : column.n }
+  }
+}
+`,
+			assert: assertSoleIndexPart("n"),
+		},
+		{
+			name: "index columns list holds a parenthesised reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    columns = [(column.n)]
+  }
+}
+`,
+			assert: assertSoleIndexField("n"),
+		},
+		{
+			name: "index columns list holds a conditional",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  column "m" { type = int }
+  index "idx_n" {
+    columns = ["n" == "n" ? column.n : column.m]
+  }
+}
+`,
+			assert: assertSoleIndexField("n"),
+		},
+		{
+			name: "primary key on parenthesised reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  primary_key {
+    on { column = (column.n) }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].PrimaryKeyParts, qt.DeepEquals, []goschema.PrimaryKeyPart{{Name: "n"}})
+			},
+		},
+		{
+			name: "partition by parenthesised reference",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  partition {
+    type = RANGE
+    by { column = (column.n) }
+  }
+}
+`,
+			assert: func(c *qt.C, db *goschema.Database) {
+				c.Assert(db.Tables, qt.HasLen, 1)
+				c.Assert(db.Tables[0].Partition, qt.DeepEquals, &goschema.PartitionSpec{
+					Type:  "RANGE",
+					Parts: []goschema.PartitionPart{{Name: "n"}},
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.IsNil)
+			test.assert(c, db)
+		})
+	}
+}
+
+func assertSoleIndexPart(name string) func(c *qt.C, db *goschema.Database) {
+	return func(c *qt.C, db *goschema.Database) {
+		c.Assert(db.Indexes, qt.HasLen, 1)
+		c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+		c.Assert(db.Indexes[0].Parts[0].Name, qt.Equals, name)
+	}
+}
+
+// The list spelling `columns = [...]` lands in Fields, not Parts -- a different
+// reader, which is the point of covering it separately.
+func assertSoleIndexField(name string) func(c *qt.C, db *goschema.Database) {
+	return func(c *qt.C, db *goschema.Database) {
+		c.Assert(db.Indexes, qt.HasLen, 1)
+		c.Assert(db.Indexes[0].Fields, qt.DeepEquals, []string{name})
+	}
+}
+
+// A conditional whose condition cannot be decided is still refused, and the
+// admission rule for a `variable` is what decides it. Each row below is a
+// variable shape the pinned Atlas community binary v1.3.0 refuses the whole file
+// for, so admitting any of them would make Ptah plan a file that binary will not
+// load -- the one direction this parser may never take.
+//
+// This is the guard's INVERSE-mutant test, and it is the only way the admission
+// rule's non-interference is provable. Each row names the part of
+// schemaVariableDefault that has to be relaxed to turn it green, and
+// TestParseReadsAColumnAttributeThroughTheParsedExpression stays green under
+// every one of those relaxations. Today each row prints
+// `index on column contains unsupported reference "<the conditional as written>"`;
+// under the mutation it is aimed at it prints nothing and the file parses.
+//
+// The last two rows are the pair worth reading together. Dropping the
+// declared-type check alone does NOT redden "default contradicts its type" --
+// a string default under `type = bool` still fails the boolean test in
+// conditionalBranch -- so that row cannot be cited as the check's discriminator.
+// The `type = int, default = "a"` row is: its condition is a string COMPARISON,
+// which yields a perfectly good boolean, so without the declared-type check Ptah
+// would plan an index on "a" for a file the pinned binary refuses with
+// `variable "pick": a number is required`.
+func TestParseRefusesAConditionalColumnWhoseConditionCannotBeDecided(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		hcl   string
+		match string
+	}{
+		{
+			name: "variable without a type",
+			hcl: `
+variable "by_a" {
+  default = true
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "variable without a default",
+			hcl: `
+variable "by_a" {
+  type = bool
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "variable typed by an unknown keyword",
+			hcl: `
+variable "by_a" {
+  type    = nonsense
+  default = true
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "no variable of that name",
+			hcl: `
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "condition is not a boolean",
+			hcl: `
+variable "by_a" {
+  type    = string
+  default = "a"
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "variable whose default contradicts its type",
+			hcl: `
+variable "by_a" {
+  type    = bool
+  default = "yes"
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.by_a ? column.a : column.b }
+  }
+}
+`,
+			match: refusedConditional,
+		},
+		{
+			name: "declared type contradicts a default the condition can still compare",
+			hcl: `
+variable "pick" {
+  type    = int
+  default = "a"
+}
+table "t" {
+  column "a" { type = int }
+  column "b" { type = int }
+  index "idx_n" {
+    on { column = var.pick == "a" ? column.a : column.b }
+  }
+}
+`,
+			match: `.*index on column contains unsupported reference "var.pick == \\"a\\" \? column.a : column.b"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
+}
+
+const refusedConditional = `.*index on column contains unsupported reference "var.by_a \? column.a : column.b"`
+
+// A branch that is taken still has to name a column. This is what keeps the
+// conditional arm from becoming a way around the #1106 refusal.
+//
+// The two rows are refused by different guards on purpose. `sql()` inside a
+// larger expression never reaches the column reader at all -- the #1131 guard
+// runs ahead of the body walk and refuses the file -- so the row pins that the
+// conditional arm did not open a route past it. The empty-string row is the one
+// the column reader itself refuses, and it is the discriminator for "resolves to
+// a name" versus "resolved successfully".
+//
+// Reverted, both rows still fail: the source-text reader refuses every
+// conditional. They go red only under a mutation that lets a taken branch
+// resolve to something that is not a column name, which is what they forbid.
+func TestParseRefusesAConditionalBranchThatCannotNameAColumn(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		hcl   string
+		match string
+	}{
+		{
+			name: "taken branch is a sql call",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = "n" == "n" ? sql("n") : column.n }
+  }
+}
+`,
+			match: `.*attribute "column": sql\(\) must be the whole attribute value, not part of a larger expression`,
+		},
+		{
+			name: "taken branch is an empty string",
+			hcl: `
+table "t" {
+  column "n" { type = int }
+  index "idx_n" {
+    on { column = "n" == "n" ? "" : column.n }
+  }
+}
+`,
+			match: `.*index on column contains unsupported reference "\\"n\\" == \\"n\\" \? \\"\\" : column.n"`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			_, err := atlashcl.Parse([]byte(test.hcl), "schema.hcl")
+			c.Assert(err, qt.ErrorMatches, test.match)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1182.

## What was wrong

The `column` attribute guard from #1165 keyed on the attribute's SOURCE TEXT:

```go
raw := p.rawExpr(attr)          // strings.TrimSpace(attr.Expr.Range().SliceBytes(p.src))
name := columnNameFromRef(raw)  // re-parses that TEXT with hcl.AbsTraversalForExpr
```

`hcl.AbsTraversalForExpr` answers no to anything that is not a bare traversal, and `""` is what the refusal keys on. So text that WRAPS a column reference read the same as text that carries no reference at all.

## Measured

`ptah-compat schema apply --dry-run --url sqlite://file?mode=memory --to file://X.hcl`, exit codes captured immediately (no pipe in front of `$?`). Columns are pre-#1165 master `c5a53f3c` / current master `3e5cf284` / this branch / the pinned Atlas community binary v1.3.0 at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`.

| fixture | pre-#1165 | master | branch | binary | column planned (branch / binary) |
|---|---|---|---|---|---|
| `index.on { column = (column.n) }` | 0 | **1** | 0 | 0 | `("n")` / `` (`n`) `` |
| the same across newlines | 0 | **1** | 0 | 0 | `("n")` / `` (`n`) `` |
| `primary_key.on { column = (column.n) }` | 0 | **1** | 0 | 0 | see note below |
| `column = var.by_a ? column.a : column.b` | 0 | **1** | 0 | 0 | `("a")` / `` (`a`) `` |
| `column = "n" == "n" ? column.n : column.n` | 0 | **1** | 0 | 0 | `("n")` / `` (`n`) `` |
| `index { columns = [(column.n)] }` | **1** | **1** | 0 | 0 | `("n")` / `` (`n`) `` |
| `index { columns = ["n" == "n" ? column.n : column.m] }` | **1** | **1** | 0 | 0 | `("n")` / `` (`n`) `` |
| `column = sql("n")` (#1106) | 0 | 1 | **1** | 1 | — |
| `column = 42` (#1106) | 0 | 1 | **1** | 1 | — |

Two corrections to the issue's own account, both in the direction of "this was worse than filed":

- **Pre-#1165 master exited 0 but planned garbage.** For the four index rows it planned `CREATE INDEX IF NOT EXISTS "main"."i" ON "t" ("")` — the empty-name corruption #1106 was filed about. So this is not "restore what master did"; master's exit 0 was never a working schema. The branch reaches what the binary does, which is strictly better than both.
- **The two `columns = [...]` rows are not part of the #1182 regression.** The sibling list reader `parseColumnRefsAttr` has read source text since before #1165, so those two exited 1 on pre-#1165 master as well. Same root cause, one call away, fixed here rather than left for the next issue.

Note on the `primary_key` row: the pinned binary plans `PRIMARY KEY ()` for it — and it plans exactly the same thing for the plain `column = column.n` spelling, so that is a binary-side quirk of `primary_key.on` on sqlite, not something the parentheses caused. Ptah plans `"n" int PRIMARY KEY` for both spellings. The issue asked for rc 0 on that row and rc 0 is what it gets; the DDL difference is pre-existing and unchanged by this PR.

## The fix

`internal/atlashcl/column_ref.go`. Two wrappers stand between the attribute and the traversal, and each needed its own answer.

**Parentheses need an explicit unwrap.** The issue suggests `hcl.AbsTraversalForExpr` on `attr.Expr` covers this. Measured: it does not. `hclsyntax.ParenthesesExpr` embeds the `hclsyntax.Expression` INTERFACE, which declares neither `AsTraversal` nor `UnwrapExpression`, so neither the `asTraversal` assertion nor `hcl.UnwrapExpressionUntil` inside `AbsTraversalForExpr` can see through it — `(column.n)` fails exactly as the sliced text did. Deleting only that arm reddens the 6 parenthesised rows and leaves the conditional rows green, which is the proof.

**A conditional is decided by evaluating its condition** against the file's own `variable` defaults. Nothing from that evaluation reaches DDL: it selects which of two column references the author wrote. This is not the general schema-file variable evaluation of #926.

**A variable enters that scope only if the binary would accept it.** Each part of the admission rule is measured, and all four rejected shapes exit 1 on the pinned binary, so admitting any of them would have made ptah-compat plan a file that binary will not load:

| variable | binary |
|---|---|
| `type = bool, default = true` | 0, index on `a` |
| `type = string, default = "a"` | 0, index on `a` |
| `type = int, default = 1` | 0, index on `a` |
| `type = int, default = 1.5` | 0, index on `b` |
| `default = true` (no type) | 1, `The argument "type" is required` |
| `type = bool` (no default) | 1, `missing value for required variable` |
| `type = nonsense, default = true` | 1, `There is no variable named "nonsense"` |
| `type = bool, default = "yes"` | 1, `a bool is required` |
| `type = int, default = "a"` | 1, `variable "pick": a number is required` |

The two `int` rows are why the rule is strict type EQUALITY and not an integer check: that binary accepts a fractional default under `type = int` and lets `var.n == 1` come out false, and the branch agrees (`("b")`).

## Parity ledger

Rule (a): zero positions where this branch exits 0 and the pinned binary exits 1. The four rejected `variable` shapes are the ones that could have created such a position and each is refused; the `type = int, default = "a"` row is the one that separates the declared-type check from the boolean check that follows it.

Rule (b): seven positions move from ptah=1 to ptah=0 against binary=0 — five that #1165 took away, two the list reader never had. Nothing moves the other way. The Ptah-only quoted-string extension `column = "n"` is untouched, and it is read from source text exactly as before, so the accepted set for a literal is byte-identical.

## Mutation testing

| mutant | red | green |
|---|---|---|
| delete the `ParenthesesExpr` arm | the 6 parenthesised rows | the 4 conditional rows, both #1106 tests, the keeps-test |
| delete the `ConditionalExpr` arm | the 4 conditional rows | the 6 parenthesised rows, both #1106 tests, the keeps-test |
| drop the whole variable admission rule | `variable without a type`, `variable typed by an unknown keyword` | everything else |
| drop ONLY the declared-type equality | `declared type contradicts a default the condition can still compare` — and nothing else | everything else |

The last two are the pair worth reading together, and they correct a trap I nearly fell into: the obvious-looking `type = bool, default = "yes"` row does NOT discriminate the declared-type check, because a string default still fails the boolean test in `conditionalBranch` afterwards. `type = int, default = "a"` does, because its condition is a string COMPARISON and yields a perfectly good boolean — without the check ptah-compat would plan an index on `a` for a file the binary refuses.

## Gates

`go build ./... && go vet ./... && go test ./... -count=1` (all packages), `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh` (OK, 175 conditional groups), `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, `gofmt -l internal/atlashcl/` (silent). No `docs/` change, so no docs gates apply.

Two gates proven live rather than assumed, since both pass silently: `go tool qtlint` reddens on `qt.Equals, nil` with `qtlint: use qt.IsNil instead of qt.Equals, nil` at the exact line, and `check-test-style.sh` reddens on one added `if` with `new test conditional violations: internal/atlashcl/column_ref_expr_test.go TestParseReadsAColumnAttributeThroughTheParsedExpression if 1`. `check-public-api.sh` and its snapshot pass but cannot go red for this change — both skip `internal/*`, and every symbol added here is unexported. Cited as run, not as coverage.