### PR TITLE
Write `migrate new` skeletons through a rooted handle (#1118)

### DIFF
--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
-	"path/filepath"
 
 	"github.com/spf13/cobra"
 
@@ -14,10 +12,6 @@ import (
 	"go.5x5.cz/ptah/cmd/migrate"
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
-	"go.5x5.cz/ptah/internal/atlasmigrateimport"
-	"go.5x5.cz/ptah/internal/migratesum"
-	"go.5x5.cz/ptah/internal/pathguard"
-	"go.5x5.cz/ptah/migration/migrator"
 )
 
 // newAtlasMigrateNewCommand returns `atlas migrate new`.
@@ -165,7 +159,12 @@ func runAtlasMigrateNewConverted(cmd *cobra.Command, verb atlasVerb, source atla
 	if err := verifyAtlasWriteDirCoveredChecksum(cmd, source); err != nil {
 		return err
 	}
-	written, err := writeAtlasMigrateNewSkeleton(source, parsed.name)
+	written, err := atlasmigrate.WriteSkeletonMigration(
+		migrateDiffWriterRoot(source.project, source.localDir),
+		source.localDir.Path,
+		source.format,
+		parsed.name,
+	)
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate %s: %w", verb.use, err))
 	}
@@ -193,116 +192,6 @@ func verifyAtlasWriteDirCoveredChecksum(cmd *cobra.Command, source atlasMigrateS
 		return err
 	}
 	return verifyCoveredAtlasDirChecksum(cmd, captured.FileSystem, source.format, requireAtlasSum)
-}
-
-// writeAtlasMigrateNewSkeleton creates the migration directory if needed, writes
-// the empty migration in the selected layout, and rewrites atlas.sum over that
-// layout's covered set. It returns the created files in creation order.
-//
-// The version is the UTC `yyyyMMddHHmmss` stamp both binaries use. When a file
-// of that name already exists the stamp is advanced by one second and the whole
-// set is retried, which is the rule [generateEmptyAtlasMigration] applies on the
-// native path: the alternative is O_EXCL failing the command for a directory
-// that merely already holds this second's migration.
-func writeAtlasMigrateNewSkeleton(source atlasMigrateSource, name string) ([]string, error) {
-	dir, err := pathguard.ResolveWithinRoot(source.localDir.Path, source.localDir.AllowedRoot)
-	if err != nil {
-		return nil, fmt.Errorf("invalid migrations directory: %w", err)
-	}
-	// The mode matches what `migrate hash` leaves on atlas.sum and what the
-	// native create path leaves on an Atlas migration, so a directory holding
-	// both does not carry two answers to "who may read a migration".
-	if err := os.MkdirAll(dir, 0o755); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	for version := atlasCompatMigrationVersion(); ; version++ {
-		files, err := atlasmigrateimport.SkeletonFiles(source.format, version, name)
-		if err != nil {
-			return nil, err
-		}
-		written, err := createAtlasMigrateNewFiles(dir, files)
-		if errors.Is(err, os.ErrExist) {
-			continue
-		}
-		if err != nil {
-			return nil, err
-		}
-		if err := rehashAtlasMigrateNewDir(dir, source.format); err != nil {
-			removeAtlasMigrateNewFiles(written)
-			return nil, err
-		}
-		return written, nil
-	}
-}
-
-// createAtlasMigrateNewFiles writes one layout's file set, removing whatever it
-// already created if a later file cannot be created. A half-written pair is
-// worse than none: `migrate hash` would then cover the up file of a migration
-// with no rollback half.
-func createAtlasMigrateNewFiles(dir string, files []atlasmigrateimport.SkeletonFile) ([]string, error) {
-	written := make([]string, 0, len(files))
-	for _, file := range files {
-		path := filepath.Join(dir, file.Name)
-		if err := writeExclusiveAtlasMigrationFile(path, file.Content); err != nil {
-			removeAtlasMigrateNewFiles(written)
-			return nil, err
-		}
-		written = append(written, path)
-	}
-	return written, nil
-}
-
-func writeExclusiveAtlasMigrationFile(path, content string) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644)
-	if err != nil {
-		return err
-	}
-	if _, err := file.WriteString(content); err != nil {
-		_ = file.Close()
-		_ = os.Remove(path)
-		return err
-	}
-	if err := file.Close(); err != nil {
-		_ = os.Remove(path)
-		return err
-	}
-	return nil
-}
-
-func removeAtlasMigrateNewFiles(paths []string) {
-	for _, path := range paths {
-		_ = os.Remove(path)
-	}
-}
-
-// rehashAtlasMigrateNewDir rewrites atlas.sum over the covered set of the
-// layout just written into.
-//
-// It is the computation `runAtlasMigrateHash` performs, called rather than
-// restated, so a migration this verb creates is one `migrate validate` accepts
-// without an intervening `migrate hash`.
-func rehashAtlasMigrateNewDir(dir string, format atlasmigrateimport.Format) error {
-	fsys := os.DirFS(dir)
-	names, err := atlasmigrateimport.SumFileNames(fsys, format)
-	if err != nil {
-		return err
-	}
-	sum, err := migratesum.ComputeAtlasFiles(fsys, names)
-	if err != nil {
-		return err
-	}
-	return migratesum.WritePrecomputedWithFormat(dir, migrator.MigrationDirFormatAtlas, sum)
-}
-
-// atlasCompatMigrationVersion returns the UTC `yyyyMMddHHmmss` migration version
-// both binaries stamp a new migration with.
-//
-// It is [atlasmigrate.MigrationVersion] rather than a second copy of the same
-// Format call: `migrate diff` had its own answer to this question until
-// stokaro/ptah#1218, and two writing verbs of one binary disagreeing about how
-// a version is spelled is what that cost.
-func atlasCompatMigrationVersion() int64 {
-	return atlasmigrate.MigrationVersion()
 }
 
 // reportAtlasMigrateNewFiles prints the created files the way the forwarded

