### PR TITLE
Require the --dir scheme on the reading verbs too

### DIFF
--- a/cmd/atlas/atlas_lint_devurl_test.go
+++ b/cmd/atlas/atlas_lint_devurl_test.go
@@ -27,7 +27,7 @@ func TestCompatCommand_MigrateLintDevURLReplaysMigration(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", migrationsDir,
+		"--dir", "file://" + migrationsDir,
 		"--dev-url", "sqlite://" + devDBPath,
 	})
 
@@ -53,7 +53,7 @@ func TestCompatCommand_MigrateLintRejectsDockerDevURL(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", migrationsDir,
+		"--dir", "file://" + migrationsDir,
 		"--dev-url", "docker://postgres/16/dev",
 	})
 

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -797,7 +797,7 @@ func TestCompatCommand_MigrateCheckpointForwardsToNative(t *testing.T) {
 	// --dir-format is pinned to ptah so this stays a test of flag forwarding.
 	// The compat default is atlas; which convention the default selects is
 	// covered by TestCompatCommand_MigrateCheckpointDefaultsToAtlasFormat.
-	cmd.SetArgs([]string{"migrate", "checkpoint", "--dir", migrationsDir, "--dev-url", shadow, "--dir-format", "ptah", "snapshot"})
+	cmd.SetArgs([]string{"migrate", "checkpoint", "--dir", "file://" + migrationsDir, "--dev-url", shadow, "--dir-format", "ptah", "snapshot"})
 
 	err := cmd.Execute()
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
@@ -821,7 +821,7 @@ func TestCompatCommand_MigrateCheckpointRequiresDevURL(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"migrate", "checkpoint", "--dir", t.TempDir()})
+	cmd.SetArgs([]string{"migrate", "checkpoint", "--dir", "file://" + t.TempDir()})
 
 	// Forwarding reaches the native command, which reports the missing shadow
 	// database rather than the old community-unsupported stub message.
