### PR TITLE
security: pin the rooted migrate-diff publication and recovery boundary (#895)

### DIFF
--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -675,6 +675,36 @@ alongside table changes) are refused.
 Docker dev databases fail explicitly until their provisioning semantics are
 implemented.
 
+### The publication boundary
+
+`migrate diff` opens the migration directory and its parent once, before
+anything is staged, and keeps both handles for the rest of the run. The parent
+is held as well because the publication journal and the commit marker sit
+beside the directory, so an interrupted run stays recoverable even when the
+directory itself was left half-built.
+
+Every later step names a direct child of one of those two handles: the staged
+files, the published migrations, `atlas.sum`, the journal, the commit marker,
+the rollback quarantine, and orphan cleanup. Recovery runs through the same
+handles, so an interrupted batch is withdrawn from the objects the run opened.
+The directory pathname survives only in reported paths and error text, and no
+write step resolves it a second time.
+
+This draws the boundary against a directory replaced after the run validated
+it. Replacing the pathname, or re-pointing a symlink on the way to it, no
+longer selects where the run writes: a migration or an `atlas.sum` can land
+only in the directory that was captured and verified. When the directory came
+from `atlas.hcl`, both handles are opened through the project root, so a
+replacement cannot move the write outside that root either.
+
+Two things stay keyed to the pathname on purpose. The cross-process lock file
+is created beside the directory before any handle exists, because it is
+cooperative mutual exclusion between Ptah processes rather than a boundary
+against a hostile writer, and every verb has to agree on its identity. The
+`--edit` callback also receives absolute staged paths, because an external
+editor cannot take a handle; the files it returns are re-validated through the
+retained handle before anything is published.
+
 ## Validate integrity
 
 `ptah-compat migrate validate` verifies the migration directory against

--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -95,6 +95,21 @@ verification, migration registration, destructive linting, shadow rollback
 verification, execution, and template reports all consume the same captured
 bytes.
 
