### PR TITLE
Decide a lint statement's schema scope once (#1249)

### DIFF
--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -897,20 +897,30 @@ review and filters nothing, which is also what every non-PostgreSQL dev URL
 does. A `search_path` naming more than one schema is not a scope: it is read as
 a single schema name, so it scopes nothing and every object stays under review.
 
-An `ALTER TABLE` belongs to its table's schema, never to the column or
-constraint it names, and a `CREATE SCHEMA` is measured against the reviewed
-schema by its own name.
+An `ALTER TABLE`'s schema changes belong to its table's schema, never to the
+column or constraint it names, and a `CREATE SCHEMA` is measured against the
+reviewed schema by its own name.
 
-The scope decision is made once per statement and drives both outputs, so the
-reported schema-change count and the reported diagnostics always describe the
-same statements. A diagnostic that names no object at all — the rules that
-report a statement rather than the objects in it — follows the decision already
-taken for the statement it belongs to: dropped when the scope removed that
-statement, and otherwise always reported, since there is nothing to measure a
-scope against and a hazard must not be silenced on an unestablished boundary.
-`ALTER TABLE app.users ADD CONSTRAINT …` under `search_path=public` therefore
-reports nothing, where it used to raise `PG105` about a change it had already
-counted as zero.
+The scope decision is made once per statement and drives both outputs, so a
+statement the scope removed contributes neither a schema change nor a
+diagnostic, and one it kept can contribute either. A diagnostic that names no
+object at all — the rules that report a statement rather than the objects in
+it — follows the decision already taken for the statement it belongs to: dropped
+when the scope removed that statement, and otherwise reported, since there is
+nothing to measure a scope against and a hazard must not be silenced on an
+unestablished boundary. `ALTER TABLE app.users ADD CONSTRAINT …` under
+`search_path=public` therefore reports nothing, where it used to raise `PG105`
+about a change it had already counted as zero.
+
+A statement is removed only when **every** table it names is out of review, not
+only the one it alters. `ALTER TABLE app.child ADD CONSTRAINT c FOREIGN KEY
+(pid) REFERENCES public.parent (id);` under `search_path=public` names two, and
+validating that key holds a `SHARE ROW EXCLUSIVE` lock on `public.parent` for
+the duration, so `PG306` is reported: the hazard lands on a table the run is
+responsible for. The same statement referencing `app.parent` reports nothing.
+This is one place the two outputs deliberately describe different statements —
+the constraint lands on `app.child`, so the reviewed schema still counts zero
+changes for it. A count of zero is not a statement of safety.
 
 Silence is not exclusion. A statement outside Ptah's SQL grammar is left under
 review whatever schema it names, because a boundary that could not be read must
@@ -919,7 +929,19 @@ parser does not model it, so `DROP INDEX public.idx;` counts no schema change
 even in the reviewed schema — the pinned community binary counts one — while
 its `PG106` diagnostic is reported in every schema. That missing change is a
 parser gap rather than a scope decision, tracked in
