### PR TITLE
Keep an unresolved identifier distinct from every other (#1290)

### DIFF
--- a/core/platform/identifier/identifier.go
+++ b/core/platform/identifier/identifier.go
@@ -278,10 +278,9 @@ func (c Comparison) ConflictKey(value string) string {
 
 const unresolvedCatalogKey = "\x00ptah:unresolved-catalog-identifier"
 
-func (s Semantics) identityKey(comparison Comparison, value string) string {
-	if comparison != ComparisonCatalogResolved {
-		return comparison.IdentityKey(value)
-	}
+// resolvedKey returns the target's equivalence key for a name and whether the
+// catalog resolved it at all.
+func (s Semantics) resolvedKey(value string) (string, bool) {
 	position, found := slices.BinarySearchFunc(
 		s.ResolvedNames,
 		value,
@@ -290,16 +289,52 @@ func (s Semantics) identityKey(comparison Comparison, value string) string {
 		},
 	)
 	if !found {
-		return unresolvedCatalogKey
+		return "", false
 	}
-	return s.ResolvedNames[position].Key
+	return s.ResolvedNames[position].Key, true
 }
 
-func (s Semantics) conflictKey(comparison Comparison, value string) string {
-	if comparison == ComparisonCatalogResolved {
-		return s.identityKey(comparison, value)
+// identityKey answers "are these two names the same object".
+//
+// A name the catalog did not resolve has no equivalence class, so it falls back
+// to what [ComparisonCatalogUnknown] already does for identity: it keeps its
+// spelling. Returning one shared constant instead made every unresolved name
+// equal to every other, and a map keyed by identity then kept exactly one of
+// them -- two grants declared on two tables that do not exist yet became one
+// grant, silently (stokaro/ptah#1290).
+//
+// The names that reach here unresolved are the desired schema's, because the
+// database side is read from the catalog and therefore always resolves. A
+// desired name the target does not have is a name it does not have, so keeping
+// such names distinct is also the answer that describes the target truthfully.
+func (s Semantics) identityKey(comparison Comparison, value string) string {
+	if comparison != ComparisonCatalogResolved {
+		return comparison.IdentityKey(value)
 	}
-	return comparison.ConflictKey(value)
+	if key, ok := s.resolvedKey(value); ok {
+		return key
+	}
+	return ComparisonCatalogUnknown.IdentityKey(value)
+}
+
+// conflictKey answers "could these two names collide in the target", which is
+// the conservative question and keeps the shared key for anything unresolved.
+//
+// The split from [Semantics.identityKey] is the point. Two unresolved names
+// differing only in case are distinct objects as far as identity goes, and may
+// still collide once the target's collation has its say -- so identity
+// distinguishes them and conflict detection warns about them. That is exactly
+// what [ComparisonCatalogUnknown] documents, and an unresolved name under
+// [ComparisonCatalogResolved] is in the same position: nothing is known about
+// its equivalence class.
+func (s Semantics) conflictKey(comparison Comparison, value string) string {
+	if comparison != ComparisonCatalogResolved {
+		return comparison.ConflictKey(value)
+	}
+	if key, ok := s.resolvedKey(value); ok {
+		return key
+	}
+	return unresolvedCatalogKey
 }
 
 func (s Semantics) qualifiedTableKey(

--- a/core/platform/identifier/unresolved_identity_test.go
+++ b/core/platform/identifier/unresolved_identity_test.go
@@ -1,0 +1,161 @@
+package identifier_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform/identifier"
+)
+
+// catalogResolvedSemantics is a target that resolved exactly one name. Everything
+// else is unresolved, which is the ordinary state of a desired schema naming
+// objects the database does not have yet.
+func catalogResolvedSemantics() identifier.Semantics {
+	return identifier.Semantics{
+		DefaultSchema: "dbo",
+		TableNames:    identifier.ComparisonCatalogResolved,
+		ColumnNames:   identifier.ComparisonCatalogResolved,
+		IndexNames:    identifier.ComparisonCatalogResolved,
+		ResolvedNames: []identifier.ResolvedName{
+			{Name: "known", Key: "KNOWN"},
+		},
+	}
+}
+
+// unresolvedIdentityCase is one pair of names and whether the two questions --
+// "same object" and "could collide" -- should answer alike.
+type unresolvedIdentityCase struct {
+	name          string
+	left          string
+	right         string
+	wantSameID    bool
+	wantSameClash bool
+}
+
+// TestSemantics_UnresolvedNamesKeepTheirIdentity pins that a name the catalog
+// did not resolve keeps its spelling for identity while staying conservative for
+// conflicts.
+//
+// Both keys used to return one shared constant for anything unresolved, so every
+// unresolved name compared equal to every other. A map keyed by identity kept
+// exactly one of them: two grants declared on two tables that do not exist yet
+// became one grant, and the other was silently dropped from the plan
+// (stokaro/ptah#1290).
+//
+// The split is the fix. Identity distinguishes them, because they are different
+// objects; conflict detection still lumps them together, because the target's
+// collation has not spoken and either may collide with anything.
+func TestSemantics_UnresolvedNamesKeepTheirIdentity(t *testing.T) {
+	c := qt.New(t)
+	semantics := catalogResolvedSemantics()
+
+	tests := []unresolvedIdentityCase{
+		{
+			// The shape that dropped a grant.
+			name:          "two unresolved names are different objects that may still collide",
+			left:          "alpha",
+			right:         "beta",
+			wantSameID:    false,
+			wantSameClash: true,
+		},
+		{
+			name:          "an unresolved name is the same object as itself",
+			left:          "alpha",
+			right:         "alpha",
+			wantSameID:    true,
+			wantSameClash: true,
+		},
+		{
+			// The control that keeps the fix from becoming "never match": a
+			// resolved name still answers with the target's own key.
+			name:          "a resolved name does not become an unresolved one",
+			left:          "known",
+			right:         "alpha",
+			wantSameID:    false,
+			wantSameClash: false,
+		},
+		{
+			// And a resolved name still matches itself through that key rather
+			// than through its spelling.
+			name:          "a resolved name matches itself",
+			left:          "known",
+			right:         "known",
+			wantSameID:    true,
+			wantSameClash: true,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			sameID := semantics.TableIdentityKey(test.left) == semantics.TableIdentityKey(test.right)
+			c.Assert(sameID, qt.Equals, test.wantSameID,
+				qt.Commentf("identity keys: %q -> %q, %q -> %q",
+					test.left, semantics.TableIdentityKey(test.left),
+					test.right, semantics.TableIdentityKey(test.right)))
+
+			sameClash := semantics.TableConflictKey(test.left) == semantics.TableConflictKey(test.right)
+			c.Assert(sameClash, qt.Equals, test.wantSameClash,
+				qt.Commentf("conflict keys: %q -> %q, %q -> %q",
+					test.left, semantics.TableConflictKey(test.left),
+					test.right, semantics.TableConflictKey(test.right)))
+		})
+	}
+}
+
+// qualifiedUnresolvedCase is one pair of schema-qualified names.
+type qualifiedUnresolvedCase struct {
+	name       string
+	left       string
+	right      string
+	wantSameID bool
+}
+
+// TestSemantics_QualifiedUnresolvedNamesKeepTheirIdentity is the same property
+// through the qualified entry point, which is what the comparators actually
+// call: [Semantics.QualifiedTableIdentityKey] keys both halves of a
+// schema.table separately, so the collapse reached tables in different schemas
+// as well as tables in one.
+func TestSemantics_QualifiedUnresolvedNamesKeepTheirIdentity(t *testing.T) {
+	c := qt.New(t)
+	semantics := catalogResolvedSemantics()
+
+	tests := []qualifiedUnresolvedCase{
+		{
+			name:       "two unresolved tables in one unresolved schema",
+			left:       "app.alpha",
+			right:      "app.beta",
+			wantSameID: false,
+		},
+		{
+			name:       "one unresolved table name in two unresolved schemas",
+			left:       "app.alpha",
+			right:      "other.alpha",
+			wantSameID: false,
+		},
+		{
+			name:       "the same qualified name twice",
+			left:       "app.alpha",
+			right:      "app.alpha",
+			wantSameID: true,
+		},
+		{
+			// An unqualified name resolves through DefaultSchema, so it is the
+			// same object as the explicitly qualified spelling. This is the row
+			// #1232 and #1283 exist for, and it must survive the fix.
+			name:       "an unqualified name is its default-schema self",
+			left:       "alpha",
+			right:      "dbo.alpha",
+			wantSameID: true,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			left := semantics.QualifiedTableIdentityKey(test.left)
+			right := semantics.QualifiedTableIdentityKey(test.right)
+			c.Assert(left == right, qt.Equals, test.wantSameID,
+				qt.Commentf("%q -> %q, %q -> %q", test.left, left, test.right, right))
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/unresolved_identity_test.go
+++ b/migration/schemadiff/internal/compare/unresolved_identity_test.go
@@ -1,0 +1,107 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// unresolvedTargetSemantics is a live target whose catalog resolved nothing the
+// desired schema names, which is the ordinary state of a first migration against
+// an existing database.
+//
+// The comparison is ComparisonCatalogResolved because that is what a connection
+// supplies; identifier.ForDialect never returns it, which is why this defect
+// could not be reached from any offline fixture.
+func unresolvedTargetSemantics() identifier.Semantics {
+	return identifier.Semantics{
+		DefaultSchema: "dbo",
+		TableNames:    identifier.ComparisonCatalogResolved,
+		ColumnNames:   identifier.ComparisonCatalogResolved,
+		IndexNames:    identifier.ComparisonCatalogResolved,
+	}
+}
+
+// TestGrantsWithSemantics_UnresolvedTablesAreNotOneTable pins that grants on
+// two tables the catalog has not resolved stay two grants.
+//
+// Keying by table identity (stokaro/ptah#1283) fixed a real defect and inherited
+// this one: every unresolved name shared a single key, so the second grant
+// overwrote the first in the map and one of them never reached the plan
+// (stokaro/ptah#1290).
+func TestGrantsWithSemantics_UnresolvedTablesAreNotOneTable(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Grants: []goschema.Grant{
+			{Role: "app", Privileges: []string{"SELECT"}, OnTable: "alpha"},
+			{Role: "app", Privileges: []string{"SELECT"}, OnTable: "beta"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.GrantsWithSemantics(generated, &types.DBSchema{}, diff, unresolvedTargetSemantics())
+
+	granted := make([]string, 0, len(diff.GrantsAdded))
+	for _, grant := range diff.GrantsAdded {
+		granted = append(granted, grant.ObjectName)
+	}
+	c.Assert(granted, qt.DeepEquals, []string{"alpha", "beta"})
+}
+
+// TestRLSEnabledTablesWithSemantics_UnresolvedTablesAreNotOneTable is the same
+// property on the other comparator #1283 moved onto table identity.
+func TestRLSEnabledTablesWithSemantics_UnresolvedTablesAreNotOneTable(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: "alpha"},
+			{Table: "beta"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.RLSEnabledTablesWithSemantics(
+		generated, &types.DBSchema{}, diff, unresolvedTargetSemantics(),
+	)
+
+	c.Assert(diff.RLSEnabledTablesAdded, qt.DeepEquals, []string{"alpha", "beta"})
+}
+
+// TestConstraintsWithSemantics_UnresolvedTablesAreNotOneTable covers the older
+// half of the class.
+//
+// tableMemberKey has keyed constraints, columns and indexes through the same
+// normalization since stokaro/ptah#1232, so the collapse predates #1283 on this
+// path. The row is here because a fix proven on grants says nothing about
+// constraints, which is how #1290 arrived.
+func TestConstraintsWithSemantics_UnresolvedTablesAreNotOneTable(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{StructName: "Alpha", Name: "alpha"},
+			{StructName: "Beta", Name: "beta"},
+		},
+		Constraints: []goschema.Constraint{
+			{StructName: "Alpha", Name: "ck", Table: "alpha", Type: "CHECK", CheckExpression: "id > 0"},
+			{StructName: "Beta", Name: "ck", Table: "beta", Type: "CHECK", CheckExpression: "id > 0"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.ConstraintsWithSemantics(generated, &types.DBSchema{}, diff, nil, unresolvedTargetSemantics())
+
+	tables := make([]string, 0, len(diff.ConstraintsAddedWithTables))
+	for _, constraint := range diff.ConstraintsAddedWithTables {
+		tables = append(tables, constraint.TableName)
+	}
+	c.Assert(tables, qt.DeepEquals, []string{"alpha", "beta"})
+}


### PR DESCRIPTION
Closes #1290. I filed that issue against my own merged #1283 and this is the fix.

`Semantics.identityKey` returned one shared constant — `unresolvedCatalogKey` — for every name the catalog did not resolve. Anything keyed by identity then treated all unresolved names as **one** name, and a map kept exactly one of them.

## Measured, before

`migration/schemadiff/internal/compare`, two grants declared on two tables that do not exist in the target yet:

```
GrantsAdded=1 (expected 2)
  added: app on beta
```

`alpha`'s grant is gone. Both names key to the constant; the second write wins.

## The class is older and wider than the comparator that surfaced it

The mutant that restores the constant reddens **three** comparators, not two:

| comparator | keyed by identity since |
|---|---|
| grants | #1283 |
| RLS enablement | #1283 |
| **constraints** | #1232, through `tableMemberKey` |

So #1283 extended the reach rather than creating the defect. That is worth stating precisely, because the issue as filed guessed the scope and the mutant corrected it.

## The fix is the design the package already documents

`ComparisonCatalogUnknown` is defined in this file as *"preserves spelling for identity while treating every distinct unresolved name as a potential catalog conflict"*. An unresolved name under `ComparisonCatalogResolved` is in exactly that position — nothing is known about its equivalence class — so identity now falls back to the unknown-catalog answer, and conflict detection keeps the shared key.

The split is the point:

- **Identity** asks "are these the same object". Two unresolved names differing only in case are different objects.
- **Conflict** asks "could these collide in the target". Those same two may well collide once the collation has its say, so that key stays conservative.

Extending the fix to conflict detection would be the over-correction, and there is a row that goes red if anyone does.

## Why no offline fixture could reach this

`identifier.ForDialect` never returns `ComparisonCatalogResolved` — SQL Server offline gets `ComparisonCatalogUnknown`, whose identity already preserves spelling. Only a live connection supplying resolved names produces it. The reachable shape is therefore: a live target, and a desired schema naming objects it does not have yet — an ordinary first migration against an existing database.

Which also settles the direction: names arrive here unresolved only from the **desired** side, because the database side is read from the catalog and always resolves. A desired name the target does not have is a name it does not have, so keeping such names distinct is the answer that describes the target truthfully.

## Mutation, both directions

Nine rows across the two levels.

| mutant | what goes red |
|---|---|
| restore the shared constant for identity | the three comparator rows, and the two "two different names" identity rows |
| apply the fix to conflict detection too | the row requiring conflicts to stay conservative, and nothing else |

All four same-name and resolved-name controls stay green under the first mutant, so the fix is not "stop matching".

## Gates

`go build` 0 · `go vet` 0 · `go test ./... -count=1` 0 (179 packages) · `go tool qtlint` 0 · `golangci-lint run ./...` 0 · `check-test-style.sh` 0 · `check-public-api.sh` 0 · `check-public-api-snapshot.sh` 0 · `check-public-api-released.sh` 0.

No exported signature changes; `resolvedKey` is unexported and the two public key methods keep their shapes.