@@ -1400,7 +1400,7 @@ func TestCompatCommand_MigrateHashDefaultsToAtlasSum(t *testing.T) {
 	var out bytes.Buffer
 	cmd.SetOut(&out)
 	cmd.SetErr(&out)
-	cmd.SetArgs([]string{"migrate", "hash", "--dir", dir})
+	cmd.SetArgs([]string{"migrate", "hash", "--dir", "file://" + dir})
 
 	err := cmd.Execute()
 
@@ -1422,7 +1422,7 @@ func TestCompatCommand_MigrateStatusReadsAtlasRevisionsByDefault(t *testing.T) {
 	var applyOut bytes.Buffer
 	apply.SetOut(&applyOut)
 	apply.SetErr(&applyOut)
-	apply.SetArgs([]string{"migrate", "apply", "--url", "sqlite://" + dbPath, "--dir", dir})
+	apply.SetArgs([]string{"migrate", "apply", "--url", "sqlite://" + dbPath, "--dir", "file://" + dir})
 	err := apply.Execute()
 	c.Assert(err, qt.IsNil)
 
@@ -1430,7 +1430,7 @@ func TestCompatCommand_MigrateStatusReadsAtlasRevisionsByDefault(t *testing.T) {
 	var statusOut bytes.Buffer
 	status.SetOut(&statusOut)
 	status.SetErr(&statusOut)
-	status.SetArgs([]string{"migrate", "status", "--url", "sqlite://" + dbPath, "--dir", dir})
+	status.SetArgs([]string{"migrate", "status", "--url", "sqlite://" + dbPath, "--dir", "file://" + dir})
 	err = status.Execute()
 
 	c.Assert(err, qt.IsNil)
@@ -1451,7 +1451,7 @@ func TestCompatCommand_MigrateStatusFormatRendersAtlasReport(t *testing.T) {
 	cmd.SetArgs([]string{
 		"migrate", "status",
 		"--url", "sqlite://" + dbPath,
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--format", "{{ .Status }}|{{ .Current }}|{{ .Next }}|{{ len .Available }}|{{ len .Pending }}|{{ (index .Pending 0).Name }}",
 	})
 
@@ -1471,7 +1471,7 @@ func TestCompatCommand_MigrateStatusFormatRendersAppliedRevisionReport(t *testin
 	var applyOut bytes.Buffer
 	apply.SetOut(&applyOut)
 	apply.SetErr(&applyOut)
-	apply.SetArgs([]string{"migrate", "apply", "--url", "sqlite://" + dbPath, "--dir", dir})
+	apply.SetArgs([]string{"migrate", "apply", "--url", "sqlite://" + dbPath, "--dir", "file://" + dir})
 	err := apply.Execute()
 	c.Assert(err, qt.IsNil)
 
@@ -1482,7 +1482,7 @@ func TestCompatCommand_MigrateStatusFormatRendersAppliedRevisionReport(t *testin
 	status.SetArgs([]string{
 		"migrate", "status",
 		"--url", "sqlite://" + dbPath,
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--format", "{{ .Status }}|{{ len .Applied }}|{{ (index .Applied 0).Version }}|{{ (index .Applied 0).Description }}|{{ (index .Applied 0).Type }}|{{ (index .Applied 0).Applied }}|{{ (index .Applied 0).Total }}|{{ (index .Applied 0).OperatorVersion }}",
 	})
 	err = status.Execute()
@@ -1570,7 +1570,7 @@ func TestCompatCommand_MigrateStatusRejectsInvalidFormatBeforeConnecting(t *test
 	cmd.SetArgs([]string{
 		"migrate", "status",
 		"--url", "sqlite://" + dbPath,
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--format", "{{ if }}",
 	})
 
@@ -1592,7 +1592,7 @@ func TestCompatCommand_MigrateLintFormatRendersAtlasFiles(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--latest", "1",
 		"--format", "{{ len .Files }}|{{ (index .Files 0).Name }}|{{ printf \"%.6s\" (index .Files 0).Text }}",
 	})
@@ -1694,7 +1694,7 @@ func TestCompatCommand_MigrateLintFormatRendersReplayFailure(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--dev-url", "sqlite://" + dbPath,
 		"--latest", "1",
 		"--format", "{{ len .Steps }}|{{ (index .Steps 1).Text }}|{{ (index .Steps 1).Error }}",
@@ -1719,7 +1719,7 @@ func TestCompatCommand_MigrateLintFormatReportsInvalidAtlasSum(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--dev-url", "sqlite://" + dbPath,
 		"--latest", "1",
 		"--format", "{{ len .Steps }}|{{ (index .Steps 0).Text }}|{{ (index .Files 0).Name }}|{{ (index .Files 0).Error }}",
@@ -1745,7 +1745,7 @@ func TestCompatCommand_MigrateLintRejectsInvalidFormatBeforeReplay(t *testing.T)
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "lint",
-		"--dir", dir,
+		"--dir", "file://" + dir,
 		"--dev-url", "sqlite://" + dbPath,
 		"--latest", "1",
 		"--format", "{{ if }}",
@@ -1766,7 +1766,7 @@ func TestCompatCommand_MigrateSetAcceptsRevisionsSchema(t *testing.T) {
 	cmd.SetErr(&out)
 	cmd.SetArgs([]string{
 		"migrate", "set", "1",
-		"--dir", t.TempDir(),
+		"--dir", "file://" + t.TempDir(),
 		"--revisions-schema", "custom_revisions",
 	})
 
@@ -1791,7 +1791,7 @@ func TestCompatCommand_MigrateSetMapsPositionalRevision(t *testing.T) {
 	cmd.SetArgs([]string{
 		"migrate", "set", "1",
 		"--url", "sqlite://" + dbPath,
-		"--dir", migrationsDir,
+		"--dir", "file://" + migrationsDir,
 	})
 
 	err := cmd.Execute()
@@ -1826,7 +1826,7 @@ func TestCompatCommand_MigrateSetFailurePathVersionArgument(t *testing.T) {
 		cmd.SetArgs([]string{
 			"migrate", "set",
 			"--url", "sqlite://" + filepath.Join(t.TempDir(), "state.db"),
-			"--dir", t.TempDir(),
+			"--dir", "file://" + t.TempDir(),
 		})
 
 		err := cmd.Execute()
@@ -1842,7 +1842,7 @@ func TestCompatCommand_MigrateSetFailurePathVersionArgument(t *testing.T) {
 		cmd.SetArgs([]string{
 			"migrate", "set", "1", "2",
 			"--url", "sqlite://" + filepath.Join(t.TempDir(), "state.db"),
-			"--dir", t.TempDir(),
+			"--dir", "file://" + t.TempDir(),
 		})
 
 		err := cmd.Execute()
@@ -1855,7 +1855,7 @@ func TestCompatCommand_MigrateSetFailurePathVersionArgument(t *testing.T) {
 		var out bytes.Buffer
 		cmd.SetOut(&out)
 		cmd.SetErr(&out)
-		cmd.SetArgs([]string{"migrate", "set", "--version", "1", "--url", "sqlite://state.db", "--dir", t.TempDir()})
+		cmd.SetArgs([]string{"migrate", "set", "--version", "1", "--url", "sqlite://state.db", "--dir", "file://" + t.TempDir()})
 
 		err := cmd.Execute()
 
@@ -1885,19 +1885,19 @@ func TestCompatCommand_MigrateMetadataRejectsUnsupportedAtlasDirFormat(t *testin
 	}{
 		{
 			name: "edit",
-			args: []string{"migrate", "edit", "1", "--dir", t.TempDir(), "--dir-format", "goose"},
+			args: []string{"migrate", "edit", "1", "--dir", "file://" + t.TempDir(), "--dir-format", "goose"},
 		},
 		{
 			name: "rebase",
-			args: []string{"migrate", "rebase", "1", "--dir", t.TempDir(), "--dir-format", "flyway"},
+			args: []string{"migrate", "rebase", "1", "--dir", "file://" + t.TempDir(), "--dir-format", "flyway"},
 		},
 		{
 			name: "rm",
-			args: []string{"migrate", "rm", "1", "--dir", t.TempDir(), "--dir-format", "liquibase"},
+			args: []string{"migrate", "rm", "1", "--dir", "file://" + t.TempDir(), "--dir-format", "liquibase"},
 		},
 		{
 			name: "test",
-			args: []string{"migrate", "test", "--dir", t.TempDir(), "--dir-format", "goose"},
+			args: []string{"migrate", "test", "--dir", "file://" + t.TempDir(), "--dir-format", "goose"},
 		},
 	}
 
@@ -4003,7 +4003,7 @@ func TestCompatCommand_MigrateSetAllowsExplicitDirToOverrideProjectDir(t *testin
 		"migrate", "set", "1",
 		"--config", "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
 		"--env", "local",
-		"--dir", migrationsDir,
+		"--dir", "file://" + migrationsDir,
 	})
 
 	err := cmd.Execute()

--- a/cmd/atlas/migrate_hash_empty_dir_test.go
+++ b/cmd/atlas/migrate_hash_empty_dir_test.go
@@ -24,7 +24,14 @@ func TestMigrateHashRejectsExplicitEmptyDirectoryWithoutWritingSum(t *testing.T)
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, `migrations directory : stat : no such file or directory`)
+	// An empty --dir carries no scheme, so it is refused by the scheme gate
+	// rather than by the directory lookup behind it. That is what the pinned
+	// community binary v1.3.0 does with the same spelling, measured 2026-08-06:
+	// `migrate hash --dir=` exits 1 with this line, where Ptah used to reach the
+	// stat and report `migrations directory : stat : no such file or directory`
+	// (stokaro/ptah#1186). What the test is really about is below: nothing is
+	// written either way.
+	c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean "file://"\?`)
 	_, statErr := os.Stat(filepath.Join(root, "atlas.sum"))
 	c.Assert(statErr, qt.ErrorIs, fs.ErrNotExist)
 }

--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -161,7 +161,7 @@ func resolveAtlasMigrateSource(
 	// it. It goes out through cmdutil.Fail rather than being returned bare so
 	// the `Error: ` line reaches stderr from the command itself, the way the
 	// #1086 checksum refusal on the same two verbs already does.
-	if verb.writesDir && spelledByAtlas && atlasDirSchemeIsAnswerable(project.project, rawDir) {
+	if spelledByAtlas && atlasDirSchemeIsAnswerable(project.project, rawDir) {
 		if err := atlasargs.RequireDirScheme(rawDir); err != nil {
 			return atlasMigrateSource{}, cmdutil.Fail(cmd, err)
 		}

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -139,6 +139,20 @@ func runAtlasMigrateLint(
 		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
 		localDir, err = project.localDirWithQuery(opts.dir)
 	} else {
+		// A --dir spelled on the command line needs the scheme the community
+		// binary requires. Measured on the pinned v1.3.0 on 2026-08-06,
+		// `migrate lint --dir mig --dir-format goose --dev-url …` exits 1 with
+		// `missing scheme for dir url. Did you mean "file://mig"?` where Ptah
+		// exited 0 (stokaro/ptah#1186). The flag default is `file://migrations`,
+		// so an omitted --dir passes.
+		//
+		// Only this branch is gated: it is the one carrying a command-line
+		// value. A directory named by atlas.hcl takes the branch above, where
+		// the community binary's own spelling rules are a separate question
+		// #1186 leaves open.
+		if err := atlasargs.RequireDirScheme(opts.dir); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 		localDir, err = atlasargs.ParseLocalDir(opts.dir)
 	}
 	if err != nil {

--- a/cmd/atlas/migrate_lint_condrop_test.go
+++ b/cmd/atlas/migrate_lint_condrop_test.go
@@ -135,7 +135,7 @@ func TestCompatCommand_MigrateLintCondropSeverity(t *testing.T) {
 				[]byte(atlasCondropProjectConfig), 0o600), qt.IsNil)
 			t.Chdir(dir)
 
-			stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", tt.env)
+			stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://migrations", "--env", tt.env)
 
 			c.Assert(exitcode.Code(err, 0), qt.Equals, tt.code)
 			// The report body is identical in all four rows -- the diagnostic
@@ -181,7 +181,7 @@ func TestCompatCommand_MigrateLintRunsWithDropSchemaConfigured(t *testing.T) {
 		[]byte(atlasDropSchemaProjectConfig), 0o600), qt.IsNil)
 	t.Chdir(dir)
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "skip_drop_schema")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://migrations", "--env", "skip_drop_schema")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -225,7 +225,7 @@ func TestCompatCommand_MigrateLintRunsWithSchemaRepoConfigured(t *testing.T) {
 		[]byte(atlasSchemaRepoProjectConfig), 0o600), qt.IsNil)
 	t.Chdir(dir)
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "repo")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://migrations", "--env", "repo")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,

--- a/cmd/atlas/migrate_lint_default_test.go
+++ b/cmd/atlas/migrate_lint_default_test.go
@@ -49,7 +49,7 @@ func TestCompatCommand_MigrateLintDefaultTextClean(t *testing.T) {
 	devDB := "sqlite://" + filepath.Join(t.TempDir(), "clean.db")
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -72,7 +72,7 @@ func TestCompatCommand_MigrateLintDefaultTextDestructive(t *testing.T) {
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "DROP TABLE users;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -99,7 +99,7 @@ func TestCompatCommand_MigrateLintDefaultTextDropColumn(t *testing.T) {
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE \"Users\" (id int PRIMARY KEY, \"Legacy\" text);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE \"Users\" DROP COLUMN \"Legacy\";\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -126,7 +126,7 @@ func TestCompatCommand_MigrateLintDefaultTextWrapsDropColumnAtMeasuredBoundary(t
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int PRIMARY KEY, c1234567890123456 text);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE users DROP COLUMN c1234567890123456;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -155,7 +155,7 @@ func TestCompatCommand_MigrateLintDefaultTextNormalizesTypeAndIdentifiers(t *tes
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE \"Users\" (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE \"Users\" ADD COLUMN \"Display Name\" VARCHAR(255) NOT NULL;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -181,7 +181,7 @@ func TestCompatCommand_MigrateLintDefaultTextCollectsFixesAfterEveryAnalyzerGrou
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int PRIMARY KEY, legacy text);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE users DROP COLUMN legacy;\nALTER TABLE users ADD COLUMN name TEXT NOT NULL;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -211,7 +211,7 @@ func TestCompatCommand_MigrateLintDefaultTextLabelsUnmeasuredTypeCopy(t *testing
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE users ADD COLUMN label CHARACTER VARYING(255) NOT NULL;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Contains, "L1 [MF103]:")
@@ -225,7 +225,7 @@ func TestCompatCommand_MigrateLintDefaultTextWrapsAnalyzerURLAtMeasuredBoundary(
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE abcdefghijklmnopqrs (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "DROP TABLE abcdefghijklmnopqrs;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -353,7 +353,7 @@ func TestCompatCommand_MigrateLintDefaultTextClassifiesRenames(t *testing.T) {
 			writeAtlasLintFile(c, dir, "2.sql", test.rename)
 
 			stdout, stderr, err := runAtlasMigrateLint(
-				c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+				c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 			c.Assert(exitcode.Code(err, 0), qt.Equals, test.exitCode)
 			c.Assert(stderr, qt.Equals, "")
@@ -369,7 +369,7 @@ func TestCompatCommand_MigrateLintDefaultTextDataDependentWarning(t *testing.T) 
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE users ADD COLUMN c2 int NOT NULL;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -400,7 +400,7 @@ func TestCompatCommand_MigrateLintDefaultTextAddNotNullFixture(t *testing.T) {
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\n\n/* Adding a not-null column without default to a table created in this file should not report. */\nALTER TABLE users ADD COLUMN c1 int NOT NULL;\n")
 	writeAtlasLintFile(c, dir, "2.sql", "ALTER TABLE users ADD COLUMN c2 int NOT NULL;\n\nALTER TABLE users ADD COLUMN c3 int NOT NULL DEFAULT 1;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "2")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "2")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -430,7 +430,7 @@ func TestCompatCommand_MigrateLintDefaultTextInlineSuppressed(t *testing.T) {
 	writeAtlasLintFile(c, dir, "1.sql", "CREATE TABLE users (id int);\nCREATE TABLE pets (id int);\n")
 	writeAtlasLintFile(c, dir, "2.sql", "\n-- atlas:nolint\nALTER TABLE users ADD COLUMN name text NOT NULL;\n\n-- atlas:nolint\nDROP TABLE pets;\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(redactAtlasLintDurations(stdout), qt.Equals,
@@ -479,7 +479,7 @@ func TestCompatCommand_MigrateLintProjectGlobalLintLog(t *testing.T) {
 	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(atlasProjectLintLogConfig), 0o600), qt.IsNil)
 	t.Chdir(dir)
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "log_name")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://migrations", "--env", "log_name")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Equals, "3.sql\n")
@@ -494,7 +494,7 @@ func TestCompatCommand_MigrateLintProjectEnvLintLog(t *testing.T) {
 	c.Assert(os.WriteFile(filepath.Join(dir, "atlas.hcl"), []byte(atlasProjectLintLogConfig), 0o600), qt.IsNil)
 	t.Chdir(dir)
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "migrations", "--env", "log_count")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://migrations", "--env", "log_count")
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout, qt.Equals, "2\n")
@@ -520,7 +520,7 @@ func TestCompatCommand_MigrateLintToleratesUnreadableTxMode(t *testing.T) {
 	writeAtlasLintFile(c, dir, "2.sql",
 		"-- atlas:txmode unknown\n\nCREATE TABLE pets (id int);\n")
 
-	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1")
+	stdout, _, err := runAtlasMigrateLint(c, "migrate", "lint", "--dir", "file://"+dir, "--dev-url", devDB, "--latest", "1")
 
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 0)
 	c.Assert(stdout, qt.Contains, "analyzing version 2")

--- a/cmd/atlas/migrate_lint_integrity_test.go
+++ b/cmd/atlas/migrate_lint_integrity_test.go
@@ -57,7 +57,7 @@ func TestCompatCommand_MigrateLintIntegrityFindingIsReportContent(t *testing.T) 
 			// Edit the hashed file so the recorded sum no longer matches it.
 			writeAtlasLintFile(c, dir, "20240101000000_init.sql", "CREATE TABLE t1 (id integer, extra text);\n")
 
-			args := append([]string{"migrate", "lint", "--dir", dir, "--dev-url", devDB, "--latest", "1"}, tt.formatArgs...)
+			args := append([]string{"migrate", "lint", "--dir", "file://" + dir, "--dev-url", devDB, "--latest", "1"}, tt.formatArgs...)
 			stdout, stderr, err := runAtlasMigrateLint(c, args...)
 
 			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)

--- a/cmd/atlas/migrate_status.go
+++ b/cmd/atlas/migrate_status.go
@@ -100,6 +100,25 @@ func runAtlasMigrateStatus(
 		opts.format = dbcli.EffectiveString(cmd, "format", opts.format, formatValue)
 		formatOutput = formatOutput || formatValue.Present
 	}
+	// The scheme refusal runs before everything this command body validates,
+	// and the position is measured rather than chosen. On the pinned community
+	// binary v1.3.0, `migrate status --dir mig` beats a missing --url, an
+	// unknown --dir-format and a malformed --format template with
+	// `missing scheme for dir url. Did you mean "file://mig"?`; the control
+	// `--dir file://mig --dir-format nosuchfmt` prints `unknown dir format
+	// "nosuchfmt"`, so the dir-format diagnostic is reachable and only the
+	// scheme outranks it. Ptah answered `database URL is required` here.
+	//
+	// Only a command-line --dir is gated; a directory named by atlas.hcl is out
+	// of scope for stokaro/ptah#1186.
+	dirFromProject := loaded &&
+		!cmd.Flags().Changed("dir") &&
+		projectCfg.StringValue(projectconfig.StringMigrationDir).Present
+	if !dirFromProject {
+		if err := atlasargs.RequireDirScheme(opts.dir); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
+	}
 	if err := validateAtlasMigrateStatusOptions(opts); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -122,11 +141,11 @@ func runAtlasMigrateStatus(
 	}
 
 	var localDir atlasargs.LocalDir
-	if loaded &&
-		!cmd.Flags().Changed("dir") &&
-		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
+	if dirFromProject {
 		localDir, err = project.localDirWithQuery(opts.dir)
 	} else {
+		// The scheme was already required above, where the measured ordering
+		// puts it.
 		localDir, err = atlasargs.ParseLocalDir(opts.dir)
 	}
 	if err != nil {

--- a/cmd/atlas/migrate_write_dir_scheme_test.go
+++ b/cmd/atlas/migrate_write_dir_scheme_test.go
@@ -298,15 +298,29 @@ func TestCompatMigrateWrite_SpellingsTheCommunityBinaryAcceptsStillWrite(t *test
 	}
 }
 
-// TestCompatMigrateRead_StillAcceptsADirectoryNamingNoScheme pins the boundary
-// on the other side: the requirement belongs to the verbs that can CREATE a
-// directory, and widening it to the verbs that only read one is a separate
-// decision with a measurable blast radius (stokaro/ptah#1186).
+// TestCompatMigrateRead_RequiresTheSchemeToo is the boundary this test used to
+// pin from the other side. It read
+// `TestCompatMigrateRead_StillAcceptsADirectoryNamingNoScheme`, and the
+// requirement belonged to the verbs that can CREATE a directory, because
+// widening it was "a separate decision with a measurable blast radius"
+// (stokaro/ptah#1186).
 //
-// It is the second half the revert cannot redden, and the same inverse mutant
-// reddens it: make the requirement unconditional and both rows fail with `got
-// non-nil error` carrying `missing scheme for dir url`.
-func TestCompatMigrateRead_StillAcceptsADirectoryNamingNoScheme(t *testing.T) {
+// That decision was taken and the blast radius was measured, so the assertion
+// is inverted rather than deleted: the reading verbs now refuse the same
+// spelling, with the same message.
+//
+// Measured on the pinned community binary v1.3.0, `--dir mig --dir-format
+// goose`, each verb in its own directory:
+//
+//	hash      binary 1, ptah 1, `missing scheme for dir url. Did you mean "file://mig"?`
+//	validate  binary 1, ptah 1, same line
+//	lint      binary 1, ptah 1, same line
+//	status    binary 1, ptah 1, same line
+//
+// The control is below: the same directory named WITH the scheme still works on
+// every one of them, which is what separates "requires the scheme" from
+// "refuses this directory".
+func TestCompatMigrateRead_RequiresTheSchemeToo(t *testing.T) {
 	verbs := []struct {
 		name string
 		args func(dir string) []string
@@ -328,6 +342,18 @@ func TestCompatMigrateRead_StillAcceptsADirectoryNamingNoScheme(t *testing.T) {
 			hashAtlasWriteFixture(c, dir)
 
 			_, _, err := runCompat(verb.args(dir)...)
+
+			c.Assert(err, qt.ErrorMatches, `missing scheme for dir url\. Did you mean ".*"\?`)
+		})
+	}
+
+	for _, verb := range verbs {
+		t.Run("control: "+verb.name+" with the scheme", func(t *testing.T) {
+			c := qt.New(t)
+			dir := writeAtlasWriteFixture(c, c.TempDir())
+			hashAtlasWriteFixture(c, dir)
+
+			_, _, err := runCompat(verb.args("file://" + dir)...)
 
 			c.Assert(err, qt.IsNil)
 		})

--- a/cmd/atlas/project_config_presence_test.go
+++ b/cmd/atlas/project_config_presence_test.go
@@ -100,7 +100,7 @@ env "ci" {
 	cmd.SetArgs([]string{
 		"migrate", "lint",
 		"--env", "ci",
-		"--dir", "migrations",
+		"--dir", "file://migrations",
 		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
 	})
 
@@ -136,7 +136,7 @@ func TestCompatCommand_ExplicitGitBaseSuppressesProjectLatest(t *testing.T) {
 	cmd.SetArgs([]string{
 		"migrate", "lint",
 		"--env", "ci",
-		"--dir", "migrations",
+		"--dir", "file://migrations",
 		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
 		"--git-base=-unsafe",
 	})
@@ -177,7 +177,7 @@ func TestCompatCommand_ExplicitLatestSuppressesProjectGitSelector(t *testing.T) 
 	cmd.SetArgs([]string{
 		"migrate", "lint",
 		"--env", "ci",
-		"--dir", "migrations",
+		"--dir", "file://migrations",
 		"--dev-url", "sqlite://" + filepath.Join(root, "dev.db"),
 		"--latest", "1",
 	})


### PR DESCRIPTION
Closes #1186. **Stacked on #1172** — it uses `atlasargs.RequireDirScheme`, which that PR adds, so the base here is its branch rather than master.

#1172 closed the writing half and left this one open with the reason stated: widening the requirement was "a separate decision with a measurable blast radius". This measures the radius and takes the decision.

## The divergence

Four verbs, `--dir mig --dir-format goose`, each in its own directory, against the pinned community binary v1.3.0:

| verb | binary | Ptah before | Ptah after |
| --- | --- | --- | --- |
| `migrate hash` | 1 | **0** | 1 |
| `migrate validate` | 1 | **0** | 1 |
| `migrate lint` | 1 | **0** | 1 |
| `migrate status` | 1 | **0** | 1 |

Exit 0 where the binary exits 1, on four verbs — parity rule (a). All four now print that binary's own line, and the control (the same directory named **with** the scheme) still works on every one of them.

## `migrate status` needed its position measured, not chosen

The gate had to move above the command body rather than sit beside the `--dir` parsing. On the binary:

```
migrate status --dir mig                                  -> scheme refusal, not "required flag url"
migrate status --dir mig --dir-format nosuchfmt --url …   -> scheme refusal, not "unknown dir format"
migrate status --dir mig --format '{{' --url …            -> scheme refusal, not the template error
control: --dir file://mig --dir-format nosuchfmt --url …  -> unknown dir format "nosuchfmt"
```

The control is what makes that a ranking rather than a blanket refusal. Ptah answered `database URL is required` on the first line; it now answers the same as the binary.

For `migrate lint`, cobra's `required flag(s) "dev-url" not set` and `unknown flag` both still outrank the scheme on the binary, and they do here too — those run before `RunE`.

## An empty `--dir`

`migrate hash --dir=` is now the scheme refusal rather than `migrations directory : stat : no such file or directory`. That is the binary's behavior too, measured: `Error: missing scheme for dir url. Did you mean "file://"?`. The test that pinned the old message now pins this one and keeps its real assertion — that no `atlas.sum` is written either way.

## The boundary #1172 wrote down

`TestCompatMigrateRead_StillAcceptsADirectoryNamingNoScheme` existed precisely to state that read verbs still accepted the bare spelling. It is **inverted rather than deleted**, renamed to `..._RequiresTheSchemeToo`, with a control row per verb, so the moved boundary shows up in the diff instead of vanishing from it. That test doing its job is how the change was forced to be explicit.

## Correcting my own blast-radius estimate

On the issue I reported **8 test call sites in 3 files** and called requiring the scheme "the cheap option". That was an undercount: my grep matched only string literals like `"--dir", "testdata/bad"` and missed `"--dir", tmpDir`. The real figure on the compat surface is **59 bare `--dir` call sites**, of which **34 tests** failed with only these four verbs gated. The change is still right and still mechanical, but it is four times the size I quoted, and the native surface remains untouched.

**Two rewrites that the suite caught, worth recording** because they are what a bulk edit does wrong:

- `flags: []string{"--dir", "--dir-format", …}` — a list of flag *names* — became `"file://--dir-format"`. A regex that assumes `"--dir", X` means "flag then value" is wrong wherever the next element is another flag. 14 occurrences, all reverted.
- `--dir=` was deliberately empty in one test to assert an error; the rewrite changed its subject.

Both were found by running the suite rather than by reading the diff.

## Gates

```
go build ./...              rc=0     go vet ./...              rc=0
go test ./... -count=1      no failures
go tool qtlint ./...        rc=0     golangci-lint run ./...   0 issues
scripts/check-test-style.sh OK       check-public-api.sh       rc=0
check-public-api-snapshot.sh rc=0
```

**CI note:** GitHub Actions has been failing repo-wide at `Set up job` (`Service Unavailable` / `Bad Gateway`, before any code runs) for several hours — 19 runs queued at one point, a trivial `Detect docs changes` job "running" for 74 minutes. The evidence above is local; this should not merge on a CI result that means nothing, and it must land after #1172 regardless.