### PR TITLE
Compare the full PostgreSQL index definition (#1272)

### DIFF
--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -205,6 +205,15 @@ type IndexPart struct {
 	NullsOrder string
 }
 
+// Index NULLS ordering spellings for IndexPart.NullsOrder, matching
+// [go.5x5.cz/ptah/core/ast.NullsOrderFirst] and
+// [go.5x5.cz/ptah/dbschema/types.NullsOrderFirst] so the value survives every
+// hop between the three index-part shapes unchanged.
+const (
+	NullsOrderFirst = "FIRST"
+	NullsOrderLast  = "LAST"
+)
+
 // Index represents a database index definition parsed from Go struct annotations.
 // Indexes are used to improve query performance and enforce uniqueness constraints
 // on one or more columns.

--- a/docs/atlas_hcl_schema.md
+++ b/docs/atlas_hcl_schema.md
@@ -41,6 +41,9 @@ current schema IR:
   `include`
 - `index` blocks with `columns`, `on { column = ..., prefix = ... }`,
   `on { expr = "..." }`, `desc`, `unique`, `type`, `where`, and `comment`;
+  an `on` block also accepts `nulls_first` or `nulls_last` (not both) for a key
+  whose `NULL` ordering differs from its direction's default, which is
+  `NULLS LAST` for ascending and `NULLS FIRST` for descending;
   PostgreSQL indexes also support `include`, BRIN `page_per_range`, and
   `nulls_distinct`, ClickHouse data-skipping indexes support `granularity`, and
   the Ptah `ops` parity extension preserves the Go annotation operator class

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -217,6 +217,63 @@ both the `CREATE DOMAIN` and the domain-typed column, so closing this gap meant
 keeping both halves rather than matching CE. Ptah's output replays at psql exit
 0 where CE's does not.
 
+### Reading an attribute and reconciling it are different claims
+
+The table above records what introspection preserves. It does not say what
+`schema diff` does with an index that already exists, and until
+[#1272](https://github.com/stokaro/ptah/issues/1272) the answer was: nothing.
+The PostgreSQL branch of the index comparator compared the partial predicate
+and `NULLS DISTINCT` and returned before reaching anything else, so every
+attribute the reader had learned to preserve was discarded at reconciliation
+time. Each pair below reported
+`Schemas are synced, no changes to be made.` while the pinned Atlas CE v1.3.0
+binary planned `DROP INDEX` + `CREATE INDEX`. Measured on PostgreSQL 17.10 by
+loading each side into its own database and diffing one against the other.
+
+| Current index | Desired index | Now planned |
+| --- | --- | --- |
+| `USING btree (value)` | `USING hash (value)` | Rebuild |
+| `USING gin (tsv)` | `USING gist (tsv)` | Rebuild |
+| `(value)` | `(value text_pattern_ops)`, and the reverse | Rebuild |
+| `(value NULLS FIRST)` | `(value DESC)` | Rebuild |
+| `(value)` | `(value NULLS FIRST)` | Rebuild |
+| `(value DESC)` | `(value DESC NULLS LAST)` | Rebuild |
+| `(a) INCLUDE (b)` | `(a) INCLUDE (c)`, added, removed, reordered | Rebuild |
+| `(a)` | `(lower(a))`, and the reverse | Rebuild |
+| `(lower(a))` | `(upper(a))` | Rebuild |
+| `(value)` | `UNIQUE (value)` | Rebuild |
+| `(a)` | `(b)` | Rebuild |
+
+PostgreSQL cannot alter any of these in place, so the transition is a rebuild
+rather than an `ALTER INDEX`. Every plan above was executed against the current
+database with `psql -v ON_ERROR_STOP=1` at exit 0, and both Ptah and the pinned
+binary reported the databases synced afterwards.
+
+Equivalent spellings still compare equal, so nothing is rebuilt for the sake of
+it: `btree` and `BTREE`; an omitted access method and `USING btree`; `ASC` and
+`ASC NULLS LAST`; `DESC` and `DESC NULLS FIRST`; an index-level `ops` and the
+same class written on each key.
+
+Two consequences worth naming:
+
+- The HCL surface now reads and writes `nulls_first` / `nulls_last` on an
+  `index` `on` block. These are the attribute names Atlas CE's own
+  `schema inspect` emits. `ptah-compat` previously dropped them under its
+  unknown-attribute tolerance, so a file CE produced reached Ptah with the
+  ordering gone; the native parser refused the file outright.
+- An operator class is compared as written, case-insensitively. Ptah does not
+  resolve a column type's *default* operator class, so a hand-written source
+  that spells the default out — `ops = text_ops` on a `text` column — plans a
+  rebuild on every run where CE reports the schemas synced. The catalog reports
+  only non-default classes, so neither binary's `schema inspect` produces that
+  input and no round trip reaches it. Omit a default class, which is how both
+  binaries write one.
+
+Only PostgreSQL is covered. MySQL, MariaDB, SQLite, ClickHouse, CockroachDB,
+YugabyteDB and Spanner keep the comparison they had, because what makes two
+indexes the same index is a per-dialect question and only PostgreSQL was
+measured.
+
 ## Reports
 
 - Offline corpus report:

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3482,6 +3482,7 @@ type Visitor interface {
 
 ## go.5x5.cz/ptah/core/goschema
 
+const NullsOrderFirst = "FIRST" ...
 func Deduplicate(r *Database)
 func Finalize(r *Database)
 func GetDependencyInfo(r *Database) string

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -62,7 +62,7 @@ table "users" {
 | `table` | Columns, keys, indexes, constraints, checks, row security, and Ptah `checks`, `custom`, and `platform` extensions. |
 | `column` | Type, nullability, defaults, generated/identity metadata, comments, checks, and Ptah `enum` and `platform` extensions. |
 | `primary_key` | `columns`; PostgreSQL also supports `include`. |
-| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `unique`, `type`, `where`, `comment`, ClickHouse `granularity`, and PostgreSQL include/storage options. |
+| `index` | `columns`, `on { column = ... }`, `on { expr = ... }`, `desc`, `on { nulls_first = ... }` or `on { nulls_last = ... }`, `unique`, `type`, `where`, `comment`, ClickHouse `granularity`, and PostgreSQL include/storage options. |
 | `constraint` | Ptah block used when annotation metadata cannot fit the Atlas-native constraint blocks, and for `EXCLUDE` constraints. |
 | `unique` | `columns`; PostgreSQL also supports `include` and `nulls_distinct`. |
 | `foreign_key` | One local `columns` entry and one table-qualified `ref_columns` entry. |

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -1013,6 +1013,10 @@ func (p *parser) parseIndexParts(onBlocks []*hclsyntax.Block) ([]string, []gosch
 		if err != nil {
 			return nil, nil, err
 		}
+		nullsOrder, err := p.indexPartNullsOrder(nested)
+		if err != nil {
+			return nil, nil, err
+		}
 		operator := p.optionalSQLExpression(nested.Body.Attributes["ops"])
 		prefix := p.optionalRawExpr(nested.Body.Attributes["prefix"])
 		if columnAttr != nil {
@@ -1021,7 +1025,13 @@ func (p *parser) parseIndexParts(onBlocks []*hclsyntax.Block) ([]string, []gosch
 				return nil, nil, err
 			}
 			columns = append(columns, column)
-			parts = append(parts, goschema.IndexPart{Name: column, Operator: operator, Prefix: prefix, Desc: desc})
+			parts = append(parts, goschema.IndexPart{
+				Name:       column,
+				Operator:   operator,
+				Prefix:     prefix,
+				Desc:       desc,
+				NullsOrder: nullsOrder,
+			})
 			continue
 		}
 		if prefix != "" {
@@ -1029,9 +1039,48 @@ func (p *parser) parseIndexParts(onBlocks []*hclsyntax.Block) ([]string, []gosch
 		}
 		expr := p.exprString(exprAttr)
 		columns = append(columns, expr)
-		parts = append(parts, goschema.IndexPart{Expr: expr, Operator: operator, Desc: desc})
+		parts = append(parts, goschema.IndexPart{
+			Expr:       expr,
+			Operator:   operator,
+			Desc:       desc,
+			NullsOrder: nullsOrder,
+		})
 	}
 	return columns, parts, nil
+}
+
+// indexPartNullsOrder reads the NULLS ordering of one index key.
+//
+// The two attributes are the spelling the community binary's own
+// `schema inspect` emits for a PostgreSQL index, so a file it produced was
+// reaching Ptah with the ordering silently dropped by the unknown-attribute
+// tolerance -- the property was accepted and then ignored. Only an ordering
+// that deviates from the direction's default is recorded, matching what
+// #1271's reader does with pg_index.indoption, so an explicit
+// `nulls_last = true` on an ascending key stays equal to an omitted one
+// instead of planning a rebuild (issue #1272).
+//
+// Setting both to true is refused rather than resolved: a key has one NULLS
+// ordering, and picking one of the two for the author would be a guess.
+func (p *parser) indexPartNullsOrder(block *hclsyntax.Block) (string, error) {
+	first, err := p.optionalIndexOnBool(block, "nulls_first", false)
+	if err != nil {
+		return "", err
+	}
+	last, err := p.optionalIndexOnBool(block, "nulls_last", false)
+	if err != nil {
+		return "", err
+	}
+	if first && last {
+		return "", p.blockError(block, "index on cannot set both nulls_first and nulls_last")
+	}
+	if first {
+		return goschema.NullsOrderFirst, nil
+	}
+	if last {
+		return goschema.NullsOrderLast, nil
+	}
+	return "", nil
 }
 
 type primaryKeySpec struct {
@@ -1547,11 +1596,13 @@ func (p *parser) rejectUnsupportedUniqueAttrs(block *hclsyntax.Block) error {
 
 func (p *parser) rejectUnsupportedIndexOnAttrs(block *hclsyntax.Block) error {
 	return p.rejectUnsupportedAttrs(block, map[string]bool{
-		"column": true,
-		"expr":   true,
-		"ops":    true,
-		"prefix": true,
-		"desc":   true,
+		"column":      true,
+		"expr":        true,
+		"ops":         true,
+		"prefix":      true,
+		"desc":        true,
+		"nulls_first": true,
+		"nulls_last":  true,
 	}, "index on")
 }
 

--- a/internal/atlashcl/index_nulls_order_test.go
+++ b/internal/atlashcl/index_nulls_order_test.go
@@ -1,0 +1,135 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// `nulls_first` and `nulls_last` are the spelling the pinned community binary
+// v1.3.0 emits for a PostgreSQL index key whose NULLS ordering deviates from
+// its direction's default -- measured on PostgreSQL 17.10, its `schema inspect`
+// of `CREATE INDEX i ON t (a text_pattern_ops DESC NULLS LAST, b ASC NULLS
+// FIRST)` writes `nulls_last = true` on the first key and `nulls_first = true`
+// on the second.
+//
+// Before issue #1272 neither name was modeled here. Under `ptah-compat` the
+// unknown-attribute tolerance dropped them, so a file the community binary
+// itself produced reached Ptah with the ordering silently gone; under the
+// native parser the same file was refused outright. The property is now read,
+// which is what lets the comparator treat it as part of the index definition.
+func TestParseIndexPartNullsOrder(t *testing.T) {
+	tests := []struct {
+		name     string
+		attr     string
+		wantDesc bool
+		want     string
+	}{
+		{
+			name: "nulls first on an ascending key",
+			attr: "nulls_first = true",
+			want: goschema.NullsOrderFirst,
+		},
+		{
+			name: "nulls last on an ascending key",
+			attr: "nulls_last = true",
+			want: goschema.NullsOrderLast,
+		},
+		{
+			name:     "nulls last on a descending key",
+			attr:     "desc = true\n    nulls_last = true",
+			wantDesc: true,
+			want:     goschema.NullsOrderLast,
+		},
+		{
+			// An absent ordering is the direction's default and stays
+			// unrecorded, matching what the live-database reader does with
+			// pg_index.indoption.
+			name: "no ordering attribute",
+			attr: "",
+			want: "",
+		},
+		{
+			// `false` is not an assertion of the opposite ordering; it says
+			// nothing, which is the default.
+			name: "nulls first set to false",
+			attr: "nulls_first = false",
+			want: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			db, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "a" {
+    type = text
+  }
+  index "i" {
+    on {
+      column = column.a
+      `+test.attr+`
+    }
+  }
+}
+`), "schema.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.Indexes, qt.HasLen, 1)
+			c.Assert(db.Indexes[0].Parts, qt.HasLen, 1)
+			c.Assert(db.Indexes[0].Parts[0].NullsOrder, qt.Equals, test.want)
+			c.Assert(db.Indexes[0].Parts[0].Desc, qt.Equals, test.wantDesc)
+		})
+	}
+}
+
+// TestParseIndexPartNullsOrderRejectsBoth keeps the parser from inventing an
+// answer. A key has one NULLS ordering; a file asking for both is a mistake,
+// and picking one of the two would hide it.
+func TestParseIndexPartNullsOrderRejectsBoth(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "a" {
+    type = text
+  }
+  index "i" {
+    on {
+      column      = column.a
+      nulls_first = true
+      nulls_last  = true
+    }
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*index on cannot set both nulls_first and nulls_last.*`)
+}
+
+// TestParseIndexPartNullsOrderRejectsNonBool pins the type check, so a string
+// spelling is named rather than quietly read as "no ordering".
+func TestParseIndexPartNullsOrderRejectsNonBool(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := atlashcl.Parse([]byte(`
+table "t" {
+  column "a" {
+    type = text
+  }
+  index "i" {
+    on {
+      column     = column.a
+      nulls_last = "yes"
+    }
+  }
+}
+`), "schema.hcl")
+
+	c.Assert(err, qt.ErrorMatches, `.*index on attribute "nulls_last" must be a bool.*`)
+}

--- a/internal/atlashclrender/index_nulls_order_test.go
+++ b/internal/atlashclrender/index_nulls_order_test.go
@@ -1,0 +1,92 @@
+package atlashclrender_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderIndexPartNullsOrderRoundTrip closes the loop issue #1272 opened.
+//
+// The comparator now treats a key's NULLS ordering as part of the index
+// definition, so a rendering that drops it turns a faithful `schema inspect`
+// into a permanent rebuild: `schema diff --from <db> --to <its own inspect
+// output>` would plan DROP INDEX + CREATE INDEX forever. Measured on
+// PostgreSQL 17.10 before the renderer learned these two attributes, that is
+// exactly what the fixture below did.
+func TestRenderIndexPartNullsOrderRoundTrip(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "a", Type: "text"},
+			{StructName: "T", Name: "b", Type: "text"},
+		},
+		Indexes: []goschema.Index{
+			{
+				StructName: "T",
+				Name:       "i",
+				Fields:     []string{"a", "b"},
+				Parts: []goschema.IndexPart{
+					{Name: "a", Desc: true, NullsOrder: goschema.NullsOrderLast},
+					{Name: "b", NullsOrder: goschema.NullsOrderFirst},
+				},
+			},
+		},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, "nulls_last = true")
+	c.Assert(hcl, qt.Contains, "nulls_first = true")
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.Indexes, qt.HasLen, 1)
+	c.Assert(parsed.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
+		{Name: "a", Desc: true, NullsOrder: goschema.NullsOrderLast},
+		{Name: "b", NullsOrder: goschema.NullsOrderFirst},
+	})
+}
+
+// TestRenderIndexPartNullsOrderKeepsOnBlocks guards the other half of the same
+// loss. simpleIndexParts decides between the compact `columns = [...]` spelling
+// and one `on` block per key; a part carrying only a NULLS ordering used to
+// count as simple, so the ordering disappeared even though renderIndex knew how
+// to write it.
+func TestRenderIndexPartNullsOrderKeepsOnBlocks(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{{StructName: "T", Name: "a", Type: "text"}},
+		Indexes: []goschema.Index{
+			{
+				StructName: "T",
+				Name:       "i",
+				Fields:     []string{"a"},
+				Parts: []goschema.IndexPart{
+					{Name: "a", NullsOrder: goschema.NullsOrderFirst},
+				},
+			},
+		},
+	}
+	goschema.Finalize(db)
+
+	rendered, err := atlashclrender.Render(db)
+	c.Assert(err, qt.IsNil)
+	hcl := string(rendered.Data)
+	c.Assert(hcl, qt.Contains, "on {")
+	c.Assert(hcl, qt.Contains, "nulls_first = true")
+
+	parsed, err := atlashcl.Parse(rendered.Data, "schema.hcl")
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", hcl))
+	c.Assert(parsed.Indexes[0].Parts, qt.DeepEquals, []goschema.IndexPart{
+		{Name: "a", NullsOrder: goschema.NullsOrderFirst},
+	})
+}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -685,6 +685,7 @@ func (r *renderer) renderIndex(index goschema.Index) {
 			if part.Desc {
 				r.rawAttr(3, "desc", "true")
 			}
+			r.renderIndexPartNullsOrder(part.NullsOrder)
 			r.line("    }")
 		}
 	} else {
@@ -857,9 +858,32 @@ func simplePrimaryKeyParts(parts []goschema.PrimaryKeyPart) bool {
 	return true
 }
 
+// renderIndexPartNullsOrder writes the NULLS ordering of one index key.
+//
+// The rendered value is whatever the part carries. Deciding that an ordering
+// is redundant belongs to whoever produced the part -- the live-database reader
+// records only an ordering that deviates from the direction's default -- and
+// an author who spelled one out gets it back. The two attribute names are the
+// spelling the community binary's own inspect output uses, so a rendered file
+// stays readable by both (issue #1272).
+func (r *renderer) renderIndexPartNullsOrder(order string) {
+	switch strings.ToUpper(strings.TrimSpace(order)) {
+	case goschema.NullsOrderFirst:
+		r.rawAttr(3, "nulls_first", "true")
+	case goschema.NullsOrderLast:
+		r.rawAttr(3, "nulls_last", "true")
+	}
+}
+
+// simpleIndexParts reports whether the parts carry nothing the compact
+// `columns = [...]` spelling would lose. Every field the `on` block can express
+// has to be listed: a part carrying only a NULLS ordering is not simple, and
+// omitting that check is how the ordering used to disappear from rendered HCL
+// even after #1271 taught the reader to preserve it.
 func simpleIndexParts(parts []goschema.IndexPart) bool {
 	for _, part := range parts {
-		if part.Expr != "" || part.Operator != "" || part.Prefix != "" || part.Desc {
+		if part.Expr != "" || part.Operator != "" || part.Prefix != "" ||
+			part.Desc || part.NullsOrder != "" {
 			return false
 		}
 	}

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -119,7 +119,7 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 	if emptySelection(fromErr) && emptySelection(toErr) {
 		reportEmptySelection(opts.Diagnostics, fromErr)
 	}
-	fromDB, err := diffFromDBState(fromState, from, scope)
+	fromDB, err := diffFromDBState(fromState, from, scope, dialect)
 	if err != nil && !emptySelection(err) {
 		return atlasreport.SchemaDiff{}, err
 	}
@@ -146,9 +146,10 @@ func diffFromDBState(
 	state atlassource.State,
 	filtered *goschema.Database,
 	scope atlasfilter.Scope,
+	dialect string,
 ) (*types.DBSchema, error) {
 	if state.DB == nil {
-		return schemafile.ToDBSchema(filtered), nil
+		return schemafile.ToDBSchema(filtered, dialect), nil
 	}
 	return scopeDatabaseSide(state.DB, scope, "--from schema")
 }

--- a/internal/schemafile/index_semantics_test.go
+++ b/internal/schemafile/index_semantics_test.go
@@ -1,0 +1,110 @@
+package schemafile_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/schemafile"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// postgresIndexDatabase is the desired state behind both tests: one index
+// carrying every property issue #1272 made the PostgreSQL comparator read.
+func postgresIndexDatabase() *goschema.Database {
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "a", Type: "text"},
+			{StructName: "T", Name: "b", Type: "text"},
+			{StructName: "T", Name: "c", Type: "text"},
+		},
+		Indexes: []goschema.Index{
+			{
+				StructName:     "T",
+				Name:           "i",
+				Fields:         []string{"a", "b"},
+				Type:           "btree",
+				IncludeColumns: []string{"c"},
+				Parts: []goschema.IndexPart{
+					{Name: "a", Operator: "text_pattern_ops", Desc: true, NullsOrder: goschema.NullsOrderLast},
+					{Name: "b", NullsOrder: goschema.NullsOrderFirst},
+				},
+			},
+		},
+	}
+	goschema.Finalize(db)
+	return db
+}
+
+// TestToDBSchema_CarriesPostgresIndexSemantics pins the conversion used for the
+// --from side of `schema diff` when that side is a local file.
+//
+// Everything the comparator reads has to survive this hop. The access method,
+// the structured key parts and the INCLUDE payload were dropped here, which was
+// invisible only while the PostgreSQL comparator ignored all three: once it
+// started reading them, a file diffed against the database it was inspected
+// from would have planned a rebuild for every index carrying any of them.
+func TestToDBSchema_CarriesPostgresIndexSemantics(t *testing.T) {
+	c := qt.New(t)
+
+	got := schemafile.ToDBSchema(postgresIndexDatabase(), platform.Postgres)
+
+	c.Assert(got.Indexes, qt.HasLen, 1)
+	index := got.Indexes[0]
+	c.Assert(index.Method, qt.Equals, "btree")
+	c.Assert(index.IncludeColumns, qt.DeepEquals, []string{"c"})
+	c.Assert(index.Parts, qt.DeepEquals, []dbschematypes.DBIndexPart{
+		{Name: "a", Operator: "text_pattern_ops", Desc: true, NullsOrder: dbschematypes.NullsOrderLast},
+		{Name: "b", NullsOrder: dbschematypes.NullsOrderFirst},
+	})
+}
+
+// TestToDBSchema_PostgresIndexSemanticsAreIdempotent is the churn control for
+// the same hop: a desired state converted to the DB shape and compared against
+// itself must report nothing. It fails the moment any index property is lost on
+// the way through, which is what makes it worth having next to the field-level
+// assertions above.
+func TestToDBSchema_PostgresIndexSemanticsAreIdempotent(t *testing.T) {
+	c := qt.New(t)
+	db := postgresIndexDatabase()
+
+	current := schemafile.ToDBSchema(db, platform.Postgres)
+	diff := schemadiff.CompareWithDialect(db, current, platform.Postgres)
+
+	c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+	c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+}
+
+// TestToDBSchema_ClickHouseSkippingIndexTypeIsNotAnAccessMethod keeps the two
+// concepts goschema.Index.Type carries apart. On ClickHouse the field is the
+// data-skipping-index type, which the DB shape keeps in DBIndex.Type; reporting
+// it as a PostgreSQL access method would make a ClickHouse "bloom_filter" and a
+// PostgreSQL "gin" indistinguishable at the comparison layer.
+func TestToDBSchema_ClickHouseSkippingIndexTypeIsNotAnAccessMethod(t *testing.T) {
+	c := qt.New(t)
+	db := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "E", Name: "events"}},
+		Fields: []goschema.Field{{StructName: "E", Name: "payload", Type: "String"}},
+		Indexes: []goschema.Index{
+			{
+				StructName:  "E",
+				Name:        "idx_events_payload",
+				Fields:      []string{"payload"},
+				Type:        "bloom_filter",
+				Granularity: 64,
+			},
+		},
+	}
+	goschema.Finalize(db)
+
+	got := schemafile.ToDBSchema(db, platform.ClickHouse)
+
+	c.Assert(got.Indexes, qt.HasLen, 1)
+	c.Assert(got.Indexes[0].Method, qt.Equals, "")
+	c.Assert(got.Indexes[0].Type, qt.Equals, "bloom_filter")
+	c.Assert(got.Indexes[0].Granularity, qt.Equals, 64)
+}

