### PR TITLE
Honor the Atlas --dir default on migrate apply and new (#1241 items 2, 3, 4)

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -74,7 +74,15 @@ type atlasPositionalArg struct {
 
 const (
 	atlasDirFormatDefault = "atlas"
-	atlasErrorExitCode    = 1
+	// atlasDefaultMigrationDirURL is the migration directory every verb that
+	// documents a `--dir` default falls back to. The pinned community binary
+	// v1.3.0 prints `(default "file://migrations")` on `migrate apply`,
+	// `migrate new`, `migrate diff`, `migrate status`, `migrate set`,
+	// `migrate lint`, `migrate hash` and `migrate validate`; Ptah honored it
+	// on some and not others (stokaro/ptah#1241 items 2 and 3), so the value
+	// lives here once instead of being retyped per verb.
+	atlasDefaultMigrationDirURL = "file://migrations"
+	atlasErrorExitCode          = 1
 	// atlasErrorPrefix is the diagnostic prefix of the whole compat surface.
 	// It is declared once on the root command (see NewCompatCommand) and
 	// resolved from the command tree at print time, so every diagnostic below

--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -766,6 +766,15 @@ func TestCompatCommand_MapsAtlasFlagFormsToNativeFlags(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
+			// Run somewhere with no ./migrations. Since stokaro/ptah#1241 item
+			// 2 gave `migrate apply` the Atlas-documented `--dir` default,
+			// omitting the flag no longer stops at `migrations directory is
+			// required`; the run reaches the directory and fails to open it.
+			// The proxy still proves what this test is about — every spelling
+			// of --url got past `database URL is required` — but it now
+			// depends on the working directory, so it is pinned rather than
+			// inherited from the package directory.
+			t.Chdir(t.TempDir())
 			cmd := NewCompatCommand("atlas")
 			var out bytes.Buffer
 			cmd.SetOut(&out)
@@ -774,7 +783,7 @@ func TestCompatCommand_MapsAtlasFlagFormsToNativeFlags(t *testing.T) {
 
 			err := cmd.Execute()
 
-			c.Assert(err, qt.ErrorMatches, "migrations directory is required")
+			c.Assert(err, qt.ErrorMatches, `atlas migrate apply --dir: open migrations directory: .*`)
 		})
 	}
 }

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -43,6 +43,18 @@ type atlasMigrateApplyOptions struct {
 
 func newAtlasMigrateApplyCommand() *cobra.Command {
 	opts := atlasMigrateApplyOptions{
+		// `--dir` defaults to the same directory `migrate status` and
+		// `migrate set` already default to (stokaro/ptah#1241 item 2).
+		// Measured on the pinned community binary v1.3.0: in a directory
+		// holding a hashed ./migrations, `migrate apply --url sqlite://local.db`
+		// with no --dir exits 0 and applies, where Ptah exited 1 with
+		// `migrations directory is required`. Its own --help documents
+		// `(default "file://migrations")` for this flag.
+		//
+		// The default is a default, never a fallback: --dir naming a directory
+		// that is not there still fails rather than quietly reading
+		// ./migrations, which is what keeps a typo visible.
+		dir:       atlasDefaultMigrationDirURL,
 		dirFormat: atlasDirFormatDefault,
 		txMode:    string(migrator.MigrationTxModeFile),
 		execOrder: string(migrator.ExecOrderLinear),
@@ -63,7 +75,7 @@ Native Ptah equivalent: ptah migrations up.`,
 
 	flags := cmd.Flags()
 	flags.StringVarP(&opts.url, "url", "u", "", "Database URL to apply migrations to")
-	flags.StringVar(&opts.dir, "dir", "", "Migration directory URL")
+	flags.StringVar(&opts.dir, "dir", opts.dir, "Migration directory URL")
 	flags.BoolVar(&opts.dryRun, "dry-run", false, "Show migrations without applying them")
 	flags.StringVar(&opts.txMode, "tx-mode", opts.txMode, "Transaction mode: file, all, or none")
 	flags.StringVar(&opts.execOrder, "exec-order", opts.execOrder, "Execution order: linear, linear-skip, or non-linear")

--- a/cmd/atlas/migrate_dir_default_test.go
+++ b/cmd/atlas/migrate_dir_default_test.go
@@ -1,0 +1,371 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/atlascompat"
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// The `--dir` default matrix for stokaro/ptah#1241 items 2, 3 and 4.
+//
+// Every expectation below was measured against the pinned Atlas community
+// binary v1.3.0 on 2026-08-07, each cell in its own freshly built directory,
+// with the exit status read on a line of its own rather than through a pipe.
+// Before the change the three "defaults to ./migrations" rows exited 1 with
+// `migrations directory is required` and the two "creates missing parents" rows
+// exited 1 with `parent directory … is not available`, while that binary exited
+// 0 and wrote in all five.
+//
+// The rows that do NOT move are the point of the file. A default that also acts
+// as a fallback is worse than no default: `--dir file://migrtions` beside a
+// perfectly good ./migrations would silently migrate the wrong directory, and a
+// default that is consulted before the atlas.sum gate would let `migrate new`
+// append to a drifted directory. Those rows are measured too, and they are the
+// ones that go red when the default is turned into a fallback.
+
+// dirDefaultCase is one cell: a fixture, an argv, and what must be true after.
+type dirDefaultCase struct {
+	name   string
+	setup  func(c *qt.C, root string)
+	args   []string
+	assert func(c *qt.C, root string, err error, output string)
+}
+
+func TestCompatMigrateDirDefaults(t *testing.T) {
+	migrationSQL := "CREATE TABLE wanted (id INTEGER PRIMARY KEY);\n"
+	decoySQL := "CREATE TABLE decoy (id INTEGER PRIMARY KEY);\n"
+
+	tests := []dirDefaultCase{
+		{
+			// #1241 item 2. The headline row.
+			name: "apply defaults to file://migrations",
+			setup: func(c *qt.C, root string) {
+				writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_init.sql", migrationSQL)
+			},
+			args: []string{"migrate", "apply", "--url", "sqlite://local.db?_fk=1"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertSQLiteTablePresent(c, filepath.Join(root, "local.db"), "wanted")
+			},
+		},
+		{
+			// The default names a directory, it does not invent one: with no
+			// ./migrations the pinned binary exits 1 with
+			// `sql/migrate: stat migrations: no such file or directory`.
+			name:  "apply without ./migrations still fails",
+			setup: func(_ *qt.C, _ string) {},
+			args:  []string{"migrate", "apply", "--url", "sqlite://local.db?_fk=1"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				// Deliberately not just "any error": before the default
+				// existed this row also failed, with `migrations directory is
+				// required`. Naming the failed OPEN is what makes the row
+				// distinguish a default that resolved and found nothing from a
+				// verb that never had a directory to look for.
+				c.Assert(err.Error(), qt.Contains, "open migrations directory")
+				c.Assert(err.Error(), qt.Contains, "no such file or directory")
+				assertPathAbsent(c, filepath.Join(root, "migrations"))
+			},
+		},
+		{
+			// An explicit --dir still wins. The decoy ./migrations is hashed
+			// and applicable, so a default that beat the flag would exit 0 and
+			// create the wrong table rather than failing visibly.
+			name: "apply --dir overrides the default",
+			setup: func(c *qt.C, root string) {
+				writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_decoy.sql", decoySQL)
+				writeHashedAtlasDir(c, filepath.Join(root, "elsewhere"), "20240101000000_init.sql", migrationSQL)
+			},
+			args: []string{"migrate", "apply", "--url", "sqlite://local.db?_fk=1", "--dir", "file://elsewhere"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertSQLiteTablePresent(c, filepath.Join(root, "local.db"), "wanted")
+				assertSQLiteTableAbsent(c, filepath.Join(root, "local.db"), "decoy")
+			},
+		},
+		{
+			// The typo control. `migrtions` does not exist and ./migrations
+			// does; a fallback would apply the wrong directory and exit 0.
+			name: "apply --dir typo does not fall back to the default",
+			setup: func(c *qt.C, root string) {
+				writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_decoy.sql", decoySQL)
+			},
+			args: []string{"migrate", "apply", "--url", "sqlite://local.db?_fk=1", "--dir", "file://migrtions"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(err.Error(), qt.Contains, "migrtions")
+				assertSQLiteTableAbsent(c, filepath.Join(root, "local.db"), "decoy")
+			},
+		},
+		{
+			// The default reaches the same atlas.sum gate an explicit --dir
+			// reaches. Measured: the pinned binary exits 1 with
+			// `checksum mismatch` on this fixture with no --dir at all.
+			name: "apply default directory is still checksum gated",
+			setup: func(c *qt.C, root string) {
+				dir := filepath.Join(root, "migrations")
+				writeHashedAtlasDir(c, dir, "20240101000000_init.sql", migrationSQL)
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, "20240101000000_init.sql"),
+					[]byte("CREATE TABLE edited (id INTEGER PRIMARY KEY);\n"),
+					0o600,
+				), qt.IsNil)
+			},
+			args: []string{"migrate", "apply", "--url", "sqlite://local.db?_fk=1"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(err.Error(), qt.Contains, "checksum mismatch")
+				assertSQLiteTableAbsent(c, filepath.Join(root, "local.db"), "wanted")
+			},
+		},
+		{
+			// #1241 item 3. `migrate new` documented the default and ignored
+			// it; the pinned binary creates ./migrations and writes into it.
+			name:  "new defaults to file://migrations and creates it",
+			setup: func(_ *qt.C, _ string) {},
+			args:  []string{"migrate", "new", "addcol"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertOneMigrationNamed(c, filepath.Join(root, "migrations"), "*_addcol.sql")
+				assertPathPresent(c, filepath.Join(root, "migrations", atlascompat.AtlasSumFileName))
+			},
+		},
+		{
+			name: "new --dir overrides the default",
+			setup: func(c *qt.C, root string) {
+				c.Assert(os.MkdirAll(filepath.Join(root, "migrations"), 0o755), qt.IsNil)
+			},
+			args: []string{"migrate", "new", "addcol", "--dir", "file://elsewhere"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertOneMigrationNamed(c, filepath.Join(root, "elsewhere"), "*_addcol.sql")
+				assertDirEmpty(c, filepath.Join(root, "migrations"))
+			},
+		},
+		{
+			// #1241 item 4, at three missing levels rather than one: measured,
+			// the pinned binary creates a, a/b, a/b/c, the migration and
+			// atlas.sum, and exits 0.
+			name:  "new --dir creates missing parent directories",
+			setup: func(_ *qt.C, _ string) {},
+			args:  []string{"migrate", "new", "addcol", "--dir", "file://a/b/c"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertOneMigrationNamed(c, filepath.Join(root, "a", "b", "c"), "*_addcol.sql")
+				assertPathPresent(c, filepath.Join(root, "a", "b", "c", atlascompat.AtlasSumFileName))
+			},
+		},
+		{
+			// Creating parents must not create them THROUGH a regular file.
+			// Measured: the pinned binary exits 1 with
+			// `sql/migrate: stat a/b: not a directory`.
+			name: "new --dir refuses a parent that is a regular file",
+			setup: func(c *qt.C, root string) {
+				c.Assert(os.WriteFile(filepath.Join(root, "a"), []byte("not a directory\n"), 0o600), qt.IsNil)
+			},
+			args: []string{"migrate", "new", "addcol", "--dir", "file://a/b"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				// `a` is still the file it was: nothing was replaced or
+				// written through it. Statting `a/b` reports ENOTDIR rather
+				// than ENOENT here, so absence is asserted on the parent's
+				// contents instead of on the child's stat error.
+				assertRegularFileContent(c, filepath.Join(root, "a"), "not a directory\n")
+			},
+		},
+		{
+			// The default reaches the #1086 write gate. An unhashed
+			// ./migrations is refused with nothing added, exactly as the
+			// pinned binary refuses it (`checksum file not found`).
+			name: "new default directory is still checksum gated",
+			setup: func(c *qt.C, root string) {
+				dir := filepath.Join(root, "migrations")
+				c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+				c.Assert(os.WriteFile(
+					filepath.Join(dir, "20240101000000_init.sql"),
+					[]byte(migrationSQL),
+					0o600,
+				), qt.IsNil)
+			},
+			args: []string{"migrate", "new", "addcol"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(err.Error(), qt.Contains, "checksum file not found")
+				assertNoMigrationNamed(c, filepath.Join(root, "migrations"), "*_addcol.sql")
+			},
+		},
+		{
+			// atlas.hcl outranks the default on both binaries: measured, each
+			// writes into mydir and leaves the hashed decoy ./migrations
+			// untouched.
+			name: "new atlas.hcl migration.dir outranks the default",
+			setup: func(c *qt.C, root string) {
+				writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_decoy.sql", decoySQL)
+				c.Assert(os.MkdirAll(filepath.Join(root, "mydir"), 0o755), qt.IsNil)
+				c.Assert(os.WriteFile(filepath.Join(root, "atlas.hcl"), []byte(`env "local" {
+  migration {
+    dir = "file://mydir"
+  }
+}
+`), 0o600), qt.IsNil)
+			},
+			args: []string{"migrate", "new", "addcol", "--env", "local"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertOneMigrationNamed(c, filepath.Join(root, "mydir"), "*_addcol.sql")
+				assertNoMigrationNamed(c, filepath.Join(root, "migrations"), "*_addcol.sql")
+			},
+		},
+		{
+			// PTAH_MIGRATIONS_DIR is the native flag's own environment twin,
+			// the layer atlasargs.appendDefaultArgs consults before it fills
+			// in a default. It has no counterpart on the pinned binary, so the
+			// rule it protects is Ptah's own: adding an Atlas default must not
+			// take a capability away (AGENTS.md, third part).
+			name: "new PTAH_MIGRATIONS_DIR outranks the default",
+			setup: func(c *qt.C, root string) {
+				c.Assert(os.MkdirAll(filepath.Join(root, "migrations"), 0o755), qt.IsNil)
+				c.Setenv("PTAH_MIGRATIONS_DIR", filepath.Join(root, "mydir"))
+			},
+			args: []string{"migrate", "new", "addcol"},
+			assert: func(c *qt.C, root string, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				assertOneMigrationNamed(c, filepath.Join(root, "mydir"), "*_addcol.sql")
+				assertDirEmpty(c, filepath.Join(root, "migrations"))
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			t.Chdir(root)
+			tt.setup(c, root)
+
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+
+			tt.assert(c, root, err, out.String())
+		})
+	}
+}
+
+// TestCompatMigrateDirDefaultIsDocumented pins the help line to the runtime.
+//
+// `migrate new` used to print no default at all while refusing to run without a
+// directory, and `migrate hash` / `migrate validate` printed no default while
+// silently using ./migrations — two ways for `--help` and the runtime to
+// disagree. The pinned community binary v1.3.0 prints
+// `(default "file://migrations")` on every migrate verb that registers --dir.
+func TestCompatMigrateDirDefaultIsDocumented(t *testing.T) {
+	verbs := []string{"apply", "new", "diff", "status", "set", "lint", "hash", "validate"}
+	for _, verb := range verbs {
+		t.Run(verb, func(t *testing.T) {
+			c := qt.New(t)
+			cmd := atlas.NewCompatCommand("atlas")
+			var out bytes.Buffer
+			cmd.SetOut(&out)
+			cmd.SetErr(&out)
+			cmd.SetArgs([]string{"migrate", verb, "--help"})
+
+			c.Assert(cmd.Execute(), qt.IsNil)
+
+			c.Assert(out.String(), qt.Contains, `(default "file://migrations")`)
+		})
+	}
+}
+
+func writeHashedAtlasDir(c *qt.C, dir, name, body string) {
+	c.Helper()
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, name), []byte(body), 0o600), qt.IsNil)
+	sum, err := atlascompat.ComputeSum(os.DirFS(dir), migrator.MigrationDirFormatAtlas)
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, atlascompat.AtlasSumFileName), sum.Bytes(), 0o600), qt.IsNil)
+}
+
+func assertOneMigrationNamed(c *qt.C, dir, pattern string) {
+	c.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 1)
+}
+
+func assertNoMigrationNamed(c *qt.C, dir, pattern string) {
+	c.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 0)
+}
+
+func assertDirEmpty(c *qt.C, dir string) {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0)
+}
+
+func assertPathPresent(c *qt.C, path string) {
+	c.Helper()
+	_, err := os.Stat(path)
+	c.Assert(err, qt.IsNil)
+}
+
+func assertPathAbsent(c *qt.C, path string) {
+	c.Helper()
+	_, err := os.Stat(path)
+	c.Assert(os.IsNotExist(err), qt.IsTrue, qt.Commentf("expected %s to be absent, stat error was %v", path, err))
+}
+
+func assertRegularFileContent(c *qt.C, path, want string) {
+	c.Helper()
+	info, err := os.Lstat(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(info.Mode().IsRegular(), qt.IsTrue)
+	got, err := os.ReadFile(path)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(got), qt.Equals, want)
+}
+
+// sqliteTableNames reads the tables a migration run actually created. The
+// assertions below name a table rather than counting revisions because the two
+// fixtures differ only in which directory was read, and the table name is the
+// only observable that says which one won.
+func sqliteTableNames(c *qt.C, dbPath string) []string {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(schema.Tables))
+	for _, table := range schema.Tables {
+		names = append(names, table.Name)
+	}
+	return names
+}
+
+func assertSQLiteTablePresent(c *qt.C, dbPath, table string) {
+	c.Helper()
+	c.Assert(sqliteTableNames(c, dbPath), qt.Contains, table)
+}
+
+func assertSQLiteTableAbsent(c *qt.C, dbPath, table string) {
+	c.Helper()
+	c.Assert(sqliteTableNames(c, dbPath), qt.Not(qt.Contains), table)
+}

