### PR TITLE
Record the driver error and the written statement on a failed migration (#1196 items 1 and 2)

### DIFF
--- a/cmd/atlas/migrate_dirty_retry_test.go
+++ b/cmd/atlas/migrate_dirty_retry_test.go
@@ -191,6 +191,11 @@ func TestCompatCommand_MigrateStatusReportsTheDirtyMigration(t *testing.T) {
 	c.Assert(statusOut, qt.Contains, "  -- Executed Files:  2 (last one partially)\n")
 	c.Assert(statusOut, qt.Contains, "  -- Pending Files:   1\n")
 	c.Assert(statusOut, qt.Contains, "\nLast migration attempt had errors:\n")
-	c.Assert(statusOut, qt.Contains, "  -- SQL:   THIS IS A FAILING STATEMENT")
-	c.Assert(statusOut, qt.Contains, "  -- ERROR: failed to execute migration SQL")
+	// Both lines are the shape the pinned community binary v1.3.0 prints: the
+	// statement with its terminator, and the database's own message with no
+	// Ptah wrapping in front of it (stokaro/ptah#1196). The negative assertion
+	// is what keeps the wrapping from creeping back.
+	c.Assert(statusOut, qt.Contains, "  -- SQL:   THIS IS A FAILING STATEMENT;")
+	c.Assert(statusOut, qt.Not(qt.Contains), "failed to execute migration SQL")
+	c.Assert(statusOut, qt.Contains, "  -- ERROR: ")
 }

--- a/cmd/atlas/migrate_status_report_shape_test.go
+++ b/cmd/atlas/migrate_status_report_shape_test.go
@@ -182,13 +182,14 @@ func TestCompatMigrateStatus_HalfAppliedFailureBlock(t *testing.T) {
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr))
 	c.Assert(stdout, qt.Contains, "  -- Pending Files:   1\n\nLast migration attempt had errors:\n")
