### PR TITLE
Stamp `migrate diff` with the UTC timestamp version (#1218)

### DIFF
--- a/cmd/atlas/migrate_diff_version_test.go
+++ b/cmd/atlas/migrate_diff_version_test.go
@@ -1,0 +1,169 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// futureDatedMigration is a version no clock will reach, whose seconds field is
+// 59. Both halves matter: the version is higher than any stamp `migrate diff`
+// could produce, and adding one to it yields `29991231235960` -- a sixtieth
+// second, which is not a time.
+const futureDatedMigration = "29991231235959_future.sql"
+
+// hashMigrationDir writes atlas.sum over dir. A directory that already holds a
+// migration is refused by the checksum preflight without it, which would make
+// every row below fail for a reason that is not the version.
+func hashMigrationDir(c *qt.C, dir string) {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{"migrate", "hash", "--dir", "file://" + dir})
+
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("output:\n%s", out.String()))
+}
+
+// dirEntryNames lists the base names in dir.
+func dirEntryNames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// runMigrateDiffInto plans one migration into dir and returns the base names
+// that were not there before, excluding atlas.sum. Comparing against a listing
+// taken first keeps the caller from having to know which files it seeded.
+func runMigrateDiffInto(c *qt.C, dir string) []string {
+	c.Helper()
+	before := dirEntryNames(c, dir)
+	desiredPath := seedSQLiteDB(c.TB.(*testing.T), "CREATE TABLE desired_users (id INTEGER PRIMARY KEY)")
+	devPath := filepath.Join(c.TB.(*testing.T).TempDir(), "dev.db")
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "diff", "add_desired_users",
+		"--to", "sqlite://" + desiredPath,
+		"--dev-url", "sqlite://" + devPath,
+		"--dir", "file://" + dir,
+	})
+
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("output:\n%s", out.String()))
+
+	var written []string
+	for _, name := range dirEntryNames(c, dir) {
+		if name == "atlas.sum" || slices.Contains(before, name) {
+			continue
+		}
+		written = append(written, name)
+	}
+	return written
+}
+
+// TestMigrateDiffStampsTheUTCTimestampVersion pins the version spelling
+// `migrate diff` writes (stokaro/ptah#1218).
+//
+// Both rows were divergences from the pinned community binary v1.3.0, and they
+// were different divergences, which is why one row would not have found the
+// other:
+//
+//   - into an empty directory the version came from `time.Now().Unix()`, a
+//     ten-digit epoch that is not a timestamp in any spelling;
+//   - into a directory holding a higher version it came from `max + 1`, which
+//     on a neighbour ending in `59` seconds produces `...235960`.
+//
+// The binary answers the current UTC stamp to both, and to the future-dated one
+// it does so even though the result sorts BEFORE the migration already there.
+func TestMigrateDiffStampsTheUTCTimestampVersion(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(c *qt.C, dir string)
+	}{
+		{
+			name:  "an empty directory",
+			setup: func(*qt.C, string) {},
+		},
+		{
+			name: "a directory holding a future-dated migration",
+			setup: func(c *qt.C, dir string) {
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, futureDatedMigration),
+					[]byte("CREATE TABLE placeholder (id INTEGER);\n"),
+					0o600,
+				), qt.IsNil)
+				hashMigrationDir(c, dir)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := filepath.Join(t.TempDir(), "migrations")
+			c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+			test.setup(c, dir)
+			before := time.Now().UTC().Add(-time.Second)
+
+			written := runMigrateDiffInto(c, dir)
+
+			c.Assert(written, qt.HasLen, 1)
+			version, _, found := strings.Cut(written[0], "_")
+			c.Assert(found, qt.IsTrue, qt.Commentf("file name %q carries no version", written[0]))
+			// Fourteen digits rules out the epoch, which has ten.
+			c.Assert(version, qt.HasLen, 14)
+			stamp, err := time.Parse("20060102150405", version)
+			// Parsing rules out `...235960`, which has fourteen digits and is
+			// still not a time.
+			c.Assert(err, qt.IsNil, qt.Commentf("version %q does not parse as a timestamp", version))
+			c.Assert(stamp.Before(before), qt.IsFalse, qt.Commentf("version %q predates the run", version))
+			c.Assert(stamp.After(time.Now().UTC().Add(time.Minute)), qt.IsFalse,
+				qt.Commentf("version %q is in the future", version))
+		})
+	}
+}
+
+// TestMigrateDiffAdvancesPastAnExistingVersionOfThisSecond covers what the
+// wall clock alone cannot: a directory that already holds the stamp this run
+// would produce. The version advances by a second rather than colliding, which
+// is the rule `migrate new` already applies.
+func TestMigrateDiffAdvancesPastAnExistingVersionOfThisSecond(t *testing.T) {
+	c := qt.New(t)
+	dir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	taken := time.Now().UTC().Format("20060102150405")
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, taken+"_taken.sql"),
+		[]byte("CREATE TABLE taken (id INTEGER);\n"),
+		0o600,
+	), qt.IsNil)
+	hashMigrationDir(c, dir)
+
+	written := runMigrateDiffInto(c, dir)
+
+	c.Assert(written, qt.HasLen, 1)
+	version, _, _ := strings.Cut(written[0], "_")
+	takenVersion, err := strconv.ParseInt(taken, 10, 64)
+	c.Assert(err, qt.IsNil)
+	plannedVersion, err := strconv.ParseInt(version, 10, 64)
+	c.Assert(err, qt.IsNil)
+	c.Assert(plannedVersion > takenVersion, qt.IsTrue,
+		qt.Commentf("planned %d does not advance past taken %d", plannedVersion, takenVersion))
+}

