### PR TITLE
Address converted Flyway migrations by their source version on migrate set

### DIFF
--- a/cmd/atlas/migrate_apply_foreign_flyway.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway.go
@@ -262,6 +262,18 @@ func foreignFlywaySetRoute(
 		}
 	}
 	unrun := foreignFlywayUnrunBelowHead(head, covered, stale, applied)
+	// The operand is the SOURCE version token, because that is what `migrate
+	// set` takes on a converted Flyway directory since stokaro/ptah#1206 — the
+	// ordering key printed in the table above is no longer an accepted
+	// spelling, on this build or on the community binary. A refusal that prints
+	// a command the same binary then rejects is worse than no route at all, and
+	// the tests below run what this prints rather than only matching it.
+	//
+	// The head always has a token: it is the largest `current` among the stale
+	// revisions, and a revision only becomes stale when its token parses as an
+	// int64, so the empty-token fallback is unreachable rather than a silent
+	// blank operand.
+	operand := foreignFlywaySetOperand(head, covered)
 	if len(removed) == 0 && len(unrun) == 0 {
 		// The count of listed migrations is deliberately NOT reported as the
 		// size of what `migrate set` writes: a database that recorded some of
@@ -269,17 +281,18 @@ func foreignFlywaySetRoute(
 		// source tool's has more rows landing in than the refusal listed, and
 		// both kinds have run. What every one of them has in common is having
 		// executed, and that is what the sentence claims.
-		return fmt.Sprintf("  - adopt the versions this build uses: `migrate set %d`, with the same --dir "+
-			"and --url, records every migration up to and including that version as applied under those "+
-			"versions. On this database every migration it would record has already run here, so nothing "+
+		return fmt.Sprintf("  - adopt the versions this build uses: `migrate set %s`, with the same --dir "+
+			"and --url, names the migration by the source version token its file carries and records "+
+			"every migration up to and including it as applied under the versions this build uses. On "+
+			"this database every migration it would record has already run here, so nothing "+
 			"is recorded that did not execute. It is a one-way switch: the revision table then carries "+
 			"both spellings, and the implementation that wrote it refuses a migration added afterwards "+
-			"as out of order.\n", head)
+			"as out of order.\n", operand)
 	}
 
 	var b strings.Builder
-	fmt.Fprintf(&b, "\nadopting the versions this build uses has no safe route here: `migrate set %d` would "+
-		"move the database to exactly that version, and on this database that is not a no-op:\n", head)
+	fmt.Fprintf(&b, "\nadopting the versions this build uses has no safe route here: `migrate set %s` would "+
+		"move the database to exactly that version, and on this database that is not a no-op:\n", operand)
 	if len(unrun) > 0 {
 		labels := make([]string, 0, len(unrun))
 		for _, migration := range unrun {
@@ -298,6 +311,24 @@ func foreignFlywaySetRoute(
 			"really ran\n", strings.Join(labels, ", "))
 	}
 	return b.String()
+}
+
+// foreignFlywaySetOperand spells the head the way `migrate set` takes it: the
+// source version token of the covered migration that converts to it.
+//
+// The decimal fallback is for a head no covered migration produces, which the
+// caller cannot reach — see the comment at the call site — and exists so a
+// future caller cannot get an empty operand printed into a command.
+func foreignFlywaySetOperand(
+	head int64,
+	covered []atlasmigrateimport.FlywayCoveredSourceVersion,
+) string {
+	for _, migration := range covered {
+		if migration.Version == head && migration.Token != "" {
+			return migration.Token
+		}
+	}
+	return strconv.FormatInt(head, 10)
 }
 
 // foreignFlywayUnrunBelowHead reports the covered migrations `migrate set head`

--- a/cmd/atlas/migrate_apply_foreign_flyway_test.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway_test.go
@@ -175,6 +175,18 @@ func TestCompatMigrateApply_ForeignFlywayDryRunRefused(t *testing.T) {
 // a change to what is printed and a change to what works cannot drift apart.
 var migrateSetVersion = regexp.MustCompile("`migrate set ([0-9]+)`")
 
+// foreignFlywaySetOperandV2 is the operand the route prints for a database
+// whose head is V2__*.sql: the SOURCE version token, not the ordering key it
+// converts to.
+//
+// Since stokaro/ptah#1206 `migrate set` on a converted Flyway directory takes
+// the token, and the ordering key — measured on the pinned community binary
+// v1.3.0 — is a spelling that binary has always refused. Pinning the two values
+// apart is what makes this an assertion rather than a restatement: before the
+// change the route printed foreignFlywayV2 and running it worked; after it,
+// printing foreignFlywayV2 would still match the regexp and then fail to run.
+const foreignFlywaySetOperandV2 = "2"
+
 // TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery runs the
 // route the refusal prints, verbatim, and then applies again.
 //
@@ -209,7 +221,7 @@ func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing
 	message := errorText(err) + stderr
 	match := migrateSetVersion.FindStringSubmatch(message)
 	c.Assert(match, qt.HasLen, 2)
-	c.Assert(match[1], qt.Equals, foreignFlywayV2)
+	c.Assert(match[1], qt.Equals, foreignFlywaySetOperandV2)
 	// The version alone does not say the route was OFFERED: the withdrawal
 	// names the same command while telling the reader not to run it. Both
 	// wordings have to be pinned or one can silently become the other.
@@ -334,7 +346,7 @@ func TestCompatMigrateApply_ForeignFlywaySetRouteOfferedWithPendingAboveTheHead(
 
 	match := migrateSetVersion.FindStringSubmatch(message)
 	c.Assert(match, qt.HasLen, 2)
-	c.Assert(match[1], qt.Equals, foreignFlywayV2)
+	c.Assert(match[1], qt.Equals, foreignFlywaySetOperandV2)
 	stdout, stderr, err = runCompat(
 		"migrate", "set", match[1],
 		"--url", "sqlite://"+dbPath,

--- a/cmd/atlas/migrate_dir_source.go
+++ b/cmd/atlas/migrate_dir_source.go
@@ -134,6 +134,25 @@ func (c atlasDirCapture) coveredNames() ([]string, error) {
 	return atlasmigrateimport.SumFileNames(c.gateFS(), c.format)
 }
 
+// versionTokens returns the two-way dictionary between the versions an operator
+// can name and the versions this build executes, for a directory whose layout
+// has a version space of its own. It is empty for every layout but Flyway.
+//
+// It reads the GATE filesystem, which for a foreign layout is the same
+// immutable snapshot [atlasDirCapture.migrationFS] converts, so a token can
+// never belong to a different read of the directory than the migration it
+// names.
+//
+// Call it only after the gate has passed, for the same reason migrationFS says
+// so: it interprets the source layout.
+func (c atlasDirCapture) versionTokens() (flywayVersionTokens, error) {
+	covered, err := atlasmigrateimport.FlywayCoveredSourceVersions(c.gateFS(), c.format)
+	if err != nil {
+		return flywayVersionTokens{}, err
+	}
+	return newFlywayVersionTokens(covered), nil
+}
+
 // migrationFS returns the filesystem the verb interprets as Atlas migrations.
 // A foreign layout is rebuilt in memory as up-only Atlas migrations, which is
 // the same conversion `migrate apply` executes -- so the versions a status

--- a/cmd/atlas/migrate_flyway_version_token.go
+++ b/cmd/atlas/migrate_flyway_version_token.go
@@ -1,0 +1,106 @@
+package atlas
+
+import (
+	"strconv"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// flywayVersionTokens is the two-way dictionary between the version an operator
+// can see and the version this build executes, for a directory read through
+// `?format=flyway` / `--dir-format flyway`.
+//
+// WHY IT EXISTS. Atlas CE identifies a Flyway migration by the opaque version
+// STRING between the prefix letter and the `__` separator; Ptah's migrator
+// identifies a migration by an int64, so conversion projects that token onto
+// the band-and-slot ordering key documented above
+// atlasmigrateimport.flywayComponentSlot. The projection is correct at ordering,
+// which is its job. It is wrong as an ADDRESS: `V1.sql` is called `1` by Flyway,
+// `1` by the pinned community binary v1.3.0, and `4611686018427469511` here — a
+// number that appears in no file the operator wrote (stokaro/ptah#1206).
+//
+// Measured on the pinned community binary v1.3.0, the token is matched BYTE FOR
+// BYTE, not numerically. On a directory holding `V01__a.sql` and `V2__b.sql`:
+//
+//	migrate set 01   -> exit 0, "Current version is 01 (1 set)", row 01|a
+//	migrate set 1    -> exit 1, migration with version "1" not found
+//	migrate set 002  -> exit 1, migration with version "002" not found
+//	migrate set 2    -> exit 0, "Current version is 2 (2 set)", rows 01|a and 2|b
+//
+// So the lookup below is a plain string key rather than anything that
+// normalizes, and `1` deliberately fails to reach `V01__a.sql`.
+//
+// It is empty for every layout other than Flyway. The single layout gate lives
+// inside [atlasmigrateimport.FlywayCoveredSourceVersions], which reports nothing
+// for the others, so the plain-numeric-prefix layouts (golang-migrate, goose,
+// dbmate, liquibase) keep resolving and rendering exactly as before — their
+// token IS the int64 they convert to, so routing them through here would be the
+// identity function anyway, and two independent gates for one rule is a rule no
+// test can hold.
+type flywayVersionTokens struct {
+	// byToken resolves an operator's version token to the version this build
+	// executes and records it under.
+	byToken map[string]int64
+	// byVersion renders an executed version back as the operator's token.
+	byVersion map[int64]string
+}
+
+// newFlywayVersionTokens indexes the covered migrations of a converted Flyway
+// directory. It returns the zero value for every other layout, which behaves as
+// "no translation" throughout.
+//
+// Duplicate tokens cannot reach the index. A directory carrying two files with
+// the same Atlas version is refused by rejectDuplicateFlywayVersions while the
+// directory is converted, which every caller of this does before it resolves an
+// operand, so the last-write-wins in the map below is unreachable rather than a
+// silent choice between two files.
+//
+// A repeatable's token is the empty string — Atlas CE gives `R__a.sql`,
+// `R1__a.sql` and `Rfoo.sql` all the version "" — and an empty key is skipped in
+// byToken so no operand can resolve to it. It is still carried in byVersion,
+// because "" is genuinely what that migration is called.
+func newFlywayVersionTokens(covered []atlasmigrateimport.FlywayCoveredSourceVersion) flywayVersionTokens {
+	if len(covered) == 0 {
+		return flywayVersionTokens{}
+	}
+	tokens := flywayVersionTokens{
+		byToken:   make(map[string]int64, len(covered)),
+		byVersion: make(map[int64]string, len(covered)),
+	}
+	for _, migration := range covered {
+		tokens.byVersion[migration.Version] = migration.Token
+		if migration.Token == "" {
+			continue
+		}
+		tokens.byToken[migration.Token] = migration.Version
+	}
+	return tokens
+}
+
+// translates reports whether this directory has a version space of its own. A
+// native Atlas directory and every plain-numeric-prefix layout do not, and every
+// method below is then the identity.
+func (t flywayVersionTokens) translates() bool {
+	return len(t.byVersion) != 0
+}
+
+// resolve maps an operator's version token to the version this build executes
+// it under. The second result is false when this directory holds no migration
+// by that name, which is the operand-not-found case the caller reports.
+func (t flywayVersionTokens) resolve(token string) (int64, bool) {
+	version, ok := t.byToken[token]
+	return version, ok
+}
+
+// render spells an executed version the way the operator's directory does.
+//
+// A version this directory does not produce falls back to its decimal form
+// rather than to the empty string. That is reachable from a revision table
+// holding rows a baseline squash has retired, and printing nothing there would
+// turn a row an operator can still see in their database into a blank.
+func (t flywayVersionTokens) render(version int64) string {
+	if token, ok := t.byVersion[version]; ok {
+		return token
+	}
+	return strconv.FormatInt(version, 10)
+}

--- a/cmd/atlas/migrate_revision_converted_test.go
+++ b/cmd/atlas/migrate_revision_converted_test.go
@@ -3,12 +3,9 @@ package atlas_test
 import (
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
-
-	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 )
 
 // These tests pin stokaro/ptah#1002 on `ptah-compat migrate status` and
@@ -29,6 +26,10 @@ import (
 const (
 	revisionConvertedFirst  = "V1__first.sql"
 	revisionConvertedSecond = "V2__second.sql"
+	// revisionConvertedFirstToken is the version the FIRST file spells: what
+	// Flyway calls it, what the pinned community binary v1.3.0 calls it, and
+	// since stokaro/ptah#1206 what `migrate set` takes here.
+	revisionConvertedFirstToken = "1"
 )
 
 // writeConvertedFlywayDir writes a two-migration Flyway directory and no
@@ -51,32 +52,6 @@ func hashConvertedFlywayDir(c *qt.C, dir string) {
 	c.Helper()
 	_, stderr, err := runCompatExit("migrate", "hash", "--dir", "file://"+dir+"?format=flyway")
 	c.Assert(err, qt.IsNil, qt.Commentf("hash stderr: %s", stderr))
-}
-
-// convertedFlywayVersions returns the Atlas versions the Flyway directory
-// converts to, in execution order.
-//
-// They are read from the importer rather than written into the test, because
-// they are not the Flyway tokens. Ptah's migrator identifies a migration by an
-// int64 while the community binary identifies a Flyway migration by an opaque
-// string, so the conversion projects one space onto the other and the numbers
-// it produces are large and synthetic. Pinning them literally here would pin
-// that projection, which is not what these tests are about.
-func convertedFlywayVersions(c *qt.C, dir string) []string {
-	c.Helper()
-	loaded, err := atlasmigrateimport.LoadFS(
-		os.DirFS(dir),
-		dir,
-		atlasmigrateimport.FormatFlyway,
-	)
-	c.Assert(err, qt.IsNil)
-	versions := make([]string, 0, len(loaded.Entries))
-	for _, entry := range loaded.Entries {
-		name, _, found := strings.Cut(entry.Name, "_")
-		c.Assert(found, qt.IsTrue, qt.Commentf("converted entry %q carries no version prefix", entry.Name))
-		versions = append(versions, name)
-	}
-	return versions
 }
 
 // revisionDBURL returns a URL for a database file that does not exist yet, so
@@ -188,22 +163,27 @@ func TestCompatMigrateStatus_ConvertedDirRefusesDrift(t *testing.T) {
 // stopped refusing the layout, and recorded a version no converted file
 // carries, would still exit 0 here — and would then report two pending
 // migrations rather than one.
+//
+// The operand is the Flyway version TOKEN since stokaro/ptah#1206. It used to be
+// the int64 ordering key the token converts to, read back out of the importer;
+// that spelling was the only one this build accepted and the only one the
+// pinned community binary v1.3.0 refuses, so it is retired here rather than
+// carried alongside. The convertedFlywayVersions helper this test used to call
+// went with it — nothing else consulted the projection.
 func TestCompatMigrateSet_ConvertedDirWritesConvertedVersion(t *testing.T) {
 	t.Parallel()
 	c := qt.New(t)
 	dir := writeConvertedFlywayDir(c)
 	hashConvertedFlywayDir(c, dir)
-	versions := convertedFlywayVersions(c, dir)
-	c.Assert(versions, qt.HasLen, 2)
 	url := revisionDBURL(c)
 
 	stdout, stderr, err := runCompatExit(
-		"migrate", "set", versions[0],
+		"migrate", "set", revisionConvertedFirstToken,
 		"--dir", "file://"+dir+"?format=flyway",
 		"--url", url,
 	)
 	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
-	c.Assert(stdout, qt.Contains, "Current version is "+versions[0])
+	c.Assert(stdout, qt.Contains, "Current version is "+revisionConvertedFirstToken+" (1 set)")
 
 	stdout, stderr, err = runCompatExit(
 		"migrate", "status",

--- a/cmd/atlas/migrate_set.go
+++ b/cmd/atlas/migrate_set.go
@@ -103,6 +103,13 @@ func runAtlasMigrateSet(
 	if err != nil {
 		return failAtlasCommand(cmd, fmt.Errorf("atlas migrate set --dir: %w", err))
 	}
+	// Resolved from the same verified snapshot the conversion above reads, and
+	// after it, so a directory this build refuses to convert never gets as far
+	// as being addressed by token.
+	tokens, err := captured.versionTokens()
+	if err != nil {
+		return failAtlasCommand(cmd, fmt.Errorf("atlas migrate set --dir: %w", err))
+	}
 
 	connectCtx, cancel := dbcli.ConnectContext(cmd.Context(), dbcli.DefaultConnectTimeout)
 	defer cancel()
@@ -118,7 +125,7 @@ func runAtlasMigrateSet(
 	if err := atlasMigrateSetExactArgs(cmd, args); err != nil {
 		return err
 	}
-	version, err := parseAtlasMigrateSetVersion(args[0])
+	version, err := resolveAtlasMigrateSetVersion(tokens, args[0])
 	if err != nil {
 		return failAtlasCommand(cmd, err)
 	}
@@ -131,7 +138,7 @@ func runAtlasMigrateSet(
 	if err != nil {
 		return failAtlasCommand(cmd, err)
 	}
-	if err := writeAtlasMigrateSetResult(cmd, result); err != nil {
+	if err := writeAtlasMigrateSetResult(cmd, tokens, result); err != nil {
 		return failAtlasCommand(cmd, err)
 	}
 	return nil
@@ -229,7 +236,44 @@ func prepareAtlasMigrateSet(
 	return prepared, nil
 }
 
-func parseAtlasMigrateSetVersion(value string) (int64, error) {
+// resolveAtlasMigrateSetVersion turns the positional operand into the version
+// the migrator addresses migrations by.
+//
+// On a directory with a version space of its own — today only a converted
+// Flyway directory — the operand is the SOURCE version token, matched byte for
+// byte, and the ordering key it projects to stops being an accepted spelling.
+// That is the decision stokaro/ptah#1206 asks to be made explicitly rather than
+// left to fall out of the implementation, and both halves of it are measured
+// against the pinned community binary v1.3.0 on `V1.sql` + `V2__ok.sql`:
+//
+//	migrate set 1                    community exit 0    here, before: exit 1
+//	migrate set 4611686018427469511  community exit 1    here, before: exit 0
+//
+// The second row is the reason this is not merely a convenience. Accepting a
+// version the binary being mirrored refuses is the one direction parity never
+// allows, and the ordering key was the ONLY spelling that worked here.
+//
+// The not-found message quotes the operand as typed, which is also measured:
+// the community binary answers `migration with version "abc" not found` and
+// `migration with version "0" not found` on that directory, so a token that is
+// not an int64 and a token that is out of range are the same answer as a token
+// that simply names no file. Ptah reported `--version "abc" is not a valid
+// migration version: strconv.ParseInt ...` and `--version must be greater than
+// zero`, which are diagnostics about int64 parsing on a directory that has no
+// int64 versions to parse.
+//
+// A native Atlas directory, and every plain-numeric-prefix converted layout,
+// keeps the int64 parsing it had: their file names ARE the versions, so there is
+// no second spelling to translate, and the golang-migrate control in
+// stokaro/ptah#1206 stays green by construction.
+func resolveAtlasMigrateSetVersion(tokens flywayVersionTokens, value string) (int64, error) {
+	if tokens.translates() {
+		version, ok := tokens.resolve(value)
+		if !ok {
+			return 0, fmt.Errorf("migration with version %q not found", value)
+		}
+		return version, nil
+	}
 	version, err := atlasmigrate.ParseMigrationVersionFlag("version", value)
 	if err != nil {
 		return 0, err
@@ -240,7 +284,16 @@ func parseAtlasMigrateSetVersion(value string) (int64, error) {
 	return version, nil
 }
 
-func writeAtlasMigrateSetResult(cmd *cobra.Command, result migrator.AtlasRevisionSetResult) error {
+// writeAtlasMigrateSetResult renders the summary in the version spelling the
+// operand was given in, so a directory addressed by its Flyway tokens is
+// reported back in them: `Current version is 1.5 (2 set)` with `+ 1 (a)` and
+// `+ 1.5 (b)`, measured on the pinned community binary v1.3.0. On every other
+// layout render is the decimal form of the version and the output is unchanged.
+func writeAtlasMigrateSetResult(
+	cmd *cobra.Command,
+	tokens flywayVersionTokens,
+	result migrator.AtlasRevisionSetResult,
+) error {
 	if len(result.Set) == 0 && len(result.Removed) == 0 {
 		return nil
 	}
@@ -255,19 +308,19 @@ func writeAtlasMigrateSetResult(cmd *cobra.Command, result migrator.AtlasRevisio
 	out := cmd.OutOrStdout()
 	if _, err := fmt.Fprintf(
 		out,
-		"Current version is %d (%s):\n\n",
-		result.CurrentVersion,
+		"Current version is %s (%s):\n\n",
+		tokens.render(result.CurrentVersion),
 		strings.Join(changes, ", "),
 	); err != nil {
 		return fmt.Errorf("write migrate set summary: %w", err)
 	}
 	for _, revision := range result.Set {
-		if err := writeAtlasMigrateSetRevision(out, "+", revision); err != nil {
+		if err := writeAtlasMigrateSetRevision(out, tokens, "+", revision); err != nil {
 			return err
 		}
 	}
 	for _, revision := range result.Removed {
-		if err := writeAtlasMigrateSetRevision(out, "-", revision); err != nil {
+		if err := writeAtlasMigrateSetRevision(out, tokens, "-", revision); err != nil {
 			return err
 		}
 	}
@@ -279,16 +332,18 @@ func writeAtlasMigrateSetResult(cmd *cobra.Command, result migrator.AtlasRevisio
 
 func writeAtlasMigrateSetRevision(
 	out io.Writer,
+	tokens flywayVersionTokens,
 	action string,
 	revision migrator.AtlasRevisionChange,
 ) error {
+	version := tokens.render(revision.Version)
 	if revision.Description == "" {
-		if _, err := fmt.Fprintf(out, "  %s %d\n", action, revision.Version); err != nil {
+		if _, err := fmt.Fprintf(out, "  %s %s\n", action, version); err != nil {
 			return fmt.Errorf("write migrate set revision: %w", err)
 		}
 		return nil
 	}
-	if _, err := fmt.Fprintf(out, "  %s %d (%s)\n", action, revision.Version, revision.Description); err != nil {
+	if _, err := fmt.Fprintf(out, "  %s %s (%s)\n", action, version, revision.Description); err != nil {
 		return fmt.Errorf("write migrate set revision: %w", err)
 	}
 	return nil

--- a/cmd/atlas/migrate_set_flyway_version_test.go
+++ b/cmd/atlas/migrate_set_flyway_version_test.go
@@ -1,0 +1,289 @@
+package atlas_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+	_ "modernc.org/sqlite"
+)
+
+// These tests pin stokaro/ptah#1206 on `ptah-compat migrate set`: a migration
+// converted from a Flyway directory is addressed by the version its own file
+// spells, not by the int64 ordering key the conversion projects that version
+// onto.
+//
+// Every expectation below is a measurement against the pinned community binary
+// v1.3.0 at ptah-atlas-conformance/bin/atlas, run by absolute path on the same
+// fixtures, each invocation unpiped with its own exit code read on the next
+// line. Before this change:
+//
+//	migrate set 1                    community exit 0    ptah exit 1
+//	migrate set 1.5                  community exit 0    ptah exit 1
+//	migrate set 01                   community exit 0    ptah exit 1
+//	migrate set 4611686018427469511  community exit 1    ptah exit 0
+//
+// The last row is the one that made this a parity violation rather than an
+// inconvenience: ptah-compat exited 0 where the binary it stands in for exits
+// 1, on the only spelling that worked here.
+
+// setFlywayMigration is one file in a Flyway fixture.
+type setFlywayMigration struct {
+	name string
+	body string
+}
+
+// setFlywayRow is one revision row, as the version and description columns
+// spell it.
+type setFlywayRow struct {
+	// Exported so quicktest's DeepEquals can compare rows; cmp refuses
+	// unexported fields.
+	Version     string
+	Description string
+}
+
+// writeHashedFlywayDir writes a Flyway directory and the atlas.sum that layout
+// covers, through the shipped `migrate hash` so the gate these tests pass is
+// the one a user's directory passes.
+func writeHashedFlywayDir(c *qt.C, migrations []setFlywayMigration) string {
+	c.Helper()
+	dir := filepath.Join(c.TempDir(), "migrations")
+	for _, migration := range migrations {
+		writeAtlasApplyProjectMigration(c, dir, migration.name, migration.body)
+	}
+	hashConvertedApplyDir(c, dir, "flyway")
+	return dir
+}
+
+// revisionRows reads the version and description columns in recorded order.
+//
+// It tolerates a database with no revision table, which is the state a refused
+// `migrate set` leaves behind: the refusal precedes the write, but the
+// connection has already created the file. The absence is established by
+// reading sqlite_master rather than by swallowing a query error, so a table
+// that exists and cannot be read still fails the test instead of reporting
+// "nothing was recorded".
+func revisionRows(c *qt.C, dbPath string) []setFlywayRow {
+	c.Helper()
+	if _, err := os.Stat(dbPath); err != nil {
+		return nil
+	}
+	db, err := sql.Open("sqlite", dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	if !revisionTableExists(c, db) {
+		return nil
+	}
+	rows, err := db.Query(`SELECT version, description FROM atlas_schema_revisions ORDER BY rowid`)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Check(rows.Close(), qt.IsNil) }()
+	var out []setFlywayRow
+	for rows.Next() {
+		var row setFlywayRow
+		c.Assert(rows.Scan(&row.Version, &row.Description), qt.IsNil)
+		out = append(out, row)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return out
+}
+
+func revisionTableExists(c *qt.C, db *sql.DB) bool {
+	c.Helper()
+	var count int
+	c.Assert(db.QueryRow(
+		`SELECT count(*) FROM sqlite_master WHERE type = 'table' AND name = 'atlas_schema_revisions'`,
+	).Scan(&count), qt.IsNil)
+	return count == 1
+}
+
+// Fixtures. Each is one of the three token shapes stokaro/ptah#1206 measures,
+// because the projection collapses each of them differently: a plain token is
+// the only one that even looks like an int64, a dotted token cannot be parsed
+// as one at all, and a zero-padded token parses to a DIFFERENT string than the
+// one the community binary records.
+var (
+	setFlywayPlain = []setFlywayMigration{
+		{name: "V1.sql", body: "CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"},
+		{name: "V2__ok.sql", body: "CREATE TABLE gadgets (id INTEGER PRIMARY KEY);\n"},
+	}
+	setFlywayDotted = []setFlywayMigration{
+		{name: "V1__a.sql", body: "CREATE TABLE a (id INTEGER PRIMARY KEY);\n"},
+		{name: "V1.5__b.sql", body: "CREATE TABLE b (id INTEGER PRIMARY KEY);\n"},
+		{name: "V2__c.sql", body: "CREATE TABLE c (id INTEGER PRIMARY KEY);\n"},
+	}
+	setFlywayZeroPadded = []setFlywayMigration{
+		{name: "V01__a.sql", body: "CREATE TABLE a (id INTEGER PRIMARY KEY);\n"},
+		{name: "V2__b.sql", body: "CREATE TABLE b (id INTEGER PRIMARY KEY);\n"},
+	}
+)
+
+// TestCompatMigrateSet_ConvertedFlywayTakesTheSourceToken is the discriminator.
+//
+// Reverting resolveAtlasMigrateSetVersion to the int64 parsing it had turns
+// every accepted row here into `Error: migration with version "1" not found`
+// (or, on the dotted fixture, `--version "1.5" is not a valid migration
+// version: strconv.ParseInt: parsing "1.5": invalid syntax`), and turns the
+// ordering-key row from a refusal back into a success.
+func TestCompatMigrateSet_ConvertedFlywayTakesTheSourceToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name       string
+		migrations []setFlywayMigration
+		operand    string
+		wantStdout string
+		wantErr    string
+		wantRows   []setFlywayRow
+	}{
+		{
+			name:       "plain token reaches the first migration",
+			migrations: setFlywayPlain,
+			operand:    "1",
+			wantStdout: "Current version is 1 (1 set):\n\n  + 1\n\n",
+			wantRows:   []setFlywayRow{{Description: ""}},
+		},
+		{
+			name:       "plain token reaches the last migration and sets both",
+			migrations: setFlywayPlain,
+			operand:    "2",
+			wantStdout: "Current version is 2 (2 set):\n\n  + 1\n  + 2 (ok)\n\n",
+			wantRows:   []setFlywayRow{{Description: ""}, {Description: "ok"}},
+		},
+		{
+			name:       "dotted token is addressable at all",
+			migrations: setFlywayDotted,
+			operand:    "1.5",
+			wantStdout: "Current version is 1.5 (2 set):\n\n  + 1 (a)\n  + 1.5 (b)\n\n",
+			wantRows:   []setFlywayRow{{Description: "a"}, {Description: "b"}},
+		},
+		{
+			name:       "zero-padded token is matched byte for byte",
+			migrations: setFlywayZeroPadded,
+			operand:    "01",
+			wantStdout: "Current version is 01 (1 set):\n\n  + 01 (a)\n\n",
+			wantRows:   []setFlywayRow{{Description: "a"}},
+		},
+		{
+			name:       "a zero-padded token is not reachable by its numeric value",
+			migrations: setFlywayZeroPadded,
+			operand:    "1",
+			wantErr:    `migration with version "1" not found`,
+		},
+		{
+			name:       "a plain token is not reachable by a zero-padded spelling",
+			migrations: setFlywayPlain,
+			operand:    "01",
+			wantErr:    `migration with version "01" not found`,
+		},
+		{
+			name:       "a dotted token is not reachable with the separator dropped",
+			migrations: setFlywayDotted,
+			operand:    "15",
+			wantErr:    `migration with version "15" not found`,
+		},
+		{
+			// The parity violation. This spelling exited 0 here and exits 1 on
+			// the community binary, which is the one direction that is never
+			// allowed.
+			name:       "the ordering key is no longer an accepted spelling",
+			migrations: setFlywayPlain,
+			operand:    "4611686018427469511",
+			wantErr:    `migration with version "4611686018427469511" not found`,
+		},
+		{
+			// Ptah answered `--version must be greater than zero` and
+			// `--version "abc" is not a valid migration version: ...`, both
+			// diagnostics about int64 parsing on a directory whose versions are
+			// not int64s.
+			name:       "zero is a token this directory does not carry",
+			migrations: setFlywayPlain,
+			operand:    "0",
+			wantErr:    `migration with version "0" not found`,
+		},
+		{
+			name:       "a non-numeric operand is a token like any other",
+			migrations: setFlywayPlain,
+			operand:    "abc",
+			wantErr:    `migration with version "abc" not found`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+			dir := writeHashedFlywayDir(c, test.migrations)
+			dbPath := filepath.Join(filepath.Dir(dir), "set.db")
+
+			stdout, stderr, err := runCompatExit(
+				"migrate", "set", test.operand,
+				"--dir", "file://"+dir+"?format=flyway",
+				"--url", "sqlite://"+dbPath,
+			)
+
+			c.Assert(errorText(err), qt.Equals, test.wantErr)
+			c.Assert(stdout, qt.Equals, test.wantStdout)
+			c.Assert(stderr, qt.Equals, errorLine(test.wantErr))
+			// The descriptions are asserted here rather than the versions: the
+			// version column still holds the ordering key, which is the half of
+			// stokaro/ptah#1206 this change does not settle. Row COUNT and
+			// description are what say which migrations were recorded.
+			c.Assert(revisionDescriptions(revisionRows(c, dbPath)), qt.DeepEquals,
+				revisionDescriptions(test.wantRows))
+		})
+	}
+}
+
+// TestCompatMigrateSet_PlainPrefixLayoutsAreUnchanged is the control that
+// separates "converted directories are addressed by token" (false) from "the
+// Flyway projection is addressed by token" (true).
+//
+// golang-migrate, goose, dbmate and liquibase carry a plain numeric prefix, so
+// their token IS the int64 they convert to and the projection is the identity
+// on them. The single layout gate lives inside
+// atlasmigrateimport.FlywayCoveredSourceVersions, so routing a plain-prefix
+// layout through the token path would show up here as a changed diagnostic.
+//
+// Measured on the community binary v1.3.0 on the same directory: `migrate set
+// 1` exits 0 with `Current version is 1 (1 set):` and `+ 1 (init)`, and the
+// revision row is `1|init` on both binaries.
+func TestCompatMigrateSet_PlainPrefixLayoutsAreUnchanged(t *testing.T) {
+	t.Parallel()
+	c := qt.New(t)
+	dir := filepath.Join(c.TempDir(), "migrations")
+	writeAtlasApplyProjectMigration(c, dir, "1_init.up.sql",
+		"CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n")
+	writeAtlasApplyProjectMigration(c, dir, "1_init.down.sql", "DROP TABLE widgets;\n")
+	hashConvertedApplyDir(c, dir, "golang-migrate")
+	dbPath := filepath.Join(filepath.Dir(dir), "gm.db")
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "set", "1",
+		"--dir", "file://"+dir+"?format=golang-migrate",
+		"--url", "sqlite://"+dbPath,
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr: %s", stderr))
+	c.Assert(stdout, qt.Equals, "Current version is 1 (1 set):\n\n  + 1 (init)\n\n")
+	c.Assert(revisionRows(c, dbPath), qt.DeepEquals,
+		[]setFlywayRow{{Version: "1", Description: "init"}})
+}
+
+// errorLine renders the stderr a refusal writes, so the expectation is derived
+// from the message rather than repeated beside it.
+func errorLine(message string) string {
+	if message == "" {
+		return ""
+	}
+	return "Error: " + message + "\n"
+}
+
+// revisionDescriptions projects rows onto the column this change settles.
+func revisionDescriptions(rows []setFlywayRow) []string {
+	out := make([]string, 0, len(rows))
+	for _, row := range rows {
+		out = append(out, row.Description)
+	}
+	return out
+}


### PR DESCRIPTION
Refs #1206.

## Reproduced first, end to end, before a line changed

`go build -o <scratch>/bin/ptah-compat ./cmd/ptah-compat` on a clean tree, compared against `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas` (self-reported `atlas community version v1.3.0`), invoked by absolute path. Every command was run unpiped into its own file with `$?` read on the next line, so no exit code belongs to a pipe stage. Fixtures were copied out of `internal/atlasmigrateimport/testdata/ce-sums/flyway/{no-separator,minor-version-ordering,leading-zero}` and `.../golang-migrate/basic`, each with the `atlas.sum` the community binary wrote, so both binaries read through the same integrity gate.

Every cell in the issue reproduces, value for value:

| cell | community v1.3.0 | ptah-compat, before |
| --- | --- | --- |
| `migrate apply` | exit 0, rows `1\|` `2\|ok` | exit 0, rows `4611686018427469511\|` `4611686018427510315\|ok` |
| `migrate set 1` | exit 0, `Current version is 1 (1 set)` | **exit 1**, `migration with version "1" not found`, no revision table |
| `migrate set 4611686018427469511` | **exit 1**, not found | **exit 0**, records it |
| `migrate set 1.5` | exit 0, `+ 1 (a)` `+ 1.5 (b)` | exit 1, `--version "1.5" is not a valid migration version: strconv.ParseInt` |
| `migrate set 01` | exit 0, row `01\|a` verbatim | exit 1, `migration with version "1" not found` |
| `migrate lint --latest 1` | `Analyzing changes from version 1 to 2` | `Analyzing changes from version 4611686018427469511 to 4611686018427510315` |
| `migrate status` | `Current Version: 2` | `Current Version: 4611686018427510315` |
| `migrate import` | `1.sql` `2_ok.sql` | `4611686018427469511.sql` `4611686018427510315_ok.sql` |
| control, golang-migrate `apply` and `set 1` | exit 0, `1\|init` | exit 0, `1\|init` — identical |

## What this changes

**`migrate set` on a converted Flyway directory takes the SOURCE version token.** The int64 ordering key `internal/atlasmigrateimport` projects that token onto stops being an accepted spelling.

The third row of the table above is why this is the part that had to move first. `migrate set 4611686018427469511` exited 0 here and exits 1 on the binary being mirrored — ptah-compat accepting what that binary refuses is the one direction the parity rule never allows, and it was the *only* spelling that worked. Nothing else in the measured set is in that direction.

Matching is measured, not inferred. The token is compared BYTE FOR BYTE, which the zero-padded fixture is what separates:

```
V01__a.sql, V2__b.sql        community v1.3.0
  migrate set 01   -> exit 0, "Current version is 01 (1 set)", row 01|a
  migrate set 1    -> exit 1, migration with version "1" not found
  migrate set 002  -> exit 1, migration with version "002" not found
  migrate set 2    -> exit 0, "Current version is 2 (2 set)", rows 01|a and 2|b
```

So `1` deliberately fails to reach `V01__a.sql`, and the index is a plain string key with nothing that normalizes.

The `Current version is ...` summary and the `+ N (desc)` lines render the same spelling, so on the fixtures above ptah-compat's stdout is now byte-identical to the community binary's.

The not-found message quotes the operand as typed. Measured: the community binary answers `migration with version "abc" not found` and `migration with version "0" not found` on a Flyway directory, where ptah answered `--version "abc" is not a valid migration version: strconv.ParseInt...` and `--version must be greater than zero` — diagnostics about int64 parsing on a directory that has no int64 versions.

**The #1100 refusal now prints a command that runs.** `foreignFlywaySetRoute` offered `migrate set <ordering key>` as the way forward. After this change that command is refused, so the refusal prints the token. The three tests that *execute* what the refusal prints, rather than only matching it, are what caught this — see the killed mutants below.

## Re-measured after the change

Same harness, same binaries, same fixtures. Every `migrate set` cell matches on exit code AND on stdout:

| operand | fixture | community | ptah-compat, after |
| --- | --- | --- | --- |
| `1` | V1.sql, V2__ok.sql | 0 | 0, stdout identical |
| `2` | V1.sql, V2__ok.sql | 0 | 0, stdout identical |
| `4611686018427469511` | V1.sql, V2__ok.sql | 1 | 1, stderr identical |
| `7` / `0` / `abc` | V1.sql, V2__ok.sql | 1 | 1, stderr identical |
| `1.5` | V1__a, V1.5__b, V2__c | 0 | 0, stdout identical |
| `15` | V1__a, V1.5__b, V2__c | 1 | 1, stderr identical |
| `01` | V01__a, V2__b | 0 | 0, stdout identical |
| `1` | V01__a, V2__b | 1 | 1, stderr identical |
| `2` | V01__a, V2__b | 0 | 0, stdout identical |
| **control** `1` | golang-migrate basic | 0 | 0, stdout identical, row `1\|init` |

The golang-migrate control is what separates "converted directories are addressed by token" (false) from "the Flyway projection is addressed by token" (true). It is pinned as `TestCompatMigrateSet_PlainPrefixLayoutsAreUnchanged` rather than only re-measured by hand. There is exactly one layout gate, inside `atlasmigrateimport.FlywayCoveredSourceVersions`, which reports nothing for the plain-numeric-prefix layouts.

One cell still diverges on message only, and it is untouched and pre-existing: `migrate set abc` on a **golang-migrate** directory. Both exit 1; the community binary says `migration with version "abc" not found` and ptah says `--version "abc" is not a valid migration version`. Fixing that means changing the native Atlas directory path too, which is not this issue.

## Mutation coverage

Each mutant was applied to the shipped source, the tests run, and the source restored. Nothing was staged while a mutant was in the tree.

1. **`resolve` never consulted** (`if tokens.translates()` → `if false`): 8 of the 10 rows of `TestCompatMigrateSet_ConvertedFlywayTakesTheSourceToken` FAIL, including `the_ordering_key_is_no_longer_an_accepted_spelling` and `dotted_token_is_addressable_at_all`.
2. **numeric normalization instead of a byte-exact match** (fall back to `ParseInt` on both sides of the lookup): exactly the two rows mutant 1 left alive FAIL — `a_zero-padded_token_is_not_reachable_by_its_numeric_value` and `a_plain_token_is_not_reachable_by_a_zero-padded_spelling`. The two mutants partition the table; neither rule is held by the other's rows.
3. **`render` never translates** (return `strconv.FormatInt` unconditionally): the four accepted rows FAIL on stdout, and so does `TestCompatMigrateSet_ConvertedDirWritesConvertedVersion`.
4. **the refusal prints the ordering key again** (`operand := strconv.FormatInt(head, 10)`): `ForeignFlywayRefusalPrintsWorkingRecovery`, `ForeignFlywaySetRouteOfferedWithPendingAboveTheHead` and `ForeignFlywayBaselineOverForeignHistory` FAIL — they run the printed command.

The test-style gate was also proved to be running rather than reporting: adding one `if` to a test body turns `scripts/check-test-style.sh` red with `new test conditional violations: cmd/atlas/migrate_set_flyway_version_test.go`, and removing it turns it green again.

## What this does NOT settle, and why it stops here

**The recorded `atlas_schema_revisions.version` column still holds the ordering key.** After `migrate set 1` the row is `4611686018427469511|`, where the community binary writes `1|`. `migrate apply`, `migrate lint`, `migrate status` and `migrate import` still print and write the key. Re-measured after this change, all of those are exactly as the issue describes them.

Recording the token means making migration identity in `migration/migrator` a string rather than an int64, and that package is public (`docs/public_api.md`). Concretely, the surface that would have to change:

- `Migration.Version int64`, `MigrationFile.Version int64`, `MigrationRevision.Version int64`, `MigrationStatus.CurrentVersion/TargetVersion/Versions`, `AtlasRevisionSetResult.CurrentVersion`, `AtlasRevisionChange.Version` — the identity type itself.
- `Migrator.SetAtlasRevision(ctx, int64)`, `Migrator.SetRevision`, `Migrator.MigrateTo`, `Migrator.Baseline`, `Migrator.GetCurrentVersion`, `Migrator.GetAppliedMigrations`, `CreateMigrationFromSQL`, `NewMigrationFromSQLFiles`, `MigrateUpOptions.TargetVersion`, `Migrator.WithOutOfOrderExempt([]int64)` — every entry point that names a version.

It is not only the Go types. The Atlas revision SQL orders and maxes over `CAST(version AS BIGINT)` (`atlasVersionNumberExpressionFor`), the reader parses the column with `strconv.ParseInt` (`parseAtlasRevisionVersion`), and `getRevisionsAboveSQL` compares `version > ?` in SQL. A `1.5` in that column is a PostgreSQL cast error before it is a Go problem, so the change is to how the migrator orders revisions for *every* Atlas-format user, not only for converted directories.

`cmd/atlas/migrate_apply_foreign_flyway.go` already named this trade in prose — "reproduce its version space (which changes migration identity in the migrator, far past this issue)" — and the front running this work was instructed to stop before a public API change and report the surface. That is what this section is.

Two consequences worth stating plainly rather than leaving to be discovered:

- **The CLI and the column now disagree.** `migrate set 1` prints `1` and writes `4611686018427469511`. That inconsistency is the residue of the half that is left; it did not exist before because the CLI printed the key too. It is strictly better than the previous state — the addressable and printed namespace is now the community binary's on the verb where accepting the key was a parity violation — but it is not the end state.
- **#1180's refusal is unaffected and still shut**, because the column is unchanged. Its printed recovery command now works, which it did not after the operand change until `foreignFlywaySetOperand` landed.

## Gates

All run in this worktree, each exit status read on its own line.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (`175 conditional groups, 45 white-box files`) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |

Nothing under `docs/` was touched, so the docs checks do not apply.

## Not verified

- Only SQLite was used for the revision tables, because that is the driver both binaries take on the same URL and the issue's measurements are on it. No PostgreSQL, MySQL or MariaDB run was made for this change. `migrate set`'s operand resolution is dialect-independent by construction (it happens in `cmd/atlas`, before the migrator sees a version), but that is an argument, not a measurement.
- `migrate apply`, `migrate lint`, `migrate status` and `migrate import` were re-measured to confirm they still print the ordering key. They were not changed and no test was added pinning them to the token.
- No fixture here covers a converted Flyway directory holding a repeatable or a surviving baseline as the `migrate set` operand. A repeatable's token is the empty string, which `newFlywayVersionTokens` deliberately keeps out of the addressable index; that choice is documented but not pinned by a test.
