### PR TITLE
Render a user-defined type's base through sql() (#1260)

### DIFF
--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -102,7 +102,7 @@ func (r *renderer) renderDomain(domain goschema.Domain) {
 	if domain.Schema != "" {
 		r.rawAttr(1, "schema", schemaRef(domain.Schema))
 	}
-	r.rawAttr(1, "type", typeExpr(domain.BaseType))
+	r.rawAttr(1, "type", userTypeExpr(domain.BaseType))
 	if domain.NotNull {
 		r.rawAttr(1, "null", "false")
 	}
@@ -128,7 +128,7 @@ func (r *renderer) renderComposite(composite goschema.CompositeType) {
 	r.stringAttr(1, "comment", composite.Comment)
 	for _, field := range composite.Fields {
 		r.linef(`  field %s {`, quote(field.Name))
-		r.rawAttr(2, "type", typeExpr(field.Type))
+		r.rawAttr(2, "type", userTypeExpr(field.Type))
 		r.line("  }")
 	}
 	r.line("}")
@@ -141,7 +141,7 @@ func (r *renderer) renderRange(rangeType goschema.Range) {
 	if rangeType.Schema != "" {
 		r.rawAttr(1, "schema", schemaRef(rangeType.Schema))
 	}
-	r.rawAttr(1, "subtype", typeExpr(rangeType.Subtype))
+	r.rawAttr(1, "subtype", userTypeExpr(rangeType.Subtype))
 	r.stringAttr(1, "subtype_opclass", rangeType.SubtypeOpClass)
 	r.stringAttr(1, "collation", rangeType.Collation)
 	r.stringAttr(1, "canonical", rangeType.Canonical)

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -978,6 +978,41 @@ func typeExpr(value string) string {
 	return value
 }
 
+// userTypeExpr renders the type a user-defined type is built on: a domain's
+// base type, a composite field's type, a range's subtype.
+//
+// These are not column type positions and do not follow the column rules. The
+// pinned Atlas community binary v1.3.0 reads only a sql() call in the first two,
+// measured with everything else held fixed:
+//
+//	domain    type = text          refused, There is no variable named "text"
+//	domain    type = "text"        refused, schemahcl: failed reading spec
+//	domain    type = sql("text")   accepted
+//	composite type = text          refused
+//	composite type = "text"        refused
+//	composite type = sql("text")   accepted
+//
+// A range is the odd one, and it is why this was measured rather than inferred
+// from the other two:
+//
+//	range     subtype = int4          refused
+//	range     subtype = "int4"        ACCEPTED
+//	range     subtype = sql("int4")   accepted
+//
+// It takes the quoted string the other two refuse. sql() is used for all three
+// because it is the one spelling every position accepts, and one rule beats
+// three. Ptah's own parser reads it back to the bare name in each -- text, text,
+// int4 -- so the round trip is unaffected (stokaro/ptah#1260).
+//
+// An empty value keeps typeExpr's behavior rather than becoming sql(""), which
+// would round trip as a type named nothing.
+func userTypeExpr(value string) string {
+	if strings.TrimSpace(value) == "" {
+		return typeExpr(value)
+	}
+	return sqlCall(value)
+}
+
 func sqlCall(value string) string {
 	return "sql(" + quote(value) + ")"
 }

--- a/internal/atlashclrender/user_type_expr_test.go
+++ b/internal/atlashclrender/user_type_expr_test.go
@@ -1,0 +1,122 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderWritesUserTypeBasesAsSQLCalls pins how the type a user-defined type
+// is built on reaches HCL (stokaro/ptah#1260 item 2).
+//
+// A domain's base type, a composite field's type and a range's subtype are not
+// column type positions and do not follow the column rules. Measured against the
+// pinned Atlas community binary v1.3.0, one attribute varied at a time in a
+// document it otherwise accepts:
+//
+//	domain    type = text          refused, There is no variable named "text"
+//	domain    type = "text"        refused, schemahcl: failed reading spec
+//	domain    type = sql("text")   accepted
+//	composite type = text          refused
+//	composite type = "text"        refused
+//	composite type = sql("text")   accepted
+//	range     subtype = int4       refused
+//	range     subtype = "int4"     ACCEPTED
+//	range     subtype = sql("int4") accepted
+//
+// The range row is why this was measured rather than inferred from the other
+// two: it takes the quoted string they refuse. All three take sql(), so one rule
+// covers them, which is what the last three rows below pin.
+func TestRenderWritesUserTypeBasesAsSQLCalls(t *testing.T) {
+	tests := []struct {
+		name string
+		db   *goschema.Database
+		want string
+	}{
+		{
+			name: "a domain's base type",
+			db:   &goschema.Database{Domains: []goschema.Domain{{Name: "d", BaseType: "text"}}},
+			want: `  type = sql("text")` + "\n",
+		},
+		{
+			name: "a composite field's type",
+			db: &goschema.Database{CompositeTypes: []goschema.CompositeType{{
+				Name:   "c",
+				Fields: []goschema.CompositeTypeField{{Name: "f", Type: "text"}},
+			}}},
+			want: `    type = sql("text")` + "\n",
+		},
+		{
+			name: "a range's subtype",
+			db:   &goschema.Database{Ranges: []goschema.Range{{Name: "r", Subtype: "int4"}}},
+			want: `  subtype = sql("int4")` + "\n",
+		},
+		{
+			// A type carrying a size or a space would be a syntax error bare and
+			// a refused string quoted; the call takes it verbatim.
+			name: "a sized type survives verbatim",
+			db:   &goschema.Database{Domains: []goschema.Domain{{Name: "d", BaseType: "character varying(100)"}}},
+			want: `  type = sql("character varying(100)")` + "\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.Render(test.db)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+		})
+	}
+}
+
+// TestRenderedUserTypeBasesRoundTrip pins that the call costs Ptah nothing on
+// its own side: the parser reads each position back to the bare type name.
+//
+// Without this the change would be measured only against the other binary, and
+// a rendering Ptah itself could no longer read would still look like progress.
+func TestRenderedUserTypeBasesRoundTrip(t *testing.T) {
+	c := qt.New(t)
+
+	db := &goschema.Database{
+		Schemas:        []goschema.Schema{{Name: "public"}},
+		Domains:        []goschema.Domain{{Name: "d", Schema: "public", BaseType: "text"}},
+		CompositeTypes: []goschema.CompositeType{{Name: "c", Schema: "public", Fields: []goschema.CompositeTypeField{{Name: "f", Type: "text"}}}},
+		Ranges:         []goschema.Range{{Name: "r", Schema: "public", Subtype: "int4"}},
+	}
+
+	result, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+
+	parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Domains, qt.HasLen, 1)
+	c.Assert(parsed.Domains[0].BaseType, qt.Equals, "text")
+	c.Assert(parsed.CompositeTypes, qt.HasLen, 1)
+	c.Assert(parsed.CompositeTypes[0].Fields, qt.HasLen, 1)
+	c.Assert(parsed.CompositeTypes[0].Fields[0].Type, qt.Equals, "text")
+	c.Assert(parsed.Ranges, qt.HasLen, 1)
+	c.Assert(parsed.Ranges[0].Subtype, qt.Equals, "int4")
+}
+
+// TestRenderKeepsAnEmptyUserTypeBaseUnwrapped pins the one value that must not
+// become a call: sql("") would round trip as a type named nothing, where the
+// existing fallback renders something readable.
+func TestRenderKeepsAnEmptyUserTypeBaseUnwrapped(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.Render(&goschema.Database{
+		Domains: []goschema.Domain{{Name: "d", BaseType: ""}},
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Not(qt.Contains), `sql("")`)
+}


### PR DESCRIPTION
Closes item 2 of #1260. Item 1 (the schema-qualified table reference) is untouched — its design is settled on the issue but needs `objectRef` to become a renderer method, which is a bigger change.

## The defect

A domain's base type, a composite field's type and a range's subtype went through `typeExpr`, the **column** type renderer. They are not column type positions and do not follow those rules. Bare, each is an HCL variable reference with nothing behind it, and the pinned Atlas community binary v1.3.0 refuses the whole file over one of them.

## Measured, one attribute at a time

Everything else held fixed, in a document that binary otherwise accepts:

| position | spelling | verdict |
| --- | --- | --- |
| `domain` | `type = text` | refused — `There is no variable named "text"` |
| `domain` | `type = "text"` | refused — `schemahcl: failed reading spec` |
| `domain` | `type = sql("text")` | **accepted** |
| `composite` | `type = text` | refused |
| `composite` | `type = "text"` | refused |
| `composite` | `type = sql("text")` | **accepted** |
| `range` | `subtype = int4` | refused |
| `range` | `subtype = "int4"` | **accepted** |
| `range` | `subtype = sql("int4")` | **accepted** |

## The range row is the point

#1260 recorded a guess: composite fields and range subtypes *probably* behave like a domain, since all three go through `typeExpr`. **A range takes the quoted string a domain and a composite refuse.**

The guess was wrong in the direction that would have shipped. Quoting looks like the natural fix after seeing the sequence work in #1255, and it would have passed on whichever fixture got built first while leaving domains and composites broken. That is exactly why the issue recorded it as unmeasured rather than as a conclusion.

All three accept `sql()`, so one rule covers them and one rule beats three.

## The round trip is pinned, not assumed

Ptah's own parser reads each position back to the bare name — `text`, `text`, `int4`. `TestRenderedUserTypeBasesRoundTrip` asserts it. A rendering that pleased the other binary while Ptah could no longer read it would still look like progress in a diff.

An empty value keeps `typeExpr`'s fallback rather than becoming `sql("")`, which would round trip as a type named nothing. That has its own test.

## Mutation-checked

Reverting the helper to `typeExpr` turns **5 subtests** red. Reverted, observed, restored, tree verified clean.

## Gates

`go build` · `go vet` · `go test ./... -count=1` · `qtlint` · `check-test-style` · `check-public-api` · `check-public-api-snapshot` — all exit 0.

Two honest notes:

- **`golangci-lint` exits 1 here, and none of it is this change.** All 85 findings are under `../`, i.e. other agents' worktrees parked beside this one. Controlled: the same command on the unmodified base commit in the same worktree reports the identical 85, all foreign. Scoped runs of the changed package are clean.
- `TestSVGReportsGraphvizStderrOnFailure` failed once at exactly 10.01s during a full run under heavy parallel load and passes in 0.4s alone. Load-sensitive external `dot` process, not a regression.