+## Writing back to the directory
+
+The verbs that write a migration directory — `migrate diff` and native
+`ptah migrate generate` — bind it the same way and keep the binding. They open
+the directory and its parent once, before staging, and every staged file,
+published migration, `atlas.sum`, journal, commit marker, rollback quarantine
+and cleanup entry is named as a direct child of one of those two handles.
+Recovery of an interrupted batch runs through the same handles.
+
+Replacing the directory after the run validated it therefore cannot redirect
+what it writes, and a directory configured through `atlas.hcl` stays inside the
+opened project root. See
+[the publication boundary](../../atlas/migrate-commands/#the-publication-boundary)
+for what remains keyed to the pathname and why.
+
 ## Consequences
 
 - **The directory is portable.** Every environment replays the same files in

--- a/internal/atlasmigrate/diff_renamed_directory_unix_test.go
+++ b/internal/atlasmigrate/diff_renamed_directory_unix_test.go
@@ -1,0 +1,135 @@
+//go:build !windows
+
+package atlasmigrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+)
+
+// This is stokaro/ptah#895's own reproduction, kept as a regression test.
+//
+// It differs from the rows in diff_root_unix_test.go in the shape of the
+// replacement, and that difference is the point. Those rows put a symlink at
+// the --dir pathname up front and re-point it; here --dir names a real
+// directory when the run binds it, and the directory itself is then MOVED --
+// renamed aside, with a symlink to a decoy dropped into the name it vacated.
+//
+// A writer that carries the pathname cannot tell the two apart: both leave the
+// same string resolving somewhere else. A writer that carries the opened handle
+// survives both, but for different reasons -- a re-pointed symlink never
+// touched the object it opened, whereas here the object it opened is the one
+// that moved, and the handle has to follow it.
+//
+// The decoy is seeded with a live copy of the migration directory, staged
+// temporary file included, rather than being left empty. That is deliberate:
+// against an empty decoy a pathname writer merely errors out on a staging file
+// it can no longer find, which is a visible failure. Against a copy it succeeds
+// -- exit 0, a migration and an atlas.sum written somewhere the operator never
+// named -- and silent success is the defect the issue reported.
+//
+// The swap runs from PreparePublication, the last callback before anything is
+// published: the lock is held, recovery has run, the snapshot has been captured
+// and verified, and the batch is already staged. Everything the run writes after
+// that point -- the migration file, atlas.sum, the journal, the commit marker
+// and any rollback -- is therefore decided entirely by whether the writer still
+// means the directory it opened.
+//
+// Unix only. The fixture renames a directory that the run holds open, which
+// POSIX permits and Win32 refuses unless the handle carries FILE_SHARE_DELETE.
+// The guarantee under test is that a retained handle keeps naming the same
+// object across such a rename; on Windows the rename is denied outright, so the
+// hostile step cannot be performed and there is nothing to measure.
+func TestGenerateDiff_RenamedDirectoryCannotRedirectPublication(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name string
+		// swap replaces the migration directory from inside the callback. The
+		// control leaves the tree alone, so the same assertions must hold with
+		// and without the hostile step -- that is what makes "the decoy received
+		// nothing" evidence rather than an artifact of reading the wrong tree.
+		swap func(c *qt.C, migrations, retained, decoy string)
+		// published names the directory that must receive the run's output.
+		published func(migrations, retained string) string
+	}{
+		{
+			name: "directory renamed aside and replaced by a symlink to a live copy",
+			swap: func(c *qt.C, migrations, retained, decoy string) {
+				// The copy carries the staged temporary file along with the
+				// migrations. That is what lets a pathname writer complete its
+				// run against the decoy instead of failing on a staging file it
+				// can no longer find.
+				c.Assert(os.CopyFS(decoy, os.DirFS(migrations)), qt.IsNil)
+				c.Assert(os.Rename(migrations, retained), qt.IsNil)
+				c.Assert(os.Symlink(decoy, migrations), qt.IsNil)
+			},
+			published: func(_, retained string) string { return retained },
+		},
+		{
+			name:      "control: nothing is replaced",
+			swap:      func(*qt.C, string, string, string) {},
+			published: func(migrations, _ string) string { return migrations },
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			root := c.TempDir()
+			migrations := filepath.Join(root, "migrations")
+			retained := filepath.Join(root, "migrations.moved")
+			decoy := filepath.Join(root, "decoy")
+			c.Assert(os.MkdirAll(migrations, 0o755), qt.IsNil)
+			c.Assert(os.MkdirAll(decoy, 0o755), qt.IsNil)
+			// The directory already holds a migration, so a run that follows the
+			// replacement still passes every version and checksum check on the
+			// way in and fails only where the write lands.
+			c.Assert(os.WriteFile(
+				filepath.Join(migrations, "1_init.sql"),
+				[]byte("CREATE TABLE legacy (id INTEGER PRIMARY KEY);\n"),
+				0o600,
+			), qt.IsNil)
+			schemaPath := filepath.Join(root, "schema.sql")
+			c.Assert(os.WriteFile(schemaPath, []byte(`
+CREATE TABLE legacy (id INTEGER PRIMARY KEY);
+CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT NOT NULL DEFAULT '');
+`), 0o600), qt.IsNil)
+			conn := connectSQLite(c, filepath.Join(root, "dev.db"))
+			defer dbschema.CloseAndWarn(conn)
+
+			prepared := 0
+			var decoyAfterSwap []string
+			result, err := atlasmigrate.GenerateDiff(context.Background(), conn, atlasmigrate.DiffOptions{
+				Dir:         migrations,
+				Root:        openDiffProjectRoot(c, root),
+				Desired:     localDesiredSet(c, "file://"+schemaPath),
+				Name:        "add_users",
+				LockTimeout: time.Second,
+				PreparePublication: func([]string) error {
+					prepared++
+					test.swap(c, migrations, retained, decoy)
+					decoyAfterSwap = dirEntryNames(c, decoy)
+					return nil
+				},
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(prepared, qt.Equals, 1)
+			c.Assert(result.MigrationPaths, qt.HasLen, 1)
+			// The run published into the object it opened.
+			published := test.published(migrations, retained)
+			c.Assert(atlasSQLFiles(c, published), qt.HasLen, 2)
+			c.Assert(fileExists(filepath.Join(published, "atlas.sum")), qt.IsTrue)
+			// The decoy holds exactly what the swap left in it: no migration, no
+			// checksum, no journal and no recovery artifact reached it.
+			c.Assert(dirEntryNames(c, decoy), qt.DeepEquals, decoyAfterSwap)
+		})
+	}
+}

