### PR TITLE
Render inspected column types the pinned binary can read (#1138)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -20,6 +20,26 @@ jobs:
 
     env:
       PTAH_ATLAS_FUZZ_N: '200'
+      # The column-type conformance run needs a real PostgreSQL dev database.
+      # The binary resolves a column type by materializing it there, so a run
+      # without a server could not tell a type it does not model from a type the
+      # engine does not have -- and those are the two verdicts that run exists to
+      # keep apart.
+      PTAH_ATLAS_ORACLE_POSTGRES_DEV_URL: 'postgres://postgres:pw@localhost:5432/dev?sslmode=disable&search_path=public'
+
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_PASSWORD: pw
+          POSTGRES_DB: dev
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
 
     steps:
       - uses: actions/checkout@v7
@@ -109,6 +129,33 @@ jobs:
           # A missing oracle skips these silently. That is the exact failure
           # mode this job exists to prevent, so a skip fails the job.
           ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-file-sandbox-run"
+
+      # The set of column types the HCL schema models is the third contract in
+      # this repository whose authority is the community binary rather than any
+      # document (stokaro/ptah#1138). A wrong row emits HCL that binary refuses
+      # to read, so the set is re-measured here instead of being trusted.
+      # Listed before it is run, for the same reason as above.
+      - name: Verify column-type conformance selection
+        run: |
+          GOWORK=off go test -list '^TestOracle' \
+            ./internal/atlashclrender > "$RUNNER_TEMP/atlas-column-type-tests"
+          cat "$RUNNER_TEMP/atlas-column-type-tests"
+          grep -Fx 'TestOracleModeledColumnTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
+          grep -Fx 'TestOracleAcceptsTheWrapItFallsBackTo' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 2
+
+      - name: Run column-type conformance tests
+        run: |
+          GOWORK=off go test -count=1 -v -run '^TestOracle' ./internal/atlashclrender \
+            > "$RUNNER_TEMP/atlas-column-type-run" 2>&1 || {
+              cat "$RUNNER_TEMP/atlas-column-type-run"
+              exit 1
+            }
+          cat "$RUNNER_TEMP/atlas-column-type-run"
+          # A missing oracle skips these silently, and so does a missing dev
+          # database URL -- which would leave every PostgreSQL row unmeasured
+          # while the job stayed green. Both are fatal here.
+          ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/internal/atlashclrender/modeled_types.go
+++ b/internal/atlashclrender/modeled_types.go
@@ -1,0 +1,218 @@
+package atlashclrender
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// modeledColumnTypes lists, per dialect, the column type names the Atlas HCL
+// schema models as a type expression. A type outside its dialect's list has to
+// be written as a sql() call, because the pinned Atlas community binary v1.3.0
+// refuses every other spelling of one.
+//
+// Both refusals are measured, not assumed. On SQLite, feeding that binary a
+// column whose type is written bare:
+//
+//	type = integer                     accepted, exit 0
+//	type = USER_DEFINED                refused, exit 1, `There is no type named "USER_DEFINED"`
+//	type = timestamp                   refused, exit 1, the same complaint
+//
+// and on PostgreSQL, feeding it the spellings Ptah's inspect produces today for
+// an ordinary table:
+//
+//	type = NUMERIC(10,2)               refused, exit 1, `There is no function named "NUMERIC"`
+//	type = "timestamp with time zone"  refused, exit 1, `schemahcl: failed reading spec`
+//	type = "text[]"                    refused, exit 1, the same complaint
+//	type = sql("timestamp with time zone")  accepted, exit 0
+//
+// `timestamp` is why this list cannot be derived from Ptah's own type
+// vocabulary, or from intuition: it is an ordinary type name that Ptah models
+// and that binary does not model for SQLite. `NUMERIC` is why the case rule in
+// modeledColumnType is load bearing rather than cosmetic: written upper case a
+// sized type does not merely fail to resolve, it parses as a CALL, and the
+// complaint that comes back names a missing function rather than a missing
+// type.
+//
+// A hand-copied table mirroring another tool's registry drifts, and
+// internal/atlashcl/sqlrawexpr.go records why this repository refused to carry
+// one before: "a wrong row in that table breaks drop-in silently". Two things
+// answer that here.
+//
+// The first is that the failure is asymmetric, so a list that is too SHORT is
+// safe and a list that is too LONG is not: wrapping a type that did not need it
+// produces sql("integer"), which round trips. That is measured rather than
+// assumed -- every one of the 57 type names measured as accepted bare on
+// PostgreSQL was re-fed to the same binary wrapped, and all 57 were accepted,
+// with no counterexample.
+//
+// The second is that the list is not trusted:
+// TestOracleModeledColumnTypesMatchTheBinary re-measures every entry against the
+// pinned binary, so a row that stops being true turns the Atlas CE Oracle job
+// red instead of silently degrading a round trip.
+//
+// What wrapping does NOT do is rescue a type the ENGINE does not have, and
+// conflating the two would make this list look more powerful than it is. The
+// binary evaluates a sql() body against the dev database, so on PostgreSQL
+//
+//	type = sql("hstore")               refused, exit 1, extension not installed
+//	type = sql("citext")               refused, exit 1
+//	type = sql("USER-DEFINED")         refused, exit 1
+//	type = sql("ARRAY")                refused, exit 1
+//
+// all fail, exactly as their bare spellings do. Wrapping rescues a type the HCL
+// schema does not MODEL. A column whose type does not exist in the dev database
+// is a different defect, and the catalog placeholders `USER-DEFINED` and
+// `ARRAY` are resolved before rendering -- see goSchemaFieldType in
+// internal/convert/dbschematogo.
+//
+// Dialects absent from this map wrap nothing, which is exactly today's
+// behavior for them (stokaro/ptah#1138).
+var modeledColumnTypes = map[string]map[string]struct{}{
+	platform.SQLite: namesToSet(
+		"bigint",
+		"blob",
+		"bool",
+		"boolean",
+		"character",
+		"date",
+		"datetime",
+		"decimal",
+		"double",
+		"float",
+		"int",
+		"integer",
+		"json",
+		"jsonb",
+		"numeric",
+		"real",
+		"smallint",
+		"text",
+		"uuid",
+		"varchar",
+	),
+	// Measured by feeding each name to the pinned binary bare, as
+	// `type = <name>`, against a PostgreSQL 17 dev database. Names refused
+	// there are deliberately absent: hstore, citext, ltree and geometry are
+	// extension types the dev database does not carry, and they are refused
+	// wrapped as well, so listing them would not have helped.
+	//
+	// The multi-word spellings PostgreSQL's own catalog reports -- `character
+	// varying`, `double precision`, `timestamp with time zone`, `time without
+	// time zone` -- are absent for a different reason: they are not writable
+	// bare at all, because two identifiers separated by a space is not one HCL
+	// expression. They reach the binary through sql(), which accepts all four.
+	platform.Postgres: namesToSet(
+		"bigint",
+		"bigserial",
+		"bit",
+		"bool",
+		"boolean",
+		"box",
+		"bytea",
+		"char",
+		"character",
+		"cidr",
+		"circle",
+		"date",
+		"daterange",
+		"decimal",
+		"float",
+		"float4",
+		"float8",
+		"inet",
+		"int",
+		"int2",
+		"int4",
+		"int4range",
+		"int8",
+		"int8range",
+		"integer",
+		"interval",
+		"json",
+		"jsonb",
+		"line",
+		"lseg",
+		"macaddr",
+		"macaddr8",
+		"money",
+		"name",
+		"numeric",
+		"numrange",
+		"oid",
+		"path",
+		"point",
+		"polygon",
+		"real",
+		"regclass",
+		"serial",
+		"smallint",
+		"smallserial",
+		"text",
+		"time",
+		"timestamp",
+		"timestamptz",
+		"timetz",
+		"tsquery",
+		"tsrange",
+		"tstzrange",
+		"tsvector",
+		"uuid",
+		"varchar",
+		"xml",
+	),
+}
+
+func namesToSet(names ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		set[name] = struct{}{}
+	}
+	return set
+}
+
+// modeledColumnType reports how a column type has to be written for the named
+// dialect: the modeled spelling and true, or "" and false when it has to become
+// a sql() call.
+//
+// The size argument is split off before the lookup and put back afterwards:
+// `varchar(100)` is the modeled type `varchar` carrying a length, and the
+// binary accepts it written that way. So are `numeric(10,2)`, `bit(8)`,
+// `timestamptz(3)` and `character(10)`, all measured.
+//
+// The name comes back lower-cased because that binary's type names are CASE
+// SENSITIVE. Measured on SQLite:
+//
+//	type = integer      accepted, exit 0
+//	type = INTEGER      refused, exit 1, `There is no type named "INTEGER"`
+//	type = Text         refused, exit 1, `Did you mean "text"?`
+//
+// and identically on PostgreSQL, where `integer` and `varchar` are accepted
+// while `INTEGER` and `VARCHAR` are not.
+//
+// This is not a detail. Both readers upper-case: Ptah's SQLite reader
+// upper-cases every type it reads, and its PostgreSQL reader reports
+// `NUMERIC(10,2)` and `VARCHAR(100)` for an ordinary table. Before this, every
+// such column rendered as HCL that binary could not read -- not just the
+// user-defined column the conformance fixture happened to compare.
+//
+// A dialect with no measured list keeps whatever the IR holds.
+func modeledColumnType(dialect, columnType string) (string, bool) {
+	modeled, known := modeledColumnTypes[platform.NormalizeDialect(dialect)]
+	if !known {
+		return columnType, true
+	}
+	trimmed := strings.TrimSpace(columnType)
+	if trimmed == "" {
+		return trimmed, true
+	}
+	name, argument := trimmed, ""
+	if open := strings.IndexByte(trimmed, '('); open >= 0 {
+		name, argument = strings.TrimSpace(trimmed[:open]), trimmed[open:]
+	}
+	lowered := strings.ToLower(name)
+	if _, ok := modeled[lowered]; !ok {
+		return "", false
+	}
+	return lowered + argument, true
+}

