### PR TITLE
docs: state what Ptah is for before stating what it does

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
 # Ptah
 
+Some systems are built to carry the weight of the world as it already exists.
+
+Ptah begins from a different premise: infrastructure should not merely bear
+complexity, but shape it. Named after the ancient Egyptian god of architects and
+craftsmen, Ptah turns intent into structure through four deliberate stages:
+**Parse, Transform, Apply, Harmonize**.
+
+It is built to understand the current state, reshape it with precision, apply
+change safely, and bring systems into alignment — without inheriting more weight
+than necessary.
+
+## What Ptah does
+
 Ptah is a schema and migration toolkit for Go projects. It can read annotated Go
 models, YAML schema files, supported HCL schema files, and live databases;
 render SQL; plan and run migrations; and validate migration hashes. A separate

--- a/docs/site/src/content/docs/index.mdx
+++ b/docs/site/src/content/docs/index.mdx
@@ -25,6 +25,17 @@ hero:
 
 import { LinkCard, CardGrid } from '@astrojs/starlight/components';
 
+Some systems are built to carry the weight of the world as it already exists.
+
+Ptah begins from a different premise: infrastructure should not merely bear
+complexity, but shape it. Named after the ancient Egyptian god of architects and
+craftsmen, Ptah turns intent into structure through four deliberate stages:
+**Parse, Transform, Apply, Harmonize**.
+
+It is built to understand the current state, reshape it with precision, apply
+change safely, and bring systems into alignment — without inheriting more weight
+than necessary.
+
 ## What do you need?
 
 <CardGrid>


### PR DESCRIPTION
Closes #1163.

The text is Denis's from the issue, used as written. It goes in two places:

- **`README.md`** — as the opening, above the existing feature paragraph. That paragraph now sits under a `## What Ptah does` heading instead of floating untitled between the title and the legal section.
- **`docs/site/src/content/docs/index.mdx`** — between the hero and `## What do you need?`, so the landing page opens the same way the README does.

No other content changed.

## Gates

Every docs gate, from `docs/site`:

```
check:style rc=0        check:links rc=0         check:core-doc-links rc=0
check:page-health rc=0  check:redirects rc=0     check:exit-codes rc=0
node scripts/build-feature-matrix.mjs --check rc=0
npm run build rc=0
check:responsive rc=0   -> OK (60 routes x 2 viewports, cells within 8 lines)
```

`check:responsive` needs a built `dist` and is the gate that broke master twice, so it was run against a fresh build rather than trusted.

**Control.** A gate that passes without inspecting the changed file proves nothing, so `check:style` was made to fail on purpose — inserting a banned filler word into the new paragraph:

```
$ npm run check:style
- docs/site/src/content/docs/index.mdx:31: banned filler "simply"; state the action instead
rc=1
```

Removing it returns rc=0. The gate reads the new text.