### PR TITLE
compat inspect: omit the block types the pinned binary refuses (#1251, Category B)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -133,18 +133,24 @@ jobs:
       # The set of column types the HCL schema models is the third contract in
       # this repository whose authority is the community binary rather than any
       # document (stokaro/ptah#1138). A wrong row emits HCL that binary refuses
-      # to read, so the set is re-measured here instead of being trusted.
-      # Listed before it is run, for the same reason as above.
-      - name: Verify column-type conformance selection
+      # to read, so the set is re-measured here instead of being trusted. The
+      # set of top-level BLOCK types it refuses is the same kind of contract
+      # (stokaro/ptah#1251): ptah-compat omits those blocks, and a list nothing
+      # re-measures would go on withholding a construct that binary started
+      # modeling. Both live in internal/atlashclrender and are listed before
+      # they are run, for the same reason as above.
+      - name: Verify HCL render conformance selection
         run: |
           GOWORK=off go test -list '^TestOracle' \
             ./internal/atlashclrender > "$RUNNER_TEMP/atlas-column-type-tests"
           cat "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleModeledColumnTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleAcceptsTheWrapItFallsBackTo' "$RUNNER_TEMP/atlas-column-type-tests"
-          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 2
+          grep -Fx 'TestOracleAtlasRefusedBlockTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
+          grep -Fx 'TestOracleToleratesTheBlockTypesPtahStillRenders' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 4
 
-      - name: Run column-type conformance tests
+      - name: Run HCL render conformance tests
         run: |
           GOWORK=off go test -count=1 -v -run '^TestOracle' ./internal/atlashclrender \
             > "$RUNNER_TEMP/atlas-column-type-run" 2>&1 || {
@@ -156,6 +162,15 @@ jobs:
           # database URL -- which would leave every PostgreSQL row unmeasured
           # while the job stayed green. Both are fatal here.
           ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-column-type-run"
+          # A selection that matched no subtest is the other way to stay green
+          # while measuring nothing: the refused list is the whole subject here,
+          # so its rows are named rather than counted in bulk.
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/base' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/extension' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/policy' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/sequence' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/postgres/tolerated/wibble' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/sqlite/tolerated/sequence' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -38,6 +38,12 @@ require --dev-url: the dev database is reset, the source is materialized on
 it, and the result is introspected, mirroring Atlas dev-database
 normalization.
 
+On PostgreSQL, HCL output omits ` + "`extension`" + `, ` + "`sequence`" + ` and
+` + "`policy`" + ` blocks: Atlas CE refuses a whole schema file that declares
+any one of them, so emitting one would make the output unreadable to the tool
+this binary stands in for. Each omitted object is reported on standard error.
+SQL output keeps them, and native ` + "`ptah schema inspect`" + ` omits nothing.
+
 The default output is HCL. SQL output is supported with --format sql or
 --format '{{ sql . }}', JSON with --format json, and custom Go templates
 through the same --format flag. Split/write exports support the documented
@@ -156,7 +162,13 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
 		IgnoreUnknownHCLNames: true,
-		Vars:                  schemaVars,
+		// This surface stands in for a binary that refuses a whole schema file
+		// for containing an extension, sequence or policy block, so it renders
+		// what that binary can read and reports what it left out on stderr
+		// (stokaro/ptah#1251). Native `ptah schema inspect` sets nothing here
+		// and keeps describing every construct Ptah models.
+		OmitAtlasRefusedBlocks: true,
+		Vars:                   schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -142,6 +142,38 @@ community binary applies on a schema-bound URL. A pattern too deep for any
 scope, such as `*.*.*.*`, is refused before a database is contacted, so its
 message carries no schema prefix.
 
+### Blocks the compatibility surface leaves out
+
+`ptah-compat schema inspect` omits three top-level HCL block types on
+PostgreSQL: `extension`, `sequence`, and `policy`. The pinned Atlas community
+binary refuses an entire schema file that declares any one of them, answering
+`postgres: extensions are not supported by this version` and the equivalent for
+the other two. Output a drop-in replacement writes has to be output the tool it
+replaces can read back, and one such block costs the whole document.
+
+Nothing is dropped quietly. Every omitted object is reported on standard error,
+one line each, alongside the other loss diagnostics inspection already writes:
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL" > schema.hcl
+warning: extensions.pgcrypto: omitted from Atlas-compatible schema inspect output: ...
+warning: sequences.order_seq: omitted from Atlas-compatible schema inspect output: ...
+warning: rls_policies.accounts_all: omitted from Atlas-compatible schema inspect output: ...
+```
+
+The omission is scoped as narrowly as the measurement is. It applies to HCL
+output on PostgreSQL only: `--format sql` still writes the extension, the
+sequence, and the policy, because SQL output is read by a database rather than
+by that binary. On SQLite the same three blocks are accepted, so nothing is
+omitted there. Every other block Ptah renders — `role`, `function`, `view`,
+`materialized`, `trigger`, `permission` — is kept, because that binary drops a
+block type it does not model and reads the file anyway.
+
+Native `ptah schema inspect` omits nothing; see
+[Inspect a database](../../direct/inspect/). Which block types that binary
+refuses is re-measured by the Atlas CE Oracle job rather than frozen, so a
+construct a later build starts modeling stops being withheld.
+
 ### Select what is inspected with `--include`
 
 `--include` positively selects which top-level resources survive inspection,

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -115,6 +115,13 @@ table "users" {
 }
 ```
 
+Native inspection describes every construct Ptah models, including PostgreSQL
+extensions, sequences, and row-level security policies. The Atlas-compatible
+binary leaves those three block types out of its HCL, because the tool it
+stands in for refuses a file containing them; that filtering is a property of
+`ptah-compat` alone and never reaches this command. See
+[Blocks the compatibility surface leaves out](../../atlas/schema-commands/#blocks-the-compatibility-surface-leaves-out).
+
 `--format sql` and `--format json` select SQL and JSON output. `--schemas`,
 `--include`, and `--exclude` select what is inspected, in that order:
 `--schemas` names the database schemas, `--include` picks top-level resources

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -1,0 +1,91 @@
+package atlashclrender
+
+import (
+	"fmt"
+	"slices"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// Top-level HCL block spellings an inspected render can emit. Only the ones a
+// refusal list or a diagnostic names are constants: the token has to be spelled
+// identically by the renderer, by [atlasRefusedBlockTypes], and by the
+// conformance run that re-measures that list against the binary, and three
+// string literals drift where one constant cannot.
+const (
+	blockExtension = "extension"
+	blockPolicy    = "policy"
+	blockSequence  = "sequence"
+)
+
+// atlasRefusedBlockTypes lists, per dialect, the top-level block types the
+// pinned Atlas community binary v1.3.0 refuses AS A FEATURE: not because of how
+// Ptah spells an attribute inside them, but because that build does not model
+// the construct at all. One such block anywhere in a file costs the WHOLE file,
+// so the Atlas-compatible surface omits them rather than emitting a document
+// its counterpart cannot read (stokaro/ptah#1251).
+//
+// Every row is measured, and the message is what makes the row a row. Measured
+// on PostgreSQL 17 by starting from a file that binary accepts -- its own
+// inspect output for the same database, verified at exit 0 -- and adding one
+// block type at a time:
+//
+//	extension "pgcrypto" {}     exit 1  postgres: extensions are not supported by this version
+//	sequence "order_seq" {}     exit 1  postgres: sequences are not supported by this version
+//	policy "accounts_all" {}    exit 1  postgres: policies are not supported by this version
+//
+// The blocks are empty on purpose. A `sequence` carrying the `type = bigint`
+// Ptah writes today is refused with `There is no variable named "bigint"`
+// instead, which is Ptah's own rendering defect and is fixed rather than
+// suppressed. Stripping the block to its label separates the two verdicts: what
+// survives is a refusal of the block type itself, which no spelling can lift.
+//
+// Nothing else Ptah's inspect emits belongs here, and that too is measured. Off
+// the same accepted base, one block at a time:
+//
+//	role, function, view, materialized, trigger, permission, range   exit 0
+//	wibble "x" {}                                                    exit 0
+//
+// The last row is why the others are not evidence of support: that binary drops
+// a top-level block whose name it does not model and carries on, so exit 0 says
+// only "harmless to the file", which is all the compatibility surface needs.
+// Suppressing those would lose description for nothing.
+//
+// The map is keyed by dialect because the refusal is, and that is measured too:
+// on SQLite the same three blocks are accepted and dropped exactly like
+// `wibble`, all at exit 0. A dialect absent here suppresses nothing.
+//
+// A later build may model any of these, at which point suppressing it would
+// silently withhold something the reader could have used.
+// TestOracleAtlasRefusedBlockTypesMatchTheBinary re-measures the list in both
+// directions so that turns the Atlas CE Oracle job red rather than going
+// unnoticed.
+var atlasRefusedBlockTypes = map[string][]string{
+	platform.Postgres: {blockExtension, blockPolicy, blockSequence},
+}
+
+// atlasRefusesBlock reports whether the pinned binary refuses a whole file for
+// containing this block type on this dialect.
+func atlasRefusesBlock(dialect, block string) bool {
+	return slices.Contains(atlasRefusedBlockTypes[dialect], block)
+}
+
+// omitsBlock reports whether this render drops a top-level block type entirely.
+// Only the Atlas-compatible surface does; a native render describes everything
+// Ptah models.
+func (r *renderer) omitsBlock(block string) bool {
+	return r.atlasCompatible && atlasRefusesBlock(r.dialect, block)
+}
+
+// omitAtlasRefusedBlock records one omitted object on the render's diagnostics,
+// which schema inspect writes to standard error.
+//
+// Dropping an object silently would make the output lie about the database, so
+// the omission is reported through the same loss-diagnostic channel the
+// renderer already uses for constructs it cannot represent.
+func (r *renderer) omitAtlasRefusedBlock(path, block string) {
+	r.warn(path, fmt.Sprintf(
+		"omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses a %s schema file that declares any %s block, and one of them makes the whole document unreadable to it",
+		r.dialect, block,
+	))
+}

--- a/internal/atlashclrender/atlas_refused_blocks_oracle_internal_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_oracle_internal_test.go
@@ -1,0 +1,233 @@
+package atlashclrender
+
+// White-box testing required: the subject of this conformance run is the
+// contents of atlasRefusedBlockTypes, an unexported map. Enumerating it is the
+// whole point -- a black-box run could only ask about block types it already
+// thought of, and the drift this run exists to catch is precisely a row that
+// stopped being true without anyone asking.
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// atlasFeatureRefusal is the substring that separates the two refusals this
+// front had to keep apart. "postgres: sequences are not supported by this
+// version" is the binary declining to model a construct, which no spelling of
+// ours can lift and which the compatibility surface therefore omits. `There is
+// no variable named "bigint"` is Ptah's own rendering, which is fixed rather
+// than suppressed -- so a row that starts failing for THAT reason must not keep
+// counting as a feature gap.
+const atlasFeatureRefusal = "are not supported by this version"
+
+// atlasToleratedBlockTypes are top-level block types Ptah's inspect renders
+// that the pinned binary does NOT refuse, and which the compatibility surface
+// therefore keeps.
+//
+// They are the control in the opposite direction. Without them this run could
+// pass with a list that suppressed everything, or with one grown by guesswork:
+// each name here is asserted to be readable, so a block type that STARTS being
+// refused turns the job red and says "this now belongs in the list" instead of
+// shipping unreadable output.
+//
+// `wibble` is the sharpest of them. It is not a construct at all, and the
+// binary accepts it exactly as it accepts `role` or `view` -- which is what
+// makes exit 0 on those names evidence of tolerance rather than of support.
+var atlasToleratedBlockTypes = map[string][]string{
+	platform.Postgres: {
+		"role",
+		"function",
+		"view",
+		"materialized",
+		"trigger",
+		"permission",
+		"wibble",
+	},
+	platform.SQLite: {
+		// The three PostgreSQL refuses. They are listed here rather than in
+		// atlasRefusedBlockTypes because the refusal is the PostgreSQL driver's
+		// and not the file format's, which is why that map is keyed by dialect
+		// at all. If SQLite ever starts refusing them, this run says so.
+		"extension",
+		"sequence",
+		"policy",
+		"wibble",
+	},
+}
+
+// TestOracleAtlasRefusedBlockTypesMatchTheBinary re-measures every entry of
+// atlasRefusedBlockTypes against the pinned community binary.
+//
+// A list nothing re-measures rots silently, and this one rots in a direction
+// that costs the user: a block type a later build starts modeling would go on
+// being withheld from the compatibility output forever, describing less of the
+// database than the reader could have used. So each entry is asserted in the
+// direction that would make the suppression stale -- the binary must still
+// refuse it -- and the refusal must still be the FEATURE refusal, because a row
+// that began failing over one of Ptah's own spellings is not this list's
+// business.
+//
+// Every probe starts from a base asserted to exit 0 first. An earlier attempt
+// at this measurement built an invalid base, and every row inherited its error;
+// the base subtest is what makes that impossible to repeat.
+//
+// The probes deliberately do NOT run in parallel. Each dialect's probes share
+// one dev database and the binary materializes the file there, so concurrent
+// probes collide inside the server with errors that read like verdicts about
+// the block under test.
+func TestOracleAtlasRefusedBlockTypesMatchTheBinary(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	c := qt.New(t)
+	c.Assert(atlasRefusedBlockTypes, qt.Not(qt.HasLen), 0,
+		qt.Commentf("an empty map would make this run measure nothing"))
+
+	for _, dialect := range slices.Sorted(maps.Keys(atlasRefusedBlockTypes)) {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+
+			refused := atlasRefusedBlockTypes[dialect]
+			c.Assert(refused, qt.Not(qt.HasLen), 0,
+				qt.Commentf("a dialect in the map with no entries would measure nothing"))
+
+			t.Run("base", func(t *testing.T) {
+				c := qt.New(t)
+
+				out, code := runBlockOracle(c, oracle, devURL, dialect, "")
+				c.Assert(code, qt.Equals, 0,
+					qt.Commentf("the base this run adds one block to is not accepted, so no row below means anything: %s", out))
+			})
+
+			for _, block := range refused {
+				t.Run("refused/"+block, func(t *testing.T) {
+					c := qt.New(t)
+
+					out, code := runBlockOracle(c, oracle, devURL, dialect, block)
+					c.Assert(code, qt.Not(qt.Equals), 0,
+						qt.Commentf("the binary now reads a %s block on %s; suppressing it withholds a construct the reader could use: %s",
+							block, dialect, out))
+					c.Assert(out, qt.Contains, atlasFeatureRefusal,
+						qt.Commentf("the %s block on %s is refused for a reason that is not a feature gap, so it is not this list's to suppress: %s",
+							block, dialect, out))
+				})
+			}
+		})
+	}
+}
+
+// TestOracleToleratesTheBlockTypesPtahStillRenders measures the other
+// direction: everything the compatibility surface still emits stays readable.
+//
+// This is what keeps the omission surgical. The binary drops a top-level block
+// whose name it does not model and carries on, so these blocks cost the reader
+// nothing, and omitting them would cost a description for no compatibility
+// gain. If one of them starts being refused, this run goes red rather than
+// ptah-compat quietly emitting a file its counterpart cannot read.
+func TestOracleToleratesTheBlockTypesPtahStillRenders(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	c := qt.New(t)
+	c.Assert(atlasToleratedBlockTypes, qt.Not(qt.HasLen), 0,
+		qt.Commentf("an empty map would make this run measure nothing"))
+
+	for _, dialect := range slices.Sorted(maps.Keys(atlasToleratedBlockTypes)) {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+
+			tolerated := atlasToleratedBlockTypes[dialect]
+			c.Assert(tolerated, qt.Not(qt.HasLen), 0,
+				qt.Commentf("a dialect with no controls controls nothing"))
+
+			for _, block := range tolerated {
+				t.Run("tolerated/"+block, func(t *testing.T) {
+					c := qt.New(t)
+
+					c.Assert(atlasRefusesBlock(dialect, block), qt.IsFalse,
+						qt.Commentf("%q is a control: it must stay out of the suppression list for that list to have a boundary", block))
+
+					out, code := runBlockOracle(c, oracle, devURL, dialect, block)
+					c.Assert(code, qt.Equals, 0,
+						qt.Commentf("the binary now refuses a %s block on %s, so ptah-compat is emitting a file it cannot read: %s",
+							block, dialect, out))
+				})
+			}
+		})
+	}
+}
+
+// runBlockOracle asks the pinned binary to read a file holding one extra
+// top-level block, and returns its combined output and exit status.
+//
+// The block is written bare -- a label and an empty body -- on purpose. A block
+// carrying the attributes Ptah writes today would be refused over one of them
+// first, which is a different verdict about a different defect; stripping it to
+// the label is what leaves a refusal of the block TYPE and nothing else.
+//
+// The column type is a sql() wrap because that is the one spelling
+// TestOracleAcceptsTheWrapItFallsBackTo already measures as readable on every
+// dialect here, so the base cannot fail for a reason this run is not about.
+func runBlockOracle(c *qt.C, oracle, devURL, dialect, block string) (string, int) {
+	c.Helper()
+
+	schema := schemaNameByDialect[dialect]
+	c.Assert(schema, qt.Not(qt.Equals), "",
+		qt.Commentf("dialect %q has no schema name; add one before adding the dialect", dialect))
+
+	probe, ok := blockProbeSources[block]
+	c.Assert(ok, qt.IsTrue,
+		qt.Commentf("block %q has no probe spelling; add one before measuring it", block))
+
+	source := fmt.Sprintf(`schema %q {
+}
+table "probe" {
+  schema = schema.%s
+  column "c" {
+    type = sql("integer")
+  }
+}
+%s`, schema, schema, probe)
+
+	path := filepath.Join(c.TempDir(), "blocks.hcl")
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+
+	//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+	cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", devURL)
+	// The error is the exit status, which is the measurement; a process that
+	// never started leaves ProcessState nil and fails the assertion instead.
+	out, _ := cmd.CombinedOutput() //nolint:errcheck // exit status is read from ProcessState below
+	c.Assert(cmd.ProcessState, qt.IsNotNil, qt.Commentf("the oracle did not run: %s", out))
+	return string(out), cmd.ProcessState.ExitCode()
+}
+
+// blockProbeSources spells each probed block the way Ptah's inspect renders it.
+// The empty key is the base probe, which adds nothing to the base.
+//
+// The spellings are written out rather than composed from the block name so
+// that adding a block type to atlasRefusedBlockTypes or to
+// atlasToleratedBlockTypes without deciding how it is spelled fails the run
+// instead of measuring a form Ptah never emits. `permission` is why that
+// matters: it is the one block Ptah renders with no label at all.
+var blockProbeSources = map[string]string{
+	"":             "",
+	"extension":    "extension \"probe_block\" {\n}\n",
+	"function":     "function \"probe_block\" {\n}\n",
+	"materialized": "materialized \"probe_block\" {\n}\n",
+	"permission":   "permission {\n}\n",
+	"policy":       "policy \"probe_block\" {\n}\n",
+	"role":         "role \"probe_block\" {\n}\n",
+	"sequence":     "sequence \"probe_block\" {\n}\n",
+	"trigger":      "trigger \"probe_block\" {\n}\n",
+	"view":         "view \"probe_block\" {\n}\n",
+	"wibble":       "wibble \"probe_block\" {\n}\n",
+}

