### PR TITLE
fix(atlasfilter): refuse --exclude patterns deeper than their scope

### DIFF
--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -96,8 +96,7 @@ follows the documented Atlas behavior.
 `--exclude` accepts repeated or comma-separated Atlas-style glob patterns,
 including `[type=...]` selectors, and removes matching resources from HCL,
 SQL, JSON, and custom-template output. Field-level exclude selector support
-includes the Atlas-documented `*[type=extension].version` form, including
-schema-qualified globs such as `public.*[type=extension].version`.
+includes the Atlas-documented `*[type=extension].version` form.
 
 Other field-level selectors, and type selectors on non-final pattern segments,
 fail explicitly before any database is contacted. Schema-qualified function
@@ -119,6 +118,29 @@ database URL only `public.users` matches, and on a schema-bound URL
 (`?search_path=public`) only `users` does. Ptah honors both in both scopes.
 The extra matches only ever remove more objects from a plan, so the looser
 rule cannot turn a protected object into a dropped one.
+
+That looseness applies to objects, not to their children. A pattern names at
+most an object and one of its children, and Ptah always filters inside a single
+schema, so the schema slot is filled by the connection and the pattern is read
+relative to it: `users` names the table, `users.name` names its column, and
+`users.users_name_idx` names its index. A third part has nowhere left to go.
+Ptah refuses it with the community binary's own message, which quotes the
+pattern with the schema already prefixed:
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL" --exclude public.users.name
+Error: too many parts in pattern: "public.public.users.name"
+```
+
+The refusal is a usage error rather than a no-op on purpose. A pattern that
+deep is almost always an attempt to name a table, and matching it against
+columns would answer a question that was not asked by removing a column from a
+table the user was trying to keep whole. Parts are counted on the pattern as
+written, selector text included, so `*[type=extension].version` is accepted and
+`public.*[type=extension].version` is refused — the same arithmetic the
+community binary applies on a schema-bound URL. A pattern too deep for any
+scope, such as `*.*.*.*`, is refused before a database is contacted, so its
+message carries no schema prefix.
 
 ### Select what is inspected with `--include`
 

--- a/internal/atlasfilter/filter.go
+++ b/internal/atlasfilter/filter.go
@@ -34,7 +34,7 @@ func ExcludeDatabaseWithDefaultSchema(
 	patterns []string,
 	defaultSchema string,
 ) (*dbschematypes.DBSchema, error) {
-	filters, err := parsePatterns(patterns)
+	filters, err := parsePatterns(patterns, defaultSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -76,7 +76,7 @@ func ExcludeGeneratedWithDefaultSchema(
 	patterns []string,
 	defaultSchema string,
 ) (*goschema.Database, error) {
-	filters, err := parsePatterns(patterns)
+	filters, err := parsePatterns(patterns, defaultSchema)
 	if err != nil {
 		return nil, err
 	}
@@ -133,12 +133,16 @@ const (
 // forms Ptah cannot honor: malformed globs, unsupported selector kinds, field
 // selectors beyond the documented extension version form, and type selectors
 // on non-final pattern segments. Commands run it before any database work.
+// The depth rule needs the schema the patterns are relative to, which commands
+// only learn once a connection is open, so this pre-connect pass applies the
+// scope-independent half of it: a pattern too deep for any scope is rejected
+// before a database is contacted, and the rest is caught by the filter.
 func ValidateExcludeSelectors(values []string) error {
-	_, err := parsePatterns(values)
+	_, err := parsePatterns(values, "")
 	return err
 }
 
-func parsePatterns(values []string) ([]resourcePattern, error) {
+func parsePatterns(values []string, defaultSchema string) ([]resourcePattern, error) {
 	var patterns []resourcePattern
 	for _, value := range values {
 		for part := range strings.SplitSeq(value, ",") {
@@ -146,12 +150,50 @@ func parsePatterns(values []string) ([]resourcePattern, error) {
 			if err != nil {
 				return nil, err
 			}
-			if pattern.glob != "" {
-				patterns = append(patterns, pattern)
+			if pattern.glob == "" {
+				continue
 			}
+			if err := checkPatternDepth(strings.TrimSpace(part), defaultSchema); err != nil {
+				return nil, err
+			}
+			patterns = append(patterns, pattern)
 		}
 	}
 	return patterns, nil
+}
+
+// maxPatternParts is the deepest object an Atlas exclude pattern can name:
+// schema.object.child. The pinned community binary splits a pattern on "." and
+// refuses anything deeper.
+const maxPatternParts = 3
+
+// checkPatternDepth refuses an exclude pattern that names more parts than its
+// scope can address.
+//
+// A pattern is relative to the scope the URL names. Ptah always filters inside
+// one schema — every reader is schema-scoped, and the connection's schema is
+// the default for the objects introspection leaves unqualified — which is the
+// community binary's schema-bound-URL scope. There a pattern names `object` or
+// `object.child`, because the binary prefixes the schema before counting; a
+// third part has nowhere left to go, and the binary reports the prefixed
+// spelling, so `--exclude public.users.name` on a PostgreSQL connection is
+// refused as "public.public.users.name". Ptah reports it identically.
+//
+// The column part itself is not the error. `users.name` names the column and is
+// honored, exactly as the binary honors it in this scope. What has no meaning
+// is a pattern whose schema slot is already filled by the connection.
+//
+// With no default schema the pattern is realm-relative instead and the full
+// schema.object.child depth is addressable, which is the binary's other scope.
+func checkPatternDepth(raw, defaultSchema string) error {
+	effective := raw
+	if strings.TrimSpace(defaultSchema) != "" {
+		effective = strings.TrimSpace(defaultSchema) + "." + raw
+	}
+	if strings.Count(effective, ".")+1 <= maxPatternParts {
+		return nil
+	}
+	return fmt.Errorf("too many parts in pattern: %q", effective)
 }
 
 func parsePattern(value, kind string) (resourcePattern, error) {
@@ -335,7 +377,10 @@ func (s *exclusionState) qualifiedNameCandidatesFor(name string) []string {
 }
 
 // childNameCandidates returns the names an exclude pattern can match for a
-// child of a table: "table.child" and "schema.table.child".
+// child of a table: "table.child" and "schema.table.child". The qualified
+// spelling is reachable only in the realm-relative scope; once a default schema
+// is in play, [checkPatternDepth] refuses a pattern that deep before it can be
+// matched against.
 func (s *exclusionState) childNameCandidates(schema, table, child string) []string {
 	return tableChildNameCandidates(s.effectiveSchema(schema), table, child)
 }

--- a/internal/atlasfilter/filter_default_schema_test.go
+++ b/internal/atlasfilter/filter_default_schema_test.go
@@ -64,6 +64,12 @@ func defaultSchemaExtensionNames(extensions []dbschematypes.DBExtension) []strin
 // rows fail with the excluded object still listed — exactly the reported bug —
 // while the bare-name and non-default-schema rows stay green, which is what
 // makes them controls rather than duplicates.
+//
+// The qualified spelling reaches objects, not their children: a pattern deep
+// enough to name a child of a qualified object is refused by
+// [atlasfilter.ExcludeDatabaseWithDefaultSchema] rather than matched, so the
+// column row here uses the schema-relative spelling. See
+// TestExcludeDatabaseWithDefaultSchema_RefusesPatternsDeeperThanTheScope.
 func TestExcludeDatabaseWithDefaultSchema_QualifiedPatternsReachDefaultSchema(t *testing.T) {
 	tests := []struct {
 		name    string
@@ -107,8 +113,11 @@ func TestExcludeDatabaseWithDefaultSchema_QualifiedPatternsReachDefaultSchema(t 
 			},
 		},
 		{
-			name:    "qualified default-schema column",
-			pattern: "public.users.name",
+			// The column the schema-relative spelling names. The qualified
+			// spelling of the same column is a depth error, not a deeper
+			// selector; see TestExcludeDatabaseWithDefaultSchema_RefusesPatternsDeeperThanTheScope.
+			name:    "schema-relative column",
+			pattern: "users.name",
 			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
 				c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users", "app.orders"})
 				c.Assert(columnNames(got.Tables[0].Columns), qt.DeepEquals, []string{"id"})

--- a/internal/atlasfilter/filter_pattern_depth_test.go
+++ b/internal/atlasfilter/filter_pattern_depth_test.go
@@ -1,0 +1,266 @@
+package atlasfilter_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasfilter"
+)
+
+// TestExcludeDatabaseWithDefaultSchema_RefusesPatternsDeeperThanTheScope pins
+// every cell issue #1181 measured against the pinned community binary, plus the
+// three it recorded as pre-existing and two found while reproducing it.
+//
+// The want strings are the binary's own, byte for byte: it prefixes the
+// connection's schema onto the pattern before counting parts, so it names
+// "public.public.users.name" for a pattern the user wrote as
+// "public.users.name". Ptah models the same scope, so it reports the same text.
+//
+// Reverting the depth gate prints, for every row, `got non-nil error / got:
+// nil` from the error assertion — and the six mutation rows would additionally
+// return a schema whose `users` table has lost a column, which is the half of
+// the bug that mattered. Rows whose pattern is deep enough to be refused by
+// part count alone (the two four-part rows) stay red on a gate that only
+// consulted the raw pattern and never prefixed the schema, which is what
+// separates them from the three-part rows.
+func TestExcludeDatabaseWithDefaultSchema_RefusesPatternsDeeperThanTheScope(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		want    string
+	}{
+		{
+			name:    "qualified column",
+			pattern: "public.users.name",
+			want:    `too many parts in pattern: "public.public.users.name"`,
+		},
+		{
+			name:    "qualified primary key column",
+			pattern: "public.users.id",
+			want:    `too many parts in pattern: "public.public.users.id"`,
+		},
+		{
+			name:    "qualified every column of a table",
+			pattern: "public.users.*",
+			want:    `too many parts in pattern: "public.public.users.*"`,
+		},
+		{
+			name:    "qualified column across tables",
+			pattern: "public.*.name",
+			want:    `too many parts in pattern: "public.public.*.name"`,
+		},
+		{
+			name:    "wildcard schema column",
+			pattern: "*.users.name",
+			want:    `too many parts in pattern: "public.*.users.name"`,
+		},
+		{
+			name:    "wildcard at every depth",
+			pattern: "*.*.*",
+			want:    `too many parts in pattern: "public.*.*.*"`,
+		},
+		{
+			name:    "past the column",
+			pattern: "public.users.name.x",
+			want:    `too many parts in pattern: "public.public.users.name.x"`,
+		},
+		{
+			name:    "wildcard past the column",
+			pattern: "*.*.*.*",
+			want:    `too many parts in pattern: "public.*.*.*.*"`,
+		},
+		{
+			name:    "schema-relative past the column",
+			pattern: "users.name.x",
+			want:    `too many parts in pattern: "public.users.name.x"`,
+		},
+		{
+			// A table whose name contains dots reads as a three-part pattern.
+			// The binary refuses it here too, so ptah loses no spelling the
+			// binary offers.
+			name:    "dotted object name",
+			pattern: "a.b.c",
+			want:    `too many parts in pattern: "public.a.b.c"`,
+		},
+		{
+			// The documented extension field selector is counted the way the
+			// binary counts it: on the raw pattern, selector text included.
+			name:    "qualified extension field selector",
+			pattern: "public.*[type=extension].version",
+			want:    `too many parts in pattern: "public.public.*[type=extension].version"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := atlasfilter.ExcludeDatabaseWithDefaultSchema(
+				defaultSchemaFixture(), []string{test.pattern}, "public")
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.want)
+			c.Assert(got, qt.IsNil)
+		})
+	}
+}
+
+// TestExcludeGeneratedWithDefaultSchema_RefusesPatternsDeeperThanTheScope keeps
+// the desired side refusing what the introspected side refuses.
+//
+// Both sides of a comparison subtract the same patterns. A depth gate on only
+// one of them would let a pattern strip a column from the desired state while
+// the introspected state kept it, and the plan would then contain the DROP the
+// user was trying to prevent.
+//
+// Reverting the gate on the generated path alone prints `got non-nil error /
+// got: nil` here while the database test above stays green, which is exactly
+// the asymmetry this row exists to catch.
+func TestExcludeGeneratedWithDefaultSchema_RefusesPatternsDeeperThanTheScope(t *testing.T) {
+	c := qt.New(t)
+
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "User", Name: "users"}},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "INTEGER", Primary: true},
+			{StructName: "User", Name: "name", Type: "TEXT"},
+		},
+	}
+
+	got, err := atlasfilter.ExcludeGeneratedWithDefaultSchema(schema, []string{"public.users.name"}, "public")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, `too many parts in pattern: "public.public.users.name"`)
+	c.Assert(got, qt.IsNil)
+}
+
+// TestExcludeDatabase_RealmRelativeDepthStaysAddressable is the inverse mutant
+// of the depth gate. The gate keys on whether a default schema fills the schema
+// slot, not on the raw part count, so with no default schema the full
+// schema.object.child depth is still addressable — which is what the binary
+// does on a URL that names a database rather than a schema.
+//
+// Reverting the gate leaves this green: it asserts pre-existing behavior.
+// Replacing the gate with a flat "at most two parts" rule turns it red with
+// `too many parts in pattern: "app.orders.id"`, and narrowing it to columns
+// only turns the index assertion red with "orders_id_idx" still listed.
+func TestExcludeDatabase_RealmRelativeDepthStaysAddressable(t *testing.T) {
+	c := qt.New(t)
+
+	got, err := atlasfilter.ExcludeDatabase(defaultSchemaFixture(), []string{"app.orders.id"})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users", "app.orders"})
+	c.Assert(columnNames(got.Tables[1].Columns), qt.HasLen, 0)
+	c.Assert(indexNames(got.Indexes), qt.DeepEquals, []string{"users_name_idx"})
+}
+
+// TestExcludeDatabaseWithDefaultSchema_SchemaRelativeChildrenStayAddressable is
+// the cost control: the fix refuses a spelling, never a capability. Every child
+// the refused three-part patterns reached is still reachable by the
+// schema-relative spelling the binary itself requires in this scope, and
+// `--exclude users.name` on a schema-bound URL is measured to drop the column
+// on the pinned binary too.
+//
+// Reverting the gate leaves this green. Widening the gate to refuse two-part
+// patterns as well — the reading that says "the grammar admits no column part"
+// — turns every row red with `too many parts in pattern: "public.users.name"`
+// and its siblings.
+func TestExcludeDatabaseWithDefaultSchema_SchemaRelativeChildrenStayAddressable(t *testing.T) {
+	tests := []struct {
+		name    string
+		pattern string
+		assert  func(*qt.C, *dbschematypes.DBSchema)
+	}{
+		{
+			name:    "column",
+			pattern: "users.name",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(columnNames(got.Tables[0].Columns), qt.DeepEquals, []string{"id"})
+			},
+		},
+		{
+			name:    "every column of a table",
+			pattern: "users.*",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(columnNames(got.Tables[0].Columns), qt.HasLen, 0)
+			},
+		},
+		{
+			name:    "index",
+			pattern: "users.users_name_idx",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(columnNames(got.Tables[0].Columns), qt.DeepEquals, []string{"id", "name"})
+				c.Assert(indexNames(got.Indexes), qt.DeepEquals, []string{"orders_id_idx"})
+			},
+		},
+		{
+			// extensionVersions renders "name:version", so the empty tails are
+			// cleared versions rather than dropped extensions — the fixture
+			// carries "pgcrypto:1.3" and "plpgsql:1.0" before the filter.
+			name:    "extension field selector",
+			pattern: "*[type=extension].version",
+			assert: func(c *qt.C, got *dbschematypes.DBSchema) {
+				c.Assert(extensionVersions(got.Extensions), qt.DeepEquals, []string{"pgcrypto:", "plpgsql:"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got, err := atlasfilter.ExcludeDatabaseWithDefaultSchema(
+				defaultSchemaFixture(), []string{test.pattern}, "public")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(tableNames(got.Tables), qt.DeepEquals, []string{"users", "app.orders"})
+			test.assert(c, got)
+		})
+	}
+}
+
+// TestValidateExcludeSelectors_RefusesDepthNoScopeCanAddress covers the
+// pre-connect pass, which runs before a schema is known and can therefore only
+// apply the scope-independent half of the rule: a pattern too deep for the
+// deepest scope that exists is rejected without contacting a database, and a
+// pattern that only a schema prefix pushes over the limit is left to the filter.
+//
+// Reverting the gate prints `got non-nil error / got: nil` for the two refused
+// rows. Moving the whole rule here instead — where the default schema is not
+// known — turns the "three parts" row red with a refusal of a pattern that is
+// legal against a database-scoped URL.
+func TestValidateExcludeSelectors_RefusesDepthNoScopeCanAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		values  []string
+		wantErr string
+	}{
+		{name: "one part", values: []string{"users"}},
+		{name: "two parts", values: []string{"users.name"}},
+		{name: "three parts", values: []string{"public.users.name"}},
+		{
+			name:    "four parts",
+			values:  []string{"public.users.name.x"},
+			wantErr: `too many parts in pattern: "public.users.name.x"`,
+		},
+		{
+			name:    "four parts inside a comma list",
+			values:  []string{"users,*.*.*.*"},
+			wantErr: `too many parts in pattern: "*.*.*.*"`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			err := atlasfilter.ValidateExcludeSelectors(test.values)
+
+			c.Assert(errorText(err), qt.Equals, test.wantErr)
+		})
+	}
+}

