### PR TITLE
Let a MySQL connection name the schema that owns its tables (#1244)

### DIFF
--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -781,6 +781,18 @@ func getDatabaseInfo(ctx context.Context, db *sql.DB, dialect string, parsedURL 
 			}
 			info.Schema = dbName
 		}
+		// A MySQL-family schema is a database, so no static dialect rule can
+		// name the one that owns an unqualified table the way "public" and
+		// "main" do; only the connection knows it. Leaving the field empty is
+		// what made the two comparison sides key differently: the catalog
+		// reports every table with no schema, while a desired state written as
+		// Atlas HCL carries `schema = schema.<database>`. Measured on live
+		// MySQL 9.7.1, `schema apply` fed the database's own inspected HCL
+		// planned CREATE TABLE and DROP TABLE for every table where the pinned
+		// Atlas community v1.3.0 binary answered "Schema is synced, no changes
+		// to be made" (stokaro/ptah#1244). SQL Server pins the same field from
+		// the same place, in getSQLServerDatabaseInfo.
+		info.IdentifierSemantics.DefaultSchema = info.Schema
 	case platform.ClickHouse:
 		var version string
 		if err := db.QueryRow("SELECT version()").Scan(&version); err != nil {

--- a/dbschema/mysql_identifier_live_test.go
+++ b/dbschema/mysql_identifier_live_test.go
@@ -1,0 +1,84 @@
+package dbschema_test
+
+import (
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// TestMySQLLiveConnection_DefaultSchemaIsTheConnectedDatabase pins that a
+// MySQL-family connection reports the connected database as the schema that
+// owns unqualified objects (stokaro/ptah#1244).
+//
+// A schema on these engines is a database, so the offline dialect rules have no
+// static default to offer and deliberately carry an empty one -- unlike
+// PostgreSQL's "public" or SQLite's "main". The connection is the only place
+// that knows the answer, and until it filled the field in, schema comparison
+// keyed a table the catalog reports with no schema differently from the same
+// table a desired state names explicitly, and planned to create and drop every
+// one of them. SQL Server resolves the same field from the same place.
+//
+// Live-only: the value comes from the URL path or from SELECT DATABASE(), and
+// asserting it against anything but a real connection would only restate the
+// test's own fixture.
+func TestMySQLLiveConnection_DefaultSchemaIsTheConnectedDatabase(t *testing.T) {
+	tests := []struct {
+		name           string
+		environmentKey string
+	}{
+		{name: "mysql", environmentKey: "MYSQL_TEST_URL"},
+		{name: "mariadb", environmentKey: "MARIADB_TEST_URL"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			databaseURL := requireLiveMySQLURL(c, test.environmentKey)
+			wantSchema := databaseNameFromURL(c, databaseURL)
+
+			conn, err := dbschema.ConnectToDatabase(c.Context(), databaseURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() {
+				dbschema.CloseAndWarn(conn)
+			})
+
+			info := conn.Info()
+
+			c.Assert(info.Schema, qt.Equals, wantSchema)
+			c.Assert(info.IdentifierSemantics.DefaultSchema, qt.Equals, wantSchema)
+			// The pairing is the invariant, not either value alone: comparison
+			// resolves an absent schema through DefaultSchema, and a connection
+			// whose two fields disagree would key its own tables against a
+			// database it is not connected to.
+			c.Assert(info.IdentifierSemantics.DefaultSchema, qt.Equals, info.Schema)
+		})
+	}
+}
+
+func requireLiveMySQLURL(c *qt.C, environmentKey string) string {
+	c.Helper()
+	databaseURL := os.Getenv(environmentKey)
+	if databaseURL == "" {
+		c.Skip(environmentKey + " is not set")
+	}
+	return databaseURL
+}
+
+// databaseNameFromURL reads the database the URL selects. A MySQL URL without a
+// path leaves the connection to resolve it with SELECT DATABASE(), which this
+// test cannot predict, so it is skipped rather than guessed at.
+func databaseNameFromURL(c *qt.C, rawURL string) string {
+	c.Helper()
+	parsed, err := url.Parse(rawURL)
+	c.Assert(err, qt.IsNil)
+	name := strings.TrimPrefix(parsed.Path, "/")
+	if name == "" {
+		c.Skip("the configured URL names no database")
+	}
+	return name
+}

--- a/migration/schemadiff/internal/compare/constraint_synthesis.go
+++ b/migration/schemadiff/internal/compare/constraint_synthesis.go
@@ -104,7 +104,7 @@ func synthesizeTablePrimaryKeyConstraints(
 			continue
 		}
 
-		name := tablePrimaryKeyConstraintName(table, database.Constraints, dialect)
+		name := tablePrimaryKeyConstraintName(table, database.Constraints, dialect, semantics)
 		synthesized = append(synthesized, goschema.Constraint{
 			StructName: table.StructName,
 			Name:       name,
@@ -116,9 +116,31 @@ func synthesizeTablePrimaryKeyConstraints(
 	return synthesized
 }
 
-func tablePrimaryKeyConstraintName(table goschema.Table, dbConstraints []types.DBConstraint, dialect string) string {
+// tablePrimaryKeyConstraintName adopts the name the database already uses for
+// this table's primary key, so the synthesized constraint compares equal to it
+// instead of being reported as a rename.
+//
+// The lookup normalizes both sides for the same reason the keys around it do:
+// the database reports the schema as empty wherever the engine treats it as
+// implicit, and the desired side carries it. Comparing the two spellings
+// directly meant the lookup never matched and the name always came from the
+// fallback below. That was invisible wherever the fallback happens to be right
+// -- MySQL always names it PRIMARY, PostgreSQL usually names it <table>_pkey --
+// and wrong the moment a schema names its primary key itself, which surfaced as
+// dropping the real constraint and adding a differently named one
+// (stokaro/ptah#1244).
+func tablePrimaryKeyConstraintName(
+	table goschema.Table,
+	dbConstraints []types.DBConstraint,
+	dialect string,
+	semantics identifier.Semantics,
+) string {
+	wanted := newQualifiedTableIdentity(table.QualifiedName(), semantics)
 	for _, constraint := range dbConstraints {
-		if constraint.Type == "PRIMARY KEY" && constraint.QualifiedTableName() == table.QualifiedName() {
+		if constraint.Type != "PRIMARY KEY" {
+			continue
+		}
+		if newQualifiedTableIdentity(constraint.QualifiedTableName(), semantics) == wanted {
 			return constraint.Name
 		}
 	}

--- a/migration/schemadiff/internal/compare/constraints.go
+++ b/migration/schemadiff/internal/compare/constraints.go
@@ -65,7 +65,34 @@ func Constraints(generated *goschema.Database, database *types.DBSchema, diff *d
 	if opts != nil {
 		dialect = opts.Dialect
 	}
-	semantics := identifier.ForDialect(dialect)
+	ConstraintsWithSemantics(generated, database, diff, opts, identifier.ForDialect(dialect))
+}
+
+// ConstraintsWithSemantics is [Constraints] told which identifier rules the
+// target actually has, rather than the offline defaults its dialect name
+// implies. Table and index comparison already take the resolved rules; this
+// entry point exists so constraint comparison stops being the one side that
+// rebuilds them from the dialect string.
+//
+// The difference is not cosmetic on MySQL and MariaDB. A schema there is a
+// database, so [identifier.ForDialect] cannot name the one that owns an
+// unqualified table and returns an empty DefaultSchema; only a connection can
+// supply it. Re-deriving the offline rules here discarded that value, the
+// normalization in [tableMemberKey] became a no-op, and every constraint the
+// database had was reported as removed -- the exact failure #1232 fixed on
+// PostgreSQL and SQLite, still live on MySQL because it could never see a
+// default schema (stokaro/ptah#1244).
+func ConstraintsWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	opts *config.CompareOptions,
+	semantics identifier.Semantics,
+) {
+	dialect := ""
+	if opts != nil {
+		dialect = opts.Dialect
+	}
 
 	// Create maps for detailed constraint comparison
 	genConstraints := make(map[tableMemberKey]goschema.Constraint)

--- a/migration/schemadiff/mysql_connection_schema_test.go
+++ b/migration/schemadiff/mysql_connection_schema_test.go
@@ -1,0 +1,329 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompareWithDatabaseInfo_MySQLConnectionSchemaMatchesTheDesiredSchema pins
+// that constraint comparison honors the default schema the connection resolved
+// rather than the one the dialect name implies (stokaro/ptah#1244).
+//
+// MySQL and MariaDB are the dialects where those two differ. A schema there is
+// a database, so [identifier.ForDialect] has no static default to return and
+// returns an empty one; the connected database name is the only answer, and
+// only a connection has it. Constraint comparison used to rebuild the offline
+// rules from the dialect string, so it saw the empty default no matter what the
+// connection had resolved. The catalog reports a table with no schema and a
+// desired state written as Atlas HCL carries `schema = schema.<database>`, so
+// the two keys never met and every constraint the database had was reported as
+// removed.
+//
+// Measured on live MySQL 9.7.1: `ptah-compat schema apply` fed the database's
+// own unedited `atlas schema inspect` output planned CREATE TABLE and DROP
+// TABLE for every table, plus DROP PRIMARY KEY and DROP FOREIGN KEY, where the
+// pinned Atlas community binary v1.3.0 answered "Schema is synced, no changes
+// to be made" and exited 0.
+//
+// The rows with a non-empty wantRemoved are the control and they carry the
+// weight. A "fix" that stopped reporting constraint removals, or that collapsed
+// every database name onto one key, satisfies every no-change row here and
+// fails these.
+func TestCompareWithDatabaseInfo_MySQLConnectionSchemaMatchesTheDesiredSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		dialect     string
+		connSchema  string
+		genSchema   string
+		dbSchema    string
+		dbTableName string
+		wantRemoved []string
+	}{
+		{
+			name:        "mysql reports the schema as nothing where the desired side names the database",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			name:        "mariadb reports the schema as nothing where the desired side names the database",
+			dialect:     "mariadb",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			// The fill-in has to work in this direction too: a desired state
+			// built from Go annotations names no schema, while a reader that
+			// does report the database must not drift against it.
+			name:        "the database naming it and the desired side not is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "",
+			dbSchema:    "shop",
+			dbTableName: "users",
+		},
+		{
+			name:        "both sides naming the database is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "shop",
+			dbTableName: "users",
+		},
+		{
+			name:        "neither side naming it is unaffected",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "",
+			dbSchema:    "",
+			dbTableName: "users",
+		},
+		{
+			// The control. A constraint on a table the desired schema genuinely
+			// does not have must still be reported, or idempotency has been
+			// bought by making removal impossible.
+			name:        "a constraint on a table the desired schema does not have is still removed",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "",
+			dbTableName: "orphaned",
+			wantRemoved: []string{"orphaned_pkey"},
+		},
+		{
+			// The other control. Another database is another table, and the
+			// fill-in must not collapse them onto one key.
+			name:        "a table in another database is not the desired one",
+			dialect:     "mysql",
+			connSchema:  "shop",
+			genSchema:   "shop",
+			dbSchema:    "reporting",
+			dbTableName: "users",
+			wantRemoved: []string{"users_pkey"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				implicitSchemaDesired(test.genSchema),
+				implicitSchemaDatabase(test.dbSchema, test.dbTableName),
+				mysqlConnectionInfo(test.dialect, test.connSchema),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, test.wantRemoved,
+				qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfo_MySQLConnectionSchemaPlansNothingAtAll is the
+// assertion a partial fix cannot satisfy.
+//
+// Supplying the connection's default schema without also letting constraint
+// comparison see it removed the CREATE TABLE / DROP TABLE churn and left
+// `ALTER TABLE users DROP PRIMARY KEY` behind — the same silent-corruption
+// shape #1232 describes on PostgreSQL, reached from a different direction. So
+// the assertion is that the comparison reports no change at all, not merely
+// that the tables match.
+func TestCompareWithDatabaseInfo_MySQLConnectionSchemaPlansNothingAtAll(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				implicitSchemaDesired("shop"),
+				implicitSchemaDatabase("", "users"),
+				mysqlConnectionInfo(test.dialect, "shop"),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("diff: %#v", diff))
+			c.Assert(diff.TablesAdded, qt.HasLen, 0)
+			c.Assert(diff.TablesRemoved, qt.HasLen, 0)
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, 0)
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfo_MySQLForeignKeyOnTheConnectionSchema covers the
+// field-level foreign key, which reaches the diff through a different route:
+// it is synthesized only for columns the database already has, and that lookup
+// keys the owning table the same way. Unsynthesized, the database's own foreign
+// key has no counterpart and is dropped.
+func TestCompareWithDatabaseInfo_MySQLForeignKeyOnTheConnectionSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		genSchema   string
+		dbSchema    string
+		wantRemoved []string
+	}{
+		{name: "desired side names the database", genSchema: "shop", dbSchema: ""},
+		{name: "neither side names it", genSchema: "", dbSchema: ""},
+		{
+			name:        "another database is another table",
+			genSchema:   "shop",
+			dbSchema:    "reporting",
+			wantRemoved: []string{"fk_posts_user"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				mysqlForeignKeyDesired(test.genSchema),
+				mysqlForeignKeyDatabase(test.dbSchema),
+				mysqlConnectionInfo("mysql", "shop"),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.ConstraintsRemoved, qt.DeepEquals, test.wantRemoved,
+				qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_PrimaryKeyKeepsTheNameTheDatabaseGaveIt pins the
+// second half of the same defect on the dialect where it is easiest to hit.
+//
+// A synthesized primary key adopts the name the database already uses, so an
+// unchanged schema compares equal. That lookup compared the two table spellings
+// as raw strings, so it never matched a database that reports the schema as
+// implicit, and the name always came from the fallback. Wherever the fallback
+// agrees with what the engine would have picked the mistake is invisible; a
+// schema that names its own primary key exposes it as a drop of the real
+// constraint plus an add of a differently named one.
+func TestCompareWithDialect_PrimaryKeyKeepsTheNameTheDatabaseGaveIt(t *testing.T) {
+	tests := []struct {
+		name           string
+		dialect        string
+		genSchema      string
+		constraintName string
+	}{
+		{name: "postgres conventional name", dialect: "postgres", genSchema: "public", constraintName: "users_pkey"},
+		{name: "postgres schema-chosen name", dialect: "postgres", genSchema: "public", constraintName: "pk_users"},
+		{name: "sqlite schema-chosen name", dialect: "sqlite", genSchema: "main", constraintName: "pk_users"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			database := implicitSchemaDatabase("", "users")
+			database.Constraints[0].Name = test.constraintName
+
+			diff := schemadiff.CompareWithDialect(
+				implicitSchemaDesired(test.genSchema),
+				database,
+				test.dialect,
+			)
+
+			c.Assert(diff.ConstraintsRemoved, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+			c.Assert(diff.ConstraintsAdded, qt.HasLen, 0, qt.Commentf("diff: %#v", diff))
+		})
+	}
+}
+
+// mysqlConnectionInfo is the metadata a live MySQL-family connection carries:
+// the connected database as the schema, and the same value as the default
+// schema that owns unqualified objects. getDatabaseInfo pins the second field
+// from the first; dbschema's live test covers that it does.
+func mysqlConnectionInfo(dialect, schema string) types.DBInfo {
+	semantics := identifier.ForDialect(dialect)
+	semantics.DefaultSchema = schema
+	return types.DBInfo{
+		Dialect:             dialect,
+		Schema:              schema,
+		IdentifierSemantics: semantics,
+	}
+}
+
+// mysqlForeignKeyDesired builds a desired side whose foreign key is declared on
+// the field, which is how an Atlas HCL `foreign_key` block arrives.
+func mysqlForeignKeyDesired(schema string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Users", Name: "users", Schema: schema},
+			{StructName: "Posts", Name: "posts", Schema: schema},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Users", Name: "id", Type: "BIGINT", Nullable: false},
+			{StructName: "Posts", Name: "id", Type: "BIGINT", Nullable: false},
+			{
+				StructName:     "Posts",
+				Name:           "user_id",
+				Type:           "BIGINT",
+				Nullable:       false,
+				Foreign:        "users(id)",
+				ForeignKeyName: "fk_posts_user",
+			},
+		},
+	}
+}
+
+// mysqlForeignKeyDatabase builds the matching database side as a MySQL reader
+// reports it.
+func mysqlForeignKeyDatabase(schema string) *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name:   "users",
+				Schema: schema,
+				Type:   "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "BIGINT", IsNullable: "NO"},
+				},
+			},
+			{
+				Name:   "posts",
+				Schema: schema,
+				Type:   "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "id", DataType: "BIGINT", IsNullable: "NO"},
+					{Name: "user_id", DataType: "BIGINT", IsNullable: "NO"},
+				},
+			},
+		},
+		Constraints: []types.DBConstraint{{
+			Name:          "fk_posts_user",
+			TableName:     "posts",
+			Schema:        schema,
+			Type:          "FOREIGN KEY",
+			ColumnNames:   []string{"user_id"},
+			ForeignTable:  new("users"),
+			ForeignColumn: new("id"),
+		}},
+	}
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -178,7 +178,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.Grants(generated, database, diff)
 
 	// Compare table-level constraints (EXCLUDE, CHECK, UNIQUE, etc.)
-	compare.Constraints(generated, database, diff, opts)
+	compare.ConstraintsWithSemantics(generated, database, diff, opts, identifierSemantics)
 
 	return diff
 }


### PR DESCRIPTION
Fixes #1244. Supersedes #1250, which was branched from `issue-1232-implicit-schema-constraints` before #1238 merged; this is the same commit rebased onto master, where that work now lives.

## What was wrong

Fed a canonical Atlas-HCL description of the schema **already in the database**, `ptah-compat schema apply` on MySQL planned `CREATE TABLE` *and* `DROP TABLE` for every table, plus add and drop of every index and foreign key, then exited 1 and applied nothing. Measured on a live MySQL 9.7.1 against the pinned Atlas community binary v1.3.0, which answers `Schema is synced, no changes to be made` and exits 0.

Reproduced with `ptah-compat` built from `issue-1232-implicit-schema-constraints`, byte-identical to the plan from `master` — so it is not the constraint-keying defect #1232 fixed.

## Cause

Everything created was database-qualified, everything dropped was bare. Instrumented dump of the two sides immediately before `schemadiff.CompareWithDatabase`:

```
dialect="mysql" info.Schema="w3a98_tgt" sem.DefaultSchema=""
desired table: Schema="w3a98_tgt" Name="users"
current table: Schema=""           Name="users"
```

A MySQL reader reports every table with an empty schema; a desired state written as Atlas HCL carries `schema = schema.<database>`. Both sides key through `newTableIdentity`, which resolves an absent schema to `semantics.DefaultSchema` — but a MySQL-family schema *is* a database, so `identifier.ForDialect` has no static default to give and returns an empty one. The normalization was a no-op and the keys never met.

The empty value is correct. Nothing was supplying the real one from the place that has it.

## What changed

Three fixes, one family, all needed together.

1. **`dbschema/connection.go`** — the MySQL/MariaDB branch pins `IdentifierSemantics.DefaultSchema` from `info.Schema`, exactly as `getSQLServerDatabaseInfo` already does for the dialect with the same shape. `internal/atlasschema/scope.go` already stated the rule this violated: *"MySQL-family schemas are databases, so only a database-backed side can name the default."* The filter path honored it; the comparison path did not.

2. **`ConstraintsWithSemantics`** — constraint comparison discarded the resolved semantics and rebuilt static ones from the dialect string (`semantics := identifier.ForDialect(dialect)`), so it saw the empty default no matter what the connection had resolved. Table and index comparison already take the validated value; constraints now do too.

3. **`tablePrimaryKeyConstraintName`** — the same raw-string table comparison, in a spot #1232 did not reach. It adopts the name the database gave the primary key; comparing the two spellings directly meant the lookup never matched and the name always came from the fallback. Invisible wherever the fallback agrees with the engine (MySQL always says `PRIMARY`, PostgreSQL usually says `<table>_pkey`), and wrong the moment a schema names its own primary key — surfacing as a drop of the real constraint plus an add of a differently named one. Found by the test written for (1) and (2).

**Half of this is worse than none.** With only (1), the table churn disappears and `ALTER TABLE users DROP PRIMARY KEY` stays behind — the silent-corruption shape #1232 describes on PostgreSQL, reached from another direction. Both halves land together.

## Verification

Live MySQL 9.7.1, target of primary key + foreign key + plain index, desired state its own unedited `atlas schema inspect` output:

| binary | exit | output |
| --- | --- | --- |
| pinned Atlas community v1.3.0 | 0 | `Schema is synced, no changes to be made` |
| `ptah-compat` before | 1 | `CREATE TABLE` + `DROP TABLE` for every table |
| `ptah-compat` after | 0 | `Schema is synced, no changes to be made.` |

The target database was unchanged after the run.

Each fix was checked against its own **inverse mutant** — reverting any one of the three reddens the test that covers it, and only that test. Notably, reverting (3) leaves the `postgres conventional name` row green and reddens only the schema-chosen-name rows, which is exactly why nobody caught it.

The two controls (a constraint on a table the desired schema does not have; a table in another database) fail any change that buys idempotency by making removal impossible.

`dbschema/mysql_identifier_live_test.go` is env-gated on `MYSQL_TEST_URL` / `MARIADB_TEST_URL`; it was run against the live MySQL 9.7.1 and passes, and fails when (1) is reverted. The MariaDB row was skipped — not measured.

## What is not fixed here

A residue remains when the schema carries a **unique index**. MySQL reports it both as an index and as a `UNIQUE` constraint; the object is added by the index pool and removed by the constraint pool. Different mechanism, filed as #1245 with the instrumented diff.

The dev-database halves of the original failure — the simulation executing target-qualified DDL against the dev connection, and the dev database never being cleaned — are #1240, independently reproduced during this work. Neither is touched here.

## Gates

Run on the rebased tree, each exit status read on its own line.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1 -p 2` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |

`go test ./...` at default parallelism is load-flaky on the machine this ran on — `cmd/viz` and `cmd/ptah-ls` time out, and both reproduce on an unmodified base checkout. `-p 2` is clean.

No documentation change is owed: no flag, output format, config key or documented behavior changes, and nothing in the docs claimed the broken shape.