--- a/internal/atlasmigrate/publication_retained_recovery_nonwindows_internal_test.go
+++ b/internal/atlasmigrate/publication_retained_recovery_nonwindows_internal_test.go
@@ -1,0 +1,118 @@
+//go:build !windows
+
+package atlasmigrate
+
+// White-box testing required: recovery of an interrupted publication is reached
+// through no exported callback, so the interrupted state has to be built with
+// the internal staging and journal primitives and the bound writer handed to
+// recovery directly.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// Recovery is the half of stokaro/ptah#895 that no callback can reach: it runs
+// before the first callback of a diff run, and on the native generate surface
+// it runs as the whole operation. The tests around it therefore build the
+// interrupted state, replace the directory underneath the bound writer, and
+// then call recovery directly.
+//
+// Both rows assert the same two things, because either one alone can be
+// satisfied by the wrong code: recovery repaired the directory it opened, AND
+// it left the replacement completely untouched. A recovery that follows the
+// pathname satisfies neither -- it withdraws the decoy's copy and leaves the
+// retained directory holding the file the interrupted batch published.
+//
+// Unix only, for the same reason as
+// TestGenerateDiff_RenamedDirectoryCannotRedirectPublication: the fixture
+// renames a directory the writer holds open, which Win32 refuses outright.
+
+// entryExists reports whether path names an entry at all. It does not follow a
+// final symlink, so an assertion about a name inside the retained directory
+// answers for that directory rather than for whatever a link would reach.
+func entryExists(path string) bool {
+	_, err := os.Lstat(path)
+	return err == nil
+}
+
+// replaceBoundDirectory moves dir aside to retained and leaves a symlink to
+// decoy in its place, the way a hostile writer would between the moment the
+// interrupted run was cut short and the moment the next lock holder recovers.
+func replaceBoundDirectory(c *qt.C, dir, retained, decoy string) {
+	c.Helper()
+	// The decoy is a live copy, staged temporary files included, so a recovery
+	// that follows the pathname finds a complete interrupted batch there and
+	// withdraws that one instead of erroring out on a missing file.
+	c.Assert(os.CopyFS(decoy, os.DirFS(dir)), qt.IsNil)
+	c.Assert(os.Rename(dir, retained), qt.IsNil)
+	c.Assert(os.Symlink(decoy, dir), qt.IsNil)
+}
+
+func TestRecoverPendingPublication_RollsBackInTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	retained := filepath.Join(root, "migrations.moved")
+	decoy := filepath.Join(root, "decoy")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "1_initial.sql"), []byte("SELECT 1;"), 0o600), qt.IsNil)
+	_, err := migratesum.WriteWithFormat(dir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	writer := openTestWriter(c, dir)
+	batch, err := stageMigrationBatchAt(
+		writer,
+		"interrupted",
+		2,
+		[]MigrationFileContent{{SQL: "SELECT 2;"}},
+	)
+	c.Assert(err, qt.IsNil)
+	_, _ = beginTestPublication(c, writer, batch, []MigrationFileContent{{SQL: "SELECT 2;"}})
+	published, err := publishMigrationBatch(writer, batch)
+	c.Assert(err, qt.IsNil)
+	c.Assert(published, qt.Equals, 1)
+	publishedName := filepath.Base(batch.paths[0])
+	stagedName := batch.stagedNames[0]
+	replaceBoundDirectory(c, dir, retained, decoy)
+
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
+
+	// The retained directory is the one that was rolled back.
+	c.Assert(entryExists(filepath.Join(retained, publishedName)), qt.IsFalse)
+	c.Assert(entryExists(filepath.Join(retained, stagedName)), qt.IsFalse)
+	c.Assert(entryExists(testJournalPath(writer)), qt.IsFalse)
+	// The replacement kept every byte it was given.
+	c.Assert(entryExists(filepath.Join(decoy, publishedName)), qt.IsTrue)
+	c.Assert(entryExists(filepath.Join(decoy, stagedName)), qt.IsTrue)
+}
+
+func TestRecoverPendingPublication_CleansUpInTheRetainedDirectory(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	dir := filepath.Join(root, "migrations")
+	retained := filepath.Join(root, "migrations.moved")
+	decoy := filepath.Join(root, "decoy")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	writer := openTestWriter(c, dir)
+	// An orphan staging file with no journal beside it: the shape an aborted run
+	// leaves behind, which recovery removes as cleanup rather than as rollback.
+	stagedName, err := stageRootedFile(
+		writer.dir,
+		stagedMigrationPattern,
+		[]byte("SELECT 1;"),
+		publishedFileMode,
+	)
+	c.Assert(err, qt.IsNil)
+	replaceBoundDirectory(c, dir, retained, decoy)
+
+	c.Assert(recoverPendingPublication(writer), qt.IsNil)
+
+	c.Assert(entryExists(filepath.Join(retained, stagedName)), qt.IsFalse)
+	c.Assert(entryExists(filepath.Join(decoy, stagedName)), qt.IsTrue)
+}


