### PR TITLE
compat inspect: ask what an extension provides, not what it is called

### DIFF
--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -40,12 +40,14 @@ it, and the result is introspected, mirroring Atlas dev-database
 normalization.
 
 On PostgreSQL, HCL output omits an ` + "`extension`" + `, ` + "`sequence`" + ` or
-` + "`policy`" + ` block that nothing else in the document names: Atlas CE
+` + "`policy`" + ` block that nothing else in the document depends on: Atlas CE
 refuses a whole schema file that declares any one of them, so emitting one
 would make the output unreadable to the tool this binary stands in for. A block
-something DOES name — a sequence behind a column default, for instance — is
-kept, because a document that references an object it did not declare is
-readable by nobody. Every decision is reported on standard error. Set
+something still NEEDS — a sequence behind a column default, an extension
+supplying a column's type — is kept, because a document that references an
+object it did not declare is readable by nobody. For an extension the test is
+what the catalog says it supplies, not its name: ` + "`isn`" + ` supplies the
+type ` + "`isbn`" + `. Every decision is reported on standard error. Set
 ` + "`PTAH_ATLAS_INSPECT_ALL_BLOCKS=1`" + ` to emit every block Ptah models on
 this surface. SQL output keeps them all, and native
 ` + "`ptah schema inspect`" + ` omits nothing.

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -386,6 +386,16 @@ type Extension struct {
 	IfNotExists bool   // Whether to use IF NOT EXISTS clause
 	Version     string // Specific version requirement (optional)
 	Comment     string // Extension comment/description
+
+	// Provides lists the catalog names this extension supplies -- types,
+	// functions, relations, operator classes and operator families. It is filled
+	// in when the schema was read from a live PostgreSQL catalog and answers
+	// "what stops resolving without this extension", which is almost never the
+	// extension's own name: `isn` supplies the type `isbn`.
+	//
+	// Empty means not measured. Annotation and YAML sources have no catalog to
+	// ask and leave it unset.
+	Provides []string
 }
 
 // Table represents a database table configuration parsed from Go struct annotations.

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -310,6 +310,18 @@ type DBExtension struct {
 	Comment          *string `json:"comment"`           // Extension comment/description
 	DefaultVersion   *string `json:"default_version"`   // Default version available
 	InstalledVersion *string `json:"installed_version"` // Currently installed version (may differ from default)
+
+	// Provides lists the catalog names this extension supplies -- its types,
+	// functions, relations, operator classes and operator families -- read from
+	// pg_depend. It answers "what would stop resolving if this extension were
+	// not here", which is a different question from the extension's own name and
+	// usually a disjoint set of words: `isn` supplies the type `isbn`, and
+	// `pgcrypto` supplies the function `gen_salt`.
+	//
+	// Empty means not measured rather than "supplies nothing" -- every extension
+	// supplies something, and readers that do not consult a catalog (Go
+	// annotations, YAML) leave this unset.
+	Provides []string `json:"provides,omitempty"`
 }
 
 // DBSequence represents a standalone PostgreSQL sequence read from the database.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3836,6 +3836,16 @@ type Extension struct {
     IfNotExists bool   // Whether to use IF NOT EXISTS clause
     Version     string // Specific version requirement (optional)
     Comment     string // Extension comment/description
+
+    // Provides lists the catalog names this extension supplies -- types,
+    // functions, relations, operator classes and operator families. It is filled
+    // in when the schema was read from a live PostgreSQL catalog and answers
+    // "what stops resolving without this extension", which is almost never the
+    // extension's own name: `isn` supplies the type `isbn`.
+    //
+    // Empty means not measured. Annotation and YAML sources have no catalog to
+    // ask and leave it unset.
+    Provides []string
 }
     Extension represents a PostgreSQL extension definition parsed from Go struct
     annotations. Extensions enable additional functionality in PostgreSQL
@@ -5363,6 +5373,18 @@ type DBExtension struct {
     Comment          *string `json:"comment"`           // Extension comment/description
     DefaultVersion   *string `json:"default_version"`   // Default version available
     InstalledVersion *string `json:"installed_version"` // Currently installed version (may differ from default)
+
+    // Provides lists the catalog names this extension supplies -- its types,
+    // functions, relations, operator classes and operator families -- read from
+    // pg_depend. It answers "what would stop resolving if this extension were
+    // not here", which is a different question from the extension's own name and
+    // usually a disjoint set of words: `isn` supplies the type `isbn`, and
+    // `pgcrypto` supplies the function `gen_salt`.
+    //
+    // Empty means not measured rather than "supplies nothing" -- every extension
+    // supplies something, and readers that do not consult a catalog (Go
+    // annotations, YAML) leave this unset.
+    Provides []string `json:"provides,omitempty"`
 }
     DBExtension represents a PostgreSQL extension installed in the database
 

