### PR TITLE
Resolve the PostgreSQL connection schema from search_path

### DIFF
--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -749,17 +749,27 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 		// resolving to nothing (stokaro/ptah#1198).
 		//
 		// current_schema() is NULL when search_path names only schemas that do
-		// not exist. "public" is kept for that case: it is what every caller
-		// assumed before, and inventing a refusal here would change far more
-		// than the drop.
+		// not exist. That is refused rather than folded back to "public": a
+		// caller who named a schema and silently got a different one is the
+		// failure this whole change is about, and answering "public" would
+		// resume dropping the schemas that one does not cover. Ptah is
+		// pre-general-availability, so the previous fallback is not owed
+		// compatibility.
+		//
+		// The message names the schema, because the operator's mistake is in the
+		// URL and nothing downstream can say so: without this, the run reaches
+		// the replay and fails on a CREATE TABLE with "no schema has been
+		// selected to create in", which sends them to their migration.
 		var currentSchema sql.NullString
 		if err := db.QueryRowContext(ctx, "SELECT current_schema()").Scan(&currentSchema); err != nil {
 			return info, fmt.Errorf("failed to resolve PostgreSQL current schema: %w", err)
 		}
-		info.Schema = "public"
-		if currentSchema.Valid && currentSchema.String != "" {
-			info.Schema = currentSchema.String
+		if !currentSchema.Valid || currentSchema.String == "" {
+			return info, fmt.Errorf(
+				"database URL selects schema %q, which does not exist in this database",
+				postgresSearchPathSelection(parsedURL))
 		}
+		info.Schema = currentSchema.String
 
 	case platform.MySQL, platform.MariaDB:
 		// Get MySQL/MariaDB version
@@ -1029,4 +1039,19 @@ func removePostgresPoolParams(dbURL string) string {
 	q.Del("pool_min_conns")
 	parsedURL.RawQuery = q.Encode()
 	return parsedURL.String()
+}
+
+// postgresSearchPathSelection returns the schema the URL's search_path names, so
+// a refusal can quote the operator's own value back at them. It is only ever
+// called on the refusal path, where current_schema() resolved to nothing.
+//
+// An absent search_path cannot reach that path: PostgreSQL's own default
+// resolves to "public", which exists in every database Ptah connects to, so the
+// empty string here means the URL carried no selection and the server still
+// answered nothing -- a shape worth reporting verbatim rather than guessing at.
+func postgresSearchPathSelection(parsedURL *url.URL) string {
+	if parsedURL == nil {
+		return ""
+	}
+	return parsedURL.Query().Get("search_path")
 }

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -740,14 +740,26 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 		info.Dialect = detectPostgresWireDialect(dialect, version)
 		info.IdentifierSemantics = identifier.ForDialect(info.Dialect)
 
-		// Get schema name (default to 'public' if not specified in URL)
-		schema := "public"
-		if parsedURL.Path != "" && len(parsedURL.Path) > 1 {
-			// Extract database name from path, schema is typically 'public'
-			// For PostgreSQL, schema is usually specified via search_path or defaults to 'public'
-			schema = "public"
+		// The schema is whatever the server resolves this session's search_path
+		// to, which is what a `?search_path=` on the URL selects. It used to be
+		// the constant "public", with a branch on the URL path that assigned
+		// "public" again, so a dev URL naming another schema was not merely
+		// ignored -- the writer treated that schema as a stranger's and DROPPED
+		// it while cleaning the database realm, then replayed with a search_path
+		// resolving to nothing (stokaro/ptah#1198).
+		//
+		// current_schema() is NULL when search_path names only schemas that do
+		// not exist. "public" is kept for that case: it is what every caller
+		// assumed before, and inventing a refusal here would change far more
+		// than the drop.
+		var currentSchema sql.NullString
+		if err := db.QueryRowContext(ctx, "SELECT current_schema()").Scan(&currentSchema); err != nil {
+			return info, fmt.Errorf("failed to resolve PostgreSQL current schema: %w", err)
 		}
-		info.Schema = schema
+		info.Schema = "public"
+		if currentSchema.Valid && currentSchema.String != "" {
+			info.Schema = currentSchema.String
+		}
 
 	case platform.MySQL, platform.MariaDB:
 		// Get MySQL/MariaDB version

--- a/integration/postgres_dev_schema_scope_e2e_test.go
+++ b/integration/postgres_dev_schema_scope_e2e_test.go
@@ -83,12 +83,6 @@ func TestPostgresConnectionResolvesTheSearchPathSchemaE2E(t *testing.T) {
 		name:       "a search_path naming public resolves to public",
 		searchPath: "public",
 		want:       "public",
-	}, {
-		// The fallback: a search_path pointing at nothing leaves current_schema()
-		// NULL, and every caller before this change assumed "public".
-		name:       "a search_path naming no existing schema falls back to public",
-		searchPath: "nosuchschema",
-		want:       "public",
 	}}
 
 	for _, test := range tests {
@@ -100,6 +94,22 @@ func TestPostgresConnectionResolvesTheSearchPathSchemaE2E(t *testing.T) {
 			c.Assert(conn.Info().Schema, qt.Equals, test.want)
 		})
 	}
