### PR TITLE
Compare a foreign key's backing index when the desired state names it

### DIFF
--- a/migration/schemadiff/internal/compare/fk_backing_index_test.go
+++ b/migration/schemadiff/internal/compare/fk_backing_index_test.go
@@ -1,0 +1,208 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// postsForeignKey is the constraint both #1258 fixtures carry. MySQL reports it
+// through information_schema.TABLE_CONSTRAINTS regardless of what the backing
+// index ended up being called.
+func postsForeignKey() []types.DBConstraint {
+	return []types.DBConstraint{
+		{
+			Name:        "fk_posts_user",
+			TableName:   "posts",
+			Type:        "FOREIGN KEY",
+			ColumnName:  "user_id",
+			ColumnNames: []string{"user_id"},
+		},
+	}
+}
+
+// TestIndexes_ForeignKeyBackingIndexIdempotency pins issue #1258 and its
+// control together.
+//
+// Both rows are transcribed from live MySQL 9.7.1. The desired side of each is
+// what the pinned community binary's own `schema inspect` emits for that
+// database -- it writes the backing index back out as an `index` block in both
+// layouts -- and the pinned binary reports "Schema is synced, no changes to be
+// made" for both when that output is applied to the database it came from.
+//
+// The "auto-named" row is the defect: a bare `CONSTRAINT ... FOREIGN KEY` with
+// no `KEY` clause makes MySQL name the backing index after the constraint, and
+// the database-side filter used to hide it unconditionally, so the declared
+// index had nothing to match and was planned as `CREATE INDEX fk_posts_user`.
+// MySQL answers that statement with Error 1061, Duplicate key name.
+//
+// The "distinctly-named" row is the control. It passed before the fix and must
+// keep passing: if it ever goes red the suppression has been widened into
+// ignoring index drift rather than narrowed.
+func TestIndexes_ForeignKeyBackingIndexIdempotency(t *testing.T) {
+	tests := []struct {
+		name      string
+		indexName string
+	}{
+		{
+			// CONSTRAINT fk_posts_user FOREIGN KEY (user_id) REFERENCES users(id)
+			// -> information_schema.STATISTICS reports index "fk_posts_user".
+			name:      "backing index auto-named after the constraint",
+			indexName: "fk_posts_user",
+		},
+		{
+			// KEY idx_posts_user (user_id), CONSTRAINT fk_posts_user ...
+			// -> MySQL adopts the existing index as the backing index.
+			name:      "backing index carries its own name",
+			indexName: "idx_posts_user",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: test.indexName, TableName: "posts", Fields: []string{"user_id"}},
+				},
+			}
+			database := &types.DBSchema{
+				Constraints: postsForeignKey(),
+				Indexes: []types.DBIndex{
+					{Name: test.indexName, TableName: "posts", Columns: []string{"user_id"}},
+					{Name: "PRIMARY", TableName: "posts", Columns: []string{"id"}, IsPrimary: true, IsUnique: true},
+				},
+			}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, "mysql")
+
+			c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestIndexes_ForeignKeyBackingIndexDrift is the guard against buying that
+// idempotency by ignoring index drift. Every row keeps the foreign key and its
+// auto-named backing index in the database and varies only what the desired
+// state declares, so each expectation isolates one consequence of narrowing the
+// filter.
+func TestIndexes_ForeignKeyBackingIndexDrift(t *testing.T) {
+	backingIndex := types.DBIndex{
+		Name: "fk_posts_user", TableName: "posts", Columns: []string{"user_id"},
+	}
+	unrelatedIndex := types.DBIndex{
+		Name: "idx_posts_created", TableName: "posts", Columns: []string{"created_at"},
+	}
+	declaredBackingIndex := goschema.Index{
+		Name: "fk_posts_user", TableName: "posts", Fields: []string{"user_id"},
+	}
+	declaredUnrelatedIndex := goschema.Index{
+		Name: "idx_posts_created", TableName: "posts", Fields: []string{"created_at"},
+	}
+
+	tests := []struct {
+		name          string
+		generated     []goschema.Index
+		database      []types.DBIndex
+		wantAdditions []difftypes.IndexRef
+		wantRemovals  []difftypes.IndexRef
+	}{
+		{
+			// A genuinely missing index is still reported even though the table
+			// also carries a foreign key whose backing index shares its name.
+			name:      "index the database lacks is still added",
+			generated: []goschema.Index{declaredBackingIndex, declaredUnrelatedIndex},
+			database:  []types.DBIndex{backingIndex},
+			wantAdditions: []difftypes.IndexRef{
+				{Name: "idx_posts_created", TableName: "posts"},
+			},
+		},
+		{
+			// The reason the filter exists. A desired state that never mentions
+			// the backing index must not plan a DROP INDEX: MySQL refuses to drop
+			// the index a live foreign key needs (Error 1553).
+			name:      "undeclared backing index is not dropped",
+			generated: nil,
+			database:  []types.DBIndex{backingIndex},
+		},
+		{
+			// Narrowing the filter must not make an unrelated index immortal.
+			name:      "unrelated index the desired state dropped is still removed",
+			generated: []goschema.Index{declaredBackingIndex},
+			database:  []types.DBIndex{backingIndex, unrelatedIndex},
+			wantRemovals: []difftypes.IndexRef{
+				{Name: "idx_posts_created", TableName: "posts"},
+			},
+		},
+		{
+			// Both halves at once: the backing index the desired state stopped
+			// declaring stays hidden, while the index it still declares is
+			// compared normally.
+			name:      "dropping only the backing index declaration changes nothing",
+			generated: []goschema.Index{declaredUnrelatedIndex},
+			database:  []types.DBIndex{backingIndex, unrelatedIndex},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{Indexes: test.generated}
+			database := &types.DBSchema{
+				Constraints: postsForeignKey(),
+				Indexes:     test.database,
+			}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, "mysql")
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, test.wantAdditions)
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, test.wantRemovals)
+		})
+	}
+}
+
+// TestIndexes_ForeignKeyBackingIndexDialects pins which dialects the narrowed
+// filter reaches. Only MySQL and MariaDB create a backing index per foreign
+// key, so only they populate the filter at all; PostgreSQL never did, and an
+// index that happens to share a constraint's name there is an ordinary index.
+func TestIndexes_ForeignKeyBackingIndexDialects(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				Indexes: []goschema.Index{
+					{Name: "fk_posts_user", TableName: "posts", Fields: []string{"user_id"}},
+				},
+			}
+			database := &types.DBSchema{
+				Constraints: postsForeignKey(),
+				Indexes: []types.DBIndex{
+					{Name: "fk_posts_user", TableName: "posts", Columns: []string{"user_id"}},
+				},
+			}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, test.dialect)
+
+			c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -212,7 +212,7 @@ func IndexesWithSemantics(
 		database,
 		dialect,
 		semantics,
-		fkBackedIndexes,
+		hiddenForeignKeyBackingIndexes(fkBackedIndexes, genIndexes),
 		uniqueConstraintIndexes,
 	)
 	appendIndexDifferences(
@@ -290,6 +290,48 @@ func constraintBackedIndexIdentities(
 		}
 	}
 	return foreignKeys, uniqueConstraints