-	c.Assert(stdout, qt.Contains, "\n  -- SQL:   CREATE TABLE ss_one (id INTEGER PRIMARY KEY)")
-	c.Assert(stdout, qt.Contains, "\n  -- ERROR: failed to execute migration SQL")
-	// Nine lines exactly. Ptah's applier records this failure as a TWO-line
-	// error ("...(1)\nSQL: CREATE TABLE ..."), and the report folds the stored
-	// newline to a space the way the pinned community binary folds it. Without
-	// the fold this reads 10 and a parser keying on `  -- ` loses the tail of
-	// the message to a line with no prefix.
+	c.Assert(stdout, qt.Contains, "\n  -- SQL:   CREATE TABLE ss_one (id INTEGER PRIMARY KEY);")
+	c.Assert(stdout, qt.Not(qt.Contains), "failed to execute migration SQL")
+	c.Assert(stdout, qt.Contains, "\n  -- ERROR: ")
+	// Nine lines exactly. The stored error is one line since
+	// stokaro/ptah#1196 -- Ptah's wrapping and the `SQL:` line it carried are
+	// gone -- but the report keeps folding a stored newline to a space, because
+	// a driver is still free to produce one and a parser keying on `  -- `
+	// would lose the tail of the message to a line with no prefix.
 	c.Assert(strings.Count(stdout, "\n"), qt.Equals, 9)
 }
 

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -837,6 +837,35 @@ Revisit when the conformance Atlas pin advances past v1.2.0.
 **Tracking.** [`stokaro/ptah#758`](https://github.com/stokaro/ptah/issues/758)
 
 
+### Recorded revision `error` text on a failed migration
+
+**Type.** Driver difference, not a behavior one
+
+**Current boundary.** The Atlas revision table's `error` column records the
+database's own message on both sides, but the two spell the same condition
+differently because they use different SQLite drivers. On the same failing
+migration:
+
+```text
+pinned community binary v1.3.0   no such table: missing_table
+ptah-compat                      SQL logic error: no such table: missing_table (1)
+```
+
+Ptah used to record more than that — its own `failed to execute migration SQL:`
+prefix and a `SQL:` line repeating the statement that the adjacent `error_stmt`
+column already holds in full. Both were Ptah's own additions and are gone; the
+column now carries the innermost error and nothing else. `error_stmt` matches
+byte for byte, terminating semicolon included.
+
+What is left is `modernc.org/sqlite`'s wording. Closing it would mean rewriting
+driver messages per driver and per dialect to match a different driver's
+phrasing, which trades a cosmetic difference for a table of string surgery that
+goes stale silently. The native revision format is unaffected either way: this
+applies only where the revision table is Atlas-shaped, and Ptah's own surface
+keeps the context it added.
+
+**Tracking.** [`stokaro/ptah#1196`](https://github.com/stokaro/ptah/issues/1196)
+
 ### `atlas.hcl` `file()` confinement
 
 **Type.** Deliberate divergence

--- a/migration/migrator/atlas_failure_shape.go
+++ b/migration/migrator/atlas_failure_shape.go
@@ -1,0 +1,74 @@
+package migrator
+
+import (
+	"errors"
+	"strings"
+
+	"go.5x5.cz/ptah/core/sqlutil"
+)
+
+// atlasFailureError is what the Atlas revision table's `error` column records
+// for a failed migration.
+//
+// The pinned Atlas community binary v1.3.0 records the database's own message
+// and nothing else. Ptah records the chain it built on the way up, which on
+// SQLite reads
+//
+//	failed to execute migration SQL: SQL logic error: no such table: t (1)
+//	SQL: INSERT INTO t (id) VALUES (1)
+//
+// where that binary records `no such table: t`. Two of those three parts are
+// Ptah's own: the wrapping prefix, and a `SQL:` line repeating a statement the
+// adjacent `error_stmt` column already holds in full.
+//
+// Unwrapping to the innermost error drops both. What is left is the driver's
+// message, which still differs from that binary's — ours is a different SQLite
+// driver and spells the same condition `SQL logic error: … (1)`. That residue
+// is a driver difference rather than a Ptah one and is recorded in the gap
+// register; no amount of string surgery here would close it without inventing
+// per-driver rewrites (stokaro/ptah#1196 item 1).
+//
+// The native revision format is untouched. This runs only where the revision
+// table is Atlas-shaped, and Ptah's own surface keeps the context it added.
+func atlasFailureError(failure error) string {
+	if failure == nil {
+		return ""
+	}
+	innermost := failure
+	for {
+		unwrapped := errors.Unwrap(innermost)
+		if unwrapped == nil {
+			break
+		}
+		innermost = unwrapped
+	}
+	return strings.TrimSpace(innermost.Error())
+}
+
+// atlasFailureStatement is what the `error_stmt` column records: the failing
+// statement as it was written, terminator included.
+//
+// The executor carries the normalized statement, which has had its terminating
+// semicolon stripped, so recording it loses a character that binary keeps. The
+// statement is recovered from the migration source instead, at the 1-based
+// index the failure reports.
+//
+// That index is not derivable from the applied count. A transaction that rolled
+// the body back reports zero applied while the statement that failed is still
+// the one it was, so indexing by applied would record the file's first
+// statement for every tx-mode-all failure.
+//
+// Falling back to the executor's text keeps a shape this cannot resolve — a
+// source that splits differently, or a failure with no statement — reporting
+// the statement it always did rather than nothing at all.
+func atlasFailureStatement(sqlText, dialect string, failedIndex int, stmt string) string {
+	statements := sqlutil.SplitSourceStatements(sqlText, dialect)
+	if failedIndex < 1 || failedIndex > len(statements) {
+		return stmt
+	}
+	source := strings.TrimSpace(statements[failedIndex-1].Text)
+	if source == "" {
+		return stmt
+	}
+	return source
+}

--- a/migration/migrator/atlas_failure_shape_internal_test.go
+++ b/migration/migrator/atlas_failure_shape_internal_test.go
@@ -1,0 +1,148 @@
+package migrator
+
+// White-box testing required: both helpers exist only as bound arguments on a
+// revision UPDATE, so neither is reachable through an exported API, and the
+// index one has to be exercised at values the exported surface cannot produce
+// on demand.
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestAtlasFailureError pins what the Atlas revision table's `error` column
+// records (stokaro/ptah#1196 item 1).
+//
+// The pinned community binary v1.3.0 records the database's own message and
+// nothing else. Ptah recorded the chain it built on the way up, whose first
+// line carried a `failed to execute migration SQL:` prefix and whose second
+// repeated the statement that `error_stmt` already holds in full.
+func TestAtlasFailureError(t *testing.T) {
+	driverFailure := errors.New("SQL logic error: no such table: missing_table (1)")
+
+	tests := []struct {
+		name    string
+		failure error
+		want    string
+	}{
+		{
+			name:    "no failure records nothing",
+			failure: nil,
+			want:    "",
+		},
+		{
+			name:    "a bare driver error is recorded as it is",
+			failure: driverFailure,
+			want:    "SQL logic error: no such table: missing_table (1)",
+		},
+		{
+			name:    "Ptah's own wrapping is dropped",
+			failure: fmt.Errorf("failed to execute migration SQL: %w", driverFailure),
+			want:    "SQL logic error: no such table: missing_table (1)",
+		},
+		{
+			name: "every layer of it, however deep",
+			failure: fmt.Errorf("apply migration 20260101000001: %w",
+				fmt.Errorf("failed to execute migration SQL: %w", driverFailure)),
+			want: "SQL logic error: no such table: missing_table (1)",
+		},
+		{
+			name:    "an unwrapped error that merely mentions a cause is left alone",
+			failure: errors.New("failed to execute migration SQL: something"),
+			want:    "failed to execute migration SQL: something",
+		},
+		{
+			// A driver whose message arrives padded, which is why the recorded
+			// value is trimmed rather than passed through.
+			name:    "surrounding whitespace is trimmed",
+			failure: paddedError{},
+			want:    "no such table: t",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			c.Assert(atlasFailureError(test.failure), qt.Equals, test.want)
+		})
+	}
+}
+
+// paddedError stands in for a driver that pads its own message. Written as a
+// type rather than errors.New because the linter reads a padded literal as a
+// malformed error string, which is exactly the shape being covered here.
+type paddedError struct{}
+
+func (paddedError) Error() string { return "  no such table: t \n" }
+
+// TestAtlasFailureStatement pins the `error_stmt` column (item 2).
+//
+// The row that matters is the tx-mode-all one. The applied count is zeroed
+// whenever the transaction rolled the body back, so indexing the source by it
+// would record the file's FIRST statement for every such failure — a plausible
+// value, in the column an operator reads to find out what broke.
+func TestAtlasFailureStatement(t *testing.T) {
+	const source = "-- atlas:txmode none\n\nCREATE TABLE a (id int);\nINSERT INTO missing_table (id) VALUES (1);\n"
+
+	tests := []struct {
+		name        string
+		sql         string
+		failedIndex int
+		stmt        string
+		want        string
+	}{
+		{
+			name:        "the failing statement carries its terminator",
+			sql:         source,
+			failedIndex: 2,
+			stmt:        "INSERT INTO missing_table (id) VALUES (1)",
+			want:        "INSERT INTO missing_table (id) VALUES (1);",
+		},
+		{
+			name:        "the first statement is reachable too",
+			sql:         source,
+			failedIndex: 1,
+			stmt:        "CREATE TABLE a (id int)",
+			want:        "CREATE TABLE a (id int);",
+		},
+		{
+			name:        "a terminator on its own line comes back as written",
+			sql:         "CREATE TABLE q (id int)\n;\nINSERT INTO nope (id) VALUES (1);\n",
+			failedIndex: 1,
+			stmt:        "CREATE TABLE q (id int)",
+			want:        "CREATE TABLE q (id int)\n;",
+		},
+		{
+			name:        "an index past the source falls back to the executor's text",
+			sql:         source,
+			failedIndex: 9,
+			stmt:        "INSERT INTO missing_table (id) VALUES (1)",
+			want:        "INSERT INTO missing_table (id) VALUES (1)",
+		},
+		{
+			name:        "no reported index falls back too",
+			sql:         source,
+			failedIndex: 0,
+			stmt:        "INSERT INTO missing_table (id) VALUES (1)",
+			want:        "INSERT INTO missing_table (id) VALUES (1)",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			c.Assert(
+				atlasFailureStatement(test.sql, "sqlite", test.failedIndex, test.stmt),
+				qt.Equals,
+				test.want,
+			)
+		})
+	}
+}

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -148,32 +148,52 @@ func (m *Migrator) migrationStatementCount(sqlText string) int {
 	return migrationStatementCountForDialect(sqlText, m.conn.Info().Dialect)
 }
 