--- a/docs/public_api_approvals.txt
+++ b/docs/public_api_approvals.txt
@@ -45,3 +45,17 @@ v0.1.2 go.5x5.cz/ptah/migration/safety
 v0.1.2 go.5x5.cz/ptah/migration/schemadiff
 v0.1.2 go.5x5.cz/ptah/migration/schemadiff/types
 v0.1.2 go.5x5.cz/ptah/migration/seeder
+
+# Describing what a PostgreSQL extension provides needs a list, and a struct
+# with a slice field is no longer comparable. Extension and DBExtension gained
+# Provides []string so the compatibility surface can answer "does this document
+# still depend on something this extension supplies" -- the question that
+# matters, and one the extension's own name does not answer: `isn` supplies the
+# type `isbn`. Reading the name instead shipped a regression that made Ptah's
+# own inspect output unreadable to Ptah.
+#
+# The cost is comparability: consumers can no longer use == on these structs or
+# use them as map keys. Nothing else changed -- no symbol was removed and no
+# existing field altered.
+v0.2.0 go.5x5.cz/ptah/core/goschema
+v0.2.0 go.5x5.cz/ptah/dbschema/types

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -146,9 +146,12 @@ pipeline against native `ptah` verbs would not be a migration path at all.
 
 **`PTAH_ATLAS_INSPECT_ALL_BLOCKS`** — by default, `ptah-compat schema inspect`
 leaves an `extension`, `sequence` or `policy` block out of PostgreSQL HCL
-output when nothing else in the document names it, and reports each omission on
-standard error. Set it to `1` and every block Ptah models is emitted: the output
-describes the database in full, and the community CLI refuses it.
+output when nothing else in the document depends on it, and reports each
+omission on standard error. For an extension, "depends on" is measured against
+what the catalog says the extension supplies — `isn` supplies the type `isbn` —
+rather than against its name. Set it to `1` and every block Ptah models is
+emitted: the output describes the database in full, and the community CLI
+refuses it.
 
 **`PTAH_ALLOW_EXTERNAL_SCHEMA`** — by default, `atlas.hcl`
 `data "external_schema"` is not evaluated, because it runs a

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -179,12 +179,12 @@ construct a later build starts modeling stops being withheld.
 #### A referenced block is kept, and the document says so
 
 Suppression never leaves a reference behind. If anything else in the document
-names the object — a column default calling `nextval` on a sequence, a view body
-selecting from it, a `permission` block targeting it, a column whose type an
-extension supplies — the block stays, and the reason is reported:
+still depends on the object — a column default calling `nextval` on a sequence, a
+view body selecting from it, a `permission` block targeting it, a column whose
+type an extension supplies — the block stays, and the reason is reported:
 
 ```console
-warning: sequences.order_seq: kept in Atlas-compatible schema inspect output because another object in this document names it: ...
+warning: sequences.order_seq: kept in Atlas-compatible schema inspect output because another object in this document depends on it: ...
 ```
 
 Such a document **is not readable by the community binary**, and that is not a
@@ -203,10 +203,24 @@ it writes itself. Ptah keeps the sequence so the document stays true and stays
 readable by Ptah; dropping the column's default instead would describe a
 database that does not exist.
 
-The reference test is by name, so an extension that supplies a **type** in use
-(`citext`, `hstore`) is kept, while an extension that supplies only functions
-(`pgcrypto` behind `gen_random_uuid()`) is not named by the document and is
-omitted. Set `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` when the output has to carry it.
+For an extension the question asked is **what it supplies**, not what it is
+called, because the two are usually different words. The `isn` extension
+supplies the type `isbn`; `pgcrypto` supplies the function `gen_salt`. Neither
+name appears in a document that depends on it, so a test against the extension's
+own label would omit the block and leave the column behind. Ptah reads the
+member list from the catalog (`pg_depend` against `pg_extension`) during
+inspection and keeps the extension when the document uses any of its types,
+functions, relations, operator classes, or operator families.
+
+That set is deliberately coarse. `pgcrypto` supplies a `gen_random_uuid` that
+PostgreSQL 13 and later also supply from core, so a document using it keeps
+`pgcrypto` even though it would have resolved without it. Keeping a block that
+could have been dropped costs compatibility; dropping one that was needed costs
+a document nobody can read, so the rule errs toward keeping.
+
+An extension nothing depends on is still omitted, and the community binary
+reads that document at exit 0. Set `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` when the
+output has to carry every block regardless.
 
 #### Get the full description back
 

