### PR TITLE
Refuse to adopt a database that is not clean

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -300,33 +300,21 @@ func runAtlasMigrateApply(
 	if err != nil {
 		return err
 	}
+	if err := runAtlasMigrateApplyRefusals(cmd.Context(), atlasMigrateApplyRefusalOperands{
+		conn:            conn,
+		plan:            plan,
+		captured:        captured,
+		dirFormat:       resolvedDirFormat,
+		linearity:       linearity,
+		execOrder:       execOrder,
+		revisionsSchema: opts.revisionsSchema,
+		allowDirty:      opts.allowDirty,
+		baselineVersion: baselineVersion,
+	}); err != nil {
+		return err
+	}
+
 	noteAtlasMigrateApplyLockUnsupported(cmd, opts.lock, plan, conn.Info().Dialect)
-
-	// #982 changed the Atlas version a Flyway file converts to, which is the
-	// key `atlas_schema_revisions` stores. A database migrated by an older Ptah
-	// build therefore reads as entirely pending here. Refuse before executing
-	// anything rather than re-running migrations that already ran.
-	if err := checkLegacyFlywayRevisions(captured, resolvedDirFormat, plan, opts.revisionsSchema); err != nil {
-		return err
-	}
-
-	// The same question one implementation over: Atlas CE records a converted
-	// Flyway migration under its SOURCE version token, so a revision table it
-	// wrote also matches no file here and reads as entirely pending
-	// (stokaro/ptah#1100). The Ptah-encoding check above runs first because it
-	// is the more specific claim about who wrote the row, and its repair is a
-	// different one.
-	if err := checkForeignFlywayRevisions(captured, resolvedDirFormat, plan); err != nil {
-		return err
-	}
-
-	// The exemption above only stops the linear guard from reading the
-	// baseline's band position as "authored earlier". Whether a baseline may
-	// run against a database that already has history is a separate question,
-	// and one Atlas CE answers three incompatible ways (stokaro/ptah#1003).
-	if err := checkFlywayBaselineHistory(linearity.baseline, execOrder, plan); err != nil {
-		return err
-	}
 
 	out := cmd.OutOrStdout()
 	emitApplyStart := func([]int64) {}

--- a/cmd/atlas/migrate_apply_clean_gate.go
+++ b/cmd/atlas/migrate_apply_clean_gate.go
@@ -1,0 +1,122 @@
+package atlas
+
+import (
+	"context"
+	"io/fs"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+	"go.5x5.cz/ptah/internal/migrateclean"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// atlasMigrateApplyRefusalOperands carries everything the refusals that run
+// between planning and execution reason about.
+//
+// It is a struct rather than a parameter list because the refusals share most
+// of their inputs and the order of nine positional arguments is not something a
+// reader should have to keep straight.
+type atlasMigrateApplyRefusalOperands struct {
+	conn      *dbschema.DatabaseConnection
+	plan      atlasmigrate.ApplyPlan
+	captured  fs.FS
+	dirFormat atlasmigrateimport.Format
+	linearity flywayLinearity
+	execOrder migrator.ExecOrder
+	// revisionsSchema is the run's --revisions-schema.
+	revisionsSchema string
+	// allowDirty and baselineVersion are the two opt-outs of the not-clean
+	// gate below.
+	allowDirty      bool
+	baselineVersion int64
+}
+
+// runAtlasMigrateApplyRefusals runs every check that can stop a prepared apply
+// before it executes, in the order their measurements require.
+func runAtlasMigrateApplyRefusals(ctx context.Context, operands atlasMigrateApplyRefusalOperands) error {
+	// The adoption gate comes first. The three Flyway refusals below all
+	// reason about revision rows somebody else wrote, and this one fires only
+	// when there are none, so the order between them is not observable — but
+	// stating it keeps the more fundamental precondition at the top.
+	if err := checkConnectedDatabaseClean(ctx, operands); err != nil {
+		return err
+	}
+
+	// #982 changed the Atlas version a Flyway file converts to, which is the
+	// key `atlas_schema_revisions` stores. A database migrated by an older Ptah
+	// build therefore reads as entirely pending here. Refuse before executing
+	// anything rather than re-running migrations that already ran.
+	if err := checkLegacyFlywayRevisions(
+		operands.captured, operands.dirFormat, operands.plan, operands.revisionsSchema,
+	); err != nil {
+		return err
+	}
+
+	// The same question one implementation over: Atlas CE records a converted
+	// Flyway migration under its SOURCE version token, so a revision table it
+	// wrote also matches no file here and reads as entirely pending
+	// (stokaro/ptah#1100). The Ptah-encoding check above runs first because it
+	// is the more specific claim about who wrote the row, and its repair is a
+	// different one.
+	if err := checkForeignFlywayRevisions(operands.captured, operands.dirFormat, operands.plan); err != nil {
+		return err
+	}
+
+	// The exemption above only stops the linear guard from reading the
+	// baseline's band position as "authored earlier". Whether a baseline may
+	// run against a database that already has history is a separate question,
+	// and one Atlas CE answers three incompatible ways (stokaro/ptah#1003).
+	return checkFlywayBaselineHistory(operands.linearity.baseline, operands.execOrder, operands.plan)
+}
+
+// checkConnectedDatabaseClean refuses to adopt a database that already holds
+// tables no migration in the directory created (stokaro/ptah#1231 case 1).
+//
+// It is an adoption gate, not a standing drift check. Measured against the
+// pinned community binary v1.3.0 on PostgreSQL 17, MySQL 9.7 and SQLite, the
+// refusal fires only while the revision table is empty: a managed database that
+// later grows an unmanaged table applies its next migration at exit 0, so a
+// single recorded revision turns the gate off for good. That is the whole point
+// of it — it protects the first run against a database somebody else's tooling
+// owns, and after that the revision table is the record of ownership.
+//
+// The exemption operand is the revision ROW COUNT rather than the plan's
+// applied-migration list, which is intersected with the directory: rotating
+// migration files out of the directory would otherwise make a long-managed
+// database read as unadopted and refuse.
+//
+// Placement is measured too. This runs after atlasmigrate.PrepareApply so that
+// an unresolvable --baseline still reports the baseline diagnostic (the binary
+// does the same), and before the plan executes so that --dry-run refuses as
+// well — the binary refuses a dry run against an unclean database, which it
+// could not do if the check lived in the execution path.
+func checkConnectedDatabaseClean(ctx context.Context, operands atlasMigrateApplyRefusalOperands) error {
+	// The two documented opt-ins. --allow-dirty says "the schema is not empty,
+	// proceed"; --baseline says "treat history as starting here". Measured,
+	// either one makes the binary apply against the same unclean database at
+	// exit 0, so honoring them is the half of the parity rule that forbids
+	// being stricter, not a convenience.
+	//
+	// --baseline is checked explicitly rather than left to the revision count
+	// it usually produces, because a dry-run baseline records no row at all.
+	if operands.allowDirty || operands.baselineVersion > 0 {
+		return nil
+	}
+	if !migrateclean.Governs(operands.conn.Info().Dialect) {
+		return nil
+	}
+	revisions, err := operands.plan.RevisionCount(ctx)
+	if err != nil {
+		return err
+	}
+	if revisions > 0 {
+		return nil
+	}
+	revisionsSchema, revisionTable := operands.plan.RevisionTable()
+	scope, err := migrateclean.Inspect(ctx, operands.conn, revisionTable, revisionsSchema)
+	if err != nil {
+		return err
+	}
+	return scope.Refusal()
+}

--- a/cmd/atlas/migrate_apply_clean_gate_test.go
+++ b/cmd/atlas/migrate_apply_clean_gate_test.go
@@ -1,0 +1,325 @@
+package atlas_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// stokaro/ptah#1231 case 1: the compat surface applied every migration to a
+// database that already held objects it did not create, and exited 0, where the
+// pinned community binary v1.3.0 refuses and leaves the database untouched.
+//
+// Every expected string here was transcribed from that binary on 2026-08-07
+// against SQLite files; the state each one belongs to is named on the test.
+
+const (
+	cleanGateVersionOne = "20240101000000"
+	cleanGateVersionTwo = "20240102000000"
+)
+
+// writeCleanGateFixture writes a hashed two-migration Atlas directory and
+// returns it with a path for a database file that does not exist yet.
+func writeCleanGateFixture(c *qt.C) (migrationsDir, dbPath string) {
+	c.Helper()
+	root := c.TempDir()
+	migrationsDir = filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	files := map[string]string{
+		cleanGateVersionOne + "_first.sql":  "CREATE TABLE cg_users (id INTEGER PRIMARY KEY);\n",
+		cleanGateVersionTwo + "_second.sql": "CREATE TABLE cg_orders (id INTEGER PRIMARY KEY);\n",
+	}
+	for name, body := range files {
+		c.Assert(os.WriteFile(filepath.Join(migrationsDir, name), []byte(body), 0o600), qt.IsNil)
+	}
+	_, err := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	return migrationsDir, filepath.Join(root, "gate.db")
+}
+
+// execCleanGateSQL runs statements against the fixture database directly, so a
+// test can put it in a state no migration in the directory produces.
+func execCleanGateSQL(c *qt.C, dbPath string, statements ...string) {
+	c.Helper()
+	ctx := context.Background()
+	conn, err := dbschema.ConnectToDatabase(ctx, atlasurl.SQLiteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	for _, statement := range statements {
+		_, execErr := conn.ExecContext(ctx, statement)
+		c.Assert(execErr, qt.IsNil, qt.Commentf("statement: %s", statement))
+	}
+}
+
+// runCleanGateApply applies the fixture with any extra flags the case needs.
+func runCleanGateApply(c *qt.C, migrationsDir, dbPath string, extra ...string) (stdout string, err error) {
+	c.Helper()
+	args := []string{
+		"migrate", "apply",
+		"--url", atlasurl.SQLiteURLFromPath(dbPath),
+		"--dir", "file://" + migrationsDir,
+	}
+	args = append(args, extra...)
+	stdout, _, err = runCompatStreams(c, args...)
+	return stdout, err
+}
+
+// TestCompatCommand_MigrateApplyRefusesUncleanDatabase is the headline
+// reproduction. The refusal text and the count in it are the binary's, measured
+// on a SQLite database holding one unrelated table.
+//
+// Reverted, this test fails on the first assertion: the apply succeeds, and
+// cg_users exists in a database nobody asked Ptah to adopt.
+func TestCompatCommand_MigrateApplyRefusesUncleanDatabase(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	_, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Equals,
+		"sql/migrate: connected database is not clean: found multiple tables: 2. "+
+			"baseline version or allow-dirty is required",
+	)
+	// The refusal is worth nothing if the migrations ran anyway.
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "cg_users")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "cg_orders")
+}
+
+// The count grows with the number of unmanaged tables, exactly as measured, so
+// a reader can tell one stray table from a whole legacy schema.
+func TestCompatCommand_MigrateApplyUncleanCountReportsEveryTable(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+	execCleanGateSQL(c, dbPath,
+		"CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)",
+		"CREATE TABLE other_stuff (id INTEGER PRIMARY KEY)",
+	)
+
+	_, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Equals,
+		"sql/migrate: connected database is not clean: found multiple tables: 3. "+
+			"baseline version or allow-dirty is required",
+	)
+}
+
+// A dry run refuses too. The binary checks before it decides whether anything
+// will be written, so --dry-run against an unclean database is an error rather
+// than a printed plan — and the count is the same one a real apply reports,
+// even though this implementation has not created its revisions table yet.
+func TestCompatCommand_MigrateApplyDryRunRefusesUncleanDatabase(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	stdout, err := runCleanGateApply(c, migrationsDir, dbPath, "--dry-run")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(
+		err.Error(),
+		qt.Equals,
+		"sql/migrate: connected database is not clean: found multiple tables: 2. "+
+			"baseline version or allow-dirty is required",
+	)
+	c.Assert(stdout, qt.Not(qt.Contains), "Would have applied")
+}
+
+// The gate is unconditional on how much work there is: the binary refuses even
+// when the directory has nothing to run, so an operator cannot discover the
+// problem only once a migration is added.
+func TestCompatCommand_MigrateApplyRefusesUncleanDatabaseWithEmptyDirectory(t *testing.T) {
+	c := qt.New(t)
+	root := c.TempDir()
+	migrationsDir := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	_, sumErr := migratesum.WriteWithFormat(migrationsDir, migrator.MigrationDirFormatAtlas)
+	c.Assert(sumErr, qt.IsNil)
+	dbPath := filepath.Join(root, "empty-dir.db")
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	_, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "connected database is not clean")
+}
+
+// --allow-dirty and --baseline are the binary's two documented opt-ins, and
+// each one alone applies against the same database the gate refused. Refusing
+// either would be the other half of the parity rule broken.
+func TestCompatCommand_MigrateApplyUncleanOptIns(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		extra []string
+		// wantApplied names a table the run must have created, which is how
+		// each row proves the opt-in ran migrations rather than merely
+		// exiting 0.
+		wantApplied string
+	}{
+		{name: "allow-dirty", extra: []string{"--allow-dirty"}, wantApplied: "cg_users"},
+		{
+			name:        "baseline",
+			extra:       []string{"--baseline", cleanGateVersionOne},
+			wantApplied: "cg_orders",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			migrationsDir, dbPath := writeCleanGateFixture(c)
+			execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+			_, err := runCleanGateApply(c, migrationsDir, dbPath, test.extra...)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(compatTableNames(c, dbPath), qt.Contains, test.wantApplied)
+			c.Assert(compatTableNames(c, dbPath), qt.Contains, "legacy_stuff")
+		})
+	}
+}
+
+// --baseline under --dry-run is the cell where honoring the baseline opt-out
+// is load-bearing rather than redundant. A real --baseline run records a
+// revision row, which switches the gate off on its own; a dry run records
+// nothing, so a gate that only asked "are there revisions yet" would refuse
+// here. Measured on PostgreSQL 17 and SQLite, the binary exits 0 and prints its
+// plan.
+func TestCompatCommand_MigrateApplyDryRunBaselineAcceptsUncleanDatabase(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	stdout, err := runCleanGateApply(c, migrationsDir, dbPath,
+		"--baseline", cleanGateVersionOne, "--dry-run")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Would have applied 1 migrations.")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "cg_orders")
+}
+
+// The two opt-ins are not composable. Measured, the binary refuses the pair
+// before recording anything, because they select different histories.
+func TestCompatCommand_MigrateApplyBaselineAndAllowDirtyAreExclusive(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	_, err := runCleanGateApply(c, migrationsDir, dbPath,
+		"--allow-dirty", "--baseline", cleanGateVersionOne)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, "sql/migrate: baseline and allow-dirty are mutually exclusive")
+	// Refused before the baseline was recorded: no revisions table exists to
+	// carry a row the operator never asked to keep.
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "atlas_schema_revisions")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "cg_orders")
+}
+
+// The states the binary calls clean. Each row is a database the gate must let
+// through, and the assertion is that the migrations really ran.
+func TestCompatCommand_MigrateApplyAcceptsCleanDatabases(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// setup puts the database into the state under test. A nil-free
+		// signature keeps the table free of behavior switches.
+		setup func(c *qt.C, dbPath string)
+	}{
+		{
+			name:  "no database file at all",
+			setup: func(_ *qt.C, _ string) {},
+		},
+		{
+			name: "a view is not a table",
+			setup: func(c *qt.C, dbPath string) {
+				execCleanGateSQL(c, dbPath, "CREATE VIEW cg_view AS SELECT 1 AS one")
+			},
+		},
+		{
+			name: "SQLite's own bookkeeping table does not count",
+			setup: func(c *qt.C, dbPath string) {
+				execCleanGateSQL(c, dbPath,
+					"CREATE TABLE cg_seq (id INTEGER PRIMARY KEY AUTOINCREMENT)",
+					"INSERT INTO cg_seq DEFAULT VALUES",
+					"DROP TABLE cg_seq",
+				)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			migrationsDir, dbPath := writeCleanGateFixture(c)
+			test.setup(c, dbPath)
+
+			stdout, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(stdout, qt.Contains, "Migration complete. Current version: "+cleanGateVersionTwo)
+			c.Assert(compatTableNames(c, dbPath), qt.Contains, "cg_users")
+		})
+	}
+}
+
+// An empty revisions table left behind by an earlier run is not dirt: measured,
+// the binary applies against a database whose only table is its own. This is
+// the row that stops the gate from being "the schema must have no tables".
+func TestCompatCommand_MigrateApplyAcceptsLoneEmptyRevisionsTable(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+
+	_, firstErr := runCleanGateApply(c, migrationsDir, dbPath)
+	c.Assert(firstErr, qt.IsNil)
+	// Roll the database back to "adopted once, then emptied": the revisions
+	// table survives with no rows and nothing else remains.
+	execCleanGateSQL(c, dbPath,
+		"DROP TABLE cg_users",
+		"DROP TABLE cg_orders",
+		"DELETE FROM atlas_schema_revisions",
+	)
+	c.Assert(compatTableNames(c, dbPath), qt.DeepEquals, []string{"atlas_schema_revisions"})
+
+	stdout, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Migration complete. Current version: "+cleanGateVersionTwo)
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "cg_users")
+}
+
+// The gate is an adoption gate, not a standing drift check. Once a revision has
+// been recorded, a table that appears later never triggers it again — measured,
+// the binary applies the next migration against exactly this state at exit 0.
+//
+// Reverted to a check that reads the schema instead of the revision rows, this
+// test fails on the second apply with the not-clean refusal.
+func TestCompatCommand_MigrateApplyIgnoresDriftOnAnAdoptedDatabase(t *testing.T) {
+	c := qt.New(t)
+	migrationsDir, dbPath := writeCleanGateFixture(c)
+
+	_, firstErr := runCleanGateApply(c, migrationsDir, dbPath, "--to-version", cleanGateVersionOne)
+	c.Assert(firstErr, qt.IsNil)
+	execCleanGateSQL(c, dbPath, "CREATE TABLE legacy_stuff (id INTEGER PRIMARY KEY)")
+
+	stdout, err := runCleanGateApply(c, migrationsDir, dbPath)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Migration complete. Current version: "+cleanGateVersionTwo)
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "cg_orders")
+}

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -1387,12 +1387,12 @@
   },
   {
     "area": "Versioned migrations",
-    "feature": "migrate apply `--allow-dirty` semantics",
-    "ptah": "partial",
+    "feature": "migrate apply `--allow-dirty` semantics and the not-clean adoption gate",
+    "ptah": "yes",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite).",
-    "evidence": "/tmp/c-compat migrate apply onto SQLite with a pre-existing table succeeded with no flag ('Migration complete'); after a failed migration, apply refuses ('is dirty'), and --allow-dirty errors 'UNIQUE constraint failed: atlas_schema_revisions.version'. Flag in CE inventory, cli-surface.md line 27; help: 'Allow applying migrations when the revision table is dirty'."
+    "note": "The flag carries both meanings CE gives it: it clears a dirty revision row, and it opts in to adopting a schema that already holds unmanaged tables. Without it that database is refused.",
+    "evidence": "/tmp/c-compat migrate apply onto SQLite with a pre-existing table succeeded with no flag ('Migration complete'); after a failed migration, apply refuses ('is dirty'), and --allow-dirty errors 'UNIQUE constraint failed: atlas_schema_revisions.version'. Flag in CE inventory, cli-surface.md line 27; help: 'Allow applying migrations when the revision table is dirty'. The dirty-row half was fixed in stokaro/ptah#966. The non-empty-target half was stokaro/ptah#1231 case 1 and is fixed on this branch. Measured 2026-08-07 against the pinned community binary v1.3.0 on PostgreSQL 17, MySQL 9.7 and SQLite, one database per cell with exit codes read unpiped: an unmanaged table refuses on both tools with byte-identical text ('sql/migrate: connected database is not clean: found table \"X\" in schema \"S\". baseline version or allow-dirty is required'; SQLite reports 'found multiple tables: N' instead). Clean on both: empty schema, a lone empty atlas_schema_revisions, a view, a sequence, sqlite_sequence, an empty non-default schema, and a table in another schema. The gate is an adoption gate — once any revision row exists it never fires again, measured on a managed database that grew an unmanaged table and then applied a new migration at exit 0 on both tools. --allow-dirty and --baseline each opt out; passing both exits 1 with 'sql/migrate: baseline and allow-dirty are mutually exclusive' on both tools, which ptah-compat previously accepted at exit 0. The discriminating fixture for the predicate is `--revisions-schema revs`, which leaves `public` holding exactly one table: both tools still refuse and name that table, which rules out 'more than one table' and pins the rule at 'any table other than this run's revision table'."
   },
   {
     "area": "Versioned migrations",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -76,13 +76,13 @@ Across the 166 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 92 |
-| Ptah supports it with a stated limitation | 50 |
+| Ptah supports it fully | 93 |
+| Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
-| Ptah and Atlas CE both support it | 24 |
+| Ptah and Atlas CE both support it | 25 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
 | Ptah has it and neither Atlas edition does | 20 |
-| Atlas CE has it and Ptah does not, or only in part | 26 |
+| Atlas CE has it and Ptah does not, or only in part | 25 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
 Every 🟡 in the Ptah column names its specific limitation, reproduced against a
@@ -174,7 +174,7 @@ seven of them as open capabilities regardless.
 | Failed rollback state is recorded and recoverable | ✅ | ❌ | ❌ | Native `ptah migrations down` marks the row failed with the error and completed-statement count, so status reports it dirty and `migrations repair` clears it; compat matches Atlas, which records none. |
 | Flyway repeatable (`R__`) migration import | 🟡 | ✅ | ✅ | Compat import converts `R__` to a one-time migration ordered last, as Atlas CE runs it. Editing the body then fails on a Ptah revision checksum where CE exits 0. |
 | Generate migrations from a schema diff | 🟡 | ✅ | ✅ | New versions are a Unix epoch in an empty dir and latest+1 otherwise, not the UTC YYYYMMDDHHMMSS stamp migrate new and Atlas dirs carry. |
-| migrate apply `--allow-dirty` semantics | 🟡 | ✅ | ✅ | Flag gates a dirty revision row, not a non-empty target: a pre-populated database applies without it, and the recovery re-insert fails with UNIQUE on atlas_schema_revisions (SQLite). |
+| migrate apply `--allow-dirty` semantics and the not-clean adoption gate | ✅ | ✅ | ✅ | The flag carries both meanings CE gives it: it clears a dirty revision row, and it opts in to adopting a schema that already holds unmanaged tables. Without it that database is refused. |
 | Migration checkpoints (squash history) | ✅ | ❌ | ✅ | Replays the directory on `--shadow-db` into a cumulative checkpoint: the ptah reversible pair, or Atlas's single `-- atlas:checkpoint` file under `--dir-format atlas`. CE gates the verb. |
 | Migration import from other tools | 🟡 | ✅ | ✅ | Native import converts golang-migrate/Goose/Flyway/Liquibase-SQL to ptah format (`R__` becomes one-time); the compat path writes atlas format and rejects `R__`. Liquibase XML/YAML/JSON not parsed. |
 | Migration linting | ✅ | 🟡 | ✅ | CE registers `migrate lint` with a basic Open rule set; Atlas's features page marks the lint CLI Pro. Ptah loads custom rules only through the Go API at compile time. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -250,6 +250,42 @@ measured Atlas checkpoint semantics — a fresh database applies only the
 latest checkpoint plus later migrations, and a database that already applied
 pre-checkpoint history skips the checkpoint silently.
 
+### Adopting a database that already has tables
+
+`migrate apply` refuses to adopt a database whose schema already holds tables no
+migration recorded, matching Atlas:
+
+```text
+Error: sql/migrate: connected database is not clean: found table "legacy_stuff" in schema "public". baseline version or allow-dirty is required
+```
+
+On SQLite the same refusal reports a count instead of a name:
+`found multiple tables: 2`.
+
+The check is an adoption gate, not a standing drift check. It runs only while
+the revision table holds no rows, so it fires on the first apply against a
+database somebody else's tooling owns and never again — a managed database that
+later grows an unmanaged table applies its next migration normally. Views,
+sequences, and tables in other schemas are not tables in the connected schema
+and do not trigger it, and neither does the revision table itself. The refusal
+also fires under `--dry-run` and on a directory with nothing pending, because
+the question it answers is about the database rather than about the work.
+
+Two flags opt in, and they cannot be combined:
+
+- `--allow-dirty` applies every pending migration against the existing schema.
+- `--baseline <version>` records history as starting at that version and applies
+  only what comes after it.
+
+Passing both exits `1` with
+`Error: sql/migrate: baseline and allow-dirty are mutually exclusive` before
+anything is recorded.
+
+The gate is enforced on PostgreSQL, MySQL, MariaDB, and SQLite. Other dialects
+are not gated, because the behavior to match has not been measured on them.
+Native [`ptah migrations up`](../../versioned/apply/) has no equivalent gate; see
+[#1231](https://github.com/stokaro/ptah/issues/1231).
+
 ```bash
 ptah-compat migrate apply 2 \
   --url "$DATABASE_URL" \

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/revisiontable"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -177,6 +178,39 @@ func (p ApplyPlan) MigrationLockSkipped() bool {
 	return p.mig != nil && p.mig.MigrationLockSkipped()
 }
 
+// RevisionCount reports how many rows this run's revision table holds.
+//
+// The operand is the row count rather than Status.AppliedMigrations, which is
+// intersected with the directory: a database whose migration directory has been
+// rotated reports no applied migrations while its revision table is full, and a
+// caller asking "has any migration ever been recorded here" must not read that
+// as a database nothing has been applied to.
+//
+// A run that has not created the revision table yet — a dry run — reports zero
+// rather than failing, because the migrator answers an absent table with an
+// empty result.
+func (p ApplyPlan) RevisionCount(ctx context.Context) (int, error) {
+	if p.mig == nil {
+		return 0, errors.New("migrate apply revision count requires a prepared plan")
+	}
+	revisions, err := p.mig.GetRevisions(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("error reading migration revisions: %w", err)
+	}
+	return len(revisions), nil
+}
+
+// RevisionTable reports where this run records revisions: the schema, empty
+// when the connection's own schema is used, and the unqualified table name.
+//
+// The table name is the Atlas default rather than a value read back from the
+// migrator because newApplyMigrator pins RevisionTableFormatAtlas and passes no
+// table-name override, so this path has exactly one answer. The schema is the
+// caller's --revisions-schema, which is the only part a run can move.
+func (p ApplyPlan) RevisionTable() (schema, table string) {
+	return p.opts.RevisionsSchema, revisiontable.Atlas
+}
+
 // Execute applies the selected plan. Dry-run and no-op plans return metadata
 // without modifying schema state.
 func (p ApplyPlan) Execute(ctx context.Context) (ApplyResult, error) {
@@ -328,6 +362,19 @@ func validateApplyOptions(conn *dbschema.DatabaseConnection, opts ApplyOptions) 
 	// the run must not start.
 	if opts.ToVersion > 0 && opts.Amount > 0 {
 		return errors.New("--to-version and the amount argument cannot both be set")
+	}
+	// The two opt-outs of the not-clean gate are not composable, and the pinned
+	// community binary v1.3.0 says so before it records anything: measured on
+	// PostgreSQL 17, MySQL 9.7 and SQLite, `--allow-dirty --baseline <v>`
+	// together exits 1 with this text and leaves the revision table empty,
+	// while either alone exits 0. They select different histories — a baseline
+	// records a version as applied and skips it, allow-dirty records nothing
+	// and runs everything — so there is no defensible precedence between them.
+	//
+	// This is checked before the baseline is recorded rather than after, so a
+	// refused invocation cannot leave a baseline row behind.
+	if opts.AllowDirty && opts.BaselineVersion > 0 {
+		return errors.New("sql/migrate: baseline and allow-dirty are mutually exclusive")
 	}
 	return nil
 }

--- a/internal/migrateclean/migrateclean.go
+++ b/internal/migrateclean/migrateclean.go
@@ -1,0 +1,276 @@
+// Package migrateclean answers the precondition the Atlas-compatible
+// `migrate apply` enforces before it adopts a database for the first time:
+// whether the connected schema already holds tables that no migration in the
+// directory created.
+//
+// It sits between the compat command in cmd/atlas and the live catalog. The
+// command owns the two questions this package cannot see — whether the run was
+// opted out of the gate, and whether the revision table already holds rows —
+// and this package owns the two it can: which tables are in scope, and what
+// the refusal says.
+//
+// Every operand below is measured against the pinned community binary v1.3.0
+// rather than designed. The fixtures are named on the declarations they pin.
+package migrateclean
+
+import (
+	"context"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// Governs reports whether the not-clean gate is enforced for a dialect.
+//
+// The list is the set of dialects the gate was measured on, not the set the
+// catalog probes below could be written for. A dialect answers "no" until
+// somebody runs the pinned binary against it and records what it does, because
+// the cost of guessing is asymmetric: guessing "enforce" turns every existing
+// run on that dialect into a refusal the other implementation may never make,
+// which is the drop-in regression the compatibility policy forbids outright.
+//
+// Measured 2026-08-07: PostgreSQL 17, MySQL 9.7, SQLite. MariaDB is included
+// because it reads the same information_schema through the same code path as
+// MySQL, and is called out as inferred in the pull request rather than passed
+// off as measured.
+func Governs(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.Postgres, platform.MySQL, platform.MariaDB, platform.SQLite:
+		return true
+	default:
+		return false
+	}
+}
+
+// Scope is the set of tables the gate reasons about, plus everything the
+// refusal has to name.
+//
+// Tables holds only the connected schema's own tables. A table in another
+// schema is deliberately absent: measured on PostgreSQL 17, a database whose
+// `public` is empty and whose `extra` schema holds a table applies at exit 0,
+// so widening the scope past the connection's schema would refuse where the
+// pinned binary accepts.
+type Scope struct {
+	// Dialect is the connection's dialect, as reported by dbschema.
+	Dialect string
+	// Schema names the connected schema the refusal reports. It is the schema
+	// the tables were read from, so a message can never name a schema the
+	// probe did not look in.
+	Schema string
+	// Tables lists the base tables found in Schema, sorted by name.
+	Tables []string
+	// RevisionTable is the unqualified table this run records revisions in,
+	// when that table lives inside Schema. It is empty when the run was
+	// pointed at another schema with --revisions-schema, because the gate then
+	// has no bookkeeping table of its own inside the scope to exempt.
+	RevisionTable string
+}
+
+// Inspect reads the base tables in the connection's own schema.
+//
+// revisionTable and revisionsSchema describe where the calling run records its
+// revisions. They are passed in rather than assumed because the compat surface
+// lets --revisions-schema move that table out of the connected schema, and the
+// exemption must follow it: measured on PostgreSQL 17, `migrate apply
+// --revisions-schema revs` against a `public` holding exactly one unrelated
+// table still refuses and names that table, which is what proves the rule is
+// "any table other than this run's revision table" rather than "more than one
+// table".
+//
+// A dialect Governs does not cover yields a zero Scope, whose Refusal is nil.
+func Inspect(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	revisionTable string,
+	revisionsSchema string,
+) (Scope, error) {
+	if conn == nil {
+		return Scope{}, fmt.Errorf("migrate apply clean check requires a database connection")
+	}
+	dialect := conn.Info().Dialect
+	if !Governs(dialect) {
+		return Scope{}, nil
+	}
+	scope := Scope{Dialect: dialect, Schema: strings.TrimSpace(conn.Info().Schema)}
+	query, args := tableProbe(dialect, scope.Schema)
+	if query == "" {
+		// Governs said yes and this function has no probe for it. Reporting a
+		// clean database would be a gate that passes without running, so it
+		// fails loudly instead.
+		return Scope{}, fmt.Errorf("migrate apply clean check has no catalog probe for dialect %q", dialect)
+	}
+	rows, err := conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return Scope{}, fmt.Errorf("migrate apply clean check: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	for rows.Next() {
+		schema, name, scanErr := scanProbeRow(dialect, rows)
+		if scanErr != nil {
+			return Scope{}, fmt.Errorf("migrate apply clean check: %w", scanErr)
+		}
+		// The schema comes back with the rows so the refusal names the schema
+		// the probe really read, not the one the connection was configured
+		// with — those differ whenever the URL pins no search_path and the
+		// probe falls back to the session's own schema.
+		if schema != "" {
+			scope.Schema = schema
+		}
+		scope.Tables = append(scope.Tables, name)
+	}
+	if err := rows.Err(); err != nil {
+		return Scope{}, fmt.Errorf("migrate apply clean check: %w", err)
+	}
+	slices.Sort(scope.Tables)
+	scope.RevisionTable = revisionTableInScope(dialect, scope.Schema, revisionTable, revisionsSchema)
+	return scope, nil
+}
+
+// Refusal returns the pinned binary's refusal when the scope holds a table this
+// run's revisions table does not account for, and nil when it does not.
+//
+// The two message shapes are measured, and they differ in more than wording.
+//
+// PostgreSQL 17 and MySQL 9.7 name a single table and its schema, and the table
+// they name is the alphabetically first one in the schema INCLUDING the
+// revisions table: with `legacy_stuff` present the refusal names
+// `atlas_schema_revisions`, and with `aaa_legacy` present it names
+// `aaa_legacy`. Creation order is not the operand — `zzz_first` created before
+// `bbb_second` still yields `atlas_schema_revisions`.
+//
+// SQLite reports a count instead of a name, and the count includes the
+// revisions table while excluding SQLite's own `sqlite_*` tables: one unrelated
+// table reads `found multiple tables: 2`, two read `3`, and a database holding
+// nothing but `sqlite_sequence` applies at exit 0.
+//
+// The count and the named candidate are both computed over Tables plus
+// RevisionTable rather than over Tables alone, because a dry run never creates
+// the revisions table on this implementation while the pinned binary creates it
+// before checking. Without the addition the same database would report one
+// table fewer under --dry-run than under a real apply, and the SQLite count
+// would disagree with the pinned binary by exactly one.
+func (s Scope) Refusal() error {
+	if !Governs(s.Dialect) {
+		return nil
+	}
+	candidates := s.candidates()
+	unmanaged := 0
+	for _, table := range candidates {
+		if table != s.RevisionTable {
+			unmanaged++
+		}
+	}
+	if unmanaged == 0 {
+		return nil
+	}
+	if platform.NormalizeDialect(s.Dialect) == platform.SQLite {
+		return fmt.Errorf(
+			"sql/migrate: connected database is not clean: found multiple tables: %d. baseline version or allow-dirty is required",
+			len(candidates),
+		)
+	}
+	return fmt.Errorf(
+		"sql/migrate: connected database is not clean: found table %q in schema %q. baseline version or allow-dirty is required",
+		candidates[0], s.Schema,
+	)
+}
+
+// candidates returns the sorted table names the refusal reasons about: every
+// table the probe saw, plus this run's revisions table when the probe did not
+// already see it.
+func (s Scope) candidates() []string {
+	candidates := slices.Clone(s.Tables)
+	if s.RevisionTable != "" && !slices.Contains(candidates, s.RevisionTable) {
+		candidates = append(candidates, s.RevisionTable)
+	}
+	slices.Sort(candidates)
+	return slices.Compact(candidates)
+}
+
+// revisionTableInScope reports the revisions table name to exempt, or "" when
+// this run keeps its revisions outside the connected schema.
+//
+// SQLite has no schemas, so --revisions-schema cannot move anything there and
+// the table is always in scope.
+func revisionTableInScope(dialect, connectedSchema, revisionTable, revisionsSchema string) string {
+	revisionTable = strings.TrimSpace(revisionTable)
+	if revisionTable == "" {
+		return ""
+	}
+	revisionsSchema = strings.TrimSpace(revisionsSchema)
+	if revisionsSchema == "" || platform.NormalizeDialect(dialect) == platform.SQLite {
+		return revisionTable
+	}
+	if strings.EqualFold(revisionsSchema, connectedSchema) {
+		return revisionTable
+	}
+	return ""
+}
+
+// probeRow is the row shape scanProbeRow reads. It exists so the two-column and
+// one-column probes can share one scanning path.
+type probeRow interface {
+	Scan(dest ...any) error
+}
+
+func scanProbeRow(dialect string, row probeRow) (schema, name string, err error) {
+	if platform.NormalizeDialect(dialect) == platform.SQLite {
+		if err := row.Scan(&name); err != nil {
+			return "", "", err
+		}
+		return "", name, nil
+	}
+	if err := row.Scan(&schema, &name); err != nil {
+		return "", "", err
+	}
+	return schema, name, nil
+}
+
+// tableProbe builds the catalog query that lists the base tables inside the
+// gate's scope.
+//
+// The scope is the connection's own schema, defaulted the way each dialect's
+// session defaults it rather than to a literal, so a URL that pins no schema is
+// asked about the schema its statements would really land in.
+//
+// An unrecognized dialect returns an empty query rather than falling through to
+// another dialect's catalog; Inspect turns that into an error.
+func tableProbe(dialect, schema string) (string, []any) {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.SQLite:
+		// The ESCAPE clause matters: in LIKE, `_` matches any single
+		// character, so an unescaped 'sqlite_%' would also hide a user table
+		// named `sqliteXthing` and under-report the database.
+		return `
+			SELECT name
+			FROM sqlite_master
+			WHERE type = 'table'
+			  AND name NOT LIKE 'sqlite\_%' ESCAPE '\'
+			ORDER BY name`, nil
+	case platform.MySQL, platform.MariaDB:
+		return `
+			SELECT table_schema, table_name
+			FROM information_schema.tables
+			WHERE table_schema = COALESCE(NULLIF(?, ''), DATABASE())
+			  AND table_type = 'BASE TABLE'
+			ORDER BY table_name`, []any{schema}
+	case platform.Postgres:
+		// relkind 'r' and 'p' are ordinary and partitioned tables. Views,
+		// sequences, materialized views and indexes are excluded on purpose:
+		// measured on PostgreSQL 17, a database holding only a view or only a
+		// sequence applies at exit 0.
+		return `
+			SELECT n.nspname, c.relname
+			FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = COALESCE(NULLIF($1, ''), current_schema())
+			  AND c.relkind IN ('r', 'p')
+			ORDER BY c.relname`, []any{schema}
+	default:
+		return "", nil
+	}
+}

--- a/internal/migrateclean/migrateclean_live_test.go
+++ b/internal/migrateclean/migrateclean_live_test.go
@@ -1,0 +1,213 @@
+//go:build integration
+
+package migrateclean_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/migrateclean"
+)
+
+// These cases pin the half of the gate a SQLite fixture cannot express: which
+// schema the catalog probe looks in. SQLite has one namespace, so the unit
+// tests can pin the predicate and the wording but not the scope.
+//
+// Each expected string was produced by the pinned community binary v1.3.0
+// against PostgreSQL 17 on 2026-08-07; the state is named on each row.
+
+const migratecleanRevisionTable = "atlas_schema_revisions"
+
+// TestInspectLive_CleanSchemas walks the states the binary applies against, so
+// the probe cannot start refusing objects that are none of its business.
+func TestInspectLive_CleanSchemas(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name  string
+		setup []string
+	}{
+		{name: "an empty schema"},
+		{
+			name:  "a table in another schema is out of scope",
+			setup: []string{"CREATE SCHEMA extra", "CREATE TABLE extra.legacy_stuff (id integer PRIMARY KEY)"},
+		},
+		{
+			name:  "an empty schema beside the connected one",
+			setup: []string{"CREATE SCHEMA extra"},
+		},
+		{
+			name:  "a view is not a table",
+			setup: []string{"CREATE VIEW v AS SELECT 1 AS one"},
+		},
+		{
+			name:  "a sequence is not a table",
+			setup: []string{"CREATE SEQUENCE s1"},
+		},
+		{
+			name:  "the run's own revisions table alone",
+			setup: []string{"CREATE TABLE atlas_schema_revisions (version varchar PRIMARY KEY)"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newMigratecleanLiveConnection(c, ctx)
+			applyMigratecleanFixture(c, ctx, conn, test.setup)
+
+			scope, err := migrateclean.Inspect(ctx, conn, migratecleanRevisionTable, "")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(scope.Schema, qt.Equals, "public")
+			c.Assert(scope.Refusal(), qt.IsNil)
+		})
+	}
+}
+
+// TestInspectLive_UncleanSchemas walks the states the binary refuses, and
+// checks the refusal names the table the binary names.
+func TestInspectLive_UncleanSchemas(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// setup puts the throwaway database into the state under test.
+		setup []string
+		// revisionsSchema is the run's --revisions-schema.
+		revisionsSchema string
+		wantErr         string
+	}{
+		{
+			name: "one unrelated table beside the revisions table",
+			setup: []string{
+				"CREATE TABLE legacy_stuff (id integer PRIMARY KEY)",
+				"CREATE TABLE atlas_schema_revisions (version varchar PRIMARY KEY)",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "atlas_schema_revisions" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// The refusal names the alphabetically first table, so a table
+			// sorting before the revisions table displaces it.
+			name: "the reported table is the alphabetically first one",
+			setup: []string{
+				"CREATE TABLE aaa_legacy (id integer PRIMARY KEY)",
+				"CREATE TABLE atlas_schema_revisions (version varchar PRIMARY KEY)",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "aaa_legacy" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// The discriminating fixture. `public` holds exactly one table and
+			// the binary still refuses, which is what rules out "more than one
+			// table" as the predicate.
+			name: "revisions kept in another schema still refuses on one table",
+			setup: []string{
+				"CREATE SCHEMA revs",
+				"CREATE TABLE revs.atlas_schema_revisions (version varchar PRIMARY KEY)",
+				"CREATE TABLE legacy_stuff (id integer PRIMARY KEY)",
+			},
+			revisionsSchema: "revs",
+			wantErr:         `sql/migrate: connected database is not clean: found table "legacy_stuff" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// A partitioned table is a table. Its partitions are too, and both
+			// relkinds are in the probe.
+			name: "a partitioned table counts",
+			setup: []string{
+				"CREATE TABLE parted (id integer NOT NULL, part integer NOT NULL) PARTITION BY RANGE (part)",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "atlas_schema_revisions" in schema "public". baseline version or allow-dirty is required`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newMigratecleanLiveConnection(c, ctx)
+			applyMigratecleanFixture(c, ctx, conn, test.setup)
+
+			scope, err := migrateclean.Inspect(
+				ctx, conn, migratecleanRevisionTable, test.revisionsSchema,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(scope.Schema, qt.Equals, "public")
+			refusal := scope.Refusal()
+			c.Assert(refusal, qt.IsNotNil)
+			c.Assert(refusal.Error(), qt.Equals, test.wantErr)
+		})
+	}
+}
+
+func applyMigratecleanFixture(
+	c *qt.C,
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	statements []string,
+) {
+	c.Helper()
+	for _, statement := range statements {
+		_, err := conn.ExecContext(ctx, statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement: %s", statement))
+	}
+}
+
+// newMigratecleanLiveConnection provisions a throwaway database, so a case that
+// creates schemas and tables cannot disturb any other live test sharing the
+// server.
+func newMigratecleanLiveConnection(c *qt.C, ctx context.Context) *dbschema.DatabaseConnection {
+	c.Helper()
+	adminURL := requireMigratecleanLiveURL(c)
+	admin, err := sql.Open("pgx", adminURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(admin.PingContext(ctx), qt.IsNil)
+
+	name := fmt.Sprintf("ptah_migrateclean_%d", time.Now().UnixNano())
+	nameIdent := pgx.Identifier{name}.Sanitize()
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+nameIdent)
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := url.Parse(adminURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	parsed.RawPath = ""
+
+	conn, err := dbschema.ConnectToDatabase(ctx, parsed.String())
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		dbschema.CloseAndWarn(conn)
+		_, dropErr := admin.ExecContext(
+			context.WithoutCancel(ctx),
+			"DROP DATABASE IF EXISTS "+nameIdent+" WITH (FORCE)",
+		)
+		c.Check(dropErr, qt.IsNil)
+		c.Check(admin.Close(), qt.IsNil)
+	})
+	return conn
+}
+
+func requireMigratecleanLiveURL(c *qt.C) string {
+	c.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		raw := os.Getenv(name)
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse(raw)
+		c.Assert(err, qt.IsNil)
+		parsed.Scheme = "postgres"
+		return parsed.String()
+	}
+	c.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	return ""
+}

