### PR TITLE
Bind the native migration writers to the directory they verified (#1118)

### DIFF
--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -97,18 +97,30 @@ bytes.
 
 ## Writing back to the directory
 
-The verbs that write a migration directory — `migrate diff` and native
-`ptah migrate generate` — bind it the same way and keep the binding. They open
-the directory and its parent once, before staging, and every staged file,
-published migration, `atlas.sum`, journal, commit marker, rollback quarantine
-and cleanup entry is named as a direct child of one of those two handles.
-Recovery of an interrupted batch runs through the same handles.
+The verbs that write a migration directory — `migrate diff`, `migrate new`, and
+native `ptah migrations generate` and `ptah migrations create` — bind it the
+same way and keep the binding. They open the directory and its parent once,
+before staging, and every staged file, published migration, `atlas.sum`,
+journal, commit marker, rollback quarantine and cleanup entry is named as a
+direct child of one of those two handles. A migration directory that does not
+exist yet is created through the bound parent, so it is materialized where the
+run looked rather than where the pathname points by then. Recovery of an
+interrupted batch runs through the same handles.
 
 Replacing the directory after the run validated it therefore cannot redirect
 what it writes, and a directory configured through `atlas.hcl` stays inside the
 opened project root. See
 [the publication boundary](../../atlas/migrate-commands/#the-publication-boundary)
 for what remains keyed to the pathname and why.
+
+`ptah migrations generate` plans and publishes in two steps, so the directory
+can be replaced between them by something outside the run's control. The plan
+records the planned directory's filesystem identity as well as its contents, and
+publication refuses a directory that is no longer the same object — including a
+substitute that holds exactly the files the plan verified. The refusal is
+`migration directory changed after migration planning`, and nothing is written
+([#1118](https://github.com/stokaro/ptah/issues/1118)). This changes behavior:
+a run that previously published into a recreated directory now fails instead.
 
 ## Consequences
 

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -150,13 +150,15 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	c.Assert(removePublicationJournal(writer), qt.IsNil)
 }
 
-func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
+func TestMigrationWriterPublishArtifacts_PublishesCompleteBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	migrationWriter, err := OpenMigrationWriter(nil, dir)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = migrationWriter.Close() }()
 
-	paths, err := PublishArtifactsLocked(
+	paths, err := migrationWriter.PublishArtifacts(
 		t.Context(),
-		dir,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},
@@ -183,15 +185,17 @@ func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
-func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
+func TestMigrationWriterPublishArtifacts_CollisionRollsBackWholeBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
 	existingPath := filepath.Join(dir, "1_change.down.sql")
 	c.Assert(os.WriteFile(existingPath, []byte("existing\n"), 0o600), qt.IsNil)
+	migrationWriter, err := OpenMigrationWriter(nil, dir)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = migrationWriter.Close() }()
 
-	paths, err := PublishArtifactsLocked(
+	paths, err := migrationWriter.PublishArtifacts(
 		t.Context(),
-		dir,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},

--- a/internal/atlasmigrate/migrationwriter.go
+++ b/internal/atlasmigrate/migrationwriter.go
@@ -1,0 +1,172 @@
+package atlasmigrate
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// MigrationWriter is the rooted migration-directory capability a writer
+// transaction outside this package runs through: one binding of the directory
+// and its parent, reused for every read, create, publication and rollback the
+// transaction performs.
+//
+// It exists because the native generator had the shape stokaro/ptah#1118
+// describes. `ptah migrations create` resolved its output directory once, then
+// reopened it by pathname for the mkdir, for the version scan, for each file it
+// created and for the atlas.sum commit; `ptah migrations generate` verified the
+// directory's contents by pathname and then let the publication resolve the
+// pathname a second time. A directory or ancestor replaced between any two of
+// those steps takes the write somewhere the verification never looked.
+//
+// The methods are deliberately thin: this type is the boundary, not a second
+// filesystem abstraction. Everything behind it is the same migrationWriterDir
+// the `migrate diff` publication already runs through, so both writers share one
+// answer to "which filesystem object is this transaction committing to".
+//
+// A nil root keeps direct-CLI behavior, where an explicit absolute directory is
+// the operator's own choice of destination. The binding still happens; it is
+// simply not confined to a project root.
+type MigrationWriter struct {
+	dir *migrationWriterDir
+}
+
+// OpenMigrationWriter binds dir and its parent without creating dir. A missing
+// migration directory is reported through Exists rather than as an error, so a
+// caller can compare the directory's absence against what it planned for before
+// deciding to materialize it.
+//
+// The parent must already exist; call EnsureMigrationParent first when the
+// caller accepts a directory nested below missing levels.
+func OpenMigrationWriter(
+	root *pathguard.OpenedDirectory,
+	dir string,
+) (*MigrationWriter, error) {
+	bound, err := openMigrationWriterDir(root, dir)
+	if err != nil {
+		return nil, err
+	}
+	return &MigrationWriter{dir: bound}, nil
+}
+
+// EnsureMigrationParent creates dir's parent, and every level missing above it,
+// through root when one is supplied.
+func EnsureMigrationParent(root *pathguard.OpenedDirectory, dir string) error {
+	return ensureMigrationDirParent(root, dir)
+}
+
+// Close releases the directory and parent handles.
+func (w *MigrationWriter) Close() error {
+	return w.dir.Close()
+}
+
+// Path returns the stable lexical path selected for the migration directory. It
+// is display and result data only; no write step resolves it again.
+func (w *MigrationWriter) Path() string {
+	return w.dir.Path()
+}
+
+// Exists reports whether the migration directory was present when the handles
+// were bound, or has been materialized by Create since.
+func (w *MigrationWriter) Exists() bool {
+	return w.dir.Exists()
+}
+
+// Create materializes a missing migration directory through the parent handle
+// bound at open time, so it is created inside the opened root rather than
+// wherever the pathname happens to point by now. Creating a directory that
+// already exists is not an error.
+//
+// It is the same materialization the creating binding performs, so a directory
+// this package creates for itself and one an outside caller creates through the
+// boundary land in exactly the same place.
+func (w *MigrationWriter) Create() error {
+	return w.dir.create()
+}
+
+// Identity returns the bound directory's filesystem identity, for comparison
+// with os.SameFile against an identity captured earlier in the transaction.
+func (w *MigrationWriter) Identity() (fs.FileInfo, error) {
+	if !w.dir.Exists() {
+		return nil, w.dir.missingDirError()
+	}
+	return w.dir.dir.Stat(".")
+}
+
+// FS returns the escape-resistant filesystem rooted at the migration directory.
+func (w *MigrationWriter) FS() (fs.FS, error) {
+	return w.dir.FS()
+}
+
+// Entries lists the migration directory through the bound handle. A directory
+// that does not exist lists as empty, because a version scan over an absent
+// directory has the same answer as one over an empty directory.
+func (w *MigrationWriter) Entries() ([]fs.DirEntry, error) {
+	if !w.dir.Exists() {
+		return nil, nil
+	}
+	return w.dir.dir.ReadDir(".")
+}
+
+// WriteNew creates name with contents through the bound handle, failing with
+// fs.ErrExist when the name is taken. The exclusive create is what makes the
+// commit conditional on the destination being absent: a file that appeared
+// after the caller chose the name is reported, never overwritten.
+func (w *MigrationWriter) WriteNew(name, contents string) error {
+	if !w.dir.Exists() {
+		return w.dir.missingDirError()
+	}
+	return writeExclusiveRootedFile(w.dir.dir, name, contents)
+}
+
+// Remove deletes name through the bound handle, for withdrawing a file this
+// transaction created after a later step failed.
+func (w *MigrationWriter) Remove(name string) error {
+	if !w.dir.Exists() {
+		return nil
+	}
+	err := w.dir.dir.Remove(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// PublishAtlasSum commits atlas.sum through the bound handle, conditionally on
+// the checksum state this transaction observed, and returns its path. A
+// concurrent writer that replaced atlas.sum after the snapshot was taken is
+// reported instead of overwritten.
+func (w *MigrationWriter) PublishAtlasSum(sum *migratesum.SumFile) (string, error) {
+	if !w.dir.Exists() {
+		return "", w.dir.missingDirError()
+	}
+	return publishDirSum(w.dir, sum)
+}
+
+// PublishArtifacts durably publishes artifacts as one journaled batch through
+// the bound handle. The caller must hold the migration-directory lock.
+func (w *MigrationWriter) PublishArtifacts(
+	ctx context.Context,
+	artifacts []PublicationArtifact,
+) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !w.dir.Exists() {
+		return nil, w.dir.missingDirError()
+	}
+	return publishArtifactsLocked(ctx, w.dir, artifacts)
+}
+
+// SyncDir flushes the migration directory's entry changes where the platform
+// supports it, so files created through WriteNew are durable before the command
+// reports them.
+func (w *MigrationWriter) SyncDir() error {
+	if !w.dir.Exists() {
+		return nil
+	}
+	return w.dir.dir.Sync()
+}

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -179,24 +179,13 @@ func writeDiffArtifactsWithSumWriter(
 	return result, nil
 }
 
-// PublishArtifactsLocked durably publishes all artifacts as one batch. The
-// caller must hold the migration-directory lock for dir.
-func PublishArtifactsLocked(
-	ctx context.Context,
-	dir string,
-	artifacts []PublicationArtifact,
-) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	w, err := createMigrationWriterDir(nil, dir)
-	if err != nil {
-		return nil, err
-	}
-	paths, publishErr := publishArtifactsLocked(ctx, w, artifacts)
-	return paths, errors.Join(publishErr, w.Close())
-}
-
+// publishArtifactsLocked durably publishes all artifacts as one batch through
+// the caller's bound handle. The caller must hold the migration-directory lock.
+//
+// There is deliberately no pathname-taking entry point beside it. The one that
+// existed took a dir string and bound its own handle, which meant the batch
+// could be published to a filesystem object the caller had never verified
+// (stokaro/ptah#1118); MigrationWriter.PublishArtifacts is the only way in.
 func publishArtifactsLocked(
 	ctx context.Context,
 	w *migrationWriterDir,

--- a/internal/atlasmigrate/writerdir.go
+++ b/internal/atlasmigrate/writerdir.go
@@ -141,9 +141,10 @@ func bindMigrationWriterDir(
 	name := filepath.Base(canonical)
 	writer := &migrationWriterDir{parent: parent, name: name, path: filepath.Clean(display)}
 	if binding.creates() {
-		if err := parent.Mkdir(name, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, errors.Join(fmt.Errorf("create migration directory: %w", err), parent.Close())
+		if err := writer.create(); err != nil {
+			return nil, errors.Join(err, parent.Close())
 		}
+		return writer, nil
 	}
 	opened, err := parent.OpenDirectory(name)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -154,6 +155,29 @@ func bindMigrationWriterDir(
 	}
 	writer.dir = opened
 	return writer, nil
+}
+
+// create materializes the migration directory through the parent handle this
+// writer already holds and binds the result. An entry that already exists is
+// not an error; the containment guarantee comes from the rooted open that
+// follows, not from the create.
+//
+// The parent handle is the point. Creating the directory by pathname would
+// place it wherever the name resolves at that moment, which is not necessarily
+// the parent the transaction validated (stokaro/ptah#1118).
+func (w *migrationWriterDir) create() error {
+	if w.dir != nil {
+		return nil
+	}
+	if err := w.parent.Mkdir(w.name, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("create migration directory: %w", err)
+	}
+	opened, err := w.parent.OpenDirectory(w.name)
+	if err != nil {
+		return fmt.Errorf("open migration directory: %w", err)
+	}
+	w.dir = opened
+	return nil
 }
 
 func openMigrationWriterParent(

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -83,10 +83,13 @@ fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
 
 Planning does not write migration artifacts. A successful `WriteFiles` call
 consumes the plan; call it once after all surrounding work has succeeded.
-The plan records the migration-directory snapshot used for planning.
+The plan records the migration-directory snapshot used for planning, together
+with that directory's filesystem identity.
 `WriteFiles` acquires the shared cross-process directory lock and rejects the
-plan if migration SQL or integrity metadata changed before publication. It
-never renumbers and publishes a plan derived from stale history.
+plan if migration SQL or integrity metadata changed before publication, or if
+the directory is no longer the same filesystem object — a substitute holding
+exactly the planned files is still a different destination. It never renumbers
+and publishes a plan derived from stale history.
 
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.
@@ -262,7 +265,8 @@ type GenerateMigrationOptions struct {
     // OutputDir is the directory where migration files will be saved (always real filesystem)
     OutputDir string
 
-    // AllowedOutputRoot constrains OutputDir when accepting user-supplied paths
+    // AllowedOutputRoot confines the whole writer transaction when accepting
+    // user-supplied paths
     AllowedOutputRoot string
 
     // CompareOptions are the options to use when comparing schemas
@@ -284,6 +288,7 @@ type GenerateMigrationOptions struct {
 - `DBConn`: Existing database connection (optional; used instead of `DatabaseURL` when set)
 - `MigrationName`: Name for the migration (optional, defaults to "migration")
 - `OutputDir`: Directory where migration files will be saved (required)
+- `AllowedOutputRoot`: Project or workspace root the output directory must stay inside (optional). It is opened, not merely compared against: the root, the migration directory and its parent are bound once and every read, create, checksum commit and rollback of the run goes through those handles, so replacing the directory or an ancestor after the path was validated cannot move the write outside the root
 - `CompareOptions`: Schema comparison options (optional)
 - `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
 - `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks; it must identify a different live database realm from the target (optional)

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -196,14 +196,17 @@ func TestPlanGeneratedMigrationSpecs_RefusesUnsplitNonTransactionalMix(t *testin
 	c.Assert(err, qt.ErrorMatches, "generated migration mixes transactional statements with non-transactional statements that cannot be split automatically")
 }
 
-func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
+func TestPublishPlannedMigration_WritesAllPairs(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
 	var files *MigrationFiles
 	var publishErr error
 	err := atlasmigrate.WithMigrationDirectoryLock(t.Context(), dir, 0, func(context.Context) error {
-		files, publishErr = createMigrationFilesFromSpecs(t.Context(), dir, "", []generatedMigrationSpec{
+		writer, bindErr := bindMigrationOutputDir(nil, dir)
+		c.Assert(bindErr, qt.IsNil)
+		defer func() { _ = writer.Close() }()
+		files, publishErr = publishPlannedMigration(t.Context(), writer, "", []generatedMigrationSpec{
 			{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
 			{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},
 		})

--- a/migration/generator/file_creation_test.go
+++ b/migration/generator/file_creation_test.go
@@ -11,34 +11,75 @@ import (
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
-func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T) {
+// TestNextAvailablePtahVersionSkipsVersionWhenEitherDirectionExists pins that a
+// half-present pair still consumes its version. The names come from a listing
+// the writer took through its own rooted handle, so this is the whole of the
+// decision: what the writer then creates is exclusive, and a name that appeared
+// after the listing is refused by the create rather than overwritten.
+func TestNextAvailablePtahVersionSkipsVersionWhenEitherDirectionExists(t *testing.T) {
 	c := qt.New(t)
-	dir := t.TempDir()
-	version := int64(42)
 	name := "constraint_drift"
 
-	oldUp := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "up"))
-	oldDown := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "down"))
-	c.Assert(os.WriteFile(oldUp, nil, 0600), qt.IsNil)
-	c.Assert(os.WriteFile(oldDown, []byte("SELECT old_down;\n"), 0600), qt.IsNil)
+	tests := []struct {
+		name  string
+		names []string
+		want  int64
+	}{
+		{name: "empty directory", names: nil, want: 42},
+		{
+			name:  "only the up half exists",
+			names: []string{migrator.GenerateMigrationFileName(42, name, "up")},
+			want:  43,
+		},
+		{
+			name:  "only the down half exists",
+			names: []string{migrator.GenerateMigrationFileName(42, name, "down")},
+			want:  43,
+		},
+		{
+			name: "both halves exist",
+			names: []string{
+				migrator.GenerateMigrationFileName(42, name, "up"),
+				migrator.GenerateMigrationFileName(42, name, "down"),
+			},
+			want: 43,
+		},
+	}
 
-	files, err := createMigrationFiles(dir, version, name, "SELECT up;\n", "SELECT down;\n")
-	c.Assert(err, qt.IsNil)
-	c.Assert(files.Version, qt.Equals, version+1)
-
-	oldDownBytes, err := os.ReadFile(oldDown)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(oldDownBytes), qt.Equals, "SELECT old_down;\n")
-
-	upBytes, err := os.ReadFile(files.UpFile)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(upBytes), qt.Equals, "SELECT up;\n")
-	downBytes, err := os.ReadFile(files.DownFile)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(downBytes), qt.Equals, "SELECT down;\n")
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(nextAvailablePtahVersion(test.names, 42, name), qt.Equals, test.want)
+		})
+	}
 }
 
-// TestCreateMigrationFilesCreatesMissingParents replaces
+// TestGenerateEmptyMigrationNeverOverwritesAnExistingHalf is the file-level
+// counterpart: the writer's creates are exclusive, so an existing file keeps its
+// contents whatever the version scan concluded.
+func TestGenerateEmptyMigrationNeverOverwritesAnExistingHalf(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	first, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "constraint drift",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(first.DownFile, []byte("SELECT old_down;\n"), 0600), qt.IsNil)
+
+	second, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "constraint drift",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.DownFile, qt.Not(qt.Equals), first.DownFile)
+
+	oldDownBytes, err := os.ReadFile(first.DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(oldDownBytes), qt.Equals, "SELECT old_down;\n")
+}
+
+// TestGenerateEmptyMigrationCreatesMissingParents replaces
 // TestCreateMigrationFilesRequiresExistingParent, which pinned the opposite
 // behavior.
 //
@@ -49,31 +90,42 @@ func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T)
 // where this refused with `parent directory "…/a" is not available` and wrote
 // nothing (stokaro/ptah#1241 item 4). Ptah's `migrate diff` writer already
 // created parents, so the two writers also disagreed with each other.
-func TestCreateMigrationFilesCreatesMissingParents(t *testing.T) {
+func TestGenerateEmptyMigrationCreatesMissingParents(t *testing.T) {
 	c := qt.New(t)
-	dir := filepath.Join(t.TempDir(), "missing", "levels", "migrations")
+	// The reported path is the one the output directory resolved to, so the
+	// expectation resolves the temporary root the same way rather than comparing
+	// against a path that is a symlink on this platform.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	c.Assert(err, qt.IsNil)
+	dir := filepath.Join(base, "missing", "levels", "migrations")
 
-	files, err := createMigrationFiles(dir, 1, "init", "SELECT 1;\n", "SELECT 2;\n")
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "init",
+		OutputDir:     dir,
+	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(filepath.Dir(files.UpFile), qt.Equals, dir)
 
 	upBytes, err := os.ReadFile(files.UpFile)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(upBytes), qt.Equals, "SELECT 1;\n")
+	c.Assert(string(upBytes), qt.Contains, "-- Direction: UP\n")
 }
 
-// TestCreateMigrationFilesRefusesParentThatIsAFile is the control for the test
+// TestGenerateEmptyMigrationRefusesParentThatIsAFile is the control for the test
 // above: creating parents must not mean creating them through something that is
 // not a directory. The pinned binary refuses that path too
 // (`stat a/b: not a directory`, exit 1), so both stay refusals.
-func TestCreateMigrationFilesRefusesParentThatIsAFile(t *testing.T) {
+func TestGenerateEmptyMigrationRefusesParentThatIsAFile(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()
 	blocker := filepath.Join(root, "a")
 	c.Assert(os.WriteFile(blocker, []byte("not a directory\n"), 0600), qt.IsNil)
 
-	_, err := createMigrationFiles(filepath.Join(blocker, "b"), 1, "init", "SELECT 1;\n", "SELECT 2;\n")
-	c.Assert(err, qt.ErrorMatches, `failed to create output directory: .*not a directory`)
+	_, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "init",
+		OutputDir:     filepath.Join(blocker, "b"),
+	})
+	c.Assert(err, qt.ErrorMatches, `.*not a directory`)
 
 	blockerBytes, err := os.ReadFile(blocker)
 	c.Assert(err, qt.IsNil)

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -31,7 +31,6 @@ import (
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/indexscope"
-	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/internal/tableref"
@@ -150,16 +149,24 @@ type MigrationFiles struct {
 // MigrationPlan is a fully validated migration that has not been written to
 // disk yet. WriteFiles publishes the planned migration once.
 type MigrationPlan struct {
-	mu           sync.Mutex
-	outputDir    string
-	outputState  migrationDirectoryState
-	reportFormat string
-	specs        []generatedMigrationSpec
-	written      bool
+	mu        sync.Mutex
+	outputDir string
+	// allowedOutputRoot is carried from planning to publication so the writer
+	// transaction can open the root it must stay inside, rather than trusting a
+	// containment check made against a pathname before planning began.
+	allowedOutputRoot string
+	outputState       migrationDirectoryState
+	reportFormat      string
+	specs             []generatedMigrationSpec
+	written           bool
 }
 
 type migrationDirectoryState struct {
-	exists   bool
+	exists bool
+	// identity is the planned directory's filesystem identity, compared with
+	// os.SameFile so a replacement is detected even when the substitute holds
+	// exactly the files the plan verified.
+	identity fs.FileInfo
 	snapshot fsnapshot.Snapshot
 }
 
@@ -178,6 +185,14 @@ type EmptyMigrationOptions struct {
 
 // GenerateEmptyMigration creates skeleton migration files for manual SQL
 // authoring.
+//
+// The whole creation runs through one rooted migration-directory handle, bound
+// before anything is read or written: the directory is materialized, the
+// version scanned, the files created and atlas.sum committed through that one
+// handle rather than through the pathname it was selected by
+// (stokaro/ptah#1118). When AllowedOutputRoot is set the handle is opened
+// through it, so the transaction stays inside that root even if the directory
+// or one of its ancestors is replaced after the path was validated.
 func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error) {
 	name := strings.TrimSpace(opts.MigrationName)
 	if strings.TrimSpace(opts.OutputDir) == "" {
@@ -192,50 +207,23 @@ func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
 	if err != nil {
 		return nil, fmt.Errorf("error validating output directory: %w", err)
 	}
-	if dirFormat == migrator.MigrationDirFormatAtlas {
-		return generateEmptyAtlasMigration(name, outputDir)
+	// The Atlas layout derives its own file name from the migration name and
+	// accepts an empty one, so only the paired layout validates it here -- and
+	// it validates before the directory is bound, so a rejected name never
+	// creates a directory.
+	if dirFormat != migrator.MigrationDirFormatAtlas {
+		if err := validateEmptyMigrationName(name); err != nil {
+			return nil, err
+		}
 	}
-	if err := validateEmptyMigrationName(name); err != nil {
+
+	root, err := openOutputRoot(opts.AllowedOutputRoot)
+	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = closeOutputRoot(root) }()
 
-	version := migrator.GetNextMigrationVersion()
-	version = nextAvailableMigrationVersion(outputDir, version, name)
-	generatedAt := time.Now().UTC().Format(time.RFC3339)
-
-	return createMigrationFiles(
-		outputDir,
-		version,
-		name,
-		emptyMigrationSQL(name, generatedAt, "UP"),
-		emptyMigrationSQL(name, generatedAt, "DOWN"),
-	)
-}
-
-func generateEmptyAtlasMigration(name, outputDir string) (*MigrationFiles, error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	version := nextAvailableAtlasMigrationVersion(outputDir, nextAtlasMigrationVersion())
-	for {
-		filePath := filepath.Join(outputDir, atlasEmptyMigrationFileName(version, name))
-		if err := writeNewMigrationFile(filePath, ""); err != nil {
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write atlas migration file: %w", err)
-		}
-		if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatAtlas); err != nil {
-			_ = os.Remove(filePath)
-			return nil, fmt.Errorf("failed to write atlas migration checksum: %w", err)
-		}
-		pair := MigrationFilePair{
-			UpFile:  filePath,
-			Version: version,
-		}
-		return migrationFilesFromPairs([]MigrationFilePair{pair}), nil
-	}
+	return writeEmptyMigration(root, outputDir, name, dirFormat)
 }
 
 func nextAtlasMigrationVersion() int64 {
@@ -246,27 +234,30 @@ func nextAtlasMigrationVersion() int64 {
 	return version
 }
 
+// nextAvailableAtlasMigrationVersion answers the version question for a
+// directory named by pathname, for readers that are not inside a writer
+// transaction. A writer holding a rooted handle asks nextAvailableAtlasVersion
+// over the names it listed through that handle instead, so it never resolves
+// the directory a second time.
 func nextAvailableAtlasMigrationVersion(outputDir string, version int64) int64 {
-	if latest := latestExistingAtlasMigrationVersion(outputDir); latest >= version {
+	return nextAvailableAtlasVersion(migrationDirFileNames(outputDir), version)
+}
+
+func nextAvailableAtlasVersion(names []string, version int64) int64 {
+	if latest := latestAtlasVersionIn(names); latest >= version {
 		version = latest + 1
 	}
-	for fileExists(filepath.Join(outputDir, atlasEmptyMigrationFileName(version, ""))) {
+	taken := nameSet(names)
+	for taken[atlasEmptyMigrationFileName(version, "")] {
 		version++
 	}
 	return version
 }
 
-func latestExistingAtlasMigrationVersion(outputDir string) int64 {
-	entries, err := os.ReadDir(outputDir)
-	if err != nil {
-		return 0
-	}
+func latestAtlasVersionIn(names []string) int64 {
 	var latest int64
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		migrationFile, err := migrator.ParseAtlasMigrationFileName(entry.Name())
+	for _, name := range names {
+		migrationFile, err := migrator.ParseAtlasMigrationFileName(name)
 		if err != nil {
 			continue
 		}
@@ -395,7 +386,7 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err != nil {
 		return nil, fmt.Errorf("error reading database schema: %w", err)
 	}
-	if err := recoverMigrationPublication(ctx, opts.OutputDir); err != nil {
+	if err := recoverMigrationPublication(ctx, opts.AllowedOutputRoot, opts.OutputDir); err != nil {
 		return nil, err
 	}
 	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
@@ -468,16 +459,40 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	}
 
 	return &MigrationPlan{
-		outputDir:    opts.OutputDir,
-		outputState:  outputState,
-		reportFormat: opts.ReportFormat,
-		specs:        specs,
+		outputDir:         opts.OutputDir,
+		allowedOutputRoot: opts.AllowedOutputRoot,
+		outputState:       outputState,
+		reportFormat:      opts.ReportFormat,
+		specs:             specs,
 	}, nil
 }
 
-func recoverMigrationPublication(ctx context.Context, outputDir string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(outputDir)), 0755); err != nil {
-		return fmt.Errorf("create migration directory parent: %w", err)
+// recoverMigrationPublication resolves an interrupted publication left by an
+// earlier run, before this one starts planning. It resolves the directory by
+// pathname because it is the start of its own transaction rather than a step
+// inside this one; the levels above it are still created through the confining
+// root, so a recovery run cannot materialize directories outside it.
+func recoverMigrationPublication(
+	ctx context.Context,
+	allowedOutputRoot, outputDir string,
+) error {
+	root, err := openOutputRoot(allowedOutputRoot)
+	if err != nil {
+		return err
+	}
+	return errors.Join(
+		recoverMigrationPublicationWithin(ctx, root, outputDir),
+		closeOutputRoot(root),
+	)
+}
+
+func recoverMigrationPublicationWithin(
+	ctx context.Context,
+	root *pathguard.OpenedDirectory,
+	outputDir string,
+) error {
+	if err := atlasmigrate.EnsureMigrationParent(root, outputDir); err != nil {
+		return err
 	}
 	if err := atlasmigrate.RecoverPendingPublication(ctx, outputDir); err != nil {
 		return fmt.Errorf("recover migration publication before planning: %w", err)
@@ -493,6 +508,15 @@ func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
 
 // WriteFilesContext publishes the migration artifacts represented by the plan.
 // The context bounds waiting for the migration-directory publication lock.
+//
+// The transaction binds the migration directory once, under the lock, and then
+// verifies and publishes through that one handle. It used to verify the
+// directory's contents by pathname and let the publication resolve the pathname
+// again, so a directory replaced between the two steps received a batch the
+// verification had approved for a different filesystem object
+// (stokaro/ptah#1118). The plan's recorded state now carries the planned
+// directory's identity as well as its contents, so a replacement is refused
+// even when the substitute holds identical files.
 func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles, error) {
 	if p == nil {
 		return nil, fmt.Errorf("migration plan is nil")
@@ -507,30 +531,19 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(p.outputDir)), 0755); err != nil {
-		return nil, fmt.Errorf("create migration directory parent: %w", err)
+	root, err := openOutputRoot(p.allowedOutputRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = closeOutputRoot(root) }()
+	if err := atlasmigrate.EnsureMigrationParent(root, p.outputDir); err != nil {
+		return nil, err
 	}
 	var files *MigrationFiles
-	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		currentState, err := captureMigrationDirectoryState(p.outputDir)
-		if err != nil {
-			return fmt.Errorf("capture migration directory before publication: %w", err)
-		}
-		if !p.outputState.equal(currentState) {
-			return ErrMigrationDirectoryChanged
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		files, err = createMigrationFilesFromSpecs(ctx, p.outputDir, p.reportFormat, p.specs)
-		if err != nil {
-			return fmt.Errorf("error creating migration files: %w", err)
-		}
-		p.written = true
-		return nil
+	err = atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
+		published, publishErr := p.publishLocked(ctx, root)
+		files = published
+		return publishErr
 	})
 	if err != nil {
 		return nil, err
@@ -538,6 +551,39 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	return files, nil
 }
 
+func (p *MigrationPlan) publishLocked(
+	ctx context.Context,
+	root *pathguard.OpenedDirectory,
+) (*MigrationFiles, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	writer, err := bindMigrationOutputDir(root, p.outputDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = writer.Close() }()
+	currentState, err := captureWriterDirectoryState(writer)
+	if err != nil {
+		return nil, fmt.Errorf("capture migration directory before publication: %w", err)
+	}
+	if !p.outputState.equal(currentState) {
+		return nil, ErrMigrationDirectoryChanged
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	files, err := publishPlannedMigration(ctx, writer, p.reportFormat, p.specs)
+	if err != nil {
+		return nil, fmt.Errorf("error creating migration files: %w", err)
+	}
+	p.written = true
+	return files, nil
+}
+
+// captureMigrationDirectoryState reads the planned directory by pathname, at
+// planning time, before any writer handle exists. The identity it records is
+// what the publication later re-establishes through its bound handle.
 func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, error) {
 	info, err := os.Stat(outputDir)
 	if errors.Is(err, os.ErrNotExist) {
@@ -553,11 +599,48 @@ func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, 
 	if err != nil {
 		return migrationDirectoryState{}, err
 	}
-	return migrationDirectoryState{exists: true, snapshot: snapshot}, nil
+	return migrationDirectoryState{exists: true, identity: info, snapshot: snapshot}, nil
 }
 
+// captureWriterDirectoryState reads the same state through a bound writer
+// handle, so what the publication compares is the object it is about to commit
+// to rather than whatever the pathname resolves to at comparison time.
+func captureWriterDirectoryState(
+	writer *atlasmigrate.MigrationWriter,
+) (migrationDirectoryState, error) {
+	if !writer.Exists() {
+		return migrationDirectoryState{}, nil
+	}
+	identity, err := writer.Identity()
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	fsys, err := writer.FS()
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	snapshot, err := migrationsnapshot.CaptureStable(fsys)
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	return migrationDirectoryState{exists: true, identity: identity, snapshot: snapshot}, nil
+}
+
+// equal reports whether the publication is committing to the directory the plan
+// was built against. Contents alone are not enough: a substitute directory
+// holding the same files is still a different destination, and publishing into
+// it would put migrations somewhere nothing verified.
 func (s migrationDirectoryState) equal(other migrationDirectoryState) bool {
-	return s.exists == other.exists && s.snapshot.Equal(other.snapshot)
+	if s.exists != other.exists {
+		return false
+	}
+	if !s.snapshot.Equal(other.snapshot) {
+		return false
+	}
+	if !s.exists {
+		return true
+	}
+	return os.SameFile(s.identity, other.identity)
 }
 
 func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {
@@ -2044,31 +2127,33 @@ func reverseRoleDiffs(roleDiffs []types.RoleDiff) []types.RoleDiff {
 	return reversed
 }
 
+// nextAvailableMigrationVersion answers the version question for a directory
+// named by pathname, for readers that are not inside a writer transaction. A
+// writer holding a rooted handle asks nextAvailablePtahVersion over the names
+// it listed through that handle instead.
 func nextAvailableMigrationVersion(outputDir string, version int64, migrationName string) int64 {
-	if latest := latestExistingMigrationVersion(outputDir); latest >= version {
+	return nextAvailablePtahVersion(migrationDirFileNames(outputDir), version, migrationName)
+}
+
+func nextAvailablePtahVersion(names []string, version int64, migrationName string) int64 {
+	if latest := latestPtahVersionIn(names); latest >= version {
 		version = latest + 1
 	}
+	taken := nameSet(names)
 	for {
-		upFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "up"))
-		downFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "down"))
-		if !fileExists(upFilePath) && !fileExists(downFilePath) {
+		upName := migrator.GenerateMigrationFileName(version, migrationName, "up")
+		downName := migrator.GenerateMigrationFileName(version, migrationName, "down")
+		if !taken[upName] && !taken[downName] {
 			return version
 		}
 		version++
 	}
 }
 
-func latestExistingMigrationVersion(outputDir string) int64 {
-	entries, err := os.ReadDir(outputDir)
-	if err != nil {
-		return 0
-	}
+func latestPtahVersionIn(names []string) int64 {
 	var latest int64
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		migrationFile, err := migrator.ParseMigrationFileName(entry.Name())
+	for _, name := range names {
+		migrationFile, err := migrator.ParseMigrationFileName(name)
 		if err != nil {
 			continue
 		}
@@ -2077,6 +2162,33 @@ func latestExistingMigrationVersion(outputDir string) int64 {
 		}
 	}
 	return latest
+}
+
+// migrationDirFileNames lists a migration directory by pathname. It is the
+// reader-side counterpart of migrationDirNames, which lists the same thing
+// through a bound writer handle; a directory that cannot be listed reads as
+// empty, so a version scan over a missing directory starts from scratch.
+func migrationDirFileNames(outputDir string) []string {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func nameSet(names []string) map[string]bool {
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+	return set
 }
 
 func fileExists(path string) bool {
@@ -2092,66 +2204,6 @@ func withNoTransactionDirective(sql string) string {
 		return sql
 	}
 	return "-- +ptah " + migrator.DirectiveNoTransaction + "\n" + sql
-}
-
-// createMigrationFiles creates the up and down migration files
-func createMigrationFiles(outputDir string, version int64, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	for {
-		upFileName := migrator.GenerateMigrationFileName(version, migrationName, "up")
-		downFileName := migrator.GenerateMigrationFileName(version, migrationName, "down")
-
-		upFilePath := filepath.Join(outputDir, upFileName)
-		downFilePath := filepath.Join(outputDir, downFileName)
-
-		if err := writeNewMigrationFile(upFilePath, upSQL); err != nil {
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write up migration file: %w", err)
-		}
-
-		if err := writeNewMigrationFile(downFilePath, downSQL); err != nil {
-			_ = os.Remove(upFilePath)
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write down migration file: %w", err)
-		}
-
-		pair := MigrationFilePair{
-			UpFile:   upFilePath,
-			DownFile: downFilePath,
-			Version:  version,
-		}
-		return migrationFilesFromPairs([]MigrationFilePair{pair}), nil
-	}
-}
-
-func createMigrationFilesFromSpecs(
-	ctx context.Context,
-	outputDir, reportFormat string,
-	specs []generatedMigrationSpec,
-) (*MigrationFiles, error) {
-	if len(specs) == 0 {
-		return nil, nil
-	}
-	artifacts, pairs, err := renderMigrationArtifacts(outputDir, reportFormat, specs)
-	if err != nil {
-		return nil, err
-	}
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	if _, err := atlasmigrate.PublishArtifactsLocked(ctx, outputDir, artifacts); err != nil {
-		return nil, err
-	}
-	return migrationFilesFromPairs(pairs), nil
 }
 
 func renderMigrationArtifacts(

--- a/migration/generator/plan_export_internal_test.go
+++ b/migration/generator/plan_export_internal_test.go
@@ -38,8 +38,10 @@ type MigrationPlanSpecForTest struct {
 }
 
 // NewMigrationPlanForTest creates a plan without database-dependent planning.
+// allowedOutputRoot is the confinement root the publication must stay inside,
+// or empty for the direct-CLI shape.
 func NewMigrationPlanForTest(
-	outputDir, reportFormat string,
+	outputDir, allowedOutputRoot, reportFormat string,
 	specs []MigrationPlanSpecForTest,
 ) (*MigrationPlan, error) {
 	outputState, err := captureMigrationDirectoryState(outputDir)
@@ -58,10 +60,11 @@ func NewMigrationPlanForTest(
 		}
 	}
 	return &MigrationPlan{
-		outputDir:    outputDir,
-		outputState:  outputState,
-		reportFormat: reportFormat,
-		specs:        generatedSpecs,
+		outputDir:         outputDir,
+		allowedOutputRoot: allowedOutputRoot,
+		outputState:       outputState,
+		reportFormat:      reportFormat,
+		specs:             generatedSpecs,
 	}, nil
 }
 

--- a/migration/generator/plan_publication_test.go
+++ b/migration/generator/plan_publication_test.go
@@ -48,7 +48,7 @@ func TestMigrationPlanWriteFiles_PublishesMultiplePairsAndReports(t *testing.T) 
 			NoTransaction: true,
 		},
 	}
-	plan, err := generator.NewMigrationPlanForTest(outputDir, "json", specs)
+	plan, err := generator.NewMigrationPlanForTest(outputDir, "", "json", specs)
 	c.Assert(err, qt.IsNil)
 
 	files, err := plan.WriteFilesContext(t.Context())
@@ -128,6 +128,7 @@ func TestMigrationPlanWriteFiles_CollisionLeavesNoPartialArtifacts(t *testing.T)
 	c.Assert(os.WriteFile(reportPath, originalReport, 0600), qt.IsNil)
 	plan, err := generator.NewMigrationPlanForTest(
 		outputDir,
+		"",
 		"json",
 		[]generator.MigrationPlanSpecForTest{{
 			Version: 1700000000,
@@ -160,6 +161,7 @@ func TestMigrationPlanWriteFiles_CreatesMissingOutputParents(t *testing.T) {
 	outputDir := filepath.Join(c.TempDir(), "nested", "migrations")
 	plan, err := generator.NewMigrationPlanForTest(
 		outputDir,
+		"",
 		"",
 		[]generator.MigrationPlanSpecForTest{{
 			Version: 1700000000,

--- a/migration/generator/plan_root_test.go
+++ b/migration/generator/plan_root_test.go
@@ -1,0 +1,57 @@
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+// A plan records which filesystem object it was built against, not merely what
+// that object contained. The window these fixtures use is the product's own:
+// PlanMigration and WriteFilesContext are separate calls, so a caller running
+// pre-publication work between them leaves a real gap, and the directory can be
+// replaced inside it (stokaro/ptah#1118).
+//
+// Measured on master, the replacement below published both migration files into
+// the substitute and returned no error, because the pre-publication comparison
+// only asked whether the contents matched and two empty directories match.
+//
+// The control that this surface can report a publication at all is
+// TestMigrationPlanWriteFiles_PublishesMultiplePairsAndReports next door: the
+// same constructor and the same call publish six artifacts when nothing is
+// replaced.
+
+func TestMigrationPlanWriteFiles_RefusesRecreatedDirectory(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
+	// Same pathname, same (empty) contents, different filesystem object.
+	c.Assert(os.Remove(outputDir), qt.IsNil)
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+	c.Assert(files, qt.IsNil)
+	entries, err := os.ReadDir(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0)
+}

--- a/migration/generator/plan_root_unix_test.go
+++ b/migration/generator/plan_root_unix_test.go
@@ -1,0 +1,85 @@
+//go:build unix
+
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+// TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication is the
+// black-box half of the rooted-writer regression: the replacement happens in
+// the product's own window between planning and publication, so no test seam is
+// involved.
+//
+// The two rows separate the two guards, because either one alone would make
+// this pass for the wrong reason. Without a confinement root the run is stopped
+// by the plan's recorded identity; with one it is stopped earlier, when the
+// rooted open refuses a directory that now resolves outside the root. Both must
+// leave the substitute untouched.
+//
+// //go:build unix because the swap is a symlink replacement.
+func TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication(t *testing.T) {
+	tests := []struct {
+		name string
+		// allowedRoot returns the confinement root, or "" for the direct-CLI
+		// shape.
+		allowedRoot func(root string) string
+		wantErr     string
+	}{
+		{
+			name:        "no allowed root: the recorded identity refuses it",
+			allowedRoot: func(string) string { return "" },
+			wantErr:     "migration directory changed after migration planning",
+		},
+		{
+			name:        "under an allowed root: the rooted open refuses it",
+			allowedRoot: func(root string) string { return root },
+			wantErr:     ".*outside allowed root.*",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			bound := filepath.Join(root, "real")
+			c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+			selected := filepath.Join(root, "migrations")
+			c.Assert(os.Symlink(bound, selected), qt.IsNil)
+
+			plan, err := generator.NewMigrationPlanForTest(
+				selected,
+				test.allowedRoot(root),
+				"",
+				[]generator.MigrationPlanSpecForTest{{
+					Version: 1700000000,
+					Name:    "create_users",
+					UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+					DownSQL: "DROP TABLE users;\n",
+				}},
+			)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(os.Remove(selected), qt.IsNil)
+			c.Assert(os.Symlink(decoy, selected), qt.IsNil)
+
+			files, err := plan.WriteFilesContext(t.Context())
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(files, qt.IsNil)
+			decoyEntries, err := os.ReadDir(decoy)
+			c.Assert(err, qt.IsNil)
+			c.Assert(decoyEntries, qt.HasLen, 0)
+			boundEntries, err := os.ReadDir(bound)
+			c.Assert(err, qt.IsNil)
+			c.Assert(boundEntries, qt.HasLen, 0)
+		})
+	}
+}

--- a/migration/generator/rootedwriter.go
+++ b/migration/generator/rootedwriter.go
@@ -1,0 +1,274 @@
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"time"
+
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// This file holds the generator's two writer transactions -- creating a
+// skeleton migration and publishing a planned one -- expressed against one
+// rooted migration-directory handle each.
+//
+// The shape is the point (stokaro/ptah#1118). Both used to resolve the output
+// directory to a string and then reopen it by pathname for every subsequent
+// step: the mkdir, the version scan, each exclusive create, the atlas.sum
+// commit, the pre-publication snapshot and the publication itself. Measured on
+// master, a `ptah migrations create` racing a symlink swap of its own migration
+// directory published the migration file and a staged atlas.sum into a
+// directory outside AllowedOutputRoot in 4 of 40 runs, and a plan whose
+// directory was replaced between planning and publication wrote both migration
+// files into the replacement while reporting success.
+//
+// So: bind once, then never name the directory again. AllowedOutputRoot is
+// opened rather than merely compared against, and every read and write below
+// goes through that handle, which is why a replacement can no longer redirect
+// one step of a transaction the earlier steps already validated.
+
+// afterMigrationWriterBound runs once a writer transaction has bound its
+// migration directory and before it reads or writes anything through it. It is
+// nil outside tests.
+//
+// It exists because neither transaction has a product callback at that moment,
+// and that moment is exactly what the rooted handle defends: a replacement
+// landing in the window a pathname-based writer would resolve again. A test
+// that swaps before the call can only exercise the open.
+var afterMigrationWriterBound func()
+
+func notifyMigrationWriterBound() {
+	if afterMigrationWriterBound != nil {
+		afterMigrationWriterBound()
+	}
+}
+
+// openOutputRoot opens the confinement root a writer transaction runs inside,
+// or returns nil for the direct-CLI shape where an explicit absolute output
+// directory is the operator's own choice of destination.
+//
+// Opening it is what makes AllowedOutputRoot mean something after resolution.
+// It used to be a string compared against once by pathguard.ResolveWithinRoot
+// and then dropped, so a directory replaced afterwards escaped a boundary the
+// caller believed was still being enforced.
+func openOutputRoot(allowedOutputRoot string) (*pathguard.OpenedDirectory, error) {
+	if allowedOutputRoot == "" {
+		return nil, nil
+	}
+	root, err := pathguard.OpenDirectory(allowedOutputRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open allowed output root: %w", err)
+	}
+	return root, nil
+}
+
+func closeOutputRoot(root *pathguard.OpenedDirectory) error {
+	if root == nil {
+		return nil
+	}
+	return root.Close()
+}
+
+// bindMigrationOutputDir creates the levels above the migration directory and
+// binds the directory itself, without creating it. The caller compares the
+// directory's absence against what it planned for before materializing it.
+func bindMigrationOutputDir(
+	root *pathguard.OpenedDirectory,
+	outputDir string,
+) (*atlasmigrate.MigrationWriter, error) {
+	if err := atlasmigrate.EnsureMigrationParent(root, outputDir); err != nil {
+		return nil, err
+	}
+	writer, err := atlasmigrate.OpenMigrationWriter(root, outputDir)
+	if err != nil {
+		return nil, err
+	}
+	notifyMigrationWriterBound()
+	return writer, nil
+}
+
+// writeEmptyMigration creates the skeleton files for one migration through a
+// rooted handle bound for the whole transaction.
+func writeEmptyMigration(
+	root *pathguard.OpenedDirectory,
+	outputDir, name string,
+	dirFormat migrator.MigrationDirFormat,
+) (*MigrationFiles, error) {
+	writer, err := bindMigrationOutputDir(root, outputDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = writer.Close() }()
+	if err := writer.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	files, err := writeEmptyMigrationFiles(writer, name, dirFormat)
+	if err != nil {
+		return nil, err
+	}
+	if err := writer.SyncDir(); err != nil {
+		return nil, fmt.Errorf("failed to flush output directory: %w", err)
+	}
+	return files, nil
+}
+
+func writeEmptyMigrationFiles(
+	writer *atlasmigrate.MigrationWriter,
+	name string,
+	dirFormat migrator.MigrationDirFormat,
+) (*MigrationFiles, error) {
+	names, err := migrationDirNames(writer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read output directory: %w", err)
+	}
+	if dirFormat == migrator.MigrationDirFormatAtlas {
+		return writeEmptyAtlasMigration(writer, names, name)
+	}
+	return writeEmptyPtahMigration(writer, names, name)
+}
+
+// writeEmptyAtlasMigration writes one Atlas-style file and commits atlas.sum
+// over it. The checksum is computed from the same handle the file was created
+// through, so it describes the directory this transaction wrote into rather
+// than whatever the pathname resolves to by the time the sum is written.
+func writeEmptyAtlasMigration(
+	writer *atlasmigrate.MigrationWriter,
+	names []string,
+	name string,
+) (*MigrationFiles, error) {
+	version := nextAvailableAtlasVersion(names, nextAtlasMigrationVersion())
+	for {
+		fileName := atlasEmptyMigrationFileName(version, name)
+		err := writer.WriteNew(fileName, "")
+		if errors.Is(err, fs.ErrExist) {
+			version++
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to write atlas migration file: %w", err)
+		}
+		if err := publishMigrationDirSum(writer); err != nil {
+			return nil, errors.Join(
+				fmt.Errorf("failed to write atlas migration checksum: %w", err),
+				writer.Remove(fileName),
+			)
+		}
+		return migrationFilesFromPairs([]MigrationFilePair{{
+			UpFile:  filepath.Join(writer.Path(), fileName),
+			Version: version,
+		}}), nil
+	}
+}
+
+// writeEmptyPtahMigration writes the paired up/down skeleton. A down file that
+// cannot be created withdraws the up file it already wrote, because a migration
+// with no rollback half is worse than none.
+func writeEmptyPtahMigration(
+	writer *atlasmigrate.MigrationWriter,
+	names []string,
+	name string,
+) (*MigrationFiles, error) {
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
+	upSQL := emptyMigrationSQL(name, generatedAt, "UP")
+	downSQL := emptyMigrationSQL(name, generatedAt, "DOWN")
+	version := nextAvailablePtahVersion(names, migrator.GetNextMigrationVersion(), name)
+	for {
+		upName := migrator.GenerateMigrationFileName(version, name, "up")
+		downName := migrator.GenerateMigrationFileName(version, name, "down")
+
+		upErr := writer.WriteNew(upName, upSQL)
+		if errors.Is(upErr, fs.ErrExist) {
+			version++
+			continue
+		}
+		if upErr != nil {
+			return nil, fmt.Errorf("failed to write up migration file: %w", upErr)
+		}
+
+		downErr := writer.WriteNew(downName, downSQL)
+		if errors.Is(downErr, fs.ErrExist) {
+			version++
+			if removeErr := writer.Remove(upName); removeErr != nil {
+				return nil, fmt.Errorf("failed to withdraw up migration file: %w", removeErr)
+			}
+			continue
+		}
+		if downErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("failed to write down migration file: %w", downErr),
+				writer.Remove(upName),
+			)
+		}
+
+		return migrationFilesFromPairs([]MigrationFilePair{{
+			UpFile:   filepath.Join(writer.Path(), upName),
+			DownFile: filepath.Join(writer.Path(), downName),
+			Version:  version,
+		}}), nil
+	}
+}
+
+// publishMigrationDirSum recomputes atlas.sum from the bound handle and commits
+// it conditionally on the checksum state that read observed.
+func publishMigrationDirSum(writer *atlasmigrate.MigrationWriter) error {
+	fsys, err := writer.FS()
+	if err != nil {
+		return err
+	}
+	sum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.PublishAtlasSum(sum); err != nil {
+		return err
+	}
+	return nil
+}
+
+// publishPlannedMigration commits a planned batch through the handle the
+// transaction already verified the directory with.
+func publishPlannedMigration(
+	ctx context.Context,
+	writer *atlasmigrate.MigrationWriter,
+	reportFormat string,
+	specs []generatedMigrationSpec,
+) (*MigrationFiles, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	artifacts, pairs, err := renderMigrationArtifacts(writer.Path(), reportFormat, specs)
+	if err != nil {
+		return nil, err
+	}
+	if err := writer.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	if _, err := writer.PublishArtifacts(ctx, artifacts); err != nil {
+		return nil, err
+	}
+	return migrationFilesFromPairs(pairs), nil
+}
+
+// migrationDirNames lists the migration directory's file names through the
+// bound handle. An absent directory lists as empty, which is the same answer
+// the version scan wants.
+func migrationDirNames(writer *atlasmigrate.MigrationWriter) ([]string, error) {
+	entries, err := writer.Entries()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}

--- a/migration/generator/rootedwriter_unix_internal_test.go
+++ b/migration/generator/rootedwriter_unix_internal_test.go
@@ -1,0 +1,245 @@
+//go:build unix
+
+package generator
+
+// White-box testing required: the moment these fixtures measure -- after the
+// migration directory is bound and before the transaction reads or writes
+// anything through it -- has no exported name, because nothing in the product
+// needs one. A test that replaces the directory before calling the exported API
+// only exercises the open, and the open is not what the rooted handle uniquely
+// defends. Everything asserted below is otherwise observable: the files on disk
+// and the contents of the directory the replacement pointed at.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// These are the `migration/generator` half of the rooted-writer regressions
+// stokaro/ptah#1118 asks for, and the counterpart to the TestGenerateDiff_*
+// rows in internal/atlasmigrate and the TestWriteSkeletonMigration_* rows
+// beside them.
+//
+// Every replacement below happens after the directory is bound: some swap the
+// migration directory itself, one swaps an ancestor. Measured on master, the
+// same replacement racing `ptah migrations create` published the migration file
+// and a staged atlas.sum into a directory outside AllowedOutputRoot in 4 of 40
+// runs, and a planned migration whose directory was replaced between planning
+// and publication wrote both files into the replacement while reporting success.
+//
+// The file is //go:build unix because Win32 refuses to rename a directory the
+// run holds open without FILE_SHARE_DELETE, so on Windows there is no hostile
+// step to perform rather than a step that is expected to fail.
+
+// replaceWithSymlink renames path aside and leaves a symlink to target in its
+// place, which is what a pathname-based writer follows from here on. It returns
+// the retained original, which is where a rooted writer's files must land.
+func replaceWithSymlink(c *qt.C, path, target string) string {
+	c.Helper()
+	retained := path + "-retained"
+	c.Assert(os.Rename(path, retained), qt.IsNil)
+	c.Assert(os.Symlink(target, path), qt.IsNil)
+	return retained
+}
+
+// generatorDirNames lists the base names in dir.
+func generatorDirNames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite asserts
+// both halves the acceptance criteria ask for: the migration lands in the
+// directory the run bound, and the directory the replacement pointed at is left
+// completely untouched.
+//
+// The second half is the one that fails when the rooted handle is removed.
+// Without it, a run that merely errored out would look the same as one that
+// stayed inside the boundary.
+func TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		// allowedRoot returns the confinement root, or "" for the direct-CLI
+		// shape where an explicit absolute directory is the operator's own
+		// choice of destination.
+		allowedRoot func(root string) string
+		dirFormat   migrator.MigrationDirFormat
+		// stage builds the tree and returns the directory the run selects.
+		stage func(c *qt.C, root, decoy string) string
+		// replace performs the swap once the directory is bound and returns the
+		// directory the bound handle still points at.
+		replace func(c *qt.C, root, decoy string) string
+		// wantFiles is how many files the layout writes: two for the Atlas
+		// layout (the migration and atlas.sum) and two for the paired layout
+		// (the up and down halves).
+		wantFiles int
+		// wantDecoyEntries is what the row staged in the decoy before the run:
+		// nothing, except the ancestor row, which needs a migrations directory
+		// for the swapped symlink to resolve through at all.
+		wantDecoyEntries int
+	}{
+		{
+			name:        "the migration directory is replaced, under an allowed root",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "the migration directory is replaced, with no allowed root",
+			allowedRoot: func(string) string { return "" },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "the migration directory is replaced, paired layout",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatPtah,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "an ancestor directory is replaced",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage: func(c *qt.C, root, decoy string) string {
+				c.Helper()
+				c.Assert(os.MkdirAll(filepath.Join(root, "nest", "migrations"), 0o755), qt.IsNil)
+				c.Assert(os.MkdirAll(filepath.Join(decoy, "migrations"), 0o755), qt.IsNil)
+				return filepath.Join(root, "nest", "migrations")
+			},
+			replace: func(c *qt.C, root, decoy string) string {
+				return filepath.Join(
+					replaceWithSymlink(c, filepath.Join(root, "nest"), decoy),
+					"migrations",
+				)
+			},
+			wantFiles:        2,
+			wantDecoyEntries: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			selected := test.stage(c, root, decoy)
+
+			var retained string
+			afterMigrationWriterBound = func() { retained = test.replace(c, root, decoy) }
+			defer func() { afterMigrationWriterBound = nil }()
+
+			files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+				MigrationName:     "added",
+				OutputDir:         selected,
+				AllowedOutputRoot: test.allowedRoot(root),
+				DirFormat:         test.dirFormat,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.IsNotNil)
+			c.Assert(generatorDirNames(c, retained), qt.HasLen, test.wantFiles)
+			c.Assert(generatorDirNames(c, decoy), qt.HasLen, test.wantDecoyEntries)
+		})
+	}
+}
+
+// stageTopLevelMigrationDir prepares root/migrations as the selected directory.
+func stageTopLevelMigrationDir(c *qt.C, root, _ string) string {
+	c.Helper()
+	selected := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+	return selected
+}
+
+// TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent covers
+// the initially-missing directory the acceptance criteria name: it is
+// materialized through the parent handle bound for the transaction, so a
+// replacement of the parent's name cannot move where it is created.
+func TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	decoy := t.TempDir()
+	c.Assert(os.MkdirAll(filepath.Join(root, "nest"), 0o755), qt.IsNil)
+	selected := filepath.Join(root, "nest", "migrations")
+
+	var retained string
+	afterMigrationWriterBound = func() {
+		retained = replaceWithSymlink(c, filepath.Join(root, "nest"), decoy)
+	}
+	defer func() { afterMigrationWriterBound = nil }()
+
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName:     "added",
+		OutputDir:         selected,
+		AllowedOutputRoot: root,
+		DirFormat:         migrator.MigrationDirFormatAtlas,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(generatorDirNames(c, filepath.Join(retained, "migrations")), qt.HasLen, 2)
+	c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+}
+
+// TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication is the
+// same measurement for the planned-migration writer: the replacement lands
+// after the directory is bound and before the pre-publication snapshot is
+// taken, which is exactly the window the old code closed with nothing.
+func TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	decoy := t.TempDir()
+	outputDir := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	state, err := captureMigrationDirectoryState(outputDir)
+	c.Assert(err, qt.IsNil)
+	plan := &MigrationPlan{
+		outputDir:         outputDir,
+		allowedOutputRoot: root,
+		outputState:       state,
+		specs: []generatedMigrationSpec{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	}
+
+	var retained string
+	afterMigrationWriterBound = func() { retained = replaceWithSymlink(c, outputDir, decoy) }
+	defer func() { afterMigrationWriterBound = nil }()
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(generatorDirNames(c, retained), qt.DeepEquals, []string{
+		"1700000000_create_users.down.sql",
+		"1700000000_create_users.up.sql",
+	})
+	c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+}


### PR DESCRIPTION
## What was already done, and what was not

Two of the three surfaces #1118 names were fixed before this branch. Naming them precisely, because claiming credit for them would be worse than fixing nothing:

| surface | status on master `4fd9f18a` |
| --- | --- |
| `ptah-compat migrate diff` | **already fixed** by 028ac05d, "fix(compat): bind migrate diff publication to the opened directory (refs #1118)". `internal/atlasmigrate/diff_root_unix_test.go` holds the three replacement regressions. |
| `ptah-compat migrate new`, foreign `--dir-format` | **already fixed** by e4b6f4c1, "Write migrate new skeletons through a rooted handle (#1222)". `cmd/atlas/migrate_new.go` calls `atlasmigrate.WriteSkeletonMigration(migrateDiffWriterRoot(...), …)`. The issue's last status comment lists this as open; it is not, as of that commit. |
| `migration/generator` | **still broken.** This PR. |

## The defect

Both of `migration/generator`'s writers resolved the output directory to a string and then reopened it by pathname for every later step.

`ptah migrations create` — and therefore the forwarded `ptah-compat migrate new` for a plain Atlas directory — reopened the pathname for the mkdir, the version scan, each file it created, and the `atlas.sum` commit. `ptah migrations generate` verified the directory's contents by pathname and then let the publication resolve the pathname a second time. `AllowedOutputRoot` was compared against once by `pathguard.ResolveWithinRoot` and then dropped.

Measured on master `4fd9f18a`:

| probe | master `4fd9f18a` | this branch |
| --- | --- | --- |
| `GenerateEmptyMigration --dir-format atlas`, `AllowedOutputRoot` set, racing a symlink swap of its own migration directory to a decoy **outside** that root; 40 runs | **4 of 40 published outside the allowed root.** Escaped artifacts included `20260807155608_added.sql` and `.atlas.sum.3342714190.tmp` | **0 of 40** |
| plan against `root/migrations -> real`, replace the symlink with an empty decoy, then `WriteFilesContext` | **exit nil.** `real=[]`, `decoy=[1700000000_create_users.down.sql 1700000000_create_users.up.sql]` | `migration directory changed after migration planning`; `real=[]`, `decoy=[]` |

The second row needs no fault injection. `PlanMigration` and `WriteFilesContext` are separate public calls, and the pre-publication comparison only asked whether the contents matched — two empty directories match.

## The change

Both writers bind the migration directory and its parent once and run the whole transaction through that binding: materializing a missing directory through the bound parent, scanning versions, creating files exclusively, committing `atlas.sum`, snapshotting before publication, publishing the batch, and rolling back. `AllowedOutputRoot` is *opened*, so the binding itself is confined. The plan additionally records the planned directory's filesystem identity, and publication refuses a directory that is no longer the same object — a substitute holding exactly the files the plan verified is still a different destination.

`atlasmigrate.PublishArtifactsLocked` is **removed** rather than kept beside the new entry point. It took a directory pathname and bound its own handle, which is precisely the unconstrained second reader the issue rules out; `MigrationWriter.PublishArtifacts` is now the only way in, and `migrationWriterDir.create` is the single place a migration directory is materialized through a bound parent.

The public `migration/generator` API is unchanged — the rooted handle is an `internal/atlasmigrate` type reached only on the internal path, which is the "internal seam" option from the issue's own analysis. `docs/public_api.snapshot` does not move and `check-public-api-released` reports no `migration/generator` entry.

**This changes behavior.** A `migrations generate` run that previously published into a recreated directory now fails and writes nothing. Pre-v1, so no compatibility with Ptah's own past is owed; documented in `docs/site/src/content/docs/concepts/migration-directory.md` and `migration/generator/README.md`.

## Regressions

`migration/generator/rootedwriter_unix_internal_test.go` (white-box, `//go:build unix`, justified after the package clause — the moment it measures, after the directory is bound and before anything is read through it, has no exported name because nothing in the product needs one):

- `TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite` — 4 rows: the migration directory replaced under an allowed root, with no allowed root, in the paired layout, and an ancestor directory replaced.
- `TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent`
- `TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication`

Black-box, no seam: `TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication` (2 rows, separating the identity guard from the rooted-open guard) and the portable `TestMigrationPlanWriteFiles_RefusesRecreatedDirectory`.

Every row asserts both halves the acceptance criteria ask for: the artifacts land in the bound directory, and the directory the replacement pointed at is left completely untouched.

## Mutation, both directions

| mutant | red | green |
| --- | --- | --- |
| **M1** revert: `WriteNew` writes by pathname | all 4 `ReplacedDirectory…` rows, `CreatesMissingDirectoryThroughTheBoundParent` | every plan test, the other 6 `GenerateEmptyMigration*` tests |
| **I1** over-correct: `WriteNew` revalidates and refuses on change | the same 5 rows, now with `failed to write up migration file: opened directory path changed: …` instead of files in the decoy | same as M1 |
| **M2** revert: `equal` drops `os.SameFile` | `RefusesRecreatedDirectory`, `RefusesDirectoryReplacedBeforePublication/no_allowed_root` | `…/under_an_allowed_root`, every create row, every happy-path publication |
| **I2** over-correct: identity always mismatches | `…ReplacedDirectoryCannotRedirectPublication`, `PublishesMultiplePairsAndReports`, `CollisionLeavesNoPartialArtifacts`, `HappyPath`, `FailurePath` | the two refusal tests, every create row |
| **M3** revert: `openOutputRoot` always nil | `RefusesDirectoryReplacedBeforePublication/under_an_allowed_root` **only** | everything else |
| **I3** over-correct: an empty root confines to the working directory | 13 rows including every direct-CLI create and publication | the rows that already run under a root |

M3 is the honest one: the create-path rows stay green without the confinement root, because the bound handle alone already keeps those writes in the retained directory. The root's unique contribution is refusing, at bind time, a directory that now resolves outside it, and exactly one row pins that.

## Gates

`go build` 0 · `go vet` 0 · `qtlint` 0 · `golangci-lint` 0 · `check-test-style` 0 · `check-public-api` 0 · `check-public-api-snapshot` 0 · `check-public-api-released` 0 · all eight `docs/site` `check:*` scripts 0 (`check-responsive` after `npm ci && npm run build`) · `build-feature-matrix --check` 0.

`go test ./... -count=1` is **exit 1**, from three packages this change does not touch:

- `cmd/ptah-ls` — a 20s process budget missed under load; passes alone (`ok 46.236s`).
- `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` — `signal: killed`. Reproduced identically in a clean worktree at `4fd9f18a`.
- `cmd/atlas` — `signal: terminated` at ~10 minutes with no test output. Reproduced identically at `4fd9f18a` (`FAIL 642.051s`). On this branch, `-run Migrate -parallel 1` — every command that goes through the writer touched here — is `ok 110.521s`.

Every package this change touches passes: `internal/atlasmigrate`, all of `migration/…`, `cmd/migrate`, `cmd/migratecheckpoint`, `cmd/migratedata`.

## Still open on this issue

- `cmd/migrate/new.go --edit` rehashes through `migrateops.Rehash(dir, format)` by pathname after the external editor exits. Separate transaction, outside `migration/generator`; the acceptance criteria's editor bullet is half covered.
- `WriteCheckpointFiles`, `WriteDataMigrationFiles` and `WriteAtlasCheckpointFile` (`ptah migrations checkpoint`, `ptah migrations data`) still write by pathname. Not named by #1118 and carrying no `AllowedOutputRoot`, but the machinery to convert them is now in place.

Refs #1118.
---

**On the gate list**: every gate is 0 except `go test ./... -count=1`, which exited 1 on three subprocess-heavy packages with `signal: killed` / `signal: terminated`. That was measured on a machine carrying roughly twenty concurrent `go test` runs, and an unmodified base checkout reproduced the same failures at the same assertion lines. No package this change touches is among them. CI is the arbiter here rather than my local run.
