### PR TITLE
Compare a unique key once, through the spelling the schema declares (#1245)

### DIFF
--- a/cmd/compare/report_coverage_internal_test.go
+++ b/cmd/compare/report_coverage_internal_test.go
@@ -20,12 +20,16 @@ import (
 )
 
 // nonCategoryFields names the SchemaDiff fields that do not carry schema
-// changes, with the reason each is not reported as a difference. A field that
-// is not a list is not a category by construction, and this map is what forces
-// that judgment to be made rather than assumed: a new non-list field fails
-// TestSchemaDiffNonCategoryFieldsAreDocumented until it is listed here.
+// changes, with the reason each is not reported as a difference. Everything
+// that is not a list is one by construction, and a list can be one too when it
+// qualifies another list rather than adding to it. This map is what forces that
+// judgment to be made rather than assumed: a field missing from both the
+// categories and this map fails TestSchemaDiffNonCategoryFieldsAreDocumented,
+// and a list listed here is a claim that reporting it would say nothing the
+// list it qualifies does not already say.
 var nonCategoryFields = map[string]string{
-	"IdentifierSemantics": "records the live catalog identifier rules the diff was produced under, not a difference between the two schemas",
+	"IdentifierSemantics":           "records the live catalog identifier rules the diff was produced under, not a difference between the two schemas",
+	"ConstraintBackedIndexRemovals": "a subset of IndexesRemoved, naming the removals whose object a UNIQUE constraint enforces so the planner spells the drop as a constraint drop; reporting it would print the same removed index a second time, and on its own it removes nothing",
 }
 
 // TestWriteComparisonReportsEveryDiffCategory is the guard for
@@ -123,8 +127,9 @@ ALTER TABLE "other"."secured" ENABLE ROW LEVEL SECURITY;
 }
 
 // diffCategoryFields returns the SchemaDiff fields that carry changes: the
-// exported list fields. It is a helper rather than an inline loop so the test
-// bodies above stay free of control flow.
+// exported list fields, less the ones nonCategoryFields excludes with a stated
+// reason. It is a helper rather than an inline loop so the test bodies above
+// stay free of control flow.
 func diffCategoryFields() []reflect.StructField {
 	structType := reflect.TypeFor[difftypes.SchemaDiff]()
 	var fields []reflect.StructField
@@ -132,16 +137,26 @@ func diffCategoryFields() []reflect.StructField {
 		if !field.IsExported() || field.Type.Kind() != reflect.Slice {
 			continue
 		}
+		if _, excluded := nonCategoryFields[field.Name]; excluded {
+			continue
+		}
 		fields = append(fields, field)
 	}
 	return fields
 }
 
+// diffNonCategoryFieldNames returns every SchemaDiff field the report guard
+// above does not exercise, which is exactly the set that has to carry a written
+// reason.
 func diffNonCategoryFieldNames() []string {
+	categories := make(map[string]struct{})
+	for _, field := range diffCategoryFields() {
+		categories[field.Name] = struct{}{}
+	}
 	structType := reflect.TypeFor[difftypes.SchemaDiff]()
 	var names []string
 	for field := range structType.Fields() {
-		if field.Type.Kind() == reflect.Slice {
+		if _, isCategory := categories[field.Name]; isCategory {
 			continue
 		}
 		names = append(names, field.Name)

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1075,6 +1075,17 @@ type DropIndexNode struct {
 	// planners set it only for standalone index drops the caller routes into a
 	// no_transaction migration.
 	Concurrently bool
+	// EnforcesUniqueConstraint reports that the index being dropped is the one
+	// a UNIQUE constraint of the same name enforces, so the statement removes a
+	// uniqueness protection and not only an access path.
+	//
+	// It carries no SQL: on MySQL and MariaDB, the engines that reach it, a
+	// unique key and its constraint are one catalog row and DROP INDEX is the
+	// statement that removes it. It exists so risk classification can tell the
+	// two apart, because the spelling cannot: dropping `uq_users_email` and
+	// dropping `idx_users_email` are the same statement shape and a very
+	// different change to the data's guarantees.
+	EnforcesUniqueConstraint bool
 	// Comment is an optional comment for the drop operation
 	Comment string
 }
@@ -1132,6 +1143,14 @@ func (n *DropIndexNode) SetIfExists() *DropIndexNode {
 //	dropIndex.SetConcurrently()
 func (n *DropIndexNode) SetConcurrently() *DropIndexNode {
 	n.Concurrently = true
+	return n
+}
+
+// SetEnforcesUniqueConstraint records that this drop removes the index a
+// UNIQUE constraint of the same name enforces. It changes no SQL; see
+// [DropIndexNode.EnforcesUniqueConstraint].
+func (n *DropIndexNode) SetEnforcesUniqueConstraint() *DropIndexNode {
+	n.EnforcesUniqueConstraint = true
 	return n
 }
 

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -193,6 +193,16 @@ type DBIndex struct {
 	IsUnique   bool          `json:"is_unique"`
 	IsPrimary  bool          `json:"is_primary"`
 	Definition string        `json:"definition"` // Full index definition
+	// KeyPartsIncomplete reports that the catalog described a key part this
+	// reader cannot name, so Columns (and Parts) list fewer parts than the key
+	// actually has. The MySQL reader sets it for a functional key part --
+	// `KEY idx ((b + 1))` -- whose information_schema.STATISTICS row carries a
+	// NULL COLUMN_NAME and an EXPRESSION column that MariaDB does not have.
+	//
+	// A comparison must not read the key columns of such an index as the whole
+	// key: it would plan a rebuild on every run for a key that never changed.
+	// Everything else about the index is reported normally.
+	KeyPartsIncomplete bool `json:"key_parts_incomplete,omitempty"`
 	// Condition is the WHERE clause for partial indexes when the dialect
 	// exposes one structurally.
 	Condition string `json:"condition,omitempty"`

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -294,20 +294,37 @@ now. A comma is a legal character in a MySQL identifier and
 11.8, which is why only the comma reaches it there). A functional key part has a
 `NULL` `COLUMN_NAME` and an `EXPRESSION` column MariaDB does not have, so the
 reader still cannot name it — it now reports the part as one it could not read
-instead of failing, and the key-column comparison declines on such an index
-rather than planning a rebuild of a key that never changed. Comparing MySQL
-expression keys is still not supported.
+instead of failing, and the key-column comparison reads what was read rather than
+treating it as the whole key, which would plan a rebuild of a key that never
+changed on every run.
+
+A partly-read key is compared as far as it was read. `KEY idx_mixed (b, (b + 1))`
+arrives as the one named column `b` plus the record of a part that could not be
+named, so a desired `idx_mixed (c, (c + 1))` is a different key by the only part
+either side can name, and the difference is reported. Proof runs one way only: a
+desired `idx_mixed (b, (c + 1))` names the same column and differs solely in the
+expression, and that pair is still reported synced. Closing it means reading
+`information_schema.STATISTICS.EXPRESSION`, which MariaDB does not have, so
+comparing a MySQL expression key remains unsupported — as does rebuilding one,
+because the down direction would recreate the key without its expression.
 
 ### A unique constraint and its index are one object, and the schema says which
 
-Every engine Ptah supports except SQL Server enforces a `UNIQUE` constraint with
-an index of the constraint's own name on the constraint's own table.
-Introspection reports that one object twice — once in the index catalog, once in
-the constraint catalog — and MySQL and MariaDB do not even have a separate
-notion to report: `ADD CONSTRAINT c UNIQUE (a)` and
-`CREATE UNIQUE INDEX c ON t (a)` leave the identical catalog row, which is why
-`schema inspect` writes MySQL uniqueness back out as `index { unique = true }`
-on both binaries and never as a constraint.
+PostgreSQL, MySQL and MariaDB enforce a `UNIQUE` constraint with an index of the
+constraint's own name on the constraint's own table. Introspection reports that
+one object twice — once in the index catalog, once in the constraint catalog —
+and MySQL and MariaDB do not even have a separate notion to report:
+`ADD CONSTRAINT c UNIQUE (a)` and `CREATE UNIQUE INDEX c ON t (a)` leave the
+identical catalog row, which is why `schema inspect` writes MySQL uniqueness
+back out as `index { unique = true }` on both binaries and never as a
+constraint.
+
+The other two engines Ptah supports do not share the name, so nothing brings the
+two representations into collision there. SQL Server keeps a `UNIQUE` constraint
+and a unique index as separate objects. SQLite backs one with an index it names
+itself: `CREATE TABLE t (a TEXT, CONSTRAINT uq_t_a UNIQUE(a))` leaves
+`sqlite_master` holding `sqlite_autoindex_t_1`, and no statement can name that
+object or the constraint that owns it.
 
 The two representations used to be compared in two pools, and the database index
 was filtered out of its pool unconditionally. The desired side is never
@@ -363,11 +380,51 @@ below are the pinned binary's own plan, matched by Ptah:
 
 Dropping the PostgreSQL one as an index answers `cannot drop index
 uq_users_email because constraint uq_users_email on table users requires it
-(SQLSTATE 2BP01)`, so the comparator marks those removals and the
-PostgreSQL-family planner renders the constraint spelling. SQL Server never
-reaches the rule — a UNIQUE constraint and a unique index are separate objects
-there — and SQLite's constraint-backed index is `sqlite_autoindex_*`, which no
-statement can name and which the comparator therefore never considers.
+(SQLSTATE 2BP01)`. The comparator therefore records **what the object is** — a
+UNIQUE constraint's — for every engine that reports it under the constraint's
+name, and each planner spells its own statement: the PostgreSQL-family planner
+drops the constraint, the MySQL and MariaDB planner keeps `DROP INDEX` and their
+plans are unchanged. SQL Server never reaches the rule, and SQLite names the
+backing index itself, so neither records anything.
+
+**The rollback restores a constraint, on every engine.** What the up direction
+dropped was a UNIQUE constraint, so `ALTER TABLE … ADD CONSTRAINT … UNIQUE` is
+what puts it back — on MySQL and MariaDB that lands the same catalog row
+`CREATE UNIQUE INDEX` would, and on PostgreSQL nothing else restores the
+`pg_constraint` row.
+
+Reversing the removal into an index addition instead restored the wrong object
+where it worked at all. Three facts govern the down direction:
+
+- The down target is the introspected schema, which omits a constraint-backed
+  index because the index is the constraint's. The index addition therefore had
+  nothing to resolve, and generation failed outright with `invalid schema diff:
+  added index users.uq_users_email at position 0 is missing or ambiguous in the
+  target schema` — measured live on PostgreSQL 17.10 and MySQL 9.7.1, where no
+  migration could be produced at all.
+- Where it did resolve, it would rebuild a plain unique index in place of the
+  constraint, leaving a catalog the migration never started from.
+- `ADD CONSTRAINT … UNIQUE` builds an index of the constraint's name, so the
+  plain index the up direction created is dropped first. Otherwise PostgreSQL
+  answers `relation "uq_users_email" already exists` (SQLSTATE 42P07) and MySQL
+  `Error 1061 (42000): Duplicate key name 'uq_users_email'`.
+
+Applied end to end against a live `CONSTRAINT uq_users_email UNIQUE (email)`, the
+up leaves a plain index and no constraint row, the down restores both, and a
+second comparison against the post-up database reports synced:
+
+| Target | up | catalog after up | down | catalog after down |
+| --- | --- | --- | --- | --- |
+| PostgreSQL 17.10 | exit 0 | `uq_users_email` a plain index, no `pg_constraint` row | exit 0 | `UNIQUE (email)` and its unique index, as before the up |
+| MySQL 9.7.1 | exit 0 | `NON_UNIQUE=1`, no `TABLE_CONSTRAINTS` row | exit 0 | `NON_UNIQUE=0` and the `UNIQUE` row, as before the up |
+
+**Losing the uniqueness is a destructive change, whichever statement says so.**
+Replacing a unique key with a plain index deletes a data guarantee, and it was
+classified only as `indexes_removed` — a warning, which passed
+`--check-destructive` and every drift threshold keyed on destructive findings, on
+all three engines. The diff now reports it as `unique_protections_removed`, and
+on MySQL and MariaDB — where the removal is spelled `DROP INDEX`, exactly like
+dropping an access path — the statement itself is classified destructive.
 
 ## Reports
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -269,10 +269,65 @@ Two consequences worth naming:
   input and no round trip reaches it. Omit a default class, which is how both
   binaries write one.
 
-Only PostgreSQL is covered. MySQL, MariaDB, SQLite, ClickHouse, CockroachDB,
-YugabyteDB and Spanner keep the comparison they had, because what makes two
-indexes the same index is a per-dialect question and only PostgreSQL was
-measured.
+MySQL and MariaDB now compare uniqueness and the key columns, and nothing else.
+That branch was added with the ownership rule below, which is what made a
+database unique index reachable by the comparison at all; see
+[#1245](https://github.com/stokaro/ptah/issues/1245) for what it deliberately
+leaves out and why. SQLite, ClickHouse, CockroachDB, YugabyteDB and Spanner keep
+the comparison they had, because what makes two indexes the same index is a
+per-dialect question and those dialects were not measured.
+
+### A unique constraint and its index are one object, and the schema says which
+
+Every engine Ptah supports except SQL Server enforces a `UNIQUE` constraint with
+an index of the constraint's own name on the constraint's own table.
+Introspection reports that one object twice — once in the index catalog, once in
+the constraint catalog — and MySQL and MariaDB do not even have a separate
+notion to report: `ADD CONSTRAINT c UNIQUE (a)` and
+`CREATE UNIQUE INDEX c ON t (a)` leave the identical catalog row, which is why
+`schema inspect` writes MySQL uniqueness back out as `index { unique = true }`
+on both binaries and never as a constraint.
+
+The two representations used to be compared in two pools, and the database index
+was filtered out of its pool unconditionally. The desired side is never
+filtered, so a desired state that spells the object as an index had nothing to
+match: index comparison reported it **added** and constraint comparison, finding
+no `UNIQUE` constraint on the desired side, reported the same name **removed**,
+in the same plan. Measured by replaying a database's own `schema inspect` output
+against the database it came from, where the pinned Atlas CE v1.3.0 binary
+reported the schema synced:
+
+| Target | Fixture | Ptah before | Result of applying it |
+| --- | --- | --- | --- |
+| MySQL 9.7.1 | `UNIQUE KEY uq_users_email (email)` | `CREATE UNIQUE INDEX` + `DROP INDEX` | exit 1, `Error 1061 (42000): Duplicate key name` |
+| MySQL 9.7.1 | `UNIQUE KEY uk_users_email (email)` | `CREATE UNIQUE INDEX` + `DROP INDEX` | exit 1, same error |
+| MariaDB 11.8.8 | `UNIQUE KEY uq_users_email (email)` | `CREATE UNIQUE INDEX` + `DROP INDEX IF EXISTS` | exit 1, same error |
+| PostgreSQL 17.10 | `CONSTRAINT uq_users_email UNIQUE (email)` against a desired `index { unique = true }` | `CREATE UNIQUE INDEX IF NOT EXISTS` + `DROP CONSTRAINT IF EXISTS` | **exit 0**, and the table left with no unique index at all |
+
+The spurious pair rode along with real work. Adding one column to the MySQL
+table above planned `ADD COLUMN`, then the same `CREATE UNIQUE INDEX` and
+`DROP INDEX`; the apply added the column, failed on the create, and exited 1
+with the migration half applied.
+
+The PostgreSQL row is the one to read twice. The `IF NOT EXISTS` guard skipped
+the create, the drop took the constraint and its index with it, and the command
+reported success while deleting the uniqueness the desired state asked for.
+
+Ownership now follows the desired state's spelling. An identity the desired
+state declares as an index reaches index comparison, whichever filter would
+otherwise have claimed it, and constraint comparison leaves that object alone; a
+desired state that spells uniqueness as a constraint, or does not mention the
+object at all, is unchanged — the constraint pool still owns it, and an
+undeclared unique key is still reported removed. The rule cannot start dropping
+anything, because an identity only survives the filters when the desired state
+names it, and an identity the desired state names is matched rather than
+removed.
+
+Two objects that merely share a name stay two: index identity carries the owning
+table, and a desired plain `index "uq_users_email"` against a database
+`UNIQUE KEY uq_users_email` is reported as a replacement — one `DROP INDEX`
+followed by one `CREATE INDEX`, which is the pair the pinned binary plans for it
+on MySQL 9.7.1 — rather than being collapsed into agreement.
 
 ## Reports
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -277,6 +277,27 @@ leaves out and why. SQLite, ClickHouse, CockroachDB, YugabyteDB and Spanner keep
 the comparison they had, because what makes two indexes the same index is a
 per-dialect question and those dialects were not measured.
 
+A key those two engines compare has to be read whole first, and one is read one
+part at a time for that reason. `information_schema.STATISTICS` describes a key
+as one row per part; joining the names in SQL and splitting them again in Go
+lost a key two ways, both of which a schema is free to hit:
+
+| Fixture on MySQL 9.7.1 | Read as | Applying a database's own `schema inspect` output |
+| --- | --- | --- |
+| `` KEY idx_weird (`a,b`) `` | two columns, `a` and `b` | exit 1, `Error 1072 (42000): Key column 'a' doesn't exist in table` |
+| a 16-part key of 64-character names, 1039 bytes past `group_concat_max_len` | the last name cut at 1024 bytes | exit 1, same error naming the truncated column |
+| `KEY idx_expr ((b + 1))` | nothing — the read failed | exit 1, `converting NULL to string is unsupported` |
+
+The pinned Atlas CE v1.3.0 binary reported all three synced, and so does Ptah
+now. A comma is a legal character in a MySQL identifier and
+`group_concat_max_len` defaults to 1024 bytes on MySQL 9.7 (1048576 on MariaDB
+11.8, which is why only the comma reaches it there). A functional key part has a
+`NULL` `COLUMN_NAME` and an `EXPRESSION` column MariaDB does not have, so the
+reader still cannot name it — it now reports the part as one it could not read
+instead of failing, and the key-column comparison declines on such an index
+rather than planning a rebuild of a key that never changed. Comparing MySQL
+expression keys is still not supported.
+
 ### A unique constraint and its index are one object, and the schema says which
 
 Every engine Ptah supports except SQL Server enforces a `UNIQUE` constraint with
@@ -318,16 +339,35 @@ state declares as an index reaches index comparison, whichever filter would
 otherwise have claimed it, and constraint comparison leaves that object alone; a
 desired state that spells uniqueness as a constraint, or does not mention the
 object at all, is unchanged — the constraint pool still owns it, and an
-undeclared unique key is still reported removed. The rule cannot start dropping
-anything, because an identity only survives the filters when the desired state
-names it, and an identity the desired state names is matched rather than
-removed.
+undeclared unique key is still reported removed. The rule never drops an object
+the desired state did not ask to change: an identity only survives the filters
+when the desired state names it, and a named identity is either matched, or
+replaced by the definition the desired state gives it — an addition paired with
+the drop of what it replaces, never a drop on its own.
 
 Two objects that merely share a name stay two: index identity carries the owning
 table, and a desired plain `index "uq_users_email"` against a database
-`UNIQUE KEY uq_users_email` is reported as a replacement — one `DROP INDEX`
-followed by one `CREATE INDEX`, which is the pair the pinned binary plans for it
-on MySQL 9.7.1 — rather than being collapsed into agreement.
+`UNIQUE KEY uq_users_email` is reported as a replacement rather than being
+collapsed into agreement.
+
+**The drop half of that replacement is spelled per engine, because the object
+is.** On MySQL and MariaDB the unique key and its constraint are one catalog row
+and `DROP INDEX` removes it. On PostgreSQL the constraint is an object of its
+own that owns the index, and the server refuses the index spelling. Both cells
+below are the pinned binary's own plan, matched by Ptah:
+
+| Target | Database | Desired | Plan |
+| --- | --- | --- | --- |
+| MySQL 9.7.1 | `UNIQUE KEY uq_users_email (email)` | `index "uq_users_email"` | `ALTER TABLE users DROP INDEX uq_users_email` then `ADD INDEX` |
+| PostgreSQL 17.10 | `CONSTRAINT uq_users_email UNIQUE (email)` | `index "uq_users_email"` | `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"` then `CREATE INDEX` |
+
+Dropping the PostgreSQL one as an index answers `cannot drop index
+uq_users_email because constraint uq_users_email on table users requires it
+(SQLSTATE 2BP01)`, so the comparator marks those removals and the
+PostgreSQL-family planner renders the constraint spelling. SQL Server never
+reaches the rule — a UNIQUE constraint and a unique index are separate objects
+there — and SQLite's constraint-backed index is `sqlite_autoindex_*`, which no
+statement can name and which the comparator therefore never considers.
 
 ## Reports
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1884,6 +1884,17 @@ type DropIndexNode struct {
     // planners set it only for standalone index drops the caller routes into a
     // no_transaction migration.
     Concurrently bool
+    // EnforcesUniqueConstraint reports that the index being dropped is the one
+    // a UNIQUE constraint of the same name enforces, so the statement removes a
+    // uniqueness protection and not only an access path.
+    //
+    // It carries no SQL: on MySQL and MariaDB, the engines that reach it, a
+    // unique key and its constraint are one catalog row and DROP INDEX is the
+    // statement that removes it. It exists so risk classification can tell the
+    // two apart, because the spelling cannot: dropping `uq_users_email` and
+    // dropping `idx_users_email` are the same statement shape and a very
+    // different change to the data's guarantees.
+    EnforcesUniqueConstraint bool
     // Comment is an optional comment for the drop operation
     Comment string
 }
@@ -1897,6 +1908,7 @@ func NewDropIndex(name string) *DropIndexNode
 func (n *DropIndexNode) Accept(visitor Visitor) error
 func (n *DropIndexNode) SetComment(comment string) *DropIndexNode
 func (n *DropIndexNode) SetConcurrently() *DropIndexNode
+func (n *DropIndexNode) SetEnforcesUniqueConstraint() *DropIndexNode
 func (n *DropIndexNode) SetIfExists() *DropIndexNode
 func (n *DropIndexNode) SetTable(table string) *DropIndexNode
 
@@ -8617,15 +8629,21 @@ type SchemaDiff struct {
 
     // ConstraintBackedIndexRemovals is the subset of IndexesRemoved whose
     // object is enforced by a UNIQUE constraint of the same name on the same
-    // table, so the drop has to be spelled
-    // `ALTER TABLE <table> DROP CONSTRAINT <name>`.
+    // table. It records what the object is; each planner spells the statement
+    // its engine accepts.
     //
-    // PostgreSQL refuses the index spelling for those:
+    // PostgreSQL refuses the index spelling for one:
     // `cannot drop index uq_users_email because constraint uq_users_email on
-    // table users requires it (SQLSTATE 2BP01)`, measured on 17.10. MySQL and
-    // MariaDB are the opposite case -- a unique key and its index are one
-    // catalog row that `DROP INDEX` drops -- so their removals are never listed
-    // here.
+    // table users requires it (SQLSTATE 2BP01)`, measured on 17.10, so its
+    // planner drops the constraint instead. MySQL and MariaDB are the opposite
+    // case -- a unique key and its index are one catalog row that `DROP INDEX`
+    // drops, which is what the pinned community binary v1.3.0 plans there -- so
+    // their planners ignore the list and their plans are unchanged by it.
+    //
+    // The list is not PostgreSQL-only, because the down direction needs it on
+    // every engine: what was dropped was a UNIQUE constraint, and a rollback
+    // that reverses it into an index addition restores the wrong object (see
+    // the generator's reverseIndexRemovals).
     ConstraintBackedIndexRemovals []IndexRef `json:"constraint_backed_index_removals,omitempty"`
 
     // ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
@@ -8821,6 +8839,7 @@ func (d *SchemaDiff) EffectiveIdentifierSemantics(dialect string) identifier.Sem
 func (d *SchemaDiff) HasChanges() bool
 func (d *SchemaDiff) IndexAdditions() []IndexRef
 func (d *SchemaDiff) IndexRemovals() []IndexRef
+func (d *SchemaDiff) IndexRemovalsRebuiltAsUniqueConstraints() map[IndexRef]struct{}
 func (d *SchemaDiff) SetConstraintBackedIndexRemovals(refs []IndexRef)
 func (d *SchemaDiff) SetIndexAdditions(refs []IndexRef)
 func (d *SchemaDiff) SetIndexRemovals(refs []IndexRef)

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5472,6 +5472,16 @@ type DBIndex struct {
     IsUnique   bool          `json:"is_unique"`
     IsPrimary  bool          `json:"is_primary"`
     Definition string        `json:"definition"` // Full index definition
+    // KeyPartsIncomplete reports that the catalog described a key part this
+    // reader cannot name, so Columns (and Parts) list fewer parts than the key
+    // actually has. The MySQL reader sets it for a functional key part --
+    // `KEY idx ((b + 1))` -- whose information_schema.STATISTICS row carries a
+    // NULL COLUMN_NAME and an EXPRESSION column that MariaDB does not have.
+    //
+    // A comparison must not read the key columns of such an index as the whole
+    // key: it would plan a rebuild on every run for a key that never changed.
+    // Everything else about the index is reported normally.
+    KeyPartsIncomplete bool `json:"key_parts_incomplete,omitempty"`
     // Condition is the WHERE clause for partial indexes when the dialect
     // exposes one structurally.
     Condition string `json:"condition,omitempty"`
@@ -8605,6 +8615,19 @@ type SchemaDiff struct {
     // plans or uniqueness protections.
     IndexesRemoved []IndexRef `json:"indexes_removed"`
 
+    // ConstraintBackedIndexRemovals is the subset of IndexesRemoved whose
+    // object is enforced by a UNIQUE constraint of the same name on the same
+    // table, so the drop has to be spelled
+    // `ALTER TABLE <table> DROP CONSTRAINT <name>`.
+    //
+    // PostgreSQL refuses the index spelling for those:
+    // `cannot drop index uq_users_email because constraint uq_users_email on
+    // table users requires it (SQLSTATE 2BP01)`, measured on 17.10. MySQL and
+    // MariaDB are the opposite case -- a unique key and its index are one
+    // catalog row that `DROP INDEX` drops -- so their removals are never listed
+    // here.
+    ConstraintBackedIndexRemovals []IndexRef `json:"constraint_backed_index_removals,omitempty"`
+
     // ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
     // but not in the current database schema
     ExtensionsAdded []string `json:"extensions_added"`
@@ -8793,10 +8816,12 @@ type SchemaDiff struct {
             fmt.Printf("Found %d new tables\n", len(diff.TablesAdded))
         }
 
+func (d *SchemaDiff) ConstraintBackedIndexRemovalSet() map[IndexRef]struct{}
 func (d *SchemaDiff) EffectiveIdentifierSemantics(dialect string) identifier.Semantics
 func (d *SchemaDiff) HasChanges() bool
 func (d *SchemaDiff) IndexAdditions() []IndexRef
 func (d *SchemaDiff) IndexRemovals() []IndexRef
+func (d *SchemaDiff) SetConstraintBackedIndexRemovals(refs []IndexRef)
 func (d *SchemaDiff) SetIndexAdditions(refs []IndexRef)
 func (d *SchemaDiff) SetIndexRemovals(refs []IndexRef)
 

--- a/internal/dbschema/mysql/reader.go
+++ b/internal/dbschema/mysql/reader.go
@@ -33,6 +33,14 @@ type tableColumnKey struct {
 	column string
 }
 
+// indexKey groups the information_schema.STATISTICS rows that belong to one
+// key. MySQL scopes an index name to its table, so the table is part of the
+// identity.
+type indexKey struct {
+	table string
+	index string
+}
+
 // NewMySQLReader creates a new MySQL schema reader
 func NewMySQLReader(db sqlrunner.Runner, schema string) *Reader {
 	if schema == "" {
@@ -492,48 +500,109 @@ func (r *Reader) readEnums(dbName string) ([]types.DBEnum, error) {
 	return enums, nil
 }
 
-// readIndexes reads all indexes
-func (r *Reader) readIndexes(dbName string) ([]types.DBIndex, error) {
-	query := `
+// indexKeyPartsQuery reads information_schema.STATISTICS one key part at a
+// time, in key order, so the key can be assembled in Go.
+//
+// The projection this replaced was
+// `GROUP_CONCAT(s.COLUMN_NAME ORDER BY s.SEQ_IN_INDEX)` split on a comma, and
+// it cannot carry a key faithfully in two ways that a schema is free to hit:
+//
+//   - A comma is a legal character in a MySQL identifier. `KEY idx (`a,b`)`
+//     came back as the two columns `a` and `b`.
+//   - GROUP_CONCAT truncates at group_concat_max_len, 1024 bytes by default on
+//     MySQL 9.7. A 16-part key of 64-character names is 1039 bytes, so the last
+//     name arrived cut in half. MariaDB 11.8 defaults to 1048576 and does not
+//     reach this one.
+//
+// Either way the reader reported column names the table does not have, and a
+// comparison that trusts them plans a rebuild for a key that never changed.
+// Measured on MySQL 9.7.1 and MariaDB 11.8.8, replaying a database's own
+// `schema inspect` output ended in
+// `Error 1072 (42000): Key column 'a' doesn't exist in table` where the pinned
+// community binary v1.3.0 reported "Schema is synced" (issue #1245).
+const indexKeyPartsQuery = `
 		SELECT
 			s.INDEX_NAME,
 			s.TABLE_NAME,
-			GROUP_CONCAT(s.COLUMN_NAME ORDER BY s.SEQ_IN_INDEX) as COLUMNS,
+			s.COLUMN_NAME,
 			s.NON_UNIQUE,
 			s.INDEX_TYPE
 		FROM information_schema.STATISTICS s
 		WHERE s.TABLE_SCHEMA = ?
 		AND s.TABLE_NAME NOT IN ('schema_migrations')
-		GROUP BY s.INDEX_NAME, s.TABLE_NAME, s.NON_UNIQUE, s.INDEX_TYPE
-		ORDER BY s.TABLE_NAME, s.INDEX_NAME`
+		ORDER BY s.TABLE_NAME, s.INDEX_NAME, s.SEQ_IN_INDEX`
 
-	rows, err := r.db.Query(query, dbName)
+// readIndexes reads all indexes, assembling each key from its parts.
+func (r *Reader) readIndexes(dbName string) ([]types.DBIndex, error) {
+	rows, err := r.db.Query(indexKeyPartsQuery, dbName)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	var indexes []types.DBIndex
+	var (
+		indexes    []types.DBIndex
+		indexTypes []string
+		positions  = make(map[indexKey]int)
+	)
 	for rows.Next() {
-		var index types.DBIndex
-		var columnsStr string
-		var nonUnique int
-		var indexType string
-
-		err := rows.Scan(&index.Name, &index.TableName, &columnsStr, &nonUnique, &indexType)
+		var (
+			name       string
+			tableName  string
+			columnName sql.NullString
+			nonUnique  int
+			indexType  string
+		)
+		err := rows.Scan(&name, &tableName, &columnName, &nonUnique, &indexType)
 		if err != nil {
 			return nil, err
 		}
-
-		index.Columns = strings.Split(columnsStr, ",")
-		index.IsUnique = nonUnique == 0
-		index.IsPrimary = index.Name == "PRIMARY"
-		index.Definition = fmt.Sprintf("%s INDEX %s ON %s (%s)", indexType, index.Name, index.TableName, columnsStr)
-
-		indexes = append(indexes, index)
+		key := indexKey{table: tableName, index: name}
+		position, started := positions[key]
+		if !started {
+			position = len(indexes)
+			positions[key] = position
+			indexes = append(indexes, types.DBIndex{
+				Name:      name,
+				TableName: tableName,
+				IsUnique:  nonUnique == 0,
+				IsPrimary: name == "PRIMARY",
+			})
+			indexTypes = append(indexTypes, indexType)
+		}
+		addIndexKeyPart(&indexes[position], columnName)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	for position := range indexes {
+		index := &indexes[position]
+		index.Definition = fmt.Sprintf(
+			"%s INDEX %s ON %s (%s)",
+			indexTypes[position],
+			index.Name,
+			index.TableName,
+			strings.Join(index.Columns, ","),
+		)
 	}
 
 	return indexes, nil
+}
+
+// addIndexKeyPart records one key part of an index.
+//
+// A NULL COLUMN_NAME is a functional key part -- `KEY idx ((b + 1))` on MySQL
+// 8.0.13 and later -- whose expression lives in a STATISTICS column MariaDB
+// does not have, so this reader cannot name it. It is recorded as a part that
+// is missing from Columns rather than dropped silently: a comparison that read
+// Columns as the whole key would plan a rebuild of a key that never changed.
+// See [types.DBIndex.KeyPartsIncomplete].
+func addIndexKeyPart(index *types.DBIndex, columnName sql.NullString) {
+	if !columnName.Valid {
+		index.KeyPartsIncomplete = true
+		return
+	}
+	index.Columns = append(index.Columns, columnName.String)
 }
 
 // readConstraints reads all constraints

--- a/internal/dbschema/mysql/reader_internal_test.go
+++ b/internal/dbschema/mysql/reader_internal_test.go
@@ -1,0 +1,216 @@
+package mysql
+
+// White-box testing required: what is under test is how readIndexes assembles a
+// key out of the information_schema.STATISTICS rows that describe it, and both
+// halves of that -- the projection and the assembly -- are unexported. Reaching
+// them through ReadSchema would mean scripting every other catalog query to
+// observe this one, and the rows this scripts are the catalog's own, so the
+// result is still measured against what MySQL reports rather than against an
+// internal shape.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// statisticsColumns is the projection readIndexes selects, one row per key
+// part.
+var statisticsColumns = []string{
+	"INDEX_NAME",
+	"TABLE_NAME",
+	"COLUMN_NAME",
+	"NON_UNIQUE",
+	"INDEX_TYPE",
+}
+
+// wideKeyColumnNames is a 16-part key of 64-character column names: 1039 bytes
+// once joined with commas, past the 1024-byte group_concat_max_len MySQL 9.7
+// defaults to. Read through GROUP_CONCAT the last name arrived truncated to
+// `abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw`, and the plan built a
+// CREATE INDEX over a column the table does not have.
+func wideKeyColumnNames() []string {
+	names := make([]string, 0, 16)
+	for part := 1; part <= 16; part++ {
+		names = append(names, fmt.Sprintf(
+			"abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyzabcdefghij%02d",
+			part,
+		))
+	}
+	return names
+}
+
+func wideKeyRows() [][]driver.Value {
+	rows := make([][]driver.Value, 0, 16)
+	for _, name := range wideKeyColumnNames() {
+		rows = append(rows, []driver.Value{"idx_wide", "wide", name, int64(1), "BTREE"})
+	}
+	return rows
+}
+
+// TestReadIndexes_AssemblesKeysFromTheirParts is stokaro/ptah#1245's second
+// half: the key columns MySQL and MariaDB are compared on have to survive the
+// read. Measured on MySQL 9.7.1 and MariaDB 11.8.8, replaying a database's own
+// `schema inspect` output for the first two rows below ended in
+// `Error 1072 (42000): Key column 'a' doesn't exist in table` where the pinned
+// community binary v1.3.0 reported "Schema is synced".
+func TestReadIndexes_AssemblesKeysFromTheirParts(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		rows   [][]driver.Value
+		assert func(c *qt.C, indexes []types.DBIndex)
+	}{
+		{
+			name: "column name containing a comma",
+			rows: [][]driver.Value{
+				{"idx_weird", "t2", "a,b", int64(1), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].Columns, qt.DeepEquals, []string{"a,b"})
+				c.Assert(indexes[0].KeyPartsIncomplete, qt.IsFalse)
+			},
+		},
+		{
+			name: "sixteen part key past group_concat_max_len",
+			rows: wideKeyRows(),
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].Columns, qt.DeepEquals, wideKeyColumnNames())
+				c.Assert(indexes[0].KeyPartsIncomplete, qt.IsFalse)
+			},
+		},
+		{
+			name: "key order follows the rows",
+			rows: [][]driver.Value{
+				{"idx_pair", "t", "b", int64(1), "BTREE"},
+				{"idx_pair", "t", "a", int64(1), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].Columns, qt.DeepEquals, []string{"b", "a"})
+			},
+		},
+		{
+			name: "one index name per owning table",
+			rows: [][]driver.Value{
+				{"idx_name", "orders", "reference", int64(1), "BTREE"},
+				{"idx_name", "users", "email", int64(0), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 2)
+				c.Assert(indexes[0].TableName, qt.Equals, "orders")
+				c.Assert(indexes[0].Columns, qt.DeepEquals, []string{"reference"})
+				c.Assert(indexes[0].IsUnique, qt.IsFalse)
+				c.Assert(indexes[1].TableName, qt.Equals, "users")
+				c.Assert(indexes[1].Columns, qt.DeepEquals, []string{"email"})
+				c.Assert(indexes[1].IsUnique, qt.IsTrue)
+			},
+		},
+		{
+			name: "unique key and its definition",
+			rows: [][]driver.Value{
+				{"uq_users_email", "users", "email", int64(0), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].IsUnique, qt.IsTrue)
+				c.Assert(indexes[0].IsPrimary, qt.IsFalse)
+				c.Assert(indexes[0].Definition, qt.Equals, "BTREE INDEX uq_users_email ON users (email)")
+			},
+		},
+		{
+			name: "primary key",
+			rows: [][]driver.Value{
+				{"PRIMARY", "users", "id", int64(0), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].IsPrimary, qt.IsTrue)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := NewMySQLReader(statisticsDB(c, test.rows).SQL, "app")
+
+			indexes, err := reader.readIndexes("app")
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, indexes)
+		})
+	}
+}
+
+// TestReadIndexes_ReportsAKeyPartItCannotName covers a functional key part,
+// whose STATISTICS row carries the expression and a NULL COLUMN_NAME. The read
+// used to fail outright -- `converting NULL to string is unsupported`, exit 1
+// on a MySQL 9.7.1 database the pinned community binary v1.3.0 reports synced
+// -- because GROUP_CONCAT collapsed the whole row. The part is now reported as
+// missing from Columns so a comparison can decline to read a partial key as a
+// whole one.
+func TestReadIndexes_ReportsAKeyPartItCannotName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		rows   [][]driver.Value
+		assert func(c *qt.C, indexes []types.DBIndex)
+	}{
+		{
+			name: "whole key is an expression",
+			rows: [][]driver.Value{
+				{"idx_expr", "t3", nil, int64(1), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].Columns, qt.HasLen, 0)
+				c.Assert(indexes[0].KeyPartsIncomplete, qt.IsTrue)
+			},
+		},
+		{
+			name: "column beside an expression",
+			rows: [][]driver.Value{
+				{"idx_mixed", "t4", "b", int64(1), "BTREE"},
+				{"idx_mixed", "t4", nil, int64(1), "BTREE"},
+			},
+			assert: func(c *qt.C, indexes []types.DBIndex) {
+				c.Assert(indexes, qt.HasLen, 1)
+				c.Assert(indexes[0].Columns, qt.DeepEquals, []string{"b"})
+				c.Assert(indexes[0].KeyPartsIncomplete, qt.IsTrue)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := NewMySQLReader(statisticsDB(c, test.rows).SQL, "app")
+
+			indexes, err := reader.readIndexes("app")
+
+			c.Assert(err, qt.IsNil)
+			test.assert(c, indexes)
+		})
+	}
+}
+
+// statisticsDB answers the index query with rows and refuses every other query,
+// so a projection change that stops selecting key parts fails here rather than
+// silently reading something else.
+func statisticsDB(c *qt.C, rows [][]driver.Value) *dbtest.DB {
+	return dbtest.Open(c, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		queried := strings.Contains(query, "FROM information_schema.STATISTICS") &&
+			strings.Contains(query, "s.SEQ_IN_INDEX")
+		c.Assert(queried, qt.IsTrue, qt.Commentf("query: %s", query))
+		return dbtest.QueryResult{Columns: statisticsColumns, Rows: rows}, nil
+	})
+}

