### PR TITLE
Report the add side of a rename in migrate lint

### DIFF
--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6441,6 +6441,7 @@ func Describe(f Finding) string
 func Register(rule Rule) error
 type Analysis struct{ ... }
     func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error)
+type BaselineColumn struct{ ... }
 type CompatibilityProfile string
     const CompatibilityProfileNative CompatibilityProfile = "" ...
 type Config struct{ ... }
@@ -6478,10 +6479,50 @@ type Analysis struct {
     snapshot.
 
 func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error)
+func (a Analysis) BaselineVersions() []int64
 func (a Analysis) Files() []File
 func (a Analysis) Findings() []Finding
 func (a Analysis) SelectedFiles() []File
 func (a Analysis) SnapshotFS() fs.FS
+
+### go.5x5.cz/ptah/migration/lint.BaselineColumn
+
+package lint // import "go.5x5.cz/ptah/migration/lint"
+
+type BaselineColumn struct {
+    // Version is the migration version whose starting state this column belongs
+    // to: the state read BEFORE that version is applied, not after.
+    Version int64
+    // Schema is the schema of the owning table, as the server spells it.
+    Schema string
+    // Table is the owning table, as the server spells it.
+    Table string
+    // Name is the column name, as the server spells it.
+    Name string
+    // DataType is the column type spelled the way the compatibility surface
+    // prints it. Empty when the caller could not establish that spelling, which
+    // leaves the diagnostic reported under Ptah's own wording rather than
+    // inventing an Atlas sentence for a type nobody measured.
+    DataType string
+    // NotNull reports whether the column rejects NULL.
+    NotNull bool
+    // HasDefault reports whether the column carries a DEFAULT expression.
+    HasDefault bool
+}
+    BaselineColumn is one column of the schema state a migration version starts
+    from, as read from the dev database the run validates against.
+
+    Reading SQL text is enough to see that `ALTER TABLE users RENAME COLUMN id
+    TO oid` retires the name `id`. It is not enough to see what the new name
+    introduces: the retired column's type, nullability and default live in an
+    earlier migration file or in the base schema, never in the rename statement.
+    A caller that replays the directory on a dev database can read them there
+    and hand them over here, and only then can the add side of a rename be
+    reported.
+
+    Callers ask Analysis.BaselineVersions which versions are worth reading,
+    so a directory with no renames costs no introspection at all.
+
 
 ### go.5x5.cz/ptah/migration/lint.CompatibilityProfile
 
@@ -6665,6 +6706,11 @@ type Options struct {
     // RuleConfigs carries per-rule severity and path-scoping overrides,
     // normally loaded from .ptah-lint.yaml.
     RuleConfigs map[string]RuleConfig
+    // Baseline carries the schema state each analyzed version starts from,
+    // normally read from the dev database after replaying the migrations that
+    // precede that version. Empty analyzes SQL text alone, which is what every
+    // run without a dev database does. See [BaselineColumn].
+    Baseline []BaselineColumn
 }
     Options configures a lint run.
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -853,18 +853,34 @@ incompatible` does not.
 Index, key and constraint renames are not reported at all: deployed application
 code does not name them.
 
-What a rename does **not** report on either surface is the column it
-introduces. Renaming a `NOT NULL` column draws the destructive diagnostic for
-the retired name from Ptah and from the CE binary alike, but the binary adds a
-second one — `MF103`, "adding a non-nullable column will fail in case the table
-is not empty" — for the new name, and Ptah does not. Ptah's analyzers read the
-migration's SQL text, and a `RENAME COLUMN` statement carries neither the
-column's type nor its nullability: both come from an earlier file or from the
-base schema, and the binary's message spells the type as the database canonicalizes
-it. Reaching that needs the replayed dev schema rather than the statement, which
-is [#1074](https://github.com/stokaro/ptah/issues/1074). Until then a rename is
-reported as destructive on both surfaces and as a data-dependent addition on
-neither, so it is one diagnostic short rather than differently classified.
+On the compatibility surface a rename also reports the column it **introduces**.
+Renaming a `NOT NULL` column with no `DEFAULT` produces a second diagnostic —
+`MF103`, "adding a non-nullable column will fail in case the table is not
+empty" — naming the new column and the retired column's type. A `RENAME COLUMN`
+statement carries neither that type nor its nullability, so this one is not read
+from the migration text: `ptah-compat migrate lint` reads the schema state the
+version starts from off the `--dev-url` database during the replay it already
+performs, before the version runs and while the retired column still exists. A
+run without `--dev-url` reports the retirement alone.
+
+Three consequences follow from where the facts come from:
+
+- The type is spelled the way the database canonicalizes it, not the way the
+  migration writes it: `int` reports as `integer` and `varchar(20)` as
+  `character varying(20)`.
+- A retired column that is nullable, or that carries a `DEFAULT`, has no such
+  diagnostic — the introduced column cannot fail on existing rows.
+- A type whose diagnostic spelling Ptah has not measured keeps the diagnostic but
+  prints Ptah's own labeled wording for it rather than a guess at the other
+  tool's.
+
+The two halves belong to different analyzers, so `-- atlas:nolint destructive`
+silences the retirement and leaves the addition, and `-- atlas:nolint
+data_depend` does the reverse.
+
+Native `ptah migrations lint` reports no addition. It models a rename as a
+rename, and a rename does not fail on a populated table, so `BC101` stays its
+single finding.
 
 The report is written to stdout even when findings fail, and error-severity
 findings still exit with code 1. The native `ptah migrations lint` output is

--- a/integration/atlas_migrate_lint_rename_add_side_e2e_test.go
+++ b/integration/atlas_migrate_lint_rename_add_side_e2e_test.go
@@ -1,0 +1,370 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// TestAtlasMigrateLintRenameAddSideE2E covers the last open scenario of
+// stokaro/ptah#1074 against a live PostgreSQL dev database.
+//
+// A rename retires one name and introduces another. The retirement is reachable
+// from the statement text and has been reported since #1120; the introduction is
+// not, because the retired column's type, nullability and default live in an
+// earlier migration file. Reaching it needs the dev database: the linter reads
+// the schema state the version starts from mid-replay, while the retired column
+// still exists.
+//
+// Every want below is the pinned community binary's output on the same fixture,
+// byte for byte apart from the elapsed durations. That includes the `integer`
+// spelling, which is the state's and not the statement's -- the migration says
+// `int`.
+//
+// The rows are chosen so each one moves a single axis away from the reporting
+// case, which is what makes them able to fail independently:
+//
+//   - nullable retired column: the add cannot fail on existing rows.
+//   - retired column with a DEFAULT: same, for the other reason.
+//   - table rename: retires a name but introduces no column, so no add side.
+//   - same-file CREATE: the table is empty, so neither half is reportable.
+//
+// A rule that reported the add side of every rename would pass the first row and
+// fail all four; a rule that reported none of them would fail only the first.
+func TestAtlasMigrateLintRenameAddSideE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	binaryPath := filepath.Join(t.TempDir(), "ptah-compat")
+	buildPtahCompat(c, ctx, repoRoot, binaryPath)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	tests := []struct {
+		name     string
+		base     string
+		rename   string
+		exitCode int
+		want     string
+	}{
+		{
+			name:     "not null column rename reports both halves",
+			base:     "CREATE TABLE users (id int NOT NULL);\n",
+			rename:   "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"integer\" column \"oid\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			// The type spelling comes from the state, not the statement:
+			// `varchar(20)` reads back as `character varying(20)`, which no
+			// analyzer working from the migration text could produce.
+			name:     "sized column rename carries the catalog type spelling",
+			base:     "CREATE TABLE users (id varchar(20) NOT NULL);\n",
+			rename:   "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"character varying(20)\" column \"oid\" will fail in case table\n" +
+				"         \"users\" is not empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			// Two renames in one file: one diagnostic per introduced column, in
+			// statement order, under one group heading, with the fix header
+			// pluralized. A single-rename fixture cannot show any of that.
+			name:   "two renames report one add side each",
+			base:   "CREATE TABLE users (zeta int NOT NULL, alpha varchar(5) NOT NULL);\n",
+			rename: "ALTER TABLE users RENAME COLUMN zeta TO zz;\nALTER TABLE users RENAME COLUMN alpha TO aa;\n",
+
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"zeta\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"      -- L2: Dropping non-virtual column \"alpha\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"integer\" column \"zz\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"      -- L2: Adding a non-nullable \"character varying(5)\" column \"aa\" will fail in case table\n" +
+				"         \"users\" is not empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fixes:\n" +
+				"      -> Add a pre-migration check to ensure column \"zeta\" is NULL before dropping it\n" +
+				"      -> Add a pre-migration check to ensure column \"alpha\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 4 diagnostics\n",
+		},
+		{
+			// A migration is free to qualify the table it alters. The scoped read
+			// does not repeat the schema name on every table, so this is the row
+			// that fails if the qualifier is compared literally.
+			name:     "control: qualified table reference resolves",
+			base:     "CREATE TABLE users (id int NOT NULL);\n",
+			rename:   "ALTER TABLE public.users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"integer\" column \"oid\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			name:     "control: nullable retired column has no add side",
+			base:     "CREATE TABLE users (id int);\n",
+			rename:   "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name:     "control: retired column with a default has no add side",
+			base:     "CREATE TABLE users (id int NOT NULL DEFAULT 7);\n",
+			rename:   "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			// The two halves of one rename belong to different analyzers, and each
+			// selector silences exactly its own half. Measured on both tools: this
+			// one leaves the add side reported and exits 0.
+			name:     "control: the destructive selector silences only the retirement",
+			base:     "CREATE TABLE users (id int NOT NULL);\n",
+			rename:   "-- atlas:nolint destructive\nALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 0,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L2: Adding a non-nullable \"integer\" column \"oid\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with warnings\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			// The mirror of the row above. An add side carrying a DS code would be
+			// silenced by `destructive` and survive `data_depend`, which is exactly
+			// the pair of results these two rows rule out.
+			name:     "control: the data dependent selector silences only the add side",
+			base:     "CREATE TABLE users (id int NOT NULL);\n",
+			rename:   "-- atlas:nolint data_depend\nALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L2: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name:     "control: table rename introduces no column",
+			base:     "CREATE TABLE users (id int NOT NULL, nick varchar(20) NOT NULL);\n",
+			rename:   "ALTER TABLE users RENAME TO accounts;\n",
+			exitCode: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping table \"users\" https://atlasgo.io/lint/analyzers#DS102\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure table \"users\" is empty before dropping it\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			name:     "control: rename of a column the same file created",
+			base:     "CREATE TABLE seed (x int);\n",
+			rename:   "CREATE TABLE users (id int NOT NULL);\nALTER TABLE users RENAME COLUMN id TO oid;\n",
+			exitCode: 0,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- no diagnostics found\n" +
+				"  -- ok (DUR)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- DUR\n" +
+				"  -- 1 version ok\n" +
+				"  -- 2 schema changes\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			testDBName := fmt.Sprintf("ptah_lint_rename_add_e2e_%d", time.Now().UnixNano())
+			createE2EDatabase(c, ctx, adminDB, testDBName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+			migrationsDir := c.TempDir()
+			writeLintE2EFile(c, migrationsDir, "1.sql", test.base)
+			writeLintE2EFile(c, migrationsDir, "2.sql", test.rename)
+
+			stdout, stderr, err := runLintE2EBinary(ctx, binaryPath,
+				"migrate", "lint",
+				"--dir", "file://"+migrationsDir,
+				"--dev-url", replaceDatabaseName(c, dbURL, testDBName),
+				"--latest", "1",
+			)
+
+			c.Assert(exitStatusOf(c, err), qt.Equals, test.exitCode)
+			c.Assert(stderr, qt.Equals, "")
+			c.Assert(redactLintE2EDurations(stdout), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestNativeMigrationsLintRenameHasNoAddSideE2E pins the surface split for the
+// half of #1074 that has no comparison binary.
+//
+// The compatibility surface says a rename "will fail in case table ... is not
+// empty" because it models the rename as a drop plus an add. Native `ptah
+// migrations lint` models it as a rename, and a rename does not fail on a
+// populated table -- so the same claim there would be false of the statement the
+// native analyzer describes. BC101 stays the single finding.
+//
+// Dropping the profile gate on the rename's add side leaves every other test in
+// the repository green, so without this row the split is unpinned.
+func TestNativeMigrationsLintRenameHasNoAddSideE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	repoRoot := e2eRepoRoot(t)
+	nativeBinary := filepath.Join(t.TempDir(), "ptah")
+	buildPtah(c, ctx, repoRoot, nativeBinary)
+
+	adminDB, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer adminDB.Close()
+
+	testDBName := fmt.Sprintf("ptah_lint_native_rename_e2e_%d", time.Now().UnixNano())
+	createE2EDatabase(c, ctx, adminDB, testDBName)
+	defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+	migrationsDir := c.TempDir()
+	writeLintE2EFile(c, migrationsDir, "1.sql", "CREATE TABLE users (id int NOT NULL);\n")
+	writeLintE2EFile(c, migrationsDir, "2.sql", "ALTER TABLE users RENAME COLUMN id TO oid;\n")
+
+	// The same directory and the same dev database the compatibility surface
+	// answers with two diagnostics.
+	stdout, stderr, err := runLintE2EBinary(ctx, nativeBinary,
+		"migrations", "lint",
+		"--dir", migrationsDir,
+		"--dir-format", "atlas",
+		"--dev-url", replaceDatabaseName(c, dbURL, testDBName),
+		"--latest", "1",
+	)
+
+	// The native report goes to stderr, so both streams are joined rather than
+	// asserted on one: reading only stdout here made a neighboring test pass
+	// against an empty string.
+	report := stdout + stderr
+
+	c.Assert(exitStatusOf(c, err), qt.Equals, 0)
+	c.Assert(report, qt.Contains, "BC101: renames are not backwards compatible")
+	c.Assert(report, qt.Contains, "1 finding(s).")
+	c.Assert(report, qt.Not(qt.Contains), "without a DEFAULT")
+}

