### PR TITLE
Scope migrate lint to the schema the dev URL covers (#1074 S1)

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6621,6 +6621,12 @@ type Options struct {
     // PathPrefix is prepended (with /) to file names in findings so they
     // point at real repository paths in CI annotations.
     PathPrefix string
+    // SchemaScope names the single schema under review, normally the schema the
+    // dev database URL restricts analysis to. Findings and schema changes that
+    // name an object in a different schema are excluded: that object is not in
+    // the state the run compares against, so changing it is not a covered
+    // change. Empty puts every schema under review and filters nothing.
+    SchemaScope string
     // Selection restricts linting to parsed migration versions while retaining
     // the full captured directory for reporting.
     Selection VersionSelection

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -771,9 +771,20 @@ that report a statement rather than the objects in it — is always reported,
 since there is nothing to measure a scope against and a hazard must not be
 silenced on an unestablished boundary.
 
-Both surfaces read the boundary from the same `--dev-url`, so `ptah-compat
-migrate lint` and native `ptah migrations lint` never disagree about what is
-under review.
+The boundary applies to `ptah-compat migrate lint` only. Native
+`ptah migrations lint` keeps every object under review, whatever the dev URL
+selects, so the two surfaces deliberately disagree about scope.
+
+The reason the boundary exists on the compatibility surface is that the tool it
+replaces reviews only what the dev URL covers, and matching that is the whole
+point of the surface. The reason it does not exist natively is that the
+justification for it — an object outside the dev URL's reach was never in the
+before-state the run compares against — describes a diff-based analyzer, and
+Ptah's linter reads SQL text. That is why it reports `TRUNCATE` and
+`DROP SCHEMA`, neither of which produces a diff. Scoped natively,
+`DROP TABLE app."Users", app.audit_log;` under `search_path=public` reports
+nothing and exits 0, on the one surface where no other tool can be consulted
+about whether that is right.
 
 ### Renames
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -745,6 +745,36 @@ per-object finding names its object in the native message, which is also what
 keeps each SARIF result's fingerprint distinct when several of them share a
 rule, a file, and a line.
 
+### Which objects are under review
+
+The dev database is what a lint run compares against, so it also decides which
+objects the run analyzes. A PostgreSQL-family `--dev-url` carrying
+`?search_path=<schema>` puts exactly that one schema under review:
+
+- an object in a different schema raises no diagnostic and counts as no schema
+  change, because it was never part of the state the run compares against;
+- an unqualified reference resolves into the reviewed schema, so it stays under
+  review, and so does a reference written out with the reviewed schema's own
+  name;
+- one statement is measured per object: `DROP TABLE users, other.audit_log;`
+  under `search_path=public` reports `users` and counts one schema change.
+
+A `--dev-url` that names no schema puts the whole connected database under
+review and filters nothing, which is also what every non-PostgreSQL dev URL
+does. A `search_path` naming more than one schema is not a scope: it is read as
+a single schema name, so it scopes nothing and every object stays under review.
+
+An `ALTER TABLE` belongs to its table's schema, never to the column or
+constraint it names, and a `CREATE SCHEMA` is measured against the reviewed
+schema by its own name. A diagnostic that names no object at all — the rules
+that report a statement rather than the objects in it — is always reported,
+since there is nothing to measure a scope against and a hazard must not be
+silenced on an unestablished boundary.
+
+Both surfaces read the boundary from the same `--dev-url`, so `ptah-compat
+migrate lint` and native `ptah migrations lint` never disagree about what is
+under review.
+
 ### Renames
 
 A rename retires one logical name and introduces another. The two surfaces

--- a/integration/atlas_migrate_lint_schema_scope_e2e_test.go
+++ b/integration/atlas_migrate_lint_schema_scope_e2e_test.go
@@ -296,3 +296,65 @@ func assertLintE2EScopedReport(
 	c.Assert(stderr, qt.Equals, "")
 	c.Assert(redactLintE2EDurations(stdout), qt.Equals, want)
 }
+
+// TestNativeMigrationsLintIgnoresTheDevURLSchemaScopeE2E pins the half of the
+// #1074 S1 decision that has no comparison binary: the schema boundary belongs
+// to the Atlas-compatible surface only.
+//
+// The argument for scoping is that an object outside the dev URL's reach was
+// never in the before-state the run compares against. That describes a
+// diff-based analyzer. Ptah's native linter reads SQL text, which is why it
+// reports TRUNCATE and DROP SCHEMA -- neither of which produces a diff. Scoping
+// it turned two error-grade DS101 findings into "No lint findings." and exit 1
+// into exit 0, silently, on the surface where no binary can be consulted about
+// whether that is right.
+//
+// Removing the profile gate in migrationlintreport leaves every other test in
+// the repository green, so without this row the split is unpinned.
+func TestNativeMigrationsLintIgnoresTheDevURLSchemaScopeE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_lint_native_scope_e2e_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	migrationsDir := c.TempDir()
+	writeLintE2EFile(c, migrationsDir, "1.sql",
+		"CREATE SCHEMA app;\nCREATE TABLE app.\"Users\" (id int);\nCREATE TABLE app.audit_log (id int);\n")
+	writeLintE2EFile(c, migrationsDir, "2.sql", "DROP TABLE app.\"Users\", app.audit_log;\n")
+
+	devURL := withLintE2ESearchPath(c, replaceDatabaseName(c, dbURL, testDBName), "public")
+
+	// The same directory and the same dev URL the compatibility surface answers
+	// with "no diagnostics found" and exit 0.
+	stdout, stderr, err := runLintE2EBinary(ctx, nativeBinary,
+		"migrations", "lint",
+		"--dir", migrationsDir,
+		"--dir-format", "atlas",
+		"--dev-url", devURL,
+		"--latest", "1",
+	)
+
+	// The native report goes to stderr, so both streams are joined rather than
+	// asserted on one: reading only stdout here made this test pass against an
+	// empty string.
+	report := stdout + stderr
+
+	c.Assert(err, qt.ErrorMatches, "exit status 1")
+	c.Assert(report, qt.Contains, `DROP TABLE permanently deletes table app."Users"`)
+	c.Assert(report, qt.Contains, "DROP TABLE permanently deletes table app.audit_log")
+	c.Assert(report, qt.Contains, "2 finding(s).")
+	c.Assert(report, qt.Not(qt.Contains), "No lint findings.")
+}

--- a/integration/atlas_migrate_lint_schema_scope_e2e_test.go
+++ b/integration/atlas_migrate_lint_schema_scope_e2e_test.go
@@ -86,10 +86,14 @@ func TestAtlasMigrateLintSchemaScopeE2E(t *testing.T) {
 		"  -- 1 version ok\n"
 
 	tests := []struct {
-		name        string
-		base        string
-		next        string
-		searchPath  string
+		name       string
+		base       string
+		next       string
+		searchPath string
+		// setupSQL runs on the fresh test database before the migrations do. Only
+		// the row that reviews a schema other than public needs it: the dev
+		// database has to already carry that schema for the snapshot to succeed.
+		setupSQL    string
 		wantExitOne bool
 		want        string
 	}{
@@ -241,6 +245,26 @@ func TestAtlasMigrateLintSchemaScopeE2E(t *testing.T) {
 				"  -- 2 schema changes\n" +
 				"  -- 2 diagnostics\n",
 		},
+		{
+			// The row that proves the scope is the URL's VALUE and not the
+			// constant "public". Every other row reviews public, so substituting
+			// that constant for whatever the URL names leaves them all green --
+			// measured, that mutant survives the entire suite without this cell.
+			//
+			// Here the dev URL reviews `app` while the migration creates and drops
+			// tables explicitly qualified as `public`, so the objects are OUT of
+			// scope and the run is silent. Under the constant they would be in
+			// scope and the run would report two DS102 and exit 1.
+			//
+			// The pinned community binary v1.3.0 answers exactly this: rc=0,
+			// `-- no diagnostics found`, `-- 1 version ok`.
+			name:       "the reviewed schema is the URL's value, not a constant",
+			setupSQL:   "CREATE SCHEMA app;",
+			base:       "CREATE TABLE public.\"Users\" (id int);\nCREATE TABLE public.audit_log (id int);\n",
+			next:       "DROP TABLE public.\"Users\", public.audit_log;\n",
+			searchPath: "app",
+			want:       silent,
+		},
 	}
 
 	for _, test := range tests {
@@ -248,6 +272,7 @@ func TestAtlasMigrateLintSchemaScopeE2E(t *testing.T) {
 			testDBName := fmt.Sprintf("ptah_lint_scope_e2e_%d", time.Now().UnixNano())
 			createE2EDatabase(c, ctx, adminDB, testDBName)
 			defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+			runLintE2ESetupSQL(c, ctx, dbURL, testDBName, test.setupSQL)
 
 			migrationsDir := c.TempDir()
 			writeLintE2EFile(c, migrationsDir, "1.sql", test.base)
@@ -258,6 +283,21 @@ func TestAtlasMigrateLintSchemaScopeE2E(t *testing.T) {
 				scopedLintE2EDevURL(c, devURL, test.searchPath), test.wantExitOne, test.want)
 		})
 	}
+}
+
+// runLintE2ESetupSQL runs a row's setup statement on its own fresh database. A
+// row that names no setup is a no-op, so the ordinary rows keep meeting an
+// untouched database.
+func runLintE2ESetupSQL(c *qt.C, ctx context.Context, dbURL, testDBName, statement string) {
+	c.Helper()
+	if statement == "" {
+		return
+	}
+	db, err := sql.Open("pgx", replaceDatabaseName(c, dbURL, testDBName))
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+	_, err = db.ExecContext(ctx, statement)
+	c.Assert(err, qt.IsNil)
 }
 
 // scopedLintE2EDevURL applies the row's search_path, if it names one.

