### PR TITLE
fix(atlashclrender): render every block body as evaluable HCL (#1251 Category A)

### DIFF
--- a/internal/atlashclrender/evaluable_blocks_test.go
+++ b/internal/atlashclrender/evaluable_blocks_test.go
@@ -1,0 +1,475 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderWritesEveryBlockBodyAsEvaluableHCL pins that no attribute Ptah
+// writes is a bare word in an attribute position (stokaro/ptah#1251).
+//
+// A bare word there is an HCL variable reference with nothing behind it, and
+// one of them makes the pinned Atlas community binary v1.3.0 refuse the WHOLE
+// document -- Ptah's inspect of a PostgreSQL 17 database carrying all of these
+// objects died on the first, `There is no variable named "bigint"`, and said
+// nothing about the other five. Same class as the `to = PUBLIC` /
+// `privileges = [USAGE]` defect fixed in #1248.
+//
+// Each row was measured against that binary by varying THAT attribute alone in
+// a document the binary otherwise accepts, because peeling errors one at a time
+// only ever identifies the first one. The per-attribute results are recorded
+// beside the code that renders them, in objects.go and render.go.
+//
+// notWant carries the bare spelling for the same reason the inverse mutant
+// exists elsewhere: `qt.Contains` on the quoted form alone still passes if the
+// renderer emits both, or emits the bare form somewhere else in the block.
+func TestRenderWritesEveryBlockBodyAsEvaluableHCL(t *testing.T) {
+	tests := []struct {
+		name    string
+		db      func() *goschema.Database
+		want    []string
+		notWant []string
+	}{
+		{
+			// `type = bigint` -> There is no variable named "bigint".
+			name: "a sequence type",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Sequences = []goschema.Sequence{{Name: "order_seq", AsType: "bigint"}}
+				return db
+			},
+			want:    []string{"\n  type = \"bigint\"\n"},
+			notWant: []string{"\n  type = bigint\n"},
+		},
+		{
+			// lang/return/security/volatility were each refused on their own.
+			// `return` is the one that looks like a type position and is not:
+			// a bare `bigint` evaluates as a column type and fails here.
+			name: "every function attribute",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Functions = []goschema.Function{{
+					Name:       "touch_users",
+					Language:   "plpgsql",
+					Returns:    "trigger",
+					Security:   "INVOKER",
+					Volatility: "VOLATILE",
+					Body:       "BEGIN RETURN NEW; END;",
+				}}
+				return db
+			},
+			want: []string{
+				"  lang = \"PLpgSQL\"\n",
+				"  return = \"trigger\"\n",
+				"  security = \"INVOKER\"\n",
+				"  volatility = \"VOLATILE\"\n",
+			},
+			notWant: []string{
+				"\n  lang = PLpgSQL\n",
+				"\n  return = trigger\n",
+				"\n  security = INVOKER\n",
+				"\n  volatility = VOLATILE\n",
+			},
+		},
+		{
+			// `for = ROW` -> There is no variable named "ROW".
+			name: "a trigger for-each",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Triggers = []goschema.Trigger{{
+					Name:    "users_touch",
+					Table:   "users",
+					Timing:  "BEFORE",
+					Event:   "UPDATE",
+					ForEach: "ROW",
+					Body:    "BEGIN RETURN NEW; END;",
+				}}
+				return db
+			},
+			want:    []string{"\n  for = \"ROW\"\n"},
+			notWant: []string{"\n  for = ROW\n"},
+		},
+		{
+			// The default is rendered through the same attribute, so an IR that
+			// carries no ForEach must not reintroduce the bare word.
+			name: "a trigger for-each Ptah defaults",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Triggers = []goschema.Trigger{{
+					Name:   "users_touch",
+					Table:  "users",
+					Timing: "BEFORE",
+					Event:  "UPDATE",
+					Body:   "BEGIN RETURN NEW; END;",
+				}}
+				return db
+			},
+			want:    []string{"\n  for = \"ROW\"\n"},
+			notWant: []string{"\n  for = ROW\n"},
+		},
+		{
+			// `for = ALL` -> There is no variable named "ALL".
+			name: "a policy for",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Roles = []goschema.Role{{Name: "rdr"}}
+				db.RLSPolicies = []goschema.RLSPolicy{{
+					Name:            "users_read",
+					Table:           "users",
+					PolicyFor:       "ALL",
+					ToRoles:         "rdr",
+					UsingExpression: "true",
+				}}
+				return db
+			},
+			want:    []string{"\n  for = \"ALL\"\n"},
+			notWant: []string{"\n  for = ALL\n"},
+		},
+		{
+			// Not a bare word, a missing one: an enum block with no schema is
+			// refused with `extract schema name from enum reference`.
+			name: "an enum block declares its schema",
+			db:   inspectedEnumTable,
+			want: []string{"enum \"status\" {\n  schema = schema.public\n"},
+		},
+		{
+			// `type = sql("status")` names a type the dev database does not
+			// have; only the enum block creates it there.
+			name: "an enum-typed column references the enum block",
+			db:   inspectedEnumTable,
+			want: []string{"    type = enum.status\n"},
+			notWant: []string{
+				"\n    type = sql(\"status\")\n",
+				"\n    type = status\n",
+				"\n    type = \"status\"\n",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(test.db(), platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			rendered := string(result.Data)
+			for _, want := range test.want {
+				c.Assert(rendered, qt.Contains, want, qt.Commentf("rendered:\n%s", rendered))
+			}
+			for _, notWant := range test.notWant {
+				c.Assert(rendered, qt.Not(qt.Contains), notWant, qt.Commentf("rendered:\n%s", rendered))
+			}
+		})
+	}
+}
+
+// TestEvaluableBlocksRoundTripThroughPtahsOwnParser pins that quoting cost
+// nothing on Ptah's own side.
+//
+// Ptah reads these blocks back, so a rendering it can no longer parse would be
+// a regression wearing the costume of a fix. Without this the change would be
+// measured only against the other binary. Three of the six attributes here
+// (sequence type, policy for, and the enum schema) sit in blocks the pinned
+// binary refuses as a feature gap whatever they say, so Ptah's own parser is
+// the only thing that can tell those rows apart at all.
+func TestEvaluableBlocksRoundTripThroughPtahsOwnParser(t *testing.T) {
+	tests := []struct {
+		name  string
+		db    func() *goschema.Database
+		check func(*qt.C, *goschema.Database)
+	}{
+		{
+			name: "a sequence keeps its type",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Sequences = []goschema.Sequence{{Name: "order_seq", AsType: "bigint"}}
+				return db
+			},
+			check: func(c *qt.C, parsed *goschema.Database) {
+				c.Assert(parsed.Sequences, qt.HasLen, 1)
+				c.Assert(parsed.Sequences[0].AsType, qt.Equals, "bigint")
+			},
+		},
+		{
+			name: "a function keeps all four attributes",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Functions = []goschema.Function{{
+					Name:       "touch_users",
+					Language:   "plpgsql",
+					Returns:    "trigger",
+					Security:   "INVOKER",
+					Volatility: "VOLATILE",
+					Body:       "BEGIN RETURN NEW; END;",
+				}}
+				return db
+			},
+			check: func(c *qt.C, parsed *goschema.Database) {
+				c.Assert(parsed.Functions, qt.HasLen, 1)
+				function := parsed.Functions[0]
+				// Canonicalize because the IR spells the language lowercase and
+				// the rendered attribute carries Atlas's mixed-case name. That
+				// detour predates this change -- the bare word was `PLpgSQL`
+				// too -- and Canonicalize is what every consumer of the IR
+				// already applies.
+				function.Canonicalize()
+				c.Assert(function.Language, qt.Equals, "plpgsql")
+				c.Assert(function.Returns, qt.Equals, "trigger")
+				c.Assert(function.Security, qt.Equals, "INVOKER")
+				c.Assert(function.Volatility, qt.Equals, "VOLATILE")
+			},
+		},
+		{
+			name: "a trigger keeps its for-each",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Triggers = []goschema.Trigger{{
+					Name:    "users_touch",
+					Table:   "users",
+					Timing:  "BEFORE",
+					Event:   "UPDATE",
+					ForEach: "ROW",
+					Body:    "BEGIN RETURN NEW; END;",
+				}}
+				return db
+			},
+			check: func(c *qt.C, parsed *goschema.Database) {
+				c.Assert(parsed.Triggers, qt.HasLen, 1)
+				c.Assert(parsed.Triggers[0].ForEach, qt.Equals, "ROW")
+				c.Assert(parsed.Triggers[0].Timing, qt.Equals, "BEFORE")
+			},
+		},
+		{
+			name: "a policy keeps its for",
+			db: func() *goschema.Database {
+				db := inspectedEnumTable()
+				db.Roles = []goschema.Role{{Name: "rdr"}}
+				db.RLSPolicies = []goschema.RLSPolicy{{
+					Name:            "users_read",
+					Table:           "users",
+					PolicyFor:       "ALL",
+					ToRoles:         "rdr",
+					UsingExpression: "true",
+				}}
+				return db
+			},
+			check: func(c *qt.C, parsed *goschema.Database) {
+				c.Assert(parsed.RLSPolicies, qt.HasLen, 1)
+				c.Assert(parsed.RLSPolicies[0].PolicyFor, qt.Equals, "ALL")
+				c.Assert(parsed.RLSPolicies[0].ToRoles, qt.Equals, "rdr")
+			},
+		},
+		{
+			// The reference spelling is the one the parser already understood:
+			// columnTypeName strips the `enum.` prefix to the enum's name and
+			// reports the type as NOT raw SQL, so a second render writes the
+			// reference again rather than falling back to sql().
+			name: "an enum-typed column keeps its type and stops being raw SQL",
+			db:   inspectedEnumTable,
+			check: func(c *qt.C, parsed *goschema.Database) {
+				c.Assert(parsed.Enums, qt.HasLen, 1)
+				c.Assert(parsed.Enums[0].Values, qt.DeepEquals, []string{"active", "inactive"})
+				state := fieldByName(parsed.Fields, "state")
+				c.Assert(state.Type, qt.Equals, "status")
+				c.Assert(state.TypeRawSQL, qt.IsFalse)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(test.db(), platform.Postgres, "public")
+			c.Assert(err, qt.IsNil)
+
+			parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+			c.Assert(err, qt.IsNil, qt.Commentf("rendered:\n%s", result.Data))
+			test.check(c, parsed)
+		})
+	}
+}
+
+// TestRenderedSchemaIsStableAcrossAParseAndRerender pins the property the
+// field-by-field round trip cannot state on its own: what Ptah reads back
+// renders to the same bytes.
+//
+// A per-attribute assertion passes even when the second render moves an
+// attribute, drops one the parser silently discarded, or re-decides a column
+// type from a different branch. This asserts the whole document instead, on the
+// fixture that carries every construct this change touched.
+//
+// The comparison starts at the SECOND render, not the first, and that is a
+// concession to a defect this change does not fix rather than a weakening of
+// the property. Parsing resolves a trigger's `on = table.users` to the table's
+// qualified name, so the next render writes `on = table.public.users` and every
+// later one repeats it. That spelling is refused by the pinned Atlas community
+// binary v1.3.0 -- `Unsupported attribute; This object does not have an
+// attribute named "public"` -- and its own cross-schema references are
+// unqualified: `ref_columns = [table.users.column.id]` reaches a table in
+// another schema at exit 0 while the qualified spelling of the same reference
+// is refused. That is a separate rendering defect in objectRef, in a different
+// attribute from the six this change is about, and it belongs to whoever fixes
+// it rather than being papered over here. Every attribute this change DID touch
+// is already at its fixed point by the first render, so the rows above cover
+// them from byte one.
+func TestRenderedSchemaIsStableAcrossAParseAndRerender(t *testing.T) {
+	c := qt.New(t)
+
+	first, err := atlashclrender.RenderInspected(everyTouchedConstruct(), platform.Postgres, "public")
+	c.Assert(err, qt.IsNil)
+
+	parsedOnce, err := atlashcl.Parse(first.Data, "rendered.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered:\n%s", first.Data))
+	second, err := atlashclrender.RenderInspected(parsedOnce, platform.Postgres, "public")
+	c.Assert(err, qt.IsNil)
+
+	parsedTwice, err := atlashcl.Parse(second.Data, "rendered.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered:\n%s", second.Data))
+	third, err := atlashclrender.RenderInspected(parsedTwice, platform.Postgres, "public")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(third.Data), qt.Equals, string(second.Data))
+	// The attributes this change owns survive from the first render, so the
+	// fixed-point framing above cannot be hiding a regression in one of them.
+	for _, want := range []string{
+		"  type = \"bigint\"\n",
+		"  lang = \"PLpgSQL\"\n",
+		"  return = \"trigger\"\n",
+		"  security = \"INVOKER\"\n",
+		"  volatility = \"VOLATILE\"\n",
+		"  for = \"ROW\"\n",
+		"  for = \"ALL\"\n",
+		"    type = enum.status\n",
+		"  schema = schema.public\n",
+	} {
+		c.Assert(string(first.Data), qt.Contains, want)
+		c.Assert(string(third.Data), qt.Contains, want)
+	}
+}
+
+// TestEnumTypedColumnKeepsANameThatIsAlsoAnotherDeclaration pins that the enum
+// reference is not written for a type name a domain, composite or range in the
+// same document also declares.
+//
+// Those are separate blocks, and `enum.status` would point at the wrong one.
+// The name collision is the only thing that separates these rows from the enum
+// row above, so each keeps everything else fixed.
+func TestEnumTypedColumnKeepsANameThatIsAlsoAnotherDeclaration(t *testing.T) {
+	tests := []struct {
+		name    string
+		declare func(*goschema.Database)
+	}{
+		{
+			name: "a domain",
+			declare: func(db *goschema.Database) {
+				db.Domains = []goschema.Domain{{Name: "status", BaseType: "text"}}
+			},
+		},
+		{
+			name: "a composite type",
+			declare: func(db *goschema.Database) {
+				db.CompositeTypes = []goschema.CompositeType{{
+					Name:   "status",
+					Fields: []goschema.CompositeTypeField{{Name: "a", Type: "text"}},
+				}}
+			},
+		},
+		{
+			name: "a range type",
+			declare: func(db *goschema.Database) {
+				db.Ranges = []goschema.Range{{Name: "status", Subtype: "int4"}}
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := inspectedEnumTable()
+			test.declare(db)
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Not(qt.Contains), "type = enum.status\n")
+		})
+	}
+}
+
+// TestRenderInspectedDeclaresTheSchemaAnEnumOnlyReadReferences pins that the
+// enum's new schema reference always has a block to resolve to.
+//
+// referencedSchemas used to return nothing when the read matched no table,
+// which is right for a document with nothing in it and wrong the moment an enum
+// block starts naming a schema: the reference would dangle, and a dangling
+// `schema.public` is refused by the pinned binary just as a missing one is.
+func TestRenderInspectedDeclaresTheSchemaAnEnumOnlyReadReferences(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{Enums: []goschema.Enum{{Name: "status", Values: []string{"active"}}}}
+
+	result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Contains, "schema \"public\" {\n}\n")
+	c.Assert(string(result.Data), qt.Contains, "  schema = schema.public\n")
+}
+
+// inspectedEnumTable builds the IR a PostgreSQL read produces for a table with
+// an enum-typed column: the enum carries no schema of its own, and the column
+// carries the type name with no record of how it was written.
+func inspectedEnumTable() *goschema.Database {
+	return &goschema.Database{
+		Enums:  []goschema.Enum{{Name: "status", Values: []string{"active", "inactive"}}},
+		Tables: []goschema.Table{{StructName: "Users", Name: "users"}},
+		Fields: []goschema.Field{
+			{StructName: "Users", Name: "id", Type: "bigint", Primary: true},
+			{StructName: "Users", Name: "state", Type: "status"},
+		},
+	}
+}
+
+// everyTouchedConstruct is inspectedEnumTable plus one of every block this
+// change re-spelled, so the stability assertion covers all of them at once.
+func everyTouchedConstruct() *goschema.Database {
+	db := inspectedEnumTable()
+	db.Roles = []goschema.Role{{Name: "rdr"}}
+	db.Sequences = []goschema.Sequence{{Name: "order_seq", AsType: "bigint"}}
+	db.Functions = []goschema.Function{{
+		Name:       "touch_users",
+		Language:   "plpgsql",
+		Returns:    "trigger",
+		Security:   "INVOKER",
+		Volatility: "VOLATILE",
+		Body:       "BEGIN RETURN NEW; END;",
+	}}
+	db.Triggers = []goschema.Trigger{{
+		Name:    "users_touch",
+		Table:   "users",
+		Timing:  "BEFORE",
+		Event:   "UPDATE",
+		ForEach: "ROW",
+		Body:    "BEGIN RETURN NEW; END;",
+	}}
+	db.RLSPolicies = []goschema.RLSPolicy{{
+		Name:            "users_read",
+		Table:           "users",
+		PolicyFor:       "ALL",
+		ToRoles:         "rdr",
+		UsingExpression: "true",
+	}}
+	return db
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -38,9 +38,20 @@ func (r *renderer) renderSequences() {
 		if sequence.Schema != "" {
 			r.rawAttr(1, "schema", schemaRef(sequence.Schema))
 		}
-		if sequence.AsType != "" {
-			r.rawAttr(1, "type", typeExpr(sequence.AsType))
-		}
+		// A quoted string, not the bare word `bigint`. Bare, it is an HCL
+		// variable reference with nothing behind it and the pinned Atlas
+		// community binary v1.3.0 refuses the whole file with `There is no
+		// variable named "bigint"`. Quoted, the file evaluates and that binary
+		// gets as far as its own feature gap -- `postgres: sequences are not
+		// supported by this version` -- which is the signal that nothing in this
+		// block is unreadable any more (stokaro/ptah#1251).
+		//
+		// The gap means that binary never writes a sequence block, so it cannot
+		// say which readable spelling it would prefer; `sql("bigint")` reaches
+		// the same message. The quoted string is chosen because it is what Ptah's
+		// own parser reads back to the same AsType, and because the value is
+		// always one of smallint/integer/bigint, never SQL needing an escape.
+		r.stringAttr(1, "type", sequence.AsType)
 		r.int64PtrAttr(1, "start", sequence.Start)
 		r.int64PtrAttr(1, "increment", sequence.Increment)
 		r.int64PtrAttr(1, "min_value", sequence.MinValue)
@@ -234,13 +245,34 @@ func (r *renderer) renderFunction(function goschema.Function) {
 	if schema := schemaNameFromQualified(function.Name); schema != "" {
 		r.rawAttr(1, "schema", schemaRef(schema))
 	}
+	// Every one of these four is a quoted string rather than a bare word.
+	// Measured on the pinned Atlas community binary v1.3.0, one attribute varied
+	// at a time against a function block it accepts:
+	//
+	//	lang = PLpgSQL         exit 1  There is no variable named "PLpgSQL"
+	//	lang = SQL             exit 1  There is no variable named "SQL"
+	//	lang = "PLpgSQL"       exit 0
+	//	return = trigger       exit 1  There is no variable named "trigger"
+	//	return = bigint        exit 1  There is no variable named "bigint"
+	//	return = "trigger"     exit 0
+	//	security = INVOKER     exit 1  There is no variable named "INVOKER"
+	//	security = "INVOKER"   exit 0
+	//	volatility = VOLATILE  exit 1  There is no variable named "VOLATILE"
+	//	volatility = "VOLATILE" exit 0
+	//
+	// `return` needed its own rows because it looks like a type position and is
+	// not: a bare `bigint` evaluates as a column's `type` and fails here, so
+	// typeExpr was the wrong renderer for it whatever the return type is.
+	//
+	// That binary accepts the block and emits nothing for it -- its output for a
+	// file with the function is byte-identical to the same file without it, and
+	// `lang = "BANANA"` is accepted too -- so it validates none of these values
+	// and the only thing to match is that the file evaluates at all.
 	r.rawAttr(1, "lang", atlasLanguage(function.Language))
-	if function.Returns != "" {
-		r.rawAttr(1, "return", typeExpr(function.Returns))
-	}
+	r.stringAttr(1, "return", function.Returns)
 	r.renderFunctionArgs(function)
-	r.rawAttr(1, "security", rawIdentifier(function.Security))
-	r.rawAttr(1, "volatility", rawIdentifier(function.Volatility))
+	r.stringAttr(1, "security", function.Security)
+	r.stringAttr(1, "volatility", function.Volatility)
 	r.stringAttr(1, "as", function.Body)
 	r.stringAttr(1, "comment", function.Comment)
 	r.line("}")
@@ -350,7 +382,20 @@ func (r *renderer) renderTrigger(trigger goschema.Trigger) {
 	r.linef("  %s {", timing)
 	r.rawAttr(2, event, "true")
 	r.line("  }")
-	r.rawAttr(1, "for", rawIdentifier(firstNonEmpty(trigger.ForEach, "ROW")))
+	// Quoted, for the same reason as everywhere else in this file. Measured on
+	// the pinned Atlas community binary v1.3.0 against a trigger block it
+	// accepts, one operand varied:
+	//
+	//	for = ROW          exit 1  There is no variable named "ROW"
+	//	for = "ROW"        exit 0
+	//	for = "STATEMENT"  exit 0
+	//	(attribute absent) exit 0
+	//
+	// The block is accepted and dropped, not modeled: that binary's output for a
+	// file containing it is byte-identical to the same file without it, and
+	// `for = "BANANA"` is accepted just as readily. So there is no spelling of
+	// its own to match, only the requirement that the file evaluate.
+	r.stringAttr(1, "for", firstNonEmpty(trigger.ForEach, "ROW"))
 	r.stringAttr(1, "as", trigger.Body)
 	r.stringAttr(1, "comment", trigger.Comment)
 	r.line("}")
@@ -369,7 +414,19 @@ func (r *renderer) renderRLSPolicies() {
 		}
 		r.linef(`policy %s {`, quote(policy.Name))
 		r.rawAttr(1, "on", objectRef("table", policy.Table))
-		r.rawAttr(1, "for", rawIdentifier(firstNonEmpty(strings.ToUpper(policy.PolicyFor), "ALL")))
+		// Quoted. Measured on the pinned Atlas community binary v1.3.0, one
+		// operand varied against an otherwise identical policy block:
+		//
+		//	for = ALL      exit 1  There is no variable named "ALL"
+		//	for = "ALL"    exit 1  postgres: policies are not supported by this version
+		//	for = "SELECT" exit 1  postgres: policies are not supported by this version
+		//
+		// Like the sequence, the block never gets past that binary's own feature
+		// gap, so the reachable target is the message changing from a parse
+		// failure over Ptah's rendering to a statement about what that binary
+		// models. The quoted string is what Ptah's parser reads back to the same
+		// PolicyFor.
+		r.stringAttr(1, "for", firstNonEmpty(strings.ToUpper(policy.PolicyFor), "ALL"))
 		if policy.ToRoles != "" {
 			r.rawAttr(1, "to", roleTargets(policy.ToRoles))
 		}
@@ -545,12 +602,15 @@ func triggerEventAttr(event string) (string, bool) {
 	return "", false
 }
 
+// atlasLanguage renders a function's `lang` attribute: the canonical spelling
+// of the language name, quoted. See renderFunction for the measurement that
+// says the bare form is refused for every value, canonical or not.
 func atlasLanguage(language string) string {
 	switch strings.ToLower(language) {
 	case "sql":
-		return "SQL"
+		return quote("SQL")
 	case "plpgsql":
-		return "PLpgSQL"
+		return quote("PLpgSQL")
 	default:
 		return quote(language)
 	}
@@ -649,13 +709,6 @@ func privilegeList(values []string) string {
 		items = append(items, quote(value))
 	}
 	return "[" + strings.Join(items, ", ") + "]"
-}
-
-func rawIdentifier(value string) string {
-	if isHCLIdentifier(value) {
-		return value
-	}
-	return quote(value)
 }
 
 func objectNameFromQualified(value string) string {

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -137,21 +137,30 @@ func (r *renderer) referencedSchemas() []string {
 		return nil
 	}
 	// Nothing to attach a schema to means nothing to declare. An inspect whose
-	// selection matched no table renders an empty document, and a lone schema
+	// selection matched no object renders an empty document, and a lone schema
 	// block there would be a declaration of nothing -- which is what the
 	// empty-include-selection contract already pins.
-	if len(r.db.Tables) == 0 {
+	//
+	// Enums count as something to attach. They now carry a schema reference of
+	// their own (see renderEnums), so a read that matched enums but no table
+	// still has to declare the block that reference points at.
+	if len(r.db.Tables) == 0 && len(r.db.Enums) == 0 {
 		return nil
 	}
 	seen := map[string]bool{}
 	var names []string
-	for _, table := range r.db.Tables {
-		name := r.schemaFor(table.Schema)
+	add := func(name string) {
 		if name == "" || seen[name] {
-			continue
+			return
 		}
 		seen[name] = true
 		names = append(names, name)
+	}
+	for _, table := range r.db.Tables {
+		add(r.schemaFor(table.Schema))
+	}
+	if len(r.db.Enums) > 0 {
+		add(r.defaultSchema)
 	}
 	slices.Sort(names)
 	return names
@@ -212,6 +221,24 @@ func (r *renderer) renderEnums() {
 	})
 	for _, enum := range enums {
 		r.linef(`enum %s {`, quote(enum.Name))
+		// An enum block with no schema is not under-specified, it is invalid.
+		// The pinned Atlas community binary v1.3.0 refuses the whole file with
+		//
+		//	extract schema name from enum reference: schemahcl: type "schema"
+		//	was not found in nil reference
+		//
+		// and accepts the identical file once `schema = schema.public` is added
+		// -- one operand, measured both ways. That binary's own inspect writes
+		// the attribute too (stokaro/ptah#1251).
+		//
+		// goschema.Enum carries no schema of its own, so the schema the whole
+		// read belongs to is the only name available. It is also the right one:
+		// a catalog omits the schema exactly where the engine treats the read's
+		// own schema as implicit, which is the same reason renderTable falls
+		// back to it.
+		if schema := r.schemaFor(""); schema != "" {
+			r.rawAttr(1, "schema", schemaRef(schema))
+		}
 		r.rawAttr(1, "values", stringList(enum.Values))
 		r.line("}")
 		r.line("")
@@ -303,7 +330,7 @@ func (r *renderer) renderTable(
 
 func (r *renderer) renderColumn(field goschema.Field) {
 	r.linef(`  column %s {`, quote(field.Name))
-	r.rawAttr(2, "type", columnTypeExpr(field, r.dialect))
+	r.rawAttr(2, "type", r.columnTypeExpr(field))
 	if field.Nullable {
 		r.rawAttr(2, "null", "true")
 	}
@@ -863,7 +890,7 @@ func parseForeignReference(value string) (string, []string) {
 // `type = USER_DEFINED` with `Unknown column.type; There is no type named
 // "USER_DEFINED"` and accepts `type = sql("USER_DEFINED")`. Measured on that
 // binary, an HCL file it plans must survive a Ptah round trip still planning.
-func columnTypeExpr(field goschema.Field, dialect string) string {
+func (r *renderer) columnTypeExpr(field goschema.Field) string {
 	if strings.TrimSpace(field.Type) == "" {
 		return typeExpr(field.Type)
 	}
@@ -871,16 +898,69 @@ func columnTypeExpr(field goschema.Field, dialect string) string {
 	// from a database it remembers nothing, so the dialect's own list of
 	// modeled types decides -- see modeled_types.go for why that list is
 	// trustworthy rather than a copied table.
+	//
+	// The raw-SQL check stays ahead of the enum check on purpose. A sql() call
+	// is the author's own escape hatch, and issue #1106's contract is to write
+	// it back exactly as written rather than re-decide it from the type name; a
+	// name that happens to match an enum block could just as well mean a domain
+	// or composite the author is reaching past Atlas's model for. A database
+	// read never sets the flag -- only the HCL parser does -- so the inspect
+	// path this fixes is not affected by the ordering.
 	if field.TypeRawSQL {
 		return sqlCall(field.Type)
 	}
-	modeled, ok := modeledColumnType(dialect, field.Type)
+	if ref, ok := r.enumTypeRef(field.Type); ok {
+		return ref
+	}
+	modeled, ok := modeledColumnType(r.dialect, field.Type)
 	if !ok {
 		// Wrapped verbatim: an engine type Atlas does not model is only
 		// readable as the text the database itself reports.
 		return sqlCall(field.Type)
 	}
 	return typeExpr(modeled)
+}
+
+// enumTypeRef returns the expression for a column whose type is an enum this
+// same document declares, and reports whether the type is one.
+//
+// The reference is not one spelling among several -- it is the only one that
+// works. Measured on the pinned Atlas community binary v1.3.0, a table with an
+// enum-typed column and the matching `enum` block, one operand varied:
+//
+//	type = enum.status     exit 0
+//	type = sql("status")   exit 1  pq: type "status" does not exist
+//	type = status          exit 1  Unknown column.type; There is no type named "status"
+//	type = "status"        exit 1  set field "type": unexpected type string
+//
+// sql() is the interesting failure and the one Ptah used to emit: the type name
+// is real in the database that was inspected but not in the dev database the
+// file gets replayed into, and only the enum block creates it there. That
+// binary's own inspect writes `type = enum.status` as well.
+//
+// The reference is unqualified because that binary keys enum blocks by name
+// alone: two `enum "status"` blocks in different schemas are refused as
+// `duplicate enum "status"`, and an `enum.status` reference resolves to a block
+// declared in a non-default schema (measured with table and enum both in
+// `reporting`).
+//
+// A name that also names a domain, composite or range is left alone. Those are
+// separate declarations in the same document, and a reference into the enum
+// block would point at the wrong one.
+func (r *renderer) enumTypeRef(typeName string) (string, bool) {
+	name := strings.TrimSpace(typeName)
+	if name == "" {
+		return "", false
+	}
+	if !slices.ContainsFunc(r.db.Enums, func(e goschema.Enum) bool { return e.Name == name }) {
+		return "", false
+	}
+	if slices.ContainsFunc(r.db.Domains, func(d goschema.Domain) bool { return d.Name == name }) ||
+		slices.ContainsFunc(r.db.CompositeTypes, func(ct goschema.CompositeType) bool { return ct.Name == name }) ||
+		slices.ContainsFunc(r.db.Ranges, func(rg goschema.Range) bool { return rg.Name == name }) {
+		return "", false
+	}
+	return "enum" + objectRefPart(name), true
 }
 
 func typeExpr(value string) string {


### PR DESCRIPTION
Fixes the Category A half of #1251: the rendering defects that make Ptah's own HCL unreadable. The Category B superset question is untouched — another front owns it.

## Method

Built a PostgreSQL 17 database carrying an extension, an enum, a sequence, a table with an enum-typed column, a view, a materialized view, a function, a trigger, RLS with a policy, a role and two grants, and verified all 13 object kinds by querying the catalog rather than trusting psql's exit status.

Every row below was measured by varying **that attribute alone** in a document the pinned Atlas community binary v1.3.0 accepts. That control matters: the binary reports only the first failure, so "removing X changed nothing" means X was not first. The base was verified at exit 0 before anything was built on it, and probes ran serially against a private dev database.

The issue reported `return = trigger` as the function block's error; measuring each attribute separately shows all four are independently refused, and `lang` is simply the one that comes first.

## Per attribute: what was emitted, what the binary said, what is emitted now

| block | was | the binary's answer | now |
| --- | --- | --- | --- |
| `sequence` | `type = bigint` | `There is no variable named "bigint"` | `type = "bigint"` |
| `function` | `lang = PLpgSQL` | `... named "PLpgSQL"` | `lang = "PLpgSQL"` |
| `function` | `return = trigger` | `... named "trigger"` | `return = "trigger"` |
| `function` | `security = INVOKER` | `... named "INVOKER"` | `security = "INVOKER"` |
| `function` | `volatility = VOLATILE` | `... named "VOLATILE"` | `volatility = "VOLATILE"` |
| `trigger` | `for = ROW` | `... named "ROW"` | `for = "ROW"` |
| `policy` | `for = ALL` | `... named "ALL"` | `for = "ALL"` |
| `enum` | no `schema` | `extract schema name from enum reference` | `schema = schema.public` |
| column | `type = sql("status")` | `pq: type "status" does not exist` | `type = enum.status` |

Each quoted form was confirmed accepted, not assumed: `lang = "PLpgSQL"`, `return = "trigger"`, `security = "INVOKER"`, `volatility = "VOLATILE"`, `for = "ROW"` all reach exit 0.

### `return` is not a type position

It looks like one, so `typeExpr` was rendering it. A bare `bigint` that evaluates fine as a column's `type` is refused there — `return = bigint` → `There is no variable named "bigint"` — so `typeExpr` was wrong for it regardless of the return type, not only for `trigger`.

### The enum-typed column, decided deliberately

The reference is the only spelling that works. One operand varied, everything else fixed:

```
type = enum.status     exit 0
type = sql("status")   exit 1  pq: type "status" does not exist
type = status          exit 1  Unknown column.type; There is no type named "status"
type = "status"        exit 1  set field "type": unexpected type string
```

`sql()` is the interesting failure and the one Ptah emitted: the type name is real in the inspected database but not in the dev database the file is replayed into, and only the `enum` block creates it there. The reference is unqualified because the binary keys enum blocks by name alone — two `enum "status"` blocks in different schemas are refused as `duplicate enum "status"`, and `enum.status` resolves to a block declared in a non-default schema.

This also settles the item the issue recorded as **not** established ("whether the binary can use an enum-declared type for a column at all was not separately established"). The isolated fixture exists now: exit 0.

The raw-SQL check deliberately stays ahead of the enum check. A `sql()` call is the author's own escape hatch and #1106's contract is to write it back as written; a database read never sets that flag, so the inspect path this fixes is unaffected by the ordering. A name that also names a domain, composite or range is left alone, covered by three rows.

### Blocks behind the binary's feature gap

`sequence` and `policy` can never reach exit 0 there, so matching output is not available. The reachable target is the error moving from a parse failure over Ptah's rendering to a statement about what that binary models — `type = "bigint"` gets `postgres: sequences are not supported by this version` — plus a clean round trip through Ptah's own parser. Both pinned.

### Is the trigger modeled?

The issue asked. Measured: **no.** The binary accepts a `trigger` block and emits nothing for it — its output for a file containing one is byte-identical to the same file without it, `for = "BANANA"` is accepted, and an attribute the block does not define is accepted too. Same for `function`. So there is no spelling of its own to match, only the requirement that the file evaluate. That is stated in the code rather than left as an assumption.

## Correct on the native surface too

Not gated to the compatibility surface. `ptah schema inspect --db-url` and `ptah-compat schema inspect --url` produce **byte-identical** output on the fixture database (`diff` exit 0).

## End to end

- **Before:** the binary refuses Ptah's inspect output — `There is no variable named "bigint"`, the first of six.
- **After, with only the three superset block types removed** (extension, sequence, policy): **exit 0**, and it round-trips the schema including `type = enum.status` and the enum with its schema.
- The same stripped file built from the pre-fix output still fails, at `PLpgSQL` — so the exit 0 is this change and not the stripping.
- Unstripped, the error is now `postgres: sequences are not supported by this version` — a feature statement, not a parse failure. That is the Category B boundary.

## Coverage

Every change round-trips through `internal/atlashcl` and is asserted on the parsed IR, plus a whole-document stability assertion. **All ten fixes carry a mutant that was observed to go red**; none passed vacuously.

`check-test-style` and `qtlint` were each broken deliberately inside the new test file and watched go red, so they are cited as having actually inspected it.

## Two adjacent defects found, deliberately not fixed

Both are the same class but outside the issue's list, and each has a real design question behind it. Measured, reported, not touched:

1. **Schema-qualified table references are refused.** Ptah writes `on = table.public.users` after a parse resolves the table name. The binary refuses it — `Unsupported attribute; This object does not have an attribute named "public"` — and its own cross-schema references are unqualified: `ref_columns = [table.users.column.id]` reaches a table in another schema at exit 0 while the qualified spelling of the same reference is refused. Affects `objectRef`, so trigger/policy `on`, permission `for`, and foreign-key `ref_columns`. It does not appear in a first inspect, only on re-render, which is why the stability test compares from the second render and says so.

2. **A domain's `type` has one readable spelling and Ptah writes neither.** `type = sql("text")` exits 0; `type = text` is `There is no variable named "text"` and `type = "text"` is `set field "type": unexpected type string`. `composite` field types and `range` subtypes go through the same `typeExpr` and are likely the same.

## Not verified

- Only PostgreSQL 17. MySQL, MariaDB, SQLite and ClickHouse inspect paths share this renderer but were not exercised.
- `view`, `materialized`, `role` and `permission` blocks were confirmed to already evaluate at exit 0; nothing in them was changed.
- `check-public-api` and `check-public-api-snapshot` pass but **cannot** go red here — the change is entirely within `internal/`, which they skip. Cited as run, not as coverage.
