### PR TITLE
Read migrate diff's directory layout the way every other verb does

### DIFF
--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -14,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
@@ -156,11 +157,25 @@ func runAtlasMigrateDiff(
 	if err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
 	}
-	// Unknown query keys are ignored here exactly as they are on the verbs that
-	// already accept them; a ?format= naming a foreign layout stays refused,
-	// because this verb WRITES and Ptah does not compute that layout's covered
-	// file set (stokaro/ptah#1013 section 1).
-	if err := checkWritingVerbDirQuery(localDir.Query); err != nil {
+	// Both spellings that can name the directory's layout are resolved here,
+	// once, with the `--dir` query outranking `--dir-format`. Unknown query keys
+	// are ignored exactly as they are on the verbs that already accept them, and
+	// a value neither spelling can parse is refused ahead of the atlas.sum gate,
+	// which is where the community binary refuses it. See
+	// [resolveWritingVerbDirFormat] for the measured table.
+	dirFormat, err := resolveWritingVerbDirFormat(opts.dirFormat, localDir.Query)
+	if err != nil {
+		return cmdutil.Fail(cmd, fmt.Errorf(
+			"atlas migrate diff %s: %w",
+			atlasDirFormatSpelling(localDir.Query),
+			err,
+		))
+	}
+	// A foreign layout named by the QUERY stays refused, because this verb
+	// WRITES and Ptah plans no reverse SQL for the layouts that carry one
+	// (stokaro/ptah#1013 section 1). Named by `--dir-format` it is refused too,
+	// but after the gate, in [prepareAtlasMigrateDiffSource].
+	if err := checkWritingVerbDirQuery(dirFormat, localDir.Query); err != nil {
 		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
 	}
 	if err := verifyAtlasWriteDirChecksum(cmd, project, localDir); err != nil {
@@ -182,7 +197,7 @@ func runAtlasMigrateDiff(
 		(len(projectCfg.SchemaSources) > 0 || atlasExternalSchemaConfigured(projectCfg)) {
 		opts.toURLs = []string{"env://src"}
 	}
-	desired, err := prepareAtlasMigrateDiffSource(opts, projectEnv)
+	desired, err := prepareAtlasMigrateDiffSource(opts, dirFormat, projectEnv)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
@@ -316,8 +331,18 @@ func needsAtlasMigrateDiffConfig(cmd *cobra.Command) bool {
 		!cmd.Flags().Changed("dev-url")
 }
 
+// prepareAtlasMigrateDiffSource validates the desired-state flags and the
+// resolved directory layout.
+//
+// dirFormat arrives already resolved from both spellings rather than being
+// re-derived from opts.dirFormat here, so "which layout is this run writing"
+// has one answer. The refusal of a foreign layout stays at this position — after
+// the atlas.sum gate — because that is where the community binary refuses it:
+// measured on the pinned v1.3.0, an unhashed directory with `--dir-format goose`
+// prints the checksum error, not a format complaint.
 func prepareAtlasMigrateDiffSource(
 	opts atlasMigrateDiffOptions,
+	dirFormat atlasmigrateimport.Format,
 	projectEnv atlassource.ProjectEnv,
 ) (atlassource.Set, error) {
 	if len(opts.toURLs) == 0 {
@@ -326,8 +351,7 @@ func prepareAtlasMigrateDiffSource(
 	if strings.TrimSpace(opts.devURL) == "" {
 		return atlassource.Set{}, fmt.Errorf("--dev-url is required")
 	}
-	dirFormat := strings.ToLower(strings.TrimSpace(opts.dirFormat))
-	if dirFormat != "" && dirFormat != string(migrator.MigrationDirFormatAtlas) {
+	if !atlasmigrate.ReadsNativeAtlasDir(dirFormat) {
 		return atlassource.Set{}, fmt.Errorf("atlas migrate diff currently writes Atlas-format migration directories only")
 	}
 	if opts.edit && opts.dryRun {

--- a/cmd/atlas/migrate_diff_dir_format_test.go
+++ b/cmd/atlas/migrate_diff_dir_format_test.go
@@ -1,0 +1,303 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// These tests pin how `atlas migrate diff` reads the two spellings that select
+// a migration directory's layout — the `--dir` URL query and `--dir-format` —
+// against the pinned community binary v1.3.0, measured through
+// ptah-atlas-conformance/bin/atlas on 2026-08-07 (stokaro/ptah#1013).
+//
+// `migrate diff` is the one compat verb that both WRITES into the directory and
+// registers `--dir-format` as its own cobra flag rather than going through
+// resolveAtlasMigrateSource. It carried its own lenient reading of that flag —
+// lowercased and trimmed — while every other verb parsed the value verbatim,
+// and the two divergences below are what that produced.
+
+// compatDiffFixtureDir writes a hashed native Atlas migration directory holding
+// one migration, and returns its path together with a desired-state .sql file
+// that adds a second table.
+//
+// The sum is written with `migrate hash`, so the atlas.sum gate this verb runs
+// before anything else passes and each row below turns on the layout selection
+// rather than on a checksum refusal.
+func compatDiffFixtureDir(c *qt.C) (dir, target string) {
+	c.Helper()
+	dir = filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "20240101000000_init.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir)
+	c.Assert(err, qt.IsNil)
+
+	target = filepath.Join(c.TempDir(), "target.sql")
+	c.Assert(os.WriteFile(
+		target,
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\nCREATE TABLE gadgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	return dir, target
+}
+
+// runCompatDiff runs `migrate diff` against a fresh fixture and reports both the
+// error and whether the directory grew a file.
+//
+// The written half is what makes an exit-code assertion mean something on a
+// verb that mutates: a refusal that still wrote is not a refusal, and an
+// acceptance that wrote nothing is not the acceptance the community binary
+// makes. Every row below asserts both.
+func runCompatDiff(c *qt.C, query string, dirFormat []string) (wrote bool, err error) {
+	c.Helper()
+	dir, target := compatDiffFixtureDir(c)
+	before := len(atlasDirEntryNames(c, dir))
+	args := []string{
+		"migrate", "diff", "dd",
+		"--dir", "file://" + dir + query,
+		"--dev-url", "sqlite://" + filepath.Join(c.TempDir(), "dev.db"),
+		"--to", "file://" + target,
+	}
+	args = append(args, dirFormat...)
+	_, _, err = runCompat(args...)
+	return len(atlasDirEntryNames(c, dir)) > before, err
+}
+
+// TestCompatMigrateDiff_DirFormatValueIsParsedVerbatim closes the forbidden
+// direction on this verb: exit 0 where the community binary exits 1, on the one
+// compat verb that mutates the directory.
+//
+// Only the verbatim value `atlas` selects the native layout on the community
+// binary. `migrate diff` used to lowercase and trim its `--dir-format` first, so
+// three spellings the community binary refuses were coerced into a match and a
+// migration file was written. Measured on the pinned v1.3.0, on the hashed
+// fixture above:
+//
+//	--dir-format ATLAS       CE 1, `unknown dir format "ATLAS"`   ptah 0, WROTE
+//	--dir-format Atlas       CE 1                                 ptah 0, WROTE
+//	--dir-format ' atlas '   CE 1                                 ptah 0, WROTE
+//	--dir-format atlas       CE 0, WROTE                          ptah 0, WROTE
+//
+// The last row is the control, and it is what keeps this from passing for the
+// wrong reason: a `migrate diff` broken for an unrelated reason fails it too,
+// rather than reporting three green refusals.
+func TestCompatMigrateDiff_DirFormatValueIsParsedVerbatim(t *testing.T) {
+	const want = `atlas migrate diff --dir-format: unknown Atlas migration directory format ` +
+		`"[^"]*": expected atlas, golang-migrate, goose, flyway, liquibase, or dbmate`
+
+	tests := []struct {
+		name  string
+		value string
+		// check asserts the outcome for this row. It carries the assertion
+		// because the accepted spelling and the refused ones assert opposite
+		// things about both the error and the directory.
+		check func(c *qt.C, err error, wrote bool)
+	}{
+		{
+			name:  "uppercase",
+			value: "ATLAS",
+			check: refusedWithoutWriting(want),
+		},
+		{
+			name:  "capitalized",
+			value: "Atlas",
+			check: refusedWithoutWriting(want),
+		},
+		{
+			name:  "padded",
+			value: " atlas ",
+			check: refusedWithoutWriting(want),
+		},
+		{
+			// Not an Atlas directory format at all. Ptah's own native
+			// `migrations checkpoint` accepts this spelling; the community
+			// binary answers `unknown dir format "ptah"`, so the compat surface
+			// must too.
+			name:  "native ptah layout",
+			value: "ptah",
+			check: refusedWithoutWriting(want),
+		},
+		{
+			name:  "verbatim atlas",
+			value: "atlas",
+			check: acceptedAndWrote,
+		},
+		{
+			// An empty value selects the native Atlas layout on both binaries.
+			name:  "empty",
+			value: "",
+			check: acceptedAndWrote,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			wrote, err := runCompatDiff(c, "", []string{"--dir-format", tt.value})
+
+			tt.check(c, err, wrote)
+		})
+	}
+}
+
+// TestCompatMigrateDiff_DirQueryFormatOutranksDirFormatFlag pins the precedence
+// the definition of done names: the `?format=` query wins over `--dir-format`.
+//
+// Measured on the pinned community binary v1.3.0, on the hashed fixture above:
+//
+//	?format=atlas  --dir-format golang-migrate   CE 0, WROTE   ptah 1, wrote nothing
+//	?format=       --dir-format golang-migrate   CE 0, WROTE   ptah 1, wrote nothing
+//	?format=atlas  --dir-format goose            CE 0, WROTE   ptah 1, wrote nothing
+//	?nonsense=1    --dir-format golang-migrate   CE 1          ptah 1
+//	(no query)     --dir-format golang-migrate   CE 1          ptah 1
+//
+// The last two rows are the controls, and they are the point. Without them a
+// green result would also be produced by "any query at all disables
+// --dir-format", which is a different and wrong rule: an unrecognized key
+// selects no layout, so the flag still decides and its refusal stands.
+func TestCompatMigrateDiff_DirQueryFormatOutranksDirFormatFlag(t *testing.T) {
+	const refused = `atlas migrate diff currently writes Atlas-format migration directories only`
+
+	tests := []struct {
+		name      string
+		query     string
+		dirFormat string
+		check     func(c *qt.C, err error, wrote bool)
+	}{
+		{
+			name:      "query names atlas over a foreign flag",
+			query:     "?format=atlas",
+			dirFormat: "golang-migrate",
+			check:     acceptedAndWrote,
+		},
+		{
+			name:      "empty query value names atlas over a foreign flag",
+			query:     "?format=",
+			dirFormat: "golang-migrate",
+			check:     acceptedAndWrote,
+		},
+		{
+			name:      "query names atlas over a second foreign flag",
+			query:     "?format=atlas",
+			dirFormat: "goose",
+			check:     acceptedAndWrote,
+		},
+		{
+			name:      "ignored key leaves the flag deciding",
+			query:     "?nonsense=1",
+			dirFormat: "golang-migrate",
+			check:     refusedWithoutWriting(refused),
+		},
+		{
+			name:      "no query leaves the flag deciding",
+			query:     "",
+			dirFormat: "golang-migrate",
+			check:     refusedWithoutWriting(refused),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			wrote, err := runCompatDiff(c, tt.query, []string{"--dir-format", tt.dirFormat})
+
+			tt.check(c, err, wrote)
+		})
+	}
+}
+
+// TestCompatMigrateDiff_ForeignQueryFormatStaysRefusedOnEveryLayout pins the one
+// cell of stokaro/ptah#1013 that is still open, across the whole format axis
+// rather than on the single layout the issue names.
+//
+// Measured on the pinned community binary v1.3.0 on 2026-08-07, running
+// `migrate diff` into an empty directory once per layout, the binary exits 0 and
+// writes REVERSE SQL as well as forward SQL in every one of them — a second file
+// for golang-migrate (`.down.sql`) and flyway (`U…__….sql`), a directive section
+// in the same file for goose (`-- +goose Down`) and dbmate (`-- migrate:down`),
+// and one `--rollback:` line per forward statement for liquibase. Ptah's
+// `migrate diff` plans forward statements only, so honoring the query would
+// write a directory whose rollback half is missing or empty. Refusing is the
+// strict side and never exits 0 where the community binary exits 1.
+//
+// All five rows are here because the layouts do not close together: the paired
+// ones are the cheap half, and a change that taught this verb golang-migrate
+// alone would leave the other four silently refusing while a single-layout test
+// stayed green. The `?format=atlas` control is what shows the refusal turns on
+// the layout and not on the query's presence.
+func TestCompatMigrateDiff_ForeignQueryFormatStaysRefusedOnEveryLayout(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		check  func(c *qt.C, err error, wrote bool)
+	}{
+		{
+			name:   "golang-migrate",
+			format: "golang-migrate",
+			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("golang-migrate")),
+		},
+		{
+			name:   "goose",
+			format: "goose",
+			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("goose")),
+		},
+		{
+			name:   "flyway",
+			format: "flyway",
+			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("flyway")),
+		},
+		{
+			name:   "liquibase",
+			format: "liquibase",
+			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("liquibase")),
+		},
+		{
+			name:   "dbmate",
+			format: "dbmate",
+			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("dbmate")),
+		},
+		{
+			name:   "atlas is not refused",
+			format: "atlas",
+			check:  acceptedAndWrote,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			wrote, err := runCompatDiff(c, "?format="+tt.format, nil)
+
+			tt.check(c, err, wrote)
+		})
+	}
+}
+
+func compatDiffForeignFormatRefusal(format string) string {
+	return `atlas migrate diff --dir: Atlas accepts \?format=` + format +
+		`, but Ptah does not implement that directory format for this command yet`
+}
+
+// refusedWithoutWriting builds the assertion for a row the compat surface must
+// refuse: the error matches, and the migration directory is untouched.
+func refusedWithoutWriting(want string) func(c *qt.C, err error, wrote bool) {
+	return func(c *qt.C, err error, wrote bool) {
+		c.Assert(err, qt.ErrorMatches, want)
+		c.Assert(wrote, qt.IsFalse, qt.Commentf("a refused run must write nothing"))
+	}
+}
+
+// acceptedAndWrote is the assertion for a row the compat surface must accept.
+func acceptedAndWrote(c *qt.C, err error, wrote bool) {
+	c.Assert(err, qt.IsNil)
+	c.Assert(wrote, qt.IsTrue, qt.Commentf("an accepted run must write the migration"))
+}

--- a/cmd/atlas/migrate_dir_query.go
+++ b/cmd/atlas/migrate_dir_query.go
@@ -5,42 +5,100 @@ import (
 	"net/url"
 
 	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 )
 
-// checkWritingVerbDirQuery validates the `--dir` query for the two verbs that
-// WRITE into the directory: `migrate new` and `migrate diff`.
+// resolveWritingVerbDirFormat resolves the migration directory layout the one
+// verb that WRITES into the directory — `migrate diff` — was pointed at, from
+// the two spellings that can select one: the `--dir` URL query and
+// `--dir-format`.
 //
-// An unrecognized KEY is ignored, matching the community binary: measured on
-// v1.3.0, `?nonsense=1` exits 0 and the directory reads as Atlas exactly as it
-// would with no query at all. [atlasmigrate.ResolveApplyDirFormat] does the
-// ignoring, so that rule lives in one place for every verb rather than being
-// restated per verb.
+// It is [atlasmigrate.ResolveApplyDirFormat], which is the same resolution
+// every verb that READS a directory already runs (resolveAtlasMigrateSource in
+// migrate_integrity.go). `migrate diff` used to carry a second rule of its own
+// — `strings.ToLower(strings.TrimSpace(--dir-format)) != "atlas"` — and that
+// rule diverged from the community binary in both directions. Measured against
+// the pinned community binary v1.3.0 on 2026-08-07, on a hashed native Atlas
+// directory:
 //
-// A `?format=` naming a foreign layout stays refused, and for these two verbs
-// that is not the same call the reading verbs make. The reading verbs — hash,
-// validate, lint, status, set — convert a foreign layout in memory and report
-// on it, which is what #992, #1002 and #1133 built. Writing one is a different
-// problem: measured against the pinned community binary, `migrate new --dir
-// 'file://goosedir?format=goose'` refuses an unhashed Goose directory over
-// GOOSE's own covered file set, so honoring the query here means computing that
-// file set before writing, not reading the directory as Atlas. Ignoring the
-// query would gate the wrong set and then write into it.
+//	--dir-format ATLAS                                CE 1 unknown dir format "ATLAS"  ptah 0, WROTE
+//	--dir-format Atlas                                CE 1                             ptah 0, WROTE
+//	--dir-format ' atlas '                            CE 1                             ptah 0, WROTE
+//	--dir 'd?format=atlas' --dir-format golang-migrate CE 0, WROTE                      ptah 1
+//	--dir 'd?format='      --dir-format golang-migrate CE 0, WROTE                      ptah 1
 //
-// Refusing is the strict side: it never exits 0 where the community binary
-// exits 1. stokaro/ptah#1013 tracks closing the gap.
+// The first three rows are the forbidden direction — exit 0 where the community
+// binary exits 1, on the one compat verb that mutates the directory — and the
+// coercion is what produced them: only the verbatim value `atlas` selects that
+// layout there. The last two are the query-outranks-the-flag precedence the
+// same binary applies wherever both spellings are present.
 //
-// An empty `?format=` value selects the native Atlas layout and passes, which is
-// what the community binary does with it too.
-func checkWritingVerbDirQuery(query url.Values) error {
-	format, err := atlasmigrate.ResolveApplyDirFormat("", query)
-	if err != nil {
-		return err
+// The rows that must NOT move, same fixture and same binary:
+//
+//	--dir-format golang-migrate                       CE 1                             ptah 1
+//	--dir 'd?nonsense=1' --dir-format golang-migrate  CE 1                             ptah 1
+//	--dir-format atlas                                CE 0, WROTE                      ptah 0, WROTE
+//	--dir-format ''                                   CE 0, WROTE                      ptah 0, WROTE
+//	no --dir-format at all                            CE 0, WROTE                      ptah 0, WROTE
+//
+// The `?nonsense=1` row is the one that separates this from "any query at all
+// disables the flag": an ignored key selects no layout, so `--dir-format` still
+// decides and the refusal stands.
+func resolveWritingVerbDirFormat(
+	configured string,
+	query url.Values,
+) (atlasmigrateimport.Format, error) {
+	return atlasmigrate.ResolveApplyDirFormat(configured, query)
+}
+
+// atlasDirFormatSpelling names the flag a rejected migration-directory format
+// value came from, so the diagnostic blames what the operator actually typed.
+//
+// A `?format=` query is the only thing that can carry a format value other than
+// the configured one, so it is the only thing that can be blamed for a rejected
+// one. A query carrying only ignored keys selects nothing, and the blame stays
+// on --dir-format.
+func atlasDirFormatSpelling(query url.Values) string {
+	if atlasmigrate.DirFormatFromQuery(query) {
+		return "--dir"
 	}
-	if !atlasmigrate.ReadsNativeAtlasDir(format) {
-		return fmt.Errorf(
-			"Atlas accepts ?format=%s, but Ptah does not implement that directory format for this command yet",
-			format,
-		)
+	return "--dir-format"
+}
+
+// checkWritingVerbDirQuery refuses a foreign layout that the `--dir` QUERY
+// named, for the one verb that WRITES into the directory: `migrate diff`.
+//
+// `migrate new` used to share this refusal. It no longer calls here at all —
+// it grew a converted path in stokaro/ptah#845 and honors `?format=goose`
+// today, exit 0 with files in that layout, matching the community binary.
+//
+// Writing a foreign layout is a different problem from reading one. The reading
+// verbs — hash, validate, lint, status, set — convert a foreign layout in
+// memory and report on it, which is what #992, #1002 and #1133 built. Measured
+// against the pinned community binary v1.3.0 on 2026-08-07, `migrate diff` in a
+// foreign layout writes reverse SQL as well as forward SQL, in five different
+// shapes: golang-migrate and flyway put it in a second file, goose and dbmate
+// put it under a directive in the same file, and liquibase interleaves one
+// `--rollback:` line per forward statement. Ptah's `migrate diff` plans forward
+// statements only, so honoring the query here would write a directory whose
+// rollback half is missing or empty. Refusing is the strict side: it never
+// exits 0 where the community binary exits 1. stokaro/ptah#1013 tracks the gap.
+//
+// The refusal is limited to the query spelling deliberately. `--dir-format`
+// naming a foreign layout is refused too, but AFTER the atlas.sum gate, because
+// that is where the community binary refuses it: on an unhashed directory
+// `migrate diff demo --dir file://d --dir-format goose` prints the checksum
+// error there, not a format complaint, while `--dir-format ATLAS` — a value it
+// cannot parse at all — prints `unknown dir format` ahead of the gate.
+//
+// An empty `?format=` value selects the native Atlas layout and passes, which
+// is what the community binary does with it too.
+func checkWritingVerbDirQuery(format atlasmigrateimport.Format, query url.Values) error {
+	if atlasmigrate.ReadsNativeAtlasDir(format) || !atlasmigrate.DirFormatFromQuery(query) {
+		return nil
 	}
-	return nil
+	return fmt.Errorf(
+		"Atlas accepts ?format=%s, but Ptah does not implement that directory format for this command yet",
+		format,
+	)
 }

--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -169,15 +169,12 @@ func resolveAtlasMigrateSource(
 	configured, _ := atlasNativeArgValue(mapped, atlasVerbNativeName(verb, "dir-format"))
 	format, err := atlasmigrate.ResolveApplyDirFormat(configured, localDir.Query)
 	if err != nil {
-		// A ?format= query is the only thing that can carry a format value other
-		// than the configured one, so it is the only thing that can be blamed
-		// for a rejected one. A query carrying only ignored keys selects
-		// nothing, and the blame stays on --dir-format.
-		spelling := "--dir-format"
-		if atlasmigrate.DirFormatFromQuery(localDir.Query) {
-			spelling = "--dir"
-		}
-		return atlasMigrateSource{}, fmt.Errorf("atlas migrate %s %s: %w", verb.use, spelling, err)
+		return atlasMigrateSource{}, fmt.Errorf(
+			"atlas migrate %s %s: %w",
+			verb.use,
+			atlasDirFormatSpelling(localDir.Query),
+			err,
+		)
 	}
 
 	devURL, _ := atlasNativeArgValue(mapped, atlasVerbNativeName(verb, "dev-url"))

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -333,6 +333,14 @@ migration gets written. An unrecognized `--dir` query key is ignored; a
 `?format=` or `--dir-format` naming a non-`atlas` layout is refused, because
 nothing writes planned migration SQL in a foreign tool's convention yet.
 
+Both spellings of the layout are read the way every other migrate verb reads
+them. The value is matched verbatim, so `--dir-format ATLAS` and
+`--dir-format " atlas "` are rejected rather than coerced, and an explicit
+`?format=` outranks `--dir-format` — `--dir "file://migrations?format=atlas"
+--dir-format golang-migrate` writes the Atlas-layout migration. An
+unrecognized query key selects no layout, so `--dir-format` still decides
+there.
+
 **Desired state (`--to`)** accepts one of: local `.hcl`, `.yaml`, `.yml`, or
 `.sql` files; one directly connectable database URL; one local Atlas migration
 directory; or one `env://` reference into the evaluated `atlas.hcl`
@@ -473,10 +481,11 @@ an Atlas CE stub.
 `?format=` on this verb's `--dir` URL is still refused; use `--dir-format`. CE
 aborts every `migrate checkpoint` invocation, so there is no CE behavior to
 diverge from here and refusing an unimplemented spelling loudly is the intended
-outcome. That is **not** true of the other verbs that share the refusal —
-`migrate lint`, `new`, `diff`, `set` and `status` — where CE exits 0 and honors
-the parameter; those are parity defects, tracked in the feature matrix and its
-linked issues, not deliberate.
+outcome. `migrate diff` is now the only other verb that refuses it, and there
+the refusal **is** a parity defect rather than a deliberate choice: CE exits 0
+and writes the migration in the named layout, reverse SQL included. It is
+tracked in the feature matrix and its linked issues. `migrate lint`, `new`,
+`set` and `status` honor the parameter today.
 
 ### `ptah-compat migrate test [paths]`
 


### PR DESCRIPTION
## What this closes

`atlas migrate diff` is the one compat verb that registers `--dir-format` as its own cobra flag rather than resolving it through `resolveAtlasMigrateSource`, and it carried its own reading of the value. That second rule diverged from the pinned community binary in **both** directions. This makes the verb use the same resolution every other verb uses.

Re-measured on `master` at `2dc8417d` before touching anything. Compat built with `go build -o compat ./cmd/ptah-compat` (exit 0). Comparison: the pinned community binary at `ptah-atlas-conformance/bin/atlas`, invoked by absolute path — `atlas community version v1.3.0`. Dev/target database: PostgreSQL 
`postgres://…@localhost:15975/dev`. Every invocation was unpiped and redirected to a file, with `$?` read on its own line; every row ran on a fresh `cp -R` of the fixture, and each row records the directory contents afterwards as well as the exit code.

Fixtures: `m/` — native Atlas directory, one migration, hashed by the pinned binary. `gm/` — golang-migrate directory (`1_init.up.sql` + `1_init.down.sql`) hashed with `--dir 'file://gm?format=golang-migrate'`, so its `atlas.sum` covers only the `.up.sql`.

### The forbidden direction (exit 0 where the community binary exits 1)

`migrate diff` lowercased and trimmed `--dir-format` before comparing it to `atlas`. Only the verbatim value selects that layout on the community binary, so three spellings it refuses were coerced into a match — **and a migration file was written**. Fixture `m/`:

| `--dir-format` | community binary | ptah-compat before | ptah-compat after |
| --- | --- | --- | --- |
| `ATLAS` | 1, `unknown dir format "ATLAS"` | **0, WROTE** | 1, wrote nothing |
| `Atlas` | 1 | **0, WROTE** | 1, wrote nothing |
| `' atlas '` | 1 | **0, WROTE** | 1, wrote nothing |
| `ptah` | 1, `unknown dir format "ptah"` | 1 | 1 |

This is the only verb it happened on. `new`, `hash`, `validate` and `lint` were each measured on the same four spellings and already refused all of them, because they resolve through `atlasmigrate.ResolveApplyDirFormat`, whose parser is verbatim by design.

### The drop-in regression direction (exit 1 where the community binary exits 0)

The definition of done's precedence rule — the query wins over `--dir-format` — was unimplemented here. Fixture `m/`:

| invocation | community binary | before | after |
| --- | --- | --- | --- |
| `--dir 'file://m?format=atlas' --dir-format golang-migrate` | 0, WROTE | **1, wrote nothing** | 0, WROTE |
| `--dir 'file://m?format=' --dir-format golang-migrate` | 0, WROTE | **1, wrote nothing** | 0, WROTE |
| `--dir 'file://m?format=atlas' --dir-format goose` | 0, WROTE | **1, wrote nothing** | 0, WROTE |

### Controls — rows that must not move, and did not

| invocation | community binary | before | after |
| --- | --- | --- | --- |
| `--dir-format golang-migrate` alone | 1 | 1 | 1 |
| `--dir 'file://m?nonsense=1' --dir-format golang-migrate` | 1 | 1 | 1 |
| `--dir-format atlas` | 0, WROTE | 0, WROTE | 0, WROTE |
| `--dir-format ''` | 0, WROTE | 0, WROTE | 0, WROTE |
| no `--dir-format` at all | 0, WROTE | 0, WROTE | 0, WROTE |
| `--dir 'file://m?format=atlas&format=goose'` | 0, WROTE | 0, WROTE | 0, WROTE |
| `--dir 'file://m?format=ATLAS'` | 1 | 1 | 1 |

The `?nonsense=1` row is the one that separates the implemented rule from a plausible wrong one. "Any query at all disables `--dir-format`" would also make the three precedence rows green; it would make this row green too, and it must stay red. An ignored key selects no layout, so the flag still decides.

### Refusal ordering, measured rather than chosen

On an **unhashed** directory, the community binary refuses an unparseable format value ahead of the atlas.sum gate and a parseable-but-foreign one behind it:

```
--dir-format ATLAS   community: Error: unknown dir format "ATLAS"     ptah after: same position
--dir-format goose   community: Error: checksum file not found        ptah after: same position
no format selection  community: Error: checksum file not found        ptah: same
```

So the strict parse moved to the pre-gate position and the foreign-layout refusal stayed in `prepareAtlasMigrateDiffSource`, behind the gate. Both were already exit 1; this keeps the failure the operator sees the same one.

## What is deliberately still divergent

`?format=` naming a foreign layout stays refused on this verb. That is stokaro/ptah#1013's remaining cell, and it is the strict side — never exit 0 where the community binary exits 1.

The new test pins that refusal across **all five** foreign layouts, not the one the issue names. Measured on 2026-08-07, running `migrate diff` into a fresh empty directory once per layout, the community binary exits 0 and writes reverse SQL as well as forward SQL in every one of them, in three different shapes:

```
golang-migrate  20…_demo.up.sql + 20…_demo.down.sql   ("-- reverse: create …" / DROP TABLE)
flyway          V20…__demo.sql  + U20…__demo.sql
goose           one file, "-- +goose Up" / "-- +goose Down" sections
dbmate          one file, "-- migrate:up" / "-- migrate:down" sections
liquibase       one file, one "--rollback: DROP TABLE …" line PER forward statement
```

Ptah's `migrate diff` plans forward statements only, so these layouts do not close together and a test pinning golang-migrate alone would stay green while the other four silently diverged. The liquibase shape is the sharpest constraint: the reverse has to be produced per planned change and interleaved, not appended as one block, and `MigrationFileContent` (`internal/atlasmigrate/filecontent.go:22`) carries a single `SQL` string with no per-statement reverse.

An issue comment on #1013 records what reaching that reverse would cost, with the exact import edge and signature involved. It is a public-API-or-relocation decision and is deliberately not made here.

## Are we stricter anywhere new?

Yes, on `--dir-format ATLAS` / `Atlas` / `' atlas '`, and deliberately: the community binary refuses all three, so this is a move **towards** it, not away. The only behavior an existing Ptah user loses is a spelling that Ptah alone accepted, which pre-v1 is not owed. No spelling the community binary accepts became an error.

## Also in this PR

- `atlasDirFormatSpelling` extracts the "which flag do we blame for a rejected format value" rule out of `resolveAtlasMigrateSource`, so it has one home instead of two.
- `checkWritingVerbDirQuery`'s doc comment said it served "the two verbs that WRITE … `migrate new` and `migrate diff`". Only `migrate diff` calls it; `migrate new` grew its own converted path and honors `?format=golang-migrate` today, measured exit 0 with files in that layout on both binaries. Comment corrected.
- `docs/site/src/content/docs/reference/atlas-commands.md` said `migrate lint`, `new`, `diff`, `set` and `status` all still share the `?format=` refusal. Re-measured: only `diff` does. Sentence corrected, and the `migrate diff` section now records the verbatim-value and precedence rules.

## Gates

All run in this worktree, each exit status read on its own line, not through a pipe.

```
go build ./...                        0
go vet ./...                          0
go test ./... -count=1                0   (177 packages reported ok)
go tool qtlint ./...                  0
golangci-lint run ./...               0
scripts/check-test-style.sh           0   ("OK (175 conditional groups, 45 white-box files)")
scripts/check-public-api.sh           0
scripts/check-public-api-snapshot.sh  0
```

docs/ was touched, so every `check:*` script in `docs/site/package.json` ran, plus their selftests and the feature matrix:

```
check-exit-codes 0   check-core-doc-links 0   check-page-health 0   check-links 0
check-redirects  0   check-style          0   check-limitations  0   check-responsive 0
all six selftests 0
node docs/site/scripts/build-feature-matrix.mjs --check   0
```

`check-responsive` needs a built site; `npm ci` and `npm run build` were run first (both exit 0, 61 pages) and it then reported `OK (60 routes x 2 viewports, cells within 8 lines)`.

The snapshot gate was confirmed to actually inspect the surface rather than pass vacuously: adding a throwaway `func ProbeGateSymbol()` to `migration/generator` made `scripts/check-public-api-snapshot.sh` exit 1 and print the added line. The probe was removed before committing.

## Inverse-mutant controls

Both new guards were reverted in place and the tests were confirmed to go red on exactly the rows that own the behavior.

- Restoring `strings.ToLower(strings.TrimSpace(configured))` before the resolution: `TestCompatMigrateDiff_DirFormatValueIsParsedVerbatim` fails on `uppercase`, `capitalized` and `padded`, and on nothing else — the `ptah` row and every precedence row stay green, because lowercasing does not affect them.
- Dropping `configured` from the resolution entirely: the four refused-value rows fail **and** both `…OutranksDirFormatFlag` control rows fail, while the three precedence acceptances stay green.

Neither mutant was ever staged.

## Not verified

- MySQL, MariaDB and ClickHouse. Every row here was measured against PostgreSQL as `--dev-url`; the in-process tests use SQLite. The code path is dialect-independent — it decides a directory layout before a connection is opened — but that is an argument, not a measurement.
- No conformance-harness scenario in `ptah-atlas-conformance` pins any of these rows differentially against the binary. They are pinned in-process here. That gap is the same one #1013 records as its item (c).
- The `?format=<foreign>` cell on `migrate diff` is unchanged and still diverges. That is the point of the last test in this PR, not an oversight.

Refs stokaro/ptah#1013