--- a/integration/atlas_migrate_lint_schema_scope_e2e_test.go
+++ b/integration/atlas_migrate_lint_schema_scope_e2e_test.go
@@ -1,0 +1,298 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// withLintE2ESearchPath returns dbURL carrying a `search_path` query parameter,
+// which is how a dev URL declares the one schema a lint run reviews.
+func withLintE2ESearchPath(c *qt.C, dbURL, schema string) string {
+	c.Helper()
+	parsed, err := url.Parse(dbURL)
+	c.Assert(err, qt.IsNil)
+	query := parsed.Query()
+	query.Set("search_path", schema)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+// TestAtlasMigrateLintSchemaScopeE2E covers issue #1074 S1 against a live
+// PostgreSQL dev database: which objects `migrate lint` puts under review.
+//
+// The dev database is what a lint run diffs against, so it also decides what is
+// being analyzed. With `?search_path=public`, an object a migration creates and
+// destroys in schema `app` was never in the before-state, so its destruction is
+// not a covered change -- no diagnostic, no schema change, exit 0. Ptah used to
+// report it and exit 1, which is stricter but means the two tools disagreed
+// about what was even under review.
+//
+// The rows below are a 2x2 plus its boundary controls, and every axis is
+// separated by a row that moves only that axis:
+//
+//   - target count -- the single-target `app` row answers the same as the
+//     two-target one, which is what proves this is not the multi-target defect
+//     closed by #1112;
+//   - object kind -- the `app` DROP COLUMN row shows the boundary is the schema,
+//     not the DROP TABLE grammar;
+//   - schema -- the `public` rows must stay reported and keep exiting 1;
+//   - qualification -- `public.users` written out in full is in scope, so the
+//     filter reads the qualifier rather than merely preferring bare names;
+//   - mixed statement -- one statement dropping `users` and `app.audit_log`
+//     reports exactly one table and counts exactly one schema change, so the
+//     filter is per object rather than per statement;
+//   - the boundary itself -- the same `app` fixture through a dev URL with NO
+//     `search_path` reports both drops and exits 1, which is the row that fails
+//     if the filter ever stops depending on the dev URL.
+//
+// Verified against the pinned community binary v1.3.0 on PostgreSQL 16: every
+// `want` below is that binary's report byte for byte, with only the two elapsed
+// durations redacted, and every `wantExitOne` its exit status.
+func TestAtlasMigrateLintSchemaScopeE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah-compat")
+	buildPtahCompat(c, ctx, repoRoot, binaryPath)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	const appBase = "CREATE SCHEMA app;\nCREATE TABLE app.\"Users\" (id int);\nCREATE TABLE app.audit_log (id int);\n"
+	const publicBase = "CREATE TABLE users (id int);\nCREATE TABLE audit_log (id int);\n"
+	const silent = "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+		"\n" +
+		"  -- analyzing version 2\n" +
+		"    -- no diagnostics found\n" +
+		"  -- ok (DUR)\n" +
+		"\n" +
+		"  -------------------------\n" +
+		"  -- DUR\n" +
+		"  -- 1 version ok\n"
+
+	tests := []struct {
+		name        string
+		base        string
+		next        string
+		searchPath  string
+		wantExitOne bool
+		want        string
+	}{
+		{
+			name:       "two targets outside the reviewed schema",
+			base:       appBase,
+			next:       "DROP TABLE app.\"Users\", app.audit_log;\n",
+			searchPath: "public",
+			want:       silent,
+		},
+		{
+			name:       "one target outside the reviewed schema",
+			base:       appBase,
+			next:       "DROP TABLE app.\"Users\";\n",
+			searchPath: "public",
+			want:       silent,
+		},
+		{
+			name:       "a column dropped outside the reviewed schema",
+			base:       "CREATE SCHEMA app;\nCREATE TABLE app.users (id int, nick text);\n",
+			next:       "ALTER TABLE app.users DROP COLUMN nick;\n",
+			searchPath: "public",
+			want:       silent,
+		},
+		{
+			name:       "objects created outside the reviewed schema count no change",
+			base:       "CREATE TABLE seed (id int);\n",
+			next:       "CREATE SCHEMA app2;\nCREATE TABLE app2.t (id int);\nCREATE TABLE keep (id int);\n",
+			searchPath: "public",
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- no diagnostics found\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version ok\n" +
+				"  -- 1 schema change\n",
+		},
+		{
+			name:        "control: two targets inside the reviewed schema",
+			base:        publicBase,
+			next:        "DROP TABLE users, audit_log;\n",
+			searchPath:  "public",
+			wantExitOne: true,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"audit_log\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"audit_log\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			name:        "control: one target inside the reviewed schema",
+			base:        publicBase,
+			next:        "DROP TABLE users;\n",
+			searchPath:  "public",
+			wantExitOne: true,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name:        "control: targets qualified with the reviewed schema itself",
+			base:        "CREATE TABLE public.users (id int);\nCREATE TABLE public.audit_log (id int);\n",
+			next:        "DROP TABLE public.users, public.audit_log;\n",
+			searchPath:  "public",
+			wantExitOne: true,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"audit_log\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"audit_log\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			name:        "one statement across both schemas reports only the in-scope table",
+			base:        "CREATE SCHEMA app;\nCREATE TABLE users (id int);\nCREATE TABLE app.audit_log (id int);\n",
+			next:        "DROP TABLE users, app.audit_log;\n",
+			searchPath:  "public",
+			wantExitOne: true,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name:        "control: a dev URL naming no schema reviews the whole database",
+			base:        appBase,
+			next:        "DROP TABLE app.\"Users\", app.audit_log;\n",
+			searchPath:  "",
+			wantExitOne: true,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"Users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"      -- L1: Dropping table \"audit_log\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure table \"Users\" is empty before dropping it\n" +
+				"      -> Add a pre-migration check to ensure table \"audit_log\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 2 diagnostics\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			testDBName := fmt.Sprintf("ptah_lint_scope_e2e_%d", time.Now().UnixNano())
+			createE2EDatabase(c, ctx, adminDB, testDBName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+			migrationsDir := c.TempDir()
+			writeLintE2EFile(c, migrationsDir, "1.sql", test.base)
+			writeLintE2EFile(c, migrationsDir, "2.sql", test.next)
+
+			devURL := replaceDatabaseName(c, dbURL, testDBName)
+			assertLintE2EScopedReport(c, ctx, binaryPath, migrationsDir,
+				scopedLintE2EDevURL(c, devURL, test.searchPath), test.wantExitOne, test.want)
+		})
+	}
+}
+
+// scopedLintE2EDevURL applies the row's search_path, if it names one.
+func scopedLintE2EDevURL(c *qt.C, devURL, searchPath string) string {
+	c.Helper()
+	scoped := map[bool]func() string{
+		true:  func() string { return devURL },
+		false: func() string { return withLintE2ESearchPath(c, devURL, searchPath) },
+	}
+	return scoped[searchPath == ""]()
+}
+
+// assertLintE2EScopedReport runs the compatibility binary and asserts its
+// report and exit status together, so a matching report cannot hide a
+// divergent exit code.
+func assertLintE2EScopedReport(
+	c *qt.C,
+	ctx context.Context,
+	binaryPath, migrationsDir, devURL string,
+	wantExitOne bool,
+	want string,
+) {
+	c.Helper()
+	stdout, stderr, err := runLintE2EBinary(ctx, binaryPath,
+		"migrate", "lint",
+		"--dir", "file://"+migrationsDir,
+		"--dev-url", devURL,
+		"--latest", "1",
+	)
+
+	assertExit := map[bool]func(){
+		true:  func() { c.Assert(err, qt.ErrorMatches, "exit status 1") },
+		false: func() { c.Assert(err, qt.IsNil) },
+	}
+	assertExit[wantExitOne]()
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(redactLintE2EDurations(stdout), qt.Equals, want)
+}

