### PR TITLE
Key grants and RLS enablement by table identity, not by spelling (#1276)

### DIFF
--- a/integration/gonative/schema_boundary_guard_postgres_test.go
+++ b/integration/gonative/schema_boundary_guard_postgres_test.go
@@ -130,10 +130,13 @@ func boundaryCases() []boundaryCase {
 			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
-			// WRONG (#1276): applying a database's own description back to it
-			// plans fourteen statements. Must become nil on both surfaces.
-			wantNativePlan: boundaryOwnerGrantChurn("public", "a"),
-			wantCompatPlan: boundaryOwnerGrantChurn("public", "a"),
+			// FIXED (#1283): applying a database's own description back to it
+			// plans nothing. The fourteen statements this row used to expect
+			// were one grant revoked under the unqualified spelling and
+			// re-granted under the qualified one; keying the comparison by
+			// table identity collapsed them.
+			wantNativePlan: boundaryNoPlan,
+			wantCompatPlan: boundaryNoPlan,
 		},
 		{
 			// The control. The same content reached with an explicit
@@ -153,9 +156,10 @@ func boundaryCases() []boundaryCase {
 			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
-			// WRONG (#1276): must become nil on both surfaces.
-			wantNativePlan: boundaryOwnerGrantChurn("public", "a"),
-			wantCompatPlan: boundaryOwnerGrantChurn("public", "a"),
+			// FIXED (#1283): the grant churn is gone here too, on the URL form
+			// that pins a single schema.
+			wantNativePlan: boundaryNoPlan,
+			wantCompatPlan: boundaryNoPlan,
 		},
 		{
 			// An extension supplying a type a column uses. #1266: inspect
@@ -175,11 +179,11 @@ func boundaryCases() []boundaryCase {
 			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
-			// WRONG (#1276): must become nil on both surfaces. No extension
-			// statement appears here -- the plan is the same fourteen-statement
-			// grant churn every table gets.
-			wantNativePlan: boundaryOwnerGrantChurn("public", "books"),
-			wantCompatPlan: boundaryOwnerGrantChurn("public", "books"),
+			// FIXED (#1283): no extension statement appeared here even when
+			// this row was red -- the plan was the grant churn every table got,
+			// and it is gone. An extension a column uses stays described.
+			wantNativePlan: boundaryNoPlan,
+			wantCompatPlan: boundaryNoPlan,
 		},
 		{
 			// An extension nothing references. This is the fifth defect, and
@@ -231,9 +235,9 @@ func boundaryCases() []boundaryCase {
 			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
-			// WRONG (#1276): must become nil on both surfaces.
-			wantNativePlan: boundaryOwnerGrantChurn("public", "pk_t"),
-			wantCompatPlan: boundaryOwnerGrantChurn("public", "pk_t"),
+			// FIXED (#1283): nil on both surfaces.
+			wantNativePlan: boundaryNoPlan,
+			wantCompatPlan: boundaryNoPlan,
 		},
 		{
 			// An empty database. The floor: whatever else is broken, nothing
@@ -507,38 +511,6 @@ func boundaryStripComments(statements []string) []string {
 // boundaryNoPlan is property 2 holding: applying a database's own description
 // back to it changes nothing.
 func boundaryNoPlan(string) []string { return nil }
-
-// boundaryOwnerGrantChurn is the plan master produces for any table in these
-// fixtures, on both surfaces.
-//
-// Measured cause: the two sides key a grant on how the table is NAMED, and they
-// name it differently. The reader reports the grant against `pk_t`, exactly as
-// the catalog spelled it; the same grant parsed back out of the document
-// resolves through `for = table.pk_t` to the qualified `public.pk_t`. The
-// comparator sees seven grants removed and seven different grants added, so a
-// database's own description is never in sync with itself.
-//
-// That is #1276's pattern in its third form -- not a reader that moved narrower
-// or wider, but a change to what NAMES an object -- and it is why this guard
-// asserts a plan rather than an exit code: both sides are individually correct
-// and the boundary between them is not.
-//
-// Must become nil.
-func boundaryOwnerGrantChurn(schema, table string) func(role string) []string {
-	// The privileges PostgreSQL grants a table's owner by default, in the order
-	// the planner emits them.
-	privileges := []string{"DELETE", "INSERT", "REFERENCES", "SELECT", "TRIGGER", "TRUNCATE", "UPDATE"}
-	return func(role string) []string {
-		out := make([]string, 0, 2*len(privileges))
-		for _, privilege := range privileges {
-			out = append(out, fmt.Sprintf("REVOKE %s ON TABLE %q FROM %q", privilege, table, role))
-		}
-		for _, privilege := range privileges {
-			out = append(out, fmt.Sprintf("GRANT %s ON TABLE %q.%q TO %q WITH GRANT OPTION", privilege, schema, table, role))
-		}
-		return out
-	}
-}
 
 // boundaryDropExtension is the destructive plan: the description a database
 // gave of itself, applied back to that database, removes an object it has.

--- a/migration/schemadiff/internal/compare/grants.go
+++ b/migration/schemadiff/internal/compare/grants.go
@@ -5,18 +5,49 @@ import (
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
 
-// Grants compares PostgreSQL role privilege grants.
+// grantObjectTypeSchema is the one object type whose target is not a table.
+const grantObjectTypeSchema = "SCHEMA"
+
+// Grants compares PostgreSQL role privilege grants using the identifier rules
+// its dialect name implies.
+//
+// Callers holding a live connection should use [GrantsWithSemantics] instead:
+// on MySQL and MariaDB a schema is a database, so nothing offline can name the
+// one that owns an unqualified target.
 func Grants(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
-	generatedGrantMap := make(map[string]difftypes.GrantRef)
+	GrantsWithSemantics(generated, database, diff, identifier.ForDialect(""))
+}
+
+// GrantsWithSemantics is [Grants] told which identifier rules the target has.
+//
+// The two sides do not spell a target the same way, and until they were
+// normalized they could not match. A grant read from the catalog reports the
+// object through [types.DBGrant.QualifiedTarget], which qualifies it with the
+// schema the reader found -- `"public"."granted"`. A grant declared in Go
+// annotations or HCL carries whatever the author wrote, which is normally the
+// bare `granted`. Keyed raw, one grant became two: the declared one absent from
+// the database and therefore GRANTed, and the database one absent from the
+// declaration and therefore REVOKEd, on every run of an unchanged schema.
+//
+// This is [tableMemberKey]'s defect (stokaro/ptah#1232) in a comparator that
+// builds its own key, and one of the instances collected in stokaro/ptah#1276.
+func GrantsWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	semantics identifier.Semantics,
+) {
+	generatedGrantMap := make(map[grantIdentity]difftypes.GrantRef)
 	generatedGrantRoles := make(map[string]bool)
 	for _, grant := range generated.Grants {
 		generatedGrantRoles[grant.Role] = true
 		for _, ref := range grantRefsFromGenerated(grant) {
-			generatedGrantMap[grantRefIdentityKey(ref)] = ref
+			generatedGrantMap[newGrantIdentity(ref, semantics)] = ref
 		}
 	}
 
@@ -25,11 +56,11 @@ func Grants(generated *goschema.Database, database *types.DBSchema, diff *diffty
 		managedRoles[role.Name] = true
 	}
 
-	databaseGrantMapForAdditions := make(map[string]difftypes.GrantRef)
-	databaseGrantMapForRemovals := make(map[string]difftypes.GrantRef)
+	databaseGrantMapForAdditions := make(map[grantIdentity]difftypes.GrantRef)
+	databaseGrantMapForRemovals := make(map[grantIdentity]difftypes.GrantRef)
 	for _, grant := range database.Grants {
 		ref := grantRefFromDatabase(grant)
-		key := grantRefIdentityKey(ref)
+		key := newGrantIdentity(ref, semantics)
 		if managedRoles[ref.Role] || generatedGrantRoles[ref.Role] {
 			databaseGrantMapForAdditions[key] = ref
 		}
@@ -69,7 +100,7 @@ func grantRefsFromGenerated(grant goschema.Grant) []difftypes.GrantRef {
 	objectName := grant.OnTable
 	switch {
 	case grant.OnSchema != "":
-		objectType = "SCHEMA"
+		objectType = grantObjectTypeSchema
 		objectName = grant.OnSchema
 	case grant.OnSequence != "":
 		objectType = "SEQUENCE"
@@ -91,7 +122,7 @@ func grantRefsFromGenerated(grant goschema.Grant) []difftypes.GrantRef {
 func grantRefFromDatabase(grant types.DBGrant) difftypes.GrantRef {
 	objectType := strings.ToUpper(strings.TrimSpace(grant.ObjectType))
 	objectName := grant.QualifiedTarget()
-	if objectType == "SCHEMA" {
+	if objectType == grantObjectTypeSchema {
 		objectName = grant.ObjectName
 	}
 	return difftypes.GrantRef{
@@ -103,13 +134,36 @@ func grantRefFromDatabase(grant types.DBGrant) difftypes.GrantRef {
 	}
 }
 
-func grantRefIdentityKey(ref difftypes.GrantRef) string {
-	return strings.Join([]string{
-		strings.TrimSpace(ref.Role),
-		strings.ToUpper(strings.TrimSpace(ref.ObjectType)),
-		strings.TrimSpace(ref.ObjectName),
-		strings.ToUpper(strings.TrimSpace(ref.Privilege)),
-	}, "\x00")
+// grantIdentity is what makes two grants the same grant: a role, a privilege,
+// and the object they are about.
+//
+// The object is a normalized [tableIdentity] rather than the string it was
+// written as, for the reason given on [GrantsWithSemantics]. A SCHEMA grant is
+// the exception -- its target is a schema, so there is no owning schema to
+// resolve -- and it goes in the schema slot with the table slot left empty,
+// which also keeps `GRANT ... ON SCHEMA app` from colliding with
+// `GRANT ... ON TABLE app`.
+type grantIdentity struct {
+	role       string
+	privilege  string
+	objectType string
+	object     tableIdentity
+}
+
+func newGrantIdentity(ref difftypes.GrantRef, semantics identifier.Semantics) grantIdentity {
+	objectType := strings.ToUpper(strings.TrimSpace(ref.ObjectType))
+	object := newQualifiedTableIdentity(ref.ObjectName, semantics)
+	if objectType == grantObjectTypeSchema {
+		object = tableIdentity{
+			schema: semantics.TableIdentityKey(strings.TrimSpace(ref.ObjectName)),
+		}
+	}
+	return grantIdentity{
+		role:       strings.TrimSpace(ref.Role),
+		privilege:  strings.ToUpper(strings.TrimSpace(ref.Privilege)),
+		objectType: objectType,
+		object:     object,
+	}
 }
 
 func sortGrantRefs(refs []difftypes.GrantRef) {

--- a/migration/schemadiff/internal/compare/grants_qualified_test.go
+++ b/migration/schemadiff/internal/compare/grants_qualified_test.go
@@ -1,0 +1,170 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// grantIdentityCase is one pair of spellings for the same grant, or for two
+// grants that only look alike, with what the comparison owes each.
+type grantIdentityCase struct {
+	name      string
+	generated []goschema.Grant
+	roles     []goschema.Role
+	database  []types.DBGrant
+	assert    func(c *qt.C, diff *difftypes.SchemaDiff)
+}
+
+// TestGrantsWithSemantics_QualifiedTargetIdentity pins that a grant is matched
+// by the object it is about rather than by the string that object was written
+// as.
+//
+// The two sides never spelled it the same. A grant read from the catalog goes
+// through [types.DBGrant.QualifiedTarget], which qualifies the target with the
+// schema the reader found -- `"public"."granted"`. A grant declared in Go
+// annotations or HCL carries whatever the author wrote, normally the bare
+// `granted`. Keyed raw, one grant became two, so an unchanged schema planned a
+// GRANT for the declaration and a REVOKE for the database row on every run.
+//
+// This is stokaro/ptah#1232's defect in a comparator that builds its own key,
+// collected as an instance of stokaro/ptah#1276.
+func TestGrantsWithSemantics_QualifiedTargetIdentity(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []grantIdentityCase{
+		{
+			// The headline row: identical grant, two spellings.
+			name: "a declared bare table matches the qualified row the reader reports",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"SELECT"}, OnTable: "granted"},
+			},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "SELECT", ObjectType: "TABLE", Schema: "public", ObjectName: "granted"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// The same in the other direction: the author qualified it and the
+			// reader reported the same schema.
+			name: "a declared qualified table matches the same qualified row",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"SELECT"}, OnTable: "public.granted"},
+			},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "SELECT", ObjectType: "TABLE", Schema: "public", ObjectName: "granted"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// The control that stops the fix from becoming "everything
+			// matches". A different schema is a different table.
+			name: "the same table name in another schema is another grant",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"SELECT"}, OnTable: "other.granted"},
+			},
+			roles: []goschema.Role{{Name: "app_user"}},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "SELECT", ObjectType: "TABLE", Schema: "public", ObjectName: "granted"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 1)
+				c.Assert(diff.GrantsAdded[0].ObjectName, qt.Equals, "other.granted")
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 1)
+			},
+		},
+		{
+			// A SCHEMA grant's target is a schema, so there is no owning schema
+			// to resolve. It must not pick up the default one and start
+			// matching a table of the same name.
+			name: "a schema grant does not collide with a table of that name",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"USAGE"}, OnSchema: "app"},
+			},
+			roles: []goschema.Role{{Name: "app_user"}},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "USAGE", ObjectType: "TABLE", Schema: "public", ObjectName: "app"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 1)
+				c.Assert(diff.GrantsAdded[0].ObjectType, qt.Equals, "SCHEMA")
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 1)
+				c.Assert(diff.GrantsRemoved[0].ObjectType, qt.Equals, "TABLE")
+			},
+		},
+		{
+			// A schema grant still round-trips against its own row, which is
+			// the control for the row above: that assertion must not pass
+			// merely because schema grants stopped matching anything.
+			name: "a schema grant matches its own row",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"USAGE"}, OnSchema: "app"},
+			},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "USAGE", ObjectType: "SCHEMA", ObjectName: "app"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// A sequence grant travels the same qualification path as a table
+			// grant, so it gets the same normalization and the same control.
+			name: "a declared bare sequence matches the qualified row",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"USAGE"}, OnSequence: "order_seq"},
+			},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "USAGE", ObjectType: "SEQUENCE", Schema: "public", ObjectName: "order_seq"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// The grant-option paths key through the same identity, so they
+			// were unreachable for a qualified target too: this row reached
+			// neither GrantOptionsAdded nor a plain re-GRANT.
+			name: "a grant option is detected across the two spellings",
+			generated: []goschema.Grant{
+				{Role: "app_user", Privileges: []string{"SELECT"}, OnTable: "granted", WithOption: true},
+			},
+			roles: []goschema.Role{{Name: "app_user"}},
+			database: []types.DBGrant{
+				{Role: "app_user", Privilege: "SELECT", ObjectType: "TABLE", Schema: "public", ObjectName: "granted"},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.GrantsAdded, qt.HasLen, 0)
+				c.Assert(diff.GrantsRemoved, qt.HasLen, 0)
+				c.Assert(diff.GrantOptionsAdded, qt.HasLen, 1)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := &goschema.Database{Grants: test.generated, Roles: test.roles}
+			database := &types.DBSchema{Grants: test.database}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.GrantsWithSemantics(generated, database, diff, identifier.ForDialect(platform.Postgres))
+
+			test.assert(c, diff)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/rls.go
+++ b/migration/schemadiff/internal/compare/rls.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/migration/schemadiff/internal/normalize"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
@@ -160,29 +161,53 @@ func RLSPolicies(generated *goschema.Database, database *types.DBSchema, diff *d
 //
 // Results are sorted alphabetically for consistent output across multiple runs.
 func RLSEnabledTables(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
+	RLSEnabledTablesWithSemantics(generated, database, diff, identifier.ForDialect(""))
+}
+
+// RLSEnabledTablesWithSemantics is [RLSEnabledTables] told which identifier
+// rules the target has.
+//
+// The two sides spell the table differently and could not match until they were
+// normalized: the database side comes from [types.DBTable.QualifiedName], which
+// carries the schema the reader found, while a declaration carries whatever the
+// author wrote. `secured` and `public.secured` were two tables, so an unchanged
+// schema planned `ENABLE ROW LEVEL SECURITY` on a table that already had it and
+// `DISABLE` on the same table, every run.
+//
+// Same defect as [tableMemberKey] (stokaro/ptah#1232), in a comparator that
+// keys by raw string; one of the instances collected in stokaro/ptah#1276.
+//
+// The reported names stay the strings each side supplied, because they are what
+// the planner renders. Only the matching is normalized.
+func RLSEnabledTablesWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	semantics identifier.Semantics,
+) {
 	// Create sets for comparison
-	genRLSTables := make(map[string]bool)
+	genRLSTables := make(map[tableIdentity]string)
 	for _, rlsTable := range generated.RLSEnabledTables {
-		genRLSTables[rlsTable.Table] = true
+		genRLSTables[newQualifiedTableIdentity(rlsTable.Table, semantics)] = rlsTable.Table
 	}
 
-	dbRLSTables := make(map[string]bool)
+	dbRLSTables := make(map[tableIdentity]string)
 	for _, table := range database.Tables {
 		if table.RLSEnabled {
-			dbRLSTables[table.QualifiedName()] = true
+			dbRLSTables[newTableIdentity(table.Schema, table.Name, semantics)] = table.QualifiedName()
 		}
 	}
 
 	// Find tables that need RLS enabled
-	for tableName := range genRLSTables {
-		if !dbRLSTables[tableName] {
+	for identity, tableName := range genRLSTables {
+		if _, enabled := dbRLSTables[identity]; !enabled {
 			diff.RLSEnabledTablesAdded = append(diff.RLSEnabledTablesAdded, tableName)
 		}
 	}
 
 	// Find tables that need RLS disabled
-	for tableName := range dbRLSTables {
-		if !genRLSTables[tableName] {
+	for identity, tableName := range dbRLSTables {
+		if _, declared := genRLSTables[identity]; !declared {
 			diff.RLSEnabledTablesRemoved = append(diff.RLSEnabledTablesRemoved, tableName)
 		}
 	}

--- a/migration/schemadiff/internal/compare/rls_enabled_qualified_test.go
+++ b/migration/schemadiff/internal/compare/rls_enabled_qualified_test.go
@@ -1,0 +1,107 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// rlsEnabledIdentityCase is one pair of spellings for a table's RLS enablement
+// and what the comparison owes it.
+type rlsEnabledIdentityCase struct {
+	name      string
+	generated []goschema.RLSEnabledTable
+	database  []types.DBTable
+	assert    func(c *qt.C, diff *difftypes.SchemaDiff)
+}
+
+// TestRLSEnabledTablesWithSemantics_QualifiedTableIdentity pins that RLS
+// enablement is matched by table identity rather than by the string the table
+// was written as.
+//
+// The database side comes from [types.DBTable.QualifiedName] and carries the
+// schema the reader found; a declaration carries whatever the author wrote. So
+// `secured` and `public.secured` were two tables, and an unchanged schema
+// planned ENABLE ROW LEVEL SECURITY on a table that already had it and DISABLE
+// on that same table, on every run.
+//
+// Same defect as tableMemberKey's (stokaro/ptah#1232) in a comparator that keys
+// by raw string, collected as an instance of stokaro/ptah#1276.
+func TestRLSEnabledTablesWithSemantics_QualifiedTableIdentity(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []rlsEnabledIdentityCase{
+		{
+			name:      "a bare declaration matches the qualified table the reader reports",
+			generated: []goschema.RLSEnabledTable{{Table: "secured"}},
+			database:  []types.DBTable{{Schema: "public", Name: "secured", RLSEnabled: true}},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.RLSEnabledTablesAdded, qt.HasLen, 0)
+				c.Assert(diff.RLSEnabledTablesRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			name:      "a qualified declaration matches the same table",
+			generated: []goschema.RLSEnabledTable{{Table: "public.secured"}},
+			database:  []types.DBTable{{Schema: "public", Name: "secured", RLSEnabled: true}},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.RLSEnabledTablesAdded, qt.HasLen, 0)
+				c.Assert(diff.RLSEnabledTablesRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// The control against the fix becoming "everything matches".
+			name:      "the same table name in another schema is another table",
+			generated: []goschema.RLSEnabledTable{{Table: "other.secured"}},
+			database:  []types.DBTable{{Schema: "public", Name: "secured", RLSEnabled: true}},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.RLSEnabledTablesAdded, qt.DeepEquals, []string{"other.secured"})
+				c.Assert(diff.RLSEnabledTablesRemoved, qt.DeepEquals, []string{"public.secured"})
+			},
+		},
+		{
+			// A table whose RLS the database does not have still needs
+			// enabling, and it is reported under the name the declaration used
+			// because that is what the planner renders.
+			name:      "a declared table the database has not enabled is still added",
+			generated: []goschema.RLSEnabledTable{{Table: "secured"}},
+			database:  []types.DBTable{{Schema: "public", Name: "secured"}},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.RLSEnabledTablesAdded, qt.DeepEquals, []string{"secured"})
+				c.Assert(diff.RLSEnabledTablesRemoved, qt.HasLen, 0)
+			},
+		},
+		{
+			// And the reverse: RLS on a table nothing declares is still
+			// reported for removal, under the qualified name the reader gave.
+			name:      "an undeclared enabled table is still removed",
+			generated: nil,
+			database:  []types.DBTable{{Schema: "public", Name: "unmanaged", RLSEnabled: true}},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.RLSEnabledTablesAdded, qt.HasLen, 0)
+				c.Assert(diff.RLSEnabledTablesRemoved, qt.DeepEquals, []string{"public.unmanaged"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := &goschema.Database{RLSEnabledTables: test.generated}
+			database := &types.DBSchema{Tables: test.database}
+			diff := &difftypes.SchemaDiff{}
+
+			compare.RLSEnabledTablesWithSemantics(
+				generated, database, diff, identifier.ForDialect(platform.Postgres),
+			)
+
+			test.assert(c, diff)
+		})
+	}
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -169,13 +169,13 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.RLSPolicies(generated, database, diff)
 
 	// Compare RLS enabled tables (PostgreSQL-specific feature)
-	compare.RLSEnabledTables(generated, database, diff)
+	compare.RLSEnabledTablesWithSemantics(generated, database, diff, identifierSemantics)
 
 	// Compare roles (PostgreSQL-specific feature)
 	compare.Roles(generated, database, diff)
 
 	// Compare role privilege grants (PostgreSQL-specific feature)
-	compare.Grants(generated, database, diff)
+	compare.GrantsWithSemantics(generated, database, diff, identifierSemantics)
 
 	// Compare table-level constraints (EXCLUDE, CHECK, UNIQUE, etc.)
 	compare.ConstraintsWithSemantics(generated, database, diff, opts, identifierSemantics)


### PR DESCRIPTION
Refs #1276. Two more instances of its shared root: a comparator that builds its own map key from a raw string, which is exactly what #1232 fixed for `tableMemberKey` and what the doc comment there warns the next caller about.

## The defect

`compare.Grants` keyed on the object name as written. The database side comes from `DBGrant.QualifiedTarget`, which carries the schema the reader found; the declared side carries whatever the author wrote. So `granted` and `"public"."granted"` were two grants — the declaration absent from the database and therefore GRANTed, the database row absent from the declaration and therefore REVOKEd, on every run of an unchanged schema. The grant-option paths key through the same identity, so a qualified target reached neither `GrantOptionsAdded` nor `GrantOptionsRevoked`.

`compare.RLSEnabledTables` had the same shape against `DBTable.QualifiedName`: `secured` and `public.secured` were two tables, so an unchanged schema planned ENABLE on a table that already had it and DISABLE on that same table.

## The fix

Both key through `newQualifiedTableIdentity`, following the package's existing convention — `GrantsWithSemantics` / `RLSEnabledTablesWithSemantics` take the resolved rules, the old names delegate with `identifier.ForDialect("")`, and `schemadiff.go` passes the `identifierSemantics` it already has in scope. Same shape as `ConstraintsWithSemantics` / `Constraints`.

A SCHEMA grant is the one target that is not a table, so it goes in the schema slot with the table slot left empty. That also stops `GRANT ... ON SCHEMA app` from colliding with `GRANT ... ON TABLE app`, which a single normalized string key would have allowed.

Reported names stay the strings each side supplied, because the planner renders them. Only the matching is normalized.

## Mutation, both directions

Twelve rows added across two files.

| mutant | rows that go red |
|---|---|
| grant key reverted to the raw string | bare table, bare sequence, grant option — 3 of 7 |
| RLS key reverted to the raw string | bare declaration — 1 of 5 |
| schema component dropped from both keys | the two cross-schema controls, and nothing else |

The controls that stay green under the first two mutants are the ones that must: a target in a different schema is still a different target, and a SCHEMA grant still does not match a TABLE grant of the same name.

## Reachability — measured, not assumed

On a single-schema PostgreSQL 17.10 database the defect does **not** surface, and it is worth saying why: `Reader.outputSchema` returns an empty schema for the connection's own schema, so both sides spell the table bare and match. Reading two schemas is what separates them. `ptah introspect --schemas public,other` against a database with `other.granted` and `other.secured` writes:

```
//ptah:schema:grant role="rg1276_app" privilege="SELECT" on_table="other.granted"
//ptah:schema:table name="granted" schema="other"
//ptah:schema:rls:enable table="secured"
```

The grant is qualified and matches. The RLS enablement is bare, against a reader that reports `other.secured`.

## What I could not demonstrate, and why it matters

I could not show either defect or its fix through `ptah schema compare`. That command reports `[]` on this fixture — and it still reports `[]` after I disabled RLS in the database with the annotation demanding it enabled, which is the control that says the surface is not merely agreeing with me. The comparator's RLS and grant results do not reach that command's rendering at all.

So this PR's evidence is the comparator's own behavior plus the introspect spellings above. `internal/planner/dialects/postgres`, `migration/generator` and `migration/safety` do read these fields; `cmd`'s compare rendering does not. That gap is its own defect and I have not fixed it here.

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 · `go tool qtlint` 0 · `golangci-lint run ./...` 0 · `check-test-style.sh` 0 · `check-public-api.sh` 0 · `check-public-api-snapshot.sh` 0 · `check-public-api-released.sh` 0.

`compare` is an internal package, so the two new exported names move no public API gate.
