### PR TITLE
Read PostgreSQL expression index keys as expressions (refs #1242)

### DIFF
--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -151,6 +151,11 @@ func (r DBRange) QualifiedName() string { return QualifyTableName(r.Schema, r.Na
 // DBIndexPart represents one ordered key column in an introspected index.
 type DBIndexPart struct {
 	Name string `json:"name"`
+	// Expr is a raw indexed expression, such as lower(name). It is mutually
+	// exclusive with Name: an expression is not an identifier, and a reader
+	// that reports one in Name makes the renderer quote it into a column
+	// reference that does not exist.
+	Expr string `json:"expr,omitempty"`
 	Desc bool   `json:"desc,omitempty"`
 }
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -168,6 +168,33 @@ matched rather than refused, because there Atlas CE is right: it executes the
 file's bytes verbatim, drops nothing, and records the revision honestly. See
 [`stokaro/ptah#981`](https://github.com/stokaro/ptah/issues/981).
 
+## Known PostgreSQL Introspection Gaps
+
+Reading a live PostgreSQL database currently loses index attributes that the
+pinned Atlas CE v1.3.0 binary preserves. Measured on PostgreSQL 17.10 by
+diffing an empty database against a source database with each binary and
+replaying the emitted SQL into a fresh database with
+`psql -v ON_ERROR_STOP=1`. These affect the live-database read path only; an
+HCL source carrying the same attributes renders correctly.
+
+| Attribute | Ptah reads it? | Replays? | Tracked in |
+| --- | --- | --- | --- |
+| Access method (`USING gin` / `gist` / `brin` / `hash`) | No, every index collapses to the btree default | psql exits 0 and leaves a btree index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Operator class, for example `text_pattern_ops` | No, the opclass is dropped | psql exits 0 and leaves an index that no longer serves the queries it was built for | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Sort order (`DESC`, `NULLS FIRST`, `NULLS LAST`) | No, ordering is dropped | psql exits 0 and leaves an ascending index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Domain used as a column type | The `CREATE DOMAIN` is emitted, but the column is flattened to the domain's base type | psql exits 0 and leaves a column without the domain's `CHECK` | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Expression index, for example `lower(name)` | Yes | Yes | fixed |
+
+The first four replay without an error, so nothing reports the loss at the time
+it happens. Treat a green replay of introspected PostgreSQL index DDL as
+unverified until these are closed.
+
+Domains are the one row where Atlas CE is also wrong, in the opposite
+direction: it keeps the column's declared type and never emits the
+`CREATE DOMAIN`, so its own output fails to replay with
+`ERROR: type "..." does not exist`. Ptah emits the `CREATE DOMAIN` already, and
+closing this gap means keeping both halves rather than matching CE.
+
 ## Reports
 
 - Offline corpus report:

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5442,6 +5442,11 @@ package types // import "go.5x5.cz/ptah/dbschema/types"
 
 type DBIndexPart struct {
     Name string `json:"name"`
+    // Expr is a raw indexed expression, such as lower(name). It is mutually
+    // exclusive with Name: an expression is not an identifier, and a reader
+    // that reports one in Name makes the renderer quote it into a column
+    // reference that does not exist.
+    Expr string `json:"expr,omitempty"`
     Desc bool   `json:"desc,omitempty"`
 }
     DBIndexPart represents one ordered key column in an introspected index.

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -207,6 +207,7 @@ func convertIndexParts(parts []dbschematypes.DBIndexPart) []goschema.IndexPart {
 	for position, part := range parts {
 		converted[position] = goschema.IndexPart{
 			Name: part.Name,
+			Expr: part.Expr,
 			Desc: part.Desc,
 		}
 	}

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -460,6 +460,39 @@ func TestConvertDBSchemaToGoSchema_PreservesIndexPartDirection(t *testing.T) {
 	})
 }
 
+func TestConvertDBSchemaToGoSchema_PreservesIndexPartExpression(t *testing.T) {
+	c := qt.New(t)
+	// An expression key must arrive in the model as an expression. Dropping it
+	// into Name makes the renderer quote it, and CREATE INDEX ... ("lower(name)")
+	// is rejected by PostgreSQL with `column "lower(name)" does not exist`.
+	// See #1242.
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{
+			{Schema: "public", Name: "users"},
+		},
+		Indexes: []types.DBIndex{
+			{
+				Schema:    "public",
+				TableName: "users",
+				Name:      "idx_users_lower_name",
+				Columns:   []string{"tenant_id", "lower(name)"},
+				Parts: []types.DBIndexPart{
+					{Name: "tenant_id"},
+					{Expr: "lower(name)"},
+				},
+			},
+		},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Indexes, qt.HasLen, 1)
+	c.Assert(result.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
+		{Name: "tenant_id"},
+		{Expr: "lower(name)"},
+	})
+}
+
 func TestConvertDBSchemaToGoSchema_DBDefaultExpression(t *testing.T) {
 	c := qt.New(t)
 	statusDefault := "'draft'::enum_product_status"

--- a/internal/dbschema/postgres/index_parts_internal_test.go
+++ b/internal/dbschema/postgres/index_parts_internal_test.go
@@ -1,0 +1,104 @@
+package postgres
+
+// White-box testing required: parsePostgresIndexParts decodes the
+// pg_index.indkey attribute-number vector that readIndexesForSchema fetches
+// alongside the index key texts. Mapping attnum 0 to "this key is an
+// expression" is the whole of the fix for #1242, and it is not observable
+// through the exported reader API without a live PostgreSQL server, because
+// the attnum vector has no other source.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+)
+
+func TestParsePostgresIndexParts_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		columns  []string
+		attnums  string
+		expected []types.DBIndexPart
+	}{
+		{
+			// Measured on PostgreSQL 17.10: CREATE INDEX i ON t (lower(name))
+			// reports indkey {0} and key text "lower(name)".
+			name:     "single expression key",
+			columns:  []string{"lower(name)"},
+			attnums:  "[0]",
+			expected: []types.DBIndexPart{{Expr: "lower(name)"}},
+		},
+		{
+			name:     "single column key",
+			columns:  []string{"plain"},
+			attnums:  "[2]",
+			expected: []types.DBIndexPart{{Name: "plain"}},
+		},
+		{
+			name:    "column and expression in one index",
+			columns: []string{"tenant_id", "lower(name)"},
+			attnums: "[2,0]",
+			expected: []types.DBIndexPart{
+				{Name: "tenant_id"},
+				{Expr: "lower(name)"},
+			},
+		},
+		{
+			// A column whose name is spelled like a call must stay a column:
+			// its attnum is positive, so the attnum vector is what separates
+			// it from the expression case above.
+			name:     "column named like a function call",
+			columns:  []string{"lower(name)"},
+			attnums:  "[3]",
+			expected: []types.DBIndexPart{{Name: "lower(name)"}},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			parts, err := parsePostgresIndexParts(test.columns, test.attnums)
+			c.Assert(err, qt.IsNil)
+			c.Assert(parts, qt.DeepEquals, test.expected)
+		})
+	}
+}
+
+func TestParsePostgresIndexParts_FallsBackToColumnsOnly(t *testing.T) {
+	c := qt.New(t)
+
+	// Returning nil leaves DBIndex.Parts empty, which the rest of the pipeline
+	// reads as "this reader supplied only the legacy Columns form" rather than
+	// as "this index has no keys".
+	tests := []struct {
+		name    string
+		columns []string
+		attnums string
+	}{
+		{name: "empty attnum text", columns: []string{"a"}, attnums: ""},
+		{name: "empty attnum array", columns: []string{"a"}, attnums: "[]"},
+		{name: "fewer attnums than keys", columns: []string{"a", "b"}, attnums: "[2]"},
+		{name: "more attnums than keys", columns: []string{"a"}, attnums: "[2,3]"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			parts, err := parsePostgresIndexParts(test.columns, test.attnums)
+			c.Assert(err, qt.IsNil)
+			c.Assert(parts, qt.IsNil)
+		})
+	}
+}
+
+func TestParsePostgresIndexParts_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("attnum text is not json", func(c *qt.C) {
+		parts, err := parsePostgresIndexParts([]string{"a"}, "{not json}")
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(parts, qt.IsNil)
+	})
+}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -684,6 +684,17 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 				FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
 				WHERE keys.ordinality <= ix.indnkeyatts
 			), '[]') as index_columns,
