### PR TITLE
Let a MySQL connection name the schema that owns its tables (#1244)

### DIFF
--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -781,6 +781,18 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 			}
 			info.Schema = dbName
 		}
+		// A MySQL-family schema is a database, so no static dialect rule can
+		// name the one that owns an unqualified table the way "public" and
+		// "main" do; only the connection knows it. Leaving the field empty is
+		// what made the two comparison sides key differently: the catalog
+		// reports every table with no schema, while a desired state written as
+		// Atlas HCL carries `schema = schema.<database>`. Measured on live
+		// MySQL 9.7.1, `schema apply` fed the database's own inspected HCL
+		// planned CREATE TABLE and DROP TABLE for every table where the pinned
+		// Atlas community v1.3.0 binary answered "Schema is synced, no changes
+		// to be made" (stokaro/ptah#1244). SQL Server pins the same field from
+		// the same place, in getSQLServerDatabaseInfo.
+		info.IdentifierSemantics.DefaultSchema = info.Schema
 	case platform.ClickHouse:
 		var version string
 		if err := db.QueryRow("SELECT version()").Scan(&version); err != nil {

--- a/dbschema/mysql_identifier_live_test.go
+++ b/dbschema/mysql_identifier_live_test.go
@@ -1,0 +1,84 @@
+package dbschema_test
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// TestMySQLLiveConnection_DefaultSchemaIsTheConnectedDatabase pins that a
+// MySQL-family connection reports the connected database as the schema that
+// owns unqualified objects (stokaro/ptah#1244).
+//
+// A schema on these engines is a database, so the offline dialect rules have no
+// static default to offer and deliberately carry an empty one -- unlike
+// PostgreSQL's "public" or SQLite's "main". The connection is the only place
+// that knows the answer, and until it filled the field in, schema comparison
+// keyed a table the catalog reports with no schema differently from the same
+// table a desired state names explicitly, and planned to create and drop every
+// one of them. SQL Server resolves the same field from the same place.
+//
+// Live-only: the value comes from the URL path or from SELECT DATABASE(), and
+// asserting it against anything but a real connection would only restate the
+// test's own fixture.
+func TestMySQLLiveConnection_DefaultSchemaIsTheConnectedDatabase(t *testing.T) {
+	tests := []struct {
+		name           string
+		environmentKey string
+	}{
+		{name: "mysql", environmentKey: "MYSQL_TEST_URL"},
+		{name: "mariadb", environmentKey: "MARIADB_TEST_URL"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			databaseURL := requireLiveMySQLURL(c, test.environmentKey)
+			wantSchema := databaseNameFromURL(c, databaseURL)
+
+			conn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(conn)
+			})
+
+			info := conn.Info()
+
+			c.Assert(info.Schema, qt.Equals, wantSchema)
+			c.Assert(info.IdentifierSemantics.DefaultSchema, qt.Equals, wantSchema)
+			// The pairing is the invariant, not either value alone: comparison
+			// resolves an absent schema through DefaultSchema, and a connection
+			// whose two fields disagree would key its own tables against a
+			// database it is not connected to.
+			c.Assert(info.IdentifierSemantics.DefaultSchema, qt.Equals, info.Schema)
+		})
+	}
+}
+
+func requireLiveMySQLURL(c *qt.C, environmentKey string) string {
+	c.Helper()
+	databaseURL := os.Getenv(environmentKey)
+	if databaseURL == "" {
+		c.Skip(environmentKey + " is not set")
+	}
+	return databaseURL
+}
+
+// databaseNameFromURL reads the database the URL selects. A MySQL URL without a
+// path leaves the connection to resolve it with SELECT DATABASE(), which this
+// test cannot predict, so it is skipped rather than guessed at.
+func databaseNameFromURL(c *qt.C, rawURL string) string {
+	c.Helper()
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	name := strings.TrimPrefix(parsed.Path, "/")
+	if name == "" {
+		c.Skip("the configured URL names no database")
+	}
+	return name
+}

--- a/migration/schemadiff/internal/compare/constraint_synthesis.go
+++ b/migration/schemadiff/internal/compare/constraint_synthesis.go
@@ -104,7 +104,7 @@ func synthesizeTablePrimaryKeyConstraints(
 			continue
 		}
 
