### PR TITLE
docs: put the atlas.hcl file() confinement in the gap register

### DIFF
--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -671,6 +671,7 @@ tracked. This table is the index; the sections carry the boundary detail.
 | [HCL schema and Atlas project config subset audit](#hcl-schema-and-atlas-project-config-subset-audit) | Product behavior and coverage | [#511](https://github.com/stokaro/ptah/issues/511) |
 | [Live and differential corpus breadth](#live-and-differential-corpus-breadth) | Conformance coverage | [ptah-atlas-conformance#167](https://github.com/stokaro/ptah-atlas-conformance/issues/167) |
 | [Verbs beyond the CE pin](#verbs-beyond-the-ce-pin) | Triage record | [#758](https://github.com/stokaro/ptah/issues/758) |
+| [`atlas.hcl` `file()` confinement](#atlashcl-file-confinement) | Deliberate divergence | [#1042](https://github.com/stokaro/ptah/issues/1042) |
 
 ### Atlas-compatible command runtime placeholders
 
@@ -834,6 +835,35 @@ Triage: `migrate ls` is covered by native `ptah migrations status` (lists every 
 Revisit when the conformance Atlas pin advances past v1.2.0.
 
 **Tracking.** [`stokaro/ptah#758`](https://github.com/stokaro/ptah/issues/758)
+
+
+### `atlas.hcl` `file()` confinement
+
+**Type.** Deliberate divergence
+
+**Current boundary.** `ptah-compat` reads `file()` and `fileset()` inside an
+`atlas.hcl` only from the directory holding that `atlas.hcl`. Three shapes are
+refused that the pinned community binary reads: an absolute path, a
+parent-traversal path, and a plain relative name that resolves out of the
+directory through a symbolic link. The refusal names which of the three applies
+and points at `getenv()` for passing a value in from outside.
+
+This is the one place `ptah-compat` is deliberately stricter than the binary it
+replaces, and it is stricter rather than looser, so it cannot exit 0 where the
+binary exits 1. The reason is that an `atlas.hcl` is usually repository-controlled
+and `file()` is evaluated before anything is applied: without confinement, a
+config file arriving in a pull request can read any file the process can and
+place the contents somewhere observable, such as a database URL or an error
+message. That is a different class of cost from the footguns the drop-in rule
+was written for.
+
+Both halves are measured rather than remembered. The Ptah half is pinned by
+`TestOraclePlacesOutsideFileContentsWhereTheCallerCanSeeThem` in
+`config/projectconfig`; the community half is pinned by four `ce-gating`
+scenarios in the conformance repository, so the day a community build starts
+confining `file()` the gate goes red and this divergence can be retired.
+
+**Tracking.** [`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042)
 
 A green docs build only proves the documentation site builds and internal links
 resolve. It is not parity evidence. Use the conformance reports for measured


### PR DESCRIPTION
Closes #1042, together with [ptah-atlas-conformance#272](https://github.com/stokaro/ptah-atlas-conformance/pull/272), which closes the issue's other open item.

The issue's definition of done had three parts. The decision and its reasoning were already recorded; what was missing was the measurement and the register entry.

## What this changes

The divergence was written up in the HCL-and-config section of `comparison.md`. The **gap register** — the index a reader consults to find what `ptah-compat` does differently — had nine rows and none of them was this one. A deliberate divergence that is not in the register is indistinguishable from a defect.

The index gains a tenth row and a section below it carrying the boundary: which three shapes are refused, why being stricter than the binary it replaces is the right trade here, and where both halves are pinned.

The issue's completion criterion was `sed -n '/^## Gap register/,$p' docs/site/src/content/docs/atlas/comparison.md | grep -c 1042` printing non-zero where it printed `0`, with the index at 10 rows where it had 9. It prints `2`, and the index has 10.

## The other half

The section claims both sides are measured, so both had to be true before it could say so:

- **Ptah side** — `TestOraclePlacesOutsideFileContentsWhereTheCallerCanSeeThem` in `config/projectconfig/atlas_file_sandbox_oracle_test.go:130`. Already present; verified to exist rather than cited from memory.
- **Community side** — was *not* measured anywhere. ptah-atlas-conformance#272 adds four `ce-gating` scenarios covering the absolute path, the parent traversal, the symlink, and a content control, all measured 2026-08-06 against the pinned community binary v1.3.0. Until that merges, this section's claim is ahead of the evidence by one PR.

## Gates

```
check:style rc=0        check:links rc=0        check:core-doc-links rc=0
check:page-health rc=0  check:redirects rc=0    check:exit-codes rc=0
node scripts/build-feature-matrix.mjs --check rc=0
npm run build rc=0
check:responsive rc=0   -> OK (60 routes x 2 viewports, cells within 8 lines)
```

`check:responsive` was run against a fresh `dist`, since it needs one and is the gate that has broken master twice.