--- a/internal/migrateclean/migrateclean_test.go
+++ b/internal/migrateclean/migrateclean_test.go
@@ -1,0 +1,250 @@
+package migrateclean_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migrateclean"
+)
+
+// The expected strings below are transcribed from runs of the pinned community
+// binary v1.3.0 on 2026-08-07: PostgreSQL 17 in a throwaway container, MySQL
+// 9.7 in a throwaway container, and SQLite files. Each row names the state the
+// binary was in when it produced that line.
+
+func TestGoverns_EnforcedDialects(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "postgres", dialect: "postgres"},
+		{name: "postgres driver spelling", dialect: "pgx"},
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "sqlite", dialect: "sqlite"},
+		{name: "sqlite driver spelling", dialect: "sqlite3"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(migrateclean.Governs(test.dialect), qt.IsTrue)
+		})
+	}
+}
+
+// The gate stays off for dialects nobody has run the pinned binary against.
+// Turning it on for them would refuse runs that work today with no measurement
+// saying the other implementation refuses them, which is the drop-in
+// regression the compatibility policy forbids.
+func TestGoverns_UnmeasuredDialects(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "clickhouse", dialect: "clickhouse"},
+		{name: "sqlserver", dialect: "sqlserver"},
+		{name: "spanner", dialect: "spanner"},
+		{name: "cockroachdb", dialect: "cockroachdb"},
+		{name: "yugabytedb", dialect: "yugabytedb"},
+		{name: "empty", dialect: ""},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(migrateclean.Governs(test.dialect), qt.IsFalse)
+		})
+	}
+}
+
+func TestScopeRefusal_CleanDatabases(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		scope migrateclean.Scope
+	}{
+		{
+			// A brand new database. The binary applies at exit 0.
+			name: "postgres empty schema",
+			scope: migrateclean.Scope{
+				Dialect:       "postgres",
+				Schema:        "public",
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+		{
+			// Measured: a database holding nothing but an empty
+			// atlas_schema_revisions applies at exit 0, so an empty revision
+			// table does not make a database unclean on its own.
+			name: "postgres revisions table only",
+			scope: migrateclean.Scope{
+				Dialect:       "postgres",
+				Schema:        "public",
+				Tables:        []string{"atlas_schema_revisions"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+		{
+			name: "mysql revisions table only",
+			scope: migrateclean.Scope{
+				Dialect:       "mysql",
+				Schema:        "app",
+				Tables:        []string{"atlas_schema_revisions"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+		{
+			// Measured: a SQLite database whose only table is
+			// atlas_schema_revisions applies at exit 0.
+			name: "sqlite revisions table only",
+			scope: migrateclean.Scope{
+				Dialect:       "sqlite",
+				Tables:        []string{"atlas_schema_revisions"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+		{
+			name: "sqlite empty file",
+			scope: migrateclean.Scope{
+				Dialect:       "sqlite",
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+		{
+			// A dialect the gate does not govern reports clean even with
+			// tables present, so that turning Governs on is the one decision
+			// that widens enforcement.
+			name: "ungoverned dialect with tables",
+			scope: migrateclean.Scope{
+				Dialect:       "clickhouse",
+				Schema:        "default",
+				Tables:        []string{"legacy_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(test.scope.Refusal(), qt.IsNil)
+		})
+	}
+}
+
+func TestScopeRefusal_UncleanDatabases(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		scope   migrateclean.Scope
+		wantErr string
+	}{
+		{
+			// The measured quirk: the binary names the alphabetically first
+			// table in the schema, and its own revisions table sorts before
+			// `legacy_stuff`, so that is the name it reports.
+			name: "postgres unrelated table sorting after the revisions table",
+			scope: migrateclean.Scope{
+				Dialect:       "postgres",
+				Schema:        "public",
+				Tables:        []string{"atlas_schema_revisions", "legacy_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "atlas_schema_revisions" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// The same state with a table that sorts first. This row and the
+			// one above are what separate "alphabetically first" from "the
+			// offending table": only one ordering satisfies both.
+			name: "postgres unrelated table sorting before the revisions table",
+			scope: migrateclean.Scope{
+				Dialect:       "postgres",
+				Schema:        "public",
+				Tables:        []string{"aaa_legacy", "atlas_schema_revisions"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "aaa_legacy" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// --revisions-schema moved the bookkeeping out of the connected
+			// schema, so `public` holds exactly one table and the binary still
+			// refuses. This is the fixture that kills "more than one table" as
+			// the predicate.
+			name: "postgres single table with revisions kept in another schema",
+			scope: migrateclean.Scope{
+				Dialect: "postgres",
+				Schema:  "public",
+				Tables:  []string{"legacy_stuff"},
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "legacy_stuff" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// A dry run never creates the revisions table here, while the
+			// binary creates it before checking. Counting it anyway is what
+			// makes --dry-run report the same table the binary reports.
+			name: "postgres dry run before the revisions table exists",
+			scope: migrateclean.Scope{
+				Dialect:       "postgres",
+				Schema:        "public",
+				Tables:        []string{"legacy_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "atlas_schema_revisions" in schema "public". baseline version or allow-dirty is required`,
+		},
+		{
+			// MySQL reports the database as the schema.
+			name: "mysql unrelated table",
+			scope: migrateclean.Scope{
+				Dialect:       "mysql",
+				Schema:        "app",
+				Tables:        []string{"aaa_legacy", "atlas_schema_revisions"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found table "aaa_legacy" in schema "app". baseline version or allow-dirty is required`,
+		},
+		{
+			// SQLite reports a count instead of a name, and the count includes
+			// the revisions table.
+			name: "sqlite one unrelated table",
+			scope: migrateclean.Scope{
+				Dialect:       "sqlite",
+				Tables:        []string{"atlas_schema_revisions", "legacy_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found multiple tables: 2. baseline version or allow-dirty is required`,
+		},
+		{
+			name: "sqlite two unrelated tables",
+			scope: migrateclean.Scope{
+				Dialect:       "sqlite",
+				Tables:        []string{"atlas_schema_revisions", "legacy_stuff", "other_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found multiple tables: 3. baseline version or allow-dirty is required`,
+		},
+		{
+			// The count survives the dry run too: one real table plus the
+			// revisions table the binary would have created is still 2.
+			name: "sqlite dry run before the revisions table exists",
+			scope: migrateclean.Scope{
+				Dialect:       "sqlite",
+				Tables:        []string{"legacy_stuff"},
+				RevisionTable: "atlas_schema_revisions",
+			},
+			wantErr: `sql/migrate: connected database is not clean: found multiple tables: 2. baseline version or allow-dirty is required`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := test.scope.Refusal()
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.wantErr)
+		})
+	}
+}


### PR DESCRIPTION
Closes the first case of #1231: `ptah-compat migrate apply` exited `0` and executed every migration against a database that already held tables it did not create, where the pinned community binary v1.3.0 exits `1` and leaves the database untouched.

Base: `master` at 2dc8417d. Not the #1232 branch — that fix is in schema diff/apply table matching, and nothing here reads schema diffs; this gate lives on the `migrate apply` path and queries the catalog directly.

## What the binary actually does

Measured 2026-08-07 with a throwaway PostgreSQL 17 container, a throwaway MySQL 9.7 container, and SQLite files. One database per cell, exit status read on its own line from an unpiped invocation.

The predicate is: **the revision table holds no rows, AND the connected schema holds at least one table other than this run's revision table.**

It is an adoption gate, not a standing drift check. Once any revision row exists it never fires again.

### PostgreSQL 17, one database per cell

| state | pinned binary | ptah-compat before | ptah-compat after |
| --- | --- | --- | --- |
| empty schema | 0 | 0 | 0 |
| one unrelated table | **1** | **0, applied both** | 1 |
| lone empty `atlas_schema_revisions` | 0 | 0 | 0 |
| empty revisions table + unrelated table | **1** | **0** | 1 |
| empty non-default schema `extra` present | 0 | 0 | 0 |
| table inside schema `extra`, `public` empty | 0 | 0 | 0 |
| a view only | 0 | 0 | 0 |
| a sequence only | 0 | 0 | 0 |
| managed database + unmanaged table, nothing pending | 0 | 0 | 0 |
| managed database + unmanaged table + a new migration | 0 | 0 | 0 |
| `--baseline <v>` on the unclean database | 0 | 0 | 0 |
| `--allow-dirty` on the unclean database | 0 | 0 | 0 |
| `--allow-dirty --baseline <v>` together | **1** | **0** | 1 |
| `--baseline <v>` on a clean database | 0 | 0 | 0 |
| `--baseline <unknown>` on the unclean database | 1 | 1 | 1 |
| `--baseline <v> --dry-run` on the unclean database | 0 | 0 | 0 |
| `--dry-run` on the unclean database | **1** | **0, printed the plan** | 1 |
| unclean + a table sorting before the revisions table | **1** | **0** | 1 |
| `--revisions-schema revs`, `public` holds one table | **1** | **0** | 1 |
| empty migration directory on the unclean database | **1** | **0** | 1 |
| tampered `atlas.sum` on the unclean database | 1 (checksum) | **0** | 1 (not-clean — see below) |

### SQLite, one database file per cell

| state | pinned binary | ptah-compat before | ptah-compat after |
| --- | --- | --- | --- |
| no file / empty file | 0 | 0 | 0 |
| one unrelated table | **1** `found multiple tables: 2` | **0** | 1, same text |
| two unrelated tables | **1** `found multiple tables: 3` | **0** | 1, same text |
| a view only | 0 | 0 | 0 |
| lone empty `atlas_schema_revisions` | 0 | 0 | 0 |
| empty revisions table + unrelated table | **1** | **0** | 1 |
| only `sqlite_sequence` | 0 | 0 | 0 |
| `--allow-dirty` | 0 | 0 | 0 |
| `--baseline <v>` | 0 | 0 | 0 |
| `--allow-dirty --baseline <v>` | **1** | **0** | 1 |

### MySQL 9.7, one database per cell

Same shape as PostgreSQL, with the database name in the `in schema` position: empty (0/0), one unrelated table (**1**/**0** → 1), a table sorting first (**1**/**0** → 1), a view only (0/0), lone revisions table (0/0), empty revisions table + unrelated table (**1**/**0** → 1), `--allow-dirty` (0/0), `--baseline` (0/0), both flags (**1**/**0** → 1).

Every cell now agrees on exit status, and the refusal text is byte-identical on all three dialects.

## The two message shapes are different, and both are reproduced

```text
# PostgreSQL and MySQL
Error: sql/migrate: connected database is not clean: found table "legacy_stuff" in schema "public". baseline version or allow-dirty is required

# SQLite
Error: sql/migrate: connected database is not clean: found multiple tables: 2. baseline version or allow-dirty is required
```

Two measured quirks are reproduced rather than improved on, because the exit code and the remedy are identical either way and tooling reads the text:

- The named table is the **alphabetically first** table in the schema, *including* the binary's own revisions table. With `legacy_stuff` present the binary names `atlas_schema_revisions`; with `aaa_legacy` present it names `aaa_legacy`. Creation order is not the operand — `zzz_first` created before `bbb_second` still yields `atlas_schema_revisions`.
- The SQLite count includes the revisions table. This build never creates that table during a `--dry-run`, so the count and the candidate list add it explicitly; without that, the same database would report one table fewer under `--dry-run` than under a real apply.

## The fixture that pins the predicate

`--revisions-schema revs` puts `atlas_schema_revisions` outside the connected schema, leaving `public` with exactly **one** table. The binary still refuses, and names that one table. That kills "more than one table" as the reading and pins the rule at "any table other than this run's revision table". A test carries it (`internal/migrateclean/migrateclean_live_test.go`, and the pure twin in `migrateclean_test.go`).

## Where it lives

- `internal/migrateclean` — new. `Governs(dialect)` decides enforcement; `Inspect` runs the per-dialect catalog probe scoped to the connection's own schema; `Scope.Refusal()` owns the predicate and both measured message shapes.
- `cmd/atlas/migrate_apply_clean_gate.go` — new. `checkConnectedDatabaseClean` plus `runAtlasMigrateApplyRefusals`, which now groups this gate with the three Flyway refusals that already ran between planning and execution. That extraction also brought `runAtlasMigrateApply` back under the `funlen` limit it had crossed.
- `internal/atlasmigrate/apply.go` — `ApplyPlan.RevisionCount` and `ApplyPlan.RevisionTable` accessors, plus the `--allow-dirty` / `--baseline` mutual-exclusion refusal in `validateApplyOptions`, which runs before the baseline is recorded so a refused invocation leaves no row behind.

Placement is measured, not incidental. The gate runs **after** `PrepareApply`, so an unresolvable `--baseline` still reports the baseline diagnostic the binary reports; and **before** execution, so `--dry-run` refuses too. The exemption operand is the revision **row count**, not `Status.AppliedMigrations`, which is intersected with the directory — rotating migration files out would otherwise make a long-managed database read as unadopted and refuse.

## Deliberate non-enforcement

`Governs` covers PostgreSQL, MySQL, MariaDB and SQLite. ClickHouse, SQL Server, Spanner, CockroachDB and YugabyteDB are **not** gated: nobody has run the pinned binary against them, and enabling the gate on a guess would refuse runs that work today, which is the drop-in regression the second half of the policy forbids. MariaDB is the one inferred entry — it reads the same `information_schema` through the same code path as MySQL, but it was not measured directly.

## One cell that still differs, and it is #1231 case 4, not this one

On a tampered `atlas.sum` against an unclean database, the binary refuses with `checksum mismatch` and this build now refuses with the not-clean message. Both exit `1`, so the rule-(a) direction holds; the ordering differs because ptah-compat's checksum gate does not fire for that particular tampering, which is case 4 of the same issue and out of scope here.

## Should native `ptah migrations up` get the same gate?

**Recommendation: yes in principle, no in this pull request.** Three reasons, in order of weight.

1. **The opt-in flag name is taken, and it means the opposite kind of dirty.** On the compat surface `--allow-dirty` means "the schema is not empty, proceed". On the native surface `--allow-dirty` is documented as the recovery escape hatch for a *revision row* left dirty by a partially applied migration (`migration/migrator/migrator.go`), and measured on the pinned binary, its `--allow-dirty` does **not** release any dirty-revision guard — the two flags share a spelling and share no meaning. Reusing it natively would collapse two unrelated safety questions into one flag, and an operator reaching for the documented recovery would silently also opt out of adoption protection. Native needs its own spelling, and choosing one is a design decision that deserves its own issue rather than a paragraph in a parity fix.
2. **Native already ships the better adoption story, and the gate should point at it.** `ptah migrations baseline --version/--force/--shadow-db` is a richer opt-in than Atlas's `--baseline`, including shadow-database verification. A native gate's refusal should name that verb, not `--allow-dirty` — which again makes it a different change with different text and different tests, not a reuse of this one.
3. **There is no oracle for the native surface.** Every operand above was pinned by running the pinned binary. A native gate would be pinned by nothing but taste, and its blast radius is every existing `ptah migrations up` user deploying into a pre-existing database. Pre-v1 permits the break (AGENTS.md), but permission is not a reason; it needs its own measurement of what native users actually do.

What argues *for* doing it: the failure it prevents is identical and unpleasant. `ptah migrations up` against a database with pre-existing tables typically dies partway through with `table ... already exists`, leaving a dirty revision row that then needs `migrations repair`. A gate would turn that into one clear refusal before anything ran.

So: file it as a follow-up on the native surface, with its own flag decision, its own refusal text pointing at `ptah migrations baseline`, and its own tests. This change deliberately leaves `ptah migrations up` exactly as it was, and the documentation says so.

## Tests

- `internal/migrateclean/migrateclean_test.go` — pure, runs in the default gate. Pins `Governs` on both sides, the six clean states, and eight unclean states including both message shapes, both name-ordering cells, the `--revisions-schema` cell, and both dry-run counting cells.
- `internal/migrateclean/migrateclean_live_test.go` — `//go:build integration`, PostgreSQL. Pins the catalog probe's schema scope, which SQLite cannot express. **It does not run in `go test ./...`**; it was run by hand against PostgreSQL 17 with `POSTGRES_TEST_DSN` set — 10 cases, all passing.
- `cmd/atlas/migrate_apply_clean_gate_test.go` — end to end through the compat command on SQLite, in the default gate: the headline refusal (and that nothing was applied), the growing count, `--dry-run`, the empty directory, both opt-ins, `--baseline --dry-run`, the mutual exclusion, three clean states, the lone empty revisions table, and drift on an adopted database.

### Mutation check

Nine mutants applied one at a time, each reverted immediately afterward; every one turned a test red, and the named test is the one that failed:

| mutant | reddened |
| --- | --- |
| predicate becomes "more than one table" | `TestScopeRefusal_UncleanDatabases/postgres_single_table_with_revisions_kept_in_another_schema`, `TestInspectLive_UncleanSchemas/revisions_kept_in_another_schema...` |
| drop the revisions-table injection | both `..._dry_run_before_the_revisions_table_exists` rows |
| PostgreSQL probe counts views and sequences | `TestInspectLive_CleanSchemas/a_view_is_not_a_table`, `/a_sequence_is_not_a_table` |
| PostgreSQL probe loses its schema scope | `TestInspectLive_CleanSchemas/a_table_in_another_schema_is_out_of_scope` |
| SQLite probe stops excluding `sqlite_*` | `TestCompatCommand_MigrateApplyAcceptsCleanDatabases/SQLite's_own_bookkeeping_table_does_not_count` |
| the gate is never called | `TestCompatCommand_MigrateApplyRefusesUncleanDatabase` + 2 |
| the gate ignores `--allow-dirty` / `--baseline` | `TestCompatCommand_MigrateApplyUncleanOptIns/allow-dirty`, `TestCompatCommand_MigrateApplyDryRunBaselineAcceptsUncleanDatabase` |
| the gate becomes a standing drift check | `TestCompatCommand_MigrateApplyIgnoresDriftOnAnAdoptedDatabase` |
| the mutual-exclusion refusal is removed | `TestCompatCommand_MigrateApplyBaselineAndAllowDirtyAreExclusive` |
| `Governs` turned off for every dialect | `TestCompatCommand_MigrateApplyRefusesUncleanDatabase` + 1 |

The opt-in mutant is worth a note: on the first attempt it killed only the `--allow-dirty` row, because a real `--baseline` records a revision row that switches the gate off anyway. That exposed the one cell where honoring `--baseline` explicitly is load-bearing — `--baseline --dry-run`, which records nothing — so a measurement was taken (the binary exits `0`) and a test was added. The mutant now kills both.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | **1**, see below |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `node docs/site/scripts/check-style.mjs` | 0 |
| `node docs/site/scripts/build-feature-matrix.mjs` | 0 |

`golangci-lint run ./...` exits 1 with exactly two `gosec` findings, both in `internal/dbschema/postgres/reader.go` **as resolved outside this worktree**, in another checkout under `/private/tmp/...`. That file in this tree carries `//nolint:gosec` on both lines. The same two findings, with the same foreign path, reproduce on the unmodified base commit with this branch's changes stashed, so they are environmental rather than introduced here. `golangci-lint run ./cmd/atlas/... ./internal/migrateclean/... ./internal/atlasmigrate/...` reports `0 issues`.

`go test ./... -count=1` failed once earlier in the session on `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` with `signal: killed` after a 10s budget. The identical failure reproduced on the unmodified base commit with this branch's changes stashed, and the test passes on its own with `-count=3`; it is load sensitivity on a busy machine, not a regression. The final full run on this branch was clean.

Closes part of #1231.
