### PR TITLE
Record `partial_hashes` for a partially applied migration (#1196 item 3)

### DIFF
--- a/core/sqlutil/source_statements.go
+++ b/core/sqlutil/source_statements.go
@@ -1,0 +1,109 @@
+package sqlutil
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/dialectlexer"
+	"go.5x5.cz/ptah/internal/lexer"
+)
+
+// SourceStatement is one statement as it was written, rather than as an
+// executor would normalize it.
+type SourceStatement struct {
+	// Text runs from the statement's first meaningful token through its
+	// terminating semicolon, verbatim. Whitespace and comments that preceded
+	// the first token are not part of it; whitespace inside it — including a
+	// newline between the body and the terminator — is.
+	Text string
+	// Terminated reports whether a semicolon closed the statement, as opposed
+	// to the input ending.
+	Terminated bool
+}
+
+// SplitSourceStatements returns each statement's source text.
+//
+// [SplitSQLStatementsForDialect] answers a different question and cannot be
+// post-processed into this one: it trims the statement on both sides, so
+//
+//	CREATE TABLE q (id int)
+//	;
+//
+// comes back as `CREATE TABLE q (id int)`, indistinguishable from the same
+// statement written with the semicolon flush against it. Anything that hashes
+// statement text needs to tell those apart, because the two spell different
+// bytes and therefore different digests.
+func SplitSourceStatements(sql, dialect string) []SourceStatement {
+	if strings.TrimSpace(sql) == "" {
+		return nil
+	}
+
+	normalized := NormalizeClientDelimiters(sql)
+	lexr := lexer.NewLexerWithOptions(normalized, dialectlexer.Options(platform.NormalizeDialect(dialect)))
+	state := statementSplitState{dialect: platform.NormalizeDialect(dialect)}
+
+	var statements []SourceStatement
+	var current strings.Builder
+	for {
+		token := lexr.NextToken()
+		if token.Type == lexer.TokenEOF {
+			break
+		}
+		if token.Type == lexer.TokenSemicolon && !state.keepSemicolonInsideStatement() {
+			statements = appendSourceStatement(statements, current.String()+token.Value, true)
+			current.Reset()
+			state.reset()
+			continue
+		}
+		state.observe(token)
+		current.WriteString(token.Value)
+	}
+	return appendSourceStatement(statements, current.String(), false)
+}
+
+// appendSourceStatement trims the leading trivia off one accumulated statement
+// and keeps it when anything is left.
+//
+// Only the leading side is trimmed. The trailing side is the whole point: the
+// bytes between the last token of the body and the terminator are part of what
+// was written.
+func appendSourceStatement(statements []SourceStatement, raw string, terminated bool) []SourceStatement {
+	text := trimLeadingSQLTrivia(raw)
+	// A terminated statement whose body is empty -- a stray `;`, or one
+	// following nothing but a comment -- is trivia too, so the terminator alone
+	// does not make it content.
+	if strings.TrimSpace(strings.TrimSuffix(text, ";")) == "" {
+		return statements
+	}
+	return append(statements, SourceStatement{Text: text, Terminated: terminated})
+}
+
+// trimLeadingSQLTrivia drops leading whitespace and comments, returning "" when
+// nothing but trivia is left.
+func trimLeadingSQLTrivia(raw string) string {
+	rest := raw
+	for {
+		trimmed := strings.TrimLeft(rest, " \t\r\n")
+		switch {
+		case strings.HasPrefix(trimmed, "--"):
+			if end := strings.IndexAny(trimmed, "\r\n"); end >= 0 {
+				rest = trimmed[end:]
+				continue
+			}
+			return ""
+		case strings.HasPrefix(trimmed, "/*"):
+			if end := strings.Index(trimmed[2:], "*/"); end >= 0 {
+				rest = trimmed[2+end+2:]
+				continue
+			}
+			return ""
+		default:
+			rest = trimmed
+		}
+		break
+	}
+	if strings.TrimSpace(rest) == "" {
+		return ""
+	}
+	return rest
+}

