### PR TITLE
Keep the schema apply dev simulation inside the dev database (#1240)

### DIFF
--- a/cmd/atlas/schema_apply_lock_test.go
+++ b/cmd/atlas/schema_apply_lock_test.go
@@ -119,12 +119,14 @@ CREATE TABLE sim_orders (id INTEGER PRIMARY KEY);
 
 	err := cmd.Execute()
 
-	// The dev database ends at recreated current state plus the rehearsed
-	// plan, with stale objects gone; the target gets the plan afterwards.
+	// The dev database is borrowed and handed back: the pre-existing litter is
+	// gone, and so is everything the rehearsal created. The target gets the
+	// plan afterwards, which is what proves the rehearsal was not skipped —
+	// planning it required no dev database, but reaching the apply did.
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
 	c.Assert(out.String(), qt.Contains, "Schema apply completed successfully.")
-	c.Assert(sqliteTableCount(c, devPath, "sim_users"), qt.Equals, 1)
-	c.Assert(sqliteTableCount(c, devPath, "sim_orders"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, devPath, "sim_users"), qt.Equals, 0)
+	c.Assert(sqliteTableCount(c, devPath, "sim_orders"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, devPath, "sim_stale"), qt.Equals, 0)
 	c.Assert(sqliteTableCount(c, dbPath, "sim_orders"), qt.Equals, 1)
 }