--- a/internal/planner/dialects/mysql/constraint_backed_index_test.go
+++ b/internal/planner/dialects/mysql/constraint_backed_index_test.go
@@ -1,0 +1,110 @@
+package mysql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// uniqueKeyRebuildDiff is a database `UNIQUE KEY uq_users_email (email)` against
+// a desired state that names the same object as a plain index: one object,
+// replaced, which the comparator states as an index addition plus the removal of
+// the index it replaces, with the removal marked as a UNIQUE constraint's.
+func uniqueKeyRebuildDiff() *types.SchemaDiff {
+	return &types.SchemaDiff{
+		IndexesAdded:   []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		IndexesRemoved: []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		ConstraintBackedIndexRemovals: []types.IndexRef{
+			{Name: "uq_users_email", TableName: "users"},
+		},
+	}
+}
+
+func uniqueKeyRebuildSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables:  []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields:  []goschema.Field{{Name: "email", StructName: "User", Type: "VARCHAR(255)"}},
+		Indexes: []goschema.Index{{Name: "uq_users_email", StructName: "User", Fields: []string{"email"}}},
+	}
+}
+
+// TestPlanner_MySQLFamilyDropsAConstraintBackedKeyAsAnIndex pins the spelling
+// these engines accept, now that the comparator marks a constraint-backed
+// removal on every engine rather than only where the spelling changes.
+//
+// A unique key and its constraint are one catalog row here and
+// `ALTER TABLE ... DROP INDEX` removes it, which is what the pinned community
+// binary v1.3.0 plans on MySQL 9.7.1. Reading the mark as "spell this as a
+// constraint drop" -- the PostgreSQL-family answer -- would emit
+// ALTER TABLE ... DROP CONSTRAINT here and change a plan that was already right.
+func TestPlanner_MySQLFamilyDropsAConstraintBackedKeyAsAnIndex(t *testing.T) {
+	for _, test := range mysqlFamilyPlannerCases() {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			nodes, err := test.planner.GenerateMigrationASTChecked(
+				uniqueKeyRebuildDiff(),
+				uniqueKeyRebuildSchema(),
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(nodes, qt.HasLen, 2)
+			drop, isDropIndex := nodes[0].(*ast.DropIndexNode)
+			c.Assert(isDropIndex, qt.IsTrue, qt.Commentf("first node: %T", nodes[0]))
+			c.Assert(drop.Name, qt.Equals, "uq_users_email")
+			c.Assert(drop.Table, qt.Equals, "users")
+			create, isIndex := nodes[1].(*ast.IndexNode)
+			c.Assert(isIndex, qt.IsTrue, qt.Commentf("second node: %T", nodes[1]))
+			c.Assert(create.Name, qt.Equals, "uq_users_email")
+		})
+	}
+}
+
+// TestPlanner_MySQLFamilyMarksTheUniquenessLossOnTheDrop covers what the mark is
+// for on these engines: the statement is the same either way, so the risk
+// classifier cannot read the spelling. Without the flag on the node, replacing a
+// unique key with a plain index passes `--check-destructive`.
+func TestPlanner_MySQLFamilyMarksTheUniquenessLossOnTheDrop(t *testing.T) {
+	for _, test := range mysqlFamilyPlannerCases() {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			nodes, err := test.planner.GenerateMigrationASTChecked(
+				uniqueKeyRebuildDiff(),
+				uniqueKeyRebuildSchema(),
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(nodes, qt.HasLen, 2)
+			drop, isDropIndex := nodes[0].(*ast.DropIndexNode)
+			c.Assert(isDropIndex, qt.IsTrue, qt.Commentf("first node: %T", nodes[0]))
+			c.Assert(drop.EnforcesUniqueConstraint, qt.IsTrue)
+		})
+	}
+}
+
+// TestPlanner_MySQLFamilyLeavesAPlainIndexDropUnmarked is the control: an index
+// no constraint enforces carries no mark, so its removal keeps the warning
+// severity a query-plan change deserves.
+func TestPlanner_MySQLFamilyLeavesAPlainIndexDropUnmarked(t *testing.T) {
+	for _, test := range mysqlFamilyPlannerCases() {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &types.SchemaDiff{
+				IndexesRemoved: []types.IndexRef{{Name: "idx_users_email", TableName: "users"}},
+			}
+
+			nodes, err := test.planner.GenerateMigrationASTChecked(diff, &goschema.Database{})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(nodes, qt.HasLen, 1)
+			drop, isDropIndex := nodes[0].(*ast.DropIndexNode)
+			c.Assert(isDropIndex, qt.IsTrue, qt.Commentf("only node: %T", nodes[0]))
+			c.Assert(drop.EnforcesUniqueConstraint, qt.IsFalse)
+		})
+	}
+}