--- a/core/sqlutil/source_statements_test.go
+++ b/core/sqlutil/source_statements_test.go
@@ -1,0 +1,90 @@
+package sqlutil_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/sqlutil"
+)
+
+// TestSplitSourceStatements pins what makes this different from
+// [sqlutil.SplitSQLStatementsForDialect], which trims both sides.
+//
+// The rows that matter are the ones where the two disagree: a terminator that
+// is not flush against the statement, and comments around one. Anything that
+// hashes statement text needs the first distinction, because the two spellings
+// are different bytes; stokaro/ptah#1196 is where that bit.
+func TestSplitSourceStatements(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want []sqlutil.SourceStatement
+	}{
+		{
+			name: "a terminator flush against the statement",
+			sql:  "CREATE TABLE q (id int);\n",
+			want: []sqlutil.SourceStatement{{Text: "CREATE TABLE q (id int);", Terminated: true}},
+		},
+		{
+			name: "a terminator on its own line keeps the newline",
+			sql:  "CREATE TABLE q (id int)\n;\n",
+			want: []sqlutil.SourceStatement{{Text: "CREATE TABLE q (id int)\n;", Terminated: true}},
+		},
+		{
+			name: "a leading directive and blank lines are dropped",
+			sql:  "-- atlas:txmode none\n\nCREATE TABLE q (id int);\n",
+			want: []sqlutil.SourceStatement{{Text: "CREATE TABLE q (id int);", Terminated: true}},
+		},
+		{
+			name: "a comment between statements belongs to neither",
+			sql:  "CREATE TABLE m (id int);\n-- between\nCREATE TABLE n (v text);\n",
+			want: []sqlutil.SourceStatement{
+				{Text: "CREATE TABLE m (id int);", Terminated: true},
+				{Text: "CREATE TABLE n (v text);", Terminated: true},
+			},
+		},
+		{
+			name: "a block comment before a statement is dropped",
+			sql:  "/* header */ CREATE TABLE q (id int);\n",
+			want: []sqlutil.SourceStatement{{Text: "CREATE TABLE q (id int);", Terminated: true}},
+		},
+		{
+			name: "an unterminated final statement reports so",
+			sql:  "CREATE TABLE q (id int)\n",
+			want: []sqlutil.SourceStatement{{Text: "CREATE TABLE q (id int)\n", Terminated: false}},
+		},
+		{
+			name: "an empty terminator is not a statement",
+			sql:  "CREATE TABLE a (id int);;\nCREATE TABLE b (v text);\n",
+			want: []sqlutil.SourceStatement{
+				{Text: "CREATE TABLE a (id int);", Terminated: true},
+				{Text: "CREATE TABLE b (v text);", Terminated: true},
+			},
+		},
+		{
+			name: "comments alone are not a statement",
+			sql:  "-- nothing here\n",
+			want: nil,
+		},
+		{
+			name: "empty input",
+			sql:  "   \n\t\n",
+			want: nil,
+		},
+		{
+			name: "a semicolon inside a string literal does not split",
+			sql:  "INSERT INTO t (v) VALUES ('a;b');\n",
+			want: []sqlutil.SourceStatement{{Text: "INSERT INTO t (v) VALUES ('a;b');", Terminated: true}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			c.Assert(sqlutil.SplitSourceStatements(test.sql, "sqlite"), qt.DeepEquals, test.want)
+		})
+	}
+}

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5105,6 +5105,27 @@ func SplitSQLStatements(sql string) []string
 func SplitSQLStatementsForDialect(sql string, dialect string) []string
 func StripComments(sql string) string
 func StripCommentsForDialect(sql, dialect string) string