--- a/cmd/schema/apply_test.go
+++ b/cmd/schema/apply_test.go
@@ -189,9 +189,10 @@ func TestSchemaApplyDevSimulationRunsBeforeTarget(t *testing.T) {
 	c.Assert(err, qt.IsNil, qt.Commentf("%s", out))
 	c.Assert(out, qt.Contains, "Schema apply completed successfully.")
 	c.Assert(listSQLiteTables(c, dbPath), qt.DeepEquals, []string{"orders", "users"})
-	// The dev database rehearsed the plan: the recreated current schema plus
-	// the planned changes.
-	c.Assert(listSQLiteTables(c, devPath), qt.DeepEquals, []string{"orders", "users"})
+	// The dev database rehearsed the plan and was then handed back with
+	// nothing in it, the way the pinned community binary leaves its own dev
+	// database. A dev URL stays reusable by the next command.
+	c.Assert(listSQLiteTables(c, devPath), qt.HasLen, 0)
 }
 
 func TestSchemaApplyPlanFileExecutesAndRefusesStaleTarget(t *testing.T) {

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -269,10 +269,24 @@ required.
 
 Before a non-dry-run apply touches the target, the generated plan is rehearsed
 on the dev database: Ptah resets the dev database, recreates the target's
-introspected current schema on it, and executes the exact ordered plan
-statements — including SQL edited through `--edit` — under the same
-transaction mode as the target apply. A failed rehearsal refuses the apply and
-leaves the target unchanged.
+introspected current schema on it, and executes the ordered plan statements —
+including SQL edited through `--edit` — under the same transaction mode as the
+target apply. A failed rehearsal refuses the apply and leaves the target
+unchanged.
+
+On MySQL, MariaDB, and ClickHouse a schema *is* a database, so a plan
+qualified with the target's schema name would modify the target whichever
+connection issued it. Ptah re-scopes those statements onto the dev database
+before rehearsing them, so the rehearsal runs entirely inside `--dev-url`. A
+statement naming a third database — one that is neither the target nor the dev
+database — cannot be re-scoped and is refused rather than executed somewhere
+nobody asked for. On the PostgreSQL family, SQLite, and SQL Server a schema is
+a namespace inside the connected database, so the plan is rehearsed exactly as
+planned.
+
+The dev database is handed back with nothing the rehearsal put in it, on both
+the success and the failure path, so the same `--dev-url` stays usable by the
+next command.
 
 The dev database must not be the target itself or a database-URL `--to`
 desired state (it is reset destructively), must be directly connectable (no

--- a/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
+++ b/docs/site/src/content/docs/concepts/database-urls-and-dev-databases.md
@@ -37,11 +37,17 @@ whose state matters after the command exits.
 
 **A dev database** (`--dev-url`) is a disposable replay target used for
 validation: `ptah migrations validate` and `ptah migrations lint` clean it and
-replay the migration directory on it to prove the SQL executes, and
-Atlas-compatible verbs use it for planning, linting, and rollback verification.
-Ptah cleans the replay realm before migration execution, after a failed replay,
-and after a successful replay. Commands that inspect the replayed state do so
-between execution and the final cleanup on the same pinned database session.
+replay the migration directory on it to prove the SQL executes, `schema apply`
+rehearses its plan on it before touching the target, and Atlas-compatible verbs
+use it for planning, linting, and rollback verification. Ptah cleans the replay
+realm before migration execution, after a failed replay, and after a successful
+replay. Commands that inspect the replayed state do so between execution and
+the final cleanup on the same pinned database session.
+
+Everything a dev database runs stays inside it. Where a schema names a database
+rather than a namespace — MySQL, MariaDB, and ClickHouse — a plan carrying the
+target's schema name is re-scoped onto the dev database before it is rehearsed,
+and a statement naming some third database is refused instead of run.
 
 **A shadow database** (`--shadow-db`) is a disposable verification target for
 commands that write or record migrations: `ptah migrations generate` replays

--- a/docs/site/src/content/docs/direct/apply.md
+++ b/docs/site/src/content/docs/direct/apply.md
@@ -43,8 +43,10 @@ ptah schema apply --db-url "sqlite://$PWD/app.db" --plan change.plan.json
 On the Atlas-compatible surface, `--to` additionally accepts a database URL
 whose live schema becomes the desired state, or an Atlas-format migration
 directory replayed on the required `--dev-url` dev database. When `--dev-url`
-is set, the exact ordered plan is rehearsed on the dev database before the
-target is touched, and a failed rehearsal refuses the apply. `--lock-timeout`
+is set, the ordered plan is rehearsed on the dev database before the target is
+touched, and a failed rehearsal refuses the apply. The rehearsal runs entirely
+inside the dev database, which is handed back empty afterwards — see
+[Atlas schema commands](../../atlas/schema-commands/). `--lock-timeout`
 bounds the session advisory lock that serializes concurrent applies,
 `--tx-mode` selects the transaction mode, `--edit` opens the planned SQL in
 `$VISUAL`/`$EDITOR`, and `--schemas`, `--include`, and `--exclude` scope both

--- a/internal/atlasschema/devscope.go
+++ b/internal/atlasschema/devscope.go
@@ -1,0 +1,246 @@
+package atlasschema
+
+import (
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/lexer"
+	"go.5x5.cz/ptah/internal/sqlident"
+)
+
+// DevScopeError reports that a statement about to be rehearsed on the dev
+// database names a schema the dev database does not own, on a dialect where a
+// schema *is* a database. Executing it would modify that other database no
+// matter which connection issues it, so the rehearsal is refused instead.
+type DevScopeError struct {
+	// StatementIndex is the 1-based position of the offending statement.
+	StatementIndex int
+	// Schema is the schema name the statement carries.
+	Schema string
+	// DevSchema is the database the dev connection is bound to.
+	DevSchema string
+	// Dialect is the normalized dialect whose schema names a database.
+	Dialect string
+}
+
+func (e *DevScopeError) Error() string {
+	return fmt.Sprintf(
+		"dev database simulation refused: statement %d names schema %q, but the dev database is %q. "+
+			"On %s a schema is a database, so that statement would modify %q no matter which connection "+
+			"issues it, and a simulation must not touch anything but the dev database",
+		e.StatementIndex, e.Schema, e.DevSchema, e.Dialect, e.Schema)
+}
+
+// IsDevScopeEscape reports whether err wraps a dev database scope refusal.
+func IsDevScopeEscape(err error) bool {
+	var target *DevScopeError
+	return errors.As(err, &target)
+}
+
+// schemaScopeNamesDatabase reports whether a connection's schema scope names a
+// whole database rather than a namespace inside the connected one.
+//
+// This is the difference that makes stokaro/ptah#1240 a MySQL defect. Measured
+// on 2026-08-07 against a live MySQL 9.7 and a live PostgreSQL 17, one apply
+// each from a freshly created target/dev pair:
+//
+//   - MySQL: the plan reads CREATE TABLE `target`.`users`; rehearsing it on the
+//     dev connection created `users` in the TARGET database and left the dev
+//     database empty.
+//   - PostgreSQL: the plan reads CREATE TABLE "public"."users"; rehearsing it on
+//     the dev connection created `public.users` in the DEV database. The same
+//     qualified-plan-against-dev shape is present, and it is contained, because
+//     a PostgreSQL schema cannot name anything outside the connected database.
+func schemaScopeNamesDatabase(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		return true
+	default:
+		return false
+	}
+}
+
+// rescopeStatementsForDevDatabase rewrites an apply plan so it rehearses inside
+// the dev database, and refuses it when that cannot be guaranteed.
+//
+// On dialects where a schema is a namespace inside the connected database the
+// statements are returned untouched: the connection already contains them.
+// Where a schema is a database, every schema name the statements carry is the
+// target's, and executing them unchanged would modify the target. Each such
+// name is rewritten to the dev database's own name, and any name that is left
+// naming neither the dev database (a cross-database reference, or a spelling
+// this rewrite does not recognize) refuses the rehearsal rather than running it
+// somewhere unknown.
+func rescopeStatementsForDevDatabase(statements []string, dialect, targetSchema, devSchema string) ([]string, error) {
+	if !schemaScopeNamesDatabase(dialect) {
+		return statements, nil
+	}
+	dev := strings.TrimSpace(devSchema)
+	if dev == "" {
+		return nil, errors.New(
+			"--dev-url must name a database: the apply plan carries the target's schema name, and on this dialect a " +
+				"schema is a database, so rehearsing the plan needs the dev database's own name to put in its place")
+	}
+	target := strings.TrimSpace(targetSchema)
+	rescoped := make([]string, len(statements))
+	for i, statement := range statements {
+		rewritten := rewriteSchemaNames(statement, dialect, target, dev)
+		if err := checkStatementScopedToDev(rewritten, i+1, dialect, dev); err != nil {
+			return nil, err
+		}
+		rescoped[i] = rewritten
+	}
+	return rescoped, nil
+}
+
+// rewriteSchemaNames replaces every schema name spelled `from` with `to`,
+// quoted for dialect. Only bare and dialect-quoted identifiers are rewritten;
+// anything else is left for checkStatementScopedToDev to refuse.
+func rewriteSchemaNames(statement, dialect, from, to string) string {
+	if from == "" || from == to {
+		return statement
+	}
+	tokens := significantTokens(statement, dialectUsesBackslashEscapes(dialect), dialect)
+	positions := schemaNamePositions(tokens)
+	replacement := sqlident.Quote(dialect, to)
+	// Splice from the end so earlier offsets stay valid.
+	for _, position := range slices.Backward(positions) {
+		token := tokens[position]
+		if token.Type != lexer.TokenIdentifier || unquoteSchemaName(token) != from {
+			continue
+		}
+		statement = statement[:token.Start] + replacement + statement[token.End:]
+	}
+	return statement
+}
+
+// checkStatementScopedToDev refuses a statement that still names a schema other
+// than the dev database's own. It scans under both string-escape
+// interpretations, like [CheckPlanStatementsSandboxable], so a statement whose
+// tokenization depends on the escape mode cannot hide a name under the one that
+// was not checked.
+func checkStatementScopedToDev(statement string, index int, dialect, devSchema string) error {
+	for _, backslashEscapes := range []bool{false, true} {
+		tokens := significantTokens(statement, backslashEscapes, dialect)
+		for _, position := range schemaNamePositions(tokens) {
+			name := unquoteSchemaName(tokens[position])
+			if name == devSchema {
+				continue
+			}
+			return &DevScopeError{
+				StatementIndex: index,
+				Schema:         name,
+				DevSchema:      devSchema,
+				Dialect:        platform.NormalizeDialect(dialect),
+			}
+		}
+	}
+	return nil
+}
+
+// schemaNamePositions returns the token indexes that name a schema:
+//
+//   - a qualifier, the head of a dotted object reference (`db`.`users`);
+//   - the operand of USE, and of CREATE/DROP/ALTER SCHEMA|DATABASE, which name
+//     a database directly rather than through a dot.
+//
+// The second form is restricted to the statement's leading keywords so that an
+// ordinary column named `database` — legal and unreserved in MySQL — is not
+// mistaken for one.
+func schemaNamePositions(tokens []lexer.Token) []int {
+	var positions []int
+	for i := range tokens {
+		if !isSchemaNameToken(tokens[i]) {
+			continue
+		}
+		if i+1 >= len(tokens) || !tokens[i+1].MatchOperatorValue(".") {
+			continue
+		}
+		// The tail of a longer dotted path names an object, not a schema.
+		if i > 0 && tokens[i-1].MatchOperatorValue(".") {
+			continue
+		}
+		positions = append(positions, i)
+	}
+	if operand, ok := schemaOperandPosition(tokens); ok {
+		positions = append(positions, operand)
+	}
+	slices.Sort(positions)
+	return slices.Compact(positions)
+}
+
+// schemaOperandPosition finds the database named directly by a statement's
+// leading keywords: `USE <db>` and `CREATE|DROP|ALTER SCHEMA|DATABASE [IF [NOT]
+// EXISTS] <db>`. USE matters most: a plan that switches the session's database
+// would silently move every later statement out of the dev database.
+func schemaOperandPosition(tokens []lexer.Token) (int, bool) {
+	if len(tokens) >= 2 && isKeyword(tokens[0], "USE") && isSchemaNameToken(tokens[1]) {
+		return 1, true
+	}
+	if len(tokens) < 3 {
+		return 0, false
+	}
+	if !isKeyword(tokens[0], "CREATE") && !isKeyword(tokens[0], "DROP") && !isKeyword(tokens[0], "ALTER") {
+		return 0, false
+	}
+	if !isKeyword(tokens[1], "SCHEMA") && !isKeyword(tokens[1], "DATABASE") {
+		return 0, false
+	}
+	position := 2
+	for position < len(tokens) && (isKeyword(tokens[position], "IF") ||
+		isKeyword(tokens[position], "NOT") || isKeyword(tokens[position], "EXISTS")) {
+		position++
+	}
+	if position >= len(tokens) || !isSchemaNameToken(tokens[position]) {
+		return 0, false
+	}
+	return position, true
+}
+
+// isSchemaNameToken reports whether a token can name a schema. Double-quoted
+// names arrive from the lexer as strings, and they are accepted here so a
+// quoted foreign schema name is refused rather than silently unseen; only bare
+// and dialect-quoted identifiers are ever rewritten.
+func isSchemaNameToken(token lexer.Token) bool {
+	switch token.Type {
+	case lexer.TokenIdentifier:
+		return true
+	case lexer.TokenString:
+		return strings.HasPrefix(token.Value, `"`)
+	default:
+		return false
+	}
+}
+
+// unquoteSchemaName returns the schema name a token spells, undoubling the
+// escaped delimiter the SQL standard uses inside a quoted identifier.
+func unquoteSchemaName(token lexer.Token) string {
+	value := token.Value
+	for _, quote := range []string{"`", `"`, "[]"} {
+		open, closing := quote[:1], quote[len(quote)-1:]
+		if !strings.HasPrefix(value, open) || !strings.HasSuffix(value, closing) || len(value) < 2 {
+			continue
+		}
+		inner := value[1 : len(value)-1]
+		if open == closing {
+			inner = strings.ReplaceAll(inner, open+open, open)
+		}
+		return inner
+	}
+	return value
+}
+
+// dialectUsesBackslashEscapes reports the string-escape interpretation the
+// server actually applies, so a rewrite edits the same token stream the engine
+// will parse. MySQL, MariaDB, and ClickHouse honor backslash escapes.
+func dialectUsesBackslashEscapes(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/atlasschema/devscope_internal_test.go
+++ b/internal/atlasschema/devscope_internal_test.go
@@ -1,0 +1,280 @@
+package atlasschema
+
+// White-box testing required: rescopeStatementsForDevDatabase is the step that
+// keeps a dev-database rehearsal inside the dev database, and it runs between
+// two package-private stages (plan preparation and the rehearsal core) that no
+// exported entry point exposes separately. Driving it through `schema apply`
+// would need a live MySQL server for every row; the rewrite and the refusal are
+// pure string work and are asserted directly here. The end-to-end property —
+// a failed apply leaves the target byte-identical — is covered live in
+// simulate_mysql_live_test.go.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+)
+
+func TestRescopeStatementsForDevDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		dialect    string
+		target     string
+		dev        string
+		statements []string
+		assert     func(c *qt.C, got []string, err error)
+	}{
+		{
+			name:       "mysql qualified create table moves to the dev database",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `app`.`users` (\n  `id` int PRIMARY KEY\n)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE TABLE `appdev`.`users` (\n  `id` int PRIMARY KEY\n)"})
+			},
+		},
+		{
+			name:    "mysql rewrites every qualifier in one statement",
+			dialect: platform.MySQL,
+			target:  "app",
+			dev:     "appdev",
+			statements: []string{
+				"ALTER TABLE `app`.`posts` ADD CONSTRAINT `fk` FOREIGN KEY (`user_id`) REFERENCES `app`.`users` (`id`)",
+			},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{
+					"ALTER TABLE `appdev`.`posts` ADD CONSTRAINT `fk` FOREIGN KEY (`user_id`) REFERENCES `appdev`.`users` (`id`)",
+				})
+			},
+		},
+		{
+			name:       "mysql quotes a bare qualifier on the way to the dev database",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"DROP TABLE IF EXISTS app.users"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"DROP TABLE IF EXISTS `appdev`.users"})
+			},
+		},
+		{
+			name:       "mysql rewrites a session database switch",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"USE app"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"USE `appdev`"})
+			},
+		},
+		{
+			name:       "mysql rewrites a schema creation naming the target",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE SCHEMA IF NOT EXISTS `app`"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE SCHEMA IF NOT EXISTS `appdev`"})
+			},
+		},
+		{
+			name:       "mysql refuses a third database the rewrite cannot claim",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `elsewhere`.`users` (`id` int)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(got, qt.IsNil)
+				c.Assert(IsDevScopeEscape(err), qt.IsTrue, qt.Commentf("error: %v", err))
+				c.Assert(err, qt.ErrorMatches,
+					`dev database simulation refused: statement 1 names schema "elsewhere", but the dev database is "appdev"\..*`)
+			},
+		},
+		{
+			name:       "mysql refuses a session switch to a third database",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"USE elsewhere"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(got, qt.IsNil)
+				c.Assert(IsDevScopeEscape(err), qt.IsTrue, qt.Commentf("error: %v", err))
+			},
+		},
+		{
+			name:       "mysql reports the offending statement index",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `app`.`a` (`id` int)", "CREATE TABLE `elsewhere`.`b` (`id` int)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(got, qt.IsNil)
+				var scopeErr *DevScopeError
+				c.Assert(err, qt.ErrorAs, &scopeErr)
+				c.Assert(scopeErr.StatementIndex, qt.Equals, 2)
+				c.Assert(scopeErr.Schema, qt.Equals, "elsewhere")
+			},
+		},
+		{
+			name:       "mysql refuses a double-quoted foreign schema rather than missing it",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{`CREATE TABLE "elsewhere"."users" ("id" int)`},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(got, qt.IsNil)
+				c.Assert(IsDevScopeEscape(err), qt.IsTrue, qt.Commentf("error: %v", err))
+			},
+		},
+		{
+			name:       "mysql leaves a decimal literal alone",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"ALTER TABLE `app`.`t` ADD COLUMN `score` decimal(10,2) NOT NULL DEFAULT 1.5"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{
+					"ALTER TABLE `appdev`.`t` ADD COLUMN `score` decimal(10,2) NOT NULL DEFAULT 1.5",
+				})
+			},
+		},
+		{
+			name:       "mysql leaves an unreserved column named database alone",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE t (database varchar(10))"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE TABLE t (database varchar(10))"})
+			},
+		},
+		{
+			name:       "mysql leaves a string literal spelling the target alone",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"INSERT INTO `app`.`audit` (`note`) VALUES ('app.users was migrated')"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{
+					"INSERT INTO `appdev`.`audit` (`note`) VALUES ('app.users was migrated')",
+				})
+			},
+		},
+		{
+			name:       "mariadb is rescoped like mysql",
+			dialect:    platform.MariaDB,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `app`.`users` (`id` int)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE TABLE `appdev`.`users` (`id` int)"})
+			},
+		},
+		{
+			name:       "clickhouse is rescoped like mysql",
+			dialect:    platform.ClickHouse,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `app`.`users` (`id` Int32) ENGINE = MergeTree ORDER BY `id`"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{
+					"CREATE TABLE `appdev`.`users` (`id` Int32) ENGINE = MergeTree ORDER BY `id`",
+				})
+			},
+		},
+		{
+			name:       "postgres statements are left exactly as planned",
+			dialect:    platform.Postgres,
+			target:     "public",
+			dev:        "public",
+			statements: []string{`CREATE TABLE "public"."users" ("id" int PRIMARY KEY NOT NULL)`},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				// A PostgreSQL schema is a namespace inside the connected
+				// database, so the qualified plan already runs where the dev
+				// connection points. Measured 2026-08-07 on live PostgreSQL 17:
+				// the rehearsal created public.users in the dev database.
+				c.Assert(got, qt.DeepEquals, []string{`CREATE TABLE "public"."users" ("id" int PRIMARY KEY NOT NULL)`})
+			},
+		},
+		{
+			name:       "sqlite statements are left exactly as planned",
+			dialect:    platform.SQLite,
+			target:     "",
+			dev:        "",
+			statements: []string{"CREATE TABLE sim_added (id INTEGER PRIMARY KEY)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE TABLE sim_added (id INTEGER PRIMARY KEY)"})
+			},
+		},
+		{
+			name:       "mysql dev connection must name a database",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "  ",
+			statements: []string{"CREATE TABLE `app`.`users` (`id` int)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(got, qt.IsNil)
+				c.Assert(err, qt.ErrorMatches, `--dev-url must name a database: .*`)
+			},
+		},
+		{
+			name:       "mysql unqualified statements need no rewrite",
+			dialect:    platform.MySQL,
+			target:     "app",
+			dev:        "appdev",
+			statements: []string{"CREATE TABLE `users` (`id` int)"},
+			assert: func(c *qt.C, got []string, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(got, qt.DeepEquals, []string{"CREATE TABLE `users` (`id` int)"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, err := rescopeStatementsForDevDatabase(test.statements, test.dialect, test.target, test.dev)
+			test.assert(c, got, err)
+		})
+	}
+}
+
+func TestSchemaScopeNamesDatabase(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		want    bool
+	}{
+		{name: "mysql", dialect: platform.MySQL, want: true},
+		{name: "mariadb", dialect: platform.MariaDB, want: true},
+		{name: "clickhouse", dialect: platform.ClickHouse, want: true},
+		{name: "postgres", dialect: platform.Postgres, want: false},
+		{name: "cockroachdb", dialect: platform.CockroachDB, want: false},
+		{name: "sqlite", dialect: platform.SQLite, want: false},
+		{name: "sqlserver", dialect: platform.SQLServer, want: false},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(schemaScopeNamesDatabase(test.dialect), qt.Equals, test.want)
+		})
+	}
+}