--- a/internal/planner/dialects/mysql/mysql.go
+++ b/internal/planner/dialects/mysql/mysql.go
@@ -859,6 +859,7 @@ func (p *Planner) addNewIndexes(
 		diff.IndexRemovals(),
 	)
 	guardedDrops := p.capabilities().Has(capability.DropIndexIfExists)
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
 	for _, ref := range diff.IndexAdditions() {
 		index, err := indexes.Resolve(ref)
 		if err != nil {
@@ -868,6 +869,9 @@ func (p *Planner) addNewIndexes(
 			dropIndexNode := ast.NewDropIndex(removal.Name).SetTable(removal.TableName)
 			if guardedDrops {
 				dropIndexNode.SetIfExists()
+			}
+			if _, ownedByConstraint := constraintBacked[removal]; ownedByConstraint {
+				dropIndexNode.SetEnforcesUniqueConstraint()
 			}
 			result = append(result, dropIndexNode)
 		}
@@ -894,13 +898,25 @@ func (p *Planner) removeIndexes(
 		diff.EffectiveIdentifierSemantics(p.targetDialect()),
 		diff.IndexAdditions(),
 	)
+	rebuiltAsConstraint := diff.IndexRemovalsRebuiltAsUniqueConstraints()
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
 	for _, ref := range diff.IndexRemovals() {
 		if replacements.Contains(ref) {
+			continue
+		}
+		// A removal a UNIQUE constraint addition rebuilds was already emitted
+		// ahead of that addition, which is the only order the server accepts;
+		// dropping it again here would land after the add and delete the key
+		// the constraint now is.
+		if _, rebuilt := rebuiltAsConstraint[ref]; rebuilt {
 			continue
 		}
 		dropIndexNode := ast.NewDropIndex(ref.Name).SetTable(ref.TableName)
 		if guarded {
 			dropIndexNode.SetIfExists()
+		}
+		if _, ownedByConstraint := constraintBacked[ref]; ownedByConstraint {
+			dropIndexNode.SetEnforcesUniqueConstraint()
 		}
 		result = append(result, dropIndexNode)
 	}
@@ -1288,7 +1304,14 @@ func (p *Planner) addNewConstraints(
 	maps.Copy(state.droppedForModify, bracketDropped)
 
 	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
-	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
+	result = p.addCheckAndUniqueConstraintsWithTables(
+		result,
+		diff.ConstraintsAddedWithTables,
+		state.removalByTableName,
+		state.handled,
+		state.droppedForModify,
+		diff.IndexRemovalsRebuiltAsUniqueConstraints(),
+	)
 	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, nonForeignKeyConstraints)
 	result = p.addForeignKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
 	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, foreignKeyConstraints)
@@ -1499,6 +1522,7 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 	removalByTableName map[constraintHostKey]types.ConstraintRemovalInfo,
 	handled map[string]struct{},
 	droppedForModify map[constraintHostKey]struct{},
+	rebuiltIndexes map[types.IndexRef]struct{},
 ) []ast.Node {
 	for _, add := range additions {
 		constraint := p.constraintAdditionNode(add)
@@ -1509,6 +1533,7 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 		if info, modified := removalByTableName[key]; modified {
 			result = p.appendScopedDrop(result, info, droppedForModify)
 		}
+		result = p.dropIndexRebuiltAsConstraint(result, add, rebuiltIndexes)
 		result = append(result, &ast.AlterTableNode{
 			Name:       add.TableName,
 			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: constraint}},
@@ -1516,6 +1541,31 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 		handled[add.Name] = struct{}{}
 	}
 	return result
+}
+
+// dropIndexRebuiltAsConstraint drops the key this UNIQUE constraint addition is
+// about to rebuild, before the addition rather than after it.
+//
+// A unique key and its constraint are one catalog row here, so
+// `ADD CONSTRAINT ... UNIQUE` collides with a key of that name on that table:
+// MySQL 9.7.1 answers `Error 1061 (42000): Duplicate key name 'uq_users_email'`.
+// The pipeline emits constraint additions before index removals, so the drop is
+// emitted here and [Planner.removeIndexes] leaves it alone; see
+// [types.SchemaDiff.IndexRemovalsRebuiltAsUniqueConstraints].
+func (p *Planner) dropIndexRebuiltAsConstraint(
+	result []ast.Node,
+	add types.ConstraintAdditionInfo,
+	rebuiltIndexes map[types.IndexRef]struct{},
+) []ast.Node {
+	ref := types.IndexRef{Name: add.Name, TableName: add.TableName}
+	if _, rebuilt := rebuiltIndexes[ref]; !rebuilt {
+		return result
+	}
+	dropIndexNode := ast.NewDropIndex(ref.Name).SetTable(ref.TableName)
+	if p.capabilities().Has(capability.DropIndexIfExists) {
+		dropIndexNode.SetIfExists()
+	}
+	return append(result, dropIndexNode)
 }
 
 func (p *Planner) constraintAdditionNode(add types.ConstraintAdditionInfo) *ast.ConstraintNode {

--- a/internal/planner/dialects/postgres/category_rendering_test.go
+++ b/internal/planner/dialects/postgres/category_rendering_test.go
@@ -105,6 +105,17 @@ func diffCategoryFixtures() []categoryFixture {
 			&goschema.Database{},
 		},
 		{
+			// A subset of IndexesRemoved, so the fixture carries both lists:
+			// the marker changes the spelling of a drop the removal list asks
+			// for, and on its own it asks for nothing.
+			"ConstraintBackedIndexRemovals",
+			&types.SchemaDiff{
+				IndexesRemoved:                []types.IndexRef{{Name: "uq", TableName: "t"}},
+				ConstraintBackedIndexRemovals: []types.IndexRef{{Name: "uq", TableName: "t"}},
+			},
+			&goschema.Database{},
+		},
+		{
 			"ExtensionsAdded",
 			&types.SchemaDiff{ExtensionsAdded: []string{"pg_trgm"}},
 			&goschema.Database{Extensions: []goschema.Extension{{Name: "pg_trgm"}}},

--- a/internal/planner/dialects/postgres/constraint_backed_index_drop_test.go
+++ b/internal/planner/dialects/postgres/constraint_backed_index_drop_test.go
@@ -1,0 +1,108 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// uniqueKeyRebuildDiff is a database `CONSTRAINT uq_users_email UNIQUE (email)`
+// against a desired state that names the same object as a plain index: one
+// object, replaced, which the comparator states as an index addition plus the
+// removal of the index it replaces.
+func uniqueKeyRebuildDiff(constraintBacked []types.IndexRef) *types.SchemaDiff {
+	return &types.SchemaDiff{
+		IndexesAdded:                  []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		IndexesRemoved:                []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		ConstraintBackedIndexRemovals: constraintBacked,
+	}
+}
+
+func uniqueKeyRebuildSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables:  []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields:  []goschema.Field{{Name: "email", StructName: "User", Type: "TEXT"}},
+		Indexes: []goschema.Index{{Name: "uq_users_email", StructName: "User", Fields: []string{"email"}}},
+	}
+}
+
+// TestPlanner_ConstraintBackedIndexRebuildDropsTheConstraint pins the spelling
+// PostgreSQL accepts for the drop half of a rebuild whose object a UNIQUE
+// constraint owns. Measured on PostgreSQL 17.10, `DROP INDEX "uq_users_email"`
+// against a table with `CONSTRAINT uq_users_email UNIQUE (email)` answers
+// `cannot drop index uq_users_email because constraint uq_users_email on table
+// users requires it (SQLSTATE 2BP01)`, and the pinned community binary v1.3.0
+// plans `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"` followed by the
+// CREATE INDEX for the same change.
+func TestPlanner_ConstraintBackedIndexRebuildDropsTheConstraint(t *testing.T) {
+	c := qt.New(t)
+
+	nodes, err := postgres.New().GenerateMigrationASTChecked(
+		uniqueKeyRebuildDiff([]types.IndexRef{{Name: "uq_users_email", TableName: "users"}}),
+		uniqueKeyRebuildSchema(),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodes, qt.HasLen, 2)
+	drop, isAlterTable := nodes[0].(*ast.AlterTableNode)
+	c.Assert(isAlterTable, qt.IsTrue, qt.Commentf("first node: %T", nodes[0]))
+	c.Assert(drop.Name, qt.Equals, "users")
+	c.Assert(drop.Operations, qt.HasLen, 1)
+	dropConstraint, isDropConstraint := drop.Operations[0].(*ast.DropConstraintOperation)
+	c.Assert(isDropConstraint, qt.IsTrue, qt.Commentf("first operation: %T", drop.Operations[0]))
+	c.Assert(dropConstraint.ConstraintName, qt.Equals, "uq_users_email")
+	c.Assert(dropConstraint.IfExists, qt.IsTrue)
+	create, isIndex := nodes[1].(*ast.IndexNode)
+	c.Assert(isIndex, qt.IsTrue, qt.Commentf("second node: %T", nodes[1]))
+	c.Assert(create.Name, qt.Equals, "uq_users_email")
+	c.Assert(create.Table, qt.Equals, "users")
+}
+
+// TestPlanner_UnmarkedIndexRebuildStillDropsTheIndex is the control: the
+// constraint spelling is reserved for the removals the comparator marked. An
+// ordinary index rebuild -- the same diff with nothing marked -- keeps
+// DROP INDEX, which is the only statement that removes an index PostgreSQL
+// does not enforce a constraint with.
+func TestPlanner_UnmarkedIndexRebuildStillDropsTheIndex(t *testing.T) {
+	c := qt.New(t)
+
+	nodes, err := postgres.New().GenerateMigrationASTChecked(
+		uniqueKeyRebuildDiff(nil),
+		uniqueKeyRebuildSchema(),
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodes, qt.HasLen, 2)
+	drop, isDropIndex := nodes[0].(*ast.DropIndexNode)
+	c.Assert(isDropIndex, qt.IsTrue, qt.Commentf("first node: %T", nodes[0]))
+	c.Assert(drop.Name, qt.Equals, "uq_users_email")
+	c.Assert(drop.IfExists, qt.IsTrue)
+}
+
+// TestPlanner_ConstraintBackedStandaloneRemovalDropsTheConstraint covers the
+// removal that has no addition beside it. The object is the same catalog row
+// either way, so the statement that removes it is the same one.
+func TestPlanner_ConstraintBackedStandaloneRemovalDropsTheConstraint(t *testing.T) {
+	c := qt.New(t)
+	diff := &types.SchemaDiff{
+		IndexesRemoved:                []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		ConstraintBackedIndexRemovals: []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+	}
+
+	nodes, err := postgres.New().GenerateMigrationASTChecked(diff, &goschema.Database{})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodes, qt.HasLen, 1)
+	drop, isAlterTable := nodes[0].(*ast.AlterTableNode)
+	c.Assert(isAlterTable, qt.IsTrue, qt.Commentf("only node: %T", nodes[0]))
+	c.Assert(drop.Name, qt.Equals, "users")
+	c.Assert(drop.Operations, qt.HasLen, 1)
+	dropConstraint, isDropConstraint := drop.Operations[0].(*ast.DropConstraintOperation)
+	c.Assert(isDropConstraint, qt.IsTrue, qt.Commentf("only operation: %T", drop.Operations[0]))
+	c.Assert(dropConstraint.ConstraintName, qt.Equals, "uq_users_email")
+}

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -954,12 +954,20 @@ func (p *Planner) removeIndexes(
 	// composed set) actually changes the plan.
 	guarded := p.capabilities().Has(capability.DropIndexIfExists)
 	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
+	rebuiltAsConstraint := diff.IndexRemovalsRebuiltAsUniqueConstraints()
 	indexAdditions := indexscope.NewConflictSetWithSemantics(
 		diff.EffectiveIdentifierSemantics(p.targetDialect()),
 		diff.IndexAdditions(),
 	)
 	for _, ref := range diff.IndexRemovals() {
 		if indexAdditions.Contains(ref) {
+			continue
+		}
+		// A removal a UNIQUE constraint addition rebuilds was already emitted
+		// ahead of that addition, which is the only order the server accepts;
+		// dropping it again here would land after the add and delete the index
+		// the constraint now needs.
+		if _, rebuilt := rebuiltAsConstraint[ref]; rebuilt {
 			continue
 		}
 		if _, ownedByConstraint := constraintBacked[ref]; ownedByConstraint {
@@ -2074,7 +2082,14 @@ func (p *Planner) addNewConstraints(result []ast.Node, diff *types.SchemaDiff, g
 	state := newConstraintPlanState(diff)
 
 	result = p.addPrimaryKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
-	result = p.addCheckAndUniqueConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state.removalByTableName, state.handled, state.droppedForModify)
+	result = p.addCheckAndUniqueConstraintsWithTables(
+		result,
+		diff.ConstraintsAddedWithTables,
+		state.removalByTableName,
+		state.handled,
+		state.droppedForModify,
+		diff.IndexRemovalsRebuiltAsUniqueConstraints(),
+	)
 	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, nonForeignKeyConstraints)
 	result = p.addForeignKeyConstraintsWithTables(result, diff.ConstraintsAddedWithTables, state)
 	result = p.addNamedConstraintsByKind(result, diff, generated, structToTable, state, foreignKeyConstraints)
@@ -2287,6 +2302,7 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 	removalByTableName map[constraintHostKey]types.ConstraintRemovalInfo,
 	handled map[string]struct{},
 	droppedForModify map[constraintHostKey]struct{},
+	rebuiltIndexes map[types.IndexRef]struct{},
 ) []ast.Node {
 	for _, add := range additions {
 		constraint := constraintAdditionNode(add)
@@ -2297,6 +2313,7 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 		if _, modified := removalByTableName[key]; modified {
 			result = p.emitModifyDrop(result, add, droppedForModify)
 		}
+		result = p.dropIndexRebuiltAsConstraint(result, add, rebuiltIndexes)
 		result = append(result, &ast.AlterTableNode{
 			Name:       add.TableName,
 			Operations: []ast.AlterOperation{&ast.AddConstraintOperation{Constraint: constraint}},
@@ -2304,6 +2321,32 @@ func (p *Planner) addCheckAndUniqueConstraintsWithTables(
 		handled[add.Name] = struct{}{}
 	}
 	return result
+}
+
+// dropIndexRebuiltAsConstraint drops the index this UNIQUE constraint addition
+// is about to rebuild, before the addition rather than after it.
+//
+// ADD CONSTRAINT ... UNIQUE builds an index named after the constraint, so an
+// index of that name on that table has to be gone first: PostgreSQL 17.10
+// answers `relation "uq_users_email" already exists (SQLSTATE 42P07)`
+// otherwise. The pipeline emits constraint additions before index removals, so
+// the drop is emitted here and [Planner.removeIndexes] leaves it alone; see
+// [types.SchemaDiff.IndexRemovalsRebuiltAsUniqueConstraints] for the shape that
+// produces the collision.
+func (p *Planner) dropIndexRebuiltAsConstraint(
+	result []ast.Node,
+	add types.ConstraintAdditionInfo,
+	rebuiltIndexes map[types.IndexRef]struct{},
+) []ast.Node {
+	ref := types.IndexRef{Name: add.Name, TableName: add.TableName}
+	if _, rebuilt := rebuiltIndexes[ref]; !rebuilt {
+		return result
+	}
+	dropIndexNode := ast.NewDropIndex(ref.Name).SetTable(ref.TableName)
+	if p.capabilities().Has(capability.DropIndexIfExists) {
+		dropIndexNode.SetIfExists()
+	}
+	return append(result, dropIndexNode)
 }
 
 func constraintAdditionNode(add types.ConstraintAdditionInfo) *ast.ConstraintNode {

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -908,6 +908,7 @@ func (p *Planner) addNewIndexes(
 		diff.IndexRemovals(),
 	)
 	guardedDrops := p.capabilities().Has(capability.DropIndexIfExists)
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
 
 	for _, ref := range diff.IndexAdditions() {
 		index, err := indexes.Resolve(ref)
@@ -915,6 +916,10 @@ func (p *Planner) addNewIndexes(
 			return nil, err
 		}
 		for removal := range indexRemovals.Matches(ref) {
+			if _, ownedByConstraint := constraintBacked[removal]; ownedByConstraint {
+				result = append(result, p.constraintBackedIndexDropNode(removal))
+				continue
+			}
 			dropIndexNode := ast.NewDropIndex(removal.Name).
 				SetTable(removal.TableName)
 			if guardedDrops {
@@ -948,12 +953,17 @@ func (p *Planner) removeIndexes(
 	// the default preset keeps today's output; a preset without it (or a
 	// composed set) actually changes the plan.
 	guarded := p.capabilities().Has(capability.DropIndexIfExists)
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
 	indexAdditions := indexscope.NewConflictSetWithSemantics(
 		diff.EffectiveIdentifierSemantics(p.targetDialect()),
 		diff.IndexAdditions(),
 	)
 	for _, ref := range diff.IndexRemovals() {
 		if indexAdditions.Contains(ref) {
+			continue
+		}
+		if _, ownedByConstraint := constraintBacked[ref]; ownedByConstraint {
+			result = append(result, p.constraintBackedIndexDropNode(ref))
 			continue
 		}
 		dropIndexNode := ast.NewDropIndex(ref.Name).
@@ -963,16 +973,43 @@ func (p *Planner) removeIndexes(
 		}
 		// CONCURRENTLY on a drop is opt-in policy AND capability-gated, exactly
 		// like the build side. A redefinition never reaches here (it is skipped
-		// above as an addition conflict), so a concurrent drop is always a
-		// standalone index removal — never the drop half of a rebuild and never
-		// an index backing a constraint, both of which PostgreSQL refuses to
-		// drop concurrently.
+		// above as an addition conflict), and a constraint's backing index left
+		// through the branch above, so a concurrent drop is always a standalone
+		// index removal — never the drop half of a rebuild and never an index
+		// backing a constraint, both of which PostgreSQL refuses to drop
+		// concurrently.
 		if p.usesConcurrentIndexDrop(ref) && p.capabilities().Has(capability.DropIndexConcurrently) {
 			dropIndexNode.SetConcurrently()
 		}
 		result = append(result, dropIndexNode)
 	}
 	return result
+}
+
+// constraintBackedIndexDropNode removes an index a UNIQUE constraint enforces,
+// through the constraint.
+//
+// PostgreSQL does not accept the index spelling for one: `DROP INDEX
+// "uq_users_email"` comes back as `cannot drop index uq_users_email because
+// constraint uq_users_email on table users requires it (SQLSTATE 2BP01)`,
+// measured on 17.10. Dropping the constraint takes its index with it, which is
+// what the pinned community binary v1.3.0 plans for the same change:
+// `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`, followed by the
+// CREATE INDEX that replaces it when there is one. The comparator marks these
+// removals (ConstraintBackedIndexRemovals) because it is the side that read the
+// constraint catalog.
+//
+// IF EXISTS is unconditional, matching removeConstraints: every supported
+// PostgreSQL line accepts it on DROP CONSTRAINT, and the DropIndexIfExists
+// capability speaks for the DROP INDEX spelling only.
+func (p *Planner) constraintBackedIndexDropNode(ref types.IndexRef) ast.Node {
+	return &ast.AlterTableNode{
+		Name: ref.TableName,
+		Operations: []ast.AlterOperation{&ast.DropConstraintOperation{
+			ConstraintName: ref.Name,
+			IfExists:       true,
+		}},
+	}
 }
 
 // appendSkipComments emits one clearly-marked comment per change omitted by the

--- a/migration/generator/constraint_backed_index_down_internal_test.go
+++ b/migration/generator/constraint_backed_index_down_internal_test.go
@@ -1,0 +1,189 @@
+package generator
+
+// White-box testing required: these tests drive the unexported up/down
+// generation entry points (generateUpMigrationSQL / generateDownMigrationSQL)
+// over the real schemadiff comparator, which the exported migration-file API
+// does not expose without a filesystem and database connection.
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// constraintBackedIndexFixtures is a database whose `uq_users_email` object is a
+// UNIQUE constraint -- reported once in the index catalog and once in the
+// constraint catalog, which is what every reader on PostgreSQL, MySQL and
+// MariaDB does -- against a desired state that names the same object as a PLAIN
+// index. That is a real change to one object, and index comparison states it as
+// a replacement.
+func constraintBackedIndexFixtures() (*goschema.Database, *dbschematypes.DBSchema) {
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: "BIGINT", StructName: "User", Primary: true, AutoInc: true},
+			{Name: "email", Type: "VARCHAR(255)", StructName: "User", Nullable: false},
+		},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			Name:       "uq_users_email",
+			TableName:  "users",
+			Fields:     []string{"email"},
+			Unique:     false,
+		}},
+	}
+	emailLength := 255
+	database := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{{
+			Name: "users",
+			Type: "BASE TABLE",
+			Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "bigint", IsNullable: "NO", IsPrimaryKey: true, IsAutoIncrement: true},
+				{
+					Name:               "email",
+					DataType:           "varchar",
+					ColumnType:         "varchar(255)",
+					CharacterMaxLength: &emailLength,
+					IsNullable:         "NO",
+				},
+			},
+		}},
+		Indexes: []dbschematypes.DBIndex{{
+			Name:      "uq_users_email",
+			TableName: "users",
+			Columns:   []string{"email"},
+			IsUnique:  true,
+		}},
+		Constraints: []dbschematypes.DBConstraint{{
+			Name:        "uq_users_email",
+			TableName:   "users",
+			Type:        "UNIQUE",
+			ColumnName:  "email",
+			ColumnNames: []string{"email"},
+		}},
+	}
+	return generated, database
+}
+
+// constraintBackedIndexDialects carries the per-dialect spelling of the same
+// three statements. The UP drop differs because the object differs: on
+// PostgreSQL the constraint owns the index and the server refuses the index
+// spelling (`cannot drop index uq_users_email because constraint uq_users_email
+// on table users requires it`, SQLSTATE 2BP01, measured on 17.10), while on
+// MySQL and MariaDB a unique key and its constraint are one catalog row that
+// DROP INDEX removes, which is what the pinned community binary v1.3.0 plans
+// there. The DOWN restore does not differ: ADD CONSTRAINT ... UNIQUE is what
+// puts the dropped object back on all three, and on MySQL and MariaDB it lands
+// the same catalog row CREATE UNIQUE INDEX would.
+var constraintBackedIndexDialects = []struct {
+	name    string
+	upDrop  string
+	create  string
+	downDro string
+	restore string
+}{
+	{
+		name:    "postgres",
+		upDrop:  `ALTER TABLE "users" DROP CONSTRAINT IF EXISTS "uq_users_email"`,
+		create:  `CREATE INDEX IF NOT EXISTS "uq_users_email" ON "users" ("email")`,
+		downDro: `DROP INDEX IF EXISTS "uq_users_email"`,
+		restore: `ALTER TABLE "users" ADD CONSTRAINT "uq_users_email" UNIQUE ("email")`,
+	},
+	{
+		name:    "mysql",
+		upDrop:  "DROP INDEX `uq_users_email` ON `users`",
+		create:  "CREATE INDEX `uq_users_email` ON `users` (`email`)",
+		downDro: "DROP INDEX `uq_users_email` ON `users`",
+		restore: "ALTER TABLE `users` ADD CONSTRAINT `uq_users_email` UNIQUE (`email`)",
+	},
+	{
+		name:    "mariadb",
+		upDrop:  "DROP INDEX IF EXISTS `uq_users_email` ON `users`",
+		create:  "CREATE INDEX `uq_users_email` ON `users` (`email`)",
+		downDro: "DROP INDEX IF EXISTS `uq_users_email` ON `users`",
+		restore: "ALTER TABLE `users` ADD CONSTRAINT `uq_users_email` UNIQUE (`email`)",
+	},
+}
+
+// TestGenerateMigration_ConstraintBackedIndexReplacement_DownRestoresTheConstraint
+// is the rollback of the #1245 ownership rule.
+//
+// Letting a declared index own a UNIQUE constraint's object means the plan can
+// replace that object, and the down direction has to put back what the up
+// direction dropped -- a UNIQUE constraint, not an index. Reversing the removal
+// into an index addition did neither: the down direction's target schema comes
+// from ConvertDBSchemaToGoSchema, which omits a constraint-backed index because
+// the index is the constraint's, so down generation failed outright with
+// `invalid schema diff: added index users.uq_users_email at position 0 is
+// missing or ambiguous in the target schema`. Measured live on PostgreSQL 17.10
+// and MySQL 9.7.1 against a database holding `CONSTRAINT uq_users_email UNIQUE
+// (email)`: no migration could be generated at all.
+//
+// The order in the down file is part of the assertion. ADD CONSTRAINT ... UNIQUE
+// builds an index of the constraint's name, so the plain index the up direction
+// created has to be dropped first -- PostgreSQL 17.10 answers `relation
+// "uq_users_email" already exists` (SQLSTATE 42P07) and MySQL 9.7.1
+// `Error 1061 (42000): Duplicate key name 'uq_users_email'` otherwise -- and the
+// planners emit constraint additions before index removals.
+func TestGenerateMigration_ConstraintBackedIndexReplacement_DownRestoresTheConstraint(t *testing.T) {
+	generated, database := constraintBackedIndexFixtures()
+
+	for _, test := range constraintBackedIndexDialects {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.name)
+			c.Assert(diff.ConstraintBackedIndexRemovals, qt.HasLen, 1)
+
+			up, err := generateUpMigrationSQL(diff, generated, test.name)
+			c.Assert(err, qt.IsNil)
+			assertOrderedPair(c, up, test.upDrop, test.create)
+
+			down, err := generateDownMigrationSQL(diff, generated, database, test.name)
+			c.Assert(err, qt.IsNil)
+			assertOrderedPair(c, down, test.downDro, test.restore)
+		})
+	}
+}
+
+// TestGenerateMigration_PlainIndexReplacement_DownRebuildsTheIndex is the
+// control for the partition: a removal no UNIQUE constraint enforces still
+// reverses into an index addition, which is the only thing that restores it.
+// Turning every removal into a constraint restoration would emit an
+// ADD CONSTRAINT for a constraint the database never had.
+func TestGenerateMigration_PlainIndexReplacement_DownRebuildsTheIndex(t *testing.T) {
+	generated, database := constraintBackedIndexFixtures()
+	generated.Indexes[0].Name = "idx_users_email"
+	database.Indexes[0].Name = "idx_users_email"
+	database.Indexes[0].IsUnique = true
+	database.Constraints = nil
+
+	for _, test := range constraintBackedIndexDialects {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.name)
+			c.Assert(diff.ConstraintBackedIndexRemovals, qt.HasLen, 0)
+
+			down, err := generateDownMigrationSQL(diff, generated, database, test.name)
+			c.Assert(err, qt.IsNil)
+			c.Assert(down, qt.Not(qt.Contains), "ADD CONSTRAINT")
+			c.Assert(strings.Contains(down, "UNIQUE INDEX") ||
+				strings.Contains(down, "CREATE UNIQUE"), qt.IsTrue,
+				qt.Commentf("down must rebuild the unique index:\n%s", down))
+		})
+	}
+}
+
+func assertOrderedPair(c *qt.C, sql, first, second string) {
+	c.Helper()
+	c.Assert(strings.Count(sql, first), qt.Equals, 1, qt.Commentf("want one %q in:\n%s", first, sql))
+	c.Assert(strings.Count(sql, second), qt.Equals, 1, qt.Commentf("want one %q in:\n%s", second, sql))
+	c.Assert(strings.Index(sql, first) < strings.Index(sql, second), qt.IsTrue,
+		qt.Commentf("%q must precede %q in:\n%s", first, second, sql))
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -896,6 +896,12 @@ func concurrentIndexRefsForPolicy(
 // A removal that is also an addition under the same identity is a redefinition
 // whose drop the planner pairs with the rebuild; it is excluded here so the
 // pair is never split across a transactional and a non-transactional file.
+//
+// A UNIQUE constraint's backing index is excluded for a different reason: it is
+// not dropped as an index at all (the planner spells it
+// ALTER TABLE ... DROP CONSTRAINT), and PostgreSQL has no concurrent form of
+// that statement. Routing it into the no-transaction file would also strand the
+// marker, which the no-transaction diff does not carry.
 func concurrentIndexDropRefsForPolicy(
 	diff *types.SchemaDiff,
 	info dbschematypes.DBInfo,
@@ -915,9 +921,13 @@ func concurrentIndexDropRefsForPolicy(
 		diff.EffectiveIdentifierSemantics(info.Dialect),
 		diff.IndexAdditions(),
 	)
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
 	var refs []types.IndexRef
 	for _, ref := range diff.IndexRemovals() {
 		if additions.Contains(ref) {
+			continue
+		}
+		if _, ownedByConstraint := constraintBacked[ref]; ownedByConstraint {
 			continue
 		}
 		refs = append(refs, ref)
@@ -1023,6 +1033,7 @@ func cloneSchemaDiff(diff *types.SchemaDiff) *types.SchemaDiff {
 	clone.EnumsModified = slices.Clone(diff.EnumsModified)
 	clone.IndexesAdded = slices.Clone(diff.IndexesAdded)
 	clone.IndexesRemoved = slices.Clone(diff.IndexesRemoved)
+	clone.ConstraintBackedIndexRemovals = slices.Clone(diff.ConstraintBackedIndexRemovals)
 	clone.ExtensionsAdded = slices.Clone(diff.ExtensionsAdded)
 	clone.ExtensionsRemoved = slices.Clone(diff.ExtensionsRemoved)
 	clone.FunctionsAdded = slices.Clone(diff.FunctionsAdded)

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1458,9 +1458,94 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
 		ConstraintsAddedWithTables:   reverseConstraintAdditions(diff, dbSchema),
 	}
-	reversed.SetIndexAdditions(diff.IndexRemovals())
+	indexAdditions, constraintRestorations := reverseIndexRemovals(diff, dbSchema)
+	reversed.SetIndexAdditions(indexAdditions)
 	reversed.SetIndexRemovals(diff.IndexAdditions())
+	for _, restored := range constraintRestorations {
+		reversed.ConstraintsAdded = append(reversed.ConstraintsAdded, restored.Name)
+		reversed.ConstraintsAddedWithTables = append(reversed.ConstraintsAddedWithTables, restored)
+	}
 	return reversed
+}
+
+// reverseIndexRemovals splits the up direction's index removals by what the
+// object each one names actually is, because the down direction has to put that
+// object back and only one of the two spellings does.
+//
+// An ordinary index removal reverses into an index addition, which the down
+// path resolves from the introspected schema. A removal the comparator marked
+// as constraint-backed (ConstraintBackedIndexRemovals) does not: the object is
+// a UNIQUE constraint whose index carries the constraint's name, the up
+// direction dropped it with ALTER TABLE ... DROP CONSTRAINT, and the statement
+// that restores it is ALTER TABLE ... ADD CONSTRAINT ... UNIQUE. Reversing it
+// into an index addition is wrong twice over: the down path builds its target
+// from ConvertDBSchemaToGoSchema, which deliberately omits a constraint-backed
+// index (it is the constraint's, not an index of its own), so the addition has
+// no definition to resolve and down generation fails outright with
+// `added index users.uq_users_email at position 0 is missing or ambiguous in
+// the target schema` -- and where it did resolve it would rebuild a plain
+// unique index in place of the constraint, leaving the rollback's catalog
+// different from the one the migration started against.
+//
+// The prior body comes from the introspected constraint, the same source
+// reverseConstraintAdditions restores a removed UNIQUE constraint from, so a
+// covering INCLUDE list and NULLS [NOT] DISTINCT survive the round trip.
+//
+// A marked removal with no introspected constraint to rebuild from -- a nil
+// dbSchema, or a hand-built diff -- stays an index addition rather than
+// disappearing. That is the loud failure above, which is the right outcome: a
+// down migration that silently omits the uniqueness protection it is supposed
+// to restore is worse than one that refuses to be generated.
+func reverseIndexRemovals(
+	diff *types.SchemaDiff,
+	dbSchema *dbschematypes.DBSchema,
+) (additions []types.IndexRef, restored []types.ConstraintAdditionInfo) {
+	removals := diff.IndexRemovals()
+	constraintBacked := diff.ConstraintBackedIndexRemovalSet()
+	if len(constraintBacked) == 0 {
+		return removals, nil
+	}
+	uniqueConstraints := introspectedUniqueConstraintsByHost(dbSchema)
+	for _, ref := range removals {
+		if _, ownedByConstraint := constraintBacked[ref]; !ownedByConstraint {
+			additions = append(additions, ref)
+			continue
+		}
+		dbConstraint, hasBody := uniqueConstraints[tableMemberKey{table: ref.TableName, member: ref.Name}]
+		columns := dbConstraint.ColumnNamesOrDefault()
+		if !hasBody || len(columns) == 0 {
+			additions = append(additions, ref)
+			continue
+		}
+		restored = append(restored, types.ConstraintAdditionInfo{
+			Name:           ref.Name,
+			TableName:      ref.TableName,
+			Type:           "UNIQUE",
+			Columns:        slices.Clone(columns),
+			IncludeColumns: slices.Clone(dbConstraint.IncludeColumns),
+			NullsDistinct:  cloneBoolPtr(dbConstraint.NullsDistinct),
+		})
+	}
+	return additions, restored
+}
+
+// introspectedUniqueConstraintsByHost keys the pre-change UNIQUE constraints by
+// the host table and name an IndexRef names, which is the identity the
+// comparator marked the removal under.
+func introspectedUniqueConstraintsByHost(
+	dbSchema *dbschematypes.DBSchema,
+) map[tableMemberKey]dbschematypes.DBConstraint {
+	constraints := make(map[tableMemberKey]dbschematypes.DBConstraint)
+	if dbSchema == nil {
+		return constraints
+	}
+	for _, constraint := range dbSchema.Constraints {
+		if constraint.Type != "UNIQUE" {
+			continue
+		}
+		constraints[tableMemberKey{table: constraint.QualifiedTableName(), member: constraint.Name}] = constraint
+	}
+	return constraints
 }
 
 func generatedTableByStructName(tables []goschema.Table, structName string) *goschema.Table {

--- a/migration/safety/safety.go
+++ b/migration/safety/safety.go
@@ -68,6 +68,12 @@ func ClassifySchemaDiff(diff *types.SchemaDiff) []Finding {
 	add(&findings, "enums_removed", len(diff.EnumsRemoved), Destructive)
 	add(&findings, "indexes_added", len(diff.IndexesAdded), Warning)
 	add(&findings, "indexes_removed", len(diff.IndexesRemoved), Warning)
+	// A removal whose object a UNIQUE constraint enforces takes the uniqueness
+	// with it, whichever statement the engine spells it as, so it is counted
+	// again under its own destructive category rather than folded into the
+	// warning above. Losing a uniqueness protection is not a query-plan change
+	// and must not pass a destructive gate or a drift threshold as one.
+	add(&findings, "unique_protections_removed", len(diff.ConstraintBackedIndexRemovals), Destructive)
 	add(&findings, "extensions_added", len(diff.ExtensionsAdded), Safe)
 	add(&findings, "extensions_removed", len(diff.ExtensionsRemoved), Destructive)
 	add(&findings, "functions_added", len(diff.FunctionsAdded), Safe)
@@ -353,6 +359,11 @@ func assessNode(node ast.Node) StatementAssessment {
 		}
 	case *ast.DropIndexNode:
 		assessment.Subject = n.Name
+		if n.EnforcesUniqueConstraint {
+			assessment.Severity = Destructive
+			assessment.Reason = "DROP INDEX removes the uniqueness a UNIQUE constraint enforces"
+			return assessment
+		}
 		assessment.Severity = Warning
 		assessment.Reason = "DROP INDEX can affect query plans and constraints"
 	case *ast.AlterTypeNode:

--- a/migration/safety/unique_protection_test.go
+++ b/migration/safety/unique_protection_test.go
@@ -1,0 +1,96 @@
+package safety_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/migration/safety"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestClassifySchemaDiff_UniqueProtectionRemovalIsDestructive covers the loss of
+// a uniqueness guarantee that is stated as an index removal.
+//
+// Replacing a database `UNIQUE KEY uq_users_email (email)` with a desired plain
+// `index "uq_users_email"` deletes the guarantee that no two rows share an
+// email, and the comparator states it in IndexesRemoved because the object is
+// reported by the index catalog. Classified only as `indexes_removed`, the whole
+// change was a warning: it passed `--check-destructive` and every drift
+// threshold that keys on destructive findings, on PostgreSQL as well as MySQL
+// and MariaDB.
+func TestClassifySchemaDiff_UniqueProtectionRemovalIsDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		IndexesAdded:   []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		IndexesRemoved: []types.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		ConstraintBackedIndexRemovals: []types.IndexRef{
+			{Name: "uq_users_email", TableName: "users"},
+		},
+	}
+
+	findings := safety.ClassifySchemaDiff(diff)
+
+	c.Assert(safety.HasDestructive(findings), qt.IsTrue, qt.Commentf("findings: %+v", findings))
+	c.Assert(findings, qt.Contains, safety.Finding{
+		Category: "unique_protections_removed",
+		Count:    1,
+		Severity: safety.Destructive,
+	})
+	c.Assert(safety.Highest(findings), qt.Equals, safety.Destructive)
+}
+
+// TestClassifySchemaDiff_PlainIndexRemovalStaysAWarning is the control: dropping
+// an index no constraint enforces costs query plans, not guarantees, and must
+// not start failing a destructive gate.
+func TestClassifySchemaDiff_PlainIndexRemovalStaysAWarning(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		IndexesRemoved: []types.IndexRef{{Name: "idx_users_email", TableName: "users"}},
+	}
+
+	findings := safety.ClassifySchemaDiff(diff)
+
+	c.Assert(safety.HasDestructive(findings), qt.IsFalse, qt.Commentf("findings: %+v", findings))
+	c.Assert(safety.Highest(findings), qt.Equals, safety.Warning)
+}
+
+// TestClassify_DropIndexOfAUniqueKeyIsDestructive covers the statement side of
+// the same loss, which is where `--check-destructive` reads its verdict.
+//
+// On MySQL and MariaDB a unique key and its constraint are one catalog row, so
+// the statement that removes a uniqueness guarantee is spelled exactly like the
+// statement that removes an access path. The spelling cannot tell them apart;
+// the planner marks the node that does.
+func TestClassify_DropIndexOfAUniqueKeyIsDestructive(t *testing.T) {
+	c := qt.New(t)
+
+	node := ast.NewDropIndex("uq_users_email").
+		SetTable("users").
+		SetEnforcesUniqueConstraint()
+
+	assessments := safety.Assess([]ast.Node{node})
+
+	c.Assert(assessments, qt.HasLen, 1)
+	c.Assert(assessments[0].Severity, qt.Equals, safety.Destructive)
+	c.Assert(assessments[0].Reason, qt.Equals,
+		"DROP INDEX removes the uniqueness a UNIQUE constraint enforces")
+	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsTrue)
+}
+
+// TestClassify_DropOfAPlainIndexStaysAWarning is the statement-level control for
+// the mark: an unmarked DROP INDEX keeps the severity it always had.
+func TestClassify_DropOfAPlainIndexStaysAWarning(t *testing.T) {
+	c := qt.New(t)
+
+	assessments := safety.Assess([]ast.Node{
+		ast.NewDropIndex("idx_users_email").SetTable("users"),
+	})
+
+	c.Assert(assessments, qt.HasLen, 1)
+	c.Assert(assessments[0].Severity, qt.Equals, safety.Warning)
+	c.Assert(safety.HasDestructiveAssessment(assessments), qt.IsFalse)
+}

--- a/migration/schemadiff/internal/compare/constraints.go
+++ b/migration/schemadiff/internal/compare/constraints.go
@@ -150,17 +150,14 @@ func ConstraintsWithSemantics(
 		}
 	}
 
