### PR TITLE
Describe every schema `schema inspect` can see (#1264)

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -1325,7 +1325,15 @@ func TestCompatCommand_SchemaInspectUsesAtlasProjectFormatAndSchemaMode(t *testi
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Equals, "{}")
+	// `mode { tables = false }` drops the tables, not the schema they lived in.
+	// The document still describes `main`, which is what the pinned community
+	// binary v1.3.0 does with the same project file: measured on SQLite, it
+	// renders `schema "main" {}` — in fact it renders the tables too, so it
+	// ignores this mode block entirely on inspect. Rendering `{}` for a
+	// database that has a schema is the defect stokaro/ptah#1264 is about, and
+	// this row is the one place it survived a filter rather than an empty
+	// database.
+	c.Assert(out.String(), qt.Equals, `{"schemas":[{"name":"main"}]}`)
 }
 
 // TestCompatCommand_SchemaInspectRejectsProOnlyOutputFlags pins the inspect

--- a/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
+++ b/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
@@ -81,6 +81,7 @@ func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 				types.DBInfo{Dialect: "postgres", Schema: "public"},
 				&diagnostics,
 				atlasInspectOmitsRefusedBlocks(),
+				true,
 			)
 
 			hcl, err := report.MarshalHCL()
@@ -119,6 +120,7 @@ func TestAtlasInspectKeepsAReferencedBlockInEitherState(t *testing.T) {
 				types.DBInfo{Dialect: "postgres", Schema: "public"},
 				&diagnostics,
 				atlasInspectOmitsRefusedBlocks(),
+				true,
 			)
 
 			hcl, err := report.MarshalHCL()

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -600,8 +600,36 @@ func QualifyTableName(schema, table string) string {
 //	MySQL:
 //	  CREATE TABLE users (status ENUM('active', 'inactive', 'suspended') DEFAULT 'active');
 type Enum struct {
-	Name   string   // The generated enum type name (e.g., "enum_user_status")
+	Name string // The generated enum type name (e.g., "enum_user_status")
+	// Schema owns the enum, empty for the connection's or document's default
+	// schema. It is a field rather than a qualifier folded into Name because
+	// Name is what a column's declared type is matched against, and a domain,
+	// composite and range each keep the two apart for the same reason.
+	//
+	// An enum is a TYPE, so its identity is (schema, name) exactly as a
+	// domain's is: public.mood and extra.mood are two types with different
+	// value sets. Without this field an enum read out of a non-default schema
+	// was described as belonging to the connected one, and applying that
+	// description built the type in the wrong schema and typed the column that
+	// uses it against the wrong type (stokaro/ptah#1276).
+	Schema string
 	Values []string // The allowed enum values (e.g., ["active", "inactive", "suspended"])
+}
+
+// QualifiedName returns schema.name when Schema is set, or Name otherwise.
+//
+// Name is returned VERBATIM when Schema is empty, rather than through
+// QualifyTableName, because Name is not always a bare identifier here. A SQL
+// schema file loaded through internal/convert/toschema parks the qualifier in
+// Name -- `public.e1` -- and an enum may legitimately be named with a literal
+// dot, which QualifyTableName canonicalizes by quoting. Running either through
+// it changes the identifier: `public.e1` becomes the single quoted name
+// "public.e1", and the already-quoted "tenant.data" gains a second layer.
+func (e Enum) QualifiedName() string {
+	if strings.TrimSpace(e.Schema) == "" {
+		return e.Name
+	}
+	return QualifyTableName(e.Schema, e.Name)
 }
 
 // Domain represents a PostgreSQL domain type parsed from Go annotations.

--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -38,7 +38,21 @@ func (r *Renderer) Render(node ast.Node) (string, error) {
 	return r.Output(), nil
 }
 
+// defaultSchema is the namespace every unqualified SQLite object already
+// belongs to. It is not a schema anybody creates.
+const defaultSchema = "main"
+
 func (r *Renderer) VisitCreateSchema(node *ast.CreateSchemaNode) error {
+	if node.Name == defaultSchema {
+		// `main` is where the connection already is, so there is nothing to
+		// create and nothing to refuse. An introspected SQLite database
+		// describes it as a schema — the pinned Atlas community binary v1.3.0
+		// renders `schema "main" {}` in HCL and no statement at all in SQL —
+		// and turning that into a "not supported" comment would put a refusal
+		// in the output for something the author never asked for
+		// (stokaro/ptah#1264).
+		return nil
+	}
 	r.notSupported("schemas", node.Name)
 	return nil
 }

--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -759,6 +759,13 @@ func GetOrderedCreateStatementsWithCapabilities(
 		if err != nil {
 			return nil, err
 		}
+		// A node a dialect renders as nothing is not a statement. Keeping it
+		// put a bare `;` in front of the script — SQLite renders no statement
+		// for its `main` namespace, which an introspected database now
+		// describes as a schema (stokaro/ptah#1264).
+		if strings.TrimSpace(sql) == "" {
+			continue
+		}
 		statements = append(statements, sql)
 	}
 

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -189,6 +189,9 @@ type DBEnum struct {
 	Values []string `json:"values"`
 }
 
+// QualifiedName returns schema.name when Schema is set, or Name otherwise.
+func (e DBEnum) QualifiedName() string { return QualifyTableName(e.Schema, e.Name) }
+
 // DBDomain represents a PostgreSQL domain type read from the database.
 type DBDomain struct {
 	Name     string `json:"name"`
@@ -594,6 +597,9 @@ type DBFunction struct {
 	Body       string `json:"body"`       // Function body/implementation
 	Comment    string `json:"comment"`    // Function comment/description
 }
+
+// QualifiedName returns schema.name when Schema is set, or Name otherwise.
+func (f DBFunction) QualifiedName() string { return QualifyTableName(f.Schema, f.Name) }
 
 // DBView represents a database view read from the database.
 type DBView struct {

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3930,7 +3930,19 @@ type EmbeddedSources struct {
 package goschema // import "go.5x5.cz/ptah/core/goschema"
 
 type Enum struct {
-    Name   string   // The generated enum type name (e.g., "enum_user_status")
+    Name string // The generated enum type name (e.g., "enum_user_status")
+    // Schema owns the enum, empty for the connection's or document's default
+    // schema. It is a field rather than a qualifier folded into Name because
+    // Name is what a column's declared type is matched against, and a domain,
+    // composite and range each keep the two apart for the same reason.
+    //
+    // An enum is a TYPE, so its identity is (schema, name) exactly as a
+    // domain's is: public.mood and extra.mood are two types with different
+    // value sets. Without this field an enum read out of a non-default schema
+    // was described as belonging to the connected one, and applying that
+    // description built the type in the wrong schema and typed the column that
+    // uses it against the wrong type (stokaro/ptah#1276).
+    Schema string
     Values []string // The allowed enum values (e.g., ["active", "inactive", "suspended"])
 }
     Enum represents a global enumeration type definition that can be shared
@@ -3977,6 +3989,7 @@ type Enum struct {
         MySQL:
           CREATE TABLE users (status ENUM('active', 'inactive', 'suspended') DEFAULT 'active');
 
+func (e Enum) QualifiedName() string
 
 ### go.5x5.cz/ptah/core/goschema.Extension
 
@@ -5656,6 +5669,7 @@ type DBEnum struct {
 }
     DBEnum represents a database enum type (PostgreSQL)
 
+func (e DBEnum) QualifiedName() string
 
 ### go.5x5.cz/ptah/dbschema/types.DBExtension
 
@@ -5724,6 +5738,7 @@ type DBFunction struct {
 }
     DBFunction represents a PostgreSQL custom function read from the database
 
+func (f DBFunction) QualifiedName() string
 
 ### go.5x5.cz/ptah/dbschema/types.DBGrant
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -86,6 +86,15 @@ ptah-compat schema inspect --url "postgres://…/app?sslmode=disable"
 ptah-compat schema inspect --url "postgres://…/app?sslmode=disable&search_path=public"
 ```
 
+Every object in the document names the schema that owns it, not the one the
+connection happens to be on. That applies to the non-table kinds as much as to
+tables: an `enum` block carries `schema = schema.<name>`, a `function`, `view`,
+`materialized`, `domain`, `composite`, `range` and `sequence` block each carry
+the attribute wherever the object is outside the document's default schema, and
+a column declared against a type in another schema is written against that
+schema's type. Applying such a document therefore rebuilds each object where it
+was, and applying it back to the database it describes plans nothing.
+
 `--schema` / `-s` narrows inspection when the underlying database reader supports
 schema scoping, and outranks the URL's scope: naming a schema that does not
 exist renders an empty document rather than falling back to the connection's

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -70,8 +70,26 @@ ptah-compat schema inspect \
   --dev-url "$DEV_DATABASE_URL" > schema.hcl
 ```
 
+### What a URL puts under inspection
+
+A PostgreSQL-family URL that pins no `search_path` describes the whole
+database — every non-system schema, with its tables — and one that pins a
+schema describes exactly that schema. An empty database still describes the
+schema it has rather than rendering an empty document, so a consumer walking
+`.schemas` does not break on a database that is merely empty.
+
+```bash
+# Every schema of the database, `public` and `extra` alike.
+ptah-compat schema inspect --url "postgres://…/app?sslmode=disable"
+
+# Only `public`.
+ptah-compat schema inspect --url "postgres://…/app?sslmode=disable&search_path=public"
+```
+
 `--schema` / `-s` narrows inspection when the underlying database reader supports
-schema scoping. `--format`
+schema scoping, and outranks the URL's scope: naming a schema that does not
+exist renders an empty document rather than falling back to the connection's
+own schema. `--format`
 accepts Atlas-style Go templates with `.MarshalHCL`, `hcl`, `sql`, `json`,
 `base64url`, `mermaid`, `split`, and `write`. Split-write exports are
 supported for HCL and SQL output with the documented Atlas split strategies:

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -836,6 +836,16 @@ schema files, prints the planned SQL, and applies it after interactive
 confirmation. Use `--dry-run` to print the plan without applying it, or
 `--auto-approve` to skip the prompt explicitly.
 
+### Which schemas the current side is read at
+
+The database is read at the scope the desired state names, so both sides of the
+diff cover the same schemas. A desired state that names schemas beyond the one
+the connection is on — as an inspected document of a multi-schema database does
+— is compared against those schemas too, which is what makes inspecting a
+database and applying its own output back a no-op. A desired state that names
+only the connected schema reads only that one, so a schema the document never
+mentions is never planned for removal. `--schema` outranks both.
+
 Use `--tx-mode=file` or `--tx-mode=all` to execute the generated plan in one
 transaction, or `--tx-mode=none` to execute statements without transaction
 wrapping. With `--edit`, the planned SQL opens in `$VISUAL` or `$EDITOR`

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -67,6 +67,7 @@ table "users" {
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |
 | `foreign_key` | One local `columns` entry and one table-qualified `ref_columns` entry. |
 | `check` | `expr`. |
+| `enum` | `values`, plus the `schema` that owns the type. A PostgreSQL enum is created in that schema and a column declared against it is qualified with it. |
 | `extension` | PostgreSQL `if_not_exists`, `version`, and comments. |
 | `role` | PostgreSQL role attributes, including `password`. |
 | `permission` | PostgreSQL table, schema, and sequence permissions. |

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -665,7 +665,7 @@ CREATE ROLE pgbouncer_undescribed_137 LOGIN;`)
 	c.Assert(err, qt.IsNil)
 	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
 	var inspectDiag bytes.Buffer
-	inspected, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+	inspected, err := atlasschema.Inspect(t.Context(), conn, atlasschema.InspectOptions{
 		Schemas:     []string{"ptah_undescribed_schema_137"},
 		Diagnostics: &inspectDiag,
 	})

--- a/integration/gonative/schema_boundary_guard_postgres_test.go
+++ b/integration/gonative/schema_boundary_guard_postgres_test.go
@@ -18,12 +18,13 @@
 // suppression behind one of the failures below exists only there, so a
 // native-only guard cannot see it at all.
 //
-// It is a CHARACTERIZATION test, not a green one. Master does not hold either
-// property on most of these fixtures. Every expectation that records a WRONG
-// answer says so in a comment naming #1276 and what the value must become, so
-// the file can be read as a list of what is broken. Nothing here is skipped:
-// a skipped row is invisible in a green run, which is the exact failure mode
-// #1276 is about.
+// It is a CHARACTERIZATION test, not a green one: it records what the tree
+// answers today, whether or not that answer is right. Every expectation that
+// records a WRONG one says so in a comment naming the issue and what the value
+// must become, so the file can be read as a list of what is broken, and every
+// row that has since reached its stated target says FIXED and names what moved
+// it. Nothing here is skipped: a skipped row is invisible in a green run, which
+// is the exact failure mode #1276 is about.
 //
 // Every value below was measured against live PostgreSQL 17 and PostgreSQL 18,
 // which agreed on all of them. First measured on f2e7fa0c (#1274) and
@@ -39,6 +40,35 @@
 // v1.3.0 -- exit 1 `There is no variable named "schema"` before, exit 0 after.
 // Every other row's values are unchanged, which is the claim that the common
 // path did not move.
+//
+// #1298 gave the comparator a third state -- present, authoritatively absent,
+// and NOT DESCRIBED -- and turned `extension_nothing_references`'s compatibility
+// plan from `DROP EXTENSION IF EXISTS "pgcrypto"` to nothing. Property 2 now
+// holds on every fixture and on both surfaces.
+//
+// Re-measured on PostgreSQL 17.10 and 18.4 for #1264, which moves the read side.
+// `schema inspect` describes the schemas the URL reaches, `schema apply` reads
+// the database at the scope the document it was handed describes, and the reader
+// reports the schemas it read instead of denying it read any. Property 2 is
+// untouched by that and stays nil everywhere: without the apply-scope half it
+// would have grown a CREATE SCHEMA and a CREATE TABLE for objects the database
+// already has, which is what held this branch.
+//
+// The two rows #1234 moved are where the two issues meet. #1234 made the
+// document declare `public`; #1264 makes the reader say it read `public`. Each
+// alone leaves the pair disagreeing, and the resulting `wantDocumentOnly:
+// [schema:public]` was the value #1276 said must become empty. With both, it is
+// empty.
+//
+// One row still records a difference, and it is a difference in DEFAULT SCOPE
+// rather than in fidelity: `two_schemas_plain_url`'s document reaches `extra`
+// because inspection resolves realm scope from the URL, while the reader called
+// with no allow-list still covers the connected schema alone. Widening that
+// default is not free and is not this issue's: measured on the same database, a
+// hand-written document declaring only `public`, compared against a two-schema
+// read, plans `DROP TABLE IF EXISTS "extra"."b" CASCADE` -- a schema the
+// operator never named, removed. The caller has to name the scope it wants,
+// which is what inspection and apply now both do.
 
 package gonative_test
 
@@ -114,29 +144,35 @@ func boundaryCases() []boundaryCase {
 			seed:  []string{"CREATE SCHEMA extra", "CREATE TABLE public.a (id integer)", "CREATE TABLE extra.b (id integer)"},
 			query: "",
 
-			// WRONG (#1276): the database has two schemas and the document
-			// describes one. `extra` and `extra.b` are absent from the
-			// document because the reader was never asked about them, and
-			// nothing downstream can tell that from "the database has no
-			// schema `extra`". Must become []string{"extra", "public"} -- the
-			// same answer the scoped URL below gives for `public`, extended to
-			// every schema a plain URL reaches.
-			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): the reader reports NO schemas at all, for every
-			// fixture in this file, while the renderer synthesizes a schema
-			// block from the tables it was given. Two sides, two independent
-			// answers. Must become []string{"extra", "public"}.
-			wantReadSchemas: nil,
+			// FIXED (#1264): the database has two schemas and the document now
+			// describes both, which is this row's stated target and what the
+			// pinned Atlas community binary v1.3.0 renders for the same URL.
+			// `extra` and `extra.b` used to be absent because the reader was
+			// never asked about them, and nothing downstream could tell that
+			// from "the database has no schema `extra`".
+			wantDescribedSchemas: []string{"extra", "public"},
+			// FIXED (#1276), at the reader's own scope: the reader used to
+			// report NO schemas at all while the renderer synthesized a schema
+			// block from the tables it was given. It now reports the schemas it
+			// read. Called with no allow-list, as here, that list is the
+			// connected schema -- see the header for why widening the DEFAULT
+			// is a separate decision from widening what inspection asks for.
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): the document declares a schema the reader never
-			// reported. Must become empty once both sides read the same list.
+			// The one row still recording a difference, and it is the scope
+			// gap named in the header rather than a fidelity gap: the document
+			// reaches `extra` because inspection resolved realm scope off the
+			// URL, and this read did not ask for it. Every object listed is one
+			// the database really has, so the document is not describing
+			// anything that is not there -- which property 2 below confirms by
+			// planning nothing when this document is applied back.
 			//
-			// Note what this row canNOT see: `extra.b` is missing from BOTH
-			// sides, so it does not appear in the difference. Two sides that
-			// agree on a lie look exactly like two sides that agree. That is
-			// why wantDescribedSchemas above is asserted separately against
-			// the database's real shape rather than against the reader.
-			wantDocumentOnly: []string{"schema:public"},
+			// Note what this row canNOT see: an object missing from BOTH sides
+			// does not appear in the difference. Two sides that agree on a lie
+			// look exactly like two sides that agree. That is why
+			// wantDescribedSchemas above is asserted separately against the
+			// database's real shape rather than against the reader.
+			wantDocumentOnly: []string{"column:extra.b.id", "schema:extra", "table:extra.b"},
 			wantDatabaseOnly: nil,
 
 			// FIXED (#1283): applying a database's own description back to it
@@ -155,14 +191,17 @@ func boundaryCases() []boundaryCase {
 			seed:  []string{"CREATE SCHEMA extra", "CREATE TABLE public.a (id integer)", "CREATE TABLE extra.b (id integer)"},
 			query: "search_path=public",
 
-			// CORRECT and must stay correct.
+			// CORRECT and must stay correct. A URL that pins a schema keeps
+			// describing exactly that one, so #1264's widening of the plain URL
+			// above did not widen this.
 			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): must become []string{"public"} -- one schema,
-			// because that is what this URL asked for.
-			wantReadSchemas: nil,
+			// FIXED (#1276): one schema, because that is what this URL asked
+			// for.
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): must become empty.
-			wantDocumentOnly: []string{"schema:public"},
+			// FIXED (#1276): both sides read the same list, so the difference
+			// is empty.
+			wantDocumentOnly: nil,
 			wantDatabaseOnly: nil,
 
 			// FIXED (#1283): the grant churn is gone here too, on the URL form
@@ -180,12 +219,12 @@ func boundaryCases() []boundaryCase {
 
 			// CORRECT and must stay correct.
 			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): must become []string{"public"}.
-			wantReadSchemas: nil,
+			// FIXED (#1276).
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): must become empty. The extension itself is on
-			// neither side of this difference, which is #1274 holding.
-			wantDocumentOnly: []string{"schema:public"},
+			// FIXED (#1276): empty. The extension itself is on neither side of
+			// this difference, which is #1274 holding.
+			wantDocumentOnly: nil,
 			wantDatabaseOnly: nil,
 
 			// FIXED (#1283): no extension statement appeared here even when
@@ -212,18 +251,21 @@ func boundaryCases() []boundaryCase {
 			// against this exact document, exit 1 with `There is no variable
 			// named "schema"` before #1234 and exit 0 after it. What a document
 			// declares is now collected from what it referenced, so the
-			// declaration cannot go missing again.
+			// declaration cannot go missing again. #1264 reaches the same value
+			// from the other direction -- inspection asks for the schemas the
+			// URL covers -- so the two agree rather than compete.
 			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): must become []string{"public"} -- the reader did
-			// read `public`, it just does not say so.
-			wantReadSchemas: nil,
+			// FIXED (#1276): the reader did read `public`, and now says so.
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): must become empty, and for the same reason as every
-			// other row -- the reader reports no schemas while the document
-			// declares the one it references. The extension itself is on neither
-			// side of this difference, which is #1274 holding; the damage this
-			// row exists for is in the plan below.
-			wantDocumentOnly: []string{"schema:public"},
+			// FIXED (#1276): empty. This row needed BOTH halves and had only
+			// one: #1234 made the document declare the schema it references,
+			// which is what put `schema:public` on the document side, and #1264
+			// makes the reader report the schema it read, which puts it on the
+			// database side too. The extension itself is on neither side of this
+			// difference, which is #1274 holding; the damage this row exists for
+			// is in the plan below.
+			wantDocumentOnly: nil,
 			wantDatabaseOnly: nil,
 
 			// CORRECT: the native document declares the extension, so applying
@@ -261,12 +303,12 @@ func boundaryCases() []boundaryCase {
 
 			// CORRECT and must stay correct.
 			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): must become []string{"public"}.
-			wantReadSchemas: nil,
+			// FIXED (#1276).
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): must become empty. The primary key itself round
-			// trips: it is on neither side of this difference.
-			wantDocumentOnly: []string{"schema:public"},
+			// FIXED (#1276): empty. The primary key itself round trips: it is
+			// on neither side of this difference.
+			wantDocumentOnly: nil,
 			wantDatabaseOnly: nil,
 
 			// FIXED (#1283): nil on both surfaces.
@@ -284,12 +326,15 @@ func boundaryCases() []boundaryCase {
 			// document declare what it references. This is the smallest instance
 			// of that defect -- there is no table here to predict a schema from,
 			// which is how a rule that predicted rather than collected missed it.
+			// #1264 asks for the same schema from the read side, so an empty
+			// database is described by both halves rather than by neither.
 			wantDescribedSchemas: []string{"public"},
-			// WRONG (#1276): must become []string{"public"}.
-			wantReadSchemas: nil,
+			// FIXED (#1276).
+			wantReadSchemas: []string{"public"},
 
-			// WRONG (#1276): must become empty, as on every other row.
-			wantDocumentOnly: []string{"schema:public"},
+			// FIXED (#1276): empty, and it took both halves here too -- see
+			// `extension_nothing_references` above.
+			wantDocumentOnly: nil,
 			wantDatabaseOnly: nil,
 
 			// CORRECT: property 2 holds on both surfaces.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -330,8 +330,15 @@ func (p *parser) parseEnum(block *hclsyntax.Block) error {
 	if len(values) == 0 {
 		return p.blockError(block, "enum %q requires values", block.Labels[0])
 	}
+	// The `schema` attribute is read rather than merely tolerated. It was
+	// accepted by rejectUnsupportedEnumAttrs and then discarded, so a document
+	// declaring `enum "mood" { schema = schema.extra }` was read back as an
+	// enum belonging to nothing, and applying it created the type in whatever
+	// schema the connection defaulted to (stokaro/ptah#1276). A `function`
+	// block's schema has always been read here; an enum's is the same fact.
 	p.db.Enums = append(p.db.Enums, goschema.Enum{
 		Name:   block.Labels[0],
+		Schema: p.optionalRefName(block.Body.Attributes["schema"]),
 		Values: values,
 	})
 	return nil

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -241,8 +241,13 @@ table "users" {
 }
 `), "schema.hcl")
 	c.Assert(err, qt.IsNil)
+	// The block's `schema` attribute is carried rather than discarded. An enum
+	// is a type, and a type declared in `main` is not the same type as one
+	// declared anywhere else, so the DDL below names the schema on both the
+	// CREATE TYPE and the column that is declared against it
+	// (stokaro/ptah#1276).
 	c.Assert(db.Enums, qt.DeepEquals, []goschema.Enum{
-		{Name: "status", Values: []string{"active", "inactive"}},
+		{Name: "status", Schema: "main", Values: []string{"active", "inactive"}},
 	})
 	c.Assert(db.Fields, qt.HasLen, 1)
 	c.Assert(db.Fields[0].Type, qt.Equals, "status")
@@ -250,8 +255,8 @@ table "users" {
 	c.Assert(db.Fields[0].DefaultSet, qt.IsTrue)
 
 	sql := legacyRenderedSQL(strings.Join(renderStatements(c, db, "postgres"), "\n"))
-	c.Assert(sql, qt.Contains, "CREATE TYPE status AS ENUM ('active', 'inactive');")
-	c.Assert(sql, qt.Contains, "status status NOT NULL DEFAULT 'active'")
+	c.Assert(sql, qt.Contains, "CREATE TYPE main.status AS ENUM ('active', 'inactive');")
+	c.Assert(sql, qt.Contains, "status main.status NOT NULL DEFAULT 'active'")
 }
 
 func TestParseEnumRequiresStringValues(t *testing.T) {

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -441,7 +441,7 @@ func (r *renderer) renderSchemas() {
 func (r *renderer) renderEnums() {
 	enums := append([]goschema.Enum(nil), r.db.Enums...)
 	sort.Slice(enums, func(i, j int) bool {
-		return enums[i].Name < enums[j].Name
+		return enums[i].QualifiedName() < enums[j].QualifiedName()
 	})
 	for _, enum := range enums {
 		r.linef(`enum %s {`, quote(enum.Name))
@@ -455,12 +455,21 @@ func (r *renderer) renderEnums() {
 		// -- one operand, measured both ways. That binary's own inspect writes
 		// the attribute too (stokaro/ptah#1251).
 		//
-		// goschema.Enum carries no schema of its own, so the schema the whole
-		// read belongs to is the only name available. It is also the right one:
-		// a catalog omits the schema exactly where the engine treats the read's
-		// own schema as implicit, which is the same reason renderTable falls
-		// back to it.
-		if schema := r.schemaFor(""); schema != "" {
+		// The schema is the ENUM'S, falling back to the render's default only
+		// where the enum names none -- the rule renderTable follows, for the
+		// same reason: a catalog blanks the schema exactly where the engine
+		// treats the read's own schema as implicit.
+		//
+		// It used to be the render's default unconditionally, because
+		// goschema.Enum carried no schema. That is right for every read of one
+		// schema and wrong for every read of more than one: `schema inspect`
+		// against a URL that pins no schema describes the whole realm, so
+		// `extra.mood` was written as `schema = schema.public` -- an enum
+		// attributed to a schema that does not hold it. Applying that document
+		// created the type in `public` and typed `extra.b.feeling` against it,
+		// so the round trip produced a database whose column type pointed at
+		// the wrong schema (stokaro/ptah#1276).
+		if schema := r.schemaFor(enum.Schema); schema != "" {
 			r.rawAttr(1, "schema", r.schemaRef(schema))
 		}
 		r.rawAttr(1, "values", stringList(enum.Values))

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -33,19 +33,29 @@ type atlasSchemaInspectJSONRealm struct {
 	Schemas []atlasSchemaInspectJSONSchema `json:"schemas,omitempty"`
 }
 
+// atlasSchemaInspectJSONSchema and atlasSchemaInspectJSONTable both carry their
+// attributes AFTER their children, because that is where the pinned community
+// binary v1.3.0 puts them. Measured on PostgreSQL 17 and MySQL 9.7:
+//
+//	{"name":"public","tables":[…],"comment":"standard public schema"}
+//	{"name":"t","columns":[…],"comment":"table comment"}
+//	{"name":"adv_dev","tables":[…],"charset":"utf8mb4","collate":"utf8mb4_0900_ai_ci"}
+//
+// Go emits object keys in field order, embedded fields included, so the field
+// order here is the byte order of the document a consumer diffs.
 type atlasSchemaInspectJSONSchema struct {
-	Name string `json:"name"`
-	atlasSchemaInspectJSONAttrs
+	Name   string                        `json:"name"`
 	Tables []atlasSchemaInspectJSONTable `json:"tables,omitempty"`
+	atlasSchemaInspectJSONAttrs
 }
 
 type atlasSchemaInspectJSONTable struct {
-	Name string `json:"name"`
-	atlasSchemaInspectJSONAttrs
+	Name        string                             `json:"name"`
 	Columns     []atlasSchemaInspectJSONColumn     `json:"columns,omitempty"`
 	Indexes     []atlasSchemaInspectJSONIndex      `json:"indexes,omitempty"`
 	PrimaryKey  *atlasSchemaInspectJSONIndex       `json:"primary_key,omitempty"`
 	ForeignKeys []atlasSchemaInspectJSONForeignKey `json:"foreign_keys,omitempty"`
+	atlasSchemaInspectJSONAttrs
 }
 
 type atlasSchemaInspectJSONAttrs struct {
@@ -271,10 +281,30 @@ func atlasSchemaInspectBase64URL(value any) string {
 	return strings.NewReplacer("+", "-", "/", "_", "=", "").Replace(atlasTemplateString(value))
 }
 
+// atlasSchemaInspectJSON builds the realm document.
+//
+// The schema list comes from the schemas the reader described, NOT from the
+// tables it found. Deriving it from tables made a schema disappear the moment
+// it held none: an empty database rendered as `{}` where the pinned community
+// binary v1.3.0 renders `{"schemas":[{"name":"public","comment":"standard
+// public schema"}]}` — measured on PostgreSQL 17, and the same on SQLite with
+// `main` and on MySQL 9.7 with the connected database (stokaro/ptah#1264).
+//
+// Tables still contribute their schema, so a reader that describes no schemas
+// keeps rendering what it did before rather than losing its tables to a
+// missing row.
 func atlasSchemaInspectJSON(schema *dbschematypes.DBSchema, info dbschematypes.DBInfo) atlasSchemaInspectJSONRealm {
 	schemasByName := make(map[string]*atlasSchemaInspectJSONSchema)
 	indexesByTable := atlasSchemaInspectIndexesByTable(schema.Indexes)
 	constraintsByTable := atlasSchemaInspectConstraintsByTable(schema.Constraints)
+	for _, described := range schema.Schemas {
+		jsonSchema := atlasSchemaInspectSchemaForName(schemasByName, described.Name)
+		jsonSchema.atlasSchemaInspectJSONAttrs = atlasSchemaInspectJSONAttrs{
+			Comment: described.Comment,
+			Charset: described.Charset,
+			Collate: described.Collate,
+		}
+	}
 	for _, table := range schema.Tables {
 		schemaName := atlasSchemaInspectSchemaName(table.Schema, info)
 		jsonSchema := atlasSchemaInspectSchemaForName(schemasByName, schemaName)

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -25,8 +25,27 @@ type SchemaInspectReport struct {
 	// refuses to read where nothing in the document names them; see
 	// [go.5x5.cz/ptah/internal/atlashclrender.RenderInspectedForAtlasCLI].
 	omitAtlasRefusedBlocks bool
-	Realm                  atlasSchemaInspectJSONRealm `json:"-"`
-	Schema                 atlasSchemaInspectJSONRealm `json:"-"`
+	// describeSchemas renders the schema itself -- CREATE SCHEMA, its comment,
+	// its charset and collation -- into the SQL format. It is false when the
+	// connection URL chose the scope rather than the run choosing it.
+	//
+	// The distinction is the pinned community binary v1.3.0's, measured on
+	// PostgreSQL 17.10 against a database holding `public` and `extra`, counting
+	// `CREATE SCHEMA` in `--format '{{ sql . }}'`:
+	//
+	//	plain URL                    2
+	//	?search_path=public          0
+	//	--schema public              1
+	//	--schema public --schema extra   2
+	//	MySQL 9.7, connected database    0
+	//
+	// So it is not "realm scope only": naming a schema explicitly renders it.
+	// What that binary leaves out is the schema it was merely connected to. The
+	// JSON format does list that schema (stokaro/ptah#1264), so the two surfaces
+	// genuinely disagree and only the SQL one is gated here.
+	describeSchemas bool
+	Realm           atlasSchemaInspectJSONRealm `json:"-"`
+	Schema          atlasSchemaInspectJSONRealm `json:"-"`
 }
 
 type atlasSchemaInspectJSONRealm struct {
@@ -134,12 +153,16 @@ func RenderSchemaInspect(format string, report *SchemaInspectReport) (SchemaInsp
 // nothing else in the document names them, and reports every decision on
 // diagnostics. It is false on the native surface, which describes every
 // construct Ptah models.
+//
+// describeSchemas gates schema DDL out of the SQL format for a run whose scope
+// came from the connection URL; see the field's own documentation.
 func NewSchemaInspectReport(
 	db *goschema.Database,
 	schema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	diagnostics io.Writer,
 	omitAtlasRefusedBlocks bool,
+	describeSchemas bool,
 ) *SchemaInspectReport {
 	realm := atlasSchemaInspectJSON(schema, info)
 	return &SchemaInspectReport{
@@ -147,6 +170,7 @@ func NewSchemaInspectReport(
 		info:                   info,
 		diagnostics:            diagnostics,
 		omitAtlasRefusedBlocks: omitAtlasRefusedBlocks,
+		describeSchemas:        describeSchemas,
 		Realm:                  realm,
 		Schema:                 realm,
 	}
@@ -235,12 +259,31 @@ func (r *SchemaInspectReport) renderHCL() (atlashclrender.Result, error) {
 	return atlashclrender.RenderInspected(r.db, r.info.Dialect, r.defaultSchemaName())
 }
 
+// sqlSource is the database the SQL format renders, which is the inspected one
+// minus the schema rows when the run did not choose its own scope.
+//
+// Dropping the rows here rather than never reading them keeps the JSON and HCL
+// formats seeing everything the reader described: the schema row an empty
+// database needs in JSON (stokaro/ptah#1264) is the same row that would put a
+// `CREATE SCHEMA` in front of SQL output the pinned binary emits without one.
+//
+// The copy is shallow on purpose -- only the Schemas slice header is replaced,
+// and nothing downstream writes through it.
+func (r *SchemaInspectReport) sqlSource() *goschema.Database {
+	if r.describeSchemas || r.db == nil || len(r.db.Schemas) == 0 {
+		return r.db
+	}
+	source := *r.db
+	source.Schemas = nil
+	return &source
+}
+
 func (r *SchemaInspectReport) MarshalSQL(indent ...string) (string, error) {
 	if len(indent) > 1 {
 		return "", fmt.Errorf("unexpected number of arguments: %d", len(indent))
 	}
 	statements, err := renderer.GetOrderedCreateStatementsWithCapabilities(
-		r.db,
+		r.sqlSource(),
 		r.info.Dialect,
 		r.info.Capabilities,
 	)

--- a/internal/atlasreport/schema_inspect_realm_test.go
+++ b/internal/atlasreport/schema_inspect_realm_test.go
@@ -1,0 +1,161 @@
+package atlasreport_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasreport"
+)
+
+// TestRenderSchemaInspect_JSONRealmDocument pins the shape of the realm
+// document against the pinned Atlas community binary v1.3.0.
+//
+// Every want string below was produced by that binary and is reproduced byte
+// for byte, so a change of field order is a failure rather than a detail:
+// `{{ json . }}` is the scripted surface, and a consumer diffs it.
+//
+// The rows are the three divergences of stokaro/ptah#1264 plus the control that
+// stops the first one's fix from inventing a schema nobody has. Measured
+// 2026-08-07 on PostgreSQL 17, MySQL 9.7 and SQLite.
+func TestRenderSchemaInspect_JSONRealmDocument(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		schema *types.DBSchema
+		info   types.DBInfo
+		want   string
+	}{
+		{
+			// An empty database. The realm's schemas used to be derived from
+			// its tables, so no table meant no schema, and `omitempty` then
+			// removed the key entirely.
+			name: "empty postgres database still reports its schema",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{
+					{Name: "public", Comment: "standard public schema"},
+				},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want: `{"schemas":[{"name":"public","comment":"standard public schema"}]}`,
+		},
+		{
+			// The comment comes AFTER the tables. Go emits object keys in field
+			// order, embedded fields included, so this row is what pins the
+			// attributes to the end of the struct.
+			name: "schema comment follows the tables",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{
+					{Name: "public", Comment: "standard public schema"},
+				},
+				Tables: []types.DBTable{
+					{
+						Name:    "a",
+						Columns: []types.DBColumn{{Name: "id", DataType: "integer", IsNullable: "YES"}},
+					},
+				},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want: `{"schemas":[{"name":"public","tables":[{"name":"a","columns":[{"name":"id","type":"integer","null":true}]}],"comment":"standard public schema"}]}`,
+		},
+		{
+			// Realm scope: a schema that is not the connection's own keeps its
+			// tables, and the two come back in byte order.
+			name: "realm scope keeps every schema",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{
+					{Name: "public", Comment: "standard public schema"},
+					{Name: "extra"},
+				},
+				Tables: []types.DBTable{
+					{
+						Name:    "a",
+						Columns: []types.DBColumn{{Name: "id", DataType: "integer", IsNullable: "YES"}},
+					},
+					{
+						Name:    "b",
+						Schema:  "extra",
+						Columns: []types.DBColumn{{Name: "id", DataType: "integer", IsNullable: "YES"}},
+					},
+				},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want: `{"schemas":[{"name":"extra","tables":[{"name":"b","columns":[{"name":"id","type":"integer","null":true}]}]},{"name":"public","tables":[{"name":"a","columns":[{"name":"id","type":"integer","null":true}]}],"comment":"standard public schema"}]}`,
+		},
+		{
+			// A table comment sits after the columns for the same reason a
+			// schema comment sits after the tables.
+			name: "table attributes follow the columns",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{{Name: "app", Comment: "app schema comment"}},
+				Tables: []types.DBTable{
+					{
+						Name:    "t",
+						Schema:  "app",
+						Comment: "table comment",
+						Columns: []types.DBColumn{{Name: "id", DataType: "integer", IsNullable: "YES"}},
+					},
+				},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "app"},
+			want: `{"schemas":[{"name":"app","tables":[{"name":"t","columns":[{"name":"id","type":"integer","null":true}],"comment":"table comment"}],"comment":"app schema comment"}]}`,
+		},
+		{
+			// MySQL-family schemas carry a character set and a collation
+			// instead of a comment, in the same position.
+			name: "empty mysql database reports charset and collation",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{
+					{Name: "shop", Charset: "utf8mb4", Collate: "utf8mb4_0900_ai_ci"},
+				},
+			},
+			info: types.DBInfo{Dialect: "mysql", Schema: "shop"},
+			want: `{"schemas":[{"name":"shop","charset":"utf8mb4","collate":"utf8mb4_0900_ai_ci"}]}`,
+		},
+		{
+			// The control for every row above: a selection that matched nothing
+			// is an empty document on both implementations, measured with
+			// `--schema nope`. Reporting a schema here would describe one the
+			// operator was told does not exist.
+			name:   "a selection that matched nothing stays empty",
+			schema: &types.DBSchema{},
+			info:   types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want:   `{}`,
+		},
+		{
+			// A reader that describes no schemas keeps rendering its tables, so
+			// the schema list can never cost a table.
+			name: "tables without a described schema keep their schema",
+			schema: &types.DBSchema{
+				Tables: []types.DBTable{
+					{
+						Name:    "users",
+						Columns: []types.DBColumn{{Name: "id", DataType: "integer", IsNullable: "NO"}},
+					},
+				},
+			},
+			info: types.DBInfo{Dialect: "sqlite", Schema: "main"},
+			want: `{"schemas":[{"name":"main","tables":[{"name":"users","columns":[{"name":"id","type":"integer"}]}]}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			report := atlasreport.NewSchemaInspectReport(
+				&goschema.Database{},
+				test.schema,
+				test.info,
+				nil,
+				false,
+			)
+
+			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Equals, test.want)
+		})
+	}
+}

--- a/internal/atlasreport/schema_inspect_realm_test.go
+++ b/internal/atlasreport/schema_inspect_realm_test.go
@@ -150,6 +150,7 @@ func TestRenderSchemaInspect_JSONRealmDocument(t *testing.T) {
 				test.info,
 				nil,
 				false,
+				true,
 			)
 
 			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)

--- a/internal/atlasreport/schema_inspect_split_coverage_test.go
+++ b/internal/atlasreport/schema_inspect_split_coverage_test.go
@@ -212,6 +212,11 @@ func coverageSplitReport() *atlasreport.SchemaInspectReport {
 		types.DBInfo{Dialect: platform.Postgres, Schema: "public"},
 		nil,
 		true,
+		// The run did not choose its own scope, so the SQL format would leave the
+		// schema row out. These cases render HCL and split it, which carries the
+		// schema block either way; the value is the connected-schema one the
+		// fixture represents.
+		false,
 	)
 }
 

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -398,6 +398,11 @@ func TestRenderSchemaInspect_JSONColumnTypeMatchesThePinnedBinary(t *testing.T) 
 				types.DBInfo{Dialect: "postgres", Schema: "public"},
 				nil,
 				false,
+				// The run did not choose its own scope, so the SQL format would
+				// leave the schema row out. This case renders JSON, which
+				// describes it either way; the value is the connected-schema one
+				// the fixture represents.
+				false,
 			)
 
 			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -433,5 +433,6 @@ func sampleSchemaInspectReport() *atlasreport.SchemaInspectReport {
 		types.DBInfo{Dialect: "sqlite", Schema: "main"},
 		nil,
 		false,
+		true,
 	)
 }

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -138,6 +138,11 @@ type applyComputation struct {
 	statements []string
 	current    *types.DBSchema
 	desired    *goschema.Database
+	// readScope is the schema allow-list current was read at, nil when the read
+	// was the connection's own default. A saved plan records no schema scope, so
+	// [VerifyPlanTarget] re-reads at that default; a caller fingerprinting
+	// current has to know whether the two would be the same read.
+	readScope []string
 }
 
 func computeApplyPlan(
@@ -162,7 +167,8 @@ func computeApplyPlan(
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("load --to schema: %w", err)
 	}
-	current, err := dbschema.ReadSchemaWithSchemas(conn, applyReadScope(opts.Schemas, conn.Info().Schema, desired))
+	readScope := applyReadScope(opts.Schemas, conn.Info().Schema, desired)
+	current, err := dbschema.ReadSchemaWithSchemas(conn, readScope)
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("read database schema: %w", err)
 	}
@@ -198,7 +204,7 @@ func computeApplyPlan(
 			currentErr)
 	}
 
-	computation := applyComputation{current: current, desired: desired}
+	computation := applyComputation{current: current, desired: desired, readScope: readScope}
 	info := conn.Info()
 	diff, err := schemadiff.CompareWithDatabase(ctx, conn, desired, current, nil)
 	if err != nil {

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -158,17 +158,17 @@ func computeApplyPlan(
 		Exclude:       opts.Exclude,
 		DefaultSchema: conn.Info().Schema,
 	}
-	current, err := dbschema.ReadSchemaWithSchemas(conn, SplitSchemaNames(opts.Schemas))
+	desired, err := loadDesiredApplySchema(ctx, conn, opts)
+	if err != nil {
+		return applyComputation{}, fmt.Errorf("load --to schema: %w", err)
+	}
+	current, err := dbschema.ReadSchemaWithSchemas(conn, applyReadScope(opts.Schemas, conn.Info().Schema, desired))
 	if err != nil {
 		return applyComputation{}, fmt.Errorf("read database schema: %w", err)
 	}
 	current, currentReport, currentErr := scopeDatabaseSide(current, scope, "current schema")
 	if currentErr != nil && !emptySelection(currentErr) {
 		return applyComputation{}, currentErr
-	}
-	desired, err := loadDesiredApplySchema(ctx, conn, opts)
-	if err != nil {
-		return applyComputation{}, fmt.Errorf("load --to schema: %w", err)
 	}
 	desired, desiredReport, desiredErr := scopeGeneratedSide(desired, scope, "desired schema")
 	if desiredErr != nil && !emptySelection(desiredErr) {
@@ -218,6 +218,84 @@ func computeApplyPlan(
 		return applyComputation{}, fmt.Errorf("generate schema apply SQL: %w", err)
 	}
 	return computation, nil
+}
+
+// applyReadScope resolves the schemas the DATABASE side of an apply is read at.
+//
+// The two sides of a comparison have to be read at the same scope or silence on
+// one of them is mistaken for absence. `schema inspect` on a URL that pins no
+// schema now describes every schema of the realm (stokaro/ptah#1264); applying
+// that description back to the database it came from used to read only the
+// connection's own schema, find no `extra` there, and plan `CREATE SCHEMA
+// extra` and `CREATE TABLE "extra"."b"` for a schema and a table the database
+// already has. Measured on PostgreSQL 17.10: the plan never converged, and
+// executing it failed at SQLSTATE 42P07.
+//
+// The scope is taken from the DESIRED state rather than from the URL, and that
+// choice is the safety property. A URL-derived realm scope would widen the read
+// for every document, including one that describes a single schema of a
+// multi-schema database -- and a schema the database has that the document does
+// not describe is planned for removal. Measured on the same database, a
+// document declaring only `public` read at two-schema scope plans `DROP TABLE
+// IF EXISTS "extra"."b" CASCADE`. Reading exactly the schemas the document
+// names cannot reach an object no document mentions.
+//
+// An explicit `--schema` outranks both: it is the operator naming the scope.
+//
+// nil is returned when the desired state names nothing beyond the schema the
+// connection is already on, so the common case reads exactly what it read
+// before.
+func applyReadScope(requested []string, connectedSchema string, desired *goschema.Database) []string {
+	if names := SplitSchemaNames(requested); len(names) > 0 {
+		return names
+	}
+	connected := strings.TrimSpace(connectedSchema)
+	named := desiredSchemaNames(desired)
+	beyond := slices.DeleteFunc(named, func(name string) bool { return name == connected })
+	if len(beyond) == 0 {
+		return nil
+	}
+	if connected != "" {
+		beyond = append(beyond, connected)
+	}
+	slices.Sort(beyond)
+	return slices.Compact(beyond)
+}
+
+// desiredSchemaNames is every schema a desired state names, over the
+// declarations that carry one. A document may name a schema by declaring a
+// block for it or by qualifying an object with it, and both have to count: an
+// inspected document does the first, a hand-written one often only the second.
+func desiredSchemaNames(desired *goschema.Database) []string {
+	if desired == nil {
+		return nil
+	}
+	var names []string
+	add := func(name string) {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			names = append(names, trimmed)
+		}
+	}
+	for _, schema := range desired.Schemas {
+		add(schema.Name)
+	}
+	for _, table := range desired.Tables {
+		add(table.Schema)
+	}
+	for _, sequence := range desired.Sequences {
+		add(sequence.Schema)
+	}
+	for _, domain := range desired.Domains {
+		add(domain.Schema)
+	}
+	for _, composite := range desired.CompositeTypes {
+		add(composite.Schema)
+	}
+	for _, rangeType := range desired.Ranges {
+		add(rangeType.Schema)
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
 }
 
 // loadDesiredApplySchema materializes the desired schema for apply planning.

--- a/internal/atlasschema/applyscope_internal_test.go
+++ b/internal/atlasschema/applyscope_internal_test.go
@@ -1,0 +1,121 @@
+package atlasschema
+
+// White-box testing required: applyReadScope is the step that decides which
+// schemas the DATABASE side of a `schema apply` is read at, and it runs between
+// two package-private stages -- loading the desired state and reading the
+// catalog -- that no exported entry point exposes separately. Driving the
+// decision through PrepareApply would need a live multi-schema server for every
+// row, and the property under test is which names go to the reader, not what
+// the reader answers. The end-to-end property -- inspecting a two-schema
+// database and applying its own description back plans nothing -- is covered
+// live by TestPostgreSQLSchemaBoundaryGuardIntegration's `two_schemas_plain_url`
+// fixture.
+//
+// The nil rows are the load-bearing ones: nil means the reader keeps the scope
+// it had before stokaro/ptah#1264, so a document that names nothing beyond the
+// connected schema reads exactly what it read before. A row returning
+// []string{"public"} instead would be indistinguishable in the plan and would
+// still have widened what every apply asks the catalog for.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+func TestApplyReadScope(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		requested []string
+		connected string
+		desired   *goschema.Database
+		want      []string
+	}{
+		{
+			name:      "explicit schemas outrank the document",
+			requested: []string{"only_this"},
+			connected: "public",
+			desired: &goschema.Database{
+				Schemas: []goschema.Schema{{Name: "public"}, {Name: "extra"}},
+			},
+			want: []string{"only_this"},
+		},
+		{
+			name:      "a comma-separated selection is split like the flag",
+			requested: []string{"one,two"},
+			connected: "public",
+			desired:   &goschema.Database{},
+			want:      []string{"one", "two"},
+		},
+		{
+			name:      "a document naming only the connected schema keeps the default read",
+			connected: "public",
+			desired: &goschema.Database{
+				Schemas: []goschema.Schema{{Name: "public"}},
+				Tables:  []goschema.Table{{Name: "a", Schema: "public"}},
+			},
+			want: nil,
+		},
+		{
+			name:      "a document qualifying nothing keeps the default read",
+			connected: "public",
+			desired: &goschema.Database{
+				Tables: []goschema.Table{{Name: "a"}},
+			},
+			want: nil,
+		},
+		{
+			name:      "a schema block beyond the connected one widens the read",
+			connected: "public",
+			desired: &goschema.Database{
+				Schemas: []goschema.Schema{{Name: "extra"}, {Name: "public"}},
+				Tables:  []goschema.Table{{Name: "a", Schema: "public"}, {Name: "b", Schema: "extra"}},
+			},
+			want: []string{"extra", "public"},
+		},
+		{
+			name:      "a qualified table alone widens the read",
+			connected: "public",
+			desired: &goschema.Database{
+				Tables: []goschema.Table{{Name: "b", Schema: "extra"}},
+			},
+			want: []string{"extra", "public"},
+		},
+		{
+			name:      "declarations other than tables name schemas too",
+			connected: "public",
+			desired: &goschema.Database{
+				Sequences:      []goschema.Sequence{{Name: "s", Schema: "seqs"}},
+				Domains:        []goschema.Domain{{Name: "d", Schema: "doms"}},
+				CompositeTypes: []goschema.CompositeType{{Name: "c", Schema: "comps"}},
+				Ranges:         []goschema.Range{{Name: "r", Schema: "rngs"}},
+			},
+			want: []string{"comps", "doms", "public", "rngs", "seqs"},
+		},
+		{
+			name:      "blank names are not schemas",
+			connected: "public",
+			desired: &goschema.Database{
+				Schemas: []goschema.Schema{{Name: "  "}},
+				Tables:  []goschema.Table{{Name: "a", Schema: ""}},
+			},
+			want: nil,
+		},
+		{
+			name:      "no desired state reads what it read before",
+			connected: "public",
+			desired:   nil,
+			want:      nil,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(applyReadScope(tt.requested, tt.connected, tt.desired), qt.DeepEquals, tt.want)
+		})
+	}
+}

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -1,6 +1,7 @@
 package atlasschema
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -56,7 +57,7 @@ func NormalizeInspectFormat(format string) (string, error) {
 // Inspect reads a live schema and renders it with Atlas-compatible
 // formatting, applying any split/write file exports the format template
 // planned.
-func Inspect(conn *dbschema.DatabaseConnection, opts InspectOptions) (string, error) {
+func Inspect(ctx context.Context, conn *dbschema.DatabaseConnection, opts InspectOptions) (string, error) {
 	if _, err := NormalizeInspectFormat(opts.Format); err != nil {
 		return "", err
 	}
@@ -67,7 +68,7 @@ func Inspect(conn *dbschema.DatabaseConnection, opts InspectOptions) (string, er
 		return "", err
 	}
 
-	schema, err := dbschema.ReadSchemaWithSchemas(conn, SplitSchemaNames(opts.Schemas))
+	schema, err := readInspectSchema(ctx, conn, opts.Schemas)
 	if err != nil {
 		return "", fmt.Errorf("read database schema: %w", err)
 	}

--- a/internal/atlasschema/inspect.go
+++ b/internal/atlasschema/inspect.go
@@ -15,6 +15,7 @@ import (
 	"go.5x5.cz/ptah/internal/fileplan"
 	"go.5x5.cz/ptah/internal/rolescope"
 	"go.5x5.cz/ptah/internal/schemascope"
+	"go.5x5.cz/ptah/internal/schemaselection"
 )
 
 // InspectOptions configures Atlas-compatible schema inspection.
@@ -116,6 +117,7 @@ func renderInspectSchema(
 		info,
 		opts.Diagnostics,
 		opts.OmitAtlasRefusedBlocks,
+		describesSchemas(info, opts),
 	))
 	if err != nil {
 		return "", err
@@ -161,4 +163,20 @@ func applyInspectFileExports(files []atlasreport.SchemaInspectFile) error {
 // SplitSchemaNames expands repeated and comma-separated Atlas schema filters.
 func SplitSchemaNames(values []string) []string {
 	return schemascope.SplitNames(values)
+}
+
+// describesSchemas reports whether this run chose the schemas it describes,
+// rather than having the connection URL choose for it.
+//
+// It is the same branch inspectSchemaNames takes -- an explicit `--schema`
+// wins, otherwise realm scope decides -- asked a second time because the answer
+// is what the SQL format needs: the pinned community binary v1.3.0 renders a
+// schema it was told about and stays quiet about the one it merely connected
+// to. The measurements are on
+// [go.5x5.cz/ptah/internal/atlasreport.SchemaInspectReport].
+func describesSchemas(info dbschematypes.DBInfo, opts InspectOptions) bool {
+	if len(SplitSchemaNames(opts.Schemas)) > 0 {
+		return true
+	}
+	return schemaselection.Realm(info.Dialect, info.URL, info.Schema)
 }

--- a/internal/atlasschema/inspect_live_test.go
+++ b/internal/atlasschema/inspect_live_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -124,6 +125,94 @@ func TestInspectLive_ScopeSelectsSchemas(t *testing.T) {
 
 			c.Assert(err, qt.IsNil)
 			c.Assert(rendered, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestInspectLive_SQLSchemaStatements pins which runs put schema DDL in the SQL
+// rendering.
+//
+// The other two formats describe the schema in every scope, and that is
+// deliberate: stokaro/ptah#1264 is about a document that claimed a database had
+// no schema at all. The SQL format does not follow, and the split is the pinned
+// community binary v1.3.0's own. Counting `CREATE SCHEMA` in
+// `--format '{{ sql . }}'` on a PostgreSQL 17.10 database holding `public` and
+// `extra`, 2026-08-07:
+//
+//	plain URL                        2
+//	?search_path=public              0
+//	--schema public                  1
+//	--schema public --schema extra   2
+//	MySQL 9.7, connected database    0
+//
+// So the rule is not "realm scope only" — a named schema is rendered. What that
+// binary leaves out is the schema it was merely connected to.
+//
+// The `search_path` row is the one that can go red. Making the reader describe
+// the connected schema, which is what #1264 required, put a
+// `CREATE SCHEMA IF NOT EXISTS "public";` and its `COMMENT ON SCHEMA` in front
+// of every scoped PostgreSQL script and every MySQL script, where that binary
+// emits neither (stokaro/ptah#1275 review).
+//
+// The MySQL cell has no row here because this package's live PostgreSQL helper
+// cannot reach a MySQL server; it travels through the same
+// `describesSchemas` branch, which answers from the connected schema on that
+// dialect.
+func TestInspectLive_SQLSchemaStatements(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		query   string
+		schemas []string
+		want    int
+		wantSQL []string
+		notWant []string
+	}{
+		{
+			name:    "plain URL renders every schema it describes",
+			want:    2,
+			wantSQL: []string{`CREATE SCHEMA IF NOT EXISTS "extra";`},
+		},
+		{
+			name:    "search_path renders no schema statement",
+			query:   "search_path=public",
+			want:    0,
+			notWant: []string{"CREATE SCHEMA", "COMMENT ON SCHEMA"},
+		},
+		{
+			name:    "an explicit schema is rendered",
+			schemas: []string{"public"},
+			want:    1,
+		},
+		{
+			name:    "two explicit schemas are both rendered",
+			schemas: []string{"public", "extra"},
+			want:    2,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newInspectLiveConnection(c, ctx, test.query, inspectLiveMultiSchema)
+
+			rendered, err := atlasschema.Inspect(ctx, conn, atlasschema.InspectOptions{
+				Format:  "sql",
+				Schemas: test.schemas,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(strings.Count(rendered, "CREATE SCHEMA"), qt.Equals, test.want)
+			// The tables are asserted in every row so that a rendering which
+			// lost its whole body cannot pass by having zero schema statements.
+			c.Assert(rendered, qt.Contains, `CREATE TABLE`)
+			for _, want := range test.wantSQL {
+				c.Assert(rendered, qt.Contains, want)
+			}
+			for _, notWant := range test.notWant {
+				c.Assert(rendered, qt.Not(qt.Contains), notWant)
+			}
 		})
 	}
 }

--- a/internal/atlasschema/inspect_live_test.go
+++ b/internal/atlasschema/inspect_live_test.go
@@ -1,0 +1,282 @@
+//go:build integration
+
+package atlasschema_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"net/url"
+	"os"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	"github.com/jackc/pgx/v5"
+	_ "github.com/jackc/pgx/v5/stdlib"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+)
+
+// These cases pin the half of `schema inspect` a single-namespace fixture
+// cannot express: which schemas the connection's scope puts in the document.
+//
+// The two scopes are reached by two URL spellings and both are exercised on
+// the SAME database below, because a suite that always pins `search_path`
+// cannot fail on realm scope — which is exactly how stokaro/ptah#1257 stayed
+// invisible, and how the realm half of stokaro/ptah#1264 reached master.
+//
+// Every want string was produced by the pinned Atlas community binary v1.3.0
+// against PostgreSQL 17 on 2026-08-07, through `--format '{{ json . }}'`, and
+// is reproduced byte for byte. The database each row was measured on is named
+// on the row.
+
+// inspectLiveMultiSchema is the state that separates the two scopes: one table
+// in the connection's own schema and one in a schema the URL never names.
+var inspectLiveMultiSchema = []string{
+	"CREATE SCHEMA extra",
+	"CREATE TABLE public.a (id integer)",
+	"CREATE TABLE extra.b (id integer)",
+}
+
+func TestInspectLive_ScopeSelectsSchemas(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		query   string
+		setup   []string
+		schemas []string
+		want    string
+	}{
+		{
+			// The issue's headline row. `extra` and its table were absent
+			// entirely: the tool described less of the database than it found
+			// and said nothing about it.
+			name:  "plain URL describes every schema",
+			setup: inspectLiveMultiSchema,
+			want: `{"schemas":[{"name":"extra","tables":[{"name":"b","columns":[{"name":"id","type":"integer",` +
+				`"null":true}]}]},{"name":"public","tables":[{"name":"a","columns":[{"name":"id","type":"integer",` +
+				`"null":true}]}],"comment":"standard public schema"}]}`,
+		},
+		{
+			// The control for the row above, on the same state. A URL that
+			// pins a schema keeps describing exactly that schema, so the realm
+			// fix cannot be a fix that stopped filtering.
+			name:  "search_path keeps the document at one schema",
+			query: "search_path=public",
+			setup: inspectLiveMultiSchema,
+			want: `{"schemas":[{"name":"public","tables":[{"name":"a","columns":[{"name":"id","type":"integer",` +
+				`"null":true}]}],"comment":"standard public schema"}]}`,
+		},
+		{
+			// An empty database reports the schema it has, at both scopes. It
+			// used to report `{}`, so anything walking `.schemas` broke on a
+			// database that was merely empty.
+			name: "empty database reports its schema at realm scope",
+			want: `{"schemas":[{"name":"public","comment":"standard public schema"}]}`,
+		},
+		{
+			name:  "empty database reports its schema at schema scope",
+			query: "search_path=public",
+			want:  `{"schemas":[{"name":"public","comment":"standard public schema"}]}`,
+		},
+		{
+			// --schema outranks the URL's realm scope.
+			name:    "an explicit schema narrows realm scope",
+			setup:   inspectLiveMultiSchema,
+			schemas: []string{"extra"},
+			want: `{"schemas":[{"name":"extra","tables":[{"name":"b","columns":[{"name":"id","type":"integer",` +
+				`"null":true}]}]}]}`,
+		},
+		{
+			// The control that stops "an empty database reports its schema"
+			// from becoming "every database reports a schema": a selection that
+			// matched nothing is an empty document on both implementations.
+			name:    "a schema that does not exist stays an empty document",
+			setup:   inspectLiveMultiSchema,
+			schemas: []string{"nope"},
+			want:    `{}`,
+		},
+		{
+			// A schema comment is carried wherever the catalog has one, not
+			// only on `public`.
+			name: "schema comments are carried",
+			setup: []string{
+				"CREATE SCHEMA app",
+				"COMMENT ON SCHEMA app IS 'app schema comment'",
+			},
+			schemas: []string{"app"},
+			want:    `{"schemas":[{"name":"app","comment":"app schema comment"}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newInspectLiveConnection(c, ctx, test.query, test.setup)
+
+			rendered, err := atlasschema.Inspect(ctx, conn, atlasschema.InspectOptions{
+				Format:  "json",
+				Schemas: test.schemas,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(rendered, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestInspectLive_HCLRealmScope records what the HCL surface does with the same
+// two URL forms.
+//
+// It is the same scope question in the other rendering, and the fix reaches it
+// through the same reader: a plain URL now renders a `schema` block for every
+// schema, and the tables of a schema the URL never named. Only the blocks this
+// issue is about are asserted — the compatibility surface also renders roles
+// and permissions the pinned binary does not model, which is Ptah describing
+// more of the database and is not what this test is for.
+func TestInspectLive_HCLRealmScope(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name    string
+		query   string
+		want    []string
+		notWant []string
+	}{
+		{
+			name: "plain URL renders both schemas and both tables",
+			want: []string{
+				`schema "extra" {`,
+				`schema "public" {`,
+				`table "a" {`,
+				`table "b" {`,
+			},
+		},
+		{
+			name:  "search_path renders only the schema it pins",
+			query: "search_path=public",
+			want: []string{
+				`schema "public" {`,
+				`table "a" {`,
+			},
+			notWant: []string{
+				`schema "extra" {`,
+				`table "b" {`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newInspectLiveConnection(c, ctx, test.query, inspectLiveMultiSchema)
+
+			rendered, err := atlasschema.Inspect(ctx, conn, atlasschema.InspectOptions{Format: "hcl"})
+
+			c.Assert(err, qt.IsNil)
+			for _, block := range test.want {
+				c.Assert(rendered, qt.Contains, block)
+			}
+			for _, block := range test.notWant {
+				c.Assert(rendered, qt.Not(qt.Contains), block)
+			}
+		})
+	}
+}
+
+// newInspectLiveConnection provisions a throwaway database in the state the
+// case is about, so a case that creates schemas and tables cannot disturb any
+// other live test sharing the server.
+//
+// query is appended to the URL and is what selects the scope. Passing "" is the
+// plain URL the compatibility documentation uses, and it is a fixture in its
+// own right.
+//
+// setup runs through a separate connection that is closed again before the
+// connection under test is opened, which is the real order: the database is
+// already in that state when a run reaches it.
+func newInspectLiveConnection(
+	c *qt.C,
+	ctx context.Context,
+	query string,
+	setup []string,
+) *dbschema.DatabaseConnection {
+	c.Helper()
+	adminURL := requireInspectLiveURL(c)
+	admin, err := sql.Open("pgx", adminURL)
+	c.Assert(err, qt.IsNil)
+	c.Assert(admin.PingContext(ctx), qt.IsNil)
+
+	name := fmt.Sprintf("ptah_inspect_%d", time.Now().UnixNano())
+	nameIdent := pgx.Identifier{name}.Sanitize()
+	_, err = admin.ExecContext(ctx, "CREATE DATABASE "+nameIdent)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_, dropErr := admin.ExecContext(
+			context.WithoutCancel(ctx),
+			"DROP DATABASE IF EXISTS "+nameIdent+" WITH (FORCE)",
+		)
+		c.Check(dropErr, qt.IsNil)
+		c.Check(admin.Close(), qt.IsNil)
+	})
+
+	parsed, err := url.Parse(adminURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	parsed.RawPath = ""
+	applyInspectLiveFixture(c, ctx, parsed.String(), setup)
+
+	parsed.RawQuery = inspectLiveQuery(parsed.RawQuery, query)
+	conn, err := dbschema.ConnectToDatabase(ctx, parsed.String())
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+	return conn
+}
+
+// applyInspectLiveFixture puts the throwaway database into the state under test
+// through a connection of its own.
+func applyInspectLiveFixture(c *qt.C, ctx context.Context, dbURL string, statements []string) {
+	c.Helper()
+	if len(statements) == 0 {
+		return
+	}
+	seed, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Check(seed.Close(), qt.IsNil) }()
+	for _, statement := range statements {
+		_, execErr := seed.ExecContext(ctx, statement)
+		c.Assert(execErr, qt.IsNil, qt.Commentf("statement: %s", statement))
+	}
+}
+
+// inspectLiveQuery joins the admin URL's own parameters, such as sslmode, with
+// the fixture's.
+func inspectLiveQuery(base, extra string) string {
+	switch {
+	case base == "":
+		return extra
+	case extra == "":
+		return base
+	default:
+		return base + "&" + extra
+	}
+}
+
+func requireInspectLiveURL(c *qt.C) string {
+	c.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL"} {
+		raw := os.Getenv(name)
+		if raw == "" {
+			continue
+		}
+		parsed, err := url.Parse(raw)
+		c.Assert(err, qt.IsNil)
+		parsed.Scheme = "postgres"
+		return parsed.String()
+	}
+	c.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, or TEST_DATABASE_URL is not set")
+	return ""
+}

--- a/internal/atlasschema/inspect_object_schema_live_test.go
+++ b/internal/atlasschema/inspect_object_schema_live_test.go
@@ -1,0 +1,372 @@
+//go:build integration
+
+package atlasschema_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// A `schema inspect` document has to say which schema each object belongs to,
+// and applying that document has to put the object there. This exercises the
+// whole chain for one object kind at a time -- read, render, parse, plan,
+// execute -- and then asks the CATALOG rather than the document, because the
+// two disagreed exactly where this issue lives: the document named the right
+// table and the wrong enum, and only pg_type.typnamespace says so.
+//
+// Measured on PostgreSQL 17.10 before the fix, against a database holding
+// `probe.mood` and `probe.f_probe`:
+//
+//	ENUM     public|mood                      (source: probe|mood)
+//	FUNCTION public|f_probe                   (source: probe|f_probe)
+//	COLTYPE  probe.probe_enum.feeling -> public.mood
+//
+// A plain URL describes every schema it reaches (stokaro/ptah#1264), so before
+// this every one of those objects was ABSENT from the document instead of
+// wrong. Turning "not described" into "described incorrectly" is what
+// stokaro/ptah#1276 exists to prevent, which is why each row here asserts the
+// schema and not merely the presence of the object.
+//
+// Every row seeds its own database. A shared fixture would let one kind's
+// success stand in for another's, and the whole point of a row per kind is
+// that reverting one line of the fix reddens exactly the rows it broke.
+//
+// Kinds deliberately absent, and why: `role` is cluster-scoped and belongs to
+// no schema; `extension` carries a schema the goschema model does not model at
+// all, so the document claims none (see the issue's per-kind table); `grant`
+// and `policy` name their target relation, so their schema is the table row's
+// answer, and both are additionally suppressed on the Atlas-compatible surface.
+func TestInspectLive_EveryObjectKindKeepsItsSchema(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// setup seeds the source database with a control object in the
+		// connected schema and the same kind of object in a schema the URL
+		// never names.
+		setup []string
+		// omitRefused mirrors the Atlas-compatible surface, which leaves out
+		// the block types the pinned Atlas community binary v1.3.0 refuses. A
+		// row about one of those kinds turns it off, or there is no block to
+		// carry a schema.
+		omitRefused bool
+		// probe reads the catalog of the database the document was applied to.
+		probe func(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) []string
+		want  []string
+	}{
+		{
+			name: "table",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY)",
+			},
+			omitRefused: true,
+			probe:       relationProbe("r", "t_ctl", "t_probe"),
+			want:        []string{"probe.t_probe", "public.t_ctl"},
+		},
+		{
+			// The reported defect. The enum block's schema attribute is
+			// mandatory -- the pinned binary refuses a block without one -- so
+			// it was written unconditionally as the connected schema.
+			name: "enum",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TYPE public.e_ctl AS ENUM ('a', 'b')",
+				"CREATE TYPE probe.e_probe AS ENUM ('x', 'y')",
+			},
+			omitRefused: true,
+			probe:       typeProbe("e"),
+			want:        []string{"probe.e_probe", "public.e_ctl"},
+		},
+		{
+			// The damage the block header does to a column. The enum is
+			// referenced from the table as `type = enum.e_probe`, so a block
+			// naming the wrong schema retypes the column against a type in
+			// that schema, and only information_schema.columns.udt_schema
+			// reports it.
+			name: "enum column type",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TYPE public.e_ctl AS ENUM ('a', 'b')",
+				"CREATE TYPE probe.e_probe AS ENUM ('x', 'y')",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY, shade public.e_ctl)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY, feeling probe.e_probe)",
+			},
+			omitRefused: true,
+			probe:       columnTypeProbe(),
+			want: []string{
+				"probe.t_probe.feeling -> probe.e_probe",
+				"public.t_ctl.shade -> public.e_ctl",
+			},
+		},
+		{
+			// The reported defect's second half. A function block carried no
+			// schema attribute at all, because the conversion left the schema
+			// off the name the renderer reads it from.
+			name: "function",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE FUNCTION public.f_ctl(n integer) RETURNS integer LANGUAGE sql IMMUTABLE AS $$ SELECT n + 1 $$",
+				"CREATE FUNCTION probe.f_probe(n integer) RETURNS integer LANGUAGE sql IMMUTABLE AS $$ SELECT n + 2 $$",
+			},
+			omitRefused: true,
+			probe:       functionProbe("f_ctl", "f_probe"),
+			want:        []string{"probe.f_probe", "public.f_ctl"},
+		},
+		{
+			name: "domain",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE DOMAIN public.d_ctl AS integer CHECK (VALUE > 0)",
+				"CREATE DOMAIN probe.d_probe AS integer CHECK (VALUE >= 0)",
+			},
+			omitRefused: true,
+			probe:       typeProbe("d"),
+			want:        []string{"probe.d_probe", "public.d_ctl"},
+		},
+		{
+			name: "composite",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TYPE public.c_ctl AS (x integer, y integer)",
+				"CREATE TYPE probe.c_probe AS (a integer, b integer)",
+			},
+			omitRefused: true,
+			probe:       compositeProbe(),
+			want:        []string{"probe.c_probe", "public.c_ctl"},
+		},
+		{
+			name: "range",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TYPE public.r_ctl AS RANGE (subtype = float8)",
+				"CREATE TYPE probe.r_probe AS RANGE (subtype = int8)",
+			},
+			omitRefused: true,
+			probe:       typeProbe("r"),
+			want:        []string{"probe.r_probe", "public.r_ctl"},
+		},
+		{
+			name: "view",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY)",
+				"CREATE VIEW public.v_ctl AS SELECT id FROM public.t_ctl",
+				"CREATE VIEW probe.v_probe AS SELECT id FROM probe.t_probe",
+			},
+			omitRefused: true,
+			probe:       relationProbe("v", "v_ctl", "v_probe"),
+			want:        []string{"probe.v_probe", "public.v_ctl"},
+		},
+		{
+			name: "materialized view",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY)",
+				"CREATE MATERIALIZED VIEW public.m_ctl AS SELECT id FROM public.t_ctl",
+				"CREATE MATERIALIZED VIEW probe.m_probe AS SELECT id FROM probe.t_probe",
+			},
+			omitRefused: true,
+			probe:       relationProbe("m", "m_ctl", "m_probe"),
+			want:        []string{"probe.m_probe", "public.m_ctl"},
+		},
+		{
+			// A trigger carries no schema of its own: it belongs to the
+			// relation it fires on, which is what the `on` reference names.
+			name: "trigger",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY)",
+				"CREATE FUNCTION public.g_ctl() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+				"CREATE FUNCTION probe.g_probe() RETURNS trigger LANGUAGE plpgsql AS $$ BEGIN RETURN NEW; END $$",
+				"CREATE TRIGGER x_ctl BEFORE INSERT ON public.t_ctl FOR EACH ROW EXECUTE FUNCTION public.g_ctl()",
+				"CREATE TRIGGER x_probe BEFORE INSERT ON probe.t_probe FOR EACH ROW EXECUTE FUNCTION probe.g_probe()",
+			},
+			omitRefused: true,
+			probe:       triggerProbe(),
+			want:        []string{"probe.t_probe.x_probe", "public.t_ctl.x_ctl"},
+		},
+		{
+			// A sequence block is one the pinned binary refuses, so the
+			// Atlas-compatible surface leaves it out and this row has to ask
+			// for the full document Ptah models.
+			name: "sequence",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE SEQUENCE public.s_ctl",
+				"CREATE SEQUENCE probe.s_probe",
+			},
+			probe: relationProbe("S", "s_ctl", "s_probe"),
+			want:  []string{"probe.s_probe", "public.s_ctl"},
+		},
+		{
+			// An index belongs to the schema of the table it is on, and the
+			// catalog is where a mis-scoped one would show up.
+			name: "index",
+			setup: []string{
+				"CREATE SCHEMA probe",
+				"CREATE TABLE public.t_ctl (id integer PRIMARY KEY, label text)",
+				"CREATE TABLE probe.t_probe (id integer PRIMARY KEY, label text)",
+				"CREATE INDEX i_ctl ON public.t_ctl (label)",
+				"CREATE INDEX i_probe ON probe.t_probe (label)",
+			},
+			omitRefused: true,
+			probe:       relationProbe("i", "i_ctl", "i_probe"),
+			want:        []string{"probe.i_probe", "public.i_ctl"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			source := newInspectLiveConnection(c, ctx, "", test.setup)
+
+			document, err := atlasschema.Inspect(ctx, source, atlasschema.InspectOptions{
+				Format:                 "hcl",
+				OmitAtlasRefusedBlocks: test.omitRefused,
+			})
+			c.Assert(err, qt.IsNil)
+
+			path := filepath.Join(c.TempDir(), "desired.hcl")
+			c.Assert(os.WriteFile(path, []byte(document), 0o600), qt.IsNil)
+
+			// The document put back against the database it describes has to
+			// plan nothing. It is the other half of the same fact and it fails
+			// differently: an object described in the wrong schema is BOTH
+			// absent from the schema the read reports and present in one the
+			// desired state does not name, so the plan creates it and drops it
+			// in the same run. Measured before the fix, from a document of the
+			// database it was applied back to:
+			//
+			//	CREATE TYPE "public"."p_color" AS ENUM ('red', 'green');
+			//	DROP TYPE IF EXISTS "p_color" CASCADE;
+			noop, err := atlasschema.PlanApply(ctx, source, atlasschema.ApplyOptions{
+				ToURLs: []string{"file://" + path},
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(noop.Statements(), qt.HasLen, 0,
+				qt.Commentf("document:\n%s\nplan:\n%s", document, noop.SQL()))
+
+			target := newInspectLiveConnection(c, ctx, "", nil)
+			plan, err := atlasschema.PlanApply(ctx, target, atlasschema.ApplyOptions{
+				ToURLs: []string{"file://" + path},
+			})
+			c.Assert(err, qt.IsNil, qt.Commentf("document:\n%s", document))
+			c.Assert(
+				atlasschema.ApplyStatements(ctx, target, migrator.MigrationTxModeNone, plan.Statements()),
+				qt.IsNil,
+				qt.Commentf("document:\n%s\nplan:\n%s", document, plan.SQL()),
+			)
+
+			c.Assert(test.probe(c, ctx, target), qt.DeepEquals, test.want,
+				qt.Commentf("document:\n%s", document))
+		})
+	}
+}
+
+// relationProbe reads pg_class for one relkind, narrowed to the two names the
+// row created so that an unrelated relation cannot make a row pass or fail.
+func relationProbe(relkind string, names ...string) objectSchemaProbe {
+	return catalogProbe(`
+		SELECT n.nspname || '.' || c.relname
+		FROM pg_class c
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE c.relkind::text = $1 AND c.relname::text = ANY($2)
+		ORDER BY 1`, relkind, names)
+}
+
+// typeProbe reads pg_type.typnamespace, which is the fact an `enum`, `domain`
+// or `range` block's schema attribute decides.
+func typeProbe(typtype string) objectSchemaProbe {
+	return catalogProbe(`
+		SELECT n.nspname || '.' || t.typname
+		FROM pg_type t
+		JOIN pg_namespace n ON n.oid = t.typnamespace
+		WHERE t.typtype::text = $1 AND n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'
+		ORDER BY 1`, typtype)
+}
+
+// compositeProbe reads pg_type for standalone composite types only. Every
+// table, view and materialized view has a composite type of its own, so
+// typtype = 'c' alone answers a different question.
+func compositeProbe() objectSchemaProbe {
+	return catalogProbe(`
+		SELECT n.nspname || '.' || t.typname
+		FROM pg_type t
+		JOIN pg_namespace n ON n.oid = t.typnamespace
+		JOIN pg_class c ON c.oid = t.typrelid
+		WHERE t.typtype = 'c' AND c.relkind = 'c'
+		  AND n.nspname NOT LIKE 'pg\_%' AND n.nspname <> 'information_schema'
+		ORDER BY 1`)
+}
+
+// functionProbe reads pg_proc.pronamespace, narrowed to the row's own names:
+// a range type contributes constructor functions and a trigger contributes the
+// function Ptah generates for its body, and neither is what this row is about.
+func functionProbe(names ...string) objectSchemaProbe {
+	return catalogProbe(`
+		SELECT n.nspname || '.' || p.proname
+		FROM pg_proc p
+		JOIN pg_namespace n ON n.oid = p.pronamespace
+		WHERE p.proname::text = ANY($1)
+		ORDER BY 1`, names)
+}
+
+// triggerProbe reports each user trigger as schema.table.trigger, which is the
+// only spelling that separates a trigger recreated on the right relation from
+// one recreated on a same-named relation in another schema.
+func triggerProbe() objectSchemaProbe {
+	return catalogProbe(`
+		SELECT n.nspname || '.' || c.relname || '.' || t.tgname
+		FROM pg_trigger t
+		JOIN pg_class c ON c.oid = t.tgrelid
+		JOIN pg_namespace n ON n.oid = c.relnamespace
+		WHERE NOT t.tgisinternal
+		ORDER BY 1`)
+}
+
+// columnTypeProbe reads information_schema.columns.udt_schema, the catalog's
+// answer to "which schema's type is this column declared against".
+func columnTypeProbe() objectSchemaProbe {
+	return catalogProbe(`
+		SELECT table_schema || '.' || table_name || '.' || column_name
+		       || ' -> ' || udt_schema || '.' || udt_name
+		FROM information_schema.columns
+		WHERE data_type = 'USER-DEFINED'
+		  AND table_schema NOT LIKE 'pg\_%' AND table_schema <> 'information_schema'
+		ORDER BY 1`)
+}
+
+// objectSchemaProbe reads one kind's (schema, name) pairs out of a live
+// catalog.
+type objectSchemaProbe func(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) []string
+
+func catalogProbe(query string, args ...any) objectSchemaProbe {
+	return func(c *qt.C, ctx context.Context, conn *dbschema.DatabaseConnection) []string {
+		c.Helper()
+		rows, err := conn.QueryContext(ctx, query, args...)
+		c.Assert(err, qt.IsNil)
+		defer func() { c.Check(rows.Close(), qt.IsNil) }()
+
+		found := []string{}
+		for rows.Next() {
+			var value string
+			c.Assert(rows.Scan(&value), qt.IsNil)
+			found = append(found, value)
+		}
+		c.Assert(rows.Err(), qt.IsNil)
+		return found
+	}
+}

--- a/internal/atlasschema/inspect_scope.go
+++ b/internal/atlasschema/inspect_scope.go
@@ -1,0 +1,168 @@
+package atlasschema
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/schemaselection"
+)
+
+// readInspectSchema reads the schemas one inspection describes.
+//
+// It exists because "which schemas" has three answers and the reader defaults
+// to the narrowest of them. `--schema` names them outright; otherwise the URL
+// decides, and a URL that pins no schema puts the whole realm under inspection.
+// Reading only the connection's own schema there described one schema of a
+// multi-schema database and said nothing about the rest — a database holding
+// `public.a` and `extra.b` lost `extra` and its table entirely, where the
+// pinned community binary v1.3.0 lists both (stokaro/ptah#1264, measured on
+// PostgreSQL 17).
+//
+// The schema names are always passed explicitly, even when they resolve to the
+// one schema the reader would have defaulted to. That is what makes the reader
+// report the schemas themselves rather than only their tables, which is the
+// other half of the same issue: an empty database rendered as `{}` where the
+// binary renders its schema.
+func readInspectSchema(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	requested []string,
+) (*dbschematypes.DBSchema, error) {
+	names, err := inspectSchemaNames(ctx, conn, requested)
+	if err != nil {
+		return nil, err
+	}
+	schema, err := dbschema.ReadSchemaWithSchemas(conn, names)
+	if err != nil {
+		return nil, err
+	}
+	schema = withConnectedSchemaRow(schema, conn.Info(), requested)
+	if err := inspectSchemaAttributes(ctx, conn, schema); err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+// inspectSchemaNames resolves the schema names to read.
+//
+// An explicit `--schema` wins over the URL's scope: it is the operator naming
+// what they want described, and a name that turns out not to exist stays
+// absent from the result rather than being replaced by a schema they did not
+// ask for. Measured on PostgreSQL 17, `--schema nope` renders `{}` on both
+// implementations.
+func inspectSchemaNames(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	requested []string,
+) ([]string, error) {
+	if names := SplitSchemaNames(requested); len(names) > 0 {
+		return names, nil
+	}
+	info := conn.Info()
+	if !schemaselection.Realm(info.Dialect, info.URL, info.Schema) {
+		return []string{info.Schema}, nil
+	}
+	names, err := schemaselection.RealmSchemas(ctx, info.Dialect, conn)
+	if err != nil {
+		return nil, fmt.Errorf("read database schema: %w", err)
+	}
+	return names, nil
+}
+
+// withConnectedSchemaRow makes sure a run that named no schema describes the
+// one it is connected to, even on a dialect whose reader reports no schema rows
+// of its own.
+//
+// Only the PostgreSQL-family reader answers DBSchema.Schemas today, so on
+// MySQL, MariaDB, SQLite and ClickHouse an empty database still arrived here
+// with nothing in it and rendered as an empty document. The connection is the
+// proof the schema exists — it was opened against it.
+//
+// It does not fire when `--schema` named something, because there the empty
+// result is the answer: the named schema is not there.
+func withConnectedSchemaRow(
+	schema *dbschematypes.DBSchema,
+	info dbschematypes.DBInfo,
+	requested []string,
+) *dbschematypes.DBSchema {
+	if schema == nil || len(SplitSchemaNames(requested)) > 0 {
+		return schema
+	}
+	name := connectedSchemaName(info)
+	if name == "" {
+		return schema
+	}
+	if slices.ContainsFunc(schema.Schemas, func(row dbschematypes.DBSchemaInfo) bool {
+		return row.Name == name
+	}) {
+		return schema
+	}
+	schema.Schemas = append(schema.Schemas, dbschematypes.DBSchemaInfo{Name: name})
+	return schema
+}
+
+// connectedSchemaName is the schema an unqualified object of this connection
+// belongs to: `current_schema()` on PostgreSQL, the database on MySQL-family
+// and ClickHouse connections, and `main` on SQLite.
+//
+// dbschema resolves all of those into DBInfo.Schema at connect time, so this
+// only has to refuse an empty one rather than re-derive it.
+func connectedSchemaName(info dbschematypes.DBInfo) string {
+	return strings.TrimSpace(info.Schema)
+}
+
+// inspectSchemaAttributes fills in the attributes of a schema row the reader
+// did not describe, so a schema-only document is not thinner than the one the
+// pinned binary prints.
+//
+// MySQL-family schemas carry a character set and a collation, and the pinned
+// binary prints both for an empty database: measured on MySQL 9.7,
+// `{"name":"…","charset":"utf8mb4","collate":"utf8mb4_0900_ai_ci"}`. Nothing
+// else reaches this: the PostgreSQL-family reader fills its own rows including
+// the comment, and SQLite's single namespace carries no attributes on either
+// implementation.
+func inspectSchemaAttributes(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	schema *dbschematypes.DBSchema,
+) error {
+	if schema == nil {
+		return nil
+	}
+	info := conn.Info()
+	switch platform.NormalizeDialect(info.Dialect) {
+	case platform.MySQL, platform.MariaDB:
+	default:
+		return nil
+	}
+	for i := range schema.Schemas {
+		row := &schema.Schemas[i]
+		if row.Charset != "" || row.Collate != "" {
+			continue
+		}
+		var charset, collate string
+		err := conn.QueryRowContext(ctx, `
+			SELECT default_character_set_name, default_collation_name
+			FROM information_schema.schemata
+			WHERE schema_name = ?`, row.Name).Scan(&charset, &collate)
+		if errors.Is(err, sql.ErrNoRows) {
+			// A schema that is not in the catalog has no attributes to carry.
+			// Inspection is read-only, so it describes what it found rather
+			// than failing on a schema that went away between the two reads.
+			continue
+		}
+		if err != nil {
+			return fmt.Errorf("read schema %q attributes: %w", row.Name, err)
+		}
+		row.Charset = charset
+		row.Collate = collate
+	}
+	return nil
+}

--- a/internal/atlasschema/inspect_scope_test.go
+++ b/internal/atlasschema/inspect_scope_test.go
@@ -1,0 +1,77 @@
+package atlasschema_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+)
+
+// TestInspect_EmptyDatabaseReportsItsSchema pins the dialect half of
+// stokaro/ptah#1264 that no PostgreSQL fixture can reach: a reader that
+// describes no schemas of its own.
+//
+// SQLite's is one of those, so before the fix an empty SQLite database rendered
+// `{}` — the connection was open on `main` and the document said the database
+// had no schema at all. The pinned Atlas community binary v1.3.0 renders
+// `{"schemas":[{"name":"main"}]}`, measured 2026-08-07.
+//
+// The same shape holds on MySQL 9.7, where the row also carries the character
+// set and collation the binary prints; that cell has no fixture here because
+// this package's tests do not reach a live MySQL server.
+func TestInspect_EmptyDatabaseReportsItsSchema(t *testing.T) {
+	c := qt.New(t)
+	conn := connectSQLite(c, filepath.Join(t.TempDir(), "inspect-empty.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
+		Format: "json",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Equals, `{"schemas":[{"name":"main"}]}`)
+}
+
+// TestInspect_EmptyDatabaseRendersItsSchemaBlock is the same state in the HCL
+// rendering, where the binary prints `schema "main" {}`.
+//
+// It also pins that describing `main` as a schema does not put SQLite's
+// "schemas are not supported" refusal in the output: `main` is the namespace
+// the connection is already in, so there is nothing to refuse.
+func TestInspect_EmptyDatabaseRendersItsSchemaBlock(t *testing.T) {
+	c := qt.New(t)
+	conn := connectSQLite(c, filepath.Join(t.TempDir(), "inspect-empty-hcl.db"))
+	defer dbschema.CloseAndWarn(conn)
+
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
+		Format: "hcl",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, `schema "main" {`)
+	c.Assert(rendered, qt.Not(qt.Contains), "not supported")
+}
+
+// TestInspect_SQLOutputHasNoStatementForTheDefaultNamespace pins the SQL
+// rendering of the same schema row: the binary emits no statement for `main`,
+// and an empty rendering must not reach the script as a bare `;`.
+func TestInspect_SQLOutputHasNoStatementForTheDefaultNamespace(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "inspect-sql.db")
+	conn := connectSQLite(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+	createInspectSchema(c, conn)
+
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
+		Format: "sql",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(rendered, qt.Contains, `CREATE TABLE "users"`)
+	c.Assert(rendered, qt.Not(qt.Contains), "not supported")
+	c.Assert(rendered, qt.Not(qt.Matches), "(?s)^;.*")
+}

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -101,7 +101,7 @@ func InspectSource(ctx context.Context, opts InspectSourceOptions) (string, erro
 			return "", fmt.Errorf("connect to --url: %w", err)
 		}
 		defer dbschema.CloseAndWarn(conn)
-		return Inspect(conn, inspectOpts)
+		return Inspect(ctx, conn, inspectOpts)
 	}
 	return inspectOnDev(ctx, set, opts, inspectOpts)
 }
@@ -174,7 +174,7 @@ func inspectOnDev(
 			set.Sources[0].Path,
 			migrator.MigrationDirFormatAtlas,
 			func(replayConn *dbschema.DatabaseConnection) error {
-				schema, err := readInspectDevSchema(replayConn, opts.Schemas)
+				schema, err := readInspectDevSchema(ctx, replayConn, opts.Schemas)
 				if err != nil {
 					return err
 				}
@@ -198,7 +198,7 @@ func inspectOnDev(
 			desired,
 			opts.Diagnostics,
 			func(materializedConn *dbschema.DatabaseConnection) error {
-				schema, err := readInspectDevSchema(materializedConn, opts.Schemas)
+				schema, err := readInspectDevSchema(ctx, materializedConn, opts.Schemas)
 				if err != nil {
 					return err
 				}
@@ -331,11 +331,16 @@ func devMaterializableSchema(
 	return &materializable, nil
 }
 
+// readInspectDevSchema reads back a source that was materialized on the dev
+// database. It resolves scope exactly the way a database source does, so
+// `schema inspect -u file://…` describes the same set of schemas the same URL
+// would describe as a target.
 func readInspectDevSchema(
+	ctx context.Context,
 	devConn *dbschema.DatabaseConnection,
 	schemas []string,
 ) (*dbschematypes.DBSchema, error) {
-	schema, err := dbschema.ReadSchemaWithSchemas(devConn, SplitSchemaNames(schemas))
+	schema, err := readInspectSchema(ctx, devConn, schemas)
 	if err != nil {
 		return nil, fmt.Errorf("read dev database schema: %w", err)
 	}

--- a/internal/atlasschema/inspect_test.go
+++ b/internal/atlasschema/inspect_test.go
@@ -17,7 +17,7 @@ func TestInspect_HappyPathHCL(t *testing.T) {
 	defer dbschema.CloseAndWarn(conn)
 	createInspectSchema(c, conn)
 
-	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 		Format: "hcl",
 	})
 
@@ -32,7 +32,7 @@ func TestInspect_HappyPathCustomTemplate(t *testing.T) {
 	defer dbschema.CloseAndWarn(conn)
 	createInspectSchema(c, conn)
 
-	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 		Format: `{{ len .Realm.Schemas }}/{{ len (index .Schema.Schemas 0).Tables }}/{{ base64url "a+b/c=" }}/{{ printf "%.6s" (sql .) }}`,
 	})
 
@@ -46,7 +46,7 @@ func TestInspect_ExcludeFilter(t *testing.T) {
 	defer dbschema.CloseAndWarn(conn)
 	createInspectSchema(c, conn)
 
-	rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+	rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 		Format:  "hcl",
 		Exclude: []string{"posts"},
 	})
@@ -65,7 +65,7 @@ func TestInspect_IncludeSelection(t *testing.T) {
 		defer dbschema.CloseAndWarn(conn)
 		createInspectSchema(c, conn)
 
-		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 			Format:  "hcl",
 			Include: []string{"users"},
 		})
@@ -82,7 +82,7 @@ func TestInspect_IncludeSelection(t *testing.T) {
 		defer dbschema.CloseAndWarn(conn)
 		createInspectSchema(c, conn)
 
-		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 			Format:  "hcl",
 			Include: []string{"posts"},
 		})
@@ -96,13 +96,13 @@ func TestInspect_IncludeSelection(t *testing.T) {
 		defer dbschema.CloseAndWarn(conn)
 		createInspectSchema(c, conn)
 
-		withoutInclude, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		withoutInclude, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 			Format:  "hcl",
 			Exclude: []string{"posts"},
 		})
 		c.Assert(err, qt.IsNil)
 
-		withEmptyInclude, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		withEmptyInclude, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 			Format:  "hcl",
 			Exclude: []string{"posts"},
 			Include: []string{"", " "},
@@ -119,7 +119,7 @@ func TestInspect_FailurePath(t *testing.T) {
 	c := qt.New(t)
 
 	c.Run("invalid format before connection", func(c *qt.C) {
-		rendered, err := atlasschema.Inspect(nil, atlasschema.InspectOptions{
+		rendered, err := atlasschema.Inspect(context.Background(), nil, atlasschema.InspectOptions{
 			Format: "{{ if }}",
 		})
 		c.Assert(err, qt.ErrorMatches, `parse --format template: .*`)
@@ -127,7 +127,7 @@ func TestInspect_FailurePath(t *testing.T) {
 	})
 
 	c.Run("nil connection", func(c *qt.C) {
-		rendered, err := atlasschema.Inspect(nil, atlasschema.InspectOptions{})
+		rendered, err := atlasschema.Inspect(context.Background(), nil, atlasschema.InspectOptions{})
 		c.Assert(err, qt.ErrorMatches, "schema inspect requires database connection")
 		c.Assert(rendered, qt.Equals, "")
 	})
@@ -136,7 +136,7 @@ func TestInspect_FailurePath(t *testing.T) {
 		conn := connectSQLite(c, filepath.Join(c.TempDir(), "inspect-mismatch.db"))
 		defer dbschema.CloseAndWarn(conn)
 
-		rendered, err := atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		rendered, err := atlasschema.Inspect(context.Background(), conn, atlasschema.InspectOptions{
 			DevURL: "postgres://localhost/dev",
 		})
 		c.Assert(err, qt.ErrorMatches, `--dev-url dialect "postgres" does not match --url dialect "sqlite"`)

--- a/internal/atlasschema/plan.go
+++ b/internal/atlasschema/plan.go
@@ -127,7 +127,11 @@ func PreparePlanFile(
 		return PlanFile{}, err
 	}
 
-	fromFingerprint, err := SchemaFingerprint(computation.current)
+	from, err := planSourceSchema(conn, computation, opts.Exclude)
+	if err != nil {
+		return PlanFile{}, err
+	}
+	fromFingerprint, err := SchemaFingerprint(from)
 	if err != nil {
 		return PlanFile{}, fmt.Errorf("fingerprint current schema: %w", err)
 	}
@@ -152,6 +156,44 @@ func PreparePlanFile(
 		Destructive:     destructive,
 		Statements:      statements,
 	}, nil
+}
+
+// planSourceSchema is the target state a plan's from-fingerprint describes.
+//
+// It has to be the read [VerifyPlanTarget] will make when the plan is used, and
+// that read is the connection's own default: a plan file records an exclude
+// list and no schema scope, so nothing in it can tell the verifier which
+// schemas the planning run covered. Planning may nonetheless have read wider —
+// the database side is read at the scope the desired state names, so a document
+// declaring a schema beyond the connected one is compared against it — and
+// fingerprinting that wider read made a freshly saved plan report itself stale
+// against the database it had just been computed from. Measured on PostgreSQL
+// 17.10, a two-schema document against a database holding `public.a` and an
+// empty `extra`: `schema plan` then `schema apply --plan` refused with "the
+// target database schema does not match the plan's source fingerprint" with
+// nothing having changed in between.
+//
+// The extra read happens only when the two scopes differ, which is the case a
+// desired state naming another schema creates and no other. The exclusion is
+// applied here the way computeApplyPlan applied it to its own read, so the two
+// fingerprints describe the same subtraction.
+func planSourceSchema(
+	conn *dbschema.DatabaseConnection,
+	computation applyComputation,
+	exclude []string,
+) (*types.DBSchema, error) {
+	if computation.readScope == nil {
+		return computation.current, nil
+	}
+	current, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	if err != nil {
+		return nil, fmt.Errorf("read database schema: %w", err)
+	}
+	current, err = atlasfilter.ExcludeDatabaseWithDefaultSchema(current, exclude, conn.Info().Schema)
+	if err != nil {
+		return nil, fmt.Errorf("apply plan exclude patterns to current schema: %w", err)
+	}
+	return current, nil
 }
 
 // classifyPlanStatements records the safety assessment of each raw statement

--- a/internal/atlasschema/plan_scope_live_test.go
+++ b/internal/atlasschema/plan_scope_live_test.go
@@ -1,0 +1,122 @@
+//go:build integration
+
+package atlasschema_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasschema"
+)
+
+// A saved plan records an exclude list and no schema scope, so `schema apply
+// --plan` re-reads the target at the connection's own default. Planning reads
+// the database at the scope the desired state names, which for a document
+// declaring a schema beyond the connected one is wider. The two reads have to
+// produce the same from-fingerprint or a plan is stale the moment it is saved.
+//
+// Measured on PostgreSQL 17.10 with the planning read fingerprinted directly:
+//
+//	Error: pre-planned migration is stale: the target database schema does not
+//	match the plan's source fingerprint
+//
+// against the database the plan had just been computed from, with nothing
+// changed in between. Live because the property is about two reads of one
+// server agreeing, which no fake can be wrong about in the same way.
+
+// planScopeTwoSchemaDocument declares a schema the connection is not on, which
+// is what makes the planning read wider than the verification read.
+const planScopeTwoSchemaDocument = `schema "extra" {
+}
+
+schema "public" {
+  comment = "standard public schema"
+}
+
+table "a" {
+  schema = schema.public
+  column "id" {
+    null = true
+    type = integer
+  }
+}
+
+table "b" {
+  schema = schema.extra
+  column "id" {
+    null = true
+    type = integer
+  }
+}
+`
+
+func TestPlanLive_SavedPlanIsNotStaleAgainstItsOwnSource(t *testing.T) {
+	c := qt.New(t)
+	ctx := context.Background()
+
+	tests := []struct {
+		name string
+		// setup leaves the database in a state the document does not match, so
+		// the plan carries statements rather than being empty.
+		setup []string
+		// document is the desired state, written to a file the plan reads.
+		document string
+	}{
+		{
+			// The regression row: `extra` exists and is empty, so the plan
+			// creates only `extra.b` while the read that fingerprints the
+			// source covers a schema the verification read does not.
+			name:     "a document naming a schema beyond the connected one",
+			setup:    []string{"CREATE SCHEMA extra", "CREATE TABLE public.a (id integer)"},
+			document: planScopeTwoSchemaDocument,
+		},
+		{
+			// The control: a document that names only the connected schema
+			// reads at the same scope on both sides, and did before too.
+			name:  "a document naming only the connected schema",
+			setup: []string{"CREATE TABLE public.a (id integer)"},
+			document: `schema "public" {
+  comment = "standard public schema"
+}
+
+table "a" {
+  schema = schema.public
+  column "id" {
+    null = true
+    type = integer
+  }
+}
+
+table "c" {
+  schema = schema.public
+  column "id" {
+    null = true
+    type = integer
+  }
+}
+`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			conn := newInspectLiveConnection(c, ctx, "", test.setup)
+
+			path := filepath.Join(c.TempDir(), "desired.hcl")
+			c.Assert(os.WriteFile(path, []byte(test.document), 0o600), qt.IsNil)
+
+			plan, err := atlasschema.PreparePlanFile(ctx, conn, atlasschema.PlanFileOptions{
+				ToURLs: []string{"file://" + path},
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(plan.Statements, qt.Not(qt.HasLen), 0,
+				qt.Commentf("an empty plan cannot show the fingerprints disagreeing"))
+
+			c.Assert(atlasschema.VerifyPlanTarget(conn, plan), qt.IsNil)
+		})
+	}
+}

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -88,10 +88,19 @@ func newDatabase() *goschema.Database {
 	}
 }
 
+// convertEnums carries the schema the reader recorded, exactly as the domain,
+// composite and range conversions below do.
+//
+// Dropping it made every enum in the result belong to whatever schema the
+// consumer defaulted to. On a read covering more than one schema that is a
+// claim about a type the database does not hold: `extra.mood` was described as
+// `public.mood`, applying the description built the type in `public`, and the
+// column in `extra` that uses it was typed against it (stokaro/ptah#1276).
 func convertEnums(database *goschema.Database, dbEnums []dbschematypes.DBEnum) {
 	for _, dbEnum := range dbEnums {
 		database.Enums = append(database.Enums, goschema.Enum{
 			Name:   dbEnum.Name,
+			Schema: dbEnum.Schema,
 			Values: dbEnum.Values,
 		})
 	}
@@ -280,11 +289,21 @@ func convertRLSPolicies(
 	}
 }
 
+// convertFunctions carries the schema the reader recorded, in Name, which is
+// where goschema.Function keeps it -- the same place views and materialized
+// views keep theirs, and the same place the HCL parser already writes it from a
+// `function` block's `schema` attribute.
+//
+// Dropping it left the name unqualified, so the Atlas-compatible render wrote a
+// `function` block with no schema attribute at all and an apply recreated the
+// function in whatever schema the connection defaulted to. On a read covering
+// more than one schema, `extra.f_extra` came back as `public.f_extra`
+// (stokaro/ptah#1276).
 func convertFunctions(database *goschema.Database, dbFunctions []dbschematypes.DBFunction) {
 	for _, dbFunction := range dbFunctions {
 		function := goschema.Function{
 			StructName: "", // Functions are not associated with specific structs in DB schema
-			Name:       dbFunction.Name,
+			Name:       dbFunction.QualifiedName(),
 			Parameters: dbFunction.Parameters,
 			Returns:    dbFunction.Returns,
 			Language:   dbFunction.Language,

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -378,6 +378,19 @@ func handleEnumTypes(field goschema.Field, enums []goschema.Enum, targetPlatform
 	// at the same time, which is how `--dialect sqlite3` used to drop the enum
 	// entirely and render the column as the bare type name `enum_status`.
 	if emitsStandaloneEnumDefinitions(targetPlatform) {
+		// A standalone enum type is created in a schema, and a column declared
+		// against it has to name the same one. The declared type is matched by
+		// bare name -- that is what makes an annotation `type="mood"` find the
+		// enum -- so the qualifier is put back here, from the enum's own
+		// schema, rather than being expected in the field.
+		//
+		// Without it, `CREATE TYPE "extra"."mood"` was followed by
+		// `CREATE TABLE "extra"."b" ("feeling" mood)`, which resolves through
+		// search_path and fails with `type "mood" does not exist` on every
+		// schema off the path (stokaro/ptah#1276). An enum with no schema is
+		// left exactly as it was, which is every enum a Go annotation, a YAML
+		// schema, or a single-schema read can produce.
+		field.Type = enum.QualifiedName()
 		return field
 	}
 
@@ -1527,7 +1540,7 @@ func FromExtension(extension goschema.Extension) *ast.ExtensionNode {
 // Returns an *ast.EnumNode ready for SQL generation by dialect-specific visitors.
 // The visitor implementation determines how the enum is rendered for each database type.
 func FromEnum(enum goschema.Enum) *ast.EnumNode {
-	return ast.NewEnum(enum.Name, enum.Values...)
+	return ast.NewEnum(enum.QualifiedName(), enum.Values...)
 }
 
 // qualifyTypeName returns schema.name when schema is set, or name otherwise. The

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -261,32 +261,6 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 	c.Assert(*tables[0].Columns[1].CharacterMaxLength, qt.Equals, 255)
 }
 
-func TestPostgreSQLReaderReadSchemasSkipsMissingScopedSchema(t *testing.T) {
-	c := qt.New(t)
-	db := dbtest.Open(t, func(_ string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
-		return dbtest.QueryResult{
-			Columns: []string{"nspname", "schema_comment"},
-		}, nil
-	})
-	reader := NewPostgreSQLReader(db.SQL, "public")
-	reader.SetSchemas([]string{"missing"})
-
-	schemas, err := reader.readSchemas()
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(schemas, qt.HasLen, 0)
-}
-
-func TestPostgreSQLReaderReadSchemasUnscopedDoesNotQuery(t *testing.T) {
-	c := qt.New(t)
-	reader := NewPostgreSQLReader(nil, "public")
-
-	schemas, err := reader.readSchemas()
-
-	c.Assert(err, qt.IsNil)
-	c.Assert(schemas, qt.IsNil)
-}
-
 func TestPostgreSQLReader_ExtensionFunctionFiltering(t *testing.T) {
 	c := qt.New(t)
 

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -202,12 +202,23 @@ func (r *Reader) ReadSchema() (*types.DBSchema, error) {
 	return schema, nil
 }
 
+// readSchemas reports the schemas this read covered.
+//
+// It asks schemasToRead(), the same list readTables, readIndexes and every
+// other read below iterate, so the schema list and the objects underneath it
+// are one decision rather than two. It used to answer nothing at all unless an
+// allow-list had been passed, which meant an unscoped read described tables in
+// `public` while denying it had read any schema -- and whatever consumed that
+// silence had to guess. stokaro/ptah#1276.
+//
+// Which schemas an unscoped read covers is a separate question, and this
+// change does not move it: it is still the connected schema. What moves is that
+// the read says so. `schema inspect` resolves its own wider scope from the URL
+// and hands the names in explicitly (stokaro/ptah#1264).
 func (r *Reader) readSchemas() ([]types.DBSchemaInfo, error) {
-	if !r.scoped {
-		return nil, nil
-	}
-	schemas := make([]types.DBSchemaInfo, 0, len(r.schemasToRead()))
-	for _, schemaName := range r.schemasToRead() {
+	names := r.schemasToRead()
+	schemas := make([]types.DBSchemaInfo, 0, len(names))
+	for _, schemaName := range names {
 		schema, err := r.readSchemaInfo(schemaName)
 		if err != nil {
 			if errors.Is(err, sql.ErrNoRows) {

--- a/internal/dbschema/postgres/reader_schemas_internal_test.go
+++ b/internal/dbschema/postgres/reader_schemas_internal_test.go
@@ -1,0 +1,130 @@
+package postgres
+
+// White-box testing required: readSchemas is unexported, and what it reports is
+// not observable through ReadSchema without a live server -- the exported path
+// returns a whole DBSchema whose other members would have to be faked to reach
+// this one field.
+//
+// The property under test is that the schema list and the objects underneath it
+// come from ONE decision: readSchemas must report exactly schemasToRead(), the
+// list readTables and every other read below iterates. It used to report
+// nothing at all unless an allow-list had been passed, so an unscoped read
+// described tables in `public` while denying it had read any schema
+// (stokaro/ptah#1276).
+//
+// The fake server answers per bound schema name, which is what makes the count
+// assertion load-bearing: a reader that reported a name it never asked about
+// would leave the count behind, and a reader that asked and discarded the answer
+// would lose the comment. Both spellings of the defect are therefore visible
+// here, and neither is visible from the parsers alone.
+
+import (
+	"database/sql/driver"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// pgNamespaceFixture is pg_namespace as PostgreSQL 17.10 reports it for a
+// database holding one extra schema. The `public` comment is the server's own
+// default, measured on that server; carrying it is how a caller can tell a row
+// that came from the catalog from one synthesized downstream.
+func pgNamespaceFixture() map[string][][]driver.Value {
+	return map[string][][]driver.Value{
+		"public": {{"public", "standard public schema"}},
+		"extra":  {{"extra", ""}},
+	}
+}
+
+// pgNamespaceServer answers readSchemaInfo's query for the schema it was asked
+// about. A name absent from the fixture yields no rows, which is what a real
+// server does for a schema that does not exist.
+func pgNamespaceServer(catalog map[string][][]driver.Value) dbtest.QueryHandler {
+	return func(_ string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+		name, _ := args[0].Value.(string)
+		return dbtest.QueryResult{
+			Columns: []string{"nspname", "schema_comment"},
+			Rows:    catalog[name],
+		}, nil
+	}
+}
+
+func TestPostgreSQLReaderReadSchemasReportsWhatItRead(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// connected is the schema the connection itself is on, which is what an
+		// unscoped read covers.
+		connected string
+		// scope is the allow-list, nil for an unscoped read.
+		scope []string
+		want  []types.DBSchemaInfo
+		// wantQueries is how many schemas were asked about. It pins the list the
+		// reader worked from rather than the list it returned: the two were
+		// allowed to differ, and that is the defect.
+		wantQueries int
+	}{
+		{
+			// The #1276 row. Nothing was named, so the read covers the schema
+			// the connection is on -- and says so, comment included.
+			name:        "unscoped reports the connected schema",
+			connected:   "public",
+			scope:       nil,
+			want:        []types.DBSchemaInfo{{Name: "public", Comment: "standard public schema"}},
+			wantQueries: 1,
+		},
+		{
+			// The connected schema is not hardcoded: a connection on `extra`
+			// covers `extra`.
+			name:        "unscoped follows the connection",
+			connected:   "extra",
+			scope:       nil,
+			want:        []types.DBSchemaInfo{{Name: "extra"}},
+			wantQueries: 1,
+		},
+		{
+			// The control against over-correction. Widening the unscoped answer
+			// must not widen a scoped one: a read told to cover `extra` reports
+			// `extra` and not the schema it is connected to.
+			name:        "scoped reports only what was named",
+			connected:   "public",
+			scope:       []string{"extra"},
+			want:        []types.DBSchemaInfo{{Name: "extra"}},
+			wantQueries: 1,
+		},
+		{
+			name:        "scoped reports every name it was given",
+			connected:   "public",
+			scope:       []string{"extra", "public"},
+			want:        []types.DBSchemaInfo{{Name: "extra"}, {Name: "public", Comment: "standard public schema"}},
+			wantQueries: 2,
+		},
+		{
+			// A named schema that is not there is reported as absent rather
+			// than invented, and it does not fall back to the connected one.
+			name:        "scoped drops a schema the server does not have",
+			connected:   "public",
+			scope:       []string{"missing"},
+			want:        []types.DBSchemaInfo{},
+			wantQueries: 1,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db := dbtest.Open(c, pgNamespaceServer(pgNamespaceFixture()))
+			reader := NewPostgreSQLReader(db.SQL, test.connected)
+			reader.SetSchemas(test.scope)
+
+			schemas, err := reader.readSchemas()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(schemas, qt.DeepEquals, test.want)
+			c.Assert(db.QueryCount(), qt.Equals, test.wantQueries)
+		})
+	}
+}

--- a/internal/migrateclean/migrateclean.go
+++ b/internal/migrateclean/migrateclean.go
@@ -234,36 +234,13 @@ func (s Scope) ForRevisions(revisionsSchema, revisionTable string) Scope {
 // realmScoped reports whether the connection left the run at realm scope, which
 // is the question that decides which catalog Inspect reads.
 //
-// It is answered per dialect from the URL, NOT from the session, and the
-// difference is observable. Measured on PostgreSQL 17, a URL carrying
-// `options=-c search_path=extra` puts the session's `current_schema()` in
-// `extra` and the pinned binary still evaluates the whole realm: with an empty
-// `extra` present it refuses `found schema "extra"`. Only the `search_path`
-// query parameter moves it to schema scope. Reading the session back would
-// therefore get that URL wrong in the forbidden direction.
-//
-// The PostgreSQL half defers to [schemaselection], which is where
-// stokaro/ptah#1207 put the single answer to "did this URL restrict the run to
-// one schema", so the gate and `migrate lint` cannot drift apart. A
-// comma-carrying `search_path` selects nothing there, which lands here as realm
-// scope — the direction that evaluates more rather than less.
-//
-// MySQL-family connections answer from the connected schema instead of the URL
-// because dbschema resolves the database for both URL spellings, and an empty
-// answer is unreachable today: a MySQL URL with no database fails to connect
-// before any of this runs, on a NULL DATABASE() scan.
+// The decision itself lives in [schemaselection.Realm], with the measurements
+// that produced it, because this gate is no longer its only caller: the
+// Atlas-compatible `schema inspect` surface asks the same question of the same
+// URL (stokaro/ptah#1264), and two answers to it would drift apart exactly the
+// way stokaro/ptah#1207 describes.
 func realmScoped(dialect, rawURL, connectedSchema string) bool {
-	switch platform.NormalizeDialect(dialect) {
-	case platform.SQLite:
-		// SQLite has one namespace, so there is no wider scope to select.
-		return false
-	case platform.Postgres:
-		return schemaselection.FromURL(rawURL).Scope == ""
-	case platform.MySQL, platform.MariaDB:
-		return strings.TrimSpace(connectedSchema) == ""
-	default:
-		return false
-	}
+	return schemaselection.Realm(dialect, rawURL, connectedSchema)
 }
 
 // inspectRealm reads every non-system schema of the realm with the base tables
@@ -552,15 +529,16 @@ func realmProbe(dialect string) string {
 	if platform.NormalizeDialect(dialect) != platform.Postgres {
 		return ""
 	}
-	// The ESCAPE clause matters for the same reason it does in the SQLite probe
-	// above: an unescaped 'pg_%' would also hide a schema named `pgapp`.
+	// Which schemas belong to the realm is [schemaselection.PostgresNonSystemSchemas],
+	// shared so this gate and `schema inspect` cannot disagree about it. What
+	// this probe adds is the tables, which the gate needs and inspection does
+	// not.
 	return `
 		SELECT n.nspname, COALESCE(c.relname, '')
 		FROM pg_namespace n
 		LEFT JOIN pg_class c
 		  ON c.relnamespace = n.oid
 		 AND c.relkind IN ('r', 'p')
-		WHERE n.nspname <> 'information_schema'
-		  AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'
+		WHERE ` + schemaselection.PostgresNonSystemSchemas + `
 		ORDER BY n.nspname, c.relname`
 }

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -431,7 +431,7 @@ func lintDirectory(
 		FS:                analysis.SnapshotFS(),
 		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
 		ObserveVersion:    replayVersionObserver(baseline, capture),
-		ObserveReplayed:   capture.replayedObserver(),
+		ObserveReplayed:   capture.replayedObserver(ctx),
 	}); err != nil {
 		return analysis, capture.result(), fmt.Errorf("error validating migration SQL on dev database: %w", err)
 	}
@@ -471,11 +471,17 @@ func (c *schemaCapture) result() replayedSchemas {
 	return replayedSchemas{current: c.current, desired: c.desired}
 }
 
-func (c *schemaCapture) replayedObserver() func(*dbschema.DatabaseConnection) error {
+// replayedObserver closes over the run's context, because the hook the replay
+// takes carries none and the read behind it is a database round trip that has
+// to be cancelable with the rest of the run. It is the shape
+// [go.5x5.cz/ptah/internal/atlasschema] uses for the same callback.
+func (c *schemaCapture) replayedObserver(ctx context.Context) func(*dbschema.DatabaseConnection) error {
 	if c == nil {
 		return nil
 	}
-	return c.observeReplayed
+	return func(conn *dbschema.DatabaseConnection) error {
+		return c.observeReplayed(ctx, conn)
+	}
 }
 
 // replayVersionObserver combines the two per-version readers into the single

--- a/internal/migrationlintreport/schemacapture.go
+++ b/internal/migrationlintreport/schemacapture.go
@@ -67,14 +67,14 @@ func firstAnalyzedVersion(analysis lint.Analysis) (int64, bool) {
 
 // observeVersion records the state the first analyzed version starts from.
 func (c *schemaCapture) observeVersion(
-	_ context.Context,
+	ctx context.Context,
 	version int64,
 	conn *dbschema.DatabaseConnection,
 ) error {
 	if c == nil || !c.hasBase || version != c.baseVersion {
 		return nil
 	}
-	rendered, err := c.render(conn)
+	rendered, err := c.render(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -83,11 +83,14 @@ func (c *schemaCapture) observeVersion(
 }
 
 // observeReplayed records the state the directory leaves behind.
-func (c *schemaCapture) observeReplayed(conn *dbschema.DatabaseConnection) error {
+func (c *schemaCapture) observeReplayed(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) error {
 	if c == nil {
 		return nil
 	}
-	rendered, err := c.render(conn)
+	rendered, err := c.render(ctx, conn)
 	if err != nil {
 		return err
 	}
@@ -98,8 +101,11 @@ func (c *schemaCapture) observeReplayed(conn *dbschema.DatabaseConnection) error
 	return nil
 }
 
-func (c *schemaCapture) render(conn *dbschema.DatabaseConnection) (string, error) {
-	return atlasschema.Inspect(conn, atlasschema.InspectOptions{
+func (c *schemaCapture) render(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+) (string, error) {
+	return atlasschema.Inspect(ctx, conn, atlasschema.InspectOptions{
 		DevURL:  c.devURL,
 		Schemas: c.schemas,
 		Format:  "hcl",

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -248,14 +248,12 @@ func (p *Planner) usesConcurrentIndexDrop(ref types.IndexRef) bool {
 func (p *Planner) addNewEnums(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	for _, enumName := range diff.EnumsAdded {
 		for _, enum := range generated.Enums {
-			if enum.Name == enumName {
-				values := make([]string, len(enum.Values))
-				for i, v := range enum.Values {
-					values[i] = "'" + v + "'"
-				}
-
-				enumNode := ast.NewEnum(enum.Name, enum.Values...)
-				result = append(result, enumNode)
+			// The diff names enums by qualified name, so the lookup does too.
+			// Building the node through fromschema.FromEnum keeps the CREATE
+			// TYPE identifier and the column type that references it derived
+			// from one place (stokaro/ptah#1276).
+			if enum.QualifiedName() == enumName {
+				result = append(result, fromschema.FromEnum(enum))
 				break
 			}
 		}
@@ -306,7 +304,7 @@ func postgresEnumValues(generated *goschema.Database, enumName string) ([]string
 		return nil, false
 	}
 	for _, enum := range generated.Enums {
-		if enum.Name == enumName {
+		if enum.QualifiedName() == enumName {
 			return append([]string(nil), enum.Values...), true
 		}
 	}
@@ -322,9 +320,16 @@ func postgresEnumColumnUsages(generated *goschema.Database, enumName string) []p
 		tablesByStruct[table.StructName] = table
 	}
 
+	// A field names its declared type by bare name -- that is what
+	// fromschema.declaredEnum matches on -- while the diff names the enum by
+	// qualified name. Both spellings are accepted so a rebuild of an enum in a
+	// non-default schema still finds the columns it has to convert. Where two
+	// schemas hold an enum of one name the bare spelling cannot separate them;
+	// see the residual note on stokaro/ptah#1276.
+	bareName := postgresBaseName(enumName)
 	usages := make([]postgresEnumColumnUsage, 0)
 	for _, field := range generated.Fields {
-		if field.Type != enumName {
+		if field.Type != enumName && field.Type != bareName {
 			continue
 		}
 		table, ok := tablesByStruct[field.StructName]
@@ -441,8 +446,6 @@ func quotePostgresIdentifier(name string) string {
 func (p *Planner) addNewTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
 	orderedTables := deporder.TablesForCreate(generated, diff.TablesAdded)
 
-	result = p.addSchemaPreconditions(result, orderedTables)
-
 	// Phase 1: Create tables without foreign key constraints
 	result = p.createTablesWithoutForeignKeys(result, generated, orderedTables)
 
@@ -453,10 +456,54 @@ func (p *Planner) addForeignKeyConstraintsForNewTables(result []ast.Node, diff *
 	return p.addForeignKeyConstraints(result, generated, deporder.TablesForCreate(generated, diff.TablesAdded))
 }
 
-func (p *Planner) addSchemaPreconditions(result []ast.Node, tables []goschema.Table) []ast.Node {
-	seen := make(map[string]struct{})
-	for _, table := range tables {
-		schema := strings.TrimSpace(table.Schema)
+// addSchemaPreconditions creates every schema this migration is about to put an
+// object into, before it puts anything into any of them.
+//
+// It reads the diff rather than the desired state, so a run that changes nothing
+// emits nothing and an inspect/apply round trip stays the clean no-op it has to
+// be. And it reads EVERY added-object list rather than the tables alone, which
+// is the defect it replaces: the preconditions used to be derived from
+// diff.TablesAdded inside addNewTables, so they were emitted after the types,
+// sequences and functions phases and covered none of them. Measured on
+// PostgreSQL 17.10, applying a `schema inspect` document of a multi-schema
+// database to an empty one:
+//
+//	CREATE SEQUENCE "s_misc"."m_seq" ...
+//	ERROR: schema "s_misc" does not exist (SQLSTATE 3F000)
+//
+// with `CREATE SCHEMA IF NOT EXISTS s_misc` seventeen statements further down.
+// The same shape reaches CREATE DOMAIN, CREATE TYPE and CREATE FUNCTION
+// (stokaro/ptah#1276).
+//
+// The schema is taken from the qualified name each comparison already puts on
+// the diff -- tables, enums, domains, composites, ranges, sequences, functions,
+// views, materialized views and a trigger's target relation are all named that
+// way -- so a kind added later is covered by adding its list here and nothing
+// else. Names that carry no schema contribute none, which is every name on a
+// single-schema migration.
+func (p *Planner) addSchemaPreconditions(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+	names := make([]string, 0, len(diff.TablesAdded))
+	names = append(names, diff.TablesAdded...)
+	names = append(names, diff.EnumsAdded...)
+	names = append(names, diff.DomainsAdded...)
+	names = append(names, diff.CompositeTypesAdded...)
+	names = append(names, diff.RangesAdded...)
+	names = append(names, diff.SequencesAdded...)
+	names = append(names, diff.FunctionsAdded...)
+	names = append(names, diff.ViewsAdded...)
+	names = append(names, diff.MaterializedViewsAdded...)
+	for _, trigger := range diff.TriggersAdded {
+		names = append(names, trigger.TableName)
+	}
+
+	seen := make(map[string]struct{}, len(names))
+	schemas := make([]string, 0, len(names))
+	for _, name := range names {
+		ref, ok := tableref.Parse(name)
+		if !ok || !ref.Qualified {
+			continue
+		}
+		schema := strings.TrimSpace(ref.Schema)
 		if schema == "" {
 			continue
 		}
@@ -464,6 +511,10 @@ func (p *Planner) addSchemaPreconditions(result []ast.Node, tables []goschema.Ta
 			continue
 		}
 		seen[schema] = struct{}{}
+		schemas = append(schemas, schema)
+	}
+	slices.Sort(schemas)
+	for _, schema := range schemas {
 		result = append(result, ast.NewRawSQL("CREATE SCHEMA IF NOT EXISTS "+schema))
 	}
 	return result
@@ -1400,7 +1451,12 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 		result = appendSkipComments(result, skipped)
 	}
 
-	// 0. Add new extensions first (PostgreSQL extensions should be created before other objects)
+	// 0. Create the schemas this migration adds objects to, before anything is
+	// created in them. Every phase below can name a schema, so this cannot sit
+	// inside one of them.
+	result = p.addSchemaPreconditions(result, diff)
+
+	// 0b. Add new extensions (PostgreSQL extensions should be created before other objects)
 	result = p.addNewExtensions(result, diff, generated)
 
 	// 1. Add new roles (roles may be referenced by RLS policies and functions)

--- a/internal/schemaselection/schemaselection.go
+++ b/internal/schemaselection/schemaselection.go
@@ -23,6 +23,7 @@ import (
 	"database/sql"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 
 	"go.5x5.cz/ptah/core/platform"
@@ -32,6 +33,20 @@ import (
 // searchPathParam is the PostgreSQL-family query parameter that restricts a
 // database URL to a single schema.
 const searchPathParam = "search_path"
+
+// PostgresNonSystemSchemas is the WHERE predicate that keeps the schemas a
+// realm describes and drops the server's own, over a `pg_namespace n`.
+//
+// The ESCAPE clause matters: in LIKE, `_` matches any single character, so an
+// unescaped 'pg\_%' would also hide a user schema named `pgapp` and describe
+// less of the database than is there.
+//
+// It is one string rather than two because two callers ask about the same set
+// — this package's [RealmSchemas] and the not-clean gate's realm probe in
+// go.5x5.cz/ptah/internal/migrateclean, which needs each schema's tables as
+// well. Those two questions differ; "which schemas is the realm" does not.
+const PostgresNonSystemSchemas = `n.nspname <> 'information_schema'
+			  AND n.nspname NOT LIKE 'pg\_%' ESCAPE '\'`
 
 // RowQuerier is the part of *sql.DB and *sql.Tx [Selection.Resolve] needs.
 // Taking the narrow interface keeps this package off the connection layer,
@@ -110,6 +125,95 @@ func fromQuery(query url.Values) Selection {
 	}
 	selection.Scope = raw
 	return selection
+}
+
+// Realm reports whether a connection left the run at realm scope — describing
+// every schema of the connected database rather than one.
+//
+// It is answered per dialect from the URL, NOT from the session, and the
+// difference is observable. Measured on PostgreSQL 17, a URL carrying
+// `options=-c search_path=extra` puts the session's `current_schema()` in
+// `extra` and the pinned community binary v1.3.0 still evaluates the whole
+// realm: with an empty `extra` present the not-clean gate refuses `found schema
+// "extra"`. Only the `search_path` query parameter moves it to schema scope.
+// Reading the session back would therefore get that URL wrong.
+//
+// The PostgreSQL half defers to [FromURL] above, so every caller of this
+// distinction shares one answer to "did this URL restrict the run to one
+// schema". A comma-carrying `search_path` selects nothing there, which lands
+// here as realm scope — the direction that describes more of the database
+// rather than less.
+//
+// MySQL-family connections answer from the connected schema instead of the URL
+// because dbschema resolves the database for both URL spellings, and an empty
+// answer is unreachable today: a MySQL URL with no database fails to connect
+// before any of this runs, on a NULL DATABASE() scan.
+//
+// Two callers share this: the not-clean adoption gate (stokaro/ptah#1257) and
+// the Atlas-compatible `schema inspect` surface (stokaro/ptah#1264), which had
+// collapsed the two scopes into the connection's own schema and so described
+// only one schema of a multi-schema database.
+func Realm(dialect, rawURL, connectedSchema string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.SQLite:
+		// SQLite has one namespace, so there is no wider scope to select.
+		return false
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		return FromURL(rawURL).Scope == ""
+	case platform.MySQL, platform.MariaDB:
+		return strings.TrimSpace(connectedSchema) == ""
+	default:
+		// A dialect whose realm boundary nobody has measured stays at schema
+		// scope, which is what every such connection already describes.
+		return false
+	}
+}
+
+// RowsQuerier is the part of *sql.DB and dbschema.DatabaseConnection
+// [RealmSchemas] needs.
+type RowsQuerier interface {
+	QueryContext(ctx context.Context, query string, args ...any) (*sql.Rows, error)
+}
+
+// RealmSchemas returns every schema a realm-scoped run describes, sorted in
+// byte order.
+//
+// The sort is Go's rather than the server's ORDER BY, which is
+// collation-dependent: measured on PostgreSQL 17 with schemas "Zed" and "app"
+// present, the pinned binary walks "Zed" first, which is byte order and not
+// what this database's default collation returns.
+//
+// A dialect with no probe is an error rather than an empty list. Answering
+// "no schemas" would let a caller describe an empty database where the server
+// holds one, which is the failure stokaro/ptah#1264 is about. Only PostgreSQL
+// reaches realm scope through [Realm] with a connection that can be opened at
+// all, so only it has a probe.
+func RealmSchemas(ctx context.Context, dialect string, q RowsQuerier) ([]string, error) {
+	if !platform.IsPostgresFamily(dialect) {
+		return nil, fmt.Errorf("no realm-scope schema probe for dialect %q", dialect)
+	}
+	rows, err := q.QueryContext(ctx, `
+		SELECT n.nspname
+		FROM pg_namespace n
+		WHERE `+PostgresNonSystemSchemas)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list realm schemas: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var names []string
+	for rows.Next() {
+		var name string
+		if scanErr := rows.Scan(&name); scanErr != nil {
+			return nil, fmt.Errorf("failed to list realm schemas: %w", scanErr)
+		}
+		names = append(names, name)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("failed to list realm schemas: %w", err)
+	}
+	slices.Sort(names)
+	return names, nil
 }
 
 // Resolve asks the server which schema this session actually resolved to. It is

--- a/migration/schemadiff/internal/compare/enum_schema_test.go
+++ b/migration/schemadiff/internal/compare/enum_schema_test.go
@@ -1,0 +1,125 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// An enum is a type, so its identity is (schema, name). Matching the two sides
+// is asymmetric, because a blank schema means a different thing on each: the
+// reader blanks the connection's own schema, while a generated enum that names
+// none is UNQUALIFIED -- a Go annotation cannot name a schema at all.
+//
+// Both halves reached a live database before they were pinned here
+// (stokaro/ptah#1276), and each row below names the run it came from.
+func TestEnumsWithSemantics_SchemaIdentity(t *testing.T) {
+	tests := []struct {
+		name      string
+		generated []goschema.Enum
+		database  []types.DBEnum
+		semantics identifier.Semantics
+		want      difftypes.SchemaDiff
+	}{
+		{
+			// The `schema inspect` round trip. An enum block always writes its
+			// schema, the pinned Atlas community binary v1.3.0 having no
+			// reading for a block without one, so the document says `public`
+			// where the read says nothing. Compared raw this planned a CREATE
+			// and a DROP of the same type.
+			name:      "an explicit default schema matches the reader's blank",
+			generated: []goschema.Enum{{Name: "p_color", Schema: "public", Values: []string{"red"}}},
+			database:  []types.DBEnum{{Name: "p_color", Values: []string{"red"}}},
+			semantics: identifier.Semantics{DefaultSchema: "public"},
+			want:      difftypes.SchemaDiff{},
+		},
+		{
+			// `ptah introspect --schemas <s>` writes annotations that carry no
+			// schema, and the read they are compared against names one.
+			name:      "a generated enum naming no schema matches a unique read",
+			generated: []goschema.Enum{{Name: "status_type", Values: []string{"a"}}},
+			database:  []types.DBEnum{{Name: "status_type", Schema: "brownfield", Values: []string{"a"}}},
+			semantics: identifier.Semantics{DefaultSchema: "public"},
+			want:      difftypes.SchemaDiff{},
+		},
+		{
+			// The control that keeps the row above from becoming "any name
+			// matches anything". Two schemas holding one name is exactly where
+			// a guess would attribute the type to the wrong schema.
+			name:      "an ambiguous bare name matches nothing",
+			generated: []goschema.Enum{{Name: "mood", Values: []string{"a"}}},
+			database: []types.DBEnum{
+				{Name: "mood", Schema: "one", Values: []string{"a"}},
+				{Name: "mood", Schema: "two", Values: []string{"a"}},
+			},
+			semantics: identifier.Semantics{DefaultSchema: "public"},
+			want: difftypes.SchemaDiff{
+				EnumsAdded:   []string{"mood"},
+				EnumsRemoved: []string{"one.mood", "two.mood"},
+			},
+		},
+		{
+			// Two schemas, one name, both sides qualified: the pairing is by
+			// schema and the differing values are reported against the enum
+			// that actually differs. Keyed on the bare name this reported
+			// nothing at all.
+			name: "same name in two schemas pairs by schema",
+			generated: []goschema.Enum{
+				{Name: "mood", Schema: "one", Values: []string{"a"}},
+				{Name: "mood", Schema: "two", Values: []string{"a", "b"}},
+			},
+			database: []types.DBEnum{
+				{Name: "mood", Schema: "one", Values: []string{"a"}},
+				{Name: "mood", Schema: "two", Values: []string{"a"}},
+			},
+			semantics: identifier.Semantics{DefaultSchema: "public"},
+			want: difftypes.SchemaDiff{
+				EnumsModified: []difftypes.EnumDiff{
+					{EnumName: "two.mood", ValuesAdded: []string{"b"}},
+				},
+			},
+		},
+		{
+			// A qualified generated enum naming a schema the read does not
+			// hold is added there, not silently matched against the enum of
+			// the same name somewhere else.
+			name:      "a qualified name does not fall back to another schema",
+			generated: []goschema.Enum{{Name: "mood", Schema: "wanted", Values: []string{"a"}}},
+			database:  []types.DBEnum{{Name: "mood", Schema: "other", Values: []string{"a"}}},
+			semantics: identifier.Semantics{DefaultSchema: "public"},
+			want: difftypes.SchemaDiff{
+				EnumsAdded:   []string{"wanted.mood"},
+				EnumsRemoved: []string{"other.mood"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := &difftypes.SchemaDiff{}
+			compare.EnumsWithSemantics(
+				&goschema.Database{Enums: test.generated},
+				&types.DBSchema{Enums: test.database},
+				diff,
+				test.semantics,
+			)
+
+			c.Assert(diff.EnumsAdded, qt.DeepEquals, test.want.EnumsAdded)
+			c.Assert(diff.EnumsRemoved, qt.DeepEquals, test.want.EnumsRemoved)
+			c.Assert(diff.EnumsModified, qt.HasLen, len(test.want.EnumsModified))
+			for i, wantDiff := range test.want.EnumsModified {
+				c.Assert(diff.EnumsModified[i].EnumName, qt.Equals, wantDiff.EnumName)
+				c.Assert(diff.EnumsModified[i].ValuesAdded, qt.DeepEquals, wantDiff.ValuesAdded)
+				c.Assert(diff.EnumsModified[i].ValuesRemoved, qt.DeepEquals, wantDiff.ValuesRemoved)
+			}
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/enums.go
+++ b/migration/schemadiff/internal/compare/enums.go
@@ -2,9 +2,12 @@ package compare
 
 import (
 	"sort"
+	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/tableref"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
 
@@ -80,34 +83,73 @@ import (
 // # Output Consistency
 //
 // Results are sorted alphabetically for consistent output across multiple runs.
+// Enums compares enum types under the connection's default schema.
+//
+// It delegates to [EnumsWithSemantics] with zero semantics, which is the
+// no-default-schema rule: a blank schema stays blank and only matches a blank
+// one. Callers that have a live connection have a default schema and should
+// pass it.
 func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	EnumsWithSemantics(generated, database, diff, identifier.Semantics{})
+}
+
+// EnumsWithSemantics compares enum types by (schema, name) identity.
+//
+// An enum is a TYPE, and a type's identity is its schema and its name together:
+// public.mood and extra.mood hold different values, so keying on the bare name
+// made a read covering two schemas collapse them into one and report a changed
+// enum as converged. Every name this puts on the diff is qualified wherever the
+// enum names a schema, which is what lets the planner emit
+// `CREATE TYPE "extra"."mood"` instead of creating it wherever the connection
+// happens to point (stokaro/ptah#1276).
+//
+// The identity is canonicalized against semantics.DefaultSchema, exactly as a
+// table's is, and that is not decoration. The two sides spell the default schema
+// DIFFERENTLY BY CONSTRUCTION: a reader blanks it, while an `enum` block always
+// writes `schema = schema.<name>` because the pinned Atlas community binary
+// v1.3.0 refuses a block without one. Compared raw, `public.p_color` from the
+// document and `p_color` from the read are two enums, and a `schema inspect`
+// document applied back to its own database planned
+//
+//	CREATE TYPE "public"."p_color" AS ENUM ('red', 'green');
+//	DROP TYPE IF EXISTS "p_color" CASCADE;
+//
+// -- measured on PostgreSQL 17.10. Domains, composites and ranges avoid this
+// only because their blocks omit the attribute for the default schema, so an
+// enum could not borrow their rule and needed the table's.
+func EnumsWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	semantics identifier.Semantics,
+) {
 	// Create maps for quick lookup
-	genEnums := make(map[string]goschema.Enum)
+	genEnums := make(map[tableIdentity]goschema.Enum)
 	for _, enum := range generated.Enums {
-		genEnums[enum.Name] = enum
+		genEnums[enumIdentity(enum.Schema, enum.Name, semantics)] = enum
 	}
 
-	dbEnums := make(map[string]types.DBEnum)
+	dbEnums := make(map[tableIdentity]types.DBEnum)
 	for _, enum := range database.Enums {
-		dbEnums[enum.Name] = enum
+		dbEnums[enumIdentity(enum.Schema, enum.Name, semantics)] = enum
 	}
 
 	// Find added and removed enums
-	for enumName := range genEnums {
-		if _, exists := dbEnums[enumName]; !exists {
-			diff.EnumsAdded = append(diff.EnumsAdded, enumName)
+	for identity, enum := range genEnums {
+		if _, exists := dbEnums[identity]; !exists {
+			diff.EnumsAdded = append(diff.EnumsAdded, enum.QualifiedName())
 		}
 	}
 
-	for enumName := range dbEnums {
-		if _, exists := genEnums[enumName]; !exists {
-			diff.EnumsRemoved = append(diff.EnumsRemoved, enumName)
+	for identity, enum := range dbEnums {
+		if _, exists := genEnums[identity]; !exists {
+			diff.EnumsRemoved = append(diff.EnumsRemoved, enum.QualifiedName())
 		}
 	}
 
 	// Find modified enums
-	for enumName, genEnum := range genEnums {
-		if dbEnum, exists := dbEnums[enumName]; exists {
+	for identity, genEnum := range genEnums {
+		if dbEnum, exists := dbEnums[identity]; exists {
 			enumDiff := EnumValues(genEnum, dbEnum)
 			if len(enumDiff.ValuesAdded) > 0 || len(enumDiff.ValuesRemoved) > 0 {
 				diff.EnumsModified = append(diff.EnumsModified, enumDiff)
@@ -121,6 +163,26 @@ func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 	sort.Slice(diff.EnumsModified, func(i, j int) bool {
 		return diff.EnumsModified[i].EnumName < diff.EnumsModified[j].EnumName
 	})
+}
+
+// enumIdentity keys one enum for comparison.
+//
+// It reads a qualifier out of the NAME when the schema field is empty, because
+// not every producer fills the field: a SQL schema file loaded through
+// internal/convert/toschema names an enum `public.e1` outright. Without this,
+// that spelling and the reader's separate (public, e1) were two different
+// enums.
+//
+// tableref.Parse is what separates a qualifier from a literal dot -- an enum
+// named "tenant.data" is one quoted part and stays whole -- so this cannot turn
+// a name into a schema it never had.
+func enumIdentity(schema, name string, semantics identifier.Semantics) tableIdentity {
+	if strings.TrimSpace(schema) == "" {
+		if ref, ok := tableref.Parse(name); ok && ref.Qualified {
+			return newTableIdentity(ref.Schema, ref.Name, semantics)
+		}
+	}
+	return newTableIdentity(schema, name, semantics)
 }
 
 // EnumValues performs detailed value-level comparison between generated and database enum types.
@@ -194,7 +256,10 @@ func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 // Value lists are sorted alphabetically to ensure deterministic migration
 // generation and reliable testing across multiple runs.
 func EnumValues(genEnum goschema.Enum, dbEnum types.DBEnum) difftypes.EnumDiff {
-	enumDiff := difftypes.EnumDiff{EnumName: genEnum.Name}
+	// The qualified name, so the planner can name the type it has to alter.
+	// It is the bare name for every enum that names no schema, which is every
+	// enum a Go annotation can declare (stokaro/ptah#1276).
+	enumDiff := difftypes.EnumDiff{EnumName: genEnum.QualifiedName()}
 
 	// Create sets for comparison
 	genValues := make(map[string]bool)

--- a/migration/schemadiff/internal/compare/enums.go
+++ b/migration/schemadiff/internal/compare/enums.go
@@ -206,7 +206,7 @@ func findDatabaseEnum(
 // tableref.Parse is what separates a qualifier from a literal dot -- an enum
 // named "tenant.data" is one quoted part and stays whole -- so this cannot turn
 // a name into a schema it never had.
-func enumParts(schema, name string) (string, string) {
+func enumParts(schema, name string) (enumSchema, enumName string) {
 	if strings.TrimSpace(schema) != "" {
 		return schema, name
 	}

--- a/migration/schemadiff/internal/compare/enums.go
+++ b/migration/schemadiff/internal/compare/enums.go
@@ -103,58 +103,69 @@ func Enums(generated *goschema.Database, database *types.DBSchema, diff *difftyp
 // `CREATE TYPE "extra"."mood"` instead of creating it wherever the connection
 // happens to point (stokaro/ptah#1276).
 //
-// The identity is canonicalized against semantics.DefaultSchema, exactly as a
-// table's is, and that is not decoration. The two sides spell the default schema
-// DIFFERENTLY BY CONSTRUCTION: a reader blanks it, while an `enum` block always
-// writes `schema = schema.<name>` because the pinned Atlas community binary
-// v1.3.0 refuses a block without one. Compared raw, `public.p_color` from the
-// document and `p_color` from the read are two enums, and a `schema inspect`
-// document applied back to its own database planned
+// The matching rule is the one views and functions use, and it is deliberately
+// ASYMMETRIC, because a blank schema means a different thing on each side:
+//
+//   - On the DATABASE side, blank means the connection's own schema, which the
+//     reader blanks by convention. It is canonicalized against
+//     semantics.DefaultSchema before anything is compared.
+//   - On the GENERATED side, blank means UNQUALIFIED -- the author named no
+//     schema. A Go annotation cannot name one at all, so an introspected
+//     brownfield schema round-tripped through annotations arrives here with an
+//     enum that names none against a read that names the schema it was scoped
+//     to. Such a name matches a uniquely-named enum wherever it lives, and
+//     nothing when two schemas hold that name, because guessing there is what
+//     would attribute the type to a schema it does not belong to.
+//
+// Both halves are load-bearing and each was measured. Without the first, an
+// `enum` block's `schema = schema.public` -- which is mandatory, the pinned
+// Atlas community binary v1.3.0 having no reading for a block without one --
+// did not match the read's blank, and a `schema inspect` document applied back
+// to its own database planned
 //
 //	CREATE TYPE "public"."p_color" AS ENUM ('red', 'green');
 //	DROP TYPE IF EXISTS "p_color" CASCADE;
 //
-// -- measured on PostgreSQL 17.10. Domains, composites and ranges avoid this
-// only because their blocks omit the attribute for the default schema, so an
-// enum could not borrow their rule and needed the table's.
+// Without the second, `ptah introspect --schemas <s>` followed by a comparison
+// of the generated annotations against the same read reported
+//
+//	EnumsAdded:   {"status_type"}
+//	EnumsRemoved: {"<s>.status_type"}
+//
+// for a schema nothing had changed. Both on PostgreSQL 17.10.
 func EnumsWithSemantics(
 	generated *goschema.Database,
 	database *types.DBSchema,
 	diff *difftypes.SchemaDiff,
 	semantics identifier.Semantics,
 ) {
-	// Create maps for quick lookup
-	genEnums := make(map[tableIdentity]goschema.Enum)
-	for _, enum := range generated.Enums {
-		genEnums[enumIdentity(enum.Schema, enum.Name, semantics)] = enum
-	}
-
-	dbEnums := make(map[tableIdentity]types.DBEnum)
+	dbByIdentity := make(map[tableIdentity]types.DBEnum, len(database.Enums))
+	dbByName := make(map[string][]types.DBEnum, len(database.Enums))
 	for _, enum := range database.Enums {
-		dbEnums[enumIdentity(enum.Schema, enum.Name, semantics)] = enum
+		schema, name := enumParts(enum.Schema, enum.Name)
+		dbByIdentity[newTableIdentity(schema, name, semantics)] = enum
+		dbByName[semantics.TableIdentityKey(name)] = append(dbByName[semantics.TableIdentityKey(name)], enum)
 	}
 
-	// Find added and removed enums
-	for identity, enum := range genEnums {
-		if _, exists := dbEnums[identity]; !exists {
-			diff.EnumsAdded = append(diff.EnumsAdded, enum.QualifiedName())
+	matched := make(map[string]struct{}, len(database.Enums))
+	for _, genEnum := range generated.Enums {
+		dbEnum, exists := findDatabaseEnum(genEnum, dbByIdentity, dbByName, semantics)
+		if !exists {
+			diff.EnumsAdded = append(diff.EnumsAdded, genEnum.QualifiedName())
+			continue
+		}
+		matched[dbEnum.QualifiedName()] = struct{}{}
+		enumDiff := EnumValues(genEnum, dbEnum)
+		if len(enumDiff.ValuesAdded) > 0 || len(enumDiff.ValuesRemoved) > 0 {
+			diff.EnumsModified = append(diff.EnumsModified, enumDiff)
 		}
 	}
 
-	for identity, enum := range dbEnums {
-		if _, exists := genEnums[identity]; !exists {
-			diff.EnumsRemoved = append(diff.EnumsRemoved, enum.QualifiedName())
+	for _, enum := range database.Enums {
+		if _, ok := matched[enum.QualifiedName()]; ok {
+			continue
 		}
-	}
-
-	// Find modified enums
-	for identity, genEnum := range genEnums {
-		if dbEnum, exists := dbEnums[identity]; exists {
-			enumDiff := EnumValues(genEnum, dbEnum)
-			if len(enumDiff.ValuesAdded) > 0 || len(enumDiff.ValuesRemoved) > 0 {
-				diff.EnumsModified = append(diff.EnumsModified, enumDiff)
-			}
-		}
+		diff.EnumsRemoved = append(diff.EnumsRemoved, enum.QualifiedName())
 	}
 
 	// Sort for consistent output
@@ -165,7 +176,26 @@ func EnumsWithSemantics(
 	})
 }
 
-// enumIdentity keys one enum for comparison.
+// findDatabaseEnum resolves one generated enum against the read.
+func findDatabaseEnum(
+	genEnum goschema.Enum,
+	dbByIdentity map[tableIdentity]types.DBEnum,
+	dbByName map[string][]types.DBEnum,
+	semantics identifier.Semantics,
+) (types.DBEnum, bool) {
+	schema, name := enumParts(genEnum.Schema, genEnum.Name)
+	if strings.TrimSpace(schema) != "" {
+		enum, ok := dbByIdentity[newTableIdentity(schema, name, semantics)]
+		return enum, ok
+	}
+	candidates := dbByName[semantics.TableIdentityKey(name)]
+	if len(candidates) != 1 {
+		return types.DBEnum{}, false
+	}
+	return candidates[0], true
+}
+
+// enumParts splits one enum into the schema and name to compare it under.
 //
 // It reads a qualifier out of the NAME when the schema field is empty, because
 // not every producer fills the field: a SQL schema file loaded through
@@ -176,13 +206,14 @@ func EnumsWithSemantics(
 // tableref.Parse is what separates a qualifier from a literal dot -- an enum
 // named "tenant.data" is one quoted part and stays whole -- so this cannot turn
 // a name into a schema it never had.
-func enumIdentity(schema, name string, semantics identifier.Semantics) tableIdentity {
-	if strings.TrimSpace(schema) == "" {
-		if ref, ok := tableref.Parse(name); ok && ref.Qualified {
-			return newTableIdentity(ref.Schema, ref.Name, semantics)
-		}
+func enumParts(schema, name string) (string, string) {
+	if strings.TrimSpace(schema) != "" {
+		return schema, name
 	}
-	return newTableIdentity(schema, name, semantics)
+	if ref, ok := tableref.Parse(name); ok && ref.Qualified {
+		return ref.Schema, ref.Name
+	}
+	return "", name
 }
 
 // EnumValues performs detailed value-level comparison between generated and database enum types.

--- a/migration/schemadiff/internal/compare/schema_objects.go
+++ b/migration/schemadiff/internal/compare/schema_objects.go
@@ -87,24 +87,43 @@ func Functions(generated *goschema.Database, database *types.DBSchema, diff *dif
 		generatedFunctionMap[fn.Name] = fn
 	}
 
-	databaseFunctionMap := make(map[string]types.DBFunction)
+	// A generated function's name may be schema-qualified -- the HCL parser
+	// writes `extra.f` from a `function` block's schema attribute, and so does
+	// a database read -- while the reader reports the two parts separately. The
+	// two sides are matched the way views are, by qualified name where the
+	// generated side carries one and by bare name where it does not, so that a
+	// document describing `extra.f` is not compared against `public.f` and a
+	// round trip does not plan a redundant CREATE OR REPLACE (stokaro/ptah#1276).
+	databaseFunctionsByName := make(map[string][]types.DBFunction, len(database.Functions))
+	databaseFunctionsByQualifiedName := make(map[string]types.DBFunction, len(database.Functions))
 	for _, fn := range database.Functions {
-		databaseFunctionMap[fn.Name] = fn
+		databaseFunctionsByName[fn.Name] = append(databaseFunctionsByName[fn.Name], fn)
+		databaseFunctionsByQualifiedName[fn.QualifiedName()] = fn
 	}
 
-	// Use generic comparison helper for add/remove detection
-	addedFunctions, removedFunctions := compareNamedItems(generatedFunctionMap, databaseFunctionMap)
-	diff.FunctionsAdded = append(diff.FunctionsAdded, addedFunctions...)
-	diff.FunctionsRemoved = append(diff.FunctionsRemoved, removedFunctions...)
-
-	// Detect function definition modifications
+	matchedDatabaseFunctions := make(map[string]struct{}, len(database.Functions))
 	for functionName, generatedFunction := range generatedFunctionMap {
-		if databaseFunction, functionExists := databaseFunctionMap[functionName]; functionExists {
-			functionComparison := FunctionDefinitions(generatedFunction, databaseFunction)
-			if len(functionComparison.Changes) > 0 {
-				diff.FunctionsModified = append(diff.FunctionsModified, functionComparison)
-			}
+		databaseFunction, exists := findDatabaseFunction(
+			functionName,
+			databaseFunctionsByName,
+			databaseFunctionsByQualifiedName,
+		)
+		if !exists {
+			diff.FunctionsAdded = append(diff.FunctionsAdded, functionName)
+			continue
 		}
+		matchedDatabaseFunctions[databaseFunction.QualifiedName()] = struct{}{}
+		functionComparison := FunctionDefinitions(generatedFunction, databaseFunction)
+		if len(functionComparison.Changes) > 0 {
+			diff.FunctionsModified = append(diff.FunctionsModified, functionComparison)
+		}
+	}
+
+	for _, fn := range database.Functions {
+		if _, ok := matchedDatabaseFunctions[fn.QualifiedName()]; ok {
+			continue
+		}
+		diff.FunctionsRemoved = append(diff.FunctionsRemoved, fn.QualifiedName())
 	}
 
 	// Ensure consistent ordering of results
@@ -113,6 +132,35 @@ func Functions(generated *goschema.Database, database *types.DBSchema, diff *dif
 	sort.Slice(diff.FunctionsModified, func(i, j int) bool {
 		return diff.FunctionsModified[i].FunctionName < diff.FunctionsModified[j].FunctionName
 	})
+}
+
+// findDatabaseFunction resolves one generated function name against the read.
+//
+// A qualified name is matched only against the same (schema, name); a bare one
+// is matched against a uniquely named function, and against nothing when two
+// schemas hold that name -- guessing there is what would attribute a function to
+// a schema it does not belong to. It is the shape
+// [findDatabaseViewForGeneratedView] uses, and deliberately so: both answer the
+// same question about an object whose generated name may or may not carry its
+// schema.
+func findDatabaseFunction(
+	name string,
+	byName map[string][]types.DBFunction,
+	byQualifiedName map[string]types.DBFunction,
+) (types.DBFunction, bool) {
+	ref, ok := tableref.Parse(name)
+	if !ok {
+		return types.DBFunction{}, false
+	}
+	if ref.Qualified {
+		fn, ok := byQualifiedName[tableref.Canonical(ref.Schema, ref.Name)]
+		return fn, ok
+	}
+	candidates := byName[ref.Name]
+	if len(candidates) != 1 {
+		return types.DBFunction{}, false
+	}
+	return candidates[0], true
 }
 
 // Views compares view definitions between generated and database schemas.

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -188,8 +188,11 @@ func CompareReportingUndecidedAdditions(
 		cov,
 	)
 
-	// Compare enum type definitions and values
-	compare.Enums(generated, database, diff)
+	// Compare enum type definitions and values. The semantics carry the
+	// connection's default schema, without which an `enum` block's mandatory
+	// `schema = schema.public` and the reader's blanked schema read as two
+	// different types (stokaro/ptah#1276).
+	compare.EnumsWithSemantics(generated, database, diff, identifierSemantics)
 
 	// Compare database index definitions
 	compare.IndexesWithSemantics(generated, database, diff, opts.Dialect, identifierSemantics)


### PR DESCRIPTION
Closes #1264.

**The semantic hold is lifted.** Both halves of the fix are in this branch, and
the branch now sits on top of the PRESENT / AUTHORITATIVELY ABSENT / NOT
DESCRIBED model that #1298 merged, rather than beside it.

## What the hold was for

Describing more of the database moved one side of the read/compare boundary and
left the other where it was:

1. `schema inspect` began seeing both `public` and `extra`.
2. `schema apply`, when comparing, still read only `public`.
3. So `extra.b` looked non-existent, and Ptah planned to CREATE a schema and a
   table the database already had:

```
CREATE SCHEMA IF NOT EXISTS extra;
CREATE TABLE "extra"."b" ("id" integer);

Error: apply schema changes: failed to execute SQL statement:
       ERROR: relation "b" already exists (SQLSTATE 42P07)
```

It never converged: three consecutive applies planned the same thing.

## The two halves, and the property that shapes them

**The reader reports the schemas it read.** `readSchemas` gated on `r.scoped` and
answered nothing for any read not handed an allow-list, while every other read
below it iterated `schemasToRead()`. One list, two answers. Which schemas an
unscoped read *covers* does not move; what moves is that the read says so.

**`schema apply` reads the database at the scope the DESIRED STATE names** — not
at the URL's realm scope, and that choice is the safety property rather than an
implementation detail. A URL-derived realm scope would widen the read for every
document, including one describing a single schema of a multi-schema database,
and a schema the database has that the document does not describe is planned for
removal. The read is always at least what it was and at most what it was plus
the schemas the document itself names; `--schema` still outranks both.

`cmd/schema/apply.go` and `cmd/atlas/schema_apply.go` share the entry point, so
the native surface gets it too.

**The saved-plan fingerprint follows the read that will verify it.** A plan file
records an exclude list and no schema scope, so `schema apply --plan` re-reads at
the connection's default. Fingerprinting the wider planning read made a freshly
saved plan report itself stale against the database it had just been computed
from.

## How this sits on #1298

#1298 gave the comparator the third state this work needed. The two changes
compose rather than compete, and the boundary guard is where that is visible:

| row | #1234 gave | #1264 gives | together |
| --- | --- | --- | --- |
| `extension_nothing_references` | the document declares `public` | the reader says it read `public` | `wantDocumentOnly` is empty |
| `empty_database` | the document declares `public` | the reader says it read `public` | `wantDocumentOnly` is empty |

Each half alone leaves the pair disagreeing, which is the `[schema:public]`
difference #1276 said must become empty. With both, it is empty. Property 2 now
holds on every fixture and on both surfaces: #1298 turned the extension row's
compatibility plan from `DROP EXTENSION IF EXISTS "pgcrypto"` to nothing, and
this branch keeps it there.

The coverage header rides through unchanged — an inspected multi-schema document
carries `ptah:not-described extension/policy/sequence` **and** declares every
schema the URL reaches.

## What the rebase had to reconcile

Rebased onto `master`. Three conflicts, all resolved as unions of meaning rather
than by choosing a side, plus one defect no conflict reported.

**`internal/atlasschema/apply.go`.** #1329 widened `scopeGeneratedSide` to return
an exclude-match report; this branch moved the desired-state load *above* the
database read, because the read now needs it. Taking either side whole breaks:
master's side duplicates the load and redeclares `desired`, the branch's side
drops `desiredReport` and `UnmatchedAcrossStates` loses the desired half.
Resolved by keeping the hoisted load and master's three-return call.

**`integration/gonative/schema_boundary_guard_postgres_test.go`**, three hunks.
The header comment is the union of #1234's paragraph and this issue's, with one
sentence corrected: it claimed property 2 held "except the extension row", which
#1298 has since closed. The two data hunks keep master's explanation of
`wantDescribedSchemas` — #1234 reached that value first, by collecting what the
document references, so the branch's older prose claiming the row "read nil" is
no longer true of this base — and take this branch's `wantReadSchemas`.

The consequence neither parent states is `wantDocumentOnly` on those two rows.
Git auto-merged it to master's `[schema:public]` because this branch never edited
that line. With both halves present the observed value is `nil`, and putting
master's value back reddens the guard:

```
--- FAIL: .../empty_database/property_1
    diff (-got +want):
      - nil,
      + {"schema:public"},
```

**A clean merge that did not compile.** `NewSchemaInspectReport` took a sixth
parameter here while master grew two more call sites — #1306 in
`schema_inspect_test.go` and #1298 in `schema_inspect_split_coverage_test.go`.
Different files, different lines, no conflict, red tree:

```
vet: not enough arguments in call to atlasreport.NewSchemaInspectReport
     have (*goschema.Database, *types.DBSchema, types.DBInfo, nil, bool)
     want (*goschema.Database, *types.DBSchema, types.DBInfo, io.Writer, bool, bool)
```

Both get `false`, the connected-schema case each fixture represents. Neither
assertion can move on the value: `describeSchemas` is read only by `sqlSource`,
which only `MarshalSQL` calls, and those two cases render `{{ json . }}` and
`{{ hcl . | split }}`.

## Boundary matrix, measured on the rebased tree

Live PostgreSQL 17.10, MySQL 9.7 and SQLite, 2026-08-09. Exit status read on its
own line, never through a pipe. Throwaway databases, one dev database dropped and
recreated between runs.

| | property | result |
| --- | --- | --- |
| A | plain PostgreSQL URL describes ALL schemas | `extra`, `public`, `third`, with `public`'s comment |
| B | `?search_path=public` describes ONLY `public` | one schema |
| C | inspect a multi-schema database, apply back | `Schema is synced`, compat and native |
| D | a document about only `public` does NOT delete `extra` | `Schema is synced`; catalog still holds `extra.b`, `public.a`, `third.c` |
| E | a fresh target receives ALL schemas | catalog holds `extra.b`, `public.a`, `third.c` |
| F | a saved multi-schema plan is not stale at birth | no staleness refusal |
| G | #1298 coverage and #1329 unmatched-exclude survive | below |
| H | SQLite and MySQL empty databases | `{"schemas":[{"name":"main"}]}` · `{"schemas":[{"name":"…","charset":"utf8mb4","collate":"utf8mb4_0900_ai_ci"}]}` |

**D was executed, not rendered** — `--auto-approve` against a live database, then
the catalog asserted. Collapsing `applyReadScope` to the URL's realm scope turns
that exact run into

```
DROP TABLE IF EXISTS "extra"."b" CASCADE;
DROP TABLE IF EXISTS "third"."c" CASCADE;
```

so the synced answer is the guard working, not the guard being vacuous.

**G, #1298 half.** Inspecting a database holding an unreferenced `pgcrypto`, a
standalone `order_seq` and a policy `p`, then applying that document back to it:
`Schema is synced`. Same document with the three header lines deleted:
`DROP POLICY` / `DROP SEQUENCE` / `DROP EXTENSION`. The suppression is not
universal.

**G, #1329 half.** `schema inspect --exclude nosuchobject_zzz` warns and exits 0;
`schema apply` with the same selector exits 1; `PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE=1`
restores the permissive behavior at exit 0.

## Corrected: a one-part `--exclude` now drops a schema

An earlier revision of this description recorded that "at realm scope the binary
reads a one-part pattern as a schema name; here it never addresses a schema", and
said it wanted its own issue. **That claim is withdrawn.** #1329 closed it, and on
a plain URL — the form this branch makes describe the whole realm —
`--exclude extra` now removes `schema "extra"` and its table, with no unmatched
warning:

```
$ ptah-compat schema inspect --url "$PLAIN_URL" --exclude extra --format '{{ json . }}'
{"schemas":[{"name":"public",…},{"name":"third",…}]}
```

The two changes meet here: before #1264 a plain URL never described `extra`, so
#1329's schema filter had nothing to reach.

## Gates, literal exit codes read directly

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1` | 0 (186 packages) |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (0 issues) |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| docs `check:exit-codes` `check:core-doc-links` `check:page-health` `check:links` `check:redirects` `check:style` `check:limitations` `versions:selftest` | 0 each |
| `build-feature-matrix.mjs --check` | 0 (177 rows) |
| live `go test -tags integration ./integration/gonative/` | 0 |
| live `go test -tags integration ./internal/atlasschema/` | 0 |

`check:responsive` exits 1 with `dist not found` on an unbuilt tree; `npm run
build` exits 0 and it then exits 0. Both results reported. `git status --short`
is empty after the full `go test` sweep.

The four live fixtures this work turns on were confirmed to RUN rather than skip:
`TestInspectLive_ScopeSelectsSchemas`, `TestInspectLive_SQLSchemaStatements`,
`TestInspectLive_HCLRealmScope`, `TestPlanLive_SavedPlanIsNotStaleAgainstItsOwnSource`,
all PASS.

## Still diverging, deliberately, and not touched here

- **`two_schemas_plain_url`'s `wantDocumentOnly` is a DEFAULT-SCOPE difference,
  not a fidelity one.** The document reaches `extra` because inspection resolves
  realm scope from the URL; the reader called with no allow-list still covers the
  connected schema alone. Every object listed is one the database really has.
  Widening the reader's default is what produces the `DROP TABLE` row above, so
  the caller names the scope it wants — which inspection and apply now both do.
- **Column comments are dropped.** `dbschema.DBColumn` has no field for one, so
  this is a reader change rather than a rendering change.
- **`?search_path=public --schema extra`** reports `extra` here. Pre-existing;
  honoring the operator's flag is the direction that describes what was asked for.
- **`--format hcl` / `format { schema { inspect = "json" } }`** are normalized to
  the format here rather than treated as literal template text. Pre-existing.
- **`ptah introspect` on an unscoped connection writes one more annotation**,
  because the reader no longer denies the schema it read:
  `//ptah:schema:schema name="public" comment="standard public schema"`.
  Rendering it emits `CREATE SCHEMA IF NOT EXISTS "public"` and
  `COMMENT ON SCHEMA "public"`; the latter requires schema ownership. Both were
  already reachable through `--schemas public`; what changed is that the default
  reaches them. Whether the connected schema's comment belongs in rendered DDL at
  all deserves its own decision.

## Pre-existing defect found while verifying, NOT introduced here

`schema apply --plan --to` does not converge for a desired document that spans
more schemas than the connection's default. `RehearsePlanStatements` seeds the dev
database with `ReadSchemaWithSchemas(conn, nil)` — deliberately the default scope,
so it matches what `VerifyPlanTarget` will read — and the end-state comparison
reads the dev connection the same way, so objects in the other schemas are absent
from the rehearsal and reported as drift.

Measured on the same fixture with a binary built from `master` at `fc77c58c`:
master fails the identical check with the identical error, listing five objects
of drift where this branch lists two. So the branch narrows the failure and does
not cause it. It wants its own issue; the fix is for the rehearsal seed and the
plan's read scope to be the same decision.