--- a/internal/atlashclrender/atlas_refused_blocks_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_test.go
@@ -1,0 +1,257 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// nativeInspectedBlockTypes is every top-level block spelling an inspected
+// render emits for [inspectedRichDatabase]. It is the list the native surface
+// owes its reader: `ptah schema inspect` describes what Ptah models, and the
+// compatibility argument for leaving something out belongs to `ptah-compat`
+// alone (stokaro/ptah#1251).
+var nativeInspectedBlockTypes = []string{
+	"composite \"pair\"",
+	"data {",
+	"domain \"positive\"",
+	"enum \"status\"",
+	"extension \"pgcrypto\"",
+	"function \"touch_accounts\"",
+	"materialized \"account_counts\"",
+	"permission {",
+	"policy \"accounts_all\"",
+	"range \"intrange\"",
+	"role \"app_reader\"",
+	"schema \"public\"",
+	"sequence \"order_seq\"",
+	"table \"accounts\"",
+	"trigger \"accounts_touch\"",
+	"view \"active_accounts\"",
+}
+
+// TestRenderInspectedKeepsEveryBlockTypeOnTheNativeSurface fails if a block
+// stops being rendered natively.
+//
+// This is the guard on the other half of stokaro/ptah#1251: the compatibility
+// surface omits three block types, and nothing about that decision may leak
+// into the surface whose job is to describe the database completely. A native
+// render that quietly lost a construct would still pass every compatibility
+// test in this package, so it is pinned here on its own.
+func TestRenderInspectedKeepsEveryBlockTypeOnTheNativeSurface(t *testing.T) {
+	for _, block := range nativeInspectedBlockTypes {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block,
+				qt.Commentf("native inspect stopped emitting a block it models"))
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIOmitsTheBlocksTheBinaryRefuses pins the three
+// block types the compatibility surface leaves out.
+//
+// Measured against the pinned Atlas community binary v1.3.0 on PostgreSQL 17,
+// starting from a file it accepts and adding one bare block:
+//
+//	extension "pgcrypto" {}     exit 1  postgres: extensions are not supported by this version
+//	sequence "order_seq" {}     exit 1  postgres: sequences are not supported by this version
+//	policy "accounts_all" {}    exit 1  postgres: policies are not supported by this version
+//
+// One such block costs the whole file, so a compatibility surface that emits
+// one is not compatible in any useful sense.
+func TestRenderInspectedForAtlasCLIOmitsTheBlocksTheBinaryRefuses(t *testing.T) {
+	for _, block := range []string{"extension \"", "sequence \"", "policy \""} {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Not(qt.Contains), block)
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIKeepsEverythingElse is the other direction, and
+// it is what keeps the omission surgical.
+//
+// Every row here is a block type the pinned binary DROPS rather than refuses:
+// measured off the same accepted base, each one exits 0, as does an invented
+// `wibble "x" {}`. Exit 0 therefore says only "harmless to the file", which is
+// the whole test the compatibility surface applies. Omitting these would cost
+// the reader a description and buy nothing.
+func TestRenderInspectedForAtlasCLIKeepsEverythingElse(t *testing.T) {
+	kept := []string{
+		"composite \"pair\"",
+		"domain \"positive\"",
+		"enum \"status\"",
+		"function \"touch_accounts\"",
+		"materialized \"account_counts\"",
+		"permission {",
+		"range \"intrange\"",
+		"role \"app_reader\"",
+		"schema \"public\"",
+		"table \"accounts\"",
+		"trigger \"accounts_touch\"",
+		"view \"active_accounts\"",
+	}
+
+	for _, block := range kept {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block)
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIReportsEveryOmission pins that nothing is
+// dropped quietly.
+//
+// An inspect output that silently omitted an extension would describe a
+// database that does not exist, and the operator reading it has no other way to
+// learn what was left out. The omission rides the renderer's existing loss
+// diagnostics, which `schema inspect` writes to standard error.
+func TestRenderInspectedForAtlasCLIReportsEveryOmission(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.RenderInspectedForAtlasCLI(
+		inspectedRichDatabase(), platform.Postgres, "public",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.DeepEquals, []atlashclrender.Diagnostic{
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "extensions.pgcrypto",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any extension block, and one of them makes the whole" +
+				" document unreadable to it",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "sequences.order_seq",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any sequence block, and one of them makes the whole" +
+				" document unreadable to it",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "rls_policies.accounts_all",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any policy block, and one of them makes the whole" +
+				" document unreadable to it",
+		},
+	})
+}
+
+// TestRenderInspectedNativeReportsNoOmission pins the native counterpart: the
+// surface that drops nothing has nothing to disclose, so an operator cannot
+// mistake a native inspect for a filtered one.
+func TestRenderInspectedNativeReportsNoOmission(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.RenderInspected(
+		inspectedRichDatabase(), platform.Postgres, "public",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.HasLen, 0)
+}
+
+// TestRenderInspectedForAtlasCLIOmitsNothingOnSQLite pins that the omission is
+// scoped to the dialect it was measured on.
+//
+// The refusal is the PostgreSQL driver's, not the file format's: measured on
+// the pinned binary with a SQLite dev database, `extension`, `sequence` and
+// `policy` blocks are all accepted at exit 0, dropped exactly like an invented
+// `wibble "x" {}`. Suppressing them there would lose description with no reader
+// to please.
+func TestRenderInspectedForAtlasCLIOmitsNothingOnSQLite(t *testing.T) {
+	kept := []string{"extension \"pgcrypto\"", "sequence \"order_seq\"", "policy \"accounts_all\""}
+
+	for _, block := range kept {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.SQLite, "main",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block)
+			c.Assert(result.Diagnostics, qt.HasLen, 0)
+		})
+	}
+}
+
+// inspectedRichDatabase builds an IR carrying one object of every construct the
+// inspected renderer emits a top-level block for, so a block that stops being
+// rendered is visible rather than absent for want of an input.
+func inspectedRichDatabase() *goschema.Database {
+	start := int64(1)
+	return &goschema.Database{
+		Extensions: []goschema.Extension{{Name: "pgcrypto", Version: "1.3"}},
+		Sequences:  []goschema.Sequence{{Name: "order_seq", AsType: "bigint", Start: &start}},
+		Domains:    []goschema.Domain{{Name: "positive", BaseType: "integer"}},
+		CompositeTypes: []goschema.CompositeType{{
+			Name:   "pair",
+			Fields: []goschema.CompositeTypeField{{Name: "a", Type: "integer"}},
+		}},
+		Ranges: []goschema.Range{{Name: "intrange", Subtype: "integer"}},
+		Enums:  []goschema.Enum{{Name: "status", Values: []string{"active", "inactive"}}},
+		Roles:  []goschema.Role{{Name: "app_reader", Inherit: true}},
+		Tables: []goschema.Table{{StructName: "Account", Name: "accounts", Schema: "public"}},
+		Fields: []goschema.Field{{StructName: "Account", Name: "id", Type: "bigint"}},
+		Functions: []goschema.Function{{
+			Name:     "touch_accounts",
+			Language: "plpgsql",
+			Returns:  "trigger",
+			Body:     "BEGIN RETURN NEW; END;",
+		}},
+		Views:             []goschema.View{{Name: "active_accounts", Body: "SELECT id FROM accounts"}},
+		MaterializedViews: []goschema.MaterializedView{{Name: "account_counts", Body: "SELECT id FROM accounts"}},
+		Triggers: []goschema.Trigger{{
+			Name:   "accounts_touch",
+			Table:  "accounts",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "BEGIN RETURN NEW; END;",
+		}},
+		RLSEnabledTables: []goschema.RLSEnabledTable{{Table: "accounts"}},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "accounts_all",
+			Table:           "accounts",
+			PolicyFor:       "ALL",
+			UsingExpression: "true",
+		}},
+		Grants: []goschema.Grant{{
+			Role:       "app_reader",
+			OnTable:    "accounts",
+			Privileges: []string{"SELECT"},
+		}},
+		ManagedData: []goschema.ManagedData{{Table: "accounts", Keys: []string{"id"}, File: "accounts.csv"}},
+	}
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -15,6 +15,12 @@ func (r *renderer) renderExtensions() {
 	slices.SortFunc(extensions, func(a, b goschema.Extension) int {
 		return cmp.Compare(a.Name, b.Name)
 	})
+	if r.omitsBlock(blockExtension) {
+		for _, extension := range extensions {
+			r.omitAtlasRefusedBlock("extensions."+extension.Name, blockExtension)
+		}
+		return
+	}
 	for _, extension := range extensions {
 		r.linef(`extension %s {`, quote(extension.Name))
 		if extension.IfNotExists {
@@ -32,6 +38,12 @@ func (r *renderer) renderSequences() {
 	slices.SortFunc(sequences, func(a, b goschema.Sequence) int {
 		return cmp.Compare(a.QualifiedName(), b.QualifiedName())
 	})
+	if r.omitsBlock(blockSequence) {
+		for _, sequence := range sequences {
+			r.omitAtlasRefusedBlock("sequences."+sequence.QualifiedName(), blockSequence)
+		}
+		return
+	}
 	for _, sequence := range sequences {
 		sequence.Canonicalize()
 		r.linef(`sequence %s {`, quote(sequence.Name))
@@ -362,6 +374,12 @@ func (r *renderer) renderRLSPolicies() {
 	slices.SortFunc(policies, func(a, b goschema.RLSPolicy) int {
 		return cmp.Or(cmp.Compare(a.Table, b.Table), cmp.Compare(a.Name, b.Name))
 	})
+	if r.omitsBlock(blockPolicy) {
+		for _, policy := range policies {
+			r.omitAtlasRefusedBlock("rls_policies."+policy.Name, blockPolicy)
+		}
+		return
+	}
 	for _, policy := range policies {
 		if policy.Table == "" {
 			r.warn("rls_policies."+policy.Name, "RLS policy requires a target table for HCL schema export")

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -63,7 +63,7 @@ func Render(db *goschema.Database) (Result, error) {
 // their input was HCL, so the raw-SQL marker the parser set is already right and
 // re-deciding it from the type name would second-guess the author.
 func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
-	return render(db, dialect, "")
+	return render(db, dialect, "", false)
 }
 
 // RenderInspected renders a schema that was read out of a database, declaring
@@ -89,18 +89,33 @@ func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
 // here, so their IR already carries whatever the author wrote, and synthesizing
 // a schema there would invent one the author did not declare.
 func RenderInspected(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
-	return render(db, dialect, strings.TrimSpace(defaultSchema))
+	return render(db, dialect, strings.TrimSpace(defaultSchema), false)
 }
 
-func render(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
+// RenderInspectedForAtlasCLI renders an inspected schema for the
+// Atlas-compatible surface, omitting the top-level block types the pinned Atlas
+// community binary v1.3.0 refuses as a feature and reporting each omission as a
+// loss diagnostic.
+//
+// It differs from [RenderInspected] in nothing else. The omission is a property
+// of the reader the compatibility binary stands in for, not of the database and
+// not of Ptah, so the native surface keeps describing everything Ptah models;
+// see [atlasRefusedBlockTypes] for the list and the measurement behind it
+// (stokaro/ptah#1251).
+func RenderInspectedForAtlasCLI(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
+	return render(db, dialect, strings.TrimSpace(defaultSchema), true)
+}
+
+func render(db *goschema.Database, dialect, defaultSchema string, atlasCompatible bool) (Result, error) {
 	if db == nil {
 		return Result{}, fmt.Errorf("schema database is nil")
 	}
 
 	r := renderer{
-		db:            db,
-		dialect:       dialect,
-		defaultSchema: defaultSchema,
+		db:              db,
+		dialect:         dialect,
+		defaultSchema:   defaultSchema,
+		atlasCompatible: atlasCompatible,
 	}
 	r.render()
 	return Result{
@@ -116,8 +131,12 @@ type renderer struct {
 	// IR is taken as written, which is what every parse-and-re-render caller
 	// wants.
 	defaultSchema string
-	builder       strings.Builder
-	diagnostics   []Diagnostic
+	// atlasCompatible marks the render as feeding the Atlas-compatible surface,
+	// which omits the block types the pinned binary refuses; see
+	// [atlasRefusedBlockTypes].
+	atlasCompatible bool
+	builder         strings.Builder
+	diagnostics     []Diagnostic
 }
 
 // schemaFor returns the schema name to write for an object, which is the one it

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -20,8 +20,12 @@ type SchemaInspectReport struct {
 	db          *goschema.Database
 	info        dbschematypes.DBInfo
 	diagnostics io.Writer
-	Realm       atlasSchemaInspectJSONRealm `json:"-"`
-	Schema      atlasSchemaInspectJSONRealm `json:"-"`
+	// omitAtlasRefusedBlocks renders HCL for the Atlas-compatible surface,
+	// which omits the block types the pinned Atlas community binary refuses to
+	// read; see [go.5x5.cz/ptah/internal/atlashclrender.RenderInspectedForAtlasCLI].
+	omitAtlasRefusedBlocks bool
+	Realm                  atlasSchemaInspectJSONRealm `json:"-"`
+	Schema                 atlasSchemaInspectJSONRealm `json:"-"`
 }
 
 type atlasSchemaInspectJSONRealm struct {
@@ -112,19 +116,27 @@ func RenderSchemaInspect(format string, report *SchemaInspectReport) (SchemaInsp
 	return SchemaInspectOutput{Text: out.String(), Files: files}, nil
 }
 
+// NewSchemaInspectReport builds the report one schema inspect renders from.
+//
+// omitAtlasRefusedBlocks selects the Atlas-compatible HCL rendering, which
+// leaves out the block types the pinned Atlas community binary refuses and
+// reports each omission on diagnostics. It is false on the native surface,
+// which describes every construct Ptah models.
 func NewSchemaInspectReport(
 	db *goschema.Database,
 	schema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	diagnostics io.Writer,
+	omitAtlasRefusedBlocks bool,
 ) *SchemaInspectReport {
 	realm := atlasSchemaInspectJSON(schema, info)
 	return &SchemaInspectReport{
-		db:          db,
-		info:        info,
-		diagnostics: diagnostics,
-		Realm:       realm,
-		Schema:      realm,
+		db:                     db,
+		info:                   info,
+		diagnostics:            diagnostics,
+		omitAtlasRefusedBlocks: omitAtlasRefusedBlocks,
+		Realm:                  realm,
+		Schema:                 realm,
 	}
 }
 
@@ -188,7 +200,7 @@ func (r *SchemaInspectReport) defaultSchemaName() string {
 }
 
 func (r *SchemaInspectReport) MarshalHCL() (string, error) {
-	rendered, err := atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
+	rendered, err := r.renderHCL()
 	if err != nil {
 		return "", fmt.Errorf("render HCL schema: %w", err)
 	}
@@ -198,6 +210,17 @@ func (r *SchemaInspectReport) MarshalHCL() (string, error) {
 		}
 	}
 	return string(rendered.Data), nil
+}
+
+// renderHCL picks the rendering the surface asked for. Only the HCL output is
+// split this way: what the compatibility surface omits, it omits because the
+// binary it stands in for cannot PARSE the block, and that is a question only
+// the HCL document raises.
+func (r *SchemaInspectReport) renderHCL() (atlashclrender.Result, error) {
+	if r.omitAtlasRefusedBlocks {
+		return atlashclrender.RenderInspectedForAtlasCLI(r.db, r.info.Dialect, r.defaultSchemaName())
+	}
+	return atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
 }
 
 func (r *SchemaInspectReport) MarshalSQL(indent ...string) (string, error) {

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -347,5 +347,6 @@ func sampleSchemaInspectReport() *atlasreport.SchemaInspectReport {
 		},
 		types.DBInfo{Dialect: "sqlite", Schema: "main"},
 		nil,
+		false,
 	)
 }

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -27,6 +27,13 @@ type InspectOptions struct {
 	Exclude     []string
 	Format      string
 	Diagnostics io.Writer
+	// OmitAtlasRefusedBlocks renders HCL for the Atlas-compatible surface,
+	// which leaves out the top-level block types the pinned Atlas community
+	// binary refuses as a feature and reports each omission on Diagnostics.
+	// Only `ptah-compat` sets it; the native surface renders every construct
+	// Ptah models. See
+	// [go.5x5.cz/ptah/internal/atlashclrender.RenderInspectedForAtlasCLI].
+	OmitAtlasRefusedBlocks bool
 }
 
 // NormalizeInspectFormat returns and validates the executable Atlas schema
@@ -92,6 +99,7 @@ func renderInspectSchema(
 		schema,
 		info,
 		opts.Diagnostics,
+		opts.OmitAtlasRefusedBlocks,
 	))
 	if err != nil {
 		return "", err

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -55,6 +55,9 @@ type InspectSourceOptions struct {
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
 	IgnoreUnknownHCLNames bool
+	// OmitAtlasRefusedBlocks is the Atlas-compatible surface's block-type
+	// policy for rendered HCL; see [InspectOptions].
+	OmitAtlasRefusedBlocks bool
 }
 
 // InspectSource classifies the --url inspection source and renders it with
@@ -82,12 +85,13 @@ func InspectSource(ctx context.Context, opts InspectSourceOptions) (string, erro
 	}
 
 	inspectOpts := InspectOptions{
-		DevURL:      opts.DevURL,
-		Schemas:     opts.Schemas,
-		Include:     opts.Include,
-		Exclude:     opts.Exclude,
-		Format:      opts.Format,
-		Diagnostics: opts.Diagnostics,
+		DevURL:                 opts.DevURL,
+		Schemas:                opts.Schemas,
+		Include:                opts.Include,
+		Exclude:                opts.Exclude,
+		Format:                 opts.Format,
+		Diagnostics:            opts.Diagnostics,
+		OmitAtlasRefusedBlocks: opts.OmitAtlasRefusedBlocks,
 	}
 	if set.Kind == atlassource.KindDatabase {
 		conn, err := connectInspectSource(ctx, set.Sources[0].Raw, opts.ConnectTimeout)


### PR DESCRIPTION
Closes the Category B half of stokaro/ptah#1251. Category A (the bare identifiers in `sequence`, `function`, `trigger` and `policy`, the `enum` block's missing schema, and the enum-typed column) is a separate front and is **not** touched here.

## What this is: a COMPATIBILITY ADAPTER

Under stokaro/ptah#1213 this is a compatibility adapter, not a general capability. Nothing here improves Ptah's model of a database — it strictly *reduces* what one binary describes, and the reduction's only justification is a property of the tool `ptah-compat` stands in for. A general capability would apply on both binaries and would survive that tool changing; this must not, and is measured so it does not. The whole point of the oracle run below is that the day the pinned binary starts modeling one of these blocks, the adapter stops filtering it.

## The measurement

PostgreSQL 17, live database carrying an extension, an enum, a sequence, a table, a view, a materialized view, a function, a trigger, RLS with a policy, a role and two grants. Base = the pinned binary's **own** inspect output for that database, asserted at exit 0 first; then one bare block added at a time.

| block added | exit | answer |
| --- | --- | --- |
| *(base alone)* | **0** | — |
| `extension "pgcrypto" {}` | 1 | `postgres: extensions are not supported by this version` |
| `sequence "order_seq" {}` | 1 | `postgres: sequences are not supported by this version` |
| `policy "accounts_all" {}` | 1 | `postgres: policies are not supported by this version` |
| `role`, `function`, `view`, `materialized`, `trigger`, `permission`, `range` | 0 | dropped, file read |
| `wibble "x" {}` | 0 | dropped, file read |

Two things make these rows mean what they say.

**The blocks are stripped to their label.** Carrying the attributes Ptah writes today, `sequence` comes back with `There is no variable named "bigint"` — Ptah's own rendering, same class as the `to = PUBLIC` defect fixed in #1248, and not this front's to suppress. Bare, what is left is a refusal of the block *type*, which no spelling can lift.

**`wibble` is why exit 0 on the others is not evidence of support.** That binary drops a top-level block whose name it does not model and carries on. Exit 0 says only "harmless to the file" — which is the entire test a compatibility surface needs. Omitting `role` or `view` would lose description and buy nothing.

Also recorded, not acted on:

- `domain`/`composite` carrying `type = int` are refused with `schemahcl: failed reading spec as *postgres.doc: set field "type"`. Bare, both are accepted. That is an attribute spelling inside an ignored block — Category A's class, not a feature gap.
- Ptah's unlabeled `data {` collides with a real Atlas `data` block (`must have exactly 2 labels`). Out of scope: an inspected database read never produces `ManagedData`, so `data` cannot appear in inspect output.
- **The binary's own inspect** of that same rich database emits exactly three block types: `enum`, `schema`, `table`. It silently omits the extension, the sequence, the view, the materialized view, the function, the trigger, the policy, the role and both grants. We do not copy that; we omit only what it cannot *read*.

## Scope, as narrow as the measurement

- **Compatibility surface only.** `cmd/atlas` sets `OmitAtlasRefusedBlocks: true`. Native `ptah schema inspect` sets nothing. Verified against the live database: native output is byte-identical to before this change.
- **HCL only.** `--format sql` keeps all three. SQL output is read by a database, not by that binary; filtering it would lose data for no reader.
- **PostgreSQL only.** On SQLite the same three blocks are accepted and dropped exactly like `wibble`, all at exit 0 — the refusal is the PostgreSQL driver's, so the list is keyed by dialect and SQLite has no entries. MySQL/MariaDB were **not** measured and suppress nothing.

## Suppression is visible

Every omitted object is reported through the renderer's existing loss-diagnostic channel — the one already used for constructs Ptah cannot represent — which `schema inspect` writes to stderr:

```
warning: extensions.pgcrypto: omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses a postgres schema file that declares any extension block, and one of them makes the whole document unreadable to it
warning: sequences.order_seq: ...
warning: rls_policies.accounts_all: ...
```

## The list is re-measured, not frozen

Two oracle runs in `internal/atlashclrender`, following `TestOracleModeledColumnTypesMatchTheBinary`, both enumerated by name in `.github/workflows/atlas-oracle.yml` (count raised 2 → 4, plus per-subtest `grep -Fq` lines so a selection that matched nothing cannot pass):

- **`TestOracleAtlasRefusedBlockTypesMatchTheBinary`** — each entry must still be refused **and** still refused with `are not supported by this version`. A build that starts modeling one turns the job red rather than withholding it forever; a row that starts failing over one of *our* spellings stops counting as a feature gap. A `base` subtest asserts the base exits 0 before any row is believed — the earlier attempt at this measurement built an invalid base and every row inherited its error.
- **`TestOracleToleratesTheBlockTypesPtahStillRenders`** — the opposite direction. `role`, `function`, `view`, `materialized`, `trigger`, `permission` and `wibble` on PostgreSQL, and `extension`/`sequence`/`policy` on SQLite, must all stay readable; each also asserts it is *absent* from the suppression list, so the list keeps a boundary.

Probes run serially: each dialect's probes share one dev database and the binary materializes the file there.

Mutation-checked, all four directions:

| mutant | result |
| --- | --- |
| suppression reverted (`omitsBlock` → false) | 5 red, incl. `...OmitsTheBlocksTheBinaryRefuses`, `...ReportsEveryOmission` |
| guard dropped (suppression leaks to native) | red: `...KeepsEveryBlockTypeOnTheNativeSurface`, `...NativeReportsNoOmission` |
| `role` added to the refused list | red: oracle `refused/role` **and** control `tolerated/role` |
| `sequence` moved out of the refused list | red: oracle `tolerated/sequence` |

## What this does NOT do

**It does not make compat inspect readable on its own, and it is not claimed to.** With the three blocks gone, the pinned binary refuses the real `ptah-compat` output at the next bare identifier:

```
Error: compat.hcl:43,10-17: Unknown variable; There is no variable named "PLpgSQL".
```

The first refusal moved from `bigint` (the sequence) to `PLpgSQL` (the function), which is itself the evidence the Category B blocks are gone. Hand-fixing the remaining Category A spellings on that same file — the four bare words, the `enum` block's `schema`, and `type = sql("status")` → `type = enum.status` — brings it to **exit 0**. So the two fronts are jointly sufficient and neither is sufficient alone. The issue's definition of done ("no hand editing") needs Category A to land too.

## Not verified

- MySQL, MariaDB, ClickHouse: not measured. They suppress nothing, which is the status quo.
- PostgreSQL-family dialects other than `postgres` (`cockroachdb`, `yugabytedb`, `spanner`): not measured, not suppressed.
- Whether that binary can use an `enum`-declared type for a column was not separately established here either; it writes `type = enum.status` itself and read the hand-fixed file at exit 0, which is consistent but is not an isolated fixture.