+			-- pg_index.indkey holds 0 for a key that is an expression rather
+			-- than a column. Without it the key texts above are ambiguous:
+			-- lower(name) and a column literally named "lower(name)" arrive
+			-- identically, and treating the former as an identifier renders
+			-- CREATE INDEX ... ("lower(name)"), which PostgreSQL rejects with
+			-- ERROR: column "lower(name)" does not exist. See #1242.
+			COALESCE((
+				SELECT json_agg(keys.attnum ORDER BY keys.ordinality)::text
+				FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+				WHERE keys.ordinality <= ix.indnkeyatts
+			), '[]') as index_key_attnums,
 			COALESCE(pg_get_expr(ix.indpred, ix.indrelid), '') as predicate,
 			ix.indisprimary,
 			ix.indisunique
@@ -703,9 +714,9 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 
 	var indexes []types.DBIndex
 	for rows.Next() {
-		var schemaName, tableName, indexName, indexDef, indexColumns, predicate string
+		var schemaName, tableName, indexName, indexDef, indexColumns, keyAttnums, predicate string
 		var isPrimary, isUnique bool
-		err := rows.Scan(&schemaName, &tableName, &indexName, &indexDef, &indexColumns, &predicate, &isPrimary, &isUnique)
+		err := rows.Scan(&schemaName, &tableName, &indexName, &indexDef, &indexColumns, &keyAttnums, &predicate, &isPrimary, &isUnique)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan index: %w", err)
 		}