--- a/internal/atlasmigrate/skeleton.go
+++ b/internal/atlasmigrate/skeleton.go
@@ -1,0 +1,135 @@
+package atlasmigrate
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// WriteSkeletonMigration writes one foreign layout's empty migration into dir
+// and rewrites atlas.sum over that layout's covered set. It returns the created
+// files in creation order.
+//
+// Every step goes through one rooted handle, opened once. `migrate new` used to
+// resolve dir to a string and then reopen it by pathname for the mkdir, for each
+// file, for the covered-set listing and for the checksum commit, so a directory
+// or ancestor replaced after the path was validated could take any of those
+// writes somewhere the gate never looked (stokaro/ptah#1118). Creating a missing
+// directory goes through the same boundary, so it is materialized inside the
+// opened root rather than wherever the pathname happens to point.
+//
+// A nil root keeps direct-CLI behavior, where an explicit absolute --dir is the
+// operator's own choice of destination. The handle still exists; it is simply
+// not confined to a project root.
+//
+// The version is the UTC stamp both binaries write. A name that already exists
+// advances it by a second and retries the whole set, rather than failing the
+// command for a directory that merely already holds this second's migration.
+func WriteSkeletonMigration(
+	root *pathguard.OpenedDirectory,
+	dir string,
+	format atlasmigrateimport.Format,
+	name string,
+) ([]string, error) {
+	w, err := createMigrationWriterDir(root, dir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = w.Close() }()
+	if afterSkeletonDirBound != nil {
+		afterSkeletonDirBound()
+	}
+
+	for version := MigrationVersion(); ; version++ {
+		files, err := atlasmigrateimport.SkeletonFiles(format, version, name)
+		if err != nil {
+			return nil, err
+		}
+		written, err := createSkeletonFiles(w, files)
+		if errors.Is(err, fs.ErrExist) {
+			continue
+		}
+		if err != nil {
+			return nil, err
+		}
+		if err := rehashSkeletonDir(w, format); err != nil {
+			return nil, errors.Join(err, removeRootedFiles(w.dir, written))
+		}
+		paths := make([]string, 0, len(written))
+		for _, entry := range written {
+			paths = append(paths, filepath.Join(w.Path(), entry))
+		}
+		return paths, nil
+	}
+}
+
+// afterSkeletonDirBound runs once the migration directory is bound and before
+// anything is written. It is nil outside tests.
+//
+// It exists because this path has no product callback to hang the rooted-writer
+// regression on, and the thing that has to be measured is a replacement that
+// happens AFTER the directory was validated -- exactly what a pre-swap test
+// cannot show, since that only exercises the open. `migrate diff` gets the same
+// moment for free from its editor-preparation callback; this is the equivalent
+// seam, kept unexported and unset in production.
+var afterSkeletonDirBound func()
+
+// createSkeletonFiles writes one layout's file set through the rooted handle,
+// removing whatever it already created if a later file cannot be created. A
+// half-written pair is worse than none: a rehash would then cover the up file
+// of a migration with no rollback half.
+//
+// fs.ErrExist is returned unwrapped so the caller can tell "this second is
+// taken" from a real failure and retry the whole set at the next second.
+func createSkeletonFiles(w *migrationWriterDir, files []atlasmigrateimport.SkeletonFile) ([]string, error) {
+	written := make([]string, 0, len(files))
+	for _, file := range files {
+		if err := writeExclusiveRootedFile(w.dir, file.Name, file.Content); err != nil {
+			return nil, errors.Join(err, removeRootedFiles(w.dir, written))
+		}
+		written = append(written, file.Name)
+	}
+	return written, nil
+}
+
+func writeExclusiveRootedFile(d *pathguard.OpenedDirectory, name, content string) error {
+	file, err := d.OpenFile(name, os.O_CREATE|os.O_EXCL|os.O_WRONLY, publishedFileMode)
+	if err != nil {
+		return err
+	}
+	if _, err := file.WriteString(content); err != nil {
+		return errors.Join(err, file.Close(), d.Remove(name))
+	}
+	if err := file.Close(); err != nil {
+		return errors.Join(err, d.Remove(name))
+	}
+	return nil
+}
+
+// rehashSkeletonDir rewrites atlas.sum over the covered set of the layout just
+// written into, reading that set through the same handle the files were written
+// through.
+func rehashSkeletonDir(w *migrationWriterDir, format atlasmigrateimport.Format) error {
+	fsys, err := w.FS()
+	if err != nil {
+		return err
+	}
+	names, err := atlasmigrateimport.SumFileNames(fsys, format)
+	if err != nil {
+		return err
+	}
+	sum, err := migratesum.ComputeAtlasFiles(fsys, names)
+	if err != nil {
+		return err
+	}
+	if _, err := publishDirSum(w, sum); err != nil {
+		return fmt.Errorf("write %s: %w", migratesum.AtlasFileName, err)
+	}
+	return nil
+}