--- a/internal/schemafile/schemafile.go
+++ b/internal/schemafile/schemafile.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlashcl"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
@@ -117,7 +118,14 @@ func LoadAll(rawURLs []string, opts Options) (*goschema.Database, error) {
 // ToDBSchema converts Ptah's desired-schema IR into the DB schema shape used by
 // schema comparison. It is intended for local file-to-file comparisons where no
 // live database reader is involved.
-func ToDBSchema(db *goschema.Database) *dbschematypes.DBSchema {
+//
+// dialect names the target the converted schema will be compared under. It only
+// decides how the one goschema field that carries two concepts is unpacked:
+// goschema.Index.Type is the PostgreSQL access method on a PostgreSQL-family
+// target and the ClickHouse data-skipping-index type on ClickHouse, and the DB
+// shape keeps those apart in Method and Type. An empty dialect converts as if
+// no target were known and leaves Method unset.
+func ToDBSchema(db *goschema.Database, dialect string) *dbschematypes.DBSchema {
 	if db == nil {
 		return &dbschematypes.DBSchema{}
 	}
@@ -131,7 +139,7 @@ func ToDBSchema(db *goschema.Database) *dbschematypes.DBSchema {
 		Schemas:     toDBSchemas(db.Schemas),
 		Tables:      toDBTables(db.Tables, db.Fields, db.RLSEnabledTables),
 		Enums:       toDBEnums(db.Enums),
-		Indexes:     toDBIndexes(db.Indexes, tableByStruct),
+		Indexes:     toDBIndexes(db.Indexes, tableByStruct, dialect),
 		Constraints: toDBConstraints(db.Tables, db.Fields, db.Constraints, tableByStruct),
 		Extensions:  toDBExtensions(db.Extensions),
 		Functions:   toDBFunctions(db.Functions),
@@ -333,23 +341,74 @@ func toDBEnums(enums []goschema.Enum) []dbschematypes.DBEnum {
 	return out
 }
 
-func toDBIndexes(indexes []goschema.Index, tables map[string]goschema.Table) []dbschematypes.DBIndex {
+// toDBIndexes converts desired-state indexes into the DB shape.
+//
+// Everything the comparator reads has to survive this hop. Before issue #1272
+// the access method, the structured key parts and the INCLUDE payload were
+// dropped here, which was invisible only because the PostgreSQL comparator
+// ignored all three; once it started reading them, a `schema diff` whose
+// --from side is a local file would have reported a rebuild for every index
+// carrying any of them against the database it was inspected from.
+func toDBIndexes(
+	indexes []goschema.Index,
+	tables map[string]goschema.Table,
+	dialect string,
+) []dbschematypes.DBIndex {
 	out := make([]dbschematypes.DBIndex, 0, len(indexes))
 	for _, index := range indexes {
 		tableName, schema := indexTable(index.StructName, index.TableName, tables)
 		out = append(out, dbschematypes.DBIndex{
-			Name:          index.Name,
-			TableName:     tableName,
-			Schema:        schema,
-			Columns:       append([]string(nil), index.Fields...),
-			IsUnique:      index.Unique,
-			Condition:     index.Condition,
-			NullsDistinct: index.NullsDistinct,
-			Type:          index.Type,
-			Granularity:   index.Granularity,
+			Name:           index.Name,
+			TableName:      tableName,
+			Schema:         schema,
+			Columns:        append([]string(nil), index.Fields...),
+			Parts:          toDBIndexParts(index.Parts, index.Operator),
+			IsUnique:       index.Unique,
+			Condition:      index.Condition,
+			NullsDistinct:  index.NullsDistinct,
+			Method:         indexAccessMethod(index.Type, dialect),
+			IncludeColumns: append([]string(nil), index.IncludeColumns...),
+			Type:           index.Type,
+			Granularity:    index.Granularity,
 		})
 	}
 	return out
+}
+
+// indexAccessMethod reports goschema.Index.Type as an access method only where
+// that is what it means. On ClickHouse the same field carries the
+// data-skipping-index type, which is a different concept the DB shape keeps in
+// DBIndex.Type.
+func indexAccessMethod(indexType, dialect string) string {
+	if !platform.IsPostgresFamily(dialect) {
+		return ""
+	}
+	return indexType
+}
+
+// toDBIndexParts converts structured key parts, resolving the index-level
+// operator class the way the renderer applies it: a part without its own class
+// inherits the index's, so the DB shape -- which has no index-level slot --
+// records the resolved value per part.
+func toDBIndexParts(parts []goschema.IndexPart, indexOperator string) []dbschematypes.DBIndexPart {
+	if len(parts) == 0 {
+		return nil
+	}
+	converted := make([]dbschematypes.DBIndexPart, len(parts))
+	for position, part := range parts {
+		operator := part.Operator
+		if operator == "" {
+			operator = indexOperator
+		}
+		converted[position] = dbschematypes.DBIndexPart{
+			Name:       part.Name,
+			Expr:       part.Expr,
+			Operator:   operator,
+			Desc:       part.Desc,
+			NullsOrder: part.NullsOrder,
+		}
+	}
+	return converted
 }
 
 func toDBConstraints(

--- a/internal/schemafile/schemafile_test.go
+++ b/internal/schemafile/schemafile_test.go
@@ -114,7 +114,7 @@ table "users" {
 	db, err := schemafile.Load(path, schemafile.Options{})
 	c.Assert(err, qt.IsNil)
 
-	got := schemafile.ToDBSchema(db)
+	got := schemafile.ToDBSchema(db, platform.Postgres)
 
 	c.Assert(got.Tables, qt.HasLen, 1)
 	c.Assert(got.Tables[0].Name, qt.Equals, "users")
@@ -168,7 +168,7 @@ func TestToDBSchema_PreservesExtendedSchemaObjects(t *testing.T) {
 	}
 	goschema.Finalize(db)
 
-	got := schemafile.ToDBSchema(db)
+	got := schemafile.ToDBSchema(db, platform.Postgres)
 
 	c.Assert(got.Schemas, qt.HasLen, 1)
 	c.Assert(got.Schemas[0].Comment, qt.Equals, "Application")
@@ -219,7 +219,7 @@ func TestToDBSchema_FieldLevelConstraintsStayIdempotent(t *testing.T) {
 		},
 	}
 
-	current := schemafile.ToDBSchema(db)
+	current := schemafile.ToDBSchema(db, platform.Postgres)
 	diff := schemadiff.CompareWithDialect(db, current, platform.Postgres)
 
 	c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("field-level CHECK/FK should not produce a file-to-file churn diff: %#v", diff))
@@ -245,7 +245,7 @@ func TestToDBSchema_ExplicitConstraintOverridesFieldLevelConstraintWithSameName(
 		}},
 	}
 
-	got := schemafile.ToDBSchema(db)
+	got := schemafile.ToDBSchema(db, platform.Postgres)
 
 	c.Assert(got.Constraints, qt.HasLen, 1)
 	c.Assert(*got.Constraints[0].CheckClause, qt.Equals, "status IN ('active', 'disabled')")
@@ -296,7 +296,7 @@ func TestToDBSchema_PreservesStructuralObjectIdentities(t *testing.T) {
 	}
 	goschema.Finalize(db)
 
-	got := schemafile.ToDBSchema(db)
+	got := schemafile.ToDBSchema(db, platform.Postgres)
 
 	c.Assert(got.Tables[0].Columns[0].IsPrimaryKey, qt.IsTrue)
 	c.Assert(got.Tables[0].Columns[1].IsPrimaryKey, qt.IsFalse)

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -450,11 +450,236 @@ func indexDefinitionsChanged(
 		indexPredicateChanged(generated.Condition, database.Condition, dialect) {
 		return true
 	}
-	if platform.NormalizeDialect(dialect) != platform.SQLServer {
+	// Every other property is compared per dialect, because "these two indexes
+	// are the same index" is a dialect question. Adding a dialect here means
+	// deciding what its catalog reports and what it leaves implicit; a dialect
+	// that has not been measured keeps the name-only comparison rather than
+	// getting guessed semantics (issue #1272 scope).
+	switch platform.NormalizeDialect(dialect) {
+	case platform.SQLServer:
+		return generated.Unique != database.IsUnique ||
+			indexKeyPartsChanged(generated, database, semantics)
+	case platform.Postgres:
+		return postgresIndexDefinitionChanged(generated, database, semantics)
+	default:
 		return false
 	}
+}
+
+// postgresIndexDefinitionChanged answers whether a PostgreSQL index has to be
+// rebuilt to match the desired definition.
+//
+// Until issue #1272 the PostgreSQL branch compared nothing beyond the partial
+// predicate and NULLS DISTINCT, so every property #1246 and #1271 taught the
+// reader to preserve was read and then discarded at reconciliation time.
+// Measured on PostgreSQL 17.10 against the pinned community binary v1.3.0,
+// each of these pairs made `schema diff` print "Schemas are synced, no changes
+// to be made" while the pinned binary planned DROP INDEX + CREATE INDEX:
+//
+//	USING btree (value)        -> USING hash (value)
+//	USING gin (tsv)            -> USING gist (tsv)
+//	(value)                    -> (value text_pattern_ops)   and the reverse
+//	(value)                    -> (value DESC)
+//	(value)                    -> (value NULLS FIRST)
+//	(value DESC)               -> (value DESC NULLS LAST)
+//	(a) INCLUDE (b)            -> (a) INCLUDE (c), added, and removed
+//	(a)                        -> (lower(a))                 and the reverse
+//	(lower(a))                 -> (upper(a))
+//	(value)                    -> UNIQUE (value)
+//	(a)                        -> (b)
+//
+// PostgreSQL cannot alter any of them in place: there is no ALTER INDEX form
+// for the access method, the key list, an operator class, a key's sort or
+// NULLS ordering, or the INCLUDE payload. Reporting the change is therefore
+// enough -- the planner already emits DROP INDEX followed by CREATE INDEX for
+// an index that is both added and removed, which is the transition the pinned
+// binary plans and the one the server accepts.
+func postgresIndexDefinitionChanged(
+	generated goschema.Index,
+	database types.DBIndex,
+	semantics identifier.Semantics,
+) bool {
 	return generated.Unique != database.IsUnique ||
-		indexKeyPartsChanged(generated, database, semantics)
+		postgresAccessMethod(generated.Type) != postgresAccessMethod(database.Method) ||
+		postgresIndexKeysChanged(generated, database, semantics) ||
+		postgresIncludeColumnsChanged(generated.IncludeColumns, database.IncludeColumns, semantics)
+}
+
+// postgresDefaultAccessMethod is the method PostgreSQL uses when CREATE INDEX
+// carries no USING clause.
+const postgresDefaultAccessMethod = "btree"
+
+// postgresAccessMethod reduces an access method to a comparison key.
+//
+// The two sides spell it differently by construction: an annotation or HCL
+// source writes BTREE/GIN, while the reader reports pg_am.amname verbatim,
+// which PostgreSQL spells btree/gin. An absent method is the default one, so
+// `USING btree (x)` and `(x)` are the same index and must not churn.
+func postgresAccessMethod(method string) string {
+	normalized := strings.ToLower(strings.TrimSpace(method))
+	if normalized == "" {
+		return postgresDefaultAccessMethod
+	}
+	return normalized
+}
+
+func postgresIndexKeysChanged(
+	generated goschema.Index,
+	database types.DBIndex,
+	semantics identifier.Semantics,
+) bool {
+	generatedParts := effectiveGeneratedIndexParts(generated)
+	databaseParts := effectiveDatabaseIndexParts(database)
+	if len(generatedParts) != len(databaseParts) {
+		return true
+	}
+	for position, generatedPart := range generatedParts {
+		generatedKey := postgresGeneratedIndexKey(generatedPart, generated.Operator, semantics)
+		if generatedKey != postgresDatabaseIndexKey(databaseParts[position], semantics) {
+			return true
+		}
+	}
+	return false
+}
+
+// postgresIndexKey is one index key reduced to the form the two sides can be
+// compared in. It is comparable, so a key is one `!=` rather than a chain of
+// per-attribute comparisons that a later attribute could be forgotten from.
+//
+// column and expr are separate fields on purpose, and exactly one is ever set.
+// That is the distinction #1246 established: an index on lower(name) and an
+// index on a column literally named "lower(name)" are different indexes, and
+// collapsing them is how the reader used to emit
+// CREATE INDEX ... ("lower(name)"), which psql rejects.
+type postgresIndexKey struct {
+	column     string
+	expr       string
+	operator   string
+	desc       bool
+	nullsOrder string
+}
+
+// resolvedNullsOrder resolves this key's NULLS ordering to the ordering the
+// server actually applies.
+//
+// The default is direction-dependent -- NULLS LAST for ASC, NULLS FIRST for
+// DESC -- so an omitted ordering and an explicit spelling of that direction's
+// default are the same key. #1271's reader records only the deviating spelling,
+// so resolving both sides is what keeps `ASC` and `ASC NULLS LAST` from
+// planning a rebuild against each other while `ASC` and `ASC NULLS FIRST` still
+// report one.
+func (k postgresIndexKey) resolvedNullsOrder(order string) string {
+	switch strings.ToUpper(strings.TrimSpace(order)) {
+	case types.NullsOrderFirst:
+		return types.NullsOrderFirst
+	case types.NullsOrderLast:
+		return types.NullsOrderLast
+	}
+	if k.desc {
+		return types.NullsOrderFirst
+	}
+	return types.NullsOrderLast
+}
+
+// postgresGeneratedIndexKey reduces one desired key.
+//
+// indexOperator is the index-level operator class an annotation may set for
+// every key at once. The renderer applies it to each key that has none, so the
+// comparison resolves it the same way.
+func postgresGeneratedIndexKey(
+	part goschema.IndexPart,
+	indexOperator string,
+	semantics identifier.Semantics,
+) postgresIndexKey {
+	key := postgresIndexKey{
+		operator: postgresOperatorClass(part.Operator, indexOperator),
+		desc:     part.Desc,
+	}
+	key.column, key.expr = postgresIndexKeyTarget(part.Name, part.Expr, semantics)
+	key.nullsOrder = key.resolvedNullsOrder(part.NullsOrder)
+	return key
+}
+
+// postgresDatabaseIndexKey reduces one introspected key. The database shape has
+// no index-level operator class slot, so every class it reports is already
+// per-key.
+func postgresDatabaseIndexKey(
+	part types.DBIndexPart,
+	semantics identifier.Semantics,
+) postgresIndexKey {
+	key := postgresIndexKey{
+		operator: postgresOperatorClass(part.Operator, ""),
+		desc:     part.Desc,
+	}
+	key.column, key.expr = postgresIndexKeyTarget(part.Name, part.Expr, semantics)
+	key.nullsOrder = key.resolvedNullsOrder(part.NullsOrder)
+	return key
+}
+
+// postgresIndexKeyTarget splits what a key indexes into its column slot and its
+// expression slot, filling exactly one. An expression is normalized the way a
+// check-constraint expression is, so spacing and keyword case do not make a new
+// index; a column goes through the dialect's identifier semantics.
+func postgresIndexKeyTarget(
+	name, expr string,
+	semantics identifier.Semantics,
+) (column, expression string) {
+	trimmedExpr := strings.TrimSpace(expr)
+	if trimmedExpr != "" {
+		return "", normalizeCheckExpression(trimmedExpr)
+	}
+	return semantics.ColumnIdentityKey(name), ""
+}
+
+// postgresOperatorClass reduces an operator class to a comparison key.
+//
+// Only case and surrounding space are normalized. PostgreSQL reports an
+// operator class in pg_index.indclass for every key, and #1271's reader
+// deliberately records only the ones that are not the key type's default, so
+// an introspected index names a class exactly when the choice was not the
+// default and both sides of an inspect/replay round trip agree.
+//
+// A hand-written source that spells the default out -- `ops = text_ops` on a
+// text column -- is the one case where this diverges from the pinned community
+// binary v1.3.0, which resolves type defaults and reported "Schemas are synced"
+// for that fixture on PostgreSQL 17.10 where Ptah plans a rebuild. Ptah does
+// not resolve default operator classes, and inventing the resolution from a
+// version-pinned catalog table would be worse than the churn: the alternative
+// is to ignore a named class, which would silently accept a real operator-class
+// change. Neither binary's `schema inspect` emits a default class, so no
+// round trip reaches this branch. Recorded in docs/conformance.md.
+func postgresOperatorClass(partOperator, indexOperator string) string {
+	operator := strings.TrimSpace(partOperator)
+	if operator == "" {
+		operator = strings.TrimSpace(indexOperator)
+	}
+	return strings.ToLower(operator)
+}
+
+// postgresIncludeColumnsChanged compares the INCLUDE payload.
+//
+// Order is significant, matching both PostgreSQL -- which stores the payload
+// columns in the order they were written and reports them that way -- and the
+// pinned community binary v1.3.0, which planned a rebuild for
+// `INCLUDE (b, c)` against `INCLUDE (c, b)` on PostgreSQL 17.10.
+//
+// The payload is compared separately from the keys and never merged into them:
+// an index on (a) INCLUDE (b) is not an index on (a, b), and treating the
+// payload as a trailing key would make the two compare equal.
+func postgresIncludeColumnsChanged(
+	generated, database []string,
+	semantics identifier.Semantics,
+) bool {
+	if len(generated) != len(database) {
+		return true
+	}
+	for position, column := range generated {
+		if semantics.ColumnIdentityKey(column) !=
+			semantics.ColumnIdentityKey(database[position]) {
+			return true
+		}
+	}
+	return false
 }
 
 func indexKeyPartsChanged(

--- a/migration/schemadiff/internal/compare/postgres_index_semantics_test.go
+++ b/migration/schemadiff/internal/compare/postgres_index_semantics_test.go
@@ -1,0 +1,569 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// The fixtures below are transcribed from live PostgreSQL 17.10 (container
+// ptah1074-dev). Each pair was created with psql, introspected by both
+// binaries, and diffed; the "want" column of every changed row is what the
+// pinned community binary v1.3.0 planned for that pair, and the "want" of
+// every control row is the "Schemas are synced, no changes to be made." it
+// printed instead.
+//
+// Before issue #1272 the PostgreSQL branch of indexDefinitionsChanged returned
+// false before comparing anything but the partial predicate and NULLS
+// DISTINCT, so every changed row here reported "synced" -- including the plain
+// key-column change, which nothing else in the suite covered either.
+
+// postgresIndexTable is the table every fixture in this file indexes. It exists
+// so a row can name a column without also having to describe a schema.
+const postgresIndexTable = "t"
+
+// databaseIndex is the introspected side of one fixture: one index named "i" on
+// table "t", spelled the way internal/dbschema/postgres/reader.go reports it
+// after #1246 and #1271 -- an access method from pg_am, one part per key with
+// the operator class recorded only when it is not the type default, and the
+// NULLS ordering recorded only when it deviates from the direction's default.
+func databaseIndex(parts []types.DBIndexPart) types.DBIndex {
+	return types.DBIndex{
+		Name:      "i",
+		TableName: postgresIndexTable,
+		Method:    "btree",
+		Parts:     parts,
+		Columns:   databaseIndexColumns(parts),
+	}
+}
+
+func databaseIndexColumns(parts []types.DBIndexPart) []string {
+	columns := make([]string, 0, len(parts))
+	for _, part := range parts {
+		columns = append(columns, part.Name)
+	}
+	return columns
+}
+
+// generatedIndex is the desired side: one index named "i" on table "t" as a
+// schema source describes it.
+func generatedIndex(parts []goschema.IndexPart) goschema.Index {
+	return goschema.Index{
+		Name:      "i",
+		TableName: postgresIndexTable,
+		Parts:     parts,
+		Fields:    generatedIndexFields(parts),
+	}
+}
+
+func generatedIndexFields(parts []goschema.IndexPart) []string {
+	fields := make([]string, 0, len(parts))
+	for _, part := range parts {
+		fields = append(fields, part.Name)
+	}
+	return fields
+}
+
+// TestPostgresIndexSemantics_AxisIsDetected walks the axes issue #1272 lists.
+// Every row differs from its database side in exactly one semantic attribute,
+// and every row must plan the same DROP INDEX + CREATE INDEX pair PostgreSQL
+// requires: there is no ALTER INDEX form for any of these properties.
+//
+// These rows are the mutation detectors. Deleting the corresponding comparison
+// from postgresIndexDefinitionChanged turns exactly the rows for that attribute
+// red and leaves the controls green.
+func TestPostgresIndexSemantics_AxisIsDetected(t *testing.T) {
+	tests := []struct {
+		name      string
+		generated goschema.Index
+		database  types.DBIndex
+	}{
+		{
+			// CREATE INDEX i ON t USING btree (value)
+			//   -> CREATE INDEX i ON t USING hash (value)
+			name: "access method btree to hash",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+				index.Type = "hash"
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// CREATE INDEX i ON t USING gin (tsv)
+			//   -> CREATE INDEX i ON t USING gist (tsv)
+			name: "access method gin to gist",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "tsv"}})
+				index.Type = "gist"
+				return index
+			}(),
+			database: func() types.DBIndex {
+				index := databaseIndex([]types.DBIndexPart{{Name: "tsv"}})
+				index.Method = "gin"
+				return index
+			}(),
+		},
+		{
+			// (value) -> (value text_pattern_ops)
+			name:      "operator class added",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", Operator: "text_pattern_ops"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// (value text_pattern_ops) -> (value)
+			name:      "operator class removed",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value", Operator: "text_pattern_ops"}}),
+		},
+		{
+			// The index-level operator class an annotation may set once for
+			// every key. The renderer applies it to each key that has none, so
+			// the comparison has to resolve it the same way or a
+			// `ops="gin_trgm_ops"` index would compare equal to a default one.
+			name: "index level operator class added",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+				index.Operator = "text_pattern_ops"
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// (value) -> (value DESC)
+			name:      "sort direction",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", Desc: true}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// (value NULLS FIRST) -> (value DESC).
+			//
+			// This row exists because the one above cannot prove the direction
+			// comparison is load-bearing: `(value)` resolves to NULLS LAST and
+			// `(value DESC)` to NULLS FIRST, so deleting the direction
+			// comparison left it passing on the NULLS ordering alone. Here both
+			// sides resolve to NULLS FIRST -- PostgreSQL 17.10 reports the
+			// first as `btree (value NULLS FIRST)` and the second as
+			// `btree (value DESC)` -- so direction is the only difference left,
+			// and the pinned community binary v1.3.0 planned a rebuild for it.
+			name:      "sort direction with the same resolved nulls ordering",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", Desc: true}}),
+			database: databaseIndex([]types.DBIndexPart{
+				{Name: "value", NullsOrder: types.NullsOrderFirst},
+			}),
+		},
+		{
+			// (value) -> (value NULLS FIRST): NULLS LAST is the ASC default,
+			// so FIRST deviates and the reader records it.
+			name:      "nulls first on an ascending key",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", NullsOrder: goschema.NullsOrderFirst}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// (value DESC) -> (value DESC NULLS LAST): NULLS FIRST is the DESC
+			// default, so LAST deviates.
+			name: "nulls last on a descending key",
+			generated: generatedIndex([]goschema.IndexPart{
+				{Name: "value", Desc: true, NullsOrder: goschema.NullsOrderLast},
+			}),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value", Desc: true}}),
+		},
+		{
+			// (a) INCLUDE (b) -> (a) INCLUDE (c)
+			name: "include payload changed",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"c"}
+				return index
+			}(),
+			database: func() types.DBIndex {
+				index := databaseIndex([]types.DBIndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"b"}
+				return index
+			}(),
+		},
+		{
+			// (a) -> (a) INCLUDE (b)
+			name: "include payload added",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"b"}
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "a"}}),
+		},
+		{
+			// (a) INCLUDE (b) -> (a)
+			name:      "include payload removed",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "a"}}),
+			database: func() types.DBIndex {
+				index := databaseIndex([]types.DBIndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"b"}
+				return index
+			}(),
+		},
+		{
+			// INCLUDE (b, c) -> INCLUDE (c, b). PostgreSQL stores the payload
+			// in the written order and the pinned binary planned a rebuild for
+			// this pair, so the comparison is positional.
+			name: "include payload reordered",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"c", "b"}
+				return index
+			}(),
+			database: func() types.DBIndex {
+				index := databaseIndex([]types.DBIndexPart{{Name: "a"}})
+				index.IncludeColumns = []string{"b", "c"}
+				return index
+			}(),
+		},
+		{
+			// (a) -> (lower(a)). The #1246 distinction: an expression key is
+			// not a column key spelling the same text.
+			name:      "column key becomes an expression",
+			generated: generatedIndex([]goschema.IndexPart{{Expr: "lower(a)"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "a"}}),
+		},
+		{
+			// (lower(a)) -> (a)
+			name:      "expression key becomes a column",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "a"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Expr: "lower(a)"}}),
+		},
+		{
+			// (lower(a)) -> (upper(a))
+			name:      "expression key changed",
+			generated: generatedIndex([]goschema.IndexPart{{Expr: "upper(a)"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Expr: "lower(a)"}}),
+		},
+		{
+			// An expression and a column that spell the same text stay
+			// distinct. Collapsing them is what made the reader emit
+			// CREATE INDEX ... ("lower(name)"), which psql rejects.
+			name:      "expression and identically spelled column stay distinct",
+			generated: generatedIndex([]goschema.IndexPart{{Expr: "lower(a)"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "lower(a)"}}),
+		},
+		{
+			// (value) -> UNIQUE (value)
+			name: "uniqueness added",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+				index.Unique = true
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// (a) -> (b). The plainest change of all, and it reported "synced"
+			// too: the PostgreSQL branch never reached the key comparison.
+			name:      "key column changed",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "b"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "a"}}),
+		},
+		{
+			// (a) -> (a, b)
+			name:      "key column added",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "a"}, {Name: "b"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "a"}}),
+		},
+		{
+			// The mixed multi-key fixture issue #1272 asks for, mutated one
+			// position at a time. pg_index exposes keys, operator classes and
+			// sort options as three parallel arrays, so a comparison that
+			// matched keys by name instead of by position would miss an
+			// operator class moving from the first key to the second.
+			name: "mixed multi-key index, operator class moves to the second key",
+			generated: generatedIndex([]goschema.IndexPart{
+				{Name: "a", Desc: true, NullsOrder: goschema.NullsOrderLast},
+				{Name: "b", Operator: "text_pattern_ops", NullsOrder: goschema.NullsOrderFirst},
+			}),
+			database: mixedDatabaseIndex(),
+		},
+		{
+			name: "mixed multi-key index, key order swapped",
+			generated: generatedIndex([]goschema.IndexPart{
+				{Name: "a", Operator: "text_pattern_ops", NullsOrder: goschema.NullsOrderFirst},
+				{Name: "b", Desc: true, NullsOrder: goschema.NullsOrderLast},
+			}),
+			database: mixedDatabaseIndex(),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{Indexes: []goschema.Index{test.generated}}
+			database := &types.DBSchema{Indexes: []types.DBIndex{test.database}}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, platform.Postgres)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{
+				{Name: "i", TableName: postgresIndexTable},
+			})
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{
+				{Name: "i", TableName: postgresIndexTable},
+			})
+		})
+	}
+}
+
+// mixedDatabaseIndex is the combined fixture:
+//
+//	CREATE INDEX i ON t USING btree (
+//	    a text_pattern_ops DESC NULLS LAST,
+//	    b ASC NULLS FIRST
+//	) INCLUDE (c);
+//
+// as PostgreSQL 17.10 reports it.
+func mixedDatabaseIndex() types.DBIndex {
+	index := databaseIndex([]types.DBIndexPart{
+		{Name: "a", Operator: "text_pattern_ops", Desc: true, NullsOrder: types.NullsOrderLast},
+		{Name: "b", NullsOrder: types.NullsOrderFirst},
+	})
+	index.IncludeColumns = []string{"c"}
+	return index
+}
+
+// TestPostgresIndexSemantics_EquivalentDefinitionsDoNotChurn carries the fix.
+//
+// Buying detection by rebuilding every index on every apply would be worse than
+// the bug it fixes, so each row here is a pair the pinned community binary
+// v1.3.0 reported as "Schemas are synced, no changes to be made." on live
+// PostgreSQL 17.10 and Ptah must agree.
+func TestPostgresIndexSemantics_EquivalentDefinitionsDoNotChurn(t *testing.T) {
+	tests := []struct {
+		name      string
+		generated goschema.Index
+		database  types.DBIndex
+	}{
+		{
+			name:      "identical single-key index",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			name: "identical mixed multi-key index",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{
+					{Name: "a", Operator: "text_pattern_ops", Desc: true, NullsOrder: goschema.NullsOrderLast},
+					{Name: "b", NullsOrder: goschema.NullsOrderFirst},
+				})
+				index.IncludeColumns = []string{"c"}
+				index.Type = "btree"
+				return index
+			}(),
+			database: mixedDatabaseIndex(),
+		},
+		{
+			// An annotation or HCL source spells the access method BTREE; the
+			// reader reports pg_am.amname, which PostgreSQL spells btree.
+			name: "access method differs only in case",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+				index.Type = "BTREE"
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// A source that says nothing about the access method means the
+			// default one, which is what the reader reports.
+			name:      "unspecified access method is the default one",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// GIN and gin are the same access method.
+			name: "non-default access method differs only in case",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "tsv"}})
+				index.Type = "GIN"
+				return index
+			}(),
+			database: func() types.DBIndex {
+				index := databaseIndex([]types.DBIndexPart{{Name: "tsv"}})
+				index.Method = "gin"
+				return index
+			}(),
+		},
+		{
+			// ASC and ASC NULLS LAST are the same key: NULLS LAST is the
+			// ascending default, so #1271's reader does not record it and a
+			// source that spells it out must still compare equal.
+			name:      "explicit nulls last on an ascending key is the default",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", NullsOrder: goschema.NullsOrderLast}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+		},
+		{
+			// DESC and DESC NULLS FIRST are the same key.
+			name: "explicit nulls first on a descending key is the default",
+			generated: generatedIndex([]goschema.IndexPart{
+				{Name: "value", Desc: true, NullsOrder: goschema.NullsOrderFirst},
+			}),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value", Desc: true}}),
+		},
+		{
+			// The reverse direction: the database side spells the default and
+			// the desired side omits it.
+			name:      "database side spells the ascending default",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value"}}),
+			database: databaseIndex([]types.DBIndexPart{
+				{Name: "value", NullsOrder: types.NullsOrderLast},
+			}),
+		},
+		{
+			// Operator classes are compared case-insensitively, like every
+			// other identifier PostgreSQL folds.
+			name:      "operator class differs only in case",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "value", Operator: "TEXT_PATTERN_OPS"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Name: "value", Operator: "text_pattern_ops"}}),
+		},
+		{
+			// An index-level operator class and the same class written on the
+			// key are the same index; the renderer emits one clause either way.
+			name: "index level and per-key operator class agree",
+			generated: func() goschema.Index {
+				index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+				index.Operator = "text_pattern_ops"
+				return index
+			}(),
+			database: databaseIndex([]types.DBIndexPart{{Name: "value", Operator: "text_pattern_ops"}}),
+		},
+		{
+			// Expression spelling is normalized the same way check-constraint
+			// expressions are: whitespace and keyword case do not make a new
+			// index.
+			name:      "expression differs only in spacing and case",
+			generated: generatedIndex([]goschema.IndexPart{{Expr: "LOWER( a )"}}),
+			database:  databaseIndex([]types.DBIndexPart{{Expr: "lower(a)"}}),
+		},
+		{
+			// A source that lists plain column names without structured parts
+			// still matches an introspected index whose parts are all plain.
+			name: "unstructured field list matches plain introspected parts",
+			generated: goschema.Index{
+				Name: "i", TableName: postgresIndexTable, Fields: []string{"a", "b"},
+			},
+			database: databaseIndex([]types.DBIndexPart{{Name: "a"}, {Name: "b"}}),
+		},
+		{
+			// A reader that reported only Columns (no structured parts) still
+			// matches a plain desired index, so the legacy shape does not churn.
+			name:      "introspected index without structured parts",
+			generated: generatedIndex([]goschema.IndexPart{{Name: "a"}, {Name: "b"}}),
+			database: types.DBIndex{
+				Name: "i", TableName: postgresIndexTable, Method: "btree",
+				Columns: []string{"a", "b"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{Indexes: []goschema.Index{test.generated}}
+			database := &types.DBSchema{Indexes: []types.DBIndex{test.database}}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, platform.Postgres)
+
+			c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestPostgresIndexSemantics_ChangeStaysInItsOwnSchema pins the fixture issue
+// #1272 asks for outside the default schema: two tables named "t" in two
+// schemas, each carrying an index named "i", with only the app-schema one
+// changing access method.
+//
+// Measured against the same pair on PostgreSQL 17.10, the pinned community
+// binary v1.3.0 planned exactly one rebuild, on "app"."i".
+func TestPostgresIndexSemantics_ChangeStaysInItsOwnSchema(t *testing.T) {
+	c := qt.New(t)
+	generated := &goschema.Database{
+		Indexes: []goschema.Index{
+			{Name: "i", TableName: "public.t", Fields: []string{"value"}},
+			{Name: "i", TableName: "app.t", Fields: []string{"value"}, Type: "hash"},
+		},
+	}
+	database := &types.DBSchema{
+		Indexes: []types.DBIndex{
+			{
+				Name: "i", TableName: "t", Schema: "public", Method: "btree",
+				Columns: []string{"value"}, Parts: []types.DBIndexPart{{Name: "value"}},
+			},
+			{
+				Name: "i", TableName: "t", Schema: "app", Method: "btree",
+				Columns: []string{"value"}, Parts: []types.DBIndexPart{{Name: "value"}},
+			},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.IndexesWithDialect(generated, database, diff, platform.Postgres)
+
+	c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{
+		{Name: "i", TableName: "app.t"},
+	})
+	c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{
+		{Name: "i", TableName: "app.t"},
+	})
+}
+
+// TestPostgresIndexSemantics_OtherDialectsAreUnaffected is the isolation
+// control issue #1272 requires. The comparison lives in shared infrastructure,
+// so every dialect routes through the same function; only PostgreSQL was
+// measured, and a dialect whose catalog semantics have not been measured keeps
+// the name-only comparison it had rather than getting guessed ones.
+//
+// Each row is the access-method fixture -- the axis with the widest reach,
+// since goschema.Index.Type means something different on ClickHouse -- under a
+// dialect that must not react to it.
+func TestPostgresIndexSemantics_OtherDialectsAreUnaffected(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: platform.MySQL},
+		{name: "mariadb", dialect: platform.MariaDB},
+		{name: "sqlite", dialect: platform.SQLite},
+		{name: "clickhouse", dialect: platform.ClickHouse},
+		{name: "cockroachdb", dialect: platform.CockroachDB},
+		{name: "yugabytedb", dialect: platform.YugabyteDB},
+		{name: "spanner", dialect: platform.Spanner},
+		{name: "unset dialect", dialect: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{Indexes: []goschema.Index{
+				func() goschema.Index {
+					index := generatedIndex([]goschema.IndexPart{{Name: "value"}})
+					index.Type = "hash"
+					return index
+				}(),
+			}}
+			database := &types.DBSchema{Indexes: []types.DBIndex{
+				databaseIndex([]types.DBIndexPart{{Name: "value"}}),
+			}}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.IndexesWithDialect(generated, database, diff, test.dialect)
+
+			c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+		})
+	}
+}


