### PR TITLE
Ask what an extension supplies that nothing else does (#1280)

### DIFF
--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -402,6 +402,13 @@ type Extension struct {
 	// "what stops resolving without this extension", which is almost never the
 	// extension's own name: `isn` supplies the type `isbn`.
 	//
+	// Names the extension supplies that pg_catalog also supplies are excluded,
+	// because those keep resolving with the extension dropped. Contrib
+	// extensions mostly supply overloads of core functions, so the unfiltered
+	// list is full of ordinary words -- `citext` supplies `max`, `strpos` and
+	// `replace` -- and treating those as evidence would tie the extension to
+	// every schema that happens to use them.
+	//
 	// Empty means not measured. Annotation and YAML sources have no catalog to
 	// ask and leave it unset.
 	Provides []string

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -318,6 +318,13 @@ type DBExtension struct {
 	// usually a disjoint set of words: `isn` supplies the type `isbn`, and
 	// `pgcrypto` supplies the function `gen_salt`.
 	//
+	// Names pg_catalog also supplies are excluded, because a document using one
+	// resolves it with the extension dropped. This matters because contrib
+	// extensions mostly supply overloads of core functions: unfiltered, `citext`
+	// contributes `max`, `min`, `strpos`, `replace` and `split_part`, and
+	// `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
+	// PostgreSQL 13.
+	//
 	// Empty means not measured rather than "supplies nothing" -- every extension
 	// supplies something, and readers that do not consult a catalog (Go
 	// annotations, YAML) leave this unset.

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3844,6 +3844,13 @@ type Extension struct {
     // "what stops resolving without this extension", which is almost never the
     // extension's own name: `isn` supplies the type `isbn`.
     //
+    // Names the extension supplies that pg_catalog also supplies are excluded,
+    // because those keep resolving with the extension dropped. Contrib
+    // extensions mostly supply overloads of core functions, so the unfiltered
+    // list is full of ordinary words -- `citext` supplies `max`, `strpos` and
+    // `replace` -- and treating those as evidence would tie the extension to
+    // every schema that happens to use them.
+    //
     // Empty means not measured. Annotation and YAML sources have no catalog to
     // ask and leave it unset.
     Provides []string
@@ -5381,6 +5388,13 @@ type DBExtension struct {
     // not here", which is a different question from the extension's own name and
     // usually a disjoint set of words: `isn` supplies the type `isbn`, and
     // `pgcrypto` supplies the function `gen_salt`.
+    //
+    // Names pg_catalog also supplies are excluded, because a document using one
+    // resolves it with the extension dropped. This matters because contrib
+    // extensions mostly supply overloads of core functions: unfiltered, `citext`
+    // contributes `max`, `min`, `strpos`, `replace` and `split_part`, and
+    // `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
+    // PostgreSQL 13.
     //
     // Empty means not measured rather than "supplies nothing" -- every extension
     // supplies something, and readers that do not consult a catalog (Go

--- a/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
+++ b/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
@@ -53,8 +53,17 @@ type atlasCompatExtensionRoundTripCase struct {
 // the pinned Atlas community binary, measured on PostgreSQL 17.10. The omission
 // was not a compatibility win, it was a document nobody could read.
 //
-// The third row is the control that keeps the fix from becoming "never omit an
-// extension", which would throw away what #1266 bought.
+// The rows expecting no block are the control that keeps the fix from becoming
+// "never omit an extension", which would throw away what #1266 bought. Three of
+// them are the shapes stokaro/ptah#1280 measured going the other way: a
+// document naming `strpos`, `max` or `gen_random_uuid` kept the extension that
+// overloads them although pg_catalog supplies all three, and the pinned Atlas
+// community binary refuses ANY document declaring an extension block -- so a
+// spurious keep is not a smaller compatibility win, it is none at all.
+//
+// The last row is the control in the other direction. Excluding the shadowed
+// names must not exclude a name only the extension supplies, or the fix would
+// have traded #1280's shapes back for #1266's.
 func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 	adminURL := requirePostgresE2EDatabaseURL(t)
 
@@ -84,6 +93,39 @@ func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 			seed:      "CREATE TABLE plain (id integer PRIMARY KEY, label text NOT NULL)",
 			wantBlock: false,
 			why:       "nothing uses anything isn supplies, so #1266's omission still applies",
+		},
+		{
+			name:      "core function an extension also overloads, in a check",
+			extension: "citext",
+			seed: "CREATE TABLE t (id integer PRIMARY KEY, label text," +
+				" CONSTRAINT ck CHECK (strpos(label, 'x') = 0))",
+			wantBlock: false,
+			why: "citext overloads strpos, but pg_catalog supplies it too and is always" +
+				" on the search path, so this document resolves with citext dropped",
+		},
+		{
+			name:      "core function an extension also overloads, in a view",
+			extension: "citext",
+			seed: "CREATE TABLE t (id integer PRIMARY KEY, n integer);" +
+				" CREATE VIEW v AS SELECT max(n) AS m FROM t",
+			wantBlock: false,
+			why:       "max is one of the fifteen names citext overloads that pg_catalog also supplies",
+		},
+		{
+			name:      "extension function core has since absorbed",
+			extension: "pgcrypto",
+			seed:      "CREATE TABLE u (id uuid PRIMARY KEY DEFAULT gen_random_uuid())",
+			wantBlock: false,
+			why: "pgcrypto supplies gen_random_uuid, but so has pg_catalog since" +
+				" PostgreSQL 13; the default evaluates without the extension",
+		},
+		{
+			name:      "extension supplying a column type it also overloads functions for",
+			extension: "citext",
+			seed:      "CREATE TABLE t (id integer PRIMARY KEY, label citext NOT NULL)",
+			wantBlock: true,
+			why: "the control against over-narrowing: dropping the shadowed names must not" +
+				" drop citext's own type, which nothing but citext supplies",
 		},
 	}
 

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -170,17 +170,20 @@ func (r *renderer) omitRefusedBlock(path, block string, names ...string) bool {
 // documentNamesAny reports whether anything the surviving document emits names
 // any of these identifiers.
 //
-// Matching is case-insensitive because unquoted PostgreSQL identifiers are, and
-// because the direction of a wrong answer matters: a false positive keeps a
-// block that could have been omitted, which costs compatibility; a false
-// negative emits a document with a hole in it, which costs correctness -- a
-// document nobody, including the pinned binary, can read. This errs toward
-// keeping.
+// Matching is case-insensitive because unquoted PostgreSQL identifiers are.
 //
-// That asymmetry is what makes the coarse `Provides` set the right input even
-// though it over-matches. `pgcrypto` supplies `gen_random_uuid`, which
-// PostgreSQL 17 also supplies from core, so a document using it keeps pgcrypto
-// although it would have resolved without it. That is the harmless direction.
+// Neither direction of a wrong answer is safe, so this does not lean either
+// way. A false negative emits a document with a hole in it: the Atlas community
+// CLI refuses it and so does everything else, because the document names an
+// object nothing declares. A false positive emits a correct document carrying
+// an extension block, and that binary refuses ANY schema file declaring one --
+// measured, every kept block is a refusal, not a partial loss. So a spurious
+// match costs the entire result this suppression exists to produce, on a schema
+// with no relationship to the extension (stokaro/ptah#1280).
+//
+// What makes the answer precise is therefore the input: the names in
+// [goschema.Extension.Provides] are only those the extension supplies that do
+// not also resolve without it.
 func (r *renderer) documentNamesAny(names []string) bool {
 	if r.references == nil {
 		r.references = collectReferencedNames(r.db)

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1467,6 +1467,22 @@ func (r *Reader) readExtensions() ([]types.DBExtension, error) {
 // Measured on PostgreSQL 17.10: no pg_namespace row is ever an extension member
 // for an extension installed into an existing schema, so `public` does not enter
 // this set and naming the schema does not pin every extension in the database.
+//
+// Every arm excludes members whose name also resolves in pg_catalog. Contrib
+// extensions overwhelmingly supply OVERLOADS of core functions, so their raw
+// member lists contain ordinary words: measured on PostgreSQL 17.10, `citext`
+// supplies fifteen names pg_catalog also supplies, among them `max`, `min`,
+// `strpos`, `replace`, `split_part` and `translate`, and `pgcrypto` supplies
+// `gen_random_uuid`, which core has had since 13. A name pg_catalog also
+// supplies is no evidence of a dependency, because pg_catalog is always on the
+// search path -- the document resolves it with the extension dropped. Counting
+// such a name as evidence pins the extension to schemas that have no
+// relationship to it (stokaro/ptah#1280).
+//
+// The exclusion cannot cost a genuine dependency. Reaching an extension's
+// overload rather than the core one requires arguments of that extension's own
+// type, and naming that type is what keeps the extension alive through the
+// pg_type arm.
 func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 	const membersQuery = `
 		SELECT e.extname AS extension_name, t.typname AS member_name
@@ -1474,30 +1490,50 @@ func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 		  JOIN pg_extension e ON e.oid = d.refobjid
 		  JOIN pg_type t ON t.oid = d.objid
 		 WHERE d.deptype = 'e' AND d.classid = 'pg_type'::regclass
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_type core
+		         JOIN pg_namespace corens ON corens.oid = core.typnamespace
+		        WHERE corens.nspname = 'pg_catalog' AND core.typname = t.typname)
 		UNION
 		SELECT e.extname, p.proname
 		  FROM pg_depend d
 		  JOIN pg_extension e ON e.oid = d.refobjid
 		  JOIN pg_proc p ON p.oid = d.objid
 		 WHERE d.deptype = 'e' AND d.classid = 'pg_proc'::regclass
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_proc core
+		         JOIN pg_namespace corens ON corens.oid = core.pronamespace
+		        WHERE corens.nspname = 'pg_catalog' AND core.proname = p.proname)
 		UNION
 		SELECT e.extname, c.relname
 		  FROM pg_depend d
 		  JOIN pg_extension e ON e.oid = d.refobjid
 		  JOIN pg_class c ON c.oid = d.objid
 		 WHERE d.deptype = 'e' AND d.classid = 'pg_class'::regclass
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_class core
+		         JOIN pg_namespace corens ON corens.oid = core.relnamespace
+		        WHERE corens.nspname = 'pg_catalog' AND core.relname = c.relname)
 		UNION
 		SELECT e.extname, opc.opcname
 		  FROM pg_depend d
 		  JOIN pg_extension e ON e.oid = d.refobjid
 		  JOIN pg_opclass opc ON opc.oid = d.objid
 		 WHERE d.deptype = 'e' AND d.classid = 'pg_opclass'::regclass
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_opclass core
+		         JOIN pg_namespace corens ON corens.oid = core.opcnamespace
+		        WHERE corens.nspname = 'pg_catalog' AND core.opcname = opc.opcname)
 		UNION
 		SELECT e.extname, opf.opfname
 		  FROM pg_depend d
 		  JOIN pg_extension e ON e.oid = d.refobjid
 		  JOIN pg_opfamily opf ON opf.oid = d.objid
 		 WHERE d.deptype = 'e' AND d.classid = 'pg_opfamily'::regclass
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_opfamily core
+		         JOIN pg_namespace corens ON corens.oid = core.opfnamespace
+		        WHERE corens.nspname = 'pg_catalog' AND core.opfname = opf.opfname)
 		 ORDER BY 1, 2`
 
 	rows, err := r.db.Query(membersQuery)


### PR DESCRIPTION
Closes #1280.

`ptah-compat schema inspect` omits an `extension` block when nothing in the document needs it, because the Atlas community CLI refuses any PostgreSQL schema file that declares one. #1274 made that test ask what the extension *provides* rather than what it is *called*, and took the answer from `pg_depend` unfiltered.

Contrib extensions overwhelmingly supply **overloads of core functions**, so those member lists are full of ordinary words. Measured on PostgreSQL 17.10, `citext` supplies fifteen names `pg_catalog` also supplies — `max`, `min`, `strpos`, `replace`, `split_part`, `translate`, the `regexp_*` family. A document saying `max` pinned `citext`, although `pg_catalog` is always on the search path and the document resolves with `citext` dropped.

## The comment this replaces was wrong, and that is the interesting part

`documentNamesAny` argued the over-match was safe:

> a false positive keeps a block that could have been omitted, which costs compatibility; a false negative emits a document with a hole in it, which costs correctness […] That is the harmless direction.

That asymmetry does not exist. The pinned binary refuses **any** file declaring an extension block, so a spurious keep does not shrink the compatibility win — it removes it, reaching the same rc=1 the hole reaches, from the other side. In every measurement below, a kept block is a refusal.

The comment even named `pgcrypto`/`gen_random_uuid` as its example of the harmless direction. That is one of the three regressions.

## Measured

Fresh databases on PostgreSQL 17.10, every object verified through the catalog, in none of which anything depends on the extension. `base` is 3acddbdf (parent of #1274), `head` is 4c4a8a1d, `fix` is this branch. `ext` counts `extension` blocks in the rendered document; `orc` is the pinned Atlas community binary v1.3.0 reading that document against a **separate clean** dev database.

| fixture | ext base → head → fix | orc base → head → fix |
|---|---|---|
| `citext`, nothing referencing it | 0 → 0 → 0 | 0 → 0 → 0 |
| `citext` + `CHECK (strpos(label,'x') = 0)` | 0 → **1** → **0** | 0 → **1** → **0** |
| `citext` + `VIEW v AS SELECT max(n) FROM t` | 0 → **1** → **0** | 0 → **1** → **0** |
| `pgcrypto` + `DEFAULT gen_random_uuid()` | 0 → **1** → **0** | 0 → **1** → **0** |
| `isn` + column typed `isbn` | 0 → 1 → **1** | 1 → 1 → 1 |
| `pgcrypto` + `DEFAULT gen_salt('bf')` | 0 → 1 → **1** | 1 → 1 → 1 |
| `citext` + column typed `citext` | 1 → 1 → **1** | 1 → 1 → 1 |

Every failure is `Error: postgres: extensions are not supported by this version.` The bottom three rows are what #1274 bought, unchanged. Their `orc=1` is the honest cost of a genuine dependency, reported on stderr and reversible with `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1`.

The first `orc base = 1` in the `isn` row is #1266's own bug: the base document drops the extension and keeps `type = sql("isbn")`, so the binary fails with `type "isbn" does not exist` — a different refusal, and the one #1274 fixed.

## The fix

Every arm of the members query excludes members whose name `pg_catalog` also supplies. It is exact rather than heuristic — such a name resolves with the extension dropped — and it cannot cost a genuine dependency: reaching an extension's overload instead of the core one requires arguments of that extension's own type, and naming that type keeps the extension alive through the `pg_type` arm.

## The diagnostic was also false

```
warning: extensions.citext: kept in Atlas-compatible schema inspect output because
another object in this document depends on it
```

on a database where nothing did. With the precise input the sentence is true.

## Guarding, both directions

Four rows added to `TestAtlasCompatInspectExtensionRoundTripE2E`, run against live PostgreSQL 17.10:

- Remove the `pg_proc` filter → the three regression rows go red, the four others stay green.
- Over-narrow `pg_type` **and** `pg_proc` together → the `isn` and `gen_salt` rows go red, the rest stay green.

Both arms are needed for the second mutant: `isn` supplies functions named `isbn`, `issn` and `upc` alongside the types, so breaking either arm alone is absorbed by the other. Worth recording, because it is also why this narrowing is hard to make destructive.

The `citext`-typed control does not move under the second mutant — its type name equals the extension label, so the keep-alive matches on the label. The `isn` row is what covers that axis; it is in the suite for exactly this reason.

## Not fixed here

`hstore` supplies three functions named `delete`, which `pg_catalog` does not, so a `plpgsql` body doing `DELETE FROM audit` still pins `hstore` (ext 0 → 1 → 1, orc 0 → 1 → 1). `delete` is **unreserved** in PostgreSQL, so a reserved-word filter misses it and the 327-word unreserved list would drop genuine member names. Telling a keyword from a call needs the body parsed. Filed as #1281 with the measurement.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 (178 packages) · `go tool qtlint` 0 · `golangci-lint run ./...` 0 ("0 issues") · `check-test-style.sh` 0 · `check-public-api.sh` 0 · `check-public-api-snapshot.sh` 0 (regenerated — the snapshot carries doc comments) · `check-public-api-released.sh` 0.

`check-public-api-released.sh` is listed explicitly because #1274 shipped with it red: the `Provides []string` field made `Extension` and `DBExtension` non-comparable and the gate is a separate step from the other two API checks. This change adds no fields, and the gate is 0.