+
+	// A search_path naming a schema that does not exist is REFUSED, naming the
+	// schema. Folding it back to "public" was the first shape of this change and
+	// is wrong for the same reason the bug was: a caller who named a schema and
+	// silently got a different one is exactly what this fixes, and "public" would
+	// resume dropping the schemas it does not cover.
+	//
+	// The message has to name the schema. Without it the run reaches the replay
+	// and dies on a CREATE TABLE with "no schema has been selected to create in",
+	// which sends the operator to their migration instead of their URL.
+	c.Run("a search_path naming no existing schema is refused", func(c *qt.C) {
+		_, err := dbschema.ConnectToDatabase(ctx, withDevSearchPath(c, scopedURL, "nosuchschema"))
+
+		c.Assert(err, qt.ErrorMatches,
+			`.*database URL selects schema "nosuchschema", which does not exist in this database.*`)
+	})
 }
 
 // TestPostgresRealmCleanupKeepsTheSelectedSchemaE2E is the consequence the

--- a/integration/postgres_dev_schema_scope_e2e_test.go
+++ b/integration/postgres_dev_schema_scope_e2e_test.go
@@ -1,0 +1,158 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// withDevSearchPath returns dbURL carrying a search_path query parameter.
+func withDevSearchPath(c *qt.C, dbURL, schema string) string {
+	c.Helper()
+	parsed, err := url.Parse(dbURL)
+	c.Assert(err, qt.IsNil)
+	query := parsed.Query()
+	query.Set("search_path", schema)
+	parsed.RawQuery = query.Encode()
+	return parsed.String()
+}
+
+// countDevSchema returns how many namespaces of the given name exist.
+func countDevSchema(c *qt.C, ctx context.Context, db *sql.DB, name string) int {
+	c.Helper()
+	var count int
+	err := db.QueryRowContext(ctx,
+		"SELECT count(*) FROM pg_namespace WHERE nspname = $1", name).Scan(&count)
+	c.Assert(err, qt.IsNil)
+	return count
+}
+
+// TestPostgresConnectionResolvesTheSearchPathSchemaE2E pins the schema a
+// PostgreSQL connection reports, because a writer decides from it which schemas
+// belong to the caller and which are strangers it may drop.
+//
+// It used to be the constant "public": the code assigned "public", then branched
+// on the URL path to assign "public" again. A dev URL naming another schema was
+// therefore not merely ignored — the realm cleanup treated that schema as a
+// stranger and DROPPED it, and the replay that followed ran under a search_path
+// resolving to nothing, failing with "no schema has been selected to create in"
+// (stokaro/ptah#1198). The pinned community binary leaves the schema standing.
+//
+// The rows are a pair plus the fallback: only the search_path moves.
+func TestPostgresConnectionResolvesTheSearchPathSchemaE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_dev_schema_scope_e2e_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	scopedURL := replaceDatabaseName(c, dbURL, testDBName)
+	setupDB, err := sql.Open("pgx", scopedURL)
+	c.Assert(err, qt.IsNil)
+	defer setupDB.Close()
+	_, err = setupDB.ExecContext(ctx, "CREATE SCHEMA app")
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		name       string
+		searchPath string
+		want       string
+	}{{
+		name:       "a search_path naming another schema resolves to it",
+		searchPath: "app",
+		want:       "app",
+	}, {
+		name:       "a search_path naming public resolves to public",
+		searchPath: "public",
+		want:       "public",
+	}, {
+		// The fallback: a search_path pointing at nothing leaves current_schema()
+		// NULL, and every caller before this change assumed "public".
+		name:       "a search_path naming no existing schema falls back to public",
+		searchPath: "nosuchschema",
+		want:       "public",
+	}}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn, err := dbschema.ConnectToDatabase(ctx, withDevSearchPath(c, scopedURL, test.searchPath))
+			c.Assert(err, qt.IsNil)
+			defer dbschema.CloseAndWarn(conn)
+
+			c.Assert(conn.Info().Schema, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestPostgresRealmCleanupKeepsTheSelectedSchemaE2E is the consequence the
+// resolution above exists for: cleaning the database realm through a dev URL
+// that selects `app` must leave `app` standing, and must still clean the
+// realm's other user schemas.
+//
+// Restoring the hardcoded "public" reddens the `app` assertion, which is the
+// half this change is about.
+//
+// The `bystander` schema is NOT an independent assertion, and saying so is the
+// point of this comment. Sparing every schema but the root — the inverse mutant
+// that would have to prove it — is caught one line earlier, by the production
+// code's own verification:
+//
+//	e`PostgreSQL database realm cleanup left residual user schema "bystander"`
+//
+// returned from DropDatabaseRealm, which the test already asserts is nil. So
+// the bystander is here to give the cleanup something to do and to make that
+// verification reachable; the count below restates the outcome for a reader
+// rather than adding coverage the error check does not already have.
+func TestPostgresRealmCleanupKeepsTheSelectedSchemaE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_dev_realm_keep_e2e_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	scopedURL := replaceDatabaseName(c, dbURL, testDBName)
+	setupDB, err := sql.Open("pgx", scopedURL)
+	c.Assert(err, qt.IsNil)
+	defer setupDB.Close()
+	for _, statement := range []string{"CREATE SCHEMA app", "CREATE SCHEMA bystander"} {
+		_, err = setupDB.ExecContext(ctx, statement)
+		c.Assert(err, qt.IsNil)
+	}
+
+	conn, err := dbschema.ConnectToDatabase(ctx, withDevSearchPath(c, scopedURL, "app"))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	writer, ok := conn.SchemaWriter().(interface{ DropDatabaseRealm(context.Context) error })
+	c.Assert(ok, qt.IsTrue)
+	c.Assert(writer.DropDatabaseRealm(ctx), qt.IsNil)
+
+	c.Assert(countDevSchema(c, ctx, setupDB, "app"), qt.Equals, 1)
+	c.Assert(countDevSchema(c, ctx, setupDB, "bystander"), qt.Equals, 0)
+}