--- a/internal/atlasreport/migrate_lint_text.go
+++ b/internal/atlasreport/migrate_lint_text.go
@@ -146,8 +146,14 @@ func writeMigrateLintTextSummary(w io.Writer, model migrateLintText, elapsed str
 	if _, err := fmt.Fprintf(w, "  -- %s\n", versionSummary(model.okCount, model.warnCount, model.errCount)); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(w, "  -- %s\n", pluralize(model.changes, "schema change", "schema changes")); err != nil {
-		return err
+	// A run that expresses no schema change prints no schema-change line at all
+	// rather than "0 schema changes". Measured on two shapes: a version whose
+	// only statement is an INSERT, and a version whose only changes are to a
+	// schema the dev URL does not cover -- both end at the version-summary line.
+	if model.changes > 0 {
+		if _, err := fmt.Fprintf(w, "  -- %s\n", pluralize(model.changes, "schema change", "schema changes")); err != nil {
+			return err
+		}
 	}
 	if model.diagnostics == 0 {
 		return nil

--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -520,12 +520,15 @@ func TestWriteMigrateLintText_RendersAtlasDiagnostics(t *testing.T) {
 			// and the diagnostic count rises. Written users first, reported pets
 			// first.
 			//
-			// The `0 schema changes` line is a known divergence, not parity:
+			// The missing schema-change line is a known divergence, not parity:
 			// Ptah's parser does not model the standalone RENAME TABLE
 			// statement, so it contributes no semantic change, where the
 			// analyzer this tool matches counts four. It is pre-existing --
-			// master reports 0 here too -- and dialect-specific to the MySQL
-			// grammar; the diagnostics above are what #1074 aligned.
+			// master reports zero here too -- and dialect-specific to the MySQL
+			// grammar; the diagnostics above are what #1074 aligned. A count of
+			// zero prints no line at all (see the INSERT-only case below), so
+			// the divergence now shows as an absent line rather than as
+			// "0 schema changes".
 			name: "several table renames in one statement are ordered by name",
 			files: map[string]string{
 				"1.sql": "CREATE TABLE users (id int);\nCREATE TABLE pets (id int);\n",
@@ -546,8 +549,31 @@ func TestWriteMigrateLintText_RendersAtlasDiagnostics(t *testing.T) {
 				"  -------------------------\n" +
 				"  -- 0s\n" +
 				"  -- 1 version with errors\n" +
-				"  -- 0 schema changes\n" +
 				"  -- 2 diagnostics\n",
+		},
+		{
+			// #1074 S1: a version that expresses no schema change prints no
+			// schema-change line at all. Measured against the pinned community
+			// binary v1.3.0: a version whose only statement is an INSERT ends at
+			// the version-summary line, where Ptah used to add
+			// "-- 0 schema changes". The scope filter made this reachable on
+			// versions that do carry DDL, because DDL against a schema the dev
+			// URL does not cover counts nothing.
+			name: "a version expressing no schema change prints no change line",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE t (id int);\n",
+				"2.sql": "INSERT INTO t (id) VALUES (1);\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- no diagnostics found\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version ok\n",
 		},
 	}
 

--- a/internal/atlasurl/schema_scope.go
+++ b/internal/atlasurl/schema_scope.go
@@ -1,0 +1,58 @@
+package atlasurl
+
+import (
+	"net/url"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// searchPathParam is the PostgreSQL-family query parameter that restricts a
+// database URL to a single schema.
+const searchPathParam = "search_path"
+
+// SchemaScope returns the one schema a database URL restricts schema analysis
+// to, or the empty string when the URL puts every schema of the connected
+// database under review.
+//
+// This is the boundary `migrate lint` reviews within: the dev database snapshot
+// a lint run diffs against covers exactly this scope, so an object a migration
+// creates or destroys outside it was never in the before-state and its
+// destruction is not a covered change.
+//
+// Only the PostgreSQL-family `search_path` form is recognized, and only when it
+// names exactly one schema. Measured against the pinned community binary
+// v1.3.0 on PostgreSQL 16, with an earlier migration creating `app."Users"` and
+// `app.audit_log` and the next one dropping both:
+//
+//   - `postgres://…?search_path=public` reports no diagnostic, counts no schema
+//     change and exits 0;
+//   - the same directory through the same URL WITHOUT `search_path` reports one
+//     DS102 per dropped table and exits 1;
+//   - `search_path=public,app` is not a search-path list to that binary but one
+//     schema NAME, and it refuses the run outright with
+//     `taking database snapshot: postgres: schema "public,app" was not found`.
+//
+// The third case has no scoping behavior to match, so a comma-carrying value
+// scopes nothing here and every object stays under review. Every other dialect
+// scopes nothing for the same reason: the boundary has not been measured there,
+// and reviewing more than the comparison tool does is the safe direction.
+func SchemaScope(rawURL string) string {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return ""
+	}
+	dialect, err := DialectFromURL(rawURL)
+	if err != nil || !platform.IsPostgresFamily(dialect) {
+		return ""
+	}
+	parsed, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+	scope := strings.TrimSpace(parsed.Query().Get(searchPathParam))
+	if scope == "" || strings.Contains(scope, ",") {
+		return ""
+	}
+	return scope
+}

--- a/internal/atlasurl/schema_scope_test.go
+++ b/internal/atlasurl/schema_scope_test.go
@@ -1,0 +1,112 @@
+package atlasurl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasurl"
+)
+
+// TestSchemaScope pins which dev URLs restrict schema analysis to one schema
+// (stokaro/ptah#1074 S1).
+//
+// The empty results are what keep the boundary honest: a URL that scopes
+// nothing leaves every object under review, which is how a dialect or a URL
+// form that has not been measured against the pinned community binary v1.3.0
+// stays at least as strict as it is today.
+func TestSchemaScope(t *testing.T) {
+	tests := []struct {
+		name   string
+		rawURL string
+		want   string
+	}{
+		{
+			name:   "empty URL scopes nothing",
+			rawURL: "",
+			want:   "",
+		},
+		{
+			name:   "postgres without search_path scopes nothing",
+			rawURL: "postgres://localhost:5432/dev?sslmode=disable",
+			want:   "",
+		},
+		{
+			name:   "postgres search_path names the reviewed schema",
+			rawURL: "postgres://localhost:5432/dev?sslmode=disable&search_path=public",
+			want:   "public",
+		},
+		{
+			name:   "a non-public search_path is honored as written",
+			rawURL: "postgres://localhost:5432/dev?search_path=app",
+			want:   "app",
+		},
+		{
+			name:   "the postgresql spelling is the same dialect",
+			rawURL: "postgresql://localhost/dev?search_path=reporting",
+			want:   "reporting",
+		},
+		{
+			name:   "cockroachdb is in the PostgreSQL family",
+			rawURL: "cockroach://localhost:26257/dev?search_path=app",
+			want:   "app",
+		},
+		{
+			name:   "yugabytedb is in the PostgreSQL family",
+			rawURL: "yugabyte://localhost:5433/dev?search_path=app",
+			want:   "app",
+		},
+		{
+			// The pinned binary reads this value as one schema NAME and refuses
+			// the run with `schema "public,app" was not found`, so there is no
+			// scoping behavior to match and nothing is filtered.
+			name:   "a comma-carrying search_path scopes nothing",
+			rawURL: "postgres://localhost/dev?search_path=public,app",
+			want:   "",
+		},
+		{
+			name:   "an empty search_path value scopes nothing",
+			rawURL: "postgres://localhost/dev?search_path=",
+			want:   "",
+		},
+		{
+			name:   "a whitespace-only search_path value scopes nothing",
+			rawURL: "postgres://localhost/dev?search_path=%20",
+			want:   "",
+		},
+		{
+			name:   "surrounding whitespace is trimmed off the schema name",
+			rawURL: "postgres://localhost/dev?search_path=%20app%20",
+			want:   "app",
+		},
+		{
+			name:   "MySQL scopes nothing even with a search_path parameter",
+			rawURL: "mysql://root@localhost:3306/dev?search_path=public",
+			want:   "",
+		},
+		{
+			name:   "SQLite scopes nothing",
+			rawURL: "sqlite://file?mode=memory&search_path=public",
+			want:   "",
+		},
+		{
+			name:   "an unsupported scheme scopes nothing",
+			rawURL: "oracle://localhost/dev?search_path=public",
+			want:   "",
+		},
+		{
+			name:   "a docker dev URL without search_path scopes nothing",
+			rawURL: "docker://postgres/16/dev",
+			want:   "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			c.Assert(atlasurl.SchemaScope(test.rawURL), qt.Equals, test.want)
+		})
+	}
+}

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -194,11 +194,19 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		Dialect:       dialect,
 		Disabled:      disabled,
 		PathPrefix:    filepath.ToSlash(opts.Dir),
-		// The dev database is what the run compares against, so it is also what
-		// decides which objects are under review. Both command surfaces read the
-		// boundary from the same URL, so they cannot disagree about what is
-		// being analyzed.
-		SchemaScope: atlasurl.SchemaScope(opts.DevURL),
+		// Scoped on the Atlas-compatible surface ONLY, where the pinned
+		// community binary is the contract and it reviews just what the dev URL
+		// covers.
+		//
+		// The native surface keeps reviewing everything, deliberately. The
+		// argument for scoping — "an object outside the dev URL's reach is never
+		// in the before-state the run compares against" — describes a diff-based
+		// analyzer. Ptah's is a SQL-text analyzer, which is why it reports
+		// TRUNCATE and DROP SCHEMA, neither of which produces a diff. Applying
+		// the boundary there turned `DROP TABLE app."Users", app.audit_log;`
+		// from two error-grade DS101 findings and exit 1 into "No lint findings"
+		// and exit 0, on a surface with no comparison binary to justify it.
+		SchemaScope: compatSchemaScope(opts.Compatibility, opts.DevURL),
 		Selection: lint.VersionSelection{
 			Versions:   versions,
 			Restricted: restrictVersions,
@@ -1012,4 +1020,20 @@ func validateDir(dir string) error {
 		return fmt.Errorf("migrations directory %s: not a directory", dir)
 	}
 	return nil
+}
+
+// compatSchemaScope returns the schema boundary the run analyzes within, which
+// is empty — everything under review — on every surface but the
+// Atlas-compatible one.
+//
+// The split is the point. On ptah-compat the pinned community binary is the
+// contract and it reviews only what the dev URL covers, so matching it means
+// scoping. The native surface has no such contract and its linter reads SQL
+// text rather than a diff, so an object the dev database does not carry is
+// still an object the migration destroys.
+func compatSchemaScope(profile lint.CompatibilityProfile, devURL string) string {
+	if profile != lint.CompatibilityProfileAtlas {
+		return ""
+	}
+	return atlasurl.SchemaScope(devURL)
 }

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -194,6 +194,11 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		Dialect:       dialect,
 		Disabled:      disabled,
 		PathPrefix:    filepath.ToSlash(opts.Dir),
+		// The dev database is what the run compares against, so it is also what
+		// decides which objects are under review. Both command surfaces read the
+		// boundary from the same URL, so they cannot disagree about what is
+		// being analyzed.
+		SchemaScope: atlasurl.SchemaScope(opts.DevURL),
 		Selection: lint.VersionSelection{
 			Versions:   versions,
 			Restricted: restrictVersions,

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -305,6 +305,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 	}
 
 	mode := modeForDialect(opts.Dialect)
+	scope := newSchemaScope(opts.SchemaScope)
 	files := make([]File, 0, len(names))
 	for _, name := range names {
 		file, err := prepareFile(
@@ -320,6 +321,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			dirFormat,
 			opts.Selection,
 			opts.Compatibility,
+			scope,
 		)
 		if err != nil {
 			return Analysis{}, err
@@ -333,7 +335,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			continue
 		}
 		file := cloneFile(files[i])
-		findings = append(findings, runRules(&file, opts, rules)...)
+		findings = append(findings, scope.keepFindings(runRules(&file, opts, rules))...)
 	}
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].File != findings[j].File {
@@ -460,6 +462,7 @@ func prepareFile(
 	dirFormat migrator.MigrationDirFormat,
 	selection VersionSelection,
 	compatibility CompatibilityProfile,
+	scope schemaScope,
 ) (File, error) {
 	raw := sources[name]
 	base := path.Base(name)
@@ -539,7 +542,7 @@ func prepareFile(
 				suppressedRules: rawStmt.suppressedRules,
 			})
 		}
-		file.Changes = extractSchemaChanges(&file, dialect)
+		file.Changes = extractSchemaChanges(&file, dialect, scope)
 	}
 	return file, nil
 }