### PR DESCRIPTION
Closes #1272.

## What was wrong

`indexDefinitionsChanged` in `migration/schemadiff/internal/compare/indexes.go`
compared `NullsDistinct` and the partial predicate, then:

```go
if platform.NormalizeDialect(dialect) != platform.SQLServer {
    return false
}
```

On PostgreSQL nothing else was compared — not the access method, not the
operator class, not the sort direction, not the NULLS ordering, not `INCLUDE`,
and not the key columns either. Everything #1246 and #1271 taught the reader to
preserve was read and then discarded at reconciliation time.

## Measurement

Live PostgreSQL 17.10 (container `ptah1074-dev`). Each axis is one fixture pair
loaded into two databases differing in exactly one attribute, then
`schema diff --from <current> --to <desired>` on `ptah-compat`, native `ptah`,
and the pinned Atlas CE v1.3.0 binary. Exit statuses read on their own line.

| Current | Desired | ptah before | ptah after | Atlas CE v1.3.0 |
| --- | --- | --- | --- | --- |
| `USING btree (value)` | `USING hash (value)` | synced | rebuild | rebuild |
| `USING gin (tsv)` | `USING gist (tsv)` | synced | rebuild | rebuild |
| `(value)` | `(value text_pattern_ops)` | synced | rebuild | rebuild |
| `(value text_pattern_ops)` | `(value)` | synced | rebuild | rebuild |
| `(value)` | `(value DESC)` | synced | rebuild | rebuild |
| `(value NULLS FIRST)` | `(value DESC)` | synced | rebuild | rebuild |
| `(value)` | `(value NULLS FIRST)` | synced | rebuild | rebuild |
| `(value DESC)` | `(value DESC NULLS LAST)` | synced | rebuild | rebuild |
| `(a) INCLUDE (b)` | `(a) INCLUDE (c)` | synced | rebuild | rebuild |
| `(a)` | `(a) INCLUDE (b)` | synced | rebuild | rebuild |
| `(a) INCLUDE (b)` | `(a)` | synced | rebuild | rebuild |
| `(a) INCLUDE (b, c)` | `(a) INCLUDE (c, b)` | synced | rebuild | rebuild |
| `(a)` | `(lower(a))` | synced | rebuild | rebuild |
| `(lower(a))` | `(a)` | synced | rebuild | rebuild |
| `(lower(a))` | `(upper(a))` | synced | rebuild | rebuild |
| mixed key, opclass on key 1 | opclass on key 2 | synced | rebuild | rebuild |
| mixed key | keys swapped | synced | rebuild | rebuild |
| `(value)` | `UNIQUE (value)` | synced | rebuild | rebuild |
| `(a)` | `(b)` | synced | rebuild | rebuild |