--- a/internal/atlasschema/planverify.go
+++ b/internal/atlasschema/planverify.go
@@ -121,6 +121,9 @@ func RehearsePlanStatements(
 		return err
 	}
 	defer dbschema.CloseAndWarn(devConn)
+	// Registered after the close so it runs before it, and after the
+	// end-state comparison below, which reads the rehearsed state it drops.
+	defer discardDevRehearsalArtifacts(ctx, devConn)
 
 	if err := rehearseStatementsOnDev(ctx, conn, devConn, current, opts.TxMode, statements); err != nil {
 		return err

--- a/internal/atlasschema/simulate.go
+++ b/internal/atlasschema/simulate.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"strings"
+	"time"
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
@@ -97,8 +99,41 @@ func (p ApplyRuntimePlan) SimulateOnDev(ctx context.Context, opts SimulateOption
 		return err
 	}
 	defer dbschema.CloseAndWarn(devConn)
+	// Registered after the close, so it runs before it: the dev database is
+	// handed back with nothing the rehearsal put in it, whether the rehearsal
+	// succeeded or failed.
+	defer discardDevRehearsalArtifacts(ctx, devConn)
 
 	return rehearseStatementsOnDev(ctx, p.conn, devConn, p.current, p.txMode, statements)
+}
+
+// devCleanupTimeout bounds the post-rehearsal cleanup so a canceled command
+// still returns the dev database empty instead of leaving the rehearsal behind.
+const devCleanupTimeout = 30 * time.Second
+
+// discardDevRehearsalArtifacts drops what the rehearsal created in the dev
+// database, on every exit path.
+//
+// A dev database is scratch space the tool is trusted to borrow. The pinned
+// community binary v1.3.0 hands it back empty, measured 2026-08-07 against a
+// live MySQL 9.7 with a freshly created target/dev pair each time: after a
+// successful `schema apply` the dev database held no tables, and after a run
+// that failed inside the dev database (Error 3780, incompatible foreign key
+// column types) it held no tables either. Ptah matches that on both paths.
+//
+// Failure to clean is reported rather than returned: it must not replace the
+// rehearsal's own verdict, which is what the caller acts on.
+func discardDevRehearsalArtifacts(ctx context.Context, devConn *dbschema.DatabaseConnection) {
+	if devConn == nil {
+		return
+	}
+	cleanupCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), devCleanupTimeout)
+	defer cancel()
+	devConn.SchemaWriter().SetDryRun(false)
+	if err := devConn.SchemaWriter().DropAllTables(cleanupCtx); err != nil {
+		slog.Warn("failed to clean the dev database after the rehearsal; it may still hold rehearsed objects",
+			"error", err)
+	}
 }
 
 // connectSimulationDev validates the dev database URL against the target and