--- a/internal/atlashclrender/modeled_types_oracle_internal_test.go
+++ b/internal/atlashclrender/modeled_types_oracle_internal_test.go
@@ -1,0 +1,309 @@
+package atlashclrender
+
+// White-box testing required: the subject of this conformance run is the
+// contents of modeledColumnTypes, an unexported map. Enumerating it is the whole
+// point -- a black-box run could only ask about type names it already thought
+// of, which is exactly the drift this run exists to catch.
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// oracleEnv names the environment variable holding the path to the pinned
+// Atlas CE binary this conformance run compares against.
+const oracleEnv = "PTAH_ATLAS_ORACLE"
+
+// oracleVersion is the only build this conformance run trusts. A different
+// build may model a different set of types, which is the very thing under
+// measurement here, so comparing against it would report drift that is really
+// version drift.
+const oracleVersion = "atlas community version v1.3.0"
+
+// devURLEnvByDialect names the environment variable carrying each dialect's dev
+// database URL.
+//
+// SQLite needs none: in-memory keeps the common case self-contained. PostgreSQL
+// cannot be faked, because the binary resolves a type against the dev database
+// it is given -- that is precisely why sql("hstore") is refused there while
+// sql("timestamp with time zone") is accepted, and a run without a real server
+// would measure neither.
+var devURLEnvByDialect = map[string]string{
+	platform.Postgres: "PTAH_ATLAS_ORACLE_POSTGRES_DEV_URL",
+}
+
+// defaultDevURLByDialect is the dev URL for a dialect that needs no server.
+var defaultDevURLByDialect = map[string]string{
+	platform.SQLite: "sqlite://file?mode=memory",
+}
+
+// schemaNameByDialect is the schema an inspected database of that dialect puts
+// its tables in, and therefore the one these probes declare.
+var schemaNameByDialect = map[string]string{
+	platform.SQLite:   "main",
+	platform.Postgres: "public",
+}
+
+// unmodeledControls are type names deliberately ABSENT from each dialect's
+// modeled set, which the pinned binary must refuse when they are written bare.
+//
+// Without them this run could pass with an empty map, or with a map the binary
+// happens to accept every name in for an unrelated reason. They are what make
+// "this list is a real boundary" a measurement rather than a claim.
+//
+// `timestamp` on SQLite is the sharpest of them: an ordinary type name Ptah
+// models, which that binary does not model for that dialect. It is why the
+// modeled set cannot be derived from Ptah's own vocabulary.
+var unmodeledControls = map[string][]string{
+	platform.SQLite: {
+		"timestamp",
+		"bytea",
+		"inet",
+		"USER_DEFINED",
+	},
+	platform.Postgres: {
+		"hstore",
+		"citext",
+		"ltree",
+		"USER_DEFINED",
+	},
+}
+
+// TestOracleModeledColumnTypesMatchTheBinary re-measures every entry of
+// modeledColumnTypes against the pinned community binary.
+//
+// The asymmetry this guards is recorded on the map itself: a list that is too
+// SHORT costs a needless sql() wrap, which round trips, while a list that is too
+// LONG emits HCL the binary refuses to read at all. So each entry is asserted in
+// the direction that can break drop-in -- written bare, it must be accepted --
+// and the controls are asserted in the other, so an entry silently added without
+// measurement is caught by the run rather than by a user.
+//
+// The probes deliberately do NOT run in parallel, and adding t.Parallel() back
+// would be worse than slow. Every probe of a dialect shares one dev database,
+// and the binary materializes the schema there to resolve a type, so concurrent
+// probes collide inside the server rather than in this process. Measured: with
+// the subtests parallel, 34 of the 57 PostgreSQL rows failed with
+// `pq: duplicate key value violates unique constraint "pg_type_typname_nsp_index"`
+// -- and every one of them would have been reported as "the binary refuses
+// `type = uuid`", a parity finding about a type the binary accepts perfectly
+// well when asked on its own.
+func TestOracleModeledColumnTypesMatchTheBinary(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	for _, dialect := range sortedDialects() {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+
+			modeled := slices.Sorted(maps.Keys(modeledColumnTypes[dialect]))
+			c.Assert(modeled, qt.Not(qt.HasLen), 0,
+				qt.Commentf("a dialect present in the map with no entries would make this run measure nothing"))
+
+			for _, name := range modeled {
+				t.Run("modeled/"+name, func(t *testing.T) {
+					c := qt.New(t)
+
+					out, code := runTypeOracle(c, oracle, devURL, dialect, name)
+					c.Assert(code, qt.Equals, 0,
+						qt.Commentf("the binary refuses `type = %s` on %s, so rendering it bare emits unreadable HCL: %s",
+							name, dialect, out))
+				})
+			}
+
+			for _, name := range unmodeledControls[dialect] {
+				t.Run("control/"+name, func(t *testing.T) {
+					c := qt.New(t)
+
+					_, ok := modeledColumnType(dialect, name)
+					c.Assert(ok, qt.IsFalse,
+						qt.Commentf("%q is a control: it must stay absent from the modeled set", name))
+
+					out, code := runTypeOracle(c, oracle, devURL, dialect, name)
+					c.Assert(code, qt.Not(qt.Equals), 0,
+						qt.Commentf("the binary now accepts `type = %s` on %s; the control has stopped controlling anything: %s",
+							name, dialect, out))
+				})
+			}
+		})
+	}
+}
+
+// TestOracleAcceptsTheWrapItFallsBackTo measures the fallback the renderer
+// reaches for whenever a type is not modeled, which is what makes a short list
+// safe.
+//
+// The second row of each dialect is the one that keeps this honest: wrapping
+// rescues a type the HCL schema does not MODEL, and does nothing for a type the
+// dev database does not HAVE. Recording both stops the sql() call from being
+// read as a universal escape hatch.
+func TestOracleAcceptsTheWrapItFallsBackTo(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	tests := []struct {
+		name     string
+		dialect  string
+		expr     string
+		wantZero bool
+	}{
+		{
+			name:     "sqlite wraps a type it does not model",
+			dialect:  platform.SQLite,
+			expr:     `sql("timestamp")`,
+			wantZero: true,
+		},
+		{
+			name:     "sqlite wrapping a modeled type is still readable",
+			dialect:  platform.SQLite,
+			expr:     `sql("integer")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres wraps the catalog's own multi-word spelling",
+			dialect:  platform.Postgres,
+			expr:     `sql("timestamp with time zone")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres wraps an array, which the catalog reports as a category",
+			dialect:  platform.Postgres,
+			expr:     `sql("character varying(100)[]")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres wrapping a modeled type is still readable",
+			dialect:  platform.Postgres,
+			expr:     `sql("integer")`,
+			wantZero: true,
+		},
+		{
+			// The limit of the fallback: the binary evaluates the body against
+			// the dev database, so a type no engine there has is refused
+			// wrapped exactly as it is bare.
+			name:     "postgres wrapping does not conjure an absent extension type",
+			dialect:  platform.Postgres,
+			expr:     `sql("hstore")`,
+			wantZero: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, test.dialect)
+
+			out, code := runTypeOracle(c, oracle, devURL, test.dialect, test.expr)
+			c.Assert(code == 0, qt.Equals, test.wantZero,
+				qt.Commentf("`type = %s` on %s exited %d: %s", test.expr, test.dialect, code, out))
+		})
+	}
+}
+
+// sortedDialects returns the dialects under measurement in a stable order, so a
+// failing subtest names the same thing on every run.
+func sortedDialects() []string {
+	return slices.Sorted(maps.Keys(modeledColumnTypes))
+}
+
+func requireTypeOracle(t *testing.T) string {
+	t.Helper()
+
+	oracle := os.Getenv(oracleEnv)
+	if oracle == "" {
+		t.Skipf("SKIPPED: set %s to the pinned Atlas CE binary (%s) to run the column-type conformance run",
+			oracleEnv, oracleVersion)
+	}
+
+	out, err := exec.Command(oracle, "version").Output() //nolint:gosec // the oracle path is operator-provided via PTAH_ATLAS_ORACLE
+	if err != nil {
+		t.Fatalf("%s=%s is not runnable: %v", oracleEnv, oracle, err)
+	}
+	got, _, _ := strings.Cut(string(out), "\n")
+	if strings.TrimSpace(got) != oracleVersion {
+		t.Fatalf("%s=%s reports %q, want %q; a different build may model a different set of types",
+			oracleEnv, oracle, strings.TrimSpace(got), oracleVersion)
+	}
+	return oracle
+}
+
+// requireDevURL returns the dev database URL for a dialect, skipping when a
+// dialect that needs a server was not given one.
+//
+// The skip is deliberately loud, and the Atlas CE Oracle job fails on any
+// SKIPPED line: a dialect measured against nothing is the failure mode this run
+// exists to prevent, not an acceptable partial result.
+func requireDevURL(t *testing.T, dialect string) string {
+	t.Helper()
+
+	if url, ok := defaultDevURLByDialect[dialect]; ok {
+		return url
+	}
+	env, ok := devURLEnvByDialect[dialect]
+	if !ok {
+		t.Fatalf("dialect %q is in the modeled map with no dev URL source; add one before adding the dialect", dialect)
+	}
+	url := os.Getenv(env)
+	if url == "" {
+		t.Skipf("SKIPPED: set %s to a %s dev database to measure its modeled types", env, dialect)
+	}
+	return url
+}
+
+// typeOracleWarmup absorbs a once-per-environment notice before the first
+// measurement.
+//
+// The binary prints an edition notice on its first `schema inspect` in a fresh
+// environment and on that run only. Nothing here compares output text, so the
+// notice cannot corrupt a verdict -- but it is spent on a throwaway anyway, so
+// the first subtest is not the one paying for it in an otherwise parallel run.
+var typeOracleWarmup sync.Once
+
+func runTypeOracle(c *qt.C, oracle, devURL, dialect, typeExpression string) (string, int) {
+	c.Helper()
+
+	schema := schemaNameByDialect[dialect]
+	c.Assert(schema, qt.Not(qt.Equals), "",
+		qt.Commentf("dialect %q has no schema name; add one before adding the dialect", dialect))
+
+	source := fmt.Sprintf(`schema %q {
+}
+table "probe" {
+  schema = schema.%s
+  column "c" {
+    type = %s
+  }
+}
+`, schema, schema, typeExpression)
+
+	typeOracleWarmup.Do(func() {
+		path := filepath.Join(c.TempDir(), "warmup.hcl")
+		//nolint:errcheck // this run exists only to spend the notice
+		_ = os.WriteFile(path, []byte(source), 0o600)
+		//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+		cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", devURL)
+		//nolint:errcheck // output and status are both discarded
+		_, _ = cmd.CombinedOutput()
+	})
+
+	path := filepath.Join(c.TempDir(), "probe.hcl")
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+
+	//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+	cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", devURL)
+	// The error is the exit status, which is the measurement; a process that
+	// never started leaves ProcessState nil and fails the assertion instead.
+	out, _ := cmd.CombinedOutput() //nolint:errcheck // exit status is read from ProcessState below
+	c.Assert(cmd.ProcessState, qt.IsNotNil, qt.Commentf("the oracle did not run: %s", out))
+	return string(out), cmd.ProcessState.ExitCode()
+}

--- a/internal/atlashclrender/modeled_types_test.go
+++ b/internal/atlashclrender/modeled_types_test.go
@@ -1,0 +1,162 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderForDialectWritesTypesTheBinaryCanRead pins how an INSPECTED column
+// type reaches HCL (stokaro/ptah#1138).
+//
+// A type that came out of a database carries no record of how it was written,
+// so the dialect's modeled set decides. The pinned Atlas community binary
+// v1.3.0 accepts a modeled name written bare and refuses every other spelling
+// of an unmodeled one -- both the bare identifier and the quoted string -- so
+// the only two outputs that read back are the ones asserted here.
+//
+// The case rows carry the weight. Ptah's SQLite reader upper-cases every type
+// it reads and its PostgreSQL reader reports NUMERIC(10,2) and VARCHAR(100), so
+// before this every ordinary inspected column produced HCL that binary refused.
+// An upper-case sized type is the worse of the two: it parses as a CALL, and the
+// binary complains about a missing function rather than a missing type.
+func TestRenderForDialectWritesTypesTheBinaryCanRead(t *testing.T) {
+	tests := []struct {
+		name       string
+		dialect    string
+		columnType string
+		want       string
+	}{
+		{
+			name:       "a modeled name goes out bare",
+			dialect:    platform.SQLite,
+			columnType: "integer",
+			want:       "    type = integer\n",
+		},
+		{
+			name:       "a modeled name the reader upper-cased is lowered",
+			dialect:    platform.SQLite,
+			columnType: "INTEGER",
+			want:       "    type = integer\n",
+		},
+		{
+			name:       "a size survives the lowering",
+			dialect:    platform.SQLite,
+			columnType: "VARCHAR(100)",
+			want:       "    type = varchar(100)\n",
+		},
+		{
+			name:       "a type SQLite's schema does not model is wrapped",
+			dialect:    platform.SQLite,
+			columnType: "TIMESTAMP",
+			want:       `    type = sql("TIMESTAMP")` + "\n",
+		},
+		{
+			name:       "PostgreSQL lowers a sized type that would otherwise parse as a call",
+			dialect:    platform.Postgres,
+			columnType: "NUMERIC(10,2)",
+			want:       "    type = numeric(10,2)\n",
+		},
+		{
+			name:       "PostgreSQL wraps the catalog's multi-word spelling",
+			dialect:    platform.Postgres,
+			columnType: "timestamp with time zone",
+			want:       `    type = sql("timestamp with time zone")` + "\n",
+		},
+		{
+			name:       "PostgreSQL wraps an array",
+			dialect:    platform.Postgres,
+			columnType: "character varying(100)[]",
+			want:       `    type = sql("character varying(100)[]")` + "\n",
+		},
+		{
+			name:       "an alias of the dialect name resolves to the same set",
+			dialect:    "pgx",
+			columnType: "NUMERIC(10,2)",
+			want:       "    type = numeric(10,2)\n",
+		},
+		{
+			// A dialect with no measured set keeps whatever the IR holds, which
+			// is what every caller had before this and what the parse-and-
+			// re-render callers still want.
+			name:       "an unmeasured dialect is left alone",
+			dialect:    platform.ClickHouse,
+			columnType: "Int64",
+			want:       "    type = Int64\n",
+		},
+		{
+			name:       "no dialect is left alone too",
+			dialect:    "",
+			columnType: "INTEGER",
+			want:       "    type = INTEGER\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderForDialect(inspectedColumn(test.columnType), test.dialect)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+		})
+	}
+}
+
+// TestRenderForDialectKeepsAnAuthoredSQLCall pins that the modeled set never
+// overrules what the schema author wrote.
+//
+// When the IR came from HCL the parser already recorded the sql() call, and
+// re-deciding it from the type name would second-guess the author: `integer` is
+// modeled, so a set-driven render would unwrap sql("integer") into a bare name
+// and change a file the author controls.
+func TestRenderForDialectKeepsAnAuthoredSQLCall(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "on a dialect with a measured set", dialect: platform.Postgres},
+		{name: "on a dialect without one", dialect: platform.ClickHouse},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedColumn("integer")
+			db.Fields[0].TypeRawSQL = true
+
+			result, err := atlashclrender.RenderForDialect(db, test.dialect)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, `    type = sql("integer")`+"\n")
+		})
+	}
+}
+
+// TestRenderIgnoresTheDialect pins that the plain entry point is unchanged, so
+// every caller that parses HCL and renders it back keeps the behavior it had.
+func TestRenderIgnoresTheDialect(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.Render(inspectedColumn("NUMERIC(10,2)"))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Contains, "    type = NUMERIC(10,2)\n")
+}
+
+// inspectedColumn builds the IR a database read produces for a one-column
+// table: a type with no record of how it was written.
+func inspectedColumn(columnType string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "Probe", Name: "probe"}},
+		Fields: []goschema.Field{{StructName: "Probe", Name: "c", Type: columnType}},
+	}
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -46,13 +46,30 @@ type Result struct {
 }
 
 // Render renders a finalized Ptah schema IR as deterministic HCL schema text.
+//
+// It renders every column type as the IR spells it. Use [RenderForDialect] when
+// the schema came out of a database rather than out of HCL: an inspected type
+// carries no record of how it was written, and some of them have to be written
+// as a sql() call to be readable at all.
 func Render(db *goschema.Database) (Result, error) {
+	return RenderForDialect(db, "")
+}
+
+// RenderForDialect renders the IR for a named dialect, writing a column type
+// that dialect's Atlas HCL schema does not model as a sql() call.
+//
+// The dialect matters only for that decision. An empty dialect renders exactly
+// what [Render] renders, which is what the parse-and-re-render callers want:
+// their input was HCL, so the raw-SQL marker the parser set is already right and
+// re-deciding it from the type name would second-guess the author.
+func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
 	if db == nil {
 		return Result{}, fmt.Errorf("schema database is nil")
 	}
 
 	r := renderer{
-		db: db,
+		db:      db,
+		dialect: dialect,
 	}
 	r.render()
 	return Result{
@@ -63,6 +80,7 @@ func Render(db *goschema.Database) (Result, error) {
 
 type renderer struct {
 	db          *goschema.Database
+	dialect     string
 	builder     strings.Builder
 	diagnostics []Diagnostic
 }
@@ -198,7 +216,7 @@ func (r *renderer) renderTable(
 
 func (r *renderer) renderColumn(field goschema.Field) {
 	r.linef(`  column %s {`, quote(field.Name))
-	r.rawAttr(2, "type", columnTypeExpr(field))
+	r.rawAttr(2, "type", columnTypeExpr(field, r.dialect))
 	if field.Nullable {
 		r.rawAttr(2, "null", "true")
 	}
@@ -758,11 +776,24 @@ func parseForeignReference(value string) (string, []string) {
 // `type = USER_DEFINED` with `Unknown column.type; There is no type named
 // "USER_DEFINED"` and accepts `type = sql("USER_DEFINED")`. Measured on that
 // binary, an HCL file it plans must survive a Ptah round trip still planning.
-func columnTypeExpr(field goschema.Field) string {
-	if field.TypeRawSQL && strings.TrimSpace(field.Type) != "" {
+func columnTypeExpr(field goschema.Field, dialect string) string {
+	if strings.TrimSpace(field.Type) == "" {
+		return typeExpr(field.Type)
+	}
+	// The IR remembers the call when the schema came from HCL. When it came
+	// from a database it remembers nothing, so the dialect's own list of
+	// modeled types decides -- see modeled_types.go for why that list is
+	// trustworthy rather than a copied table.
+	if field.TypeRawSQL {
 		return sqlCall(field.Type)
 	}
-	return typeExpr(field.Type)
+	modeled, ok := modeledColumnType(dialect, field.Type)
+	if !ok {
+		// Wrapped verbatim: an engine type Atlas does not model is only
+		// readable as the text the database itself reports.
+		return sqlCall(field.Type)
+	}
+	return typeExpr(modeled)
 }
 
 func typeExpr(value string) string {

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -188,7 +188,7 @@ func (r *SchemaInspectReport) defaultSchemaName() string {
 }
 
 func (r *SchemaInspectReport) MarshalHCL() (string, error) {
-	rendered, err := atlashclrender.Render(r.db)
+	rendered, err := atlashclrender.RenderForDialect(r.db, r.info.Dialect)
 	if err != nil {
 		return "", fmt.Errorf("render HCL schema: %w", err)
 	}


### PR DESCRIPTION
Closes part of #1138.

## What was wrong

A column type that came out of a database carries no record of how it was written. Ptah rendered it as the IR spelled it, and the pinned Atlas community binary v1.3.0 refuses almost every spelling that produces.

Measured against that binary, feeding it a column written each way:

| written as | verdict |
| --- | --- |
| `type = integer` | accepted |
| `type = INTEGER` | refused — `There is no type named "INTEGER"` |
| `type = NUMERIC(10,2)` | refused — `There is no function named "NUMERIC"` |
| `type = "timestamp with time zone"` | refused — `schemahcl: failed reading spec` |
| `type = sql("timestamp with time zone")` | accepted |

Its type names are case sensitive, and both readers upper-case: the SQLite reader upper-cases everything it reads, and the PostgreSQL reader reports `NUMERIC(10,2)` and `VARCHAR(100)` for an ordinary table. So this was never confined to the user-defined column the conformance fixture happened to compare — **every ordinary inspected column** produced HCL that binary could not read. The sized upper-case form is the worse of the two, because it parses as a *call* and the complaint names a missing function rather than a missing type.

## What this changes

`RenderForDialect` consults a per-dialect set of the type names the HCL schema models. A modeled name goes out bare and lower-cased, carrying its size argument; anything else goes out as a `sql()` call, verbatim. An authored `sql()` call is never second-guessed, and a dialect with no measured set is left exactly as it was.

## Measured end to end

A nine-column table on a live PostgreSQL 17, inspected by `ptah-compat`, then handed back to the pinned binary:

- before: `rc=1`, `There is no function named "NUMERIC"` at the second column
- after: `rc=1`, and the first refusal has moved off the types entirely

Every column type in that file now reads back. What is left are two defects that are not about types:

1. Ptah renders `permission { to = PUBLIC ... }`; the binary answers `There is no variable named "PUBLIC"`.
2. Ptah omits the `schema "public" { }` block and the table's `schema = schema.public`; the binary answers `cannot extract schema name for table "t"`.

Removing both by hand takes the same file to `rc=0`. They are filed separately and this PR does not claim to close them. The `extension "plpgsql"` block was checked and is **not** a blocker.

## Why the set is trustworthy

This repository refused to carry a hand-copied type table before, and `internal/atlashcl/sqlrawexpr.go` records why: "a wrong row in that table breaks drop-in silently". Two things answer that.

**The failure is asymmetric**, so a set that is too short is safe and one that is too long is not — wrapping a type that did not need it yields `sql("integer")`, which round trips. That is measured, not assumed: all 57 PostgreSQL names accepted bare were re-fed wrapped, and all 57 were accepted, with no counterexample.

**The set is re-measured, not trusted.** `TestOracleModeledColumnTypesMatchTheBinary` feeds every entry to the pinned binary, and asserts unmodeled controls are still *refused* — so the run can fail in both directions. The Atlas CE Oracle job gains a PostgreSQL service, because the binary resolves a type by materializing it in the dev database; without a server the run could not tell a type it does not model from a type the engine does not have. The job fails on any `SKIPPED` line, so a missing server cannot make it green.

## What wrapping does not do

`sql()` rescues a type the HCL schema does not **model**, not one the **engine** does not have. On PostgreSQL, `sql("hstore")`, `sql("citext")`, `sql("USER-DEFINED")` and `sql("ARRAY")` are all refused, exactly as their bare spellings are. That limit is pinned by a test row rather than left to be rediscovered.

## Mutation-checked

- a bogus name added to the modeled set → oracle run red on that row
- the lower-casing removed → unit run red

Both were reverted and the tree re-verified clean before committing.

## Gates

`go build` · `go vet` · `go test ./... -count=1` · `qtlint` · `golangci-lint` (0 issues) · `check-test-style` · `check-public-api` · `check-public-api-snapshot` — all exit 0. The oracle run: 93 subtests, 0 failures, 0 skips, against the pinned binary and a live PostgreSQL 17.
