### PR TITLE
Roll back the nine categories the reverse plan never mentioned (#1287)

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -233,6 +233,19 @@ jobs:
           go test -v -count=1 ./migration/migrator -run 'TestSQLServerMigratorHonorsURLSchemaForMetadata|TestMigrationAdvisoryLock_SQLServer(DefaultTimeout|Timeout)Integration|TestAtlasRevisionMetadata_SQLServerIntegration|TestAtlasTxtarChecks_SQLServer(SequenceDoesNotAdvance)?Integration|TestDryRunRevisionState_SQLServerIntegration' -timeout 3m
           go test -v -count=1 ./migration/generator -run 'TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive' -timeout 5m
 
+      # The reverse plan for views, materialized views and triggers is decided
+      # by what PostgreSQL accepts, and rendering the rollback proves only that
+      # a statement exists. This applies it. The test is behind the integration
+      # build tag in ./migration/generator, which no other step in this file
+      # compiles, so without this step the only live gate for the rollback would
+      # run nowhere.
+      - name: Run reverse view-like rollback round trip
+        env:
+          POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -tags=integration ./migration/generator -list '^TestReverseViewLikeObjects_DownRoundTrip_Integration$' | grep -q '^TestReverseViewLikeObjects_DownRoundTrip_Integration$'
+          go test -v -count=1 -tags=integration ./migration/generator -run '^TestReverseViewLikeObjects_DownRoundTrip_Integration$' -timeout 5m
+
       - name: Run database-realm cleanup and replay tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -278,6 +278,18 @@ table. Live comparisons also snapshot catalog identifier semantics into the
 diff so comparison, destructive-change policy, forward planning, and reverse
 planning use one source of truth.
 
+`migration/schemadiff/types.ViewDiff` also records the view body that is in
+force before the diff is applied, and whether the entry is being planned as a
+rollback. Planners read the body to decide whether the target engine accepts an
+in-place view replacement; PostgreSQL accepts `CREATE OR REPLACE VIEW` only when
+the new query appends to the old column list over the same relations. Where that
+can be neither proved nor ruled out — an unknown prior body, a `WITH` prefix, a
+`SELECT *` projection, a top-level set operation — the rollback flag settles it:
+a forward plan keeps the replacement, which preserves dependent objects and the
+privileges on the view and fails loudly if the engine refuses it, while a
+rollback drops and recreates, which always applies. Embedders that build a
+`ViewDiff` by hand and leave both fields empty get the forward answer.
+
 `core/platform/identifier` exposes the reusable value types and conservative
 dialect defaults behind that contract.
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -9231,6 +9231,43 @@ package types // import "go.5x5.cz/ptah/migration/schemadiff/types"
 type ViewDiff struct {
     ViewName string            `json:"view_name"`
     Changes  map[string]string `json:"changes"`
+
+    // PreviousBody is the view body that is in force before this diff is
+    // applied: the database side of a forward comparison, and the post-up side
+    // of a reversed one. It is what makes the modification path decidable.
+    //
+    // PostgreSQL accepts CREATE OR REPLACE VIEW only when the new query yields
+    // the old column list with columns appended to the end -- same names, same
+    // types, same order. Dropping, renaming or retyping a column is refused at
+    // execution time, and a down migration built with CREATE OR REPLACE is
+    // therefore un-appliable for every view modification except the one shape
+    // the up migration is least likely to have made. A planner that cannot see
+    // the prior body cannot tell the legal case from the refused one, so it has
+    // to choose between an un-appliable statement and always dropping the view
+    // with CASCADE, which takes dependents with it.
+    //
+    // An empty value means "not known". It does not on its own select a plan:
+    // what a planner cannot decide is settled by Rollback below, so a forward
+    // plan still attempts the replace -- the engine refuses it if it is illegal,
+    // and refusing costs nothing -- while a rollback takes the drop and
+    // recreate that always applies.
+    PreviousBody string `json:"previous_body,omitempty"`
+
+    // Rollback reports that this entry is being planned in the DOWN direction:
+    // the statement rendered for it runs while an operator is undoing a
+    // migration.
+    //
+    // It decides nothing on its own. It settles the cases where a planner cannot
+    // prove whether the engine accepts an in-place replace, and the two
+    // directions want opposite answers there. Going forward, the replace is
+    // worth attempting: it keeps dependent objects and the privileges granted on
+    // the view, and if the engine refuses it the migration stops with nothing
+    // destroyed. A rollback cannot be stopped that way -- it is already running
+    // during the incident -- so it takes the drop-and-recreate that always
+    // applies, and pays for it by rebuilding what CASCADE removes.
+    //
+    // Reverse plan builders set it; a forward comparison leaves it false.
+    Rollback bool `json:"rollback,omitempty"`
 }
     ViewDiff represents changes to a view definition.
 

--- a/internal/deporder/deporder.go
+++ b/internal/deporder/deporder.go
@@ -592,6 +592,22 @@ func viewLikeID(object ViewLike, index int) string {
 // ReferencesIdentifier reports whether the SQL body references name as a
 // standalone or qualified identifier. It backs view-like dependency ordering
 // and the schema-scope cross-reference diagnostics.
+//
+// Only the code of the body counts. A name that appears inside a string
+// literal, a dollar-quoted string, a line comment or a block comment names
+// nothing, and treating it as a reference is not a harmless over-approximation:
+// the PostgreSQL planner asks this question to work out what
+// DROP VIEW ... CASCADE takes with it, and an answer of "yes" there puts a
+// DROP MATERIALIZED VIEW ... CASCADE into the plan. Measured on PostgreSQL
+// 17.10, a materialized view whose body is
+// "SELECT 'base_view' AS label, count(*) AS total FROM accounts" -- which reads
+// no view at all -- was dropped and recreated when base_view was modified,
+// taking a hand-made dependent view, a unique index on the materialized view
+// and the privileges granted on it, none of which the plan rebuilds.
+//
+// Quoted identifiers are code and still match, because "base_view" is a
+// reference to base_view. Their contents are opaque, so a quotation mark or a
+// comment marker inside one cannot open a literal or a comment.
 func ReferencesIdentifier(body, name string) bool {
 	body = strings.ToLower(body)
 	name = strings.ToLower(strings.TrimSpace(name))
@@ -599,6 +615,7 @@ func ReferencesIdentifier(body, name string) bool {
 		return false
 	}
 
+	code := sqlCodeMask(body)
 	for start := 0; start < len(body); {
 		index := strings.Index(body[start:], name)
 		if index < 0 {
@@ -606,12 +623,153 @@ func ReferencesIdentifier(body, name string) bool {
 		}
 		index += start
 		end := index + len(name)
-		if (isIdentifierBoundary(body, index-1) || isQualifiedIdentifierTail(body, index-1)) && isIdentifierBoundary(body, end) {
+		if spanIsCode(code, index, end) &&
+			(isIdentifierBoundary(body, index-1) || isQualifiedIdentifierTail(body, index-1)) &&
+			isIdentifierBoundary(body, end) {
 			return true
 		}
 		start = end
 	}
 	return false
+}
+
+// spanIsCode reports whether every byte of body[start:end] is SQL code.
+func spanIsCode(code []bool, start, end int) bool {
+	for i := start; i < end; i++ {
+		if !code[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// sqlCodeMask marks the byte offsets of body that are SQL code: everything
+// outside string literals, dollar-quoted strings, line comments and block
+// comments. Quoted identifiers are code, but their contents are copied through
+// without being re-scanned, so "a--b" is one identifier rather than the start of
+// a comment.
+//
+// The mask is computed over the same string the caller searches, so no offset
+// can slide out from under it.
+func sqlCodeMask(body string) []bool {
+	mask := make([]bool, len(body))
+	for i := 0; i < len(body); {
+		switch {
+		case strings.HasPrefix(body[i:], "--"):
+			i = skipLineComment(body, i)
+		case strings.HasPrefix(body[i:], "/*"):
+			i = skipBlockComment(body, i)
+		case body[i] == '\'':
+			i = skipStringLiteral(body, i)
+		case body[i] == '"':
+			end := skipQuotedIdentifier(body, i)
+			for ; i < end; i++ {
+				mask[i] = true
+			}
+		case body[i] == '$':
+			end, ok := skipDollarQuoted(body, i)
+			if !ok {
+				mask[i] = true
+				i++
+				continue
+			}
+			i = end
+		default:
+			mask[i] = true
+			i++
+		}
+	}
+	return mask
+}
+
+func skipLineComment(body string, start int) int {
+	if end := strings.IndexByte(body[start:], '\n'); end >= 0 {
+		return start + end + 1
+	}
+	return len(body)
+}
+
+// skipBlockComment consumes a /* ... */ comment. PostgreSQL nests them, so the
+// scan counts depth rather than stopping at the first close.
+func skipBlockComment(body string, start int) int {
+	depth := 0
+	for i := start; i < len(body); {
+		switch {
+		case strings.HasPrefix(body[i:], "/*"):
+			depth++
+			i += 2
+		case strings.HasPrefix(body[i:], "*/"):
+			depth--
+			i += 2
+			if depth == 0 {
+				return i
+			}
+		default:
+			i++
+		}
+	}
+	return len(body)
+}
+
+// skipStringLiteral consumes a '...' literal. A doubled quote continues it, and
+// a backslash escapes the next byte only in a literal introduced by E, which is
+// the one spelling where PostgreSQL reads backslashes as escapes.
+func skipStringLiteral(body string, start int) int {
+	escapes := start > 0 && body[start-1] == 'e' &&
+		(start == 1 || !isSQLIdentifierRune(rune(body[start-2])))
+	for i := start + 1; i < len(body); {
+		switch {
+		case escapes && body[i] == '\\' && i+1 < len(body):
+			i += 2
+		case body[i] == '\'' && i+1 < len(body) && body[i+1] == '\'':
+			i += 2
+		case body[i] == '\'':
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(body)
+}
+
+// skipQuotedIdentifier consumes a "..." identifier, including the doubled quote
+// that spells a quotation mark inside one.
+func skipQuotedIdentifier(body string, start int) int {
+	for i := start + 1; i < len(body); {
+		switch {
+		case body[i] == '"' && i+1 < len(body) && body[i+1] == '"':
+			i += 2
+		case body[i] == '"':
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(body)
+}
+
+// skipDollarQuoted consumes a $tag$ ... $tag$ string, reporting false when the
+// dollar sign does not open one -- a positional parameter such as $1, or a
+// dollar sign inside an identifier.
+func skipDollarQuoted(body string, start int) (int, bool) {
+	end := start + 1
+	for end < len(body) {
+		r, size := utf8.DecodeRuneInString(body[end:])
+		if r == '_' || unicode.IsLetter(r) || (end > start+1 && unicode.IsDigit(r)) {
+			end += size
+			continue
+		}
+		break
+	}
+	if end >= len(body) || body[end] != '$' {
+		return start, false
+	}
+
+	tag := body[start : end+1]
+	if closing := strings.Index(body[end+1:], tag); closing >= 0 {
+		return end + 1 + closing + len(tag), true
+	}
+	return len(body), true
 }
 
 func isIdentifierBoundary(value string, index int) bool {

--- a/internal/deporder/deporder_test.go
+++ b/internal/deporder/deporder_test.go
@@ -192,6 +192,111 @@ func TestViewLikesForCreate_MatchesSchemaQualifiedReferences(t *testing.T) {
 	}
 }
 
+// TestReferencesIdentifier_ReadsCodeOnly pins what counts as a reference.
+//
+// The PostgreSQL planner asks this question to work out what
+// DROP VIEW ... CASCADE takes with it, and every "yes" puts a
+// DROP MATERIALIZED VIEW ... CASCADE or a CREATE OR REPLACE VIEW into the plan
+// for the named object. A name spelled inside a string literal or a comment
+// refers to nothing, so answering "yes" there is a destructive statement issued
+// against an object that had no part in the change.
+func TestReferencesIdentifier_ReadsCodeOnly(t *testing.T) {
+	cases := []struct {
+		name string
+		body string
+		want bool
+	}{
+		{
+			name: "plain reference",
+			body: "SELECT id FROM base_view",
+			want: true,
+		},
+		{
+			name: "quoted reference",
+			body: `SELECT id FROM "base_view"`,
+			want: true,
+		},
+		{
+			name: "string literal only",
+			body: "SELECT 'base_view' AS label, count(*) AS total FROM accounts",
+			want: false,
+		},
+		{
+			name: "string literal with a doubled quote before it",
+			body: "SELECT 'it''s base_view' AS label FROM accounts",
+			want: false,
+		},
+		{
+			name: "escape string literal with a backslash-escaped quote",
+			body: `SELECT E'\'base_view' AS label FROM accounts`,
+			want: false,
+		},
+		{
+			name: "line comment only",
+			body: "SELECT id FROM accounts -- used to read base_view\n",
+			want: false,
+		},
+		{
+			name: "block comment only",
+			body: "SELECT id /* base_view was here */ FROM accounts",
+			want: false,
+		},
+		{
+			name: "nested block comment only",
+			body: "SELECT id /* outer /* base_view */ still comment */ FROM accounts",
+			want: false,
+		},
+		{
+			name: "dollar quoted body only",
+			body: "SELECT fn($tag$ SELECT id FROM base_view $tag$) FROM accounts",
+			want: false,
+		},
+		{
+			name: "code after a closed literal",
+			body: "SELECT 'base_view' AS label FROM base_view",
+			want: true,
+		},
+		{
+			name: "code after a closed line comment",
+			body: "SELECT id -- base_view\nFROM base_view",
+			want: true,
+		},
+		{
+			name: "positional parameter is not a dollar quote",
+			body: "SELECT id FROM base_view WHERE id = $1",
+			want: true,
+		},
+		{
+			name: "comment marker inside a quoted identifier does not start a comment",
+			body: `SELECT id FROM "od--d", base_view`,
+			want: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			c.Assert(deporder.ReferencesIdentifier(tc.body, "base_view"), qt.Equals, tc.want,
+				qt.Commentf("body: %s", tc.body))
+		})
+	}
+}
+
+// TestViewLikesForCreate_IgnoresNamesInsideLiteralsAndComments is the ordering
+// half of the same rule: a literal that happens to spell another object's name
+// must not create a dependency edge between them.
+func TestViewLikesForCreate_IgnoresNamesInsideLiteralsAndComments(t *testing.T) {
+	c := qt.New(t)
+
+	objects := deporder.ViewLikesForCreate([]deporder.ViewLike{
+		{Name: "a_report", Body: "SELECT 'z_base' AS label FROM users /* z_base */"},
+		{Name: "z_base", Body: "SELECT id FROM users", Materialized: true},
+	})
+
+	c.Assert(viewLikeNames(objects), qt.DeepEquals, []string{"a_report", "z_base"})
+}
+
 func tableNames(tables []goschema.Table) []string {
 	names := make([]string, 0, len(tables))
 	for _, table := range tables {

--- a/internal/planner/dialects/mysql/mysql.go
+++ b/internal/planner/dialects/mysql/mysql.go
@@ -14,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/indexscope"
+	"go.5x5.cz/ptah/internal/planner/objectlookup"
 	"go.5x5.cz/ptah/internal/planner/tablelookup"
 	"go.5x5.cz/ptah/internal/tableref"
 	"go.5x5.cz/ptah/migration/schemadiff/types"
@@ -1218,21 +1219,11 @@ func (p *Planner) removeTriggers(result []ast.Node, diff *types.SchemaDiff) []as
 }
 
 func findView(views []goschema.View, name string) *goschema.View {
-	for i := range views {
-		if views[i].Name == name {
-			return &views[i]
-		}
-	}
-	return nil
+	return objectlookup.View(views, name)
 }
 
 func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
-	for i := range triggers {
-		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
-			return &triggers[i]
-		}
-	}
-	return nil
+	return objectlookup.Trigger(triggers, tableName, triggerName)
 }
 
 // addNewConstraints adds new table-level constraints via ALTER TABLE statements.

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -13,6 +13,7 @@ import (
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/indexscope"
+	"go.5x5.cz/ptah/internal/planner/objectlookup"
 	"go.5x5.cz/ptah/internal/planner/tablelookup"
 	"go.5x5.cz/ptah/internal/tableref"
 	"go.5x5.cz/ptah/migration/diffpolicy"
@@ -1917,13 +1918,187 @@ func (p *Planner) addNewViewLikeObjects(result []ast.Node, diff *types.SchemaDif
 	return result
 }
 
+// modifyExistingViews re-renders each modified view, choosing between
+// CREATE OR REPLACE VIEW and DROP + CREATE per view.
+//
+// Both statements cost something, and the two costs land in different places.
+// PostgreSQL accepts CREATE OR REPLACE VIEW only for appending trailing columns;
+// dropping, renaming or retyping a projected column is refused at execution
+// time, so the replace can render perfectly and fail when it runs. The drop
+// always applies, but it carries CASCADE: it takes dependent views and
+// materialized views with it, along with the privileges granted on the view
+// itself, none of which the replace disturbs.
+//
+// So the choice is made per view from what viewReplaceLegality can prove, and
+// the undecidable case is resolved by the direction being planned:
+//
+//	appends columns    replace, both directions -- PostgreSQL accepts it
+//	moves columns      drop and recreate, both directions -- the replace would
+//	                   be refused, and rendering a statement we know the engine
+//	                   rejects helps nobody
+//	undecidable        replace going forward, drop on a rollback. Forward, a
+//	                   body this parser cannot read is usually a predicate-only
+//	                   edit to a WITH / star / set-operation view, where the
+//	                   column list never moves and the replace is accepted; if
+//	                   it is not, PostgreSQL says so and the migration stops
+//	                   with nothing destroyed. A rollback cannot afford that
+//	                   answer -- it runs while an operator is undoing a
+//	                   migration, and a rollback that fails is discovered during
+//	                   the incident it was meant to end -- so it takes the
+//	                   statement that always applies.
+//
+// Whatever the drop path takes with it, this step puts back: every declared view
+// and materialized view that reads a dropped view, transitively, is recreated
+// after it. Without that the plan silently left the database short of the schema
+// it was generated from, and re-planning did not converge (issue #1287). What
+// CASCADE removes and this cannot rebuild is anything Ptah does not declare -- a
+// hand-made view, a rule, privileges on the view -- which is why the drop is
+// taken only where it buys something.
+//
+// The drop and the create are emitted from inside the modify step, not by
+// pushing the view into ViewsRemoved and ViewsAdded. The plan runs additions
+// before removals, so a modification expressed from outside comes out
+// create-then-drop and ends with no view at all.
 func (p *Planner) modifyExistingViews(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	var dropped []string
+	replaced := make([]deporder.ViewLike, 0, len(diff.ViewsModified))
 	for _, viewDiff := range diff.ViewsModified {
-		if view := findView(generated.Views, viewDiff.ViewName); view != nil {
-			result = append(result, fromschema.FromView(*view).SetReplace())
+		view := objectlookup.View(generated.Views, viewDiff.ViewName)
+		if view == nil {
+			continue
+		}
+		if viewReplaceKeepsDependents(viewDiff, view.Body) {
+			replaced = append(replaced, deporder.ViewLike{Name: view.Name, Body: view.Body})
+			continue
+		}
+		dropped = append(dropped, view.Name)
+	}
+
+	for _, name := range dropped {
+		result = append(result, ast.NewDropView(name).SetIfExists().SetCascade())
+	}
+
+	// A view on the replace path can also be a dependent of one on the drop
+	// path, in which case it is on both lists and must still be rendered once.
+	recreate := viewLikesLostToCascade(generated, dropped)
+	named := make(map[string]bool, len(recreate))
+	for _, object := range recreate {
+		named[object.Name] = true
+	}
+	for _, object := range replaced {
+		if !named[object.Name] {
+			recreate = append(recreate, object)
 		}
 	}
+
+	for _, object := range deporder.ViewLikesForCreate(recreate) {
+		result = p.appendViewLikeRecreate(result, generated, object, dropped)
+	}
 	return result
+}
+
+// appendViewLikeRecreate renders the CREATE that puts one view-like object back.
+//
+// A view this step dropped itself is created outright. Everything else is
+// re-asserted rather than created blind: a dependent is on the list because its
+// body names a dropped view in code, which is a syntactic test rather than a
+// resolved one, and a CREATE OR REPLACE costs nothing if the object survived
+// after all while a bare CREATE would fail on "already exists". A materialized
+// view has no in-place replace, so it is dropped first for the same reason.
+func (p *Planner) appendViewLikeRecreate(
+	result []ast.Node,
+	generated *goschema.Database,
+	object deporder.ViewLike,
+	dropped []string,
+) []ast.Node {
+	if object.Materialized {
+		view := objectlookup.MaterializedView(generated.MaterializedViews, object.Name)
+		if view == nil {
+			return result
+		}
+		result = append(result, ast.NewDropMaterializedView(view.Name).SetIfExists().SetCascade())
+		return append(result, fromschema.FromMaterializedView(*view))
+	}
+
+	view := objectlookup.View(generated.Views, object.Name)
+	if view == nil {
+		return result
+	}
+	if slices.Contains(dropped, object.Name) {
+		return append(result, fromschema.FromView(*view))
+	}
+	return append(result, fromschema.FromView(*view).SetReplace())
+}
+
+// viewReplaceKeepsDependents decides whether one modified view keeps the
+// in-place replace, which is the statement that leaves dependents and grants
+// alone. The table in modifyExistingViews explains the three answers.
+func viewReplaceKeepsDependents(viewDiff types.ViewDiff, targetBody string) bool {
+	switch viewReplaceLegality(viewDiff.PreviousBody, targetBody) {
+	case viewReplaceAppendsColumns:
+		return true
+	case viewReplaceMovesColumns:
+		return false
+	default:
+		return !viewDiff.Rollback
+	}
+}
+
+// viewLikesLostToCascade returns the declared views and materialized views that
+// DROP VIEW ... CASCADE removes when it drops the named views, the dropped views
+// themselves included, so the caller can put every one of them back.
+//
+// Dependency is read off the declared bodies, the same test that orders view
+// creation, and it is applied transitively: dropping a view takes the view that
+// reads it, and the view that reads that one.
+//
+// The test reads the code of those bodies and not their text. A name inside a
+// string literal or a comment reads nothing, and putting it on this list is not
+// a harmless over-approximation: everything on the list is answered with a
+// statement, and for a materialized view that statement is
+// DROP MATERIALIZED VIEW ... CASCADE. On PostgreSQL 17.10 that took a hand-made
+// dependent view, a unique index and a GRANT off an object no part of the
+// migration touched -- none of them declared, so nothing put them back.
+func viewLikesLostToCascade(generated *goschema.Database, dropped []string) []deporder.ViewLike {
+	if len(dropped) == 0 {
+		return nil
+	}
+
+	candidates := make([]deporder.ViewLike, 0, len(generated.Views)+len(generated.MaterializedViews))
+	for _, view := range generated.Views {
+		candidates = append(candidates, deporder.ViewLike{Name: view.Name, Body: view.Body})
+	}
+	for _, view := range generated.MaterializedViews {
+		candidates = append(candidates, deporder.ViewLike{Name: view.Name, Body: view.Body, Materialized: true})
+	}
+
+	lost := make([]deporder.ViewLike, 0, len(dropped))
+	taken := make(map[string]bool, len(dropped))
+	frontier := make([]string, 0, len(dropped))
+	for _, name := range dropped {
+		if taken[name] {
+			continue
+		}
+		taken[name] = true
+		frontier = append(frontier, name)
+		if view := objectlookup.View(generated.Views, name); view != nil {
+			lost = append(lost, deporder.ViewLike{Name: view.Name, Body: view.Body})
+		}
+	}
+
+	for len(frontier) > 0 {
+		gone := frontier[0]
+		frontier = frontier[1:]
+		for _, candidate := range candidates {
+			if taken[candidate.Name] || !deporder.ReferencesIdentifier(candidate.Body, gone) {
+				continue
+			}
+			taken[candidate.Name] = true
+			frontier = append(frontier, candidate.Name)
+			lost = append(lost, candidate)
+		}
+	}
+	return lost
 }
 
 func (p *Planner) removeViews(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
@@ -1980,30 +2155,15 @@ func (p *Planner) removeTriggers(result []ast.Node, diff *types.SchemaDiff) []as
 }
 
 func findView(views []goschema.View, name string) *goschema.View {
-	for i := range views {
-		if views[i].Name == name {
-			return &views[i]
-		}
-	}
-	return nil
+	return objectlookup.View(views, name)
 }
 
 func findMaterializedView(views []goschema.MaterializedView, name string) *goschema.MaterializedView {
-	for i := range views {
-		if views[i].Name == name {
-			return &views[i]
-		}
-	}
-	return nil
+	return objectlookup.MaterializedView(views, name)
 }
 
 func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
-	for i := range triggers {
-		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
-			return &triggers[i]
-		}
-	}
-	return nil
+	return objectlookup.Trigger(triggers, tableName, triggerName)
 }
 
 func findRLSPolicy(policies []goschema.RLSPolicy, tableName, policyName string) *goschema.RLSPolicy {

--- a/internal/planner/dialects/postgres/schema_objects_test.go
+++ b/internal/planner/dialects/postgres/schema_objects_test.go
@@ -12,6 +12,15 @@ import (
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
 
+// TestPlanner_GenerateMigrationAST_SchemaObjectsModified pins the forward plan
+// for the diff an embedder builds by hand: a modified view, materialized view
+// and trigger, with no PreviousBody on the view.
+//
+// The missing prior body is the point. That is what every ViewDiff built outside
+// the comparator carries, and this test says what the planner does with it
+// rather than being handed the field that would decide it. A fixture that grew a
+// PreviousBody to keep this assertion green would have moved the input to meet
+// the behavior and pinned nothing.
 func TestPlanner_GenerateMigrationAST_SchemaObjectsModified(t *testing.T) {
 	c := qt.New(t)
 	planner := postgres.New()
@@ -34,7 +43,10 @@ func TestPlanner_GenerateMigrationAST_SchemaObjectsModified(t *testing.T) {
 		}},
 	}
 	diff := &difftypes.SchemaDiff{
-		ViewsModified:             []difftypes.ViewDiff{{ViewName: "active_users", Changes: map[string]string{"body": "old -> new"}}},
+		ViewsModified: []difftypes.ViewDiff{{
+			ViewName: "active_users",
+			Changes:  map[string]string{"body": "old -> new"},
+		}},
 		MaterializedViewsModified: []difftypes.MaterializedViewDiff{{ViewName: "user_stats", Changes: map[string]string{"body": "old -> new"}}},
 		TriggersModified:          []difftypes.TriggerDiff{{TriggerName: "set_updated_at", TableName: "users", Changes: map[string]string{"body": "old -> new"}}},
 	}
@@ -45,9 +57,455 @@ func TestPlanner_GenerateMigrationAST_SchemaObjectsModified(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	sql = legacyRenderedSQL(sql)
 	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW active_users")
+	c.Assert(sql, qt.Not(qt.Contains), "DROP VIEW")
 	c.Assert(sql, qt.Contains, "DROP MATERIALIZED VIEW IF EXISTS user_stats CASCADE;")
 	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW user_stats AS")
 	c.Assert(sql, qt.Contains, "CREATE OR REPLACE TRIGGER set_updated_at BEFORE UPDATE ON users FOR EACH ROW EXECUTE FUNCTION ptah_trigger_users_set_updated_at();")
+}
+
+// TestPlanner_GenerateMigrationAST_ModifiedViewDropsWhenReplaceWouldBeRefused
+// pins the branch PostgreSQL refuses. Measured on PostgreSQL 17.10 against a
+// view over (id bigint, email text, age integer): appending a trailing column
+// is accepted, while dropping the appended column, renaming a column and
+// changing a column's type each fail with "cannot drop columns from view",
+// "cannot change name of view column" and "cannot change data type of view
+// column". A plan that renders the replace for those shapes is refused at
+// execution time, which on a rollback means the operator finds out during the
+// incident.
+//
+// A swapped relation belongs here too. The select list alone answered "appends
+// only" for it, because a plain reference reduces to the bare column name, and
+// PostgreSQL then refused the statement: the type of a projected column is fixed
+// by the relation it reads.
+//
+// Every row is decided by the change itself, so the direction being planned does
+// not enter into it; the shapes that direction DOES decide are
+// TestPlanner_GenerateMigrationAST_UndecidableViewBodyFollowsTheDirection.
+func TestPlanner_GenerateMigrationAST_ModifiedViewDropsWhenReplaceWouldBeRefused(t *testing.T) {
+	cases := []struct {
+		name         string
+		previousBody string
+		nextBody     string
+		wantReplace  bool
+	}{
+		{
+			name:         "append a trailing column",
+			previousBody: "SELECT id, email FROM users",
+			nextBody:     "SELECT id, email, age FROM users",
+			wantReplace:  true,
+		},
+		{
+			name:         "drop the appended column",
+			previousBody: "SELECT id, email, age FROM users",
+			nextBody:     "SELECT id, email FROM users",
+			wantReplace:  false,
+		},
+		{
+			name:         "rename a column",
+			previousBody: "SELECT id, email FROM users",
+			nextBody:     "SELECT id AS uid, email FROM users",
+			wantReplace:  false,
+		},
+		{
+			name:         "change a column type",
+			previousBody: "SELECT id, email FROM users",
+			nextBody:     "SELECT id::text AS id, email FROM users",
+			wantReplace:  false,
+		},
+		{
+			name:         "swap the relation under an unchanged column",
+			previousBody: "SELECT id FROM other_users",
+			nextBody:     "SELECT id, email FROM users",
+			wantReplace:  false,
+		},
+		{
+			name:         "join in a second relation",
+			previousBody: "SELECT id, email FROM users",
+			nextBody:     "SELECT id, email FROM users JOIN accounts ON accounts.user_id = users.id",
+			wantReplace:  false,
+		},
+		{
+			name:         "change only the predicate",
+			previousBody: "SELECT id, email FROM users WHERE id > 0",
+			nextBody:     "SELECT id, email FROM users WHERE id > 10",
+			wantReplace:  true,
+		},
+		{
+			name:         "change only the ordering",
+			previousBody: "SELECT id, email FROM users ORDER BY id",
+			nextBody:     "SELECT id, email FROM users ORDER BY email",
+			wantReplace:  true,
+		},
+		{
+			name:         "read the catalog spelling of the same projection",
+			previousBody: "SELECT users.id, users.email FROM users WHERE id > 0",
+			nextBody:     "SELECT id, email FROM users WHERE id > 10",
+			wantReplace:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			planner := postgres.New()
+
+			generated := &goschema.Database{
+				Views: []goschema.View{{Name: "active_users", Body: tc.nextBody}},
+			}
+			diff := &difftypes.SchemaDiff{
+				ViewsModified: []difftypes.ViewDiff{{
+					ViewName:     "active_users",
+					Changes:      map[string]string{"body": "old -> new"},
+					PreviousBody: tc.previousBody,
+				}},
+			}
+
+			nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+			c.Assert(err, qt.IsNil)
+			sql, err := renderer.RenderSQL("postgres", nodes...)
+			c.Assert(err, qt.IsNil)
+			sql = legacyRenderedSQL(sql)
+
+			c.Assert(strings.Contains(sql, "CREATE OR REPLACE VIEW active_users"), qt.Equals, tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+			c.Assert(strings.Contains(sql, "DROP VIEW IF EXISTS active_users CASCADE;"), qt.Equals, !tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+			c.Assert(sql, qt.Contains, tc.nextBody)
+		})
+	}
+}
+
+// TestPlanner_GenerateMigrationAST_UndecidableViewBodyFollowsTheDirection pins
+// the shapes the mechanical test cannot decide, where the two directions want
+// opposite answers.
+//
+// Forward, the replace is worth attempting: a body this parser cannot read is
+// most often a predicate-only edit to a WITH, star or set-operation view, where
+// the column list never moves and PostgreSQL accepts the replace, and where the
+// drop would take dependent objects the plan never rebuilt. If the replace turns
+// out to be illegal the engine says so and the migration stops having destroyed
+// nothing. A rollback cannot be answered that way -- it is already running
+// during the incident -- so it takes the statement that always applies.
+func TestPlanner_GenerateMigrationAST_UndecidableViewBodyFollowsTheDirection(t *testing.T) {
+	cases := []struct {
+		name         string
+		previousBody string
+		nextBody     string
+		rollback     bool
+		wantReplace  bool
+	}{
+		{
+			name:         "prior body unknown, forward",
+			previousBody: "",
+			nextBody:     "SELECT id, email FROM users",
+			wantReplace:  true,
+		},
+		{
+			name:         "prior body unknown, rollback",
+			previousBody: "",
+			nextBody:     "SELECT id, email FROM users",
+			rollback:     true,
+			wantReplace:  false,
+		},
+		{
+			name:         "star projection hides the column list, forward",
+			previousBody: "SELECT * FROM users",
+			nextBody:     "SELECT * FROM users WHERE id > 10",
+			wantReplace:  true,
+		},
+		{
+			name:         "star projection hides the column list, rollback",
+			previousBody: "SELECT * FROM users",
+			nextBody:     "SELECT * FROM users WHERE id > 10",
+			rollback:     true,
+			wantReplace:  false,
+		},
+		{
+			name:         "with prefix, forward",
+			previousBody: "WITH src AS (SELECT id, email FROM users) SELECT id, email FROM src",
+			nextBody:     "WITH src AS (SELECT id, email FROM users WHERE id > 10) SELECT id, email FROM src",
+			wantReplace:  true,
+		},
+		{
+			name:         "with prefix, rollback",
+			previousBody: "WITH src AS (SELECT id, email FROM users) SELECT id, email FROM src",
+			nextBody:     "WITH src AS (SELECT id, email FROM users WHERE id > 10) SELECT id, email FROM src",
+			rollback:     true,
+			wantReplace:  false,
+		},
+		{
+			name:         "set operation, forward",
+			previousBody: "SELECT id FROM users UNION SELECT id FROM archived_users",
+			nextBody:     "SELECT id FROM users WHERE id > 1 UNION SELECT id FROM archived_users",
+			wantReplace:  true,
+		},
+		{
+			name:         "set operation, rollback",
+			previousBody: "SELECT id FROM users UNION SELECT id FROM archived_users",
+			nextBody:     "SELECT id FROM users WHERE id > 1 UNION SELECT id FROM archived_users",
+			rollback:     true,
+			wantReplace:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			planner := postgres.New()
+
+			generated := &goschema.Database{
+				Views: []goschema.View{{Name: "active_users", Body: tc.nextBody}},
+			}
+			diff := &difftypes.SchemaDiff{
+				ViewsModified: []difftypes.ViewDiff{{
+					ViewName:     "active_users",
+					Changes:      map[string]string{"body": "old -> new"},
+					PreviousBody: tc.previousBody,
+					Rollback:     tc.rollback,
+				}},
+			}
+
+			nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+			c.Assert(err, qt.IsNil)
+			sql, err := renderer.RenderSQL("postgres", nodes...)
+			c.Assert(err, qt.IsNil)
+			sql = legacyRenderedSQL(sql)
+
+			c.Assert(strings.Contains(sql, "CREATE OR REPLACE VIEW active_users"), qt.Equals, tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+			c.Assert(strings.Contains(sql, "DROP VIEW IF EXISTS active_users CASCADE;"), qt.Equals, !tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+			c.Assert(sql, qt.Contains, tc.nextBody)
+		})
+	}
+}
+
+// TestPlanner_GenerateMigrationAST_ModifiedViewsDropInDependencyOrder pins the
+// ordering the drop path needs. DROP VIEW ... CASCADE takes dependent views with
+// it, so every drop is emitted before any create and the creates follow
+// dependency order -- a view that reads another must be recreated after it.
+func TestPlanner_GenerateMigrationAST_ModifiedViewsDropInDependencyOrder(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{
+			{Name: "a_report", Body: "SELECT id FROM z_base"},
+			{Name: "z_base", Body: "SELECT id FROM users"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsModified: []difftypes.ViewDiff{
+			{ViewName: "a_report", Changes: map[string]string{"body": "old -> new"}, Rollback: true},
+			{ViewName: "z_base", Changes: map[string]string{"body": "old -> new"}, Rollback: true},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP VIEW IF EXISTS a_report CASCADE;", "CREATE VIEW z_base AS")
+	assertBefore(t, sql, "DROP VIEW IF EXISTS z_base CASCADE;", "CREATE VIEW z_base AS")
+	assertBefore(t, sql, "CREATE VIEW z_base AS", "CREATE VIEW a_report AS")
+}
+
+// TestPlanner_GenerateMigrationAST_DroppedViewRebuildsDeclaredDependents pins
+// what the drop path owes the schema it was generated from.
+//
+// DROP VIEW ... CASCADE does not stop at the view named. It takes every view and
+// materialized view that reads it, transitively, and none of those are mentioned
+// anywhere else in the plan -- so a migration that only dropped and recreated the
+// named view applied cleanly and left the database short of objects the same
+// schema declares. Re-planning did not repair it either: the next plan created
+// the dependent and dropped it again in the same file.
+func TestPlanner_GenerateMigrationAST_DroppedViewRebuildsDeclaredDependents(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{
+			{Name: "base_view", Body: "SELECT id, email FROM users"},
+			{Name: "mid_view", Body: "SELECT id FROM base_view"},
+			{Name: "leaf_view", Body: "SELECT id FROM mid_view"},
+			{Name: "unrelated_view", Body: "SELECT id FROM accounts"},
+		},
+		MaterializedViews: []goschema.MaterializedView{
+			{Name: "mid_stats", Body: "SELECT count(*) AS total FROM base_view", RefreshStrategy: "manual"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsModified: []difftypes.ViewDiff{{
+			ViewName: "base_view",
+			Changes:  map[string]string{"body": "old -> new"},
+			// The column list shrank, so the replace is refused and the drop is
+			// the only statement that applies -- in both directions.
+			PreviousBody: "SELECT id, email, age FROM users",
+		}},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	c.Assert(sql, qt.Contains, "DROP VIEW IF EXISTS base_view CASCADE;", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE VIEW base_view AS", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW mid_view AS", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW leaf_view AS", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW mid_stats AS", qt.Commentf("rendered:\n%s", sql))
+
+	// A view the CASCADE cannot reach has no business in this plan.
+	c.Assert(sql, qt.Not(qt.Contains), "unrelated_view", qt.Commentf("rendered:\n%s", sql))
+
+	// And the rebuild has to follow the read order, or the same CASCADE takes it
+	// straight back out.
+	assertBefore(t, sql, "CREATE VIEW base_view AS", "CREATE OR REPLACE VIEW mid_view AS")
+	assertBefore(t, sql, "CREATE OR REPLACE VIEW mid_view AS", "CREATE OR REPLACE VIEW leaf_view AS")
+}
+
+// TestPlanner_GenerateMigrationAST_CascadeRebuildReadsCodeNotText pins the
+// other side of the rebuild set: what the CASCADE cannot reach must stay out of
+// the plan even when the dropped view's name appears in the body as text.
+//
+// The rebuild list exists to put back what DROP VIEW ... CASCADE takes, so every
+// name on it is answered with a statement: a materialized view is dropped and
+// recreated, a view is re-asserted. Reading the name out of a string literal or
+// a comment therefore does not merely add a redundant statement -- it issues
+// DROP MATERIALIZED VIEW ... CASCADE against an object no part of the migration
+// touched. Measured on PostgreSQL 17.10, that took a hand-made dependent view, a
+// unique index on the materialized view, and the SELECT granted on it; none of
+// the three is declared, so nothing put them back.
+func TestPlanner_GenerateMigrationAST_CascadeRebuildReadsCodeNotText(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	generated := &goschema.Database{
+		Views: []goschema.View{
+			{Name: "base_view", Body: "SELECT id, email FROM users"},
+			{Name: "reader_view", Body: "SELECT id FROM base_view"},
+			{Name: "label_view", Body: "SELECT id, 'base_view' AS label FROM accounts"},
+			{Name: "note_view", Body: "SELECT id FROM accounts -- was base_view once\n"},
+		},
+		MaterializedViews: []goschema.MaterializedView{
+			{Name: "label_stats", Body: "SELECT 'base_view' AS label, count(*) AS total FROM accounts", RefreshStrategy: "manual"},
+			{Name: "reader_stats", Body: "SELECT count(*) AS total FROM base_view", RefreshStrategy: "manual"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		ViewsModified: []difftypes.ViewDiff{{
+			ViewName: "base_view",
+			Changes:  map[string]string{"body": "old -> new"},
+			// The column list shrank, so the drop is the only statement that
+			// applies and the rebuild list is what decides who else is touched.
+			PreviousBody: "SELECT id, email, age FROM users",
+		}},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	// The genuine dependents are still rebuilt.
+	c.Assert(sql, qt.Contains, "DROP VIEW IF EXISTS base_view CASCADE;", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE OR REPLACE VIEW reader_view AS", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Contains, "CREATE MATERIALIZED VIEW reader_stats AS", qt.Commentf("rendered:\n%s", sql))
+
+	// The objects that only spell the name are not named by any statement.
+	c.Assert(sql, qt.Not(qt.Contains), "label_view", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "note_view", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "label_stats", qt.Commentf("rendered:\n%s", sql))
+	c.Assert(sql, qt.Not(qt.Contains), "DROP MATERIALIZED VIEW IF EXISTS label_stats", qt.Commentf("rendered:\n%s", sql))
+}
+
+// TestPlanner_GenerateMigrationAST_QuotedRelationCaseIsNotFolded pins the
+// identity of a quoted relation.
+//
+// PostgreSQL folds an unquoted identifier to lower case and keeps a quoted one
+// exactly, so "Foo" and "foo" are two different relations and a view moved
+// between them takes its column types from a different place. Folding the whole
+// FROM text to lower case answered "the relations did not change" and produced
+// CREATE OR REPLACE VIEW, which PostgreSQL 17.10 refused with `cannot change
+// data type of view column "id" from bigint to text` -- rc=3 under
+// psql -v ON_ERROR_STOP=1, in the down direction, which is the exact failure
+// this change exists to prevent.
+func TestPlanner_GenerateMigrationAST_QuotedRelationCaseIsNotFolded(t *testing.T) {
+	cases := []struct {
+		name         string
+		previousBody string
+		nextBody     string
+		wantReplace  bool
+	}{
+		{
+			name:         "quoted relations differing only in case are different relations",
+			previousBody: `SELECT id FROM "Foo"`,
+			nextBody:     `SELECT id FROM "foo"`,
+			wantReplace:  false,
+		},
+		{
+			name:         "the same quoted relation still appends",
+			previousBody: `SELECT id FROM "Foo"`,
+			nextBody:     `SELECT id, email FROM "Foo"`,
+			wantReplace:  true,
+		},
+		{
+			name:         "the same quoted relation with only a predicate change still replaces",
+			previousBody: `SELECT id FROM "Foo" WHERE id > 0`,
+			nextBody:     `SELECT id FROM "Foo" WHERE id > 10`,
+			wantReplace:  true,
+		},
+		{
+			name:         "case still folds outside quotes",
+			previousBody: "SELECT id FROM foo",
+			nextBody:     "select id FROM FOO",
+			wantReplace:  true,
+		},
+		{
+			// A literal decides no column's type, so its case still folds -- and
+			// the quotation mark inside it must not be read as opening an
+			// identifier, which would carry the rest of the body through
+			// unfolded.
+			name:         "a quotation mark inside a literal does not open an identifier",
+			previousBody: `SELECT 'a"b' AS label FROM foo`,
+			nextBody:     `SELECT 'A"B' AS label, id FROM FOO`,
+			wantReplace:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+			planner := postgres.New()
+
+			generated := &goschema.Database{
+				Views: []goschema.View{{Name: "probe_view", Body: tc.nextBody}},
+			}
+			diff := &difftypes.SchemaDiff{
+				ViewsModified: []difftypes.ViewDiff{{
+					ViewName:     "probe_view",
+					Changes:      map[string]string{"body": "old -> new"},
+					PreviousBody: tc.previousBody,
+					Rollback:     true,
+				}},
+			}
+
+			nodes, err := planner.GenerateMigrationASTChecked(diff, generated)
+			c.Assert(err, qt.IsNil)
+			sql, err := renderer.RenderSQL("postgres", nodes...)
+			c.Assert(err, qt.IsNil)
+			sql = legacyRenderedSQL(sql)
+
+			c.Assert(strings.Contains(sql, "CREATE OR REPLACE VIEW probe_view"), qt.Equals, tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+			c.Assert(strings.Contains(sql, "DROP VIEW IF EXISTS probe_view CASCADE;"), qt.Equals, !tc.wantReplace,
+				qt.Commentf("rendered:\n%s", sql))
+		})
+	}
 }
 
 func TestPlanner_GenerateMigrationAST_DuplicateTriggerNamesUseDistinctFunctions(t *testing.T) {

--- a/internal/planner/dialects/postgres/view_replace.go
+++ b/internal/planner/dialects/postgres/view_replace.go
@@ -1,0 +1,579 @@
+package postgres
+
+import (
+	"strings"
+	"unicode"
+	"unicode/utf8"
+)
+
+// viewReplaceVerdict is what the mechanical test can say about replacing one
+// view body with another.
+//
+// Three answers are needed rather than two, because "PostgreSQL will refuse
+// this" and "this parser cannot tell" select different plans. A refusal is a
+// fact about the change and holds in both directions. Not being able to tell is
+// a fact about the parser, and the caller resolves it from the direction it is
+// planning: see viewReplaceKeepsDependents.
+type viewReplaceVerdict int
+
+const (
+	// viewReplaceUndecidable means at least one of the two bodies has a shape
+	// this parser does not model, so nothing is known about the change: a WITH
+	// prefix, a top-level set operation, a parenthesized query, a star
+	// projection whose columns are not spelled out, a select item whose output
+	// column name cannot be derived, or an empty previous body.
+	viewReplaceUndecidable viewReplaceVerdict = iota
+
+	// viewReplaceAppendsColumns means both bodies parsed, they read the same
+	// relations, and the new select list is the old one with columns appended
+	// to the end. That is the one shape PostgreSQL accepts for an in-place
+	// replace.
+	viewReplaceAppendsColumns
+
+	// viewReplaceMovesColumns means both bodies parsed and the new select list
+	// is NOT the old one with columns appended -- a column was dropped, renamed
+	// or given a different type-determining expression -- or the two read
+	// different relations, which fixes the types of the shared items and cannot
+	// be checked from the select list alone. PostgreSQL refuses the replace for
+	// the first group; for the second it may or may not, and answering "do not
+	// replace" is the only appliable choice.
+	viewReplaceMovesColumns
+)
+
+// viewReplaceLegality classifies a change from previousBody to nextBody.
+//
+// PostgreSQL accepts CREATE OR REPLACE VIEW only when the new query produces the
+// old column list with columns appended to the end -- the same names, the same
+// types, in the same order. Measured on PostgreSQL 17.10 against a view over
+// (id bigint, email text, age integer):
+//
+//	append a trailing column   accepted
+//	drop the appended column   ERROR: cannot drop columns from view
+//	rename a column            ERROR: cannot change name of view column "id" to "uid"
+//	change a column type       ERROR: cannot change data type of view column "id"
+//	change only the predicate  accepted
+//
+// Column names are read off the select list, which is the only place a view's
+// projection is written down. Two items are the same column when their output
+// names match and either both are plain references to the same column, or both
+// are the same expression text. That comparison sees through the two spellings
+// the same view legitimately has -- "SELECT id FROM t" as authored and
+// "SELECT t.id FROM t" as pg_get_viewdef reads it back -- while a cast, a rename
+// or a different expression changes it.
+//
+// A select item's TYPE, though, is fixed by the relation it reads, and the
+// select list does not say what that relation is. Comparing the items alone
+// answered "appends only" for a swapped relation, which PostgreSQL then refused:
+//
+//	CREATE VIEW v AS SELECT id FROM b;            -- b.id is text
+//	CREATE OR REPLACE VIEW v AS SELECT id FROM a; -- a.id is bigint
+//	ERROR:  cannot change data type of view column "id" from text to bigint
+//
+// So the FROM/JOIN text is part of the comparison: any change to the relations,
+// including one that merely spells them differently, answers
+// viewReplaceMovesColumns. The clauses that do not decide a type -- WHERE,
+// GROUP BY, HAVING, ORDER BY and the rest -- are excluded, so a predicate-only
+// edit still answers viewReplaceAppendsColumns and keeps the cheap replace.
+//
+// "Spelled the same way" is decided by PostgreSQL's identifier rules rather
+// than by letter case alone -- see normalizeExpression, which folds case
+// everywhere except inside quoted identifiers, because "Foo" and "foo" are two
+// relations.
+//
+// The residual assumption is narrow: the shared items read the same relations,
+// spelled the same way, and those relations' columns were not retyped by the
+// same migration. PostgreSQL refuses to alter a column type a view depends on,
+// so reaching that last state requires dropping the view first, which is a
+// different plan than this one.
+func viewReplaceLegality(previousBody, nextBody string) viewReplaceVerdict {
+	previous, previousFrom, ok := viewProjection(previousBody)
+	if !ok {
+		return viewReplaceUndecidable
+	}
+	next, nextFrom, ok := viewProjection(nextBody)
+	if !ok {
+		return viewReplaceUndecidable
+	}
+	if previousFrom != nextFrom {
+		return viewReplaceMovesColumns
+	}
+	if len(next) < len(previous) {
+		return viewReplaceMovesColumns
+	}
+	for i, item := range previous {
+		if item != next[i] {
+			return viewReplaceMovesColumns
+		}
+	}
+	return viewReplaceAppendsColumns
+}
+
+// viewSelectItem is one entry of a view's top-level select list, reduced to the
+// two properties PostgreSQL compares when replacing a view: the output column
+// name, and whatever determines that column's type.
+type viewSelectItem struct {
+	// column is the output column name PostgreSQL records for the item.
+	column string
+	// source is the item's type-determining text: "col:" plus the referenced
+	// column name for a plain reference, or "expr:" plus the normalized
+	// expression otherwise. The prefixes keep a bare reference to "x" distinct
+	// from an expression that happens to read "x".
+	source string
+}
+
+// viewProjection parses a view body into its top-level select list and the
+// normalized text of the relations it reads. The last result is false whenever
+// the body has a shape this parser does not model, in which case the caller
+// knows nothing about the change and must not treat the view as replaceable.
+func viewProjection(body string) ([]viewSelectItem, string, bool) {
+	projection, from, ok := viewProjectionText(body)
+	if !ok {
+		return nil, "", false
+	}
+
+	parts := splitTopLevel(projection, ',')
+	items := make([]viewSelectItem, 0, len(parts))
+	for _, part := range parts {
+		item, ok := parseViewSelectItem(part)
+		if !ok {
+			return nil, "", false
+		}
+		items = append(items, item)
+	}
+	if len(items) == 0 {
+		return nil, "", false
+	}
+	return items, from, true
+}
+
+// viewProjectionText returns the text between the leading SELECT and the
+// top-level FROM (or the end of the query when there is none), plus the
+// normalized FROM/JOIN text that follows it.
+//
+// The FROM clause ends at the first top-level clause keyword that cannot
+// introduce a relation, so a change to a predicate, a grouping or an ordering
+// is not mistaken for a change to what the view reads.
+func viewProjectionText(body string) (projection, from string, ok bool) {
+	query := strings.TrimSpace(strings.TrimSuffix(strings.TrimSpace(stripSQLComments(body)), ";"))
+	if query == "" {
+		return "", "", false
+	}
+
+	rest, ok := cutLeadingKeyword(query, "select")
+	if !ok {
+		// A WITH prefix or a parenthesized query. Both can project columns this
+		// parser would have to resolve through another query level.
+		return "", "", false
+	}
+	if after, ok := cutLeadingKeyword(rest, "all"); ok {
+		rest = after
+	} else if after, ok := cutLeadingKeyword(rest, "distinct"); ok {
+		// DISTINCT ON (...) puts an expression list before the projection.
+		if _, isOn := cutLeadingKeyword(after, "on"); isOn {
+			return "", "", false
+		}
+		rest = after
+	}
+
+	// A top-level set operation resolves the result types across both branches,
+	// so the first branch's select list does not decide them on its own.
+	for _, keyword := range []string{"union", "intersect", "except"} {
+		if indexTopLevelKeyword(rest, keyword) >= 0 {
+			return "", "", false
+		}
+	}
+
+	projection = rest
+	if start := indexTopLevelKeyword(rest, "from"); start >= 0 {
+		projection = rest[:start]
+		from = normalizeExpression(rest[start+len("from") : viewFromClauseEnd(rest, start+len("from"))])
+	}
+	projection = strings.TrimSpace(projection)
+	if projection == "" {
+		return "", "", false
+	}
+	return projection, from, true
+}
+
+// viewFromClauseEnd returns the offset at which the FROM clause that starts at
+// start gives way to a clause that cannot introduce a relation.
+//
+// Everything from FROM up to that point decides the types of the columns the
+// select list projects; everything after it filters, groups or orders rows that
+// already have their types. Keeping the split here is what lets a predicate-only
+// edit stay replaceable while a swapped relation does not.
+func viewFromClauseEnd(text string, start int) int {
+	end := len(text)
+	for _, keyword := range []string{"where", "group", "having", "window", "order", "limit", "offset", "fetch", "for"} {
+		forEachTopLevelKeyword(text, keyword, func(offset int) {
+			if offset >= start && offset < end {
+				end = offset
+			}
+		})
+	}
+	return end
+}
+
+// parseViewSelectItem reduces one select-list entry to its output column and
+// the text that fixes its type.
+func parseViewSelectItem(text string) (viewSelectItem, bool) {
+	expression := strings.TrimSpace(text)
+	if expression == "" {
+		return viewSelectItem{}, false
+	}
+
+	alias := ""
+	if as := lastTopLevelKeyword(expression, "as"); as >= 0 {
+		aliasText := strings.TrimSpace(expression[as+len("as"):])
+		name, ok := plainIdentifier(aliasText)
+		if !ok {
+			return viewSelectItem{}, false
+		}
+		alias = name
+		expression = strings.TrimSpace(expression[:as])
+	}
+
+	if expression == "" {
+		return viewSelectItem{}, false
+	}
+	// A star projection does not spell its columns out, so neither their names
+	// nor their count can be read here.
+	if strings.HasSuffix(expression, "*") {
+		return viewSelectItem{}, false
+	}
+
+	if column, ok := plainColumnReference(expression); ok {
+		name := alias
+		if name == "" {
+			name = column
+		}
+		return viewSelectItem{column: name, source: "col:" + column}, true
+	}
+
+	// An expression with no alias takes an output name PostgreSQL derives from
+	// the expression itself, which this parser does not reproduce.
+	if alias == "" {
+		return viewSelectItem{}, false
+	}
+	return viewSelectItem{column: alias, source: "expr:" + normalizeExpression(expression)}, true
+}
+
+// plainColumnReference returns the referenced column name when the expression
+// is nothing but a (possibly qualified) column reference.
+func plainColumnReference(expression string) (string, bool) {
+	parts := splitTopLevel(expression, '.')
+	if len(parts) == 0 || len(parts) > 3 {
+		return "", false
+	}
+	last := ""
+	for _, part := range parts {
+		name, ok := plainIdentifier(part)
+		if !ok {
+			return "", false
+		}
+		last = name
+	}
+	return last, true
+}
+
+// plainIdentifier normalizes a single SQL identifier the way PostgreSQL does:
+// an unquoted identifier folds to lower case, a quoted one keeps its spelling.
+func plainIdentifier(text string) (string, bool) {
+	name := strings.TrimSpace(text)
+	if name == "" {
+		return "", false
+	}
+	if strings.HasPrefix(name, `"`) {
+		if len(name) < 2 || !strings.HasSuffix(name, `"`) {
+			return "", false
+		}
+		inner := name[1 : len(name)-1]
+		if inner == "" || strings.Contains(inner, `"`) {
+			return "", false
+		}
+		return inner, true
+	}
+	for i, r := range name {
+		if r == '_' || unicode.IsLetter(r) {
+			continue
+		}
+		if i > 0 && (r == '$' || unicode.IsDigit(r)) {
+			continue
+		}
+		return "", false
+	}
+	return strings.ToLower(name), true
+}
+
+// normalizeExpression collapses the differences that never change an
+// expression's type: surrounding and repeated whitespace, and letter case
+// outside quoted identifiers. Case folding is safe there because no SQL
+// construct changes its result type with the case of its spelling -- a string
+// literal's case does not alter that it is a string, and a function or type
+// name is case-insensitive.
+//
+// A quoted identifier is the exception, and it is the whole reason this is not
+// one call to strings.ToLower. PostgreSQL folds an unquoted identifier to lower
+// case but keeps a quoted one exactly, so "Foo" and "foo" are two different
+// relations. Folding them together answered "the relations did not change" for
+// a swap between them, and the CREATE OR REPLACE VIEW that produced was refused
+// on PostgreSQL 17.10 with `cannot change data type of view column "id" from
+// bigint to text`. The contents of a quoted identifier are therefore copied
+// through byte for byte, whitespace included, because "my view" and "my  view"
+// are also two different relations.
+//
+// The quotation marks are kept, so a quoted identifier never compares equal to
+// the same word unquoted. That is the conservative side: `"foo"` and `foo` are
+// the same relation to PostgreSQL and this answers "changed", which costs a
+// drop and recreate rather than an un-appliable replace.
+//
+// A string literal is skipped over rather than interpreted, so a quotation mark
+// inside one does not open an identifier -- but its own case is still folded,
+// because a literal decides no column's type.
+func normalizeExpression(expression string) string {
+	var out strings.Builder
+	pendingSpace := false
+	written := false
+
+	writeSpace := func() {
+		if pendingSpace && written {
+			out.WriteByte(' ')
+		}
+		pendingSpace = false
+	}
+
+	for i := 0; i < len(expression); {
+		switch {
+		case expression[i] == '"':
+			end := quotedIdentifierEnd(expression, i)
+			writeSpace()
+			out.WriteString(expression[i:end])
+			written = true
+			i = end
+		case expression[i] == '\'':
+			end := stringLiteralEnd(expression, i)
+			writeSpace()
+			out.WriteString(strings.ToLower(expression[i:end]))
+			written = true
+			i = end
+		case isASCIISpace(expression[i]):
+			pendingSpace = true
+			i++
+		default:
+			writeSpace()
+			r, size := utf8.DecodeRuneInString(expression[i:])
+			out.WriteRune(unicode.ToLower(r))
+			written = true
+			i += size
+		}
+	}
+	return out.String()
+}
+
+// stringLiteralEnd returns the offset just past the '...' literal that starts at
+// start, treating a doubled quotation mark as one inside it.
+func stringLiteralEnd(text string, start int) int {
+	for i := start + 1; i < len(text); {
+		switch {
+		case text[i] == '\'' && i+1 < len(text) && text[i+1] == '\'':
+			i += 2
+		case text[i] == '\'':
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(text)
+}
+
+func isASCIISpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r' || b == '\v' || b == '\f'
+}
+
+// quotedIdentifierEnd returns the offset just past the quoted identifier that
+// starts at start, treating a doubled quotation mark as one inside it.
+func quotedIdentifierEnd(text string, start int) int {
+	for i := start + 1; i < len(text); {
+		switch {
+		case text[i] == '"' && i+1 < len(text) && text[i+1] == '"':
+			i += 2
+		case text[i] == '"':
+			return i + 1
+		default:
+			i++
+		}
+	}
+	return len(text)
+}
+
+// splitTopLevel splits on a separator that appears outside every parenthesis,
+// single-quoted string and quoted identifier.
+func splitTopLevel(text string, separator rune) []string {
+	var parts []string
+	var current strings.Builder
+	scanSQL(text, func(r rune, topLevel bool) {
+		if topLevel && r == separator {
+			parts = append(parts, current.String())
+			current.Reset()
+			return
+		}
+		current.WriteRune(r)
+	})
+	return append(parts, current.String())
+}
+
+// indexTopLevelKeyword returns the byte offset of the first occurrence of a
+// whole-word keyword outside every parenthesis and quote, or -1.
+func indexTopLevelKeyword(text, keyword string) int {
+	found := -1
+	forEachTopLevelKeyword(text, keyword, func(offset int) {
+		if found < 0 {
+			found = offset
+		}
+	})
+	return found
+}
+
+// lastTopLevelKeyword returns the byte offset of the last such occurrence.
+func lastTopLevelKeyword(text, keyword string) int {
+	found := -1
+	forEachTopLevelKeyword(text, keyword, func(offset int) {
+		found = offset
+	})
+	return found
+}
+
+// forEachTopLevelKeyword visits every whole-word, case-insensitive occurrence
+// of keyword that lies outside every parenthesis and quote.
+//
+// The comparison is done against the original text rather than a lower-cased
+// copy on purpose: lower-casing can change a string's byte length (U+0130
+// folds to two runes), which would slide the offsets out from under the
+// top-level marks computed on the original.
+func forEachTopLevelKeyword(text, keyword string, visit func(offset int)) {
+	offsets := topLevelOffsets(text)
+	for i := 0; i+len(keyword) <= len(text); i++ {
+		if !offsets[i] {
+			continue
+		}
+		if !strings.EqualFold(text[i:i+len(keyword)], keyword) {
+			continue
+		}
+		if i > 0 && isIdentifierByte(text[i-1]) {
+			continue
+		}
+		if i+len(keyword) < len(text) && isIdentifierByte(text[i+len(keyword)]) {
+			continue
+		}
+		visit(i)
+	}
+}
+
+// topLevelOffsets marks the byte offsets that lie outside every parenthesis,
+// single-quoted string and quoted identifier.
+func topLevelOffsets(text string) []bool {
+	marks := make([]bool, len(text))
+	scanSQLIndexed(text, func(index int, _ rune, topLevel bool) {
+		marks[index] = topLevel
+	})
+	return marks
+}
+
+func isIdentifierByte(b byte) bool {
+	return b == '_' || b == '$' ||
+		('0' <= b && b <= '9') ||
+		('a' <= b && b <= 'z') ||
+		('A' <= b && b <= 'Z')
+}
+
+// scanSQL walks the text reporting, for each rune, whether it sits outside
+// every parenthesis, single-quoted string and quoted identifier.
+func scanSQL(text string, visit func(r rune, topLevel bool)) {
+	scanSQLIndexed(text, func(_ int, r rune, topLevel bool) { visit(r, topLevel) })
+}
+
+func scanSQLIndexed(text string, visit func(index int, r rune, topLevel bool)) {
+	depth := 0
+	inString := false
+	inQuotedIdentifier := false
+	for index, r := range text {
+		switch {
+		case inString:
+			if r == '\'' {
+				inString = false
+			}
+		case inQuotedIdentifier:
+			if r == '"' {
+				inQuotedIdentifier = false
+			}
+		case r == '\'':
+			inString = true
+		case r == '"':
+			inQuotedIdentifier = true
+		case r == '(':
+			depth++
+		case r == ')':
+			depth--
+		}
+		visit(index, r, depth == 0 && !inString && !inQuotedIdentifier)
+	}
+}
+
+// cutLeadingKeyword removes a leading whole-word keyword, reporting whether it
+// was there.
+func cutLeadingKeyword(text, keyword string) (string, bool) {
+	trimmed := strings.TrimSpace(text)
+	if len(trimmed) < len(keyword) {
+		return text, false
+	}
+	if !strings.EqualFold(trimmed[:len(keyword)], keyword) {
+		return text, false
+	}
+	rest := trimmed[len(keyword):]
+	if rest != "" && isIdentifierByte(rest[0]) {
+		return text, false
+	}
+	return strings.TrimSpace(rest), true
+}
+
+// stripSQLComments removes line and block comments so a comment can neither
+// hide a keyword nor invent one.
+func stripSQLComments(text string) string {
+	var out strings.Builder
+	inString := false
+	inQuotedIdentifier := false
+	for i := 0; i < len(text); i++ {
+		switch {
+		case inString:
+			if text[i] == '\'' {
+				inString = false
+			}
+		case inQuotedIdentifier:
+			if text[i] == '"' {
+				inQuotedIdentifier = false
+			}
+		case text[i] == '\'':
+			inString = true
+		case text[i] == '"':
+			inQuotedIdentifier = true
+		case strings.HasPrefix(text[i:], "--"):
+			end := strings.IndexByte(text[i:], '\n')
+			if end < 0 {
+				return out.String()
+			}
+			i += end
+			out.WriteByte('\n')
+			continue
+		case strings.HasPrefix(text[i:], "/*"):
+			end := strings.Index(text[i+2:], "*/")
+			if end < 0 {
+				return out.String()
+			}
+			i += 2 + end + 1
+			out.WriteByte(' ')
+			continue
+		}
+		out.WriteByte(text[i])
+	}
+	return out.String()
+}

--- a/internal/planner/dialects/sqlite/sqlite.go
+++ b/internal/planner/dialects/sqlite/sqlite.go
@@ -13,6 +13,7 @@ import (
 	"go.5x5.cz/ptah/core/ptaherr"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/indexscope"
+	"go.5x5.cz/ptah/internal/planner/objectlookup"
 	"go.5x5.cz/ptah/internal/tableref"
 	"go.5x5.cz/ptah/migration/schemadiff/types"
 )
@@ -809,12 +810,7 @@ func (p *Planner) removeViews(diff *types.SchemaDiff) []ast.Node {
 }
 
 func findView(views []goschema.View, name string) *goschema.View {
-	for i := range views {
-		if views[i].Name == name {
-			return &views[i]
-		}
-	}
-	return nil
+	return objectlookup.View(views, name)
 }
 
 func (p *Planner) addTriggers(
@@ -862,12 +858,7 @@ func (p *Planner) removeTriggers(diff *types.SchemaDiff) []ast.Node {
 }
 
 func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
-	for i := range triggers {
-		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
-			return &triggers[i]
-		}
-	}
-	return nil
+	return objectlookup.Trigger(triggers, tableName, triggerName)
 }
 
 func unsupportedFeaturef(format string, args ...any) error {

--- a/internal/planner/objectlookup/objectlookup.go
+++ b/internal/planner/objectlookup/objectlookup.go
@@ -1,0 +1,102 @@
+// Package objectlookup resolves the views, materialized views and triggers a
+// SchemaDiff entry names against the schema a migration planner renders from.
+package objectlookup
+
+import (
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/tableref"
+)
+
+// View returns the declared view a diff entry names, or nil when the schema
+// holds no single view under that name.
+//
+// The two sides do not always spell the name the same way, and comparing the
+// strings directly loses whole objects. A diff records a modified view under the
+// name the Go schema spells, which is normally unqualified, while a schema
+// converted back from an introspected database names every view
+// "<schema>.<view>" through dbschema/types.DBView.QualifiedName -- always on
+// MySQL and MariaDB, whose reader reports the database name for every view, and
+// on PostgreSQL for every view outside the schema being read. The down direction
+// plans against exactly that converted schema, so a planner that compared the
+// two spellings found nothing, rendered no statement, and produced a rollback
+// that said "No rollback operations needed" while the view kept its post-up body
+// (issue #1287).
+//
+// An exact match wins, so a schema that spells the name the same way is never
+// re-interpreted. Otherwise the two are compared on their unqualified names, and
+// only a single candidate is accepted: two views of the same name in different
+// schemas name no one object, and choosing between them would be a guess.
+func View(views []goschema.View, name string) *goschema.View {
+	return resolve(views, name, func(view goschema.View) string { return view.Name })
+}
+
+// MaterializedView returns the declared materialized view a diff entry names,
+// on the same terms as [View].
+func MaterializedView(views []goschema.MaterializedView, name string) *goschema.MaterializedView {
+	return resolve(views, name, func(view goschema.MaterializedView) string { return view.Name })
+}
+
+// Trigger returns the declared trigger a diff entry names, or nil.
+//
+// A trigger is identified by its own name plus the table it hangs on, and it is
+// the table that carries the schema, so the same qualified-versus-unqualified
+// split [View] describes applies to the table half of the key.
+func Trigger(triggers []goschema.Trigger, tableName, triggerName string) *goschema.Trigger {
+	for i := range triggers {
+		if triggers[i].Table == tableName && triggers[i].Name == triggerName {
+			return &triggers[i]
+		}
+	}
+
+	ref, ok := tableref.Parse(tableName)
+	if !ok {
+		return nil
+	}
+	match := -1
+	for i := range triggers {
+		if triggers[i].Name != triggerName {
+			continue
+		}
+		candidate, ok := tableref.Parse(triggers[i].Table)
+		if !ok || candidate.Name != ref.Name {
+			continue
+		}
+		if match >= 0 {
+			return nil
+		}
+		match = i
+	}
+	if match < 0 {
+		return nil
+	}
+	return &triggers[match]
+}
+
+// resolve implements the exact-then-unqualified match [View] documents.
+func resolve[T any](items []T, name string, nameOf func(T) string) *T {
+	for i := range items {
+		if nameOf(items[i]) == name {
+			return &items[i]
+		}
+	}
+
+	ref, ok := tableref.Parse(name)
+	if !ok {
+		return nil
+	}
+	match := -1
+	for i := range items {
+		candidate, ok := tableref.Parse(nameOf(items[i]))
+		if !ok || candidate.Name != ref.Name {
+			continue
+		}
+		if match >= 0 {
+			return nil
+		}
+		match = i
+	}
+	if match < 0 {
+		return nil
+	}
+	return &items[match]
+}

--- a/internal/planner/objectlookup/objectlookup_test.go
+++ b/internal/planner/objectlookup/objectlookup_test.go
@@ -1,0 +1,158 @@
+package objectlookup_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/planner/objectlookup"
+)
+
+// TestView_HappyPath pins the two spellings a diff and a schema legitimately use
+// for the same view. The down direction plans against a schema converted back
+// from an introspected database, which qualifies every name it read; the diff
+// records the name the Go schema spells, which is normally bare.
+func TestView_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		views    []goschema.View
+		lookup   string
+		wantBody string
+	}{
+		{
+			name:     "exact name",
+			views:    []goschema.View{{Name: "active_users", Body: "exact"}},
+			lookup:   "active_users",
+			wantBody: "exact",
+		},
+		{
+			name:     "diff spells it bare, schema qualifies it",
+			views:    []goschema.View{{Name: "reporting.active_users", Body: "qualified"}},
+			lookup:   "active_users",
+			wantBody: "qualified",
+		},
+		{
+			name:     "diff qualifies it, schema spells it bare",
+			views:    []goschema.View{{Name: "active_users", Body: "bare"}},
+			lookup:   "reporting.active_users",
+			wantBody: "bare",
+		},
+		{
+			name: "an exact match wins over an unqualified one",
+			views: []goschema.View{
+				{Name: "reporting.active_users", Body: "qualified"},
+				{Name: "active_users", Body: "bare"},
+			},
+			lookup:   "active_users",
+			wantBody: "bare",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got := objectlookup.View(test.views, test.lookup)
+			c.Assert(got, qt.IsNotNil)
+			c.Assert(got.Body, qt.Equals, test.wantBody)
+		})
+	}
+}
+
+// TestView_FailurePath pins what the resolver refuses to guess at. Two views of
+// the same name in different schemas name no one object, and rendering a
+// statement for either of them would be a coin toss on which one the migration
+// destroys.
+func TestView_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		views  []goschema.View
+		lookup string
+	}{
+		{
+			name:   "no candidate at all",
+			views:  []goschema.View{{Name: "other_view"}},
+			lookup: "active_users",
+		},
+		{
+			name: "the same name in two schemas",
+			views: []goschema.View{
+				{Name: "reporting.active_users", Body: "reporting"},
+				{Name: "archive.active_users", Body: "archive"},
+			},
+			lookup: "active_users",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(objectlookup.View(test.views, test.lookup), qt.IsNil)
+		})
+	}
+}
+
+func TestMaterializedView_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	views := []goschema.MaterializedView{{Name: "reporting.user_stats", Body: "qualified"}}
+	got := objectlookup.MaterializedView(views, "user_stats")
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(got.Body, qt.Equals, "qualified")
+}
+
+func TestMaterializedView_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	views := []goschema.MaterializedView{
+		{Name: "reporting.user_stats"},
+		{Name: "archive.user_stats"},
+	}
+	c.Assert(objectlookup.MaterializedView(views, "user_stats"), qt.IsNil)
+}
+
+// TestTrigger_HappyPath covers the half of a trigger's identity that carries a
+// schema: the table it hangs on.
+func TestTrigger_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	triggers := []goschema.Trigger{{Name: "touch", Table: "reporting.users", Body: "qualified"}}
+	got := objectlookup.Trigger(triggers, "users", "touch")
+	c.Assert(got, qt.IsNotNil)
+	c.Assert(got.Body, qt.Equals, "qualified")
+}
+
+func TestTrigger_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		triggers []goschema.Trigger
+		table    string
+		trigger  string
+	}{
+		{
+			name:     "the trigger name still has to match",
+			triggers: []goschema.Trigger{{Name: "touch", Table: "reporting.users"}},
+			table:    "users",
+			trigger:  "other",
+		},
+		{
+			name: "the same trigger name on the same table in two schemas",
+			triggers: []goschema.Trigger{
+				{Name: "touch", Table: "reporting.users"},
+				{Name: "touch", Table: "archive.users"},
+			},
+			table:   "users",
+			trigger: "touch",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(objectlookup.Trigger(test.triggers, test.table, test.trigger), qt.IsNil)
+		})
+	}
+}

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -360,8 +360,126 @@ capability preset disables the keyword.
 4. **Version Control**: Commit migration files to version control
 5. **Sequential Application**: Apply migrations in the correct order based on timestamps
 
+## How the reverse plan handles each category
+
+A DOWN migration is planned from the UP diff with the added and removed
+collections exchanged and the pre-change database schema supplied as the target.
+Three rules decide what happens to each field of the diff, and every field has
+exactly one of them:
+
+- **Added and removed are exchanged** where both sides carry the same kind of
+  value and the reverse operation is the inverse of the forward one: tables,
+  enums, indexes, extensions, functions, sequences, domains, composite types,
+  ranges, views, materialized views, triggers, RLS policies, RLS enablement,
+  roles, grants, grant options and constraints. A created view is dropped on
+  rollback; a dropped view is recreated from the pre-change schema.
+- **Modified entries are carried across, not exchanged.** A modification is not
+  the inverse of itself. The planner re-renders a modified object from the schema
+  it is given, and the DOWN direction is given the pre-change database schema, so
+  carrying the entry across is what restores the prior definition. The recorded
+  `old -> new` description is flipped so the diff reads truthfully in the DOWN
+  direction, and a view's recorded prior body is exchanged for the UP
+  migration's target body, because that is the state the database is in when the
+  rollback runs.
+- **Derived entries are rebuilt** from the pre-change database rather than
+  swapped, because a rollback must restore the prior body rather than the new
+  one. This covers the table-qualified constraint collections. The recorded
+  catalog identifier semantics are copied rather than reversed: they describe the
+  catalog the diff was measured against, which has no direction.
+
+No category is dropped from the rollback. Two tests hold that claim up, and they
+check different things. A reflection test over `SchemaDiff` fails when a field is
+added and the reverse builder does not read it, because adding a field to a
+struct literal is silent about the fields the literal omits. A second test
+renders the rollback and requires the modified view, materialized view and
+trigger to appear in it: reaching the reversed diff is not the same as reaching
+the file, because a modified object is re-rendered from the pre-change schema by
+a name lookup, and a lookup that misses renders nothing at all.
+
+### View modifications choose per view, and the direction settles the rest
+
+PostgreSQL accepts `CREATE OR REPLACE VIEW` only when the new query produces the
+old column list with columns appended to the end. Measured on PostgreSQL 17.10
+against a view over `(id bigint, email text, age integer)`:
+
+| change to the view | PostgreSQL |
+| --- | --- |
+| append a trailing column | accepted |
+| drop the appended column | `ERROR: cannot drop columns from view` |
+| rename a column | `ERROR: cannot change name of view column "id" to "uid"` |
+| change a column type | `ERROR: cannot change data type of view column "id"` |
+| change only the predicate | accepted |
+
+A projected column's type is fixed by the relation it reads, which the select
+list does not say, so the relations are compared as well: swapping
+`SELECT id FROM b` for `SELECT id FROM a` keeps the column name and still fails
+with `cannot change data type of view column "id"`.
+
+That comparison folds letter case only outside quoted identifiers. PostgreSQL
+folds an unquoted identifier to lower case and keeps a quoted one exactly, so
+`"Foo"` and `"foo"` are two relations; folding them together answered "the
+relations did not change" and produced a `CREATE OR REPLACE VIEW` PostgreSQL
+17.10 refuses with `cannot change data type of view column "id" from bigint to
+text` — `psql -v ON_ERROR_STOP=1 -f` exits 3. The
+conservative side of the same rule is that `"foo"` and `foo`, which *are* the
+same relation, compare as changed and cost a drop and recreate. Telling those
+apart needs a real parse of the `FROM` clause, because `"join"` is a relation
+where `join` is a keyword.
+
+Both statements cost something. The replace can be refused at execution time. The
+drop always applies and carries `CASCADE`, which takes dependent views and
+materialized views with it along with the privileges granted on the view. So Ptah
+decides per view:
+
+| what Ptah can prove | UP | DOWN |
+| --- | --- | --- |
+| the new column list appends to the old one, over the same relations | replace | replace |
+| the column list moved, or the relations changed | drop and recreate | drop and recreate |
+| neither — a `WITH` prefix, a `SELECT *` projection, a top-level set operation, or no prior body at all | replace | drop and recreate |
+
+The last row is the only place direction enters. Going forward, an undecidable
+body is usually a predicate-only edit where the column list never moves and the
+replace is accepted; if it is not, PostgreSQL refuses the statement and the
+migration stops having destroyed nothing. A rollback cannot be answered that way,
+because it is already running during the incident it was meant to end, so it
+takes the statement that always applies.
+
+Wherever the drop path runs, the plan rebuilds every view and materialized view
+the `CASCADE` takes, transitively, in dependency order. What it cannot rebuild is
+anything Ptah does not declare.
+
+That rebuild list is read off the declared bodies, and it reads their **code**:
+a name spelled inside a string literal, a dollar-quoted string, a line comment
+or a block comment refers to nothing and does not join the list. The distinction
+is not cosmetic, because every name on the list is answered with a statement —
+a materialized view is dropped with `CASCADE` and recreated. Measured on
+PostgreSQL 17.10, a materialized view whose body is
+`SELECT 'base_view' AS label, count(*) AS total FROM accounts` was dropped when
+`base_view` was modified, and the drop took a hand-made dependent view, a unique
+index on the materialized view and the `SELECT` granted on it; none of the three
+is declared, so nothing put them back.
+
 ## Limitations
 
 - **Data Loss Warning**: DOWN migrations may result in data loss (e.g., dropping columns/tables)
 - **Complex Changes**: Some complex schema changes may require manual intervention
 - **Database-Specific Features**: Some database-specific features may not be fully supported in reverse migrations
+- **Materialized View Contents**: A rollback that recreates a materialized view
+  recreates its definition, and PostgreSQL populates it as part of the `CREATE`
+  — Ptah does not emit `WITH NO DATA`. The contents are therefore recomputed
+  from the base tables as they stand at rollback time, not restored: a snapshot
+  that had deliberately not been refreshed is silently refreshed, and the
+  rollback pays for the whole query. Anything attached to the old materialized
+  view rather than to its definition — its indexes, and the privileges granted
+  on it — is gone with the drop.
+- **Dependents of a Recreated View**: `DROP ... CASCADE` takes dependent objects
+  with it. Every view and materialized view Ptah declares is rebuilt after the
+  view it reads, but an object Ptah does not declare — a hand-made view, a rule,
+  or a privilege granted on the view itself — is not, and is lost with the drop.
+- **Views Read Under Two Names**: A modified object is found in the pre-change
+  schema by name, and the two sides do not always spell it the same way: the diff
+  records the name the Go schema uses while the introspected schema qualifies it
+  with the schema or database it was read from. The lookup accepts either
+  spelling, but only where one candidate carries the unqualified name. Two views
+  of the same name in different schemas are ambiguous, and the modification is
+  skipped rather than guessed at.

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1536,6 +1536,44 @@ func reverseSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 // to rebuild prior FK/PK/CHECK/UNIQUE definitions for reversed constraint
 // additions; it may be nil when callers only have the generated schema (the
 // reversed additions then fall back to the name-only path).
+//
+// # Every field of SchemaDiff is accounted for here
+//
+// This function builds a fresh SchemaDiff literal, and a literal that
+// enumerates fields has no compiler check for the ones it forgets. Nine fields
+// -- views, materialized views and triggers, added/removed/modified -- were
+// once simply absent, so every down migration silently dropped those whole
+// categories: an up that created a view rolled back to "No rollback operations
+// needed" and left the view in place (issue #1287). Three dispositions are
+// available, and every field must have exactly one:
+//
+//   - Exchanged. Added and removed swap where both sides carry the same kind of
+//     value and the reverse operation is the inverse of the forward one:
+//     tables, enums, indexes, extensions, functions, sequences, domains,
+//     composite types, ranges, views, materialized views, triggers, RLS
+//     policies, RLS enablement, roles, grants, grant options and constraints.
+//   - Carried. A Modified entry is not the inverse of itself. The planner
+//     re-renders a modified object from the schema it is handed, and the down
+//     direction is handed the pre-change database schema, so carrying the entry
+//     across is what restores the prior definition. Only the recorded
+//     "old -> new" description is flipped, plus any recorded prior state (a
+//     view's PreviousBody) that names a side rather than a change.
+//   - Derived. IdentifierSemantics is cloned rather than reversed: it describes
+//     the catalog the diff was measured against, which does not have a
+//     direction. The table-qualified constraint collections are rebuilt from
+//     the pre-change database schema by reverseConstraintAdditions and
+//     reverseConstraintRemovals rather than swapped, because a down migration
+//     must restore the prior body, not the new one. ConstraintBackedIndexRemovals
+//     is derived too, and it redirects rather than reverses: it names the subset
+//     of the index removals whose object is really a UNIQUE constraint, so
+//     reverseIndexRemovals turns exactly that subset into constraint additions
+//     rebuilt from the introspected constraint, and leaves the rest as index
+//     additions.
+//
+// No field is deliberately dropped, and none is unreachable in the down
+// direction. TestReverseSchemaDiff_AccountsForEverySchemaDiffField enforces
+// that by reflection: it zeroes one field of a fully populated diff at a time
+// and fails when doing so leaves the reverse plan unchanged.
 func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Database, dbSchema *dbschematypes.DBSchema) *types.SchemaDiff {
 	reversed := &types.SchemaDiff{
 		IdentifierSemantics: cloneIdentifierSemantics(diff.IdentifierSemantics),
@@ -1573,6 +1611,31 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		SequencesAdded:    diff.SequencesRemoved, // Sequences to remove become sequences to add
 		SequencesRemoved:  diff.SequencesAdded,   // Sequences to add become sequences to remove
 		SequencesModified: reverseSequenceDiffs(diff.SequencesModified),
+
+		// Reverse view, materialized view and trigger operations.
+		//
+		// Each side carries the same kind of value (view names, materialized
+		// view names, table-qualified trigger refs) and DROP is the inverse of
+		// CREATE for all three, so the plain swap is the correct reversal.
+		//
+		// The Modified entries are carried across rather than swapped: the
+		// planner re-renders a modified object from the schema it is handed,
+		// which in the down direction is the pre-change database schema, so the
+		// entry itself is what selects the prior definition. A view carries the
+		// body it will be replacing as well, and THAT is a side rather than a
+		// change, so it is exchanged for the up migration's target body -- the
+		// state the database is actually in when the rollback runs.
+		ViewsAdded:    diff.ViewsRemoved, // Views to remove become views to add
+		ViewsRemoved:  diff.ViewsAdded,   // Views to add become views to remove
+		ViewsModified: reverseViewDiffs(diff.ViewsModified, schema),
+
+		MaterializedViewsAdded:    diff.MaterializedViewsRemoved, // Materialized views to remove become materialized views to add
+		MaterializedViewsRemoved:  diff.MaterializedViewsAdded,   // Materialized views to add become materialized views to remove
+		MaterializedViewsModified: reverseMaterializedViewDiffs(diff.MaterializedViewsModified),
+
+		TriggersAdded:    diff.TriggersRemoved, // Triggers to remove become triggers to add
+		TriggersRemoved:  diff.TriggersAdded,   // Triggers to add become triggers to remove
+		TriggersModified: reverseTriggerDiffs(diff.TriggersModified),
 
 		// Reverse RLS policy operations. Both directions carry the owning
 		// table, so reversing is a swap and no name-to-table resolution is
@@ -2197,6 +2260,83 @@ func reverseDomainDiffs(domainDiffs []types.DomainDiff, schema *goschema.Databas
 			DomainName:      domainDiff.DomainName,
 			Changes:         reverseChangeMap(domainDiff.Changes),
 			CurrentBaseType: targetDomainBaseType(schema, domainDiff.DomainName),
+		}
+	}
+	return reversed
+}
+
+// reverseViewDiffs carries modified views into the down direction.
+//
+// The entry is carried across rather than swapped with anything: the planner
+// renders a modified view from the schema it is given (the pre-change database
+// schema, in the down direction), so the entry itself is what selects the prior
+// definition.
+//
+// PreviousBody is different in kind: it names the body the view HAS when the
+// statement runs, not a change. When the rollback runs, the database holds what
+// the up migration wrote, which is the generated schema's body -- so that is
+// what the reversed entry must carry. Getting this wrong is not cosmetic: the
+// PostgreSQL planner reads it to decide whether CREATE OR REPLACE VIEW is legal
+// for the rollback, and PostgreSQL refuses the replace for every column-list
+// change except a trailing append.
+//
+// A nil schema (the deprecated reverseSchemaDiff entry point) leaves it empty,
+// which planners read as "not known" and answer with drop-and-recreate. That is
+// the safe direction: it always applies.
+//
+// Rollback is set for the same reason and is the other half of it. Where a
+// planner can neither prove the replace legal nor prove it refused, the answer
+// it should give differs by direction, and this is the only place that knows
+// which direction is being built.
+func reverseViewDiffs(viewDiffs []types.ViewDiff, schema *goschema.Database) []types.ViewDiff {
+	reversed := make([]types.ViewDiff, len(viewDiffs))
+	for i, viewDiff := range viewDiffs {
+		reversed[i] = types.ViewDiff{
+			ViewName:     viewDiff.ViewName,
+			Changes:      reverseChangeMap(viewDiff.Changes),
+			PreviousBody: generatedViewBody(schema, viewDiff.ViewName),
+			Rollback:     true,
+		}
+	}
+	return reversed
+}
+
+func generatedViewBody(schema *goschema.Database, viewName string) string {
+	if schema == nil {
+		return ""
+	}
+	for _, view := range schema.Views {
+		if view.Name == viewName {
+			return strings.TrimSpace(view.Body)
+		}
+	}
+	return ""
+}
+
+// reverseMaterializedViewDiffs carries modified materialized views into the
+// down direction, on the same terms as reverseViewDiffs. A materialized view
+// has no in-place replace at all, so there is no prior body to record: both
+// directions drop and recreate it.
+func reverseMaterializedViewDiffs(viewDiffs []types.MaterializedViewDiff) []types.MaterializedViewDiff {
+	reversed := make([]types.MaterializedViewDiff, len(viewDiffs))
+	for i, viewDiff := range viewDiffs {
+		reversed[i] = types.MaterializedViewDiff{ViewName: viewDiff.ViewName, Changes: reverseChangeMap(viewDiff.Changes)}
+	}
+	return reversed
+}
+
+// reverseTriggerDiffs carries modified triggers into the down direction, on the
+// same terms as reverseViewDiffs. TableName is part of the trigger's identity
+// rather than a changed value, so it is preserved. PostgreSQL 17.10 accepts
+// CREATE OR REPLACE TRIGGER even for a timing change, so a trigger needs no
+// legality test of its own.
+func reverseTriggerDiffs(triggerDiffs []types.TriggerDiff) []types.TriggerDiff {
+	reversed := make([]types.TriggerDiff, len(triggerDiffs))
+	for i, triggerDiff := range triggerDiffs {
+		reversed[i] = types.TriggerDiff{
+			TriggerName: triggerDiff.TriggerName,
+			TableName:   triggerDiff.TableName,
+			Changes:     reverseChangeMap(triggerDiff.Changes),
 		}
 	}
 	return reversed

--- a/migration/generator/reverse_diff_coverage_internal_test.go
+++ b/migration/generator/reverse_diff_coverage_internal_test.go
@@ -1,0 +1,401 @@
+package generator
+
+// White-box testing required: reverseSchemaDiffWithSchema is unexported, and
+// this gate has to build the reverse plan directly in order to observe which
+// input fields it actually reads. The exported API surfaces only rendered SQL,
+// which cannot tell "the builder ignored this field" apart from "the planner
+// rendered this field to nothing".
+
+import (
+	"reflect"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestReverseSchemaDiff_AccountsForEverySchemaDiffField is the gate issue #1287
+// asks for: it fails when a field is added to SchemaDiff and the reverse builder
+// does not handle it.
+//
+// The enumeration is by reflection on purpose. reverseSchemaDiffWithSchema
+// builds a fresh struct literal, and a literal is silent about the fields it
+// omits: nine of them -- views, materialized views and triggers -- were missing
+// for as long as those categories existed, so every rollback dropped them
+// without a word. The tests that were in place asserted the swap itself
+// (result.TablesAdded == input.TablesRemoved), which is a tautology that can
+// never notice an absent field, and a hand-written field list is exactly what
+// rotted.
+//
+// The property checked here is that every field REACHES the reverse plan:
+// zeroing one field of a fully populated diff must change the plan the builder
+// produces. A field the builder never reads leaves the plan identical, and the
+// subtest named after that field goes red.
+func TestReverseSchemaDiff_AccountsForEverySchemaDiffField(t *testing.T) {
+	c := qt.New(t)
+
+	schema, dbSchema := reverseCoverageContext()
+	baseline := reverseSchemaDiffWithSchema(reverseCoverageDiff(), schema, dbSchema)
+
+	diffType := reflect.TypeFor[types.SchemaDiff]()
+	c.Assert(diffType.NumField() > 0, qt.IsTrue,
+		qt.Commentf("reflection found no fields on SchemaDiff; the gate would pass vacuously"))
+
+	for i := range diffType.NumField() {
+		field := diffType.Field(i)
+		c.Run(field.Name, func(c *qt.C) {
+			withoutField := reverseCoverageDiff()
+			reflect.ValueOf(withoutField).Elem().Field(i).SetZero()
+
+			reversed := reverseSchemaDiffWithSchema(withoutField, schema, dbSchema)
+
+			c.Assert(reflect.DeepEqual(baseline, reversed), qt.IsFalse,
+				qt.Commentf(
+					"SchemaDiff.%s never reaches the reverse plan: zeroing it left the down plan "+
+						"byte-identical. Reverse it in reverseSchemaDiffWithSchema, or record there "+
+						"why the down direction cannot carry it -- and if a generic value cannot "+
+						"exercise it, give it an entry in reverseCoverageDiff.",
+					field.Name))
+		})
+	}
+}
+
+// TestReverseSchemaDiff_EveryModifiedCategoryReachesTheRenderedRollback is the
+// companion the gate above needs, and the one that would have caught the failure
+// it missed.
+//
+// Reaching the reversed SchemaDiff is not reaching the rollback. A field can be
+// swapped faithfully and still render nothing at all, and the "...Modified"
+// fields are where that happens: a modified object is not described by the diff,
+// it is re-rendered from the pre-change schema, which the planner finds BY NAME.
+// When the two sides spell the name differently the lookup misses, the category
+// renders nothing, and the file says "No rollback operations needed" while the
+// reflection gate above stays green. That is exactly what every modified view
+// outside the default schema did -- and every modified view at all on MySQL and
+// MariaDB, whose reader reports a schema for all of them (issue #1287).
+//
+// So this one renders. Each subtest plans a rollback whose ONLY populated field
+// is one modified category, and requires the down file to carry the prior
+// definition. Every object lives in a NAMED schema, because that is the spelling
+// the two sides disagree about and an unqualified fixture proves nothing here.
+//
+// The scope is the three categories issue #1287 put into the rollback. The other
+// "...Modified" fields -- tables, enums, functions, sequences, domains,
+// composite types, RLS policies, roles -- reached the rollback before this
+// change and are covered by their own tests; a rendered gate over all of them
+// wants a fixture that declares one of every object kind, which is worth
+// building and is not built here. The three names are read back off SchemaDiff
+// by reflection, so renaming a field breaks this test rather than quietly
+// emptying it.
+func TestReverseSchemaDiff_EveryModifiedCategoryReachesTheRenderedRollback(t *testing.T) {
+	c := qt.New(t)
+
+	schema, dbSchema := modifiedCategoryContext()
+	diffType := reflect.TypeFor[types.SchemaDiff]()
+
+	tests := []struct {
+		field string
+		diff  *types.SchemaDiff
+		wants string
+	}{
+		{
+			field: "ViewsModified",
+			diff: &types.SchemaDiff{ViewsModified: []types.ViewDiff{{
+				ViewName: modifiedCategoryView,
+				Changes:  map[string]string{"body": "old -> new"},
+			}}},
+			wants: modifiedCategoryPriorViewBody,
+		},
+		{
+			field: "MaterializedViewsModified",
+			diff: &types.SchemaDiff{MaterializedViewsModified: []types.MaterializedViewDiff{{
+				ViewName: modifiedCategoryMatView,
+				Changes:  map[string]string{"body": "old -> new"},
+			}}},
+			wants: modifiedCategoryPriorMatViewBody,
+		},
+		{
+			field: "TriggersModified",
+			diff: &types.SchemaDiff{TriggersModified: []types.TriggerDiff{{
+				TriggerName: modifiedCategoryTrigger,
+				TableName:   modifiedCategoryTable,
+				Changes:     map[string]string{"timing": "AFTER -> BEFORE"},
+			}}},
+			wants: modifiedCategoryTrigger,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.field, func(c *qt.C) {
+			_, exists := diffType.FieldByName(test.field)
+			c.Assert(exists, qt.IsTrue,
+				qt.Commentf("SchemaDiff has no field %s; this gate is naming something that moved", test.field))
+
+			downSQL, err := generateDownMigrationSQL(test.diff, schema, dbSchema, "postgres")
+			c.Assert(err, qt.IsNil)
+			downSQL = legacyRenderedSQL(downSQL)
+
+			c.Assert(downSQL, qt.Contains, test.wants,
+				qt.Commentf(
+					"SchemaDiff.%s reaches the reversed diff but not the rendered rollback. A "+
+						"modified object is re-rendered from the pre-change schema, which the "+
+						"planner finds by name, and that schema qualifies every name with %q.\n"+
+						"rendered:\n%s",
+					test.field, modifiedCategorySchema, downSQL))
+		})
+	}
+}
+
+// The fixture below is deliberately spelled the way the two sides really are: the
+// Go schema names each object bare, and the pre-change database reports it under
+// a schema, which is what dbschematogo qualifies it with.
+const (
+	modifiedCategorySchema           = "rev_reporting"
+	modifiedCategoryTable            = "rev_named_users"
+	modifiedCategoryView             = "rev_named_active"
+	modifiedCategoryMatView          = "rev_named_stats"
+	modifiedCategoryTrigger          = "rev_named_touch"
+	modifiedCategoryPriorViewBody    = "SELECT id FROM rev_named_users"
+	modifiedCategoryTargetViewBody   = "SELECT id, email FROM rev_named_users"
+	modifiedCategoryPriorMatViewBody = "SELECT count(*) AS total FROM rev_named_users"
+)
+
+func modifiedCategoryContext() (*goschema.Database, *dbschematypes.DBSchema) {
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "RevNamedUser", Name: modifiedCategoryTable}},
+		Fields: []goschema.Field{
+			{StructName: "RevNamedUser", Name: "id", Type: "BIGINT", Primary: true},
+			{StructName: "RevNamedUser", Name: "email", Type: "TEXT"},
+		},
+		Views: []goschema.View{
+			{StructName: "RevNamedActive", Name: modifiedCategoryView, Body: modifiedCategoryTargetViewBody},
+		},
+		MaterializedViews: []goschema.MaterializedView{{
+			StructName:      "RevNamedStats",
+			Name:            modifiedCategoryMatView,
+			Body:            "SELECT count(*) AS total FROM rev_named_users WHERE id > 0",
+			RefreshStrategy: "manual",
+		}},
+		Triggers: []goschema.Trigger{{
+			StructName: "RevNamedUser",
+			Name:       modifiedCategoryTrigger,
+			Table:      modifiedCategoryTable,
+			Timing:     "BEFORE",
+			Event:      "UPDATE",
+			ForEach:    "ROW",
+			Body:       "RETURN NEW;",
+		}},
+	}
+	goschema.Finalize(schema)
+
+	dbSchema := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name:   modifiedCategoryTable,
+			Schema: modifiedCategorySchema,
+			Type:   "TABLE",
+			Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true, OrdinalPosition: 1},
+				{Name: "email", DataType: "text", IsNullable: "NO", OrdinalPosition: 2},
+			},
+		}},
+		Views: []dbschematypes.DBView{
+			{Name: modifiedCategoryView, Schema: modifiedCategorySchema, Body: modifiedCategoryPriorViewBody},
+		},
+		MatViews: []dbschematypes.DBMatView{{
+			Name:            modifiedCategoryMatView,
+			Schema:          modifiedCategorySchema,
+			Body:            modifiedCategoryPriorMatViewBody,
+			RefreshStrategy: "manual",
+		}},
+		Triggers: []dbschematypes.DBTrigger{{
+			Name:    modifiedCategoryTrigger,
+			Table:   modifiedCategoryTable,
+			Schema:  modifiedCategorySchema,
+			Timing:  "AFTER",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    "RETURN NEW;",
+		}},
+	}
+	return schema, dbSchema
+}
+
+// TestReverseCoverageDiff_PopulatesEverySchemaDiffField guards the fixture the
+// gate above depends on. A field whose type the generic filler does not know how
+// to populate would arrive zero, the gate would compare two identical plans and
+// report the builder's omission as the fixture's -- so the fixture states its own
+// completeness separately.
+func TestReverseCoverageDiff_PopulatesEverySchemaDiffField(t *testing.T) {
+	c := qt.New(t)
+
+	populated := reflect.ValueOf(*reverseCoverageDiff())
+	diffType := populated.Type()
+
+	for i := range diffType.NumField() {
+		field := diffType.Field(i)
+		c.Run(field.Name, func(c *qt.C) {
+			c.Assert(populated.Field(i).IsZero(), qt.IsFalse,
+				qt.Commentf(
+					"reverseCoverageDiff left SchemaDiff.%s at its zero value; teach fillDistinctly "+
+						"about %s or set the field explicitly", field.Name, field.Type))
+		})
+	}
+}
+
+// reverseCoverageDiff returns a SchemaDiff with every field carrying a distinct
+// non-zero value.
+//
+// The bulk is filled generically from the field name so that a field added
+// tomorrow is populated without anyone touching this file. A few fields need
+// more than a generic value because the builder does not swap them: it rebuilds
+// them from the pre-change database, and a value that names no real constraint
+// would rebuild to nothing.
+func reverseCoverageDiff() *types.SchemaDiff {
+	diff := &types.SchemaDiff{}
+	fillDistinctly(reflect.ValueOf(diff).Elem(), "")
+
+	// ConstraintBackedIndexRemovals is the subset of IndexesRemoved whose object
+	// is a UNIQUE constraint of the same name on the same table, and
+	// reverseIndexRemovals reverses exactly that subset into constraint
+	// additions instead of index additions. A generic value satisfies neither
+	// half of that relation -- it names a removal no removal list holds and a
+	// constraint no host has -- so every removal falls through as an index
+	// addition and zeroing the field leaves the plan identical. The entry is
+	// therefore spelled out, and the same reference is appended to the removals
+	// it has to be a subset of; reverseCoverageContext introspects the UNIQUE
+	// constraint it names.
+	constraintBacked := types.IndexRef{Name: revCoverageUniqueName, TableName: revCoverageTable}
+	diff.IndexesRemoved = append(diff.IndexesRemoved, constraintBacked)
+	diff.ConstraintBackedIndexRemovals = []types.IndexRef{constraintBacked}
+
+	// reverseConstraintAdditions restores the prior body of each removed
+	// constraint from the introspected schema, so the entry has to name a
+	// constraint type it reconstructs and a host reverseCoverageContext has.
+	diff.ConstraintsRemovedWithTables = []types.ConstraintRemovalInfo{{
+		Name:      revCoverageCheckName,
+		TableName: revCoverageTable,
+		Type:      "CHECK",
+	}}
+	// reverseConstraintRemovals resolves each added constraint's owning table,
+	// and skips any addition that does not name one.
+	diff.ConstraintsAddedWithTables = []types.ConstraintAdditionInfo{{
+		Name:      revCoverageCheckName,
+		TableName: revCoverageTable,
+		Type:      "CHECK",
+	}}
+	// The planner refuses a snapshot that disagrees with the dialect it is
+	// planning for, so this one field cannot carry an invented value: a generic
+	// filler would make every rendered-rollback subtest fail on the same error
+	// instead of on the field it names.
+	postgresSemantics := identifier.ForDialect("postgres")
+	diff.IdentifierSemantics = &postgresSemantics
+	return diff
+}
+
+const (
+	revCoverageTable      = "rev_coverage_hosts"
+	revCoverageCheckName  = "rev_coverage_check"
+	revCoverageUniqueName = "rev_coverage_unique"
+)
+
+// reverseCoverageContext supplies the generated schema and the pre-change
+// database the reverse builder consults for the fields it derives rather than
+// swaps.
+func reverseCoverageContext() (*goschema.Database, *dbschematypes.DBSchema) {
+	checkClause := "id > 0"
+
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "RevCoverageHost", Name: revCoverageTable}},
+		Fields: []goschema.Field{{StructName: "RevCoverageHost", Name: "id", Type: "BIGINT", Primary: true}},
+		Constraints: []goschema.Constraint{{
+			StructName:      "RevCoverageHost",
+			Name:            revCoverageCheckName,
+			Table:           revCoverageTable,
+			Type:            "CHECK",
+			CheckExpression: checkClause,
+		}},
+	}
+	goschema.Finalize(schema)
+
+	dbSchema := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name: revCoverageTable,
+			Type: "TABLE",
+			Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true, OrdinalPosition: 1},
+			},
+		}},
+		Constraints: []dbschematypes.DBConstraint{
+			{
+				Name:        revCoverageCheckName,
+				TableName:   revCoverageTable,
+				Type:        "CHECK",
+				CheckClause: &checkClause,
+			},
+			// The UNIQUE constraint behind the constraint-backed index removal
+			// in reverseCoverageDiff. reverseIndexRemovals reads its columns to
+			// rebuild the ALTER TABLE ... ADD CONSTRAINT the rollback needs;
+			// without a body here the removal would fall back to an index
+			// addition and the field would look unreached.
+			{
+				Name:        revCoverageUniqueName,
+				TableName:   revCoverageTable,
+				Type:        "UNIQUE",
+				ColumnNames: []string{"id"},
+			},
+		},
+	}
+	return schema, dbSchema
+}
+
+// fillDistinctly writes a non-zero value derived from the field path into every
+// reachable leaf, so that two different fields never collide and a reversed
+// "old -> new" description is observably different from the original.
+//
+// A kind it does not know about is left at its zero value, which
+// TestReverseCoverageDiff_PopulatesEverySchemaDiffField turns into a failure
+// naming the field and its type.
+func fillDistinctly(value reflect.Value, label string) {
+	switch value.Kind() {
+	case reflect.String:
+		value.SetString(label)
+	case reflect.Bool:
+		value.SetBool(true)
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		value.SetInt(1)
+	case reflect.Pointer:
+		pointed := reflect.New(value.Type().Elem())
+		fillDistinctly(pointed.Elem(), label)
+		value.Set(pointed)
+	case reflect.Slice:
+		element := reflect.New(value.Type().Elem()).Elem()
+		fillDistinctly(element, label)
+		value.Set(reflect.Append(reflect.MakeSlice(value.Type(), 0, 1), element))
+	case reflect.Map:
+		key := reflect.New(value.Type().Key()).Elem()
+		fillDistinctly(key, label)
+		element := reflect.New(value.Type().Elem()).Elem()
+		// A change map records "old -> new"; giving the two sides different text
+		// is what makes a flipped map distinguishable from an unflipped one.
+		fillDistinctly(element, label+"_old -> "+label+"_new")
+		created := reflect.MakeMap(value.Type())
+		created.SetMapIndex(key, element)
+		value.Set(created)
+	case reflect.Struct:
+		structType := value.Type()
+		for i := range structType.NumField() {
+			fillDistinctly(value.Field(i), distinctLabel(label, structType.Field(i).Name))
+		}
+	}
+}
+
+func distinctLabel(parent, name string) string {
+	if parent == "" {
+		return name
+	}
+	return parent + "_" + name
+}