--- a/cmd/atlas/migrate_hash.go
+++ b/cmd/atlas/migrate_hash.go
@@ -42,7 +42,14 @@ func atlasMigrateHashVerb() atlasVerb {
 		native:  "migrations hash",
 		factory: newSilentNativeMigrateHashCommand,
 		flags: []atlasargs.Flag{
-			atlasargs.NativeLocalDir("dir", "", "Migration directory", "dir"),
+			// Measured: this verb already READ ./migrations without --dir,
+			// because the native `ptah migrations hash` defaults its own --dir
+			// to the same directory. Only the help line was silent about it,
+			// so `--help` and the runtime disagreed. Declaring the value here
+			// makes the printed default the one that is used.
+			atlasargs.NativeLocalDirDefault(
+				"dir", "", "Migration directory", "dir", atlasDefaultMigrationDirURL,
+			),
 			atlasMigrateDirFormatFlag("dir-format"),
 		},
 	}

--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -71,7 +71,22 @@ func atlasMigrateNewVerb() atlasVerb {
 		writesDir:  true,
 		factory:    migrate.NewMigrateCreateCommand,
 		flags: []atlasargs.Flag{
-			atlasargs.NativeLocalDir("dir", "", "Migration directory", "migrations-dir"),
+			// `ptah migrations create` registers no default for its own
+			// --migrations-dir, so before this default was declared here the
+			// compat verb refused every invocation that did not spell --dir --
+			// exit 1 with `migrations directory is required` where the pinned
+			// community binary v1.3.0 created ./migrations and a file in it,
+			// and where its own --help already promised
+			// `(default "file://migrations")` (stokaro/ptah#1241 item 3).
+			//
+			// Declared on the Atlas flag rather than on the native one: the
+			// native command is also reachable as `ptah migrations create`,
+			// where no Atlas default is owed, and atlas.hcl `migration.dir`
+			// and PTAH_MIGRATIONS_DIR both still win because
+			// atlasargs.appendDefaultArgs only fills an absent flag.
+			atlasargs.NativeLocalDirDefault(
+				"dir", "", "Migration directory", "migrations-dir", atlasDefaultMigrationDirURL,
+			),
 			atlasMigrateDirFormatFlag("dir-format"),
 			atlasargs.NativeBool("edit", "", "Edit the created migration files", "edit"),
 		},

--- a/cmd/atlas/migrate_validate.go
+++ b/cmd/atlas/migrate_validate.go
@@ -34,7 +34,11 @@ func atlasMigrateValidateVerb() atlasVerb {
 		factory: migratevalidate.NewAtlasMigrateValidateCommand,
 		flags: []atlasargs.Flag{
 			atlasargs.NativeString("dev-url", "", "Dev database URL", "dev-url"),
-			atlasargs.NativeLocalDir("dir", "", "Migration directory", "dir"),
+			// Same as `migrate hash`: the directory was already defaulted by
+			// the native command, and only the help line failed to say so.
+			atlasargs.NativeLocalDirDefault(
+				"dir", "", "Migration directory", "dir", atlasDefaultMigrationDirURL,
+			),
 			atlasMigrateDirFormatFlag("dir-format"),
 		},
 	}

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -684,6 +684,15 @@
     "evidence": "verified `ptah-compat migrate new init_users --dir file://atlasdir` wrote one .sql plus atlas.sum, and `ptah migrations create` wrote an up/down pair; ptah migrations create --help (--editor defaults to $VISUAL then $EDITOR); measured 2026-08-06 against pinned Atlas CE v1.3.0, `ptah-compat migrate new addcol --dir-format <layout>` writes `<V>_addcol.up.sql`+`.down.sql` for golang-migrate, `V<V>__addcol.sql`+`U<V>__addcol.sql` for flyway, and one `<V>_addcol.sql` carrying the goose, dbmate or liquibase directive header, each byte-identical to CE's on the same empty directory, with atlas.sum covering the up-side file only for golang-migrate and flyway"
   },
   {
+    "area": "Versioned migrations — directory",
+    "feature": "`--dir` defaults to `file://migrations`",
+    "ptah": "yes",
+    "atlas_oss": "yes",
+    "atlas_pro": "yes",
+    "note": "All eight migrate verbs registering `--dir` default it to `file://migrations`. Never a fallback: the flag, `PTAH_DIR`, `PTAH_MIGRATIONS_DIR` and `atlas.hcl` outrank it, and `atlas.sum` is still gated.",
+    "evidence": "Measured 2026-08-07 against the pinned Atlas CE v1.3.0, each cell in its own freshly built directory with the exit status read on its own line (stokaro/ptah#1241 items 2, 3 and 4). Before: `migrate apply --url sqlite://local.db` and `migrate new addcol` with no `--dir` exited 1 with `migrations directory is required` in a directory holding a hashed `./migrations`, where CE exited 0 and applied / created the file; `migrate new addcol --dir file://a/b` exited 1 with `parent directory \"…/a\" is not available` at two and at three missing levels, where CE created the whole chain plus the migration and `atlas.sum`. CE's own `--help` promised `(default \"file://migrations\")` on apply, new, diff, status, set, lint, hash and validate; ptah-compat printed it on diff, status, set and lint only, and hash and validate used the directory without printing it. After: all rows match, and the created file sets are identical. Controls, all measured and all still exit 1 with nothing written: `--dir file://migrtions` beside a valid `./migrations` (no fallback), `--dir ''` (`missing scheme for dir url`), a drifted `./migrations` with no `--dir` (`checksum mismatch`), an unhashed one (`checksum file not found`), `./migrations` existing as a regular file, and `--dir file://a/b` over a regular file `a`. Precedence measured with a decoy: `atlas.hcl migration.dir = \"file://mydir\"`, `PTAH_DIR` and `PTAH_MIGRATIONS_DIR` each still win over the default on both binaries where they exist. `migrate hash` and `migrate validate` were already reading `./migrations` through the native command's own default, so only their help line changed."
+  },
+  {
     "area": "Versioned migrations — revision state",
     "feature": "Set revision state to a version",
     "ptah": "yes",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -72,11 +72,11 @@ row for a migration decision.
 
 ## At a glance
 
-Across the 167 capabilities below:
+Across the 168 capabilities below:
 
 | Reading | Count |
 | --- | --- |
-| Ptah supports it fully | 94 |
+| Ptah supports it fully | 95 |
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
 | Ptah and Atlas CE both support it | 26 |

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -79,7 +79,7 @@ Across the 167 capabilities below:
 | Ptah supports it fully | 94 |
 | Ptah supports it with a stated limitation | 49 |
 | Ptah does not implement it | 24 |
-| Ptah and Atlas CE both support it | 25 |
+| Ptah and Atlas CE both support it | 26 |
 | Ptah implements it openly where Atlas gates it behind Pro or Cloud | 42 |
 | Ptah has it and neither Atlas edition does | 21 |
 | Atlas CE has it and Ptah does not, or only in part | 25 |
@@ -160,6 +160,7 @@ seven of them as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
+| `--dir` defaults to `file://migrations` | ✅ | ✅ | ✅ | All eight migrate verbs registering `--dir` default it to `file://migrations`. Never a fallback: the flag, `PTAH_DIR`, `PTAH_MIGRATIONS_DIR` and `atlas.hcl` outrank it, and `atlas.sum` is still gated. |
 | Apply pending migrations (apply/up) | 🟡 | ✅ | ✅ | Dry runs read stored revisions, select only pending files, and retain execution-time validation. ClickHouse Atlas-format revision tables are covered. |
 | Atlas R-suffixed (`1R_`, `R__`) migration execution | ❌ | ✅ | ✅ | Ptah refuses an Atlas directory holding one, naming every such file; CE executes it keyed on the version string the name spells. Dropping it at exit 0 was stokaro/ptah#846. |
 | Atlas SQL template migrations (`--atlas-env`) | ✅ | ❌ | ❌ | Go-template actions in Atlas-format migration files render before execution with .Env set by `--atlas-env`; sibling *.sql files supply shared {{ template }} definitions. CE runs the braces as SQL. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -35,6 +35,37 @@ plus the flag translation rules are on the
 Per-verb status detail — Atlas differences, waivers, and the inputs that fail
 explicitly — is on [Atlas-compatible commands](../../reference/atlas-commands/).
 
+### The `--dir` default
+
+Every `migrate` verb that registers `--dir` defaults it to
+`file://migrations`, so `ptah-compat migrate apply --url "$DATABASE_URL"` run
+from a project root reads `./migrations` with no flag at all. That is
+`apply`, `new`, `diff`, `status`, `set`, `lint`, `hash` and `validate` — the
+same eight verbs Atlas documents the default on, and the same value
+([#1241](https://github.com/stokaro/ptah/issues/1241)). `migrate apply` and
+`migrate new` used to refuse a run with no `--dir`, and `migrate hash` and
+`migrate validate` used the directory without printing the default in `--help`.
+
+The default is a default, not a fallback. Every layer that names a directory
+outranks it — `--dir`, `PTAH_DIR`, `PTAH_MIGRATIONS_DIR`, and `atlas.hcl`
+`migration.dir` — and a `--dir` naming a directory that is not there fails
+rather than quietly reading `./migrations`:
+
+```bash
+ptah-compat migrate apply --url "$DATABASE_URL" --dir file://migrtions
+# Error: atlas migrate apply --dir: open migrations directory: openat migrtions: no such file or directory
+```
+
+The default also does not skip anything. A defaulted directory reaches the
+`atlas.sum` gate exactly as an explicit one does, so an unhashed or drifted
+`./migrations` is still refused with `Error: checksum file not found` or
+`Error: checksum mismatch`.
+
+The writing verbs create the directory they are pointed at, including missing
+parents: `ptah-compat migrate new add_users --dir file://db/migrations` creates
+`db` and `db/migrations`. A path component that already exists and is not a
+directory is still refused, and nothing is written.
+
 ## Worked example: an Atlas-format directory
 
 Atlas-style migration files can include `migration.sql`, `down.sql`, the

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -279,6 +279,15 @@ nothing. The same applies to its `PTAH_DIR` twin. The verbs that only read a
 directory still accept a bare path, as does `atlas.hcl` `migration.dir`
 ([#1186](https://github.com/stokaro/ptah/issues/1186)).
 
+Omitted entirely, `--dir` defaults to `file://migrations`, so
+`ptah-compat migrate new add_users` creates `./migrations` and writes into it
+([#1241](https://github.com/stokaro/ptah/issues/1241)). Missing parents are
+created too: `--dir file://db/migrations` creates `db` and `db/migrations`. A
+path component that exists and is not a directory is still refused, and nothing
+is written. See
+[The `--dir` default](../../atlas/migrate-commands/#the---dir-default) for how
+the default ranks against `PTAH_DIR`, `PTAH_MIGRATIONS_DIR` and `atlas.hcl`.
+
 ### `ptah-compat migrate set [version]`
 
 Moves Atlas revision history to the positional version without executing

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -117,6 +117,26 @@ func NativeLocalDir(name, shorthand, usage, nativeName string) Flag {
 	return flag
 }
 
+// NativeLocalDirDefault is [NativeLocalDir] carrying the Atlas-documented
+// default directory URL for the flag.
+//
+// The default is what [registerAtlasFlags] prints in `--help` and what
+// [appendDefaultArgs] folds into the arguments when no layer named a directory,
+// so declaring it here is what makes the help line and the runtime agree. On
+// the pinned community binary v1.3.0 every migrate verb that registers --dir
+// documents `(default "file://migrations")`; Ptah honored it on some verbs and
+// not others, and `migrate new` printed the flag with no default at all while
+// refusing to run without one (stokaro/ptah#1241 item 3).
+//
+// It is a DEFAULT, not a fallback: a --dir naming a directory that is not there
+// still fails, because the value only ever fills in for an absent flag and is
+// never consulted after a failed open.
+func NativeLocalDirDefault(name, shorthand, usage, nativeName, defaultValue string) Flag {
+	flag := NativeLocalDir(name, shorthand, usage, nativeName)
+	flag.Default = defaultValue
+	return flag
+}
+
 // NativeBool creates an Atlas boolean flag that forwards to a native Ptah flag
 // with a different name.
 func NativeBool(name, shorthand, usage, nativeName string) Flag {

--- a/migration/generator/file_creation_test.go
+++ b/migration/generator/file_creation_test.go
@@ -38,12 +38,46 @@ func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T)
 	c.Assert(string(downBytes), qt.Equals, "SELECT down;\n")
 }
 
-func TestCreateMigrationFilesRequiresExistingParent(t *testing.T) {
+// TestCreateMigrationFilesCreatesMissingParents replaces
+// TestCreateMigrationFilesRequiresExistingParent, which pinned the opposite
+// behavior.
+//
+// This changes behavior; pre-v1, so no compatibility with Ptah's own past is
+// owed (AGENTS.md). The requirement came from parity: measured on the pinned
+// Atlas community binary v1.3.0, `migrate new addcol --dir file://a/b` in an
+// empty directory creates a, a/b, the migration and atlas.sum and exits 0,
+// where this refused with `parent directory "…/a" is not available` and wrote
+// nothing (stokaro/ptah#1241 item 4). Ptah's `migrate diff` writer already
+// created parents, so the two writers also disagreed with each other.
+func TestCreateMigrationFilesCreatesMissingParents(t *testing.T) {
 	c := qt.New(t)
-	dir := filepath.Join(t.TempDir(), "missing", "migrations")
+	dir := filepath.Join(t.TempDir(), "missing", "levels", "migrations")
 
-	_, err := createMigrationFiles(dir, 1, "init", "SELECT 1;\n", "SELECT 2;\n")
-	c.Assert(err, qt.ErrorMatches, `failed to create output directory: parent directory .* is not available: .*`)
+	files, err := createMigrationFiles(dir, 1, "init", "SELECT 1;\n", "SELECT 2;\n")
+	c.Assert(err, qt.IsNil)
+	c.Assert(filepath.Dir(files.UpFile), qt.Equals, dir)
+
+	upBytes, err := os.ReadFile(files.UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upBytes), qt.Equals, "SELECT 1;\n")
+}
+
+// TestCreateMigrationFilesRefusesParentThatIsAFile is the control for the test
+// above: creating parents must not mean creating them through something that is
+// not a directory. The pinned binary refuses that path too
+// (`stat a/b: not a directory`, exit 1), so both stay refusals.
+func TestCreateMigrationFilesRefusesParentThatIsAFile(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	blocker := filepath.Join(root, "a")
+	c.Assert(os.WriteFile(blocker, []byte("not a directory\n"), 0600), qt.IsNil)
+
+	_, err := createMigrationFiles(filepath.Join(blocker, "b"), 1, "init", "SELECT 1;\n", "SELECT 2;\n")
+	c.Assert(err, qt.ErrorMatches, `failed to create output directory: .*not a directory`)
+
+	blockerBytes, err := os.ReadFile(blocker)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(blockerBytes), qt.Equals, "not a directory\n")
 }
 
 func TestGenerateEmptyMigrationCreatesSkeletonPair(t *testing.T) {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -2221,6 +2221,23 @@ func migrationFilesFromPairs(pairs []MigrationFilePair) *MigrationFiles {
 	}
 }
 
+// ensureMigrationOutputDir creates the migration output directory, including
+// every missing parent above it.
+//
+// The parents are the point. This used to os.Mkdir the leaf after requiring its
+// parent to already exist, so `--dir file://a/b` with no `a` failed with
+// `parent directory "…/a" is not available` and wrote nothing, where the pinned
+// community binary v1.3.0 created `a`, `a/b`, the migration file and atlas.sum
+// and exited 0 — measured on 2026-08-07 at two and at three missing levels
+// (stokaro/ptah#1241 item 4). Ptah's OTHER writing verb already did this: the
+// `migrate diff` writer creates parents through
+// internal/atlasmigrate.ensureMigrationDirParent, so the two writers disagreed
+// with each other as well as with that binary.
+//
+// What must NOT relax is a path component that exists and is not a directory.
+// os.MkdirAll refuses that with ENOTDIR naming the offending component, and the
+// pinned binary refuses it too (`--dir file://a/b` over a regular file `a`
+// exits 1 with `stat a/b: not a directory`), so both stay exit 1.
 func ensureMigrationOutputDir(outputDir string) error {
 	info, err := os.Stat(outputDir)
 	if err == nil {
@@ -2232,14 +2249,7 @@ func ensureMigrationOutputDir(outputDir string) error {
 	if !errors.Is(err, os.ErrNotExist) {
 		return err
 	}
-
-	parent := filepath.Dir(outputDir)
-	if parentInfo, statErr := os.Stat(parent); statErr != nil {
-		return fmt.Errorf("parent directory %q is not available: %w", parent, statErr)
-	} else if !parentInfo.IsDir() {
-		return fmt.Errorf("parent path %q is not a directory", parent)
-	}
-	return os.Mkdir(outputDir, 0755)
+	return os.MkdirAll(outputDir, 0755)
 }
 
 func writeNewMigrationFile(path, content string) error {


### PR DESCRIPTION
Closes items **2, 3 and 4** of #1241 — three of the fifteen orphan divergences where `ptah-compat` exits 1 and the pinned community binary v1.3.0 exits 0. They share one shape: the `--dir` default.

Item 1 of that issue (apply wedged after a failure) is explicitly **out of scope**; the dirty-revision gate is untouched.

## What was measured, before any code changed

Measured 2026-08-07 against the pinned binary. Each cell ran in its own freshly built directory, `cd`-ing into it, with the exit status read on a line of its own after a redirect — never through a pipe. Fixtures were hashed with the pinned binary's own `migrate hash`.

| cell | pinned binary | ptah-compat (before) |
| --- | --- | --- |
| `migrate apply --url sqlite://local.db` in a dir with hashed `./migrations` | **0**, applies | **1** `migrations directory is required` |
| same, `./migrations` present but empty | **0** `No migration files to execute` | **1**, same message |
| `migrate new addcol`, no `./migrations` | **0**, creates `migrations/`, the file and `atlas.sum` | **1**, same message |
| `migrate new addcol`, hashed `./migrations` present | **0**, adds a file | **1**, same message |
| `migrate new addcol --dir file://a/b` | **0**, creates `a`, `a/b`, file, `atlas.sum` | **1** `parent directory "…/a" is not available` |
| `migrate new addcol --dir file://a/b/c` | **0**, creates all three levels | **1**, same |
| `migrate new` with no name at all | **0**, writes `<version>.sql` | **1**, same message |

`--help` on the pinned binary documents `(default "file://migrations")` on **eight** verbs: apply, new, diff, status, set, lint, hash, validate. Ptah printed it on diff, status, set and lint only.

### Enumerating every verb, not only the two the issue named

`migrate hash` and `migrate validate` were also silent about the default — but measured, they were already **reading** `./migrations` with no `--dir` (exit 0 on a hashed dir, exit 1 on a missing one, matching), because the native command they forward to defaults its own `--dir`. Only their help line lied. Those two get the help default and no runtime change.

## The fix

- `migrate apply`: `--dir` defaults to `file://migrations`, registered the way `migrate status` and `migrate set` already do it.
- `migrate new`: the default is declared on the Atlas flag descriptor (`atlasargs.NativeLocalDirDefault`), so one declaration supplies both the `--help` line and the value `appendDefaultArgs` folds in. Declared on the Atlas flag rather than the native one: `ptah migrations create` is also reachable directly, where no Atlas default is owed.
- `migration/generator.ensureMigrationOutputDir` creates missing parents (`os.MkdirAll`) instead of requiring the parent to exist.
- One shared constant, `atlasDefaultMigrationDirURL`, instead of the value retyped per verb.

## Controls — what stops a default becoming a silent fallback

Every one of these was measured on both binaries and is a test row.

- **Typo.** `migrate apply --dir file://migrtions` beside a hashed, applicable `./migrations` still exits 1 and creates nothing. A fallback would have applied the wrong directory at exit 0.
- **Explicit override.** `--dir file://elsewhere` with a hashed decoy `./migrations` applies `elsewhere`. The two fixtures differ only in which table they create, so "landed in the wrong place" shows up as content, not as an exit code.
- **The gate still runs on a defaulted directory.** Drifted `./migrations` with no `--dir` → `checksum mismatch`; unhashed → `checksum file not found`; nothing written. Both byte-identical to the pinned binary on the same fixture.
- **Precedence.** `atlas.hcl` `migration.dir`, `PTAH_DIR` and `PTAH_MIGRATIONS_DIR` each still win, verified against a hashed decoy `./migrations` that must stay untouched. On the `atlas.hcl` row both binaries applied the same migration from `mydir`, confirmed by reading the resulting table out of the SQLite file.
- **Refusals stay refusals.** `--dir ''` → `missing scheme for dir url. Did you mean "file://"?` (the pinned binary's own text). `./migrations` existing as a regular file → exit 1. `--dir file://a/b` where `a` is a regular file → exit 1, and `a` is byte-unchanged.

## Parity rule (a)

Across 46 measured cells: **no cell where ptah-compat exits 0 and the pinned binary exits 1**, before or after. Of the eleven differing cells in the main matrix, eight close. The three that remain are pre-existing refusals outside this front and were already exit 1 on master:

- `--dir mem://x` on `new` and `apply` — Ptah refuses a non-`file://` migration directory; the pinned binary exits 0 and silently discards the file.
- `--dir file://../outside` — the rooted-path refusal, which is #1241 **item 11**.

## Behavior change for native Ptah

`ptah migrations create --migrations-dir a/b` now creates `a`. This replaces `TestCreateMigrationFilesRequiresExistingParent`, which pinned the opposite. This changes behavior; pre-v1, so no compatibility with Ptah's own past is owed (AGENTS.md). Ptah's *other* writing verb already created parents (`internal/atlasmigrate.ensureMigrationDirParent`) — measured, `migrate diff --dir file://a/b` succeeds on master — so the two writers disagreed with each other as well as with the pinned binary.

`TestCompatCommand_MapsAtlasFlagFormsToNativeFlags` used "no `--dir`" as its proxy for "the `--url` spellings parsed". It now pins its working directory and expects the directory-open diagnostic, which still proves every spelling got past `database URL is required`.

## Mutation coverage

Six mutants, each applied and reverted. Three are **inverse** mutants — a revert of the fix can never produce them, so they are what actually exercises the controls.

| mutant | red |
| --- | --- |
| apply default removed | 3 rows (`apply` default, gated default, help) |
| new default removed | 3 rows |
| `os.MkdirAll` → `os.Mkdir` + parent check | 1 row (parent creation) |
| **inverse:** default consulted again after a failed open | the typo control |
| **inverse:** write gate skipped for a defaulted directory | the checksum control |
| **inverse:** default appended unconditionally | both precedence controls + 3 more |

In every case the non-interference controls stayed green.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 (proved live: adding an `if` to the new table body reddens it naming the file) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| all 15 `check:*` in `docs/site/package.json` | 0 — `check:responsive` after `npm ci` + `npm run build`, genuinely running (60 routes × 2 viewports) |
| `build-feature-matrix.mjs --check` | 0 |

## Not verified

- **SQLite only**, matching the scope #1241 declares. Not re-checked on PostgreSQL, MySQL, MariaDB, ClickHouse or Spanner. Nothing in the change is dialect-specific — it is flag defaulting and directory creation, both above the driver — but the issue asks for a server-backed re-check before a finding is called closed, and that is not done here.
- `migrate diff`'s `--dir` default was already correct and is unchanged; it was measured, not modified.
- The `migrate apply` success report still differs in wording from the pinned binary's (`Migrating to version … (1 migrations in total)` block). That is a pre-existing output-shape divergence, not part of these items.
- Whether the pinned binary's tolerance of `--dir mem://x` is contract or accident was not investigated; Ptah stays stricter there, as before.