Controls — all three binaries report `Schemas are synced, no changes to be
made.`, before and after:

| Current | Desired |
| --- | --- |
| `(value)` | `(value)` |
| `(value)` | `(value NULLS LAST)` |
| `(value DESC)` | `(value DESC NULLS FIRST)` |

### The transition is a rebuild, and it executes

PostgreSQL has no `ALTER INDEX` form for any of these. Every plan above was
executed against its current database with `psql -v ON_ERROR_STOP=1`, then
re-diffed. All 17 rows: `psql` exit 0, Ptah re-diff synced, and the **pinned
binary as a neutral observer** re-diff synced. A green execution alone would not
have proved the resulting index has the requested semantics.

### Schema qualification

`public.t` and `app.t` each carrying an index named `i`, with only the app one
changing access method: Ptah plans exactly one rebuild, on `app.i`. The pinned
binary plans the same one.

## What changed

**`migration/schemadiff/internal/compare/indexes.go`** — the fix. A PostgreSQL
branch compares uniqueness, access method, per-position key identity (column vs
expression, operator class, direction, NULLS ordering) and the `INCLUDE`
payload. Keys are reduced to a comparable `postgresIndexKey`, compared by
position because `pg_index` exposes keys, operator classes and sort options as
three parallel arrays — matching keys by name would miss an operator class
moving from one key to another.

