### PR TITLE
docs: state that compatibility with older Ptah is not owed before v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,31 @@ When the two halves pull apart, say so in the commit and in the issue rather
 than picking silently. "We are stricter here, deliberately, and here is the
 measurement" is a complete answer; quietly matching is not.
 
+### Compatibility with older Ptah is a different axis, and it is not owed
+
+Everything above is about the community binary. Compatibility with **Ptah's own
+previous behavior is a separate question, and until Ptah ships v1 the answer is
+no.** There is no supported upgrade path to preserve, so:
+
+- Do not keep a fallback, an alias, a tolerated old spelling, or a second reader
+  for a retired format only because an earlier Ptah produced it.
+- Do not soften a refusal because it would break something an earlier Ptah
+  accepted.
+- Do not carry a default only because changing it would alter existing output.
+  Pick the default that is right for a reader meeting it for the first time.
+
+Changing behavior is the normal, cheap thing to do right now, and the cost of
+not changing it compounds. When a change alters behavior, say so plainly in the
+issue and the commit -- "this changes behavior; pre-v1, so no compatibility is
+owed" -- rather than quietly designing around it.
+
+This does **not** license breaking parity with the community binary, which is a
+contract with users of that CLI rather than with Ptah's own history, nor
+silently discarding user data. It licenses changing Ptah's defaults, spellings,
+internal formats, and error text without a migration path.
+
+The rule expires when Ptah reaches v1.
+
 ### A worked example
 
 `-- atlas:txmode none` marks a migration that must run outside a transaction --
@@ -153,7 +178,10 @@ Ptah treats `.golangci.yml` as a strict contract. Fix code to satisfy the config
 Ptah is pre-GA. Do not preserve old command aliases, compatibility wrappers,
 fallback APIs, or backward-compatibility behavior only to keep an older internal
 shape. Prefer the cleaner architecture and update callers/tests/docs unless a
-maintainer explicitly asks for a compatibility layer.
+maintainer explicitly asks for a compatibility layer. This paragraph is the
+[compatibility-with-older-Ptah rule](#compatibility-with-older-ptah-is-a-different-axis-and-it-is-not-owed)
+applied to code shape; the rule itself is broader and covers defaults, output,
+formats and error text as well.
 
 Atlas OSS command parity belongs in the separate `ptah-compat` binary, the
 Atlas-style root command surface for drop-in script migration. The `ptah`


### PR DESCRIPTION
Per Denis: mark explicitly that backward compatibility with older Ptah is not needed, and write the rule into AGENTS.md. The rule holds until v1.

## What was already there

A pre-GA rule existed at `AGENTS.md`, under **Code Style And Linting**:

> Ptah is pre-GA. Do not preserve old command aliases, compatibility wrappers, fallback APIs, or backward-compatibility behavior only to keep an older internal shape.

Read literally that is a rule about *code shape*. It says nothing about the cases where the question actually comes up: a default that would change existing output, a retired file format, an error message, a refusal that would break something an earlier Ptah accepted. Three separate decisions today ran into exactly those and had to reason it out from scratch.

## What this adds

A first-class section in **Compatibility Policy**, which is where the distinction it needs is available. Everything else in that section is about the pinned community binary — which **is** a contract with users of that CLI. Compatibility with Ptah's own history is the other axis and is not a contract. Conflating the two is how a change gets designed around a migration path nobody is owed.

The scope is stated in both directions, because a rule with only the permissive half gets over-applied:

- **It licenses** changing Ptah's defaults, spellings, internal formats and error text without a migration path.
- **It does not license** breaking parity with the community binary, nor silently discarding user data.
- **It expires at v1.**

The existing code-shape paragraph stays where it is and now points at the rule, since it is that rule applied to one narrow case.

## Note on how this was nearly shipped wrong

The first attempt wrote the section in a checkout sitting on a different branch and copied the file across. That silently **deleted** the `### A second worked example` section — the `file()` confinement write-up for #1042 — which exists on master but not on that branch. Caught by reading the diff rather than the stat line: an additive change showing `30 insertions, 27 deletions` is not additive. Redone in place; the diff is now 29 insertions and the single replaced paragraph, and `A second worked example` is still there.

`node docs/site/scripts/check-style.mjs` — OK (100 documentation files).

A sweep over the open issues, adding the note where a proposal genuinely changes existing behavior, is running separately.