+}
+
+// hiddenForeignKeyBackingIndexes narrows the foreign-key backing index filter
+// to the identities the desired state never mentions.
+//
+// MySQL and MariaDB create a backing index for every FOREIGN KEY. With a bare
+// `CONSTRAINT ... FOREIGN KEY` and no `KEY` clause -- the ordinary way a MySQL
+// schema is written -- the backing index carries the constraint's own name, so
+// `information_schema.STATISTICS` reports an index named `fk_posts_user`
+// alongside the constraint named `fk_posts_user`. Hiding that identity from
+// the database side keeps a desired state that says nothing about the backing
+// index from planning a DROP INDEX that would take the constraint with it.
+//
+// Hiding it unconditionally was one-sided: the desired side is never filtered,
+// so an index the author did declare had no counterpart to match and was
+// planned as an addition. That is not a hypothetical desired state -- the
+// pinned community binary's own `schema inspect` output writes the backing
+// index back out as an `index` block, so applying a database's own inspect
+// output to the database it came from planned
+// `CREATE INDEX "fk_posts_user"` where the pinned binary reported
+// "Schema is synced". That statement is not executable: run against the same
+// fixture, MySQL 9.7.1 answers it with
+// `Error 1061 (42000): Duplicate key name 'fk_posts_user'` (issue #1258).
+//
+// Letting declared identities through restores the comparison rather than
+// suppressing it: a declared backing index is matched, replaced, or added on
+// the same terms as any other index. The filter cannot start dropping
+// anything either, because an identity only survives it when the desired
+// state names that identity, and an identity the desired state names is
+// matched instead of removed.
+func hiddenForeignKeyBackingIndexes(
+	foreignKeys map[difftypes.IndexRef]struct{},
+	declared map[difftypes.IndexRef]generatedIndexEntry,
+) map[difftypes.IndexRef]struct{} {
+	hidden := make(map[difftypes.IndexRef]struct{}, len(foreignKeys))
+	for identity := range foreignKeys {
+		if _, isDeclared := declared[identity]; isDeclared {
+			continue
+		}
+		hidden[identity] = struct{}{}
+	}
+	return hidden
 }
 
 func collectDatabaseIndexes(


### PR DESCRIPTION
Closes #1258.

## Root cause, measured

Instrumented `compare.IndexesWithSemantics` and dumped both sides on the live
fixture rather than reasoning from the symptom. The desired side was never the
problem — it holds the index. The database side had been emptied:

```
DEBUG fkBackedIndexes  = map[{Name:fk_posts_user TableName:i1258_auto.posts}:{}]
DEBUG genIndexes(map)  = map[{Name:fk_posts_user TableName:i1258_auto.posts}: ...]
DEBUG dbIndexes(map)   = map[]        <-- the only non-primary index, filtered away
```

`constraintBackedIndexIdentities` collects every MySQL/MariaDB `FOREIGN KEY`
constraint name and `collectDatabaseIndexes` drops any database index matching
one. That exists for a good reason: a desired state that says nothing about the
backing index must not plan a `DROP INDEX` and take the constraint with it.

But it was applied to one side only. The desired side is never filtered, so an
index the author *did* declare had no counterpart to match and fell through to
`appendIndexAddition`. The pinned community binary's own `schema inspect` writes
the backing index back out as an `index` block, so this is what you get from
applying a database's own inspect output to itself.

The control fixture passes today for the mundane reason that `idx_posts_user`
and `fk_posts_user` are different strings, so the filter never touches it.

## The fix

`hiddenForeignKeyBackingIndexes` narrows the filter to the identities the
desired state does not name. A declared backing index is compared like any
other index; an undeclared one stays hidden exactly as before.

The narrowing cannot start dropping anything: an identity only survives the
filter when the desired state names it, and a named identity is matched rather
than removed.

Scope note: the sibling unique-constraint suppression a few lines down has the
same one-sided shape (measured below), but half of its symptom comes from the
constraints comparator rather than from `indexes.go`, and fixing only the index
half would leave a bare destructive `DROP INDEX`. Left alone — that is #1245.

## Measurements

Desired state is each database's own unedited `schema inspect` output from the
pinned binary, applied back to the database it came from.

| fixture | server | pinned binary | before | after |
| --- | --- | --- | --- | --- |
| auto-named backing index | MySQL 9.7.1 | 0, synced | 0, plans `CREATE INDEX fk_posts_user` | 0, synced |
| auto-named backing index | MariaDB 10.11.18 | 0, synced | 0, plans `CREATE INDEX fk_posts_user` | 0, synced |
| distinctly-named (control) | MySQL 9.7.1 | 0, synced | 0, synced | 0, synced |
| distinctly-named (control) | MariaDB 10.11.18 | 0, synced | 0, synced | 0, synced |

The planned statement is not executable. Run against the same fixture, both
servers answer it with `ERROR 1061 (42000): Duplicate key name 'fk_posts_user'`
and exit 1.

### Live guards — the fix must not buy idempotency by ignoring drift

| case | pinned binary | ptah-compat (after) |
| --- | --- | --- |
| desired adds `idx_extra` the DB lacks | `ADD INDEX idx_extra` | `CREATE INDEX idx_extra` |
| desired drops the distinctly-named backing index | `DROP INDEX idx_posts_user` | `DROP INDEX idx_posts_user` |
| desired keeps the FK, deletes the backing index block | `DROP INDEX fk_posts_user` | synced, no changes |

The third row is a deliberate divergence, unchanged by this PR (verified: the
pre-change binary behaves identically). The pinned binary's plan is not
executable — `--auto-approve` exits 1 on `Error 1553 (HY000): Cannot drop index
'fk_posts_user': needed in a foreign key constraint`, leaving the target
untouched partway through. The desired state is not representable in MySQL, so
declining to plan an unexecutable statement is the better answer rather than a
defect to reproduce. Flagged here per the Compatibility Policy rather than
picked silently.

### Mutation coverage

| mutant | new tests |
| --- | --- |
| call site reverted to the unconditional `fkBackedIndexes` | red — defect rows and the MySQL/MariaDB dialect rows |
| predicate inverted (hide only *declared* identities) | red — including `undeclared backing index is not dropped`, so that guard is not vacuous |
| restored | green |

The control rows (`backing index carries its own name`, `postgres`) stayed
green under both mutants, so they are genuine non-interference controls rather
than rows that follow the fix.

## Not fixed here, found while measuring

Two things worth their own issues; neither is introduced by this PR.

1. **`schema apply --auto-approve` reported success for DDL the server
   rejected.** With the fix off, the duplicate `CREATE INDEX` was handed to the
   MySQL transaction writer, exit was 0, output was "Schema apply completed
   successfully", and the catalog was unchanged — while the byte-identical
   statement through the `mysql` client returns 1061 and exit 1. Not a blanket
   swallow: an unrelated failing statement (`Error 1062`) does surface and exit
   1, and an accepted `CREATE INDEX` through the same path does apply for real.
   Mechanism **not determined**. This is worse than the symptom #1258
   described (exit 1), because a false success is more dangerous than a loud
   failure.

2. **The unique-constraint sibling (#1245) reproduces on the same surface.**
   `CONSTRAINT uk_accounts_email UNIQUE (email)`, desired state = the pinned
   binary's own inspect output: the pinned binary reports synced, ptah-compat
   plans both `CREATE UNIQUE INDEX uk_accounts_email` **and**
   `ALTER TABLE accounts DROP INDEX uk_accounts_email`. Confirmed by
   instrumentation that the `DROP` comes from the constraints comparator, not
   from `indexes.go`.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 (253 packages ok/no-test-files, no FAIL) |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 (175 conditional groups, 45 white-box files) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |

`golangci-lint` first exited 1 with 75 issues whose every path was in an
unrelated checkout parked under the shared scratchpad, reached through the
shared result cache. Re-run with an isolated `GOLANGCI_LINT_CACHE` it reports
0 issues. Verified the isolated run is not reporting without running: a
deliberately unused function in the changed file turned it red, then was
removed and the file confirmed byte-identical to the committed version.

Both public-API gates are cited as run, not as coverage — every changed file is
under `migration/schemadiff/internal/`, so neither can go red for this change.
Docs were not touched, so the `docs/site` checks do not apply.