+type SourceStatement struct{ ... }
+    func SplitSourceStatements(sql, dialect string) []SourceStatement
+
+### go.5x5.cz/ptah/core/sqlutil.SourceStatement
+
+package sqlutil // import "go.5x5.cz/ptah/core/sqlutil"
+
+type SourceStatement struct {
+    // Text runs from the statement's first meaningful token through its
+    // terminating semicolon, verbatim. Whitespace and comments that preceded
+    // the first token are not part of it; whitespace inside it — including a
+    // newline between the body and the terminator — is.
+    Text string
+    // Terminated reports whether a semicolon closed the statement, as opposed
+    // to the input ending.
+    Terminated bool
+}
+    SourceStatement is one statement as it was written, rather than as an
+    executor would normalize it.
+
+func SplitSourceStatements(sql, dialect string) []SourceStatement
 
 ## go.5x5.cz/ptah/dbschema
 

--- a/migration/migrator/partial_hashes.go
+++ b/migration/migrator/partial_hashes.go
@@ -1,0 +1,73 @@
+package migrator
+
+import (
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+
+	"go.5x5.cz/ptah/core/sqlutil"
+)
+
+// partialHashPrefix is the tag Atlas puts on every digest it records, the same
+// one atlas.sum uses.
+const partialHashPrefix = "h1:"
+
+// atlasPartialHashes returns the value the `partial_hashes` column takes for a
+// migration that stopped after applied statements out of total.
+//
+// The column records one digest per applied statement, and each digest covers
+// every statement up to and including that one: entry i is over
+// S1 ‖ S2 ‖ … ‖ Si+1, concatenated with no separator. That is what lets a
+// resume verify the statements already applied are the same statements in the
+// same order, rather than merely the same count.
+//
+// Each Sk is the statement's SOURCE text, from its first meaningful token
+// through its terminating semicolon, verbatim. Not the executor's normalized
+// form: measured against the pinned Atlas community binary v1.3.0,
+//
+//	CREATE TABLE q (id int)
+//	;
+//
+// hashes as "CREATE TABLE q (id int)\n;" and not as "CREATE TABLE q (id int);".
+// Comments preceding a statement are excluded. See stokaro/ptah#1196.
+//
+// A null is returned for anything that is not a partial application, which is
+// what that binary writes: nothing applied has no prefix to record, and a clean
+// success has nothing to resume.
+func (m *Migrator) atlasPartialHashes(sqlText string, applied, total int) any {
+	hashes, ok := atlasPartialHashValues(sqlText, m.connectionDialect(), applied, total)
+	if !ok {
+		return m.atlasNullJSONValue()
+	}
+	encoded, err := json.Marshal(hashes)
+	if err != nil {
+		// json.Marshal of []string cannot fail; falling back to the null keeps
+		// the failure-recording path from turning a migration failure into a
+		// second, unrelated one.
+		return m.atlasNullJSONValue()
+	}
+	return m.atlasJSONValue(string(encoded))
+}
+
+// atlasPartialHashValues computes the cumulative digests, reporting false when
+// the run is not a partial application or the statements cannot be recovered.
+func atlasPartialHashValues(sqlText, dialect string, applied, total int) ([]string, bool) {
+	if applied <= 0 || applied >= total {
+		return nil, false
+	}
+	statements := sqlutil.SplitSourceStatements(sqlText, dialect)
+	if len(statements) < applied {
+		// The executor counted more statements than the source split finds.
+		// Recording a prefix shorter than the one that ran would tell a resume
+		// that fewer statements are committed than really are, so the honest
+		// answer is the null the column already carried.
+		return nil, false
+	}
+	hashes := make([]string, 0, applied)
+	digest := sha256.New()
+	for _, statement := range statements[:applied] {
+		digest.Write([]byte(statement.Text))
+		hashes = append(hashes, partialHashPrefix+base64.StdEncoding.EncodeToString(digest.Sum(nil)))
+	}
+	return hashes, true
+}