--- a/internal/atlasreport/migrate_lint_atlas_text.go
+++ b/internal/atlasreport/migrate_lint_atlas_text.go
@@ -142,7 +142,63 @@ func atlasDataType(value string) (string, bool) {
 	if strings.ReplaceAll(normalized, " ", "") == "varchar(255)" {
 		return "varchar", true
 	}
+	if catalogSpelledDataType(normalized) {
+		return normalized, true
+	}
 	return "", false
+}
+
+// catalogDataTypes are the PostgreSQL catalog type names the compatibility
+// surface prints unchanged, each measured against the pinned community binary
+// v1.3.0 on PostgreSQL 16 by renaming a NOT NULL column of that type and reading
+// the MF103 diagnostic it produces (stokaro/ptah#1074).
+//
+// The set is deliberately short. `timestamp with time zone` is absent because
+// the measured diagnostic says `timestamptz`, `timestamp without time zone`
+// because it says `timestamp`, and array types because the diagnostic says
+// `integer[]` where the catalog says `ARRAY` -- none of those is the catalog's
+// own spelling, so passing the catalog through would print a type the tool being
+// matched never prints. Those fall through to Ptah's labeled prose instead.
+var catalogDataTypes = map[string]bool{
+	"bigint":            true,
+	"boolean":           true,
+	"bytea":             true,
+	"character":         true,
+	"character varying": true,
+	"date":              true,
+	"double precision":  true,
+	"integer":           true,
+	"json":              true,
+	"jsonb":             true,
+	"numeric":           true,
+	"real":              true,
+	"smallint":          true,
+	"text":              true,
+	"uuid":              true,
+}
+
+// catalogSpelledDataType reports whether a lower-cased type name is one of the
+// measured catalog spellings, with or without the length or precision the
+// diagnostic carries in parentheses.
+//
+// Measured forms: `character varying(20)`, `character(5)`, `numeric(10,2)` and
+// `numeric(10)` -- PostgreSQL reports scale 0 for `numeric(10,0)` and the
+// diagnostic prints `numeric(10)` for both spellings.
+func catalogSpelledDataType(normalized string) bool {
+	base, arguments, found := strings.Cut(normalized, "(")
+	if !found {
+		return catalogDataTypes[normalized]
+	}
+	arguments, closed := strings.CutSuffix(arguments, ")")
+	if !closed || arguments == "" || !catalogDataTypes[base] {
+		return false
+	}
+	for argument := range strings.SplitSeq(arguments, ",") {
+		if argument == "" || strings.TrimLeft(argument, "0123456789") != "" {
+			return false
+		}
+	}
+	return true
 }
 
 // atlasSoleSubject returns the schema object a one-object diagnostic is about.

--- a/internal/atlasreport/migrate_lint_text.go
+++ b/internal/atlasreport/migrate_lint_text.go
@@ -363,8 +363,19 @@ func analyzerGroupLabel(analyzer string) string {
 	}
 }
 
-// groupDiagnostics collects a file's diagnostics into analyzer groups, keeping
-// the order in which each analyzer first appears.
+// groupDiagnostics collects a file's diagnostics into analyzer groups.
+//
+// Groups are emitted in analyzer order, not in the order the first diagnostic of
+// each happens to appear. One version reporting a drop on line 2 and a
+// non-nullable add on line 1 still prints the destructive group first: measured
+// against the pinned community binary v1.3.0, `ALTER TABLE users ADD COLUMN x
+// int NOT NULL` on line 1 followed by `ALTER TABLE users DROP COLUMN nick` on
+// line 2 prints "destructive changes detected" above "data dependent changes
+// detected". Ordering by first appearance printed them the other way round.
+//
+// Only analyzers whose relative order has been measured are ranked. Ptah's own
+// diagnostics have no counterpart to be measured against, so they keep
+// first-appearance order among themselves and follow the ranked groups.
 func groupDiagnostics(diags []migrateLintTextDiag) []migrateLintTextGroup {
 	var groups []migrateLintTextGroup
 	index := map[string]int{}
@@ -377,7 +388,24 @@ func groupDiagnostics(diags []migrateLintTextDiag) []migrateLintTextGroup {
 		}
 		groups[at].diags = append(groups[at].diags, diag)
 	}
+	slices.SortStableFunc(groups, func(a, b migrateLintTextGroup) int {
+		return cmp.Compare(analyzerGroupRank(a.label), analyzerGroupRank(b.label))
+	})
 	return groups
