### PR TITLE
Keep protobuf reservation state as ranges

### DIFF
--- a/docs/site/src/content/docs/schema/protobuf.md
+++ b/docs/site/src/content/docs/schema/protobuf.md
@@ -202,6 +202,12 @@ wire-relevant feature default differs between the two editions, and Edition
 Under editions, `reserved` names are bare identifiers (`reserved nickname;`),
 the inverse of the quoted form `proto2` and `proto3` use.
 
+Reservations are read back and written out as ranges, never as the numbers a
+range covers. A range is accepted at any width the field-number space allows,
+so a previous file carrying `reserved 20000 to 536870911;` round-trips
+unchanged and contiguous retired numbers are written as `reserved 2 to 8;`
+rather than one entry each.
+
 ## Type mapping
 
 The lookup is dialect-agnostic, so the Postgres and MySQL spellings Ptah emits
@@ -511,10 +517,6 @@ permanent, so nothing on this list is an unowned gap.
   next run read it as a type that left the schema: a previous file carrying
   `message AuditMarker {}` for a table still present in the source is refused
   with `types removed from the source schema: AuditMarker`.
-- A previous type whose `reserved` ranges expand past 1,048,576 individual
-  numbers is refused instead of being loaded partially. Partial loading could
-  reallocate a number that remains reserved in the published wire contract.
-  Tracked by [#1147](https://github.com/stokaro/ptah/issues/1147).
 - The three header comment lines are copied into whatever `protoc-gen-go`
   generates, so the content digest appears at the top of the `.pb.go` files
   too. It changes only when the schema changes. Tracked by

--- a/internal/protobufrender/model.go
+++ b/internal/protobufrender/model.go
@@ -1,6 +1,7 @@
 package protobufrender
 
 import (
+	"cmp"
 	"slices"
 	"sort"
 )
@@ -11,14 +12,6 @@ const (
 	reservedRangeStart = 19000
 	reservedRangeEnd   = 19999
 	maxFieldNumber     = 536870911
-
-	// maxReservedNumbers bounds how many individual numbers one type's
-	// reservations may expand to when a previous export is read back. The
-	// exporter only ever writes ranges it built from individual numbers, so
-	// reaching this cap means the input is not something this exporter produced;
-	// the bound keeps a "reserved 1 to max" style range from allocating two
-	// billion entries before the digest gate can reject the file.
-	maxReservedNumbers = 1 << 20
 )
 
 // field is one message field in the generated file.
@@ -40,16 +33,39 @@ type enumValue struct {
 // reservations are the numbers and names a type may never reuse. They are what
 // buys the WIRE_JSON compatibility guarantee: buf reports a removed field as
 // breaking unless both its number and its name are reserved.
+//
+// Numbers are held as ranges, the same shape a .proto spells them in. A single
+// legal range covers the whole 536,870,911-number field space, so expanding one
+// into individual numbers would make both loading and storage proportional to
+// the width of the reservation rather than to the number of ranges.
 type reservations struct {
-	Numbers []int32
-	Names   []string
+	Ranges []numberRange
+	Names  []string
+}
+
+// hasNumbers reports whether the type reserves any number at all.
+func (r *reservations) hasNumbers() bool {
+	return len(r.Ranges) > 0
+}
+
+// highest returns the largest reserved number, or 0 when nothing is reserved.
+func (r *reservations) highest() int32 {
+	var highest int32
+	for _, rng := range r.Ranges {
+		highest = max(highest, rng.End)
+	}
+	return highest
 }
 
 func (r *reservations) addNumber(n int32) {
-	if slices.Contains(r.Numbers, n) {
-		return
-	}
-	r.Numbers = append(r.Numbers, n)
+	r.addRange(n, n)
+}
+
+// addRange records [start, end] inclusive. Overlaps and duplicates are folded
+// away by normalizeRanges before the model is written, so callers may add the
+// same number twice.
+func (r *reservations) addRange(start, end int32) {
+	r.Ranges = append(r.Ranges, numberRange{Start: start, End: end})
 }
 
 func (r *reservations) addName(name string) {
@@ -63,16 +79,12 @@ func (r *reservations) hasName(name string) bool {
 	return slices.Contains(r.Names, name)
 }
 
-func (r *reservations) count() int {
-	return len(r.Numbers)
-}
-
 func (r *reservations) dropName(name string) {
 	r.Names = slices.DeleteFunc(r.Names, func(existing string) bool { return existing == name })
 }
 
 func (r *reservations) sort() {
-	slices.Sort(r.Numbers)
+	r.Ranges = normalizeRanges(r.Ranges)
 	slices.Sort(r.Names)
 }
 
@@ -133,40 +145,42 @@ type numberRange struct {
 	End   int32
 }
 
-// collapseRanges folds a sorted number list into contiguous runs so the writer
-// can emit "reserved 1 to 7;" instead of seven separate entries.
-func collapseRanges(numbers []int32) []numberRange {
-	if len(numbers) == 0 {
+// normalizeRanges sorts ranges ascending and folds overlapping or adjacent runs
+// into one, so two separately retired neighbors are written as "reserved 2 to
+// 3;" rather than "reserved 2, 3;". Merging is a correctness requirement and not
+// only formatting: protoc refuses a file whose reserved ranges overlap, and the
+// same number can reach the model from both a removed field and a range the
+// previous file already carried.
+func normalizeRanges(in []numberRange) []numberRange {
+	if len(in) == 0 {
 		return nil
 	}
-	sorted := slices.Clone(numbers)
-	slices.Sort(sorted)
-
-	ranges := []numberRange{{Start: sorted[0], End: sorted[0]}}
-	for _, n := range sorted[1:] {
-		last := &ranges[len(ranges)-1]
-		switch n {
-		case last.End:
-			// duplicate, already covered
-		case last.End + 1:
-			last.End = n
-		default:
-			ranges = append(ranges, numberRange{Start: n, End: n})
+	sorted := slices.Clone(in)
+	slices.SortFunc(sorted, func(a, b numberRange) int {
+		if a.Start != b.Start {
+			return cmp.Compare(a.Start, b.Start)
 		}
+		return cmp.Compare(a.End, b.End)
+	})
+
+	out := []numberRange{sorted[0]}
+	for _, rng := range sorted[1:] {
+		last := &out[len(out)-1]
+		// Compared in int64 so an end of the maximum field number cannot
+		// overflow the adjacency test.
+		if int64(rng.Start) <= int64(last.End)+1 {
+			last.End = max(last.End, rng.End)
+			continue
+		}
+		out = append(out, rng)
 	}
-	return ranges
+	return out
 }
 
-// nextNumber returns the next free field number for a type, given every number
-// it has ever used. Gaps are never filled and the protobuf implementation range
-// is skipped, so a number retired by a removed column can never come back.
-func nextNumber(used []int32) (int32, bool) {
-	var highest int32
-	for _, n := range used {
-		if n > highest {
-			highest = n
-		}
-	}
+// nextNumber returns the next free field number for a type, given the highest
+// number it has ever used. Gaps are never filled and the protobuf implementation
+// range is skipped, so a number retired by a removed column can never come back.
+func nextNumber(highest int32) (int32, bool) {
 	next := highest + 1
 	if next >= reservedRangeStart && next <= reservedRangeEnd {
 		next = reservedRangeEnd + 1

--- a/internal/protobufrender/previous.go
+++ b/internal/protobufrender/previous.go
@@ -55,15 +55,16 @@ type previousType struct {
 	Reserved reservations
 }
 
-// used returns every number the type has ever held, live or reserved, which is
-// what new allocations must exceed.
-func (p previousType) used() []int32 {
-	out := make([]int32, 0, len(p.Numbers)+len(p.Reserved.Numbers))
+// highestUsed returns the largest number the type has ever held, live or
+// reserved, which is what new allocations must exceed. It is a single number
+// rather than the list of every number ever used because a reserved range may
+// legally cover the whole field-number space.
+func (p previousType) highestUsed() int32 {
+	highest := p.Reserved.highest()
 	for _, n := range p.Numbers {
-		out = append(out, n)
+		highest = max(highest, n)
 	}
-	out = append(out, p.Reserved.Numbers...)
-	return out
+	return highest
 }
 
 // previousFile is the whole compatibility state of a previous export.
@@ -193,30 +194,23 @@ func enumState(ed protoreflect.EnumDescriptor) (previousType, error) {
 	return state, nil
 }
 
-// addRange records every number in [start, end] (inclusive) as reserved,
-// iterating in int64 so an end of MaxInt32 cannot overflow the counter. It
-// refuses unsupported or oversized state instead of truncating it: truncation
-// could make a later allocation reuse a number that remains reserved on the
-// wire.
+// addRange records [start, end] (inclusive) as reserved. The bounds are taken
+// in int64 because a descriptor's exclusive end is one past the largest legal
+// field number, which the caller decrements before it gets here.
+//
+// The range is kept as a range. Expanding it into individual numbers would cost
+// one entry per number and force a cap on the width the loader accepts, and a
+// capped loader must then refuse a reservation that protobuf itself considers
+// ordinary: the legal field-number space runs to 536,870,911 and a published
+// contract may legitimately retire all of it.
 func addRange(res *reservations, start, end int64) error {
+	// end >= start for every range protocompile produces, so bounding the end
+	// bounds the start too and both conversions below are in range.
 	if start < 0 || end > maxFieldNumber {
 		return fmt.Errorf("reserved range %d to %d is outside Ptah's supported numbering space", start, end)
 	}
-	size := end - start + 1
-	remaining := int64(maxReservedNumbers - res.count())
-	if size > remaining {
-		return fmt.Errorf(
-			"reserved ranges expand to more than %d numbers; refusing to truncate compatibility state",
-			maxReservedNumbers)
-	}
-	// protocompile has already rejected overlapping ranges. Append directly so
-	// loading a large valid range stays O(n); addNumber's duplicate scan would
-	// make this loop quadratic.
-	for n := start; n <= end; n++ {
-		// The bounds check above proves n fits the generator's int32 range.
-		number := int32(n) //nolint:gosec // Conversion is guarded by the supported-numbering-space check.
-		res.Numbers = append(res.Numbers, number)
-	}
+	//nolint:gosec // Both conversions are guarded by the supported-numbering-space check.
+	res.addRange(int32(start), int32(end))
 	return nil
 }
 

--- a/internal/protobufrender/previous_test.go
+++ b/internal/protobufrender/previous_test.go
@@ -70,15 +70,6 @@ func rejectionCases() []rejectionCase {
 		wantMsg:      "output file is not valid protobuf",
 		wantSentinel: protobufrender.ErrMalformed,
 	}, {
-		name: "oversized reserved state",
-		damage: func(_ *qt.C, _ []byte) []byte {
-			return previousExport(
-				"enum Huge {\n  HUGE_UNSPECIFIED = 0;\n  reserved 1 to 1048577;\n}\n")
-		},
-		wantMsg: "output file is not valid protobuf: enum \"Huge\": reserved ranges expand to more than 1048576 numbers; " +
-			"refusing to truncate compatibility state",
-		wantSentinel: protobufrender.ErrMalformed,
-	}, {
 		name: "unsupported negative reserved state",
 		damage: func(_ *qt.C, _ []byte) []byte {
 			return previousExport(

--- a/internal/protobufrender/reconcile.go
+++ b/internal/protobufrender/reconcile.go
@@ -114,7 +114,7 @@ func (b *builder) reconcileMessage(dm desiredMessage, prev *previousFile) (messa
 	}
 	msg.Reserved = cloneReservations(state.Reserved)
 
-	used := state.used()
+	highest := state.highestUsed()
 	live := map[string]bool{}
 
 	for _, df := range dm.Fields {
@@ -150,13 +150,13 @@ func (b *builder) reconcileMessage(dm desiredMessage, prev *previousFile) (messa
 		}
 
 		if !existed {
-			allocated, ok := nextNumber(used)
+			allocated, ok := nextNumber(highest)
 			if !ok {
 				return message{}, fmt.Errorf("message %q has exhausted the protobuf field number space", dm.Name)
 			}
 			number = allocated
 		}
-		used = append(used, number)
+		highest = max(highest, number)
 		msg.Fields = append(msg.Fields, field{
 			Name:     df.Name,
 			Number:   number,
@@ -191,16 +191,16 @@ func (b *builder) reconcileEnum(de enum, prev *previousFile) (enum, error) {
 	}
 	out.Reserved = cloneReservations(state.Reserved)
 
-	used := state.used()
+	highest := state.highestUsed()
 	live := map[string]bool{}
 
 	for _, dv := range de.Values {
 		live[dv.Name] = true
 
-		// The zero value is synthesized and always keeps number 0.
+		// The zero value is synthesized and always keeps number 0, which never
+		// raises the high-water mark: highestUsed is never negative.
 		if dv.Number == 0 {
 			out.Values = append(out.Values, enumValue{Name: dv.Name, Number: 0, Comment: dv.Comment})
-			used = append(used, 0)
 			continue
 		}
 
@@ -210,13 +210,13 @@ func (b *builder) reconcileEnum(de enum, prev *previousFile) (enum, error) {
 
 		number, existed := state.Numbers[dv.Name]
 		if !existed {
-			allocated, ok := nextNumber(used)
+			allocated, ok := nextNumber(highest)
 			if !ok {
 				return enum{}, fmt.Errorf("enum %q has exhausted the protobuf number space", de.Name)
 			}
 			number = allocated
 		}
-		used = append(used, number)
+		highest = max(highest, number)
 		out.Values = append(out.Values, enumValue{Name: dv.Name, Number: number, Comment: dv.Comment})
 	}
 
@@ -299,14 +299,14 @@ const tombstoneComment = "Removed from the source schema; retained for wire comp
 // no live fields, but numbers reserved. Detected structurally rather than from
 // the comment, because comments are not part of the compatibility state.
 func isMessageTombstone(state previousType) bool {
-	return len(state.Numbers) == 0 && len(state.Reserved.Numbers) > 0
+	return len(state.Numbers) == 0 && state.Reserved.hasNumbers()
 }
 
 // isEnumTombstone reports whether a previous enum is already a tombstone. An
 // enum can never be emptied - protoc rejects an enum with no values - so a
 // tombstoned enum retains exactly its synthesized zero value.
 func isEnumTombstone(state previousType) bool {
-	if len(state.Reserved.Numbers) == 0 || len(state.Numbers) != 1 {
+	if !state.Reserved.hasNumbers() || len(state.Numbers) != 1 {
 		return false
 	}
 	for _, number := range state.Numbers {
@@ -317,8 +317,8 @@ func isEnumTombstone(state previousType) bool {
 
 func cloneReservations(in reservations) reservations {
 	return reservations{
-		Numbers: append([]int32(nil), in.Numbers...),
-		Names:   append([]string(nil), in.Names...),
+		Ranges: append([]numberRange(nil), in.Ranges...),
+		Names:  append([]string(nil), in.Names...),
 	}
 }
 

--- a/internal/protobufrender/render.go
+++ b/internal/protobufrender/render.go
@@ -91,20 +91,20 @@ func renderEnum(sb *strings.Builder, en enum) {
 }
 
 func hasReservations(res reservations) bool {
-	return len(res.Numbers) > 0 || len(res.Names) > 0
+	return res.hasNumbers() || len(res.Names) > 0
 }
 
-// writeReservations emits numbers as one ascending statement with contiguous
-// runs collapsed, then names as one statement in ascending order. Under
-// editions the names are bare identifiers: quoting them is a hard parse error,
-// which is the inverse of proto2/proto3.
+// writeReservations emits numbers as one ascending statement, each range
+// written the way it is held, then names as one statement in ascending order.
+// Under editions the names are bare identifiers: quoting them is a hard parse
+// error, which is the inverse of proto2/proto3.
 func writeReservations(sb *strings.Builder, res reservations) {
-	if len(res.Numbers) == 0 && len(res.Names) == 0 {
+	if !hasReservations(res) {
 		return
 	}
-	if len(res.Numbers) > 0 {
-		parts := make([]string, 0, len(res.Numbers))
-		for _, r := range collapseRanges(res.Numbers) {
+	if res.hasNumbers() {
+		parts := make([]string, 0, len(res.Ranges))
+		for _, r := range res.Ranges {
 			if r.Start == r.End {
 				parts = append(parts, strconv.FormatInt(int64(r.Start), 10))
 				continue

--- a/internal/protobufrender/reservedrange_test.go
+++ b/internal/protobufrender/reservedrange_test.go
@@ -1,0 +1,187 @@
+package protobufrender_test
+
+import (
+	"runtime"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// wideRangeCase is one previous baseline whose only distinguishing property is
+// the width of a single reserved range.
+type wideRangeCase struct {
+	name string
+	// reserved is the range statement as the baseline spells it.
+	reserved string
+	// widened is the same statement covering one more number, used to damage
+	// the baseline without re-stamping its digest.
+	widened string
+}
+
+// wideRangeCases walk the reserved range from narrower than the retired
+// 1,048,576-number expansion cap up to the whole legal field-number space.
+// Every row is otherwise byte-identical, so the set measures the width of the
+// reservation and nothing else.
+func wideRangeCases() []wideRangeCase {
+	return []wideRangeCase{{
+		name:     "6 numbers, narrower than the retired cap",
+		reserved: "20000 to 20005",
+		widened:  "20000 to 20006",
+	}, {
+		name:     "1010001 numbers, just under the retired cap",
+		reserved: "20000 to 1030000",
+		widened:  "20000 to 1030001",
+	}, {
+		name:     "2080001 numbers, past the retired cap",
+		reserved: "20000 to 2100000",
+		widened:  "20000 to 2100001",
+	}, {
+		name:     "536850912 numbers, the whole legal space above the implementation range",
+		reserved: "20000 to 536870911",
+		// The whole legal space cannot grow upward, so it grows downward.
+		widened: "19999 to 536870911",
+	}}
+}
+
+func TestReservedRangesSurviveRegardlessOfWidth(t *testing.T) {
+	for _, rc := range wideRangeCases() {
+		t.Run(rc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			previous := previousExport(
+				"message Thing {\n  int64 id = 1;\n\n  reserved " + rc.reserved + ";\n}\n")
+
+			// The range must come back as a range. Expanding it into individual
+			// numbers is what forced the loader to cap the width it accepts.
+			rewritten := mustRenderText(c, oneTable(column("id", "BIGINT")), withPrevious(previous))
+			c.Assert(section(rewritten, "message Thing {"), qt.Equals,
+				"message Thing {\n  int64 id = 1;\n\n  reserved "+rc.reserved+";\n}")
+
+			// Regenerating from the file just produced reproduces it exactly, so
+			// the range survives a full write-then-read cycle rather than only
+			// the first rewrite.
+			again := mustRenderText(c, oneTable(column("id", "BIGINT")), withPrevious([]byte(rewritten)))
+			c.Assert(again, qt.Equals, rewritten)
+		})
+	}
+}
+
+func TestReservedRangesStillGuardTheirBaseline(t *testing.T) {
+	// Non-interference control: widening the range by one number without
+	// re-stamping the digest is still refused. Without it, accepting the wide
+	// baselines above could equally mean the integrity gate stopped running on
+	// them.
+	for _, rc := range wideRangeCases() {
+		t.Run(rc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			previous := previousExport(
+				"message Thing {\n  int64 id = 1;\n\n  reserved " + rc.reserved + ";\n}\n")
+			damaged := strings.Replace(string(previous),
+				"reserved "+rc.reserved+";", "reserved "+rc.widened+";", 1)
+			c.Assert(damaged, qt.Not(qt.Equals), string(previous))
+
+			message := mustFail(c, oneTable(column("id", "BIGINT")), withPrevious([]byte(damaged)))
+			c.Assert(message, qt.Contains, "output file was modified since it was generated")
+		})
+	}
+}
+
+func TestReservedEnumRangesKeepTheirInclusiveEnd(t *testing.T) {
+	c := qt.New(t)
+
+	// Enum reserved ranges carry an INCLUSIVE end where message ranges carry an
+	// exclusive one, so a width past the retired cap has to prove the last
+	// number is neither dropped nor invented.
+	previous := previousExport(
+		"message Thing {\n  ThingState state = 1;\n}\n\n" +
+			"enum ThingState {\n  THING_STATE_UNSPECIFIED = 0;\n  THING_STATE_NEW = 1;\n\n" +
+			"  reserved 20000 to 2100000;\n}\n")
+
+	rewritten := mustRenderText(c, inlineEnumTable("new"), withPrevious(previous))
+	c.Assert(section(rewritten, "enum ThingState {"), qt.Equals,
+		"enum ThingState {\n"+
+			"  THING_STATE_UNSPECIFIED = 0;\n"+
+			"  THING_STATE_NEW = 1;\n"+
+			"\n"+
+			"  reserved 20000 to 2100000;\n"+
+			"}")
+}
+
+func TestReservedRangeAllocationClearsTheWholeRange(t *testing.T) {
+	c := qt.New(t)
+
+	// Every number inside a reserved range is retired for good, so a new column
+	// allocates above the range's end rather than into the hole it leaves.
+	previous := previousExport(
+		"message Thing {\n  int64 id = 1;\n\n  reserved 20000 to 2100000;\n}\n")
+
+	grown := mustRenderText(c, oneTable(column("id", "BIGINT"), column("extra", "TEXT")),
+		withPrevious(previous))
+	c.Assert(section(grown, "message Thing {"), qt.Equals,
+		"message Thing {\n  int64 id = 1;\n  string extra = 2100001;\n\n  reserved 20000 to 2100000;\n}")
+}
+
+func TestReservedRangesMergeWithNewlyRetiredNeighbors(t *testing.T) {
+	c := qt.New(t)
+
+	// A number retired by this run that sits immediately above a range the
+	// previous file already carried extends that range instead of being written
+	// beside it, so a column removed one at a time produces the same statement
+	// as the same columns removed together.
+	previous := previousExport(
+		"message Thing {\n  int64 id = 1;\n  string keep = 8;\n\n  reserved 2 to 7;\n  reserved sku;\n}\n")
+
+	shrunk := mustRenderText(c, oneTable(column("id", "BIGINT")), withPrevious(previous))
+	c.Assert(section(shrunk, "message Thing {"), qt.Equals,
+		"message Thing {\n  int64 id = 1;\n\n  reserved 2 to 8;\n  reserved keep, sku;\n}")
+}
+
+func TestReservedRangeCoveringALiveNumberIsRefused(t *testing.T) {
+	c := qt.New(t)
+
+	// A baseline that reserves a number one of its own fields still holds is
+	// not valid protobuf and must stay refused however wide the range is:
+	// loading it would carry the contradiction forward into the next export.
+	previous := previousExport(
+		"message Thing {\n  int64 id = 5;\n\n  reserved 1 to 2100000;\n}\n")
+
+	message := mustFail(c, oneTable(column("id", "BIGINT")), withPrevious(previous))
+	c.Assert(message, qt.Contains, "output file is not valid protobuf")
+	c.Assert(message, qt.Contains,
+		"message acme.inventory.v1.Thing: field id is using tag 5 which is in reserved range 1 to 2100000")
+}
+
+func TestReservedRangeLoadingDoesNotExpandTheRange(t *testing.T) {
+	c := qt.New(t)
+
+	// Loading is linear in the number of ranges, not in the count of numbers
+	// they cover. The range below covers 40,000,000 numbers, which is 160 MB as
+	// a []int32 and 320 MB as a []numberRange. The whole export is held to a
+	// 64 MiB budget, measured at 119,344 bytes, so the budget sits far above
+	// what the range representation needs and far below any expansion of it.
+	//
+	// The width is 40,000,000 rather than the whole legal space so that an
+	// expanding implementation fails this assertion instead of exhausting the
+	// machine before it can be measured.
+	previous := previousExport(
+		"message Thing {\n  int64 id = 1;\n\n  reserved 20000 to 40019999;\n}\n")
+
+	before := totalAlloc()
+	rewritten := mustRenderText(c, oneTable(column("id", "BIGINT")), withPrevious(previous))
+	allocated := totalAlloc() - before
+
+	c.Assert(rewritten, qt.Contains, "  reserved 20000 to 40019999;\n")
+	c.Assert(allocated < 64<<20, qt.IsTrue,
+		qt.Commentf("export allocated %d bytes loading one 40000000-number reserved range", allocated))
+}
+
+// totalAlloc reports the process's cumulative allocated bytes. The difference
+// across one call is what distinguishes a range kept as a range from a range
+// expanded into individual numbers.
+func totalAlloc() uint64 {
+	var stats runtime.MemStats
+	runtime.ReadMemStats(&stats)
+	return stats.TotalAlloc
+}


### PR DESCRIPTION
Closes #1147.

`internal/protobufrender` read a previous export's `reserved` statements by expanding every range into individual `int32` entries. That representation forced a cap — `maxReservedNumbers = 1 << 20` — and a wider range was refused. The legal field-number space runs to 536,870,911, so a published contract may reserve more than the loader accepted.

`reservations` now holds `[]numberRange` instead of `[]int32`. `addRange` stores the range as the file spells it, `reservations.sort` normalizes by sorting and merging overlapping or adjacent runs, and `previousType.used` (every number ever held) becomes `highestUsed`, with `nextNumber` taking that high-water mark instead of the list.

## Measured

CLI, one `ptah` built from this branch, one models directory (`accounts(id BIGINT, email TEXT)`), three hand-built baselines identical except for the width of one `reserved` range, each re-stamped with a valid `ptah:content-sha256`:

| Previous baseline | Individual numbers | Result |
| --- | --- | --- |
| `reserved 20000 to 20005;` | 6 | exit **0** |
| `reserved 20000 to 2100000;` | 2,080,001 | exit **0**, file byte-identical, digest `50ab9778…` unchanged |
| `reserved 20000 to 536870911;` | 536,850,912 | exit **0**, file byte-identical, digest `6ea7e3d9…` unchanged |

Acceptance 3 is unchanged behavior and is now pinned by a test: a baseline whose live field sits inside a reserved range is still refused with

```
output file is not valid protobuf: acme/inventory/v1/schema.proto:9:14: message acme.inventory.v1.Thing: field id is using tag 5 which is in reserved range 1 to 2100000
```

Acceptance 4 is measured, not asserted from the shape of the code: loading one 40,000,000-number range allocates 119,344 bytes for the whole export, against a 64 MiB budget in the test.

## Mutants

**M1 — restore the retired cap in `addRange`** (revert of the behavior change). Five tests redden; the 6-number and 1,010,001-number rows and the digest control stay green, so the pair measures the range width and nothing else:

```
--- FAIL: TestReservedRangesSurviveRegardlessOfWidth (0.00s)
    --- FAIL: TestReservedRangesSurviveRegardlessOfWidth/2080001_numbers,_past_the_retired_cap (0.00s)
            error:
              got non-nil error
            got:
              e`output file is not valid protobuf: message "Thing": reserved ranges expand to more than 1048576 numbers; refusing to truncate compatibility state`
    --- FAIL: TestReservedRangesSurviveRegardlessOfWidth/536850912_numbers,_the_whole_legal_space_above_the_implementation_range (0.00s)
--- FAIL: TestReservedEnumRangesKeepTheirInclusiveEnd (0.00s)
--- FAIL: TestReservedRangeAllocationClearsTheWholeRange (0.00s)
--- FAIL: TestReservedRangeLoadingDoesNotExpandTheRange (0.00s)
FAIL	go.5x5.cz/ptah/internal/protobufrender	0.380s
```

The same mutant built as a binary reproduces the issue at the CLI, and the narrow baseline separates it from a binary that is simply broken:

```
$ ptah-m1 schema export --to protobuf … --out …/wide/schema.proto
error: output file is not valid protobuf: message "Account": reserved ranges expand to more than 1048576 numbers; refusing to truncate compatibility state
exit=2

$ ptah-m1 schema export --to protobuf … --out …/narrow/schema.proto   # reserved 20000 to 20005
Exported 1 message(s), 2 field(s), 0 enum(s)
exit=0
```

**M2 — drop the cap but keep the expansion** (`for n := start; n <= end; n++ { res.addRange(int32(n), int32(n)) }`). This is the mutant that matters, because `TestReservedRangesSurviveRegardlessOfWidth/2080001_numbers…` **passes** under it — the emitted text is identical, so width alone cannot tell a range from an expansion. Only the allocation assertion separates them:

```
--- FAIL: TestReservedRangeLoadingDoesNotExpandTheRange (1.15s)
    reservedrange_test.go:176:
        error:
          value is not true
        comment:
          export allocated 2519306952 bytes loading one 40000000-number reserved range
        got:
          bool(false)
FAIL	go.5x5.cz/ptah/internal/protobufrender	1.596s
```

The fixture width is 40,000,000 rather than the whole space so an expanding implementation fails the assertion instead of exhausting the machine before it can be measured.

## Other changes

- The rejection case `oversized reserved state` is deleted from `previous_test.go`: it pinned the refusal this PR removes. The `unsupported negative reserved state` case stays, and `reserved -1;` is still refused with `reserved range -1 to -1 is outside Ptah's supported numbering space`.
- `normalizeRanges` merges adjacent runs, so a number retired by this run that sits directly above a range the previous file carried extends that range (`reserved 2 to 7;` + retired 8 → `reserved 2 to 8;`) rather than being written beside it. Pinned by `TestReservedRangesMergeWithNewlyRetiredNeighbors`.
- Docs: the Limitations bullet about the 1,048,576 cap is removed, and the editions section states that reservations round-trip as ranges at any legal width.

## Gates

From the repo root of the worktree, exit code confirmed for each:

- `go build ./...` 0
- `go vet ./...` 0
- `go test ./... -count=1` 0 (176 packages ok)
- `go tool qtlint ./...` 0
- `golangci-lint run ./...` 0 issues
- `./scripts/check-test-style.sh` OK (175 conditional groups, 45 white-box files)
- `./scripts/check-public-api.sh` 0
- `./scripts/check-public-api-snapshot.sh` 0

Docs gates, run because `docs/site` is touched: `check:exit-codes` (+selftest), `check:core-doc-links`, `check:page-health`, `check:links` (+selftest), `check:redirects` (+selftest), `check:style` (+selftest), `check:limitations` OK (1 governed page) and its selftest OK (7 assertions), `versions:selftest`, and `node docs/site/scripts/build-feature-matrix.mjs --check` OK (164 rows).

`check:responsive` did **not** run: it reports `SKIPPED (playwright is not installed…)` and exits 0 without measuring anything. Installing playwright here would write into a `node_modules` outside this worktree. That check reddens on table row count; this diff adds no table and removes no table row.