### PR TITLE
Ask what an extension supplies that a caller must spell (#1281)

### DIFF
--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -409,6 +409,12 @@ type Extension struct {
 	// `replace` -- and treating those as evidence would tie the extension to
 	// every schema that happens to use them.
 	//
+	// Function names that are SQL keywords are excluded for the same reason:
+	// `hstore` supplies three functions named `delete`, and a caller reading
+	// identifiers out of SQL text cannot tell `DELETE FROM audit` from
+	// `delete(h, 'k')`. Nothing is lost, because a genuine call needs a value of
+	// the extension's own type and naming that type keeps the extension here.
+	//
 	// Empty means not measured. Annotation and YAML sources have no catalog to
 	// ask and leave it unset.
 	Provides []string

--- a/core/goschema/types.go
+++ b/core/goschema/types.go
@@ -409,11 +409,14 @@ type Extension struct {
 	// `replace` -- and treating those as evidence would tie the extension to
 	// every schema that happens to use them.
 	//
-	// Function names that are SQL keywords are excluded for the same reason:
-	// `hstore` supplies three functions named `delete`, and a caller reading
-	// identifiers out of SQL text cannot tell `DELETE FROM audit` from
-	// `delete(h, 'k')`. Nothing is lost, because a genuine call needs a value of
-	// the extension's own type and naming that type keeps the extension here.
+	// A function name that is a SQL keyword is excluded for the same reason, but
+	// only when this list also carries a type of the same extension that appears
+	// in that function's signature: `hstore` supplies three functions named
+	// `delete`, and a caller reading identifiers out of SQL text cannot tell
+	// `DELETE FROM audit` from `delete(h, 'k')`, while a genuine call needs an
+	// `hstore` value and the type entry is what keeps the extension here. Where
+	// no such type entry exists -- an extension supplying `merge(text, text)`
+	// and no type at all -- the name is the only evidence there is and it stays.
 	//
 	// Empty means not measured. Annotation and YAML sources have no catalog to
 	// ask and leave it unset.

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -325,6 +325,13 @@ type DBExtension struct {
 	// `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
 	// PostgreSQL 13.
 	//
+	// Function names pg_get_keywords() reports as SQL keywords are excluded too,
+	// because a name read out of SQL text carries no position: `hstore` supplies
+	// three functions named `delete`, and `DELETE FROM audit` in a plpgsql body
+	// is indistinguishable from a call to `delete(h, 'k')`. A genuine call takes
+	// or returns one of the extension's own types, so the type entry answers for
+	// it.
+	//
 	// Empty means not measured rather than "supplies nothing" -- every extension
 	// supplies something, and readers that do not consult a catalog (Go
 	// annotations, YAML) leave this unset.

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -325,12 +325,15 @@ type DBExtension struct {
 	// `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
 	// PostgreSQL 13.
 	//
-	// Function names pg_get_keywords() reports as SQL keywords are excluded too,
+	// A function name pg_get_keywords() reports as a SQL keyword is excluded too,
 	// because a name read out of SQL text carries no position: `hstore` supplies
 	// three functions named `delete`, and `DELETE FROM audit` in a plpgsql body
-	// is indistinguishable from a call to `delete(h, 'k')`. A genuine call takes
-	// or returns one of the extension's own types, so the type entry answers for
-	// it.
+	// is indistinguishable from a call to `delete(h, 'k')`. That exclusion is
+	// conditional on the redundancy that makes it free -- the same extension
+	// must also contribute to this list a type appearing in that function's
+	// signature, so a genuine call spells the type and the type entry answers
+	// for it. An extension supplying `merge(text, text)` and no type has its
+	// only evidence in the name, and the name is kept.
 	//
 	// Empty means not measured rather than "supplies nothing" -- every extension
 	// supplies something, and readers that do not consult a catalog (Go

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3851,11 +3851,14 @@ type Extension struct {
     // `replace` -- and treating those as evidence would tie the extension to
     // every schema that happens to use them.
     //
-    // Function names that are SQL keywords are excluded for the same reason:
-    // `hstore` supplies three functions named `delete`, and a caller reading
-    // identifiers out of SQL text cannot tell `DELETE FROM audit` from
-    // `delete(h, 'k')`. Nothing is lost, because a genuine call needs a value of
-    // the extension's own type and naming that type keeps the extension here.
+    // A function name that is a SQL keyword is excluded for the same reason, but
+    // only when this list also carries a type of the same extension that appears
+    // in that function's signature: `hstore` supplies three functions named
+    // `delete`, and a caller reading identifiers out of SQL text cannot tell
+    // `DELETE FROM audit` from `delete(h, 'k')`, while a genuine call needs an
+    // `hstore` value and the type entry is what keeps the extension here. Where
+    // no such type entry exists -- an extension supplying `merge(text, text)`
+    // and no type at all -- the name is the only evidence there is and it stays.
     //
     // Empty means not measured. Annotation and YAML sources have no catalog to
     // ask and leave it unset.
@@ -5402,12 +5405,15 @@ type DBExtension struct {
     // `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
     // PostgreSQL 13.
     //
-    // Function names pg_get_keywords() reports as SQL keywords are excluded too,
+    // A function name pg_get_keywords() reports as a SQL keyword is excluded too,
     // because a name read out of SQL text carries no position: `hstore` supplies
     // three functions named `delete`, and `DELETE FROM audit` in a plpgsql body
-    // is indistinguishable from a call to `delete(h, 'k')`. A genuine call takes
-    // or returns one of the extension's own types, so the type entry answers for
-    // it.
+    // is indistinguishable from a call to `delete(h, 'k')`. That exclusion is
+    // conditional on the redundancy that makes it free -- the same extension
+    // must also contribute to this list a type appearing in that function's
+    // signature, so a genuine call spells the type and the type entry answers
+    // for it. An extension supplying `merge(text, text)` and no type has its
+    // only evidence in the name, and the name is kept.
     //
     // Empty means not measured rather than "supplies nothing" -- every extension
     // supplies something, and readers that do not consult a catalog (Go

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -3851,6 +3851,12 @@ type Extension struct {
     // `replace` -- and treating those as evidence would tie the extension to
     // every schema that happens to use them.
     //
+    // Function names that are SQL keywords are excluded for the same reason:
+    // `hstore` supplies three functions named `delete`, and a caller reading
+    // identifiers out of SQL text cannot tell `DELETE FROM audit` from
+    // `delete(h, 'k')`. Nothing is lost, because a genuine call needs a value of
+    // the extension's own type and naming that type keeps the extension here.
+    //
     // Empty means not measured. Annotation and YAML sources have no catalog to
     // ask and leave it unset.
     Provides []string
@@ -5395,6 +5401,13 @@ type DBExtension struct {
     // contributes `max`, `min`, `strpos`, `replace` and `split_part`, and
     // `pgcrypto` contributes `gen_random_uuid`, which core has supplied since
     // PostgreSQL 13.
+    //
+    // Function names pg_get_keywords() reports as SQL keywords are excluded too,
+    // because a name read out of SQL text carries no position: `hstore` supplies
+    // three functions named `delete`, and `DELETE FROM audit` in a plpgsql body
+    // is indistinguishable from a call to `delete(h, 'k')`. A genuine call takes
+    // or returns one of the extension's own types, so the type entry answers for
+    // it.
     //
     // Empty means not measured rather than "supplies nothing" -- every extension
     // supplies something, and readers that do not consult a catalog (Go

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -212,11 +212,28 @@ member list from the catalog (`pg_depend` against `pg_extension`) during
 inspection and keeps the extension when the document uses any of its types,
 functions, relations, operator classes, or operator families.
 
-That set is deliberately coarse. `pgcrypto` supplies a `gen_random_uuid` that
-PostgreSQL 13 and later also supply from core, so a document using it keeps
-`pgcrypto` even though it would have resolved without it. Keeping a block that
-could have been dropped costs compatibility; dropping one that was needed costs
-a document nobody can read, so the rule errs toward keeping.
+Two kinds of member name are left out of that list, because neither one is
+evidence of anything. A name `pg_catalog` also supplies keeps resolving with the
+extension dropped: `citext` supplies fifteen of those, among them `max`,
+`strpos` and `replace`, and `pgcrypto` supplies a `gen_random_uuid` that
+PostgreSQL 13 and later supply from core. A function whose name is a SQL keyword
+cannot be told from the statement that shares the word: `hstore` supplies three
+functions named `delete`, and a `plpgsql` body doing `DELETE FROM audit` calls
+none of them. Either name would pin the extension to a schema that has no
+relationship to it, and the community binary refuses any file declaring an
+extension block, so a keep that did not have to happen does not shrink the
+compatibility win — it removes it.
+
+Neither exclusion can cost a dependency the document really has. Reaching an
+extension's overload instead of the core function takes arguments of that
+extension's own type, and a genuine call to `delete` takes an `hstore` value, so
+the type is named on a column, in a function signature or in a cast, and that is
+what keeps the extension. Only function names are tested against the keyword
+list, which the server itself supplies through `pg_get_keywords()`: a type, a
+relation and an operator class are each named by nothing but themselves, so
+dropping a keyword-shaped one would throw away the only evidence there is. The
+`cube` extension shows what that leaves behind — its type and its constructor
+are both called `cube`, so a view saying `GROUP BY CUBE(x)` still keeps it.
 
 An extension nothing depends on is still omitted, and the community binary
 reads that document at exit 0. Set `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` when the

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -224,16 +224,23 @@ relationship to it, and the community binary refuses any file declaring an
 extension block, so a keep that did not have to happen does not shrink the
 compatibility win — it removes it.
 
-Neither exclusion can cost a dependency the document really has. Reaching an
-extension's overload instead of the core function takes arguments of that
-extension's own type, and a genuine call to `delete` takes an `hstore` value, so
-the type is named on a column, in a function signature or in a cast, and that is
-what keeps the extension. Only function names are tested against the keyword
-list, which the server itself supplies through `pg_get_keywords()`: a type, a
-relation and an operator class are each named by nothing but themselves, so
-dropping a keyword-shaped one would throw away the only evidence there is. The
-`cube` extension shows what that leaves behind — its type and its constructor
-are both called `cube`, so a view saying `GROUP BY CUBE(x)` still keeps it.
+Neither exclusion can cost a dependency the document really has, and the keyword
+one carries the condition that makes that true. Reaching an extension's overload
+instead of the core function takes arguments of that extension's own type, so a
+genuine call to `delete` takes an `hstore` value and the type is named on a
+column, in a function signature or in a cast. A keyword-named function is
+therefore dropped only when the same extension also puts a type in this list
+that appears in that function's signature — the entry that will keep the
+extension in its place. An extension supplying `merge(text, text)` and no type
+at all has its only evidence in that name, so the name stays and the block
+with it.
+
+Only function names are tested against the keyword list, which the server itself
+supplies through `pg_get_keywords()`. A type, a relation and an operator class
+are each named by nothing but themselves, so dropping a keyword-shaped one would
+throw away the only evidence there is. The `cube` extension shows what that
+leaves behind — its type and its constructor are both called `cube`, so a view
+saying `GROUP BY CUBE(x)` still keeps it.
 
 An extension nothing depends on is still omitted, and the community binary
 reads that document at exit 0. Set `PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` when the

--- a/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
+++ b/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
@@ -64,6 +64,25 @@ type atlasCompatExtensionRoundTripCase struct {
 // The last row is the control in the other direction. Excluding the shadowed
 // names must not exclude a name only the extension supplies, or the fix would
 // have traded #1280's shapes back for #1266's.
+//
+// The five rows after it are stokaro/ptah#1281: the same over-match arriving
+// through SQL keywords instead of through pg_catalog. `hstore` supplies three
+// functions named `delete` and `ltree` supplies one named `index`, and
+// pg_catalog supplies neither, so the shadowed-name filter keeps both -- while
+// the scan that consumes the member list reads words rather than positions, so
+// a plpgsql body saying `DELETE FROM audit` or `CREATE INDEX` looks exactly
+// like a call. Both of those pinned an extension the database does not use, and
+// the pinned Atlas community binary refused the result: `postgres: extensions
+// are not supported by this version`, exit 1, PostgreSQL 17.10.
+//
+// The three that follow expect a block, and they are what makes dropping
+// keyword-named members a fix rather than a deletion. Two of them are the
+// redundancy the issue asked to measure rather than assume: a genuine call to
+// `delete` needs an hstore value, so the document spells that type either on a
+// column or in the calling function's own signature, and the extension survives
+// on it. The third is `cube`, where the keyword is the type's name and the
+// extension's label at once; it is the row that fails if the exclusion is moved
+// off the member list and onto the words the keep decision matches.
 func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 	adminURL := requirePostgresE2EDatabaseURL(t)
 
@@ -126,6 +145,62 @@ func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 			wantBlock: true,
 			why: "the control against over-narrowing: dropping the shadowed names must not" +
 				" drop citext's own type, which nothing but citext supplies",
+		},
+		{
+			name:      "keyword-named extension function in statement position",
+			extension: "hstore",
+			seed: "CREATE TABLE audit (id integer PRIMARY KEY);" +
+				" CREATE FUNCTION purge() RETURNS void LANGUAGE plpgsql" +
+				" AS $$ BEGIN DELETE FROM audit; END $$",
+			wantBlock: false,
+			why: "hstore supplies three functions named delete and pg_catalog supplies none," +
+				" so the shadowed-name filter keeps every one of them; DELETE FROM audit is" +
+				" a statement and nothing in this database uses hstore",
+		},
+		{
+			name:      "keyword-named extension function in nested DDL",
+			extension: "ltree",
+			seed: "CREATE TABLE docs (id integer PRIMARY KEY, title text);" +
+				" CREATE FUNCTION reindex_docs() RETURNS void LANGUAGE plpgsql AS $$ BEGIN" +
+				" CREATE INDEX IF NOT EXISTS docs_title_idx ON docs (title); END $$",
+			wantBlock: false,
+			// A second keyword and a second extension, because a fix that only
+			// knows the word `delete` would pass the row above and nothing else.
+			why: "ltree supplies a function named index; CREATE INDEX in a body is not a call to it",
+		},
+		{
+			name:      "keyword-named extension function called on a column of the extension's type",
+			extension: "hstore",
+			seed: "CREATE TABLE attrs (id integer PRIMARY KEY, props hstore NOT NULL," +
+				" CONSTRAINT attrs_no_secret CHECK (delete(props, 'secret') = props))",
+			wantBlock: true,
+			why: "the call is genuine, and it is the column type hstore rather than the word" +
+				" delete that keeps the extension -- which is what makes dropping the" +
+				" keyword-named member safe",
+		},
+		{
+			name:      "keyword-named extension function called with no column of that type",
+			extension: "hstore",
+			seed: "CREATE TABLE audit (id integer PRIMARY KEY);" +
+				" CREATE FUNCTION strip_secret(h hstore) RETURNS hstore LANGUAGE sql" +
+				" AS $$ SELECT delete(h, 'secret') $$",
+			wantBlock: true,
+			why: "the only hstore here is the function's own signature; parameter and return" +
+				" types are scanned as well, so the redundancy holds without a column",
+		},
+		{
+			name:      "extension whose TYPE name is a keyword",
+			extension: "cube",
+			seed:      "CREATE TABLE points (id integer PRIMARY KEY, loc cube NOT NULL)",
+			wantBlock: true,
+			// This row is why the exclusion is applied to the member list, on the
+			// function arm, instead of to the words the keep decision matches.
+			// `cube` is an unreserved keyword, and it is equally cube's type and
+			// cube's own label: a keyword filter sitting where the names are
+			// matched drops all three at once and leaves this column with nothing
+			// declaring its type. Measured -- with the filter moved there, this is
+			// the only one of the twelve rows that fails.
+			why: "cube is a keyword, cube's type and cube's label at once; the column has no other evidence",
 		},
 	}
 

--- a/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
+++ b/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
@@ -73,16 +73,45 @@ type atlasCompatExtensionRoundTripCase struct {
 // a plpgsql body saying `DELETE FROM audit` or `CREATE INDEX` looks exactly
 // like a call. Both of those pinned an extension the database does not use, and
 // the pinned Atlas community binary refused the result: `postgres: extensions
-// are not supported by this version`, exit 1, PostgreSQL 17.10.
+// are not supported by this version`, exit 1, PostgreSQL 18.4.
 //
 // The three that follow expect a block, and they are what makes dropping
 // keyword-named members a fix rather than a deletion. Two of them are the
-// redundancy the issue asked to measure rather than assume: a genuine call to
-// `delete` needs an hstore value, so the document spells that type either on a
-// column or in the calling function's own signature, and the extension survives
-// on it. The third is `cube`, where the keyword is the type's name and the
-// extension's label at once; it is the row that fails if the exclusion is moved
-// off the member list and onto the words the keep decision matches.
+// redundancy the fix relies on: a genuine call to `delete` needs an hstore
+// value, so the document spells that type either on a column or in the calling
+// function's own signature, and the extension survives on it. The third is
+// `cube`, where the keyword is the type's name and the extension's label at
+// once; it is the row that fails if the exclusion is moved off the member list
+// and onto the words the keep decision matches.
+//
+// The last two rows are why that redundancy is a PRECONDITION of the exclusion
+// rather than a description of contrib. Over the 46 extensions this build ships
+// every keyword-named function member does take or return a type its own
+// extension supplies -- but nothing in the catalog requires that, and a filter
+// resting on it drops the only evidence there is the moment an extension
+// supplies `merge(text, text)` and no type at all. Measured on PostgreSQL 18.4
+// against a fixture extension of exactly that shape: the block went away, the
+// CHECK calling `merge` stayed, and the pinned Atlas community binary v1.3.0
+// answered `create "names" table: pq: function merge(text, text) does not
+// exist` where before it had refused the extension block instead.
+//
+// Both rows build that shape through `ALTER EXTENSION ... ADD`, which writes
+// the same pg_depend membership rows an extension's install script writes, so
+// no fixture control file has to be installed on the server for CI to run them.
+// The dependent call therefore lives in a plpgsql body, which PostgreSQL does
+// not resolve at creation time, so the document still materializes on a dev
+// database that has the extension but not the added member -- the assertion
+// that carries these two rows is the block, not the round trip. The word in
+// that body is also indistinguishable from the false positives above, which is
+// the whole point: the decision cannot be made from the word, only from what
+// the extension is the only supplier of.
+//
+// The second of the two pins the answering type against its own arm. An
+// extension supplying a type named like a pg_catalog type has that name
+// filtered out as shadowed, so it can no longer answer for anything, and a
+// keyword filter that consults the raw membership instead of the reported
+// member list drops the function name too -- the refuted shape again, one level
+// down.
 func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 	adminURL := requirePostgresE2EDatabaseURL(t)
 
@@ -201,6 +230,41 @@ func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 			// declaring its type. Measured -- with the filter moved there, this is
 			// the only one of the twelve rows that fails.
 			why: "cube is a keyword, cube's type and cube's label at once; the column has no other evidence",
+		},
+		{
+			name:      "keyword-named extension function no type of that extension answers for",
+			extension: "pgcrypto",
+			seed: "CREATE FUNCTION merge(a text, b text) RETURNS text LANGUAGE sql IMMUTABLE" +
+				" AS $fn$ SELECT a || b $fn$;" +
+				" ALTER EXTENSION pgcrypto ADD FUNCTION merge(text, text);" +
+				" CREATE TABLE names (id integer PRIMARY KEY, a text NOT NULL, b text NOT NULL);" +
+				" CREATE FUNCTION combined(row_id integer) RETURNS text LANGUAGE plpgsql AS $fn$" +
+				" DECLARE result text;" +
+				" BEGIN SELECT merge(names.a, names.b) INTO result FROM names" +
+				" WHERE names.id = row_id; RETURN result; END $fn$",
+			wantBlock: true,
+			why: "merge is an unreserved keyword and pgcrypto supplies no type at all, so the" +
+				" name is the only evidence the document carries; dropping it because it is a" +
+				" keyword leaves a body calling a function nothing declares",
+		},
+		{
+			name:      "keyword-named extension function whose answering type pg_catalog shadows",
+			extension: "pgcrypto",
+			seed: "CREATE DOMAIN public.box AS text;" +
+				" ALTER EXTENSION pgcrypto ADD DOMAIN public.box;" +
+				" CREATE FUNCTION public.merge(a public.box, b public.box) RETURNS public.box" +
+				" LANGUAGE sql IMMUTABLE AS $fn$ SELECT (a::text || b::text)::public.box $fn$;" +
+				" ALTER EXTENSION pgcrypto ADD FUNCTION public.merge(public.box, public.box);" +
+				" CREATE TABLE labels (id integer PRIMARY KEY, a public.box NOT NULL," +
+				" b public.box NOT NULL);" +
+				" CREATE FUNCTION labelled(row_id integer) RETURNS text LANGUAGE plpgsql AS $fn$" +
+				" DECLARE result text;" +
+				" BEGIN SELECT merge(labels.a, labels.b)::text INTO result FROM labels" +
+				" WHERE labels.id = row_id; RETURN result; END $fn$",
+			wantBlock: true,
+			why: "the type in merge's signature is named box, which pg_catalog also supplies," +
+				" so the type arm already dropped it and it cannot answer for anything;" +
+				" excluding merge as well leaves this document with no evidence either",
 		},
 	}
 

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -183,7 +183,11 @@ func (r *renderer) omitRefusedBlock(path, block string, names ...string) bool {
 //
 // What makes the answer precise is therefore the input: the names in
 // [goschema.Extension.Provides] are only those the extension supplies that do
-// not also resolve without it.
+// not also resolve without it, and among functions only those whose name is not
+// a SQL keyword. This scan reads words, not positions, so `DELETE FROM audit`
+// in a plpgsql body is the same token as a call to hstore's `delete`, and a
+// database using no hstore was carrying an hstore block because of it
+// (stokaro/ptah#1281).
 func (r *renderer) documentNamesAny(names []string) bool {
 	if r.references == nil {
 		r.references = collectReferencedNames(r.db)
@@ -298,6 +302,11 @@ func collectReferencedNames(db *goschema.Database) map[string]bool {
 // yield `order_seq` through a quote and a cast, and a SQL parser per dialect
 // would be a much larger thing to keep correct than a rule whose failure mode
 // is keeping a block that did not have to be kept.
+//
+// The words it yields carry no position, so a statement keyword and a call to a
+// function of the same name are the same token here. That is answered where the
+// member list is built rather than guessed at afterwards: the PostgreSQL reader
+// leaves keyword-named functions out of [goschema.Extension.Provides].
 func sqlIdentifierTokens(text string) []string {
 	var tokens []string
 	var current strings.Builder

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -183,11 +183,14 @@ func (r *renderer) omitRefusedBlock(path, block string, names ...string) bool {
 //
 // What makes the answer precise is therefore the input: the names in
 // [goschema.Extension.Provides] are only those the extension supplies that do
-// not also resolve without it, and among functions only those whose name is not
-// a SQL keyword. This scan reads words, not positions, so `DELETE FROM audit`
-// in a plpgsql body is the same token as a call to hstore's `delete`, and a
-// database using no hstore was carrying an hstore block because of it
-// (stokaro/ptah#1281).
+// not also resolve without it, and among functions a keyword-named one is left
+// out only where a type of the same extension is in the list and stands in for
+// it. This scan reads words, not positions, so `DELETE FROM audit` in a plpgsql
+// body is the same token as a call to hstore's `delete`, and a database using
+// no hstore was carrying an hstore block because of it (stokaro/ptah#1281).
+// Where no type stands in, the keyword-shaped name is all this scan has and the
+// reader keeps it -- dropping it would cost a document its only declaration of
+// what it calls.
 func (r *renderer) documentNamesAny(names []string) bool {
 	if r.references == nil {
 		r.references = collectReferencedNames(r.db)
@@ -306,7 +309,9 @@ func collectReferencedNames(db *goschema.Database) map[string]bool {
 // The words it yields carry no position, so a statement keyword and a call to a
 // function of the same name are the same token here. That is answered where the
 // member list is built rather than guessed at afterwards: the PostgreSQL reader
-// leaves keyword-named functions out of [goschema.Extension.Provides].
+// leaves a keyword-named function out of [goschema.Extension.Provides] when a
+// type of the same extension is in that list to answer for it, and keeps it
+// when none is.
 func sqlIdentifierTokens(text string) []string {
 	var tokens []string
 	var current strings.Builder

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1565,9 +1565,15 @@ func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 		            WHERE typedep.deptype = 'e'
 		              AND typedep.classid = 'pg_type'::regclass
 		              AND typedep.refobjid = e.oid
-		              AND (answering.oid = p.prorettype
-		                   OR answering.oid = ANY (p.proargtypes)
-		                   OR answering.oid = ANY (COALESCE(p.proallargtypes, '{}'::oid[])))
+		              -- Argument position ONLY. The redundancy this gate relies on
+		              -- is that a genuine call spells the answering type, and only
+		              -- an argument obliges the caller to: a return type or an OUT
+		              -- parameter is named by the function, not by the call site.
+		              -- Measured: an extension supplying merge(text, text)
+		              -- RETURNS kwbox had its member dropped while the document
+		              -- kept a CHECK calling merge, which then failed to
+		              -- materialize (stokaro/ptah#1281).
+		              AND answering.oid = ANY (p.proargtypes)
 		              AND NOT EXISTS (
 		                  SELECT 1 FROM pg_type core
 		                    JOIN pg_namespace corens ON corens.oid = core.typnamespace

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1483,6 +1483,39 @@ func (r *Reader) readExtensions() ([]types.DBExtension, error) {
 // overload rather than the core one requires arguments of that extension's own
 // type, and naming that type is what keeps the extension alive through the
 // pg_type arm.
+//
+// The function arm excludes one more class of name: the ones that are SQL
+// keywords, which the server enumerates itself through pg_get_keywords().
+// Measured on PostgreSQL 17.10, `hstore` supplies three functions named
+// `delete` and pg_catalog supplies none, so the exclusion above keeps all
+// three -- and the scan that consumes this list splits SQL text into
+// identifier-shaped words with no notion of position, so `DELETE FROM audit`
+// in a plpgsql body reads exactly like a call to `delete(h, 'k')` and pins
+// hstore to a database that does not use it (stokaro/ptah#1281).
+//
+// The list has to come from the server because no hand-written one is right.
+// `delete`, `each` and `index` are UNRESERVED words: PostgreSQL 17.10 reports
+// 78 reserved words against 327 unreserved ones, so filtering the reserved list
+// catches none of the three, and pinning the unreserved list in Go would be 327
+// words that move every release.
+//
+// Dropping such a name is safe because the pg_type arm answers for it, and that
+// is measured rather than assumed. Over the 45 extensions this PostgreSQL 17.10
+// build makes available, the keyword-named function members are hstore's
+// `delete` and `each`, ltree's `index` and cube's `cube` -- and every one of
+// them takes or returns a type the same extension supplies. A document
+// containing a genuine call therefore spells that type somewhere it can be
+// seen: a column, a function parameter or return, a domain, a cast. The
+// extension stays through pg_type.
+//
+// Only this arm is filtered. A relation, an operator class and an operator
+// family are each named by nothing but themselves, so excluding a
+// keyword-shaped one would throw away the only evidence there is. `cube` shows
+// the residue that leaves: its type and its constructor share a name, the type
+// arm keeps supplying it, and a view saying `GROUP BY CUBE(x)` still pins the
+// extension. That is the cheaper of the two errors -- a block kept where it
+// could have been dropped costs this document its compatibility, a block
+// dropped where a column needs it costs a document nobody can read.
 func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 	const membersQuery = `
 		SELECT e.extname AS extension_name, t.typname AS member_name
@@ -1504,6 +1537,8 @@ func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 		       SELECT 1 FROM pg_proc core
 		         JOIN pg_namespace corens ON corens.oid = core.pronamespace
 		        WHERE corens.nspname = 'pg_catalog' AND core.proname = p.proname)
+		   AND NOT EXISTS (
+		       SELECT 1 FROM pg_get_keywords() k WHERE k.word = p.proname)
 		UNION
 		SELECT e.extname, c.relname
 		  FROM pg_depend d

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1484,32 +1484,50 @@ func (r *Reader) readExtensions() ([]types.DBExtension, error) {
 // type, and naming that type is what keeps the extension alive through the
 // pg_type arm.
 //
-// The function arm excludes one more class of name: the ones that are SQL
-// keywords, which the server enumerates itself through pg_get_keywords().
-// Measured on PostgreSQL 17.10, `hstore` supplies three functions named
-// `delete` and pg_catalog supplies none, so the exclusion above keeps all
-// three -- and the scan that consumes this list splits SQL text into
-// identifier-shaped words with no notion of position, so `DELETE FROM audit`
-// in a plpgsql body reads exactly like a call to `delete(h, 'k')` and pins
-// hstore to a database that does not use it (stokaro/ptah#1281).
+// The function arm drops one more class of name, and only where dropping it is
+// provably free: a name that is a SQL keyword, when the SAME extension also
+// contributes a type this member list reports and that type appears in the
+// function's own signature. The keyword list comes from the server through
+// pg_get_keywords().
+//
+// The reason to drop such a name at all is that the scan consuming this list
+// splits SQL text into identifier-shaped words with no notion of position.
+// Measured on PostgreSQL 18.4, `hstore` supplies three functions named `delete`
+// and pg_catalog supplies none, so the exclusion above keeps all three, and
+// `DELETE FROM audit` in a plpgsql body then reads exactly like a call to
+// `delete(h, 'k')` and pins hstore to a database that does not use it
+// (stokaro/ptah#1281).
 //
 // The list has to come from the server because no hand-written one is right.
-// `delete`, `each` and `index` are UNRESERVED words: PostgreSQL 17.10 reports
-// 78 reserved words against 327 unreserved ones, so filtering the reserved list
-// catches none of the three, and pinning the unreserved list in Go would be 327
+// `delete`, `each` and `index` are UNRESERVED words: PostgreSQL 18.4 reports 78
+// reserved words against 330 unreserved ones, so filtering the reserved list
+// catches none of the three, and pinning the unreserved list in Go would be 330
 // words that move every release.
 //
-// Dropping such a name is safe because the pg_type arm answers for it, and that
-// is measured rather than assumed. Over the 45 extensions this PostgreSQL 17.10
-// build makes available, the keyword-named function members are hstore's
-// `delete` and `each`, ltree's `index` and cube's `cube` -- and every one of
-// them takes or returns a type the same extension supplies. A document
-// containing a genuine call therefore spells that type somewhere it can be
-// seen: a column, a function parameter or return, a domain, a cast. The
-// extension stays through pg_type.
+// The type condition is what makes the drop safe, and it is enforced here
+// rather than asserted about the extensions that happen to be installed. An
+// earlier form of this filter dropped every keyword-named function member and
+// justified it with a survey: over the contrib extensions this build ships, the
+// keyword-named function members are hstore's `delete` and `each`, ltree's
+// `index` and cube's `cube`, and every one of them takes or returns a type the
+// same extension supplies, so a genuine call spells that type on a column, in a
+// signature or in a cast and the pg_type arm keeps the extension. That is a
+// property of contrib, not of the query. An extension supplying `merge(text,
+// text)` and no type at all has its only evidence in that name, and dropping it
+// leaves a document whose CHECK calls a function nothing declares -- measured
+// on PostgreSQL 18.4 against a fixture extension of exactly that shape, where
+// the pinned Atlas community binary v1.3.0 answered `create "names" table: pq:
+// function merge(text, text) does not exist`. Requiring the answering type
+// makes the redundancy a precondition instead of a coincidence; on the 46
+// extensions available here it excludes the same four names as the survey did.
 //
-// Only this arm is filtered. A relation, an operator class and an operator
-// family are each named by nothing but themselves, so excluding a
+// The answering type must itself survive the pg_type arm, or the redundancy is
+// asserted one level down instead of two: an extension supplying a type named
+// like a pg_catalog type has that name filtered out above, so it can no longer
+// answer for anything.
+//
+// Only this arm is filtered. A type, a relation, an operator class and an
+// operator family are each named by nothing but themselves, so excluding a
 // keyword-shaped one would throw away the only evidence there is. `cube` shows
 // the residue that leaves: its type and its constructor share a name, the type
 // arm keeps supplying it, and a view saying `GROUP BY CUBE(x)` still pins the
@@ -1537,8 +1555,24 @@ func (r *Reader) readExtensionMembers() (map[string][]string, error) {
 		       SELECT 1 FROM pg_proc core
 		         JOIN pg_namespace corens ON corens.oid = core.pronamespace
 		        WHERE corens.nspname = 'pg_catalog' AND core.proname = p.proname)
-		   AND NOT EXISTS (
-		       SELECT 1 FROM pg_get_keywords() k WHERE k.word = p.proname)
+		   AND NOT (
+		       EXISTS (
+		           SELECT 1 FROM pg_get_keywords() k WHERE k.word = p.proname)
+		       AND EXISTS (
+		           SELECT 1
+		             FROM pg_depend typedep
+		             JOIN pg_type answering ON answering.oid = typedep.objid
+		            WHERE typedep.deptype = 'e'
+		              AND typedep.classid = 'pg_type'::regclass
+		              AND typedep.refobjid = e.oid
+		              AND (answering.oid = p.prorettype
+		                   OR answering.oid = ANY (p.proargtypes)
+		                   OR answering.oid = ANY (COALESCE(p.proallargtypes, '{}'::oid[])))
+		              AND NOT EXISTS (
+		                  SELECT 1 FROM pg_type core
+		                    JOIN pg_namespace corens ON corens.oid = core.typnamespace
+		                   WHERE corens.nspname = 'pg_catalog'
+		                     AND core.typname = answering.typname)))
 		UNION
 		SELECT e.extname, c.relname
 		  FROM pg_depend d


### PR DESCRIPTION
Closes #1281. Two commits: the original fix, and the narrowing an independent review found necessary.

## The defect

`hstore` supplies three functions named `delete`, `pg_catalog` supplies none, so #1282's filter kept all three. `sqlIdentifierTokens` reads words rather than positions, so a `plpgsql` body doing `DELETE FROM audit` produced the token `delete` and pinned `hstore` to a database that does not use it — and the pinned Atlas community binary v1.3.0 then refuses the whole document, because it refuses any schema file declaring an extension block. `ltree`'s `index` against `CREATE INDEX` in a body reproduced the same way.

## The gate, and why it needed narrowing

A keyword-named `pg_proc` member is dropped only when the same extension supplies a type appearing in that function's signature — the redundancy being that a genuine call spells the type, so the extension survives through the `pg_type` arm.

The first form of that gate accepted the answering type in **any** signature position. Only an **argument** obliges the caller to spell the type; a return type and an OUT parameter are named by the function, not by the call site. Reproduced on PostgreSQL 17 with a fixture extension supplying

```
CREATE TYPE kwbox AS (lo integer, hi integer);
CREATE FUNCTION merge(a text, b text) RETURNS kwbox ...
```

against `CHECK ((merge(a, b)).lo >= 0)` and zero `kwbox`-typed columns:

| gate | extension blocks | round trip |
|---|---|---|
| any signature position | 0 | rc=1 `function merge(text, text) does not exist (SQLSTATE 42883)` |
| argument position only | 1 | — |

## No shipped extension can express that shape

Recorded because it is the kind of thing that gets rediscovered. Across the 45 extensions this build makes available, the keyword-named function members are exactly `cube.cube`, `hstore.delete`, `hstore.each`, `ltree.index`.

- `hstore`'s two and `ltree`'s take their answering type as an argument, so they were never at risk.
- `cube.cube` does have its answering type in return position — `cube(double precision) -> cube` — but the extension is itself named `cube`, and `omitRefusedBlock` receives the extension's label prepended to `Provides`. A document calling `cube()` matches the **label**, so the block is kept whatever happens to the member. Measured: `CHECK (cube(x) IS NOT NULL)` with no cube column keeps the extension on both commits.

**So the e2e suite gains no row for the narrowing.** A synthetic extension needs `.control` and `.sql` files on the server's filesystem, which a CI service container does not offer. Stating that rather than adding a fixture that looks like coverage and is not.

## Direction of the trade

The narrowing drops fewer members, so more documents keep their extension. That costs compatibility on shapes where the answering type sits in return or OUT position — precisely where dropping it produced a document nobody could read. Second half of the compatibility policy over the first.

## What still holds

All fourteen rows of `TestAtlasCompatInspectExtensionRoundTripE2E` pass, including the two the original fix exists for and the controls that must not move:

| row | blocks | meaning |
|---|---|---|
| `hstore` + `DELETE FROM audit` in a plpgsql body | 0 | the defect, fixed |
| `ltree` + `CREATE INDEX` in a body | 0 | the defect, fixed |
| `hstore` column + `CHECK (delete(props,'secret') = props)` | 1 | genuine call, preserved |
| `cube` column | 1 | keyword-shaped type name, preserved |

`PTAH_ATLAS_INSPECT_ALL_BLOCKS=1` output is byte-identical to base, and native `ptah schema inspect` still emits every extension block — nothing was removed from any surface.

## Gates

`go build` 0 · `go vet` 0 · `go vet -tags integration` 0 · `go test ./... -count=1` 0 (178 packages) · `go tool qtlint` 0 · `golangci-lint run ./...` 0 · `check-test-style.sh` 0 · `check-public-api.sh` 0 · `check-public-api-snapshot.sh` 0 · `check-public-api-released.sh` 0. Live e2e against PostgreSQL 17 in a CI-shaped container: 14/14.