--- a/migration/generator/reverse_viewlike_down_live_internal_test.go
+++ b/migration/generator/reverse_viewlike_down_live_internal_test.go
@@ -1,0 +1,460 @@
+//go:build integration
+
+package generator
+
+// White-box testing required: the rollback under test is produced by the
+// unexported generateDownMigrationSQL from the unexported reverse plan builder.
+// Driving it through the exported GenerateMigration would write migration files
+// to disk and read them back, which adds a filesystem to a test whose subject is
+// what PostgreSQL accepts.
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"sort"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestReverseViewLikeObjects_DownRoundTrip_Integration is the live-database gate
+// for issue #1287. Rendering a rollback proves the statement exists, not that
+// PostgreSQL accepts it: the CREATE OR REPLACE VIEW an earlier attempt produced
+// renders perfectly and is refused at execution time for every column-list
+// change except a trailing append.
+//
+// Each case seeds the pre-up state through Ptah itself, applies the generated
+// up migration, applies the generated down migration, and then asserts two
+// things: that the down applied at all, and that the catalog it left behind is
+// the pre-up catalog. The table the objects hang off exists before and after
+// every case, so a DROP TABLE ... CASCADE can never be what removes them.
+func TestReverseViewLikeObjects_DownRoundTrip_Integration(t *testing.T) {
+	cases := []struct {
+		name   string
+		prior  func() *goschema.Database
+		target func() *goschema.Database
+		// downHas and downLacks pin the shape of the rollback where the shape is
+		// the point. The legality test reads the body PostgreSQL hands back
+		// through pg_get_viewdef, which spells the same projection differently
+		// from the annotation ("SELECT id" comes back as " SELECT id\n FROM t;"),
+		// so these assertions are what prove the decision survives the catalog's
+		// own spelling rather than only the hand-written fixtures'.
+		downHas   []string
+		downLacks []string
+		// upLacks pins the shape of the FORWARD plan. The same modify step
+		// serves both directions, and a statement that is merely wasteful on a
+		// rollback can be destructive going forward.
+		upLacks []string
+	}{
+		{
+			name:      "up creates the view, materialized view and trigger",
+			prior:     func() *goschema.Database { return revIntSchema(revIntOptions{}) },
+			target:    func() *goschema.Database { return revIntSchema(revIntOptions{objects: true}) },
+			downHas:   []string{"DROP VIEW IF EXISTS", "DROP MATERIALIZED VIEW IF EXISTS", "DROP TRIGGER IF EXISTS"},
+			downLacks: []string{"DROP TABLE"},
+		},
+		{
+			name:      "up drops the view, materialized view and trigger",
+			prior:     func() *goschema.Database { return revIntSchema(revIntOptions{objects: true}) },
+			target:    func() *goschema.Database { return revIntSchema(revIntOptions{}) },
+			downHas:   []string{"CREATE VIEW", "CREATE MATERIALIZED VIEW", "CREATE TRIGGER"},
+			downLacks: []string{"DROP TABLE"},
+		},
+		{
+			name:  "up appends a column to the view",
+			prior: func() *goschema.Database { return revIntSchema(revIntOptions{objects: true}) },
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:  true,
+					viewBody: "SELECT id, email FROM " + revIntTable,
+				})
+			},
+			// Taking the column away again is what PostgreSQL refuses with
+			// "cannot drop columns from view", so the rollback must not replace.
+			downHas:   []string{"DROP VIEW IF EXISTS " + revIntView + " CASCADE"},
+			downLacks: []string{"CREATE OR REPLACE VIEW"},
+		},
+		{
+			name:  "up changes only the view predicate",
+			prior: func() *goschema.Database { return revIntSchema(revIntOptions{objects: true}) },
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:  true,
+					viewBody: "SELECT id FROM " + revIntTable + " WHERE id > 10",
+				})
+			},
+			// The column list never moved, so the rollback keeps the replace and
+			// its dependents.
+			downHas:   []string{"CREATE OR REPLACE VIEW " + revIntView},
+			downLacks: []string{"DROP VIEW"},
+		},
+		{
+			name:  "up rewrites the materialized view and the trigger",
+			prior: func() *goschema.Database { return revIntSchema(revIntOptions{objects: true}) },
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:     true,
+					matViewBody: "SELECT count(id) AS total FROM " + revIntTable,
+					triggerBody: "NEW.email = lower(NEW.email); RETURN NEW;",
+				})
+			},
+			downHas: []string{
+				"DROP MATERIALIZED VIEW IF EXISTS " + revIntMatView + " CASCADE",
+				"CREATE MATERIALIZED VIEW " + revIntMatView,
+				"CREATE OR REPLACE TRIGGER " + revIntTrigger,
+			},
+		},
+		{
+			// The forward direction of a body the legality parser cannot read.
+			// A WITH prefix hides the projection, so nothing can be proved about
+			// the change -- but the edit here is predicate-only, PostgreSQL
+			// accepts the replace, and the declared dependent view survives it.
+			// Dropping the view instead applies cleanly and leaves the database
+			// short of the schema it was generated from, which step 6 catches.
+			name: "up changes only the predicate inside a WITH view that has a dependent",
+			prior: func() *goschema.Database {
+				return revIntSchema(revIntOptions{objects: true, dependent: true, viewBody: revIntWithBody})
+			},
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:   true,
+					dependent: true,
+					viewBody:  revIntWithBodyFiltered,
+				})
+			},
+			upLacks: []string{"DROP VIEW"},
+			// The rollback cannot afford the undecidable answer, so it drops --
+			// and then rebuilds the dependent the CASCADE took with it.
+			downHas:   []string{"DROP VIEW IF EXISTS " + revIntView + " CASCADE", "VIEW " + revIntDepView + " AS"},
+			downLacks: []string{"DROP TABLE"},
+		},
+		{
+			// The rollback the select-list comparison got wrong. The up swaps the
+			// relation under a column whose name does not change, and the two
+			// relations type that column differently; a rollback that puts the
+			// prior body back with CREATE OR REPLACE VIEW is refused with
+			// "cannot change data type of view column", which step 3 executes.
+			name: "up swaps the relation under a shared column",
+			prior: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:   true,
+					altTable:  true,
+					viewBody:  "SELECT id, email FROM " + revIntTable,
+					matView:   false,
+					noTrigger: true,
+				})
+			},
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:   true,
+					altTable:  true,
+					viewBody:  "SELECT id FROM " + revIntAltTable,
+					matView:   false,
+					noTrigger: true,
+				})
+			},
+			downHas:   []string{"DROP VIEW IF EXISTS " + revIntView + " CASCADE"},
+			downLacks: []string{"CREATE OR REPLACE VIEW"},
+		},
+		{
+			// The cascade rebuild list decides who else the plan touches, and it
+			// reads the code of the declared bodies rather than their raw text.
+			// A materialized view that only spells the dropped view's name inside
+			// a string literal reads no view at all; naming it here means
+			// DROP MATERIALIZED VIEW ... CASCADE against an object the migration
+			// never touched, which on PostgreSQL 17.10 took a hand-made dependent
+			// view, a unique index and a GRANT with it.
+			name: "up appends a column while a materialized view only names the view in a literal",
+			prior: func() *goschema.Database {
+				return revIntSchema(revIntOptions{objects: true, matViewBody: revIntLabelMatViewBody})
+			},
+			target: func() *goschema.Database {
+				return revIntSchema(revIntOptions{
+					objects:     true,
+					viewBody:    "SELECT id, email FROM " + revIntTable,
+					matViewBody: revIntLabelMatViewBody,
+				})
+			},
+			downHas:   []string{"DROP VIEW IF EXISTS " + revIntView + " CASCADE"},
+			downLacks: []string{"MATERIALIZED VIEW " + revIntMatView},
+		},
+	}
+
+	url := revIntRequireURL(t)
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			conn := revIntConnect(t, url)
+			revIntDropAll(conn)
+			t.Cleanup(func() { revIntDropAll(conn) })
+
+			// 1. Install the pre-up state with Ptah's own planner, so the bodies
+			//    in the catalog are the ones Ptah writes rather than a hand-typed
+			//    approximation of them.
+			prior := tc.prior()
+			seedDiff := schemadiff.CompareWithDialect(prior, &dbschematypes.DBSchema{}, "postgres")
+			seedSQL, err := generateUpMigrationSQL(seedDiff, prior, "postgres")
+			c.Assert(err, qt.IsNil)
+			execScript(c, conn, seedSQL, "SEED")
+
+			dbPrior, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			priorCatalog := revIntCatalog(dbPrior)
+
+			// 2. The up migration under test.
+			target := tc.target()
+			upDiff := schemadiff.CompareWithDialect(target, dbPrior, "postgres")
+			c.Assert(upDiff.HasChanges(), qt.IsTrue, qt.Commentf("the up migration must have something to do"))
+
+			upSQL, err := generateUpMigrationSQL(upDiff, target, "postgres")
+			c.Assert(err, qt.IsNil)
+			unquotedUp := legacyRenderedSQL(upSQL)
+			for _, fragment := range tc.upLacks {
+				c.Assert(unquotedUp, qt.Not(qt.Contains), fragment, qt.Commentf("up SQL:\n%s", upSQL))
+			}
+			execScript(c, conn, upSQL, "UP")
+
+			dbAfterUp, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			c.Assert(revIntCatalog(dbAfterUp), qt.Not(qt.DeepEquals), priorCatalog,
+				qt.Commentf("the up migration must actually change the catalog, or the down proves nothing"))
+
+			// 2b. Applying cleanly is not the same as arriving. Every object the
+			//     target declares has to be in the catalog afterwards -- a plan
+			//     that drops a dependent it never rebuilds exits 0 and leaves the
+			//     database short of the schema it was generated from.
+			c.Assert(revIntMissingObjects(target, dbAfterUp), qt.HasLen, 0,
+				qt.Commentf("up SQL:\n%s", upSQL))
+
+			// 3. THE GATE. The down is generated exactly as the generator does it,
+			//    and applying it must not error. A CREATE OR REPLACE VIEW that
+			//    removes or renames a column fails right here.
+			downSQL, err := generateDownMigrationSQL(upDiff, target, dbPrior, "postgres")
+			c.Assert(err, qt.IsNil)
+			unquotedDown := legacyRenderedSQL(downSQL)
+			for _, fragment := range tc.downHas {
+				c.Assert(unquotedDown, qt.Contains, fragment, qt.Commentf("down SQL:\n%s", downSQL))
+			}
+			for _, fragment := range tc.downLacks {
+				c.Assert(unquotedDown, qt.Not(qt.Contains), fragment, qt.Commentf("down SQL:\n%s", downSQL))
+			}
+			execScript(c, conn, downSQL, "DOWN")
+
+			// 4. The rollback has to land on the pre-up catalog, not merely apply.
+			dbAfterDown, err := conn.Reader().ReadSchema()
+			c.Assert(err, qt.IsNil)
+			c.Assert(revIntCatalog(dbAfterDown), qt.DeepEquals, priorCatalog,
+				qt.Commentf("down SQL:\n%s", downSQL))
+
+			// 5. And the table the objects hang off must have survived untouched.
+			c.Assert(revIntHasTable(dbAfterDown), qt.IsTrue,
+				qt.Commentf("the rollback must not have taken the pre-existing table with it"))
+		})
+	}
+}
+
+// revIntRequireURL and revIntConnect keep the two skip decisions out of the
+// test body: an absent POSTGRES_URL and an unreachable server are environment
+// facts, not branches of the behavior under test.
+func revIntRequireURL(t *testing.T) string {
+	t.Helper()
+	url := os.Getenv("POSTGRES_URL")
+	if url == "" {
+		t.Skip("skipping reverse view-like down round trip: POSTGRES_URL not set")
+	}
+	return url
+}
+
+func revIntConnect(t *testing.T, url string) *dbschema.DatabaseConnection {
+	t.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), url)
+	if err != nil {
+		t.Skipf("skipping reverse view-like down round trip: cannot connect: %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+const (
+	revIntTable    = "ptah_rev_view_users"
+	revIntAltTable = "ptah_rev_alt_users"
+	revIntView     = "ptah_rev_active_users"
+	revIntDepView  = "ptah_rev_active_ids"
+	revIntMatView  = "ptah_rev_user_stats"
+	revIntTrigger  = "ptah_rev_touch"
+	revIntViewBody = "SELECT id FROM " + revIntTable
+	// revIntWithBody and revIntWithBodyFiltered differ only in the predicate
+	// inside the CTE, so the column list never moves and PostgreSQL accepts
+	// CREATE OR REPLACE VIEW between them -- while the WITH prefix keeps the
+	// legality parser from being able to say so.
+	revIntWithBody         = "WITH src AS (SELECT id, email FROM " + revIntTable + ") SELECT id, email FROM src"
+	revIntWithBodyFiltered = "WITH src AS (SELECT id, email FROM " + revIntTable +
+		" WHERE id > 1) SELECT id, email FROM src"
+	revIntDepViewBody = "SELECT id FROM " + revIntView
+	revIntMatViewBody = "SELECT count(*) AS total FROM " + revIntTable
+	// revIntLabelMatViewBody spells the view's name and reads none of it. The
+	// cascade rebuild list has to tell those apart, because every name on it is
+	// answered with a DROP MATERIALIZED VIEW ... CASCADE. The cast is written
+	// out because PostgreSQL adds it when it reads the body back, and a body
+	// that does not round-trip would land in MaterializedViewsModified on its
+	// own and prove nothing about the rebuild list.
+	revIntLabelMatViewBody = "SELECT '" + revIntView + "'::text AS label, count(*) AS total FROM " + revIntTable
+	revIntTriggerBody      = "NEW.email = NEW.email; RETURN NEW;"
+)
+
+type revIntOptions struct {
+	objects     bool
+	viewBody    string
+	matViewBody string
+	triggerBody string
+	// dependent declares a second view reading the first, which is what
+	// DROP VIEW ... CASCADE takes and what the plan then has to put back.
+	dependent bool
+	// altTable declares a second table typing "id" differently, so a view can
+	// be moved from one to the other without its column names changing.
+	altTable bool
+	// matView and noTrigger trim the fixture where a case is about the view
+	// alone and the other objects would only add noise to the catalog compare.
+	matView   bool
+	noTrigger bool
+}
+
+func revIntSchema(opts revIntOptions) *goschema.Database {
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "RevIntUser", Name: revIntTable}},
+		Fields: []goschema.Field{
+			{StructName: "RevIntUser", Name: "id", Type: "BIGINT", Primary: true},
+			{StructName: "RevIntUser", Name: "email", Type: "TEXT", Nullable: true},
+		},
+	}
+	if opts.altTable {
+		schema.Tables = append(schema.Tables, goschema.Table{StructName: "RevIntAltUser", Name: revIntAltTable})
+		schema.Fields = append(schema.Fields,
+			goschema.Field{StructName: "RevIntAltUser", Name: "id", Type: "TEXT", Primary: true},
+			goschema.Field{StructName: "RevIntAltUser", Name: "email", Type: "TEXT", Nullable: true},
+		)
+	}
+	if opts.objects {
+		schema.Views = []goschema.View{{
+			StructName: "RevIntActiveUsers",
+			Name:       revIntView,
+			Body:       cmp.Or(opts.viewBody, revIntViewBody),
+		}}
+		if opts.dependent {
+			schema.Views = append(schema.Views, goschema.View{
+				StructName: "RevIntActiveIDs",
+				Name:       revIntDepView,
+				Body:       revIntDepViewBody,
+			})
+		}
+		if !opts.noTrigger {
+			schema.Triggers = []goschema.Trigger{{
+				StructName: "RevIntUser",
+				Name:       revIntTrigger,
+				Table:      revIntTable,
+				Timing:     "BEFORE",
+				Event:      "UPDATE",
+				ForEach:    "ROW",
+				Body:       cmp.Or(opts.triggerBody, revIntTriggerBody),
+			}}
+		}
+		if !opts.noTrigger || opts.matView {
+			schema.MaterializedViews = []goschema.MaterializedView{{
+				StructName:      "RevIntUserStats",
+				Name:            revIntMatView,
+				Body:            cmp.Or(opts.matViewBody, revIntMatViewBody),
+				RefreshStrategy: "manual",
+			}}
+		}
+	}
+	goschema.Finalize(schema)
+	return schema
+}
+
+// revIntMissingObjects names the view-like objects a schema declares that the
+// catalog does not hold. An empty result is what "the migration arrived" means;
+// a non-empty one is a plan that applied and still left work undone.
+func revIntMissingObjects(schema *goschema.Database, db *dbschematypes.DBSchema) []string {
+	var missing []string
+	for _, view := range schema.Views {
+		if !slices.ContainsFunc(db.Views, func(candidate dbschematypes.DBView) bool {
+			return candidate.Name == view.Name
+		}) {
+			missing = append(missing, "view "+view.Name)
+		}
+	}
+	for _, view := range schema.MaterializedViews {
+		if !slices.ContainsFunc(db.MatViews, func(candidate dbschematypes.DBMatView) bool {
+			return candidate.Name == view.Name
+		}) {
+			missing = append(missing, "matview "+view.Name)
+		}
+	}
+	for _, trigger := range schema.Triggers {
+		if !slices.ContainsFunc(db.Triggers, func(candidate dbschematypes.DBTrigger) bool {
+			return candidate.Name == trigger.Name
+		}) {
+			missing = append(missing, "trigger "+trigger.Name)
+		}
+	}
+	return missing
+}
+
+// revIntCatalog reduces the introspected schema to the view-like objects this
+// test governs, so a mismatch names the object rather than dumping a whole
+// schema.
+func revIntCatalog(db *dbschematypes.DBSchema) []string {
+	var lines []string
+	for _, view := range db.Views {
+		lines = append(lines, fmt.Sprintf("view %s = %s", view.Name, revIntNormalize(view.Body)))
+	}
+	for _, view := range db.MatViews {
+		lines = append(lines, fmt.Sprintf("matview %s = %s", view.Name, revIntNormalize(view.Body)))
+	}
+	for _, trigger := range db.Triggers {
+		lines = append(lines, fmt.Sprintf("trigger %s on %s = %s %s %s / %s",
+			trigger.Name, trigger.Table, trigger.Timing, trigger.Event, trigger.ForEach,
+			revIntNormalize(trigger.Body)))
+	}
+	for _, function := range db.Functions {
+		lines = append(lines, fmt.Sprintf("function %s = %s", function.Name, revIntNormalize(function.Body)))
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+func revIntNormalize(body string) string {
+	return strings.Join(strings.Fields(body), " ")
+}
+
+func revIntHasTable(db *dbschematypes.DBSchema) bool {
+	return slices.ContainsFunc(db.Tables, func(table dbschematypes.DBTable) bool {
+		return table.Name == revIntTable
+	})
+}
+
+func revIntDropAll(conn *dbschema.DatabaseConnection) {
+	statements := []string{
+		"DROP VIEW IF EXISTS " + revIntDepView + " CASCADE",
+		"DROP VIEW IF EXISTS " + revIntView + " CASCADE",
+		"DROP MATERIALIZED VIEW IF EXISTS " + revIntMatView + " CASCADE",
+		"DROP TRIGGER IF EXISTS " + revIntTrigger + " ON " + revIntTable + " CASCADE",
+		"DROP TABLE IF EXISTS " + revIntTable + " CASCADE",
+		"DROP TABLE IF EXISTS " + revIntAltTable + " CASCADE",
+		"DROP FUNCTION IF EXISTS ptah_trigger_" + revIntTable + "_" + revIntTrigger + "() CASCADE",
+	}
+	for _, statement := range statements {
+		_, _ = conn.Exec(statement)
+	}
+}

--- a/migration/generator/reverse_viewlike_internal_test.go
+++ b/migration/generator/reverse_viewlike_internal_test.go
@@ -1,0 +1,370 @@
+package generator
+
+// White-box testing required: the reverse plan is built by the unexported
+// reverseSchemaDiffWithSchema and rendered by the unexported
+// generateDownMigrationSQL. Asserting on the reversed SchemaDiff alone would
+// only restate the swap; these tests need the rendered down SQL, which is not
+// reachable through the exported GenerateMigration API without writing
+// migration files to disk and reading them back.
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// indexOfFragment reports where a fragment starts, so an ordering assertion can
+// be written as a comparison rather than as control flow in a test body.
+func indexOfFragment(sql, fragment string) int {
+	return strings.Index(sql, fragment)
+}
+
+// viewLikeTable is the table both the view-like objects and the trigger hang
+// off. It exists in the database before and after every case below, so a
+// DROP TABLE ... CASCADE can never be what removes the view, the materialized
+// view or the trigger: the down migration has to name them itself.
+func viewLikeTable() goschema.Table {
+	return goschema.Table{StructName: "RevViewUser", Name: "rev_view_users"}
+}
+
+func viewLikeFields() []goschema.Field {
+	return []goschema.Field{
+		{StructName: "RevViewUser", Name: "id", Type: "BIGINT", Primary: true},
+		{StructName: "RevViewUser", Name: "email", Type: "TEXT"},
+	}
+}
+
+func viewLikeDBWithTableOnly() *dbschematypes.DBSchema {
+	return &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{
+				Name: "rev_view_users",
+				Type: "TABLE",
+				Columns: []dbschematypes.DBColumn{
+					{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true, OrdinalPosition: 1},
+					{Name: "email", DataType: "text", IsNullable: "NO", OrdinalPosition: 2},
+				},
+			},
+		},
+	}
+}
+
+func viewLikeGoSchemaWithObjects(viewBody, matViewBody, triggerBody string) *goschema.Database {
+	schema := &goschema.Database{
+		Tables: []goschema.Table{viewLikeTable()},
+		Fields: viewLikeFields(),
+		Views: []goschema.View{
+			{StructName: "RevActiveUsers", Name: "rev_active_users", Body: viewBody},
+		},
+		MaterializedViews: []goschema.MaterializedView{
+			{
+				StructName:      "RevUserStats",
+				Name:            "rev_user_stats",
+				Body:            matViewBody,
+				RefreshStrategy: "manual",
+			},
+		},
+		Triggers: []goschema.Trigger{
+			{
+				StructName: "RevViewUser",
+				Name:       "rev_touch",
+				Table:      "rev_view_users",
+				Timing:     "BEFORE",
+				Event:      "UPDATE",
+				ForEach:    "ROW",
+				Body:       triggerBody,
+			},
+		},
+	}
+	goschema.Finalize(schema)
+	return schema
+}
+
+func viewLikeDBWithObjects(viewBody, matViewBody, triggerBody string) *dbschematypes.DBSchema {
+	db := viewLikeDBWithTableOnly()
+	db.Views = []dbschematypes.DBView{
+		{Name: "rev_active_users", Body: viewBody},
+	}
+	db.MatViews = []dbschematypes.DBMatView{
+		{Name: "rev_user_stats", Body: matViewBody, RefreshStrategy: "manual"},
+	}
+	db.Triggers = []dbschematypes.DBTrigger{
+		{
+			Name:    "rev_touch",
+			Table:   "rev_view_users",
+			Timing:  "BEFORE",
+			Event:   "UPDATE",
+			ForEach: "ROW",
+			Body:    triggerBody,
+		},
+	}
+	return db
+}
+
+const (
+	revViewBody    = "SELECT id FROM rev_view_users"
+	revMatViewBody = "SELECT count(*) FROM rev_view_users"
+	revTriggerBody = "RETURN NEW;"
+)
+
+// TestGenerateDownMigrationSQL_DropsViewLikeObjectsCreatedByUp pins the first
+// half of issue #1287: an up migration that creates a view, a materialized view
+// and a trigger on an already-existing table must roll back by dropping all
+// three. Before the reverse plan carried these categories, the down file was
+// "-- No rollback operations needed" and every object survived the rollback.
+func TestGenerateDownMigrationSQL_DropsViewLikeObjectsCreatedByUp(t *testing.T) {
+	c := qt.New(t)
+
+	schema := viewLikeGoSchemaWithObjects(revViewBody, revMatViewBody, revTriggerBody)
+	db := viewLikeDBWithTableOnly()
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+
+	c.Assert(upDiff.ViewsAdded, qt.DeepEquals, []string{"rev_active_users"})
+	c.Assert(upDiff.MaterializedViewsAdded, qt.DeepEquals, []string{"rev_user_stats"})
+	c.Assert(upDiff.TriggersAdded, qt.DeepEquals, []types.TriggerRef{
+		{TriggerName: "rev_touch", TableName: "rev_view_users"},
+	})
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
+
+	wants := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "drops the view", fragment: "DROP VIEW IF EXISTS rev_active_users CASCADE;"},
+		{name: "drops the materialized view", fragment: "DROP MATERIALIZED VIEW IF EXISTS rev_user_stats CASCADE;"},
+		{name: "drops the trigger", fragment: "DROP TRIGGER IF EXISTS rev_touch ON rev_view_users CASCADE;"},
+		{name: "drops the trigger function", fragment: "DROP FUNCTION IF EXISTS ptah_trigger_rev_view_users_rev_touch();"},
+	}
+
+	for _, want := range wants {
+		c.Run(want.name, func(c *qt.C) {
+			c.Assert(downSQL, qt.Contains, want.fragment)
+		})
+	}
+
+	// The table pre-existed the up migration, so the rollback must not drop it.
+	c.Assert(downSQL, qt.Not(qt.Contains), "DROP TABLE")
+}
+
+// TestGenerateDownMigrationSQL_RestoresViewLikeObjectsDroppedByUp pins the
+// other direction: an up migration that drops a view, a materialized view and a
+// trigger present only in the database must roll back by recreating all three
+// from the pre-change database schema.
+func TestGenerateDownMigrationSQL_RestoresViewLikeObjectsDroppedByUp(t *testing.T) {
+	c := qt.New(t)
+
+	schema := &goschema.Database{
+		Tables: []goschema.Table{viewLikeTable()},
+		Fields: viewLikeFields(),
+	}
+	goschema.Finalize(schema)
+	db := viewLikeDBWithObjects(revViewBody, revMatViewBody, revTriggerBody)
+
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+
+	c.Assert(upDiff.ViewsRemoved, qt.DeepEquals, []string{"rev_active_users"})
+	c.Assert(upDiff.MaterializedViewsRemoved, qt.DeepEquals, []string{"rev_user_stats"})
+	c.Assert(upDiff.TriggersRemoved, qt.DeepEquals, []types.TriggerRef{
+		{TriggerName: "rev_touch", TableName: "rev_view_users"},
+	})
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
+
+	wants := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "recreates the view", fragment: "CREATE VIEW rev_active_users AS"},
+		{name: "recreates the view body", fragment: revViewBody},
+		{name: "recreates the materialized view", fragment: "CREATE MATERIALIZED VIEW rev_user_stats AS"},
+		{name: "recreates the trigger function", fragment: "CREATE OR REPLACE FUNCTION ptah_trigger_rev_view_users_rev_touch()"},
+		{name: "recreates the trigger", fragment: "CREATE TRIGGER rev_touch BEFORE UPDATE ON rev_view_users"},
+	}
+
+	for _, want := range wants {
+		c.Run(want.name, func(c *qt.C) {
+			c.Assert(downSQL, qt.Contains, want.fragment)
+		})
+	}
+}
+
+// TestGenerateDownMigrationSQL_ModifiedViewRollbackDropsInsteadOfReplacing is
+// the trap issue #1287 names. The up migration appends a column to the view;
+// the rollback has to take it away again, and PostgreSQL refuses
+// "CREATE OR REPLACE VIEW" that drops a column ("cannot drop columns from
+// view", measured on 17.10). The down plan therefore has to drop and recreate
+// the view, and it has to do so from inside the modify step: done from outside,
+// the reverse plan comes out create-then-drop and leaves no view at all.
+func TestGenerateDownMigrationSQL_ModifiedViewRollbackDropsInsteadOfReplacing(t *testing.T) {
+	c := qt.New(t)
+
+	const oldBody = "SELECT id FROM rev_view_users"
+	const newBody = "SELECT id, email FROM rev_view_users"
+
+	schema := viewLikeGoSchemaWithObjects(newBody, revMatViewBody, revTriggerBody)
+	db := viewLikeDBWithObjects(oldBody, revMatViewBody, revTriggerBody)
+
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+	c.Assert(upDiff.ViewsModified, qt.HasLen, 1)
+	c.Assert(upDiff.ViewsModified[0].ViewName, qt.Equals, "rev_active_users")
+
+	upSQL, err := generateUpMigrationSQL(upDiff, schema, "postgres")
+	c.Assert(err, qt.IsNil)
+	// Appending a trailing column is the one shape PostgreSQL does accept, so
+	// the up direction keeps the dependency-preserving replace.
+	c.Assert(legacyRenderedSQL(upSQL), qt.Contains, "CREATE OR REPLACE VIEW rev_active_users")
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
+
+	wants := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "drops the view first", fragment: "DROP VIEW IF EXISTS rev_active_users CASCADE;"},
+		{name: "recreates it with the prior body", fragment: "CREATE VIEW rev_active_users AS"},
+		{name: "restores the prior column list", fragment: oldBody},
+	}
+	for _, want := range wants {
+		c.Run(want.name, func(c *qt.C) {
+			c.Assert(downSQL, qt.Contains, want.fragment)
+		})
+	}
+
+	c.Run("never emits the refused replace", func(c *qt.C) {
+		c.Assert(downSQL, qt.Not(qt.Contains), "CREATE OR REPLACE VIEW rev_active_users")
+	})
+	c.Run("drops before it recreates", func(c *qt.C) {
+		c.Assert(indexOfFragment(downSQL, "DROP VIEW IF EXISTS rev_active_users") <
+			indexOfFragment(downSQL, "CREATE VIEW rev_active_users"), qt.IsTrue,
+			qt.Commentf("down SQL:\n%s", downSQL))
+	})
+	c.Run("does not carry the post-up body", func(c *qt.C) {
+		c.Assert(downSQL, qt.Not(qt.Contains), newBody)
+	})
+}
+
+// TestGenerateDownMigrationSQL_ModifiedViewKeepsLegalReplace is the other half
+// of the same rule. A predicate-only change leaves the column list untouched,
+// PostgreSQL accepts the replace, and the replace is worth keeping: the drop
+// carries CASCADE and would take dependent objects with it.
+func TestGenerateDownMigrationSQL_ModifiedViewKeepsLegalReplace(t *testing.T) {
+	c := qt.New(t)
+
+	const oldBody = "SELECT id FROM rev_view_users WHERE id > 0"
+	const newBody = "SELECT id FROM rev_view_users WHERE id > 10"
+
+	schema := viewLikeGoSchemaWithObjects(newBody, revMatViewBody, revTriggerBody)
+	db := viewLikeDBWithObjects(oldBody, revMatViewBody, revTriggerBody)
+
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+	c.Assert(upDiff.ViewsModified, qt.HasLen, 1)
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
+
+	c.Run("replaces in place", func(c *qt.C) {
+		c.Assert(downSQL, qt.Contains, "CREATE OR REPLACE VIEW rev_active_users")
+	})
+	c.Run("restores the prior predicate", func(c *qt.C) {
+		c.Assert(downSQL, qt.Contains, oldBody)
+	})
+	c.Run("keeps dependents by not dropping", func(c *qt.C) {
+		c.Assert(downSQL, qt.Not(qt.Contains), "DROP VIEW")
+	})
+}
+
+// TestGenerateDownMigrationSQL_ModifiedMatViewAndTriggerRollback covers the two
+// remaining modified categories. A materialized view has no in-place replace at
+// all, so both directions drop and recreate it; a trigger does, and PostgreSQL
+// accepts CREATE OR REPLACE TRIGGER even for a timing change (measured on
+// 17.10), so the trigger keeps the replace.
+func TestGenerateDownMigrationSQL_ModifiedMatViewAndTriggerRollback(t *testing.T) {
+	c := qt.New(t)
+
+	const oldMatView = "SELECT count(*) FROM rev_view_users"
+	const newMatView = "SELECT count(id) FROM rev_view_users"
+	const oldTrigger = "RETURN NEW;"
+	const newTrigger = "RETURN OLD;"
+
+	schema := viewLikeGoSchemaWithObjects(revViewBody, newMatView, newTrigger)
+	db := viewLikeDBWithObjects(revViewBody, oldMatView, oldTrigger)
+
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+	c.Assert(upDiff.MaterializedViewsModified, qt.HasLen, 1)
+	c.Assert(upDiff.TriggersModified, qt.HasLen, 1)
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+	downSQL = legacyRenderedSQL(downSQL)
+
+	wants := []struct {
+		name     string
+		fragment string
+	}{
+		{name: "drops the materialized view", fragment: "DROP MATERIALIZED VIEW IF EXISTS rev_user_stats CASCADE;"},
+		{name: "recreates the materialized view", fragment: "CREATE MATERIALIZED VIEW rev_user_stats AS"},
+		{name: "restores the prior materialized body", fragment: oldMatView},
+		{name: "replaces the trigger function", fragment: "CREATE OR REPLACE FUNCTION ptah_trigger_rev_view_users_rev_touch()"},
+		{name: "restores the prior trigger body", fragment: oldTrigger},
+	}
+	for _, want := range wants {
+		c.Run(want.name, func(c *qt.C) {
+			c.Assert(downSQL, qt.Contains, want.fragment)
+		})
+	}
+}
+
+// TestReverseSchemaDiff_ReversesViewLikeChangeDescriptions checks the recorded
+// change descriptions read truthfully in the down direction. The planner does
+// not consume this map, but the diff is serialized into reports, so an
+// unreversed "old -> new" would describe the up migration on a down plan.
+func TestReverseSchemaDiff_ReversesViewLikeChangeDescriptions(t *testing.T) {
+	c := qt.New(t)
+
+	input := &types.SchemaDiff{
+		ViewsModified: []types.ViewDiff{
+			{ViewName: "v", Changes: map[string]string{"body": "OLD -> NEW"}},
+		},
+		MaterializedViewsModified: []types.MaterializedViewDiff{
+			{ViewName: "mv", Changes: map[string]string{"body": "OLD -> NEW"}},
+		},
+		TriggersModified: []types.TriggerDiff{
+			{TriggerName: "trg", TableName: "t", Changes: map[string]string{"timing": "BEFORE -> AFTER"}},
+		},
+	}
+
+	result := reverseSchemaDiff(input)
+
+	c.Run("view identity is preserved and the change is flipped", func(c *qt.C) {
+		c.Assert(result.ViewsModified, qt.HasLen, 1)
+		c.Assert(result.ViewsModified[0].ViewName, qt.Equals, "v")
+		c.Assert(result.ViewsModified[0].Changes["body"], qt.Equals, "NEW -> OLD")
+	})
+
+	c.Run("materialized view identity is preserved and the change is flipped", func(c *qt.C) {
+		c.Assert(result.MaterializedViewsModified, qt.HasLen, 1)
+		c.Assert(result.MaterializedViewsModified[0].ViewName, qt.Equals, "mv")
+		c.Assert(result.MaterializedViewsModified[0].Changes["body"], qt.Equals, "NEW -> OLD")
+	})
+
+	c.Run("trigger identity including its table is preserved", func(c *qt.C) {
+		c.Assert(result.TriggersModified, qt.HasLen, 1)
+		c.Assert(result.TriggersModified[0].TriggerName, qt.Equals, "trg")
+		c.Assert(result.TriggersModified[0].TableName, qt.Equals, "t")
+		c.Assert(result.TriggersModified[0].Changes["timing"], qt.Equals, "AFTER -> BEFORE")
+	})
+}