-func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMode) (applied int, total int, stmt string) {
+// migrationProgress is what a failed execution reports about how far it got.
+//
+// FailedIndex is deliberately separate from Applied: Applied is zeroed whenever
+// the transaction rolled the body back, and the statement that failed is still
+// the one it was. Indexing the migration source by Applied would name the
+// file's first statement for every tx-mode-all failure.
+type migrationProgress struct {
+	Applied     int
+	Total       int
+	Statement   string
+	FailedIndex int
+}
+
+func migrationExecutionProgress(
+	err error,
+	dialect string,
+	txMode MigrationTxMode,
+) migrationProgress {
 	var progressErr *statementProgressError
 	if errors.As(err, &progressErr) {
 		event := progressErr.event
-		return progressErr.applied, event.Total, event.Statement
+		return migrationProgress{
+			Applied: progressErr.applied, Total: event.Total,
+			Statement: event.Statement, FailedIndex: event.Index,
+		}
 	}
 
 	var observationErr *StatementObservationError
 	if errors.As(err, &observationErr) {
 		event := observationErr.Event
-		applied = event.Index
-		total = event.Total
-		stmt = event.Statement
+		applied := event.Index
 		if migrationProgressRolledBack(dialect, txMode) {
 			applied = 0
 		}
-		return applied, total, stmt
+		return migrationProgress{
+			Applied: applied, Total: event.Total,
+			Statement: event.Statement, FailedIndex: event.Index,
+		}
 	}
 
 	var execErr *MigrationExecutionError
 	if !errors.As(err, &execErr) {
-		return 0, 0, ""
+		return migrationProgress{}
 	}
 
-	total = execErr.Total
-	applied = execErr.StatementIndex - 1
+	applied := execErr.StatementIndex - 1
 	// The recorded counter is not decoration: a retry resumes at applied+1, so
 	// overstating it skips a statement that never ran. Whether the earlier
 	// statements survived the failure is a property of the transaction mode and
@@ -187,7 +207,10 @@ func migrationExecutionProgress(err error, dialect string, txMode MigrationTxMod
 	if applied < 0 {
 		applied = 0
 	}
-	return applied, total, execErr.Statement
+	return migrationProgress{
+		Applied: applied, Total: execErr.Total,
+		Statement: execErr.Statement, FailedIndex: execErr.StatementIndex,
+	}
 }
 
 func migrationProgressRolledBack(dialect string, txMode MigrationTxMode) bool {
@@ -1270,7 +1293,8 @@ func (m *Migrator) failMigrationRevisionWithMode(
 	}
 	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
 	defer cancelRecord()
-	applied, total, stmt := migrationExecutionProgress(failure, m.conn.Info().Dialect, txMode)
+	progress := migrationExecutionProgress(failure, m.conn.Info().Dialect, txMode)
+	applied, total, stmt, failedIndex := progress.Applied, progress.Total, progress.Statement, progress.FailedIndex
 	if total == 0 {
 		total = m.migrationStatementCount(sqlText)
 	}
@@ -1288,7 +1312,9 @@ func (m *Migrator) failMigrationRevisionWithMode(
 		applied = 0
 	}
 	if m.revisionTableFormat.isAtlas() {
-		return m.failAtlasMigrationRevision(recordCtx, migration, startedAt, failure, applied, total, stmt)
+		return m.failAtlasMigrationRevision(
+			recordCtx, migration, startedAt, failure, applied, total, stmt, failedIndex,
+		)
 	}
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
 	return executeSQLOutsideTransaction(
@@ -1317,6 +1343,7 @@ func (m *Migrator) failAtlasMigrationRevision(
 	applied int,
 	total int,
 	stmt string,
+	failedIndex int,
 ) error {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
 	return executeSQLOutsideTransaction(
@@ -1326,8 +1353,8 @@ func (m *Migrator) failAtlasMigrationRevision(
 		applied,
 		total,
 		time.Since(startedAt).Nanoseconds(),
-		strings.TrimSpace(failure.Error()),
-		stmt,
+		atlasFailureError(failure),
+		atlasFailureStatement(migration.UpSQL, m.connectionDialect(), failedIndex, stmt),
 		m.atlasPartialHashes(migration.UpSQL, applied, total),
 		ptahOperatorVersion,
 		strconv.FormatInt(migration.Version, 10),


### PR DESCRIPTION
Items 1 and 2 of #1196, following #1223 which did item 3. Item 4 — the extra revision row under four directive combinations — stays open.

## Measured, before and after

Same fixture, one file with `-- atlas:txmode none`, second statement failing:

```
error_stmt
  pinned binary v1.3.0   INSERT INTO missing_table (id) VALUES (1);
  ptah-compat, before    INSERT INTO missing_table (id) VALUES (1)
  ptah-compat, after     INSERT INTO missing_table (id) VALUES (1);      byte-identical

error
  pinned binary v1.3.0   no such table: missing_table
  ptah-compat, before    failed to execute migration SQL: SQL logic error: no such table: missing_table (1)
                         SQL: INSERT INTO missing_table (id) VALUES (1)
  ptah-compat, after     SQL logic error: no such table: missing_table (1)
```

Two of the three parts of the old `error` were Ptah's own: the wrapping prefix, and a `SQL:` line repeating what `error_stmt` already holds in full. Unwrapping to the innermost error drops both.

The residue is `modernc.org/sqlite`'s wording — the only occurrences of "SQL logic error" in the tree are comments about it. Closing that would mean rewriting driver messages per driver and per dialect to match a different driver's phrasing, so it is **recorded in the gap register** instead, which is what the issue's DoD asks for.

## `migrate status` improves with it

```
pinned binary v1.3.0            ptah-compat, after
  -- SQL:   INSERT … (1);         -- SQL:   INSERT … (1);        byte-identical
  -- ERROR: no such table: …      -- ERROR: SQL logic error: …   driver wording only
```

## The bug the existing tests caught

My first attempt indexed the migration source by the **applied count**. `TestAtlasTxModeMatrix_BodyFailurePath` went red immediately: `applied` is zeroed whenever the transaction rolled the body back, so that recorded the file's *first* statement for every tx-mode-all failure — a plausible-looking value in the column an operator reads to find out what broke.

`migrationExecutionProgress` now reports the failing statement's 1-based index alongside the applied count, as a struct rather than a fourth positional result. Reverting to `applied` reddens that test again.

## Tests

Two inverted rather than deleted: `TestCompatCommand_MigrateStatusReportsTheDirtyMigration` and `TestCompatMigrateStatus_HalfAppliedFailureBlock` pinned the old wrapped text. Each now asserts the new shape **and** that the wrapping is absent, so it cannot creep back.

New table tests cover the unwrap depth, an unwrapped error that merely mentions a cause, and the statement lookup at a terminator written on its own line — the shape `SplitSourceStatements` exists for.

## Scope

No public API change; `docs/public_api.snapshot` is unmoved. Native revision bookkeeping is untouched — this runs only where the revision table is Atlas-shaped, and Ptah's own surface keeps the context it added.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint`, and the seven `check:*` docs scripts plus the feature-matrix check — all clean.
