### PR TITLE
Name a failed statement once, not twice (#1196 item 1)

### DIFF
--- a/migration/migrator/execution_error_test.go
+++ b/migration/migrator/execution_error_test.go
@@ -1,0 +1,90 @@
+package migrator_test
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestMigrationExecutionErrorRendersOneStatementLine pins that a failure names
+// the statement once (stokaro/ptah#1196).
+//
+// Every dialect writer appends its own `SQL: <statement>` line before the error
+// reaches here — `sqlite: SQL execution failed: …\nSQL: DROP TABLE t` — and
+// this type appended another from its own Statement field. One failed statement
+// therefore printed twice, in the CLI message and in the recorded revision
+// `error` column, which is where the issue found it.
+//
+// The last row is why the check is against this error's own statement rather
+// than a search for any SQL line: a wrapped error naming a DIFFERENT statement
+// leaves nothing to deduplicate, and dropping this one's line there would lose
+// the only mention of what actually failed.
+func TestMigrationExecutionErrorRendersOneStatementLine(t *testing.T) {
+	const statement = "DROP TABLE does_not_exist"
+
+	tests := []struct {
+		name          string
+		err           error
+		wantLines     int
+		wantRemaining string
+	}{
+		{
+			name:          "a writer that already named the statement",
+			err:           fmt.Errorf("sqlite: SQL execution failed: no such table\nSQL: %s", statement),
+			wantLines:     1,
+			wantRemaining: statement,
+		},
+		{
+			name:          "a writer that did not",
+			err:           errors.New("no such table"),
+			wantLines:     1,
+			wantRemaining: statement,
+		},
+		{
+			name:          "a wrapped error naming a different statement",
+			err:           fmt.Errorf("no such table\nSQL: %s", "DROP TABLE other"),
+			wantLines:     2,
+			wantRemaining: statement,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			execErr := &migrator.MigrationExecutionError{
+				Err:            test.err,
+				Statement:      statement,
+				StatementIndex: 2,
+				Total:          2,
+			}
+
+			rendered := execErr.Error()
+
+			c.Assert(countStatementLines(rendered), qt.Equals, test.wantLines)
+			c.Assert(rendered, qt.Contains, test.wantRemaining)
+			// Unwrapping is unaffected, so callers that inspect the cause keep
+			// reaching it however the message was rendered.
+			c.Assert(errors.Unwrap(execErr), qt.Equals, test.err)
+		})
+	}
+}
+
+// countStatementLines counts the `SQL: ` lines a rendered error carries. It
+// matches at the start of a line so the words "migration SQL:" inside a
+// sentence are not counted as one.
+func countStatementLines(rendered string) int {
+	count := 0
+	for line := range strings.SplitSeq(rendered, "\n") {
+		if strings.HasPrefix(line, "SQL: ") {
+			count++
+		}
+	}
+	return count
+}

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -953,8 +953,23 @@ type MigrationExecutionError struct {
 	Total          int
 }
 
+// Error renders the wrapped failure with the statement that caused it.
+//
+// The statement line is omitted when the wrapped error already carries it. Every
+// dialect writer appends its own `SQL: <statement>` line, so adding one here
+// unconditionally printed the same statement twice for one failure -- in the
+// CLI message, and in the recorded revision `error` column, which is where
+// stokaro/ptah#1196 found it.
+//
+// The comparison is against this error's own Statement rather than a search for
+// any SQL line, so a wrapped error mentioning a DIFFERENT statement still gets
+// this one appended.
 func (e *MigrationExecutionError) Error() string {
-	return fmt.Sprintf("%v\nSQL: %s", e.Err, e.Statement)
+	message := fmt.Sprintf("%v", e.Err)
+	if strings.Contains(message, "\nSQL: "+e.Statement) {
+		return message
+	}
+	return fmt.Sprintf("%s\nSQL: %s", message, e.Statement)
 }
 
 func (e *MigrationExecutionError) Unwrap() error {


### PR DESCRIPTION
The half of #1196 item 1 that #1224 did not reach. #1224 cleaned the Atlas-format `error` column by unwrapping to the innermost error; this fixes the doubling itself, which lives on the native path.

## The defect

Every dialect writer appends its own `SQL: <statement>` line — `sqlite: SQL execution failed: …\nSQL: DROP TABLE t` — and `MigrationExecutionError.Error()` appended another from its own `Statement` field. One failed statement, two lines, in the CLI message and in the recorded revision `error` column where a consumer reads it.

Measured on a rollback whose second statement fails, native `schema_migrations`:

```text
before   SQL: DROP TABLE does_not_exist
         SQL: DROP TABLE does_not_exist
after    SQL: DROP TABLE does_not_exist
```

## Why the check is narrow

The comparison is against **this error's own** statement, not a search for any `SQL:` line. A wrapped error naming a *different* statement has nothing to deduplicate, and dropping this one's line there would lose the only mention of what actually failed. Both mutants are rejected by the test, each on its own row:

- appending unconditionally reddens `a writer that already named the statement`;
- dropping whenever any SQL line is present reddens `a wrapped error naming a different statement`.

Unwrapping is unaffected, so callers inspecting the cause reach it however the message was rendered — asserted in every row.

## A correction to my own report on the issue

I wrote earlier that the doubled `SQL:` line "does not reproduce". That measurement was of the **Atlas-format** revision table, where it appears once. It does reproduce, on the **native** `schema_migrations` table, which is a different code path and the one the issue's transcript actually shows. The claim was wrong because I checked one table and generalized to both.

## Gates

`go build`, `go vet`, `go test ./... -count=1`, `qtlint`, `check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`, `golangci-lint` — all clean. No public API change.
