### PR TITLE
Emit PostgreSQL objects for the whole PostgreSQL family, not one name (#929 items 1 and 4)

### DIFF
--- a/internal/convert/fromschema/dialect_spelling_test.go
+++ b/internal/convert/fromschema/dialect_spelling_test.go
@@ -129,6 +129,59 @@ func TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName(t *testi
 	c.Assert(divergent, qt.HasLen, 0, qt.Commentf("these spellings convert differently from their own canonical name"))
 }
 
+// nodeKinds is the sequence of AST node types a conversion produces. It is the
+// converter's whole output as far as this comparison cares: which object kinds
+// were emitted, in which order. Rendering is deliberately not involved -- see
+// the test below for why.
+func nodeKinds(database goschema.Database, dialect string) []string {
+	nodes := fromschema.FromDatabase(database, dialect)
+	kinds := make([]string, 0, len(nodes.Statements))
+	for _, node := range nodes.Statements {
+		kinds = append(kinds, fmt.Sprintf("%T", node))
+	}
+	return kinds
+}
+
+// TestFromDatabase_PostgresFamilyEmitsTheSameObjectKinds is the completion
+// criterion for stokaro/ptah#929 items 1 and 4: offline render and live plan
+// must answer the same question the same way.
+//
+// registerBuiltInPlanners routes cockroachdb, yugabytedb and spanner through
+// the PostgreSQL planner, so `schema apply --dry-run` planned sequences,
+// domains, composites, ranges, roles, grants, RLS, functions, views, matviews
+// and triggers for those targets. The offline converter gated all of them on a
+// predicate that matched the literal "postgres", so `schema render` dropped
+// every one -- with no comment, no warning and exit 0. Measured on the fixture
+// used here before the fix: postgres rendered 6 statements, each of the other
+// three rendered 1.
+//
+// The comparison is over node kinds rather than rendered SQL on purpose. Which
+// objects the converter emits is its decision; whether an engine accepts one is
+// the renderer's, and it already refuses what a preset cannot do -- rendering
+// this fixture for cockroachdb now reports `cockroachdb does not support role
+// management` instead of silently dropping the role AND everything near it.
+// Comparing SQL would fold those two separate answers into one string and make
+// this test fail for the renderer's reasons.
+func TestFromDatabase_PostgresFamilyEmitsTheSameObjectKinds(t *testing.T) {
+	c := qt.New(t)
+
+	database := spellingFixture(c)
+	want := nodeKinds(database, platform.Postgres)
+
+	// The fixture has to carry PostgreSQL object kinds for this to compare
+	// anything: a table-only fixture would agree across the family no matter
+	// what the predicate did.
+	c.Assert(len(want) > 1, qt.IsTrue, qt.Commentf("fixture emits %d nodes for postgres", len(want)))
+
+	for _, dialect := range []string{platform.CockroachDB, platform.YugabyteDB, platform.Spanner} {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(nodeKinds(database, dialect), qt.DeepEquals, want)
+		})
+	}
+}
+
 // TestFromDatabase_FixtureDiscriminatesEngines is the negative control for the
 // parity test above.
 //

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -97,7 +97,7 @@ func defaultGeneratedKind(field goschema.Field, targetPlatform string) string {
 		return field.GeneratedKind
 	}
 	switch {
-	case isPostgreSQLPlatform(targetPlatform):
+	case isPostgreSQLFamilyPlatform(targetPlatform):
 		return "STORED"
 	case isMySQLFamilyTarget(targetPlatform):
 		return "VIRTUAL"
@@ -125,8 +125,20 @@ func canonicalPlatform(targetPlatform string) string {
 	return targetPlatform
 }
 
-func isPostgreSQLPlatform(targetPlatform string) bool {
-	return platform.NormalizeDialect(targetPlatform) == platform.Postgres
+// isPostgreSQLFamilyPlatform reports whether the target renders PostgreSQL
+// object DDL: PostgreSQL itself and the wire-compatible engines.
+//
+// It asks about the family rather than about the one name because the live path
+// already does. registerBuiltInPlanners routes cockroachdb, yugabytedb and
+// spanner through the PostgreSQL planner, so `schema apply --dry-run` planned
+// sequences, domains, roles, views, functions and triggers for those targets
+// while `schema render` dropped every one of them -- silently, no comment, no
+// warning, exit 0. Two commands answering differently about the same file is
+// the defect; whether an engine of the family should then refuse a particular
+// object kind is a capability question, and there is no capability key for
+// views, functions or triggers to ask it with yet (stokaro/ptah#929).
+func isPostgreSQLFamilyPlatform(targetPlatform string) bool {
+	return platform.IsPostgresFamily(targetPlatform)
 }
 
 // typeRawSQLSurvives reports whether the column type is still the one the
@@ -2040,7 +2052,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// tables, because a sequence may back a column DEFAULT. The OWNED BY
 	// association is emitted later (after tables) via
 	// appendPostgreSQLPostForeignKeyFeatureStatements.
-	if isPostgreSQLPlatform(targetPlatform) {
+	if isPostgreSQLFamilyPlatform(targetPlatform) {
 		for _, sequence := range database.Sequences {
 			sequenceNode := FromSequence(sequence)
 			sequenceNode.OwnedBy = ""
@@ -2063,7 +2075,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// before tables so columns can reference them. Ordering within the group:
 	// domains and ranges reference base subtypes; composites may reference
 	// domains/enums, so they come last.
-	if isPostgreSQLPlatform(targetPlatform) {
+	if isPostgreSQLFamilyPlatform(targetPlatform) {
 		for _, domain := range database.Domains {
 			statements.Statements = append(statements.Statements, FromDomain(domain))
 		}
@@ -2079,7 +2091,7 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	// Use the combined field list that includes embedded field expansions
 	appendTableStatements(statements, database, allFields, targetPlatform)
 
-	isPostgreSQL := isPostgreSQLPlatform(targetPlatform)
+	isPostgreSQL := isPostgreSQLFamilyPlatform(targetPlatform)
 	if isPostgreSQL {
 		appendPostgreSQLPreIndexFeatureStatements(statements, database)
 	}

--- a/internal/convert/fromschema/testdata/dialectspellings/models.go
+++ b/internal/convert/fromschema/testdata/dialectspellings/models.go
@@ -20,7 +20,7 @@
 //   - email_lower pins defaultGeneratedKind (STORED / VIRTUAL / PERSISTED).
 //   - orders.user_id pins isSQLiteTarget (inline vs ALTER TABLE foreign keys)
 //     and isMySQLFamilyTarget (index emission order around ADD CONSTRAINT).
-//   - the PostgreSQL object block pins isPostgreSQLPlatform.
+//   - the PostgreSQL object block pins isPostgreSQLFamilyPlatform.
 //
 // The app-qualified audit table exercises renderTableName, but it does not pin
 // sqlident.Quote's quote style: the dialect renderer re-quotes the table name,


### PR DESCRIPTION
Closes items 1 and 4 of #929. Items 2 and 3 turned out to be already closed, and item 5 is a capability-registry change this does not attempt — detail below.

## The defect

`internal/convert/fromschema` gated sequences, domains, composites, ranges, roles, grants, RLS, functions, views, matviews and triggers on a predicate matching the literal `"postgres"`. `migration/planner.registerBuiltInPlanners` routes `cockroachdb`, `yugabytedb` and `spanner` through the PostgreSQL planner, so the two commands disagreed about the same file:

```
schema apply --dry-run   plans CREATE ROLE / SEQUENCE / DOMAIN / VIEW / FUNCTION
schema render            drops every one of them — no comment, no warning, exit 0
```

Measured on the fixture behind the existing dialect-spelling parity test:

```
                before   after
postgres          6        6
cockroachdb       1        6 (or a named refusal, below)
yugabytedb        1        6
spanner           1        6 (or a named refusal, below)
```

## Rendering is where an engine says no

With a role in the schema, `cockroachdb` and `spanner` now exit 2 with

```
error: error rendering cockroachdb schema: cockroachdb does not support role management
```

rather than exit 0 with the role — and the sequence, domain, view and function next to it — silently missing. That refusal is the capability system answering, and it is the same answer the apply path already gives: both go through the same renderer. Whether the CockroachDB preset is *right* that `CREATE ROLE` is unsupported is a separate question from whether render and apply agree, and this PR only settles the second.

Without the role, all four family members render the same 5 statements.

## Test

`TestFromDatabase_PostgresFamilyEmitsTheSameObjectKinds` compares the AST node kinds the converter emits, not the rendered SQL. That split is the point: which objects to emit is the converter's decision, whether an engine accepts one is the renderer's, and comparing SQL would fold the two into one string and fail for the renderer's reasons.

Reverting the predicate to its single-name form reddens all three subtests. The existing `TestFromDatabase_EveryAcceptedSpellingConvertsLikeItsCanonicalName` and `TestFromDatabase_FixtureDiscriminatesEngines` stay green throughout, so the alias parity this builds on is not disturbed.

## What is already closed, re-measured rather than assumed

Items 2 and 3 report that `mssql`/`tsql` lose views and triggers and that `pgx` loses every PostgreSQL object. Both are fixed on `master`:

```
postgres 6   postgresql 6   pgx 6
sqlserver 2  mssql 2        tsql 2
```

## What this does not do

Item 5 asks for capability keys for views, functions and triggers so a preset can express that PostgreSQL `CREATE FUNCTION … LANGUAGE plpgsql` is invalid on a given target. That is a registry addition plus per-preset decisions for three engines, and it is what would let a family member accept some PostgreSQL objects and refuse others. #929 stays open on it.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean.

Pre-v1, no backward compatibility with older Ptah is owed. The behavior change is that three dialects now render objects they silently dropped, and refuse loudly where a preset says the engine cannot do something.
