### PR TITLE
Describe only the roles the inspected scope uses (#1267)

### DIFF
--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -65,6 +65,16 @@ Ordering is dependency-aware: roles are created before the functions and
 policies that reference them, and grants are emitted after the roles and
 target objects exist.
 
+Reading a live database describes only the roles the schemas being read
+actually use, because a PostgreSQL role belongs to the cluster rather than to
+one database. A role counts as used when it owns one of those schemas or an
+object in them, when it holds or granted a privilege on one of them, or when a
+row-level security policy on a table in them names it. A role that merely
+exists elsewhere on the server is not part of the schema being described, so
+it is left out — of `ptah db read` and of `ptah-compat schema inspect` alike.
+Every role the emitted grants and policies refer to is described, so a
+description never names a role it does not also create.
+
 :::caution
 Ptah never drops a role automatically. A role that disappears from the desired
 schema stays in the database, because roles may be shared with DBAs,

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -67,13 +67,24 @@ target objects exist.
 
 Reading a live database describes only the roles the schemas being read
 actually use, because a PostgreSQL role belongs to the cluster rather than to
-one database. A role counts as used when it owns one of those schemas or an
-object in them, when it holds or granted a privilege on one of them, or when a
-row-level security policy on a table in them names it. A role that merely
-exists elsewhere on the server is not part of the schema being described, so
-it is left out — of `ptah db read` and of `ptah-compat schema inspect` alike.
-Every role the emitted grants and policies refer to is described, so a
-description never names a role it does not also create.
+one database. A role counts as used when it holds a privilege on a relation in
+those schemas or on one of the schemas themselves, when it granted one, or when
+a row-level security policy on a table in them applies to it. A role that
+merely exists elsewhere on the server is not part of the schema being
+described, so it is left out — of `ptah db read` and of `ptah-compat schema
+inspect` alike.
+
+The rule is exact in both directions: a description defines a role when some
+other statement in it names that role, and not otherwise. Ownership alone does
+not qualify, because Ptah describes no ownership — it writes no `OWNER TO` and
+no `CREATE SCHEMA ... AUTHORIZATION` — so an owner would be created and then
+never referred to.
+
+For the same reason, grant introspection reports privileges somebody granted
+rather than the built-in privileges an owner holds by default. A relation whose
+`pg_class.relacl` is null has had no `GRANT` run against it, and its owner's
+implicit privileges are no longer emitted as `GRANT` statements; replaying
+`CREATE TABLE` gives the new owner exactly those privileges again.
 
 :::caution
 Ptah never drops a role automatically. A role that disappears from the desired

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -55,12 +55,20 @@ database schemas to read; when empty, Ptah reads the connection's default
 schema.
 
 PostgreSQL roles are cluster-wide rather than per-database, so a read reports
-only the roles the schemas being read actually use: a role that owns one of
-those schemas or an object in them, that holds or granted a privilege on one
-of them, or that is named by a row-level security policy on a table in them. A
+only the roles the schemas being read actually use: a role that holds a
+privilege on a relation in them or on one of the schemas, a role that granted
+one, or a role a row-level security policy on a table in them applies to. A
 role that merely exists elsewhere on the server belongs to no schema being read
-and is not described. Every role the emitted grants and policies name is still
-described, so the output never refers to a role it does not create.
+and is not described.
+
+Equivalently, a read describes a role exactly when some other statement in the
+same output names it, so the output never refers to a role it does not create.
+Ownership alone is not a reason: Ptah writes no `OWNER TO` and no
+`CREATE SCHEMA ... AUTHORIZATION`, so an owner would be a role the output
+creates and never mentions again. For the same reason a read no longer reports
+the built-in privileges an owner holds on a relation nobody has granted
+anything on -- no `GRANT` produced them, and `CREATE TABLE` re-establishes them
+for the new owner when the output is replayed.
 
 Role creation statements in PostgreSQL output are intended for
 a clean target. If a role already exists, applying the SQL

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -52,7 +52,17 @@ sqlite3 restored.db <schema.sql
 
 On PostgreSQL-family databases, `--schemas` accepts a comma-separated list of
 database schemas to read; when empty, Ptah reads the connection's default
-schema. Cluster-role creation statements in PostgreSQL output are intended for
+schema.
+
+PostgreSQL roles are cluster-wide rather than per-database, so a read reports
+only the roles the schemas being read actually use: a role that owns one of
+those schemas or an object in them, that holds or granted a privilege on one
+of them, or that is named by a row-level security policy on a table in them. A
+role that merely exists elsewhere on the server belongs to no schema being read
+and is not described. Every role the emitted grants and policies name is still
+described, so the output never refers to a role it does not create.
+
+Role creation statements in PostgreSQL output are intended for
 a clean target. If a role already exists, applying the SQL
 fails before its description or grants are changed; this prevents privileges
 from being attached to a role with unverified security attributes. Role

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -79,9 +79,9 @@ func TestPostgreSQLDBReadRoleCommentReplayIntegration(t *testing.T) {
 	cleanupDBReadRoleIntegration(c, db)
 	c.Cleanup(func() { cleanupDBReadRoleIntegration(c, db) })
 
-	// The described role owns the schema being read, which is why the read
-	// describes it. Ownership adds no statement of its own, so the role is
-	// still named by exactly the two statements this test replays.
+	// The described role holds a privilege on the schema being read, which is
+	// why the read describes it, and the GRANT that says so is emitted beside
+	// the role -- a description names no role it does not also create.
 	//
 	// The stranger role exists in the same cluster and is used by nothing in
 	// the schema being read. PostgreSQL roles are cluster-wide, so before
@@ -91,7 +91,8 @@ func TestPostgreSQLDBReadRoleCommentReplayIntegration(t *testing.T) {
 CREATE ROLE ptah_db_read_role_137;
 COMMENT ON ROLE ptah_db_read_role_137 IS 'Database read replay role';
 CREATE ROLE ptah_db_read_stranger_137;
-CREATE SCHEMA ptah_db_read_empty_schema_137 AUTHORIZATION ptah_db_read_role_137;`)
+CREATE SCHEMA ptah_db_read_empty_schema_137;
+GRANT USAGE ON SCHEMA ptah_db_read_empty_schema_137 TO ptah_db_read_role_137;`)
 	c.Assert(err, qt.IsNil)
 
 	cmd := readdb.NewReadDBCommand()
@@ -118,9 +119,13 @@ CREATE SCHEMA ptah_db_read_empty_schema_137 AUTHORIZATION ptah_db_read_role_137;
 			return !strings.Contains(statement, "ptah_db_read_role_137")
 		},
 	)
-	c.Assert(roleStatements, qt.HasLen, 2)
+	// CREATE ROLE, COMMENT ON ROLE, and the GRANT that is the role's reason
+	// for being described at all.
+	c.Assert(roleStatements, qt.HasLen, 3)
 