Normalization, so nothing churns on spelling: `btree` == `BTREE`; an omitted
access method == the default one; `ASC` == `ASC NULLS LAST` and `DESC` ==
`DESC NULLS FIRST`; an index-level `ops` == the same class written per key;
expressions normalized like check-constraint expressions.

Two supporting losses had to be closed, or the fix would have created churn of
its own:

**`internal/atlashcl` + `internal/atlashclrender`** — `nulls_first` /
`nulls_last` on an index `on` block are now read and written. These are the
names Atlas CE's own `schema inspect` emits, so `ptah-compat` was dropping them
under its unknown-attribute tolerance and the native parser refused the file
outright. Ptah's own inspect output lost the ordering too, which would have
turned `--from <db> --to <its own inspect output>` into a permanent rebuild.
Setting both is refused rather than resolved.

**`internal/schemafile`** — `ToDBSchema` (the `--from` side when that side is a
local file) dropped the access method, the structured key parts and the
`INCLUDE` payload. It now takes the dialect, so `goschema.Index.Type` is
unpacked as a PostgreSQL access method on PostgreSQL-family targets and left as
the ClickHouse data-skipping-index type elsewhere.

## Inspect/replay is still clean

The #1246/#1271 guarantee holds in both directions, for both binaries, on the
mixed multi-key fixture:

```
ptah    db -> own inspect file    synced
ptah    own inspect file -> db    synced
pinned  db -> own inspect file    synced
pinned  own inspect file -> db    synced
```

Cross-binary: the pinned binary's inspect output (which carries
`nulls_last = true` / `nulls_first = true`) diffed against the database it came
from, by Ptah — synced.

## Mutation coverage

Eleven mutations, each removing one comparison, each reddening the rows for
that attribute and no control:

| Mutation | Reddens |
| --- | --- |
| access method comparison removed | 2 axis rows |
| operator class comparison removed | 3 axis rows |
| direction comparison removed | 2 axis rows + 1 control |
| NULLS ordering comparison removed | 2 axis rows |
| direction-default resolution removed (inverse mutant) | **3 controls** |
| `INCLUDE` comparison removed | 4 axis rows |
| `INCLUDE` compared as a set, not a sequence | the reorder row |
| expression/column distinction collapsed | the identically-spelled row |
| uniqueness comparison removed | 1 axis row |
| key comparison removed | 13 axis rows |
| dialect gate removed | 8 non-interference rows + 5 pre-existing tests |

The first attempt at the direction row (`(value)` vs `(value DESC)`) was **not**
discriminating: deleting the direction comparison left it passing on the NULLS
ordering, because the two sides resolve to different defaults. The row that
proves it is `(value NULLS FIRST)` vs `(value DESC)` — both resolve to
`NULLS FIRST`, so direction is the only difference left. Verified live: the
pinned binary plans a rebuild for that pair, origin/master Ptah reported synced.