-		name := tablePrimaryKeyConstraintName(table, database.Constraints, dialect)
+		name := tablePrimaryKeyConstraintName(table, database.Constraints, dialect, semantics)
 		synthesized = append(synthesized, goschema.Constraint{
 			StructName: table.StructName,
 			Name:       name,
@@ -116,9 +116,31 @@ func synthesizeTablePrimaryKeyConstraints(
 	return synthesized
 }
 
-func tablePrimaryKeyConstraintName(table goschema.Table, dbConstraints []types.DBConstraint, dialect string) string {
+// tablePrimaryKeyConstraintName adopts the name the database already uses for
+// this table's primary key, so the synthesized constraint compares equal to it
+// instead of being reported as a rename.
+//
+// The lookup normalizes both sides for the same reason the keys around it do:
+// the database reports the schema as empty wherever the engine treats it as
+// implicit, and the desired side carries it. Comparing the two spellings
+// directly meant the lookup never matched and the name always came from the
+// fallback below. That was invisible wherever the fallback happens to be right
+// -- MySQL always names it PRIMARY, PostgreSQL usually names it <table>_pkey --
+// and wrong the moment a schema names its primary key itself, which surfaced as
+// dropping the real constraint and adding a differently named one
+// (stokaro/ptah#1244).
+func tablePrimaryKeyConstraintName(
+	table goschema.Table,
+	dbConstraints []types.DBConstraint,
+	dialect string,
+	semantics identifier.Semantics,
+) string {
+	wanted := newQualifiedTableIdentity(table.QualifiedName(), semantics)
 	for _, constraint := range dbConstraints {
-		if constraint.Type == "PRIMARY KEY" && constraint.QualifiedTableName() == table.QualifiedName() {
+		if constraint.Type != "PRIMARY KEY" {
+			continue
+		}
+		if newQualifiedTableIdentity(constraint.QualifiedTableName(), semantics) == wanted {
 			return constraint.Name
 		}
 	}

--- a/migration/schemadiff/internal/compare/constraints.go
+++ b/migration/schemadiff/internal/compare/constraints.go
@@ -65,7 +65,34 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	if opts != nil {
 		dialect = opts.Dialect
 	}
-	semantics := identifier.ForDialect(dialect)
+	ConstraintsWithSemantics(generated, database, diff, opts, identifier.ForDialect(dialect))
+}
+
+// ConstraintsWithSemantics is [Constraints] told which identifier rules the
+// target actually has, rather than the offline defaults its dialect name
+// implies. Table and index comparison already take the resolved rules; this
+// entry point exists so constraint comparison stops being the one side that
+// rebuilds them from the dialect string.
+//
+// The difference is not cosmetic on MySQL and MariaDB. A schema there is a
+// database, so [identifier.ForDialect] cannot name the one that owns an
+// unqualified table and returns an empty DefaultSchema; only a connection can
+// supply it. Re-deriving the offline rules here discarded that value, the
+// normalization in [tableMemberKey] became a no-op, and every constraint the
+// database had was reported as removed -- the exact failure #1232 fixed on
+// PostgreSQL and SQLite, still live on MySQL because it could never see a
+// default schema (stokaro/ptah#1244).
+func ConstraintsWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	opts *config.CompareOptions,
+	semantics identifier.Semantics,
+) {
+	dialect := ""
+	if opts != nil {
+		dialect = opts.Dialect
+	}
 
 	// Create maps for detailed constraint comparison
 	genConstraints := make(map[tableMemberKey]goschema.Constraint)

--- a/migration/schemadiff/mysql_connection_schema_test.go
+++ b/migration/schemadiff/mysql_connection_schema_test.go
@@ -1,0 +1,329 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompareWithDatabaseInfo_MySQLConnectionSchemaMatchesTheDesiredSchema pins
+// that constraint comparison honors the default schema the connection resolved
+// rather than the one the dialect name implies (stokaro/ptah#1244).
+//
+// MySQL and MariaDB are the dialects where those two differ. A schema there is
+// a database, so [identifier.ForDialect] has no static default to return and
+// returns an empty one; the connected database name is the only answer, and
+// only a connection has it. Constraint comparison used to rebuild the offline
+// rules from the dialect string, so it saw the empty default no matter what the
+// connection had resolved. The catalog reports a table with no schema and a
+// desired state written as Atlas HCL carries `schema = schema.<database>`, so
+// the two keys never met and every constraint the database had was reported as
+// removed.
+//
+// Measured on live MySQL 9.7.1: `ptah-compat schema apply` fed the database's
+// own unedited `atlas schema inspect` output planned CREATE TABLE and DROP
+// TABLE for every table, plus DROP PRIMARY KEY and DROP FOREIGN KEY, where the
+// pinned Atlas community binary v1.3.0 answered "Schema is synced, no changes
+// to be made" and exited 0.
+//
+// The rows with a non-empty wantRemoved are the control and they carry the
+// weight. A "fix" that stopped reporting constraint removals, or that collapsed
+// every database name onto one key, satisfies every no-change row here and
+// fails these.
+func TestCompareWithDatabaseInfo_MySQLConnectionSchemaMatchesTheDesiredSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		dialect     string
+		connSchema  string
+		genSchema   string
+		dbSchema    string
+		dbTableName string
+		wantRemoved []string
+	}{
+		{
+			name:        "mysql reports the schema as nothing where the desired side names the database",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			name:        "mariadb reports the schema as nothing where the desired side names the database",
+			dialect:     "mariadb",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			// The fill-in has to work in this direction too: a desired state
+			// built from Go annotations names no schema, while a reader that
+			// does report the database must not drift against it.
+			name:        "the database naming it and the desired side not is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "",
+			dbSchema:    "shop",
+			dbTableName: "users",
+		},
+		{
+			name:        "both sides naming the database is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "shop",
+			dbTableName: "users",
+		},
+		{
+			name:        "neither side naming it is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			// The control. A constraint on a table the desired schema genuinely
+			// does not have must still be reported, or idempotency has been
+			// bought by making removal impossible.
+			name:        "a constraint on a table the desired schema does not have is still removed",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "orphaned",
+			wantRemoved: []string{"orphaned_pkey"},
+		},
+		{
+			// The other control. Another database is another table, and the
+			// fill-in must not collapse them onto one key.
+			name:        "a table in another database is not the desired one",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "reporting",
+			dbTableName: "users",
+			wantRemoved: []string{"users_pkey"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				implicitSchemaDesired(test.genSchema),
+				implicitSchemaDatabase(test.dbSchema, test.dbTableName),
+				mysqlConnectionInfo(test.dialect, test.connSchema),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, test.wantRemoved,
+				qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfo_MySQLConnectionSchemaPlansNothingAtAll is the
+// assertion a partial fix cannot satisfy.
+//
+// Supplying the connection's default schema without also letting constraint
+// comparison see it removed the CREATE TABLE / DROP TABLE churn and left
+// `ALTER TABLE users DROP PRIMARY KEY` behind — the same silent-corruption
+// shape #1232 describes on PostgreSQL, reached from a different direction. So
+// the assertion is that the comparison reports no change at all, not merely
+// that the tables match.
+func TestCompareWithDatabaseInfo_MySQLConnectionSchemaPlansNothingAtAll(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				implicitSchemaDesired("shop"),
+				implicitSchemaDatabase("", "users"),
+				mysqlConnectionInfo(test.dialect, "shop"),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+			c.Assert(diff.TablesAdded, qt.HasLen, 0)
+			c.Assert(diff.TablesRemoved, qt.HasLen, 0)
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, 0)
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfo_MySQLForeignKeyOnTheConnectionSchema covers the
+// field-level foreign key, which reaches the diff through a different route:
+// it is synthesized only for columns the database already has, and that lookup
+// keys the owning table the same way. Unsynthesized, the database's own foreign
+// key has no counterpart and is dropped.
+func TestCompareWithDatabaseInfo_MySQLForeignKeyOnTheConnectionSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		genSchema   string
+		dbSchema    string
+		wantRemoved []string
+	}{
+		{name: "desired side names the database", genSchema: "shop", dbSchema: ""},
+		{name: "neither side names it", genSchema: "", dbSchema: ""},
+		{
+			name:        "another database is another table",
+			genSchema:   "shop",
+			dbSchema:    "reporting",
+			wantRemoved: []string{"fk_posts_user"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				mysqlForeignKeyDesired(test.genSchema),
+				mysqlForeignKeyDatabase(test.dbSchema),
+				mysqlConnectionInfo("mysql", "shop"),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, test.wantRemoved,
+				qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_PrimaryKeyKeepsTheNameTheDatabaseGaveIt pins the
+// second half of the same defect on the dialect where it is easiest to hit.
+//
+// A synthesized primary key adopts the name the database already uses, so an
+// unchanged schema compares equal. That lookup compared the two table spellings
+// as raw strings, so it never matched a database that reports the schema as
+// implicit, and the name always came from the fallback. Wherever the fallback
+// agrees with what the engine would have picked the mistake is invisible; a
+// schema that names its own primary key exposes it as a drop of the real
+// constraint plus an add of a differently named one.
+func TestCompareWithDialect_PrimaryKeyKeepsTheNameTheDatabaseGaveIt(t *testing.T) {
+	tests := []struct {
+		name           string
+		dialect        string
+		genSchema      string
+		constraintName string
+	}{
+		{name: "postgres conventional name", dialect: "postgres", genSchema: "public", constraintName: "users_pkey"},
+		{name: "postgres schema-chosen name", dialect: "postgres", genSchema: "public", constraintName: "pk_users"},
+		{name: "sqlite schema-chosen name", dialect: "sqlite", genSchema: "main", constraintName: "pk_users"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			database := implicitSchemaDatabase("", "users")
+			database.Constraints[0].Name = test.constraintName
+
+			diff := schemadiff.CompareWithDialect(
+				implicitSchemaDesired(test.genSchema),
+				database,
+				test.dialect,
+			)
+
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// mysqlConnectionInfo is the metadata a live MySQL-family connection carries:
+// the connected database as the schema, and the same value as the default
+// schema that owns unqualified objects. getDatabaseInfo pins the second field
+// from the first; dbschema's live test covers that it does.
+func mysqlConnectionInfo(dialect, schema string) types.DBInfo {
+	semantics := identifier.ForDialect(dialect)
+	semantics.DefaultSchema = schema
+	return types.DBInfo{
+		Dialect:             dialect,
+		Schema:              schema,
+		IdentifierSemantics: semantics,
+	}
+}
+
+// mysqlForeignKeyDesired builds a desired side whose foreign key is declared on
+// the field, which is how an Atlas HCL `foreign_key` block arrives.
+func mysqlForeignKeyDesired(schema string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Users", Name: "users", Schema: schema},
+			{StructName: "Posts", Name: "posts", Schema: schema},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Users", Name: "id", Type: "BIGINT", Nullable: false},
+			{StructName: "Posts", Name: "id", Type: "BIGINT", Nullable: false},
+			{
+				StructName:     "Posts",
+				Name:           "user_id",
+				Type:           "BIGINT",
+				Nullable:       false,
+				Foreign:        "users(id)",
+				ForeignKeyName: "fk_posts_user",
+			},
+		},
+	}
+}
+
+// mysqlForeignKeyDatabase builds the matching database side as a MySQL reader
+// reports it.
+func mysqlForeignKeyDatabase(schema string) *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name:   "users",
+				Schema: schema,
+				Type:   "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "BIGINT", IsNullable: "NO"},
+				},
+			},
+			{
+				Name:   "posts",
+				Schema: schema,
+				Type:   "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "BIGINT", IsNullable: "NO"},
+					{Name: "user_id", DataType: "BIGINT", IsNullable: "NO"},
+				},
+			},
+		},
+		Constraints: []types.DBConstraint{{
+			Name:          "fk_posts_user",
+			TableName:     "posts",
+			Schema:        schema,
+			Type:          "FOREIGN KEY",
+			ColumnNames:   []string{"user_id"},
+			ForeignTable:  new("users"),
+			ForeignColumn: new("id"),
+		}},
+	}
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -178,7 +178,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.Grants(generated, database, diff)
 
 	// Compare table-level constraints (EXCLUDE, CHECK, UNIQUE, etc.)
-	compare.Constraints(generated, database, diff, opts)
+	compare.ConstraintsWithSemantics(generated, database, diff, opts, identifierSemantics)
 
 	return diff
 }


### PR DESCRIPTION
Closes #1244.

> The earlier body said this was superseded by #1254. That is no longer true: this branch was rebased onto current master (dropping the duplicated #1232 commit, which has since merged as #1238), CI re-ran on the rebased tree and is green, and #1254 — whose tree is byte-identical to this one — has been closed as the duplicate.

## What it fixes

`ptah-compat schema apply` on MySQL planned `CREATE` and `DROP` for every table because nothing on the two sides ever matched: a MySQL connection's schema is its database, and the connection did not name it.

## Verified on a live MySQL 9.7, built from this branch in its own worktree

Three applies of an unchanged file, one fresh database pair:

```
apply #1  rc=1   CREATE TABLE `g1244`.`users` (...)
                 Error: Table 'users' already exists
apply #2  rc=0   Schema is synced, no changes to be made.
apply #3  rc=0   Schema is synced, no changes to be made.
```

- the primary key survives
- **the dev database is left with zero tables**, where before it was left dirty and any later command against that dev-url hard-failed

Before this change every apply planned `DROP TABLE` for every table and nothing ever converged.

## What it does NOT fix

`apply #1` still exits 1 with `Table 'users' already exists`. That is #1240 defect 1 and is untouched here: the plan is rendered with the target's schema name baked into every statement, and in MySQL a schema *is* a database, so the dev-database simulation executes `CREATE TABLE \`g1244\`.\`users\`` against the target. The simulation creates the table, then the real apply finds it already there.

So convergence is fixed and the dev database is no longer left dirty; the first-run failure and the write-into-the-target remain, tracked separately.