+}
+
+// analyzerGroupRank orders the analyzer groups whose relative order has been
+// measured. Unranked groups share the last rank, which a stable sort leaves in
+// first-appearance order behind the measured ones.
+func analyzerGroupRank(label string) int {
+	switch label {
+	case analyzerGroupLabel(atlaslint.AnalyzerDestructive):
+		return 0
+	case analyzerGroupLabel(atlaslint.AnalyzerDataDependent):
+		return 1
+	default:
+		return 2
+	}
 }
 
 func versionSeverity(groups []migrateLintTextGroup) (hasError, hasWarning bool, count int) {

--- a/internal/atlasreport/migrate_lint_text_internal_test.go
+++ b/internal/atlasreport/migrate_lint_text_internal_test.go
@@ -139,6 +139,21 @@ func TestAtlasDiagnosticText_FallsBackForMultiSubjectSingleObjectCodes(t *testin
 // selecting the latest N versions exactly as the migrate lint command does.
 func analyzeMigrations(t *testing.T, files map[string]string, latest int) migrationlint.Analysis {
 	t.Helper()
+	return analyzeMigrationsWithBaseline(t, files, latest, nil)
+}
+
+// analyzeMigrationsWithBaseline is [analyzeMigrations] for the diagnostics that
+// need the schema state a version starts from -- the add side of a rename, whose
+// column type and nullability live in an earlier file. A live run reads that
+// state off the dev database mid-replay; here it is supplied directly so the
+// rendering can be pinned without one.
+func analyzeMigrationsWithBaseline(
+	t *testing.T,
+	files map[string]string,
+	latest int,
+	baseline []migrationlint.BaselineColumn,
+) migrationlint.Analysis {
+	t.Helper()
 	fsys := fstest.MapFS{}
 	for name, body := range files {
 		fsys[name] = &fstest.MapFile{Data: []byte(body)}
@@ -166,6 +181,7 @@ func analyzeMigrations(t *testing.T, files map[string]string, latest int) migrat
 		DirFormat:     migrator.MigrationDirFormatAtlas,
 		Dialect:       "sqlite",
 		Selection:     migrationlint.VersionSelection{Versions: versions, Restricted: true},
+		Baseline:      baseline,
 	})
 	qt.Assert(t, err, qt.IsNil)
 	return analysis
@@ -189,10 +205,11 @@ func TestWriteMigrateLintText_RendersAtlasDiagnostics(t *testing.T) {
 	}
 
 	tests := []struct {
-		name   string
-		files  map[string]string
-		latest int
-		want   string
+		name     string
+		files    map[string]string
+		latest   int
+		baseline []migrationlint.BaselineColumn
+		want     string
 	}{
 		{
 			name:   "two diagnostics in one group collect their fixes",
@@ -575,13 +592,104 @@ func TestWriteMigrateLintText_RendersAtlasDiagnostics(t *testing.T) {
 				"  -- 0s\n" +
 				"  -- 1 version ok\n",
 		},
+		{
+			// stokaro/ptah#1074. The compatibility surface models a rename as the
+			// retirement of one name plus the introduction of another, and prints
+			// both: the drop of "id" and the add of an `integer` column "oid".
+			// Verbatim from atlas community version v1.3.0 on PostgreSQL 16, which
+			// is also where the `integer` spelling comes from -- the statement says
+			// `int` and the state says `integer`.
+			name: "rename prints its add side from the baseline",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE users (id int NOT NULL);\n",
+				"2.sql": "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			},
+			latest: 1,
+			baseline: []migrationlint.BaselineColumn{{
+				Version: 2, Table: "users", Name: "id", DataType: "integer", NotNull: true,
+			}},
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"integer\" column \"oid\" will fail in case table \"users\" is not\n" +
+				"         empty https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 2 diagnostics\n",
+		},
+		{
+			// The same fixture with a NULLABLE retired column, which is the control
+			// that separates "the rename is reported" from "the rename's add side
+			// is reported". Measured: one diagnostic, no data dependent group.
+			name: "nullable rename prints no add side",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE users (id int);\n",
+				"2.sql": "ALTER TABLE users RENAME COLUMN id TO oid;\n",
+			},
+			latest: 1,
+			baseline: []migrationlint.BaselineColumn{{
+				Version: 2, Table: "users", Name: "id", DataType: "integer",
+			}},
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L1: Dropping non-virtual column \"id\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"id\" is NULL before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 1 schema change\n" +
+				"  -- 1 diagnostic\n",
+		},
+		{
+			// Analyzer groups print in analyzer order, not in the order their first
+			// diagnostic appears. The add is on line 1 and the drop on line 2, so a
+			// renderer ordering groups by first appearance prints them the other way
+			// round -- which is what it used to do. Verbatim from the pinned binary.
+			name: "analyzer groups print in measured order",
+			files: map[string]string{
+				"1.sql": "CREATE TABLE users (id int, nick int);\n",
+				"2.sql": "ALTER TABLE users ADD COLUMN x text NOT NULL;\nALTER TABLE users DROP COLUMN nick;\n",
+			},
+			latest: 1,
+			want: "Analyzing changes from version 1 to 2 (1 migration in total):\n" +
+				"\n" +
+				"  -- analyzing version 2\n" +
+				"    -- destructive changes detected:\n" +
+				"      -- L2: Dropping non-virtual column \"nick\" https://atlasgo.io/lint/analyzers#DS103\n" +
+				"    -- data dependent changes detected:\n" +
+				"      -- L1: Adding a non-nullable \"text\" column \"x\" will fail in case table \"users\" is not empty\n" +
+				"         https://atlasgo.io/lint/analyzers#MF103\n" +
+				"    -- suggested fix:\n" +
+				"      -> Add a pre-migration check to ensure column \"nick\" is NULL before dropping it\n" +
+				"  -- ok (0s)\n" +
+				"\n" +
+				"  -------------------------\n" +
+				"  -- 0s\n" +
+				"  -- 1 version with errors\n" +
+				"  -- 2 schema changes\n" +
+				"  -- 2 diagnostics\n",
+		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 			c := qt.New(t)
-			analysis := analyzeMigrations(t, tc.files, tc.latest)
+			analysis := analyzeMigrationsWithBaseline(t, tc.files, tc.latest, tc.baseline)
 			var out bytes.Buffer
 
 			err := writeMigrateLintText(&out, MigrateLintOptions{Analysis: &analysis}, fixedZeroClock())

--- a/internal/migrationlintreport/baseline.go
+++ b/internal/migrationlintreport/baseline.go
@@ -1,0 +1,91 @@
+package migrationlintreport
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/lint"
+)
+
+// readBaselineColumns records the schema state one migration version starts
+// from, in the form the linter can look columns up in.
+//
+// It is read from the dev database mid-replay, after every earlier migration has
+// been applied and before this one is. That is the only place the retired half
+// of a rename still exists: `ALTER TABLE users RENAME COLUMN id TO oid` says
+// nothing about what `id` was, and after the statement runs there is no `id`
+// left to ask about.
+func readBaselineColumns(
+	conn *dbschema.DatabaseConnection,
+	version int64,
+	schemas []string,
+) ([]lint.BaselineColumn, error) {
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, schemas)
+	if err != nil {
+		return nil, fmt.Errorf("read dev database schema: %w", err)
+	}
+	var columns []lint.BaselineColumn
+	for _, table := range schema.Tables {
+		for _, column := range table.Columns {
+			columns = append(columns, lint.BaselineColumn{
+				Version:    version,
+				Schema:     table.Schema,
+				Table:      table.Name,
+				Name:       column.Name,
+				DataType:   compatColumnDataType(column),
+				NotNull:    strings.EqualFold(strings.TrimSpace(column.IsNullable), "NO"),
+				HasDefault: column.ColumnDefault != nil && strings.TrimSpace(*column.ColumnDefault) != "",
+			})
+		}
+	}
+	return columns, nil
+}
+
+// compatColumnDataType renders the type name the compatibility surface prints
+// for one introspected column, or empty when that spelling has not been
+// measured.
+//
+// The catalog's own type name is what the diagnostic carries for the types
+// below -- `int` reads back as `integer`, `varchar(20)` as `character
+// varying(20)` -- each measured against the pinned community binary v1.3.0 on
+// PostgreSQL 16 (stokaro/ptah#1074). Types whose diagnostic spelling is NOT the
+// catalog's return empty rather than a plausible guess: `timestamptz` reads back
+// from the catalog as `timestamp without time zone`'s neighbor `timestamp with
+// time zone` while the diagnostic says `timestamptz`, and an array column reads
+// back as the bare category `ARRAY`. An empty spelling still reports the
+// diagnostic, under Ptah's own labeled wording, which is the renderer's existing
+// answer to a type it cannot spell the other tool's way.
+func compatColumnDataType(column dbschematypes.DBColumn) string {
+	dataType := strings.ToLower(strings.Join(strings.Fields(column.DataType), " "))
+	switch dataType {
+	case "character", "character varying":
+		if column.CharacterMaxLength == nil {
+			return dataType
+		}
+		return dataType + "(" + strconv.Itoa(*column.CharacterMaxLength) + ")"
+	case "numeric":
+		return numericDataType(column)
+	case "bigint", "boolean", "bytea", "date", "double precision",
+		"integer", "json", "jsonb", "real", "smallint", "text", "uuid":
+		return dataType
+	}
+	return ""
+}
+
+// numericDataType spells a numeric column the way the diagnostic does: bare when
+// the type constrains nothing, `numeric(p)` when it constrains precision alone,
+// and `numeric(p,s)` when it constrains both. Measured: `numeric(10)` and
+// `numeric(10,0)` both print `numeric(10)`, so a zero scale is not printed.
+func numericDataType(column dbschematypes.DBColumn) string {
+	if column.NumericPrecision == nil {
+		return "numeric"
+	}
+	precision := "numeric(" + strconv.Itoa(*column.NumericPrecision)
+	if column.NumericScale == nil || *column.NumericScale == 0 {
+		return precision + ")"
+	}
+	return precision + "," + strconv.Itoa(*column.NumericScale) + ")"
+}

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 
 	"go.5x5.cz/ptah/config/projectconfig"
+	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/atlasurl"
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
@@ -374,6 +375,19 @@ func effectiveDialect(opts Options, configDialect, devDialect string) (string, e
 	return dialect, nil
 }
 
+// lintDirectory analyzes the captured migration directory and replays it on the
+// dev database.
+//
+// The replay does double duty. It has always validated that the SQL runs, and it
+// now also reads the schema state the versions the analysis asked about start
+// from, because some diagnostics cannot be reached from SQL text alone -- see
+// [lint.BaselineColumn]. When it read anything, the analysis runs a second time
+// with those facts in hand.
+//
+// The analysis stays first so error precedence does not move: a directory that
+// fails to analyze reports that, not a replay error it would also have hit. The
+// second pass is skipped whenever the first one asked for nothing, which is
+// every run with no renames to resolve and every run without a dev database.
 func lintDirectory(
 	ctx context.Context,
 	opts Options,
@@ -385,16 +399,69 @@ func lintDirectory(
 	if err != nil {
 		return lint.Analysis{}, err
 	}
+	baseline := newBaselineCollector(analysis.BaselineVersions(), opts.DevURL)
 	if err := migrationreplay.Replay(ctx, migrationreplay.Options{
 		Dir:               opts.Dir,
 		DirFormat:         dirFormat,
 		DevURL:            opts.DevURL,
 		FS:                analysis.SnapshotFS(),
 		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
+		ObserveVersion:    baseline.observer(),
 	}); err != nil {
 		return analysis, fmt.Errorf("error validating migration SQL on dev database: %w", err)
 	}
-	return analysis, nil
+	if len(baseline.columns) == 0 {
+		return analysis, nil
+	}
+	lintOptions.Baseline = baseline.columns
+	return lint.AnalyzeFS(fsys, lintOptions)
+}
+
+// baselineCollector reads the dev database once per version the analysis asked
+// about, while the replay is standing on that version's starting state.
+//
+// A nil observer is handed to the replay when nothing was asked for, so a
+// directory with no renames pays no introspection at all.
+type baselineCollector struct {
+	wanted  map[int64]bool
+	schemas []string
+	columns []lint.BaselineColumn
+}
+
+func newBaselineCollector(versions []int64, devURL string) *baselineCollector {
+	collector := &baselineCollector{wanted: make(map[int64]bool, len(versions))}
+	for _, version := range versions {
+		collector.wanted[version] = true
+	}
+	if scope := schemaselection.FromURL(devURL).Scope; scope != "" {
+		collector.schemas = []string{scope}
+	}
+	return collector
+}
+
+// observer returns the replay hook, or nil when the analysis asked for nothing
+// so the replay runs exactly as it did before this existed.
+func (c *baselineCollector) observer() func(context.Context, int64, *dbschema.DatabaseConnection) error {
+	if len(c.wanted) == 0 {
+		return nil
+	}
+	return c.observe
+}
+
+func (c *baselineCollector) observe(
+	_ context.Context,
+	version int64,
+	conn *dbschema.DatabaseConnection,
+) error {
+	if c == nil || !c.wanted[version] {
+		return nil
+	}
+	columns, err := readBaselineColumns(conn, version, c.schemas)
+	if err != nil {
+		return err
+	}
+	c.columns = append(c.columns, columns...)
+	return nil
 }
 
 func validateDevURLDialect(dialect, devDialect string) error {

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -30,6 +30,11 @@ type Options struct {
 	// FS supplies an immutable migration snapshot. When nil, Replay opens Dir.
 	FS                fs.FS
 	AtlasTemplateData any
+	// ObserveVersion, when set, runs before each migration is replayed, with the
+	// connection bound to the schema state that migration starts from. It is how
+	// a caller reads the before-state of one version without replaying the
+	// directory once per version. An error from it aborts the replay.
+	ObserveVersion func(ctx context.Context, version int64, conn *dbschema.DatabaseConnection) error
 }
 
 // Replay connects to the configured dev database and replays the migration
@@ -57,7 +62,14 @@ func Replay(ctx context.Context, opts Options) error {
 	}
 	defer dbschema.CloseAndWarn(conn)
 
-	return replayOnConnection(ctx, conn, snapshot, opts.DirFormat, opts.AtlasTemplateData, nil)
+	return replayOnConnection(
+		ctx,
+		conn,
+		snapshot,
+		opts.DirFormat,
+		opts.AtlasTemplateData,
+		replayHooks{observeVersion: opts.ObserveVersion},
+	)
 }
 
 // ReplayOnConnection replays the migration directory on an already-open dev
@@ -104,7 +116,7 @@ func ReplaySnapshotOnConnection(
 	if err != nil {
 		return fmt.Errorf("capture migration snapshot: %w", err)
 	}
-	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, nil)
+	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, replayHooks{})
 }
 
 // WithReplayedSnapshot replays one immutable migration filesystem, invokes
@@ -124,7 +136,7 @@ func WithReplayedSnapshot(
 	if err != nil {
 		return fmt.Errorf("capture migration snapshot: %w", err)
 	}
-	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, consume)
+	return replayOnConnection(ctx, conn, snapshot, dirFormat, nil, replayHooks{consume: consume})
 }
 
 // WithReplayedSnapshotLocked performs the same replay as