--- a/internal/atlasmigrate/skeleton_root_unix_internal_test.go
+++ b/internal/atlasmigrate/skeleton_root_unix_internal_test.go
@@ -1,0 +1,164 @@
+//go:build unix
+
+package atlasmigrate
+
+// White-box testing required: the moment this measures -- after the migration
+// directory is bound and before anything is written -- has no exported name,
+// because nothing in the product needs one. A pre-swap test through the
+// exported API would only exercise the open, and the open is not what the
+// rooted handle uniquely defends.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// These are the `migrate new` half of the rooted-writer regressions
+// stokaro/ptah#1118 asks for, and the counterpart to the three
+// TestGenerateDiff_* rows next door.
+//
+// The swap happens AFTER the migration directory is bound and before anything
+// is written, through the package's own seam. A pre-swap test would only
+// exercise the open; what the handle uniquely defends is a replacement that
+// lands in the window a pathname-based writer would resolve again.
+//
+// This file is white-box for that reason alone: the seam is unexported because
+// nothing in the product needs it, and the moment it marks has no other name.
+// Everything asserted below is otherwise observable — the files on disk and the
+// contents of the decoy directory.
+
+// openSkeletonProjectRoot confines the run to root.
+func openSkeletonProjectRoot(c *qt.C, root string) *pathguard.OpenedDirectory {
+	c.Helper()
+	opened, err := pathguard.OpenCLIDirectory(root)
+	c.Assert(err, qt.IsNil)
+	return opened
+}
+
+// noSkeletonProjectRoot is the direct-CLI shape.
+func noSkeletonProjectRoot(*qt.C, string) *pathguard.OpenedDirectory { return nil }
+
+// closeOpenedRoot tolerates the nil handle noSkeletonProjectRoot returns.
+func closeOpenedRoot(opened *pathguard.OpenedDirectory) error {
+	if opened == nil {
+		return nil
+	}
+	return opened.Close()
+}
+
+// swapSkeletonSymlink replaces link so it points at target.
+func swapSkeletonSymlink(c *qt.C, link, target string) {
+	c.Helper()
+	c.Assert(os.Remove(link), qt.IsNil)
+	c.Assert(os.Symlink(target, link), qt.IsNil)
+}
+
+// skeletonDirNames lists the base names in dir, or nil when dir is absent.
+func skeletonDirNames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestWriteSkeletonMigration_ReplacedDirectoryCannotRedirectTheWrite asserts
+// both halves: the migration lands in the directory the run bound, and the
+// directory the symlink was swapped to is left completely untouched.
+//
+// The second half is the one that fails when the rooted handle is removed.
+// Without it a run that merely errored out would look the same as one that
+// stayed inside the boundary.
+func TestWriteSkeletonMigration_ReplacedDirectoryCannotRedirectTheWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		// openRoot returns the project root the run is confined to, or nil for
+		// the direct-CLI shape where an explicit --dir is the operator's own
+		// choice of destination.
+		openRoot func(c *qt.C, root string) *pathguard.OpenedDirectory
+		stage    func(c *qt.C, root, decoy string) (selected, bound string)
+		swapTo   func(root, decoy string) (link, target string)
+		// wantDecoyEntries is what the row staged in the decoy before the run:
+		// nothing, except the ancestor row, which needs a migrations directory
+		// for the swapped symlink to resolve to at all.
+		wantDecoyEntries int
+	}{
+		{
+			name:     "the migration directory symlink is swapped, under a project root",
+			openRoot: openSkeletonProjectRoot,
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "real")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				link := filepath.Join(root, "migrations")
+				c.Assert(os.Symlink(bound, link), qt.IsNil)
+				return link, bound
+			},
+			swapTo: func(root, decoy string) (string, string) {
+				return filepath.Join(root, "migrations"), decoy
+			},
+		},
+		{
+			name:     "the migration directory symlink is swapped, with no project root",
+			openRoot: noSkeletonProjectRoot,
+			stage: func(c *qt.C, root, _ string) (string, string) {
+				bound := filepath.Join(root, "real")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				link := filepath.Join(root, "migrations")
+				c.Assert(os.Symlink(bound, link), qt.IsNil)
+				return link, bound
+			},
+			swapTo: func(root, decoy string) (string, string) {
+				return filepath.Join(root, "migrations"), decoy
+			},
+		},
+		{
+			name:     "an ancestor symlink is swapped",
+			openRoot: openSkeletonProjectRoot,
+			stage: func(c *qt.C, root, decoy string) (string, string) {
+				bound := filepath.Join(root, "realnest", "migrations")
+				c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+				c.Assert(os.MkdirAll(filepath.Join(decoy, "migrations"), 0o755), qt.IsNil)
+				c.Assert(os.Symlink(filepath.Join(root, "realnest"), filepath.Join(root, "nest")), qt.IsNil)
+				return filepath.Join(root, "nest", "migrations"), bound
+			},
+			swapTo: func(root, decoy string) (string, string) {
+				return filepath.Join(root, "nest"), decoy
+			},
+			wantDecoyEntries: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			selected, bound := test.stage(c, root, decoy)
+
+			opened := test.openRoot(c, root)
+			defer func() { _ = closeOpenedRoot(opened) }()
+
+			link, target := test.swapTo(root, decoy)
+			afterSkeletonDirBound = func() { swapSkeletonSymlink(c, link, target) }
+			defer func() { afterSkeletonDirBound = nil }()
+
+			written, err := WriteSkeletonMigration(opened, selected, atlasmigrateimport.FormatGolangMigrate, "added")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(written, qt.HasLen, 2)
+			// The bound directory holds the pair plus atlas.sum, and the decoy
+			// holds nothing this run put there.
+			c.Assert(skeletonDirNames(c, bound), qt.HasLen, 3)
+			c.Assert(skeletonDirNames(c, decoy), qt.HasLen, test.wantDecoyEntries)
+		})
+	}
+}