--- a/migration/generator/reverse_viewlike_named_schema_internal_test.go
+++ b/migration/generator/reverse_viewlike_named_schema_internal_test.go
@@ -1,0 +1,80 @@
+package generator
+
+// White-box testing required: the rollback under test is produced by the
+// unexported generateDownMigrationSQL from the unexported reverse plan builder,
+// and the point of the test is what the down SQL says, which the exported
+// GenerateMigration API only surfaces by writing files to disk.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestGenerateDownMigrationSQL_RestoresModifiedViewInANamedSchema pins the
+// rollback of a modified view whose database side carries a schema name.
+//
+// Reaching the reverse diff is not the same as reaching the plan. The diff
+// records a view by the name the Go schema spells, while the pre-change database
+// schema the down direction plans against names it "<schema>.<view>"
+// (dbschematypes.DBView.QualifiedName, applied by internal/convert/dbschematogo).
+// A planner that compared those two strings found nothing for a view read from
+// any named schema, and the modified entry rendered nothing at all -- the whole
+// category rolled back to "No rollback operations needed" while the reflection
+// gate stayed green, because that gate asserts the field reaches the reversed
+// SchemaDiff and stops there.
+//
+// This is not a PostgreSQL corner. MySQL and MariaDB report a schema for EVERY
+// view -- information_schema.VIEWS.TABLE_SCHEMA is the database name -- so the
+// lookup missed on all of them. Measured live on MySQL 9.7 and MariaDB 11.8,
+// with the view created bare and read back qualified:
+//
+//	before  DOWN  -- No rollback operations needed                      rc=0
+//	              information_schema.VIEWS still held the post-up body
+//	after   DOWN  CREATE OR REPLACE VIEW `db`.`probe_my_v` AS select ... rc=0
+//	              information_schema.VIEWS back to the pre-up body
+func TestGenerateDownMigrationSQL_RestoresModifiedViewInANamedSchema(t *testing.T) {
+	c := qt.New(t)
+
+	const priorBody = "SELECT id FROM rev_view_users"
+	const targetBody = "SELECT id, email FROM rev_view_users"
+
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "RevViewUser", Name: "rev_view_users"}},
+		Fields: []goschema.Field{
+			{StructName: "RevViewUser", Name: "id", Type: "BIGINT", Primary: true},
+			{StructName: "RevViewUser", Name: "email", Type: "TEXT"},
+		},
+		Views: []goschema.View{
+			{StructName: "RevActiveUsers", Name: "rev_active_users", Body: targetBody},
+		},
+	}
+	goschema.Finalize(schema)
+
+	db := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name: "rev_view_users",
+			Type: "TABLE",
+			Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true, OrdinalPosition: 1},
+				{Name: "email", DataType: "text", IsNullable: "NO", OrdinalPosition: 2},
+			},
+		}},
+		Views: []dbschematypes.DBView{
+			{Name: "rev_active_users", Schema: "reporting", Body: priorBody},
+		},
+	}
+
+	upDiff := schemadiff.CompareWithDialect(schema, db, "postgres")
+	c.Assert(upDiff.ViewsModified, qt.HasLen, 1)
+
+	downSQL, err := generateDownMigrationSQL(upDiff, schema, db, "postgres")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(legacyRenderedSQL(downSQL), qt.Contains, priorBody,
+		qt.Commentf("the rollback must restore the prior view body; down SQL:\n%s", downSQL))
+}