@@ -727,6 +738,11 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 			return nil, fmt.Errorf("failed to parse index columns for %s: %w", indexName, err)
 		}
 
+		index.Parts, err = parsePostgresIndexParts(index.Columns, keyAttnums)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse index key parts for %s: %w", indexName, err)
+		}
+
 		indexes = append(indexes, index)
 	}
 
@@ -742,6 +758,39 @@ func parsePostgresIndexColumns(value, indexDef string) ([]string, error) {
 		return nil, err
 	}
 	return columns, nil
+}
+
+// parsePostgresIndexParts labels each index key as a column reference or as an
+// expression, using the pg_index.indkey attribute numbers fetched alongside the
+// key texts. An attnum of 0 marks an expression key.
+//
+// It returns nil when the attnum list is missing or does not line up with the
+// key texts, which leaves DBIndex.Parts empty and keeps the legacy
+// columns-only representation rather than guessing.
+func parsePostgresIndexParts(columns []string, attnumsJSON string) ([]types.DBIndexPart, error) {
+	trimmed := strings.TrimSpace(attnumsJSON)
+	if trimmed == "" || trimmed == "[]" {
+		return nil, nil
+	}
+	var attnums []int
+	if err := json.Unmarshal([]byte(trimmed), &attnums); err != nil {
+		return nil, err
+	}
+	if len(attnums) != len(columns) {
+		return nil, nil
+	}
+
+	parts := make([]types.DBIndexPart, len(columns))
+	for position, key := range columns {
+		// Attribute number 0 is PostgreSQL's marker for "this key is an
+		// expression"; every real column has a positive attnum.
+		if attnums[position] == 0 {
+			parts[position] = types.DBIndexPart{Expr: key}
+			continue
+		}
+		parts[position] = types.DBIndexPart{Name: key}
+	}
+	return parts, nil
 }
 
 func extractPostgresIndexColumns(indexDef string) []string {


### PR DESCRIPTION
Closes one of the five gaps filed in #1242: PostgreSQL introspection reported an expression index key as a column name, so `schema inspect` and `schema diff` emitted DDL that PostgreSQL refuses.

## The defect

```sql
-- source, on a live PostgreSQL 17.10 server
CREATE TABLE t (id integer PRIMARY KEY, name text);
CREATE INDEX i ON t (lower(name));
```

```sql
-- ptah-compat schema diff, before
CREATE INDEX IF NOT EXISTS "i" ON "t" ("lower(name)");
```

```
$ psql -v ON_ERROR_STOP=1 -f before.sql
psql:<stdin>:6: ERROR:  column "lower(name)" does not exist
$ echo $?
3
```

The pinned Atlas community v1.3.0 binary emits `CREATE INDEX "i" ON "t" ((lower(name)));` for the same source database, and that replays with psql exit 0. Run without `ON_ERROR_STOP`, ptah's output left the index silently absent.

## Where it was

Not in the renderer. `core/ast.IndexPart`, `core/goschema.IndexPart` and the PostgreSQL renderer's `renderIndexPart` already carry and emit an index-part expression as `(expr)`, and `internal/atlashcl` already populates it — which is why an HCL source with an expression index has always rendered correctly and only the live-database path was wrong.

`readIndexesForSchema` reported every index key through `DBIndex.Columns`, which is a list of names, and an expression is not a name. `pg_index.indkey` holds 0 for an expression key, so the reader now fetches that attribute-number vector alongside the key texts and labels each key. Without it the two cases are genuinely ambiguous: the expression `lower(name)` and a column literally named `lower(name)` arrive as identical text. The new test covers exactly that pair.

## Changes

- `dbschema/types.DBIndexPart` gains `Expr`, mutually exclusive with `Name`. Additive; `docs/public_api.snapshot` regenerated in this change, and its diff against the committed snapshot is exactly this one field and nothing else. `scripts/check-public-api-released.sh` exits 0; the only incompatibility it reports is the pre-existing approved `migration/migrator` one against `v0.2.0`, untouched here, so no new approval line was needed.
- `internal/dbschema/postgres/reader.go` fetches `pg_index.indkey` and populates `DBIndex.Parts`, labelling expression keys. When the attnum vector is missing or does not line up with the key texts it leaves `Parts` empty, which the rest of the pipeline already reads as "this reader supplied only the legacy `Columns` form".
- `internal/convert/dbschematogo` forwards `Expr` into the model.
- `docs/conformance.md` records the four gaps from #1242 that are **not** fixed here, with their measured replay behavior.

`DBIndex.Columns` is unchanged, so nothing that reads it moves. The PostgreSQL index comparator does not consult `Parts` (`indexKeyPartsChanged` returns early for every dialect except SQL Server), so this does not introduce diff churn.

## Verification, on a live PostgreSQL 17.10 server

Ten single-attribute fixtures, one database each so a failure names one item, run serially. Each binary's `schema diff` output replayed into a fresh database with `psql -v ON_ERROR_STOP=1`; psql's status read on its own line, never through a pipe.

| item | pinned binary | ptah before | ptah after |
| --- | --- | --- | --- |
| expr | 0 | **3** | **0** |
| gin / gist / brin / hash | 0 | 0 | 0 |
| opclass | 0 | 0 | 0 |
| orderdesc / nullsfirst | 0 | 0 | 0 |
| domain | **3** | 0 | 0 |
| control (plain btree) | 0 | 0 | 0 |

A green replay is not on its own evidence, so each replayed database was then re-diffed against its source **with the pinned binary** as a neutral observer. Before, the expr replay reported `CREATE INDEX "i" ON "t" ((lower(name)));` — the index was absent. After, it reports no changes. The other nine rows are byte-identical before and after, including the control, so nothing else moved.

On the combined fixture exercising all five items at once, ptah's `schema diff` output now replays with psql exit 0 where it previously exited 3.

Both tests were checked against a mutant: reverting the attnum check to `if false` and dropping the `Expr` forward each turn their test red.

## Deliberately not fixed here

The other four gaps in #1242 — index access method, operator class, sort order, and domain column types — still reproduce and are unchanged by this PR. They are separate fixes with different shapes: access method needs a decision about `DBIndex.Type`, which is currently documented as ClickHouse-only; `NULLS FIRST` / `NULLS LAST` has no representation anywhere in the AST, the model or the renderer and needs new fields. Bundling them would have made this unreviewable. This one was picked because it is the only one of the five that makes the emitted SQL non-executable, and because everything downstream of the reader already worked.

Note on the domain row: the pinned binary's own output does not replay there — it emits a column of type `positive_int` and never emits the `CREATE DOMAIN`. Ptah already emits the `CREATE DOMAIN`. Closing that gap means keeping both halves, not matching the pinned binary.

## Gates

Every one run on the rebased tree at `73eedb5f`, exit status read on its own line: `go build ./...` 0, `go vet ./...` 0, `go test ./... -count=1` 0 (177 packages ok), `go tool qtlint ./...` 0, `golangci-lint run ./...` 0 (0 issues), `scripts/check-test-style.sh` 0, `scripts/check-public-api.sh` 0, `scripts/check-public-api-snapshot.sh` 0. `node docs/site/scripts/check-style.mjs` also exits 0 for the `docs/conformance.md` change.

One caveat worth recording rather than hiding. On the **first** `go test ./...` after switching to this branch, `cmd/viz`'s `TestSVGReportsGraphvizStderrOnFailure` fails with `signal: killed` at exactly 10.00s, twice out of two attempts. It passes on a warm cache (twice), passes in isolation in 0.34s, and `master` passes twice. The mechanism is build load, not a behavior change: this PR touches `dbschema/types`, which most of the tree imports, so the first run after the switch recompiles nearly everything while that test is holding a 10-second deadline over a stubbed `dot`. That test looks latently load-sensitive and is worth its own issue; it is not caused by anything here.

## Base

The investigation and every live measurement above were made on a build from `issue-1232-implicit-schema-constraints` (`1694e06a`, PR #1238) rather than `master`, because this front touches `schema diff` and #1238 changed diff table keying. #1238 has since squash-merged, so this branch was rebased onto `master` and now carries a single commit. The gate results reported in the PR checklist were re-run on the rebased tree, which also picks up several other PRs that landed in the meantime.

Refs #1242