### PR DESCRIPTION
Closes the `ptah-compat migrate new` surface of #1118. `migrate diff` was already done; `migration/generator` is not, and is [scoped separately](https://github.com/stokaro/ptah/issues/1118#issuecomment-5211414194).

## The hole

The converted path resolved `--dir` to a string and then reopened it by pathname four more times:

```go
dir, err := pathguard.ResolveWithinRoot(source.localDir.Path, source.localDir.AllowedRoot)  // a string
os.MkdirAll(dir, 0o755)                                            // a missing directory
os.OpenFile(filepath.Join(dir, file.Name), O_CREATE|O_EXCL|…)      // per skeleton file
os.DirFS(dir)                                                      // the covered file set
migratesum.WritePrecomputedWithFormat(dir, …)                      // the atlas.sum commit
```

A directory or ancestor replaced between the resolve and any of those takes the write somewhere the gate never looked. The `O_EXCL` does not help: the redirected directory does not contain the file either.

## The fix

`atlasmigrate.WriteSkeletonMigration` binds the directory once through `createMigrationWriterDir` — the helper `migrate diff` already uses — and every later step names a direct child of that handle. Creating a missing directory goes through the same boundary, so it is materialized inside the opened root rather than wherever the pathname points. A nil root keeps direct-CLI behavior: an explicit absolute `--dir` is the operator's own choice of destination.

