### PR TITLE
Match a table the database reports with no schema (#1232)

### DIFF
--- a/migration/schemadiff/implicit_schema_constraints_test.go
+++ b/migration/schemadiff/implicit_schema_constraints_test.go
@@ -1,0 +1,262 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompareWithDialect_ImplicitDatabaseSchemaMatchesTheDesiredSchema pins that
+// a table the database reports with no schema is the same table the desired
+// schema names explicitly (stokaro/ptah#1232).
+//
+// The two sides genuinely disagree in spelling. A reader reports the schema as
+// empty wherever the engine treats it as implicit, while a schema built from Go
+// annotations or from HCL carries it. Table comparison has always resolved that
+// through the dialect's default schema; constraint and trigger comparison did
+// not, so every constraint the database had looked absent from the desired
+// schema and was reported as removed.
+//
+// What that cost is worth stating precisely, because the two engines hid it
+// differently. On SQLite the second `schema apply` of an unchanged file failed
+// with `rebuilding table t requires the retained table definition`, which is at
+// least loud. On PostgreSQL it emitted
+// `ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_pkey"`, applied it,
+// exited 0 and printed "Schema apply completed successfully" -- the primary key
+// was gone and the third apply then reported "Schema is synced". The pinned
+// Atlas community binary v1.3.0 reports "Schema is synced, no changes to be
+// made" on the second apply of both.
+//
+// The removal rows are the control and they carry the weight: a fix that simply
+// stopped reporting constraint removals would satisfy every no-change row here
+// and leave the tool unable to drop a constraint at all.
+func TestCompareWithDialect_ImplicitDatabaseSchemaMatchesTheDesiredSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		dialect     string
+		genSchema   string
+		dbSchema    string
+		dbTableName string
+		wantRemoved []string
+	}{
+		{
+			name:        "sqlite reports the schema as nothing where the desired side says main",
+			dialect:     "sqlite",
+			genSchema:   "main",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			name:        "postgres reports the schema as nothing where the desired side says public",
+			dialect:     "postgres",
+			genSchema:   "public",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			name:        "both sides naming the schema is unaffected",
+			dialect:     "postgres",
+			genSchema:   "public",
+			dbSchema:    "public",
+			dbTableName: "users",
+		},
+		{
+			name:        "neither side naming it is unaffected",
+			dialect:     "postgres",
+			genSchema:   "",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			// The desired side omits the schema and the database supplies it.
+			// The fill-in has to work in this direction too, or a schema read
+			// from a server that does report `public` would drift against Go
+			// annotations that do not name one.
+			name:        "the database naming it and the desired side not is unaffected",
+			dialect:     "postgres",
+			genSchema:   "",
+			dbSchema:    "public",
+			dbTableName: "users",
+		},
+		{
+			// The control. A constraint on a table that genuinely is not in the
+			// desired schema must still be reported, or the fix has bought
+			// idempotency by making removal impossible.
+			name:        "a constraint on a table the desired schema does not have is still removed",
+			dialect:     "postgres",
+			genSchema:   "public",
+			dbSchema:    "",
+			dbTableName: "orphaned",
+			wantRemoved: []string{"orphaned_pkey"},
+		},
+		{
+			// The other control: a different schema is a different table, and
+			// the fill-in must not collapse them.
+			name:        "a table in another schema is not the desired one",
+			dialect:     "postgres",
+			genSchema:   "public",
+			dbSchema:    "reporting",
+			dbTableName: "users",
+			wantRemoved: []string{"users_pkey"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff := schemadiff.CompareWithDialect(
+				implicitSchemaDesired(test.genSchema),
+				implicitSchemaDatabase(test.dbSchema, test.dbTableName),
+				test.dialect,
+			)
+
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, test.wantRemoved,
+				qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_ImplicitDatabaseSchemaPlansNothingAtAll is the
+// assertion that a fix in the wrong place cannot satisfy.
+//
+// The SQLite planner reached `findTable` with the database's unqualified
+// spelling while the generated table carried the qualified one, and returned an
+// error. Teaching only `findTable` to match would have removed the error and
+// replaced it with a real table rebuild -- CREATE, INSERT ... SELECT, DROP
+// TABLE, RENAME -- on every apply of an unchanged file. So the assertion is
+// that the comparison reports NO change, not merely that planning succeeds.
+func TestCompareWithDialect_ImplicitDatabaseSchemaPlansNothingAtAll(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialect   string
+		genSchema string
+	}{
+		{name: "sqlite", dialect: "sqlite", genSchema: "main"},
+		{name: "postgres", dialect: "postgres", genSchema: "public"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff := schemadiff.CompareWithDialect(
+				implicitSchemaDesired(test.genSchema),
+				implicitSchemaDatabase("", "users"),
+				test.dialect,
+			)
+
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, 0)
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDialect_ImplicitDatabaseSchemaMatchesTriggers covers the same
+// mismatch on triggers, which key their owning table the same way.
+//
+// It is separate from the constraint run because a trigger reaching the diff is
+// reported as removed AND added -- the desired one is unmatched too -- so the
+// symptom is a pointless drop-and-recreate rather than a bare drop.
+func TestCompareWithDialect_ImplicitDatabaseSchemaMatchesTriggers(t *testing.T) {
+	tests := []struct {
+		name      string
+		dialect   string
+		genSchema string
+		dbSchema  string
+		wantSame  bool
+	}{
+		{name: "sqlite implicit database schema", dialect: "sqlite", genSchema: "main", dbSchema: "", wantSame: true},
+		{name: "postgres implicit database schema", dialect: "postgres", genSchema: "public", dbSchema: "", wantSame: true},
+		{name: "a genuinely different schema still differs", dialect: "postgres", genSchema: "public", dbSchema: "reporting", wantSame: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			generated := implicitSchemaDesired(test.genSchema)
+			generated.Triggers = []goschema.Trigger{{
+				StructName: "Users",
+				Name:       "users_audit",
+				Table:      qualify(test.genSchema, "users"),
+				Timing:     "BEFORE",
+				Event:      "INSERT",
+				Body:       "SELECT 1",
+			}}
+			database := implicitSchemaDatabase(test.dbSchema, "users")
+			database.Triggers = []types.DBTrigger{{
+				Name:   "users_audit",
+				Table:  "users",
+				Schema: test.dbSchema,
+				Timing: "BEFORE",
+				Event:  "INSERT",
+				Body:   "SELECT 1",
+			}}
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.dialect)
+
+			c.Assert(len(diff.TriggersRemoved) == 0, qt.Equals, test.wantSame,
+				qt.Commentf("removed: %#v", diff.TriggersRemoved))
+			c.Assert(len(diff.TriggersAdded) == 0, qt.Equals, test.wantSame,
+				qt.Commentf("added: %#v", diff.TriggersAdded))
+		})
+	}
+}
+
+// implicitSchemaDesired builds the desired side: one table with a table-level
+// primary key, in the named schema.
+func implicitSchemaDesired(schema string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{
+			StructName: "Users",
+			Name:       "users",
+			Schema:     schema,
+			PrimaryKey: []string{"id"},
+		}},
+		Fields: []goschema.Field{
+			{StructName: "Users", Name: "id", Type: "INTEGER", Nullable: false},
+			{StructName: "Users", Name: "email", Type: "TEXT", Nullable: true},
+		},
+	}
+}
+
+// implicitSchemaDatabase builds the database side: the same table, as a reader
+// reports it.
+func implicitSchemaDatabase(schema, table string) *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name:   table,
+			Schema: schema,
+			Type:   "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "INTEGER", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "email", DataType: "TEXT", IsNullable: "YES"},
+			},
+		}},
+		Constraints: []types.DBConstraint{{
+			Name:        table + "_pkey",
+			TableName:   table,
+			Schema:      schema,
+			Type:        "PRIMARY KEY",
+			ColumnNames: []string{"id"},
+		}},
+	}
+}
+
+// qualify writes a table name the way the desired schema carries it.
+func qualify(schema, table string) string {
+	if schema == "" {
+		return table
+	}
+	return schema + "." + table
+}