### PR DESCRIPTION
Supersedes #1170. That branch cannot be rebased — it targets machinery #1168
(`028ac05d`) rewrote, and replaying its 1359/577 diff would reconcile two
designs hunk by hunk. This one is cut from current master and keeps only what
#1168 did not cover.

## The measurement first

#895 asked for the migrate-diff write path to publish through retained
directory handles instead of reopening the migration-directory pathname. Most
of that is already in. `internal/atlasmigrate/publication.go` on master
contains **no `os.*` filesystem call at all** — `filepath.Join` survives only
for reported paths and error text — and `migrationWriterDir`
(`internal/atlasmigrate/writerdir.go`) holds one `pathguard.OpenedDirectory`
on the migration directory and one on its parent, opened before staging.

So the first thing done here was to run #895's own reproduction against master:
swap the directory from inside `PreparePublication`, after the lock, after
recovery, after the capture and verification, and after the batch is staged.

```
generateDiff err = <nil>
MigrationPaths = [.../001/migrations/1786023915_fault_injection.sql]
SumPath        = .../001/migrations/atlas.sum
sql in ATTACKER dir .../001/attacker            = [1_init.sql]
sql in RETAINED dir .../001/migrations.retained = [1786023915_fault_injection.sql 1_init.sql]
atlas.sum in ATTACKER = false
atlas.sum in RETAINED = true
```

It passes. `DiscardIfCreatedEmpty`, which the issue names as having the same
verify-close-remove race, no longer exists anywhere in the tree, and the
rollback quarantine is a flat sibling file rather than a directory, so
"rooted cleanup cannot remove a replacement directory" holds by construction.

What was left unmet was coverage and prose. **No production file is touched by
this PR.**

## What this adds

**`TestGenerateDiff_RenamedDirectoryCannotRedirectPublication`** — #895's
reproduction, kept as a regression test.

It differs from the rows already in `diff_root_unix_test.go` in the shape of
the replacement, and that difference is the point. Those rows put a symlink at
the `--dir` pathname up front and re-point it, so the object the run opened was
never touched. Here `--dir` names a real directory when the run binds it, and
the directory itself is **moved** — renamed aside, with a symlink to a decoy
dropped into the name it vacated. A pathname writer cannot tell the two apart;
a handle writer survives both for different reasons, and only here does the
handle have to follow the object it opened.

The decoy is seeded with a live copy, staged temporary file included. Against
an empty decoy a pathname writer merely errors out on a staging file it can no
longer find, which is a visible failure. Against a copy it exits 0 and writes
a migration and an `atlas.sum` somewhere the operator never named. Silent
success is the defect the issue reported, so that is the shape the fixture has
to produce.

**`TestRecoverPendingPublication_RollsBackInTheRetainedDirectory`** and
**`_CleansUpInTheRetainedDirectory`** — acceptance criterion 2. Recovery is
reached through no callback, so these build the interrupted state with the
internal staging and journal primitives, replace the directory underneath the
bound writer, and call recovery directly. Each asserts both halves, because
either alone can be satisfied by the wrong code: the retained directory was
repaired, **and** the replacement kept every byte.

**Documentation** — acceptance criterion 7. A new "The publication boundary"
section under `migrate diff`, and a "Writing back to the directory" section on
the migration-directory concept page. They state which artifacts are addressed
relative to which handle, that recovery runs through the same handles, and
what deliberately stays keyed to the pathname: the cross-process lock file
(cooperative mutual exclusion every verb has to agree on) and the `--edit`
callback (an external editor cannot take a handle; the result is re-validated
through the retained handle).

## Windows

Both new files are `//go:build !windows`. The fixtures rename a directory the
run holds open, which POSIX permits and Win32 refuses unless the handle
carries `FILE_SHARE_DELETE`. The guarantee under test is that a retained
handle keeps naming the same object across such a rename; where the rename is
denied outright there is no hostile step to perform and nothing to measure.