--- a/migration/migrator/partial_hashes_internal_test.go
+++ b/migration/migrator/partial_hashes_internal_test.go
@@ -1,0 +1,160 @@
+package migrator
+
+// White-box testing required: the count invariant below is between two
+// splitters, one of which is unexported, and the digest computation is not
+// reachable through an exported API — it exists only as a bound argument on a
+// revision UPDATE.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/sqlutil"
+)
+
+// TestAtlasPartialHashValues pins the `partial_hashes` column against the
+// pinned Atlas community binary v1.3.0 (stokaro/ptah#1196).
+//
+// Every want below was read out of a SQLite database that binary wrote, by
+// applying the same migration with the same `-- atlas:txmode none` directive
+// and letting the last statement fail. They are not derived from this
+// implementation.
+//
+// The second row is the one that separates a correct implementation from a
+// plausible one: with the terminator on its own line the digest covers
+// "CREATE TABLE q (id int)\n;", so anything that hashes the executor's
+// normalized statement plus a semicolon produces a different value — silently,
+// and only for files written that way.
+func TestAtlasPartialHashValues(t *testing.T) {
+	tests := []struct {
+		name    string
+		sql     string
+		applied int
+		total   int
+		want    []string
+		wantOK  bool
+	}{
+		{
+			name:    "one statement applied",
+			sql:     "-- atlas:txmode none\n\nCREATE TABLE ok_table (id int);\nINSERT INTO missing_table (id) VALUES (1);\n",
+			applied: 1,
+			total:   2,
+			want:    []string{"h1:8jgptPnsBJEGnJcSP/+SQfPIpzKcTTrznDR0HMTsIG0="},
+			wantOK:  true,
+		},
+		{
+			name:    "the terminator on its own line is part of the digest",
+			sql:     "-- atlas:txmode none\n\nCREATE TABLE q (id int)\n;\nINSERT INTO nope (id) VALUES (1);\n",
+			applied: 1,
+			total:   2,
+			want:    []string{"h1:QaXL7OuhISU7XRm163GWS3emXNCpNe7H10aYOCtdbp8="},
+			wantOK:  true,
+		},
+		{
+			name:    "each entry covers every statement up to it",
+			sql:     "-- atlas:txmode none\n\nCREATE TABLE a (id int);\nCREATE TABLE b (name text NOT NULL);\nINSERT INTO missing_table (id) VALUES (1);\n",
+			applied: 2,
+			total:   3,
+			want: []string{
+				"h1:Fo9K92y+zoKkGFxsVzZuB4g8bkFV8lzihVkBjZlDO4E=",
+				"h1:PHiabMqgRVQ+Q6kLY6ZLG6LaSfJUmW12KwtOaPgLbug=",
+			},
+			wantOK: true,
+		},
+		{
+			name:    "a comment between statements is not in any digest",
+			sql:     "-- atlas:txmode none\n\nCREATE TABLE m (id int);\n-- a comment between statements\nCREATE TABLE n (v text);\nINSERT INTO nope (id) VALUES (1);\n",
+			applied: 2,
+			total:   3,
+			want: []string{
+				"h1:lFi6f+BorWqEW6ilAJebYqdkILXV8DyZXW/ttLZg1ws=",
+				"h1:ahmDNZltrM4zYl43yk/J7MRbAF6HqfbvjtksH1z62/I=",
+			},
+			wantOK: true,
+		},
+		{
+			name:    "blank lines between statements are not in any digest",
+			sql:     "-- atlas:txmode none\n\nCREATE TABLE x (id int);\n\nCREATE TABLE y (v text);\nCREATE TABLE z (w int NOT NULL DEFAULT 3);\nINSERT INTO nope (id) VALUES (1);\n",
+			applied: 3,
+			total:   4,
+			want: []string{
+				"h1:dPM5U4jjwgTZgQABLUveEHkcVOS1mAmu2al8ougQWVs=",
+				"h1:KSJHnVIWODojTFGEbln+Vb97fOt7NlbvyDNhqTERoWg=",
+				"h1:UosdOJPBbQ6nr0sLOR8k39EP4YpBfa+j630JoXmDMQo=",
+			},
+			wantOK: true,
+		},
+		{
+			// The binary records the JSON null here, not an empty array.
+			name:    "nothing applied has no prefix to record",
+			sql:     "CREATE TABLE a (id int);\nCREATE TABLE b (v text);\n",
+			applied: 0,
+			total:   2,
+			wantOK:  false,
+		},
+		{
+			// And here, because a clean success has nothing to resume.
+			name:    "a complete application records nothing",
+			sql:     "CREATE TABLE a (id int);\nCREATE TABLE b (v text);\n",
+			applied: 2,
+			total:   2,
+			wantOK:  false,
+		},
+		{
+			name:    "more statements applied than the source has is refused",
+			sql:     "CREATE TABLE a (id int);\n",
+			applied: 2,
+			total:   3,
+			wantOK:  false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			got, ok := atlasPartialHashValues(test.sql, "sqlite", test.applied, test.total)
+
+			c.Assert(ok, qt.Equals, test.wantOK)
+			c.Assert(got, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestSourceStatementCountMatchesTheExecutorSplit is the invariant
+// atlasPartialHashValues rests on.
+//
+// It indexes source statements by the count the executor reports, which comes
+// from splitSQLStatementsForDialect. A shape where the two splits disagree
+// would attach a digest to the wrong statement — a wrong value in a column
+// whose whole purpose is to be trusted on resume, which is worse than the null
+// it replaces.
+func TestSourceStatementCountMatchesTheExecutorSplit(t *testing.T) {
+	sources := []string{
+		"-- atlas:txmode none\n\nCREATE TABLE a (id int);\nCREATE TABLE b (v text);\n",
+		"CREATE TABLE q (id int)\n;\n-- between\nCREATE TABLE n (v text);\n",
+		"CREATE TABLE only (id int)\n",
+		"-- just a comment\n",
+		"CREATE TABLE a (id int);;\nCREATE TABLE b (v text);\n",
+		"CREATE TABLE a (id int); /* trailing */\n",
+		"INSERT INTO t (v) VALUES ('a;b');\nINSERT INTO t (v) VALUES ('c');\n",
+	}
+
+	for _, dialect := range []string{"sqlite", "postgres", "mysql", "sqlserver"} {
+		t.Run(dialect, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			for _, source := range sources {
+				c.Assert(
+					sqlutil.SplitSourceStatements(source, dialect),
+					qt.HasLen,
+					len(splitSQLStatementsForDialect(source, dialect)),
+					qt.Commentf("source %q", source),
+				)
+			}
+		})
+	}
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -399,7 +399,7 @@ func (m *Migrator) failMigrationSQL() string {
 		return revisionUpdateSQL(
 			m.connectionDialect(),
 			m.qualifiedMigrationsTable(),
-			"applied = ?, total = ?, execution_time = ?, error = ?, error_stmt = ?, operator_version = ?",
+			"applied = ?, total = ?, execution_time = ?, error = ?, error_stmt = ?, partial_hashes = ?, operator_version = ?",
 		)
 	}
 	return revisionUpdateSQL(
@@ -1185,6 +1185,7 @@ func (m *Migrator) markMigrationStatementInFlight(
 			time.Since(startedAt).Nanoseconds(),
 			unknownStatementOutcomeError,
 			event.Statement,
+			m.atlasPartialHashes(migration.UpSQL, event.Index-1, event.Total),
 			ptahOperatorVersion,
 			strconv.FormatInt(migration.Version, 10),
 		)
@@ -1327,6 +1328,7 @@ func (m *Migrator) failAtlasMigrationRevision(
 		time.Since(startedAt).Nanoseconds(),
 		strings.TrimSpace(failure.Error()),
 		stmt,
+		m.atlasPartialHashes(migration.UpSQL, applied, total),
 		ptahOperatorVersion,
 		strconv.FormatInt(migration.Version, 10),
 	)
@@ -1997,10 +1999,17 @@ func (m *Migrator) atlasRevisionTimestamp(at time.Time) any {
 }
 
 func (m *Migrator) atlasNullJSONValue() any {
+	return m.atlasJSONValue(atlasNullJSON)
+}
+
+// atlasJSONValue binds one JSON document the way the column that holds it was
+// declared: a plain string where the column is text (SQL Server, ClickHouse),
+// and a []byte JSON document everywhere the dialect has a real JSON type.
+func (m *Migrator) atlasJSONValue(document string) any {
 	if m.isSQLServer() || m.isClickHouse() {
-		return atlasNullJSON
+		return document
 	}
-	return []byte(atlasNullJSON)
+	return []byte(document)
 }
 
 func (m *Migrator) forceAppliedMigrationClickHouse(ctx context.Context, migration *Migration) error {


### PR DESCRIPTION
Closes item 3 of #1196 — the one with consequences beyond text shape. Items 1, 2 and 4 are untouched.

## What was broken

Ptah bound the JSON null into `partial_hashes` on every path, so a migration that stopped part-way recorded nothing about which statements had committed. The consumer-visible cost, measured on the pinned Atlas community binary v1.3.0 with two byte-identical SQLite databases differing **only** in that column:

```
partial_hashes = ["h1:8jgpt…"]   atlas migrate apply --allow-dirty   rc=0, runs only the remaining statement
partial_hashes = NULL            atlas migrate apply --allow-dirty   rc=2, panics
```

A resume cannot verify what already ran, so it refuses to try.

## The format, derived black-box

No Atlas source was read; the rule comes from hashing candidate preimages against recorded values.

```
partial_hashes[i] = "h1:" + base64(sha256(S₁ ‖ S₂ ‖ … ‖ Sᵢ₊₁))
```

Cumulative prefixes, so a resume can check the statements already applied are the same statements **in the same order**, not merely the same count. Each `Sₖ` is the statement's **source** text, from its first meaningful token through its terminating semicolon, verbatim.

That last word is load-bearing:

```sql
CREATE TABLE q (id int)
;
```

hashes as `"CREATE TABLE q (id int)\n;"`. Neither existing splitter can produce it — both trim the statement on the trailing side, which is exactly the newline that matters — so `SplitSourceStatements` trims the **leading** side only and restores the terminator. Reusing the executor split and appending `";"` yields a different digest, silently, and only for files written that way.

Comments preceding a statement, and blank lines between statements, are not in any preimage. Measured.

## The array is written only for a partial application

| applied vs total | pinned binary | this PR |
| --- | --- | --- |
| `applied = 0` | `null` | `null` |
| `0 < applied < total` | the array | the array |
| `applied = total` | `null` | `null` |

Writing an array on success would diverge on every successful migration instead of the rare failed one.

## Verification

All five fixtures record byte-identical rows to the binary, including the `\n;` case and the interleaved-comment case. Two discriminating mutants:

- hashing each statement independently instead of cumulatively reddens three rows;
- building the preimage as executor-split + `";"` — the tempting shortcut — reddens five, including the `\n;` row.

`TestSourceStatementCountMatchesTheExecutorSplit` pins the invariant the computation rests on: it indexes source statements by the count the executor reports, so a shape where the two splits disagree would attach a digest to the wrong statement. Seven shapes across four dialects, including `;;`, a trailing block comment, a semicolon inside a string literal, and a file with no terminator.

## Scope

`core/sqlutil` gains `SourceStatement` and `SplitSourceStatements`; `docs/public_api.snapshot` is regenerated. `StatementEvent` is **not** touched — the failure path already has the migration's SQL and the applied count, so nothing had to be threaded through it.

The remaining #1196 items stay open: the error text prefix and the doubled `SQL:` line, the missing terminator on `error_stmt`, and the extra revision row under four directive combinations.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean.