-	// Create map of existing database constraints, filtering out field-level constraints
-	dbConstraints := make(map[tableMemberKey]types.DBConstraint)
-	for _, constraint := range database.Constraints {
-		// Skip field-level constraints that are represented in field definitions
-		if isFieldLevelConstraint(constraint, generated, synthesizedFKKeys, semantics) {
-			continue
-		}
-
-		key := newTableMemberKey(constraint.QualifiedTableName(), constraint.Name, semantics)
-		dbConstraints[key] = constraint
-	}
+	dbConstraints := collectDatabaseConstraints(
+		generated,
+		database,
+		genConstraints,
+		synthesizedFKKeys,
+		dialect,
+		semantics,
+	)
 
 	// Find added constraints (constraints in generated schema but not in database)
 	for constraintKey, genConstraint := range genConstraints {
@@ -211,6 +208,47 @@ func ConstraintsWithSemantics(
 		}
 		return a.Name < b.Name
 	})
+}
+
+// collectDatabaseConstraints keys the database's constraints by table and name,
+// leaving out the ones another representation of the same object already owns.
+//
+// Two exclusions, and they are different in kind. A field-level constraint is
+// carried by the column it belongs to, so the column's lifecycle creates and
+// drops it. A UNIQUE constraint the desired state names as an *index* is the
+// same catalog object as that index, so index comparison creates and drops it;
+// see [uniqueConstraintOwnedByDeclaredIndex]. A desired state that names the
+// object as a constraint keeps it here, which is why the hand-off asks about
+// genConstraints first: a schema that declares both spellings of one name has
+// its constraint honored rather than being handed to a pool that would then
+// plan an ADD CONSTRAINT on top of the existing index.
+func collectDatabaseConstraints(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	genConstraints map[tableMemberKey]goschema.Constraint,
+	synthesizedFKKeys map[tableMemberKey]struct{},
+	dialect string,
+	semantics identifier.Semantics,
+) map[tableMemberKey]types.DBConstraint {
+	declaredIndexes := generatedIndexIdentities(generated, semantics)
+	dbConstraints := make(map[tableMemberKey]types.DBConstraint, len(database.Constraints))
+	for _, constraint := range database.Constraints {
+		if isFieldLevelConstraint(constraint, generated, synthesizedFKKeys, semantics) {
+			continue
+		}
+		key := newTableMemberKey(constraint.QualifiedTableName(), constraint.Name, semantics)
+		if _, declaredAsConstraint := genConstraints[key]; !declaredAsConstraint &&
+			uniqueConstraintOwnedByDeclaredIndex(
+				constraint,
+				dialect,
+				declaredIndexes,
+				semantics,
+			) {
+			continue
+		}
+		dbConstraints[key] = constraint
+	}
+	return dbConstraints
 }
 
 // appendConstraintRemoval records the table-qualified removal info for a

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -212,7 +212,8 @@ func IndexesWithSemantics(
 		database,
 		dialect,
 		semantics,
-		hiddenForeignKeyBackingIndexes(fkBackedIndexes, genIndexes),
+		genIndexes,
+		fkBackedIndexes,
 		uniqueConstraintIndexes,
 	)
 	appendIndexDifferences(
@@ -292,58 +293,57 @@ func constraintBackedIndexIdentities(
 	return foreignKeys, uniqueConstraints
 }
 
-// hiddenForeignKeyBackingIndexes narrows the foreign-key backing index filter
-// to the identities the desired state never mentions.
+// collectDatabaseIndexes keys the database's indexes by identity, leaving out
+// the ones that are not addressable as indexes and the ones another object
+// owns.
 //
-// MySQL and MariaDB create a backing index for every FOREIGN KEY. With a bare
-// `CONSTRAINT ... FOREIGN KEY` and no `KEY` clause -- the ordinary way a MySQL
-// schema is written -- the backing index carries the constraint's own name, so
-// `information_schema.STATISTICS` reports an index named `fk_posts_user`
-// alongside the constraint named `fk_posts_user`. Hiding that identity from
-// the database side keeps a desired state that says nothing about the backing
-// index from planning a DROP INDEX that would take the constraint with it.
+// **Ownership follows the desired state's spelling.** An identity the desired
+// state declares as an index is never dropped here, whichever filter below
+// would otherwise have claimed it, because a database object the desired state
+// names as an index has to reach the index comparison to be matched, replaced,
+// or left alone. Filtering it out is what strands it: the desired side is never
+// filtered, so the declared index has nothing to match and is reported as an
+// addition while the owning constraint, having no counterpart on the desired
+// side, is reported as a removal -- one object, created down one path and
+// dropped down the other, in the same plan.
 //
-// Hiding it unconditionally was one-sided: the desired side is never filtered,
-// so an index the author did declare had no counterpart to match and was
-// planned as an addition. That is not a hypothetical desired state -- the
-// pinned community binary's own `schema inspect` output writes the backing
-// index back out as an `index` block, so applying a database's own inspect
-// output to the database it came from planned
-// `CREATE INDEX "fk_posts_user"` where the pinned binary reported
-// "Schema is synced". That statement is not executable: run against the same
-// fixture, MySQL 9.7.1 answers it with
-// `Error 1061 (42000): Duplicate key name 'fk_posts_user'` (issue #1258).
+// That is not a hypothetical desired state. Both `ptah-compat schema inspect`
+// and the pinned community binary v1.3.0 write these objects back out as
+// `index` blocks, so replaying a database's own inspect output against the
+// database it came from hit it. Measured on MySQL 9.7.1 and MariaDB 11.8.8,
+// where the pinned binary reported "Schema is synced":
 //
-// Letting declared identities through restores the comparison rather than
-// suppressing it: a declared backing index is matched, replaced, or added on
-// the same terms as any other index. The filter cannot start dropping
-// anything either, because an identity only survives it when the desired
-// state names that identity, and an identity the desired state names is
-// matched instead of removed.
-func hiddenForeignKeyBackingIndexes(
-	foreignKeys map[difftypes.IndexRef]struct{},
-	declared map[difftypes.IndexRef]generatedIndexEntry,
-) map[difftypes.IndexRef]struct{} {
-	hidden := make(map[difftypes.IndexRef]struct{}, len(foreignKeys))
-	for identity := range foreignKeys {
-		if _, isDeclared := declared[identity]; isDeclared {
-			continue
-		}
-		hidden[identity] = struct{}{}
-	}
-	return hidden
-}
-
+//	fixture                     | filter that stranded it
+//	UNIQUE KEY uq_users_email   | the same-named UNIQUE constraint (#1245)
+//	UNIQUE KEY uk_users_email   | isConstraintBasedUniqueIndex's name pattern
+//	CONSTRAINT fk_posts_user    | the FOREIGN KEY backing index (#1258)
+//
+// and on PostgreSQL 17.10 for `CONSTRAINT uq_users_email UNIQUE (email)`
+// against a desired `index "uq_users_email" { unique = true }`, where the
+// pinned binary also reported "Schema is synced".
+//
+// The plans were not merely noisy. MySQL and MariaDB answer the CREATE with
+// `Error 1061 (42000): Duplicate key name 'uq_users_email'` and the apply exits
+// 1 -- and not before the statements ahead of it in the same plan have run, so
+// adding one column to a table that has a named unique key left the column
+// added and the run failed. PostgreSQL, where the statements carry
+// IF NOT EXISTS and IF EXISTS, skipped the create, ran the drop, exited 0, and
+// left the table with no unique index at all.
+//
+// Letting a declared identity through cannot start dropping anything: an
+// identity only survives the filters when the desired state names it, and an
+// identity the desired state names is matched rather than removed.
 func collectDatabaseIndexes(
 	database *types.DBSchema,
 	dialect string,
 	semantics identifier.Semantics,
+	declared map[difftypes.IndexRef]generatedIndexEntry,
 	foreignKeys map[difftypes.IndexRef]struct{},
 	uniqueConstraints map[difftypes.IndexRef]struct{},
 ) map[difftypes.IndexRef]databaseIndexEntry {
 	indexes := make(map[difftypes.IndexRef]databaseIndexEntry)
 	for _, index := range database.Indexes {
-		if ignoreDatabaseIndex(index, dialect) {
+		if unaddressableDatabaseIndex(index, dialect) {
 			continue
 		}
 		ref := difftypes.IndexRef{
@@ -351,10 +351,14 @@ func collectDatabaseIndexes(
 			TableName: index.QualifiedTableName(),
 		}
 		identity := indexscope.IdentityKeyWithSemantics(semantics, ref)
-		if _, constraintBacked := uniqueConstraints[identity]; constraintBacked {
-			continue
-		}
-		if _, foreignKeyBacked := foreignKeys[identity]; foreignKeyBacked {
+		if _, isDeclared := declared[identity]; !isDeclared &&
+			constraintOwnedDatabaseIndex(
+				index,
+				dialect,
+				identity,
+				foreignKeys,
+				uniqueConstraints,
+			) {
 			continue
 		}
 		indexes[identity] = databaseIndexEntry{
@@ -365,8 +369,45 @@ func collectDatabaseIndexes(
 	return indexes
 }
 
-func ignoreDatabaseIndex(index types.DBIndex, dialect string) bool {
-	if index.IsPrimary || isSQLiteInternalAutoindex(index.Name, dialect) {
+// unaddressableDatabaseIndex reports whether an index has no standalone
+// existence to compare at all: a primary key's index is created and dropped
+// with the key, and SQLite's sqlite_autoindex_* rows name an internal structure
+// no statement can refer to. Neither can be declared by a desired state, so
+// neither is narrowed by one.
+func unaddressableDatabaseIndex(index types.DBIndex, dialect string) bool {
+	return index.IsPrimary || isSQLiteInternalAutoindex(index.Name, dialect)
+}
+
+// constraintOwnedDatabaseIndex reports whether a database index is a
+// constraint's backing index, and so is created and dropped through that
+// constraint rather than on its own.
+//
+// A UNIQUE constraint is enforced by an index of the constraint's own name on
+// its own table everywhere except SQL Server, and MySQL and MariaDB
+// additionally create one for every FOREIGN KEY: with a bare
+// `CONSTRAINT ... FOREIGN KEY` and no `KEY` clause -- the ordinary way a MySQL
+// schema is written -- `information_schema.STATISTICS` reports an index named
+// `fk_posts_user` alongside the constraint named `fk_posts_user`. A desired
+// state that says nothing about either must not plan a DROP INDEX that would
+// take the constraint with it, which is what these two arms prevent.
+//
+// The name-pattern arm is a guess about a naming convention where the identity
+// arms are facts read from the catalog, but they are alike in what they mean
+// for the comparison, and all three are subject to the declaration narrowing in
+// [collectDatabaseIndexes] -- the FOREIGN KEY arm since
+// [#1258](https://github.com/stokaro/ptah/issues/1258), the other two since
+// [#1245](https://github.com/stokaro/ptah/issues/1245).
+func constraintOwnedDatabaseIndex(
+	index types.DBIndex,
+	dialect string,
+	identity difftypes.IndexRef,
+	foreignKeys map[difftypes.IndexRef]struct{},
+	uniqueConstraints map[difftypes.IndexRef]struct{},
+) bool {
+	if _, uniqueBacked := uniqueConstraints[identity]; uniqueBacked {
+		return true
+	}
+	if _, foreignKeyBacked := foreignKeys[identity]; foreignKeyBacked {
 		return true
 	}
 	return platform.NormalizeDialect(dialect) != platform.SQLServer &&
@@ -461,9 +502,72 @@ func indexDefinitionsChanged(
 			indexKeyPartsChanged(generated, database, semantics)
 	case platform.Postgres:
 		return postgresIndexDefinitionChanged(generated, database, semantics)
+	case platform.MySQL, platform.MariaDB:
+		return mysqlIndexDefinitionChanged(generated, database, semantics)
 	default:
 		return false
 	}
+}
+
+// mysqlIndexDefinitionChanged answers whether a MySQL or MariaDB index has to
+// be rebuilt to match the desired definition.
+//
+// Uniqueness has to be compared here, and it is the reason this branch exists.
+// On these engines a UNIQUE constraint *is* its index, so
+// [collectDatabaseIndexes] lets a declared identity through even when a UNIQUE
+// constraint of that name owns it -- and without a uniqueness comparison a
+// desired plain `index "uq_users_email"` would match a database
+// `UNIQUE KEY uq_users_email` and report synced, which is the opposite mistake
+// from the one #1245 fixed: two genuinely different objects made equal.
+// Measured on MySQL 9.7.1, the pinned community binary v1.3.0 plans
+// `ALTER TABLE users DROP INDEX uq_users_email` followed by
+// `ALTER TABLE users ADD INDEX uq_users_email (email)` for that pair.
+//
+// Key columns are compared for the same reason: `UNIQUE KEY uq (email)` against
+// a desired unique `uq (name)` is a different index, and the pinned binary
+// plans a drop and an add for it. Comparing them is also what keeps this
+// change from trading a loud failure for a silent one -- before it, that pair
+// planned CREATE plus DROP of one name and the apply failed with
+// `Error 1061 (42000): Duplicate key name`.
+//
+// Nothing else is compared, and the omissions are the reader's, not a
+// judgement that they do not matter. Ptah's MySQL reader projects
+// information_schema.STATISTICS through GROUP_CONCAT(COLUMN_NAME) and keeps
+// only the column names and NON_UNIQUE, so a descending key and a prefix key
+// both arrive as a plain column. Comparing a direction the reader always
+// reports as ascending against a desired `desc = true` would plan a rebuild on
+// every run forever, which is the oscillation this change exists to remove. An
+// expression key never reaches the comparison at all: COLUMN_NAME is NULL for
+// one and the read fails first. Those are reader gaps, recorded as such.
+func mysqlIndexDefinitionChanged(
+	generated goschema.Index,
+	database types.DBIndex,
+	semantics identifier.Semantics,
+) bool {
+	return generated.Unique != database.IsUnique ||
+		mysqlIndexKeyColumnsChanged(generated, database, semantics)
+}
+
+// mysqlIndexKeyColumnsChanged compares the key columns in order, and only the
+// columns. See [mysqlIndexDefinitionChanged] for why a key's direction is not
+// part of the comparison.
+func mysqlIndexKeyColumnsChanged(
+	generated goschema.Index,
+	database types.DBIndex,
+	semantics identifier.Semantics,
+) bool {
+	generatedParts := effectiveGeneratedIndexParts(generated)
+	databaseParts := effectiveDatabaseIndexParts(database)
+	if len(generatedParts) != len(databaseParts) {
+		return true
+	}
+	for position, generatedPart := range generatedParts {
+		if semantics.ColumnIdentityKey(generatedPart.Name) !=
+			semantics.ColumnIdentityKey(databaseParts[position].Name) {
+			return true
+		}
+	}
+	return false
 }
 
 // postgresIndexDefinitionChanged answers whether a PostgreSQL index has to be

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -188,11 +188,10 @@ type generatedIndexEntry struct {
 type databaseIndexEntry struct {
 	ref   difftypes.IndexRef
 	index types.DBIndex
-	// dropAsConstraint reports that a UNIQUE constraint of this identity
-	// enforces the index on an engine where the constraint is a catalog object
-	// of its own, so removing the index means dropping that constraint. See
-	// [uniqueConstraintOwnsTheIndexObject].
-	dropAsConstraint bool
+	// constraintBacked reports that a UNIQUE constraint of this identity
+	// enforces the index, so the object is the constraint's and both directions
+	// of a plan have to say so. See [uniqueConstraintEnforcesTheIndex].
+	constraintBacked bool
 }
 
 func IndexesWithDialect(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, dialect string) {
@@ -342,10 +341,11 @@ func constraintBackedIndexIdentities(
 // definition the desired state gives it -- [appendIndexDifferences] pairs that
 // removal with the addition that supersedes it, and never emits it alone.
 //
-// The removal is still a removal, and what removes the object depends on the
-// object. A UNIQUE constraint's backing index is dropped through the constraint
-// everywhere except MySQL and MariaDB, so each entry carries the answer; see
-// [uniqueConstraintOwnsTheIndexObject].
+// The removal is still a removal, and what it removes depends on the object. A
+// UNIQUE constraint's backing index is the constraint's object, so each entry
+// records that; the drop is spelled through the constraint everywhere except
+// MySQL and MariaDB, and the restoration through it everywhere. See
+// [uniqueConstraintEnforcesTheIndex].
 func collectDatabaseIndexes(
 	database *types.DBSchema,
 	dialect string,
@@ -377,38 +377,51 @@ func collectDatabaseIndexes(
 		indexes[identity] = databaseIndexEntry{
 			ref:              ref,
 			index:            index,
-			dropAsConstraint: uniqueConstraintOwnsTheIndexObject(dialect, identity, uniqueConstraints),
+			constraintBacked: uniqueConstraintEnforcesTheIndex(identity, uniqueConstraints),
 		}
 	}
 	return indexes
 }
 
-// uniqueConstraintOwnsTheIndexObject reports whether removing this database
-// index means dropping a UNIQUE constraint rather than dropping an index.
+// uniqueConstraintEnforcesTheIndex reports whether a UNIQUE constraint of this
+// identity enforces the database index -- whether, in other words, the object
+// the removal names belongs to the constraint catalog and not only the index
+// catalog.
 //
-// The engines split two ways. On MySQL and MariaDB a unique key and its
-// constraint are one catalog row and `ALTER TABLE ... DROP INDEX` removes it,
-// which is what the pinned community binary v1.3.0 plans there. Everywhere else
-// the constraint is an object of its own that owns the index, and the server
-// refuses to drop the index alone: PostgreSQL 17.10 answers
-// `DROP INDEX "uq_users_email"` with `cannot drop index uq_users_email because
-// constraint uq_users_email on table users requires it (SQLSTATE 2BP01)`, and
-// the pinned binary plans `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`
-// for the same change.
+// It is a fact about the object, not a spelling, and the two consumers of the
+// mark need it for opposite reasons:
+//
+//   - The UP drop is spelled per engine. On MySQL and MariaDB a unique key and
+//     its constraint are one catalog row and `ALTER TABLE ... DROP INDEX`
+//     removes it, which is what the pinned community binary v1.3.0 plans there,
+//     so their planners ignore the mark. Everywhere else the constraint is an
+//     object of its own that owns the index and the server refuses to drop the
+//     index alone: PostgreSQL 17.10 answers `DROP INDEX "uq_users_email"` with
+//     `cannot drop index uq_users_email because constraint uq_users_email on
+//     table users requires it (SQLSTATE 2BP01)`, and the pinned binary plans
+//     `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`.
+//   - The DOWN direction has to put the object back, and there the engines do
+//     not split. What was dropped was a UNIQUE constraint on every one of them,
+//     so the statement that restores it is ADD CONSTRAINT ... UNIQUE; on MySQL
+//     and MariaDB that lands the same catalog row `CREATE UNIQUE INDEX` would.
+//     Reversing the removal into an index addition instead loses the constraint
+//     on PostgreSQL and fails outright on MySQL, because the down direction's
+//     target schema omits a constraint-backed index by construction
+//     (ConvertDBSchemaToGoSchema). See [generator.reverseIndexRemovals].
+//
+// Marking only the engines whose UP spelling differs is what made the down
+// direction wrong on the other two, so the mark records the fact and each
+// planner decides its own spelling.
 //
 // SQL Server never reaches here: a UNIQUE constraint and a unique index are
 // separate objects there, so [constraintBackedIndexIdentities] records no
 // unique-constraint identities for it at all.
-func uniqueConstraintOwnsTheIndexObject(
-	dialect string,
+func uniqueConstraintEnforcesTheIndex(
 	identity difftypes.IndexRef,
 	uniqueConstraints map[difftypes.IndexRef]struct{},
 ) bool {
-	if _, constraintBacked := uniqueConstraints[identity]; !constraintBacked {
-		return false
-	}
-	normalized := platform.NormalizeDialect(dialect)
-	return normalized != platform.MySQL && normalized != platform.MariaDB
+	_, constraintBacked := uniqueConstraints[identity]
+	return constraintBacked
 }
 
 // unaddressableDatabaseIndex reports whether an index has no standalone
@@ -424,9 +437,12 @@ func unaddressableDatabaseIndex(index types.DBIndex, dialect string) bool {
 // constraint's backing index, and so is created and dropped through that
 // constraint rather than on its own.
 //
-// A UNIQUE constraint is enforced by an index of the constraint's own name on
-// its own table everywhere except SQL Server, and MySQL and MariaDB
-// additionally create one for every FOREIGN KEY: with a bare
+// On PostgreSQL, MySQL and MariaDB a UNIQUE constraint is enforced by an index
+// of the constraint's own name on its own table. (SQL Server keeps the two as
+// separate objects, and SQLite names the backing index itself --
+// `sqlite_autoindex_t_1` -- which [unaddressableDatabaseIndex] drops before the
+// pools are built.) MySQL and MariaDB additionally create one for every
+// FOREIGN KEY: with a bare
 // `CONSTRAINT ... FOREIGN KEY` and no `KEY` clause -- the ordinary way a MySQL
 // schema is written -- `information_schema.STATISTICS` reports an index named
 // `fk_posts_user` alongside the constraint named `fk_posts_user`. A desired
@@ -501,14 +517,13 @@ func appendIndexAddition(diff *difftypes.SchemaDiff, ref difftypes.IndexRef) {
 	diff.IndexesAdded = append(diff.IndexesAdded, ref)
 }
 
-// appendIndexRemoval records a database index the plan drops, and — when the
-// object is a UNIQUE constraint's on an engine that keeps the constraint as its
-// own catalog row — records that the drop has to be spelled as a constraint
-// drop. The two lists are parallel by construction: the second is a subset of
-// the first, keyed by the same reference.
+// appendIndexRemoval records a database index the plan drops, and — when a
+// UNIQUE constraint of the same identity enforces it — records that the object
+// is that constraint's. The two lists are parallel by construction: the second
+// is a subset of the first, keyed by the same reference.
 func appendIndexRemoval(diff *difftypes.SchemaDiff, entry databaseIndexEntry) {
 	diff.IndexesRemoved = append(diff.IndexesRemoved, entry.ref)
-	if entry.dropAsConstraint {
+	if entry.constraintBacked {
 		diff.ConstraintBackedIndexRemovals = append(
 			diff.ConstraintBackedIndexRemovals,
 			entry.ref,
@@ -603,19 +618,23 @@ func mysqlIndexDefinitionChanged(
 // columns. See [mysqlIndexDefinitionChanged] for why a key's direction is not
 // part of the comparison.
 //
-// A key the reader could not read whole is not compared at all. The MySQL
-// reader reports a functional key part -- `KEY idx ((b + 1))` -- as a part
-// missing from Columns, because the expression lives in a STATISTICS column
-// MariaDB does not have; see [types.DBIndex.KeyPartsIncomplete]. Comparing what
-// is left would find the key short by one part on every run and plan a rebuild
-// forever, on a database the pinned community binary v1.3.0 reports synced.
+// A key the reader could not read whole is compared as far as it was read. The
+// MySQL reader reports a functional key part -- `KEY idx ((b + 1))` -- as a
+// part missing from Columns, because the expression lives in a STATISTICS
+// column MariaDB does not have; see [types.DBIndex.KeyPartsIncomplete]. Reading
+// what is left as the whole key would find the key short by one part on every
+// run and plan a rebuild forever, on a database the pinned community binary
+// v1.3.0 reports synced -- but declining the comparison outright reported
+// `KEY idx_mixed (b, (b + 1))` and a desired `idx_mixed (c, (c + 1))` as the
+// same key, which is a different key by every part the reader could read. The
+// names that were read are compared; see [mysqlNamedKeyPartsContradict].
 func mysqlIndexKeyColumnsChanged(
 	generated goschema.Index,
 	database types.DBIndex,
 	semantics identifier.Semantics,
 ) bool {
 	if database.KeyPartsIncomplete {
-		return false
+		return mysqlNamedKeyPartsContradict(generated, database, semantics)
 	}
 	generatedParts := effectiveGeneratedIndexParts(generated)
 	databaseParts := effectiveDatabaseIndexParts(database)
@@ -627,6 +646,55 @@ func mysqlIndexKeyColumnsChanged(
 			semantics.ColumnIdentityKey(databaseParts[position].Name) {
 			return true
 		}
+	}
+	return false
+}
+
+// mysqlNamedKeyPartsContradict answers the only question a partly-read key can
+// answer: do the parts the reader COULD name already prove this is not the
+// desired key?
+//
+// The reader names every part except the functional ones, and it does not
+// record where in the key those sat, so the two key lists cannot be lined up by
+// position. What survives is the order of the named parts, which is enough for
+// the shape that matters: a database `KEY idx_mixed (b, (b + 1))` against a
+// desired `idx_mixed (c, (c + 1))` names `b` where the desired key names only
+// `c`, so the keys differ no matter what the unread part turns out to be. That
+// pair was reported synchronized while the comparison declined on sight of an
+// unreadable part.
+//
+// Proof runs one way only. When every named part does appear, in order, the key
+// may still differ in a part the reader could not read -- `(b, (b + 1))` against
+// a desired `(b, (c + 1))` reports no change here. Reporting one instead would
+// plan a rebuild on every run for a key that never changed, which is the
+// oscillation the incomplete-key record exists to prevent, and the rebuild
+// could not be reversed: the down direction rebuilds an index from the same
+// reader's output and would recreate the key without its expression. Reading
+// information_schema.STATISTICS.EXPRESSION is what closes that half, and it is
+// a reader change with its own dialect sweep (MariaDB has no such column).
+// Recorded in docs/conformance.md.
+func mysqlNamedKeyPartsContradict(
+	generated goschema.Index,
+	database types.DBIndex,
+	semantics identifier.Semantics,
+) bool {
+	generatedParts := effectiveGeneratedIndexParts(generated)
+	databaseParts := effectiveDatabaseIndexParts(database)
+	if len(databaseParts) > len(generatedParts) {
+		return true
+	}
+	next := 0
+	for _, databasePart := range databaseParts {
+		named := semantics.ColumnIdentityKey(databasePart.Name)
+		position := next
+		for position < len(generatedParts) &&
+			semantics.ColumnIdentityKey(generatedParts[position].Name) != named {
+			position++
+		}
+		if position == len(generatedParts) {
+			return true
+		}
+		next = position + 1
 	}
 	return false
 }

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -188,6 +188,11 @@ type generatedIndexEntry struct {
 type databaseIndexEntry struct {
 	ref   difftypes.IndexRef
 	index types.DBIndex
+	// dropAsConstraint reports that a UNIQUE constraint of this identity
+	// enforces the index on an engine where the constraint is a catalog object
+	// of its own, so removing the index means dropping that constraint. See
+	// [uniqueConstraintOwnsTheIndexObject].
+	dropAsConstraint bool
 }
 
 func IndexesWithDialect(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, dialect string) {
@@ -226,6 +231,7 @@ func IndexesWithSemantics(
 	)
 	diff.SetIndexAdditions(diff.IndexAdditions())
 	diff.SetIndexRemovals(diff.IndexRemovals())
+	diff.SetConstraintBackedIndexRemovals(diff.ConstraintBackedIndexRemovals)
 }
 
 func collectGeneratedIndexes(
@@ -330,9 +336,16 @@ func constraintBackedIndexIdentities(
 // IF NOT EXISTS and IF EXISTS, skipped the create, ran the drop, exited 0, and
 // left the table with no unique index at all.
 //
-// Letting a declared identity through cannot start dropping anything: an
-// identity only survives the filters when the desired state names it, and an
-// identity the desired state names is matched rather than removed.
+// Letting a declared identity through never drops an object the desired state
+// did not ask to change: an identity only survives the filters when the desired
+// state names it, and a named identity is either matched or replaced by the
+// definition the desired state gives it -- [appendIndexDifferences] pairs that
+// removal with the addition that supersedes it, and never emits it alone.
+//
+// The removal is still a removal, and what removes the object depends on the
+// object. A UNIQUE constraint's backing index is dropped through the constraint
+// everywhere except MySQL and MariaDB, so each entry carries the answer; see
+// [uniqueConstraintOwnsTheIndexObject].
 func collectDatabaseIndexes(
 	database *types.DBSchema,
 	dialect string,
@@ -362,11 +375,40 @@ func collectDatabaseIndexes(
 			continue
 		}
 		indexes[identity] = databaseIndexEntry{
-			ref:   ref,
-			index: index,
+			ref:              ref,
+			index:            index,
+			dropAsConstraint: uniqueConstraintOwnsTheIndexObject(dialect, identity, uniqueConstraints),
 		}
 	}
 	return indexes
+}
+
+// uniqueConstraintOwnsTheIndexObject reports whether removing this database
+// index means dropping a UNIQUE constraint rather than dropping an index.
+//
+// The engines split two ways. On MySQL and MariaDB a unique key and its
+// constraint are one catalog row and `ALTER TABLE ... DROP INDEX` removes it,
+// which is what the pinned community binary v1.3.0 plans there. Everywhere else
+// the constraint is an object of its own that owns the index, and the server
+// refuses to drop the index alone: PostgreSQL 17.10 answers
+// `DROP INDEX "uq_users_email"` with `cannot drop index uq_users_email because
+// constraint uq_users_email on table users requires it (SQLSTATE 2BP01)`, and
+// the pinned binary plans `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`
+// for the same change.
+//
+// SQL Server never reaches here: a UNIQUE constraint and a unique index are
+// separate objects there, so [constraintBackedIndexIdentities] records no
+// unique-constraint identities for it at all.
+func uniqueConstraintOwnsTheIndexObject(
+	dialect string,
+	identity difftypes.IndexRef,
+	uniqueConstraints map[difftypes.IndexRef]struct{},
+) bool {
+	if _, constraintBacked := uniqueConstraints[identity]; !constraintBacked {
+		return false
+	}
+	normalized := platform.NormalizeDialect(dialect)
+	return normalized != platform.MySQL && normalized != platform.MariaDB
 }
 
 // unaddressableDatabaseIndex reports whether an index has no standalone
@@ -441,7 +483,7 @@ func appendIndexDifferences(
 			semantics,
 		):
 			appendIndexAddition(diff, generatedEntry.ref)
-			appendIndexRemoval(diff, databaseEntry.ref)
+			appendIndexRemoval(diff, databaseEntry)
 		}
 	}
 
@@ -450,7 +492,7 @@ func appendIndexDifferences(
 			continue
 		}
 		if _, exists := generated[identity]; !exists {
-			appendIndexRemoval(diff, entry.ref)
+			appendIndexRemoval(diff, entry)
 		}
 	}
 }
@@ -459,8 +501,19 @@ func appendIndexAddition(diff *difftypes.SchemaDiff, ref difftypes.IndexRef) {
 	diff.IndexesAdded = append(diff.IndexesAdded, ref)
 }
 
-func appendIndexRemoval(diff *difftypes.SchemaDiff, ref difftypes.IndexRef) {
-	diff.IndexesRemoved = append(diff.IndexesRemoved, ref)
+// appendIndexRemoval records a database index the plan drops, and — when the
+// object is a UNIQUE constraint's on an engine that keeps the constraint as its
+// own catalog row — records that the drop has to be spelled as a constraint
+// drop. The two lists are parallel by construction: the second is a subset of
+// the first, keyed by the same reference.
+func appendIndexRemoval(diff *difftypes.SchemaDiff, entry databaseIndexEntry) {
+	diff.IndexesRemoved = append(diff.IndexesRemoved, entry.ref)
+	if entry.dropAsConstraint {
+		diff.ConstraintBackedIndexRemovals = append(
+			diff.ConstraintBackedIndexRemovals,
+			entry.ref,
+		)
+	}
 }
 
 func isSQLiteInternalAutoindex(indexName, dialect string) bool {
@@ -531,14 +584,12 @@ func indexDefinitionsChanged(
 // `Error 1061 (42000): Duplicate key name`.
 //
 // Nothing else is compared, and the omissions are the reader's, not a
-// judgement that they do not matter. Ptah's MySQL reader projects
-// information_schema.STATISTICS through GROUP_CONCAT(COLUMN_NAME) and keeps
-// only the column names and NON_UNIQUE, so a descending key and a prefix key
-// both arrive as a plain column. Comparing a direction the reader always
-// reports as ascending against a desired `desc = true` would plan a rebuild on
-// every run forever, which is the oscillation this change exists to remove. An
-// expression key never reaches the comparison at all: COLUMN_NAME is NULL for
-// one and the read fails first. Those are reader gaps, recorded as such.
+// judgement that they do not matter. Ptah's MySQL reader keeps only the column
+// names and NON_UNIQUE out of information_schema.STATISTICS, so a descending
+// key and a prefix key both arrive as a plain column. Comparing a direction the
+// reader always reports as ascending against a desired `desc = true` would plan
+// a rebuild on every run forever, which is the oscillation this change exists
+// to remove. Those are reader gaps, recorded as such.
 func mysqlIndexDefinitionChanged(
 	generated goschema.Index,
 	database types.DBIndex,
@@ -551,11 +602,21 @@ func mysqlIndexDefinitionChanged(
 // mysqlIndexKeyColumnsChanged compares the key columns in order, and only the
 // columns. See [mysqlIndexDefinitionChanged] for why a key's direction is not
 // part of the comparison.
+//
+// A key the reader could not read whole is not compared at all. The MySQL
+// reader reports a functional key part -- `KEY idx ((b + 1))` -- as a part
+// missing from Columns, because the expression lives in a STATISTICS column
+// MariaDB does not have; see [types.DBIndex.KeyPartsIncomplete]. Comparing what
+// is left would find the key short by one part on every run and plan a rebuild
+// forever, on a database the pinned community binary v1.3.0 reports synced.
 func mysqlIndexKeyColumnsChanged(
 	generated goschema.Index,
 	database types.DBIndex,
 	semantics identifier.Semantics,
 ) bool {
+	if database.KeyPartsIncomplete {
+		return false
+	}
 	generatedParts := effectiveGeneratedIndexParts(generated)
 	databaseParts := effectiveDatabaseIndexParts(database)
 	if len(generatedParts) != len(databaseParts) {

--- a/migration/schemadiff/internal/compare/unique_index_ownership.go
+++ b/migration/schemadiff/internal/compare/unique_index_ownership.go
@@ -1,0 +1,90 @@
+package compare
+
+import (
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/indexscope"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// generatedIndexIdentities is the identity of every index the desired state
+// declares, in the same key space the database index pool uses. It exists so
+// constraint comparison can ask the one question index comparison already
+// answers -- "does the desired state name this object as an index?" -- without
+// re-deriving index table resolution or identifier folding.
+func generatedIndexIdentities(
+	generated *goschema.Database,
+	semantics identifier.Semantics,
+) map[difftypes.IndexRef]struct{} {
+	declared, _ := collectGeneratedIndexes(generated, semantics)
+	identities := make(map[difftypes.IndexRef]struct{}, len(declared))
+	for identity := range declared {
+		identities[identity] = struct{}{}
+	}
+	return identities
+}
+
+// uniqueConstraintOwnedByDeclaredIndex reports whether a database UNIQUE
+// constraint names the same object as an index the desired state declares, and
+// so must be left to index comparison instead of compared again here.
+//
+// Every engine Ptah supports except SQL Server enforces a UNIQUE constraint
+// with an index of the constraint's own name on the constraint's own table, and
+// introspection reports that one object twice: once in the index catalog, once
+// in the constraint catalog. On MySQL and MariaDB there is not even a separate
+// notion to report --
+//
+//	ALTER TABLE users ADD CONSTRAINT uq_users_email UNIQUE (email)
+//	CREATE UNIQUE INDEX uq_users_email ON users (email)
+//
+// leave the identical catalog row, which is why `schema inspect` writes MySQL
+// uniqueness back out as `index { unique = true }` and never as a constraint,
+// on both `ptah-compat` and the pinned community binary v1.3.0.
+//
+// **Which representation wins is decided by the desired state, not by the
+// dialect.** When the desired state names the object as an index, the index
+// pool owns it and this pool stays out; when the desired state names it as a
+// constraint, or does not name it at all, nothing changes and this pool keeps
+// it. That is what makes the two sides agree without either one guessing:
+// the side that has an opinion is the side that wrote the schema.
+//
+// Compared here, the object was reported removed while index comparison
+// reported the very same name added, because the desired state written as
+// `index { unique = true }` produces no [goschema.Constraint] to match it. The
+// resulting plan cannot be applied: measured on MySQL 9.7.1 and MariaDB
+// 11.8.8, the CREATE comes back as
+// `Error 1061 (42000): Duplicate key name 'uq_users_email'` and the apply exits
+// 1; measured on PostgreSQL 17.10, where the statements carry IF NOT EXISTS and
+// IF EXISTS, the create was skipped, the drop ran, the apply exited 0 and the
+// table was left with no unique index at all. The pinned community binary
+// v1.3.0 reported "Schema is synced" for every one of those fixtures
+// (stokaro/ptah#1245).
+//
+// Uniqueness of the declared index is deliberately *not* required for the
+// hand-off. A desired plain `index "uq_users_email"` against a database
+// `UNIQUE KEY uq_users_email` is a real change, and it is one index comparison
+// states correctly as a replacement of a single object; splitting it across the
+// two pools would plan a DROP CONSTRAINT and a DROP INDEX for the same row.
+//
+// SQL Server is excluded because a UNIQUE constraint and a unique index are
+// separate objects there, which is the same reason it is excluded from
+// [constraintBackedIndexIdentities].
+func uniqueConstraintOwnedByDeclaredIndex(
+	constraint types.DBConstraint,
+	dialect string,
+	declaredIndexes map[difftypes.IndexRef]struct{},
+	semantics identifier.Semantics,
+) bool {
+	if constraint.Type != "UNIQUE" ||
+		platform.NormalizeDialect(dialect) == platform.SQLServer {
+		return false
+	}
+	identity := indexscope.IdentityKeyWithSemantics(semantics, difftypes.IndexRef{
+		Name:      constraint.Name,
+		TableName: constraint.QualifiedTableName(),
+	})
+	_, declared := declaredIndexes[identity]
+	return declared
+}

--- a/migration/schemadiff/internal/compare/unique_index_ownership.go
+++ b/migration/schemadiff/internal/compare/unique_index_ownership.go
@@ -30,11 +30,11 @@ func generatedIndexIdentities(
 // constraint names the same object as an index the desired state declares, and
 // so must be left to index comparison instead of compared again here.
 //
-// Every engine Ptah supports except SQL Server enforces a UNIQUE constraint
-// with an index of the constraint's own name on the constraint's own table, and
-// introspection reports that one object twice: once in the index catalog, once
-// in the constraint catalog. On MySQL and MariaDB there is not even a separate
-// notion to report --
+// PostgreSQL, MySQL and MariaDB enforce a UNIQUE constraint with an index of
+// the constraint's own name on the constraint's own table, and introspection
+// reports that one object twice: once in the index catalog, once in the
+// constraint catalog. On MySQL and MariaDB there is not even a separate notion
+// to report --
 //
 //	ALTER TABLE users ADD CONSTRAINT uq_users_email UNIQUE (email)
 //	CREATE UNIQUE INDEX uq_users_email ON users (email)
@@ -69,16 +69,23 @@ func generatedIndexIdentities(
 // two pools would state one object's replacement as two objects' lifecycles,
 // with no order between the drop and the create that the two pools agree on.
 //
-// The replacement's drop is still spelled per engine, because the object is
-// one catalog row on MySQL and MariaDB and a constraint owning an index
-// everywhere else. That is decided at removal time rather than here; see
-// [uniqueConstraintOwnsTheIndexObject]. On PostgreSQL 17.10 the drop is
+// The object stays the constraint's for both directions of the plan, which is
+// recorded at removal time rather than here; see
+// [uniqueConstraintEnforcesTheIndex]. The drop is spelled per engine -- one
+// catalog row on MySQL and MariaDB, a constraint owning an index everywhere
+// else, so on PostgreSQL 17.10 it is
 // `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`, which is what the
-// pinned community binary v1.3.0 plans and the only spelling the server takes.
+// pinned community binary v1.3.0 plans and the only spelling the server takes
+// -- and the down direction restores the constraint on every engine.
 //
 // SQL Server is excluded because a UNIQUE constraint and a unique index are
 // separate objects there, which is the same reason it is excluded from
-// [constraintBackedIndexIdentities].
+// [constraintBackedIndexIdentities]. SQLite needs no exclusion and gets none:
+// it names a UNIQUE constraint's backing index itself --
+// `CREATE TABLE t (a TEXT, CONSTRAINT uq_t_a UNIQUE(a))` leaves
+// `sqlite_autoindex_t_1` in sqlite_master -- so the two representations never
+// share an identity to hand off, and the reader's autoindex rows are dropped
+// before the pools are built ([unaddressableDatabaseIndex]).
 func uniqueConstraintOwnedByDeclaredIndex(
 	constraint types.DBConstraint,
 	dialect string,

--- a/migration/schemadiff/internal/compare/unique_index_ownership.go
+++ b/migration/schemadiff/internal/compare/unique_index_ownership.go
@@ -66,7 +66,15 @@ func generatedIndexIdentities(
 // hand-off. A desired plain `index "uq_users_email"` against a database
 // `UNIQUE KEY uq_users_email` is a real change, and it is one index comparison
 // states correctly as a replacement of a single object; splitting it across the
-// two pools would plan a DROP CONSTRAINT and a DROP INDEX for the same row.
+// two pools would state one object's replacement as two objects' lifecycles,
+// with no order between the drop and the create that the two pools agree on.
+//
+// The replacement's drop is still spelled per engine, because the object is
+// one catalog row on MySQL and MariaDB and a constraint owning an index
+// everywhere else. That is decided at removal time rather than here; see
+// [uniqueConstraintOwnsTheIndexObject]. On PostgreSQL 17.10 the drop is
+// `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"`, which is what the
+// pinned community binary v1.3.0 plans and the only spelling the server takes.
 //
 // SQL Server is excluded because a UNIQUE constraint and a unique index are
 // separate objects there, which is the same reason it is excluded from

--- a/migration/schemadiff/mysql_unique_index_identity_test.go
+++ b/migration/schemadiff/mysql_unique_index_identity_test.go
@@ -1,0 +1,416 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// mysqlUniqueKeyDatabaseSchema is what MySQL 9.7.1 and MariaDB 11.8.8 report for
+//
+//	CREATE TABLE users (
+//	  id BIGINT NOT NULL AUTO_INCREMENT,
+//	  email VARCHAR(255) NOT NULL,
+//	  PRIMARY KEY (id),
+//	  UNIQUE KEY uq_users_email (email)
+//	);
+//
+// One object appears twice: information_schema.STATISTICS reports the unique
+// index and information_schema.TABLE_CONSTRAINTS reports a UNIQUE constraint,
+// both named uq_users_email on users.
+func mysqlUniqueKeyDatabaseSchema() *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "users",
+			Type: "BASE TABLE",
+			Columns: []types.DBColumn{{
+				Name:       "email",
+				DataType:   "varchar(255)",
+				ColumnType: "varchar(255)",
+				IsNullable: "NO",
+				IsUnique:   true,
+			}},
+		}},
+		Indexes: []types.DBIndex{{
+			Name:      "uq_users_email",
+			TableName: "users",
+			Columns:   []string{"email"},
+			IsUnique:  true,
+		}},
+		Constraints: []types.DBConstraint{{
+			Name:        "uq_users_email",
+			TableName:   "users",
+			Type:        "UNIQUE",
+			ColumnName:  "email",
+			ColumnNames: []string{"email"},
+		}},
+	}
+}
+
+// mysqlUniqueKeyGeneratedSchema is the same table as the desired state writes
+// it. `schema inspect` on `ptah-compat` and on the pinned community binary
+// v1.3.0, and Ptah's own annotations, all spell MySQL uniqueness as an index,
+// so there is no goschema.Constraint at all.
+func mysqlUniqueKeyGeneratedSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{Name: "users", StructName: "User"}},
+		Fields: []goschema.Field{{
+			StructName: "User",
+			Name:       "email",
+			Type:       "VARCHAR(255)",
+			Nullable:   false,
+		}},
+		Indexes: []goschema.Index{{
+			StructName: "User",
+			Name:       "uq_users_email",
+			TableName:  "users",
+			Fields:     []string{"email"},
+			Unique:     true,
+		}},
+	}
+}
+
+// TestCompareWithDialect_MySQLUnchangedUniqueIndexIsSynced is stokaro/ptah#1245
+// reduced to the comparison. Measured against MySQL 9.7.1 and MariaDB 11.8.8:
+// replaying a database's own `schema inspect` output planned CREATE UNIQUE
+// INDEX plus ALTER TABLE DROP INDEX for the same object, where the pinned
+// community binary v1.3.0 reported "Schema is synced".
+func TestCompareWithDialect_MySQLUnchangedUniqueIndexIsSynced(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				mysqlUniqueKeyGeneratedSchema(),
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_NoObjectIsBothAddedAndRemoved asserts the invariant
+// #1245 asks for directly: whatever else a plan does, one name on one table is
+// never simultaneously an index addition and a constraint removal. A plan that
+// says both cannot be applied -- MySQL answers the CREATE with
+// "Error 1061 (42000): Duplicate key name".
+func TestCompareWithDialect_NoObjectIsBothAddedAndRemoved(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+		{name: "sqlite", dialect: "sqlite"},
+		{name: "sqlserver", dialect: "sqlserver"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				mysqlUniqueKeyGeneratedSchema(),
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(
+				addedIndexesAlsoRemovedAsConstraints(diff),
+				qt.HasLen,
+				0,
+				qt.Commentf("diff: %+v", diff),
+			)
+		})
+	}
+}
+
+// TestCompareWithDialect_NameHeuristicUniqueKeyIsSynced covers the other filter
+// that stranded the same object. isConstraintBasedUniqueIndex guesses from the
+// name that a unique index backs a constraint, and `uk_users_email` matches its
+// MySQL pattern, so the database index was dropped from the pool before the
+// same-name UNIQUE constraint was even consulted. Measured on MySQL 9.7.1,
+// replaying that database's own inspect output planned CREATE UNIQUE INDEX plus
+// ALTER TABLE DROP INDEX where the pinned community binary v1.3.0 reported
+// "Schema is synced".
+func TestCompareWithDialect_NameHeuristicUniqueKeyIsSynced(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name      string
+		indexName string
+	}{
+		{name: "mysql_uk_prefix", indexName: "uk_users_email"},
+		{name: "postgres_key_suffix", indexName: "users_email_key"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Indexes[0].Name = test.indexName
+			database := mysqlUniqueKeyDatabaseSchema()
+			database.Indexes[0].Name = test.indexName
+			database.Constraints[0].Name = test.indexName
+
+			diff := schemadiff.CompareWithDialect(generated, database, "mysql")
+
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_UndeclaredUniqueKeyIsStillRemoved is the control for
+// the fix itself: the hand-off to index comparison happens only because the
+// desired state declares that index. Declare nothing and the database's UNIQUE
+// constraint must still be reported removed, or #1245 would have been "fixed"
+// by making constraint removals disappear.
+func TestCompareWithDialect_UndeclaredUniqueKeyIsStillRemoved(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Indexes = nil
+
+			diff := schemadiff.CompareWithDialect(
+				generated,
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(diff.ConstraintsRemovedWithTables, qt.DeepEquals, []difftypes.ConstraintRemovalInfo{{
+				Name:      "uq_users_email",
+				TableName: "users",
+				Type:      "UNIQUE",
+			}})
+			c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDialect_UniqueKeyOnAnotherTableIsNotTheSameObject is the first
+// half of the "do not make two different objects equal" control. Index identity
+// carries the owning table, so a unique key named uq_users_email on users and
+// an index of that name declared on orders are two objects and must stay two.
+func TestCompareWithDialect_UniqueKeyOnAnotherTableIsNotTheSameObject(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Tables = append(generated.Tables, goschema.Table{
+				Name:       "orders",
+				StructName: "Order",
+			})
+			generated.Fields = append(generated.Fields, goschema.Field{
+				StructName: "Order",
+				Name:       "email",
+				Type:       "VARCHAR(255)",
+				Nullable:   false,
+			})
+			generated.Indexes[0].StructName = "Order"
+			generated.Indexes[0].TableName = "orders"
+			database := mysqlUniqueKeyDatabaseSchema()
+			database.Tables = append(database.Tables, types.DBTable{
+				Name: "orders",
+				Type: "BASE TABLE",
+				Columns: []types.DBColumn{{
+					Name:       "email",
+					DataType:   "varchar(255)",
+					ColumnType: "varchar(255)",
+					IsNullable: "NO",
+					IsUnique:   true,
+				}},
+			})
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.dialect)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "orders",
+			}})
+			c.Assert(diff.ConstraintsRemovedWithTables, qt.DeepEquals, []difftypes.ConstraintRemovalInfo{{
+				Name:      "uq_users_email",
+				TableName: "users",
+				Type:      "UNIQUE",
+			}})
+		})
+	}
+}
+
+// TestCompareWithDialect_DeclaredIndexUniquenessStillCompared is the second
+// half of that control, and the one the hand-off could have broken. Letting a
+// declared identity through means the database's unique key now has a
+// counterpart to be matched against; if the match ignored uniqueness, a desired
+// plain index would silently satisfy a database UNIQUE KEY of the same name.
+// Measured on MySQL 9.7.1, the pinned community binary v1.3.0 plans
+// DROP INDEX followed by ADD INDEX for exactly this pair.
+func TestCompareWithDialect_DeclaredIndexUniquenessStillCompared(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Indexes[0].Unique = false
+
+			diff := schemadiff.CompareWithDialect(
+				generated,
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
+			c.Assert(diff.ConstraintsRemovedWithTables, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDialect_DeclaredIndexColumnsStillCompared is the same control
+// on the other attribute the match could have swallowed. Measured on MySQL
+// 9.7.1, the pinned community binary v1.3.0 plans DROP INDEX followed by
+// ADD UNIQUE INDEX uq_users_email (name) for this pair.
+func TestCompareWithDialect_DeclaredIndexColumnsStillCompared(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Fields = append(generated.Fields, goschema.Field{
+				StructName: "User",
+				Name:       "name",
+				Type:       "VARCHAR(255)",
+				Nullable:   false,
+			})
+			generated.Indexes[0].Fields = []string{"name"}
+			database := mysqlUniqueKeyDatabaseSchema()
+			database.Tables[0].Columns = append(database.Tables[0].Columns, types.DBColumn{
+				Name:       "name",
+				DataType:   "varchar(255)",
+				ColumnType: "varchar(255)",
+				IsNullable: "NO",
+			})
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.dialect)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
+			c.Assert(diff.ConstraintsRemovedWithTables, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDialect_DeclaredUniqueConstraintKeepsConstraintOwnership
+// pins the other direction of the ownership rule: a desired state that spells
+// uniqueness as a constraint keeps the constraint pool in charge, and the
+// database's backing index stays filtered out rather than being reported
+// removed.
+func TestCompareWithDialect_DeclaredUniqueConstraintKeepsConstraintOwnership(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Indexes = nil
+			generated.Constraints = []goschema.Constraint{{
+				StructName: "User",
+				Name:       "uq_users_email",
+				Type:       "UNIQUE",
+				Table:      "users",
+				Columns:    []string{"email"},
+			}}
+
+			diff := schemadiff.CompareWithDialect(
+				generated,
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+		})
+	}
+}
+
+// addedIndexesAlsoRemovedAsConstraints reports every table-qualified name the
+// plan creates as an index and drops as a constraint in the same run.
+func addedIndexesAlsoRemovedAsConstraints(diff *difftypes.SchemaDiff) []string {
+	removed := make(map[difftypes.IndexRef]struct{}, len(diff.ConstraintsRemovedWithTables))
+	for _, constraint := range diff.ConstraintsRemovedWithTables {
+		removed[difftypes.IndexRef{
+			Name:      constraint.Name,
+			TableName: constraint.TableName,
+		}] = struct{}{}
+	}
+	collisions := make([]string, 0, len(diff.IndexesAdded))
+	for _, index := range diff.IndexesAdded {
+		if _, isRemoved := removed[index]; isRemoved {
+			collisions = append(collisions, index.TableName+"."+index.Name)
+		}
+	}
+	return collisions
+}

--- a/migration/schemadiff/mysql_unique_index_identity_test.go
+++ b/migration/schemadiff/mysql_unique_index_identity_test.go
@@ -396,6 +396,201 @@ func TestCompareWithDialect_DeclaredUniqueConstraintKeepsConstraintOwnership(t *
 	}
 }
 
+// TestCompareWithDialect_ConstraintBackedIndexRemovalCarriesItsSpelling covers
+// what a removal means when the object it names is a UNIQUE constraint's.
+//
+// The desired state below spells the object as a plain index, so it is a real
+// change and index comparison states it as a replacement -- one object, dropped
+// and recreated -- on every dialect. The statement that drops it is not the
+// same everywhere. On MySQL and MariaDB the unique key and its constraint are
+// one catalog row and `DROP INDEX` removes it, which is what the pinned
+// community binary v1.3.0 plans there. On PostgreSQL 17.10 the same spelling
+// answers `cannot drop index uq_users_email because constraint uq_users_email
+// on table users requires it (SQLSTATE 2BP01)`, and the pinned binary plans
+// `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"` instead, so the
+// comparator marks the removal for the planner.
+func TestCompareWithDialect_ConstraintBackedIndexRemovalCarriesItsSpelling(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+		want    []difftypes.IndexRef
+	}{
+		{name: "mysql", dialect: "mysql", want: nil},
+		{name: "mariadb", dialect: "mariadb", want: nil},
+		{
+			name:    "postgres",
+			dialect: "postgres",
+			want:    []difftypes.IndexRef{{Name: "uq_users_email", TableName: "users"}},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := mysqlUniqueKeyGeneratedSchema()
+			generated.Indexes[0].Unique = false
+
+			diff := schemadiff.CompareWithDialect(
+				generated,
+				mysqlUniqueKeyDatabaseSchema(),
+				test.dialect,
+			)
+
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
+			c.Assert(diff.ConstraintBackedIndexRemovals, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestCompareWithDialect_PlainIndexRemovalIsNotConstraintBacked is the control
+// for the marker: an index no constraint enforces is dropped as an index, on
+// PostgreSQL as everywhere else. Marking every removal would turn this one into
+// an ALTER TABLE DROP CONSTRAINT for a constraint that does not exist.
+func TestCompareWithDialect_PlainIndexRemovalIsNotConstraintBacked(t *testing.T) {
+	c := qt.New(t)
+
+	c.Run("postgres", func(c *qt.C) {
+		generated := mysqlUniqueKeyGeneratedSchema()
+		generated.Indexes = nil
+		database := mysqlUniqueKeyDatabaseSchema()
+		database.Constraints = nil
+		database.Indexes[0].Name = "idx_users_email"
+		database.Indexes[0].IsUnique = false
+
+		diff := schemadiff.CompareWithDialect(generated, database, "postgres")
+
+		c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+			Name:      "idx_users_email",
+			TableName: "users",
+		}})
+		c.Assert(diff.ConstraintBackedIndexRemovals, qt.HasLen, 0)
+	})
+}
+
+// TestCompareWithDialect_MySQLKeyWithAnUnreadablePartIsNotCompared covers a
+// functional key part on MySQL and MariaDB. `KEY idx_mixed (b, (b + 1))` is
+// reported by information_schema.STATISTICS as one named column and one row
+// whose COLUMN_NAME is NULL, and the reader cannot name the second part -- the
+// expression lives in a STATISTICS column MariaDB does not have. Comparing what
+// it can see would find the key short by one part against the desired state
+// every run and plan a rebuild forever, on a database MySQL 9.7.1 and the
+// pinned community binary v1.3.0 both call unchanged.
+func TestCompareWithDialect_MySQLKeyWithAnUnreadablePartIsNotCompared(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				expressionKeyGeneratedSchema(),
+				expressionKeyDatabaseSchema(true),
+				test.dialect,
+			)
+
+			c.Assert(diff.HasChanges(), qt.IsFalse, qt.Commentf("round-trip diff: %+v", diff))
+		})
+	}
+}
+
+// TestCompareWithDialect_MySQLKeyReadWholeIsStillCompared is the control: the
+// declining above is about a key the reader could not read whole, not about
+// key columns in general. The same pair with every part named is a genuine
+// difference and stays one.
+func TestCompareWithDialect_MySQLKeyReadWholeIsStillCompared(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff := schemadiff.CompareWithDialect(
+				expressionKeyGeneratedSchema(),
+				expressionKeyDatabaseSchema(false),
+				test.dialect,
+			)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "idx_mixed",
+				TableName: "t4",
+			}})
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "idx_mixed",
+				TableName: "t4",
+			}})
+		})
+	}
+}
+
+// expressionKeyDatabaseSchema is what MySQL 9.7.1 reports for
+//
+//	CREATE TABLE t4 (
+//	  id BIGINT NOT NULL AUTO_INCREMENT,
+//	  b INT NOT NULL,
+//	  PRIMARY KEY (id),
+//	  KEY idx_mixed (b, (b + 1))
+//	);
+//
+// once the reader has assembled the key: one named column, and -- when
+// incomplete is set -- the record that a second part exists which it could not
+// name.
+func expressionKeyDatabaseSchema(incomplete bool) *types.DBSchema {
+	return &types.DBSchema{
+		Tables: []types.DBTable{{
+			Name: "t4",
+			Type: "BASE TABLE",
+			Columns: []types.DBColumn{{
+				Name:       "b",
+				DataType:   "int",
+				ColumnType: "int",
+				IsNullable: "NO",
+			}},
+		}},
+		Indexes: []types.DBIndex{{
+			Name:               "idx_mixed",
+			TableName:          "t4",
+			Columns:            []string{"b"},
+			KeyPartsIncomplete: incomplete,
+		}},
+	}
+}
+
+// expressionKeyGeneratedSchema is the same key as `schema inspect` writes it:
+// the named column and the expression, both spelled out.
+func expressionKeyGeneratedSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{Name: "t4", StructName: "T4"}},
+		Fields: []goschema.Field{{
+			StructName: "T4",
+			Name:       "b",
+			Type:       "INT",
+			Nullable:   false,
+		}},
+		Indexes: []goschema.Index{{
+			StructName: "T4",
+			Name:       "idx_mixed",
+			TableName:  "t4",
+			Parts: []goschema.IndexPart{
+				{Name: "b"},
+				{Expr: "(`b` + 1)"},
+			},
+		}},
+	}
+}
+
 // addedIndexesAlsoRemovedAsConstraints reports every table-qualified name the
 // plan creates as an index and drops as a constraint in the same run.
 func addedIndexesAlsoRemovedAsConstraints(diff *difftypes.SchemaDiff) []string {

--- a/migration/schemadiff/mysql_unique_index_identity_test.go
+++ b/migration/schemadiff/mysql_unique_index_identity_test.go
@@ -396,33 +396,32 @@ func TestCompareWithDialect_DeclaredUniqueConstraintKeepsConstraintOwnership(t *
 	}
 }
 
-// TestCompareWithDialect_ConstraintBackedIndexRemovalCarriesItsSpelling covers
-// what a removal means when the object it names is a UNIQUE constraint's.
+// TestCompareWithDialect_ConstraintBackedIndexRemovalIsRecordedEverywhere
+// covers what a removal means when the object it names is a UNIQUE
+// constraint's.
 //
 // The desired state below spells the object as a plain index, so it is a real
 // change and index comparison states it as a replacement -- one object, dropped
-// and recreated -- on every dialect. The statement that drops it is not the
-// same everywhere. On MySQL and MariaDB the unique key and its constraint are
-// one catalog row and `DROP INDEX` removes it, which is what the pinned
-// community binary v1.3.0 plans there. On PostgreSQL 17.10 the same spelling
-// answers `cannot drop index uq_users_email because constraint uq_users_email
-// on table users requires it (SQLSTATE 2BP01)`, and the pinned binary plans
-// `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"` instead, so the
-// comparator marks the removal for the planner.
-func TestCompareWithDialect_ConstraintBackedIndexRemovalCarriesItsSpelling(t *testing.T) {
+// and recreated -- on every dialect. The comparator records the fact that a
+// UNIQUE constraint enforces the object, not a statement: what removes it
+// differs per engine, and what RESTORES it does not. On MySQL and MariaDB the
+// unique key and its constraint are one catalog row and `DROP INDEX` removes
+// it, which is what the pinned community binary v1.3.0 plans there; on
+// PostgreSQL 17.10 that spelling answers `cannot drop index uq_users_email
+// because constraint uq_users_email on table users requires it (SQLSTATE
+// 2BP01)` and the pinned binary plans `ALTER TABLE "users" DROP CONSTRAINT
+// "uq_users_email"`. Both planners read this one list and spell their own drop;
+// the down direction reads it on every engine, because a rollback that puts an
+// index back where a UNIQUE constraint was restores the wrong object.
+func TestCompareWithDialect_ConstraintBackedIndexRemovalIsRecordedEverywhere(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
 		dialect string
-		want    []difftypes.IndexRef
 	}{
-		{name: "mysql", dialect: "mysql", want: nil},
-		{name: "mariadb", dialect: "mariadb", want: nil},
-		{
-			name:    "postgres",
-			dialect: "postgres",
-			want:    []difftypes.IndexRef{{Name: "uq_users_email", TableName: "users"}},
-		},
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "postgres", dialect: "postgres"},
 	}
 
 	for _, test := range tests {
@@ -440,7 +439,10 @@ func TestCompareWithDialect_ConstraintBackedIndexRemovalCarriesItsSpelling(t *te
 				Name:      "uq_users_email",
 				TableName: "users",
 			}})
-			c.Assert(diff.ConstraintBackedIndexRemovals, qt.DeepEquals, test.want)
+			c.Assert(diff.ConstraintBackedIndexRemovals, qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "uq_users_email",
+				TableName: "users",
+			}})
 		})
 	}
 }