--- a/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
+++ b/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
@@ -1,0 +1,203 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+// atlasCompatExtensionRoundTripCase is one extension shape, its seed DDL, and
+// whether the compatibility surface is expected to keep the extension block.
+type atlasCompatExtensionRoundTripCase struct {
+	name string
+	// extension is the CREATE EXTENSION name.
+	extension string
+	// seed runs after the extension is installed and creates whatever depends
+	// on it (or, for the control, whatever does not).
+	seed string
+	// wantBlock is whether `extension "<extension>"` must survive into the
+	// rendered document.
+	wantBlock bool
+	// why records the measurement behind the expectation.
+	why string
+}
+
+// TestAtlasCompatInspectExtensionRoundTripE2E pins the property that
+// stokaro/ptah#1266 broke: `ptah-compat schema inspect` must emit a document
+// Ptah can read back.
+//
+// The assertion is a real round trip and not a re-run of the renderer's own
+// reference scan -- the rendered document is fed to the same binary surface
+// against a FRESH dev database, where the extension is not installed, so a
+// document that dropped a still-needed extension fails to materialize. That is
+// exactly how the regression showed up in the field:
+//
+//	CREATE EXTENSION isn;
+//	CREATE TABLE books (id integer PRIMARY KEY, code isbn NOT NULL);
+//
+// rendered at exit 0 with `extensions.isn: omitted ...` on stderr, and the
+// result was then unreadable -- `type "isbn" does not exist` -- by Ptah AND by
+// the pinned Atlas community binary, measured on PostgreSQL 17.10. The omission
+// was not a compatibility win, it was a document nobody could read.
+//
+// The third row is the control that keeps the fix from becoming "never omit an
+// extension", which would throw away what #1266 bought.
+func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
+	adminURL := requirePostgresE2EDatabaseURL(t)
+
+	tests := []atlasCompatExtensionRoundTripCase{
+		{
+			name:      "extension supplying a column type",
+			extension: "isn",
+			seed:      "CREATE TABLE books (id integer PRIMARY KEY, code isbn NOT NULL)",
+			wantBlock: true,
+			why:       "isn supplies the type isbn; the word isn appears nowhere in the document",
+		},
+		{
+			name:      "extension supplying only a function",
+			extension: "pgcrypto",
+			seed:      "CREATE TABLE tokens (id integer PRIMARY KEY, salt text NOT NULL DEFAULT gen_salt('bf'))",
+			wantBlock: true,
+			// gen_salt is the deliberate choice over gen_random_uuid: measured
+			// on PostgreSQL 17.10, gen_random_uuid also exists in pg_catalog, so
+			// a document using it round-trips even with pgcrypto dropped and
+			// would pass this test without testing anything. gen_salt has no
+			// core equivalent.
+			why: "pgcrypto supplies gen_salt, which has no core equivalent",
+		},
+		{
+			name:      "extension nothing depends on",
+			extension: "isn",
+			seed:      "CREATE TABLE plain (id integer PRIMARY KEY, label text NOT NULL)",
+			wantBlock: false,
+			why:       "nothing uses anything isn supplies, so #1266's omission still applies",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			adminDB, err := sql.Open("pgx", adminURL)
+			c.Assert(err, qt.IsNil)
+			defer adminDB.Close()
+
+			stamp := time.Now().UnixNano()
+			sourceName := fmt.Sprintf("ptah_ext_rt_src_%d", stamp)
+			devName := fmt.Sprintf("ptah_ext_rt_dev_%d", stamp)
+			createE2EDatabase(c, ctx, adminDB, sourceName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, sourceName)
+			createE2EDatabase(c, ctx, adminDB, devName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, devName)
+
+			sourceURL := replaceDatabaseName(c, adminURL, sourceName)
+			devURL := replaceDatabaseName(c, adminURL, devName)
+
+			seedAtlasCompatExtensionDB(c, ctx, sourceURL, test.extension, test.seed)
+
+			rendered := runAtlasCompatInspect(c, sourceURL, "")
+			c.Assert(
+				strings.Contains(rendered, fmt.Sprintf("extension %q", test.extension)),
+				qt.Equals, test.wantBlock,
+				qt.Commentf("%s", test.why),
+			)
+
+			// The round trip. A fresh dev database has none of these
+			// extensions, so materializing the document is what proves it
+			// carries everything it depends on.
+			documentPath := filepath.Join(t.TempDir(), "inspected.hcl")
+			c.Assert(os.WriteFile(documentPath, []byte(rendered), 0o600), qt.IsNil)
+			readBack := runAtlasCompatInspect(c, "file://"+documentPath, devURL)
+			c.Assert(readBack, qt.Not(qt.Equals), "",
+				qt.Commentf("the round trip produced an empty document"))
+		})
+	}
+}
+
+// seedAtlasCompatExtensionDB installs the extension and runs the shape's DDL,
+// then verifies through the catalog that both actually landed rather than
+// trusting that the statements returned without error.
+func seedAtlasCompatExtensionDB(c *qt.C, ctx context.Context, dbURL, extension, seed string) {
+	c.Helper()
+
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	_, err = db.ExecContext(ctx, "CREATE EXTENSION "+quoteE2EIdent(extension))
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, seed)
+	c.Assert(err, qt.IsNil)
+
+	var installed int
+	c.Assert(db.QueryRowContext(ctx,
+		"SELECT count(*) FROM pg_extension WHERE extname = $1", extension,
+	).Scan(&installed), qt.IsNil)
+	c.Assert(installed, qt.Equals, 1,
+		qt.Commentf("the catalog does not report %q installed", extension))
+
+	// pg_depend is what the reader consults to answer "what does this extension
+	// supply". An extension whose membership rows are missing would make every
+	// expectation here vacuous.
+	var members int
+	c.Assert(db.QueryRowContext(ctx, `
+		SELECT count(*)
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		 WHERE d.deptype = 'e' AND e.extname = $1`, extension,
+	).Scan(&members), qt.IsNil)
+	c.Assert(members > 0, qt.IsTrue,
+		qt.Commentf("the catalog reports %q supplying nothing", extension))
+}
+
+// runAtlasCompatInspect runs `schema inspect` on the compatibility surface and
+// returns the rendered document, failing the test on a non-nil error.
+//
+// Roles are excluded because PostgreSQL roles are CLUSTER-scoped: every role
+// any other database on the same server has ever created is visible here, and
+// replaying a document that declares them dies on "role already exists" before
+// reaching the extension question this test is about.
+func runAtlasCompatInspect(c *qt.C, sourceURL, devURL string) string {
+	c.Helper()
+
+	args := []string{
+		"schema", "inspect",
+		"--url", sourceURL,
+		"--format", "{{ hcl . }}",
+		"--exclude", "*[type=role]",
+	}
+	args = append(args, devURLArgs(devURL)...)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out, errOut bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&errOut)
+	cmd.SetArgs(args)
+	c.Assert(cmd.Execute(), qt.IsNil, qt.Commentf("stderr: %s", errOut.String()))
+
+	return out.String()
+}
+
+// devURLArgs appends --dev-url only when one was given, keeping the caller's
+// test body free of branching.
+func devURLArgs(devURL string) []string {
+	if devURL == "" {
+		return nil
+	}
+	return []string{"--dev-url", devURL}
+}

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -129,13 +129,29 @@ func atlasRefusesBlock(dialect, block string) bool {
 // referenced sequence is not readable by the pinned binary. It is readable by
 // Ptah, and it describes the database truthfully, which the two alternatives
 // cannot both do.
-func (r *renderer) omitRefusedBlock(path, block, name string) bool {
+//
+// The question asked of the document is "does anything here still DEPEND on
+// this object", which is why the caller passes every name that would stop
+// resolving without the block rather than only the block's label. For a
+// sequence and a policy those are the same word. For an extension they are
+// usually disjoint: `isn` supplies the type `isbn`, `pgcrypto` supplies the
+// function `gen_salt`, and matching the label alone omitted the extension while
+// leaving the column that needs it behind. Measured on PostgreSQL 17.10 against
+//
+//	CREATE EXTENSION isn;
+//	CREATE TABLE books (id integer PRIMARY KEY, code isbn NOT NULL);
+//
+// label-only matching rendered at exit 0 and then neither Ptah nor the pinned
+// binary could read the result back: `type "isbn" does not exist`, exit 1 from
+// both. That is strictly worse than either alternative -- it is not a
+// compatibility win, because the pinned binary rejects that document too.
+func (r *renderer) omitRefusedBlock(path, block string, names ...string) bool {
 	if !r.omitAtlasRefusedBlocks || !atlasRefusesBlock(r.dialect, block) {
 		return false
 	}
-	if r.documentNames(name) {
+	if r.documentNamesAny(names) {
 		r.warn(path, fmt.Sprintf(
-			"kept in Atlas-compatible schema inspect output because another object in this document names it:"+
+			"kept in Atlas-compatible schema inspect output because another object in this document depends on it:"+
 				" the Atlas community CLI refuses a %s schema file that declares any %s block, so it cannot read"+
 				" this document, but omitting the block would leave a reference to an object nothing declares",
 			r.dialect, block,
@@ -151,23 +167,31 @@ func (r *renderer) omitRefusedBlock(path, block, name string) bool {
 	return true
 }
 
-// documentNames reports whether anything the surviving document emits names
-// this object.
+// documentNamesAny reports whether anything the surviving document emits names
+// any of these identifiers.
 //
 // Matching is case-insensitive because unquoted PostgreSQL identifiers are, and
 // because the direction of a wrong answer matters: a false positive keeps a
 // block that could have been omitted, which costs compatibility; a false
-// negative emits a document with a hole in it, which costs correctness. This
-// errs toward keeping.
-func (r *renderer) documentNames(name string) bool {
-	name = strings.ToLower(strings.TrimSpace(name))
-	if name == "" {
-		return false
-	}
+// negative emits a document with a hole in it, which costs correctness -- a
+// document nobody, including the pinned binary, can read. This errs toward
+// keeping.
+//
+// That asymmetry is what makes the coarse `Provides` set the right input even
+// though it over-matches. `pgcrypto` supplies `gen_random_uuid`, which
+// PostgreSQL 17 also supplies from core, so a document using it keeps pgcrypto
+// although it would have resolved without it. That is the harmless direction.
+func (r *renderer) documentNamesAny(names []string) bool {
 	if r.references == nil {
 		r.references = collectReferencedNames(r.db)
 	}
-	return r.references[name]
+	for _, name := range names {
+		name = strings.ToLower(strings.TrimSpace(name))
+		if name != "" && r.references[name] {
+			return true
+		}
+	}
+	return false
 }
 
 // collectReferencedNames gathers every identifier named by the parts of an
@@ -178,12 +202,15 @@ func (r *renderer) documentNames(name string) bool {
 // exist in the output when that block does, so counting them would keep a block
 // alive on a reference that goes away with it.
 //
-// Type positions are scanned alongside expressions because an extension that
-// supplies a type is named by the columns using it -- `citext`, `hstore`. An
-// extension that supplies only FUNCTIONS is not named anywhere by this rule:
-// `pgcrypto` behind `gen_random_uuid()` is invisible to it, and that limitation
-// is documented rather than papered over, because resolving it needs a catalog
-// of what each extension provides rather than a name.
+// Type positions are scanned alongside expressions because a dependency on an
+// extension shows up as the type of a column -- `isbn`, `citext`, `hstore` --
+// as often as it shows up inside an expression.
+//
+// This builds the set of names the document USES. Deciding whether a particular
+// extension is still needed is the other half, and it belongs to
+// [goschema.Extension.Provides], which the PostgreSQL reader fills from
+// pg_depend: the names collected here are matched against what the extension
+// supplies, not against its label.
 func collectReferencedNames(db *goschema.Database) map[string]bool {
 	names := map[string]bool{}
 	add := func(text string) {

--- a/internal/atlashclrender/atlas_refused_blocks_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_test.go
@@ -273,10 +273,15 @@ func TestRenderInspectedForAtlasCLIKeepsABlockTheDocumentNames(t *testing.T) {
 			wantPath: "sequences.order_seq",
 		},
 		{
+			// citext is the easy case and, on its own, a false comfort: the
+			// extension and the type it supplies are spelled the same word, so
+			// matching the extension's own LABEL answers correctly by accident.
+			// The two rows below separate the label from what the extension
+			// supplies, which is what this rule actually has to get right.
 			name: "a column type is the type the extension supplies",
 			database: func() *goschema.Database {
 				db := standaloneSequenceDatabase()
-				db.Extensions = []goschema.Extension{{Name: "citext"}}
+				db.Extensions = []goschema.Extension{{Name: "citext", Provides: []string{"citext"}}}
 				db.Fields = append(db.Fields, goschema.Field{
 					StructName: "Order", Name: "label", Type: "citext",
 				})
@@ -284,6 +289,49 @@ func TestRenderInspectedForAtlasCLIKeepsABlockTheDocumentNames(t *testing.T) {
 			},
 			want:     "extension \"citext\"",
 			wantPath: "extensions.citext",
+		},
+		{
+			// The regression this front exists for. `isn` supplies the type
+			// `isbn`; the word "isn" appears nowhere in the document, so the
+			// label rule omitted the extension and left `code isbn` behind.
+			// Measured on PostgreSQL 17.10: neither Ptah nor the pinned binary
+			// could then read the result -- `type "isbn" does not exist`, exit 1
+			// from both -- so the omission was not even a compatibility win.
+			name: "a column type is supplied by an extension spelled differently",
+			database: func() *goschema.Database {
+				db := standaloneSequenceDatabase()
+				db.Extensions = []goschema.Extension{{
+					Name:     "isn",
+					Provides: []string{"ean13", "isbn", "isbn13", "issn", "upc"},
+				}}
+				db.Fields = append(db.Fields, goschema.Field{
+					StructName: "Order", Name: "code", Type: "isbn",
+				})
+				return db
+			},
+			want:     "extension \"isn\"",
+			wantPath: "extensions.isn",
+		},
+		{
+			// The function-only shape: nothing in a document ever spells a type
+			// supplied by pgcrypto, only a call. Measured on PostgreSQL 17.10,
+			// gen_salt is pgcrypto's and has no core equivalent, so a document
+			// that drops the extension stops resolving.
+			name: "a column default calls a function the extension supplies",
+			database: func() *goschema.Database {
+				db := standaloneSequenceDatabase()
+				db.Extensions = []goschema.Extension{{
+					Name:     "pgcrypto",
+					Provides: []string{"crypt", "digest", "gen_salt", "hmac"},
+				}}
+				db.Fields = append(db.Fields, goschema.Field{
+					StructName: "Order", Name: "salt", Type: "text",
+					DefaultExpr: "gen_salt('bf'::text)",
+				})
+				return db
+			},
+			want:     "extension \"pgcrypto\"",
+			wantPath: "extensions.pgcrypto",
 		},
 	}
 
@@ -300,7 +348,7 @@ func TestRenderInspectedForAtlasCLIKeepsABlockTheDocumentNames(t *testing.T) {
 			c.Assert(string(result.Data), qt.Contains, test.want,
 				qt.Commentf("the document names this object, so omitting its block leaves a dangling reference"))
 			c.Assert(diagnosticMessageFor(result.Diagnostics, test.wantPath), qt.Contains,
-				"kept in Atlas-compatible schema inspect output because another object in this document names it",
+				"kept in Atlas-compatible schema inspect output because another object in this document depends on it",
 				qt.Commentf("keeping a block the pinned binary refuses has to be reported, not silently done"))
 		})
 	}
@@ -321,6 +369,35 @@ func TestRenderInspectedForAtlasCLIOmitsAnUnreferencedSequence(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(string(result.Data), qt.Not(qt.Contains), "sequence \"order_seq\"")
 	c.Assert(diagnosticMessageFor(result.Diagnostics, "sequences.order_seq"), qt.Contains,
+		"omitted from Atlas-compatible schema inspect output")
+}
+
+// TestRenderInspectedForAtlasCLIOmitsAnExtensionNothingDependsOn is the control
+// that keeps the provides-aware rule from collapsing into "never omit an
+// extension", which would throw away what stokaro/ptah#1266 bought.
+//
+// The extension here supplies a full member list -- the same one that keeps the
+// block alive two tests up -- and the document simply uses none of it. Widening
+// the rule to keep any extension whose Provides is non-empty, or to keep
+// extensions unconditionally, turns this red.
+func TestRenderInspectedForAtlasCLIOmitsAnExtensionNothingDependsOn(t *testing.T) {
+	c := qt.New(t)
+
+	db := standaloneSequenceDatabase()
+	db.Extensions = []goschema.Extension{{
+		Name:     "isn",
+		Provides: []string{"ean13", "isbn", "isbn13", "issn", "upc"},
+	}}
+	db.Fields = append(db.Fields, goschema.Field{
+		StructName: "Order", Name: "label", Type: "text",
+	})
+
+	result, err := atlashclrender.RenderInspectedForAtlasCLI(db, platform.Postgres, "public")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Not(qt.Contains), "extension \"isn\"",
+		qt.Commentf("nothing in the document uses anything isn supplies, so the block still goes"))
+	c.Assert(diagnosticMessageFor(result.Diagnostics, "extensions.isn"), qt.Contains,
 		"omitted from Atlas-compatible schema inspect output")
 }
 

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -16,7 +16,12 @@ func (r *renderer) renderExtensions() {
 		return cmp.Compare(a.Name, b.Name)
 	})
 	for _, extension := range extensions {
-		if r.omitRefusedBlock("extensions."+extension.Name, blockExtension, extension.Name) {
+		// The extension's own name AND everything it supplies: a document that
+		// depends on `isn` says `isbn`, never `isn`. Provides is empty for
+		// sources with no catalog behind them, and the check then degenerates to
+		// the label, which is the most that can be known about such a source.
+		keepAlive := append([]string{extension.Name}, extension.Provides...)
+		if r.omitRefusedBlock("extensions."+extension.Name, blockExtension, keepAlive...) {
 			continue
 		}
 		r.linef(`extension %s {`, quote(extension.Name))

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -237,6 +237,10 @@ func convertExtensions(database *goschema.Database, dbExtensions []dbschematypes
 			Name:        dbExtension.Name,
 			IfNotExists: true, // Default to true for down migrations for safety
 			Version:     dbExtension.Version,
+			// Carried rather than recomputed: only the reader has the catalog,
+			// and the Atlas-compatible renderer needs it to tell an extension
+			// nothing depends on from one a column type still needs.
+			Provides: dbExtension.Provides,
 		}
 
 		// Set comment if available

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1431,8 +1431,94 @@ func (r *Reader) readExtensions() ([]types.DBExtension, error) {
 
 		extensions = append(extensions, ext)
 	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate extensions: %w", err)
+	}
+
+	provides, err := r.readExtensionMembers()
+	if err != nil {
+		return nil, err
+	}
+	for i := range extensions {
+		extensions[i].Provides = provides[extensions[i].Name]
+	}
 
 	return extensions, nil
+}
+
+// readExtensionMembers reads, per extension, the catalog names that extension
+// supplies, keyed by extension name.
+//
+// This exists because an extension is almost never referenced by its own name.
+// A document that depends on `isn` says `isbn`; one that depends on `pgcrypto`
+// says `gen_salt`. Asking the catalog is what makes "does anything still need
+// this extension" answerable without a hand-maintained table of well-known
+// extensions, which would be both unbounded and wrong the moment someone
+// installs an extension nobody listed.
+//
+// pg_depend with deptype 'e' is the extension-membership edge, and the member's
+// name lives in a different catalog per object class, hence the union. The five
+// classes covered are the ones whose names can appear as an identifier in a
+// rendered schema document: types (column types, domains), functions (defaults,
+// checks, generated and index expressions, view and trigger bodies), relations
+// (extension-supplied tables, views and sequences), and operator classes and
+// families (index USING clauses).
+//
+// Measured on PostgreSQL 17.10: no pg_namespace row is ever an extension member
+// for an extension installed into an existing schema, so `public` does not enter
+// this set and naming the schema does not pin every extension in the database.
+func (r *Reader) readExtensionMembers() (map[string][]string, error) {
+	const membersQuery = `
+		SELECT e.extname AS extension_name, t.typname AS member_name
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		  JOIN pg_type t ON t.oid = d.objid
+		 WHERE d.deptype = 'e' AND d.classid = 'pg_type'::regclass
+		UNION
+		SELECT e.extname, p.proname
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		  JOIN pg_proc p ON p.oid = d.objid
+		 WHERE d.deptype = 'e' AND d.classid = 'pg_proc'::regclass
+		UNION
+		SELECT e.extname, c.relname
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		  JOIN pg_class c ON c.oid = d.objid
+		 WHERE d.deptype = 'e' AND d.classid = 'pg_class'::regclass
+		UNION
+		SELECT e.extname, opc.opcname
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		  JOIN pg_opclass opc ON opc.oid = d.objid
+		 WHERE d.deptype = 'e' AND d.classid = 'pg_opclass'::regclass
+		UNION
+		SELECT e.extname, opf.opfname
+		  FROM pg_depend d
+		  JOIN pg_extension e ON e.oid = d.refobjid
+		  JOIN pg_opfamily opf ON opf.oid = d.objid
+		 WHERE d.deptype = 'e' AND d.classid = 'pg_opfamily'::regclass
+		 ORDER BY 1, 2`
+
+	rows, err := r.db.Query(membersQuery)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query extension members: %w", err)
+	}
+	defer rows.Close()
+
+	members := map[string][]string{}
+	for rows.Next() {
+		var extensionName, memberName string
+		if err := rows.Scan(&extensionName, &memberName); err != nil {
+			return nil, fmt.Errorf("failed to scan extension member: %w", err)
+		}
+		members[extensionName] = append(members[extensionName], memberName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to iterate extension members: %w", err)
+	}
+
+	return members, nil
 }
 
 // readSequences reads standalone PostgreSQL sequences.


### PR DESCRIPTION
## The regression

#1266 made `ptah-compat schema inspect` omit a refused block only when nothing else in the document names the object. For **extensions** that asks the wrong question. The scan matched the extension's own label, but a document that depends on an extension almost never spells its name: `isn` supplies the type `isbn`, `pgcrypto` supplies the function `gen_salt`. So the extension block was omitted while the column that needs it stayed behind.

#1266's own report listed this as a documented limitation. It is worse than documented: it breaks a round trip that worked before.

## Reproduced first, both directions

On freshly created PostgreSQL 17.10 databases, objects verified through the catalog rather than trusting the DDL echo:

```sql
CREATE EXTENSION isn;
CREATE TABLE books (id integer PRIMARY KEY, code isbn NOT NULL);
```

| | render | Ptah reads its own output back |
| --- | --- | --- |
| master before #1266 (`0b21edc0`) | rc=0 | **rc=0** |
| master now (`3acddbdf`) | rc=0, `extensions.isn: omitted` | **rc=1** `type "isbn" does not exist (SQLSTATE 42704)` |

And on that same emitted document:

| reader | result |
| --- | --- |
| pinned community binary v1.3.0 | rc=1 `pq: type "isbn" does not exist` |
| pinned binary on **its own** output for the same database | rc=1 `pq: type "isbn" does not exist` |

That last row is decisive. The omission was **not** a compatibility win — neither implementation can read the result. For this shape there is no faithful output the pinned binary can read, *including the one it writes itself*, so suppression can only choose which kind of broken. Copying that hole reproduces a defect (policy half two) and costs a working round trip.

## The fix

The catalog knows what an extension supplies, so ask it. The PostgreSQL reader reads extension membership from `pg_depend` against `pg_extension` — types, functions, relations, operator classes, operator families — and carries it on `DBExtension.Provides` / `goschema.Extension.Provides`. The renderer keeps the block when the surviving document uses the extension's name **or anything it supplies**.

Measured while designing it: no `pg_namespace` row is ever an extension member for an extension installed into an existing schema, so `public` does not enter the set and naming the schema does not pin every extension in the database.

The set is deliberately coarse and errs toward keeping. `pgcrypto` supplies a `gen_random_uuid` that PostgreSQL 13+ also supplies from core, so a document using it keeps `pgcrypto` although it would have resolved without it. Keeping a droppable block costs compatibility; dropping a needed one costs a document nobody can read.

**This is not "never omit an extension."** An extension nothing depends on is still omitted, and the pinned binary still reads that document at exit 0 — pinned by a control test in both the unit and e2e suites.

## After

| shape | extension block | Ptah round trip | pinned binary on the document |
| --- | --- | --- | --- |
| `isn` behind a column type | kept | **rc=0** | rc=1 (feature refusal, as before) |
| `pgcrypto` behind `gen_salt()` | kept | **rc=0** | rc=1 (feature refusal, as before) |
| `isn` nothing depends on | **omitted** | rc=0 | **rc=0** |

Parity rule (a) holds at the invocation level: inspecting the live database directly, both binaries exit 0.

## Does this affect sequences or policies?

No, and the reason is structural rather than lucky:

- **Sequence** — the only thing it supplies *is* its name; `nextval('order_seq')` names the sequence itself. Label-matching already asks the right question.
- **Policy** — nothing in an HCL document can reference a policy by name, so the reference test is vacuous for policies and they are always omitted. That is sound: omitting one leaves no dangling reference. It loses description (which RLS rules exist), which `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` recovers.

Verified on a live database: the sequence is kept behind its default, the policy is omitted, and the round trip still exits 0.

## Coverage

A live round-trip e2e test renders each shape and feeds Ptah's own output back to Ptah **against a fresh dev database** where the extension is not installed, requiring exit 0. `gen_salt` is used rather than `gen_random_uuid` for the function-only shape because the latter also exists in core and would pass without testing anything.

Three mutants, each observed red:

1. label-only matching → both dependent shapes red (unit + e2e); the `citext` row stays green, confirming it was a false comfort — extension and type are the same word there
2. never omit an extension → the omission controls and the env-var gate red
3. `pg_depend` never consulted → both dependent e2e shapes red

`scripts/check-test-style.sh` was also watched go red (an `if` in a test body) and then green.

## Capability

`PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` still restores every block Ptah models; verified it emits both extension blocks where the default omits them. The kept-block diagnostic now reads "depends on it" rather than "names it", which is what it always meant and is now what it measures.

Behavior change; pre-v1, so no compatibility is owed.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 (regenerated; +22 lines, 0 deletions — the two new fields only) |
| every `check:*` in `docs/site/package.json` | 0, except `check:responsive` |
| `build-feature-matrix.mjs --check` | 0 |

`check:responsive` could not run: it needs a built site and `docs/site/node_modules` is not installed in this worktree. The docs change is prose inside two existing pages — no new page, component, or CSS.

Not verified: MySQL/MariaDB/SQLite behavior (the refusal list is PostgreSQL-keyed and untouched for other dialects); non-catalog sources of `goschema.Extension` (Go annotations, YAML) leave `Provides` empty and degenerate to the previous label-only rule, which is the most that can be known about such a source.