### PR TITLE
compat inspect: omit only what nothing names, and keep the capability (#1251, Category B reshaped)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -133,18 +133,24 @@ jobs:
       # The set of column types the HCL schema models is the third contract in
       # this repository whose authority is the community binary rather than any
       # document (stokaro/ptah#1138). A wrong row emits HCL that binary refuses
-      # to read, so the set is re-measured here instead of being trusted.
-      # Listed before it is run, for the same reason as above.
-      - name: Verify column-type conformance selection
+      # to read, so the set is re-measured here instead of being trusted. The
+      # set of top-level BLOCK types it refuses is the same kind of contract
+      # (stokaro/ptah#1251): ptah-compat omits those blocks by default, and a
+      # list nothing re-measures would go on withholding a construct that binary
+      # started modeling. Both live in internal/atlashclrender and are listed
+      # before they are run, for the same reason as above.
+      - name: Verify HCL render conformance selection
         run: |
           GOWORK=off go test -list '^TestOracle' \
             ./internal/atlashclrender > "$RUNNER_TEMP/atlas-column-type-tests"
           cat "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleModeledColumnTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleAcceptsTheWrapItFallsBackTo' "$RUNNER_TEMP/atlas-column-type-tests"
-          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 2
+          grep -Fx 'TestOracleAtlasRefusedBlockTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
+          grep -Fx 'TestOracleToleratesTheBlockTypesPtahStillRenders' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 4
 
-      - name: Run column-type conformance tests
+      - name: Run HCL render conformance tests
         run: |
           GOWORK=off go test -count=1 -v -run '^TestOracle' ./internal/atlashclrender \
             > "$RUNNER_TEMP/atlas-column-type-run" 2>&1 || {
@@ -156,6 +162,15 @@ jobs:
           # database URL -- which would leave every PostgreSQL row unmeasured
           # while the job stayed green. Both are fatal here.
           ! grep -q 'SKIPPED' "$RUNNER_TEMP/atlas-column-type-run"
+          # A selection that matched no subtest is the other way to stay green
+          # while measuring nothing: the refused list is the whole subject here,
+          # so its rows are named rather than counted in bulk.
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/base' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/extension' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/policy' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/sequence' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/postgres/tolerated/wibble' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/sqlite/tolerated/sequence' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -9,6 +9,7 @@ import (
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/dbcli"
 	"go.5x5.cz/ptah/config/projectconfig"
+	"go.5x5.cz/ptah/internal/atlashclrender"
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
 )
@@ -37,6 +38,17 @@ reference into the evaluated atlas.hcl environment. Non-database sources
 require --dev-url: the dev database is reset, the source is materialized on
 it, and the result is introspected, mirroring Atlas dev-database
 normalization.
+
+On PostgreSQL, HCL output omits an ` + "`extension`" + `, ` + "`sequence`" + ` or
+` + "`policy`" + ` block that nothing else in the document names: Atlas CE
+refuses a whole schema file that declares any one of them, so emitting one
+would make the output unreadable to the tool this binary stands in for. A block
+something DOES name — a sequence behind a column default, for instance — is
+kept, because a document that references an object it did not declare is
+readable by nobody. Every decision is reported on standard error. Set
+` + "`PTAH_ATLAS_INSPECT_ALL_BLOCKS=1`" + ` to emit every block Ptah models on
+this surface. SQL output keeps them all, and native
+` + "`ptah schema inspect`" + ` omits nothing.
 
 The default output is HCL. SQL output is supported with --format sql or
 --format '{{ sql . }}', JSON with --format json, and custom Go templates
@@ -155,8 +167,9 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 		ConnectTimeout: dbcli.DefaultConnectTimeout,
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
-		IgnoreUnknownHCLNames: true,
-		Vars:                  schemaVars,
+		IgnoreUnknownHCLNames:  true,
+		OmitAtlasRefusedBlocks: atlasInspectOmitsRefusedBlocks(),
+		Vars:                   schemaVars,
 	})
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -169,6 +182,25 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	}
 	fmt.Fprint(cmd.OutOrStdout(), rendered)
 	return nil