--- a/internal/atlasfilter/scope_test.go
+++ b/internal/atlasfilter/scope_test.go
@@ -150,9 +150,12 @@ func TestValidateIncludeSelectors_FailurePath(t *testing.T) {
 
 // TestExcludeSelectorsReachChildResources pins that exclusion keeps parsing
 // the child-resource spellings it legitimately reaches. This asserts parsing
-// only: whether a given exclude spelling then matches is a separate,
-// pre-existing question — "table.child" matches on the default schema while
-// "schema.table.child" does not.
+// only, and only at the pre-connect layer, which does not yet know the schema
+// the patterns are relative to. Whether a spelling then survives the filter is
+// a separate question of depth: "table.child" names a child of the connection's
+// schema, while "schema.table.child" is one part too deep for that scope and is
+// refused there — see
+// TestExcludeDatabaseWithDefaultSchema_RefusesPatternsDeeperThanTheScope.
 func TestExcludeSelectorsReachChildResources(t *testing.T) {
 	c := qt.New(t)
 


### PR DESCRIPTION
Closes #1181.

## The decision the issue asked for

**The selector grammar does admit a column part.** The binary's refusal in the issue's six cells is a *depth* error, not a grammar prohibition — and that distinction is the whole fix.

I measured it directly. The pinned community binary reads a pattern **relative to the scope the URL names**, and caps it at three parts:

| URL scope | `--exclude users.name` | `--exclude public.users.name` |
|---|---|---|
| schema-bound (`?search_path=public`) | rc=0, **drops column `name`** | rc=1 `too many parts in pattern: "public.public.users.name"` |
| database (no `search_path`) | rc=0, no-op | rc=0, **drops column `name`** (and `public.users.users_name_idx` drops the index) |

So a third part addresses table children — columns *and* indexes — in realm scope. In schema scope the binary prefixes the schema name before counting, which is what pushes an already-qualified pattern to four parts and produces the doubled `public.public.`.

All six cells in the issue were measured on a schema-bound URL. The refusal there says the pattern's schema slot was already filled, not that columns are unaddressable.

**Ptah is always in the schema-bound scope.** Every reader is schema-scoped, `Info().Schema` is always populated (`"public"` for PostgreSQL, the database name for MySQL), and `schema inspect` against a database URL returns only the connection's schema — I verified the pinned binary lists `app.orders` there while ptah does not. So the binary's schema-scope arithmetic is the one that applies, and a three-part pattern is a usage error.

That is what this PR implements: prefix the default schema, cap at three parts, and report the binary's own message. Not an extension — the binary's own rule for the scope ptah occupies.

## Measured, PostgreSQL 16 + MySQL 8.0 in Docker

Pinned community binary at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (`atlas community version v1.3.0`) by absolute path, vs `ptah-compat` built from `d294bd86`'s descendant `3e5cf284` (before) and from this branch (after). PostgreSQL URL carries `?sslmode=disable&search_path=public`.

### The six cells the issue reported — all fixed

| `--exclude` | pinned binary | before | after |
|---|---|---|---|
| `public.users.name` | rc=1 `…"public.public.users.name"` | rc=0, drops `name` | rc=1, **byte-identical message** |
| `public.users.id` | rc=1 `…"public.public.users.id"` | rc=0, drops `id` + `primary_key` | rc=1, byte-identical |
| `public.users.*` | rc=1 `…"public.public.users.*"` | rc=0, drops every column | rc=1, byte-identical |
| `public.*.name` | rc=1 `…"public.public.*.name"` | rc=0, drops `name` | rc=1, byte-identical |
| `*.users.name` | rc=1 `…"public.*.users.name"` | rc=0, drops `name` | rc=1, byte-identical |
| `*.*.*` | rc=1 `…"public.*.*.*"` | rc=0, drops every column | rc=1, byte-identical |

MySQL, `--exclude auditdb.users.name` against `mysql://…/auditdb`: binary rc=1 `too many parts in pattern: "auditdb.auditdb.users.name"`; before rc=0 with `name` gone; after rc=1, byte-identical.

`schema diff` between two live PostgreSQL states with `--exclude public.users.name`: before rc=0 "Schemas are synced"; after rc=1 `apply --exclude to --from schema: too many parts in pattern: "public.public.users.name"`.

### The three pre-existing (a)-violating cells — **fixed, not left**

| `--exclude` | scope | pinned binary | before | after |
|---|---|---|---|---|
| `public.users.name.x` | schema-bound | rc=1 | rc=0 no-op | rc=1, byte-identical |
| `*.*.*.*` | database URL | rc=1 `…"*.*.*.*"` | rc=0 no-op | rc=1, byte-identical |
| `users.name.x` | schema-bound | rc=1 `…"public.users.name.x"` | rc=0 no-op | rc=1, byte-identical |

### A tenth cell found while reproducing

`--exclude a.b.c` against a table literally named `a.b.c`: binary rc=1 `too many parts in pattern: "public.a.b.c"`; ptah before rc=0 and **removed the table**. Now rc=1, byte-identical. The binary cannot address a dotted table name from this scope either, so no spelling it offers is lost.

### Controls — the capability survives, only the spelling is refused

Every child the refused patterns reached is still reachable, and these were measured live on the fixed binary:

| `--exclude` | result |
|---|---|
| `users.name` | rc=0, column `name` gone (and its index) — same as the pinned binary on a schema-bound URL |
| `users.users_name_idx` | rc=0, index gone, all columns intact |
| `public.users` | rc=0, table gone — #1175's fix is untouched |
| `*[type=extension].version` | rc=0, versions cleared |

MySQL control `--exclude users.name`: rc=0, column gone.

## Completion criteria

- `schema inspect --exclude public.users.name` against a database URL exits non-zero. ✅
- No `--exclude` invocation removes a column from a table it did not remove before. ✅ by construction — the change only ever *narrows* what matches. Patterns of two parts or fewer take an identical path; patterns of three or more now error and remove nothing.

## Parity rule (b): what this costs, weighed explicitly

Ptah now exits 1 for a three-part pattern where the binary on a **database** URL exits 0 and filters a table child. Two reasons that is the right trade and not a drop-in regression:

1. **Ptah has no realm scope to be measured against.** Its `schema inspect` on a database URL returns only the connection's schema. The realm reading of a three-part pattern was never available to a ptah user, so nothing that worked stops working.
2. **No capability is lost, only a spelling.** `users.name` and `users.users_name_idx` address exactly the same objects and remain accepted — and they are the spellings the binary itself requires in this scope.

Two behaviors do change for anyone who had found them:

- `--exclude a.b.c` no longer removes a table whose *name contains dots*. The binary refuses that spelling too, so this is a move toward parity, not away.
- `--exclude 'public.*[type=extension].version'` is now refused; `--exclude '*[type=extension].version'` is unaffected. Parts are counted on the raw pattern, selector text included, which is measured to be what the binary does (`public.public.*[type=extension].version`). The stale docs sentence claiming the qualified spelling works is removed.

One deliberate cosmetic difference: a pattern too deep for *any* scope (`*.*.*.*`) is refused pre-connect, where the schema is not yet known, so its message carries no schema prefix. On a schema-bound URL the binary prints `"public.*.*.*.*"` and ptah prints `"*.*.*.*"`. Same exit code, same error class; deferring it would mean contacting the database (and, for `schema clean`, resetting a dev database) before refusing.

`--include` is untouched — it has its own grammar and its own zero-match semantics from #1113.

## Tests

`internal/atlasfilter/filter_pattern_depth_test.go` pins all ten refusal cells with the binary's exact message bytes, the generated-side symmetry, the realm-relative control, and the schema-relative capability controls. The `public.users.name` row in `filter_default_schema_test.go` — which asserted the column drop and was the regression's own fixture — now uses the schema-relative spelling.

Both halves of the guard were checked with **inverse mutants**, not by reverting:

- `maxPatternParts = 2` (threshold off by one): reddens all 18 control rows including `SchemaRelativeChildrenStayAddressable` and #1175's `QualifiedPatternsReachDefaultSchema`; the refusal test stays green.
- Prefix inverted (prefix only when there is *no* default schema): reddens all 11 refusal rows, the generated-side symmetry, the realm-relative control and the pre-connect test; the shallow-pattern controls stay green.

Each half is separately load-bearing, and the tests separate them.

## Gates

`go build ./... && go vet ./... && go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh` — all green.

Docs touched, so all of `docs/site` `check:*` plus their `:selftest` variants and `node docs/site/scripts/build-feature-matrix.mjs --check` (163 rows) were run green. `check:responsive` exits 1 with "dist not found" — it was run against a real `npm run build`, not its no-op report.

## Process note

The issue is right that CI could not have caught this: no fixture asserted the column-part behavior in either direction. There is one now, in both.