### PR TITLE
Read a PostgreSQL array column type from the server, not the category (#1138 cluster B)

### DIFF
--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -72,15 +72,16 @@ func QualifyTableName(schema, table string) string {
 type DBColumn struct {
 	Name               string  `json:"name"`
 	DataType           string  `json:"data_type"`
-	UDTName            string  `json:"udt_name"`             // For PostgreSQL enum types
-	ColumnType         string  `json:"column_type"`          // For MySQL ENUM syntax
-	IsNullable         string  `json:"is_nullable"`          // YES/NO
-	ColumnDefault      *string `json:"column_default"`       // Can be NULL
-	CharacterMaxLength *int    `json:"character_max_length"` // For VARCHAR, etc.
-	Charset            string  `json:"charset,omitempty"`    // MySQL/MariaDB column character set
-	Collate            string  `json:"collate,omitempty"`    // MySQL/MariaDB column collation
-	NumericPrecision   *int    `json:"numeric_precision"`    // For DECIMAL, etc.
-	NumericScale       *int    `json:"numeric_scale"`        // For DECIMAL, etc.
+	UDTName            string  `json:"udt_name"`                 // For PostgreSQL enum types
+	FormattedType      string  `json:"formatted_type,omitempty"` // Server's own spelling, where the catalog cannot express it
+	ColumnType         string  `json:"column_type"`              // For MySQL ENUM syntax
+	IsNullable         string  `json:"is_nullable"`              // YES/NO
+	ColumnDefault      *string `json:"column_default"`           // Can be NULL
+	CharacterMaxLength *int    `json:"character_max_length"`     // For VARCHAR, etc.
+	Charset            string  `json:"charset,omitempty"`        // MySQL/MariaDB column character set
+	Collate            string  `json:"collate,omitempty"`        // MySQL/MariaDB column collation
+	NumericPrecision   *int    `json:"numeric_precision"`        // For DECIMAL, etc.
+	NumericScale       *int    `json:"numeric_scale"`            // For DECIMAL, etc.
 	OrdinalPosition    int     `json:"ordinal_position"`
 	IsAutoIncrement    bool    `json:"is_auto_increment"` // Derived field
 	IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5194,15 +5194,16 @@ package types // import "go.5x5.cz/ptah/dbschema/types"
 type DBColumn struct {
     Name               string  `json:"name"`
     DataType           string  `json:"data_type"`
-    UDTName            string  `json:"udt_name"`             // For PostgreSQL enum types
-    ColumnType         string  `json:"column_type"`          // For MySQL ENUM syntax
-    IsNullable         string  `json:"is_nullable"`          // YES/NO
-    ColumnDefault      *string `json:"column_default"`       // Can be NULL
-    CharacterMaxLength *int    `json:"character_max_length"` // For VARCHAR, etc.
-    Charset            string  `json:"charset,omitempty"`    // MySQL/MariaDB column character set
-    Collate            string  `json:"collate,omitempty"`    // MySQL/MariaDB column collation
-    NumericPrecision   *int    `json:"numeric_precision"`    // For DECIMAL, etc.
-    NumericScale       *int    `json:"numeric_scale"`        // For DECIMAL, etc.
+    UDTName            string  `json:"udt_name"`                 // For PostgreSQL enum types
+    FormattedType      string  `json:"formatted_type,omitempty"` // Server's own spelling, where the catalog cannot express it
+    ColumnType         string  `json:"column_type"`              // For MySQL ENUM syntax
+    IsNullable         string  `json:"is_nullable"`              // YES/NO
+    ColumnDefault      *string `json:"column_default"`           // Can be NULL
+    CharacterMaxLength *int    `json:"character_max_length"`     // For VARCHAR, etc.
+    Charset            string  `json:"charset,omitempty"`        // MySQL/MariaDB column character set
+    Collate            string  `json:"collate,omitempty"`        // MySQL/MariaDB column collation
+    NumericPrecision   *int    `json:"numeric_precision"`        // For DECIMAL, etc.
+    NumericScale       *int    `json:"numeric_scale"`            // For DECIMAL, etc.
     OrdinalPosition    int     `json:"ordinal_position"`
     IsAutoIncrement    bool    `json:"is_auto_increment"` // Derived field
     IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field

--- a/integration/postgres_array_column_roundtrip_e2e_test.go
+++ b/integration/postgres_array_column_roundtrip_e2e_test.go
@@ -1,0 +1,135 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+)
+
+// TestPostgresArrayColumnSurvivesAReadE2E is the round trip stokaro/ptah#1138
+// cluster B is about, measured against the only judge that matters here: the
+// server.
+//
+// PostgreSQL's information_schema describes an array column as the bare
+// category "ARRAY", with a null character_maximum_length, so neither data_type
+// nor udt_name can reconstruct `character varying(100)[]`. Reading a schema and
+// rendering it back therefore produced `records ARRAY NOT NULL`, which reports
+// success and then fails on the user's database with
+// `syntax error at or near "ARRAY"` -- the same shape of defect #1106 named,
+// moved to the read side.
+//
+// There is deliberately no comparison against the pinned community binary in
+// this test: `schema inspect --format '{{ hcl . }}'` is not available in that
+// binary at all, so PostgreSQL executing the DDL is the whole assertion.
+//
+// Reverted, the type reads back as "ARRAY" and the last step fails to create
+// the table.
+func TestPostgresArrayColumnSurvivesAReadE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	tests := []struct {
+		name     string
+		declared string
+		want     string
+	}{
+		{
+			name:     "a sized element type keeps its length",
+			declared: "varchar(100)[]",
+			want:     "character varying(100)[]",
+		},
+		{
+			name:     "an unsized element type",
+			declared: "text[]",
+			want:     "text[]",
+		},
+		{
+			// PostgreSQL stores no dimensions, so the round trip is expected to
+			// come back as a plain array rather than to preserve `[10][]`. The
+			// row is here so that expectation is written down rather than
+			// rediscovered.
+			name:     "declared dimensions are the server's to drop",
+			declared: "varchar(100)[10][]",
+			want:     "character varying(100)[]",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			adminDB, err := sql.Open("pgx", dbURL)
+			c.Assert(err, qt.IsNil)
+			defer adminDB.Close()
+
+			testDBName := fmt.Sprintf("ptah_array_roundtrip_e2e_%d", time.Now().UnixNano())
+			createE2EDatabase(c, ctx, adminDB, testDBName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+			scopedURL := replaceDatabaseName(c, dbURL, testDBName)
+			setupDB, err := sql.Open("pgx", scopedURL)
+			c.Assert(err, qt.IsNil)
+			defer setupDB.Close()
+			_, err = setupDB.ExecContext(ctx,
+				"CREATE TABLE logs (records "+test.declared+" NOT NULL)")
+			c.Assert(err, qt.IsNil)
+
+			conn, err := dbschema.ConnectToDatabase(ctx, scopedURL)
+			c.Assert(err, qt.IsNil)
+			defer dbschema.CloseAndWarn(conn)
+			read, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(postgresColumnType(read, "logs", "records"), qt.Equals, test.want)
+
+			// The type as the converter hands it onward is the value every
+			// renderer downstream writes, so recreating the column from it is
+			// what proves the read is usable and not merely non-empty.
+			converted := dbschematogo.ConvertDBSchemaToGoSchema(read)
+			c.Assert(converted.Fields, qt.Not(qt.HasLen), 0)
+			_, err = setupDB.ExecContext(ctx,
+				"CREATE TABLE logs_again (records "+converted.Fields[0].Type+" NOT NULL)")
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(livePostgresColumnFormat(c, ctx, setupDB, "logs_again", "records"),
+				qt.Equals, test.want)
+		})
+	}
+}
+
+// postgresColumnType returns the type an introspected schema carries for one
+// column, or "" when the column is not there.
+func postgresColumnType(schema *dbschematypes.DBSchema, table, column string) string {
+	for _, dbTable := range schema.Tables {
+		for _, dbColumn := range dbTable.Columns {
+			if dbTable.Name == table && dbColumn.Name == column {
+				return dbColumn.FormattedType
+			}
+		}
+	}
+	return ""
+}
+
+// livePostgresColumnFormat asks the server how it spells a column's type.
+func livePostgresColumnFormat(c *qt.C, ctx context.Context, db *sql.DB, table, column string) string {
+	c.Helper()
+	var formatted string
+	err := db.QueryRowContext(ctx, `
+		SELECT format_type(a.atttypid, a.atttypmod)
+		FROM pg_attribute a
+		WHERE a.attrelid = $1::regclass AND a.attname = $2`, table, column).Scan(&formatted)
+	c.Assert(err, qt.IsNil)
+	return formatted
+}

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -529,6 +529,22 @@ func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
 	if strings.EqualFold(dbColumn.DataType, "USER-DEFINED") && dbColumn.UDTName != "" {
 		return dbColumn.UDTName
 	}
+	// The server's own spelling wins wherever the reader had to ask for it,
+	// which today means PostgreSQL array columns. DataType there is the bare
+	// category "ARRAY" -- a word no engine accepts as a type, so a schema read
+	// back out of a database rendered DDL that could not be executed
+	// (stokaro/ptah#1138).
+	//
+	// It is read from FormattedType rather than from ColumnType deliberately.
+	// ColumnType is also what the Atlas-compatible JSON inspect output prints,
+	// and measured on the pinned community binary v1.3.0 that output is
+	// `"type": "ARRAY"` for an array column -- the same value Ptah prints there
+	// today. Routing the fix through ColumnType would have made that surface
+	// disagree with the binary in order to fix a surface the binary does not
+	// have.
+	if dbColumn.FormattedType != "" {
+		return dbColumn.FormattedType
+	}
 	if dbColumn.ColumnType != "" {
 		return dbColumn.ColumnType
 	}

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -235,6 +235,77 @@ func TestConvertDBSchemaToGoSchema_PostgresUserDefinedColumnUsesUDTName(t *testi
 	c.Assert(result.Fields[0].Type, qt.Equals, "enum_product_status")
 }
 
+// A PostgreSQL array column reaches the converter as the bare category "ARRAY"
+// -- information_schema carries no element type for one, and no length either
+// -- so the reader asks the server directly and the converter has to prefer
+// that answer (stokaro/ptah#1138).
+//
+// The rows are the three ways this can go wrong, and the last one is why the
+// obvious narrow fix is not enough: reconstructing the type from UDTName yields
+// "varchar[]" from a "varchar(100)[]" column, which parses and plans and is
+// still the wrong type.
+func TestConvertDBSchemaToGoSchema_PostgresArrayColumnUsesTheServerSpelling(t *testing.T) {
+	tests := []struct {
+		name     string
+		column   types.DBColumn
+		wantType string
+	}{
+		{
+			name: "a sized element type keeps its length",
+			column: types.DBColumn{
+				Name:          "records",
+				DataType:      "ARRAY",
+				UDTName:       "_varchar",
+				FormattedType: "character varying(100)[]",
+			},
+			wantType: "character varying(100)[]",
+		},
+		{
+			name: "an unsized element type",
+			column: types.DBColumn{
+				Name:          "tags",
+				DataType:      "ARRAY",
+				UDTName:       "_text",
+				FormattedType: "text[]",
+			},
+			wantType: "text[]",
+		},
+		{
+			name: "an enum element type is spelled by its own name",
+			column: types.DBColumn{
+				Name:          "statuses",
+				DataType:      "ARRAY",
+				UDTName:       "_status",
+				FormattedType: "status[]",
+			},
+			wantType: "status[]",
+		},
+		{
+			name: "a column the server did not have to spell is untouched",
+			column: types.DBColumn{
+				Name:               "title",
+				DataType:           "character varying",
+				CharacterMaxLength: new(64),
+			},
+			wantType: "VARCHAR(64)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbSchema := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "logs", Columns: []types.DBColumn{test.column}}},
+			}
+
+			result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+			c.Assert(result.Fields, qt.HasLen, 1)
+			c.Assert(result.Fields[0].Type, qt.Equals, test.wantType)
+		})
+	}
+}
+
 func TestConvertDBSchemaToGoSchema_SchemaQualifiedObjectOwnersUseTableStructName(t *testing.T) {
 	c := qt.New(t)
 	checkClause := "tenant_id > 0"

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -202,8 +202,8 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 		tableName := fmt.Sprintf("table_%02d", i)
 		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
 		columnRows = append(columnRows,
-			[]driver.Value{tableName, "id", "integer", "int4", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
-			[]driver.Value{tableName, "name", "character varying", "varchar", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
+			[]driver.Value{tableName, "id", "integer", "int4", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
+			[]driver.Value{tableName, "name", "character varying", "varchar", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
 		)
 	}
 
@@ -216,6 +216,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 					"column_name",
 					"data_type",
 					"udt_name",
+					"formatted_type",
 					"is_nullable",
 					"column_default",
 					"character_maximum_length",

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -300,6 +300,17 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			column_name,
 			data_type,
 			udt_name,
+			-- information_schema erases an array's element type: data_type is
+			-- the bare category "ARRAY" and character_maximum_length is null,
+			-- so varchar(100)[] cannot be reconstructed from either. Only
+			-- format_type carries it. Read for array columns alone: preferring
+			-- it everywhere would change the type string for every column and
+			-- reach the SERIAL detection and the sized-type branches
+			-- downstream (stokaro/ptah#1138).
+			CASE WHEN data_type = 'ARRAY'
+				THEN format_type(a.atttypid, a.atttypmod)
+				ELSE ''
+			END AS formatted_type,
 			is_nullable,
 			column_default,
 			character_maximum_length,
@@ -346,6 +357,7 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			&col.Name,
 			&col.DataType,
 			&col.UDTName,
+			&col.FormattedType,
 			&col.IsNullable,
 			&col.ColumnDefault,
 			&col.CharacterMaxLength,


### PR DESCRIPTION
Closes cluster B of #1138. Cluster A is already resolved and is a fixture problem — [measured separately](https://github.com/stokaro/ptah/issues/1138#issuecomment-5210664274) — so this PR does not touch it.

## The defect

PostgreSQL's `information_schema` describes an array column as the bare **category**, and carries no length for it:

```
data_type                | ARRAY
udt_name                 | _varchar
character_maximum_length |            <- null
```

So a schema read out of a database and rendered back produced `records ARRAY NOT NULL`, at exit 0:

```
1. the column in the database          character varying(100)[]
2. ptah db read                        "records" ARRAY NOT NULL
3. that DDL on PostgreSQL              ERROR: syntax error at or near "ARRAY"
```

Same shape as the defect #1106 named — a read that reports success and produces DDL that cannot run — moved to the read side.

## The fix

`format_type(a.atttypid, a.atttypmod)` is the only catalog function carrying both the element type and its length. The reader asks for it **for array columns alone**; preferring it everywhere would change the type string for every column and walk straight into the SERIAL detection and the sized-type branches below it.

After:

```
2. ptah db read                        "records" character varying(100)[] NOT NULL
3. that DDL on PostgreSQL              rc=0, column recreated as character varying(100)[]
```

## Two decisions that were measured, not chosen for tidiness

**Why a new field and not `ColumnType`.** `ColumnType` is also what the Atlas-compatible JSON inspect output prints, and there the pinned community binary v1.3.0 and Ptah already **agree**:

```
$ atlas       schema inspect --url … --format '{{ json . }}'   [{'name': 'records', 'type': 'ARRAY'}]
$ ptah-compat schema inspect --url … --format '{{ json . }}'   [{'name': 'records', 'type': 'ARRAY'}]
```

Routing the fix through `ColumnType` would have made that surface disagree with the binary in order to fix a surface the binary does not have — `{{ hcl . }}` is Pro-gated and exits 1 there. So the compat JSON output deliberately still says `ARRAY`.

**Why not reconstruct from `udt_name`.** That is the tempting narrow fix — three call sites in the tree already strip its `_` prefix — and it yields `varchar[]` from a `varchar(100)[]` column. It parses, it plans, and it is still the wrong type. The e2e rows are built to separate the two: that mutant leaves the `text[]` row green and reddens both sized rows.

## Discriminators

- reverting the converter branch: all three e2e rows red, plus the unit table;
- the `udt_name` mutant: `text[]` green, both sized rows red;
- comparison is unaffected in both directions — a schema matching the database still reports no difference, and a deliberately mismatched one still reports `type: varchar -> integer`. Comparison reads `rawDBColumnType`, which falls back to `UDTName`, and that path is untouched.

## Scope

Only the PostgreSQL reader populates the new field; every other reader leaves it empty, so the converter branch is a no-op for them.

`dbschema/types.DBColumn` gains one field, so `docs/public_api.snapshot` is regenerated. Additive; pre-v1, no backward compatibility with older Ptah is owed.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean. Full `-tags integration` run against live PostgreSQL 17 with `POSTGRES_TEST_DSN`: `./integration` and `./integration/gonative` both green.