-[`stokaro/ptah#1296`](https://github.com/stokaro/ptah/issues/1296).
+[`stokaro/ptah#1296`](https://github.com/stokaro/ptah/issues/1296). The same
+grammar boundary is why `TRUNCATE app.users;` and `DROP FUNCTION app.recalc();`
+are reported under `search_path=public` while counting no schema change.
+
+Three constructs are still measured by a name that carries no schema, because
+Ptah's parser records none for them. Measured on PostgreSQL 17.10 under
+`search_path=public`, `CREATE SEQUENCE app.s;` counts one schema change,
+`CREATE TRIGGER trg … ON app.t;` counts one and raises `PG308`, and
+`CREATE POLICY p ON app.t;` counts one — where the pinned community binary
+v1.3.0 counts no schema change and raises no diagnostic for all three. They
+over-report rather than under-report, and each is a warning at exit 0, so a
+scoped run is never told less than the truth about its database. They are listed
+here rather than left to be discovered.
 
 The boundary applies to `ptah-compat migrate lint` only. Native
 `ptah migrations lint` keeps every object under review, whatever the dev URL

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -886,7 +886,11 @@ objects the run analyzes. A PostgreSQL-family `--dev-url` carrying
   review, and so does a reference written out with the reviewed schema's own
   name;
 - one statement is measured per object: `DROP TABLE users, other.audit_log;`
-  under `search_path=public` reports `users` and counts one schema change.
+  under `search_path=public` reports `users` and counts one schema change;
+- an index is measured by the schema of the table it is on, because an index
+  name never carries one: `CREATE INDEX idx ON app.users (id);` under
+  `search_path=public` counts no schema change and raises no diagnostic, while
+  the same statement on a `public` table counts one and raises `PG101`.
 
 A `--dev-url` that names no schema puts the whole connected database under
 review and filters nothing, which is also what every non-PostgreSQL dev URL
@@ -895,10 +899,27 @@ a single schema name, so it scopes nothing and every object stays under review.
 
 An `ALTER TABLE` belongs to its table's schema, never to the column or
 constraint it names, and a `CREATE SCHEMA` is measured against the reviewed
-schema by its own name. A diagnostic that names no object at all — the rules
-that report a statement rather than the objects in it — is always reported,
-since there is nothing to measure a scope against and a hazard must not be
-silenced on an unestablished boundary.
+schema by its own name.
+
+The scope decision is made once per statement and drives both outputs, so the
+reported schema-change count and the reported diagnostics always describe the
+same statements. A diagnostic that names no object at all — the rules that
+report a statement rather than the objects in it — follows the decision already
+taken for the statement it belongs to: dropped when the scope removed that
+statement, and otherwise always reported, since there is nothing to measure a
+scope against and a hazard must not be silenced on an unestablished boundary.
+`ALTER TABLE app.users ADD CONSTRAINT …` under `search_path=public` therefore
+reports nothing, where it used to raise `PG105` about a change it had already
+counted as zero.
+
+Silence is not exclusion. A statement outside Ptah's SQL grammar is left under
+review whatever schema it names, because a boundary that could not be read must
+not be able to drop a diagnostic. `DROP INDEX` is the current example: Ptah's
+parser does not model it, so `DROP INDEX public.idx;` counts no schema change
+even in the reviewed schema — the pinned community binary counts one — while
+its `PG106` diagnostic is reported in every schema. That missing change is a
+parser gap rather than a scope decision, tracked in
+[`stokaro/ptah#1296`](https://github.com/stokaro/ptah/issues/1296).
 
 The boundary applies to `ptah-compat migrate lint` only. Native
 `ptah migrations lint` keeps every object under review, whatever the dev URL

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -3,6 +3,7 @@ package lint
 import (
 	"fmt"
 	"io/fs"
+	"maps"
 	"path"
 	"slices"
 	"sort"
@@ -154,7 +155,13 @@ type File struct {
 	// can contribute zero, one, or several changes, so len(Changes) is not the
 	// statement count. Ordered by statement, then by the order changes appear
 	// within each statement.
-	Changes         []SchemaChange
+	Changes []SchemaChange
+	// scopeExcluded holds the statement indexes the reviewed-schema filter left
+	// out, so a finding about one of them is dropped by the same decision that
+	// dropped its change. Without it the two disagreed: a rule that attaches no
+	// subject produced a finding for a statement the scope had already removed
+	// from the counts (stokaro/ptah#1249).
+	scopeExcluded   map[int]bool
 	suppressedRules []atlaslint.Target
 	// compatibility is the profile this run was started with. A rule reads it
 	// when the two command surfaces model the same statement differently; see
@@ -235,6 +242,7 @@ func cloneFiles(files []File) []File {
 func cloneFile(file File) File {
 	file.suppressedRules = slices.Clone(file.suppressedRules)
 	file.Changes = slices.Clone(file.Changes)
+	file.scopeExcluded = maps.Clone(file.scopeExcluded)
 	statements := file.Statements
 	file.Statements = make([]Statement, len(statements))
 	for i := range statements {
@@ -352,7 +360,7 @@ func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
 			continue
 		}
 		file := cloneFile(files[i])
-		findings = append(findings, scope.keepFindings(runRules(&file, opts, rules))...)
+		findings = append(findings, scope.keepFindings(file.scopeExcluded, runRules(&file, opts, rules))...)
 	}
 	sort.SliceStable(findings, func(i, j int) bool {
 		if findings[i].File != findings[j].File {
@@ -562,7 +570,7 @@ func prepareFile(
 				suppressedRules: rawStmt.suppressedRules,
 			})
 		}
-		file.Changes = extractSchemaChanges(&file, dialect, scope)
+		file.Changes, file.scopeExcluded = extractSchemaChanges(&file, dialect, scope)
 	}
 	return file, nil
 }

--- a/migration/lint/changes.go
+++ b/migration/lint/changes.go
@@ -1,6 +1,7 @@
 package lint
 
 import (
+	"slices"
 	"strings"
 
 	"go.5x5.cz/ptah/core/ast"
@@ -168,7 +169,11 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaSc
 		// Every action of an ALTER TABLE belongs to the table's schema, never
 		// to the column or constraint it names.
 		if !scope.allowsObject(n.Name) {
-			return nil, true
+			// The altered table is not the only table the statement names. See
+			// [alterReferencedTables]: a statement that reaches into the
+			// reviewed schema has not left it, so it is not scoped out, even
+			// though it still contributes no change there.
+			return nil, !slices.ContainsFunc(alterReferencedTables(n), scope.allowsObject)
 		}
 		out := make([]SchemaChange, 0, len(n.Operations))
 		for _, op := range n.Operations {
@@ -201,6 +206,47 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaSc
 	// Operational nodes (INSERT/SELECT wrappers, DO blocks, raw SQL) and any
 	// construct Ptah does not model as a schema object contribute nothing.
 	return nil, false
+}
+
+// alterReferencedTables returns the tables an ALTER TABLE names besides the one
+// it alters: the target of each foreign key it adds, written either as a table
+// constraint or inline on an added column.
+//
+// A statement names more objects than the node's primary name carries, and the
+// scope has to see all of them before it removes the statement. `ALTER TABLE
+// app.child ADD CONSTRAINT c FOREIGN KEY (pid) REFERENCES public.parent (id)`
+// validates every existing row and holds a SHARE ROW EXCLUSIVE lock on
+// `public.parent` for the duration, which is what `PG306` reports. Under a run
+// reviewing `public` that hazard lands on a table the run is responsible for, so
+// excluding the statement on the strength of `app.child` alone silenced a
+// diagnostic about an in-scope object (stokaro/ptah#1300).
+//
+// The change count is a separate question and does not move: the constraint
+// lands on `app.child`, which is out of review, so the statement still counts
+// zero changes. Not being scoped out is not the same as contributing one.
+//
+// A reference the parser did not record is left out rather than returned empty,
+// so a missing name cannot be read as "unqualified, therefore in scope" and pull
+// a statement back under review by accident.
+func alterReferencedTables(alter *ast.AlterTableNode) []string {
+	tables := make([]string, 0, len(alter.Operations))
+	for _, op := range alter.Operations {
+		table := ""
+		switch o := op.(type) {
+		case *ast.AddConstraintOperation:
+			if o.Constraint != nil && o.Constraint.Reference != nil {
+				table = o.Constraint.Reference.Table
+			}
+		case *ast.AddColumnOperation:
+			if o.Column != nil && o.Column.ForeignKey != nil {
+				table = o.Column.ForeignKey.Table
+			}
+		}
+		if strings.TrimSpace(table) != "" {
+			tables = append(tables, table)
+		}
+	}
+	return tables
 }
 
 // nodeScopeReference is the reference a change is measured against, which is not

--- a/migration/lint/changes.go
+++ b/migration/lint/changes.go
@@ -69,18 +69,42 @@ type SchemaChange struct {
 // `?search_path=public`, a version that runs `CREATE SCHEMA app2; CREATE TABLE
 // app2.t (id int); CREATE TABLE keep (id int);` counts one schema change, not
 // three, and a version that drops two `app` tables counts none.
-func extractSchemaChanges(file *File, dialect string, scope schemaScope) []SchemaChange {
+//
+// The second return names the statements the scope removed entirely, keyed by
+// statement index, so a finding about one of them is dropped by the same
+// decision that dropped its change.
+func extractSchemaChanges(file *File, dialect string, scope schemaScope) ([]SchemaChange, map[int]bool) {
 	if !file.IsUp || len(file.Statements) == 0 {
-		return nil
+		return nil, nil
 	}
 	var changes []SchemaChange
+	excluded := map[int]bool{}
 	for i := range file.Statements {
-		changes = append(changes, statementSchemaChanges(file, file.Statements[i], dialect, scope)...)
+		stmtChanges, out := statementSchemaChanges(file, file.Statements[i], dialect, scope)
+		changes = append(changes, stmtChanges...)
+		if out {
+			excluded[file.Statements[i].Index] = true
+		}
 	}
-	return changes
+	return changes, excluded
 }
 
-func statementSchemaChanges(file *File, stmt Statement, dialect string, scope schemaScope) []SchemaChange {
+// statementSchemaChanges returns the changes a statement makes and reports
+// whether the scope excluded the statement outright.
+//
+// The second return is what keeps the reported counts and the reported findings
+// describing the same set. Before it existed, an `ALTER TABLE app.users ADD
+// CONSTRAINT ...` under a run reviewing `public` contributed no change and still
+// produced a finding, because the rule that fired attaches no subject and
+// [schemaScope.allowsFinding] deliberately keeps a finding it cannot place
+// (stokaro/ptah#1249).
+//
+// A statement is excluded only when the scope rejected something it named and
+// nothing it named survived. A statement the parser cannot model, one whose
+// nodes name no object at all, and one the scope rejected nothing of are all
+// left alone -- silence there is absence of evidence, and it must not be able to
+// drop a finding.
+func statementSchemaChanges(file *File, stmt Statement, dialect string, scope schemaScope) ([]SchemaChange, bool) {
 	var opts []parser.Option
 	if strings.TrimSpace(dialect) != "" {
 		opts = []parser.Option{parser.WithDialect(dialect)}
@@ -91,16 +115,23 @@ func statementSchemaChanges(file *File, stmt Statement, dialect string, scope sc
 		// change here. The dev-database replay independently validates that the
 		// statement executes, so nothing is silently accepted; it is only
 		// excluded from the semantic change count.
-		return nil
+		return nil, false
 	}
 	var changes []SchemaChange
+	scopedOut := false
 	for _, node := range list.Statements {
-		changes = append(changes, nodeSchemaChanges(file, stmt, node, scope)...)
+		nodeChanges, out := nodeSchemaChanges(file, stmt, node, scope)
+		changes = append(changes, nodeChanges...)
+		scopedOut = scopedOut || out
 	}
-	return changes
+	return changes, scopedOut && len(changes) == 0
 }
 
-func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaScope) []SchemaChange {
+// nodeSchemaChanges returns a node's changes and reports whether the scope
+// rejected an object the node named. A node that names nothing, and a node whose
+// objects are all under review, report false: neither was scoped out, which is
+// what lets the caller tell "removed by the scope" from "modeled as no change".
+func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaScope) ([]SchemaChange, bool) {
 	change := func(kind SchemaChangeKind, object string) SchemaChange {
 		return SchemaChange{
 			Version:        file.Version,
@@ -118,24 +149,26 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaSc
 		// A CREATE SCHEMA names a schema rather than an object inside one, so
 		// it is measured against the reviewed schema by name.
 		if !scope.allowsSchema(n.Name) {
-			return nil
+			return nil, true
 		}
-		return []SchemaChange{change(SchemaChangeAdd, n.Name)}
+		return []SchemaChange{change(SchemaChangeAdd, n.Name)}, false
 	case *ast.DropTableNode:
 		names := n.TableNames()
 		out := make([]SchemaChange, 0, len(names))
+		scopedOut := false
 		for _, name := range names {
 			if !scope.allowsObject(name) {
+				scopedOut = true
 				continue
 			}
 			out = append(out, change(SchemaChangeDrop, name))
 		}
-		return out
+		return out, scopedOut
 	case *ast.AlterTableNode:
 		// Every action of an ALTER TABLE belongs to the table's schema, never
 		// to the column or constraint it names.
 		if !scope.allowsObject(n.Name) {
-			return nil
+			return nil, true
 		}
 		out := make([]SchemaChange, 0, len(n.Operations))
 		for _, op := range n.Operations {
@@ -154,20 +187,52 @@ func nodeSchemaChanges(file *File, stmt Statement, node ast.Node, scope schemaSc
 			kind, object := alterOperationChange(n, op)
 			out = append(out, change(kind, object))
 		}
-		return out
+		return out, false
 	}
 	if object, ok := addNodeObject(node); ok {
-		return scope.keepChange(change(SchemaChangeAdd, object), object)
+		return scope.keepChange(change(SchemaChangeAdd, object), nodeScopeReference(node, object))
 	}
 	if object, ok := dropNodeObject(node); ok {
-		return scope.keepChange(change(SchemaChangeDrop, object), object)
+		return scope.keepChange(change(SchemaChangeDrop, object), nodeScopeReference(node, object))
 	}
 	if object, ok := modifyNodeObject(node); ok {
-		return scope.keepChange(change(SchemaChangeModify, object), object)
+		return scope.keepChange(change(SchemaChangeModify, object), nodeScopeReference(node, object))
 	}
 	// Operational nodes (INSERT/SELECT wrappers, DO blocks, raw SQL) and any
 	// construct Ptah does not model as a schema object contribute nothing.
-	return nil
+	return nil, false
+}
+
+// nodeScopeReference is the reference a change is measured against, which is not
+// always the object it names.
+//
+// An index's own name carries no schema in any dialect Ptah renders --
+// [ast.IndexNode.Name] and [ast.DropIndexNode.Name] both document it as the raw,
+// unqualified index identifier, with the namespace derived from Table -- so
+// measuring an index by its own name puts every index in scope whatever schema
+// its table lives in. `CREATE INDEX idx ON app.users (id)` was counted as a
+// change under a run reviewing `public` (stokaro/ptah#1249).
+//
+// The table is the answer because it is where the index actually lives. A node
+// with no table recorded keeps its own name, which is all there is left to
+// measure.
+func nodeScopeReference(node ast.Node, object string) string {
+	switch n := node.(type) {
+	case *ast.IndexNode:
+		if table := strings.TrimSpace(n.Table); table != "" {
+			return table
+		}
+	case *ast.DropIndexNode:
+		// Unreachable from [extractSchemaChanges] today: Ptah's SQL parser does
+		// not model DROP INDEX, so no run produces this node. The rule is stated
+		// here anyway because the two node types carry the same contract, and
+		// leaving it out would encode the opposite claim about the one that is
+		// taught next.
+		if table := strings.TrimSpace(n.Table); table != "" {
+			return table
+		}
+	}
+	return object
 }
 
 // addNodeObject reports the object a CREATE (or GRANT) node adds.

--- a/migration/lint/changes_scope_internal_test.go
+++ b/migration/lint/changes_scope_internal_test.go
@@ -1,14 +1,24 @@
 package lint
 
-// White-box testing required: both rules below govern node shapes no lint run
-// can currently produce, so [AnalyzeFS] cannot reach them. Ptah's SQL parser
-// does not model DROP INDEX, so no [ast.DropIndexNode] ever reaches the change
-// extractor, and every ALTER TABLE form that would yield a node with no
-// operations fails to parse instead. Both rules are load-bearing the moment the
-// parser learns one of those forms — the first decides which schema an index
+// White-box testing required: neither rule below has an observable effect
+// through [AnalyzeFS] today, so a public-API fixture could not tell either
+// answer from its opposite.
+//
+// The reasons differ, and only one of them is unreachability. Ptah's SQL parser
+// does not model DROP INDEX in any spelling, so no [ast.DropIndexNode] ever
+// reaches the change extractor. A zero-operation [ast.AlterTableNode] is the
+// other case and it is reachable, not unreachable: `ALTER TABLE t;` parses to
+// exactly that node and [AnalyzeFS] hands it to [nodeSchemaChanges]. What it
+// lacks is a consequence — measured under `search_path=public`, both
+// `ALTER TABLE public.t;` and `ALTER TABLE app.users;` report no diagnostic and
+// no schema change, so whether the scope removed the statement changes nothing
+// a caller can read: there is no finding on it to drop.
+//
+// Both rules become load-bearing the moment the parser learns DROP INDEX or a
+// rule fires on a bare ALTER TABLE — the first decides which schema an index
 // drop is measured in, the second decides whether an in-scope statement's
 // findings survive — and a rule nothing pins is a rule that gets inverted by the
-// change that makes it reachable.
+// change that makes it observable.
 
 import (
 	"testing"

--- a/migration/lint/changes_scope_internal_test.go
+++ b/migration/lint/changes_scope_internal_test.go
@@ -1,0 +1,112 @@
+package lint
+
+// White-box testing required: both rules below govern node shapes no lint run
+// can currently produce, so [AnalyzeFS] cannot reach them. Ptah's SQL parser
+// does not model DROP INDEX, so no [ast.DropIndexNode] ever reaches the change
+// extractor, and every ALTER TABLE form that would yield a node with no
+// operations fails to parse instead. Both rules are load-bearing the moment the
+// parser learns one of those forms — the first decides which schema an index
+// drop is measured in, the second decides whether an in-scope statement's
+// findings survive — and a rule nothing pins is a rule that gets inverted by the
+// change that makes it reachable.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+)
+
+func TestNodeScopeReference_IndexIsMeasuredByItsTable(t *testing.T) {
+	tests := []struct {
+		name   string
+		node   ast.Node
+		object string
+		want   string
+	}{
+		{
+			name:   "a created index is measured by the table it is on",
+			node:   &ast.IndexNode{Name: "idx", Table: "app.users"},
+			object: "idx",
+			want:   "app.users",
+		},
+		{
+			name:   "a created index with no table recorded keeps its own name",
+			node:   &ast.IndexNode{Name: "idx"},
+			object: "idx",
+			want:   "idx",
+		},
+		{
+			name:   "a dropped index is measured by the table it was on",
+			node:   &ast.DropIndexNode{Name: "idx", Table: "app.users"},
+			object: "idx",
+			want:   "app.users",
+		},
+		{
+			name:   "a dropped index with no table recorded keeps its own name",
+			node:   &ast.DropIndexNode{Name: "idx"},
+			object: "idx",
+			want:   "idx",
+		},
+		{
+			name:   "every other node is measured by the object it names",
+			node:   &ast.CreateTableNode{Name: "app.users"},
+			object: "app.users",
+			want:   "app.users",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			c.Assert(nodeScopeReference(test.node, test.object), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestNodeSchemaChanges_ScopedOutMeansRejectedNotSilent pins that producing no
+// change is not the same answer as being scoped out. Only the second may drop a
+// statement's findings, so conflating them would silence a hazard on a table
+// that is under review.
+func TestNodeSchemaChanges_ScopedOutMeansRejectedNotSilent(t *testing.T) {
+	tests := []struct {
+		name          string
+		node          ast.Node
+		wantChanges   int
+		wantScopedOut bool
+	}{
+		{
+			name:          "an in-scope table with no modeled operation is not scoped out",
+			node:          &ast.AlterTableNode{Name: "public.t"},
+			wantChanges:   0,
+			wantScopedOut: false,
+		},
+		{
+			name:          "an out-of-scope table is scoped out",
+			node:          &ast.AlterTableNode{Name: "app.t"},
+			wantChanges:   0,
+			wantScopedOut: true,
+		},
+		{
+			name:          "a node naming nothing under review is not scoped out",
+			node:          &ast.CommentNode{},
+			wantChanges:   1,
+			wantScopedOut: false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			changes, scopedOut := nodeSchemaChanges(&File{}, Statement{}, test.node, newSchemaScope("public"))
+
+			c.Assert(changes, qt.HasLen, test.wantChanges)
+			c.Assert(scopedOut, qt.Equals, test.wantScopedOut)
+		})
+	}
+}

--- a/migration/lint/scope.go
+++ b/migration/lint/scope.go
@@ -89,25 +89,38 @@ func (s schemaScope) allowsFinding(finding Finding) bool {
 	return slices.ContainsFunc(finding.Context.Subjects, s.allowsSubject)
 }
 
-// keepChange returns the change when the object it names is under review, and
-// nothing when it is not. An object the node grammar exposes no name for (an
-// opaque routine body, a COMMENT ON target) is kept, for the same reason an
-// unparsable reference is.
-func (s schemaScope) keepChange(change SchemaChange, object string) []SchemaChange {
-	if !s.allowsObject(object) {
-		return nil
+// keepChange returns the change when the reference it is measured against is
+// under review, and nothing when it is not; the second return reports which of
+// the two happened. An object the node grammar exposes no name for (an opaque
+// routine body, a COMMENT ON target) is kept, for the same reason an unparsable
+// reference is. The reference is not always the object the change names: see
+// [nodeScopeReference].
+func (s schemaScope) keepChange(change SchemaChange, reference string) ([]SchemaChange, bool) {
+	if !s.allowsObject(reference) {
+		return nil, true
 	}
-	return []SchemaChange{change}
+	return []SchemaChange{change}, false
 }
 
 // keepFindings returns the findings that name an object under review, in the
 // order given.
-func (s schemaScope) keepFindings(findings []Finding) []Finding {
+//
+// excludedStatements carries the scope decision the change extraction already
+// made, keyed by statement index. It is consulted first because it is the more
+// informed answer: it was taken from the parsed node, which knows the table an
+// ALTER or an index belongs to, where a finding knows only the subjects its rule
+// chose to attach. A rule that attaches none would otherwise survive a scope
+// that had already removed its statement, and the reported counts and the
+// reported findings would describe different sets (stokaro/ptah#1249).
+func (s schemaScope) keepFindings(excludedStatements map[int]bool, findings []Finding) []Finding {
 	if s.unrestricted() {
 		return findings
 	}
 	kept := make([]Finding, 0, len(findings))
 	for _, finding := range findings {
+		if finding.Context != nil && excludedStatements[finding.Context.StatementIndex] {
+			continue
+		}
 		if s.allowsFinding(finding) {
 			kept = append(kept, finding)
 		}

--- a/migration/lint/scope_test.go
+++ b/migration/lint/scope_test.go
@@ -328,6 +328,155 @@ func TestAnalyzeFS_SchemaScopeDecidesOncePerStatement(t *testing.T) {
 	}
 }
 
+// TestAnalyzeFS_SchemaScopeRemovesOnlyStatementsNamingNothingUnderReview pins
+// that a statement is removed only when every table it names is out of review,
+// not only the one the altered table's name carries (stokaro/ptah#1300).
+//
+// `ALTER TABLE app.child ADD CONSTRAINT ... FOREIGN KEY (pid) REFERENCES
+// public.parent (id)` names two tables. PostgreSQL validates every existing row
+// and holds a SHARE ROW EXCLUSIVE lock on `public.parent` for the duration,
+// which is exactly what `PG306` reports, so under a run reviewing `public` the
+// hazard lands on a table the run is responsible for. Measured on the pinned
+// community binary v1.3.0 with `?search_path=public`: it reports no diagnostic
+// and exits 0, so keeping `PG306` is Ptah being stricter at exit 0 rather than
+// looser, and it is the behavior the base branch already had.
+//
+// Both outputs are asserted on every row because they answer different
+// questions here: the constraint lands on `app.child`, so the change count stays
+// zero on the in-scope rows too. Not being scoped out is not the same as
+// contributing a change, and a row that asserted only the count would accept a
+// fix that silenced the diagnostic.
+func TestAnalyzeFS_SchemaScopeRemovesOnlyStatementsNamingNothingUnderReview(t *testing.T) {
+	const base = "CREATE TABLE public.parent (id int PRIMARY KEY);\n" +
+		"CREATE SCHEMA app;\n" +
+		"CREATE TABLE app.parent (id int PRIMARY KEY);\n" +
+		"CREATE TABLE app.child (id int, pid int);\n" +
+		"CREATE TABLE app.users (id int);\n"
+
+	tests := []struct {
+		name         string
+		sql          string
+		wantChanges  []changeProjection
+		wantFindings []string
+	}{
+		{
+			name:         "a foreign key referencing the reviewed schema keeps its statement under review",
+			sql:          "ALTER TABLE app.child ADD CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES public.parent (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"PG306"},
+		},
+		{
+			name:         "a foreign key referencing only the unreviewed schema reports neither",
+			sql:          "ALTER TABLE app.child ADD CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES app.parent (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "an unqualified foreign key reference resolves into the reviewed schema",
+			sql:          "ALTER TABLE app.child ADD CONSTRAINT child_pid_fkey FOREIGN KEY (pid) REFERENCES parent (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"PG306"},
+		},
+		{
+			name:         "a foreign key written inline on an added column is the same reference",
+			sql:          "ALTER TABLE app.users ADD COLUMN pid int REFERENCES public.parent (id), ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"PG105"},
+		},
+		{
+			name:         "an inline foreign key outside the reviewed schema reports neither",
+			sql:          "ALTER TABLE app.users ADD COLUMN pid int REFERENCES app.parent (id), ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "a constraint naming no other table is still removed with its statement",
+			sql:          "ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "a foreign key added inside the reviewed schema reports both",
+			sql:          "ALTER TABLE public.parent ADD CONSTRAINT parent_self_fkey FOREIGN KEY (id) REFERENCES public.parent (id);\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "parent_self_fkey"}},
+			wantFindings: []string{"PG306"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, base, test.sql, "public")
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
+// TestAnalyzeFS_SchemaScopeExcludesOnlyTheScopedOutStatement pins that the
+// exclusion applies to the statement the scope removed and to no other.
+//
+// The set is keyed by statement index, and every other fixture here analyzes a
+// single-statement version, so nothing else can tell an off-by-one in that
+// lookup from correct behavior: a filter that dropped the statement before or
+// after a scoped-out one would pass the rest of this file.
+//
+// Measured with `?search_path=public`: the two-statement version reports one
+// change and one diagnostic both on the pinned community binary v1.3.0 (`MF101`)
+// and here (`PG105`), where the base branch reported two of each.
+func TestAnalyzeFS_SchemaScopeExcludesOnlyTheScopedOutStatement(t *testing.T) {
+	const base = "CREATE SCHEMA app;\nCREATE TABLE app.users (id int);\nCREATE TABLE public.t (id int);\n"
+	const inScope = "ALTER TABLE public.t ADD CONSTRAINT t_id_key UNIQUE (id);\n"
+	const scopedOut = "CREATE INDEX idx ON app.users (id);\n"
+
+	tests := []struct {
+		name         string
+		sql          string
+		wantChanges  []changeProjection
+		wantFindings []string
+	}{
+		{
+			name:         "the statement before a scoped-out one keeps its change and its finding",
+			sql:          inScope + scopedOut,
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "t_id_key"}},
+			wantFindings: []string{"PG105"},
+		},
+		{
+			name:         "the statement after a scoped-out one keeps its change and its finding",
+			sql:          scopedOut + inScope,
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "t_id_key"}},
+			wantFindings: []string{"PG105"},
+		},
+		{
+			name:         "a scoped-out statement between two in-scope ones removes only itself",
+			sql:          inScope + scopedOut + "ALTER TABLE public.t ADD CONSTRAINT t_id_check CHECK (id > 0);\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "t_id_key"}, {lint.SchemaChangeAdd, "t_id_check"}},
+			wantFindings: []string{"PG105", "PG305"},
+		},
+		{
+			name:         "two scoped-out statements report neither",
+			sql:          scopedOut + "ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, base, test.sql, "public")
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
 // TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone pins that a statement
 // Ptah's SQL parser cannot model keeps its findings under every scope, and that
 // the scope is not what suppresses its change count.

--- a/migration/lint/scope_test.go
+++ b/migration/lint/scope_test.go
@@ -221,6 +221,180 @@ func TestAnalyzeFS_SchemaScopeFiltersChanges(t *testing.T) {
 	}
 }
 
+// TestAnalyzeFS_SchemaScopeDecidesOncePerStatement pins that the reported
+// change count and the reported findings describe the same set of statements
+// (stokaro/ptah#1249).
+//
+// Two shapes disagreed before. An `ALTER TABLE app.users ADD CONSTRAINT ...`
+// contributed no change under a run reviewing `public` and still raised PG105,
+// because that rule attaches no subject and the finding filter deliberately
+// keeps a finding it cannot place. A `CREATE INDEX idx ON app.users (id)`
+// contributed a change and raised PG101, because an index was measured by its
+// own name, which never carries a schema.
+//
+// Each row asserts both outputs, because either alone would accept a fix that
+// silenced one side. The in-scope rows are the controls that separate "correctly
+// scoped out" from "never analyzed": without the `public` index row a filter
+// that dropped every index would pass, and without the unrestricted rows a fix
+// that narrowed the native surface too would pass.
+func TestAnalyzeFS_SchemaScopeDecidesOncePerStatement(t *testing.T) {
+	const appTable = "CREATE SCHEMA app;\nCREATE TABLE app.users (id int, nick text);\n"
+	const publicTable = "CREATE TABLE public.t (id int, c text);\n"
+
+	tests := []struct {
+		name         string
+		base         string
+		sql          string
+		scope        string
+		wantChanges  []changeProjection
+		wantFindings []string
+	}{
+		{
+			name:         "a constraint added outside the scope reports neither",
+			base:         appTable,
+			sql:          "ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "an index on a table outside the scope reports neither",
+			base:         appTable,
+			sql:          "CREATE INDEX idx ON app.users (id);\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "a column dropped inside the scope reports both",
+			base:         publicTable,
+			sql:          "ALTER TABLE public.t DROP COLUMN c;\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "c"}},
+			wantFindings: []string{"DS102"},
+		},
+		{
+			name:         "a column dropped outside the scope reports neither",
+			base:         "CREATE SCHEMA app;\nCREATE TABLE app.t (id int, c text);\n",
+			sql:          "ALTER TABLE app.t DROP COLUMN c;\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "an index on a table inside the scope reports both",
+			base:         "CREATE TABLE public.users (id int);\n",
+			sql:          "CREATE INDEX idx ON public.users (id);\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "idx"}},
+			wantFindings: []string{"PG101"},
+		},
+		{
+			name:         "an index on an unqualified table stays under review",
+			base:         "CREATE TABLE users (id int);\n",
+			sql:          "CREATE INDEX idx ON users (id);\n",
+			scope:        "public",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "idx"}},
+			wantFindings: []string{"PG101"},
+		},
+		{
+			name:         "an unrestricted run still reports the out-of-schema index",
+			base:         appTable,
+			sql:          "CREATE INDEX idx ON app.users (id);\n",
+			scope:        "",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "idx"}},
+			wantFindings: []string{"PG101"},
+		},
+		{
+			name:         "an unrestricted run still reports the out-of-schema constraint",
+			base:         appTable,
+			sql:          "ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);\n",
+			scope:        "",
+			wantChanges:  []changeProjection{{lint.SchemaChangeAdd, "users_id_key"}},
+			wantFindings: []string{"PG105"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, test.scope)
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
+// TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone pins that a statement
+// Ptah's SQL parser cannot model keeps its findings under every scope, and that
+// the scope is not what suppresses its change count.
+//
+// `DROP INDEX` is the measured case. stokaro/ptah#1249 read its `0 changes /
+// 1 finding` as the scope filter reaching the diagnostic but not the change;
+// it is not. `parser.NewParser("DROP INDEX app.idx").Parse()` returns
+// `unsupported DROP target: INDEX at position 5`, so the statement contributes
+// no change in the reviewed schema either. The `public` row is what says so: it
+// is the reviewed schema and it still counts zero, while the `DROP TABLE`
+// control on the same schema counts one. That missing change is a real defect
+// and a wider one, and it belongs to the parser rather than to the scope.
+//
+// The rows are also the guard on the exclusion rule: a statement is excluded
+// only when the scope rejected something it named, never merely because it
+// produced no change. Reading it the other way would silence PG106 here.
+func TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone(t *testing.T) {
+	tests := []struct {
+		name         string
+		base         string
+		sql          string
+		wantChanges  []changeProjection
+		wantFindings []string
+	}{
+		{
+			name:         "dropping an index in the reviewed schema counts no change and still reports",
+			base:         "CREATE TABLE public.t (id int);\nCREATE INDEX idx ON public.t (id);\n",
+			sql:          "DROP INDEX public.idx;\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"PG106"},
+		},
+		{
+			name:         "dropping an index outside the reviewed schema behaves identically",
+			base:         "CREATE SCHEMA app;\nCREATE TABLE app.t (id int);\nCREATE INDEX idx ON app.t (id);\n",
+			sql:          "DROP INDEX app.idx;\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"PG106"},
+		},
+		{
+			name:         "a statement the parser models as no schema object keeps its finding",
+			base:         "CREATE TABLE public.t (id int);\n",
+			sql:          "DELETE FROM pg_enum WHERE enumtypid = 1;\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{"DS106"},
+		},
+		{
+			name:         "the modeled destructive control on the same schema counts its change",
+			base:         "CREATE TABLE public.t (id int);\n",
+			sql:          "DROP TABLE public.t;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "public.t"}},
+			wantFindings: []string{"DS101"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, "public")
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
 // TestAnalyzeFS_SchemaScopeKeepsUnattributableFindings proves the filter never
 // silences a hazard whose object it cannot read.
 //


### PR DESCRIPTION
Closes #1249's first two shapes. `ptah-compat migrate lint` restricts analysis to the schema the dev URL selects, and the filter was applied in two places that disagreed, so the reported counts and the reported findings described different sets.

## Measured

PostgreSQL 17.10, dev URL carrying `?search_path=public`, oracle = the pinned Atlas community binary v1.3.0, `migrate lint --latest 1`. Each version 2 runs after a version 1 that creates the objects it touches. The dev database was dropped and recreated before every run.

| version 2 | community v1.3.0 | before | after |
| --- | --- | --- | --- |
| `ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);` | 0 changes / 0 diagnostics / rc 0 | 0 / 1 (PG105) / 0 | **0 / 0 / 0** |
| `CREATE INDEX idx ON app.users (id);` | 0 / 0 / 0 | 1 / 1 (PG101) / 0 | **0 / 0 / 0** |
| `ALTER TABLE public.t DROP COLUMN c;` — control | 1 / 1 (DS103) / 1 | 1 / 1 / 1 | 1 / 1 / 1 |
| `ALTER TABLE app.t DROP COLUMN c;` — control | 0 / 0 / 0 | 0 / 0 / 0 | 0 / 0 / 0 |
| `CREATE INDEX idx ON public.users (id);` — control | 1 / 0 / 0 | 1 / 1 (PG101) / 0 | 1 / 1 (PG101) / 0 |
| `DROP TABLE public.t;` — control | 1 / 1 (DS102) / 1 | 1 / 1 / 1 | 1 / 1 / 1 |

The control rows are byte-identical before and after apart from elapsed-time lines. Parity rule (a) holds: the oracle exits 1 on exactly two rows, and so does `ptah-compat`, before and after.

The in-scope `CREATE INDEX` control is where Ptah stays deliberately stricter than the community binary, reporting `PG101` where it is silent. That is a warning at exit 0 and predates this change. It is also what separates "correctly scoped out" from "never analyzed" on the two rows above it: without it, a change that dropped every index would pass.

## What changed

**An index is measured by the table it is on, not by its own name.** `ast.IndexNode.Name` and `ast.DropIndexNode.Name` both document themselves as the raw, unqualified index identifier with the namespace derived from `Table`. Measuring an index by its own name put every index in scope whatever schema its table lived in, which is why `CREATE INDEX idx ON app.users (id)` counted a schema change under a run reviewing `public`.

**The scope decision is made once per statement and drives both outputs.** `extractSchemaChanges` now reports which statements the scope removed, and `keepFindings` consults that before falling back to subject matching. A rule that attaches no subject previously survived a scope that had already removed its statement — which is how the `ADD CONSTRAINT` row raised a hazard about a change it had counted as zero.

**Silence is not exclusion.** A statement is excluded only when the scope rejected something it named and nothing it named survived. A statement the parser cannot model, and one whose nodes name no schema object at all, keep their findings: a boundary that could not be read must not be able to drop a diagnostic. `DELETE FROM pg_enum …` — which parses to zero nodes and fires `DS106` — is the fixture that pins it.

The boundary stays confined to `ptah-compat`. Native `ptah migrations lint` reviews every object whatever the dev URL selects (#1197); an unrestricted scope rejects nothing, so no statement is ever marked excluded there. Two fixture rows pin that this PR does not widen it.

## The issue's third shape is a different defect

#1249 listed `DROP INDEX app.idx` alongside the `ADD CONSTRAINT` case. Measured, it is not that shape and no scope decision can fix it:

```
parser.NewParser("DROP INDEX app.idx", parser.WithDialect("postgres")).Parse()
  -> unsupported DROP target: INDEX at position 5
```

Ptah's SQL parser does not model `DROP INDEX` in any spelling, so the statement contributes zero schema changes in **every** schema. `DROP INDEX public.idx` — the reviewed schema — counts 0 where the community binary counts 1, while the `DROP TABLE public.t` control on that same schema counts 1 on both tools. A destructive operation missing from the change count everywhere is a wider defect than the scope disagreement this PR closes, it lives in a package the planner, dev-database replay, migration generation and schema diff all read, and it first has to settle where a `DROP INDEX`'s schema qualifier lives. Filed as #1296 with the measurement above; `nodeScopeReference` already routes `DropIndexNode` to its table, so the lint scope follows whichever answer that issue picks.

## Tests

`migration/lint/scope_test.go` gains a row per measured cell, each asserting the change count and the findings, since either alone would accept a fix that silenced one side. `migration/lint/changes_scope_internal_test.go` is white-box, with the required justification: both rules it pins govern node shapes no run can currently produce — the parser makes no `DropIndexNode`, and every `ALTER TABLE` form that would yield a node with no operations fails to parse instead — and both become load-bearing the moment the parser learns one of them.

Mutation evidence, each mutant applied alone:

- revert the index scoping → only the out-of-scope `CREATE INDEX` row and the two white-box index rows redden;
- revert the per-statement decision → both out-of-scope rows redden, and both on the findings assertion only, with their change counts still zero. The `CREATE INDEX` row needs both changes: one to zero its count, the other to zero its finding;
- over-correct the scoping direction, refusing unqualified references → the unqualified-in-scope rows redden, including the new index one;
- over-correct the exclusion rule, treating "no changes" as "scoped out" → survived the whole package on the first attempt. That was a coverage hole rather than a pass; the `DELETE FROM pg_enum` fixture was added for it, and the mutant now dies on exactly that row.

## Documentation

`docs/site/src/content/docs/atlas/migrate-commands.md` gains the index rule, states that the scope decision is taken once per statement so the two outputs cannot disagree, and names the `DROP INDEX` gap with its measurement rather than leaving the page claiming something that is not true.


---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

REFUTED on a shape the author never built: the new per-statement exclusion silences PG306 for a foreign key whose *referenced* table is inside the reviewed schema.

## The failing shape

Fixtures I wrote (not theirs), `caseG`:

    20240101000001_base.sql
      CREATE TABLE public.parent (id int PRIMARY KEY);
      CREATE SCHEMA app;
      CREATE TABLE app.child (id int, pid int);

    20240101000002_change.sql
      ALTER TABLE app.child ADD CONSTRAINT child_pid_fkey
        FOREIGN KEY (pid) REFERENCES public.parent (id);

Command (identical for all three binaries, dev DB dropped and recreated first):

    migrate lint --dir file://<caseG> \
      --dev-url 'postgres://postgres:pw@localhost:15249/lintdev?search_path=public&sslmode=disable' \
      --latest 1

| binary | diagnostics | rc |
| --- | --- | --- |
| /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas (community v1.3.0) | 0 | 0 |
| ptah-compat @ 9820496e (base) | **1 — PG306** | 0 |
| ptah-compat @ 4d196b71 (head) | **0 — "no diagnostics found"** | 0 |

The lost diagnostic is PG306: *"adding a foreign key validates existing rows and can block writes on **both tables**; add it NOT VALID first, then validate separately"*. One of those two tables is `public.parent` — inside the reviewed schema, present in the dev database, and the table PostgreSQL takes a SHARE ROW EXCLUSIVE lock on for the whole validation.

Cause confirmed rather than inferred: I rebuilt ptah-compat from head with one line disabled — the excluded-set consultation in `keepFindings` (`migration/lint/scope.go:121`) — and PG306 comes back (`G_headM2_rc=0`, 1 diagnostic). The other half of the PR (`nodeScopeReference`) cannot reach this row: `*ast.AlterTableNode` returns from the switch in `nodeSchemaChanges` before `nodeScopeReference` is ever called.

Why the design misses it: `nodeSchemaChanges` measures an ALTER TABLE solely by the altered table's schema ("Every action of an ALTER TABLE belongs to the table's schema, never to the column or constraint it names", changes.go:167-172), so the statement is marked `scopedOut` with zero changes and every finding on it is dropped. The PR's own doc comment argues the node decision "is the more informed answer ... it knows the table an ALTER or an index belongs to, where a finding knows only the subjects its rule chose to attach". For PG306 that is backwards: the node knows one table, the statement names two, and the second one is under review. This is the AGENTS.md worked-example failure mode — trading a place where Ptah was better for a place where it is merely identical. It is a warning at exit 0, so parity rule (a) is not broken, but it is a real loss on an in-scope object, introduced by this commit, absent from their residual list.

## Second: the same defect class, one keyword away, still unfixed and unmeasured

`CREATE SEQUENCE app.order_seq;` under `search_path=public` (caseC): community v1.3.0 = **0 schema changes**, ptah-compat base = **1 schema change**, ptah-compat head = **1 schema change**. `CREATE SEQUENCE app.s` parses to `*ast.CreateSequenceNode` with `Name = "s"` — the schema is dropped — so `allowsObject("s")` reads an unqualified reference and keeps it in scope. That is exactly the "an object measured by a name that carries no schema" defect the PR names for indexes. `nodeScopeReference` enumerates only `*ast.IndexNode` and `*ast.DropIndexNode`. Same untouched leak for `CREATE TRIGGER trg ... ON app.users` (counts `add trg` **and** raises PG308 under scope `public`) and `CREATE POLICY p ON app.users` (counts `add p`). None is listed as a residual.

## Third: two prose claims that are false

- White-box justification comment in `migration/lint/changes_scope_internal_test.go` (and the task text): *"every ALTER TABLE form that would yield a node with no operations fails to parse instead."* Measured directly: `parser.NewParser("ALTER TABLE app.users", parser.WithDialect("postgres")).Parse()` returns `err=<nil>, nodes=*ast.AlterTableNode` with zero operations. `parseAlterStatement` breaks out of its operation loop on `isAtEnd()`, so the form exists and is reachable through the public `lint.AnalyzeFS`.
- `docs/site/src/content/docs/atlas/migrate-commands.md` (added by this PR): *"the reported schema-change count and the reported diagnostics always describe the same statements."* Under `search_path=public`, `TRUNCATE app.users;` counts 0 changes and reports DS108 (Error, exit 1); `DROP SCHEMA app CASCADE;` → DS107; `ALTER TABLE app.users DROP CONSTRAINT k;` → DS105; `ALTER TABLE app.users ALTER COLUMN nick TYPE varchar(10);` → DS103; `... DISABLE ROW LEVEL SECURITY;` → DS109. The next paragraph ("Silence is not exclusion") contradicts the sentence, so the section states both a rule and its negation.

## Fourth: a surviving mutant — the new statement-index coupling is unpinned

Beyond their M1/M2/M4 (all reproduced: M1 rc=1 on the index rows, M2 rc=1 on exactly the two rows they name, M4 rc=1 on the DELETE FROM pg_enum row), and my over-correction M5 (`return changes, scopedOut`, dropping the `len(changes)==0` guard) which is correctly caught by the pre-existing `only_the_in-scope_target_of_a_mixed_drop_is_reported` row, I built the inverse control they did not:

    M7: excludedStatements[idx] || excludedStatements[idx+1]

`go test ./migration/lint/ -count=1` → **rc=0, package fully green**. M7 silences the statement immediately *before* a scoped-out one. Every fixture in the two new tests is a single-statement version, so nothing pins that the exclusion applies only to the statement that was scoped out. Head behaves correctly on that shape — I measured a two-statement file (`ALTER TABLE public.t ADD CONSTRAINT t_id_key UNIQUE (id);` then `CREATE INDEX idx ON app.users (id);`): oracle 1 change/1 diag, base 2/2, head 1/1 — but no test would catch a regression in it.

## What did hold

Their eight rows reproduce on my own container (ptah1249r-dev, port 15249, removed) with my own fixtures. `CREATE INDEX 

### What it says must change

The two landed shapes are right and worth keeping; the exclusion rule is too coarse. Three things need to change before this is landable.

1. A statement must be excluded only when *every* schema-qualified object it names is out of scope — not only the one the node's primary name happens to carry. For `ALTER TABLE app.child ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES public.parent (id)`, `ast.ForeignKeyConstraint`'s referenced table is a second named object and it is under review, so the statement is not scoped out and PG306 survives. Concretely: in the `*ast.AlterTableNode` branch of `nodeSchemaChanges`, when `!scope.allowsObject(n.Name)`, walk the operations for referenced tables before returning `(nil, true)` and return `(nil, false)` if any of them is in scope. The cheap, defensible alternative if the AST walk is too wide for one PR: keep the exclusion but restrict it to statements whose text names exactly one qualified reference, using the same `tableref` scan `droppedTablesNotCreated` already uses.

2. Add the two missing fixtures. A cross-schema FK row (`ALTER TABLE app.child ADD CONSTRAINT ... REFERENCES public.parent (id)` under scope `public` still reports PG306), and a two-statement version where an in-scope statement precedes a scoped-out one — the second is what kills the M7 neighbor-leak mutant that survives the whole package today.

3. Fix the prose. Delete "every ALTER TABLE form that would yield a node with no operations fails to parse instead" from `changes_scope_internal_test.go` (`ALTER TABLE t` parses to a zero-operation `*ast.AlterTableNode`), and either drop "always" from "the reported schema-change count and the reported diagnostics always describe the same statements" in `docs/site/src/content/docs/atlas/migrate-commands.md` or rewrite the pair so the doc does not state a rule and its negation two paragraphs apart. While there, list the residuals the sweep found: `CREATE SEQUENCE app.s`, `CREATE TRIGGER ... ON app.t` and `CREATE POLICY ... ON app.t` are still measured by a name that carries no schema, so they count a change (and PG308 fires) under `search_path=public` where the community binary counts none. Either extend `nodeScopeReference` to them or file them, but do not leave the fix looking complete.

Ready-to-post PR title and body for the corrected change:

---
Title: Decide a lint statement's schema scope once, by every object it names (#1249)

Body:

`ptah-compat migrate lint` restricts analysis to the schema the dev URL selects, and the filter was applied in two places that disagreed. Measured on PostgreSQL 17.10 against the pinned Atlas community binary v1.3.0, with a dev URL carrying `?search_path=public`:

| version 2 | community v1.3.0 | before | after |
| --- | --- | --- | --- |
| `ALTER TABLE app.users ADD CONSTRAINT users_id_key UNIQUE (id);` | 0 changes / 0 diagnostics | 0 / 1 (PG105) | 0 / 0 |
| `CREATE INDEX idx ON app.users (id);` | 0 / 0 | 1 / 1 (PG101) | 0 / 0 |
| `ALTER TABLE app.child ADD CONSTRAINT c FOREIGN KEY (pid) REFERENCES public.parent (id);` | 0 / 0 | 0 / 1 (PG306) | 0 / 1 (PG306) |
| `ALTER TABLE public.t DROP COLUMN c;` (control) | 1 / 1 (DS103) | 1 / 1 | 1 / 1 |
| `ALTER TABLE app.t DROP COLUMN c;` (control) | 0 / 0 | 0 / 0 | 0 / 0 |
| `CREATE INDEX idx ON public.users (id);` (control) | 1 / 0 | 1 / 1 (PG101) | 1 / 1 (PG101) |

An index is measured by the table it is on rather than by its own name: `ast.IndexNode.Name` and `ast.DropIndexNode.Name` both document themselves as the raw, unqualified index identifier with the namespace derived from `Table`.

The scope decision is made once per statement and drives both outputs. `extractSchemaChanges` reports which statements the scope removed, and `keepFindings` consults that before falling back to subject matching.

A statement is removed only when *every* object it names is out of review. The third row is why: `ADD CONSTRAINT ... FOREIGN KEY ... REFERENCES public.parent` takes a SHARE ROW EXCLUSIVE lock on `public.pa