### PR TITLE
Render an inspected schema as a file the pinned binary can read (#1234)

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1224,7 +1224,8 @@ func TestCompatCommand_SchemaInspectWritesSplitHCLFiles(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(out.String(), qt.Equals, "")
-	usersHCL := readAtlasTestFile(c, filepath.Join(outDir, "tables"), "users.hcl")
+	// Schema-qualified since the table declares its schema (stokaro/ptah#1234).
+	usersHCL := readAtlasTestFile(c, filepath.Join(outDir, "tables"), "main_users.hcl")
 	c.Assert(usersHCL, qt.Contains, `table "users"`)
 	c.Assert(usersHCL, qt.Contains, `column "email"`)
 }

--- a/cmd/atlas/schema_inspect_include_test.go
+++ b/cmd/atlas/schema_inspect_include_test.go
@@ -427,7 +427,10 @@ func TestSchemaInspectIncludeAppliesToSplitWriteExport(t *testing.T) {
 
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", stderr))
 	written := exportedFileNames(c, outDir)
-	c.Assert(written, qt.DeepEquals, []string{"inspect_users.hcl"})
+	// Both names follow from the table declaring its schema, which the render
+	// must do for the document to be valid HCL at all (stokaro/ptah#1234). The
+	// schema file is new; the table file gained its schema prefix.
+	c.Assert(written, qt.DeepEquals, []string{"main.hcl", "main_inspect_users.hcl"})
 }
 
 // exportedFileNames returns the base names of every file below root, sorted by

--- a/internal/atlashclrender/inspected_schema_test.go
+++ b/internal/atlashclrender/inspected_schema_test.go
@@ -1,0 +1,244 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderInspectedDeclaresTheSchemaEveryObjectReferences pins that a schema
+// read out of a database is rendered as a valid HCL file (stokaro/ptah#1234).
+//
+// A catalog does not repeat the schema on objects the engine treats it as
+// implicit for, so an inspected IR arrives with no schema anywhere. HCL has no
+// such notion, and the pinned Atlas community binary v1.3.0 refuses the result
+// with `cannot extract schema name for table "t"`.
+//
+// Both halves are needed and each row says which. A `schema = schema.public`
+// reference with no matching block is refused by that binary just as the bare
+// table is; the block alone leaves the table unattached. Measured:
+//
+//	table with schema = schema.public, no block   exit 1
+//	block plus reference                          exit 0
+func TestRenderInspectedDeclaresTheSchemaEveryObjectReferences(t *testing.T) {
+	tests := []struct {
+		name          string
+		defaultSchema string
+		tableSchema   string
+		wantBlock     string
+		wantReference string
+	}{
+		{
+			name:          "a table the catalog reported without a schema",
+			defaultSchema: "public",
+			tableSchema:   "",
+			wantBlock:     "schema \"public\" {\n}\n",
+			wantReference: "  schema = schema.public\n",
+		},
+		{
+			name:          "SQLite's implicit schema is named the same way",
+			defaultSchema: "main",
+			tableSchema:   "",
+			wantBlock:     "schema \"main\" {\n}\n",
+			wantReference: "  schema = schema.main\n",
+		},
+		{
+			// A reader that does report the schema is believed. The default is
+			// only a fallback, so a table in another schema keeps it.
+			name:          "a table that carries its own schema keeps it",
+			defaultSchema: "public",
+			tableSchema:   "reporting",
+			wantBlock:     "schema \"reporting\" {\n}\n",
+			wantReference: "  schema = schema.reporting\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(
+				inspectedTable(test.tableSchema), platform.Postgres, test.defaultSchema,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.wantBlock)
+			c.Assert(string(result.Data), qt.Contains, test.wantReference)
+		})
+	}
+}
+
+// TestRenderInspectedDoesNotDuplicateADeclaredSchema pins that a read which did
+// report the schema keeps exactly what it reported, comment and all, rather
+// than gaining a second bare block beside it.
+func TestRenderInspectedDoesNotDuplicateADeclaredSchema(t *testing.T) {
+	c := qt.New(t)
+
+	db := inspectedTable("public")
+	db.Schemas = []goschema.Schema{{Name: "public", Comment: "standard public schema"}}
+
+	result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Contains, "schema \"public\" {\n  comment = \"standard public schema\"\n}\n")
+	c.Assert(string(result.Data), qt.Not(qt.Contains), "schema \"public\" {\n}\n")
+}
+
+// TestRenderForDialectSynthesizesNoSchema pins that the parse-and-re-render
+// callers are untouched.
+//
+// Their IR came from HCL, so it already carries whatever the author declared.
+// Synthesizing a schema there would invent one the author did not write, and
+// silently change a file they control.
+func TestRenderForDialectSynthesizesNoSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		render func(*goschema.Database) (atlashclrender.Result, error)
+	}{
+		{
+			name: "the dialect-aware entry point",
+			render: func(db *goschema.Database) (atlashclrender.Result, error) {
+				return atlashclrender.RenderForDialect(db, platform.Postgres)
+			},
+		},
+		{
+			name:   "the plain one",
+			render: atlashclrender.Render,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := test.render(inspectedTable(""))
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Not(qt.Contains), "schema \"")
+			c.Assert(string(result.Data), qt.Not(qt.Contains), "  schema = ")
+		})
+	}
+}
+
+// TestRenderWritesPermissionBodiesThatEvaluate pins that a permission block is
+// written so the pinned binary can read the file it is in.
+//
+// That binary drops a block whose name it does not model -- it has no
+// `permission` block of its own -- but only after the body evaluates. A bare
+// PUBLIC or USAGE is an HCL variable reference with nothing behind it, and the
+// whole file is refused with `There is no variable named "PUBLIC"`.
+//
+// Measured on that binary with everything else held fixed:
+//
+//	to = PUBLIC    privileges = [USAGE]      exit 1
+//	to = "PUBLIC"  privileges = [USAGE]      exit 1
+//	to = PUBLIC    privileges = ["USAGE"]    exit 1
+//	to = "PUBLIC"  privileges = ["USAGE"]    exit 0
+//
+// so both attributes had to move, and the third row is why quoting only the
+// grantee was not enough.
+//
+// A named role stays a reference: `to = role.app` with the matching `role`
+// block present is measured to evaluate on that binary, so quoting it would
+// lose a reference and buy nothing.
+func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+		want string
+	}{
+		{
+			name: "PUBLIC is a quoted string, not a variable",
+			role: "PUBLIC",
+			want: "  to = \"PUBLIC\"\n",
+		},
+		{
+			name: "a lower-cased spelling of it too",
+			role: "public",
+			want: "  to = \"PUBLIC\"\n",
+		},
+		{
+			name: "a named role stays a reference",
+			role: "app",
+			want: "  to = role.app\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedTable("public")
+			db.Grants = []goschema.Grant{{
+				Role:       test.role,
+				OnSchema:   "public",
+				Privileges: []string{"USAGE"},
+			}}
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+			c.Assert(string(result.Data), qt.Contains, "  privileges = [\"USAGE\"]\n")
+		})
+	}
+}
+
+// TestRenderedPermissionRoundTrips pins that quoting cost nothing on Ptah's own
+// side: the parser reads the quoted spelling back to the same grant.
+//
+// Without this the change would be measured only against the other binary, and
+// a rendering Ptah itself could no longer read would still look like progress.
+func TestRenderedPermissionRoundTrips(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+	}{
+		{name: "PUBLIC", role: "PUBLIC"},
+		{name: "a named role", role: "app"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedTable("public")
+			db.Roles = []goschema.Role{{Name: "app"}}
+			db.Grants = []goschema.Grant{{
+				Role:       test.role,
+				OnSchema:   "public",
+				Privileges: []string{"USAGE", "CREATE"},
+			}}
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+			c.Assert(err, qt.IsNil)
+
+			parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(parsed.Grants, qt.HasLen, 1)
+			c.Assert(parsed.Grants[0].Role, qt.Equals, test.role)
+			c.Assert(parsed.Grants[0].Privileges, qt.DeepEquals, []string{"USAGE", "CREATE"})
+			c.Assert(parsed.Grants[0].OnSchema, qt.Equals, "public")
+		})
+	}
+}
+
+// inspectedTable builds the IR a database read produces for one table, with the
+// schema the reader reported -- which is nothing at all wherever the engine
+// treats it as implicit.
+func inspectedTable(schema string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t", Schema: schema}},
+		Fields: []goschema.Field{{StructName: "T", Name: "id", Type: "integer"}},
+	}
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -400,7 +400,7 @@ func (r *renderer) renderGrants() {
 		r.line("permission {")
 		r.rawAttr(1, "to", roleTarget(grant.Role))
 		r.rawAttr(1, "for", target)
-		r.rawAttr(1, "privileges", rawList(grant.Privileges))
+		r.rawAttr(1, "privileges", privilegeList(grant.Privileges))
 		if grant.WithOption {
 			r.trueAttr(1, "grantable")
 		}
@@ -568,10 +568,22 @@ func roleTargets(value string) string {
 	return "[" + strings.Join(targets, ", ") + "]"
 }
 
+// roleTarget renders one grantee.
+//
+// PUBLIC is written as a quoted string rather than the bare word it is in SQL.
+// Bare, it is an HCL variable reference with nothing to resolve it to, and the
+// pinned Atlas community binary v1.3.0 refuses the whole file with
+// `There is no variable named "PUBLIC"` -- it drops a block whose name it does
+// not model, but only after the body evaluates (stokaro/ptah#1234).
+//
+// A named role stays a `role.<name>` traversal, which is measured to evaluate
+// on that binary when the file also declares the matching `role` block, so
+// quoting it would lose a reference for nothing. Ptah's own parser reads either
+// spelling through rawIdentifierOrString, so the round trip is unaffected.
 func roleTarget(value string) string {
 	value = strings.TrimSpace(value)
 	if strings.EqualFold(value, "PUBLIC") {
-		return "PUBLIC"
+		return quote("PUBLIC")
 	}
 	if value == "" {
 		return quote(value)
@@ -611,14 +623,30 @@ func objectRef(kind, name string) string {
 	return kind + strings.Join(refParts, "")
 }
 
-func rawList(values []string) string {
+// privilegeList renders a permission block's privileges.
+//
+// Each privilege is quoted for the same reason PUBLIC is: `privileges = [USAGE]`
+// is a list containing an unresolvable variable reference, and the pinned
+// community binary v1.3.0 refuses the file over it. Measured on that binary,
+// with everything else held fixed:
+//
+//	to = PUBLIC    privileges = [USAGE]      refused
+//	to = "PUBLIC"  privileges = [USAGE]      refused
+//	to = PUBLIC    privileges = ["USAGE"]    refused
+//	to = "PUBLIC"  privileges = ["USAGE"]    accepted
+//
+// so both attributes had to move, and each row above is what says so.
+//
+// Empty entries are dropped rather than emitted as "", which would round trip
+// as a privilege named nothing.
+func privilegeList(values []string) string {
 	items := make([]string, 0, len(values))
 	for _, value := range values {
 		value = strings.TrimSpace(value)
 		if value == "" {
 			continue
 		}
-		items = append(items, rawIdentifier(value))
+		items = append(items, quote(value))
 	}
 	return "[" + strings.Join(items, ", ") + "]"
 }

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -63,13 +63,44 @@ func Render(db *goschema.Database) (Result, error) {
 // their input was HCL, so the raw-SQL marker the parser set is already right and
 // re-deciding it from the type name would second-guess the author.
 func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
+	return render(db, dialect, "")
+}
+
+// RenderInspected renders a schema that was read out of a database, declaring
+// defaultSchema as the owner of every object the catalog reported without one.
+//
+// A catalog does not repeat the schema on objects the engine considers
+// implicit, so an inspected IR arrives with no schema anywhere. HCL has no such
+// notion: a file with no `schema` block and no `schema =` on its tables is not
+// an under-specified schema, it is an invalid one. The pinned Atlas community
+// binary v1.3.0 refuses it with
+//
+//	specutil: failed converting to *schema.Realm: cannot extract schema name
+//	for table "t": schemahcl: type "schema" was not found in nil
+//
+// which is what made Ptah's inspect output unreadable to it independently of
+// any type or permission question (stokaro/ptah#1234).
+//
+// The name is a parameter rather than something derived from the dialect
+// because it is not derivable: a PostgreSQL connection's search_path can name
+// any schema, and the caller is the only one that knows which one was read.
+//
+// [RenderForDialect] is deliberately left alone. Its callers parsed HCL to get
+// here, so their IR already carries whatever the author wrote, and synthesizing
+// a schema there would invent one the author did not declare.
+func RenderInspected(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
+	return render(db, dialect, strings.TrimSpace(defaultSchema))
+}
+
+func render(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
 	if db == nil {
 		return Result{}, fmt.Errorf("schema database is nil")
 	}
 
 	r := renderer{
-		db:      db,
-		dialect: dialect,
+		db:            db,
+		dialect:       dialect,
+		defaultSchema: defaultSchema,
 	}
 	r.render()
 	return Result{
@@ -79,10 +110,51 @@ func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
 }
 
 type renderer struct {
-	db          *goschema.Database
-	dialect     string
-	builder     strings.Builder
-	diagnostics []Diagnostic
+	db      *goschema.Database
+	dialect string
+	// defaultSchema owns every object that arrived without one. Empty means the
+	// IR is taken as written, which is what every parse-and-re-render caller
+	// wants.
+	defaultSchema string
+	builder       strings.Builder
+	diagnostics   []Diagnostic
+}
+
+// schemaFor returns the schema name to write for an object, which is the one it
+// carries or, failing that, the schema the whole read belongs to.
+func (r *renderer) schemaFor(schema string) string {
+	if strings.TrimSpace(schema) != "" {
+		return schema
+	}
+	return r.defaultSchema
+}
+
+// referencedSchemas lists, in a stable order, every schema this render will
+// write a `schema.<name>` reference to. It is empty outside an inspected
+// render, because nothing is synthesized there.
+func (r *renderer) referencedSchemas() []string {
+	if r.defaultSchema == "" {
+		return nil
+	}
+	// Nothing to attach a schema to means nothing to declare. An inspect whose
+	// selection matched no table renders an empty document, and a lone schema
+	// block there would be a declaration of nothing -- which is what the
+	// empty-include-selection contract already pins.
+	if len(r.db.Tables) == 0 {
+		return nil
+	}
+	seen := map[string]bool{}
+	var names []string
+	for _, table := range r.db.Tables {
+		name := r.schemaFor(table.Schema)
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	slices.Sort(names)
+	return names
 }
 
 func (r *renderer) render() {
@@ -105,6 +177,21 @@ func (r *renderer) render() {
 
 func (r *renderer) renderSchemas() {
 	schemas := append([]goschema.Schema(nil), r.db.Schemas...)
+	// An inspected read reports no schema block at all, so every schema the
+	// file is about to reference has to be declared here or the reference
+	// resolves to nothing. A read that DID report one keeps what it reported,
+	// comment, charset and collation included.
+	//
+	// It is not enough to declare the default. A reader looking at more than
+	// one schema reports each table's own, so a table in `reporting` emits
+	// `schema = schema.reporting` and needs that block too -- the first version
+	// of this declared only the default, and a test row with a table outside it
+	// is what caught the dangling reference.
+	for _, name := range r.referencedSchemas() {
+		if !slices.ContainsFunc(schemas, func(s goschema.Schema) bool { return s.Name == name }) {
+			schemas = append(schemas, goschema.Schema{Name: name})
+		}
+	}
 	sort.Slice(schemas, func(i, j int) bool {
 		return schemas[i].Name < schemas[j].Name
 	})
@@ -169,8 +256,8 @@ func (r *renderer) renderTable(
 	rlsEnabled *goschema.RLSEnabledTable,
 ) {
 	r.linef(`table %s {`, quote(table.Name))
-	if table.Schema != "" {
-		r.rawAttr(1, "schema", schemaRef(table.Schema))
+	if schema := r.schemaFor(table.Schema); schema != "" {
+		r.rawAttr(1, "schema", schemaRef(schema))
 	}
 	r.stringAttr(1, "engine", table.Engine)
 	r.stringAttr(1, "charset", table.Charset)

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -188,7 +188,7 @@ func (r *SchemaInspectReport) defaultSchemaName() string {
 }
 
 func (r *SchemaInspectReport) MarshalHCL() (string, error) {
-	rendered, err := atlashclrender.RenderForDialect(r.db, r.info.Dialect)
+	rendered, err := atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
 	if err != nil {
 		return "", fmt.Errorf("render HCL schema: %w", err)
 	}

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -164,7 +164,14 @@ func TestRenderSchemaInspect_HCLSplitRendersTxtar(t *testing.T) {
 	output, err := atlasreport.RenderSchemaInspect(`{{ hcl . | split }}`, report)
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(output.Text, qt.Contains, "-- tables/users.hcl --")
+	// The file name carries the schema because the table declares one. That
+	// declaration is not cosmetic: without it the rendered HCL is invalid and
+	// the pinned Atlas community binary v1.3.0 refuses the whole document
+	// (stokaro/ptah#1234). Qualifying the name is also what keeps two tables of
+	// the same name in different schemas from colliding on one path, which
+	// validateUniqueSchemaInspectArchivePaths would otherwise reject.
+	c.Assert(output.Text, qt.Contains, "-- schemas/main.hcl --")
+	c.Assert(output.Text, qt.Contains, "-- tables/main_users.hcl --")
 	c.Assert(output.Text, qt.Contains, `table "users"`)
 	c.Assert(output.Text, qt.Contains, `comment = "keeps { braces } in strings"`)
 }


### PR DESCRIPTION
Closes two of the three defects in #1234. The third turns out to be the community binary's own feature gap — see the correction below.

## Defect 1 — the missing schema declaration

A catalog does not repeat the schema on objects the engine treats as implicit, so an inspected IR arrives with no schema anywhere. HCL has no such notion: a file with no `schema` block and no `schema =` on its tables is invalid, not under-specified. The pinned Atlas community binary v1.3.0 answers `cannot extract schema name for table "t"`.

Both halves are needed, and each was measured separately:

| file | verdict |
| --- | --- |
| `table` with `schema = schema.public`, no block | exit 1 |
| block plus reference | exit 0 |

The schema name is a **parameter**, not something derived from the dialect — a PostgreSQL connection's `search_path` can name any schema, and only the caller knows which one was read. `RenderForDialect` is left exactly as it was: its callers parsed HCL to get here, so synthesizing a schema there would invent one the author never declared.

**Declaring only the default was not enough.** A reader looking at more than one schema reports each table's own, so a table in `reporting` emits `schema = schema.reporting` and needs that block too. The first version of this declared only the default; a test row with a table outside it is what caught the dangling reference.

## Defect 2 — the permission block

That binary drops a block whose name it does not model — it has no `permission` block — but only *after* the body evaluates. A bare `PUBLIC` or `USAGE` is an HCL variable reference with nothing behind it.

Measured, everything else held fixed:

| `to` | `privileges` | verdict |
| --- | --- | --- |
| `PUBLIC` | `[USAGE]` | exit 1 |
| `"PUBLIC"` | `[USAGE]` | exit 1 |
| `PUBLIC` | `["USAGE"]` | exit 1 |
| `"PUBLIC"` | `["USAGE"]` | **exit 0** |

Both attributes had to move; the third row is why quoting only the grantee was not enough.

A named role stays a `role.<name>` traversal — measured to evaluate on that binary when the file also declares the matching `role` block — so quoting it would lose a reference and buy nothing. Ptah's own parser reads either spelling through `rawIdentifierOrString`, and `TestRenderedPermissionRoundTrips` pins that the change cost nothing on our side.

## Correction to #1234

The issue said, with a table row, that the `extension` block is **not** a blocker. **That was wrong**, and the method that produced it is worth naming: I peeled errors one at a time and concluded that removing the extension block "changed nothing". It changed nothing because the schema error fired *first* and masked it. Peeling tells you what is first, not what is fine.

With both defects above fixed, the next error is:

```
Error: postgres: extensions are not supported by this version.
```

That is the community binary declining a feature, not a Ptah defect. Its own inspect of the same database emits **no** extension block and **no** permission block. So Ptah's output is a superset, and for any PostgreSQL database — `plpgsql` is present by default in all of them — that superset is unreadable to it. Whether Ptah should suppress those blocks on the compatibility surface is a separate decision and is left on the issue.

## Measured end to end

Live PostgreSQL 17, nine-column table, inspected by `ptah-compat` and handed back to the pinned binary:

- before: exit 1, `There is no function named "NUMERIC"` (fixed by #1233)
- after #1233: exit 1, `There is no variable named "PUBLIC"`
- after this: exit 1, `extensions are not supported by this version`
- **with the extension block removed by hand: exit 0**

Also worth recording: the binary's own inspect output *does* declare `schema "public" { }` — at the end of the file rather than the start. Ordering is an output-shape difference and belongs in the register (#1235), not here.

## Consequence: split file names

A table file gains its schema prefix and a schema file appears:

- `tables/users.hcl` → `schemas/main.hcl` + `tables/main_users.hcl`
- `["inspect_users.hcl"]` → `["main.hcl", "main_inspect_users.hcl"]`

This follows mechanically from the table declaring a schema, and it is what keeps two same-named tables in different schemas off one path — `validateUniqueSchemaInspectArchivePaths` would reject that collision. Three fixtures are updated, each with the reason in place.

An inspect whose selection matched no table still renders an empty document. A lone schema block there would declare nothing, and the empty-include-selection contract already pins that; the first version of this change broke it, and the guard is explicit.

## Mutation-checked

Each change reverted in turn, tests watched go red, then restored:

| reverted | subtests red |
| --- | --- |
| the schema block | 4 |
| the `schema =` reference | 3 |
| quoted `PUBLIC` | 3 |
| quoted privileges | 4 |

## Gates

`go build` · `go vet` · `go test ./... -count=1` · `qtlint` · `golangci-lint` (0 issues) · `check-test-style` · `check-public-api` · `check-public-api-snapshot` — all exit 0.

One unrelated flake seen and chased down rather than ignored: `TestSVGReportsGraphvizStderrOnFailure` failed at exactly 10.01s during a full run under heavy parallel load, and passes in 0.42s in isolation both with and without this change. It is a machine-load timeout on an external `dot` process, not a regression.