--- a/integration/postgres_dev_schema_scope_e2e_test.go
+++ b/integration/postgres_dev_schema_scope_e2e_test.go
@@ -120,6 +120,12 @@ func TestPostgresConnectionResolvesTheSearchPathSchemaE2E(t *testing.T) {
 // Restoring the hardcoded "public" reddens the `app` assertion, which is the
 // half this change is about.
 //
+// The "public" assertion is the other half, and it is a defect this change
+// introduced before it was caught: once the root follows the URL, "public" is
+// just another user schema, so it was dropped and never put back, and the next
+// migration naming `public.users` failed with `schema "public" does not exist`.
+// Emptying it is what a realm cleanup is for; removing it is not.
+//
 // The `bystander` schema is NOT an independent assertion, and saying so is the
 // point of this comment. Sparing every schema but the root — the inverse mutant
 // that would have to prove it — is caught one line earlier, by the production
@@ -165,4 +171,5 @@ func TestPostgresRealmCleanupKeepsTheSelectedSchemaE2E(t *testing.T) {
 
 	c.Assert(countDevSchema(c, ctx, setupDB, "app"), qt.Equals, 1)
 	c.Assert(countDevSchema(c, ctx, setupDB, "bystander"), qt.Equals, 0)
+	c.Assert(countDevSchema(c, ctx, setupDB, "public"), qt.Equals, 1)
 }

--- a/internal/dbschema/postgres/writer.go
+++ b/internal/dbschema/postgres/writer.go
@@ -1148,6 +1148,25 @@ func (w *PostgreSQLWriter) executeDatabaseRealmCleanup(
 			return nil, err
 		}
 	}
+	// "public" comes back even when it is not the root schema.
+	//
+	// It used to be the root on every run, because the connection reported
+	// "public" unconditionally, so dropping it and restoring it above was one
+	// step. Now that the root follows the dev URL's search_path, selecting any
+	// other schema left "public" dropped and never restored -- and a migration
+	// that writes `public.users` then failed with `schema "public" does not
+	// exist`, which is the same shape of damage this whole change set is fixing,
+	// just moved to the other schema.
+	//
+	// Emptying it is the point of a realm cleanup; removing it is not. Every
+	// PostgreSQL database is created with it, and DDL that names no schema
+	// resolves there for any caller who did not select another one.
+	if postgresCleanupDroppedPublicSchema(w.schema, plan) {
+		if err := restorePostgresPublicSchema(ctx, tx); err != nil {
+			return nil, err
+		}
+		preservedSchemas = appendUniqueString(preservedSchemas, "public")
+	}
 	return preservedSchemas, nil
 }
 
