### PR TITLE
Write down that compatibility never removes a capability

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,32 @@ When the two halves pull apart, say so in the commit and in the issue rather
 than picking silently. "We are stricter here, deliberately, and here is the
 measurement" is a complete answer; quietly matching is not.
 
+**Compatibility never removes a capability. Constitute it, do not discard it.**
+Where Ptah models something the community binary does not -- an extension, a
+sequence, a policy, anything the Pro surface covers or that Ptah does better --
+reaching CE compatibility must never mean deleting that capability from the
+compatibility surface. `ptah-compat` is the migration path for Atlas
+**Pro** users' scripts too, not only CE users'; a capability reachable only
+through native `ptah` does not help someone porting a Pro pipeline.
+
+The shape that satisfies both:
+
+- the compatibility surface **defaults** to what the community binary accepts,
+  so drop-in output stays drop-in;
+- the fuller behavior stays reachable on that same surface behind a `PTAH_*`
+  environment variable -- never a new flag, because the conformance
+  `cli-surface` tier asserts flag parity with the pinned binary and an
+  environment variable is invisible to the help surface. Precedent:
+  `PTAH_ALLOW_EXTERNAL_SCHEMA`;
+- what the default leaves out is reported, not dropped in silence, so an
+  operator is never told less than the truth about their database;
+- the capability is written down -- feature matrix row, user documentation, and
+  a test -- so it is a product decision rather than an accident of which branch
+  of an `if` ran.
+
+"CE refuses it, so we stopped emitting it" is an incomplete answer. The complete
+one names where the capability still lives.
+
 ### Compatibility with older Ptah is a different axis, and it is not owed
 
 Everything above is about the community binary. Compatibility with **Ptah's own

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -114,6 +114,34 @@ Registry protocol is proprietary and account-bound; the native
 [OCI registry](../../operate/oci-registry/) instead) and the `schema plan`
 registry sub-verbs. The per-command pages name each waiver where it appears.
 
+## Compatibility never costs you a capability
+
+Ptah models things the Atlas community CLI does not. PostgreSQL extensions,
+sequences and row-level security policies are the clearest examples: that CLI
+answers `postgres: extensions are not supported by this version` and refuses a
+schema file that declares any of them, while Ptah reads, diffs and applies all
+three.
+
+Being a drop-in for that CLI never means giving those up.
+
+The compatibility surface **defaults** to what the community CLI accepts, so
+output you hand back to it stays readable. What that default leaves out is
+reported rather than dropped in silence — you are told what was omitted and
+why, so a compatibility-shaped inspect never describes less of your database
+than it found without saying so.
+
+The fuller behavior stays available on the same `ptah-compat` surface through a
+`PTAH_*` environment variable. It is an environment variable rather than a flag
+on purpose: the compatibility binary's flags are held to parity with the pinned
+community CLI, so a flag Atlas does not have would break the very drop-in
+promise it was added to serve. Native `ptah` verbs always emit everything Ptah
+models, with no switch to set.
+
+This matters most if you are coming from Atlas **Pro** rather than CE. The
+compatibility surface is the migration path for Pro scripts and configuration
+too, not only CE ones — a capability you could only reach by rewriting your
+pipeline against native `ptah` verbs would not be a migration path at all.
+
 ## Parity expectations
 
 Ptah is not documented as a full Atlas OSS replacement until the external


### PR DESCRIPTION
Refs #951, #1213, #1251.

## Why now

#1256 is open and would have `ptah-compat schema inspect` stop emitting `extension`, `sequence` and `policy` blocks entirely, because the pinned Atlas community CLI refuses a schema file that declares any of them. The output becomes readable — and the capability becomes unreachable through the compatibility surface.

That is the wrong trade, and the rule that says so existed only as project knowledge and a bullet inside an umbrella issue. It belongs where the decision gets made.

## The rule

Compatibility never removes a capability. Where Ptah models something the community CLI does not, reaching CE compatibility must never mean deleting it from the compatibility surface.

`ptah-compat` is the migration path for Atlas **Pro** users' scripts as much as CE users'. A capability you can only reach by rewriting your pipeline against native `ptah` verbs is not a migration path — it is a rewrite, which is the thing a drop-in exists to avoid.

The shape that satisfies both goals:

- the compatibility surface **defaults** to what the community CLI accepts, so drop-in output stays drop-in;
- the fuller behavior stays reachable on that same surface behind a `PTAH_*` environment variable — never a new flag, because the conformance `cli-surface` tier asserts flag parity with the pinned binary, so a flag Atlas does not have would break the very promise it was added to serve. Precedent: `PTAH_ALLOW_EXTERNAL_SCHEMA`;
- what the default omits is **reported**, not dropped in silence, so an operator is never told less than the truth about their database;
- the capability is written down — matrix row, user documentation, test — so it is a product decision rather than an accident of which branch of an `if` ran.

## Where it is written

**`AGENTS.md`**, in the Compatibility Policy, beside the two halves it completes ("never be looser" and "matching is the floor, not the ceiling"). Those two say what to do when Ptah and the community binary disagree about a behavior; neither covered what to do when Ptah has a capability the binary lacks entirely.

**`docs/site/.../atlas/overview.md`**, next to Compatibility boundaries, phrased for users rather than agents, because it is a promise rather than an internal convention: being a drop-in never costs you a capability, the default is readable-by-Atlas, what is omitted is reported, and the fuller behavior is one environment variable away.

## Gates

Every `check:*` script in `docs/site/package.json` plus `build-feature-matrix.mjs --check`:

```
check:style            0        check:limitations      0
check:links            0        check:exit-codes       0
check:core-doc-links   0        check:redirects        0
check:page-health      0        build-feature-matrix   0  (166 rows)
check:responsive       1        <- see below
```

`check:responsive` needs a built `dist` and reports `dist not found; run "npm run build" first`. It fails identically on unmodified `master` in a separate worktree, so it is an environment prerequisite rather than anything this change caused.

The style gate earned its keep here: it rejected the first draft for the word "simply" in `AGENTS.md`, which is exactly the filler the style guide bans.

## Note

No code changes. #1256 should be reshaped against this rule before it merges; a review saying so is on that PR.