-	cleanupDBReadRoleIntegration(c, db)
+	// Drop the roles but keep the schema: the grant among the replayed
+	// statements has to have somewhere to land.
+	cleanupDBReadRolesOnly(c, db)
 	for _, statement := range roleStatements {
 		_, replayErr := db.Exec(statement)
 		c.Assert(replayErr, qt.IsNil, qt.Commentf("role restore failed: %s", statement))
@@ -248,9 +253,14 @@ $ptah_cleanup_roles$;`)
 
 func cleanupDBReadRoleIntegration(c *qt.C, db *sql.DB) {
 	c.Helper()
+	cleanupDBReadRolesOnly(c, db)
 	_, err := db.Exec("DROP SCHEMA IF EXISTS ptah_db_read_empty_schema_137 CASCADE")
 	c.Check(err, qt.IsNil)
-	_, err = db.Exec(`
+}
+
+func cleanupDBReadRolesOnly(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(`
 DO $ptah_cleanup_role$
 DECLARE
     role_name text;
@@ -361,4 +371,103 @@ func TestGoFixtures_ParseDirForSchemaObjects(t *testing.T) {
 	c.Assert(outStr, qt.Contains, "WITH GRANT OPTION")
 	c.Assert(outStr, qt.Contains, "CREATE ROLE fixture_app_user")
 	c.Assert(outStr, qt.Contains, "CONSTRAINT users_email_check")
+}
+
+// TestPostgreSQLDescribedRolesCoverEveryRoleTheDescriptionNamesIntegration pins
+// the invariant that scoping roles to the inspected schemas
+// (stokaro/ptah#1267) has to preserve: a description defines every role it
+// refers to. Break it and the document stops being readable -- the pinned
+// Atlas community binary refuses the whole file with
+// `Unsupported attribute; This object does not have an attribute named "..."`.
+//
+// The trap is information_schema.role_table_grants, which reports an owner's
+// built-in privileges as grants even for a table whose pg_class.relacl is
+// null, meaning nobody has ever run GRANT on it. Those are not privileges
+// anyone granted, and a role reaching a description only through them is a
+// role no GRANT statement put there.
+func TestPostgreSQLDescribedRolesCoverEveryRoleTheDescriptionNamesIntegration(t *testing.T) {
+	c := qt.New(t)
+	dsn := skipIfNoPostgreSQL(t)
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	cleanupDescribedRolesIntegration(c, db)
+	c.Cleanup(func() { cleanupDescribedRolesIntegration(c, db) })
+
+	_, err = db.Exec(`
+CREATE ROLE ptah_ref_granted_137;
+CREATE ROLE ptah_ref_owner_137;
+GRANT ptah_ref_owner_137 TO CURRENT_USER;
+CREATE TABLE ptah_ref_granted_tbl_137 (id integer PRIMARY KEY);
+GRANT SELECT ON ptah_ref_granted_tbl_137 TO ptah_ref_granted_137;
+CREATE TABLE ptah_ref_untouched_137 (id integer PRIMARY KEY);
+ALTER TABLE ptah_ref_untouched_137 OWNER TO ptah_ref_owner_137;`)
+	c.Assert(err, qt.IsNil)
+
+	reader := postgres.NewPostgreSQLReader(db, "public")
+	live, err := reader.ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	described := make([]string, 0, len(live.Roles))
+	for _, role := range live.Roles {
+		described = append(described, role.Name)
+	}
+
+	for _, named := range rolesNamedByDescription(live) {
+		c.Assert(described, qt.Contains, named,
+			qt.Commentf("the description names role %q but does not define it", named))
+	}
+
+	// The positive half, so the invariant cannot be satisfied by describing
+	// every role on the server: a role reachable only as the owner of a table
+	// nobody has granted anything on is named nowhere and described nowhere.
+	c.Assert(rolesNamedByDescription(live), qt.Not(qt.Contains), "ptah_ref_owner_137")
+	c.Assert(described, qt.Not(qt.Contains), "ptah_ref_owner_137")
+	// The control: a role an actual GRANT names is both named and described.
+	c.Assert(rolesNamedByDescription(live), qt.Contains, "ptah_ref_granted_137")
+	c.Assert(described, qt.Contains, "ptah_ref_granted_137")
+}
+
+// rolesNamedByDescription lists every role name the non-role parts of a
+// description refer to: grant subjects, grantors, and the roles a row-level
+// security policy applies to.
+func rolesNamedByDescription(schema *dbschematypes.DBSchema) []string {
+	var named []string
+	for _, grant := range schema.Grants {
+		named = append(named, grant.Role)
+		if grant.GrantedBy != "" {
+			named = append(named, grant.GrantedBy)
+		}
+	}
+	for _, policy := range schema.RLSPolicies {
+		for _, role := range strings.Split(policy.ToRoles, ",") {
+			named = append(named, strings.TrimSpace(role))
+		}
+	}
+	return slices.DeleteFunc(named, func(name string) bool {
+		return name == "" || name == "PUBLIC" || strings.HasPrefix(name, "pg_")
+	})
+}
+
+func cleanupDescribedRolesIntegration(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec("DROP TABLE IF EXISTS ptah_ref_granted_tbl_137 CASCADE")
+	c.Check(err, qt.IsNil)
+	_, err = db.Exec("DROP TABLE IF EXISTS ptah_ref_untouched_137 CASCADE")
+	c.Check(err, qt.IsNil)
+	_, err = db.Exec(`
+DO $ptah_cleanup_ref_roles$
+DECLARE
+    role_name text;
+BEGIN
+    FOREACH role_name IN ARRAY ARRAY['ptah_ref_granted_137', 'ptah_ref_owner_137'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE %I FROM %I', role_name, current_user);
+            EXECUTE format('DROP OWNED BY %I', role_name);
+            EXECUTE format('DROP ROLE %I', role_name);
+        END IF;
+    END LOOP;
+END
+$ptah_cleanup_ref_roles$;`)
+	c.Check(err, qt.IsNil)
 }

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -79,9 +79,19 @@ func TestPostgreSQLDBReadRoleCommentReplayIntegration(t *testing.T) {
 	cleanupDBReadRoleIntegration(c, db)
 	c.Cleanup(func() { cleanupDBReadRoleIntegration(c, db) })
 
+	// The described role owns the schema being read, which is why the read
+	// describes it. Ownership adds no statement of its own, so the role is
+	// still named by exactly the two statements this test replays.
+	//
+	// The stranger role exists in the same cluster and is used by nothing in
+	// the schema being read. PostgreSQL roles are cluster-wide, so before
+	// stokaro/ptah#1267 it was described here too, and reading one schema
+	// disclosed every role on the server. It must not appear.
 	_, err = db.Exec(`
 CREATE ROLE ptah_db_read_role_137;
-COMMENT ON ROLE ptah_db_read_role_137 IS 'Database read replay role';`)
+COMMENT ON ROLE ptah_db_read_role_137 IS 'Database read replay role';
+CREATE ROLE ptah_db_read_stranger_137;
+CREATE SCHEMA ptah_db_read_empty_schema_137 AUTHORIZATION ptah_db_read_role_137;`)
 	c.Assert(err, qt.IsNil)
 
 	cmd := readdb.NewReadDBCommand()
@@ -100,6 +110,7 @@ COMMENT ON ROLE ptah_db_read_role_137 IS 'Database read replay role';`)
 	c.Assert(err, qt.IsNil)
 	c.Assert(stdout.String(), qt.Contains, `CREATE ROLE "ptah_db_read_role_137"`)
 	c.Assert(stdout.String(), qt.Contains, `COMMENT ON ROLE "ptah_db_read_role_137" IS 'Database read replay role';`)
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "ptah_db_read_stranger_137")
 	c.Assert(stderr.String(), qt.Contains, "Connected to postgres database successfully!")
 	roleStatements := slices.DeleteFunc(
 		migrator.SplitSQLStatements(stdout.String()),
@@ -237,14 +248,20 @@ $ptah_cleanup_roles$;`)
 
 func cleanupDBReadRoleIntegration(c *qt.C, db *sql.DB) {
 	c.Helper()
-	_, err := db.Exec(`
+	_, err := db.Exec("DROP SCHEMA IF EXISTS ptah_db_read_empty_schema_137 CASCADE")
+	c.Check(err, qt.IsNil)
+	_, err = db.Exec(`
 DO $ptah_cleanup_role$
+DECLARE
+    role_name text;
 BEGIN
-    IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'ptah_db_read_role_137') THEN
-        EXECUTE format('REVOKE %I FROM %I', 'ptah_db_read_role_137', current_user);
-        DROP OWNED BY ptah_db_read_role_137;
-        DROP ROLE ptah_db_read_role_137;
-    END IF;
+    FOREACH role_name IN ARRAY ARRAY['ptah_db_read_role_137', 'ptah_db_read_stranger_137'] LOOP
+        IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = role_name) THEN
+            EXECUTE format('REVOKE %I FROM %I', role_name, current_user);
+            EXECUTE format('DROP OWNED BY %I', role_name);
+            EXECUTE format('DROP ROLE %I', role_name);
+        END IF;
+    END LOOP;
 END
 $ptah_cleanup_role$;`)
 	c.Check(err, qt.IsNil)

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1826,9 +1826,98 @@ func (r *Reader) readRLSPoliciesForSchema(schemaName string) ([]types.DBRLSPolic
 	return policies, nil
 }
 
-// readRoles reads all PostgreSQL roles from the database
+// rolesInScopeClauses returns the branches of the role-scoping union, one per
+// reason a role counts as used by the inspected schemas. Each branch reads the
+// catalog column that carries the reason, so the reason a role is reported is
+// always a fact about the inspected scope rather than about the server.
+//
+// The `scope` CTE the branches join against is defined by readRoles.
+func (r *Reader) rolesInScopeClauses() []string {
+	clauses := []string{
+		// Owns one of the schemas in scope (pg_namespace.nspowner).
+		`SELECT s.nspowner AS roleoid FROM scope s`,
+		// Owns a relation in scope -- table, view, materialized view,
+		// sequence or index (pg_class.relowner).
+		`SELECT c.relowner FROM pg_class c
+			JOIN scope s ON s.oid = c.relnamespace`,
+		// Owns a type in scope -- enum, domain, composite or range
+		// (pg_type.typowner).
+		`SELECT t.typowner FROM pg_type t
+			JOIN scope s ON s.oid = t.typnamespace`,
+		// Owns a routine in scope (pg_proc.proowner).
+		`SELECT p.proowner FROM pg_proc p
+			JOIN scope s ON s.oid = p.pronamespace`,
+		// Holds a privilege on a relation in scope (pg_class.relacl).
+		`SELECT acl.grantee FROM pg_class c
+			JOIN scope s ON s.oid = c.relnamespace
+			CROSS JOIN LATERAL aclexplode(c.relacl) acl`,
+		// Granted a privilege on a relation in scope (pg_class.relacl).
+		`SELECT acl.grantor FROM pg_class c
+			JOIN scope s ON s.oid = c.relnamespace
+			CROSS JOIN LATERAL aclexplode(c.relacl) acl`,
+		// Holds a privilege on a schema in scope (pg_namespace.nspacl).
+		`SELECT acl.grantee FROM scope s
+			CROSS JOIN LATERAL aclexplode(s.nspacl) acl`,
+		// Granted a privilege on a schema in scope (pg_namespace.nspacl).
+		`SELECT acl.grantor FROM scope s
+			CROSS JOIN LATERAL aclexplode(s.nspacl) acl`,
+	}
+	if r.caps.Has(capability.RowLevelSecurity) {
+		// Named by a row-level security policy on a table in scope
+		// (pg_policy.polroles), read in the same shape readRLSPolicies uses.
+		clauses = append(clauses, `SELECT policyrole FROM pg_policy pol
+			JOIN pg_class c ON c.oid = pol.polrelid
+			JOIN scope s ON s.oid = c.relnamespace
+			CROSS JOIN LATERAL unnest(pol.polroles) AS policyrole`)
+	}
+	return clauses
+}
+
+// readRoles reads the PostgreSQL roles the inspected scope actually uses.
+//
+// Roles are cluster-wide: pg_roles lists every role on the server, including
+// roles that exist only for databases this reader was never pointed at.
+// Reporting all of them describes objects the inspected schema does not
+// contain, cannot be replayed (CREATE ROLE is not idempotent, and creating a
+// fresh database does not clear cluster roles), and on a shared instance
+// discloses every other tenant's role names. See stokaro/ptah#1267.
+//
+// "Uses" is defined here, deliberately, as any of:
+//
+//   - owning an object in a schema in scope, or owning one of those schemas;
+//   - holding a privilege on an object in a schema in scope, or on one of
+//     those schemas -- or having granted one;
+//   - being named by a row-level security policy on a table in scope.
+//
+// A role that merely exists in the cluster is not used by the inspected scope
+// and is not reported. This is a scoping decision rather than a suppression:
+// a role that belongs to the inspected schemas is still reported in full, on
+// the native and the compatibility surface alike, so no capability is lost.
+//
+// The privilege clauses read the grantor as well as the grantee because
+// readGrants reports both. That makes this set a superset of every role name
+// the rest of the description can mention, so the description never references
+// a role it does not also define.
 func (r *Reader) readRoles() ([]types.DBRole, error) {
+	schemas := r.schemasToRead()
+	placeholders := make([]string, 0, len(schemas))
+	args := make([]any, 0, len(schemas))
+	for i, schemaName := range schemas {
+		placeholders = append(placeholders, fmt.Sprintf("$%d", i+1))
+		args = append(args, schemaName)
+	}
+
 	rolesQuery := `
+		WITH scope AS (
+			SELECT n.oid, n.nspowner, n.nspacl
+			FROM pg_namespace n
+			WHERE n.nspname IN (` + strings.Join(placeholders, ", ") + `)
+		),
+		used AS (
+			` + strings.Join(r.rolesInScopeClauses(), `
+			UNION
+			`) + `
+		)
 		SELECT
 			r.rolname AS role_name,
 			r.rolcanlogin AS login,
@@ -1841,11 +1930,12 @@ func (r *Reader) readRoles() ([]types.DBRole, error) {
 			COALESCE(shobj_description(r.oid, 'pg_authid'), '') AS comment
 		FROM pg_roles r
 		LEFT JOIN pg_authid a ON r.oid = a.oid
-		WHERE r.rolname NOT LIKE 'pg_%'  -- Exclude system roles
+		WHERE r.oid IN (SELECT roleoid FROM used)
+		AND r.rolname NOT LIKE 'pg_%'  -- Exclude system roles
 		AND r.rolname != 'postgres'      -- Exclude postgres superuser
 		ORDER BY r.rolname`
 
-	rows, err := r.db.Query(rolesQuery)
+	rows, err := r.db.Query(rolesQuery, args...)
 	if err != nil {
 		return nil, fmt.Errorf("failed to query roles: %w", err)
 	}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1834,21 +1834,12 @@ func (r *Reader) readRLSPoliciesForSchema(schemaName string) ([]types.DBRLSPolic
 // The `scope` CTE the branches join against is defined by readRoles.
 func (r *Reader) rolesInScopeClauses() []string {
 	clauses := []string{
-		// Owns one of the schemas in scope (pg_namespace.nspowner).
-		`SELECT s.nspowner AS roleoid FROM scope s`,
-		// Owns a relation in scope -- table, view, materialized view,
-		// sequence or index (pg_class.relowner).
-		`SELECT c.relowner FROM pg_class c
-			JOIN scope s ON s.oid = c.relnamespace`,
-		// Owns a type in scope -- enum, domain, composite or range
-		// (pg_type.typowner).
-		`SELECT t.typowner FROM pg_type t
-			JOIN scope s ON s.oid = t.typnamespace`,
-		// Owns a routine in scope (pg_proc.proowner).
-		`SELECT p.proowner FROM pg_proc p
-			JOIN scope s ON s.oid = p.pronamespace`,
-		// Holds a privilege on a relation in scope (pg_class.relacl).
-		`SELECT acl.grantee FROM pg_class c
+		// Holds a privilege on a relation in scope -- table, view,
+		// materialized view or sequence (pg_class.relacl). An owner appears
+		// here as soon as the relation carries any explicit privilege, which
+		// is also exactly when readTableGrantsForSchema reports the owner's
+		// own grants.
+		`SELECT acl.grantee AS roleoid FROM pg_class c
 			JOIN scope s ON s.oid = c.relnamespace
 			CROSS JOIN LATERAL aclexplode(c.relacl) acl`,
 		// Granted a privilege on a relation in scope (pg_class.relacl).
@@ -1884,15 +1875,29 @@ func (r *Reader) rolesInScopeClauses() []string {
 //
 // "Uses" is defined here, deliberately, as any of:
 //
-//   - owning an object in a schema in scope, or owning one of those schemas;
-//   - holding a privilege on an object in a schema in scope, or on one of
+//   - holding a privilege on a relation in a schema in scope, or on one of
 //     those schemas -- or having granted one;
 //   - being named by a row-level security policy on a table in scope.
 //
-// A role that merely exists in the cluster is not used by the inspected scope
-// and is not reported. This is a scoping decision rather than a suppression:
-// a role that belongs to the inspected schemas is still reported in full, on
-// the native and the compatibility surface alike, so no capability is lost.
+// Equivalently: a role is described exactly when some other statement in the
+// same description can name it. Nothing else is reported, and a role that
+// merely exists in the cluster certainly is not.
+//
+// Ownership is deliberately NOT a reason, and this was measured rather than
+// assumed. Ptah describes no ownership -- it emits no OWNER TO and no CREATE
+// SCHEMA ... AUTHORIZATION -- so an owner is a role the description creates
+// and then never refers to. Because the connecting superuser owns every object
+// it creates, treating ownership as a reason made every inspect describe the
+// connecting role, and a diff between a populated database and an empty dev
+// database in the same cluster then planned
+// `CREATE ROLE "..." WITH LOGIN SUPERUSER ...` and failed to apply it at
+// SQLSTATE 42710. An owner that a description does refer to still appears,
+// through the privilege clauses: granting anything on a relation makes its
+// ACL explicit, and an explicit ACL always carries the owner's own privileges.
+//
+// This is a scoping decision rather than a suppression: a role that belongs to
+// the inspected schemas is still reported in full, on the native and the
+// compatibility surface alike, so no capability is lost.
 //
 // The privilege clauses read the grantor as well as the grantee because
 // readGrants reports both. That makes this set a superset of every role name
@@ -1909,7 +1914,7 @@ func (r *Reader) readRoles() ([]types.DBRole, error) {
 
 	rolesQuery := `
 		WITH scope AS (
-			SELECT n.oid, n.nspowner, n.nspacl
+			SELECT n.oid, n.nspacl
 			FROM pg_namespace n
 			WHERE n.nspname IN (` + strings.Join(placeholders, ", ") + `)
 		),
@@ -2011,10 +2016,25 @@ func (r *Reader) readTableGrantsForSchema(schemaName string) ([]types.DBGrant, e
 			table_name,
 			is_grantable = 'YES' AS with_option,
 			grantor
-		FROM information_schema.role_table_grants
+		FROM information_schema.role_table_grants g
 		WHERE table_schema = $1
 		AND grantee NOT LIKE 'pg_%'
 		AND grantee != 'postgres'
+		-- Only relations on which some privilege has actually been granted.
+		-- information_schema reports an owner's built-in privileges as grants
+		-- even for a table whose pg_class.relacl is null, meaning nobody has
+		-- ever run GRANT on it. Describing those as GRANT statements describes
+		-- something no one wrote; CREATE TABLE re-establishes them for the new
+		-- owner on replay anyway. It also made the description name a role it
+		-- did not define once role reporting was scoped (stokaro/ptah#1267),
+		-- and the pinned Atlas community binary refuses such a document.
+		AND EXISTS (
+			SELECT 1 FROM pg_class c
+			JOIN pg_namespace n ON n.oid = c.relnamespace
+			WHERE n.nspname = g.table_schema
+			AND c.relname = g.table_name
+			AND c.relacl IS NOT NULL
+		)
 		ORDER BY table_schema, table_name, grantee, privilege_type`
 
 	rows, err := r.db.Query(query, schemaName)

--- a/internal/dbschema/postgres/reader_roles_internal_test.go
+++ b/internal/dbschema/postgres/reader_roles_internal_test.go
@@ -1,0 +1,473 @@
+package postgres
+
+// White-box testing required: the whole of stokaro/ptah#1267 is the SQL that
+// readRoles sends. PostgreSQL roles are cluster-wide, so the exported reader
+// API cannot show the difference between "this role belongs to the inspected
+// schemas" and "this role exists on the server" without a live server holding
+// a role that belongs to some other database. readRoles is unexported and the
+// query text has no other source.
+//
+// The fake server below answers a role only when the query actually reads the
+// catalog column that is the reason that role is in scope, and only when the
+// query binds the schema the reason lives in. A branch replaced by a literal,
+// or a restriction dropped, is therefore visible as a missing or an extra role
+// rather than being silently answered.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// clusterRole is one role on the simulated server together with the single
+// reason it is reachable from an inspected schema.
+type clusterRole struct {
+	// name is the role name pg_roles reports.
+	name string
+	// schema is the schema the reason lives in. An empty schema means the
+	// role has no reason at all: it exists on the server and nothing in any
+	// database refers to it. That is the role stokaro/ptah#1267 is about.
+	schema string
+	// reads lists the catalog expressions that must all appear in one single
+	// branch of the query before the server is willing to report this role.
+	// Requiring them in the same branch is the point: two branches that read
+	// the same catalog for different columns are separate reasons, and one of
+	// them stopping must not be covered by the other.
+	reads []string
+}
+
+// Catalog expressions, one per reason a role counts as used. These are the
+// expressions the query is expected to contain, not prose: SQL comments are
+// stripped before matching, so a branch documented by name but not actually
+// read cannot satisfy the guard.
+const (
+	readsSchemaOwner      = "s.nspowner"
+	readsRelationOwner    = "c.relowner"
+	readsTypeOwner        = "t.typowner"
+	readsRoutineOwner     = "p.proowner"
+	readsRelationACL      = "aclexplode(c.relacl)"
+	readsSchemaACL        = "aclexplode(s.nspacl)"
+	readsGrantee          = "acl.grantee"
+	readsGrantor          = "acl.grantor"
+	readsPolicyRoles      = "unnest(pol.polroles)"
+	readsSystemExclusion  = "NOT LIKE 'pg_%'"
+	readsPostgresExcluded = "!= 'postgres'"
+)
+
+// Reasons spelled as the branch that must carry them.
+var (
+	bySchemaOwner     = []string{readsSchemaOwner}
+	byRelationOwner   = []string{readsRelationOwner}
+	byTypeOwner       = []string{readsTypeOwner}
+	byRoutineOwner    = []string{readsRoutineOwner}
+	byRelationGrant   = []string{readsRelationACL, readsGrantee}
+	byRelationGrantor = []string{readsRelationACL, readsGrantor}
+	bySchemaGrant     = []string{readsSchemaACL, readsGrantee}
+	bySchemaGrantor   = []string{readsSchemaACL, readsGrantor}
+	byPolicy          = []string{readsPolicyRoles}
+)
+
+// stripSQLComments removes `-- ...` comments so the reader's prose cannot
+// stand in for the catalog expression it describes.
+func stripSQLComments(query string) string {
+	lines := strings.Split(query, "\n")
+	for i, line := range lines {
+		lines[i], _, _ = strings.Cut(line, "--")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// unionBranches splits a comment-stripped query at its UNION keywords, so each
+// reason can be checked against the branch that is supposed to carry it rather
+// than against the whole statement.
+func unionBranches(stripped string) []string {
+	var branches []string
+	var current []string
+	for line := range strings.SplitSeq(stripped, "\n") {
+		if strings.EqualFold(strings.TrimSpace(line), "UNION") {
+			branches = append(branches, strings.Join(current, "\n"))
+			current = nil
+			continue
+		}
+		current = append(current, line)
+	}
+	return append(branches, strings.Join(current, "\n"))
+}
+
+// newRolesServer returns a Reader backed by a server holding cluster, scoped to
+// schemas and reporting caps.
+func newRolesServer(
+	tb interface{ Cleanup(func()) },
+	cluster []clusterRole,
+	schemas []string,
+	caps capability.Capabilities,
+) *Reader {
+	db := dbtest.Open(tb, func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+		return answerRoles(query, args, cluster)
+	})
+	reader := NewPostgreSQLReaderWithCapabilities(db.SQL, schemas[0], caps)
+	reader.SetSchemas(schemas)
+	return reader
+}
+
+// answerRoles plays PostgreSQL for the roles query.
+//
+// Scope comes from the bound arguments rather than from the spelling of a
+// WHERE clause: a query that binds no schema has asked for the whole cluster,
+// which is exactly the pre-fix behavior, and the server answers accordingly.
+func answerRoles(query string, args []driver.NamedValue, cluster []clusterRole) (dbtest.QueryResult, error) {
+	stripped := stripSQLComments(query)
+
+	bound := make(map[string]bool, len(args))
+	for _, arg := range args {
+		placeholder := fmt.Sprintf("$%d", arg.Ordinal)
+		if !strings.Contains(stripped, placeholder) {
+			return dbtest.QueryResult{}, fmt.Errorf(
+				"argument %s is bound but %s never appears in the query", arg.Value, placeholder,
+			)
+		}
+		name, ok := arg.Value.(string)
+		if !ok {
+			return dbtest.QueryResult{}, fmt.Errorf("argument %s is not a schema name", placeholder)
+		}
+		bound[name] = true
+	}
+
+	result := dbtest.QueryResult{
+		Columns: []string{
+			"role_name", "login", "superuser", "create_db",
+			"create_role", "inherit", "replication", "has_password", "comment",
+		},
+	}
+	branches := unionBranches(stripped)
+	for _, role := range cluster {
+		if !roleIsAnswerable(role, stripped, branches, bound) {
+			continue
+		}
+		result.Rows = append(result.Rows, []driver.Value{
+			role.name, false, false, false, false, true, false, false, "",
+		})
+	}
+	return result, nil
+}
+
+// roleIsAnswerable reports whether the server would hand this role back for
+// the given query.
+func roleIsAnswerable(role clusterRole, stripped string, branches []string, bound map[string]bool) bool {
+	if strings.HasPrefix(role.name, "pg_") && strings.Contains(stripped, readsSystemExclusion) {
+		return false
+	}
+	if role.name == "postgres" && strings.Contains(stripped, readsPostgresExcluded) {
+		return false
+	}
+	if len(bound) == 0 {
+		// Nothing restricts the query to a database, so every role on the
+		// server is in the answer.
+		return true
+	}
+	if role.schema == "" || !bound[role.schema] {
+		return false
+	}
+	return someBranchReads(branches, role.reads)
+}
+
+// someBranchReads reports whether one branch of the query reads every catalog
+// expression the reason requires.
+func someBranchReads(branches []string, reads []string) bool {
+	for _, branch := range branches {
+		if branchReadsAll(branch, reads) {
+			return true
+		}
+	}
+	return false
+}
+
+func branchReadsAll(branch string, reads []string) bool {
+	if len(reads) == 0 {
+		return false
+	}
+	for _, expr := range reads {
+		if !strings.Contains(branch, expr) {
+			return false
+		}
+	}
+	return true
+}
+
+// fullCluster is a server holding one role per reason a role can be used by
+// the schema "public", one role used only by the schema "app", and three roles
+// that are used by nothing in this database.
+func fullCluster() []clusterRole {
+	return []clusterRole{
+		{name: "app_schema_owner", schema: "app", reads: bySchemaOwner},
+		{name: "pg_reserved", schema: "public", reads: byRelationOwner},
+		{name: "policy_named", schema: "public", reads: byPolicy},
+		{name: "postgres", schema: "public", reads: byRelationOwner},
+		{name: "relation_owner", schema: "public", reads: byRelationOwner},
+		{name: "schema_grantee", schema: "public", reads: bySchemaGrant},
+		{name: "schema_grantor", schema: "public", reads: bySchemaGrantor},
+		{name: "someone_elses", schema: "", reads: nil},
+		{name: "table_grantee", schema: "public", reads: byRelationGrant},
+		{name: "table_grantor", schema: "public", reads: byRelationGrantor},
+		{name: "third_party", schema: "", reads: nil},
+		{name: "unrelated_tenant", schema: "", reads: nil},
+	}
+}
+
+func roleNames(roles []types.DBRole) []string {
+	names := make([]string, 0, len(roles))
+	for _, role := range roles {
+		names = append(names, role.Name)
+	}
+	return names
+}
+
+func TestReadRolesReportsOneRolePerReason(t *testing.T) {
+	c := qt.New(t)
+
+	// Each row is a server holding exactly one role with a reason plus the
+	// role from stokaro/ptah#1267 that has none, so a branch that stops
+	// reading its catalog column loses its own row and nothing else.
+	tests := []struct {
+		name    string
+		used    clusterRole
+		schemas []string
+	}{
+		{
+			name:    "owns the schema in scope",
+			used:    clusterRole{name: "schema_owner", schema: "app", reads: bySchemaOwner},
+			schemas: []string{"app"},
+		},
+		{
+			name:    "owns a relation in the schema in scope",
+			used:    clusterRole{name: "relation_owner", schema: "public", reads: byRelationOwner},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "owns a type in the schema in scope",
+			used:    clusterRole{name: "type_owner", schema: "public", reads: byTypeOwner},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "owns a routine in the schema in scope",
+			used:    clusterRole{name: "routine_owner", schema: "public", reads: byRoutineOwner},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "holds a privilege on a relation in scope",
+			used:    clusterRole{name: "table_grantee", schema: "public", reads: byRelationGrant},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "granted a privilege on a relation in scope",
+			used:    clusterRole{name: "table_grantor", schema: "public", reads: byRelationGrantor},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "holds a privilege on the schema in scope",
+			used:    clusterRole{name: "schema_grantee", schema: "public", reads: bySchemaGrant},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "granted a privilege on the schema in scope",
+			used:    clusterRole{name: "schema_grantor", schema: "public", reads: bySchemaGrantor},
+			schemas: []string{"public"},
+		},
+		{
+			name:    "named by a policy on a table in scope",
+			used:    clusterRole{name: "policy_named", schema: "public", reads: byPolicy},
+			schemas: []string{"public"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			cluster := []clusterRole{
+				test.used,
+				{name: "someone_elses", schema: "", reads: nil},
+			}
+			reader := newRolesServer(c.TB, cluster, test.schemas, capability.Postgres16())
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roleNames(roles), qt.DeepEquals, []string{test.used.name})
+		})
+	}
+}
+
+func TestReadRolesLeavesClusterRolesTheScopeDoesNotUseOut(t *testing.T) {
+	c := qt.New(t)
+
+	// The headline of stokaro/ptah#1267: a database with objects of its own
+	// and no roles of its own must name no roles, however many the server has.
+	tests := []struct {
+		name    string
+		cluster []clusterRole
+		schemas []string
+	}{
+		{
+			name: "every role belongs to another database",
+			cluster: []clusterRole{
+				{name: "advsup_reader", schema: "", reads: nil},
+				{name: "app_reader", schema: "", reads: nil},
+				{name: "appuser", schema: "", reads: nil},
+				{name: "w1251c_reader", schema: "", reads: nil},
+			},
+			schemas: []string{"public"},
+		},
+		{
+			name: "a role used by a schema that is out of scope",
+			cluster: []clusterRole{
+				{name: "app_schema_owner", schema: "app", reads: bySchemaOwner},
+				{name: "someone_elses", schema: "", reads: nil},
+			},
+			schemas: []string{"public"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newRolesServer(c.TB, test.cluster, test.schemas, capability.Postgres16())
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roles, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestReadRolesFollowsTheSchemasBeingRead(t *testing.T) {
+	c := qt.New(t)
+
+	// Same server, three scopes. A filter that merely dropped some fixed set
+	// of names would answer all three the same way.
+	tests := []struct {
+		name    string
+		schemas []string
+		want    []string
+	}{
+		{
+			name:    "public only",
+			schemas: []string{"public"},
+			want: []string{
+				"policy_named", "relation_owner", "schema_grantee",
+				"schema_grantor", "table_grantee", "table_grantor",
+			},
+		},
+		{
+			name:    "app only",
+			schemas: []string{"app"},
+			want:    []string{"app_schema_owner"},
+		},
+		{
+			name:    "both schemas",
+			schemas: []string{"public", "app"},
+			want: []string{
+				"app_schema_owner", "policy_named", "relation_owner",
+				"schema_grantee", "schema_grantor", "table_grantee", "table_grantor",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newRolesServer(c.TB, fullCluster(), test.schemas, capability.Postgres16())
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roleNames(roles), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestReadRolesKeepsSystemRolesOut(t *testing.T) {
+	c := qt.New(t)
+
+	// Pre-existing behavior this change must not lose: the reserved pg_ roles
+	// and the bootstrap superuser are never described, even when they own an
+	// object in the inspected schema.
+	tests := []struct {
+		name    string
+		absent  string
+		cluster []clusterRole
+	}{
+		{
+			name:   "reserved role owning a relation in scope",
+			absent: "pg_reserved",
+			cluster: []clusterRole{
+				{name: "pg_reserved", schema: "public", reads: byRelationOwner},
+				{name: "relation_owner", schema: "public", reads: byRelationOwner},
+			},
+		},
+		{
+			name:   "bootstrap superuser owning a relation in scope",
+			absent: "postgres",
+			cluster: []clusterRole{
+				{name: "postgres", schema: "public", reads: byRelationOwner},
+				{name: "relation_owner", schema: "public", reads: byRelationOwner},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newRolesServer(c.TB, test.cluster, []string{"public"}, capability.Postgres16())
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roleNames(roles), qt.DeepEquals, []string{"relation_owner"})
+			c.Assert(roleNames(roles), qt.Not(qt.Contains), test.absent)
+		})
+	}
+}
+
+func TestReadRolesAsksForPolicyRolesOnlyWherePoliciesExist(t *testing.T) {
+	c := qt.New(t)
+
+	// pg_policy is read under the same capability that gates readRLSPolicies,
+	// so a PostgreSQL-family target that manages roles without row-level
+	// security is not sent a query naming a catalog it does not have.
+	tests := []struct {
+		name string
+		caps capability.Capabilities
+		want []string
+	}{
+		{
+			name: "row-level security supported",
+			caps: capability.Postgres16(),
+			want: []string{"policy_named", "relation_owner"},
+		},
+		{
+			name: "row-level security not supported",
+			caps: capability.Postgres16().With(capability.RowLevelSecurity, false),
+			want: []string{"relation_owner"},
+		},
+	}
+
+	cluster := []clusterRole{
+		{name: "policy_named", schema: "public", reads: byPolicy},
+		{name: "relation_owner", schema: "public", reads: byRelationOwner},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newRolesServer(c.TB, cluster, []string{"public"}, test.caps)
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roleNames(roles), qt.DeepEquals, test.want)
+		})
+	}
+}

--- a/internal/dbschema/postgres/reader_roles_internal_test.go
+++ b/internal/dbschema/postgres/reader_roles_internal_test.go
@@ -48,10 +48,6 @@ type clusterRole struct {
 // stripped before matching, so a branch documented by name but not actually
 // read cannot satisfy the guard.
 const (
-	readsSchemaOwner      = "s.nspowner"
-	readsRelationOwner    = "c.relowner"
-	readsTypeOwner        = "t.typowner"
-	readsRoutineOwner     = "p.proowner"
 	readsRelationACL      = "aclexplode(c.relacl)"
 	readsSchemaACL        = "aclexplode(s.nspacl)"
 	readsGrantee          = "acl.grantee"
@@ -69,17 +65,27 @@ const (
 	readsScopedRoleSet = "FROM used"
 )
 
+// Ownership columns. These name reasons the query must NOT act on, so they
+// exist to be asserted absent. See TestReadRolesDoesNotTreatOwnershipAsUse.
+const (
+	readsSchemaOwner   = "s.nspowner"
+	readsRelationOwner = "c.relowner"
+	readsTypeOwner     = "t.typowner"
+	readsRoutineOwner  = "p.proowner"
+)
+
 // Reasons spelled as the branch that must carry them.
 var (
-	bySchemaOwner     = []string{readsSchemaOwner}
-	byRelationOwner   = []string{readsRelationOwner}
-	byTypeOwner       = []string{readsTypeOwner}
-	byRoutineOwner    = []string{readsRoutineOwner}
 	byRelationGrant   = []string{readsRelationACL, readsGrantee}
 	byRelationGrantor = []string{readsRelationACL, readsGrantor}
 	bySchemaGrant     = []string{readsSchemaACL, readsGrantee}
 	bySchemaGrantor   = []string{readsSchemaACL, readsGrantor}
 	byPolicy          = []string{readsPolicyRoles}
+
+	bySchemaOwner   = []string{readsSchemaOwner}
+	byRelationOwner = []string{readsRelationOwner}
+	byTypeOwner     = []string{readsTypeOwner}
+	byRoutineOwner  = []string{readsRoutineOwner}
 )
 
 // stripSQLComments removes `-- ...` comments so the reader's prose cannot
@@ -214,11 +220,10 @@ func branchReadsAll(branch string, reads []string) bool {
 // that are used by nothing in this database.
 func fullCluster() []clusterRole {
 	return []clusterRole{
-		{name: "app_schema_owner", schema: "app", reads: bySchemaOwner},
-		{name: "pg_reserved", schema: "public", reads: byRelationOwner},
+		{name: "app_schema_grantee", schema: "app", reads: bySchemaGrant},
+		{name: "pg_reserved", schema: "public", reads: byRelationGrant},
 		{name: "policy_named", schema: "public", reads: byPolicy},
-		{name: "postgres", schema: "public", reads: byRelationOwner},
-		{name: "relation_owner", schema: "public", reads: byRelationOwner},
+		{name: "postgres", schema: "public", reads: byRelationGrant},
 		{name: "schema_grantee", schema: "public", reads: bySchemaGrant},
 		{name: "schema_grantor", schema: "public", reads: bySchemaGrantor},
 		{name: "someone_elses", schema: "", reads: nil},
@@ -248,26 +253,6 @@ func TestReadRolesReportsOneRolePerReason(t *testing.T) {
 		used    clusterRole
 		schemas []string
 	}{
-		{
-			name:    "owns the schema in scope",
-			used:    clusterRole{name: "schema_owner", schema: "app", reads: bySchemaOwner},
-			schemas: []string{"app"},
-		},
-		{
-			name:    "owns a relation in the schema in scope",
-			used:    clusterRole{name: "relation_owner", schema: "public", reads: byRelationOwner},
-			schemas: []string{"public"},
-		},
-		{
-			name:    "owns a type in the schema in scope",
-			used:    clusterRole{name: "type_owner", schema: "public", reads: byTypeOwner},
-			schemas: []string{"public"},
-		},
-		{
-			name:    "owns a routine in the schema in scope",
-			used:    clusterRole{name: "routine_owner", schema: "public", reads: byRoutineOwner},
-			schemas: []string{"public"},
-		},
 		{
 			name:    "holds a privilege on a relation in scope",
 			used:    clusterRole{name: "table_grantee", schema: "public", reads: byRelationGrant},
@@ -334,7 +319,7 @@ func TestReadRolesLeavesClusterRolesTheScopeDoesNotUseOut(t *testing.T) {
 		{
 			name: "a role used by a schema that is out of scope",
 			cluster: []clusterRole{
-				{name: "app_schema_owner", schema: "app", reads: bySchemaOwner},
+				{name: "app_schema_grantee", schema: "app", reads: bySchemaGrant},
 				{name: "someone_elses", schema: "", reads: nil},
 			},
 			schemas: []string{"public"},
@@ -367,21 +352,21 @@ func TestReadRolesFollowsTheSchemasBeingRead(t *testing.T) {
 			name:    "public only",
 			schemas: []string{"public"},
 			want: []string{
-				"policy_named", "relation_owner", "schema_grantee",
-				"schema_grantor", "table_grantee", "table_grantor",
+				"policy_named", "schema_grantee", "schema_grantor",
+				"table_grantee", "table_grantor",
 			},
 		},
 		{
 			name:    "app only",
 			schemas: []string{"app"},
-			want:    []string{"app_schema_owner"},
+			want:    []string{"app_schema_grantee"},
 		},
 		{
 			name:    "both schemas",
 			schemas: []string{"public", "app"},
 			want: []string{
-				"app_schema_owner", "policy_named", "relation_owner",
-				"schema_grantee", "schema_grantor", "table_grantee", "table_grantor",
+				"app_schema_grantee", "policy_named", "schema_grantee",
+				"schema_grantor", "table_grantee", "table_grantor",
 			},
 		},
 	}
@@ -410,19 +395,19 @@ func TestReadRolesKeepsSystemRolesOut(t *testing.T) {
 		cluster []clusterRole
 	}{
 		{
-			name:   "reserved role owning a relation in scope",
+			name:   "reserved role holding a privilege in scope",
 			absent: "pg_reserved",
 			cluster: []clusterRole{
-				{name: "pg_reserved", schema: "public", reads: byRelationOwner},
-				{name: "relation_owner", schema: "public", reads: byRelationOwner},
+				{name: "pg_reserved", schema: "public", reads: byRelationGrant},
+				{name: "table_grantee", schema: "public", reads: byRelationGrant},
 			},
 		},
 		{
-			name:   "bootstrap superuser owning a relation in scope",
+			name:   "bootstrap superuser holding a privilege in scope",
 			absent: "postgres",
 			cluster: []clusterRole{
-				{name: "postgres", schema: "public", reads: byRelationOwner},
-				{name: "relation_owner", schema: "public", reads: byRelationOwner},
+				{name: "postgres", schema: "public", reads: byRelationGrant},
+				{name: "table_grantee", schema: "public", reads: byRelationGrant},
 			},
 		},
 	}
@@ -434,7 +419,7 @@ func TestReadRolesKeepsSystemRolesOut(t *testing.T) {
 			roles, err := reader.readRoles()
 
 			c.Assert(err, qt.IsNil)
-			c.Assert(roleNames(roles), qt.DeepEquals, []string{"relation_owner"})
+			c.Assert(roleNames(roles), qt.DeepEquals, []string{"table_grantee"})
 			c.Assert(roleNames(roles), qt.Not(qt.Contains), test.absent)
 		})
 	}
@@ -454,18 +439,18 @@ func TestReadRolesAsksForPolicyRolesOnlyWherePoliciesExist(t *testing.T) {
 		{
 			name: "row-level security supported",
 			caps: capability.Postgres16(),
-			want: []string{"policy_named", "relation_owner"},
+			want: []string{"policy_named", "table_grantee"},
 		},
 		{
 			name: "row-level security not supported",
 			caps: capability.Postgres16().With(capability.RowLevelSecurity, false),
-			want: []string{"relation_owner"},
+			want: []string{"table_grantee"},
 		},
 	}
 
 	cluster := []clusterRole{
 		{name: "policy_named", schema: "public", reads: byPolicy},
-		{name: "relation_owner", schema: "public", reads: byRelationOwner},
+		{name: "table_grantee", schema: "public", reads: byRelationGrant},
 	}
 
 	for _, test := range tests {
@@ -476,6 +461,62 @@ func TestReadRolesAsksForPolicyRolesOnlyWherePoliciesExist(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(roleNames(roles), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestReadRolesDoesNotTreatOwnershipAsUse(t *testing.T) {
+	c := qt.New(t)
+
+	// Ptah describes no ownership: it emits no OWNER TO and no
+	// CREATE SCHEMA ... AUTHORIZATION. An owner is therefore a role the
+	// description would create and then never refer to, and since the
+	// connecting superuser owns every object it creates, reading ownership
+	// made every inspect describe the connecting role. Measured on live
+	// PostgreSQL 18.4: a diff between a populated database and an empty dev
+	// database in the same cluster planned
+	// `CREATE ROLE "ptah_user" WITH LOGIN SUPERUSER CREATEDB CREATEROLE
+	// INHERIT REPLICATION` and failed to apply it at SQLSTATE 42710.
+	//
+	// An owner a description does refer to is still described, through the
+	// privilege clauses: granting anything on a relation makes its ACL
+	// explicit, and an explicit ACL always carries the owner's own privileges.
+	// That case is TestReadRolesReportsOneRolePerReason's relation-privilege
+	// row, not this one.
+	tests := []struct {
+		name  string
+		owner clusterRole
+	}{
+		{
+			name:  "owns the schema in scope",
+			owner: clusterRole{name: "schema_owner", schema: "public", reads: bySchemaOwner},
+		},
+		{
+			name:  "owns a relation in scope",
+			owner: clusterRole{name: "relation_owner", schema: "public", reads: byRelationOwner},
+		},
+		{
+			name:  "owns a type in scope",
+			owner: clusterRole{name: "type_owner", schema: "public", reads: byTypeOwner},
+		},
+		{
+			name:  "owns a routine in scope",
+			owner: clusterRole{name: "routine_owner", schema: "public", reads: byRoutineOwner},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			cluster := []clusterRole{
+				test.owner,
+				{name: "table_grantee", schema: "public", reads: byRelationGrant},
+			}
+			reader := newRolesServer(c.TB, cluster, []string{"public"}, capability.Postgres16())
+
+			roles, err := reader.readRoles()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(roleNames(roles), qt.DeepEquals, []string{"table_grantee"})
 		})
 	}
 }

--- a/internal/dbschema/postgres/reader_roles_internal_test.go
+++ b/internal/dbschema/postgres/reader_roles_internal_test.go
@@ -59,6 +59,14 @@ const (
 	readsPolicyRoles      = "unnest(pol.polroles)"
 	readsSystemExclusion  = "NOT LIKE 'pg_%'"
 	readsPostgresExcluded = "!= 'postgres'"
+
+	// readsScopedRoleSet is the outer statement consuming the set the branches
+	// build. Binding the schema names is not on its own a restriction: the
+	// scope CTE still references them, so a query that computes the used-role
+	// set and then never applies it binds every argument and answers the whole
+	// cluster anyway. Live PostgreSQL caught exactly that mutant while an
+	// earlier version of this fake did not.
+	readsScopedRoleSet = "FROM used"
 )
 
 // Reasons spelled as the branch that must carry them.
@@ -167,9 +175,9 @@ func roleIsAnswerable(role clusterRole, stripped string, branches []string, boun
 	if role.name == "postgres" && strings.Contains(stripped, readsPostgresExcluded) {
 		return false
 	}
-	if len(bound) == 0 {
-		// Nothing restricts the query to a database, so every role on the
-		// server is in the answer.
+	if len(bound) == 0 || !strings.Contains(stripped, readsScopedRoleSet) {
+		// Nothing restricts the answer to the inspected schemas, so every role
+		// on the server is in it.
 		return true
 	}
 	if role.schema == "" || !bound[role.schema] {


### PR DESCRIPTION
Closes #1267.

PostgreSQL roles are cluster-wide. `readRoles` read `pg_roles` with no restriction beyond dropping the reserved `pg_` names and `postgres`, so inspecting a one-table database emitted every role anyone had created anywhere on the server.

## The rule

A description defines a role when some other statement in it names that role, and not otherwise. Concretely a role is described when it holds a privilege on a relation in a schema in scope (`aclexplode` of `pg_class.relacl`) or on one of the schemas (`aclexplode` of `pg_namespace.nspacl`), when it granted one, or when a row-level security policy on a table in scope applies to it (`pg_policy.polroles`, read in the shape `readRLSPolicies` already uses and gated on the same capability).

**Ownership is deliberately not a reason, and that was measured rather than assumed.** Ptah describes no ownership — no `OWNER TO`, no `CREATE SCHEMA ... AUTHORIZATION` — so an owner is a role the description creates and then never refers to. Because the connecting superuser owns every object it creates, an earlier revision of this PR that counted ownership made every inspect describe the connecting role, and CI caught it:

```
TestAtlasMigrateDiffConcurrentIndexAndQualifierE2E
Error: failed to apply migration: ERROR: role "ptah_user" already exists (SQLSTATE 42710)
SQL: CREATE ROLE "ptah_user" WITH LOGIN SUPERUSER CREATEDB CREATEROLE INHERIT REPLICATION
```

An owner a description *does* refer to still appears, through the privilege clauses: granting anything on a relation makes its ACL explicit, and an explicit ACL always carries the owner's own privileges.

## The grant side had to move too

Removing ownership alone left the document inconsistent, and the pinned Atlas community binary v1.3.0 found it — an emitted permission block said `to = role.p1267_owner` with no such role block:

```
Error: Unsupported attribute; This object does not have an attribute named "p1267_owner"
```

Master's document for the same fixture reads at exit 0, so this was a regression rather than a pre-existing hole. The source is `information_schema.role_table_grants`, which reports an owner's built-in privileges as grants even for a table whose `pg_class.relacl` is null. Measured directly — a table nobody has granted anything on still lists seven privileges for its owner:

```
ptah_ref_untouched_137 → p1267_owner: DELETE INSERT REFERENCES SELECT TRIGGER TRUNCATE UPDATE
```

No `GRANT` produced those, and `CREATE TABLE` re-establishes them for the new owner on replay. Table-grant introspection now reads only relations carrying an explicit ACL — the same source the schema and sequence grant queries already read, so all three agree.

## Measured

PostgreSQL 17.10, container `ptah1074-dev`, against master built from `f2e7fa0c` in its own worktree. Cluster holding nineteen non-system roles.

| scope | master | after |
| --- | --- | --- |
| `search_path=public` | 19 roles | **3** — `p1267_policy`, `p1267_select`, `p1267_usage` |
| `search_path=app1267` | 19 roles | **1** — `p1267_appusage` |

Absent after, present in both master columns: `p1267_owner` (owns a table nobody granted anything on), `p1267_stranger` (touches nothing — the control this issue is about), and the sixteen roles belonging to other databases on the same server. The two scopes differing is the point: a filter that merely dropped a fixed set of names would answer both the same way.

Replay, `psql -v ON_ERROR_STOP=1`, exit status read on its own line:

| | master | after |
| --- | --- | --- |
| one table, no roles of its own (this issue's shape) | 19 role blocks, **exit 3** on `role "advsup_reader" already exists` | 0 role blocks, **exit 0** |
| round trip *with* roles — inspect, drop the database and its own roles, replay into a fresh one | **exit 3** | **exit 0** |

The second row is the discriminating one: only an output naming exactly the roles it creates can reach 0, because the leaked roles belong to other databases and cannot be created twice.

## The pinned binary is a readability reference, not an oracle

Atlas community v1.3.0 emits no `role` block for any database, so it cannot say which roles are right. It reads the post-change documents (0 and 3 role blocks) at **exit 0**.

One document it still refuses, **unchanged from master and out of scope here**: a non-default schema scope emits `for = schema.app1267` with no `schema` block, and the binary answers `Unknown variable; There is no variable named "schema"`. Master's output for the same scope fails identically, so it is pre-existing and deserves its own issue.

## An integration test pinned the defect

`TestPostgreSQLDBReadRoleCommentReplayIntegration` created a role owning nothing and holding no privilege, read `--schemas ptah_db_read_empty_schema_137` — a schema it never created, so the read had no schema at all — and asserted the role came back. That is what this issue calls wrong, written down as an expectation. Pre-v1, so the expectation is corrected rather than the fix weakened.

The role now holds a privilege on the schema instead. That needs no `SET ROLE`, so it works whether or not the connection is a superuser, and all four properties the test existed for survive: the role statements, their replay into a cleaned cluster, the fail-closed collision on a second `CREATE ROLE`, and the comment restored via `COMMENT ON ROLE`. The role now appears with the `GRANT` that is its reason, so three statements are replayed rather than two. A second role, `ptah_db_read_stranger_137`, exists in the same cluster, is used by nothing in the schema being read, and must not be named.

## Tests

The white-box guard drives `readRoles` through a fake server that answers a role only when one single `UNION` branch of the query reads the catalog expression that is that role's reason, only when the query binds the schema the reason lives in, and only when the outer statement consumes the set those branches build. Comments are stripped first, so prose naming a catalog column cannot stand in for reading it. `TestReadRolesDoesNotTreatOwnershipAsUse` pins the decision by requiring the query *not* to read `nspowner`, `relowner`, `typowner` or `proowner`.

The new live guard is the one that matters: it asserts the invariant directly — every role a grant or a policy names is a role the description defines — over a fixture holding both a granted role and a role that only owns an ungranted table. Reverting the `relacl` condition turns it red and says so:

```
the description names role "ptah_ref_owner_137" but does not define it
```

Nine query mutants red with a green control in the same sweep: the whole restriction removed; the relation-grantee and relation-grantor branches stopped one at a time; the schema-grantee and schema-grantor branches likewise; the policy branch never added; the scope CTE widened to every schema on the server; the reserved-role exclusions dropped; and the restriction dropped while the schema names stay bound.

Three of the mutants in this PR escaped an earlier version of a guard rather than being predicted:

- the grantee and grantor branches read the same catalog, so a fake matching anywhere in the statement stayed green when either alone was broken — it now matches per `UNION` branch;
- dropping the restriction while leaving the schema names bound passed the fake and was caught only by live PostgreSQL, which answered with every role on the server — binding an argument is not a restriction, so the fake now requires the outer statement to consume the scoped set;
- removing ownership without moving the grant side passed every Go test and was caught only by the pinned Atlas binary refusing the document.

## Not covered

Whether MySQL, MariaDB, or any other dialect has the same server-versus-database leak was **not** measured. #1267 is scoped to PostgreSQL and `readRoles` is PostgreSQL-only, but the shape is worth checking on the other readers separately.