--- a/migration/schemadiff/internal/compare/constraint_synthesis.go
+++ b/migration/schemadiff/internal/compare/constraint_synthesis.go
@@ -2,6 +2,7 @@ package compare
 
 import (
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/migration/internal/generatedschema"
@@ -27,7 +28,11 @@ import (
 // `//ptah:schema:constraint` that happens to share the synthesized
 // name wins — synthesis never clobbers it. See the guard in
 // Constraints() where genConstraints is populated.
-func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database *types.DBSchema) []goschema.Constraint {
+func synthesizeFieldLevelCheckConstraints(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	semantics identifier.Semantics,
+) []goschema.Constraint {
 	if generated == nil || database == nil {
 		return nil
 	}
@@ -40,7 +45,7 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 	dbColumns := make(map[tableMemberKey]struct{}, 16)
 	for _, t := range database.Tables {
 		for _, c := range t.Columns {
-			dbColumns[tableMemberKey{table: t.QualifiedName(), member: c.Name}] = struct{}{}
+			dbColumns[newTableMemberKey(t.QualifiedName(), c.Name, semantics)] = struct{}{}
 		}
 	}
 
@@ -56,7 +61,7 @@ func synthesizeFieldLevelCheckConstraints(generated *goschema.Database, database
 			tableName = f.StructName
 			tableLeafName = f.StructName
 		}
-		if _, exists := dbColumns[tableMemberKey{table: tableName, member: f.Name}]; !exists {
+		if _, exists := dbColumns[newTableMemberKey(tableName, f.Name, semantics)]; !exists {
 			continue
 		}
 		name := f.CheckName
@@ -78,14 +83,15 @@ func synthesizeTablePrimaryKeyConstraints(
 	generated *goschema.Database,
 	database *types.DBSchema,
 	dialect string,
+	semantics identifier.Semantics,
 ) []goschema.Constraint {
 	if generated == nil || database == nil {
 		return nil
 	}
 
-	dbTables := make(map[string]struct{}, len(database.Tables))
+	dbTables := make(map[tableIdentity]struct{}, len(database.Tables))
 	for _, table := range database.Tables {
-		dbTables[table.QualifiedName()] = struct{}{}
+		dbTables[newQualifiedTableIdentity(table.QualifiedName(), semantics)] = struct{}{}
 	}
 
 	var synthesized []goschema.Constraint
@@ -94,7 +100,7 @@ func synthesizeTablePrimaryKeyConstraints(
 		if len(columns) == 0 {
 			continue
 		}
-		if _, exists := dbTables[table.QualifiedName()]; !exists {
+		if _, exists := dbTables[newQualifiedTableIdentity(table.QualifiedName(), semantics)]; !exists {
 			continue
 		}
 
@@ -145,7 +151,11 @@ func tablePrimaryKeyConstraintName(table goschema.Table, dbConstraints []types.D
 // Precedence: an explicit table-level constraint declared via
 // `//ptah:schema:constraint` that happens to share the synthesized name
 // wins — synthesis never clobbers it (see the guard in Constraints()).
-func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, database *types.DBSchema) []goschema.Constraint {
+func synthesizeFieldLevelForeignKeyConstraints(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	semantics identifier.Semantics,
+) []goschema.Constraint {
 	if generated == nil || database == nil {
 		return nil
 	}
@@ -153,7 +163,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 	dbColumns := make(map[tableMemberKey]struct{}, 16)
 	for _, t := range database.Tables {
 		for _, c := range t.Columns {
-			dbColumns[tableMemberKey{table: t.QualifiedName(), member: c.Name}] = struct{}{}
+			dbColumns[newTableMemberKey(t.QualifiedName(), c.Name, semantics)] = struct{}{}
 		}
 	}
 
@@ -185,7 +195,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		if tableName == "" {
 			continue
 		}
-		if _, exists := dbColumns[tableMemberKey{table: tableName, member: f.Name}]; !exists {
+		if _, exists := dbColumns[newTableMemberKey(tableName, f.Name, semantics)]; !exists {
 			continue
 		}
 		name := f.ForeignKeyName
@@ -201,7 +211,7 @@ func synthesizeFieldLevelForeignKeyConstraints(generated *goschema.Database, dat
 		if fkRef == nil {
 			continue
 		}
-		dedupeKey := tableMemberKey{table: tableName, member: name}
+		dedupeKey := newTableMemberKey(tableName, name, semantics)
 		if _, seen := dedupe[dedupeKey]; seen {
 			continue
 		}

--- a/migration/schemadiff/internal/compare/constraints.go
+++ b/migration/schemadiff/internal/compare/constraints.go
@@ -7,6 +7,7 @@ import (
 
 	"go.5x5.cz/ptah/config"
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
@@ -64,12 +65,13 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	if opts != nil {
 		dialect = opts.Dialect
 	}
+	semantics := identifier.ForDialect(dialect)
 
 	// Create maps for detailed constraint comparison
 	genConstraints := make(map[tableMemberKey]goschema.Constraint)
 	for _, constraint := range generated.Constraints {
 		constraint.Table = generatedConstraintTableName(constraint, generated.Tables)
-		key := tableMemberKey{table: constraint.Table, member: constraint.Name}
+		key := newTableMemberKey(constraint.Table, constraint.Name, semantics)
 		genConstraints[key] = constraint
 	}
 
@@ -80,8 +82,8 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	// their CHECK inline via CREATE TABLE / ALTER TABLE ADD COLUMN, and
 	// double-emitting an ALTER TABLE ADD CONSTRAINT would fail because the
 	// constraint is created in the same migration step.
-	for _, synthesized := range synthesizeFieldLevelCheckConstraints(generated, database) {
-		key := tableMemberKey{table: synthesized.Table, member: synthesized.Name}
+	for _, synthesized := range synthesizeFieldLevelCheckConstraints(generated, database, semantics) {
+		key := newTableMemberKey(synthesized.Table, synthesized.Name, semantics)
 		// Don't clobber an explicit table-level constraint that happens to
 		// share the same name.
 		if _, exists := genConstraints[key]; !exists {
@@ -89,8 +91,8 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 		}
 	}
 
-	for _, synthesized := range synthesizeTablePrimaryKeyConstraints(generated, database, dialect) {
-		key := tableMemberKey{table: synthesized.Table, member: synthesized.Name}
+	for _, synthesized := range synthesizeTablePrimaryKeyConstraints(generated, database, dialect, semantics) {
+		key := newTableMemberKey(synthesized.Table, synthesized.Name, semantics)
 		// Don't clobber an explicit table-level constraint that happens to
 		// share the same name.
 		if _, exists := genConstraints[key]; !exists {
@@ -111,8 +113,8 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	// through to the comparison instead of filtering it out — otherwise
 	// foreignKeyConstraintChanged would never run for field-level FKs.
 	synthesizedFKKeys := make(map[tableMemberKey]struct{})
-	for _, synthesized := range synthesizeFieldLevelForeignKeyConstraints(generated, database) {
-		key := tableMemberKey{table: synthesized.Table, member: synthesized.Name}
+	for _, synthesized := range synthesizeFieldLevelForeignKeyConstraints(generated, database, semantics) {
+		key := newTableMemberKey(synthesized.Table, synthesized.Name, semantics)
 		synthesizedFKKeys[key] = struct{}{}
 		// Don't clobber an explicit table-level constraint that happens to
 		// share the same name.
@@ -125,11 +127,11 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	dbConstraints := make(map[tableMemberKey]types.DBConstraint)
 	for _, constraint := range database.Constraints {
 		// Skip field-level constraints that are represented in field definitions
-		if isFieldLevelConstraint(constraint, generated, synthesizedFKKeys) {
+		if isFieldLevelConstraint(constraint, generated, synthesizedFKKeys, semantics) {
 			continue
 		}
 
-		key := tableMemberKey{table: constraint.QualifiedTableName(), member: constraint.Name}
+		key := newTableMemberKey(constraint.QualifiedTableName(), constraint.Name, semantics)
 		dbConstraints[key] = constraint
 	}
 

--- a/migration/schemadiff/internal/compare/field_constraints.go
+++ b/migration/schemadiff/internal/compare/field_constraints.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 )
 
@@ -18,16 +19,23 @@ import (
 // foreignKeyConstraintChanged (issue #189). FKs without a synthesized
 // counterpart (e.g. a column that is not yet in the database, which never gets
 // synthesized) keep the previous filter-out behavior.
-// buildTablePrimaryKeyColumnSets maps each generated table's qualified name to
-// the set of columns in its table-level primary key.
-func buildTablePrimaryKeyColumnSets(generated *goschema.Database) map[string]map[string]struct{} {
-	result := make(map[string]map[string]struct{}, len(generated.Tables))
+// buildTablePrimaryKeyColumnSets maps each generated table to the set of
+// columns in its table-level primary key.
+//
+// The key is normalized rather than the qualified name as written, because the
+// database side of the lookup spells an implicit schema as nothing at all
+// (stokaro/ptah#1232).
+func buildTablePrimaryKeyColumnSets(
+	generated *goschema.Database,
+	semantics identifier.Semantics,
+) map[tableIdentity]map[string]struct{} {
+	result := make(map[tableIdentity]map[string]struct{}, len(generated.Tables))
 	for _, table := range generated.Tables {
 		columns := make(map[string]struct{})
 		for _, column := range tablePrimaryKeyColumns(table) {
 			columns[column] = struct{}{}
 		}
-		result[table.QualifiedName()] = columns
+		result[newQualifiedTableIdentity(table.QualifiedName(), semantics)] = columns
 	}
 	return result
 }
@@ -36,13 +44,14 @@ func isFieldLevelConstraint(
 	dbConstraint types.DBConstraint,
 	generated *goschema.Database,
 	synthesizedFKKeys map[tableMemberKey]struct{},
+	semantics identifier.Semantics,
 ) bool {
 	// Create a map of table.column -> field for quick lookup
 	fieldMap := make(map[tableMemberKey]goschema.Field)
 	// tablePKColumns maps a qualified table name to the set of columns in its
 	// table-level primary key (Table.PrimaryKey), which are synthesized as a
 	// table-level PRIMARY KEY constraint.
-	tablePKColumns := buildTablePrimaryKeyColumnSets(generated)
+	tablePKColumns := buildTablePrimaryKeyColumnSets(generated, semantics)
 	for _, field := range generated.Fields {
 		// Get table name for this field
 		tableName := field.StructName // default to struct name
@@ -52,7 +61,7 @@ func isFieldLevelConstraint(
 				break
 			}
 		}
-		key := tableMemberKey{table: tableName, member: field.Name}
+		key := newTableMemberKey(tableName, field.Name, semantics)
 		fieldMap[key] = field
 	}
 
@@ -60,7 +69,7 @@ func isFieldLevelConstraint(
 	switch dbConstraint.Type {
 	case "NOT NULL":
 		// Check if there's a field with not_null=true for this column
-		key := tableMemberKey{table: dbConstraint.QualifiedTableName(), member: getConstraintColumn(dbConstraint)}
+		key := newTableMemberKey(dbConstraint.QualifiedTableName(), getConstraintColumn(dbConstraint), semantics)
 		if field, exists := fieldMap[key]; exists && !field.Nullable {
 			return true
 		}
@@ -72,15 +81,16 @@ func isFieldLevelConstraint(
 		// database constraint must stay in the comparison to match/add correctly
 		// (#708).
 		column := getConstraintColumn(dbConstraint)
-		key := tableMemberKey{table: dbConstraint.QualifiedTableName(), member: column}
+		key := newTableMemberKey(dbConstraint.QualifiedTableName(), column, semantics)
 		if field, exists := fieldMap[key]; exists && field.Primary {
-			if _, synthesized := tablePKColumns[dbConstraint.QualifiedTableName()][column]; !synthesized {
+			pkKey := newQualifiedTableIdentity(dbConstraint.QualifiedTableName(), semantics)
+			if _, synthesized := tablePKColumns[pkKey][column]; !synthesized {
 				return true
 			}
 		}
 	case "UNIQUE":
 		// Check if there's a field with unique=true for this column
-		key := tableMemberKey{table: dbConstraint.QualifiedTableName(), member: getConstraintColumn(dbConstraint)}
+		key := newTableMemberKey(dbConstraint.QualifiedTableName(), getConstraintColumn(dbConstraint), semantics)
 		if field, exists := fieldMap[key]; exists && field.Unique {
 			return true
 		}
@@ -94,7 +104,7 @@ func isFieldLevelConstraint(
 		// the constraint name rather than the column, because the synthesized
 		// name is keyed on table.constraint_name and getConstraintColumn does
 		// not always resolve the FK column.
-		key := tableMemberKey{table: dbConstraint.QualifiedTableName(), member: dbConstraint.Name}
+		key := newTableMemberKey(dbConstraint.QualifiedTableName(), dbConstraint.Name, semantics)
 		if _, synthesized := synthesizedFKKeys[key]; synthesized {
 			return false
 		}
@@ -102,7 +112,7 @@ func isFieldLevelConstraint(
 		// No synthesized counterpart (e.g. the column is not yet in the
 		// database): keep the historical behavior and treat it as field-level
 		// so it is owned by the column/table lifecycle.
-		key = tableMemberKey{table: dbConstraint.QualifiedTableName(), member: getConstraintColumn(dbConstraint)}
+		key = newTableMemberKey(dbConstraint.QualifiedTableName(), getConstraintColumn(dbConstraint), semantics)
 		if field, exists := fieldMap[key]; exists && field.Foreign != "" {
 			return true
 		}

--- a/migration/schemadiff/internal/compare/identity.go
+++ b/migration/schemadiff/internal/compare/identity.go
@@ -1,6 +1,55 @@
 package compare
 
+import (
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/internal/tableref"
+)
+
+// tableMemberKey identifies something owned by a table -- a constraint, a
+// trigger, a column -- by that table and its own name.
+//
+// The table component is a normalized [tableIdentity] rather than the string it
+// was written as, because the two sides of a comparison do not spell the same
+// table the same way. A schema read out of a database reports the table's
+// schema as empty wherever the engine treats it as implicit, while a schema
+// built from Go annotations or from HCL carries it explicitly. So `t` and
+// `main.t` arrive as two spellings of one table.
+//
+// Keying by the raw string made every constraint the database has look absent
+// from the desired schema, and therefore removed. On SQLite that surfaced as
+// `rebuilding table t requires the retained table definition`; on PostgreSQL it
+// silently emitted `ALTER TABLE "users" DROP CONSTRAINT "users_pkey"` on the
+// second apply of an unchanged file, exited 0, and reported success
+// (stokaro/ptah#1232).
+//
+// Table comparison never had the defect because it has always keyed through
+// [newTableIdentity]. Putting the same normalization inside this type rather
+// than at each use site is deliberate: there are seventeen construction sites
+// across four files, and a normalization the caller has to remember is one the
+// next caller will not.
 type tableMemberKey struct {
-	table  string
+	table  tableIdentity
 	member string
+}
+
+// newTableMemberKey builds a key from a table name that may or may not carry a
+// schema, resolving an absent one to the dialect's default.
+func newTableMemberKey(table, member string, semantics identifier.Semantics) tableMemberKey {
+	return tableMemberKey{
+		table:  newQualifiedTableIdentity(table, semantics),
+		member: member,
+	}
+}
+
+// newQualifiedTableIdentity normalizes a table name written as one string,
+// which is how both the desired schema and the database report it.
+//
+// Parsing is delegated to tableref so a table whose own name contains a dot --
+// quoted as `"tenant.data"` -- is not mistaken for a schema-qualified one.
+func newQualifiedTableIdentity(table string, semantics identifier.Semantics) tableIdentity {
+	ref, ok := tableref.Parse(table)
+	if !ok {
+		return newTableIdentity("", table, semantics)
+	}
+	return newTableIdentity(ref.Schema, ref.Name, semantics)
 }

--- a/migration/schemadiff/internal/compare/triggers.go
+++ b/migration/schemadiff/internal/compare/triggers.go
@@ -6,21 +6,40 @@ import (
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
 
 // Triggers compares trigger definitions between generated and database schemas.
 func Triggers(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	TriggersWithDialect(generated, database, diff, "")
+}
+
+// TriggersWithDialect compares triggers with the dialect's own idea of which
+// schema an unqualified table belongs to.
+//
+// The dialect matters because the two sides spell the owning table
+// differently: the desired schema carries the table's schema explicitly while
+// the database reports it as empty wherever the engine treats it as implicit.
+// Without the fill-in, every trigger on such a table read as removed and
+// re-added (stokaro/ptah#1232).
+func TriggersWithDialect(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	dialect string,
+) {
+	semantics := identifier.ForDialect(dialect)
 	generatedTriggers := make(map[tableMemberKey]goschema.Trigger)
 	for _, trigger := range generated.Triggers {
 		trigger.Canonicalize()
-		generatedTriggers[triggerKey(trigger.Table, trigger.Name)] = trigger
+		generatedTriggers[triggerKey(trigger.Table, trigger.Name, semantics)] = trigger
 	}
 
 	databaseTriggers := make(map[tableMemberKey]types.DBTrigger)
 	for _, trigger := range database.Triggers {
-		databaseTriggers[triggerKey(trigger.QualifiedTable(), trigger.Name)] = trigger
+		databaseTriggers[triggerKey(trigger.QualifiedTable(), trigger.Name, semantics)] = trigger
 	}
 
 	for key, trigger := range generatedTriggers {
@@ -58,8 +77,8 @@ func Triggers(generated *goschema.Database, database *types.DBSchema, diff *diff
 	})
 }
 
-func triggerKey(tableName, triggerName string) tableMemberKey {
-	return tableMemberKey{table: tableName, member: triggerName}
+func triggerKey(tableName, triggerName string, semantics identifier.Semantics) tableMemberKey {
+	return newTableMemberKey(tableName, triggerName, semantics)
 }
 
 func sortTriggerRefs(refs []difftypes.TriggerRef) {

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -163,7 +163,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	// Compare views, materialized views, and triggers
 	compare.ViewsWithDialect(generated, database, diff, opts.Dialect)
 	compare.MaterializedViews(generated, database, diff)
-	compare.Triggers(generated, database, diff)
+	compare.TriggersWithDialect(generated, database, diff, opts.Dialect)
 
 	// Compare RLS policies (PostgreSQL-specific feature)
 	compare.RLSPolicies(generated, database, diff)


### PR DESCRIPTION
Closes #1232.

## The defect

Constraint and trigger comparison keyed a table by the string it was written as. Table comparison has always keyed through `newTableIdentity`, which fills an absent schema in with the dialect's default. So one table arrived as `t` from the database and `main.t` from the desired schema, never matched, and **every constraint the database had was reported as removed**.

## Why this is worse than the issue title said

The two engines hid it differently, and one of them did not report it at all.

**SQLite** — the second `schema apply` of an unchanged file fails:

```
Error: generate schema apply SQL: sqlite: rebuilding table t requires the retained table definition
```

Loud, and nothing is touched.

**PostgreSQL 17, live** — it does not fail:

```
apply #1  rc=0   CREATE TABLE "users" (... PRIMARY KEY ("id"))
apply #2  rc=0   ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "users_pkey";
                 Auto-approval enabled; applying schema changes.
                 Schema apply completed successfully.
apply #3  rc=0   Schema is synced, no changes to be made.
```

After apply #2 the key is gone — `SELECT conname FROM pg_constraint WHERE conrelid = 'public.users'::regclass` returns nothing — and apply #3 reports "synced" over a schema that no longer matches the file it was applied from. Exit 0 throughout.

The pinned Atlas community binary v1.3.0, same file, same server, fresh database: apply #2 is `Schema is synced, no changes to be made`, key intact.

So this was a **silent, exit-0, destructive divergence**: applying an unchanged file twice removed a constraint that file declares.

## The fix

`tableMemberKey.table` becomes a `tableIdentity` instead of a string, so every construction goes through the normalizer. There are seventeen construction sites across four files, and a normalization the caller has to remember is one the next caller will not — making it a type means the compiler finds them all. Parsing is delegated to `tableref`, so a table whose own name contains a dot (`"tenant.data"`) is not mistaken for a qualified one.

The same normalization was missing from three places the miss had disabled, which is why nothing caught it earlier:

- `constraint_synthesis.go` — `dbTables` keyed `t`, looked up as `main.t`, so primary-key synthesis was skipped and the desired constraint set stayed empty
- `field_constraints.go` — `fieldMap` keyed `main.t`, looked up as `t`, so the database's PK was never recognized as field-level and entered the comparison unmatched
- `buildTablePrimaryKeyColumnSets` — same shape

Triggers had the identical defect and are fixed with it, through a `TriggersWithDialect` entry point. Their symptom was a pointless drop-and-recreate rather than a bare drop, because the desired trigger went unmatched too.

## Not fixed in `findTable`, deliberately

The SQLite planner reaches `findTable(generated.Tables, target.tableName)` with the database's unqualified spelling. Teaching only that to match makes the error go away — and replaces it with a **real** rebuild on every apply of an unchanged file:

```sql
CREATE TABLE "main"."__ptah_rebuild_t" (...);
INSERT INTO "main"."__ptah_rebuild_t" (...) SELECT ... FROM "main"."t";
DROP TABLE "main"."t";
ALTER TABLE "main"."__ptah_rebuild_t" RENAME TO "t";
```

That would turn a loud failure into a silent one. `TestCompareWithDialect_ImplicitDatabaseSchemaPlansNothingAtAll` asserts the comparison reports **no change**, not merely that planning succeeds, so a fix in that place cannot satisfy it.

## Verified end to end

Three applies of an unchanged file, after the change:

| target | applies | result |
| --- | --- | --- |
| PostgreSQL 17 | 0 / 0 / 0 | `users_pkey` still present |
| SQLite, primary-key fixture | 0 / 0 / 0 | synced |
| SQLite, CHECK constraint, no primary key anywhere | 0 / 0 / 0 | synced |

The pinned binary gives 0 / 0 on every one of them. The CHECK fixture is there because the inline-PK framing in the issue title was a symptom, not the boundary.

## The controls are the point

A fix that simply stopped reporting constraint removals would satisfy every no-change row and leave the tool unable to drop a constraint at all. Two rows exist to prevent that:

- a constraint on a table the desired schema genuinely does not have is **still** reported removed
- a table in a different schema is **not** collapsed into the desired one

Reverting the normalization turns 7 of the 14 subtests red. That was measured, then reverted, and the tree re-verified clean before committing.

## Gates

`go build` · `go vet` · `go test ./... -count=1` · `qtlint` · `golangci-lint` (0 issues) · `check-test-style` · `check-public-api` · `check-public-api-snapshot` — all exit 0.

The whole existing suite passes **unchanged**, which is worth recording on its own: no existing expectation had encoded the mismatch.
