### PR TITLE
Escape the underscore in every reserved-prefix filter (#1291)

### DIFF
--- a/integration/gonative/roles_pg_prefix_integration_test.go
+++ b/integration/gonative/roles_pg_prefix_integration_test.go
@@ -1,0 +1,125 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"database/sql"
+	"fmt"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/dbschema/postgres"
+)
+
+// pgPrefixRole is a role name PostgreSQL does NOT reserve and the reader's
+// system-role filter used to swallow.
+//
+// PostgreSQL reserves the prefix `pg_`, with the underscore. SQL LIKE reads a
+// bare `_` as a single-character wildcard, so the pattern `pg_%` matches `pg`
+// followed by any character: pgbouncer, pgadmin, pgpool, pguser. This name has
+// the same shape and is unique enough to run beside other work on a shared
+// cluster.
+const pgPrefixRole = "pgb1291_probe"
+
+// pgPrefixTable holds the grant, so the run covers both questions the filter is
+// asked: which roles exist, and who holds privileges.
+const pgPrefixTable = "pgb1291_granted"
+
+// TestPostgreSQLReaderDescribesRolesNamedPgSomething pins that a user role whose
+// name merely begins with `pg` is described.
+//
+// It is a live test because the defect is in SQL rather than in Go: measured on
+// PostgreSQL 17.10,
+//
+//	SELECT 'pgbouncer' LIKE 'pg_%';    -- true
+//	SELECT 'pgbouncer' LIKE 'pg\_%';   -- false
+//
+// so nothing short of asking a server can tell the two patterns apart. The role
+// was invisible to the reader, which made the comparator read it as absent and
+// plan CREATE ROLE against a database that already had it -- and grants held by
+// it were invisible for the same reason, which is the more serious half given
+// what a role like pgbouncer is usually granted (stokaro/ptah#1291).
+func TestPostgreSQLReaderDescribesRolesNamedPgSomething(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+
+	dropPgPrefixFixture(c, db)
+	c.Cleanup(func() { dropPgPrefixFixture(c, db) })
+
+	_, err = db.Exec(fmt.Sprintf("CREATE ROLE %q", pgPrefixRole))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(fmt.Sprintf("CREATE TABLE %q (id integer PRIMARY KEY)", pgPrefixTable))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(fmt.Sprintf("GRANT SELECT ON %q TO %q", pgPrefixTable, pgPrefixRole))
+	c.Assert(err, qt.IsNil)
+
+	// The catalog is asked directly first, so a reader that returns nothing
+	// cannot be confused with a database that holds nothing.
+	var seeded int
+	c.Assert(db.QueryRow(
+		"SELECT count(*) FROM pg_roles WHERE rolname = $1", pgPrefixRole,
+	).Scan(&seeded), qt.IsNil)
+	c.Assert(seeded, qt.Equals, 1)
+
+	schema, err := postgres.NewPostgreSQLReader(db, "public").ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	roleNames := make([]string, 0, len(schema.Roles))
+	for _, role := range schema.Roles {
+		roleNames = append(roleNames, role.Name)
+	}
+	c.Assert(slices.Contains(roleNames, pgPrefixRole), qt.IsTrue,
+		qt.Commentf("reader described %d roles and none of them is %q", len(roleNames), pgPrefixRole))
+
+	grantRefs := make([]string, 0, len(schema.Grants))
+	for _, grant := range schema.Grants {
+		grantRefs = append(grantRefs, grant.Role+" -> "+grant.ObjectName)
+	}
+	c.Assert(slices.Contains(grantRefs, pgPrefixRole+" -> "+pgPrefixTable), qt.IsTrue,
+		qt.Commentf("reader described %d grants and none is %q on %q: %v",
+			len(grantRefs), pgPrefixRole, pgPrefixTable, grantRefs))
+
+	// The control in the other direction: a genuinely reserved role, which the
+	// filter must still exclude. Without it this test would pass against a
+	// reader that had simply stopped filtering.
+	c.Assert(slices.ContainsFunc(roleNames, func(name string) bool {
+		return len(name) > 3 && name[:3] == "pg_"
+	}), qt.IsFalse,
+		qt.Commentf("reader described a reserved pg_ role: %v", roleNames))
+}
+
+// dropPgPrefixFixture removes the fixture, tolerating its absence. The role is
+// cluster-scoped, so it outlives the database and has to be dropped by name.
+//
+// The existence check is in SQL rather than in Go because DROP OWNED BY has no
+// IF EXISTS form and fails outright on a role that is not there, which is the
+// ordinary state on the first run. Every statement here is unconditional from
+// the caller's side, so a failure is a real failure.
+func dropPgPrefixFixture(c *qt.C, db *sql.DB) {
+	c.Helper()
+
+	_, err := db.Exec(fmt.Sprintf("DROP TABLE IF EXISTS %q", pgPrefixTable))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(fmt.Sprintf(`
+		DO $$ BEGIN
+			IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = %s) THEN
+				EXECUTE 'DROP OWNED BY %q';
+			END IF;
+		END $$`, quoteSQLLiteral(pgPrefixRole), pgPrefixRole))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(fmt.Sprintf("DROP ROLE IF EXISTS %q", pgPrefixRole))
+	c.Assert(err, qt.IsNil)
+}
+
+// quoteSQLLiteral renders a name as a single-quoted SQL string. The fixture's
+// names are constants in this file, so this only has to be correct for them.
+func quoteSQLLiteral(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "''") + "'"
+}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1721,7 +1721,7 @@ func (r *Reader) readSequenceGrantsForSchema(schemaName string, standalone map[s
 		JOIN pg_roles grantor ON grantor.oid = acl.grantor
 		WHERE c.relkind = 'S'
 		AND n.nspname = $1
-		AND COALESCE(grantee.rolname, 'PUBLIC') NOT LIKE 'pg_%'
+		AND COALESCE(grantee.rolname, 'PUBLIC') NOT LIKE 'pg\_%' ESCAPE '\'
 		AND COALESCE(grantee.rolname, 'PUBLIC') != 'postgres'
 		ORDER BY n.nspname, c.relname, COALESCE(grantee.rolname, 'PUBLIC'), acl.privilege_type`
 
@@ -2038,7 +2038,10 @@ func (r *Reader) readFunctionsForSchema(schemaName string) ([]types.DBFunction, 
 		WHERE n.nspname = $1
 		AND p.prokind = 'f'  -- Only functions, not procedures
 		AND l.lanname != 'internal'  -- Exclude internal functions
-		AND p.proname NOT LIKE 'ptah_trigger_%'
+		-- Escaped for the same reason as the role filters above: a bare _
+		-- is a LIKE wildcard, so the unescaped form also excluded ordinary
+		-- functions such as ptahxtriggery (stokaro/ptah#1291).
+		AND p.proname NOT LIKE 'ptah\_trigger\_%' ESCAPE '\'
 		-- Exclude extension-owned functions to prevent migration issues
 		-- Extension functions cannot be dropped independently and should be managed by the extension
 		AND NOT EXISTS (
@@ -2164,7 +2167,11 @@ func (r *Reader) readRoles() ([]types.DBRole, error) {
 			COALESCE(shobj_description(r.oid, 'pg_authid'), '') AS comment
 		FROM pg_roles r
 		LEFT JOIN pg_authid a ON r.oid = a.oid
-		WHERE r.rolname NOT LIKE 'pg_%'  -- Exclude system roles
+		-- The underscore is escaped because LIKE reads a bare _ as a
+		-- single-character wildcard: 'pg_%' matches pgbouncer, pgadmin and
+		-- pgpool, which are ordinary user roles. PostgreSQL reserves the
+		-- prefix WITH the underscore (stokaro/ptah#1291).
+		WHERE r.rolname NOT LIKE 'pg\_%' ESCAPE '\'  -- Exclude system roles
 		AND r.rolname != 'postgres'      -- Exclude postgres superuser
 		ORDER BY r.rolname`
 
@@ -2246,7 +2253,7 @@ func (r *Reader) readTableGrantsForSchema(schemaName string) ([]types.DBGrant, e
 			grantor
 		FROM information_schema.role_table_grants
 		WHERE table_schema = $1
-		AND grantee NOT LIKE 'pg_%'
+		AND grantee NOT LIKE 'pg\_%' ESCAPE '\'
 		AND grantee != 'postgres'
 		ORDER BY table_schema, table_name, grantee, privilege_type`
 
@@ -2284,7 +2291,7 @@ func (r *Reader) readSchemaGrantsForSchema(schemaName string) ([]types.DBGrant, 
 		LEFT JOIN pg_roles grantee ON grantee.oid = acl.grantee
 		JOIN pg_roles grantor ON grantor.oid = acl.grantor
 		WHERE n.nspname = $1
-		AND COALESCE(grantee.rolname, 'PUBLIC') NOT LIKE 'pg_%'
+		AND COALESCE(grantee.rolname, 'PUBLIC') NOT LIKE 'pg\_%' ESCAPE '\'
 		AND COALESCE(grantee.rolname, 'PUBLIC') != 'postgres'
 		ORDER BY n.nspname, COALESCE(grantee.rolname, 'PUBLIC'), acl.privilege_type`
 

--- a/internal/dbschema/sqlite/reader.go
+++ b/internal/dbschema/sqlite/reader.go
@@ -122,7 +122,7 @@ func (r *Reader) readSchemaCatalog() (sqliteSchemaCatalog, error) {
 		SELECT type, name, tbl_name, sql
 		FROM %s
 		WHERE type IN ('table', 'index', 'view', 'trigger')
-		  AND NOT (type = 'table' AND name LIKE 'sqlite_%%')
+		  AND NOT (type = 'table' AND name LIKE 'sqlite\_%%' ESCAPE '\')
 		  AND NOT (type IN ('table', 'view') AND name = 'schema_migrations')
 		ORDER BY type, tbl_name, name
 	`, r.schemaObject("sqlite_schema"))
@@ -220,7 +220,7 @@ func (r *Reader) readColumnsByTable() (map[string][]types.DBColumn, error) {
 		FROM %s AS m
 		JOIN pragma_table_xinfo(m.name, ?) AS x
 		WHERE m.type = 'table'
-		  AND m.name NOT LIKE 'sqlite_%%'
+		  AND m.name NOT LIKE 'sqlite\_%%' ESCAPE '\'
 		  AND m.name <> 'schema_migrations'
 		ORDER BY m.name, x.cid
 	`, r.schemaObject("sqlite_schema"))
@@ -362,7 +362,7 @@ func (r *Reader) readIndexEntriesByTable() (map[string][]sqliteIndexEntry, error
 		FROM %s AS m
 		JOIN pragma_index_list(m.name, ?) AS il
 		WHERE m.type = 'table'
-		  AND m.name NOT LIKE 'sqlite_%%'
+		  AND m.name NOT LIKE 'sqlite\_%%' ESCAPE '\'
 		  AND m.name <> 'schema_migrations'
 		ORDER BY m.name, il.seq
 	`, r.schemaObject("sqlite_schema"))
@@ -468,7 +468,7 @@ func (r *Reader) readIndexColumnsByIndex() (map[string]sqliteIndexColumns, error
 		JOIN pragma_index_list(m.name, ?) AS il
 		JOIN pragma_index_xinfo(il.name, ?) AS ix
 		WHERE m.type = 'table'
-		  AND m.name NOT LIKE 'sqlite_%%'
+		  AND m.name NOT LIKE 'sqlite\_%%' ESCAPE '\'
 		  AND m.name <> 'schema_migrations'
 		ORDER BY il.name, ix.seqno
 	`, r.schemaObject("sqlite_schema"))
@@ -657,7 +657,7 @@ func (r *Reader) readForeignKeysByTable(tableDDLByName map[string]string) (map[s
 		FROM %s AS m
 		JOIN pragma_foreign_key_list(m.name, ?) AS fk
 		WHERE m.type = 'table'
-		  AND m.name NOT LIKE 'sqlite_%%'
+		  AND m.name NOT LIKE 'sqlite\_%%' ESCAPE '\'
 		  AND m.name <> 'schema_migrations'
 		ORDER BY m.name, fk.id, fk.seq
 	`, r.schemaObject("sqlite_schema"))

--- a/internal/dbschema/sqlite/reserved_prefix_test.go
+++ b/internal/dbschema/sqlite/reserved_prefix_test.go
@@ -1,0 +1,89 @@
+package sqlite_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/dbschema/sqlite"
+)
+
+// reservedPrefixCase is one object name and whether DropAllTables owes it a
+// drop.
+//
+// SQLite reserves the prefix `sqlite_`, with the underscore. The cleanup query
+// spelled that as `NOT LIKE 'sqlite_%'`, and LIKE reads a bare `_` as a
+// single-character wildcard, so the pattern also matched `sqlite` followed by
+// any character. Measured with sqlite3:
+//
+//	'sqlitedata'   LIKE 'sqlite_%'             -> 1
+//	'sqlitedata'   LIKE 'sqlite\_%' ESCAPE '\' -> 0
+//	'sqlite_stat1' LIKE 'sqlite_%'             -> 1
+//
+// so a user table called `sqlitedata` survived a drop-all silently, and the
+// caller was told the database was clean (stokaro/ptah#1291).
+type reservedPrefixCase struct {
+	name      string
+	create    string
+	table     string
+	wantAfter int
+}
+
+// TestWriterDropAllTables_DropsUserObjectsNamedSqliteSomething pins that only
+// the genuinely reserved prefix is spared.
+//
+// A reserved `sqlite_` object cannot be created directly -- SQLite refuses
+// `CREATE TABLE sqlite_x` with "object name reserved for internal use" -- so the
+// control in the other direction is that the drop leaves the internal schema
+// intact and reports success, which the surrounding suite already covers.
+func TestWriterDropAllTables_DropsUserObjectsNamedSqliteSomething(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []reservedPrefixCase{
+		{
+			name:      "a table whose name begins sqlite plus one character",
+			create:    `CREATE TABLE sqlitedata (id INTEGER PRIMARY KEY)`,
+			table:     "sqlitedata",
+			wantAfter: 0,
+		},
+		{
+			// The digit form, because `sqlite3_` reads as reserved to a person
+			// and is not.
+			name:      "a table named sqlite3_cache",
+			create:    `CREATE TABLE sqlite3_cache (id INTEGER PRIMARY KEY)`,
+			table:     "sqlite3_cache",
+			wantAfter: 0,
+		},
+		{
+			// The control that keeps this from becoming "drop everything": an
+			// ordinary name is dropped too, so a passing run cannot mean the
+			// drop stopped working altogether.
+			name:      "an ordinary table",
+			create:    `CREATE TABLE users (id INTEGER PRIMARY KEY)`,
+			table:     "users",
+			wantAfter: 0,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			db := openFileSQLiteDB(t)
+			execSQL(t, db, test.create)
+
+			var before int
+			c.Assert(db.QueryRow(
+				`SELECT count(*) FROM sqlite_schema WHERE type = 'table' AND name = ?`, test.table,
+			).Scan(&before), qt.IsNil)
+			c.Assert(before, qt.Equals, 1, qt.Commentf("fixture did not create %q", test.table))
+
+			c.Assert(sqlite.NewSQLiteWriter(db, "main").DropAllTables(c.Context()), qt.IsNil)
+
+			var after int
+			c.Assert(db.QueryRow(
+				`SELECT count(*) FROM sqlite_schema WHERE type = 'table' AND name = ?`, test.table,
+			).Scan(&after), qt.IsNil)
+			c.Assert(after, qt.Equals, test.wantAfter,
+				qt.Commentf("%q survived DropAllTables", test.table))
+		})
+	}
+}

--- a/internal/dbschema/sqlite/writer.go
+++ b/internal/dbschema/sqlite/writer.go
@@ -343,7 +343,10 @@ func listAuxiliaryDatabases(ctx context.Context, conn *sql.Conn) ([]string, erro
 func listSchemaObjects(ctx context.Context, conn *sql.Conn, schema string) ([]string, error) {
 	//nolint:gosec // G202: schema is an identifier quoted by sqlident, not an SQL value.
 	query := "SELECT type || ':' || name FROM " + quoteQualifiedIdent(schema, "sqlite_schema") + `
-		WHERE name NOT LIKE 'sqlite_%'
+		-- Escaped: LIKE reads a bare _ as a single-character wildcard, so
+		-- 'sqlite_%' also matches user objects such as sqlitedata. SQLite
+		-- reserves the prefix WITH the underscore (stokaro/ptah#1291).
+		WHERE name NOT LIKE 'sqlite\_%' ESCAPE '\'
 		ORDER BY type, name
 	`
 	rows, err := conn.QueryContext(ctx, query)
@@ -445,7 +448,7 @@ func (w *Writer) listCleanupObjects(
 		FROM pragma_table_list
 		WHERE schema = ?
 		  AND type IN ('table', 'view', 'virtual')
-		  AND name NOT LIKE 'sqlite_%'
+		  AND name NOT LIKE 'sqlite\_%' ESCAPE '\'
 		  AND (? OR name <> 'schema_migrations')
 		ORDER BY CASE type WHEN 'view' THEN 0 ELSE 1 END, name
 	`


### PR DESCRIPTION
Closes #1291.

PostgreSQL reserves the role prefix `pg_` and SQLite the object prefix `sqlite_`, both **with** the underscore. Twelve queries spelled those as `LIKE 'pg_%'` and `LIKE 'sqlite_%'`, and SQL `LIKE` reads a bare `_` as a single-character wildcard, so each pattern matched the prefix followed by *any* character.

## Measured

PostgreSQL 17.10:

```
'pgbouncer'  LIKE 'pg_%'              -> true
'pgbouncer'  LIKE 'pg\_%' ESCAPE '\'  -> false
'pg_catalog' LIKE 'pg_%'              -> true    <- the intended match, unaffected
```

sqlite3:

```
'sqlitedata'   LIKE 'sqlite_%'              -> 1
'sqlitedata'   LIKE 'sqlite\_%' ESCAPE '\'  -> 0
'sqlite_stat1' LIKE 'sqlite_%'              -> 1  <- intended
```

`pgbouncer`, `pgadmin`, `pgpool`, `pguser` were treated as reserved roles; a SQLite table named `sqlitedata` or `sqlite3_cache` as an internal object.

## Twelve sites, three questions

| file | sites | what it filters |
|---|---|---|
| `internal/dbschema/postgres/reader.go` | 5 | the role list, three grantee filters, and the `ptah_trigger_` function filter |
| `internal/dbschema/sqlite/reader.go` | 5 | object filters |
| `internal/dbschema/sqlite/writer.go` | 2 | the cleanup path |

They had to move together because they answer different questions about the same names.

- **The role list.** A role excluded here is read by the comparator as *absent*, so an unchanged schema plans `CREATE ROLE` against a database that has it. That is the failure #1267 and PR #1273 are about, reached through a different door: not "out of scope read as absent" but "excluded by a wildcard read as absent".
- **The grantee filters.** Privileges held by such a role were never described, so they were never compared. Given what a role named `pgbouncer` is usually granted, this is the more serious half.
- **The SQLite cleanup path.** A user table named `sqlitedata` survived `DropAllTables`, and the caller was told the database was clean.
- **`ptah_trigger_`** is Ptah's own prefix and the least reachable, but the unescaped form also excluded ordinary functions such as `ptahxtriggery`. Same mistake, fixed the same way.

The repository already spells this correctly in `internal/migrateclean` and in the PostgreSQL writer, so this was an inconsistency rather than an open question. After the change, `grep -rn "LIKE '"` over the tree finds no literal with an unescaped underscore.

## Mutation, per half

Two fixtures, each covering both questions its engine's filter is asked.

| mutant | what goes red |
|---|---|
| revert the PostgreSQL role predicate alone | `reader described 1 roles and none of them is "pgb1291_probe"` — the grant assertion stays green |
| revert the three grantee filters alone | `reader described 8 grants and none is "pgb1291_probe"` — the role assertion stays green |
| remove the role filter entirely | the reserved-role control goes red, listing fifteen genuine `pg_` roles |
| revert the SQLite escape | `"sqlitedata"` and `"sqlite3_cache"` survive `DropAllTables`; the ordinary-table control stays green |

The third and fourth are the controls against the fix becoming "stop filtering" and "drop everything".

The PostgreSQL fixture is live because the defect is in SQL rather than in Go — nothing short of asking a server can tell `'pg_%'` from `'pg\_%'` apart. It uses `pgb1291_probe`, which has the same shape as `pgbouncer` and is unique enough to run beside other work on a shared cluster.

## Gates

`go build` 0 · `go vet` 0 · `go vet -tags integration ./integration/...` 0 · `go test ./... -count=1` 0 (179 packages) · `go tool qtlint` 0 · `golangci-lint run ./...` 0 · `check-test-style.sh` 0 ("175 conditional groups", unchanged — the fixture adds none) · `check-public-api.sh` 0 · `check-public-api-snapshot.sh` 0 · `check-public-api-released.sh` 0.

Live PostgreSQL 17.10 in a CI-shaped container (`ptah_user`-owned `ptah_test`), since the guard in `integration/gonative` is sensitive to the connecting role.