--- a/migration/schemadiff/internal/compare/schema_objects.go
+++ b/migration/schemadiff/internal/compare/schema_objects.go
@@ -339,6 +339,10 @@ func ViewDefinitionsWithDialect(genView goschema.View, dbView types.DBView, dial
 	viewDiff := difftypes.ViewDiff{
 		ViewName: genView.Name,
 		Changes:  make(map[string]string),
+		// The database body is what the view has before this diff is applied.
+		// The planner needs it to decide whether CREATE OR REPLACE VIEW is legal
+		// for the change, which is not derivable from the target body alone.
+		PreviousBody: strings.TrimSpace(dbView.Body),
 	}
 
 	if !schemaObjectBodiesEqual(genView.Body, dbView.Body, dialect, dbView.Schema) {

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -786,6 +786,43 @@ type SequenceDiff struct {
 type ViewDiff struct {
 	ViewName string            `json:"view_name"`
 	Changes  map[string]string `json:"changes"`
+
+	// PreviousBody is the view body that is in force before this diff is
+	// applied: the database side of a forward comparison, and the post-up side
+	// of a reversed one. It is what makes the modification path decidable.
+	//
+	// PostgreSQL accepts CREATE OR REPLACE VIEW only when the new query yields
+	// the old column list with columns appended to the end -- same names, same
+	// types, same order. Dropping, renaming or retyping a column is refused at
+	// execution time, and a down migration built with CREATE OR REPLACE is
+	// therefore un-appliable for every view modification except the one shape
+	// the up migration is least likely to have made. A planner that cannot see
+	// the prior body cannot tell the legal case from the refused one, so it has
+	// to choose between an un-appliable statement and always dropping the view
+	// with CASCADE, which takes dependents with it.
+	//
+	// An empty value means "not known". It does not on its own select a plan:
+	// what a planner cannot decide is settled by Rollback below, so a forward
+	// plan still attempts the replace -- the engine refuses it if it is illegal,
+	// and refusing costs nothing -- while a rollback takes the drop and
+	// recreate that always applies.
+	PreviousBody string `json:"previous_body,omitempty"`
+
+	// Rollback reports that this entry is being planned in the DOWN direction:
+	// the statement rendered for it runs while an operator is undoing a
+	// migration.
+	//
+	// It decides nothing on its own. It settles the cases where a planner cannot
+	// prove whether the engine accepts an in-place replace, and the two
+	// directions want opposite answers there. Going forward, the replace is
+	// worth attempting: it keeps dependent objects and the privileges granted on
+	// the view, and if the engine refuses it the migration stops with nothing
+	// destroyed. A rollback cannot be stopped that way -- it is already running
+	// during the incident -- so it takes the drop-and-recreate that always
+	// applies, and pays for it by rebuilding what CASCADE removes.
+	//
+	// Reverse plan builders set it; a forward comparison leaves it false.
+	Rollback bool `json:"rollback,omitempty"`
 }
 
 // MaterializedViewDiff represents changes to a materialized view definition.


### PR DESCRIPTION
Fixes #1287.

## What was wrong

`migration/generator`'s `reverseSchemaDiffWithSchema` builds a fresh `SchemaDiff` literal, and a literal that enumerates fields is silent about the fields it omits. Nine were absent for as long as the categories existed: `ViewsAdded`, `ViewsRemoved`, `ViewsModified`, the three `MaterializedViews*` and the three `Triggers*`. They were therefore zero on every down migration, so a rollback skipped the whole category. An up migration that created a view produced a down file reading exactly `-- No rollback operations needed`.

`cloneSchemaDiff`, ten lines away in the same file, enumerates all nine. Diffing the two function bodies is how you find what the reverse forgot.

## Why the obvious fix is wrong

Adding the missing fields is not enough, and this is the part worth writing down. Carrying `ViewsModified` into the down plan makes the PostgreSQL planner render `CREATE OR REPLACE VIEW`, which PostgreSQL accepts only for appending trailing columns. Measured on PostgreSQL 17.10 against a view over `(id bigint, email text, age integer)`:

| change to the view | PostgreSQL |
| --- | --- |
| append a trailing column | accepted |
| drop the appended column | `ERROR: cannot drop columns from view` |
| rename a column | `ERROR: cannot change name of view column "id" to "uid"` |
| change a column type | `ERROR: cannot change data type of view column "id" from bigint to text` |
| change only the predicate | accepted |

The rollback of an append is a drop, so a down migration built that way is un-appliable for every view modification except the one shape the up migration is least likely to have made. A rollback that fails is worse than one that is incomplete: the operator finds out during the incident.

Applying the naive plan's own output confirms it. Against the post-up state:

```
CREATE OR REPLACE VIEW "ptah_rev_active_users" AS SELECT id FROM ptah_rev_view_users;
-- rc=1  ERROR: cannot drop columns from view

DROP VIEW IF EXISTS "ptah_rev_active_users" CASCADE;
CREATE VIEW "ptah_rev_active_users" AS SELECT id FROM ptah_rev_view_users;
-- rc=0
```

## What this does

`modifyExistingViews` in the PostgreSQL planner now decides per view.

- It keeps `CREATE OR REPLACE VIEW` only where the new select list provably appends to the old one: same output column names, same type-determining text, same order. That comparison sees through the two spellings the same projection legitimately has — `SELECT id` as authored, `SELECT t.id` as `pg_get_viewdef` reads it back — while a cast, a rename or a different expression changes it. Keeping the replace where it is legal is worth the machinery, because the drop carries `CASCADE` and takes dependents with it.
- Everything it cannot decide — an unknown prior body, a `SELECT *` projection, a `WITH` prefix, a top-level set operation, an alias-less expression — takes the drop-and-recreate path, which always applies. The conservatism is one-directional on purpose: saying "no" costs a `CASCADE`, saying "yes" wrongly costs the rollback.
- The `DROP` and the `CREATE` are emitted from inside the modify step, the way `modifyExistingMaterializedViews` already does. Expressed from outside, by pushing the view into `ViewsRemoved` and `ViewsAdded`, the plan runs additions before removals and the reverse comes out create-then-drop.
- The recreated views are ordered by dependency, since a `CASCADE` takes a dependent view the same migration is also rebuilding.

The prior body has to reach the planner, which in the down direction only ever sees one side of the change, so `ViewDiff` gained `PreviousBody`: the body in force before the diff is applied. The comparator fills it from the database side; the reverse builder **exchanges** it for the up migration's target body, because that is the state the database is in when the rollback runs. Empty means "not known" and yields the conservative plan.

Materialized views need no legality test — they have no in-place replace, and both directions already drop and recreate. Triggers need none either: PostgreSQL 17.10 accepts `CREATE OR REPLACE TRIGGER` even for a `BEFORE` → `AFTER` timing change. MySQL's `CREATE OR REPLACE VIEW` is an unrestricted redefinition and the SQLite renderer already turns `SetReplace` into `DROP` + `CREATE`, so neither planner changed.

## Definition of done

**Every field accounted for.** A doc comment on `reverseSchemaDiffWithSchema` states the three dispositions — exchanged, carried, derived — and which fields take each. No field is deliberately dropped and none is unreachable in the down direction.

**A test that fails when a field is added and left unhandled.** `TestReverseSchemaDiff_AccountsForEverySchemaDiffField` enumerates `SchemaDiff` by reflection, zeroes one field of a fully populated diff at a time, and fails when the reverse plan comes out byte-identical. Adding a plausible new field and ignoring it reddens the subtest named after it:

```
--- FAIL: TestReverseSchemaDiff_AccountsForEverySchemaDiffField/PublicationsAdded
    SchemaDiff.PublicationsAdded never reaches the reverse plan: zeroing it left
    the down plan byte-identical.
```

A hand-written field list is what rotted the first time, so the fixture is filled generically from the field names too, and a second test fails if the filler ever leaves a field zero.

**Every reversed category applied, not just rendered.** `TestReverseViewLikeObjects_DownRoundTrip_Integration` seeds the pre-up state through Ptah's own planner, applies the generated up, applies the generated down, asserts it applied, and asserts the catalog it lands on is the pre-up catalog. Five cases: create the three objects, drop the three objects, append a view column, change only the view predicate, rewrite the materialized view and the trigger. The table the objects hang off exists before and after every case, so a `DROP TABLE ... CASCADE` can never be what removes them.

## Mutation coverage

Five mutations, each run and reverted:

| mutation | what reddens |
| --- | --- |
| planner always replaces (the naive fix) | 4 unit subtests, 6 planner subtests, the live append case; the mutant's own SQL exits 1 on PostgreSQL |
| planner never replaces | the predicate-only unit test, `SchemaObjectsModified`, 3 planner subtests, the live predicate case |
| drop `ViewsAdded`/`ViewsRemoved` from the literal | the reflection gate names exactly those two fields, plus both view unit tests |
| add an unhandled field to `SchemaDiff` | the reflection gate names it |
| carry `PreviousBody` instead of exchanging it | 4 unit subtests and the live append case |

## Notes

- `docs/public_api.snapshot` is regenerated. Adding a field to `ViewDiff` is a compatible change, so `check-public-api-released.sh` stays green and no approval entry was needed.
- Three integration tests in `migration/generator` — `TestConstraintDriftGenerateRoundTrip_Integration`, `TestUniqueConstraintDriftGenerateRoundTrip_Integration/postgres` and `TestMultiHostMixinFKModify_DownRoundTrip_Integration/postgres` — fail identically on `origin/master` and on this branch against a pristine database. They are pre-existing and unrelated, and no CI workflow runs them. Worth a separate issue.


---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

REFUTED. Their own measurements reproduce and every gate is genuinely green, but the change breaks a forward migration on an adjacent view shape, still produces the un-appliable rollback it exists to prevent, and still rolls a whole category back to "-- No rollback operations needed".

SETUP. My worktree checked out to eb1b8f39 (`git log --oneline -1` before every build); merge-base 9820496e checked out in a second worktree as the control (`git worktree list` confirmed both). My own container `ptahref1287-dev`, PostgreSQL 17.10, port 15801, CI role shape (ptah_user LOGIN SUPERUSER + bootstrap postgres), a fresh database per scenario, container removed at the end; MySQL 9.7 on the shared mylive-mysql:33110 in my own `ptah_r1287my`, dropped. Plans generated through the exported `generator.PlanMigration`/`GenerateMigration` from a probe module built separately against each worktree, applied with `psql -v ON_ERROR_STOP=1 -f`, exit code read directly.

WHAT HOLDS. The legality table reproduces exactly on my own fixtures: append trailing column rc=0; drop appended column rc=1 "cannot drop columns from view"; rename rc=1; retype rc=1; predicate-only rc=0. Their `TestReverseViewLikeObjects_DownRoundTrip_Integration` passes against my database (5/5, exit 0). Gates on eb1b8f39, each read directly, never after a pipe: go build 0, go vet 0, go vet -tags integration ./integration/... 0, go tool qtlint 0, golangci-lint "0 issues." 0 (private cache; my first attempt printed a false 0 because tail owned the status — re-run direct), check-test-style 0, check-public-api 0, snapshot 0, check-public-api-released 0, node docs/site/scripts/check-style.mjs 0. `go test ./... -count=1 -timeout 30m` exited 1 on `cmd/viz/TestSVGReportsGraphvizStderrOnFailure` under machine load; that package passes serially (exit 0) and is unrelated.

1. THE ADJACENT SHAPE — a forward migration now destroys a declared object. `modifyExistingViews` serves the UP plan too, and every body the new parser cannot decide (WITH prefix, SELECT *, top-level set operation) now takes DROP ... CASCADE in the forward direction. For a predicate-only edit that is a pure loss, because PostgreSQL accepts the replace for all of them. Schema: table probe_t, view probe_base = "WITH src AS (SELECT id, email FROM probe_t) SELECT id, email FROM src", plus a second DECLARED view probe_dep = "SELECT id FROM probe_base". Up changes only the CTE predicate.
  9820496e: `CREATE OR REPLACE VIEW "probe_base" AS WITH ...` rc=0, views after = probe_base, probe_dep
  eb1b8f39: `DROP VIEW IF EXISTS "probe_base" CASCADE; CREATE VIEW "probe_base" AS ...` rc=0, views after = probe_base
probe_dep is named by no statement in the plan. Identical as ptah_user and as the bootstrap postgres superuser. A dependent materialized view (3 rows) was destroyed the same way, contents included. And it does not converge: re-planning against the damaged database yields `CREATE VIEW "probe_dep" ...; DROP VIEW IF EXISTS "probe_base" CASCADE; CREATE VIEW "probe_base" ...` — the file creates the dependent and destroys it again, rc=0, probe_dep still gone. The control's plan in the same state (`CREATE VIEW probe_dep; CREATE OR REPLACE VIEW probe_base`) reaches the declared schema. Same for SELECT * and UNION bodies.

2. RENDERED IS NOT APPLIED — the change still emits the refused rollback. `viewReplaceOnlyAppendsColumns` reduces a plain reference to the bare column name and never reads the FROM clause, so "SELECT id FROM probe_a" (bigint) and "SELECT id FROM probe_b" (text) compare equal. Directly: `CREATE OR REPLACE VIEW r1287_fromv AS SELECT id FROM r1287_b` → rc=1, "cannot change data type of view column \"id\" from bigint to text". Reachable as a rollback: prior view "SELECT id, email FROM probe_a", target "SELECT id FROM probe_b". Generated up = `DROP VIEW IF EXISTS "probe_v" CASCADE; CREATE VIEW "probe_v" AS SELECT id FROM probe_b` (drop path, applies). Generated down = `CREATE OR REPLACE VIEW "probe_v" AS SELECT id, email FROM probe_a`. `psql -v ON_ERROR_STOP=1 -f <generated down file>` → rc=3, ERROR: cannot change data type of view column "id" from text to bigint. That is the exact failure mode the commit message justifies the whole design with. The doc comment's stated residual assumption ("the relations the shared items read have not themselves been retyped in the same migration") does not cover it: the relation was swapped, not retyped, and that is neither a cast, a rename, nor a different expression.

3. THE CLAIM THAT IS NOT CODE — a category is still dropped. The commit says "none is dropped or unreachable" and migration/generator/README.md says "No category is dropped from the rollback". The diff records a view under the name the Go schema spells; the pre-change schema the down plans against names it "<schema>.<view>" via DBView.QualifiedName (internal/convert/dbschematogo). findView compares those strings, so any view whose database side carries a schema never matches and ViewsModified renders nothing. Live on MySQL 9.7: up `CREATE OR REPLACE VIEW probe_my_v AS SELECT id, email FROM probe_my_t` + trigger rewrite (rc=0); generated down = `DROP TRIGGER ...; CREATE TRIGGER ...` and no view statement (rc=0); information_schema.VIEWS after rollback still holds the post-up body. Reproduced on the PostgreSQL path with Schema:"reporting" — down file reads literally "-- No rollback operations needed", the string the change is meant to have removed. Reaching the reversed SchemaDiff is not reaching the rollback, and the reflection gate only checks the former.

4. THE TEST THAT CANNOT RUN. `TestReverseViewLikeObjects_DownRoundTrip_Integration` is `//go:build integration` in `./migration/generator`. `go test ./...` never compiles it; `go vet -tags integration ./integration/...` does not cover that package; and no workflow runs `-tags=integration` there — .github/workflows/go-integration-tests.yml uses the tag only on ./integration, ./integration/gonative, ./internal/dbschema/{mysql,postg

### What it says must change

The reverse builder half of the change is right and should stay: the nine categories genuinely were absent, and exchanging added/removed while carrying the modified entries is the correct reversal. What has to change is the per-view replace decision and the claims made for it.

1. Do not let the legality test govern the forward direction. `modifyExistingViews` is shared by the UP and DOWN plans, and the UP direction had no problem to solve: before this change it emitted CREATE OR REPLACE VIEW and PostgreSQL accepted it for every shape whose column list did not move. Gate the drop-and-recreate on the plan direction, or thread the decision through so an undecidable body keeps the replace forward and only takes the drop on rollback. As it stands a predicate-only edit to a WITH/SELECT */UNION view silently destroys declared dependent views and materialized-view contents, and the plan never converges. If the drop path must ever run forward, the plan has to rebuild every dependent it takes — the CASCADE list is derivable from the generated schema the planner already holds.

2. Make the replace decision sound or make it refuse. A select item's type is fixed by the relation it reads, and the comparison never reads the FROM clause. Either include the normalized FROM/JOIN text in each item's type-determining key (so any change to the relations answers "not replaceable"), or answer "not replaceable" whenever anything outside the select list changed. Then correct view_replace.go's doc comment: the residual assumption is not "the relations have not been retyped in the same migration", it is "the relations read by shared items are the same relations".

3. Match on the same name the planner will look up. Resolve ViewsModified/MaterializedViewsModified/TriggersModified against the pre-change schema by qualified name (or record the qualified name in the diff), so a view outside the default schema is not silently skipped. Until that lands, neither the commit message nor migration/generator/README.md may say "no category is dropped from the rollback" — on MySQL/MariaDB, and on PostgreSQL for any named schema, ViewsModified still rolls back to "-- No rollback operations needed".

4. Strengthen the gate so it measures the rollback, not the reverse diff. TestReverseSchemaDiff_AccountsForEverySchemaDiffField passes while the rendered down file is empty. Add the companion assertion — zeroing a field must change the rendered DOWN SQL — which is what would have caught finding 3.

5. Wire the live test into CI or it is not coverage. Add a `go test -tags=integration ./migration/generator -run '^TestReverseViewLikeObjects_DownRoundTrip_Integration$'` step to the PostgreSQL job in .github/workflows/go-integration-tests.yml (POSTGRES_URL is already set there), and extend its table with the three shapes above: a CTE/star/union view with a declared dependent, a relation swap that retypes a shared column, and a view in a named schema.

6. Restore the un-fixtured assertion. Keep a case in TestPlanner_GenerateMigrationAST_SchemaObjectsModified with no PreviousBody so the default behavior for that scenario is pinned rather than adapted away.

7. Measure MySQL, MariaDB and SQLite live before claiming they need no change, and check CockroachDB and YugabyteDB accept the new DROP VIEW ... CASCADE the shared PostgreSQL planner now emits.

Ready-to-post PR (for the refutation commit 5db32a4a):

TITLE
Pin three shapes the per-view replace decision gets wrong (#1287)

BODY
The reverse-plan change on issue-1287-reverse-plan is right that nine SchemaDiff
fields never reached the rollback, and right that adding them naively renders a
CREATE OR REPLACE VIEW PostgreSQL refuses. Its own measurements reproduce on a
clean PostgreSQL 17.10 (append accepted; drop, rename and retype refused;
predicate-only accepted), its live round trip passes, and every gate is green.
Three shapes it never built say the decision it added is not finished. The tests
here are RED at eb1b8f39; they ar