@@ -1408,7 +1427,7 @@ func verifyPostgresDatabaseRealm(
 	}
 	for schema := range expected {
 		return fmt.Errorf(
-			"PostgreSQL database realm cleanup did not recreate root schema %q",
+			"PostgreSQL database realm cleanup did not recreate preserved schema %q",
 			schema,
 		)
 	}
@@ -1585,4 +1604,35 @@ func (w *PostgreSQLWriter) SetDryRun(dryRun bool) {
 // IsDryRun returns whether dry run mode is enabled
 func (w *PostgreSQLWriter) IsDryRun() bool {
 	return w.dryRun
+}
+
+// postgresCleanupDroppedPublicSchema reports whether the realm cleanup dropped
+// "public" without restoring it, which is true only when it existed, is not the
+// root schema, and the server does not preserve it in place.
+//
+// The three exclusions are each a case that is already handled: a database with
+// no "public" schema has nothing to put back, and recreating one would hand the
+// caller a schema they never had; "public" as the root is restored by
+// restorePostgresRootSchema with its recorded owner and grants; and a server
+// that preserves it never dropped it.
+func postgresCleanupDroppedPublicSchema(rootSchema string, plan postgresDatabaseCleanupPlan) bool {
+	if rootSchema == "public" || plan.capabilities.preservePublicSchema {
+		return false
+	}
+	return slices.Contains(plan.schemas, "public")
+}
+
+// restorePostgresPublicSchema recreates "public" after a realm cleanup dropped
+// it.
+//
+// The recreation is deliberately plain. The root schema is restored with its
+// recorded owner and grants because the caller keeps working inside it; a
+// non-root "public" is being restored only so that DDL naming it resolves, and
+// inventing privileges for it would be asserting something the cleanup never
+// measured.
+func restorePostgresPublicSchema(ctx context.Context, tx *sql.Tx) error {
+	if _, err := tx.ExecContext(ctx, `CREATE SCHEMA "public"`); err != nil {
+		return fmt.Errorf("failed to recreate the public schema after realm cleanup: %w", err)
+	}
+	return nil
 }

--- a/internal/dbschema/postgres/writer_context_test.go
+++ b/internal/dbschema/postgres/writer_context_test.go
@@ -288,10 +288,41 @@ func TestWriterDropDatabaseRealm_CreatesAbsentRootSchema(t *testing.T) {
 		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
 		`DROP SCHEMA IF EXISTS "public" RESTRICT`,
 		`CREATE SCHEMA "shadow"`,
+		`CREATE SCHEMA "public"`,
 	})
 	c.Assert(db.BeginCount(), qt.Equals, 1)
 	c.Assert(db.QueryCount(), qt.Equals, 10)
-	c.Assert(db.ExecCount(), qt.Equals, 4)
+	c.Assert(db.ExecCount(), qt.Equals, 5)
+	c.Assert(db.CommitCount(), qt.Equals, 1)
+	c.Assert(db.RollbackCount(), qt.Equals, 0)
+}
+
+// A database whose "public" schema was already gone gets nothing invented for
+// it: the cleanup restores what it dropped, and a schema the caller never had
+// is not part of that. This is what separates restoring "public" from creating
+// it unconditionally -- both look identical in
+// TestWriterDropDatabaseRealm_CreatesAbsentRootSchema, where it was present.
+func TestWriterDropDatabaseRealm_LeavesAnAbsentPublicSchemaAbsent(t *testing.T) {
+	c := qt.New(t)
+	var execQueries []string
+	queryHandler := newPostgresRealmAbsentPublicQuery()
+	db := dbtest.OpenWithExec(t, queryHandler.query, func(
+		query string,
+		_ []driver.NamedValue,
+	) (driver.Result, error) {
+		execQueries = append(execQueries, query)
+		return driver.RowsAffected(0), nil
+	})
+	writer := postgres.NewPostgreSQLWriter(db.SQL, "shadow")
+
+	err := writer.DropDatabaseRealm(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(execQueries, qt.DeepEquals, []string{
+		"\n\t\tSELECT lo_unlink(oid)\n\t\tFROM pg_largeobject_metadata\n\t\tORDER BY oid\n\t",
+		`DROP SCHEMA IF EXISTS "audit" RESTRICT`,
+		`CREATE SCHEMA "shadow"`,
+	})
 	c.Assert(db.CommitCount(), qt.Equals, 1)
 	c.Assert(db.RollbackCount(), qt.Equals, 0)
 }
@@ -750,6 +781,15 @@ func newPostgresRealmAbsentRootQuery() *postgresRealmQuery {
 		version:        "PostgreSQL 18.0",
 		database:       "ptah_test",
 		initialSchemas: [][]driver.Value{{"audit"}, {"public"}},
+		finalSchemas:   [][]driver.Value{{"public"}, {"shadow"}},
+	}
+}
+
+func newPostgresRealmAbsentPublicQuery() *postgresRealmQuery {
+	return &postgresRealmQuery{
+		version:        "PostgreSQL 18.0",
+		database:       "ptah_test",
+		initialSchemas: [][]driver.Value{{"audit"}},
 		finalSchemas:   [][]driver.Value{{"shadow"}},
 	}
 }


