### PR TITLE
Read every PostgreSQL index attribute the catalog reports (#1242)

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -520,7 +520,18 @@ type IndexPart struct {
 	Prefix string
 	// Desc indicates DESC ordering for this index part.
 	Desc bool
+	// NullsOrder carries an explicit NULLS ordering: "FIRST", "LAST", or
+	// empty when the part uses the direction's default. PostgreSQL's defaults
+	// are NULLS LAST for ASC and NULLS FIRST for DESC, so an empty value
+	// renders no clause and reproduces the index either way.
+	NullsOrder string
 }
+
+// Index NULLS ordering spellings for IndexPart.NullsOrder.
+const (
+	NullsOrderFirst = "FIRST"
+	NullsOrderLast  = "LAST"
+)
 
 // Reference returns the column name or expression represented by the index part.
 func (p IndexPart) Reference() string {

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -199,6 +199,10 @@ type IndexPart struct {
 	Operator string // PostgreSQL operator class for this part
 	Prefix   string // MySQL index prefix length
 	Desc     bool   // Whether this part is ordered DESC
+	// NullsOrder is an explicit NULLS ordering for this part: "FIRST",
+	// "LAST", or empty for the direction's default (NULLS LAST for ASC,
+	// NULLS FIRST for DESC on PostgreSQL).
+	NullsOrder string
 }
 
 // Index represents a database index definition parsed from Go struct annotations.

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -639,8 +639,15 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	parts = append(parts, "ON")
 	parts = append(parts, r.escapeQualifiedIdentifier(node.Table))
 
-	// Add index type (USING clause) for PostgreSQL
-	if node.Type != "" && node.Type != "BTREE" {
+	// Add index type (USING clause) for PostgreSQL.
+	//
+	// The btree comparison is case-insensitive because the access method now
+	// has two sources with different conventions: an annotation or HCL source
+	// spells it BTREE/GIN, while the live-database reader reports pg_am.amname
+	// verbatim, which PostgreSQL spells btree/gin. Both mean the default
+	// method, and emitting "USING btree" for every introspected index would be
+	// a gratuitous divergence from the pinned binary's output.
+	if node.Type != "" && !strings.EqualFold(node.Type, "BTREE") {
 		parts = append(parts, "USING")
 		parts = append(parts, node.Type)
 	}
@@ -657,6 +664,7 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 		if part.Desc {
 			columnSpec += " DESC"
 		}
+		columnSpec += renderIndexPartNullsOrder(part)
 		columnSpecs = append(columnSpecs, columnSpec)
 	}
 	parts = append(parts, fmt.Sprintf("(%s)", strings.Join(columnSpecs, ", ")))
@@ -686,6 +694,25 @@ func (r *Renderer) VisitIndex(node *ast.IndexNode) error {
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 
 	return nil
+}
+
+// renderIndexPartNullsOrder renders the NULLS clause for one index part.
+//
+// It renders whatever the part carries rather than second-guessing it. Deciding
+// that a clause is redundant belongs to whoever produced the part: PostgreSQL's
+// defaults are NULLS LAST for ASC and NULLS FIRST for DESC, and the live-
+// database reader already declines to record an ordering that matches its
+// direction's default, so nothing introspected reaches here with a redundant
+// value. A source that spelled one out explicitly gets it back.
+func renderIndexPartNullsOrder(part ast.IndexPart) string {
+	switch strings.ToUpper(part.NullsOrder) {
+	case ast.NullsOrderFirst:
+		return " NULLS FIRST"
+	case ast.NullsOrderLast:
+		return " NULLS LAST"
+	default:
+		return ""
+	}
 }
 
 func (r *Renderer) renderIndexStorageParams(params map[string]string) (string, error) {

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -156,8 +156,24 @@ type DBIndexPart struct {
 	// that reports one in Name makes the renderer quote it into a column
 	// reference that does not exist.
 	Expr string `json:"expr,omitempty"`
-	Desc bool   `json:"desc,omitempty"`
+	// Operator is the non-default operator class this key was built with, for
+	// example text_pattern_ops. Empty means the key uses its type's default
+	// class, which is the only case where omitting it from emitted DDL
+	// reproduces the index. See #1242.
+	Operator string `json:"operator,omitempty"`
+	Desc     bool   `json:"desc,omitempty"`
+	// NullsOrder is an explicit NULLS ordering for this key: "FIRST", "LAST",
+	// or empty when the key uses the direction's default. PostgreSQL defaults
+	// to NULLS LAST for ASC and NULLS FIRST for DESC, so only the deviating
+	// spelling has to be carried.
+	NullsOrder string `json:"nulls_order,omitempty"`
 }
+
+// Index NULLS ordering spellings for DBIndexPart.NullsOrder.
+const (
+	NullsOrderFirst = "FIRST"
+	NullsOrderLast  = "LAST"
+)
 
 // DBIndex represents a database index.
 //
@@ -183,6 +199,22 @@ type DBIndex struct {
 	// NullsDistinct carries PostgreSQL UNIQUE INDEX NULLS [NOT] DISTINCT
 	// state. Nil means the clause was not present in the definition.
 	NullsDistinct *bool `json:"nulls_distinct,omitempty"`
+
+	// Method is the index access method as the server spells it -- btree,
+	// gin, gist, brin, hash. It is deliberately not Type: Type is the
+	// ClickHouse data-skipping-index type below, a different concept that
+	// happens to share a slot in the annotation surface, and overloading one
+	// field with both would make a ClickHouse "bloom_filter" and a PostgreSQL
+	// "gin" indistinguishable at this layer. Empty means the reader did not
+	// report an access method.
+	//
+	// A dropped access method is not always a quiet degradation: an index on
+	// a type with no btree operator class, such as point, does not replay at
+	// all without it. See #1242.
+	Method string `json:"method,omitempty"`
+	// IncludeColumns carries PostgreSQL INCLUDE payload columns, the
+	// non-key columns stored in the index for index-only scans.
+	IncludeColumns []string `json:"include_columns,omitempty"`
 
 	// Type is the ClickHouse data-skipping-index type. One of
 	// "minmax" / "set(N)" / "bloom_filter" / "bloom_filter(p)" /

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -168,32 +168,54 @@ matched rather than refused, because there Atlas CE is right: it executes the
 file's bytes verbatim, drops nothing, and records the revision honestly. See
 [`stokaro/ptah#981`](https://github.com/stokaro/ptah/issues/981).
 
-## Known PostgreSQL Introspection Gaps
+## PostgreSQL Introspection: Index and Domain Attributes
 
-Reading a live PostgreSQL database currently loses index attributes that the
-pinned Atlas CE v1.3.0 binary preserves. Measured on PostgreSQL 17.10 by
-diffing an empty database against a source database with each binary and
+Reading a live PostgreSQL database once lost six attributes that the pinned
+Atlas CE v1.3.0 binary preserves. All six are now read. Measured on PostgreSQL
+17.10 by diffing an empty database against a source database with each binary,
 replaying the emitted SQL into a fresh database with
-`psql -v ON_ERROR_STOP=1`. These affect the live-database read path only; an
-HCL source carrying the same attributes renders correctly.
+`psql -v ON_ERROR_STOP=1` and reading psql's own exit status, then re-diffing
+the replayed database against the source with the pinned binary as a neutral
+observer. These affected the live-database read path only; an HCL source
+carrying the same attributes always rendered correctly.
 
-| Attribute | Ptah reads it? | Replays? | Tracked in |
+| Attribute | Read from | Before | Tracked in |
 | --- | --- | --- | --- |
-| Access method (`USING gin` / `gist` / `brin` / `hash`) | No, every index collapses to the btree default | psql exits 0 and leaves a btree index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
-| Operator class, for example `text_pattern_ops` | No, the opclass is dropped | psql exits 0 and leaves an index that no longer serves the queries it was built for | [#1242](https://github.com/stokaro/ptah/issues/1242) |
-| Sort order (`DESC`, `NULLS FIRST`, `NULLS LAST`) | No, ordering is dropped | psql exits 0 and leaves an ascending index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
-| Domain used as a column type | The `CREATE DOMAIN` is emitted, but the column is flattened to the domain's base type | psql exits 0 and leaves a column without the domain's `CHECK` | [#1242](https://github.com/stokaro/ptah/issues/1242) |
-| Expression index, for example `lower(name)` | Yes | Yes | fixed |
+| Access method (`USING gin` / `gist` / `brin` / `hash`) | `pg_am.amname` | Every index collapsed to the btree default. **Not always silent** -- see below | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Operator class, for example `text_pattern_ops` | `pg_index.indclass`, non-default classes only | Dropped: psql exited 0 and left an index that no longer served the queries it was built for | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Sort order (`DESC`, `NULLS FIRST`, `NULLS LAST`) | `pg_index.indoption` | Dropped: psql exited 0 and left an ascending index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| `INCLUDE` payload columns | `pg_index.indkey` past `indnkeyatts` | Dropped: psql exited 0 and left an index that cannot serve the index-only scans it was built for | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Expression index, for example `lower(name)` | `pg_index.indkey`, attnum 0 | Emitted as a quoted column identifier, which psql rejected at exit 3 | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Domain used as a column type | `information_schema.columns.domain_name` | The `CREATE DOMAIN` was emitted but the column was flattened to the domain's base type: psql exited 0 and left a column without the domain's `CHECK` | [#1242](https://github.com/stokaro/ptah/issues/1242) |
 
-The first four replay without an error, so nothing reports the loss at the time
-it happens. Treat a green replay of introspected PostgreSQL index DDL as
-unverified until these are closed.
+### The access-method loss was not silent in general
 
-Domains are the one row where Atlas CE is also wrong, in the opposite
-direction: it keeps the column's declared type and never emits the
-`CREATE DOMAIN`, so its own output fails to replay with
-`ERROR: type "..." does not exist`. Ptah emits the `CREATE DOMAIN` already, and
-closing this gap means keeping both halves rather than matching CE.
+An earlier version of this table said the access-method loss "replays at exit 0
+and leaves a btree index". That is fixture-dependent and false in general. It
+holds only when the indexed column's type has a default btree operator class.
+
+Measured, a `gist` index on a `point` column:
+
+```text
+emitted:  CREATE INDEX IF NOT EXISTS "i_gist" ON "t" ("p");
+replay:   psql exits 3
+          ERROR: data type point has no default operator class for access method "btree"
+```
+
+The `int4range` fixture the original claim was generalized from does have a
+btree operator class, so there the same loss degraded quietly. The loss is loud
+for `point`, `box`, `tsvector` and every other type with no btree class, and
+quiet otherwise. A green replay never proved the access method survived; it only
+proved the column type tolerated losing it.
+
+### Domains are where Atlas CE is wrong in the opposite direction
+
+CE keeps the column's declared type but never emits the `CREATE DOMAIN`, so its
+own `schema diff` output fails to replay with
+`ERROR: type "positive_int" does not exist` — measured, psql exit 3. Ptah emits
+both the `CREATE DOMAIN` and the domain-typed column, so closing this gap meant
+keeping both halves rather than matching CE. Ptah's output replays at psql exit
+0 where CE's does not.
 
 ## Reports
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -575,6 +575,7 @@ type Value[T any] struct {
 
 ## go.5x5.cz/ptah/core/ast
 
+const NullsOrderFirst = "FIRST" ...
 type AddColumnOperation struct{ ... }
 type AddConstraintOperation struct{ ... }
 type AddEnumValueOperation struct{ ... }
@@ -2363,6 +2364,11 @@ type IndexPart struct {
     Prefix string
     // Desc indicates DESC ordering for this index part.
     Desc bool
+    // NullsOrder carries an explicit NULLS ordering: "FIRST", "LAST", or
+    // empty when the part uses the direction's default. PostgreSQL's defaults
+    // are NULLS LAST for ASC and NULLS FIRST for DESC, so an empty value
+    // renders no clause and reproduces the index either way.
+    NullsOrder string
 }
     IndexPart represents one column or expression inside a CREATE INDEX column
     list.
@@ -4124,6 +4130,10 @@ type IndexPart struct {
     Operator string // PostgreSQL operator class for this part
     Prefix   string // MySQL index prefix length
     Desc     bool   // Whether this part is ordered DESC
+    // NullsOrder is an explicit NULLS ordering for this part: "FIRST",
+    // "LAST", or empty for the direction's default (NULLS LAST for ASC,
+    // NULLS FIRST for DESC on PostgreSQL).
+    NullsOrder string
 }
     IndexPart represents one column or expression inside an index definition.
 
@@ -5180,6 +5190,7 @@ type IsolatedQueryer interface {
 
 ## go.5x5.cz/ptah/dbschema/types
 
+const NullsOrderFirst = "FIRST" ...
 func QualifyTableName(schema, table string) string
 type DBColumn struct{ ... }
 type DBComposite struct{ ... }
@@ -5412,6 +5423,22 @@ type DBIndex struct {
     // state. Nil means the clause was not present in the definition.
     NullsDistinct *bool `json:"nulls_distinct,omitempty"`
 
+    // Method is the index access method as the server spells it -- btree,
+    // gin, gist, brin, hash. It is deliberately not Type: Type is the
+    // ClickHouse data-skipping-index type below, a different concept that
+    // happens to share a slot in the annotation surface, and overloading one
+    // field with both would make a ClickHouse "bloom_filter" and a PostgreSQL
+    // "gin" indistinguishable at this layer. Empty means the reader did not
+    // report an access method.
+    //
+    // A dropped access method is not always a quiet degradation: an index on
+    // a type with no btree operator class, such as point, does not replay at
+    // all without it. See #1242.
+    Method string `json:"method,omitempty"`
+    // IncludeColumns carries PostgreSQL INCLUDE payload columns, the
+    // non-key columns stored in the index for index-only scans.
+    IncludeColumns []string `json:"include_columns,omitempty"`
+
     // Type is the ClickHouse data-skipping-index type. One of
     // "minmax" / "set(N)" / "bloom_filter" / "bloom_filter(p)" /
     // "tokenbf_v1(...)" / "ngrambf_v1(...)" etc. Empty on non-ClickHouse
@@ -5447,7 +5474,17 @@ type DBIndexPart struct {
     // that reports one in Name makes the renderer quote it into a column
     // reference that does not exist.
     Expr string `json:"expr,omitempty"`
-    Desc bool   `json:"desc,omitempty"`
+    // Operator is the non-default operator class this key was built with, for
+    // example text_pattern_ops. Empty means the key uses its type's default
+    // class, which is the only case where omitting it from emitted DDL
+    // reproduces the index. See #1242.
+    Operator string `json:"operator,omitempty"`
+    Desc     bool   `json:"desc,omitempty"`
+    // NullsOrder is an explicit NULLS ordering for this key: "FIRST", "LAST",
+    // or empty when the key uses the direction's default. PostgreSQL defaults
+    // to NULLS LAST for ASC and NULLS FIRST for DESC, so only the deviating
+    // spelling has to be carried.
+    NullsOrder string `json:"nulls_order,omitempty"`
 }
     DBIndexPart represents one ordered key column in an introspected index.
 

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -338,10 +338,7 @@ func atlasSchemaInspectColumn(column dbschematypes.DBColumn) atlasSchemaInspectJ
 }
 
 func atlasSchemaInspectIndex(index dbschematypes.DBIndex) atlasSchemaInspectJSONIndex {
-	parts := make([]atlasSchemaInspectJSONIndexPart, 0, len(index.Columns))
-	for _, column := range index.Columns {
-		parts = append(parts, atlasSchemaInspectIndexPart(column))
-	}
+	parts := atlasSchemaInspectIndexParts(index)
 	if index.Expression != "" && len(parts) == 0 {
 		parts = append(parts, atlasSchemaInspectJSONIndexPart{Expr: index.Expression})
 	}
@@ -350,6 +347,45 @@ func atlasSchemaInspectIndex(index dbschematypes.DBIndex) atlasSchemaInspectJSON
 		Unique: index.IsUnique,
 		Parts:  parts,
 	}
+}
+
+// atlasSchemaInspectIndexParts prefers the reader's structured key parts over
+// the flat Columns list.
+//
+// Columns is a list of names and cannot say that a key is descending, so this
+// output dropped the direction of every index. Measured against the pinned
+// community binary v1.3.0 on PostgreSQL 17.10, for
+// CREATE INDEX i_desc ON t (a DESC) it prints
+// `{"desc": true, "column": "a"}` where Ptah printed `{"column": "a"}`.
+//
+// Falling back to Columns keeps every reader that supplies only the flat form
+// -- MySQL, MariaDB -- printing exactly what it printed before.
+func atlasSchemaInspectIndexParts(index dbschematypes.DBIndex) []atlasSchemaInspectJSONIndexPart {
+	if len(index.Parts) == 0 {
+		parts := make([]atlasSchemaInspectJSONIndexPart, 0, len(index.Columns))
+		for _, column := range index.Columns {
+			parts = append(parts, atlasSchemaInspectIndexPart(column))
+		}
+		return parts
+	}
+	parts := make([]atlasSchemaInspectJSONIndexPart, 0, len(index.Parts))
+	for _, part := range index.Parts {
+		parts = append(parts, atlasSchemaInspectStructuredIndexPart(part))
+	}
+	return parts
+}
+
+// atlasSchemaInspectStructuredIndexPart maps one structured key part. Unlike
+// the string form below it never has to guess whether a key is an expression:
+// the reader already established that from pg_index.indkey, so a column
+// literally named "lower(name)" stays a column here.
+func atlasSchemaInspectStructuredIndexPart(
+	part dbschematypes.DBIndexPart,
+) atlasSchemaInspectJSONIndexPart {
+	if part.Expr != "" {
+		return atlasSchemaInspectJSONIndexPart{Desc: part.Desc, Expr: part.Expr}
+	}
+	return atlasSchemaInspectJSONIndexPart{Desc: part.Desc, Column: part.Name}
 }
 
 func atlasSchemaInspectUniqueConstraintIndex(constraint dbschematypes.DBConstraint) atlasSchemaInspectJSONIndex {

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -6,6 +6,7 @@ package dbschematogo
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
@@ -191,12 +192,26 @@ func convertIndexes(dbSchema *dbschematypes.DBSchema, tableStructNames map[strin
 			Unique:        dbIndex.IsUnique,
 			Condition:     dbIndex.Condition,
 			NullsDistinct: cloneBoolPtr(dbIndex.NullsDistinct),
-			Type:          dbIndex.Type,
+			Type:          indexType(dbIndex),
 			Granularity:   dbIndex.Granularity,
+
+			IncludeColumns: slices.Clone(dbIndex.IncludeColumns),
 		}
 		indexes = append(indexes, index)
 	}
 	return indexes
+}
+
+// indexType picks the value goschema.Index.Type carries for an introspected
+// index. goschema keeps one field for two concepts the database layer keeps
+// apart: the PostgreSQL access method (btree/gin/gist/brin/hash) and the
+// ClickHouse data-skipping-index type (minmax/bloom_filter/...). No reader
+// sets both, so the choice is unambiguous.
+func indexType(index dbschematypes.DBIndex) string {
+	if index.Method != "" {
+		return index.Method
+	}
+	return index.Type
 }
 
 func convertIndexParts(parts []dbschematypes.DBIndexPart) []goschema.IndexPart {
@@ -206,9 +221,11 @@ func convertIndexParts(parts []dbschematypes.DBIndexPart) []goschema.IndexPart {
 	converted := make([]goschema.IndexPart, len(parts))
 	for position, part := range parts {
 		converted[position] = goschema.IndexPart{
-			Name: part.Name,
-			Expr: part.Expr,
-			Desc: part.Desc,
+			Name:       part.Name,
+			Expr:       part.Expr,
+			Operator:   part.Operator,
+			Desc:       part.Desc,
+			NullsOrder: part.NullsOrder,
 		}
 	}
 	return converted

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -2338,11 +2338,12 @@ func toASTIndexParts(parts []goschema.IndexPart) []ast.IndexPart {
 	astParts := make([]ast.IndexPart, 0, len(parts))
 	for _, part := range parts {
 		astParts = append(astParts, ast.IndexPart{
-			Name:     part.Name,
-			Expr:     part.Expr,
-			Operator: part.Operator,
-			Prefix:   part.Prefix,
-			Desc:     part.Desc,
+			Name:       part.Name,
+			Expr:       part.Expr,
+			Operator:   part.Operator,
+			Prefix:     part.Prefix,
+			Desc:       part.Desc,
+			NullsOrder: part.NullsOrder,
 		})
 	}
 	return astParts

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -303,11 +303,21 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			-- information_schema erases an array's element type: data_type is
 			-- the bare category "ARRAY" and character_maximum_length is null,
 			-- so varchar(100)[] cannot be reconstructed from either. Only
-			-- format_type carries it. Read for array columns alone: preferring
-			-- it everywhere would change the type string for every column and
-			-- reach the SERIAL detection and the sized-type branches
-			-- downstream (stokaro/ptah#1138).
-			CASE WHEN data_type = 'ARRAY'
+			-- format_type carries it. Read for array and domain columns alone:
+			-- preferring it everywhere would change the type string for every
+			-- column and reach the SERIAL detection and the sized-type
+			-- branches downstream (stokaro/ptah#1138).
+			--
+			-- It erases a domain the same way. data_type for a column of
+			-- domain positive_int is its base type, "integer", so the column
+			-- was rebuilt without the domain's CHECK and nothing said so;
+			-- domain_name is how information_schema records that the
+			-- declared type was a domain, and format_type spells it the way
+			-- the server does, schema-qualifying it when the search path
+			-- needs that. Measured against the pinned binary v1.3.0, which
+			-- reports "type":"positive_int" here, so this is also the
+			-- compatible answer. See #1242.
+			CASE WHEN data_type = 'ARRAY' OR col.domain_name IS NOT NULL
 				THEN format_type(a.atttypid, a.atttypmod)
 				ELSE ''
 			END AS formatted_type,
@@ -695,6 +705,44 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 				FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
 				WHERE keys.ordinality <= ix.indnkeyatts
 			), '[]') as index_key_attnums,
+			-- pg_index.indclass names the operator class each key was built
+			-- with. Only a non-default class has to be carried: dropping
+			-- text_pattern_ops leaves an index PostgreSQL will not use for the
+			-- LIKE prefix scans it was created for, and nothing reports it.
+			-- opcdefault separates the two, so a default class reports the
+			-- empty string rather than a name the emitted DDL does not need.
+			COALESCE((
+				SELECT json_agg(
+					CASE WHEN op.opcdefault IS NOT FALSE THEN '' ELSE op.opcname::text END
+					ORDER BY keys.ordinality
+				)::text
+				FROM unnest(ix.indclass) WITH ORDINALITY AS keys(opcoid, ordinality)
+				LEFT JOIN pg_opclass op ON op.oid = keys.opcoid
+				WHERE keys.ordinality <= ix.indnkeyatts
+			), '[]') as index_key_opclasses,
+			-- pg_index.indoption is a per-key bitmask: bit 0 is DESC, bit 1 is
+			-- NULLS FIRST. Measured on PostgreSQL 17.10: (a DESC) reports 3,
+			-- (c DESC NULLS LAST) reports 1, (b NULLS FIRST) reports 2, and a
+			-- plain ascending key reports 0.
+			COALESCE((
+				SELECT json_agg(keys.optionbits ORDER BY keys.ordinality)::text
+				FROM unnest(ix.indoption) WITH ORDINALITY AS keys(optionbits, ordinality)
+				WHERE keys.ordinality <= ix.indnkeyatts
+			), '[]') as index_key_options,
+			-- INCLUDE payload columns are the keys past indnkeyatts. They are
+			-- absent from indclass and indoption, which cover key columns
+			-- only, so they are read separately rather than filtered out of
+			-- the key list afterwards.
+			COALESCE((
+				SELECT json_agg(pg_get_indexdef(i.oid, keys.ordinality::integer, true) ORDER BY keys.ordinality)::text
+				FROM unnest(ix.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+				WHERE keys.ordinality > ix.indnkeyatts
+			), '[]') as index_include_columns,
+			-- The access method. Losing it is not always the quiet
+			-- degradation to btree it looks like: a gist index on a point
+			-- column does not replay at all without it, because point has no
+			-- default btree operator class. See #1242.
+			am.amname as index_method,
 			COALESCE(pg_get_expr(ix.indpred, ix.indrelid), '') as predicate,
 			ix.indisprimary,
 			ix.indisunique
@@ -702,6 +750,7 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 		JOIN pg_class i ON i.oid = ix.indexrelid
 		JOIN pg_class t ON t.oid = ix.indrelid
 		JOIN pg_namespace n ON n.oid = t.relnamespace
+		JOIN pg_am am ON am.oid = i.relam
 		WHERE n.nspname = $1
 		AND t.relname NOT IN ('schema_migrations')
 		ORDER BY t.relname, i.relname`
@@ -714,39 +763,191 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 
 	var indexes []types.DBIndex
 	for rows.Next() {
-		var schemaName, tableName, indexName, indexDef, indexColumns, keyAttnums, predicate string
-		var isPrimary, isUnique bool
-		err := rows.Scan(&schemaName, &tableName, &indexName, &indexDef, &indexColumns, &keyAttnums, &predicate, &isPrimary, &isUnique)
+		var row postgresIndexRow
+		err := rows.Scan(
+			&row.schemaName, &row.tableName, &row.indexName, &row.indexDef,
+			&row.keyTexts, &row.keyAttnums, &row.keyOpclasses, &row.keyOptions,
+			&row.includeColumns, &row.method,
+			&row.predicate, &row.isPrimary, &row.isUnique,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan index: %w", err)
 		}
 
-		// Parse index definition to extract columns and properties
-		index := types.DBIndex{
-			Name:          indexName,
-			TableName:     tableName,
-			Schema:        r.outputSchema(schemaName),
-			Definition:    indexDef,
-			Condition:     predicate,
-			IsUnique:      isUnique,
-			IsPrimary:     isPrimary,
-			NullsDistinct: postgresNullsDistinctFromDefinition(indexDef),
-		}
-
-		index.Columns, err = parsePostgresIndexColumns(indexColumns, indexDef)
+		index, err := buildPostgresIndex(row)
 		if err != nil {
-			return nil, fmt.Errorf("failed to parse index columns for %s: %w", indexName, err)
+			return nil, err
 		}
-
-		index.Parts, err = parsePostgresIndexParts(index.Columns, keyAttnums)
-		if err != nil {
-			return nil, fmt.Errorf("failed to parse index key parts for %s: %w", indexName, err)
-		}
+		index.Schema = r.outputSchema(row.schemaName)
 
 		indexes = append(indexes, index)
 	}
 
 	return indexes, nil
+}
+
+// postgresIndexRow is one row of the index introspection query. Each field
+// names the catalog value it carries, so the mapping below can be read without
+// counting scan positions.
+type postgresIndexRow struct {
+	schemaName string
+	tableName  string
+	indexName  string
+	indexDef   string
+	// keyTexts is the JSON array of per-key texts from pg_get_indexdef.
+	keyTexts string
+	// keyAttnums is the JSON array of pg_index.indkey attribute numbers.
+	keyAttnums string
+	// keyOpclasses is the JSON array of per-key operator class names, empty
+	// where the key uses its type's default class.
+	keyOpclasses string
+	// keyOptions is the JSON array of pg_index.indoption bitmasks.
+	keyOptions string
+	// includeColumns is the JSON array of INCLUDE payload column texts.
+	includeColumns string
+	// method is pg_am.amname.
+	method    string
+	predicate string
+	isPrimary bool
+	isUnique  bool
+}
+
+// buildPostgresIndex maps one introspection row onto the dialect-neutral index
+// model. It does not set Schema, which needs the reader's output-schema policy.
+func buildPostgresIndex(row postgresIndexRow) (types.DBIndex, error) {
+	index := types.DBIndex{
+		Name:          row.indexName,
+		TableName:     row.tableName,
+		Definition:    row.indexDef,
+		Condition:     row.predicate,
+		IsUnique:      row.isUnique,
+		IsPrimary:     row.isPrimary,
+		Method:        row.method,
+		NullsDistinct: postgresNullsDistinctFromDefinition(row.indexDef),
+	}
+
+	columns, err := parsePostgresIndexColumns(row.keyTexts, row.indexDef)
+	if err != nil {
+		return types.DBIndex{}, fmt.Errorf("failed to parse index columns for %s: %w", row.indexName, err)
+	}
+	index.Columns = columns
+
+	index.IncludeColumns, err = parsePostgresIndexIncludeColumns(row.includeColumns)
+	if err != nil {
+		return types.DBIndex{}, fmt.Errorf("failed to parse index include columns for %s: %w", row.indexName, err)
+	}
+
+	index.Parts, err = parsePostgresIndexParts(index.Columns, row.keyAttnums)
+	if err != nil {
+		return types.DBIndex{}, fmt.Errorf("failed to parse index key parts for %s: %w", row.indexName, err)
+	}
+
+	index.Parts, err = applyPostgresIndexOpclasses(index.Parts, row.keyOpclasses)
+	if err != nil {
+		return types.DBIndex{}, fmt.Errorf("failed to parse index operator classes for %s: %w", row.indexName, err)
+	}
+
+	index.Parts, err = applyPostgresIndexOptions(index.Parts, row.keyOptions)
+	if err != nil {
+		return types.DBIndex{}, fmt.Errorf("failed to parse index key options for %s: %w", row.indexName, err)
+	}
+
+	return index, nil
+}
+
+// parsePostgresIndexIncludeColumns decodes the INCLUDE payload column list. An
+// absent or empty list is not an error: most indexes have no payload.
+func parsePostgresIndexIncludeColumns(value string) ([]string, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || trimmed == "[]" {
+		return nil, nil
+	}
+	var columns []string
+	if err := json.Unmarshal([]byte(trimmed), &columns); err != nil {
+		return nil, err
+	}
+	if len(columns) == 0 {
+		return nil, nil
+	}
+	return columns, nil
+}
+
+// applyPostgresIndexOpclasses attaches the non-default operator class of each
+// key to its part.
+//
+// A list that does not line up with the parts is dropped rather than applied
+// off by one: an operator class on the wrong key builds a different index than
+// the one being read, which is worse than not carrying it at all.
+func applyPostgresIndexOpclasses(parts []types.DBIndexPart, opclassesJSON string) ([]types.DBIndexPart, error) {
+	opclasses, err := decodePostgresKeyList[string](opclassesJSON, len(parts))
+	if err != nil || opclasses == nil {
+		return parts, err
+	}
+	for position := range parts {
+		parts[position].Operator = opclasses[position]
+	}
+	return parts, nil
+}
+
+// PostgreSQL's per-key index option bits, from pg_index.indoption.
+const (
+	postgresIndexOptionDesc       = 1
+	postgresIndexOptionNullsFirst = 2
+)
+
+// applyPostgresIndexOptions attaches the sort direction and NULLS ordering of
+// each key to its part.
+//
+// Only an ordering that contradicts its direction's default is recorded:
+// PostgreSQL gives NULLS LAST to ASC and NULLS FIRST to DESC, so recording the
+// default would make the renderer emit a clause the pinned binary does not.
+func applyPostgresIndexOptions(parts []types.DBIndexPart, optionsJSON string) ([]types.DBIndexPart, error) {
+	options, err := decodePostgresKeyList[int](optionsJSON, len(parts))
+	if err != nil || options == nil {
+		return parts, err
+	}
+	for position := range parts {
+		parts[position].Desc = options[position]&postgresIndexOptionDesc != 0
+		parts[position].NullsOrder = postgresNullsOrder(options[position])
+	}
+	return parts, nil
+}
+
+// postgresNullsOrder reads the NULLS ordering out of one pg_index.indoption
+// bitmask, or returns the empty string when the ordering is the default for
+// the key's direction and does not have to be spelled out.
+//
+// The two default combinations are the two where the DESC bit and the
+// NULLS FIRST bit agree: bitmask 0 is ASC NULLS LAST and bitmask 3 is
+// DESC NULLS FIRST.
+func postgresNullsOrder(optionBits int) string {
+	descending := optionBits&postgresIndexOptionDesc != 0
+	nullsFirst := optionBits&postgresIndexOptionNullsFirst != 0
+	switch {
+	case descending == nullsFirst:
+		return ""
+	case nullsFirst:
+		return types.NullsOrderFirst
+	default:
+		return types.NullsOrderLast
+	}
+}
+
+// decodePostgresKeyList decodes a per-key JSON array fetched alongside the key
+// texts, returning nil when it is absent or does not have one entry per key.
+func decodePostgresKeyList[T any](value string, keyCount int) ([]T, error) {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" || trimmed == "[]" {
+		return nil, nil
+	}
+	var decoded []T
+	if err := json.Unmarshal([]byte(trimmed), &decoded); err != nil {
+		return nil, err
+	}
+	if len(decoded) != keyCount {
+		return nil, nil
+	}
+	return decoded, nil
 }
 
 func parsePostgresIndexColumns(value, indexDef string) ([]string, error) {

--- a/internal/dbschema/postgres/reader_columns_internal_test.go
+++ b/internal/dbschema/postgres/reader_columns_internal_test.go
@@ -1,0 +1,163 @@
+package postgres
+
+// White-box testing required: readColumnsForSchema is unexported and the SQL it
+// issues is the only place the declared type of a domain column enters the
+// process. information_schema.columns.data_type for a column of domain
+// positive_int is its base type, "integer", so the reader that trusts it hands
+// the rest of the pipeline a column that never had the domain -- and no pure
+// function downstream can notice, because there is nothing left to notice with.
+//
+// The fake server follows the same rule as the index guard next door: a
+// projection is answered from the fixture catalog only when it actually reads
+// the catalog column the answer comes from.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// pgColumnCatalog is one row of the column introspection query as PostgreSQL
+// 17.10 reports it.
+type pgColumnCatalog struct {
+	tableName  string
+	columnName string
+	// dataType is information_schema.columns.data_type, which for a domain
+	// column is the domain's base type rather than the domain.
+	dataType string
+	udtName  string
+	// formattedType is format_type(a.atttypid, a.atttypmod), the server's own
+	// spelling of the declared type. It is the only value in this query that
+	// names the domain.
+	formattedType string
+	// domainName is information_schema.columns.domain_name: how the catalog
+	// records that the declared type was a domain. Empty for a plain column.
+	domainName string
+}
+
+// domainColumnCatalog is CREATE DOMAIN positive_int AS integer CHECK (VALUE > 0)
+// followed by a qty column of that domain, measured on PostgreSQL 17.10.
+func domainColumnCatalog() pgColumnCatalog {
+	return pgColumnCatalog{
+		tableName:     "t",
+		columnName:    "qty",
+		dataType:      "integer",
+		udtName:       "int4",
+		formattedType: "positive_int",
+		domainName:    "positive_int",
+	}
+}
+
+// plainColumnCatalog is a plain integer column: same base type, no domain. It
+// is what keeps the assertion below from passing for the wrong reason -- the
+// reader must leave FormattedType empty here, or every column in every database
+// would start round-tripping through format_type.
+func plainColumnCatalog() pgColumnCatalog {
+	catalog := domainColumnCatalog()
+	catalog.columnName = "id"
+	catalog.formattedType = "integer"
+	catalog.domainName = ""
+	return catalog
+}
+
+// serveColumnQuery answers the column query. formatted_type is answered from
+// the catalog only when the projection asks whether the column's declared type
+// was a domain; a projection that does not ask cannot distinguish the two
+// fixtures above on a real server either, and gets the empty string the CASE's
+// ELSE branch returns.
+func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult, error) {
+	asksAboutDomains, err := queryAsksAboutDomains(query)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	formattedType := ""
+	if asksAboutDomains && catalog.domainName != "" {
+		formattedType = catalog.formattedType
+	}
+	return dbtest.QueryResult{
+		Columns: []string{
+			"table_name", "column_name", "data_type", "udt_name", "formatted_type",
+			"is_nullable", "column_default", "character_maximum_length",
+			"numeric_precision", "numeric_scale", "ordinal_position",
+			"generated_kind", "generated_expression", "identity_kind",
+			"owned_sequence_name",
+		},
+		Rows: [][]driver.Value{{
+			catalog.tableName, catalog.columnName, catalog.dataType, catalog.udtName, formattedType,
+			"YES", nil, nil,
+			nil, nil, int64(1),
+			"", "", "",
+			"",
+		}},
+	}, nil
+}
+
+// queryAsksAboutDomains reports whether the formatted_type projection reads
+// information_schema's domain_name.
+//
+// It inspects the projection with comments stripped -- see selectListItem next
+// door. The reader's comment above this CASE explains the domain case in prose
+// and therefore contains the words "domain_name"; a check against the raw query
+// text passes on a build that no longer reads the column, which is exactly the
+// revert this guard exists to catch.
+func queryAsksAboutDomains(query string) (bool, error) {
+	projection, ok := selectListItem(query, "formatted_type", "FROM information_schema.columns")
+	if !ok {
+		return false, fmt.Errorf("query has no projection aliased formatted_type:\n%s", query)
+	}
+	return strings.Contains(projection, "domain_name"), nil
+}
+
+// TestReadColumnsForSchema_KeepsTheDeclaredDomainType guards the last of the
+// #1242 introspection gaps. Measured on PostgreSQL 17.10, a reader that takes
+// information_schema's data_type for a domain column emits
+// `"qty" integer` for a column declared positive_int: it replays at psql exit
+// 0 and leaves a column without the domain's CHECK, and re-diffing the result
+// against the source with the pinned binary v1.3.0 then reports
+// `ALTER TABLE "t" ALTER COLUMN "qty" TYPE positive_int;`.
+func TestReadColumnsForSchema_KeepsTheDeclaredDomainType(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		catalog func() pgColumnCatalog
+		// expectedFormattedType is what the reader must carry forward.
+		// dbschematogo prefers a non-empty FormattedType over data_type when
+		// it builds the field type, so this is the value that decides whether
+		// the emitted DDL says positive_int or integer.
+		expectedFormattedType string
+	}{
+		{
+			name:                  "domain column keeps the domain",
+			catalog:               domainColumnCatalog,
+			expectedFormattedType: "positive_int",
+		},
+		{
+			name:                  "plain column is left alone",
+			catalog:               plainColumnCatalog,
+			expectedFormattedType: "",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			catalog := test.catalog()
+			db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+				return serveColumnQuery(catalog, query)
+			})
+
+			columnsByTable, err := NewPostgreSQLReader(db.SQL, "public").readColumnsForSchema("public")
+			c.Assert(err, qt.IsNil)
+			c.Assert(columnsByTable["t"], qt.HasLen, 1)
+			c.Assert(columnsByTable["t"][0].FormattedType, qt.Equals, test.expectedFormattedType)
+			// The base type stays available; the fix adds a spelling rather
+			// than replacing one.
+			c.Assert(columnsByTable["t"][0].DataType, qt.Equals, "integer")
+		})
+	}
+}

--- a/internal/dbschema/postgres/reader_indexes_internal_test.go
+++ b/internal/dbschema/postgres/reader_indexes_internal_test.go
@@ -1,0 +1,403 @@
+package postgres
+
+// White-box testing required: readIndexesForSchema is unexported, and the SQL
+// it issues is the only place pg_index's per-key catalog vectors enter the
+// process. Everything downstream -- parsePostgresIndexParts, the conversion to
+// goschema, the renderer -- can be correct while the reader simply never asks
+// the server for them, which is precisely the state this package was in before
+// #1242. A test of the pure parsers alone cannot see that: each is handed the
+// vector it is supposed to prove was fetched.
+//
+// The fake server below therefore answers each projection the way a real
+// PostgreSQL would. A projection that reads a catalog column is answered from
+// the fixture catalog; a projection that reads nothing -- a bare literal, which
+// is the shape the query had before each of these attributes was added, and the
+// shape a revert restores -- is answered with that literal. Reverting any of
+// them makes these tests fail where reverting them leaves the rest of the suite
+// green.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// pgIndexCatalog is one row of pg_index as PostgreSQL 17.10 reports it. Every
+// field records a value measured from the fixture named in its constructor
+// below, read back with the probe in the #1242 investigation.
+type pgIndexCatalog struct {
+	schemaName string
+	tableName  string
+	indexName  string
+	// indexDef is pg_get_indexdef(i.oid).
+	indexDef string
+	// keyTexts is the JSON array of per-key texts from
+	// pg_get_indexdef(i.oid, ordinality, true).
+	keyTexts string
+	// keyAttnums is the JSON array of pg_index.indkey attribute numbers. A 0
+	// marks an expression key; every real column has a positive attnum.
+	keyAttnums string
+	// keyOpclasses is the JSON array of per-key pg_opclass.opcname values,
+	// empty where opcdefault is true.
+	keyOpclasses string
+	// keyOptions is the JSON array of pg_index.indoption bitmasks.
+	keyOptions string
+	// includeColumns is the JSON array of INCLUDE payload column texts.
+	includeColumns string
+	// method is pg_am.amname.
+	method    string
+	predicate string
+	isPrimary bool
+	isUnique  bool
+}
+
+// plainCatalog is CREATE INDEX i_plain ON t (name): btree, default opclass,
+// ascending, no payload. It is the control every other fixture varies from.
+func plainCatalog() pgIndexCatalog {
+	return pgIndexCatalog{
+		schemaName:     "public",
+		tableName:      "t",
+		indexName:      "i_plain",
+		indexDef:       "CREATE INDEX i_plain ON public.t USING btree (name)",
+		keyTexts:       `["name"]`,
+		keyAttnums:     `[2]`,
+		keyOpclasses:   `[""]`,
+		keyOptions:     `[0]`,
+		includeColumns: `[]`,
+		method:         "btree",
+	}
+}
+
+// expressionCatalog is CREATE INDEX i_expr ON t (lower(name)): indkey {0}.
+func expressionCatalog() pgIndexCatalog {
+	catalog := plainCatalog()
+	catalog.indexName = "i_expr"
+	catalog.indexDef = "CREATE INDEX i_expr ON public.t USING btree (lower(name))"
+	catalog.keyTexts = `["lower(name)"]`
+	catalog.keyAttnums = `[0]`
+	return catalog
+}
+
+// columnNamedLikeACallCatalog separates the expression case from its only
+// plausible alternative: a column literally named "lower(name)". The key text
+// is byte-identical to expressionCatalog and the attnum vector is the sole
+// difference, so a reader that does not fetch the vector cannot tell them
+// apart.
+func columnNamedLikeACallCatalog() pgIndexCatalog {
+	catalog := expressionCatalog()
+	catalog.indexName = "i_quoted"
+	catalog.indexDef = `CREATE INDEX i_quoted ON public.t USING btree ("lower(name)")`
+	catalog.keyAttnums = `[3]`
+	return catalog
+}
+
+// gistOnPointCatalog is CREATE INDEX i_gist ON t USING gist (p) over a point
+// column. Dropping the access method here is not a quiet degradation: point
+// has no default btree operator class, so the emitted DDL does not replay.
+func gistOnPointCatalog() pgIndexCatalog {
+	catalog := plainCatalog()
+	catalog.indexName = "i_gist"
+	catalog.indexDef = "CREATE INDEX i_gist ON public.t USING gist (p)"
+	catalog.keyTexts = `["p"]`
+	catalog.method = "gist"
+	return catalog
+}
+
+// opclassCatalog is CREATE INDEX i_op ON t (name text_pattern_ops).
+func opclassCatalog() pgIndexCatalog {
+	catalog := plainCatalog()
+	catalog.indexName = "i_op"
+	catalog.indexDef = "CREATE INDEX i_op ON public.t USING btree (name text_pattern_ops)"
+	catalog.keyOpclasses = `["text_pattern_ops"]`
+	return catalog
+}
+
+// includeCatalog is CREATE INDEX i_inc ON t (a, b) INCLUDE (c). indclass and
+// indoption cover the two key columns only; the payload column is not in them.
+func includeCatalog() pgIndexCatalog {
+	catalog := plainCatalog()
+	catalog.indexName = "i_inc"
+	catalog.indexDef = "CREATE INDEX i_inc ON public.t USING btree (a, b) INCLUDE (c)"
+	catalog.keyTexts = `["a", "b"]`
+	catalog.keyAttnums = `[2, 3]`
+	catalog.keyOpclasses = `["", ""]`
+	catalog.keyOptions = `[0, 0]`
+	catalog.includeColumns = `["c"]`
+	return catalog
+}
+
+// sortOrderCatalog builds a one-key fixture with the given pg_index.indoption
+// bitmask. The four values were read off PostgreSQL 17.10: (a DESC) reports 3,
+// (c DESC NULLS LAST) reports 1, (b NULLS FIRST) reports 2, plain ascending
+// reports 0.
+func sortOrderCatalog(option string) func() pgIndexCatalog {
+	return func() pgIndexCatalog {
+		catalog := plainCatalog()
+		catalog.indexName = "i_sorted"
+		catalog.keyOptions = "[" + option + "]"
+		return catalog
+	}
+}
+
+// serveIndexQuery answers the reader's index query. Every value is looked up by
+// the catalog expression the query asks for rather than by the alias it
+// assigns, which is what makes a projection that stopped reading the catalog
+// visible here instead of silently answered.
+func serveIndexQuery(catalog pgIndexCatalog, query string) (dbtest.QueryResult, error) {
+	answers := []struct {
+		alias         string
+		catalogColumn string
+		value         string
+	}{
+		{"index_columns", "pg_get_indexdef", catalog.keyTexts},
+		{"index_key_attnums", "indkey", catalog.keyAttnums},
+		{"index_key_opclasses", "indclass", catalog.keyOpclasses},
+		{"index_key_options", "indoption", catalog.keyOptions},
+		{"index_include_columns", "indkey", catalog.includeColumns},
+		{"index_method", "amname", catalog.method},
+	}
+
+	values := []driver.Value{
+		catalog.schemaName, catalog.tableName, catalog.indexName, catalog.indexDef,
+	}
+	columns := []string{"schemaname", "tablename", "indexname", "indexdef"}
+	for _, answer := range answers {
+		value, err := answerProjection(query, answer.alias, answer.catalogColumn, answer.value)
+		if err != nil {
+			return dbtest.QueryResult{}, err
+		}
+		columns = append(columns, answer.alias)
+		values = append(values, value)
+	}
+	columns = append(columns, "predicate", "indisprimary", "indisunique")
+	values = append(values, catalog.predicate, catalog.isPrimary, catalog.isUnique)
+
+	return dbtest.QueryResult{Columns: columns, Rows: [][]driver.Value{values}}, nil
+}
+
+// answerProjection returns what a PostgreSQL server would hand back for the
+// SELECT-list item the query aliases to alias.
+//
+// It returns catalogValue only when that projection actually reads
+// catalogColumn. A projection that reads nothing from the catalog cannot
+// produce a catalog value on a real server either, so it is answered with the
+// empty JSON array -- the same thing `'[]' as index_key_attnums` returns.
+//
+// A query with no projection under that alias is a hard error rather than a
+// missing value: the reader scans its columns positionally, and answering an
+// alias the query never asked for would let the fake supply data the server
+// never sent.
+func answerProjection(query, alias, catalogColumn, catalogValue string) (string, error) {
+	projection, ok := selectListItem(query, alias, "FROM pg_index")
+	if !ok {
+		return "", fmt.Errorf("query has no projection aliased %q:\n%s", alias, query)
+	}
+	if strings.Contains(projection, catalogColumn) {
+		return catalogValue, nil
+	}
+	return "[]", nil
+}
+
+// selectListItem returns the SELECT-list expression the query aliases to alias,
+// splitting on commas at parenthesis depth zero so a sub-select's own commas do
+// not end an item.
+//
+// Comments are stripped first, and that is not tidiness. Each projection in the
+// reader is introduced by a comment naming the catalog column it reads and
+// saying why. Matching against the raw text would let that prose stand in for
+// the column: a mutant that deletes the sub-select and leaves the comment above
+// it would still look like it reads the catalog. Measured -- the first version
+// of the domain guard next door made exactly this mistake and stayed green
+// through the revert it existed to catch.
+//
+// Splitting on parenthesis depth also has to happen after stripping, or a
+// parenthesis inside a comment would move the depth counter.
+func selectListItem(query, alias string, fromMarker string) (string, bool) {
+	selectList := stripSQLLineComments(query)
+	if from := strings.LastIndex(selectList, fromMarker); from >= 0 {
+		selectList = selectList[:from]
+	}
+	for _, item := range splitTopLevel(selectList) {
+		trimmed := strings.TrimSpace(item)
+		// The reader spells some aliases `as` and some `AS`; neither is the
+		// thing under test.
+		if strings.HasSuffix(strings.ToLower(trimmed), " as "+strings.ToLower(alias)) {
+			return item, true
+		}
+	}
+	return "", false
+}
+
+func stripSQLLineComments(query string) string {
+	lines := strings.Split(query, "\n")
+	kept := make([]string, 0, len(lines))
+	for _, line := range lines {
+		if comment := strings.Index(line, "--"); comment >= 0 {
+			line = line[:comment]
+		}
+		kept = append(kept, line)
+	}
+	return strings.Join(kept, "\n")
+}
+
+func splitTopLevel(value string) []string {
+	var items []string
+	depth := 0
+	start := 0
+	for position, character := range value {
+		switch character {
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				items = append(items, value[start:position])
+				start = position + 1
+			}
+		}
+	}
+	return append(items, value[start:])
+}
+
+func readIndexThroughFakeServer(t *testing.T, catalog pgIndexCatalog) (types.DBIndex, error) {
+	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		return serveIndexQuery(catalog, query)
+	})
+	indexes, err := NewPostgreSQLReader(db.SQL, "public").readIndexesForSchema("public")
+	if err != nil {
+		return types.DBIndex{}, err
+	}
+	if len(indexes) != 1 {
+		return types.DBIndex{}, fmt.Errorf("expected exactly one index, got %d", len(indexes))
+	}
+	return indexes[0], nil
+}
+
+// TestReadIndexesForSchema_AsksTheCatalogForEveryKeyAttribute is the guard the
+// #1242 expression fix was missing and the guard its four siblings need.
+//
+// Removing the pg_index.indkey projection from the reader's SQL -- measured on
+// PostgreSQL 17.10 to put `schema diff` back to emitting
+// CREATE INDEX "i_expr" ON "t" ("lower(name)"), which psql rejects at exit 3
+// with `column "lower(name)" does not exist` -- left `go test ./...` at exit 0
+// before this test existed. The same was true of every other projection here.
+func TestReadIndexesForSchema_AsksTheCatalogForEveryKeyAttribute(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		catalog func() pgIndexCatalog
+		// assert states what the reader must report once the fake server has
+		// answered only the projections the query genuinely asks for.
+		assert func(c *qt.C, index types.DBIndex)
+	}{
+		{
+			name:    "plain ascending btree key carries no extras",
+			catalog: plainCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Method, qt.Equals, "btree")
+				c.Assert(index.IncludeColumns, qt.IsNil)
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{{Name: "name"}})
+			},
+		},
+		{
+			// attnum 0 is PostgreSQL's marker for an expression key. Losing it
+			// makes the renderer quote the expression into a column reference
+			// that does not exist.
+			name:    "expression key is labelled an expression",
+			catalog: expressionCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{{Expr: "lower(name)"}})
+				// The legacy columns-only view is populated either way, which
+				// is why the loss was invisible: only Parts separates the two.
+				c.Assert(index.Columns, qt.DeepEquals, []string{"lower(name)"})
+			},
+		},
+		{
+			name:    "column named like a call stays a column",
+			catalog: columnNamedLikeACallCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{{Name: "lower(name)"}})
+				c.Assert(index.Columns, qt.DeepEquals, []string{"lower(name)"})
+			},
+		},
+		{
+			name:    "access method is carried",
+			catalog: gistOnPointCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Method, qt.Equals, "gist")
+			},
+		},
+		{
+			name:    "non-default operator class is carried",
+			catalog: opclassCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "name", Operator: "text_pattern_ops"},
+				})
+			},
+		},
+		{
+			name:    "include payload columns are carried and stay out of the keys",
+			catalog: includeCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"c"})
+				c.Assert(index.Columns, qt.DeepEquals, []string{"a", "b"})
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "a"}, {Name: "b"},
+				})
+			},
+		},
+		{
+			name:    "indoption 3 is DESC with its default NULLS FIRST",
+			catalog: sortOrderCatalog("3"),
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "name", Desc: true},
+				})
+			},
+		},
+		{
+			name:    "indoption 1 is DESC NULLS LAST",
+			catalog: sortOrderCatalog("1"),
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "name", Desc: true, NullsOrder: types.NullsOrderLast},
+				})
+			},
+		},
+		{
+			name:    "indoption 2 is ascending NULLS FIRST",
+			catalog: sortOrderCatalog("2"),
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "name", NullsOrder: types.NullsOrderFirst},
+				})
+			},
+		},
+		{
+			name:    "indoption 0 is ascending with its default NULLS LAST",
+			catalog: sortOrderCatalog("0"),
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
+					{Name: "name"},
+				})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			index, err := readIndexThroughFakeServer(t, test.catalog())
+			c.Assert(err, qt.IsNil)
+			test.assert(c, index)
+		})
+	}
+}


### PR DESCRIPTION
Closes the remaining work on #1242, and the three corrections the adversarial review of #1246 filed.

## The test hole first, because it was the serious one

A reviewer replaced the `pg_index.indkey` logic #1246 shipped and the whole suite stayed green. Reproduced before writing anything:

| | |
| --- | --- |
| revert the `index_key_attnums` projection to `'[]'` | `go test ./...` **exit 0** |
| same binary, `expr` fixture replayed through psql | **exit 3**, `ERROR: column "lower(name)" does not exist` |

The mutation is behavior-changing and CI could not see it. `parsePostgresIndexParts` was tested; the SQL that feeds it and the wiring that carries its output were not, and neither is reachable from a pure-function test — the parser is handed the vector it is supposed to prove was fetched.

The new white-box tests drive `readIndexesForSchema` / `readColumnsForSchema` through a fake server that answers **each projection only when the query actually reads the catalog column the answer comes from**. A projection replaced by a literal gets the literal, exactly as a real server would, and the reader then has nothing to work with.

Comments are stripped before matching, and that is not tidiness. The reader documents every projection by naming the column it reads. A first version of the domain guard matched `domain_name` anywhere in the query text, found it in the prose above the `CASE`, and **stayed green through the revert it existed to catch**. That is in the sweep below as the row that used to be green.

### Mutation sweep

Each fix reverted in turn, guard tests run, controls on the unmutated tree in the same sweep:

```
MUTATION=none(control)   GUARD_RC=0   <- must be 0
MUTATION=indkey          GUARD_RC=1   failed=9
MUTATION=indclass        GUARD_RC=1   failed=1
MUTATION=indoption       GUARD_RC=1   failed=3
MUTATION=include         GUARD_RC=1   failed=1
MUTATION=amname          GUARD_RC=1   failed=2
MUTATION=domain          GUARD_RC=1   failed=1
MUTATION=none(restored)  GUARD_RC=0   <- must be 0
```

Every mutation leaves its explanatory comment in place, so the sweep is also the control for the comment-matching flaw. Failures are assertion failures on the reported value, not plumbing errors.

## What is fixed

The whole loss was in the reader. `ast.IndexPart`, `goschema.IndexPart`, the PostgreSQL renderer and the atlashcl read path already carried access methods, operator classes, expressions and `DESC`. `readIndexesForSchema` reported every key through `DBIndex.Columns` — a list of names, which cannot say a key is descending, cannot carry an operator class, and cannot tell an expression from a column named like one.

| gap | read from |
| --- | --- |
| access method | `pg_am.amname` |
| operator class | `pg_index.indclass`, non-default classes only |
| sort order | `pg_index.indoption` |
| `INCLUDE` payload columns | `pg_index.indkey` past `indnkeyatts` |
| domain column type | `information_schema.columns.domain_name` |

`DBIndex.Method` is a new field rather than a reuse of `DBIndex.Type` — the issue flagged that decision. `Type` is the ClickHouse data-skipping-index type; one field cannot hold both without making a ClickHouse `bloom_filter` and a PostgreSQL `gin` indistinguishable at this layer. `dbschematogo` folds them into `goschema.Index.Type`, which is one field by existing design, and no reader sets both.

`NULLS FIRST` / `NULLS LAST` needed a new field on all three `IndexPart` types, as the issue's scoping note predicted. The renderer emits whatever the part carries; deciding a clause is redundant belongs to the reader, which declines to record an ordering matching its direction's default (PostgreSQL: `NULLS LAST` for ASC, `NULLS FIRST` for DESC). That is what makes ptah spell `("a" DESC)` and `("c" DESC NULLS LAST)` the way the pinned binary does.

## Measurement

PostgreSQL 17.10, eight single-attribute fixtures in eight databases, run serially. Each diffed empty-to-source, the emitted SQL replayed into a fresh database with `psql -v ON_ERROR_STOP=1`, then the replayed database re-diffed against its source with the pinned binary as a neutral observer. Exit status read on its own line after redirecting to a file, never through a pipe.

| axis | replay before | replay after | pinned-binary re-diff before | re-diff after |
| --- | --- | --- | --- | --- |
| `gist` on `point` | **3** | 0 | recreate index | synced |
| `gin` on `jsonb` | 0 | 0 | drop + recreate | synced |
| `text_pattern_ops` | 0 | 0 | drop + recreate | synced |
| `DESC` / `NULLS FIRST` / `NULLS LAST` | 0 | 0 | drop + recreate | synced |
| `INCLUDE` | 0 | 0 | drop + recreate | synced |
| domain column | 0 | 0 | `ALTER COLUMN TYPE` | synced |
| expression (fixed by #1246) | 0 | 0 | synced | synced |
| plain btree control | 0 | 0 | synced | synced |

"Synced" is verbatim `Schemas are synced, no changes to be made.` A green replay is not a clean replay, which is why every row carries the re-diff too.

## Correction 1: the access-method loss was not silent

The docs row shipped with #1246 said it "replays at exit 0 and leaves a btree index". That is fixture-dependent and false in general, and the row is corrected with the counterexample kept in it:

```
emitted:  CREATE INDEX IF NOT EXISTS "i_gist" ON "t" ("p");
replay:   psql exit 3
          ERROR: data type point has no default operator class for access method "btree"
```

`int4range`, the type the original claim generalized from, does have a btree class. The loss is loud for `point`, `box`, `tsvector` and friends, quiet otherwise. A green replay never proved the access method survived — only that the column type tolerated losing it.

## Correction 2: INCLUDE was a sixth gap

Measured independently before fixing: pinned binary `INCLUDE ("c")`, ptah `("a", "b")`, replay exit 0, re-diff `DROP INDEX "i_inc"; CREATE INDEX "i_inc" ON "t" ("a", "b") INCLUDE ("c");`. Now in the docs table and fixed.

## Correction 3: parity half (a) is no longer NOT-MEASURED

The review noted the pinned binary never exited 1 across ~60 invocations on this front, so "ptah-compat never exits 0 where the binary exits 1" was untested here. Six cases constructed to make it exit 1:

| case | pinned binary | ptah-compat |
| --- | --- | --- |
| missing database | 1 | 1 |
| missing schema in `search_path` | 1 | 1 |
| unreachable port | 1 | 1 |
| unknown flag | 1 | 1 |
| `schema diff` with no `--to` | 1 | 1 |
| `atlas://` scheme | 1 | 1 |

No violation. Half (a) is measured on this surface now.

## Domains: keeping a capability rather than matching CE

CE is wrong here in the opposite direction. It keeps the declared column type but never emits the `CREATE DOMAIN`, so its own `schema diff` output fails to replay — measured, psql exit 3, `type "positive_int" does not exist`. Ptah emits both halves and replays at 0.

On the JSON inspect surface CE reports `"type":"positive_int"` where ptah reported `"integer"`, so the fix moves toward the binary there as well. No conflict between the two halves on this one.

## A seventh thing the measurement turned up

`schema inspect --format '{{ json . }}'` dropped the direction of every index key: CE prints `{"desc": true, "column": "a"}`, ptah printed `{"column": "a"}`. The structured parts are now used where a reader supplies them, and readers that supply only the flat `Columns` list (MySQL, MariaDB) print exactly what they printed before. All six index axes are now byte-identical to the pinned binary on that surface.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| every `check:*` in `docs/site/package.json`, incl. selftests | 0 |
| `build-feature-matrix.mjs --check` | 0 |
| `npm run build` + `check:responsive` | 0 |

`golangci-lint run ./...` first exited 1 on 14 findings, all in file paths belonging to other checkouts — a stale-cache artifact, not this tree. `golangci-lint cache clean` then gave `0 issues.` with exit 0. Three real findings in this change (a revive flag-parameter and two receiver-naming) were fixed rather than silenced.

`go test ./...` first exited 1 on `cmd/viz`'s `TestSVGReportsGraphvizStderrOnFailure` — `signal: killed` at the 10s mark under CPU contention. It passed at `-count=3` on its own and the full suite passed on re-run; the test touches nothing in this change.

Honest about which gates can go red for this change: `check-public-api-snapshot.sh` genuinely reddened (three additive fields plus two constant blocks) and the snapshot was regenerated; `check-public-api.sh` reports no approval line is owed for additive fields. The docs `check:*` gates read `docs/site/src/content/docs/`, not `docs/conformance.md`, so they were run but cannot go red for this edit — cite them as run, not as coverage.

## Not verified

- MySQL, MariaDB, SQLite, ClickHouse, SQL Server, Spanner. `DBIndex.Method` and `DBIndexPart.Operator`/`NullsOrder` stay empty on every reader that does not set them, and the `atlasreport` change falls back to the flat `Columns` list, so those paths emit what they emitted before — reasoned, not measured on a live server.
- Multi-key indexes mixing opclasses and directions per key, and indexes on non-`public` schemas. The per-key lists are positional and refuse to apply when they do not line up with the key count, but only single-attribute fixtures were replayed.
- Whether ptah's own DB-to-DB diff now *detects* a changed access method or opclass on an existing index. `indexDefinitionsChanged` compares only `NullsDistinct` and the predicate outside SQL Server, so it likely does not — a separate gap, not touched here.
- `brin` and `hash` access methods. `gin` and `gist` were measured; the code path is the same `pg_am.amname` string.
- The integration-tagged suites. `go test ./...` does not build them and they were not run.