No public API change. The rooted handle never appears in an exported signature — `internal/atlasmigrate` is where it already lives.

## Behavior is unchanged where it should be

All four foreign layouts, same second, against the pinned community binary v1.3.0:

```
                  pinned binary v1.3.0                     ptah-compat
golang-migrate    …_added.up.sql + …_added.down.sql        same pair
goose             …_added.sql                              same
flyway            V…__added.sql + U…__added.sql            same pair
dbmate            …_added.sql                              same
```

`atlas.sum` covers the same three lines in both. The checksum preflight still refuses an unhashed directory before writing anything:

```
$ ptah-compat migrate new added --dir 'file://unhashed?format=golang-migrate'
You have a checksum error in your migration directory.
  files=1_init.up.sql          <- untouched
```

## The regression, and why it is white-box

`TestWriteSkeletonMigration_ReplacedDirectoryCannotRedirectTheWrite` swaps the directory symlink — or an ancestor — **after** the bind and **before** the write, which is the window a pathname-based writer would resolve again. A pre-swap test would only exercise the open, and the open is not what the handle uniquely defends.

That moment has no exported name because nothing in the product needs one, so the test drives an unexported seam. `migrate diff` gets the same moment for free from its editor-preparation callback; this is the equivalent. Each row asserts both halves the acceptance criteria ask for: the migration lands in the bound directory, and the decoy is left untouched — the second is what fails when a run merely errors out instead of staying inside the boundary.

Restoring the pathname writes reddens all three rows.

## Also

`atlasCompatMigrationVersion` goes away with its last caller; the version rule has lived in `atlasmigrate.MigrationVersion` since #1219. That removal is what `unused` flagged, not a drive-by.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean.