@@ -173,6 +208,13 @@ func sameDirectDatabaseURL(databaseURL, candidate string) (bool, error) {
 // Every caller reaches the dev database through here, so this is where the
 // escape lint runs: a dev database executes the statements for real, whether
 // they came from a plan file or from a freshly computed apply.
+//
+// It is also where the statements are re-scoped onto the dev database. The plan
+// is rendered with the target's schema name baked into every statement, and on
+// MySQL, MariaDB, and ClickHouse a schema is a database, so running the plan
+// verbatim on the dev connection lands it in the target — the simulation
+// mutates the very database it exists to protect. See
+// [rescopeStatementsForDevDatabase] and stokaro/ptah#1240.
 func rehearseStatementsOnDev(
 	ctx context.Context,
 	targetConn *dbschema.DatabaseConnection,
@@ -184,6 +226,13 @@ func rehearseStatementsOnDev(
 	if targetConn == nil {
 		return errors.New("schema apply simulation requires target database connection")
 	}
+	statements, err := rescopeStatementsForDevDatabase(
+		statements, devConn.Info().Dialect, targetConn.Info().Schema, devConn.Info().Schema)
+	if err != nil {
+		return err
+	}
+	// The lint reads exactly what the dev database will execute, so it runs on
+	// the re-scoped statements rather than on the plan they came from.
 	if err := checkPlanStatements(statements, devConn.Info().Dialect); err != nil {
 		return err
 	}
@@ -231,12 +280,11 @@ func rehearseOnPreparedDev(
 
 // checkSimulationSchemaScope fails explicitly when the dev database's schema
 // scope differs from the target's. Only dialects whose connection schema names
-// a namespace inside the database participate: for MySQL, MariaDB, and
-// ClickHouse it names the database itself, which legitimately differs between
-// a target and its dev counterpart.
+// a namespace inside the database participate: where it names the database
+// itself the two legitimately differ, which is exactly why the plan has to be
+// re-scoped before it is rehearsed.
 func checkSimulationSchemaScope(devInfo, targetInfo dbschematypes.DBInfo) error {
-	switch platform.NormalizeDialect(targetInfo.Dialect) {
-	case platform.MySQL, platform.MariaDB, platform.ClickHouse:
+	if schemaScopeNamesDatabase(targetInfo.Dialect) {
 		return nil
 	}
 	if devInfo.Schema == targetInfo.Schema {

--- a/internal/atlasschema/simulate_mysql_live_test.go
+++ b/internal/atlasschema/simulate_mysql_live_test.go
@@ -1,0 +1,311 @@
+package atlasschema_test
+
+// Live MySQL coverage for stokaro/ptah#1240: the dev-database simulation must
+// run entirely inside the dev database.
+//
+// SQLite cannot express the defect. On MySQL a schema IS a database, so an
+// apply plan rendered with the target's schema name — which is what the planner
+// emits from an Atlas HCL desired state — lands in the target no matter which
+// connection issues it. Measured 2026-08-07 on live MySQL 9.7 before the fix:
+// one apply against a freshly created pair exited 1 reporting "the plan was not
+// applied to the target database", and the target held the table the simulation
+// had created while the dev database held nothing.
+//
+// Gated on MYSQL_TEST_DSN / MYSQL_TEST_URL like the migrator's MySQL tests.
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+func TestSimulateOnDev_MySQLFailedRehearsalLeavesTargetByteIdenticalLive(t *testing.T) {
+	c := qt.New(t)
+	baseURL := liveMySQLURLForSimulation(t)
+	targetURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_fail_target")
+	devURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_fail_dev")
+
+	targetConn := openLiveMySQL(c, targetURL)
+	c.Assert(atlasschema.ApplySQL(c.Context(), targetConn, migrator.MigrationTxModeNone,
+		"CREATE TABLE `sim_keep` (`id` int NOT NULL, `label` varchar(32) NOT NULL, PRIMARY KEY (`id`));"), qt.IsNil)
+
+	desiredPath := writeMySQLDesiredHCL(c, liveMySQLDatabaseName(c, targetURL), `
+table "sim_keep" {
+  schema = schema.%[1]s
+  column "id" {
+    type = int
+  }
+  column "label" {
+    type = varchar(32)
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+
+table "sim_added" {
+  schema = schema.%[1]s
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`)
+
+	plan, err := atlasschema.PrepareApply(c.Context(), targetConn, atlasschema.ApplyRuntimeOptions{
+		ToURLs: []string{"file://" + desiredPath},
+		TxMode: migrator.MigrationTxModeNone,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsTrue)
+	// The premise of the defect: the plan carries the TARGET's schema name.
+	// Without this the rest of the test would pass for the wrong reason.
+	c.Assert(strings.Join(plan.Statements(), "\n"), qt.Contains,
+		"`"+liveMySQLDatabaseName(c, targetURL)+"`.`sim_added`")
+
+	before := mySQLSchemaSnapshot(c, targetConn, liveMySQLDatabaseName(c, targetURL))
+
+	// The plan's own statements, plus one that collides with the baseline the
+	// rehearsal recreates on the dev database. The first statement is the one
+	// that used to land in the target; the last one guarantees the rehearsal
+	// fails after it ran.
+	statements := append(plan.Statements(),
+		"CREATE TABLE `"+liveMySQLDatabaseName(c, targetURL)+"`.`sim_keep` (`id` int NOT NULL)")
+
+	err = plan.SimulateOnDev(c.Context(), atlasschema.SimulateOptions{
+		DevURL:     devURL,
+		TargetURL:  targetURL,
+		Statements: statements,
+	})
+
+	c.Assert(atlasschema.IsSimulationFailure(err), qt.IsTrue, qt.Commentf("error: %v", err))
+	// The property worth pinning: a failed apply leaves the target exactly as
+	// it was, down to every column and index information_schema reports.
+	c.Assert(mySQLSchemaSnapshot(c, targetConn, liveMySQLDatabaseName(c, targetURL)), qt.DeepEquals, before)
+	// And the dev database is handed back empty, as the pinned community
+	// binary v1.3.0 does when its own dev-database work fails.
+	devConn := openLiveMySQL(c, devURL)
+	c.Assert(mySQLTableNames(c, devConn, liveMySQLDatabaseName(c, devURL)), qt.HasLen, 0)
+}
+
+func TestSimulateOnDev_MySQLSuccessfulRehearsalStillAppliesLive(t *testing.T) {
+	c := qt.New(t)
+	baseURL := liveMySQLURLForSimulation(t)
+	targetURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_ok_target")
+	devURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_ok_dev")
+
+	targetConn := openLiveMySQL(c, targetURL)
+	targetName := liveMySQLDatabaseName(c, targetURL)
+	desiredPath := writeMySQLDesiredHCL(c, targetName, `
+table "sim_added" {
+  schema = schema.%[1]s
+  column "id" {
+    type = int
+  }
+  column "email" {
+    type = varchar(255)
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`)
+
+	plan, err := atlasschema.PrepareApply(c.Context(), targetConn, atlasschema.ApplyRuntimeOptions{
+		ToURLs: []string{"file://" + desiredPath},
+		TxMode: migrator.MigrationTxModeNone,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.Join(plan.Statements(), "\n"), qt.Contains, "`"+targetName+"`.`sim_added`")
+
+	c.Assert(plan.SimulateOnDev(c.Context(), atlasschema.SimulateOptions{
+		DevURL:    devURL,
+		TargetURL: targetURL,
+	}), qt.IsNil)
+
+	// Isolation must not be bought by rehearsing nothing: the simulation left
+	// the target untouched, and the apply that follows it still works.
+	c.Assert(mySQLTableNames(c, targetConn, targetName), qt.HasLen, 0)
+	devConn := openLiveMySQL(c, devURL)
+	c.Assert(mySQLTableNames(c, devConn, liveMySQLDatabaseName(c, devURL)), qt.HasLen, 0)
+
+	c.Assert(plan.Execute(c.Context()), qt.IsNil)
+	c.Assert(mySQLTableNames(c, targetConn, targetName), qt.DeepEquals, []string{"sim_added"})
+	c.Assert(mySQLSchemaSnapshot(c, targetConn, targetName), qt.Contains,
+		"column|sim_added|email|2|varchar(255)|NO||<null>|")
+}
+
+func TestSimulateOnDev_MySQLRefusesAThirdDatabaseLive(t *testing.T) {
+	c := qt.New(t)
+	baseURL := liveMySQLURLForSimulation(t)
+	targetURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_third_target")
+	devURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_third_dev")
+	bystanderURL := createLiveMySQLDatabase(c, baseURL, "ptah1240_third_bystander")
+
+	bystanderConn := openLiveMySQL(c, bystanderURL)
+	bystanderName := liveMySQLDatabaseName(c, bystanderURL)
+	c.Assert(atlasschema.ApplySQL(c.Context(), bystanderConn, migrator.MigrationTxModeNone,
+		"CREATE TABLE `bystander_keep` (`id` int NOT NULL, PRIMARY KEY (`id`));"), qt.IsNil)
+	before := mySQLSchemaSnapshot(c, bystanderConn, bystanderName)
+
+	targetConn := openLiveMySQL(c, targetURL)
+	targetName := liveMySQLDatabaseName(c, targetURL)
+	desiredPath := writeMySQLDesiredHCL(c, targetName, `
+table "sim_added" {
+  schema = schema.%[1]s
+  column "id" {
+    type = int
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`)
+	plan, err := atlasschema.PrepareApply(c.Context(), targetConn, atlasschema.ApplyRuntimeOptions{
+		ToURLs: []string{"file://" + desiredPath},
+		TxMode: migrator.MigrationTxModeNone,
+	})
+	c.Assert(err, qt.IsNil)
+
+	// A statement naming a database that is neither the target nor the dev one
+	// cannot be re-scoped onto the dev database, so it is refused rather than
+	// executed somewhere nobody asked for.
+	err = plan.SimulateOnDev(c.Context(), atlasschema.SimulateOptions{
+		DevURL:     devURL,
+		TargetURL:  targetURL,
+		Statements: []string{"DROP TABLE `" + bystanderName + "`.`bystander_keep`"},
+	})
+
+	c.Assert(atlasschema.IsDevScopeEscape(err), qt.IsTrue, qt.Commentf("error: %v", err))
+	c.Assert(mySQLSchemaSnapshot(c, bystanderConn, bystanderName), qt.DeepEquals, before)
+}
+
+// liveMySQLURLForSimulation gates the live simulation tests on the same
+// environment variables as the migrator's MySQL integration tests.
+func liveMySQLURLForSimulation(t *testing.T) string {
+	t.Helper()
+	dbURL := os.Getenv("MYSQL_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("MYSQL_TEST_URL")
+	}
+	if dbURL == "" {
+		t.Skip("MYSQL_TEST_DSN or MYSQL_TEST_URL not set")
+	}
+	if !strings.HasPrefix(dbURL, "mysql://") {
+		t.Skip("MySQL URL required for schema apply simulation live tests")
+	}
+	return dbURL
+}
+
+// createLiveMySQLDatabase creates a database of its own for one probe and drops
+// it again when the test ends, so probes never share scratch space.
+func createLiveMySQLDatabase(c *qt.C, baseURL, name string) string {
+	c.Helper()
+	admin, err := dbschema.ConnectToDatabase(context.Background(), baseURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+
+	_, err = admin.ExecContext(context.Background(), "DROP DATABASE IF EXISTS `"+name+"`")
+	c.Assert(err, qt.IsNil)
+	_, err = admin.ExecContext(context.Background(), "CREATE DATABASE `"+name+"`")
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		cleanup, err := dbschema.ConnectToDatabase(context.Background(), baseURL)
+		if err != nil {
+			return
+		}
+		defer dbschema.CloseAndWarn(cleanup)
+		_, _ = cleanup.ExecContext(context.Background(), "DROP DATABASE IF EXISTS `"+name+"`")
+	})
+	return mySQLURLForDatabase(c, baseURL, name)
+}
+
+func mySQLURLForDatabase(c *qt.C, baseURL, name string) string {
+	c.Helper()
+	parsed, err := url.Parse(baseURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	return parsed.String()
+}
+
+func liveMySQLDatabaseName(c *qt.C, dbURL string) string {
+	c.Helper()
+	parsed, err := url.Parse(dbURL)
+	c.Assert(err, qt.IsNil)
+	return strings.TrimPrefix(parsed.Path, "/")
+}
+
+func openLiveMySQL(c *qt.C, dbURL string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+	return conn
+}
+
+// writeMySQLDesiredHCL writes an Atlas HCL desired state whose tables name the
+// database explicitly. That explicit `schema = schema.<database>` is what makes
+// the planner qualify every statement with the target's name, which is the
+// input the defect needs.
+func writeMySQLDesiredHCL(c *qt.C, database, tables string) string {
+	c.Helper()
+	path := filepath.Join(c.TB.TempDir(), "desired.hcl")
+	document := fmt.Sprintf("schema %q {\n}\n", database) + fmt.Sprintf(tables, database)
+	c.Assert(os.WriteFile(path, []byte(document), 0o600), qt.IsNil)
+	return path
+}
+
+// mySQLSchemaSnapshot renders every column and index information_schema reports
+// for one database as sorted text, so "the target is unchanged" is asserted
+// against the catalog rather than against an exit status.
+func mySQLSchemaSnapshot(c *qt.C, conn *dbschema.DatabaseConnection, database string) []string {
+	c.Helper()
+	snapshot := mySQLQueryLines(c, conn, `
+SELECT CONCAT_WS('|', 'column', TABLE_NAME, COLUMN_NAME, ORDINAL_POSITION, COLUMN_TYPE,
+                 IS_NULLABLE, COLUMN_KEY, IFNULL(COLUMN_DEFAULT, '<null>'), EXTRA)
+FROM information_schema.COLUMNS
+WHERE TABLE_SCHEMA = ?
+ORDER BY TABLE_NAME, ORDINAL_POSITION`, database)
+	return append(snapshot, mySQLQueryLines(c, conn, `
+SELECT CONCAT_WS('|', 'index', TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX, COLUMN_NAME, NON_UNIQUE)
+FROM information_schema.STATISTICS
+WHERE TABLE_SCHEMA = ?
+ORDER BY TABLE_NAME, INDEX_NAME, SEQ_IN_INDEX`, database)...)
+}
+
+func mySQLTableNames(c *qt.C, conn *dbschema.DatabaseConnection, database string) []string {
+	c.Helper()
+	return mySQLQueryLines(c, conn, `
+SELECT TABLE_NAME
+FROM information_schema.TABLES
+WHERE TABLE_SCHEMA = ?
+ORDER BY TABLE_NAME`, database)
+}
+
+func mySQLQueryLines(c *qt.C, conn *dbschema.DatabaseConnection, query, database string) []string {
+	c.Helper()
+	rows, err := conn.QueryContext(context.Background(), query, database)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(rows.Close(), qt.IsNil) }()
+
+	var lines []string
+	for rows.Next() {
+		var line string
+		c.Assert(rows.Scan(&line), qt.IsNil)
+		lines = append(lines, line)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return lines
+}

--- a/internal/atlasschema/simulate_test.go
+++ b/internal/atlasschema/simulate_test.go
@@ -48,7 +48,7 @@ CREATE TABLE sim_existing (
 func TestSimulateOnDev_HappyPath(t *testing.T) {
 	c := qt.New(t)
 
-	c.Run("plan rehearses on the reset dev database", func(c *qt.C) {
+	c.Run("plan rehearses on the reset dev database and hands it back empty", func(c *qt.C) {
 		dir := c.TB.TempDir()
 		dbPath := filepath.Join(dir, "target.db")
 		devPath := filepath.Join(dir, "dev.db")
@@ -70,11 +70,37 @@ CREATE TABLE sim_stale (
 		})
 
 		c.Assert(err, qt.IsNil)
-		// The dev database ends at baseline + plan: current state recreated,
-		// plan applied, stale objects gone. The target only has the baseline.
-		c.Assert(sqliteTableExists(c, devPath, "sim_existing"), qt.IsTrue)
-		c.Assert(sqliteTableExists(c, devPath, "sim_added"), qt.IsTrue)
+		// The dev database is scratch space, borrowed and handed back: nothing
+		// the rehearsal created, and nothing that was there before it, is left
+		// behind. The target only has the baseline.
+		c.Assert(sqliteTableExists(c, devPath, "sim_existing"), qt.IsFalse)
+		c.Assert(sqliteTableExists(c, devPath, "sim_added"), qt.IsFalse)
 		c.Assert(sqliteTableExists(c, devPath, "sim_stale"), qt.IsFalse)
+		c.Assert(sqliteTableExists(c, dbPath, "sim_added"), qt.IsFalse)
+	})
+
+	c.Run("the baseline and the plan really execute on the dev database", func(c *qt.C) {
+		dir := c.TB.TempDir()
+		dbPath := filepath.Join(dir, "target.db")
+		devPath := filepath.Join(dir, "dev.db")
+		plan := prepareSimulationPlan(c, dbPath)
+
+		// Cleaning the dev database afterwards must not be mistaken for a
+		// rehearsal that did nothing, so every statement here depends on the
+		// one before it: the ALTERs only parse against tables the reset,
+		// baseline recreation, and plan actually created.
+		err := plan.SimulateOnDev(c.Context(), atlasschema.SimulateOptions{
+			DevURL:    atlasurl.SQLiteURLFromPath(devPath),
+			TargetURL: atlasurl.SQLiteURLFromPath(dbPath),
+			Statements: []string{
+				"CREATE TABLE sim_added (id INTEGER PRIMARY KEY)",
+				"ALTER TABLE sim_existing ADD COLUMN probe_baseline TEXT",
+				"ALTER TABLE sim_added ADD COLUMN probe_plan TEXT",
+			},
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(sqliteTableExists(c, devPath, "sim_added"), qt.IsFalse)
 		c.Assert(sqliteTableExists(c, dbPath, "sim_added"), qt.IsFalse)
 	})
 
@@ -91,16 +117,53 @@ CREATE TABLE sim_stale (
 		devPath := filepath.Join(dir, "dev.db")
 		plan := prepareSimulationPlan(c, dbPath)
 
+		// The prepared plan also creates sim_added, so this list only runs
+		// clean if the plan was replaced rather than added to: had both
+		// rehearsed, the second CREATE would collide.
 		err := plan.SimulateOnDev(c.Context(), atlasschema.SimulateOptions{
-			DevURL:     atlasurl.SQLiteURLFromPath(devPath),
-			TargetURL:  atlasurl.SQLiteURLFromPath(dbPath),
-			Statements: []string{"CREATE TABLE sim_edited (id INTEGER PRIMARY KEY)"},
+			DevURL:    atlasurl.SQLiteURLFromPath(devPath),
+			TargetURL: atlasurl.SQLiteURLFromPath(dbPath),
+			Statements: []string{
+				"CREATE TABLE sim_edited (id INTEGER PRIMARY KEY)",
+				"CREATE TABLE sim_added (id INTEGER PRIMARY KEY)",
+				"ALTER TABLE sim_edited ADD COLUMN probe_edited TEXT",
+			},
 		})
 
 		c.Assert(err, qt.IsNil)
-		c.Assert(sqliteTableExists(c, devPath, "sim_edited"), qt.IsTrue)
-		c.Assert(sqliteTableExists(c, devPath, "sim_added"), qt.IsFalse)
+		c.Assert(sqliteTableExists(c, devPath, "sim_edited"), qt.IsFalse)
 	})
+}
+
+func TestSimulateOnDev_FailedRehearsalStillEmptiesTheDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "target.db")
+	devPath := filepath.Join(dir, "dev.db")
+	plan := prepareSimulationPlan(c, dbPath)
+
+	// The first statement succeeds and the second fails, so the dev database
+	// holds a half-applied plan at the moment the rehearsal gives up. The
+	// pinned community binary v1.3.0 leaves its dev database empty when its own
+	// dev-database work fails (measured 2026-08-07, live MySQL 9.7, Error 3780
+	// on an incompatible foreign key); Ptah matches that on the failure path,
+	// not only on the success path.
+	err := plan.SimulateOnDev(t.Context(), atlasschema.SimulateOptions{
+		DevURL:    atlasurl.SQLiteURLFromPath(devPath),
+		TargetURL: atlasurl.SQLiteURLFromPath(dbPath),
+		Statements: []string{
+			"CREATE TABLE sim_half (id INTEGER PRIMARY KEY)",
+			"CREATE TABLE sim_existing (id INTEGER PRIMARY KEY)",
+		},
+	})
+
+	c.Assert(atlasschema.IsSimulationFailure(err), qt.IsTrue, qt.Commentf("error: %v", err))
+	c.Assert(sqliteTableExists(c, devPath, "sim_half"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, devPath, "sim_existing"), qt.IsFalse)
+	// The failed rehearsal changed nothing in the target.
+	c.Assert(sqliteTableExists(c, dbPath, "sim_existing"), qt.IsTrue)
+	c.Assert(sqliteTableExists(c, dbPath, "sim_half"), qt.IsFalse)
+	c.Assert(sqliteTableExists(c, dbPath, "sim_added"), qt.IsFalse)
 }
 
 func TestSimulateOnDev_FailedSimulationLeavesTargetUnchanged(t *testing.T) {


### PR DESCRIPTION
Closes defect 1 of #1240.

## Reproduced first

Live MySQL 9.7, two freshly created databases, one apply, `ptah-compat` built from `a343471b` in its own worktree. Every state claim below is a query against `information_schema`, not an exit status.

```
schema apply -u mysql://.../d1240g --to file://d1240g.hcl \
  --dev-url mysql://.../d1240gdev --auto-approve
rc=1

Error: dev database simulation failed during plan: failed to execute SQL statement:
       Error 1074 (42000): Column length too big for column 'too_wide' (max = 16383)
SQL: CREATE TABLE `d1240g`.`zzz_last` (...); the plan was not applied to the target database
```

```
TABLE_SCHEMA   TABLE_NAME
d1240g         aaa_first        <- TARGET, created by the "simulation"
d1240gdev      (nothing)        <- dev
```

The desired state declared two tables. The first rehearsed statement succeeded — into the **target** — and the second failed, so the command exited 1 saying the plan was not applied while the target had already been changed. The issue's own repro (`Table 'users' already exists`) is the same mechanism with one table.

## PostgreSQL: measured, latent, contained

The issue recorded this as **not established**. It is now measured, live PostgreSQL 17, fresh target/dev pair:

| | plan statement | where the rehearsal landed |
| --- | --- | --- |
| MySQL 9.7 | ``CREATE TABLE `d1240a`.`users``` | the **target** database |
| PostgreSQL 17 | `CREATE TABLE "public"."users"` | the **dev** database |

Same qualified-plan-against-dev shape, different consequence: a PostgreSQL schema is a namespace inside the connected database and cannot name anything outside it. Those dialects keep their plan exactly as planned; nothing is rewritten for them.

## The fix

Statements are re-scoped onto the dev database in `rehearseStatementsOnDev`, the one gate every dev-database caller passes through (pre-apply simulation and plan-file verification both).

- On MySQL, MariaDB, and ClickHouse, every schema name the plan carries is rewritten to the dev database's own name, at the token level, so a decimal literal, a string literal spelling `target.table`, and an unreserved column named `database` are all left alone.
- `USE <db>` and `CREATE|DROP|ALTER SCHEMA|DATABASE <db>` are re-scoped too: either would silently move the rest of the plan out of the dev database.
- Anything still naming a database that is neither the target nor the dev one is **refused** (`DevScopeError`) rather than executed somewhere nobody asked for. The check runs under both string-escape interpretations, like the existing escape lint, so a statement cannot hide a name under the tokenization that was not checked.
- The escape lint now runs on the re-scoped statements, so it reads exactly what the dev database will execute.

Post-fix, same input shape, its own fresh pair: `rc=1`, and **both** databases empty. The reported SQL shows ``CREATE TABLE `d1240zdev`.`zzz_last` ``, which is what proves the rehearsal ran in the dev database.

## Dev-database cleanup, and why it is in this PR

Fixing defect 1 makes the MySQL rehearsal actually write to the dev database, which would have newly dirtied it. Defect 2 only *looked* closed on MySQL because the objects were going to the target instead. On PostgreSQL it was never closed: a successful apply measurably left `users` in the dev database.

What the pinned community binary v1.3.0 does, measured live on MySQL 9.7 with a fresh pair each time:

| run | rc | target | dev |
| --- | --- | --- | --- |
| successful apply | 0 | `users` | *empty* |
| failure inside its dev database (Error 3780, incompatible FK) | 1 | *empty* | *empty* |

Ptah now matches on both paths: the dev database is dropped back to the state its own reset produces, on every exit path including cancellation (bounded, `context.WithoutCancel`), and a cleanup failure is warned about rather than replacing the rehearsal's verdict.

This changes behavior. Pre-v1, so no compatibility with earlier Ptah is owed. It also does not remove a capability from the compatibility surface: leaving a rehearsal behind in a borrowed scratch database is the defect the issue asks to remove, not a feature, so it deliberately gets no `PTAH_*` opt-out.

## Tests

`internal/atlasschema/devscope_internal_test.go` (always runs, no server): 17 rows covering the rewrite, the refusal, the statement index, and the dialects that must **not** be rewritten. Mutation-checked:

- disabling the re-scoping reddens 14 of 17 rows; the 3 that stay green are exactly the non-interference controls (PostgreSQL, SQLite, an unqualified MySQL statement);
- neutralizing only the scope guard reddens exactly the 4 refusal rows and no rewrite row.

`internal/atlasschema/simulate_mysql_live_test.go` (gated on `MYSQL_TEST_DSN`/`MYSQL_TEST_URL`, run locally against MySQL 9.7 — all 3 pass, and all 3 go red on the pre-fix behavior):

- a failed rehearsal leaves the target **byte-identical**, asserted against a full `information_schema` column + index snapshot rather than an exit status, and each test asserts up front that the plan really does carry the target's schema name so it cannot pass for the wrong reason;
- the success path still applies — isolation is not bought by rehearsing nothing;
- a statement naming a third database is refused and that database is unchanged.

SQLite coverage in `simulate_test.go` pins the cleanup on both the success and the failure path, plus a rehearsal whose statements depend on each other so "the dev database is empty afterwards" can never be satisfied by a rehearsal that did nothing. Neutralizing the cleanup reddens exactly the cleanup assertions and leaves the scope tests green.

## Gates

`go build` 0 · `go vet` 0 · `go tool qtlint` 0 · `golangci-lint run` 0 · `scripts/check-test-style.sh` 0 · `scripts/check-public-api.sh` 0 · `scripts/check-public-api-snapshot.sh` 0 · docs `check:style`, `check:exit-codes`, `check:core-doc-links`, `check:page-health`, `check:links`, `check:redirects`, `check:limitations`, all their `:selftest` variants, and `build-feature-matrix.mjs --check` all 0.

Two honest exceptions:

- `go test ./... -count=1` exits 1 on `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` (`signal: killed` from the shell-script `dot` stub). Verified environmental: it fails identically in a control worktree checked out at the unmodified base `a343471b`. Every other package passes; `internal/atlasschema`, `cmd/atlas`, and `cmd/schema` pass with and without a live MySQL.
- `docs check:responsive` exits 1 with `dist not found` — there is no `node_modules` and no built site here, and the script exits before reading any content. Its `--selftest` reports SKIPPED (playwright absent). Not measured.

`golangci-lint run ./...` with the shared lint cache reported 85 issues from **another checkout** under the shared scratch directory plus one real `modernize` hit in this change; the real one is fixed, and the clean run above used a private `GOLANGCI_LINT_CACHE`.

## Not verified

- MariaDB and ClickHouse are re-scoped by the same code path and unit-tested, but were not exercised against a live server.
- The plan text Ptah renders on MySQL stays schema-qualified (``CREATE TABLE `db`.`users` ``) where the pinned binary emits ``CREATE TABLE `users` ``. That output-shape divergence is untouched here; this PR fixes where the plan *runs*, not how it is spelled.