@@ -144,7 +156,17 @@ func WithReplayedSnapshotLocked(
 	if err != nil {
 		return fmt.Errorf("capture migration snapshot: %w", err)
 	}
-	return replayOnLockedConnection(ctx, conn, snapshot, dirFormat, nil, consume)
+	return replayOnLockedConnection(ctx, conn, snapshot, dirFormat, nil, replayHooks{consume: consume})
+}
+
+// replayHooks are the optional callbacks a replay runs alongside the
+// migrations. The zero value replays and observes nothing.
+type replayHooks struct {
+	// observeVersion runs before each migration, with the connection bound to
+	// the state that migration starts from.
+	observeVersion func(context.Context, int64, *dbschema.DatabaseConnection) error
+	// consume runs once after every migration, before the realm is cleaned.
+	consume func(*dbschema.DatabaseConnection) error
 }
 
 func replayOnConnection(
@@ -153,7 +175,7 @@ func replayOnConnection(
 	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
 	atlasTemplateData any,
-	consume func(*dbschema.DatabaseConnection) error,
+	hooks replayHooks,
 ) (resultErr error) {
 	if conn == nil {
 		return fmt.Errorf("replay migrations: nil database connection")
@@ -165,7 +187,7 @@ func replayOnConnection(
 	defer func() {
 		resultErr = errors.Join(resultErr, lock.Release())
 	}()
-	return replayOnLockedConnection(ctx, conn, fsys, dirFormat, atlasTemplateData, consume)
+	return replayOnLockedConnection(ctx, conn, fsys, dirFormat, atlasTemplateData, hooks)
 }
 
 func replayOnLockedConnection(
@@ -174,7 +196,7 @@ func replayOnLockedConnection(
 	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
 	atlasTemplateData any,
-	consume func(*dbschema.DatabaseConnection) error,
+	hooks replayHooks,
 ) error {
 	if conn == nil {
 		return fmt.Errorf("replay migrations: nil database connection")
@@ -203,7 +225,7 @@ func replayOnLockedConnection(
 			ctx,
 			replayConn,
 			migrations,
-			consume,
+			hooks,
 		)
 	})
 }
@@ -212,7 +234,7 @@ func replayMigrations(
 	ctx context.Context,
 	conn *dbschema.DatabaseConnection,
 	migrations []*migrator.Migration,
-	consume func(*dbschema.DatabaseConnection) error,
+	hooks replayHooks,
 ) (resultErr error) {
 	if err := ctx.Err(); err != nil {
 		return err
@@ -233,12 +255,17 @@ func replayMigrations(
 		return fmt.Errorf("clean dev database: %w", err)
 	}
 	for _, migration := range migrations {
+		if hooks.observeVersion != nil {
+			if err := hooks.observeVersion(ctx, migration.Version, conn); err != nil {
+				return fmt.Errorf("observe dev database before migration %d: %w", migration.Version, err)
+			}
+		}
 		if err := migration.UpForReplay(ctx, conn); err != nil {
 			return fmt.Errorf("replay migration %d on dev database: %w", migration.Version, err)
 		}
 	}
-	if consume != nil {
-		if err := consume(conn); err != nil {
+	if hooks.consume != nil {
+		if err := hooks.consume(conn); err != nil {
 			return err
 		}
 	}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -160,6 +160,9 @@ type File struct {
 	// when the two command surfaces model the same statement differently; see
 	// [renamedNames] for the one construct where they do.
 	compatibility CompatibilityProfile
+	// baseline is the schema state this file's version starts from, when the
+	// caller supplied one. Rules read it for facts the statement cannot carry.
+	baseline baselineColumns
 }
 
 // VersionSelection selects migration versions while preserving the difference
@@ -176,9 +179,10 @@ type VersionSelection struct {
 // copies, so callers cannot modify the captured files, findings, or source
 // snapshot.
 type Analysis struct {
-	files    []File
-	findings []Finding
-	snapshot fsnapshot.Snapshot
+	files            []File
+	findings         []Finding
+	snapshot         fsnapshot.Snapshot
+	baselineVersions []int64
 }
 
 // Files returns every prepared migration file in the captured directory.
@@ -200,6 +204,17 @@ func (a Analysis) SelectedFiles() []File {
 // Findings returns the ordered lint findings.
 func (a Analysis) Findings() []Finding {
 	return cloneFindings(a.findings)
+}
+
+// BaselineVersions returns the analyzed migration versions whose starting
+// schema state would let a second analysis say more than SQL text alone can,
+// sorted ascending.
+//
+// It is empty for a run that already has nothing to gain, so a caller can skip
+// the dev-database round trips and the second analysis entirely. Feed the
+// versions back through [Options.Baseline]; see [BaselineColumn].
+func (a Analysis) BaselineVersions() []int64 {
+	return slices.Clone(a.baselineVersions)
 }
 
 // SnapshotFS returns a read-only filesystem containing the SQL sources,
@@ -306,6 +321,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 
 	mode := modeForDialect(opts.Dialect)
 	scope := newSchemaScope(opts.SchemaScope)
+	baseline := newBaselineIndex(normalizeBaselineColumns(opts.Baseline))
 	files := make([]File, 0, len(names))
 	for _, name := range names {
 		file, err := prepareFile(
@@ -322,6 +338,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			opts.Selection,
 			opts.Compatibility,
 			scope,
+			baseline,
 		)
 		if err != nil {
 			return Analysis{}, err
@@ -348,9 +365,10 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 	})
 
 	return Analysis{
-		files:    files,
-		findings: cloneFindings(findings),
-		snapshot: snapshot,
+		files:            files,
+		findings:         cloneFindings(findings),
+		snapshot:         snapshot,
+		baselineVersions: baselineVersions(files),
 	}, nil
 }
 
@@ -463,6 +481,7 @@ func prepareFile(
 	selection VersionSelection,
 	compatibility CompatibilityProfile,
 	scope schemaScope,
+	baseline map[int64]baselineColumns,
 ) (File, error) {
 	raw := sources[name]
 	base := path.Base(name)
@@ -493,6 +512,7 @@ func prepareFile(
 		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
 		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
 		compatibility:  compatibility,
+		baseline:       baseline[version],
 	}
 	if compatibility == CompatibilityProfileAtlas {
 		file.suppressedRules, file.Ignored = parseAtlasFileNoLint(raw)

--- a/migration/lint/baseline.go
+++ b/migration/lint/baseline.go
@@ -1,0 +1,171 @@
+package lint
+
+import (
+	"slices"
+	"strings"
+)
+
+// BaselineColumn is one column of the schema state a migration version starts
+// from, as read from the dev database the run validates against.
+//
+// Reading SQL text is enough to see that `ALTER TABLE users RENAME COLUMN id TO
+// oid` retires the name `id`. It is not enough to see what the new name
+// introduces: the retired column's type, nullability and default live in an
+// earlier migration file or in the base schema, never in the rename statement.
+// A caller that replays the directory on a dev database can read them there and
+// hand them over here, and only then can the add side of a rename be reported.
+//
+// Callers ask [Analysis.BaselineVersions] which versions are worth reading, so a
+// directory with no renames costs no introspection at all.
+type BaselineColumn struct {
+	// Version is the migration version whose starting state this column belongs
+	// to: the state read BEFORE that version is applied, not after.
+	Version int64
+	// Schema is the schema of the owning table, as the server spells it.
+	Schema string
+	// Table is the owning table, as the server spells it.
+	Table string
+	// Name is the column name, as the server spells it.
+	Name string
+	// DataType is the column type spelled the way the compatibility surface
+	// prints it. Empty when the caller could not establish that spelling, which
+	// leaves the diagnostic reported under Ptah's own wording rather than
+	// inventing an Atlas sentence for a type nobody measured.
+	DataType string
+	// NotNull reports whether the column rejects NULL.
+	NotNull bool
+	// HasDefault reports whether the column carries a DEFAULT expression.
+	HasDefault bool
+}
+
+// baselineColumns is one version's starting state, indexed for lookup by the
+// source-spelled references the linter reads out of SQL.
+//
+// The zero value resolves nothing, which is what every run without a dev
+// database gets and what keeps a rename reported exactly as it was before this
+// existed.
+type baselineColumns struct {
+	byRef map[string][]BaselineColumn
+	// schemaless reports that no column in this state names a schema. A reader
+	// scoped to one schema does not repeat that schema's name on every table, so
+	// a migration writing `ALTER TABLE public.users` has a qualifier the state
+	// cannot match literally. Nothing in the state can contradict that qualifier
+	// either, which is what makes dropping it safe here and not once the state
+	// carries several schemas.
+	schemaless bool
+}
+
+// newBaselineIndex groups baseline columns by the version whose starting state
+// they describe.
+func newBaselineIndex(columns []BaselineColumn) map[int64]baselineColumns {
+	if len(columns) == 0 {
+		return nil
+	}
+	index := map[int64]baselineColumns{}
+	for _, column := range columns {
+		state, ok := index[column.Version]
+		if !ok {
+			state = baselineColumns{byRef: map[string][]BaselineColumn{}, schemaless: true}
+		}
+		if column.Schema != "" {
+			state.schemaless = false
+		}
+		for _, key := range baselineKeys(column) {
+			state.byRef[key] = append(state.byRef[key], column)
+		}
+		index[column.Version] = state
+	}
+	return index
+}
+
+// baselineKeys are the reference spellings that resolve to one column.
+//
+// A migration writes `ALTER TABLE users` or `ALTER TABLE public.users` for the
+// same table, so both the qualified and the bare form are indexed. Identifiers
+// fold to the same case the rest of the linter folds them to, because the
+// alternative -- missing a column whose file spells it differently from the
+// catalog -- silently drops a diagnostic.
+func baselineKeys(column BaselineColumn) []string {
+	name := normalizeIdent(column.Name)
+	table := normalizeIdent(column.Table)
+	qualified := normalizeIdent(column.Schema) + "." + table
+	if column.Schema == "" {
+		return []string{table + "\x00" + name}
+	}
+	return []string{
+		table + "\x00" + name,
+		qualified + "\x00" + name,
+	}
+}
+
+// column returns the baseline state of one column of one table.
+//
+// tableRef and columnName are the linter's normalized identifier forms. A
+// reference that resolves to more than one column -- a bare table name carried
+// by several schemas -- is not a match: naming the wrong table's column is worse
+// than saying nothing, so ambiguity fails closed.
+func (b baselineColumns) column(tableRef, columnName string) (BaselineColumn, bool) {
+	if len(b.byRef) == 0 || tableRef == "" || columnName == "" {
+		return BaselineColumn{}, false
+	}
+	if match, ok := b.exact(tableRef, columnName); ok {
+		return match, ok
+	}
+	if !b.schemaless {
+		return BaselineColumn{}, false
+	}
+	// Comparing last components when one side is unqualified is the same match
+	// [refersToCreated] makes, and it inherits the same limit: the normalized
+	// form of `"tenant.data"` and of `tenant.data` are one string.
+	dot := strings.LastIndex(tableRef, ".")
+	if dot < 0 {
+		return BaselineColumn{}, false
+	}
+	return b.exact(tableRef[dot+1:], columnName)
+}
+
+func (b baselineColumns) exact(tableRef, columnName string) (BaselineColumn, bool) {
+	matches := b.byRef[tableRef+"\x00"+columnName]
+	if len(matches) != 1 {
+		return BaselineColumn{}, false
+	}
+	return matches[0], true
+}
+
+// baselineVersions returns the versions whose starting schema state would let
+// the analysis say more than it can from SQL text alone, sorted ascending.
+//
+// Today that is exactly the versions carrying a column rename the compatibility
+// surface models as a drop plus an add: the add side needs the retired column's
+// type and nullability, which the statement does not carry. Files whose rename
+// is exempt because this same file created the table are not listed -- nothing
+// about them is reportable, so reading the database for them would be a round
+// trip spent to learn nothing.
+func baselineVersions(files []File) []int64 {
+	var versions []int64
+	for i := range files {
+		file := &files[i]
+		if !file.Selected || !file.IsUp || file.Version == 0 {
+			continue
+		}
+		if len(renameAddSideCandidates(file)) == 0 {
+			continue
+		}
+		versions = append(versions, file.Version)
+	}
+	slices.Sort(versions)
+	return slices.Compact(versions)
+}
+
+// normalizeBaselineColumns drops entries no lookup can use, so an index never
+// carries rows that can only produce a false ambiguity.
+func normalizeBaselineColumns(columns []BaselineColumn) []BaselineColumn {
+	kept := make([]BaselineColumn, 0, len(columns))
+	for _, column := range columns {
+		if strings.TrimSpace(column.Table) == "" || strings.TrimSpace(column.Name) == "" {
+			continue
+		}
+		kept = append(kept, column)
+	}
+	return kept
+}

--- a/migration/lint/baseline_test.go
+++ b/migration/lint/baseline_test.go
@@ -1,0 +1,324 @@
+package lint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/lint"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// renameBaselineFS is the fixture every case below analyzes: one file creates a
+// table, the next renames one of its columns. The rename is the whole point --
+// the retired column's type and nullability are in file 1, so nothing in file 2
+// can tell an analyzer what the new name introduces.
+func renameBaselineFS() map[string]string {
+	return map[string]string{
+		"1_base.sql":   "CREATE TABLE users (id int NOT NULL);",
+		"2_rename.sql": "ALTER TABLE users RENAME COLUMN id TO oid;",
+	}
+}
+
+func renameBaselineOptions(baseline []lint.BaselineColumn) lint.Options {
+	return lint.Options{
+		Compatibility: lint.CompatibilityProfileAtlas,
+		Dialect:       "postgres",
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+		Selection:     lint.VersionSelection{Versions: []int64{2}, Restricted: true},
+		Baseline:      baseline,
+	}
+}
+
+// notNullBaseline is the state version 2 starts from when `users.id` is the
+// non-nullable, default-less column the pinned community binary reports an
+// MF103 for.
+func notNullBaseline() []lint.BaselineColumn {
+	return []lint.BaselineColumn{{
+		Version:  2,
+		Table:    "users",
+		Name:     "id",
+		DataType: "integer",
+		NotNull:  true,
+	}}
+}
+
+// TestAnalyzeFS_RenameAddSideNeedsTheBaseline pins the whole point of
+// [lint.BaselineColumn]: the add side of a rename is reportable only once the
+// caller has established what the retired column was.
+//
+// Measured against atlas community version v1.3.0 on PostgreSQL 16 for
+// stokaro/ptah#1074: `CREATE TABLE users (id int NOT NULL)` then `ALTER TABLE
+// users RENAME COLUMN id TO oid` reports the drop of "id" AND `Adding a
+// non-nullable "integer" column "oid" will fail in case table "users" is not
+// empty`, and exits 1.
+func TestAnalyzeFS_RenameAddSideNeedsTheBaseline(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		baseline []lint.BaselineColumn
+		want     []string
+	}{
+		{
+			// No dev database was read, so the retired column's shape was never
+			// established and the add side stays unreported.
+			name: "no baseline reports the retirement alone",
+			want: []string{"DS102"},
+		},
+		{
+			name:     "baseline reports both halves of the rename",
+			baseline: notNullBaseline(),
+			want:     []string{"DD101", "DS102"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			analysis, err := lint.AnalyzeFS(fixture(renameBaselineFS()), renameBaselineOptions(test.baseline))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_RenameAddSideSubjectCarriesTheIntroducedColumn pins what the
+// finding is about. The retirement names the OLD column and the add names the
+// NEW one, with the retired column's type: getting either half backwards would
+// print a diagnostic about a column that does not exist after the migration.
+func TestAnalyzeFS_RenameAddSideSubjectCarriesTheIntroducedColumn(t *testing.T) {
+	c := qt.New(t)
+
+	analysis, err := lint.AnalyzeFS(fixture(renameBaselineFS()), renameBaselineOptions(notNullBaseline()))
+
+	c.Assert(err, qt.IsNil)
+	findings := analysis.Findings()
+	c.Assert(findings, qt.HasLen, 2)
+	c.Assert(findings[0].Rule, qt.Equals, "DD101")
+	c.Assert(findings[0].Severity, qt.Equals, lint.SeverityWarning)
+	c.Assert(findings[0].Line, qt.Equals, 1)
+	c.Assert(findings[0].Context, qt.IsNotNil)
+	c.Assert(findings[0].Context.Subjects, qt.DeepEquals, []lint.Subject{{
+		Kind:     lint.SubjectColumn,
+		Name:     "oid",
+		Parent:   "users",
+		DataType: "integer",
+	}})
+	c.Assert(findings[1].Rule, qt.Equals, "DS102")
+	c.Assert(findings[1].Context.Subjects, qt.DeepEquals, []lint.Subject{{
+		Kind:   lint.SubjectColumn,
+		Name:   "id",
+		Parent: "users",
+	}})
+}
+
+// TestAnalyzeFS_RenameAddSideSilentCases keeps the rule to the shape it was
+// measured on. Each row is a fixture the pinned community binary reports NO
+// MF103 for, and each differs from the reporting fixture on exactly one axis, so
+// a rule that ignored that axis would fail here while the reporting case passed.
+func TestAnalyzeFS_RenameAddSideSilentCases(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		files    map[string]string
+		baseline []lint.BaselineColumn
+		want     []string
+	}{
+		{
+			// A nullable retired column introduces a nullable one, which cannot
+			// fail on existing rows. Measured: one diagnostic, the drop only.
+			name:  "nullable retired column",
+			files: renameBaselineFS(),
+			baseline: []lint.BaselineColumn{{
+				Version: 2, Table: "users", Name: "id", DataType: "integer",
+			}},
+			want: []string{"DS102"},
+		},
+		{
+			// Measured: `CREATE TABLE users (id int NOT NULL DEFAULT 7)` then the
+			// same rename reports the drop alone. A default is what makes the
+			// add survive existing rows.
+			name:  "retired column carries a default",
+			files: renameBaselineFS(),
+			baseline: []lint.BaselineColumn{{
+				Version: 2, Table: "users", Name: "id", DataType: "integer",
+				NotNull: true, HasDefault: true,
+			}},
+			want: []string{"DS102"},
+		},
+		{
+			// The table is created in the file doing the rename, so the table is
+			// empty and neither half is reportable. Measured: no diagnostics at
+			// all, exit 0.
+			name: "table created in the same file",
+			files: map[string]string{
+				"1_base.sql":   "CREATE TABLE seed (x int);",
+				"2_rename.sql": "CREATE TABLE users (id int NOT NULL);\nALTER TABLE users RENAME COLUMN id TO oid;",
+			},
+			baseline: notNullBaseline(),
+			want:     []string{},
+		},
+		{
+			// A table rename introduces no column, so it has no add side.
+			// Measured: DS102 for the retired table and nothing else.
+			name: "table rename",
+			files: map[string]string{
+				"1_base.sql":   "CREATE TABLE users (id int NOT NULL);",
+				"2_rename.sql": "ALTER TABLE users RENAME TO accounts;",
+			},
+			baseline: notNullBaseline(),
+			want:     []string{"DS101"},
+		},
+		{
+			// The baseline describes a different table, so this run never
+			// established what `users.id` was.
+			name:  "baseline carries another table",
+			files: renameBaselineFS(),
+			baseline: []lint.BaselineColumn{{
+				Version: 2, Table: "accounts", Name: "id", DataType: "integer", NotNull: true,
+			}},
+			want: []string{"DS102"},
+		},
+		{
+			// The baseline describes the state of a different version, which is
+			// not the state this file starts from.
+			name:  "baseline carries another version",
+			files: renameBaselineFS(),
+			baseline: []lint.BaselineColumn{{
+				Version: 1, Table: "users", Name: "id", DataType: "integer", NotNull: true,
+			}},
+			want: []string{"DS102"},
+		},
+		{
+			// A bare table name carried by two schemas resolves to neither:
+			// naming the wrong table's column is worse than saying nothing.
+			name:  "ambiguous bare table name",
+			files: renameBaselineFS(),
+			baseline: []lint.BaselineColumn{
+				{Version: 2, Schema: "app", Table: "users", Name: "id", DataType: "integer", NotNull: true},
+				{Version: 2, Schema: "audit", Table: "users", Name: "id", DataType: "bigint", NotNull: true},
+			},
+			want: []string{"DS102"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			analysis, err := lint.AnalyzeFS(fixture(test.files), renameBaselineOptions(test.baseline))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_RenameAddSideIsCompatibilitySurfaceOnly keeps the native surface
+// out of it. Native `ptah migrations lint` models a rename as a rename and
+// reports BC101; a rename does not fail on a populated table, so claiming it
+// might would be a statement about the statement that is false in the model that
+// surface uses.
+func TestAnalyzeFS_RenameAddSideIsCompatibilitySurfaceOnly(t *testing.T) {
+	c := qt.New(t)
+
+	options := renameBaselineOptions(notNullBaseline())
+	options.Compatibility = lint.CompatibilityProfileNative
+
+	analysis, err := lint.AnalyzeFS(fixture(renameBaselineFS()), options)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, []string{"BC101"})
+}
+
+// TestAnalyzeFS_RenameAddSideResolvesQualifiedReference covers the spelling a
+// migration is free to use for the same table. A schema-scoped read does not
+// repeat the schema name on every table, so a qualified reference has a
+// qualifier the state cannot match literally, and dropping it is what keeps the
+// diagnostic. Without this the same fixture written `ALTER TABLE public.users`
+// silently reported one diagnostic where the pinned binary reports two.
+func TestAnalyzeFS_RenameAddSideResolvesQualifiedReference(t *testing.T) {
+	c := qt.New(t)
+
+	files := map[string]string{
+		"1_base.sql":   "CREATE TABLE users (id int NOT NULL);",
+		"2_rename.sql": "ALTER TABLE public.users RENAME COLUMN id TO oid;",
+	}
+
+	analysis, err := lint.AnalyzeFS(fixture(files), renameBaselineOptions(notNullBaseline()))
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, []string{"DD101", "DS102"})
+}
+
+// TestAnalyzeFS_BaselineVersionsAsksOnlyForWhatItCanUse pins the request side.
+// A caller reads the dev database once per version listed here, so listing a
+// version with nothing to resolve spends a round trip to learn nothing, and
+// failing to list one leaves the diagnostic unreachable.
+func TestAnalyzeFS_BaselineVersionsAsksOnlyForWhatItCanUse(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		files   map[string]string
+		options lint.Options
+		want    []int64
+	}{
+		{
+			name:    "column rename",
+			files:   renameBaselineFS(),
+			options: renameBaselineOptions(nil),
+			want:    []int64{2},
+		},
+		{
+			name: "no rename",
+			files: map[string]string{
+				"1_base.sql": "CREATE TABLE users (id int NOT NULL);",
+				"2_drop.sql": "DROP TABLE users;",
+			},
+			options: renameBaselineOptions(nil),
+			want:    nil,
+		},
+		{
+			name: "rename exempted by a same-file create",
+			files: map[string]string{
+				"1_base.sql":   "CREATE TABLE seed (x int);",
+				"2_rename.sql": "CREATE TABLE users (id int NOT NULL);\nALTER TABLE users RENAME COLUMN id TO oid;",
+			},
+			options: renameBaselineOptions(nil),
+			want:    nil,
+		},
+		{
+			name: "table rename introduces no column",
+			files: map[string]string{
+				"1_base.sql":   "CREATE TABLE users (id int NOT NULL);",
+				"2_rename.sql": "ALTER TABLE users RENAME TO accounts;",
+			},
+			options: renameBaselineOptions(nil),
+			want:    nil,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			analysis, err := lint.AnalyzeFS(fixture(test.files), test.options)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(analysis.BaselineVersions(), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestAnalyzeFS_BaselineVersionsIsNativeSurfaceEmpty keeps the native surface
+// from paying for a lookup it will not use.
+func TestAnalyzeFS_BaselineVersionsIsNativeSurfaceEmpty(t *testing.T) {
+	c := qt.New(t)
+
+	options := renameBaselineOptions(nil)
+	options.Compatibility = lint.CompatibilityProfileNative
+
+	analysis, err := lint.AnalyzeFS(fixture(renameBaselineFS()), options)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(analysis.BaselineVersions(), qt.HasLen, 0)
+}

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -117,6 +117,11 @@ type Options struct {
 	// RuleConfigs carries per-rule severity and path-scoping overrides,
 	// normally loaded from .ptah-lint.yaml.
 	RuleConfigs map[string]RuleConfig
+	// Baseline carries the schema state each analyzed version starts from,
+	// normally read from the dev database after replaying the migrations that
+	// precede that version. Empty analyzes SQL text alone, which is what every
+	// run without a dev database does. See [BaselineColumn].
+	Baseline []BaselineColumn
 }
 
 func parseKnownMigrationName(name string, dirFormat migrator.MigrationDirFormat) (*migrator.MigrationFile, error) {

--- a/migration/lint/rename.go
+++ b/migration/lint/rename.go
@@ -36,6 +36,13 @@ type renamedName struct {
 	kind SubjectKind
 	// name is the retired name exactly as the source spells it.
 	name string
+	// normalized is the retired name in the linter's comparison form, used to
+	// look the retired object up in the schema state the version starts from.
+	normalized string
+	// introduced is the name the rename puts in place of the retired one,
+	// source-spelled. Empty when the statement is a rename whose target could
+	// not be read.
+	introduced string
 	// parent is the owning table of a renamed column, source-spelled.
 	parent string
 	// owner is the normalized reference of the table whose creation earlier in
@@ -123,11 +130,14 @@ func alterRenamedNames(w, sourceWords []string) []renamedName {
 			continue
 		}
 		if next < len(w) && (w[next] == "TO" || w[next] == "AS") {
+			introduced, _, _ := identifierAt(w, sourceWords, next+1)
 			names = append(names, renamedName{
-				kind:   SubjectColumn,
-				name:   identifier.name,
-				parent: table.name,
-				owner:  table.normalized,
+				kind:       SubjectColumn,
+				name:       identifier.name,
+				normalized: identifier.normalized,
+				introduced: introduced.name,
+				parent:     table.name,
+				owner:      table.normalized,
 			})
 			continue
 		}
@@ -192,6 +202,22 @@ func fileRenames(file *File) []statementRename {
 		})
 	}
 	return renames
+}
+
+// renameAddSideCandidates returns the column renames whose add side this file's
+// surface reports, before any schema state has been consulted.
+//
+// Both the request for that state ([baselineVersions]) and the finding built
+// from it ([renamedColumnAddFindings]) go through this one function, so the
+// surface split is decided in exactly one place. Deciding it twice made the
+// native surface's control unable to see the rule's own gate disappear: with no
+// baseline ever requested there, the finding could not fire whether that gate
+// was present or not, and the control stayed green either way.
+func renameAddSideCandidates(file *File) []statementRename {
+	if file.compatibility != CompatibilityProfileAtlas {
+		return nil
+	}
+	return renamesOfKind(fileRenames(file), SubjectColumn)
 }
 
 // renamesOfKind keeps the renames of one object kind, dropping statements left

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -574,7 +574,82 @@ func notNullWithoutDefaultFindings(file *File) []Finding {
 		}
 		findings = append(findings, notNullWithoutDefaultFindingsFor(file.Path, stmt.Line, i, subjects)...)
 	}
+	return append(findings, renamedColumnAddFindings(file)...)
+}
+
+// renamedColumnAddFindings reports the add side of a column rename, on the
+// compatibility surface only.
+//
+// That surface models a rename structurally, as the retirement of one name plus
+// the introduction of another (see [renamedNames]); the retirement is already
+// reported as destructive, and this is its other half. If the retired column
+// rejected NULL and had no default, the introduced name is a non-nullable column
+// with no default, which is exactly what DD101 is about. Measured against the
+// pinned community binary v1.3.0 on PostgreSQL 16: `CREATE TABLE users (id int
+// NOT NULL)` in one file and `ALTER TABLE users RENAME COLUMN id TO oid` in the
+// next reports BOTH the drop of "id" and the add of an `integer` column "oid",
+// and exits 1.
+//
+// The native surface deliberately does not get this. It models a rename as a
+// rename, and a rename does not fail on a populated table -- saying it would
+// there would be a claim about the statement that is not true of the statement
+// Ptah's own analyzer describes. On the compatibility surface the drop-plus-add
+// model is the contract, so the claim follows the model.
+//
+// It needs facts the statement does not carry: the retired column's type,
+// nullability and default live in an earlier file or the base schema. They come
+// from [Options.Baseline], so a run without a dev database reports nothing here
+// rather than guessing. A rename this file's own CREATE TABLE exempts is already
+// gone from [fileRenames], which is the same exemption the loop above applies to
+// a plain ADD COLUMN and is measured the same way.
+func renamedColumnAddFindings(file *File) []Finding {
+	var findings []Finding
+	for _, rename := range renameAddSideCandidates(file) {
+		for _, name := range rename.names {
+			subject, ok := renamedColumnAddSubject(file, name)
+			if !ok {
+				continue
+			}
+			findings = append(findings, Finding{
+				Rule:     "DD101",
+				Title:    "non-nullable column added without a default",
+				Severity: SeverityWarning,
+				File:     file.Path,
+				Line:     rename.line,
+				Message: fmt.Sprintf(
+					"RENAME introduces NOT NULL column %s without a DEFAULT, which %s",
+					subject.Name,
+					notNullWithoutDefaultAdvice,
+				),
+				Context: statementFindingContext(rename.statementIndex, subject),
+			})
+		}
+	}
 	return findings
+}
+
+// renamedColumnAddSubject resolves the column a rename introduces against the
+// schema state its version starts from, and reports whether that column is the
+// non-nullable, default-less shape DD101 covers.
+//
+// Every unresolved case returns false: an unreadable rename, a column the
+// baseline does not carry, or no baseline at all. Reporting requires having
+// established the column's shape, and a run that has not established it must not
+// claim the migration will fail on data.
+func renamedColumnAddSubject(file *File, name renamedName) (Subject, bool) {
+	if name.introduced == "" || name.normalized == "" {
+		return Subject{}, false
+	}
+	column, ok := file.baseline.column(name.owner, name.normalized)
+	if !ok || !column.NotNull || column.HasDefault {
+		return Subject{}, false
+	}
+	return Subject{
+		Kind:     SubjectColumn,
+		Name:     name.introduced,
+		Parent:   name.parent,
+		DataType: column.DataType,
+	}, true
 }
 
 // notNullWithoutDefaultFindingsFor reports one finding per column an ALTER


### PR DESCRIPTION
Closes the last open scenario of #1074 — S2, the `MF103` a rename introduces.

A rename retires one logical name and introduces another. The retirement has been reported since #1120. The introduction was unreachable, because the retired column's type, nullability and default live in an earlier migration file or in the base schema, never in the rename statement. Reaching it needs a dev-database schema read, which is why this scenario waited.

## What was measured, and how

Pinned comparison binary: `atlas community version v1.3.0` at `/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`, invoked by absolute path. Dev database: PostgreSQL 16 in a container, one freshly created database per fixture, `atlas migrate hash` then `migrate lint --dir file://… --dev-url … --latest 1` on both binaries. Reports compared byte-wise with only the two elapsed-duration lines normalized; exit codes captured from a redirected run, never from a pipe.

`ptah-compat` was built twice — once from the commit before this change, once from this branch — so every row below has a before and an after rather than only an after.

### The scenario

`CREATE TABLE users (id int NOT NULL);` then `ALTER TABLE users RENAME COLUMN id TO oid;`

| | report | exit |
|---|---|---|
| community binary | `DS103` "id" + NULL precheck, **and** `MF103` `Adding a non-nullable "integer" column "oid" …`, `2 diagnostics` | 1 |
| ptah-compat, before | `DS103` alone, `1 diagnostic` | 1 |
| ptah-compat, after | **byte-identical to the community binary** | 1 |

The completion criterion this issue's S2 comment set — that line present under a `-- data dependent changes detected:` heading with the trailer reading `-- 2 diagnostics`, and the nullable fixture unchanged at `-- 1 diagnostic` — is met.

### Full fixture table, before and after

`yes` means byte-identical to the community binary modulo the two duration lines.

| fixture | community | before | after |
|---|---|---|---|
| `id int NOT NULL` rename | rc=1 | no | **yes** |
| `id varchar(20) NOT NULL` rename | rc=1 | no | **yes** |
| two renames in one file | rc=1 | no | **yes** |
| `ALTER TABLE public.users` rename | rc=1 | no | **yes** |
| rename across two analyzed versions (`--latest 2`) | rc=1 | no | **yes** |
| quoted `"Users"."Id"` rename | rc=1 | no | **yes** |
| `-- atlas:nolint destructive` above the rename | rc=0 | no | **yes** |
| add on L1, drop on L2 (analyzer group order) | rc=1 | no, groups reversed | groups now match; still differs only by `"int"` vs `"integer"`, see below |
| `id int` nullable rename (control) | rc=1 | yes | yes |
| `id int NOT NULL DEFAULT 7` rename (control) | rc=1 | yes | yes |
| same-file `CREATE` then rename (control) | rc=0 | yes | yes |
| `ALTER TABLE users RENAME TO accounts` (control) | rc=1 | yes | yes |
| `ALTER TABLE users DROP COLUMN nick` (control) | rc=1 | yes | yes |
| `DROP TABLE users` (control) | rc=1 | yes | yes |
| `DROP TABLE users, audit_log` (control) | rc=1 | yes | yes |
| `mid`/`zeta`/`alpha` ordering fixture (control) | rc=1 | yes | yes |
| rename in a schema the dev URL excludes (control) | rc=0 | rc=0 | rc=0 |

Seven fixtures moved to byte-identical; nine controls that already matched still match, and the group-order fixture moved from wrong-order to right-order. No fixture moved the other way, and no fixture changed exit code.

### Ordering was measured, not chosen

`ALTER TABLE users RENAME COLUMN zeta TO zz;` then `… alpha TO aa;` in one file gives four diagnostics on the pinned binary: two `DS103` in statement order, then two `MF103` in statement order, with `-- suggested fixes:` pluralized. A rule emitting one finding carrying both introduced columns, or sorting them by name the way a multi-target `DROP TABLE` is sorted, produces a different report on that fixture; a single-rename fixture cannot tell those apart.

### Type spellings were measured one by one

Renaming a NOT NULL column of each type and reading the diagnostic:

`int` → `integer`, `bigint`, `smallint`, `text`, `boolean`, `date`, `json`, `jsonb`, `uuid`, `real`, `bytea`, `double precision`, `varchar(20)` → `character varying(20)`, `char(5)` → `character(5)`, `numeric(10,2)`, `numeric(10)` — and `numeric(10,0)` also prints `numeric(10)`, so a zero scale is not printed.

Three spellings are **not** the catalog's and are deliberately absent from the allow-list: `timestamptz` (catalog says `timestamp with time zone`), `timestamp` (catalog says `timestamp without time zone`), and `integer[]` (catalog says the bare category `ARRAY`). Those keep the diagnostic — same code, same line, same severity, same count, same exit status — under Ptah's own visibly labeled wording rather than a guess at the other tool's. That is the renderer's existing answer for a type it cannot spell, not a new behavior.

## What changed

The dev database the run **already replays on** now also answers what the versions start from. The analysis reports which versions it could use a starting state for (`Analysis.BaselineVersions`), the replay reads those states while standing on them — before the version runs, while the retired column still exists — and the analysis runs once more with them in hand.

- A directory with no renames asks for nothing, so it pays no introspection and no second analysis.
- A run without `--dev-url` reports exactly what it did before.
- The analysis still runs before the replay, so error precedence does not move: a directory that fails to analyze reports that, not a replay error it would also have hit.

The add side is decided by one function, `renameAddSideCandidates`, which both the request for the state and the finding built from it go through. That started as two copies of the same condition, and the first mutation run showed why that was wrong — see the mutation section.

**Native `ptah migrations lint` deliberately does not move.** It models a rename as a rename, and a rename does not fail on a populated table, so claiming it might would be false of the statement its analyzer describes. `BC101` stays its single finding, and an e2e row pins that: removing the surface gate leaves it red.

Two neighboring fixes the scenario needs:

- **Analyzer groups now print in analyzer order**, not in the order their first diagnostic appears. Measured: `ALTER TABLE users ADD COLUMN x text NOT NULL;` on line 1 and `ALTER TABLE users DROP COLUMN nick;` on line 2 print `destructive changes detected` above `data dependent changes detected` on the pinned binary; ordering by first appearance printed them the other way round. Only the two analyzers whose relative order was measured are ranked; Ptah-owned groups keep first-appearance order behind them, because there is no binary to measure them against.
- **The renderer's Atlas type-name allow-list gained the measured catalog spellings.** It stays fail-closed for everything else.

## Deliberately not matched, with the measurement

Three rows still differ. Each was reproduced against a build of the commit before this change, so each is pre-existing rather than introduced here.

1. **`"int"` vs `"integer"` on the plain `ADD COLUMN` path.** `ALTER TABLE users ADD COLUMN nick int NOT NULL;` prints `"int"` on ptah and `"integer"` on the pinned binary. That path reads the type from the statement text, where `int` is what is written. Fixing it properly means resolving the added column's type from the state **after** the version, which is a second read and a separate decision; this change reads only the before-state. Already recorded on #1074 as a pre-existing divergence belonging to its own issue.

2. **An `MF103` message whose rendered content lands on exactly 89 columns wraps on ptah and not on the pinned binary.** Reproduced without any rename: `ALTER TABLE t ADD COLUMN cccccc text NOT NULL;` diverges identically on the pre-change binary. The pinned binary's wrapping is not a single greedy width — solving the constraint system over fourteen measured diagnostics gives `smallint` requiring width ≥ 89 and `character varying(20)` requiring ≤ 88, which no one width satisfies — so matching it needs its own investigation rather than a constant change. `lintWrapWidth` is left at its measured 88.

3. **`ALTER TABLE users ADD COLUMN x int NOT NULL; ALTER TABLE users RENAME COLUMN x TO y;` in one file.** The pinned binary exits 0 and reports two `MF103`; ptah exits 1 and reports `MF103` for `x` plus `DS103` for `x`. The pinned binary exempts a rename of a column **added** in the same file, where Ptah's exemption covers only a column whose **table** the file created. This change does not touch it: ptah is stricter, which is the permitted direction, and relaxing a destructive check is not something to do as a side effect of a rename change. Same exit codes and same diagnostic count as before this branch.

None of these is in the forbidden direction. There is no fixture in this measurement where ptah-compat exits 0 and the community binary exits 1.

## Tests

- `migration/lint/baseline_test.go` — the analyzer. Seven silent rows, each one axis away from the reporting row: nullable retired column, retired column with a default, table created in the same file, table rename, baseline for another table, baseline for another version, and a bare table name carried by two schemas. Plus the surface split, the qualified-reference resolution, and what `BaselineVersions` asks for.
- `internal/atlasreport/migrate_lint_text_internal_test.go` — three rendering rows, verbatim from the pinned binary: the rename's two halves, the nullable control, and the analyzer group order.
- `integration/atlas_migrate_lint_rename_add_side_e2e_test.go` — ten rows against a live PostgreSQL 16, every `want` verbatim from the pinned binary, including both suppression selectors: `-- atlas:nolint destructive` silences the retirement and leaves the addition, `-- atlas:nolint data_depend` does the reverse. An add side carrying a DS code would pass one and fail the other. Plus the native-surface control.

### The tests were broken on purpose and watched go red

Eight mutants, each applied alone and reverted afterwards:

| mutant | red |
|---|---|
| analyzer stops emitting the add side | `TestAnalyzeFS_RenameAddSideNeedsTheBaseline`, the renderer row, four e2e rows |
| surface gate removed | `TestAnalyzeFS_RenameAddSideIsCompatibilitySurfaceOnly`, `TestAnalyzeFS_BaselineVersionsIsNativeSurfaceEmpty`, `TestNativeMigrationsLintRenameHasNoAddSideE2E` |
| analyzer group ordering reverted | the group-order renderer row, the rename renderer row, four e2e rows |
| catalog type spellings dropped from the renderer | the `character varying` e2e rows |
| qualified-reference fallback removed | `TestAnalyzeFS_RenameAddSideResolvesQualifiedReference` |
| nullability and default conditions dropped | both silent-case unit rows, both e2e control rows |
| the dev-database read never happens | four e2e rows |

The surface-gate mutant is the reason `renameAddSideCandidates` exists. On the first run it left the native control **green**: the gate was written twice, and with the version request still gated, removing the rule's own gate changed nothing observable. One gate now serves both, and the same mutant is red.

## Gates

All green on this branch:

`go build ./...` · `go vet ./...` · `go test ./... -count=1` · `go tool qtlint ./...` · `golangci-lint run ./...` · `scripts/check-test-style.sh` · `scripts/check-public-api.sh` · `scripts/check-public-api-snapshot.sh`

Documentation was touched, so every `check:*` script in `docs/site/package.json` was run as well, plus `node docs/site/scripts/build-feature-matrix.mjs --check`. `check:responsive` needs a built site; `npm ci && npm run build` were run so it could execute rather than be skipped.

`docs/public_api.snapshot` is regenerated for the two additions to `migration/lint`: `BaselineColumn` and `Analysis.BaselineVersions`.

## What this does not cover

- The three divergences listed above, each reproduced on the pre-change binary.
- PostgreSQL only. The type spellings and the whole scenario were measured on PostgreSQL 16; MySQL and MariaDB were not measured, and an unmeasured catalog spelling falls through to Ptah's prose rather than to a wrong Atlas sentence.
- Identity and `serial` columns diverge in the reporting-less direction: the pinned binary reports `MF103` for a renamed `serial` column, and Ptah does not, because the catalog gives it a `nextval(…)` default. A renamed `GENERATED ALWAYS AS IDENTITY` column has no catalog default and does report.
- S3 of #1074, the feature-matrix row, is untouched.