This is the same wall two tests on #1170's branch hit on the
`windows-publication` job. Dropping the assertion was never an option there or
here — it is the discriminator. Scoping the fixture to the platform where the
hostile step is possible is.

## Discriminators

**Mutant A** — re-resolve the migration directory by pathname after the editor
hook, which is what the pre-#1168 writer did:

```go
if reopened, reopenErr := pathguard.OpenDirectory(w.path); reopenErr == nil {
    w.dir = reopened
}
```

The new swap row goes red, with `generateDiff` still returning `nil`:

```
--- FAIL: TestGenerateDiff_RenamedDirectoryCannotRedirectPublication/directory_renamed_aside_and_replaced_by_a_symlink_to_a_live_copy
    error:
      unexpected length
    len(got):
      int(1)
    got:
      []string{".../001/migrations.moved/1_init.sql"}
    want length:
      int(2)
        c.Assert(atlasSQLFiles(c, published), qt.HasLen, 2)
--- PASS: TestGenerateDiff_RenamedDirectoryCannotRedirectPublication/control:_nothing_is_replaced
```

The no-swap control row stays green. Across the whole package mutant A reddens
exactly two tests — this one and the existing
`TestGenerateDiff_ReplacedDirectoryCannotRedirectPublication`. That existing
test fails **differently**: all four of its rows report

```
e"read staged migration file after preparation: openat .ptah-migrate-diff-5UALDGPJHFSEZMRHGJWDPESQFR.tmp: no such file or directory"
```

a visible refusal. The new row is the only one that measures the silent
redirect, which is why it is worth adding beside them.

**Mutant B** — re-resolve the pathname on entry to
`recoverPendingPublication`. Both new recovery tests go red on the same shape:

```
--- FAIL: TestRecoverPendingPublication_RollsBackInTheRetainedDirectory
    error:
      value is not false
    got:
      bool(true)
        c.Assert(entryExists(filepath.Join(retained, publishedName)), qt.IsFalse)

--- FAIL: TestRecoverPendingPublication_CleansUpInTheRetainedDirectory
    error:
      value is not false
    got:
      bool(true)
        c.Assert(entryExists(filepath.Join(retained, stagedName)), qt.IsFalse)
```

The eleven pre-existing `TestRecoverPendingPublication_*` tests all stay green
under mutant B. That is the non-interference control: the mutant does not
simply break everything it touches. Mutant A does not redden the recovery
tests and mutant B does not redden the rename-shape row, because each targets
the half its test measures.

## Gates

All from the worktree root, exit codes captured immediately:

```
build 0 · vet 0 · qtlint 0 · golangci-lint 0
check-test-style 0 (175 conditional groups, 45 white-box files)
check-public-api 0 · check-public-api-snapshot 0 · gofmt -l empty
GOOS=windows build 0 · GOOS=windows vet ./internal/... ./cmd/... ./migration/... 0
```

`docs/` is touched, so all 15 scripts in `docs/site/package.json` ran after
`npm ci` and `npm run build` — including `check:responsive`, which reports
`dist not found` and checks nothing without the build — each exit 0, plus
`node docs/site/scripts/build-feature-matrix.mjs --check` (164 rows).
`check:links` was confirmed to actually resolve the new cross-page anchor by
breaking it and watching it go red:

```
Broken internal documentation links:
- src/content/docs/concepts/migration-directory.md: ../../atlas/migrate-commands/#the-publication-boundary-typo points at #the-publication-boundary-typo, which no heading on /atlas/migrate-commands/ produces
```

`check-test-style` was likewise confirmed live: it first rejected the new
internal test file with `missing white-box justification comment after package
clause` before the justification was added.

`go test ./... -count=1` reports one failure,
`cmd/viz TestSVGReportsGraphvizStderrOnFailure`, with `render SVG with
Graphviz dot: signal: killed` at exactly 10.00s. `cmd/viz/viz.go:111` gives
the `dot` process a fixed 10-second budget, and under a full parallel run on
this machine the fake `dot` script does not get scheduled inside it. The
package passes on its own, measured twice. This PR adds two test files in
`internal/atlasmigrate` and edits two markdown pages; nothing it touches is
reachable from `cmd/viz`.

Closes #895