### PR TITLE
Name the block, not the schema, in HCL table references (#1260 item 1)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -137,8 +137,11 @@ jobs:
       # set of top-level BLOCK types it refuses is the same kind of contract
       # (stokaro/ptah#1251): ptah-compat omits those blocks by default, and a
       # list nothing re-measures would go on withholding a construct that binary
-      # started modeling. Both live in internal/atlashclrender and are listed
-      # before they are run, for the same reason as above.
+      # started modeling. The spelling of a table REFERENCE is another
+      # (stokaro/ptah#1260): `table.<schema>.<name>` costs the whole document,
+      # so the rendered output is put to that binary here rather than trusted.
+      # All of them live in internal/atlashclrender and are listed before they
+      # are run, for the same reason as above.
       - name: Verify HCL render conformance selection
         run: |
           GOWORK=off go test -list '^TestOracle' \
@@ -148,7 +151,8 @@ jobs:
           grep -Fx 'TestOracleAcceptsTheWrapItFallsBackTo' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleAtlasRefusedBlockTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleToleratesTheBlockTypesPtahStillRenders' "$RUNNER_TEMP/atlas-column-type-tests"
-          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 4
+          grep -Fx 'TestOracleReadsTheReferenceSpellingPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 5
 
       - name: Run HCL render conformance tests
         run: |
@@ -171,6 +175,14 @@ jobs:
           grep -Fq 'TestOracleAtlasRefusedBlockTypesMatchTheBinary/postgres/refused/sequence' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/postgres/tolerated/wibble' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleToleratesTheBlockTypesPtahStillRenders/sqlite/tolerated/sequence' "$RUNNER_TEMP/atlas-column-type-run"
+          # Same reason for the reference spelling (stokaro/ptah#1260): its two
+          # rows are a pair, and only the pair is a measurement. `rendered`
+          # alone would pass on a build that had stopped shortening anything,
+          # and `qualified` alone says nothing about what Ptah writes today.
+          grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/postgres/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/postgres/qualified' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/sqlite/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/sqlite/qualified' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -129,6 +129,10 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 	if err := p.parseBody(body); err != nil {
 		return nil, err
 	}
+	// After the walk, because a reference may name a block declared further
+	// down the file, and before Finalize, which reads schemas off the same
+	// blocks for the positions it covers.
+	p.resolveDocumentTableRefs()
 	goschema.Finalize(p.db)
 	return p.db, nil
 }
@@ -202,6 +206,10 @@ type parser struct {
 	// refContext decides a conditional inside a column reference. Built once
 	// from the file's own `variable` blocks -- see columnRefContext.
 	refContext *hcl.EvalContext
+	// pendingForeignRefs holds the single-column foreign key targets that can
+	// only be read once every table block is known; see
+	// [parser.resolveDocumentTableRefs].
+	pendingForeignRefs []pendingForeignRef
 }
 
 func (p *parser) parseBody(body *hclsyntax.Body) error {
@@ -1308,6 +1316,12 @@ func (p *parser) applyForeignKey(table goschema.Table, fieldsStart int, block *h
 		field.ForeignKeyName = spec.name
 		field.OnDelete = spec.onDelete
 		field.OnUpdate = spec.onUpdate
+		p.pendingForeignRefs = append(p.pendingForeignRefs, pendingForeignRef{
+			field:  i,
+			owner:  table,
+			table:  spec.foreignTable,
+			column: spec.foreignColumns[0],
+		})
 		return nil
 	}
 	return nil

--- a/internal/atlashcl/document_table_refs.go
+++ b/internal/atlashcl/document_table_refs.go
@@ -1,0 +1,101 @@
+package atlashcl
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/planner/tablelookup"
+	"go.5x5.cz/ptah/internal/tableref"
+)
+
+// pendingForeignRef is one single-column foreign key whose target table still
+// has to be read against the whole document.
+//
+// It cannot be resolved where it is parsed: a `foreign_key` block may name a
+// table block that appears further down the file, so the reference is recorded
+// during the walk and read once the walk is over.
+type pendingForeignRef struct {
+	// field indexes db.Fields. The field is already appended by the time the
+	// reference is recorded, and nothing removes fields during the walk.
+	field int
+	// owner is the table declaring the foreign key. Its schema is both the
+	// tie-breaker for a name several schemas carry and the schema this
+	// reference does not have to spell out -- see [resolveDocumentTableName].
+	owner  goschema.Table
+	table  string
+	column string
+}
+
+// resolveDocumentTableRefs restores the schema of every table reference that
+// would otherwise lose it, reading it off the block the reference names.
+//
+// A reference in HCL names a block by its labels, so a table in another schema
+// is named `table.users`, not `table.other.users` -- see the measurement on
+// objectRef in internal/atlashclrender. goschema.Finalize already reads the
+// schema back off the referenced block for constraints, indexes, policies,
+// grants and triggers. Two positions it does not cover are handled here:
+//
+//   - A SINGLE-column foreign key, which the HCL parser records on the field as
+//     `Foreign = "<table>(<column>)"` rather than as a Constraint. Measured on
+//     the pinned Atlas community binary v1.3.0's OWN inspect output for a
+//     cross-schema foreign key -- `ref_columns = [table.users.column.id]` with
+//     `users` declared in schema `other` -- Ptah read it back as `users(id)`,
+//     losing the schema, while the multi-column form of the same key read back
+//     as `other.users`. Ptah could not correctly read that binary's output for
+//     the shape it emits most.
+//   - A `data` block's table, whose schema goschema.Finalize never touches and
+//     whose block has no owning table to supply one.
+//
+// An ambiguous name is left exactly as written, matching what goschema and
+// [tablelookup.ResolveReference] both do with one: two tables of a name in
+// different schemas make the short form mean neither, and inventing a winner
+// would silently point the reference at the wrong table.
+func (p *parser) resolveDocumentTableRefs() {
+	for _, pending := range p.pendingForeignRefs {
+		resolved := resolveDocumentTableName(p.db.Tables, pending.owner, pending.table)
+		p.db.Fields[pending.field].Foreign = resolved + "(" + pending.column + ")"
+	}
+	for i := range p.db.ManagedData {
+		data := &p.db.ManagedData[i]
+		if data.Schema != "" {
+			continue
+		}
+		// A data block has no owning table, so no schema is implicit in it and
+		// the referenced block's is the only one there is.
+		resolved := resolveDocumentTableName(p.db.Tables, goschema.Table{}, data.Table)
+		ref, ok := tableref.Parse(resolved)
+		if !ok || !ref.Qualified {
+			continue
+		}
+		data.Schema = ref.Schema
+		data.Table = ref.Name
+	}
+}
+
+// resolveDocumentTableName reads the schema of an unqualified table reference
+// off the table block the document declares, and writes it into the name only
+// when the reference cannot be read without it.
+//
+// The owner's schema is the one the reader already has in hand, so a target in
+// it keeps the bare name it was written with. Qualifying that case instead
+// would be a change with nothing behind it -- every consumer of Field.Foreign
+// resolves a bare name through [tablelookup.ResolveReference] against the same
+// tables and reaches the same table -- and it is not free: measured by
+// qualifying unconditionally first, it renders `REFERENCES "main"."users"
+// ("id")` on SQLite, which that engine refuses with `near ".": syntax error`,
+// and TestInspectSource_FileExportThenDevInspectionRoundTrip went red on
+// exactly that statement.
+//
+// A reference that already carries a schema keeps it. The author wrote it, and
+// this is a restore of what a spelling drops, not a normalizer.
+func resolveDocumentTableName(tables []goschema.Table, owner goschema.Table, name string) string {
+	ref, ok := tableref.Parse(name)
+	if !ok || ref.Qualified {
+		return name
+	}
+	resolved, ok := tableref.Parse(tablelookup.ResolveReference(tables, owner, name))
+	if !ok || !resolved.Qualified || resolved.Schema == strings.TrimSpace(owner.Schema) {
+		return name
+	}
+	return tableref.Canonical(resolved.Schema, resolved.Name)
+}