@@ -470,15 +472,17 @@ func TestCompareWithDialect_PlainIndexRemovalIsNotConstraintBacked(t *testing.T)
 	})
 }
 
-// TestCompareWithDialect_MySQLKeyWithAnUnreadablePartIsNotCompared covers a
+// TestCompareWithDialect_MySQLKeyWithAnUnreadablePartDoesNotChurn covers a
 // functional key part on MySQL and MariaDB. `KEY idx_mixed (b, (b + 1))` is
 // reported by information_schema.STATISTICS as one named column and one row
 // whose COLUMN_NAME is NULL, and the reader cannot name the second part -- the
-// expression lives in a STATISTICS column MariaDB does not have. Comparing what
-// it can see would find the key short by one part against the desired state
-// every run and plan a rebuild forever, on a database MySQL 9.7.1 and the
-// pinned community binary v1.3.0 both call unchanged.
-func TestCompareWithDialect_MySQLKeyWithAnUnreadablePartIsNotCompared(t *testing.T) {
+// expression lives in a STATISTICS column MariaDB does not have. Reading what
+// it can see as the whole key would find the key short by one part against the
+// desired state every run and plan a rebuild forever, on a database MySQL 9.7.1
+// and the pinned community binary v1.3.0 both call unchanged. The named part
+// here is the desired key's own, so nothing is contradicted and nothing is
+// planned.
+func TestCompareWithDialect_MySQLKeyWithAnUnreadablePartDoesNotChurn(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
@@ -522,6 +526,61 @@ func TestCompareWithDialect_MySQLKeyReadWholeIsStillCompared(t *testing.T) {
 				expressionKeyDatabaseSchema(false),
 				test.dialect,
 			)
+
+			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "idx_mixed",
+				TableName: "t4",
+			}})
+			c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{{
+				Name:      "idx_mixed",
+				TableName: "t4",
+			}})
+		})
+	}
+}
+
+// TestCompareWithDialect_MySQLUnreadablePartDoesNotHideANamedDifference is the
+// other half of declining a key the reader could not read whole: declining on
+// sight of an unreadable part reported two keys as the same key when every part
+// the reader COULD read said otherwise.
+//
+// The database key is `KEY idx_mixed (b, (b + 1))`, read as the one named column
+// `b` plus the record of a part that could not be named. The desired key is
+// `idx_mixed (c, (c + 1))` -- a different column and a different expression.
+// It was reported synchronized. The named part is compared now, so the
+// difference is stated as the replacement it is.
+func TestCompareWithDialect_MySQLUnreadablePartDoesNotHideANamedDifference(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			generated := expressionKeyGeneratedSchema()
+			generated.Fields = append(generated.Fields, goschema.Field{
+				StructName: "T4",
+				Name:       "c",
+				Type:       "INT",
+				Nullable:   false,
+			})
+			generated.Indexes[0].Parts = []goschema.IndexPart{
+				{Name: "c"},
+				{Expr: "(`c` + 1)"},
+			}
+			database := expressionKeyDatabaseSchema(true)
+			database.Tables[0].Columns = append(database.Tables[0].Columns, types.DBColumn{
+				Name:       "c",
+				DataType:   "int",
+				ColumnType: "int",
+				IsNullable: "NO",
+			})
+
+			diff := schemadiff.CompareWithDialect(generated, database, test.dialect)
 
 			c.Assert(diff.IndexAdditions(), qt.DeepEquals, []difftypes.IndexRef{{
 				Name:      "idx_mixed",

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -165,15 +165,21 @@ type SchemaDiff struct {
 
 	// ConstraintBackedIndexRemovals is the subset of IndexesRemoved whose
 	// object is enforced by a UNIQUE constraint of the same name on the same
-	// table, so the drop has to be spelled
-	// `ALTER TABLE <table> DROP CONSTRAINT <name>`.
+	// table. It records what the object is; each planner spells the statement
+	// its engine accepts.
 	//
-	// PostgreSQL refuses the index spelling for those:
+	// PostgreSQL refuses the index spelling for one:
 	// `cannot drop index uq_users_email because constraint uq_users_email on
-	// table users requires it (SQLSTATE 2BP01)`, measured on 17.10. MySQL and
-	// MariaDB are the opposite case -- a unique key and its index are one
-	// catalog row that `DROP INDEX` drops -- so their removals are never listed
-	// here.
+	// table users requires it (SQLSTATE 2BP01)`, measured on 17.10, so its
+	// planner drops the constraint instead. MySQL and MariaDB are the opposite
+	// case -- a unique key and its index are one catalog row that `DROP INDEX`
+	// drops, which is what the pinned community binary v1.3.0 plans there -- so
+	// their planners ignore the list and their plans are unchanged by it.
+	//
+	// The list is not PostgreSQL-only, because the down direction needs it on
+	// every engine: what was dropped was a UNIQUE constraint, and a rollback
+	// that reverses it into an index addition restores the wrong object (see
+	// the generator's reverseIndexRemovals).
 	ConstraintBackedIndexRemovals []IndexRef `json:"constraint_backed_index_removals,omitempty"`
 
 	// ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
@@ -442,6 +448,43 @@ func (d *SchemaDiff) ConstraintBackedIndexRemovalSet() map[IndexRef]struct{} {
 	set := make(map[IndexRef]struct{}, len(d.ConstraintBackedIndexRemovals))
 	for _, ref := range d.ConstraintBackedIndexRemovals {
 		set[ref] = struct{}{}
+	}
+	return set
+}
+
+// IndexRemovalsRebuiltAsUniqueConstraints keys the index removals whose object
+// a UNIQUE constraint addition in the same plan puts back.
+//
+// This is the shape a rollback of a constraint-backed index replacement has:
+// the up direction turned a UNIQUE constraint into a plain index, so the down
+// direction drops that index and adds the constraint again — and ADD CONSTRAINT
+// ... UNIQUE builds an index of the constraint's name, so the two collide on
+// one name. PostgreSQL 17.10 answers the add with
+// `relation "uq_users_email" already exists (SQLSTATE 42P07)` and MySQL 9.7.1
+// with `Error 1061 (42000): Duplicate key name 'uq_users_email'` unless the
+// drop runs first, and the planners emit constraint additions before index
+// removals. A planner therefore emits the drop with the addition and skips it
+// where it would otherwise have landed, which is what this set is for.
+//
+// The match is exact rather than semantics-folded: both sides name the same
+// introspected object, recorded from one IndexRef by the reversal that built
+// the addition.
+func (d *SchemaDiff) IndexRemovalsRebuiltAsUniqueConstraints() map[IndexRef]struct{} {
+	if len(d.ConstraintsAddedWithTables) == 0 || len(d.IndexesRemoved) == 0 {
+		return nil
+	}
+	additions := make(map[IndexRef]struct{}, len(d.ConstraintsAddedWithTables))
+	for _, add := range d.ConstraintsAddedWithTables {
+		if add.Type != "UNIQUE" || add.TableName == "" {
+			continue
+		}
+		additions[IndexRef{Name: add.Name, TableName: add.TableName}] = struct{}{}
+	}
+	set := make(map[IndexRef]struct{}, len(additions))
+	for _, ref := range d.IndexesRemoved {
+		if _, rebuilt := additions[ref]; rebuilt {
+			set[ref] = struct{}{}
+		}
 	}
 	return set
 }

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -163,6 +163,19 @@ type SchemaDiff struct {
 	// plans or uniqueness protections.
 	IndexesRemoved []IndexRef `json:"indexes_removed"`
 
+	// ConstraintBackedIndexRemovals is the subset of IndexesRemoved whose
+	// object is enforced by a UNIQUE constraint of the same name on the same
+	// table, so the drop has to be spelled
+	// `ALTER TABLE <table> DROP CONSTRAINT <name>`.
+	//
+	// PostgreSQL refuses the index spelling for those:
+	// `cannot drop index uq_users_email because constraint uq_users_email on
+	// table users requires it (SQLSTATE 2BP01)`, measured on 17.10. MySQL and
+	// MariaDB are the opposite case -- a unique key and its index are one
+	// catalog row that `DROP INDEX` drops -- so their removals are never listed
+	// here.
+	ConstraintBackedIndexRemovals []IndexRef `json:"constraint_backed_index_removals,omitempty"`
+
 	// ExtensionsAdded contains names of PostgreSQL extensions that exist in the target schema
 	// but not in the current database schema
 	ExtensionsAdded []string `json:"extensions_added"`
@@ -413,6 +426,24 @@ func (d *SchemaDiff) SetIndexAdditions(refs []IndexRef) {
 // SetIndexRemovals replaces the removed index references with a sorted copy.
 func (d *SchemaDiff) SetIndexRemovals(refs []IndexRef) {
 	d.IndexesRemoved = sortedIndexRefs(refs)
+}
+
+// SetConstraintBackedIndexRemovals replaces the constraint-backed index
+// removals with a sorted copy, in the same key order as SetIndexRemovals.
+func (d *SchemaDiff) SetConstraintBackedIndexRemovals(refs []IndexRef) {
+	d.ConstraintBackedIndexRemovals = sortedIndexRefs(refs)
+}
+
+// ConstraintBackedIndexRemovalSet keys ConstraintBackedIndexRemovals for the
+// membership test a planner makes once per rendered drop. The references are
+// the ones recorded in IndexesRemoved, so an exact match is the right test:
+// both come from the same introspected index.
+func (d *SchemaDiff) ConstraintBackedIndexRemovalSet() map[IndexRef]struct{} {
+	set := make(map[IndexRef]struct{}, len(d.ConstraintBackedIndexRemovals))
+	for _, ref := range d.ConstraintBackedIndexRemovals {
+		set[ref] = struct{}{}
+	}
+	return set
 }
 
 func sortedIndexRefs(refs []IndexRef) []IndexRef {


### PR DESCRIPTION
Fixes #1245.

Replaying a MySQL database's own `schema inspect` output against the database it came from planned, in one plan:

```sql
CREATE UNIQUE INDEX `uq_users_email` ON `w3a98_tgt`.`users` (`email`);
ALTER TABLE `users` DROP INDEX `uq_users_email`;
```

The pinned Atlas CE v1.3.0 binary reports `Schema is synced` for the same pair. Measured on MySQL 9.7.1 and MariaDB 11.8.8 the apply exits 1 with `Error 1061 (42000): Duplicate key name 'uq_users_email'` — and not before the statements ahead of it in the same plan have run, so adding one column to a table that has a named unique key left the column added and the migration half applied.

## Why

Every engine Ptah supports except SQL Server enforces a `UNIQUE` constraint with an index of the constraint's own name on the constraint's own table, and introspection reports that one object twice — once in the index catalog, once in the constraint catalog. MySQL and MariaDB do not even have a separate notion: `ADD CONSTRAINT c UNIQUE (a)` and `CREATE UNIQUE INDEX c ON t (a)` leave the identical catalog row, which is why `schema inspect` writes MySQL uniqueness back out as `index { unique = true }` on both binaries and never as a constraint.

The database index was filtered out of the index pool unconditionally. The desired side is never filtered, so a desired state that spells the object as an index had nothing to match: index comparison reported it **added**, and constraint comparison, finding no `UNIQUE` constraint on the desired side, reported the same name **removed**.

## The fix is not a dialect rule

**Ownership follows the desired state's spelling.** An identity the desired state declares as an index reaches index comparison, whichever filter would otherwise have claimed it, and constraint comparison leaves that object alone. A desired state that spells uniqueness as a constraint, or does not mention the object at all, is unchanged — the constraint pool still owns it, and an undeclared unique key is still reported removed. The rule cannot start dropping anything: an identity only survives the filters when the desired state names it, and an identity the desired state names is matched rather than removed.

This is the same narrowing #1258 applied to the FOREIGN KEY backing-index filter, now applied to all three filters instead of one, so `hiddenForeignKeyBackingIndexes` folds into `collectDatabaseIndexes` and its reasoning moves there.

**Three suppression branches, not one.** The issue named the same-name `UNIQUE` constraint identity. `isConstraintBasedUniqueIndex`'s name pattern is an independent second one: `UNIQUE KEY uk_users_email (email)` never reached the identity check at all and produced the identical unappliable plan. Both are narrowed, with a test for each.

**Not MySQL-only.** The same shape is live on PostgreSQL 17.10, and there the `IF NOT EXISTS` / `IF EXISTS` guards made it worse rather than better: the create was skipped, the drop took the constraint and its index with it, the command exited **0** and reported success, and `pg_indexes` afterwards listed only `users_pkey`. A silent deletion of the uniqueness the desired state asked for.

## The other half: two objects that share a name stay two

Letting a declared identity through means a database unique key finally has a counterpart to be matched against — and MySQL had no index-definition comparison at all (#1272 left every non-PostgreSQL dialect on a name-only match), so a desired plain `index "uq_users_email"` would have silently satisfied a database `UNIQUE KEY uq_users_email`. `indexDefinitionsChanged` gains a MySQL/MariaDB branch comparing uniqueness and the key columns, both measured against the pinned binary.

Nothing else is compared there, and the omissions are the reader's, not a judgement. Ptah's MySQL reader projects `information_schema.STATISTICS` through `GROUP_CONCAT(COLUMN_NAME)` and keeps only the column names and `NON_UNIQUE`, so a descending key and a prefix key both arrive as plain columns; comparing a direction the reader always reports as ascending would plan a rebuild on every run forever, which is the oscillation this PR exists to remove. An expression key never reaches the comparison — `COLUMN_NAME` is `NULL` and the read fails first. Both are reader gaps, filed separately.

## Measured

`schema apply`, my own containers on my own ports, every `--dev-url` database recreated between runs, all removed afterwards.

| Target | Fixture | pinned v1.3.0 | before | after |
| --- | --- | --- | --- | --- |
| MySQL 9.7.1 | unchanged `UNIQUE KEY uq_users_email (email)` | 0, synced | **1**, `Error 1061` | 0, synced; run 2 also 0 |
| MySQL 9.7.1 | `UNIQUE KEY uk_users_email (email)` | 0, synced | 0, `CREATE`+`DROP` (unappliable) | 0, synced |
| MySQL 9.7.1 | `UNIQUE KEY uq_membership (tenant_id, user_id)` + a plain key | 0, synced | 0, `CREATE`+`DROP` | 0, synced |
| MySQL 9.7.1 | `ADD COLUMN` beside a named unique key | — | **1**, column added, run half applied | 0, column added; run 2 synced |
| MariaDB 11.8.8 | unchanged `UNIQUE KEY uq_users_email (email)` | 0, synced | **1**, `Error 1061` | 0, synced; run 2 also 0 |
| PostgreSQL 17.10 | `CONSTRAINT uq_users_email UNIQUE (email)` vs a desired `index { unique = true }` | 0, synced | **0, and the unique index deleted** | 0, synced; index intact |

Removal still happens where it should. With a desired state that declares neither spelling, the pinned binary plans `ALTER TABLE "users" DROP CONSTRAINT "uq_users_email"` on PostgreSQL and `ALTER TABLE users DROP INDEX uq_users_email` on MySQL, and so does Ptah after this change. The PostgreSQL `unique "…"` block that a PostgreSQL `schema inspect` emits reports synced before and after.

Genuinely different objects still report a change, and now in an order the server accepts. On MySQL 9.7.1, a desired plain `index "uq_users_email"` against a database `UNIQUE KEY uq_users_email` plans `DROP INDEX` then `CREATE INDEX`, which is the pair the pinned binary plans; before, it planned `CREATE` then `DROP` and failed at 1061.

Rule (a) holds on every cell measured: no case where `ptah-compat` exits 0 and the pinned binary exits 1.

## Tests

The invariant #1245 asks for is asserted at the comparison level rather than through rendered SQL: `TestCompareWithDialect_NoObjectIsBothAddedAndRemoved` runs the fixture on five dialects and fails if any table-qualified name is in `IndexesAdded` and `ConstraintsRemoved` at once. On the base tree it is red on mysql, mariadb, postgres and sqlite.

Mutation, both directions, all restored:

- dropping the declaration narrowing reddens the #1245 tests **and** the pre-existing #1258 foreign-key tests together;
- dropping the constraint hand-off reddens the #1245 synced tests;
- removing the MySQL/MariaDB definition branch reddens exactly the two "genuinely different objects" controls on mysql and mariadb and leaves their postgres rows green;
- making every `UNIQUE` constraint hand off regardless of declaration reddens `UndeclaredUniqueKeyIsStillRemoved`;
- matching the hand-off on name alone instead of name-and-table reddens `UniqueKeyOnAnotherTableIsNotTheSameObject`.

## Docs

`docs/conformance.md` gains "A unique constraint and its index are one object, and the schema says which", with the measurement table above and the PostgreSQL exit-0 deletion called out, and the "only PostgreSQL is covered" paragraph on index reconciliation is updated for the new MySQL/MariaDB branch and what it leaves out.

## Found while measuring, not fixed here

All reproduced on the base binary, so none is caused by this change; each will be filed separately.

- `ptah-compat` refuses the `maria://` URL scheme the pinned binary accepts (`mariadb://` works).
- MySQL introspection fails outright on a functional index: `converting NULL to string is unsupported`, where the pinned binary inspects it fine.
- Dev-database baseline materialization loses a named MySQL unique index, because the DB-to-Go conversion drops constraint-backed indexes and falls back to the column's `UNIQUE`; any plan that drops such an index then fails simulation with `Error 1091`.
- `schema diff --from` a MySQL database `--to` its own inspect output plans a full `CREATE TABLE` + `DROP TABLE` where the pinned binary reports synced, on a control with no unique object at all — the #1244 table-identity split still live on the `diff` path.

---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

SETUP. Head a7952d3a checked out in my worktree /Users/buster/Work/denis/ptah/.claude/worktrees/wf_b394c0e2-0e4-7; control worktree at the merge-base 9820496e in /private/tmp/claude-501/-Users-buster-Work-denis-ptah/2fc9aeb4-cb03-4375-ae0a-82e5047f1051/scratchpad/r1245/base. `git log --oneline -1` run inside each before every build; both binaries chmod +x. My own containers, removed at the end: r1245-mysql (mysql:9.7 -> 9.7.1, port 33141), r1245-maria (mariadb:11.8 -> 11.8.8-MariaDB-ubu2404, port 33142), r1245-pg (postgres:17 -> 17.10, port 16145, roles ptah_user SUPERUSER and bootstrap postgres). Every --dev-url database dropped and recreated before each run. Oracle: /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas, "atlas community version v1.3.0". All fixtures built by me, not copied from the report.

WHAT REPRODUCES (their headline claims hold).
- MySQL 9.7.1, `UNIQUE KEY uq_users_email (email)`, desired = that database's own unedited pinned `schema inspect`: pinned exit 0 "Schema is synced"; base exit 0 `CREATE UNIQUE INDEX ...` + `ALTER TABLE users DROP INDEX uq_users_email`; head exit 0 "Schema is synced."
- MariaDB 11.8.8, same fixture: pinned 0 synced; base 0 CREATE + `DROP INDEX IF EXISTS`; head 0 synced.
- MySQL, ADD COLUMN nickname riding along: head run 1 emits only `ALTER TABLE ... ADD COLUMN nickname varchar(64)`, exit 0; run 2 synced; SHOW CREATE TABLE still has `UNIQUE KEY uq_users_email`.
- PostgreSQL 17.10, DB `CONSTRAINT uq_users_email UNIQUE (email)` vs desired `index "uq_users_email" { unique = true, columns = [column.email] }`: pinned 0 synced, head 0 synced, base 0 with `CREATE UNIQUE INDEX IF NOT EXISTS` + `DROP CONSTRAINT IF EXISTS` and pg_indexes afterwards holding only users_pkey.
- Non-regression rows hold: PG `unique "..."` block desired state -> head synced; undeclared unique key still removed (head emits `ALTER TABLE users DROP INDEX uq_users_email` on MySQL).
- Base-tree red confirmed by copying their test file into the control worktree: MySQLUnchangedUniqueIndexIsSynced (mysql, mariadb), NoObjectIsBothAddedAndRemoved (mysql, mariadb, postgres, sqlite; sqlserver PASS), NameHeuristicUniqueKeyIsSynced (both rows), DeclaredIndexUniquenessStillCompared (all 3), DeclaredIndexColumnsStillCompared (all 3) all FAIL; the three control tests PASS on base. Control file deleted, base worktree clean.
- Gates on head, each exit code read on its own line: go build 0; go vet 0; go vet -tags integration ./integration/... 0; go tool qtlint 0; golangci-lint (private GOLANGCI_LINT_CACHE) 0, "0 issues."; scripts/check-test-style.sh 0 (175 conditional groups, 45 white-box files); scripts/check-public-api.sh 0; scripts/check-public-api-snapshot.sh 0; scripts/check-public-api-released.sh 0; node docs/site/scripts/check-style.mjs 0 (100 files). `go test ./... -count=1` exited 1 with only cmd/viz failing (TestSVGReportsGraphvizStderrOnFailure at 10.00s) under load average 26.85 with 15 concurrent `go test` processes; `go test ./cmd/viz/... -count=1 -p 1 -timeout 20m` -> 0, ok 7.069s. No new test is env-gated or skipped, and none of their edits touched an existing test's expectations (the diff is 2 new files + 2 source files + docs).

REFUTATION 1 -- NEW EXIT-1 ON MySQL 9.7.1 AND MariaDB 11.8.8, ON A DATABASE THE PINNED BINARY CALLS SYNCED.
The new `mysqlIndexDefinitionChanged` / `mysqlIndexKeyColumnsChanged` branch compares `effectiveDatabaseIndexParts`, i.e. `types.DBIndex.Columns`. `internal/dbschema/mysql/reader.go:501` projects the key through `GROUP_CONCAT(s.COLUMN_NAME ORDER BY s.SEQ_IN_INDEX)` and line 528 does `index.Columns = strings.Split(columnsStr, ",")`. That encoding is lossy in two ways the change did not enumerate.

(a) A column name containing a comma -- a legal MySQL identifier.
  CREATE TABLE t2 (id BIGINT NOT NULL AUTO_INCREMENT, `a,b` VARCHAR(64) NOT NULL, PRIMARY KEY (id), KEY idx_weird (`a,b`));
  desired = that database's own unedited pinned inspect (`index "idx_weird" { columns = [column["a,b"]] }`).
    atlas schema inspect --url "mysql://root:root_password@localhost:33141/r1245_e" > mysql_e.hcl
    <bin> schema apply --url "mysql://root:root_password@localhost:33141/r1245_e" --to "file://mysql_e.hcl" --dev-url "mysql://root:root_password@localhost:33141/r1245_dev" --auto-approve
    pinned v1.3.0   exit 0   Schema is synced, no changes to be made
    base 9820496e   exit 0   Schema is synced, no changes to be made.
    head a7952d3a   exit 1   plan: DROP INDEX `idx_weird` ON `t2`; CREATE INDEX `idx_weird` ON `r1245_e`.`t2` (`a,b`);
                             Error: dev database simulation failed during baseline: ... Error 1072 (42000):
                             Key column 'a' doesn't exist in table
                             SQL: CREATE INDEX `idx_weird` ON `t2` (`a`, `b`)
  MariaDB 11.8.8, same fixture, mariadb:// scheme: pinned 0 synced, base 0 synced, head 1 with the same Error 1072 (plan spells `DROP INDEX IF EXISTS`). Target database verified untouched afterwards.

(b) No unusual identifier needed: a 16-part composite index whose column names overflow MySQL's default `group_concat_max_len`. `SELECT @@group_concat_max_len` on mysql:9.7 is 1024; 16 names of 64 chars plus separators is 1039 bytes, so the reader receives the last name truncated. Same three-way result: pinned exit 0 synced, base exit 0 synced, head exit 1 `Error 1072 (42000): Key column 'abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvw' doesn't exist in table`. MariaDB's default is 1048576, so (b) is MySQL-specific.

Causation, mutant control: I reverted only the new arm -- `case platform.MySQL, platform.MariaDB: return false` in `indexDefinitionsChanged` -- rebuilt ptah-compat, and BOTH fixtures returned to exit 0 "Schema is synced." The same mutant reddens exactly `TestCompareWithDialect_DeclaredIndexUniquenessStillCompared/{mysql,mariadb}` and `.../DeclaredIndexColumnsStillCompared/{mysql,mariadb}` and leaves their /postgres rows green -- it is the author's own A3 mut

### What it says must change

Send it back. The #1245 ownership rule itself is sound and well-tested; the two things bolted onto it are not.

1. Do not derive MySQL/MariaDB key columns from a comma-joined projection. `internal/dbschema/mysql/reader.go:497-536` must select one row per (INDEX_NAME, SEQ_IN_INDEX) and assemble Columns/Parts in Go -- which also removes the `COLUMN_NAME IS NULL` scan failure on expression indexes that the report already filed. Until the reader is fixed, the MySQL/MariaDB arm of `indexDefinitionsChanged` must not compare key columns; compare uniqueness only, which is all #1245 needs to keep a plain index from matching a UNIQUE KEY.
2. Add both fixtures to migration/schemadiff and re-measure the MySQL neighborhood live: a column named `a,b`, and a 16-part composite index whose names exceed `group_concat_max_len` (1024 by default on MySQL). Both are exit 1 today on a database the pinned v1.3.0 binary reports synced, and both were green on 9820496e.
3. Decide what an index removal means for a constraint-backed object on PostgreSQL. Either render it as `ALTER TABLE ... DROP CONSTRAINT` (what the pinned binary emits and the only form the server accepts), or restrict the hand-off to MySQL/MariaDB, where a unique key and its index are literally one catalog row. Then run the author's own "two different objects" controls on PostgreSQL, not only on MySQL.
4. Delete or correct the three claims the measurement falsifies: "The rule cannot start dropping anything ... matched rather than removed" in docs/conformance.md and in the `collectDatabaseIndexes` doc comment, and "splitting it across the two pools would plan a DROP CONSTRAINT and a DROP INDEX for the same row" in unique_index_ownership.go.

Nothing was committed in my worktree: the finding is measurement, and a speculative reader rewrite would need its own dialect sweep and documentation pass. Both worktrees are clean at a7952d3a and 9820496e; all three containers removed.

Ready-to-post PR title for the corrective change:

  Read a MySQL key one column at a time (#1245)

Body:

  #1245 taught MySQL and MariaDB to compare an index's key columns. The two sides
  of that comparison do not carry the same information: `internal/dbschema/mysql/reader.go`
  projects the key through `GROUP_CONCAT(COLUMN_NAME ORDER BY SEQ_IN_INDEX)` and splits the
  result on a comma, so a key survives the read only when no column name contains a comma and
  the whole list fits in `group_concat_max_len`.

  Measured on MySQL 9.7.1 and MariaDB 11.8.8, replaying a database's own unedited
  `schema inspect` output from the pinned Atlas CE v1.3.0 binary, which reported the schema
  synced for both fixtures:

  | fixture | before #1245 | after #1245 |
  | --- | --- | --- |
  | `KEY idx_weird (\`a,b\`)` | exit 0, synced | exit 1, `Error 1072 (42000): Key column 'a' doesn't exist in table` |
  | 16-part key, names past `group_concat_max_len` (1024, MySQL default) | exit 0, synced | exit 1, same error naming the truncated column |

  The plan is `DROP INDEX` followed by a `CREATE INDEX` over the mis-split names, so it never
  converges; on MySQL the dev-database baseline refuses to materialize and the run stops
  before the target is touched. MariaDB's default `group_concat_max_len` is 1048576, so only
  the comma fixture reaches it there.

  The read now returns one row per key part and assembles the column list in Go. That also
  ends the scan failure on an expression key, where `COLUMN_NAME` is NULL and the
  concatenation collapsed the whole row.

  Reverting the assembly reddens the two new fixtures on both engines; widening the
  comparison to a key's direction reddens the descending-key round trip, which is the
  reader gap #1245 documented and this change does not close.