### PR DESCRIPTION
Closes #1198.

`info.Schema` for PostgreSQL was the constant `"public"` — the code assigned `"public"`, then branched on the URL path to assign `"public"` again, under a comment saying the schema "is usually specified via search_path or defaults to 'public'". The search_path was never read.

## Why that is worse than ignoring a flag

A writer decides from `info.Schema` which schemas belong to the caller and which are strangers it may drop. So a dev URL carrying `?search_path=app` did not merely get ignored — `DropDatabaseRealm` treated `app` as a stranger and **dropped a schema Ptah did not create**, then the replay ran under a search_path resolving to nothing and failed on the first unqualified `CREATE TABLE`:

```
ERROR: no schema has been selected to create in (SQLSTATE 3F000)
SQL: CREATE TABLE "Users" (id int)
```

A message that describes neither step, so the operator goes and looks at their migration.

## Measured

Same database, same fixture, schema counted before and after each run, pinned community binary v1.3.0 by absolute path:

| | `app` before → after | result |
| --- | --- | --- |
| `ptah-compat`, master | **1 → 0** | exit 1, 0 diagnostics, the error above |
| pinned binary | 1 → 1 | exit 1, 2 × DS102, 2 schema changes |
| `ptah-compat`, this branch | **1 → 1** | exit 1, 2 × DS102, 2 schema changes |

## The fix

`SELECT current_schema()` — what the server resolves `search_path` to, which is what the URL selects.

`current_schema()` is NULL when `search_path` names only schemas that do not exist. `"public"` is kept for that case: it is what every caller assumed before, and inventing a refusal there would change far more than the drop. The third row of the new resolution test pins that fallback.

## Mutants

**Direct** — hardcode `"public"` again:

```
--- FAIL: TestPostgresConnectionResolvesTheSearchPathSchemaE2E/a_search_path_naming_another_schema_resolves_to_it
--- FAIL: TestPostgresRealmCleanupKeepsTheSelectedSchemaE2E
```

**Inverse, and the reason the second test's comment says what it says.** The realm test also asserts a `bystander` schema is still cleaned. That is a non-interference claim, so I ran the inverse mutant to see whether it discriminates — spare every schema but the root — and it does **not** belong to the assertion I wrote it for. It is caught one line earlier, by the production code's own verification:

```
e`PostgreSQL database realm cleanup left residual user schema "bystander"`
```

returned from `DropDatabaseRealm`, which the test already asserts is nil. So the bystander is there to give the cleanup something to do and make that verification reachable; the count restates the outcome for a reader rather than adding coverage the error check does not already have. The comment in the file says exactly that instead of claiming a control it cannot prove.

(The first inverse attempt — drop nothing at all — reddens the test too, but through `failed to recreate root schema "app": schema "app" already exists`, a third path again. Recorded because it is the kind of thing that reads as confirmation if you stop at "the test went red".)

## Controls

With no `search_path`, and with `search_path=public`, `migrate lint` output is byte-identical to master modulo elapsed durations, same exit code, and the realm is still cleaned to `public` alone.

## Gates

```
go build ./...              rc=0     go vet ./...              rc=0
go test ./... -count=1      no failures
go tool qtlint ./...        rc=0     golangci-lint run ./...   0 issues
scripts/check-test-style.sh OK       check-public-api.sh       rc=0
check-public-api-snapshot.sh rc=0
integration, -tags integration, live PostgreSQL 17: the four new cells pass
```

One thing worth recording about that unit run: with `POSTGRES_TEST_DSN` exported for the integration tests, `TestMigrateGenerateShadowVerificationWithRealDB` fails with `shadow database must be distinct from target database`. That is my shell pointing target and shadow at one database, not this change — unset it and the suite is clean. Checked rather than assumed, because "a test failed after my change" is the easiest thing to misattribute in either direction.

**CI note:** GitHub Actions has been failing to resolve action download info repo-wide for several hours (`Service Unavailable` / `Bad Gateway` at `Set up job`, before any code runs), including on master with no code change. This PR should not be merged until CI can produce a green that means something; the evidence above is local.