### PR TITLE
Record the migrate lint scope and analyzer-shape boundary (#1074 S3)

### DIFF
--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -864,6 +864,24 @@
     "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} — no rule definition. config/projectconfig/atlas.go parseLintPolicyBlocks accepts only concurrent_index, condrop, data_depend, destructive, git, nestedtx, incompatible; parseLintAnalyzer tolerates `force` without acting on it. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
   },
   {
+    "area": "Lint analyzers",
+    "feature": "Dev-URL schema scope on `migrate lint`",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "`ptah-compat migrate lint` reviews only the schema the dev URL's search_path names, matching the pinned CE binary. Native `ptah migrations lint` reads SQL text and deliberately does not scope.",
+    "evidence": "Measured against the pinned CE binary v1.3.0 on PostgreSQL, migrations creating app.\"Users\" and app.audit_log then dropping both: with ?search_path=public both exit 0 with no diagnostic; without search_path both exit 1 with one DS102 per dropped table; ?search_path=app reviews app rather than a constant. Pinned by the ten rows of integration/atlas_migrate_lint_schema_scope_e2e_test.go plus TestNativeMigrationsLintIgnoresTheDevURLSchemaScopeE2E, which reddens if the boundary is applied to the native surface. internal/migrationlintreport/report.go compatSchemaScope gates it to the compatibility profile; internal/schemaselection derives it (stokaro/ptah#1074 S1, #1197, #1207)."
+  },
+  {
+    "area": "Lint analyzers",
+    "feature": "Analyzers that need a dev-database schema diff",
+    "ptah": "partial",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "Ptah's analyzers read SQL text, so a concern whose subject appears only in the resulting schema is unreported: a RENAME COLUMN draws DS103 from both, but only Atlas adds MF103 for the new column.",
+    "evidence": "Measured on the pinned CE binary v1.3.0 against PostgreSQL 17, `CREATE TABLE users (id int NOT NULL)` then `ALTER TABLE users RENAME COLUMN id TO oid`: CE reports DS103 plus `Adding a non-nullable \"integer\" column \"oid\" ... MF103` and exits 1; ptah-compat reports DS103 alone and exits 1. The renamed column's type and nullability come from an earlier file or the base schema rather than from the statement, and the message spells the dialect-canonical type name, so reaching it needs the replayed dev schema rather than the SQL text. migration/lint/rules.go notNullWithoutDefaultFindings scans ADD COLUMN clauses only. Tracked by stokaro/ptah#1074 S2."
+  },
+  {
     "area": "Lint policy and suppression",
     "feature": "Inline nolint suppression",
     "ptah": "yes",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -72,17 +72,17 @@ row for a migration decision.
 
 ## At a glance
 
-Across the 164 capabilities below:
+Across the 166 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 91 |
-| Ptah supports it with a stated limitation | 49 |
+| Ptah supports it fully | 92 |
+| Ptah supports it with a stated limitation | 50 |
 | Ptah does not implement it | 24 |
-| Ptah and Atlas CE both support it | 23 |
+| Ptah and Atlas CE both support it | 24 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
 | Ptah has it and neither Atlas edition does | 20 |
-| Atlas CE has it and Ptah does not, or only in part | 25 |
+| Atlas CE has it and Ptah does not, or only in part | 26 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
@@ -198,6 +198,7 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | `schema apply --skip-lint` | ✅ | ❌ | ✅ | With an atlas.hcl `lint` policy, the planned SQL is linted against the rules it names and an error-rated finding refuses the apply; `--skip-lint` applies anyway. No policy, no lint pass, as in CE. |
+| Analyzers that need a dev-database schema diff | 🟡 | ✅ | ✅ | Ptah's analyzers read SQL text, so a concern whose subject appears only in the resulting schema is unreported: a RENAME COLUMN draws DS103 from both, but only Atlas adds MF103 for the new column. |
 | Apply-time destructive-change gate | ✅ | ❌ | ➖ | migrations up refuses destructive pending files; .ptah-lint.yaml disabled-rules reopens the gate and ptah.sum does not hash that file. |
 | Atlas Pro analyzer code coverage | 🟡 | ➖ | ✅ | OW101/OW102 have no rule; PG301, PG304, MY130, MY133, MY136 fire under broader codes (DS103, PG104, CD103, MY101), not dedicated ones. |
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
@@ -205,6 +206,7 @@ seven of them as open capabilities regardless.
 | CI integration (GitHub Action, annotations) | ✅ | 🟡 | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. The community binary has no annotation mode; its lint `--format` takes a Go template only. |
 | Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
+| Dev-URL schema scope on `migrate lint` | ✅ | ✅ | ✅ | `ptah-compat migrate lint` reviews only the schema the dev URL's search_path names, matching the pinned CE binary. Native `ptah migrations lint` reads SQL text and deliberately does not scope. |
 | Generation-time destructive-change gate | ✅ | ❌ | ❌ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
 | Inline nolint suppression | ✅ | ✅ | ✅ | Every code the compat surface prints is silenced by that code; analyzer names work on both surfaces; a blank line detaches a directive. Unknown selectors accepted silently, matching CE. |
 | Native migration lint rule set | ✅ | 🟡 | ✅ | 42 codes across 9 families, gated by `--dialect`. Atlas lists destructive and backward-incompatible rules Open; concurrent-index rules Pro. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -853,6 +853,19 @@ incompatible` does not.
 Index, key and constraint renames are not reported at all: deployed application
 code does not name them.
 
+What a rename does **not** report on either surface is the column it
+introduces. Renaming a `NOT NULL` column draws the destructive diagnostic for
+the retired name from Ptah and from the CE binary alike, but the binary adds a
+second one — `MF103`, "adding a non-nullable column will fail in case the table
+is not empty" — for the new name, and Ptah does not. Ptah's analyzers read the
+migration's SQL text, and a `RENAME COLUMN` statement carries neither the
+column's type nor its nullability: both come from an earlier file or from the
+base schema, and the binary's message spells the type as the database canonicalizes
+it. Reaching that needs the replayed dev schema rather than the statement, which
+is [#1074](https://github.com/stokaro/ptah/issues/1074). Until then a rename is
+reported as destructive on both surfaces and as a data-dependent addition on
+neither, so it is one diagnostic short rather than differently classified.
+
 The report is written to stdout even when findings fail, and error-severity
 findings still exit with code 1. The native `ptah migrations lint` output is
 unchanged. Custom output is selected by `--format`, by `format.migrate.lint`,


### PR DESCRIPTION
Closes the S3 half of #1074: the feature matrix and lint documentation now carry the support boundary the rest of that issue established.

Two rows in `feature-matrix-rows.json`, both measured against the pinned community binary v1.3.0 rather than read off the code.

**Dev-URL schema scope on `migrate lint`** — ✅/✅/✅. `ptah-compat migrate lint` reviews only the schema the dev URL's `search_path` names; native `ptah migrations lint` reads SQL text and deliberately does not scope. That split is what the #1197 review caught before it shipped, and a reader otherwise finds it by running both.

**Analyzers that need a dev-database schema diff** — 🟡/✅/✅, the open half. Re-measured today on PostgreSQL 17:

```
CREATE TABLE users (id int NOT NULL);
ALTER TABLE users RENAME COLUMN id TO oid;

pinned binary v1.3.0   DS103 + MF103 "Adding a non-nullable \"integer\" column \"oid\""   rc=1
ptah-compat            DS103                                                            rc=1
```

The renamed column's type and nullability come from an earlier file or the base schema rather than from the statement, and the binary spells the type as the database canonicalizes it (`integer`, not `int`), so reaching that needs the replayed dev schema rather than the SQL text. `migration/lint/rules.go` `notNullWithoutDefaultFindings` scans `ADD COLUMN` clauses only.

Worth stating plainly because it changes what the gap *is*: Ptah is one diagnostic short here, not differently classified. The rename classification itself now matches exactly — same rule, same subject, same suggested fix, same exit code — which I re-measured on `master` rather than assuming from #1074's 2026-08-03 table:

```
CREATE TABLE users (id int); ALTER TABLE users RENAME COLUMN id TO oid;

both binaries: DS103, "Dropping non-virtual column \"id\"", the NULL-precheck fix, rc=1
```

The docs half is a paragraph in the Renames section of `atlas/migrate-commands.md` saying the same thing in prose.

#1074 stays open on S2 — closing it needs the dev-database schema diff, which is a real engine change rather than a wording one.

Gates: `node scripts/build-feature-matrix.mjs --check` plus all seven `check:*` docs scripts. `check:responsive` needs a built `dist` and runs in CI. No Go code changed.