--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -6,8 +6,6 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
-	"strconv"
-	"time"
 
 	"github.com/spf13/cobra"
 
@@ -298,12 +296,13 @@ func rehashAtlasMigrateNewDir(dir string, format atlasmigrateimport.Format) erro
 
 // atlasCompatMigrationVersion returns the UTC `yyyyMMddHHmmss` migration version
 // both binaries stamp a new migration with.
+//
+// It is [atlasmigrate.MigrationVersion] rather than a second copy of the same
+// Format call: `migrate diff` had its own answer to this question until
+// stokaro/ptah#1218, and two writing verbs of one binary disagreeing about how
+// a version is spelled is what that cost.
 func atlasCompatMigrationVersion() int64 {
-	version, err := strconv.ParseInt(time.Now().UTC().Format("20060102150405"), 10, 64)
-	if err != nil {
-		return migrator.GetNextMigrationVersion()
-	}
-	return version
+	return atlasmigrate.MigrationVersion()
 }
 
 // reportAtlasMigrateNewFiles prints the created files the way the forwarded

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -14,7 +14,9 @@ import (
 	"path/filepath"
 	"regexp"
 	"slices"
+	"strconv"
 	"strings"
+	"time"
 
 	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/fsnapshot"
@@ -116,7 +118,7 @@ func writeDiffArtifactsWithSumWriter(
 	if err := recoverPendingPublication(w); err != nil {
 		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
 	}
-	version, err := nextMigrationVersionFS(baseSnapshot)
+	version, err := nextMigrationVersionFS(baseSnapshot, len(contents))
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -1275,7 +1277,7 @@ func stageMigrationBatch(
 	if err != nil {
 		return migrationBatch{}, err
 	}
-	version, err := nextMigrationVersionFS(fsys)
+	version, err := nextMigrationVersionFS(fsys, len(contents))
 	if err != nil {
 		return migrationBatch{}, err
 	}
@@ -1394,18 +1396,62 @@ func stageRootedFile(
 	return name, nil
 }
 
-func nextMigrationVersionFS(fsys fs.FS) (int64, error) {
+// MigrationVersion returns the migration version this compatibility surface
+// stamps: the UTC `yyyyMMddHHmmss` value the pinned community binary v1.3.0
+// writes, in every case.
+//
+// "In every case" is measured, not assumed. A directory holding one
+// future-dated `29991231235959_future.sql` still gets today's stamp from that
+// binary -- a version that sorts BEFORE the migration already there. It does
+// not bump past its neighbours and it does not refuse, so neither does this.
+//
+// The fallback is unreachable in practice: Format produces fourteen digits,
+// which fits an int64 until the year 922337. It exists so a clock that somehow
+// yields an unparseable stamp degrades to a usable version rather than an
+// error from a function with nothing to report.
+func MigrationVersion() int64 {
+	version, err := strconv.ParseInt(time.Now().UTC().Format("20060102150405"), 10, 64)
+	if err != nil {
+		return migrator.GetNextMigrationVersion()
+	}
+	return version
+}
+
+// nextMigrationVersionFS returns the first version at which count consecutive
+// migration versions are all free.
+//
+// Only collisions move it. Taking `max(existing) + 1` -- what this did before
+// stokaro/ptah#1218 -- differed from the community binary twice over: on an
+// empty directory it started from `time.Now().Unix()`, a ten-digit epoch rather
+// than a timestamp, and on a directory whose newest version ended in `59`
+// seconds it produced `...235960`, which is not a time anyone can parse back.
+func nextMigrationVersionFS(fsys fs.FS, count int) (int64, error) {
 	files, err := migrator.DiscoverMigrationFiles(fsys, migrator.MigrationDirFormatAtlas)
 	if err != nil {
 		return 0, err
 	}
-	version := migrator.GetNextMigrationVersion()
+	taken := make(map[int64]struct{}, len(files))
 	for _, file := range files {
-		if file.Version >= version {
-			version = file.Version + 1
-		}
+		taken[file.Version] = struct{}{}
+	}
+	version := MigrationVersion()
+	for collidesWithTakenVersions(taken, version, count) {
+		version++
 	}
 	return version, nil
+}
+
+// collidesWithTakenVersions reports whether any of the count consecutive
+// versions starting at version is already used. A multi-file plan is staged at
+// version+0, version+1, ..., so checking only the first would let a later file
+// of the batch land on an existing name.
+func collidesWithTakenVersions(taken map[int64]struct{}, version int64, count int) bool {
+	for i := range int64(max(count, 1)) {
+		if _, ok := taken[version+i]; ok {
+			return true
+		}
+	}
+	return false
 }
 
 var migrationSlugInvalidChars = regexp.MustCompile(`[^a-z0-9_]+`)


### PR DESCRIPTION
Closes #1218.

`ptah-compat migrate new` and `ptah-compat migrate diff` spelled a migration version two different ways, and only `new` matched the pinned community binary v1.3.0.

## Measured, before

Same second, fresh empty directory each time:

```
--- migrate new addstuff
  pinned binary v1.3.0   20260807003410_addstuff.sql
  ptah-compat            20260807003410_addstuff.sql     <- matches

--- migrate diff addorders
  pinned binary v1.3.0   20260807003410_addorders.sql
  ptah-compat            1786062850_addorders.sql        <- a unix epoch
```

The epoch is only reachable on an **empty** directory — otherwise `nextMigrationVersionFS` took `max(existing) + 1`. That branch is its own divergence, and a sharper one. Against a directory holding `29991231235959_future.sql`:

```
  pinned binary v1.3.0   20260807003631_addorders.sql
  ptah-compat            29991231235960_addorders.sql
```

`...235960` is the sixtieth second of the fifty-ninth minute. It goes into the file name, the revision table and `migrate status`, and nothing parses it back into a time. Reaching it needs a newest version whose seconds field is `59` — one run in sixty.

## The rule, and why it is unconditional

That corner case is what settles the design. The binary wrote **today's** stamp even though it sorts *before* the migration already in the directory: it does not bump past a neighbour, and it does not refuse. So there is no monotonicity rule to match, and taking the wall clock unconditionally is not a simplification — it is the measurement.

Only a collision moves the version, by the one second `migrate new` already advances by, and the check covers the whole range a multi-file plan stages rather than just its first entry.

`atlasCompatMigrationVersion` now delegates to `atlasmigrate.MigrationVersion` instead of keeping a second copy of the same `Format` call — one definition is what stops the two verbs drifting apart again.

## After

```
--- empty directory
  pinned binary v1.3.0   20260807003909_addorders.sql
  ptah-compat            20260807003910_addorders.sql
--- future-dated neighbour
  pinned binary v1.3.0   20260807003910_addorders.sql
  ptah-compat            20260807003910_addorders.sql
```

## Discriminators

Two tests, and each mutant reddens only its own:

- restoring the `max+1` rule reddens both rows of `TestMigrateDiffStampsTheUTCTimestampVersion` — the empty row on the digit count (ten against fourteen), the future-dated row on `time.Parse` refusing `...235960`;
- dropping the collision check reddens `TestMigrateDiffAdvancesPastAnExistingVersionOfThisSecond` and nothing else.

Native `ptah migrations` verbs keep `GetNextMigrationVersion()`; `internal/atlasmigrate` is reached only from the compatibility surface, so this does not touch them.

Existing directories are not rewritten — only newly created files change. Pre-v1, no backward compatibility with older Ptah is owed.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean.