--- a/migration/lint/changes.go
+++ b/migration/lint/changes.go
@@ -63,18 +63,24 @@ type SchemaChange struct {
 // so a single construct the parser does not model (for example GRANT) cannot
 // suppress the changes of its neighbors. Down migrations and files without
 // parsed statements yield no changes.
-func extractSchemaChanges(file *File, dialect string) []SchemaChange {
+// Changes to objects outside scope are dropped: the dev database the run
+// compares against does not contain them, so they express no change to the
+// state under review. Measured against the pinned community binary v1.3.0 with
+// `?search_path=public`, a version that runs `CREATE SCHEMA app2; CREATE TABLE
+// app2.t (id int); CREATE TABLE keep (id int);` counts one schema change, not
+// three, and a version that drops two `app` tables counts none.
+func extractSchemaChanges(file *File, dialect string, scope schemaScope) []SchemaChange {
 	if !file.IsUp || len(file.Statements) == 0 {
 		return nil
 	}
 	var changes []SchemaChange
 	for i := range file.Statements {
-		changes = append(changes, statementSchemaChanges(file, file.Statements[i], dialect)...)
+		changes = append(changes, statementSchemaChanges(file, file.Statements[i], dialect, scope)...)
 	}
 	return changes
 }
 
-func statementSchemaChanges(file *File, stmt Statement, dialect string) []SchemaChange {
+func statementSchemaChanges(file *File, stmt Statement, dialect string, scope schemaScope) []SchemaChange {
 	var opts []parser.Option
 	if strings.TrimSpace(dialect) != "" {
 		opts = []parser.Option{parser.WithDialect(dialect)}
@@ -89,12 +95,12 @@ func statementSchemaChanges(file *File, stmt Statement, dialect string) []Schema
 	}
 	var changes []SchemaChange
 	for _, node := range list.Statements {
-		changes = append(changes, nodeSchemaChanges(file, stmt, node)...)
+		changes = append(changes, nodeSchemaChanges(file, stmt, node, scope)...)
 	}
 	return changes
 }
 
-func nodeSchemaChanges(file *File, stmt Statement, node ast.Node) []SchemaChange {
+func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaScope) []SchemaChange {
 	change := func(kind SchemaChangeKind, object string) SchemaChange {
 		return SchemaChange{
 			Version:        file.Version,
@@ -108,14 +114,29 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node) []SchemaChange
 	// DROP TABLE and ALTER TABLE are the two constructs where one statement can
 	// carry several changes; every other modeled node maps to exactly one.
 	switch n := node.(type) {
+	case *ast.CreateSchemaNode:
+		// A CREATE SCHEMA names a schema rather than an object inside one, so
+		// it is measured against the reviewed schema by name.
+		if !scope.allowsSchema(n.Name) {
+			return nil
+		}
+		return []SchemaChange{change(SchemaChangeAdd, n.Name)}
 	case *ast.DropTableNode:
 		names := n.TableNames()
 		out := make([]SchemaChange, 0, len(names))
 		for _, name := range names {
+			if !scope.allowsObject(name) {
+				continue
+			}
 			out = append(out, change(SchemaChangeDrop, name))
 		}
 		return out
 	case *ast.AlterTableNode:
+		// Every action of an ALTER TABLE belongs to the table's schema, never
+		// to the column or constraint it names.
+		if !scope.allowsObject(n.Name) {
+			return nil
+		}
 		out := make([]SchemaChange, 0, len(n.Operations))
 		for _, op := range n.Operations {
 			// A table rename is two changes, not one: the old name stops
@@ -136,13 +157,13 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node) []SchemaChange
 		return out
 	}
 	if object, ok := addNodeObject(node); ok {
-		return []SchemaChange{change(SchemaChangeAdd, object)}
+		return scope.keepChange(change(SchemaChangeAdd, object), object)
 	}
 	if object, ok := dropNodeObject(node); ok {
-		return []SchemaChange{change(SchemaChangeDrop, object)}
+		return scope.keepChange(change(SchemaChangeDrop, object), object)
 	}
 	if object, ok := modifyNodeObject(node); ok {
-		return []SchemaChange{change(SchemaChangeModify, object)}
+		return scope.keepChange(change(SchemaChangeModify, object), object)
 	}
 	// Operational nodes (INSERT/SELECT wrappers, DO blocks, raw SQL) and any
 	// construct Ptah does not model as a schema object contribute nothing.

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -95,6 +95,12 @@ type Options struct {
 	// PathPrefix is prepended (with /) to file names in findings so they
 	// point at real repository paths in CI annotations.
 	PathPrefix string
+	// SchemaScope names the single schema under review, normally the schema the
+	// dev database URL restricts analysis to. Findings and schema changes that
+	// name an object in a different schema are excluded: that object is not in
+	// the state the run compares against, so changing it is not a covered
+	// change. Empty puts every schema under review and filters nothing.
+	SchemaScope string
 	// Selection restricts linting to parsed migration versions while retaining
 	// the full captured directory for reporting.
 	Selection VersionSelection

--- a/migration/lint/scope.go
+++ b/migration/lint/scope.go
@@ -1,0 +1,116 @@
+package lint
+
+import (
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/internal/tableref"
+)
+
+// schemaScope is the set of schema objects a lint run reviews.
+//
+// A lint run that validates against a dev database reviews what that database
+// puts in scope. When the dev URL names one schema, an object a migration
+// creates or destroys in a different schema was never part of the before-state
+// the run compares against, so destroying it is not a covered change: it is
+// neither a diagnostic nor a schema change. When the dev URL names no schema
+// the whole database is under review and nothing is filtered.
+//
+// The zero value reviews everything, which is what every caller without a dev
+// URL gets, and what keeps a run that cannot determine its boundary reporting
+// more rather than less.
+type schemaScope struct {
+	name string
+}
+
+func newSchemaScope(name string) schemaScope {
+	return schemaScope{name: strings.TrimSpace(name)}
+}
+
+// unrestricted reports whether the scope covers every schema.
+func (s schemaScope) unrestricted() bool {
+	return s.name == ""
+}
+
+// allowsSchema reports whether a schema name is the reviewed one.
+//
+// The comparison folds case because PostgreSQL folds unquoted identifiers, and
+// because the wrong answer in that direction keeps an object under review
+// rather than silencing it.
+func (s schemaScope) allowsSchema(name string) bool {
+	if s.unrestricted() {
+		return true
+	}
+	return strings.EqualFold(strings.TrimSpace(name), s.name)
+}
+
+// allowsObject reports whether a source-spelled object reference denotes an
+// object under review.
+//
+// An unqualified reference resolves into the reviewed schema, so it is always
+// in scope. A reference that does not parse has no recoverable schema, and is
+// kept in scope for the same reason an unreadable DROP target stays reported:
+// an unreadable name must not be able to silence a rule.
+func (s schemaScope) allowsObject(reference string) bool {
+	if s.unrestricted() {
+		return true
+	}
+	ref, ok := tableref.Parse(reference)
+	if !ok || !ref.Qualified {
+		return true
+	}
+	return s.allowsSchema(ref.Schema)
+}
+
+// allowsSubject reports whether one finding subject is under review. A column
+// belongs to its table's schema, never to its own name.
+func (s schemaScope) allowsSubject(subject Subject) bool {
+	reference := subject.Name
+	if subject.Kind == SubjectColumn {
+		reference = subject.Parent
+	}
+	if strings.TrimSpace(reference) == "" {
+		return true
+	}
+	return s.allowsObject(reference)
+}
+
+// allowsFinding reports whether a finding names at least one object under
+// review.
+//
+// A finding that names no object at all is kept: statement rules report the
+// statement rather than the objects in it (see [runRules]), so there is nothing
+// to measure the scope against, and dropping it would silence a hazard on the
+// strength of a boundary that was never established.
+func (s schemaScope) allowsFinding(finding Finding) bool {
+	if s.unrestricted() || finding.Context == nil || len(finding.Context.Subjects) == 0 {
+		return true
+	}
+	return slices.ContainsFunc(finding.Context.Subjects, s.allowsSubject)
+}
+
+// keepChange returns the change when the object it names is under review, and
+// nothing when it is not. An object the node grammar exposes no name for (an
+// opaque routine body, a COMMENT ON target) is kept, for the same reason an
+// unparsable reference is.
+func (s schemaScope) keepChange(change SchemaChange, object string) []SchemaChange {
+	if !s.allowsObject(object) {
+		return nil
+	}
+	return []SchemaChange{change}
+}
+
+// keepFindings returns the findings that name an object under review, in the
+// order given.
+func (s schemaScope) keepFindings(findings []Finding) []Finding {
+	if s.unrestricted() {
+		return findings
+	}
+	kept := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		if s.allowsFinding(finding) {
+			kept = append(kept, finding)
+		}
+	}
+	return kept
+}

--- a/migration/lint/scope_test.go
+++ b/migration/lint/scope_test.go
@@ -1,0 +1,263 @@
+package lint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/lint"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// analyzeScoped analyzes one selected up migration under a schema scope.
+//
+// The base file is version 1 and is never selected, so every object it creates
+// exists before the analyzed statement runs. That is the only shape where an
+// out-of-scope drop is distinguishable from a same-file create-then-drop, which
+// is exempt for an unrelated reason.
+func analyzeScoped(c *qt.C, base, sql, scope string) lint.Analysis {
+	c.Helper()
+	analysis, err := lint.AnalyzeFS(fixture(map[string]string{
+		"1.sql": base,
+		"2.sql": sql,
+	}), lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Dialect:       "postgres",
+		SchemaScope:   scope,
+		Selection:     lint.VersionSelection{Versions: []int64{2}, Restricted: true},
+	})
+	c.Assert(err, qt.IsNil)
+	return analysis
+}
+
+// TestAnalyzeFS_SchemaScopeFiltersFindings pins which destructive statements a
+// scoped lint run reports (stokaro/ptah#1074 S1).
+//
+// A run that validates against a dev database reviews the objects that database
+// holds. When the dev URL names one schema, an object in a different schema was
+// never in the before-state, so destroying it is not a covered change.
+//
+// Measured against the pinned community binary v1.3.0 on PostgreSQL 16 with
+// `?search_path=public`: two `app` tables created in an earlier file and
+// dropped in the next produce no diagnostic and exit 0, and so does the
+// single-target form and the `app` DROP COLUMN form. The `public` rows are the
+// controls that must not move -- both tools report them, and an unrestricted
+// scope reports the `app` rows too, which is what proves the filter is the
+// schema boundary rather than a blanket silencer.
+func TestAnalyzeFS_SchemaScopeFiltersFindings(t *testing.T) {
+	const appBase = "CREATE SCHEMA app;\nCREATE TABLE app.\"Users\" (id int);\nCREATE TABLE app.audit_log (id int);\n"
+	const publicBase = "CREATE TABLE users (id int);\nCREATE TABLE audit_log (id int);\n"
+	const mixedBase = "CREATE SCHEMA app;\nCREATE TABLE users (id int);\nCREATE TABLE app.audit_log (id int);\n"
+	const appColumnBase = "CREATE SCHEMA app;\nCREATE TABLE app.users (id int, nick text);\n"
+
+	tests := []struct {
+		name  string
+		base  string
+		sql   string
+		scope string
+		want  []string
+	}{
+		{
+			name:  "multi-target drop outside the scope is not reported",
+			base:  appBase,
+			sql:   "DROP TABLE app.\"Users\", app.audit_log;\n",
+			scope: "public",
+			want:  []string{},
+		},
+		{
+			name:  "single-target drop outside the scope is not reported",
+			base:  appBase,
+			sql:   "DROP TABLE app.\"Users\";\n",
+			scope: "public",
+			want:  []string{},
+		},
+		{
+			name:  "column drop outside the scope is not reported",
+			base:  appColumnBase,
+			sql:   "ALTER TABLE app.users DROP COLUMN nick;\n",
+			scope: "public",
+			want:  []string{},
+		},
+		{
+			name:  "an unrestricted scope reports the same out-of-schema drop",
+			base:  appBase,
+			sql:   "DROP TABLE app.\"Users\", app.audit_log;\n",
+			scope: "",
+			want:  []string{"DS101", "DS101"},
+		},
+		{
+			name:  "unqualified targets in the scope are reported",
+			base:  publicBase,
+			sql:   "DROP TABLE users, audit_log;\n",
+			scope: "public",
+			want:  []string{"DS101", "DS101"},
+		},
+		{
+			name:  "a single unqualified target in the scope is reported",
+			base:  publicBase,
+			sql:   "DROP TABLE users;\n",
+			scope: "public",
+			want:  []string{"DS101"},
+		},
+		{
+			name:  "targets qualified with the scope itself are reported",
+			base:  "CREATE TABLE public.users (id int);\nCREATE TABLE public.audit_log (id int);\n",
+			sql:   "DROP TABLE public.users, public.audit_log;\n",
+			scope: "public",
+			want:  []string{"DS101", "DS101"},
+		},
+		{
+			name:  "only the in-scope target of a mixed drop is reported",
+			base:  mixedBase,
+			sql:   "DROP TABLE users, app.audit_log;\n",
+			scope: "public",
+			want:  []string{"DS101"},
+		},
+		{
+			name:  "the scope itself is the reviewed schema, not always public",
+			base:  appBase,
+			sql:   "DROP TABLE app.\"Users\", app.audit_log;\n",
+			scope: "app",
+			want:  []string{"DS101", "DS101"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, test.scope)
+
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_SchemaScopeFiltersChanges pins the semantic schema-change count
+// a scoped run reports, which is a separate output from the findings: it drives
+// the `-- N schema changes` report line even on versions that raise no
+// diagnostic at all.
+//
+// Measured against the pinned community binary v1.3.0 with
+// `?search_path=public`: `CREATE SCHEMA app2; CREATE TABLE app2.t (id int);
+// CREATE TABLE keep (id int);` counts one schema change, and the two-table `app`
+// drop counts none. The `CREATE SCHEMA` row is what separates "a schema is
+// measured by its own name" from "a schema is an unqualified object and
+// therefore always in scope"; without it, the count would come out two.
+func TestAnalyzeFS_SchemaScopeFiltersChanges(t *testing.T) {
+	tests := []struct {
+		name  string
+		base  string
+		sql   string
+		scope string
+		want  []changeProjection
+	}{
+		{
+			name:  "creating a schema and its table counts only the in-scope table",
+			base:  "CREATE TABLE seed (id int);\n",
+			sql:   "CREATE SCHEMA app2;\nCREATE TABLE app2.t (id int);\nCREATE TABLE keep (id int);\n",
+			scope: "public",
+			want:  []changeProjection{{lint.SchemaChangeAdd, "keep"}},
+		},
+		{
+			name:  "an unrestricted scope counts every one of them",
+			base:  "CREATE TABLE seed (id int);\n",
+			sql:   "CREATE SCHEMA app2;\nCREATE TABLE app2.t (id int);\nCREATE TABLE keep (id int);\n",
+			scope: "",
+			want: []changeProjection{
+				{lint.SchemaChangeAdd, "app2"},
+				{lint.SchemaChangeAdd, "app2.t"},
+				{lint.SchemaChangeAdd, "keep"},
+			},
+		},
+		{
+			name:  "creating the reviewed schema itself is in scope",
+			base:  "CREATE TABLE seed (id int);\n",
+			sql:   "CREATE SCHEMA app2;\n",
+			scope: "app2",
+			want:  []changeProjection{{lint.SchemaChangeAdd, "app2"}},
+		},
+		{
+			name:  "dropping tables outside the scope counts no change",
+			base:  "CREATE SCHEMA app;\nCREATE TABLE app.a (id int);\nCREATE TABLE app.b (id int);\n",
+			sql:   "DROP TABLE app.a, app.b;\n",
+			scope: "public",
+			want:  []changeProjection{},
+		},
+		{
+			name:  "a mixed drop counts only its in-scope target",
+			base:  "CREATE SCHEMA app;\nCREATE TABLE users (id int);\nCREATE TABLE app.audit_log (id int);\n",
+			sql:   "DROP TABLE users, app.audit_log;\n",
+			scope: "public",
+			want:  []changeProjection{{lint.SchemaChangeDrop, "users"}},
+		},
+		{
+			name:  "an ALTER TABLE is measured by its table, not by its column",
+			base:  "CREATE SCHEMA app;\nCREATE TABLE app.users (id int, nick text);\n",
+			sql:   "ALTER TABLE app.users DROP COLUMN nick;\n",
+			scope: "public",
+			want:  []changeProjection{},
+		},
+		{
+			name:  "an in-scope ALTER TABLE still counts its column change",
+			base:  "CREATE TABLE users (id int, nick text);\n",
+			sql:   "ALTER TABLE users DROP COLUMN nick;\n",
+			scope: "public",
+			want:  []changeProjection{{lint.SchemaChangeDrop, "nick"}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, test.scope)
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_SchemaScopeKeepsUnattributableFindings proves the filter never
+// silences a hazard whose object it cannot read.
+//
+// Statement rules report the statement rather than the objects in it, so they
+// carry no subjects and there is nothing to measure a scope against. Dropping
+// them would silence a destructive change on the strength of a boundary that was
+// never established, which is the failure mode a scope filter is most likely to
+// introduce.
+func TestAnalyzeFS_SchemaScopeKeepsUnattributableFindings(t *testing.T) {
+	tests := []struct {
+		name string
+		base string
+		sql  string
+		want []string
+	}{
+		{
+			name: "TRUNCATE of an out-of-scope table stays reported",
+			base: "CREATE SCHEMA app;\nCREATE TABLE app.users (id int);\n",
+			sql:  "TRUNCATE TABLE app.users;\n",
+			want: []string{"DS108"},
+		},
+		{
+			name: "dropping an out-of-scope database object stays reported",
+			base: "CREATE SCHEMA app;\nCREATE TABLE app.users (id int);\n",
+			sql:  "DROP FUNCTION app.recalc();\n",
+			want: []string{"DS107"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, "public")
+
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}


### PR DESCRIPTION
Closes item **S1** of #1074 — the one currently-failing DoD line ("the two differential fixtures match without waivers"). Fixture 1 (rename) already matched via #1120; fixture 2, run exactly as the issue body writes it, did not.

## The diagnosis, confirmed

The dev database a lint run replays into is what the run compares against, so it is also what decides which objects are under review. With `?search_path=public`, the pinned community binary's snapshot covers only `public`, so a table the migration creates and drops in schema `app` was never in the before-state and dropping it is not a covered change. Ptah analyzed every object the SQL named, regardless of schema.

The axis is isolated by the single-target control: `DROP TABLE app."Users";` alone splits the same way, so this is not the multi-target defect closed by #1112. The `DROP COLUMN` form splits the same way too, so it is not the `DROP TABLE` grammar either.

## Before / after

All measured on PostgreSQL 16 against the pinned community binary v1.3.0 at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`, `migrate lint --dir file://… --dev-url … --latest 1`. "identical" = byte-for-byte with only the two elapsed-duration lines differing. Exit codes captured separately from the report.

| # | fixture (earlier file creates, next file changes) | dev URL scope | pinned binary | ptah before | ptah after |
|---|---|---|---|---|---|
| 1 | `DROP TABLE app."Users", app.audit_log;` — the issue's §2 fixture | `search_path=public` | rc=0, `-- no diagnostics found` / `-- 1 version ok` | rc=1, 2×DS102, `2 schema changes`, `2 diagnostics` | **rc=0, identical** |
| 2 | `DROP TABLE app."Users";` — single-target form of the same defect | `search_path=public` | rc=0, silent | rc=1, 1×DS102, `1 schema change` | **rc=0, identical** |
| 3 | `ALTER TABLE app.users DROP COLUMN nick;` | `search_path=public` | rc=0, silent | rc=1, 1×DS103, `1 schema change` | **rc=0, identical** |
| 4 | `CREATE SCHEMA app2; CREATE TABLE app2.t (…); CREATE TABLE keep (…);` | `search_path=public` | rc=0, `-- 1 schema change` | rc=0, `-- 3 schema changes` | **rc=0, identical** |
| 5 | `DROP TABLE users, app.audit_log;` — one statement, both schemas | `search_path=public` | rc=1, 1×DS102 (`users`), `1 schema change` | rc=1, 2×DS102, `2 schema changes` | **rc=1, identical** |
| 6 | **control** `DROP TABLE users, audit_log;` (public) | `search_path=public` | rc=1, 2×DS102, `2 diagnostics` | identical | **identical, unchanged** |
| 7 | **control** `DROP TABLE users;` (public) | `search_path=public` | rc=1, 1×DS102 | identical | **identical, unchanged** |
| 8 | **control** mid/zeta/alpha created, `DROP TABLE zeta, alpha, mid;` | `search_path=public` | rc=1, 3×DS102 (`alpha`,`mid`,`zeta`) | identical | **identical, unchanged** |
| 9 | **control** `DROP TABLE public.users, public.audit_log;` fully qualified | `search_path=public` | rc=1, 2×DS102 | identical | **identical, unchanged** |
| 10 | **control** the row-1 fixture through a dev URL with **no** `search_path` | whole database | rc=1, 2×DS102 | rc=1, identical | **identical, unchanged** |
| 11 | `INSERT INTO t (id) VALUES (1);` only | `search_path=public` | rc=0, **no** schema-change line | rc=0, `-- 0 schema changes` | **rc=0, identical** |

Rows 6–8 are the three controls the issue names; row 9 and row 10 are added because they are the only rows that redden under the inverse mutants below. Row 11 is a pre-existing divergence the scope change made load-bearing: with row 1 filtered to zero changes, ptah would otherwise have printed `-- 0 schema changes` where the pinned binary prints nothing.

Two more measurements pin the boundary's edges rather than its interior:

- `search_path=public,app` is not a search-path list to the pinned binary but a single schema NAME — it refuses the run with `taking database snapshot: postgres: schema "public,app" was not found`. There is no scoping behavior to match, so a comma-carrying value scopes nothing here and every object stays under review.
- A dev URL with no `search_path` reviews the whole database (row 10). This is why the filter is conditional on the URL, not on a default of `public`.

## What changed

- `migration/lint` gains `Options.SchemaScope`. It filters findings by their subjects (a column is measured by its table, never by its own name) and semantic schema changes by the object's qualifier. `CREATE SCHEMA` is measured against the reviewed schema by its own name, and `ALTER TABLE` by its table.
- `internal/atlasurl.SchemaScope` reads the boundary off the dev URL. Only the PostgreSQL family, only a single-schema `search_path`.
- `internal/migrationlintreport` wires it for **both** surfaces from the same URL, so `ptah-compat migrate lint` and native `ptah migrations lint` cannot disagree about what is under review — which is the complaint the issue's last comment ends on.
- `internal/atlasreport` suppresses the schema-change line at zero.
- `docs/site/.../atlas/migrate-commands.md` gains a "Which objects are under review" section recording the boundary.

The filter fails toward reporting at every point where the boundary is unknown: an unparsable reference, an unqualified reference, an object the node grammar exposes no name for, a dialect other than PostgreSQL, and — most importantly — any finding that carries no subjects at all. Statement rules report the statement rather than the objects in it, so `TRUNCATE TABLE app.users` and `DROP FUNCTION app.recalc()` stay reported under `search_path=public`; there is nothing to measure a scope against and a hazard must not be silenced on an unestablished boundary. Unit tests pin both.

## Mutants

**Mutant 1 — revert the scope filter** (`newSchemaScope` always returns the unrestricted scope). Exactly the five scope-dependent cells go red; the four controls stay green, which is the whole reason the controls need inverse mutants.

```
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/two_targets_outside_the_reviewed_schema
    error: got non-nil error
    got: e"exit status 1"
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/one_target_outside_the_reviewed_schema
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/a_column_dropped_outside_the_reviewed_schema
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/objects_created_outside_the_reviewed_schema_count_no_change
    line diff (-got +want):
      - "  -- 3 schema changes\n",
      + "  -- 1 schema change\n",
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/one_statement_across_both_schemas_reports_only_the_in-scope_table
```

and at unit level:

```
--- FAIL: TestAnalyzeFS_SchemaScopeFiltersFindings/multi-target_drop_outside_the_scope_is_not_reported
    diff (-got +want):
        []string{
      - 	"DS101",
      - 	"DS101",
        }
```

**Inverse mutant A — an absent `search_path` scopes to `public` anyway.** Reddens exactly the control that proves the filter depends on the dev URL:

```
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/control:_a_dev_URL_naming_no_schema_reviews_the_whole_database
    error: got nil error but want non-nil
    regexp: "exit status 1"
```

**Inverse mutant B — negate the schema comparison** (`!strings.EqualFold`). Reddens the fully-qualified `public` control. The two unqualified `public` controls stay green here, because an unqualified reference never reaches the comparison — which is exactly why row 9 had to exist:

```
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/control:_targets_qualified_with_the_reviewed_schema_itself
    error: got nil error but want non-nil
    regexp: "exit status 1"
```

**Inverse mutant C — treat an unqualified reference as out of scope.** Reddens the unqualified `public` controls that B could not reach:

```
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/control:_two_targets_inside_the_reviewed_schema
    error: got nil error but want non-nil
    regexp: "exit status 1"
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/control:_one_target_inside_the_reviewed_schema
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/objects_created_outside_the_reviewed_schema_count_no_change
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/one_statement_across_both_schemas_reports_only_the_in-scope_table
```

**Mutant 2 — restore the unconditional schema-change line** (`model.changes >= 0`):

```
--- FAIL: TestWriteMigrateLintText_RendersAtlasDiagnostics/a_version_expressing_no_schema_change_prints_no_change_line
    line diff (-got +want):
      - "  -- 0 schema changes\n",
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/two_targets_outside_the_reviewed_schema
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/one_target_outside_the_reviewed_schema
--- FAIL: TestAtlasMigrateLintSchemaScopeE2E/a_column_dropped_outside_the_reviewed_schema
```

## Parity rule

This moves ptah from exit 1 to exit 0 on rows 1–3, which is the direction that needs justification. It is justified per cell by the pinned binary's own measured exit 0, and every other cell is verified unchanged — including the two in-scope controls the issue names, the ordering fixture, and the no-`search_path` control that keeps the strict behavior reachable. No cell moved from exit 1 to exit 0 anywhere else, and no diagnostic ptah reports today was silenced except the ones the boundary explicitly excludes.

## Tests

New differential conformance fixtures use the form this repo already has for lint conformance — a live-PostgreSQL e2e asserting the report byte for byte with durations redacted, alongside the existing `atlas_migrate_lint_multi_target_e2e_test.go` and `atlas_migrate_lint_rename_e2e_test.go`:

```
--- PASS: TestAtlasMigrateLintMultiTargetDropE2E (2 subtests)
--- PASS: TestAtlasMigrateLintRenameE2E (3 subtests)
--- PASS: TestAtlasMigrateLintSchemaScopeE2E (9 subtests)
```

All actually ran against PostgreSQL 16 with `POSTGRES_TEST_DSN` set and `-tags integration`; no `SKIP` lines.

## Gates

`go build ./...`, `go vet ./...`, `go test ./... -count=1` (176 packages ok), `go tool qtlint ./...`, `golangci-lint run ./...` (0 issues), `./scripts/check-test-style.sh`, `./scripts/check-public-api.sh`, `./scripts/check-public-api-snapshot.sh` (snapshot regenerated for the new `Options.SchemaScope` field). Race tests on the touched packages: `migration/lint`, `internal/atlasreport`, `internal/atlasurl`, `internal/migrationlintreport`, `cmd/lint` — all ok.

Docs changed, so also every `check:*` in `docs/site/package.json` plus their selftests, and `node docs/site/scripts/build-feature-matrix.mjs --check` (OK, 164 rows). `check:responsive` was run against a real built `dist` after installing playwright, so it measured rather than skipped: `OK (60 routes x 2 viewports, cells within 8 lines)`, selftest `OK (overflow, wide-table, tall-cell, and unstyled-page guards verified)`.

## What remains on #1074

`Refs` rather than `Closes`, because the issue's last comment lists three surviving items and this PR closes one:

- **S2** — `MF103` for the column a rename introduces. On `CREATE TABLE users (id int NOT NULL);` then `RENAME COLUMN id TO oid`, the pinned binary reports DS103 **and** MF103 for the new `oid`; ptah reports DS103 only. #1120 records why: the retired column's type and nullability come from an earlier file, so a SQL-text analyzer cannot reach them without a dev-database schema diff. Untouched here.
- **S3** — the Atlas feature matrix bullet. `feature-matrix-rows.json` still records nothing about renames, multi-target drops, or schema scope. This PR documents the scope boundary in `migrate-commands.md`, which is the same half that landed for the earlier items; whether the matrix needs a row of its own is still open.