+}
+
+// atlasInspectOmitsRefusedBlocks is this surface's default for the top-level
+// block types the pinned Atlas community binary refuses to read.
+//
+// It stands in for a binary that refuses a whole schema file for containing an
+// extension, sequence or policy block, so by default it renders what that
+// binary can read and reports what it left out on standard error
+// (stokaro/ptah#1251). The capability is not deleted with it:
+// PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 restores every block Ptah models on this same
+// surface, because compatibility never removes a capability (AGENTS.md). It is
+// an environment variable rather than a flag because the conformance
+// cli-surface tier asserts flag parity with that binary, and a flag it does not
+// register would break the promise this surface exists to keep.
+//
+// Native `ptah schema inspect` never calls this and always describes every
+// construct Ptah models.
+func atlasInspectOmitsRefusedBlocks() bool {
+	return !atlashclrender.KeepAtlasRefusedBlocks()
 }
 
 func needsAtlasSchemaInspectConfig(cmd *cobra.Command) bool {

--- a/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
+++ b/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
@@ -1,0 +1,151 @@
+package atlas
+
+// White-box testing required: the subject is atlasInspectOmitsRefusedBlocks,
+// the unexported expression that decides what the Atlas-compatible surface
+// renders. Its polarity is the whole capability gate -- inverted, either every
+// document becomes unreadable to the pinned binary or the opt-in stops
+// restoring anything -- and it is not reachable from outside the package.
+// Asserting it from a black-box test would need a live PostgreSQL database,
+// which is where the end-to-end measurement runs instead.
+
+import (
+	"bytes"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+	"go.5x5.cz/ptah/internal/atlasreport"
+)
+
+// TestAtlasInspectRefusedBlockGate pins both states of the capability gate, and
+// pins them by what comes OUT rather than by what was read.
+//
+// The default has to be the narrower document: `ptah-compat` stands in for a
+// binary that refuses a whole schema file containing an extension, sequence or
+// policy block, and unreadable output is a real defect. The opt-in has to bring
+// the blocks back on this same surface, because a capability reachable only
+// through native `ptah` is a rewrite rather than a migration path (AGENTS.md,
+// "Compatibility never removes a capability"). A test that only checked the
+// variable had been read would pass with an opt-in wired to nothing, so each
+// row asserts the blocks themselves.
+func TestAtlasInspectRefusedBlockGate(t *testing.T) {
+	tests := []struct {
+		name   string
+		value  string
+		assert func(c *qt.C, hcl, diagnostics string)
+	}{
+		{
+			name:  "unset omits the blocks the pinned binary refuses",
+			value: "",
+			assert: func(c *qt.C, hcl, diagnostics string) {
+				c.Assert(hcl, qt.Not(qt.Contains), "extension \"pgcrypto\"")
+				c.Assert(hcl, qt.Not(qt.Contains), "sequence \"lonely_seq\"")
+				c.Assert(hcl, qt.Contains, "table \"accounts\"")
+				c.Assert(diagnostics, qt.Contains, "extensions.pgcrypto")
+				c.Assert(diagnostics, qt.Contains,
+					"set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models")
+			},
+		},
+		{
+			name:  "the opt-in puts every block back",
+			value: "1",
+			assert: func(c *qt.C, hcl, diagnostics string) {
+				c.Assert(hcl, qt.Contains, "extension \"pgcrypto\"")
+				c.Assert(hcl, qt.Contains, "sequence \"lonely_seq\"")
+				c.Assert(hcl, qt.Contains, "table \"accounts\"")
+				c.Assert(diagnostics, qt.Not(qt.Contains), "omitted from Atlas-compatible")
+			},
+		},
+		{
+			name:  "a false value keeps the compatible default",
+			value: "false",
+			assert: func(c *qt.C, hcl, diagnostics string) {
+				c.Assert(hcl, qt.Not(qt.Contains), "extension \"pgcrypto\"")
+				c.Assert(diagnostics, qt.Contains, "omitted from Atlas-compatible")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, test.value)
+
+			var diagnostics bytes.Buffer
+			report := atlasreport.NewSchemaInspectReport(
+				refusedBlockGateDatabase(),
+				&types.DBSchema{},
+				types.DBInfo{Dialect: "postgres", Schema: "public"},
+				&diagnostics,
+				atlasInspectOmitsRefusedBlocks(),
+			)
+
+			hcl, err := report.MarshalHCL()
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, hcl, diagnostics.String())
+		})
+	}
+}
+
+// TestAtlasInspectKeepsAReferencedBlockInEitherState pins the one thing neither
+// state may do: emit a document that names an object it did not declare.
+//
+// Measured on PostgreSQL 17, the pinned binary's own inspect of a sequence-backed
+// column default emits `default = sql("nextval('order_seq'::regclass)")` with no
+// `sequence` block and then refuses that output itself --
+// `pq: relation "order_seq" does not exist`. Reproducing it would be copying a
+// defect, so the sequence stays whichever way the gate is set.
+func TestAtlasInspectKeepsAReferencedBlockInEitherState(t *testing.T) {
+	for _, value := range []string{"", "1"} {
+		t.Run("PTAH_ATLAS_INSPECT_ALL_BLOCKS="+value, func(t *testing.T) {
+			c := qt.New(t)
+			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, value)
+
+			var diagnostics bytes.Buffer
+			db := refusedBlockGateDatabase()
+			db.Fields = append(db.Fields, goschema.Field{
+				StructName:  "Account",
+				Name:        "seq_id",
+				Type:        "integer",
+				DefaultExpr: "nextval('lonely_seq'::regclass)",
+			})
+			report := atlasreport.NewSchemaInspectReport(
+				db,
+				&types.DBSchema{},
+				types.DBInfo{Dialect: "postgres", Schema: "public"},
+				&diagnostics,
+				atlasInspectOmitsRefusedBlocks(),
+			)
+
+			hcl, err := report.MarshalHCL()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(hcl, qt.Contains, "sequence \"lonely_seq\"")
+			c.Assert(hcl, qt.Contains, "nextval('lonely_seq'::regclass)",
+				qt.Commentf("the reference and the block it names have to travel together"))
+		})
+	}
+}
+
+// refusedBlockGateDatabase carries one object of each refused block type with
+// nothing naming it, plus a table so the document is not empty.
+func refusedBlockGateDatabase() *goschema.Database {
+	start := int64(1)
+	return &goschema.Database{
+		Extensions:       []goschema.Extension{{Name: "pgcrypto", Version: "1.3"}},
+		Sequences:        []goschema.Sequence{{Name: "lonely_seq", AsType: "bigint", Start: &start}},
+		Tables:           []goschema.Table{{StructName: "Account", Name: "accounts", Schema: "public"}},
+		Fields:           []goschema.Field{{StructName: "Account", Name: "id", Type: "bigint"}},
+		RLSEnabledTables: []goschema.RLSEnabledTable{{Table: "accounts"}},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "accounts_all",
+			Table:           "accounts",
+			PolicyFor:       "ALL",
+			UsingExpression: "true",
+		}},
+	}
+}

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -405,6 +405,15 @@
     "evidence": "conformance cli-surface.md line 47 lists Atlas CE `schema inspect` flags as --config --dev-url --env --exclude --format --schema --url --var, with no --include; pinned Atlas CE v1.3.0 `schema inspect -u sqlite://app.db --include users` exits 1 with \"Error: unknown flag: --include\". Built ptah-compat after this change: `schema inspect -u sqlite://app.db --include t1` renders t1 with its columns and drops t2; `--include 'main.t1.*'` matches no top-level object, so it renders nothing, exits 0, and reports `Warning: the --include selection matched no objects: \"main.t1.*\".` on stderr; `--include t2` refuses the projection because t2's foreign key targets unselected t1. `--include t1` matches Ptah, `--include '*.t1'` is read at child depth and renders t1 without columns plus an empty t2 shell, `--include 'main.t1.*'` exits 1 with \"too many parts in pattern\" (measured; observation study, scenario, verbs-and-flags)"
   },
   {
+    "area": "Schema inspection filters",
+    "feature": "Compat inspect block superset opt-in",
+    "ptah": "yes",
+    "atlas_oss": "no",
+    "atlas_pro": "no",
+    "note": "Compat inspect omits unreferenced extension, sequence and policy blocks; an env variable restores them.",
+    "evidence": "Measured 2026-08-07 on PostgreSQL 17 against the pinned community binary (reports \"atlas community version v1.3.0\"). Each block bare in a file that binary accepts: `extension` / `sequence` / `policy` -> exit 1 `postgres: <kind> are not supported by this version`; `role`, `function`, `view`, `materialized`, `trigger`, `permission` and an invented `wibble` -> exit 0, dropped. Re-measured by TestOracleAtlasRefusedBlockTypesMatchTheBinary and TestOracleToleratesTheBlockTypesPtahStillRenders, both enumerated in .github/workflows/atlas-oracle.yml. Suppression is reference-aware because that binary's own inspect of `CREATE SEQUENCE order_seq; CREATE TABLE orders (id integer DEFAULT nextval('order_seq'::regclass))` emits the default with no sequence block and then refuses its own output (`pq: relation \"order_seq\" does not exist`, exit 1); ptah-compat keeps the sequence, so Ptah reads that document at exit 0 while the community binary answers `postgres: sequences are not supported by this version`. With nothing referencing them, ptah-compat output is read by that binary at exit 0 and round-trips through Ptah at exit 0. `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` output is byte-identical to Ptah's pre-suppression output; the variable is inert on native `ptah schema inspect` (cmd/atlas/schema_inspect_refused_blocks_internal_test.go, internal/atlashclrender/atlas_refused_blocks_test.go). A flag was not used because the conformance cli-surface tier asserts flag parity."
+  },
+  {
     "area": "Migration directory formats",
     "feature": "Atlas R-suffixed (`1R_`, `R__`) migration execution",
     "ptah": "no",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -72,16 +72,16 @@ row for a migration decision.
 
 ## At a glance
 
-Across the 166 capabilities below:
+Across the 167 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 93 |
+| Ptah supports it fully | 94 |
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
 | Ptah and Atlas CE both support it | 25 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
-| Ptah has it and neither Atlas edition does | 20 |
+| Ptah has it and neither Atlas edition does | 21 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
 | An Atlas column is ❔ — not established by this page's evidence | 5 |
 
@@ -137,6 +137,7 @@ seven of them as open capabilities regardless.
 | `schema inspect --include` filtering | ✅ | ❌ | ✅ | Compat and native inspect select top-level resources with the apply/diff selector engine. CE rejects the flag as unknown. A selection matching nothing renders nothing, exits 0, and says so on stderr. |
 | `schema inspect --output` | ✅ | ❌ | ✅ | `-o/--output` writes the rendered schema to a file instead of stdout, published atomically so a reader never sees a partial document. |
 | Apply advisory lock, `--lock-timeout`, `--lock-name`, `--skip-lock` | ✅ | 🟡 | ✅ | Real locks on PostgreSQL, YugabyteDB, MySQL, MariaDB, SQL Server; others run unlocked with a note. `--lock-name` and `--skip-lock` are Pro surface adopted openly; CE registers only `--lock-timeout`. |
+| Compat inspect block superset opt-in | ✅ | ❌ | ❌ | Compat inspect omits unreferenced extension, sequence and policy blocks; an env variable restores them. |
 | Desired-state sources for `--to` and `--from` | 🟡 | ✅ | ✅ | Files, one DB URL, one atlas.sum dir, or env://. A plain file:// schema directory without atlas.sum is rejected; atlas:// fails early. |
 | Dev-database rehearsal before apply | ✅ | ✅ | ✅ | Dev DB reset, target schema recreated, exact plan rehearsed; dev==target and failed rehearsal abort. docker:// dev URLs have their own row. |
 | Drift detection against desired schema | ✅ | ❌ | ✅ | Native `ptah schema drift`: `--severity`, `--exit-code`, `--ignore`, text/json/github-actions. Atlas Cloud drift monitoring is out of scope. |

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -142,6 +142,45 @@ compatibility surface is the migration path for Pro scripts and configuration
 too, not only CE ones — a capability you could only reach by rewriting your
 pipeline against native `ptah` verbs would not be a migration path at all.
 
+### The variables
+
+**`PTAH_ATLAS_INSPECT_ALL_BLOCKS`** — by default, `ptah-compat schema inspect`
+leaves an `extension`, `sequence` or `policy` block out of PostgreSQL HCL
+output when nothing else in the document names it, and reports each omission on
+standard error. Set it to `1` and every block Ptah models is emitted: the output
+describes the database in full, and the community CLI refuses it.
+
+**`PTAH_ALLOW_EXTERNAL_SCHEMA`** — by default, `atlas.hcl`
+`data "external_schema"` is not evaluated, because it runs a
+repository-controlled program. Set it to `1` and the data source is evaluated,
+matching the native `--allow-external-schema` flag.
+
+### One shape has no Atlas-readable form at all
+
+Suppression can only leave out a block nothing else names. A **sequence behind a
+column default** is named, so the block stays and the document is not readable
+by the community CLI:
+
+```sql
+CREATE SEQUENCE order_seq;
+CREATE TABLE orders (id integer NOT NULL DEFAULT nextval('order_seq'::regclass));
+```
+
+This is not a gap Ptah can close. Measured on PostgreSQL 17, the community CLI's
+own inspect of that database emits
+`default = sql("nextval('order_seq'::regclass)")` with no `sequence` block, and
+then cannot read its own output back: `pq: relation "order_seq" does not exist`.
+There is no faithful description of that database the CLI can read — not Ptah's
+and not its own. Ptah keeps the sequence, so the document is at least readable
+by Ptah and true about the database, and says so on standard error. Dropping the
+column's default to make the file readable would describe a database you do not
+have, which is the one outcome worse than a refusal.
+
+So `ptah-compat schema inspect` is not a promise that every PostgreSQL database
+produces community-CLI-readable HCL. It is a promise that the output is always
+self-consistent, that nothing disappears without being reported, and that the
+full description is one environment variable away.
+
 ## Parity expectations
 
 Ptah is not documented as a full Atlas OSS replacement until the external

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -142,6 +142,85 @@ community binary applies on a schema-bound URL. A pattern too deep for any
 scope, such as `*.*.*.*`, is refused before a database is contacted, so its
 message carries no schema prefix.
 
+### Blocks the compatibility surface leaves out by default
+
+`ptah-compat schema inspect` omits three top-level HCL block types on
+PostgreSQL — `extension`, `sequence`, and `policy` — **when nothing else in the
+document names the object**. The pinned Atlas community binary refuses an entire
+schema file that declares any one of them, answering
+`postgres: extensions are not supported by this version` and the equivalent for
+the other two. Output a drop-in replacement writes has to be output the tool it
+replaces can read back, and one such block costs the whole document.
+
+Nothing is dropped quietly. Every omitted object is reported on standard error,
+one line each, alongside the other loss diagnostics inspection already writes,
+and the message names the variable that brings it back:
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL" > schema.hcl
+warning: extensions.pgcrypto: omitted from Atlas-compatible schema inspect output: ... set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models
+warning: sequences.order_seq: omitted from ...
+warning: rls_policies.accounts_all: omitted from ...
+```
+
+The omission is scoped as narrowly as the measurement is. It applies to HCL
+output on PostgreSQL only: `--format sql` still writes the extension, the
+sequence, and the policy, because SQL output is read by a database rather than
+by that binary. On SQLite the same three blocks are accepted, so nothing is
+omitted there. Every other block Ptah renders — `role`, `function`, `view`,
+`materialized`, `trigger`, `permission` — is kept, because that binary drops a
+block type it does not model and reads the file anyway.
+
+Native `ptah schema inspect` omits nothing; see
+[Inspect a database](../../direct/inspect/). Which block types that binary
+refuses is re-measured by the Atlas CE Oracle job rather than frozen, so a
+construct a later build starts modeling stops being withheld.
+
+#### A referenced block is kept, and the document says so
+
+Suppression never leaves a reference behind. If anything else in the document
+names the object — a column default calling `nextval` on a sequence, a view body
+selecting from it, a `permission` block targeting it, a column whose type an
+extension supplies — the block stays, and the reason is reported:
+
+```console
+warning: sequences.order_seq: kept in Atlas-compatible schema inspect output because another object in this document names it: ...
+```
+
+Such a document **is not readable by the community binary**, and that is not a
+defect Ptah can fix. Measured on PostgreSQL 17 for
+
+```sql
+CREATE SEQUENCE order_seq;
+CREATE TABLE orders (id integer NOT NULL DEFAULT nextval('order_seq'::regclass));
+```
+
+that binary's own inspect emits `default = sql("nextval('order_seq'::regclass)")`
+with no `sequence` block, and then refuses that output when it is fed back:
+`pq: relation "order_seq" does not exist`. There is no faithful description of a
+sequence-backed column default the community binary can read, including the one
+it writes itself. Ptah keeps the sequence so the document stays true and stays
+readable by Ptah; dropping the column's default instead would describe a
+database that does not exist.
+
+The reference test is by name, so an extension that supplies a **type** in use
+(`citext`, `hstore`) is kept, while an extension that supplies only functions
+(`pgcrypto` behind `gen_random_uuid()`) is not named by the document and is
+omitted. Set `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` when the output has to carry it.
+
+#### Get the full description back
+
+```console
+$ PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 ptah-compat schema inspect --url "$PG_URL"
+```
+
+Every block Ptah models is emitted and nothing is reported as omitted. The
+result describes the database in full and the community binary refuses it, which
+is the trade the variable exists to let you make. It is an environment variable
+rather than a flag because `ptah-compat`'s flag surface is held to parity with
+the pinned binary; see
+[Compatibility never costs you a capability](../overview/#compatibility-never-costs-you-a-capability).
+
 ### Select what is inspected with `--include`
 
 `--include` positively selects which top-level resources survive inspection,

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -115,6 +115,14 @@ table "users" {
 }
 ```
 
+Native inspection describes every construct Ptah models, including PostgreSQL
+extensions, sequences, and row-level security policies. The Atlas-compatible
+binary leaves those three block types out of its HCL by default, because the
+tool it stands in for refuses a file containing them; that filtering is a
+property of `ptah-compat` alone, never reaches this command, and
+`PTAH_ATLAS_INSPECT_ALL_BLOCKS` has no effect here. See
+[Blocks the compatibility surface leaves out by default](../../atlas/schema-commands/#blocks-the-compatibility-surface-leaves-out-by-default).
+
 `--format sql` and `--format json` select SQL and JSON output. `--schemas`,
 `--include`, and `--exclude` select what is inspected, in that order:
 `--schemas` names the database schemas, `--include` picks top-level resources

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -1,0 +1,291 @@
+package atlashclrender
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// Top-level HCL block spellings an inspected render can emit. Only the ones a
+// refusal list or a diagnostic names are constants: the token has to be spelled
+// identically by the renderer, by [atlasRefusedBlockTypes], and by the
+// conformance run that re-measures that list against the binary, and three
+// string literals drift where one constant cannot.
+const (
+	blockExtension = "extension"
+	blockPolicy    = "policy"
+	blockSequence  = "sequence"
+)
+
+// KeepAtlasRefusedBlocksEnvVar restores the full set of blocks Ptah models on
+// the Atlas-compatible surface, including the ones the pinned Atlas community
+// binary v1.3.0 refuses.
+//
+// It is an environment variable and not a flag on purpose. The conformance
+// cli-surface tier asserts that `ptah-compat` registers exactly the flags the
+// pinned binary registers, so a flag that binary does not have would break the
+// very promise this surface exists to keep. Precedent and spelling:
+// [go.5x5.cz/ptah/internal/atlassource.AllowExternalSchemaEnvVar].
+//
+// The variable exists because compatibility must not delete a capability
+// (AGENTS.md, "Compatibility never removes a capability"). Ptah models
+// extensions, sequences and row-level security policies; defaulting to what the
+// community binary can read is a drop-in requirement, but a user porting a
+// pipeline that needs those blocks has to be able to get them back on this same
+// surface rather than being told to rewrite against native `ptah`.
+const KeepAtlasRefusedBlocksEnvVar = "PTAH_ATLAS_INSPECT_ALL_BLOCKS"
+
+// KeepAtlasRefusedBlocks reports whether the opt-in variable is set to a true
+// boolean value. Unset, empty, false and unparsable values all keep the
+// default, mirroring how [go.5x5.cz/ptah/internal/atlassource] reads its own
+// opt-in.
+func KeepAtlasRefusedBlocks() bool {
+	keep, err := strconv.ParseBool(os.Getenv(KeepAtlasRefusedBlocksEnvVar))
+	return err == nil && keep
+}
+
+// atlasRefusedBlockTypes lists, per dialect, the top-level block types the
+// pinned Atlas community binary v1.3.0 refuses AS A FEATURE: not because of how
+// Ptah spells an attribute inside them, but because that build does not model
+// the construct at all. One such block anywhere in a file costs the WHOLE file,
+// so the Atlas-compatible surface omits them by default rather than emitting a
+// document its counterpart cannot read (stokaro/ptah#1251).
+//
+// Every row is measured, and the message is what makes the row a row. Measured
+// on PostgreSQL 17 by starting from a file that binary accepts -- its own
+// inspect output for the same database, verified at exit 0 -- and adding one
+// block type at a time:
+//
+//	extension "pgcrypto" {}     exit 1  postgres: extensions are not supported by this version
+//	sequence "order_seq" {}     exit 1  postgres: sequences are not supported by this version
+//	policy "accounts_all" {}    exit 1  postgres: policies are not supported by this version
+//
+// The blocks are empty on purpose. A `sequence` carrying the `type = bigint`
+// Ptah wrote before #1255 is refused with `There is no variable named "bigint"`
+// instead, which is Ptah's own rendering defect and was fixed rather than
+// suppressed. Stripping the block to its label separates the two verdicts: what
+// survives is a refusal of the block type itself, which no spelling can lift.
+//
+// Nothing else Ptah's inspect emits belongs here, and that too is measured. Off
+// the same accepted base, one block at a time:
+//
+//	role, function, view, materialized, trigger, permission, range   exit 0
+//	wibble "x" {}                                                    exit 0
+//
+// The last row is why the others are not evidence of support: that binary drops
+// a top-level block whose name it does not model and carries on, so exit 0 says
+// only "harmless to the file", which is all the compatibility surface needs.
+// Suppressing those would lose description for nothing.
+//
+// The map is keyed by dialect because the refusal is, and that is measured too:
+// on SQLite the same three blocks are accepted and dropped exactly like
+// `wibble`, all at exit 0. A dialect absent here suppresses nothing.
+//
+// A later build may model any of these, at which point suppressing it would
+// silently withhold something the reader could have used.
+// TestOracleAtlasRefusedBlockTypesMatchTheBinary re-measures the list in both
+// directions so that turns the Atlas CE Oracle job red rather than going
+// unnoticed.
+var atlasRefusedBlockTypes = map[string][]string{
+	platform.Postgres: {blockExtension, blockPolicy, blockSequence},
+}
+
+// atlasRefusesBlock reports whether the pinned binary refuses a whole file for
+// containing this block type on this dialect.
+func atlasRefusesBlock(dialect, block string) bool {
+	return slices.Contains(atlasRefusedBlockTypes[dialect], block)
+}
+
+// omitRefusedBlock decides one object's fate on the Atlas-compatible surface,
+// records the decision on the render's diagnostics, and reports whether the
+// block is left out.
+//
+// Suppression is REFERENCE-AWARE rather than a fixed list of block types, and
+// the measurement that forces this is the pinned binary's own output. For
+//
+//	CREATE SEQUENCE order_seq;
+//	CREATE TABLE orders (id integer NOT NULL DEFAULT nextval('order_seq'::regclass));
+//
+// that binary emits `default = sql("nextval('order_seq'::regclass)")` and no
+// `sequence` block, because it does not model sequences -- and then cannot read
+// its own output back: `pq: relation "order_seq" does not exist`, exit 1,
+// measured on PostgreSQL 17. So for that shape there is no faithful output that
+// binary can read, including its own; suppression cannot produce one, it can
+// only choose which kind of broken.
+//
+// Copying that hole would be reproducing a defect, which the compatibility
+// policy's second half forbids, and it would cost something real: before the
+// suppression existed, Ptah read this document back at exit 0. Dropping the
+// referencing attribute along with the block would instead describe a database
+// that does not exist. So the block stays when the document names it, and the
+// diagnostic says so.
+//
+// The consequence is stated rather than hidden: a document that keeps a
+// referenced sequence is not readable by the pinned binary. It is readable by
+// Ptah, and it describes the database truthfully, which the two alternatives
+// cannot both do.
+func (r *renderer) omitRefusedBlock(path, block, name string) bool {
+	if !r.omitAtlasRefusedBlocks || !atlasRefusesBlock(r.dialect, block) {
+		return false
+	}
+	if r.documentNames(name) {
+		r.warn(path, fmt.Sprintf(
+			"kept in Atlas-compatible schema inspect output because another object in this document names it:"+
+				" the Atlas community CLI refuses a %s schema file that declares any %s block, so it cannot read"+
+				" this document, but omitting the block would leave a reference to an object nothing declares",
+			r.dialect, block,
+		))
+		return false
+	}
+	r.warn(path, fmt.Sprintf(
+		"omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses a %s schema file"+
+			" that declares any %s block, and one of them makes the whole document unreadable to it;"+
+			" set %s=1 to keep every block Ptah models",
+		r.dialect, block, KeepAtlasRefusedBlocksEnvVar,
+	))
+	return true
+}
+
+// documentNames reports whether anything the surviving document emits names
+// this object.
+//
+// Matching is case-insensitive because unquoted PostgreSQL identifiers are, and
+// because the direction of a wrong answer matters: a false positive keeps a
+// block that could have been omitted, which costs compatibility; a false
+// negative emits a document with a hole in it, which costs correctness. This
+// errs toward keeping.
+func (r *renderer) documentNames(name string) bool {
+	name = strings.ToLower(strings.TrimSpace(name))
+	if name == "" {
+		return false
+	}
+	if r.references == nil {
+		r.references = collectReferencedNames(r.db)
+	}
+	return r.references[name]
+}
+
+// collectReferencedNames gathers every identifier named by the parts of an
+// inspected document that survive suppression.
+//
+// The candidate blocks' own bodies are deliberately NOT scanned. A sequence's
+// `owned_by`, an extension's `version`, and a policy's `using` expression only
+// exist in the output when that block does, so counting them would keep a block
+// alive on a reference that goes away with it.
+//
+// Type positions are scanned alongside expressions because an extension that
+// supplies a type is named by the columns using it -- `citext`, `hstore`. An
+// extension that supplies only FUNCTIONS is not named anywhere by this rule:
+// `pgcrypto` behind `gen_random_uuid()` is invisible to it, and that limitation
+// is documented rather than papered over, because resolving it needs a catalog
+// of what each extension provides rather than a name.
+func collectReferencedNames(db *goschema.Database) map[string]bool {
+	names := map[string]bool{}
+	add := func(text string) {
+		for _, token := range sqlIdentifierTokens(text) {
+			names[token] = true
+		}
+	}
+
+	for _, field := range db.Fields {
+		add(field.Type)
+		add(field.DefaultExpr)
+		add(field.UpdateExpression)
+		add(field.GeneratedExpression)
+		add(field.Check)
+		add(field.UniqueExpr)
+	}
+	for _, table := range db.Tables {
+		add(table.CustomSQL)
+		for _, check := range table.Checks {
+			add(check)
+		}
+		if table.Partition != nil {
+			for _, part := range table.Partition.Parts {
+				add(part.Expr)
+			}
+		}
+	}
+	for _, constraint := range db.Constraints {
+		add(constraint.CheckExpression)
+		add(constraint.WhereCondition)
+		add(constraint.ExcludeElements)
+	}
+	for _, index := range db.Indexes {
+		add(index.Condition)
+		for _, part := range index.Parts {
+			add(part.Expr)
+		}
+	}
+	for _, view := range db.Views {
+		add(view.Body)
+	}
+	for _, view := range db.MaterializedViews {
+		add(view.Body)
+	}
+	for _, function := range db.Functions {
+		add(function.Body)
+		add(function.Parameters)
+		add(function.Returns)
+	}
+	for _, trigger := range db.Triggers {
+		add(trigger.Body)
+	}
+	for _, domain := range db.Domains {
+		add(domain.BaseType)
+		add(domain.DefaultExpr)
+		add(domain.Check)
+	}
+	for _, composite := range db.CompositeTypes {
+		for _, field := range composite.Fields {
+			add(field.Type)
+		}
+	}
+	for _, rangeType := range db.Ranges {
+		add(rangeType.Subtype)
+		add(rangeType.Canonical)
+		add(rangeType.SubtypeDiff)
+	}
+	// A grant's target is an HCL traversal in the rendered `permission` block,
+	// so an omitted target leaves a reference to a block that is not there.
+	// Measured on PostgreSQL 17: a GRANT on a sequence arrives with the
+	// sequence in OnTable rather than OnSequence, so both are read here.
+	for _, grant := range db.Grants {
+		add(grant.OnTable)
+		add(grant.OnSequence)
+	}
+	return names
+}
+
+// sqlIdentifierTokens splits text into lowercased identifier-shaped words.
+//
+// The split is deliberately naive: `nextval('order_seq'::regclass)` has to
+// yield `order_seq` through a quote and a cast, and a SQL parser per dialect
+// would be a much larger thing to keep correct than a rule whose failure mode
+// is keeping a block that did not have to be kept.
+func sqlIdentifierTokens(text string) []string {
+	var tokens []string
+	var current strings.Builder
+	flush := func() {
+		if current.Len() > 0 {
+			tokens = append(tokens, strings.ToLower(current.String()))
+			current.Reset()
+		}
+	}
+	for _, r := range text {
+		switch {
+		case r == '_' || r == '$' ||
+			r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' || r >= '0' && r <= '9':
+			current.WriteRune(r)
+		default:
+			flush()
+		}
+	}
+	flush()
+	return tokens
+}

--- a/internal/atlashclrender/atlas_refused_blocks_env_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_env_test.go
@@ -1,0 +1,54 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestKeepAtlasRefusedBlocksReadsTheOptIn pins how the opt-in is parsed.
+//
+// The variable is the whole reason the compatibility surface may default to a
+// narrower document at all: a capability that cannot be reached is a capability
+// that was removed (AGENTS.md, "Compatibility never removes a capability"). The
+// rows mirror [go.5x5.cz/ptah/internal/atlassource]'s own opt-in, so an
+// operator who learned one spelling is not surprised by the other -- unset,
+// empty, false and unparsable all keep the default.
+func TestKeepAtlasRefusedBlocksReadsTheOptIn(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "unset keeps the compatible default", value: "", want: false},
+		{name: "1 restores the superset", value: "1", want: true},
+		{name: "true restores the superset", value: "true", want: true},
+		{name: "TRUE restores the superset", value: "TRUE", want: true},
+		{name: "0 keeps the compatible default", value: "0", want: false},
+		{name: "false keeps the compatible default", value: "false", want: false},
+		{name: "an unparsable value keeps the compatible default", value: "yes please", want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, test.value)
+
+			c.Assert(atlashclrender.KeepAtlasRefusedBlocks(), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestKeepAtlasRefusedBlocksEnvVarIsSpelledLikeItsPrecedent pins the name the
+// diagnostics, the documentation and the feature matrix all quote.
+//
+// The spelling is part of the interface: an operator meets it in a stderr
+// warning and types it back. Renaming it silently would leave every document
+// that quotes it wrong, so the constant is asserted rather than assumed.
+func TestKeepAtlasRefusedBlocksEnvVarIsSpelledLikeItsPrecedent(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(atlashclrender.KeepAtlasRefusedBlocksEnvVar, qt.Equals, "PTAH_ATLAS_INSPECT_ALL_BLOCKS")
+}

--- a/internal/atlashclrender/atlas_refused_blocks_oracle_internal_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_oracle_internal_test.go
@@ -1,0 +1,233 @@
+package atlashclrender
+
+// White-box testing required: the subject of this conformance run is the
+// contents of atlasRefusedBlockTypes, an unexported map. Enumerating it is the
+// whole point -- a black-box run could only ask about block types it already
+// thought of, and the drift this run exists to catch is precisely a row that
+// stopped being true without anyone asking.
+
+import (
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+// atlasFeatureRefusal is the substring that separates the two refusals this
+// front had to keep apart. "postgres: sequences are not supported by this
+// version" is the binary declining to model a construct, which no spelling of
+// ours can lift and which the compatibility surface therefore omits. `There is
+// no variable named "bigint"` was Ptah's own rendering, fixed in #1255 rather
+// than suppressed -- so a row that starts failing for THAT reason must not keep
+// counting as a feature gap.
+const atlasFeatureRefusal = "are not supported by this version"
+
+// atlasToleratedBlockTypes are top-level block types Ptah's inspect renders
+// that the pinned binary does NOT refuse, and which the compatibility surface
+// therefore keeps.
+//
+// They are the control in the opposite direction. Without them this run could
+// pass with a list that suppressed everything, or with one grown by guesswork:
+// each name here is asserted to be readable, so a block type that STARTS being
+// refused turns the job red and says "this now belongs in the list" instead of
+// shipping unreadable output.
+//
+// `wibble` is the sharpest of them. It is not a construct at all, and the
+// binary accepts it exactly as it accepts `role` or `view` -- which is what
+// makes exit 0 on those names evidence of tolerance rather than of support.
+var atlasToleratedBlockTypes = map[string][]string{
+	platform.Postgres: {
+		"role",
+		"function",
+		"view",
+		"materialized",
+		"trigger",
+		"permission",
+		"wibble",
+	},
+	platform.SQLite: {
+		// The three PostgreSQL refuses. They are listed here rather than in
+		// atlasRefusedBlockTypes because the refusal is the PostgreSQL driver's
+		// and not the file format's, which is why that map is keyed by dialect
+		// at all. If SQLite ever starts refusing them, this run says so.
+		"extension",
+		"sequence",
+		"policy",
+		"wibble",
+	},
+}
+
+// TestOracleAtlasRefusedBlockTypesMatchTheBinary re-measures every entry of
+// atlasRefusedBlockTypes against the pinned community binary.
+//
+// A list nothing re-measures rots silently, and this one rots in a direction
+// that costs the user: a block type a later build starts modeling would go on
+// being withheld from the compatibility output forever, describing less of the
+// database than the reader could have used. So each entry is asserted in the
+// direction that would make the suppression stale -- the binary must still
+// refuse it -- and the refusal must still be the FEATURE refusal, because a row
+// that began failing over one of Ptah's own spellings is not this list's
+// business.
+//
+// Every probe starts from a base asserted to exit 0 first. An earlier attempt
+// at this measurement built an invalid base, and every row inherited its error;
+// the base subtest is what makes that impossible to repeat.
+//
+// The probes deliberately do NOT run in parallel. Each dialect's probes share
+// one dev database and the binary materializes the file there, so concurrent
+// probes collide inside the server with errors that read like verdicts about
+// the block under test.
+func TestOracleAtlasRefusedBlockTypesMatchTheBinary(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	c := qt.New(t)
+	c.Assert(atlasRefusedBlockTypes, qt.Not(qt.HasLen), 0,
+		qt.Commentf("an empty map would make this run measure nothing"))
+
+	for _, dialect := range slices.Sorted(maps.Keys(atlasRefusedBlockTypes)) {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+
+			refused := atlasRefusedBlockTypes[dialect]
+			c.Assert(refused, qt.Not(qt.HasLen), 0,
+				qt.Commentf("a dialect in the map with no entries would measure nothing"))
+
+			t.Run("base", func(t *testing.T) {
+				c := qt.New(t)
+
+				out, code := runBlockOracle(c, oracle, devURL, dialect, "")
+				c.Assert(code, qt.Equals, 0,
+					qt.Commentf("the base this run adds one block to is not accepted, so no row below means anything: %s", out))
+			})
+
+			for _, block := range refused {
+				t.Run("refused/"+block, func(t *testing.T) {
+					c := qt.New(t)
+
+					out, code := runBlockOracle(c, oracle, devURL, dialect, block)
+					c.Assert(code, qt.Not(qt.Equals), 0,
+						qt.Commentf("the binary now reads a %s block on %s; suppressing it withholds a construct the reader could use: %s",
+							block, dialect, out))
+					c.Assert(out, qt.Contains, atlasFeatureRefusal,
+						qt.Commentf("the %s block on %s is refused for a reason that is not a feature gap, so it is not this list's to suppress: %s",
+							block, dialect, out))
+				})
+			}
+		})
+	}
+}
+
+// TestOracleToleratesTheBlockTypesPtahStillRenders measures the other
+// direction: everything the compatibility surface still emits stays readable.
+//
+// This is what keeps the omission surgical. The binary drops a top-level block
+// whose name it does not model and carries on, so these blocks cost the reader
+// nothing, and omitting them would cost a description for no compatibility
+// gain. If one of them starts being refused, this run goes red rather than
+// ptah-compat quietly emitting a file its counterpart cannot read.
+func TestOracleToleratesTheBlockTypesPtahStillRenders(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	c := qt.New(t)
+	c.Assert(atlasToleratedBlockTypes, qt.Not(qt.HasLen), 0,
+		qt.Commentf("an empty map would make this run measure nothing"))
+
+	for _, dialect := range slices.Sorted(maps.Keys(atlasToleratedBlockTypes)) {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+
+			tolerated := atlasToleratedBlockTypes[dialect]
+			c.Assert(tolerated, qt.Not(qt.HasLen), 0,
+				qt.Commentf("a dialect with no controls controls nothing"))
+
+			for _, block := range tolerated {
+				t.Run("tolerated/"+block, func(t *testing.T) {
+					c := qt.New(t)
+
+					c.Assert(atlasRefusesBlock(dialect, block), qt.IsFalse,
+						qt.Commentf("%q is a control: it must stay out of the suppression list for that list to have a boundary", block))
+
+					out, code := runBlockOracle(c, oracle, devURL, dialect, block)
+					c.Assert(code, qt.Equals, 0,
+						qt.Commentf("the binary now refuses a %s block on %s, so ptah-compat is emitting a file it cannot read: %s",
+							block, dialect, out))
+				})
+			}
+		})
+	}
+}
+
+// runBlockOracle asks the pinned binary to read a file holding one extra
+// top-level block, and returns its combined output and exit status.
+//
+// The block is written bare -- a label and an empty body -- on purpose. A block
+// carrying the attributes Ptah writes would be refused over one of them first,
+// which is a different verdict about a different defect; stripping it to the
+// label is what leaves a refusal of the block TYPE and nothing else.
+//
+// The column type is a sql() wrap because that is the one spelling
+// TestOracleAcceptsTheWrapItFallsBackTo already measures as readable on every
+// dialect here, so the base cannot fail for a reason this run is not about.
+func runBlockOracle(c *qt.C, oracle, devURL, dialect, block string) (string, int) {
+	c.Helper()
+
+	schema := schemaNameByDialect[dialect]
+	c.Assert(schema, qt.Not(qt.Equals), "",
+		qt.Commentf("dialect %q has no schema name; add one before adding the dialect", dialect))
+
+	probe, ok := blockProbeSources[block]
+	c.Assert(ok, qt.IsTrue,
+		qt.Commentf("block %q has no probe spelling; add one before measuring it", block))
+
+	source := fmt.Sprintf(`schema %q {
+}
+table "probe" {
+  schema = schema.%s
+  column "c" {
+    type = sql("integer")
+  }
+}
+%s`, schema, schema, probe)
+
+	path := filepath.Join(c.TempDir(), "blocks.hcl")
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+
+	//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+	cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", devURL)
+	// The error is the exit status, which is the measurement; a process that
+	// never started leaves ProcessState nil and fails the assertion instead.
+	out, _ := cmd.CombinedOutput() //nolint:errcheck // exit status is read from ProcessState below
+	c.Assert(cmd.ProcessState, qt.IsNotNil, qt.Commentf("the oracle did not run: %s", out))
+	return string(out), cmd.ProcessState.ExitCode()
+}
+
+// blockProbeSources spells each probed block the way Ptah's inspect renders it.
+// The empty key is the base probe, which adds nothing to the base.
+//
+// The spellings are written out rather than composed from the block name so
+// that adding a block type to atlasRefusedBlockTypes or to
+// atlasToleratedBlockTypes without deciding how it is spelled fails the run
+// instead of measuring a form Ptah never emits. `permission` is why that
+// matters: it is the one block Ptah renders with no label at all.
+var blockProbeSources = map[string]string{
+	"":             "",
+	"extension":    "extension \"probe_block\" {\n}\n",
+	"function":     "function \"probe_block\" {\n}\n",
+	"materialized": "materialized \"probe_block\" {\n}\n",
+	"permission":   "permission {\n}\n",
+	"policy":       "policy \"probe_block\" {\n}\n",
+	"role":         "role \"probe_block\" {\n}\n",
+	"sequence":     "sequence \"probe_block\" {\n}\n",
+	"trigger":      "trigger \"probe_block\" {\n}\n",
+	"view":         "view \"probe_block\" {\n}\n",
+	"wibble":       "wibble \"probe_block\" {\n}\n",
+}