--- a/internal/atlashcl/document_table_refs_test.go
+++ b/internal/atlashcl/document_table_refs_test.go
@@ -1,0 +1,209 @@
+package atlashcl_test
+
+import (
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// foreignKeyDocument writes a document whose `posts` table holds one
+// single-column foreign key spelled exactly as given.
+//
+// Everything but the reference and the extra table blocks is fixed, so a
+// difference in the parsed Foreign is attributable to the spelling alone.
+func foreignKeyDocument(reference, extraTables string) []byte {
+	return fmt.Appendf(nil, `
+schema "public" {
+}
+
+schema "other" {
+}
+
+table "users" {
+  schema = schema.other
+  column "id" {
+    type = bigint
+  }
+}
+%s
+table "posts" {
+  schema = schema.public
+  column "author_id" {
+    type = bigint
+  }
+  foreign_key "posts_author_fk" {
+    columns     = [column.author_id]
+    ref_columns = [%s]
+  }
+}
+`, extraTables, reference)
+}
+
+const publicUsersTable = `
+table "users" {
+  schema = schema.public
+  column "id" {
+    type = bigint
+  }
+}
+`
+
+// TestParseReadsForeignKeySchemaOffTheReferencedBlock covers the reference
+// spellings a single-column foreign key can arrive in.
+//
+// The first row is the one that made this code exist: it is the pinned Atlas
+// community binary v1.3.0's OWN inspect output for a cross-schema foreign key,
+// and Ptah used to read it as `users(id)` -- the schema silently gone. The
+// multi-column form of the same key never lost it, because goschema.Finalize
+// resolves a Constraint's ForeignTable and nothing resolved a Field's Foreign.
+func TestParseReadsForeignKeySchemaOffTheReferencedBlock(t *testing.T) {
+	tests := []struct {
+		name        string
+		reference   string
+		extraTables string
+		want        string
+		// why records what the row is holding in place.
+		why string
+	}{
+		{
+			name:      "cross-schema short form gains the schema it names",
+			reference: "table.users.column.id",
+			want:      "other.users(id)",
+			why: "the only `users` block is in `other`, so that is the table the reference names;" +
+				" this is the spelling the pinned binary writes and the one Ptah now writes",
+		},
+		{
+			name:        "same-schema short form keeps the short name",
+			reference:   "table.users.column.id",
+			extraTables: publicUsersTable,
+			want:        "users(id)",
+			why: "`public.users` is in the declaring table's own schema, which every reader of this IR" +
+				" already has in hand; writing it out renders `REFERENCES \"main\".\"users\"` on SQLite," +
+				" which that engine refuses with `near \".\": syntax error`",
+		},
+		{
+			name:      "author-written schema survives",
+			reference: "table.other.users.column.id",
+			want:      "other.users(id)",
+			why:       "this restores what a spelling drops; it never rewrites what the author wrote",
+		},
+		{
+			name:        "author-written schema survives even when it is the declaring table's own",
+			reference:   "table.public.users.column.id",
+			extraTables: publicUsersTable,
+			want:        "public.users(id)",
+			why: "the row above cannot tell the difference -- resolving that reference reaches the same" +
+				" qualified name either way. This one can: shortening rather than reading is the only" +
+				" way to lose the `public.` the author typed",
+		},
+		{
+			name:      "absent target keeps what was written",
+			reference: "table.ghost.column.id",
+			want:      "ghost(id)",
+			why:       "no block declares `ghost`, so there is no schema to read off anything",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			db, err := atlashcl.Parse(foreignKeyDocument(test.reference, test.extraTables), "schema.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(fieldByName(db.Fields, "posts", "author_id").Foreign, qt.Equals, test.want,
+				qt.Commentf("%s", test.why))
+		})
+	}
+}
+
+// TestParseLeavesAmbiguousForeignKeyReferenceAsWritten pins the direction a
+// wrong answer must not go.
+//
+// Two tables of one name in different schemas are legal, and the pinned binary
+// refuses a document with an unqualified reference to them -- `specutil: failed
+// converting to *schema.Realm: multiple reference tables found for "users"` --
+// rather than picking one. Ptah keeps the name as written for the same reason:
+// a reference that resolves to the wrong table is worse than one that resolves
+// to nothing, because nothing about the result says it happened.
+func TestParseLeavesAmbiguousForeignKeyReferenceAsWritten(t *testing.T) {
+	c := qt.New(t)
+
+	db, err := atlashcl.Parse(foreignKeyDocument("table.users.column.id", `
+table "users" {
+  schema = schema.billing
+  column "id" {
+    type = bigint
+  }
+}
+
+schema "billing" {
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(fieldByName(db.Fields, "posts", "author_id").Foreign, qt.Equals, "users(id)")
+}
+
+// TestParseReadsManagedDataSchemaOffTheReferencedBlock covers the other
+// position goschema.Finalize does not reach.
+//
+// A `data` block has no owning table, so nothing else in it carries a schema:
+// either the referenced block supplies one or the block points at whichever
+// `users` the reader assumes.
+func TestParseReadsManagedDataSchemaOffTheReferencedBlock(t *testing.T) {
+	tests := []struct {
+		name        string
+		extraTables string
+		wantSchema  string
+		why         string
+	}{
+		{
+			name:       "short form gains the schema of the block it names",
+			wantSchema: "other",
+			why:        "the only `users` block is in `other`",
+		},
+		{
+			name:        "ambiguous name resolves to nothing",
+			extraTables: publicUsersTable,
+			wantSchema:  "",
+			why:         "two `users` blocks make the short form mean neither; picking one would be silent and wrong",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			source := fmt.Appendf(nil, `
+schema "public" {
+}
+
+schema "other" {
+}
+
+table "users" {
+  schema = schema.other
+  column "id" {
+    type = bigint
+  }
+}
+%s
+data {
+  table = table.users
+  keys  = ["id"]
+  file  = "seed.csv"
+}
+`, test.extraTables)
+
+			db, err := atlashcl.Parse(source, "schema.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.ManagedData, qt.HasLen, 1)
+			c.Assert(db.ManagedData[0].Table, qt.Equals, "users")
+			c.Assert(db.ManagedData[0].Schema, qt.Equals, test.wantSchema, qt.Commentf("%s", test.why))
+		})
+	}
+}

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -168,7 +168,7 @@ func (r *renderer) renderManagedData() {
 	})
 	for _, data := range managedData {
 		r.line("data {")
-		r.rawAttr(1, "table", objectRef("table", managedDataTable(data)))
+		r.rawAttr(1, "table", r.tableRef(managedDataTable(data)))
 		r.rawAttr(1, "keys", stringList(data.Keys))
 		r.stringAttr(1, "file", data.File)
 		r.line("}")
@@ -384,7 +384,7 @@ func (r *renderer) renderTrigger(trigger goschema.Trigger) {
 		return
 	}
 	r.linef(`trigger %s {`, quote(trigger.Name))
-	r.rawAttr(1, "on", objectRef("table", trigger.Table))
+	r.rawAttr(1, "on", r.tableRef(trigger.Table))
 	r.linef("  %s {", timing)
 	r.rawAttr(2, event, "true")
 	r.line("  }")
@@ -422,7 +422,7 @@ func (r *renderer) renderRLSPolicies() {
 			continue
 		}
 		r.linef(`policy %s {`, quote(policy.Name))
-		r.rawAttr(1, "on", objectRef("table", policy.Table))
+		r.rawAttr(1, "on", r.tableRef(policy.Table))
 		// Quoted. Measured on the pinned Atlas community binary v1.3.0, one
 		// operand varied against an otherwise identical policy block:
 		//
@@ -452,13 +452,13 @@ func (r *renderer) renderGrants() {
 	slices.SortFunc(grants, func(a, b goschema.Grant) int {
 		return cmp.Or(
 			cmp.Compare(a.Role, b.Role),
-			cmp.Compare(grantTarget(a), grantTarget(b)),
+			cmp.Compare(r.grantTarget(a), r.grantTarget(b)),
 			cmp.Compare(strings.Join(a.Privileges, ","), strings.Join(b.Privileges, ",")),
 		)
 	})
 	for _, grant := range grants {
 		grant.Canonicalize()
-		target := grantTarget(grant)
+		target := r.grantTarget(grant)
 		if grant.Role == "" || target == "" || len(grant.Privileges) == 0 {
 			r.warn("grants."+grant.Role, "grant requires role, table, schema, or sequence target, and at least one privilege")
 			continue
@@ -660,12 +660,12 @@ func roleTarget(value string) string {
 	return "role" + objectRefPart(value)
 }
 
-func grantTarget(grant goschema.Grant) string {
+func (r *renderer) grantTarget(grant goschema.Grant) string {
 	if grant.OnSchema != "" {
 		return schemaRef(grant.OnSchema)
 	}
 	if grant.OnTable != "" {
-		return objectRef("table", grant.OnTable)
+		return r.tableRef(grant.OnTable)
 	}
 	if grant.OnSequence != "" {
 		return objectRef("sequence", grant.OnSequence)
@@ -673,6 +673,58 @@ func grantTarget(grant goschema.Grant) string {
 	return ""
 }
 
+// tableRef renders a reference to a table block.
+//
+// A reference in HCL names a BLOCK, and a block is named by its labels. Ptah
+// writes a table block with one label, so `table.<schema>.<name>` does not read
+// as "the table <name> in schema <schema>" -- it reads as "the <schema>
+// attribute of the table object", which is exactly what the pinned Atlas
+// community binary v1.3.0 says. Measured on PostgreSQL 17, realm-scope dev URL,
+// with `users` in `other` and `posts` in `public`, one operand varied:
+//
+//	ref_columns = [table.users.column.id]        exit 0
+//	ref_columns = [table.other.users.column.id]  exit 1  Unsupported attribute;
+//	                                                     This object does not have
+//	                                                     an attribute named "other"
+//	on = table.users        (trigger)            exit 0
+//	on = table.other.users  (trigger)            exit 1  same message
+//	for = table.users       (permission)         exit 0
+//	for = table.other.users (permission)         exit 1  same message
+//
+// It is not a cross-schema special case: with the target in the SAME schema as
+// the referring table, `table.public.users` is refused the same way. The short
+// form is that binary's OWN spelling -- its inspect of the cross-schema foreign
+// key above emits `ref_columns = [table.users.column.id]`.
+//
+// The schema is dropped only when [renderer.documentResolvesTableRef] says this
+// document resolves the short form back to the same table, because that is the
+// only case where nothing is lost. A reference to a table the document does not
+// render -- a filtered export, an orphan trigger -- keeps the qualified form:
+// there is no block to read the schema off on the way back, so the short form
+// would destroy it irrecoverably, and a document missing the referenced table is
+// not readable by that binary under either spelling (stokaro/ptah#1260).
+// Everything the short form is not written for -- an empty name, a name that
+// does not parse, one carrying no schema, one this document cannot resolve --
+// falls through to [objectRef], which is what Ptah wrote for every reference
+// before this rule existed.
+func (r *renderer) tableRef(name string) string {
+	ref, ok := tableref.Parse(name)
+	if !ok || !ref.Qualified || !r.documentResolvesTableRef(ref.Schema, ref.Name) {
+		return objectRef("table", name)
+	}
+	return "table" + objectRefPart(ref.Name)
+}
+
+// objectRef renders a reference to a block, with whatever schema the name
+// carries.
+//
+// Only [renderer.tableRef] shortens a reference, and only table positions call
+// it, so a sequence target keeps `sequence.<schema>.<name>`. That is a
+// structural guarantee rather than a policy: a permission naming a sequence
+// keeps that sequence block in the document, and the pinned binary refuses any
+// PostgreSQL file declaring one with `postgres: sequences are not supported by
+// this version` before any reference is resolved, so nothing measured says
+// which spelling it would take there.
 func objectRef(kind, name string) string {
 	if name == "" {
 		return quote("")

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -144,9 +144,44 @@ type renderer struct {
 	// once per render by [collectReferencedNames]. Nil means not yet built,
 	// which is distinguishable from "built and empty" because a document with
 	// no references at all still answers every lookup false.
-	references  map[string]bool
-	builder     strings.Builder
-	diagnostics []Diagnostic
+	references map[string]bool
+	// tableSchemas caches, per table block label this render will write, the
+	// schema each block carries. Nil means not yet built, which is
+	// distinguishable from "built and empty" because a document with no tables
+	// still answers every lookup. See [renderer.documentResolvesTableRef].
+	tableSchemas map[string][]string
+	builder      strings.Builder
+	diagnostics  []Diagnostic
+}
+
+// documentResolvesTableRef reports whether an unqualified `table.<name>`
+// reference in this document resolves to exactly the table the qualified name
+// meant.
+//
+// It is true only when the document writes ONE table block with that label and
+// that block carries this schema. Both halves are load-bearing:
+//
+//   - One block, because two tables of one name in different schemas are legal.
+//     Measured on the pinned Atlas community binary v1.3.0 with `public.users`
+//     and `other.users` both declared and an unqualified `ref_columns`, it
+//     refuses the document with `specutil: failed converting to *schema.Realm:
+//     multiple reference tables found for "users"`. Ptah's own reader is no
+//     happier: goschema's resolveTableReference gives up on an ambiguous name
+//     and leaves the reference unqualified, so dropping the schema there would
+//     lose it silently -- worse than a refusal.
+//   - That block's schema, because a lone `public.users` does not make
+//     `table.users` mean `other.users`. Without this half a reference to a table
+//     the document does not contain would resolve, quietly, to a different one.
+func (r *renderer) documentResolvesTableRef(schema, name string) bool {
+	if r.tableSchemas == nil {
+		schemas := make(map[string][]string, len(r.db.Tables))
+		for _, table := range r.db.Tables {
+			schemas[table.Name] = append(schemas[table.Name], r.schemaFor(table.Schema))
+		}
+		r.tableSchemas = schemas
+	}
+	blocks := r.tableSchemas[name]
+	return len(blocks) == 1 && blocks[0] == schema
 }
 
 // schemaFor returns the schema name to write for an object, which is the one it
@@ -643,7 +678,7 @@ func atlasPrimaryKeyConstraint(constraint goschema.Constraint) bool {
 func (r *renderer) renderForeignKey(name string, columns []string, foreignTable string, foreignColumns []string, onDelete string, onUpdate string) {
 	r.linef(`  foreign_key %s {`, quote(name))
 	r.rawAttr(2, "columns", columnRefs(columns))
-	r.rawAttr(2, "ref_columns", tableColumnRefs(foreignTable, foreignColumns))
+	r.rawAttr(2, "ref_columns", r.tableColumnRefs(foreignTable, foreignColumns))
 	r.stringAttr(2, "on_delete", onDelete)
 	r.stringAttr(2, "on_update", onUpdate)
 	r.line("  }")
@@ -1086,8 +1121,8 @@ func schemaRef(name string) string {
 	return "schema" + objectRefPart(name)
 }
 
-func tableColumnRefs(table string, columns []string) string {
-	tableRef := objectRef("table", table)
+func (r *renderer) tableColumnRefs(table string, columns []string) string {
+	tableRef := r.tableRef(table)
 	refs := make([]string, 0, len(columns))
 	for _, column := range columns {
 		if table == "" || column == "" {

--- a/internal/atlashclrender/render_test.go
+++ b/internal/atlashclrender/render_test.go
@@ -135,9 +135,17 @@ func TestRenderTablesIndexesConstraintsAndDiagnostics(t *testing.T) {
 	c.Assert(parsed.Constraints, qt.HasLen, 2)
 	c.Assert(parsed.Functions, qt.HasLen, 1)
 	c.Assert(constraintByName(parsed.Constraints, "users_email_key").IncludeColumns, qt.DeepEquals, []string{"created_at"})
-	c.Assert(fieldByName(parsed.Fields, "account_id").Foreign, qt.Equals, "auth.accounts(id)")
+	// `accounts`, not `auth.accounts`: the reference names the `accounts` block,
+	// which the same document declares in `auth`, so the schema is written once
+	// on that block instead of on every reference to it. The declaring table is
+	// in `auth` too, which is what makes the short name unambiguous to every
+	// reader of this IR -- tablelookup.ResolveReference, the one the DDL path
+	// calls, resolves it to `auth.accounts` from these same tables. Only a
+	// reference the document cannot resolve keeps its schema; see
+	// TestRenderKeepsQualifiedReferenceWhenTargetTableIsAbsent.
+	c.Assert(fieldByName(parsed.Fields, "account_id").Foreign, qt.Equals, "accounts(id)")
 	c.Assert(fieldByName(parsed.Fields, "account_id").ForeignKeyName, qt.Equals, "users_account_fk")
-	c.Assert(fieldByName(parsed.Fields, "team_id").Foreign, qt.Equals, "auth.teams(id)")
+	c.Assert(fieldByName(parsed.Fields, "team_id").Foreign, qt.Equals, "teams(id)")
 	c.Assert(fieldByName(parsed.Fields, "team_id").OnUpdate, qt.Equals, "CASCADE")
 }
 
@@ -232,8 +240,14 @@ func TestRender_ExplicitTableReferencePreservesStructuralIdentity(t *testing.T) 
 	c.Assert(parsed.Indexes, qt.HasLen, 2)
 	c.Assert(parsed.Indexes[0].TableName, qt.Equals, `"tenant.data"`)
 	c.Assert(parsed.Indexes[1].TableName, qt.Equals, "tenant.data")
+	// The two identities stay apart, which is what this test is for. The literal
+	// name keeps its quotes and its dot -- it is one name, not a qualification,
+	// and nothing shortens it. The qualified one loses the schema from the
+	// REFERENCE, because the `data` block the document declares carries it and
+	// the declaring table is in `tenant` as well; what it must not do is come
+	// back looking like the literal one.
 	c.Assert(fieldByName(parsed.Fields, "literal_id").Foreign, qt.Equals, `"tenant.data"(literal_id)`)
-	c.Assert(fieldByName(parsed.Fields, "qualified_id").Foreign, qt.Equals, "tenant.data(qualified_id)")
+	c.Assert(fieldByName(parsed.Fields, "qualified_id").Foreign, qt.Equals, "data(qualified_id)")
 	c.Assert(parsed.Triggers, qt.HasLen, 2)
 	c.Assert(parsed.Triggers[0].Table, qt.Equals, `"tenant.data"`)
 	c.Assert(parsed.Triggers[1].Table, qt.Equals, "tenant.data")
@@ -690,8 +704,17 @@ func TestRenderPreservesQualifiedTargetsAndRoleInheritance(t *testing.T) {
 	hcl := string(rendered.Data)
 	c.Assert(hcl, qt.Contains, `inherit = true`)
 	c.Assert(hcl, qt.Contains, `inherit = false`)
-	c.Assert(hcl, qt.Contains, `on = table.auth.users`)
-	c.Assert(hcl, qt.Contains, `for = table.auth.users`)
+	// The reference names the `users` block, which this document declares, and a
+	// block is named by its label alone. `table.auth.users` is what the pinned
+	// Atlas community binary v1.3.0 refuses with `Unsupported attribute; This
+	// object does not have an attribute named "auth"` -- measured with the
+	// target in the SAME schema as the referring table too, so this is not a
+	// cross-schema special case. What has to survive is the IR below, and it
+	// does: the schema is written on the table block and read back off it.
+	c.Assert(hcl, qt.Contains, `on = table.users`)
+	c.Assert(hcl, qt.Contains, `for = table.users`)
+	c.Assert(hcl, qt.Contains, `table "users" {`)
+	c.Assert(hcl, qt.Contains, `schema = schema.auth`)
 	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
 	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
 	c.Assert(roleByName(parsed.Roles, "inheriting").Inherit, qt.IsTrue)

--- a/internal/atlashclrender/table_reference_oracle_internal_test.go
+++ b/internal/atlashclrender/table_reference_oracle_internal_test.go
@@ -1,0 +1,145 @@
+package atlashclrender
+
+// White-box testing required: this run reuses the oracle harness the other two
+// conformance runs in this package define -- oracleVersion, requireTypeOracle,
+// requireDevURL, schemaNameByDialect and the warmup that absorbs the binary's
+// one-off notice. A private copy would drift from the pinned version constant,
+// and the whole value of these runs is that they measure the SAME build.
+
+import (
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// TestOracleReadsTheReferenceSpellingPtahRenders measures the rendered document
+// itself, not a hand-written fixture, so the thing under measurement is the
+// output a user gets.
+//
+// Both spellings are put to the binary in the same run, off the same document,
+// with only the reference text differing. The refusal has to be the attribute
+// error and not merely a non-zero status: a document rejected for some unrelated
+// reason would otherwise look like confirmation and this run would keep passing
+// after it stopped measuring anything.
+//
+// Three positions ride on one document -- a foreign key's `ref_columns`, a
+// trigger's `on`, and a permission's `for`. `policy.on` is left out because a
+// PostgreSQL policy block never gets past that binary's own feature gap, and
+// `data.table` because it refuses Ptah's unlabeled data block on its shape
+// (`data block "data" must have exactly 2 labels`) before evaluating anything
+// in it; neither can answer a question about a reference.
+//
+// SQLite needs no server and produces the identical pair of verdicts, so this
+// run measures something even where no dev database is configured.
+func TestOracleReadsTheReferenceSpellingPtahRenders(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	for _, dialect := range slices.Sorted(maps.Keys(schemaNameByDialect)) {
+		t.Run(dialect, func(t *testing.T) {
+			c := qt.New(t)
+			devURL := requireDevURL(t, dialect)
+			schema := schemaNameByDialect[dialect]
+
+			rendered, err := RenderForDialect(referenceOracleSchema(schema), dialect)
+			c.Assert(err, qt.IsNil)
+			short := string(rendered.Data)
+			c.Assert(short, qt.Contains, "ref_columns = [table.users.column.id]")
+			c.Assert(short, qt.Contains, "on = table.users")
+			c.Assert(short, qt.Contains, "for = table.users")
+
+			t.Run("rendered", func(t *testing.T) {
+				c := qt.New(t)
+
+				out, code := runReferenceOracle(c, oracle, devURL, short)
+
+				c.Assert(code, qt.Equals, 0,
+					qt.Commentf("the binary refuses the document Ptah renders on %s: %s\n%s", dialect, out, short))
+			})
+
+			t.Run("qualified", func(t *testing.T) {
+				c := qt.New(t)
+				// The spelling Ptah wrote before stokaro/ptah#1260, produced from
+				// the accepted document so that nothing else differs between the
+				// two runs.
+				long := strings.ReplaceAll(short, "table.users", "table."+schema+".users")
+				c.Assert(long, qt.Not(qt.Equals), short,
+					qt.Commentf("the qualified variant is identical to the accepted one, so this row measures nothing"))
+
+				out, code := runReferenceOracle(c, oracle, devURL, long)
+
+				c.Assert(code, qt.Not(qt.Equals), 0,
+					qt.Commentf("the binary now reads `table.%s.users` on %s; the short form is no longer required and this rule can go: %s",
+						schema, dialect, out))
+				c.Assert(out, qt.Contains, `does not have an attribute named "`+schema+`"`,
+					qt.Commentf("the qualified document is refused for a reason that is not the reference, so this row is not measuring the spelling: %s", out))
+			})
+		})
+	}
+}
+
+// referenceOracleSchema is the smallest IR carrying every reference position
+// this run measures.
+//
+// It declares nothing the binary refuses as a feature -- no extension, sequence
+// or policy -- so a non-zero status is attributable to a reference and not to a
+// construct that build does not model.
+func referenceOracleSchema(schema string) *goschema.Database {
+	return &goschema.Database{
+		Schemas: []goschema.Schema{{Name: schema}},
+		Tables: []goschema.Table{
+			{StructName: "User", Name: "users", Schema: schema},
+			{StructName: "Post", Name: "posts", Schema: schema},
+		},
+		Fields: []goschema.Field{
+			{StructName: "User", Name: "id", Type: "integer", Primary: true},
+			{
+				StructName:     "Post",
+				Name:           "author_id",
+				Type:           "integer",
+				Foreign:        schema + ".users(id)",
+				ForeignKeyName: "posts_author_fk",
+			},
+		},
+		Roles: []goschema.Role{{Name: "probe_role"}},
+		Triggers: []goschema.Trigger{{
+			Name:    "users_touch",
+			Table:   schema + ".users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "SELECT 1",
+		}},
+		Grants: []goschema.Grant{{
+			Role:       "probe_role",
+			Privileges: []string{"SELECT"},
+			OnTable:    schema + ".users",
+		}},
+	}
+}
+
+// runReferenceOracle asks the pinned binary to read one document and returns its
+// combined output and exit status.
+func runReferenceOracle(c *qt.C, oracle, devURL, source string) (string, int) {
+	c.Helper()
+
+	typeOracleWarmup.Do(func() {})
+
+	path := filepath.Join(c.TempDir(), "schema.hcl")
+	c.Assert(os.WriteFile(path, []byte(source), 0o600), qt.IsNil)
+
+	//nolint:gosec // operator-provided oracle path, and path is a test temp dir
+	cmd := exec.Command(oracle, "schema", "inspect", "-u", "file://"+path, "--dev-url", devURL)
+	// The error is the exit status, which is the measurement; a process that
+	// never started leaves ProcessState nil and fails the assertion instead.
+	out, _ := cmd.CombinedOutput() //nolint:errcheck // exit status is read from ProcessState below
+	c.Assert(cmd.ProcessState, qt.IsNotNil, qt.Commentf("the oracle did not run: %s", out))
+	return string(out), cmd.ProcessState.ExitCode()
+}

--- a/internal/atlashclrender/table_reference_test.go
+++ b/internal/atlashclrender/table_reference_test.go
@@ -1,0 +1,261 @@
+package atlashclrender_test
+
+import (
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// crossSchemaDocument builds a document whose every table reference points at
+// `other.users` from `public.posts`, one reference per position that goes
+// through the reference renderer.
+//
+// [withoutTargetTable] takes the referenced block back out. That pair is the
+// single thing under test -- everything else is held fixed, so a difference
+// between the two renders is attributable to nothing else.
+func crossSchemaDocument() *goschema.Database {
+	return &goschema.Database{
+		Schemas: []goschema.Schema{{Name: "public"}, {Name: "other"}},
+		Tables: []goschema.Table{
+			{StructName: "Post", Name: "posts", Schema: "public"},
+			{StructName: "User", Name: "users", Schema: "other"},
+		},
+		Fields: []goschema.Field{
+			{
+				StructName:     "Post",
+				Name:           "author_id",
+				Type:           "bigint",
+				Foreign:        "other.users(id)",
+				ForeignKeyName: "posts_author_fk",
+			},
+			{StructName: "User", Name: "id", Type: "bigint"},
+		},
+		Triggers: []goschema.Trigger{{
+			Name:    "users_touch",
+			Table:   "other.users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "RETURN NEW;",
+		}},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "users_policy",
+			Table:           "other.users",
+			PolicyFor:       "SELECT",
+			UsingExpression: "true",
+		}},
+		Roles: []goschema.Role{{Name: "app_user"}},
+		Grants: []goschema.Grant{{
+			Role:       "app_user",
+			Privileges: []string{"SELECT"},
+			OnTable:    "other.users",
+		}},
+		ManagedData: []goschema.ManagedData{{
+			Table:  "users",
+			Schema: "other",
+			Keys:   []string{"id"},
+			File:   "seed.csv",
+		}},
+	}
+}
+
+// withoutTargetTable removes the `other.users` block and its column, leaving
+// every reference to it in place. That is a filtered export or an orphan
+// trigger: the references are still meant, and nothing in the document says
+// which schema they meant.
+func withoutTargetTable(db *goschema.Database) *goschema.Database {
+	db.Tables = slices.DeleteFunc(db.Tables, func(table goschema.Table) bool {
+		return table.StructName == "User"
+	})
+	db.Fields = slices.DeleteFunc(db.Fields, func(field goschema.Field) bool {
+		return field.StructName == "User"
+	})
+	return db
+}
+
+// TestRenderShortensTableReferenceWhenDocumentDeclaresTheTarget pins the
+// spelling every position must use when the referenced table block is present.
+//
+// A reference in HCL names a BLOCK, and a block is named by its labels, so the
+// schema belongs on the block and not in the reference. Measured on the pinned
+// Atlas community binary v1.3.0 (PostgreSQL 17, realm-scope dev URL) against a
+// document it accepts, one attribute varied at a time:
+//
+//	ref_columns = [table.users.column.id]        exit 0
+//	ref_columns = [table.other.users.column.id]  exit 1  Unsupported attribute;
+//	                                                     ... named "other"
+//	on  = table.users        / table.other.users        (trigger)     0 / 1
+//	on  = table.users        / table.other.users        (policy)      1 / 1 *
+//	for = table.users        / table.other.users        (permission)  0 / 1
+//
+// (*) A policy never gets past that binary's own feature gap -- `postgres:
+// policies are not supported by this version` for the short form against
+// `Unsupported attribute` for the long one -- so the reachable target there is
+// the same one #1255 used: the message stops being about Ptah's spelling.
+//
+// `data` is the one position where the spelling is unreachable: that binary
+// models `data` as a labeled data source and refuses Ptah's unlabeled block
+// with `data block "data" must have exactly 2 labels` before evaluating any
+// attribute, identically for both spellings. It is rendered the same way anyway
+// because Ptah's own reader is the one that has to agree with itself.
+func TestRenderShortensTableReferenceWhenDocumentDeclaresTheTarget(t *testing.T) {
+	c := qt.New(t)
+
+	rendered, err := atlashclrender.Render(crossSchemaDocument())
+
+	c.Assert(err, qt.IsNil)
+	hcl := string(rendered.Data)
+	for _, want := range []string{
+		`ref_columns = [table.users.column.id]`,
+		`on = table.users`,
+		`for = table.users`,
+		`table = table.users`,
+		`table "users" {`,
+		`schema = schema.other`,
+	} {
+		c.Assert(hcl, qt.Contains, want, qt.Commentf("rendered HCL:\n%s", hcl))
+	}
+	c.Assert(hcl, qt.Not(qt.Contains), "table.other.users",
+		qt.Commentf("rendered HCL:\n%s", hcl))
+	// Two positions spell `on`, so counting is what says both moved rather than
+	// one of them carrying the assertion for both.
+	c.Assert(strings.Count(hcl, "on = table.users"), qt.Equals, 2,
+		qt.Commentf("rendered HCL:\n%s", hcl))
+}
+
+// TestRenderCrossSchemaReferencesRoundTripToTheSameIR is the other half of the
+// rule: the short form costs nothing because the schema is read back off the
+// block the reference names.
+//
+// It asserts the IR after a render-and-parse rather than the text, because the
+// text is what changed and the IR is what must not.
+func TestRenderCrossSchemaReferencesRoundTripToTheSameIR(t *testing.T) {
+	c := qt.New(t)
+	db := crossSchemaDocument()
+
+	rendered, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", string(rendered.Data)))
+
+	c.Assert(fieldByName(parsed.Fields, "author_id").Foreign, qt.Equals, "other.users(id)")
+	c.Assert(parsed.Triggers, qt.HasLen, 1)
+	c.Assert(parsed.Triggers[0].Table, qt.Equals, "other.users")
+	c.Assert(parsed.RLSPolicies, qt.HasLen, 1)
+	c.Assert(parsed.RLSPolicies[0].Table, qt.Equals, "other.users")
+	c.Assert(parsed.Grants, qt.HasLen, 1)
+	c.Assert(parsed.Grants[0].OnTable, qt.Equals, "other.users")
+	c.Assert(parsed.ManagedData, qt.HasLen, 1)
+	c.Assert(parsed.ManagedData[0].Table, qt.Equals, "users")
+	c.Assert(parsed.ManagedData[0].Schema, qt.Equals, "other")
+}
+
+// TestRenderKeepsQualifiedReferenceWhenDocumentCannotResolveIt covers the cases
+// where dropping the schema would destroy it or point the reference somewhere
+// else. Each row is a document the short form would be wrong for.
+func TestRenderKeepsQualifiedReferenceWhenDocumentCannotResolveIt(t *testing.T) {
+	tests := []struct {
+		name string
+		// db returns a document referring to `other.users` from `public.posts`.
+		db func() *goschema.Database
+		// why records what the short form would cost here.
+		why string
+	}{
+		{
+			name: "target table absent",
+			db:   func() *goschema.Database { return withoutTargetTable(crossSchemaDocument()) },
+			why: "no block carries the schema, so dropping it loses it for good:" +
+				" a filtered export or an orphan trigger has nothing to resolve against",
+		},
+		{
+			name: "name declared in two schemas",
+			db: func() *goschema.Database {
+				db := crossSchemaDocument()
+				db.Tables = append(db.Tables, goschema.Table{StructName: "PublicUser", Name: "users", Schema: "public"})
+				db.Fields = append(db.Fields, goschema.Field{StructName: "PublicUser", Name: "id", Type: "bigint"})
+				return db
+			},
+			why: "two tables of one name are legal, and the pinned binary refuses the short form" +
+				" with `multiple reference tables found for \"users\"` rather than picking one;" +
+				" goschema gives up on the same ambiguity, so the schema would be lost silently",
+		},
+		{
+			name: "only a same-named table in another schema",
+			db: func() *goschema.Database {
+				db := withoutTargetTable(crossSchemaDocument())
+				db.Tables = append(db.Tables, goschema.Table{StructName: "PublicUser", Name: "users", Schema: "public"})
+				db.Fields = append(db.Fields, goschema.Field{StructName: "PublicUser", Name: "id", Type: "bigint"})
+				return db
+			},
+			why: "the one `users` block this document declares is a DIFFERENT table," +
+				" so the short form would resolve, quietly, to the wrong one",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			rendered, err := atlashclrender.Render(test.db())
+
+			c.Assert(err, qt.IsNil)
+			hcl := string(rendered.Data)
+			for _, want := range []string{
+				`ref_columns = [table.other.users.column.id]`,
+				`on = table.other.users`,
+				`for = table.other.users`,
+				`table = table.other.users`,
+			} {
+				c.Assert(hcl, qt.Contains, want, qt.Commentf("%s\nrendered HCL:\n%s", test.why, hcl))
+			}
+		})
+	}
+}
+
+// TestRenderKeepsQualifiedSequenceTarget is the control on the other axis: the
+// rule is about TABLE references only.
+//
+// A permission naming a sequence keeps that sequence block in the document, and
+// the pinned binary refuses any PostgreSQL file declaring one -- `postgres:
+// sequences are not supported by this version` -- before a reference is ever
+// resolved. So nothing measured says which spelling it would take, and a rule
+// applied there would be a guess.
+//
+// The document deliberately declares a TABLE of the sequence's name in the
+// sequence's schema. PostgreSQL could not produce it -- tables and sequences
+// share one relation namespace -- and that is the point: without it, a table
+// block is never a candidate for this name and the assertion holds no matter
+// what the sequence path does. With it, pointing the sequence target at
+// [renderer.tableRef] shortens the reference and this test says so.
+func TestRenderKeepsQualifiedSequenceTarget(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Schemas:   []goschema.Schema{{Name: "app"}},
+		Sequences: []goschema.Sequence{{Name: "order_seq", Schema: "app"}},
+		Tables:    []goschema.Table{{StructName: "OrderSeq", Name: "order_seq", Schema: "app"}},
+		Fields:    []goschema.Field{{StructName: "OrderSeq", Name: "id", Type: "bigint"}},
+		Roles:     []goschema.Role{{Name: "app_user"}},
+		Grants: []goschema.Grant{{
+			Role:       "app_user",
+			Privileges: []string{"USAGE"},
+			OnSequence: "app.order_seq",
+		}},
+	}
+
+	rendered, err := atlashclrender.Render(db)
+
+	c.Assert(err, qt.IsNil)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, `for = sequence.app.order_seq`, qt.Commentf("rendered HCL:\n%s", hcl))
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.Grants, qt.HasLen, 1)
+	c.Assert(parsed.Grants[0].OnSequence, qt.Equals, "app.order_seq")
+}

--- a/internal/goannotationexport/parity_test.go
+++ b/internal/goannotationexport/parity_test.go
@@ -109,7 +109,16 @@ func TestExport_HappyPath_PreservesGoAnnotationSemantics(t *testing.T) {
 	c.Assert(fields["app.users.audit_created_at"].Overrides["mysql"]["type"], qt.Equals, "DATETIME(6)")
 	c.Assert(fields["app.users.metadata"].Nullable, qt.IsTrue)
 	c.Assert(fields["app.users.metadata"].Overrides["mysql"]["type"], qt.Equals, "JSON")
-	c.Assert(fields["app.users.manager_id"].Foreign, qt.Equals, "app.accounts(id)")
+	// The annotation writes ref="app.accounts(id)" and the export writes
+	// `ref_columns = [table.accounts.column.id]`, because an HCL reference names
+	// a block by its label and the pinned Atlas community binary v1.3.0 refuses
+	// `table.app.accounts` outright. The target is unchanged: `accounts` is
+	// declared once in this document, in `app`, which is also the schema of the
+	// table holding the field, so every reader -- including the DDL path, via
+	// tablelookup.ResolveReference -- gets back to app.accounts. A cross-schema
+	// target does keep its schema here; see the round-trip coverage in
+	// internal/atlashcl.
+	c.Assert(fields["app.users.manager_id"].Foreign, qt.Equals, "accounts(id)")
 	c.Assert(fields["app.users.manager_id"].OnDelete, qt.Equals, "SET NULL")
 	c.Assert(fields["app.users.manager_id"].Overrides["mysql"]["type"], qt.Equals, "BIGINT UNSIGNED")
 	indexes := indexesByName(after.Indexes)


### PR DESCRIPTION
Closes item 1 of #1260.

## What the binary does, re-measured

Every row below was re-measured on the pinned Atlas community binary v1.3.0
before being trusted, off a base document asserted at exit 0 first, adding or
varying exactly one thing.

PostgreSQL 17, realm-scope dev URL, `users` in `other`, `posts` in `public`:

| attribute | short form | qualified form |
| --- | --- | --- |
| `ref_columns` (foreign key) | **exit 0** | exit 1 `Unsupported attribute; This object does not have an attribute named "other"` |
| `on` (trigger) | **exit 0** | exit 1, same message |
| `for` (permission) | **exit 0** | exit 1, same message |
| `on` (policy) | exit 1 `postgres: policies are not supported by this version` | exit 1 `Unsupported attribute` |
| `table` (data) | exit 1 `data block "data" must have exactly 2 labels` | exit 1, same message |

The three positions the issue recorded as unmeasured are now measured:

- **`permission.for` behaves exactly like `trigger.on` and `ref_columns`.**
- **`policy.on` cannot reach exit 0** — a PostgreSQL policy block never gets past
  that binary's own feature gap. The reachable target is the one #1255 used: the
  message stops being about Ptah's spelling and becomes a statement about what
  that build models.
- **`data.table` cannot answer at all.** That binary models `data` as a labeled
  data source and refuses Ptah's unlabeled block on its shape before evaluating
  any attribute; `data "probe" "seed"` and `data "sql" "seed"` are refused too
  (`missing data source handler`). Both spellings fail identically, so the
  position is rendered for Ptah's own reader, not for that binary's.

Two more measurements that were not in the issue:

- **It is not a cross-schema special case.** With the target in the SAME schema
  as the referring table, `table.public.users` is refused identically. That is
  the common shape — Ptah's qualified spelling was refused on essentially every
  multi-schema document it wrote, not only cross-schema ones.
- **SQLite reproduces both verdicts with no server**, `sqlite://file?mode=memory`,
  which is what lets the new conformance run measure something even where no dev
  database is configured.

## The rule, and the two halves of its condition

> Render the reference unqualified when the referenced table is present in the
> document; keep the qualified form when it is not.

Implemented with the presence test spelled out as: the document declares exactly
**one** table block with that label **and** that block carries **this** schema.

- One block, because two tables of one name in different schemas are legal, and
  the short form there is refused with `specutil: failed converting to
  *schema.Realm: multiple reference tables found for "users"`. goschema gives up
  on the same ambiguity, so shortening would lose the schema silently — worse
  than a refusal.
- That block's schema, because a lone `public.users` does not make `table.users`
  mean `other.users`.

`objectRef` became `renderer.tableRef` for the five table positions;
`tableColumnRefs` and `grantTarget` became methods to reach it. A sequence target
keeps `sequence.<schema>.<name>` **by construction** — only table positions call
the shortening path — because a permission naming a sequence keeps that sequence
block in the document, and the binary refuses any PostgreSQL file declaring one
before resolving anything.

The four tests the issue reported as red are green without weakening what they
are for. `TestRender_ExplicitTableReferencePreservesStructuralIdentity` still
keeps a table literally named `"tenant.data"` apart from table `data` in schema
`tenant`; the quoted literal name is untouched by this rule.

## The round trip needed a parser fix

A **single-column** foreign key is recorded on the field as
`Foreign = "<table>(<column>)"` rather than as a Constraint, and nothing resolved
it against the document. So Ptah read the pinned binary's own inspect output for
a cross-schema foreign key as `users(id)` — schema gone — while the multi-column
form of the same key read back as `other.users`. A `data` block's schema had the
same hole. Both are now read off the referenced block, through the same
`tablelookup.ResolveReference` every consumer of `Field.Foreign` already calls.

The schema is written into `Field.Foreign` only where the reference cannot be
read without it: a target in the declaring table's own schema keeps the short
name. That is not a preference. Writing it out unconditionally renders
`REFERENCES "main"."users" ("id")` on SQLite, which that engine refuses with
`near ".": syntax error` —
`TestInspectSource_FileExportThenDevInspectionRoundTrip` went red on exactly that
statement, and it is used below as the control for that decision.

## Two things this PR does not fix, both measured

1. **SQLite renders an invalid `REFERENCES` clause for any schema-qualified
   target.** This is pre-existing and independent of this change: on master, a Go
   annotation with `ref="main.users(id)"` renders
   `"user_id" INTEGER NOT NULL CONSTRAINT "posts_user_fk" REFERENCES "main"."users" ("id")`,
   which SQLite refuses. SQLite's foreign-key clause has no schema slot.
2. **Ptah cannot render the ambiguous document readably.** When two schemas hold
   a table of one name, this PR keeps the qualified form and that binary refuses
   it — but the binary itself has a spelling for this case, and it is one Ptah's
   parser already reads: TWO labels. Measured at exit 0:

   ```hcl
   table "other" "users" { ... }
   table "public" "users" { ... }
   ...
   ref_columns = [table.other.users.column.id]
   ```

   and its own inspect of that database emits exactly that pairing. Adopting it
   unconditionally would break byte-identity with that binary's output for the
   unambiguous case, where it writes one label — so it belongs in a follow-up
   scoped to ambiguous names.

## Coverage

New: `internal/atlashclrender/table_reference_test.go` (rendered spelling for all
five positions, the three documents that must keep the qualified form, the
sequence control), `internal/atlashcl/document_table_refs_test.go` (parser round
trip, ambiguity, author-written schema), and
`internal/atlashclrender/table_reference_oracle_internal_test.go` — a conformance
run that puts **the document Ptah actually renders** to the pinned binary and
asserts the previously-rendered spelling is still refused *with the attribute
error*, so the measurement cannot rot into a pass.

Thirteen mutants were applied one at a time against the final tree and each
observed red: shortening unconditionally, never shortening, dropping either half
of the presence condition, routing a sequence target through the shortening path,
removing the parser pass or either of its two halves, dropping the
qualified-as-written guard, dropping the implicit-schema shortcut (seen both by
the parser rows and by the SQLite round trip), removing the ambiguity guard, and
reverting the renderer under the conformance run.

A fourteenth SURVIVED and is why the sequence path is structural rather than a
`kind == "table"` conditional: the control could not see its own mutation,
because its document declared no table of the sequence's name, so nothing
distinguished "sequences are excluded" from "no table matched". The fixture now
declares one — a document PostgreSQL could not produce, deliberately — and the
re-run is red.

## End to end, through the real CLI

Against a PostgreSQL 17 database holding `other.users` and two `public` tables
whose foreign keys reference it, `ptah-compat schema inspect -s public -s other`,
output handed to the pinned binary:

| compat binary built from | rendered reference | pinned binary |
| --- | --- | --- |
| origin/master (3acddbdf) | `ref_columns = [table.other.users.column.id]` | exit 1 `Unsupported attribute ... named "other"` |
| this branch | `ref_columns = [table.users.column.id]` | **exit 0** |

One neighboring case is worth naming because it is NOT fixed by this and is not
caused by it: inspecting only `public` on that same database emits a foreign key
referencing a `users` block the document does not declare, and the pinned binary
refuses it. The two binaries produce byte-identical output there — the target's
schema is gone from the IR before rendering, so there is nothing for this rule to
keep qualified. That belongs to the schema-selection surface, not to this one.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 1, the single failure being
`TestSVGReportsGraphvizStderrOnFailure` at exactly 10.00s under load, which
passes alone (exit 0) and is the known load-sensitive test · `go tool qtlint` 0 ·
`golangci-lint run` 0 (private cache) · `scripts/check-test-style.sh` 0 ·
`scripts/check-public-api.sh` 0 · `scripts/check-public-api-snapshot.sh` 0.

The two public-API gates cannot go red for this change — everything here is under
`internal/` — so they are cited as run, not as coverage. The other two script
gates were each deliberately broken and observed red first: an `if` in a test
body turns `check-test-style` red, and removing the white-box justification
comment from the new conformance file turns it red for that reason instead;
`qt.Not(qt.IsNil)` turns `qtlint` red.