Supporting changes have their own mutation checks: dropping `Method`, `Parts` or
`IncludeColumns` from `ToDBSchema`, reporting a ClickHouse skipping-index type
as an access method, dropping the HCL parse, dropping the both-set guard,
dropping the render, and letting a NULLS-only part count as "simple" — each
reddens its own test.

## Scope and non-interference

PostgreSQL only. MySQL, MariaDB, SQLite, ClickHouse, CockroachDB, YugabyteDB
and Spanner keep the comparison they had, with a per-dialect non-interference
test. Routing every dialect through the new semantics reddens all eight of those
rows plus `TestIndexes_UnhappyPath` and `TestIssue34_ExplicitlyDefinedUniqueIndexes`,
so the isolation is measured rather than asserted.

The comparison lives in shared schema-diff infrastructure. Native `ptah` and
`ptah-compat` produce identical plans on every axis; `ptah-compat` does not own
a separate definition of index equality.

## Deliberate divergence

An operator class is compared as written, case-insensitively. Ptah does not
resolve a column type's *default* operator class, so a hand-written source that
spells it out — `ops = text_ops` on a `text` column — plans a rebuild where the
pinned binary reports synced. Measured, and recorded in `docs/conformance.md`.

The alternative is to ignore a named class when the catalog reports none, which
would silently accept a real operator-class change — the exact defect this PR
fixes. `pg_index.indclass` reports only non-default classes, so neither binary's
`schema inspect` produces that input and no round trip reaches it. Omit a
default class, which is how both binaries write one.

## Public API

`core/goschema` gains `NullsOrderFirst` / `NullsOrderLast`, matching the pair
already in `core/ast` and `dbschema/types`. Additive; snapshot regenerated
(one line).

## Gates

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| every `check:*` in `docs/site/package.json` (14) | 0 |
| `build-feature-matrix.mjs --check` | 0 |

`check:responsive` needed `npm ci` + `npm run build` first; both artifacts were
removed afterwards.