--- a/internal/atlashclrender/atlas_refused_blocks_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_test.go
@@ -1,0 +1,486 @@
+package atlashclrender_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// nativeInspectedBlockTypes is every top-level block spelling an inspected
+// render emits for [inspectedRichDatabase]. It is the list the native surface
+// owes its reader: `ptah schema inspect` describes what Ptah models, and the
+// compatibility argument for leaving something out belongs to `ptah-compat`
+// alone (stokaro/ptah#1251).
+var nativeInspectedBlockTypes = []string{
+	"composite \"pair\"",
+	"data {",
+	"domain \"positive\"",
+	"enum \"status\"",
+	"extension \"pgcrypto\"",
+	"function \"touch_accounts\"",
+	"materialized \"account_counts\"",
+	"permission {",
+	"policy \"accounts_all\"",
+	"range \"intrange\"",
+	"role \"app_reader\"",
+	"schema \"public\"",
+	"sequence \"order_seq\"",
+	"table \"accounts\"",
+	"trigger \"accounts_touch\"",
+	"view \"active_accounts\"",
+}
+
+// TestRenderInspectedKeepsEveryBlockTypeOnTheNativeSurface fails if a block
+// stops being rendered natively.
+//
+// This is the guard on the other half of stokaro/ptah#1251: the compatibility
+// surface omits three block types by default, and nothing about that decision
+// may leak into the surface whose job is to describe the database completely. A
+// native render that quietly lost a construct would still pass every
+// compatibility test in this package, so it is pinned here on its own.
+func TestRenderInspectedKeepsEveryBlockTypeOnTheNativeSurface(t *testing.T) {
+	for _, block := range nativeInspectedBlockTypes {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block,
+				qt.Commentf("native inspect stopped emitting a block it models"))
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIOmitsTheBlocksTheBinaryRefuses pins the three
+// block types the compatibility surface leaves out when nothing names them.
+//
+// Measured against the pinned Atlas community binary v1.3.0 on PostgreSQL 17,
+// starting from a file it accepts and adding one bare block:
+//
+//	extension "pgcrypto" {}     exit 1  postgres: extensions are not supported by this version
+//	sequence "order_seq" {}     exit 1  postgres: sequences are not supported by this version
+//	policy "accounts_all" {}    exit 1  postgres: policies are not supported by this version
+//
+// One such block costs the whole file, so a compatibility surface that emits
+// one is not compatible in any useful sense.
+func TestRenderInspectedForAtlasCLIOmitsTheBlocksTheBinaryRefuses(t *testing.T) {
+	for _, block := range []string{"extension \"", "sequence \"", "policy \""} {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Not(qt.Contains), block)
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIKeepsEverythingElse is the other direction, and
+// it is what keeps the omission surgical.
+//
+// Every row here is a block type the pinned binary DROPS rather than refuses:
+// measured off the same accepted base, each one exits 0, as does an invented
+// `wibble "x" {}`. Exit 0 therefore says only "harmless to the file", which is
+// the whole test the compatibility surface applies. Omitting these would cost
+// the reader a description and buy nothing.
+func TestRenderInspectedForAtlasCLIKeepsEverythingElse(t *testing.T) {
+	kept := []string{
+		"composite \"pair\"",
+		"domain \"positive\"",
+		"enum \"status\"",
+		"function \"touch_accounts\"",
+		"materialized \"account_counts\"",
+		"permission {",
+		"range \"intrange\"",
+		"role \"app_reader\"",
+		"schema \"public\"",
+		"table \"accounts\"",
+		"trigger \"accounts_touch\"",
+		"view \"active_accounts\"",
+	}
+
+	for _, block := range kept {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block)
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIReportsEveryOmission pins that nothing is
+// dropped quietly, and that the message says how to get the block back.
+//
+// An inspect output that silently omitted an extension would describe a
+// database that does not exist, and the operator reading it has no other way to
+// learn what was left out. The omission rides the renderer's existing loss
+// diagnostics, which `schema inspect` writes to standard error. Naming the
+// environment variable in the message is what makes the capability reachable
+// from the place the operator actually meets it.
+func TestRenderInspectedForAtlasCLIReportsEveryOmission(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.RenderInspectedForAtlasCLI(
+		inspectedRichDatabase(), platform.Postgres, "public",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.DeepEquals, []atlashclrender.Diagnostic{
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "extensions.pgcrypto",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any extension block, and one of them makes the whole" +
+				" document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "sequences.order_seq",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any sequence block, and one of them makes the whole" +
+				" document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models",
+		},
+		{
+			Severity: atlashclrender.SeverityWarning,
+			Path:     "rls_policies.accounts_all",
+			Message: "omitted from Atlas-compatible schema inspect output: the Atlas community CLI refuses" +
+				" a postgres schema file that declares any policy block, and one of them makes the whole" +
+				" document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block Ptah models",
+		},
+	})
+}
+
+// TestRenderInspectedNativeReportsNoOmission pins the native counterpart: the
+// surface that drops nothing has nothing to disclose, so an operator cannot
+// mistake a native inspect for a filtered one.
+func TestRenderInspectedNativeReportsNoOmission(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.RenderInspected(
+		inspectedRichDatabase(), platform.Postgres, "public",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(result.Diagnostics, qt.HasLen, 0)
+}
+
+// TestRenderInspectedForAtlasCLIOmitsNothingOnSQLite pins that the omission is
+// scoped to the dialect it was measured on.
+//
+// The refusal is the PostgreSQL driver's, not the file format's: measured on
+// the pinned binary with a SQLite dev database, `extension`, `sequence` and
+// `policy` blocks are all accepted at exit 0, dropped exactly like an invented
+// `wibble "x" {}`. Suppressing them there would lose description with no reader
+// to please.
+func TestRenderInspectedForAtlasCLIOmitsNothingOnSQLite(t *testing.T) {
+	kept := []string{"extension \"pgcrypto\"", "sequence \"order_seq\"", "policy \"accounts_all\""}
+
+	for _, block := range kept {
+		t.Run(block, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				inspectedRichDatabase(), platform.SQLite, "main",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, block)
+			c.Assert(result.Diagnostics, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIKeepsABlockTheDocumentNames is the reference
+// rule, and the case that forced it is the pinned binary's own defect.
+//
+// Measured on PostgreSQL 17 for
+//
+//	CREATE SEQUENCE order_seq;
+//	CREATE TABLE orders (id integer NOT NULL DEFAULT nextval('order_seq'::regclass));
+//
+// that binary's inspect emits `default = sql("nextval('order_seq'::regclass)")`
+// and no `sequence` block, exit 0 -- and refuses its own output when it is fed
+// back: `pq: relation "order_seq" does not exist`, exit 1. Copying that hole
+// would reproduce a defect, and it would take something away that worked:
+// Ptah read the same document at exit 0 before any suppression existed.
+//
+// Each row is one shape in which the surviving document names the object, so a
+// scan narrowed to one of them fails the others.
+func TestRenderInspectedForAtlasCLIKeepsABlockTheDocumentNames(t *testing.T) {
+	tests := []struct {
+		name     string
+		database func() *goschema.Database
+		want     string
+		wantPath string
+	}{
+		{
+			name:     "a column default calls nextval on the sequence",
+			database: sequenceBackedDefaultDatabase,
+			want:     "sequence \"order_seq\"",
+			wantPath: "sequences.order_seq",
+		},
+		{
+			name: "a view body selects from the sequence",
+			database: func() *goschema.Database {
+				db := standaloneSequenceDatabase()
+				db.Views = []goschema.View{{
+					Name: "next_order",
+					Body: "SELECT nextval('order_seq') AS n",
+				}}
+				return db
+			},
+			want:     "sequence \"order_seq\"",
+			wantPath: "sequences.order_seq",
+		},
+		{
+			name: "a permission block targets the sequence",
+			database: func() *goschema.Database {
+				db := standaloneSequenceDatabase()
+				db.Roles = []goschema.Role{{Name: "app_reader", Inherit: true}}
+				// PostgreSQL 17 introspection reports a GRANT on a sequence
+				// with the sequence in OnTable, so the rendered `permission`
+				// block carries a traversal naming it. Omitting the sequence
+				// under it leaves a reference to a block nothing declares.
+				db.Grants = []goschema.Grant{{
+					Role:       "app_reader",
+					OnTable:    "order_seq",
+					Privileges: []string{"USAGE"},
+				}}
+				return db
+			},
+			want:     "sequence \"order_seq\"",
+			wantPath: "sequences.order_seq",
+		},
+		{
+			name: "a column type is the type the extension supplies",
+			database: func() *goschema.Database {
+				db := standaloneSequenceDatabase()
+				db.Extensions = []goschema.Extension{{Name: "citext"}}
+				db.Fields = append(db.Fields, goschema.Field{
+					StructName: "Order", Name: "label", Type: "citext",
+				})
+				return db
+			},
+			want:     "extension \"citext\"",
+			wantPath: "extensions.citext",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				test.database(), platform.Postgres, "public",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want,
+				qt.Commentf("the document names this object, so omitting its block leaves a dangling reference"))
+			c.Assert(diagnosticMessageFor(result.Diagnostics, test.wantPath), qt.Contains,
+				"kept in Atlas-compatible schema inspect output because another object in this document names it",
+				qt.Commentf("keeping a block the pinned binary refuses has to be reported, not silently done"))
+		})
+	}
+}
+
+// TestRenderInspectedForAtlasCLIOmitsAnUnreferencedSequence is the control for
+// the rule above: without the reference, the same sequence goes.
+//
+// Without this row the reference rule could be satisfied by never omitting a
+// sequence at all, which would make the whole front a no-op.
+func TestRenderInspectedForAtlasCLIOmitsAnUnreferencedSequence(t *testing.T) {
+	c := qt.New(t)
+
+	result, err := atlashclrender.RenderInspectedForAtlasCLI(
+		standaloneSequenceDatabase(), platform.Postgres, "public",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Not(qt.Contains), "sequence \"order_seq\"")
+	c.Assert(diagnosticMessageFor(result.Diagnostics, "sequences.order_seq"), qt.Contains,
+		"omitted from Atlas-compatible schema inspect output")
+}
+
+// TestRenderInspectedForAtlasCLIOutputIsSelfConsistent is the invariant the
+// whole reshape exists to hold: whatever the surface decides to omit, the
+// document it emits still describes itself.
+//
+// The assertion is a real round trip rather than a re-run of the renderer's own
+// reference scan: the output is parsed back by Ptah's HCL reader, and every
+// sequence a column default calls nextval on must come back as a declared
+// sequence. A document that omitted a referenced block parses into an IR whose
+// table needs a sequence the IR does not have, which is exactly the state that
+// made `ptah-compat schema inspect -u file://<its own output>` exit 1.
+func TestRenderInspectedForAtlasCLIOutputIsSelfConsistent(t *testing.T) {
+	tests := []struct {
+		name     string
+		database func() *goschema.Database
+	}{
+		{name: "one object of every construct", database: inspectedRichDatabase},
+		{name: "a sequence behind a column default", database: sequenceBackedDefaultDatabase},
+		{name: "a sequence nothing names", database: standaloneSequenceDatabase},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspectedForAtlasCLI(
+				test.database(), platform.Postgres, "public",
+			)
+			c.Assert(err, qt.IsNil)
+
+			parsed, err := atlashcl.Parse(result.Data, "compat.hcl")
+			c.Assert(err, qt.IsNil, qt.Commentf("Ptah cannot read its own compatibility output"))
+
+			declared := map[string]bool{}
+			for _, sequence := range parsed.Sequences {
+				declared[sequence.Name] = true
+			}
+			for _, field := range parsed.Fields {
+				for _, named := range nextvalSequenceNames(field.DefaultExpr) {
+					c.Assert(declared[named], qt.IsTrue,
+						qt.Commentf("column %q defaults to a sequence the document does not declare", field.Name))
+				}
+			}
+		})
+	}
+}
+
+// diagnosticMessageFor returns the message reported for one diagnostic path, or
+// the empty string when nothing was reported for it.
+func diagnosticMessageFor(diagnostics []atlashclrender.Diagnostic, path string) string {
+	for _, diagnostic := range diagnostics {
+		if diagnostic.Path == path {
+			return diagnostic.Message
+		}
+	}
+	return ""
+}
+
+// nextvalSequenceNames extracts the sequence names a default expression calls
+// nextval on. It reads the one shape a PostgreSQL catalog reports --
+// `nextval('name'::regclass)` -- because that is the shape the round-trip
+// assertion is about.
+func nextvalSequenceNames(expr string) []string {
+	var names []string
+	rest := expr
+	for {
+		start := strings.Index(strings.ToLower(rest), "nextval('")
+		if start < 0 {
+			return names
+		}
+		rest = rest[start+len("nextval('"):]
+		end := strings.Index(rest, "'")
+		if end < 0 {
+			return names
+		}
+		name := rest[:end]
+		if dot := strings.LastIndex(name, "."); dot >= 0 {
+			name = name[dot+1:]
+		}
+		names = append(names, name)
+		rest = rest[end:]
+	}
+}
+
+// sequenceBackedDefaultDatabase is the shape that forced the reference rule:
+// a sequence, and a column whose default calls it.
+func sequenceBackedDefaultDatabase() *goschema.Database {
+	start := int64(1)
+	return &goschema.Database{
+		Sequences: []goschema.Sequence{{Name: "order_seq", AsType: "bigint", Start: &start}},
+		Tables:    []goschema.Table{{StructName: "Order", Name: "orders", Schema: "public"}},
+		Fields: []goschema.Field{{
+			StructName:  "Order",
+			Name:        "id",
+			Type:        "integer",
+			DefaultExpr: "nextval('order_seq'::regclass)",
+		}},
+	}
+}
+
+// standaloneSequenceDatabase is the same database with the reference removed,
+// so a test can vary exactly one operand against sequenceBackedDefaultDatabase.
+func standaloneSequenceDatabase() *goschema.Database {
+	db := sequenceBackedDefaultDatabase()
+	db.Fields[0].DefaultExpr = ""
+	return db
+}
+
+// inspectedRichDatabase builds an IR carrying one object of every construct the
+// inspected renderer emits a top-level block for, so a block that stops being
+// rendered is visible rather than absent for want of an input.
+//
+// Nothing in it names the extension, the sequence or the policy, which is what
+// makes it the fixture for the omission tests: those three go because they are
+// unreferenced, not because of their block type alone.
+func inspectedRichDatabase() *goschema.Database {
+	start := int64(1)
+	return &goschema.Database{
+		Extensions: []goschema.Extension{{Name: "pgcrypto", Version: "1.3"}},
+		Sequences:  []goschema.Sequence{{Name: "order_seq", AsType: "bigint", Start: &start}},
+		Domains:    []goschema.Domain{{Name: "positive", BaseType: "integer"}},
+		CompositeTypes: []goschema.CompositeType{{
+			Name:   "pair",
+			Fields: []goschema.CompositeTypeField{{Name: "a", Type: "integer"}},
+		}},
+		Ranges: []goschema.Range{{Name: "intrange", Subtype: "integer"}},
+		Enums:  []goschema.Enum{{Name: "status", Values: []string{"active", "inactive"}}},
+		Roles:  []goschema.Role{{Name: "app_reader", Inherit: true}},
+		Tables: []goschema.Table{{StructName: "Account", Name: "accounts", Schema: "public"}},
+		Fields: []goschema.Field{{StructName: "Account", Name: "id", Type: "bigint"}},
+		Functions: []goschema.Function{{
+			Name:     "touch_accounts",
+			Language: "plpgsql",
+			Returns:  "trigger",
+			Body:     "BEGIN RETURN NEW; END;",
+		}},
+		Views:             []goschema.View{{Name: "active_accounts", Body: "SELECT id FROM accounts"}},
+		MaterializedViews: []goschema.MaterializedView{{Name: "account_counts", Body: "SELECT id FROM accounts"}},
+		Triggers: []goschema.Trigger{{
+			Name:   "accounts_touch",
+			Table:  "accounts",
+			Timing: "BEFORE",
+			Event:  "UPDATE",
+			Body:   "BEGIN RETURN NEW; END;",
+		}},
+		RLSEnabledTables: []goschema.RLSEnabledTable{{Table: "accounts"}},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "accounts_all",
+			Table:           "accounts",
+			PolicyFor:       "ALL",
+			UsingExpression: "true",
+		}},
+		Grants: []goschema.Grant{{
+			Role:       "app_reader",
+			OnTable:    "accounts",
+			Privileges: []string{"SELECT"},
+		}},
+		ManagedData: []goschema.ManagedData{{Table: "accounts", Keys: []string{"id"}, File: "accounts.csv"}},
+	}
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -16,6 +16,9 @@ func (r *renderer) renderExtensions() {
 		return cmp.Compare(a.Name, b.Name)
 	})
 	for _, extension := range extensions {
+		if r.omitRefusedBlock("extensions."+extension.Name, blockExtension, extension.Name) {
+			continue
+		}
 		r.linef(`extension %s {`, quote(extension.Name))
 		if extension.IfNotExists {
 			r.trueAttr(1, "if_not_exists")
@@ -33,6 +36,9 @@ func (r *renderer) renderSequences() {
 		return cmp.Compare(a.QualifiedName(), b.QualifiedName())
 	})
 	for _, sequence := range sequences {
+		if r.omitRefusedBlock("sequences."+sequence.QualifiedName(), blockSequence, sequence.Name) {
+			continue
+		}
 		sequence.Canonicalize()
 		r.linef(`sequence %s {`, quote(sequence.Name))
 		if sequence.Schema != "" {
@@ -410,6 +416,9 @@ func (r *renderer) renderRLSPolicies() {
 	for _, policy := range policies {
 		if policy.Table == "" {
 			r.warn("rls_policies."+policy.Name, "RLS policy requires a target table for HCL schema export")
+			continue
+		}
+		if r.omitRefusedBlock("rls_policies."+policy.Name, blockPolicy, policy.Name) {
 			continue
 		}
 		r.linef(`policy %s {`, quote(policy.Name))

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -63,7 +63,7 @@ func Render(db *goschema.Database) (Result, error) {
 // their input was HCL, so the raw-SQL marker the parser set is already right and
 // re-deciding it from the type name would second-guess the author.
 func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
-	return render(db, dialect, "")
+	return render(db, dialect, "", false)
 }
 
 // RenderInspected renders a schema that was read out of a database, declaring
@@ -89,18 +89,38 @@ func RenderForDialect(db *goschema.Database, dialect string) (Result, error) {
 // here, so their IR already carries whatever the author wrote, and synthesizing
 // a schema there would invent one the author did not declare.
 func RenderInspected(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
-	return render(db, dialect, strings.TrimSpace(defaultSchema))
+	return render(db, dialect, strings.TrimSpace(defaultSchema), false)
 }
 
-func render(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
+// RenderInspectedForAtlasCLI renders an inspected schema for the
+// Atlas-compatible surface, leaving out the top-level block types the pinned
+// Atlas community binary v1.3.0 refuses as a feature -- but only where nothing
+// else in the document names the object -- and reporting every decision as a
+// loss diagnostic.
+//
+// It differs from [RenderInspected] in nothing else. The omission is a property
+// of the reader the compatibility binary stands in for, not of the database and
+// not of Ptah, so the native surface keeps describing everything Ptah models;
+// see [atlasRefusedBlockTypes] for the list and the measurement behind it, and
+// [renderer.omitRefusedBlock] for why suppression is reference-aware
+// (stokaro/ptah#1251).
+//
+// The capability is not deleted by the default. Setting
+// [KeepAtlasRefusedBlocksEnvVar] restores every block on this same surface.
+func RenderInspectedForAtlasCLI(db *goschema.Database, dialect, defaultSchema string) (Result, error) {
+	return render(db, dialect, strings.TrimSpace(defaultSchema), true)
+}
+
+func render(db *goschema.Database, dialect, defaultSchema string, omitAtlasRefusedBlocks bool) (Result, error) {
 	if db == nil {
 		return Result{}, fmt.Errorf("schema database is nil")
 	}
 
 	r := renderer{
-		db:            db,
-		dialect:       dialect,
-		defaultSchema: defaultSchema,
+		db:                     db,
+		dialect:                dialect,
+		defaultSchema:          defaultSchema,
+		omitAtlasRefusedBlocks: omitAtlasRefusedBlocks,
 	}
 	r.render()
 	return Result{
@@ -116,8 +136,17 @@ type renderer struct {
 	// IR is taken as written, which is what every parse-and-re-render caller
 	// wants.
 	defaultSchema string
-	builder       strings.Builder
-	diagnostics   []Diagnostic
+	// omitAtlasRefusedBlocks marks the render as feeding the Atlas-compatible
+	// surface, which leaves out the block types the pinned binary refuses
+	// unless the document names the object; see [renderer.omitRefusedBlock].
+	omitAtlasRefusedBlocks bool
+	// references caches the identifiers the surviving document names, built
+	// once per render by [collectReferencedNames]. Nil means not yet built,
+	// which is distinguishable from "built and empty" because a document with
+	// no references at all still answers every lookup false.
+	references  map[string]bool
+	builder     strings.Builder
+	diagnostics []Diagnostic
 }
 
 // schemaFor returns the schema name to write for an object, which is the one it

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -20,8 +20,13 @@ type SchemaInspectReport struct {
 	db          *goschema.Database
 	info        dbschematypes.DBInfo
 	diagnostics io.Writer
-	Realm       atlasSchemaInspectJSONRealm `json:"-"`
-	Schema      atlasSchemaInspectJSONRealm `json:"-"`
+	// omitAtlasRefusedBlocks renders HCL for the Atlas-compatible surface,
+	// which leaves out the block types the pinned Atlas community binary
+	// refuses to read where nothing in the document names them; see
+	// [go.5x5.cz/ptah/internal/atlashclrender.RenderInspectedForAtlasCLI].
+	omitAtlasRefusedBlocks bool
+	Realm                  atlasSchemaInspectJSONRealm `json:"-"`
+	Schema                 atlasSchemaInspectJSONRealm `json:"-"`
 }
 
 type atlasSchemaInspectJSONRealm struct {
@@ -112,19 +117,28 @@ func RenderSchemaInspect(format string, report *SchemaInspectReport) (SchemaInsp
 	return SchemaInspectOutput{Text: out.String(), Files: files}, nil
 }
 
+// NewSchemaInspectReport builds the report one schema inspect renders from.
+//
+// omitAtlasRefusedBlocks selects the Atlas-compatible HCL rendering, which
+// leaves out the block types the pinned Atlas community binary refuses where
+// nothing else in the document names them, and reports every decision on
+// diagnostics. It is false on the native surface, which describes every
+// construct Ptah models.
 func NewSchemaInspectReport(
 	db *goschema.Database,
 	schema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	diagnostics io.Writer,
+	omitAtlasRefusedBlocks bool,
 ) *SchemaInspectReport {
 	realm := atlasSchemaInspectJSON(schema, info)
 	return &SchemaInspectReport{
-		db:          db,
-		info:        info,
-		diagnostics: diagnostics,
-		Realm:       realm,
-		Schema:      realm,
+		db:                     db,
+		info:                   info,
+		diagnostics:            diagnostics,
+		omitAtlasRefusedBlocks: omitAtlasRefusedBlocks,
+		Realm:                  realm,
+		Schema:                 realm,
 	}
 }
 
@@ -188,7 +202,7 @@ func (r *SchemaInspectReport) defaultSchemaName() string {
 }
 
 func (r *SchemaInspectReport) MarshalHCL() (string, error) {
-	rendered, err := atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
+	rendered, err := r.renderHCL()
 	if err != nil {
 		return "", fmt.Errorf("render HCL schema: %w", err)
 	}
@@ -198,6 +212,17 @@ func (r *SchemaInspectReport) MarshalHCL() (string, error) {
 		}
 	}
 	return string(rendered.Data), nil
+}
+
+// renderHCL picks the rendering the surface asked for. Only the HCL output is
+// split this way: what the compatibility surface omits, it omits because the
+// binary it stands in for cannot PARSE the block, and that is a question only
+// the HCL document raises. SQL output is read by a database.
+func (r *SchemaInspectReport) renderHCL() (atlashclrender.Result, error) {
+	if r.omitAtlasRefusedBlocks {
+		return atlashclrender.RenderInspectedForAtlasCLI(r.db, r.info.Dialect, r.defaultSchemaName())
+	}
+	return atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
 }
 
 func (r *SchemaInspectReport) MarshalSQL(indent ...string) (string, error) {

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -347,5 +347,6 @@ func sampleSchemaInspectReport() *atlasreport.SchemaInspectReport {
 		},
 		types.DBInfo{Dialect: "sqlite", Schema: "main"},
 		nil,
+		false,
 	)
 }

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -27,6 +27,16 @@ type InspectOptions struct {
 	Exclude     []string
 	Format      string
 	Diagnostics io.Writer
+	// OmitAtlasRefusedBlocks renders HCL for the Atlas-compatible surface,
+	// which leaves out the top-level block types the pinned Atlas community
+	// binary refuses as a feature -- unless something else in the document
+	// names the object -- and reports every decision on Diagnostics. Only
+	// `ptah-compat` sets it, and setting
+	// [go.5x5.cz/ptah/internal/atlashclrender.KeepAtlasRefusedBlocksEnvVar]
+	// turns it back off there; the native surface renders every construct Ptah
+	// models. See
+	// [go.5x5.cz/ptah/internal/atlashclrender.RenderInspectedForAtlasCLI].
+	OmitAtlasRefusedBlocks bool
 }
 
 // NormalizeInspectFormat returns and validates the executable Atlas schema
@@ -92,6 +102,7 @@ func renderInspectSchema(
 		schema,
 		info,
 		opts.Diagnostics,
+		opts.OmitAtlasRefusedBlocks,
 	))
 	if err != nil {
 		return "", err

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -55,6 +55,9 @@ type InspectSourceOptions struct {
 	// IgnoreUnknownHCLNames is the Atlas-compatible surface's unknown-name
 	// policy; see [go.5x5.cz/ptah/internal/atlassource.ResolveOptions].
 	IgnoreUnknownHCLNames bool
+	// OmitAtlasRefusedBlocks is the Atlas-compatible surface's block-type
+	// policy for rendered HCL; see [InspectOptions].
+	OmitAtlasRefusedBlocks bool
 }
 
 // InspectSource classifies the --url inspection source and renders it with
@@ -82,12 +85,13 @@ func InspectSource(ctx context.Context, opts InspectSourceOptions) (string, erro
 	}
 
 	inspectOpts := InspectOptions{
-		DevURL:      opts.DevURL,
-		Schemas:     opts.Schemas,
-		Include:     opts.Include,
-		Exclude:     opts.Exclude,
-		Format:      opts.Format,
-		Diagnostics: opts.Diagnostics,
+		DevURL:                 opts.DevURL,
+		Schemas:                opts.Schemas,
+		Include:                opts.Include,
+		Exclude:                opts.Exclude,
+		Format:                 opts.Format,
+		Diagnostics:            opts.Diagnostics,
+		OmitAtlasRefusedBlocks: opts.OmitAtlasRefusedBlocks,
 	}
 	if set.Kind == atlassource.KindDatabase {
 		conn, err := connectInspectSource(ctx, set.Sources[0].Raw, opts.ConnectTimeout)


### PR DESCRIPTION
Supersedes #1256. Rebuilt on current `master` (which now carries #1255's Category A fixes and #1259's capability rule), so this is a fresh branch rather than a force-push. **#1256 should be closed in favour of this one.**

Everything in #1256's measurement survives unchanged — the three-block list and its per-message evidence, the `wibble` control, stripping probes to their label, the dialect keying, HCL-only scope, and both oracle runs enumerated by name in `atlas-oracle.yml`. Two things about its *shape* did not.

## 1. It removed a capability — now gated, not deleted

`cmd/atlas/schema_inspect.go` set `OmitAtlasRefusedBlocks: true` unconditionally, so `ptah-compat schema inspect` became unable to express an extension, a sequence or an RLS policy at all. AGENTS.md (#1259) forbids that.

Added **`PTAH_ATLAS_INSPECT_ALL_BLOCKS`**, spelled and plumbed after `PTAH_ALLOW_EXTERNAL_SCHEMA` (`internal/atlassource/atlassource.go:74`). Not a flag — the conformance `cli-surface` tier asserts flag parity with the pinned binary.

Measured on PostgreSQL 17, a database with `pgcrypto`, a standalone sequence, a table and an RLS policy:

| run | result |
| --- | --- |
| `ptah-compat schema inspect` (default) | extension, sequence, policy omitted; three stderr warnings, each naming the variable |
| `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 ptah-compat schema inspect` | **byte-identical to `master`'s output** (`diff` exit 0), no omission warnings |
| `ptah schema inspect` (native, variable set and unset) | identical both ways — the variable is inert on the native surface |
| `--format sql` on the compat surface | `CREATE EXTENSION`, `CREATE SEQUENCE`, `CREATE POLICY` all present, no warnings |

The stderr message names the variable, so an operator learns the way out from the message itself:

```
warning: extensions.pgcrypto: omitted from Atlas-compatible schema inspect output: the Atlas
community CLI refuses a postgres schema file that declares any extension block, and one of them
makes the whole document unreadable to it; set PTAH_ATLAS_INSPECT_ALL_BLOCKS=1 to keep every block
Ptah models
```

## 2. It emitted dangling references — suppression is now reference-aware

Re-verified on `a172cc0d` against a private PostgreSQL 17, one database per fixture:

```
CREATE SEQUENCE order_seq;
CREATE TABLE orders (id integer NOT NULL DEFAULT nextval('order_seq'::regclass));
```

| build | inspect | feed its own output back to Ptah |
| --- | --- | --- |
| `master` | sequence block present | **rc=0** |
| #1256 head | sequence block dropped, `default = sql("nextval('order_seq'::regclass)")` kept | **rc=1** `relation "order_seq" does not exist` |

### The decisive measurement, re-confirmed here

The pinned community binary v1.3.0 has the same hole. Its own inspect of that database:

```hcl
# atlas schema inspect -u postgres://.../f1251b_seqref    rc=0
table "orders" {
  schema = schema.public
  column "id" {
    null    = false
    type    = integer
    default = sql("nextval('order_seq'::regclass)")
  }
}
schema "public" {
  comment = "standard public schema"
}
```

Fed straight back:

```
atlas schema inspect -u file://<its own output> --dev-url ...
rc=1
Error: create "orders" table: pq: relation "order_seq" does not exist at column 62 (42P01)
```

So for that shape **no faithful output is readable by that binary, including its own.** Option 1 (copy the hole) reproduces a defect — forbidden by the policy's second half. Option 3 (drop the default with the block) describes a database that does not exist. Option 2 is the one that survives both halves.

### What landed

> Omit a block the binary refuses **unless** something else in the surviving document names the object; report either way.

Measured on the reshaped build:

| fixture | compat output | pinned binary reads it | Ptah reads it back |
| --- | --- | --- | --- |
| standalone extension + sequence + policy | all three omitted, 4 warnings | **rc=0** | **rc=0** |
| sequence behind a column default | `sequence "order_seq"` **kept**, warning says why | rc=1 `postgres: sequences are not supported by this version` | **rc=0** |

The second row is the honest answer, not a regression: the refusal is now that binary's own feature gap rather than a file with a hole in it, and Ptah reads the document where before the reshape it could not.

The reference scan reads the surviving document's SQL expression and type positions plus grant targets — a `nextval` default, a view or function or trigger body, a check or index expression, a column/domain/composite/range type, a `permission` target. It deliberately does **not** read the candidate blocks' own bodies, since a reference that disappears with the block cannot keep it alive.

`permission` targets are in the scan because PostgreSQL 17 introspection reports a GRANT on a sequence with the sequence in `OnTable`, so the rendered `permission { for = table.granted_seq }` is a real traversal at the omitted block.

**Stated limitation, not papered over:** the test is by name, so an extension supplying a *type* in use (`citext`, `hstore`) is kept, while one supplying only *functions* (`pgcrypto` behind `gen_random_uuid()`) is not named and is omitted. Resolving that needs a catalog of what each extension provides. It is written down in `schema-commands.md`.

## Self-consistency is asserted, not hoped for

`TestRenderInspectedForAtlasCLIOutputIsSelfConsistent` renders each fixture, parses the result back with `atlashcl.Parse`, and requires every sequence a column default calls `nextval` on to come back as a declared sequence — a real round trip, not a re-run of the renderer's own scan.

## Docs

- `atlas/overview.md`: the variable sits beside the #1259 rule, plus a section saying plainly that **a sequence-backed column default has no Atlas-readable representation** — not Ptah's and not that binary's — so the page does not imply the surface is now fully compatible.
- `atlas/schema-commands.md`: what is omitted, what is kept and why, the referenced-block case with its measurement, and how to get the full description back.
- `direct/inspect.md`: native omits nothing and the variable has no effect there.
- Feature matrix row `Compat inspect block superset opt-in` (`ptah` ✅ / CE ❌ / Pro ❌ — no Atlas edition has a `PTAH_*` variable), with the measurement in its evidence field.

## The list is still re-measured, not frozen

Both oracle runs are carried over unchanged and still enumerated by name in `.github/workflows/atlas-oracle.yml` (count 2 → 4, plus per-subtest `grep -Fq`). Run here against the pinned binary with a live PostgreSQL 17 dev database: **0 SKIPPED**, all `refused/{extension,policy,sequence}`, the `base` subtest, and all 11 `tolerated/*` rows including `postgres/tolerated/wibble` and `sqlite/tolerated/sequence` PASS.

## Mutants, each observed red

| mutant | red |
| --- | --- |
| reference-awareness reverted (`documentNames` → false) | `...KeepsABlockTheDocumentNames` (4 rows), `...OutputIsSelfConsistent/a_sequence_behind_a_column_default`, `TestAtlasInspectKeepsAReferencedBlockInEitherState` |
| gate polarity inverted (`atlasInspectOmitsRefusedBlocks`) | `TestAtlasInspectRefusedBlockGate`, all 3 rows |
| opt-in reader wired to nothing | `TestKeepAtlasRefusedBlocksReadsTheOptIn` (3 rows), `...RefusedBlockGate/the_opt-in_puts_every_block_back` |
| `role` added to the refused list | oracle `refused/role` **and** control `tolerated/role` |
| `sequence` removed from the refused list | 8 subtests across both packages |
| diagnostic stops naming the variable | `...ReportsEveryOmission`, `...RefusedBlockGate/unset...` |
| native guard dropped (suppression leaks) | `...KeepsEveryBlockTypeOnTheNativeSurface` (3 rows), `...NativeReportsNoOmission`, plus 4 pre-existing #1255 tests |

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 · `go tool qtlint` 0 · `golangci-lint run` 0 · `scripts/check-test-style.sh` 0 · `scripts/check-public-api.sh` 0 · `scripts/check-public-api-snapshot.sh` 0

Docs (this PR touches `docs/`): every `check:*` plus their selftests and `build-feature-matrix.mjs --check` — all 0, `check:responsive` included, run against a real `npm run build` dist.

`golangci-lint` first exited 1 reporting 40+ findings **all located in another agent's scratchpad worktree**; re-run with a private `GOLANGCI_LINT_CACHE` it reports `0 issues.` The cited status is the isolated run.

`check:responsive` initially failed on `/atlas/overview/` and `/atlas/feature-matrix/`. That was **my** regression, not the known dist-missing failure: removing just the new matrix row and rebuilding turned it green, which is how the two long cells were found and shortened. It is green now with the row present.

`check-public-api.sh` and its snapshot pass but **cannot go red** for this change — every new symbol is under `internal/`. Cited as run, not as coverage.

## Not verified

- MySQL, MariaDB, ClickHouse, SQL Server: not measured; they suppress nothing, which is the status quo.
- PostgreSQL-family dialects other than `postgres` (`cockroachdb`, `yugabytedb`, `spanner`): not measured, not suppressed.
- The single field assignment `OmitAtlasRefusedBlocks: atlasInspectOmitsRefusedBlocks()` inside `runAtlasSchemaInspect` has no unit test — reaching it needs a live PostgreSQL database. It is covered by the end-to-end live runs in both variable states reported above, not by CI.
- A sequence-grant fixture (`GRANT USAGE ON SEQUENCE`) is covered by unit test only: roles are cluster-scoped, so any Ptah document containing a `role` block fails to materialize on a dev database in the same cluster for a pre-existing reason unrelated to this front.
- The extension-supplying-only-functions case is a known limitation, documented, not fixed.