### PR TITLE
Write an inspected array through sql() and name the column's domain (#1138)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -183,6 +183,14 @@ jobs:
           grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/postgres/qualified' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/sqlite/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheReferenceSpellingPtahRenders/sqlite/qualified' "$RUNNER_TEMP/atlas-column-type-run"
+          # The array rows are a pair for the same reason (stokaro/ptah#1138).
+          # The wrapped row alone would pass on a build that had stopped
+          # refusing anything, and the quoted row alone says nothing about the
+          # spelling Ptah writes today. Both are named so a selection that
+          # silently stopped matching them cannot leave the job green.
+          grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_wraps_a_sized_array_whose_element_name_is_modeled' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_refuses_that_same_array_quoted' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_refuses_an_array_written_bare' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -113,6 +113,19 @@ type DBColumn struct {
 	IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field
 	IsUnique           bool    `json:"is_unique"`         // Derived field
 
+	// DomainName names the domain a column is declared with, empty for every
+	// column whose declared type is not a domain (PostgreSQL only today).
+	//
+	// It is a separate fact rather than something read back out of
+	// FormattedType, because FormattedType is filled for arrays as well and the
+	// two shapes want opposite answers: an array's spelling is a TYPE, which may
+	// be compared and normalized like any other, while a domain's spelling is an
+	// IDENTIFIER its author chose and must only ever be compared by identity.
+	// Nothing but the catalog can tell them apart -- a domain over an array is
+	// reported with data_type "ARRAY" exactly like a plain array column
+	// (stokaro/ptah#1138).
+	DomainName string `json:"domain_name,omitempty"`
+
 	// GeneratedExpression holds the generated-column expression. Nil for plain
 	// columns.
 	GeneratedExpression *string `json:"generated_expression,omitempty"`

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -126,6 +126,25 @@ type DBColumn struct {
 	// (stokaro/ptah#1138).
 	DomainName string `json:"domain_name,omitempty"`
 
+	// DomainSchema names the schema holding that domain, empty for every column
+	// whose declared type is not a domain.
+	//
+	// A domain's identity is (schema, name), and the name alone is not it:
+	// public.status and other.status are two different types with different
+	// CHECK constraints over possibly different base types. A comparator handed
+	// only "status" for both calls a column that must be converted unchanged,
+	// while the plan still drops the domain the desired schema no longer
+	// declares -- so DROP DOMAIN ... CASCADE takes the column and its data with
+	// nothing having converted it first (stokaro/ptah#1138).
+	//
+	// It is recorded raw, exactly as information_schema.columns.domain_schema
+	// reports it, rather than blanked for the schema being read: the domain a
+	// column is declared with may live in a schema the read never visits, and
+	// blanking it there erases the very distinction this field exists for.
+	// FormattedType cannot stand in, because the server writes a qualifier
+	// there only when the search path forces one.
+	DomainSchema string `json:"domain_schema,omitempty"`
+
 	// GeneratedExpression holds the generated-column expression. Nil for plain
 	// columns.
 	GeneratedExpression *string `json:"generated_expression,omitempty"`

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -562,6 +562,50 @@ and `c` for a standalone `CREATE UNIQUE INDEX`. Only the first is part of the
 column's declaration, and only the first is folded now. A declared column
 `UNIQUE` still round-trips through its own implicit index.
 
+### A domain column is reconciled by identity
+
+The same split applies to the domain row of the table above. Reading a column's
+domain is one claim; comparing it is another, and the comparison must not go
+through type normalization. Normalization matches by substring — anything
+containing `int` is an integer and anything containing `text` is text — which
+is right for type names and wrong for a name a schema author picked. Measured
+on PostgreSQL 17.10, two domains over `integer` with ordinary names:
+
+```sql
+CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
+CREATE DOMAIN context  AS integer;
+CREATE TABLE t (id serial PRIMARY KEY, a waypoint NOT NULL, b context NOT NULL);
+```
+
+against a desired `a bigint, b text`, `waypoint` matched `bigint` and `context`
+matched `text`, so neither `ALTER COLUMN ... TYPE` was planned while the
+`DROP DOMAIN ... CASCADE` both columns depend on stayed. `schema apply
+--auto-approve` exited 0, printed `Schema apply completed successfully`, and
+left the table with only its `id` column and the row's other two values gone
+([#1138](https://github.com/stokaro/ptah/issues/1138)).
+
+A domain column now agrees only with a desired type that names the same domain,
+in `ptah-compat schema diff`, `ptah-compat schema apply` and native
+`ptah schema compare` alike. `information_schema.columns.domain_name` is what
+separates a domain from a plain column of the same base type, and it is read
+for that reason: a domain over an array is reported with `data_type` `ARRAY`
+exactly like a plain array column, and an array's spelling is a type that must
+keep normalizing like one.
+
+The reverse pair was missed as well, and there the pinned binary was right where
+Ptah was silent. A plain `integer` column against a desired schema that declares
+`waypoint` and types the column with it:
+
+| | plan |
+| --- | --- |
+| Atlas CE v1.3.0 | `ALTER TABLE "t" ALTER COLUMN "a" TYPE waypoint;` |
+| Ptah, before | `Schemas are synced, no changes to be made.` |
+| Ptah, now | the same `ALTER`, executed at exit 0 with the row intact |
+
+A desired type names a domain when the desired schema declares one by that
+name, which is how every source Ptah reads carries it. A bare name with no
+declaration behind it stays an ordinary type name.
+
 ## Reports
 
 - Offline corpus report:

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -190,7 +190,7 @@ carrying the same attributes always rendered correctly.
 | Sort order (`DESC`, `NULLS FIRST`, `NULLS LAST`) | `pg_index.indoption` | Dropped: psql exited 0 and left an ascending index | [#1242](https://github.com/stokaro/ptah/issues/1242) |
 | `INCLUDE` payload columns | `pg_index.indkey` past `indnkeyatts` | Dropped: psql exited 0 and left an index that cannot serve the index-only scans it was built for | [#1242](https://github.com/stokaro/ptah/issues/1242) |
 | Expression index, for example `lower(name)` | `pg_index.indkey`, attnum 0 | Emitted as a quoted column identifier, which psql rejected at exit 3 | [#1242](https://github.com/stokaro/ptah/issues/1242) |
-| Domain used as a column type | `information_schema.columns.domain_name` | The `CREATE DOMAIN` was emitted but the column was flattened to the domain's base type: psql exited 0 and left a column without the domain's `CHECK` | [#1242](https://github.com/stokaro/ptah/issues/1242) |
+| Domain used as a column type | `information_schema.columns.domain_name` and `domain_schema` | The `CREATE DOMAIN` was emitted but the column was flattened to the domain's base type: psql exited 0 and left a column without the domain's `CHECK` | [#1242](https://github.com/stokaro/ptah/issues/1242) |
 
 ### The access-method loss was not silent in general
 
@@ -591,6 +591,31 @@ separates a domain from a plain column of the same base type, and it is read
 for that reason: a domain over an array is reported with `data_type` `ARRAY`
 exactly like a plain array column, and an array's spelling is a type that must
 keep normalizing like one.
+
+`domain_schema` is read beside it, because a domain's identity is both halves.
+Measured on the same server, one database holding `public.status` and one
+holding `other.status`, over a table with one row:
+
+| | plan for the column | outcome of `schema apply --auto-approve` |
+| --- | --- | --- |
+| name alone | none; only `DROP DOMAIN IF EXISTS "status" CASCADE` | exit 0, `Schema apply completed successfully`, table left with `id` only |
+| identity | `ALTER TABLE "t" ALTER COLUMN "s" TYPE other.status` ahead of the drop | the column and its row survive |
+
+A desired type that names its schema is held to that schema exactly. One that
+does not is resolved through the domain the desired schema declares by that
+name; with nothing declaring it, the bare name decides on its own, since which
+domain an unqualified reference reaches is a search-path question and Ptah does
+not answer that for the server.
+
+One case is still open and is stated rather than claimed closed: when the desired
+schema declares the same bare name in two schemas, an unqualified reference to it
+stays undecided, and a column that should move between those two domains is
+reported only if one side spells its schema. Measured on PostgreSQL 17.10 with
+`public.status` and `other.status` both declared and both schemas selected, a
+column of `other.status` against a desired `public.status` reported
+`Schemas are synced`. Nothing is dropped in that shape, so the cost is drift
+rather than data loss. Deciding it needs the desired column to carry its domain's
+schema instead of a type string.
 
 The reverse pair was missed as well, and there the pinned binary was right where
 Ptah was silent. A plain `integer` column against a desired schema that declares

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5307,6 +5307,19 @@ type DBColumn struct {
     IsPrimaryKey       bool    `json:"is_primary_key"`    // Derived field
     IsUnique           bool    `json:"is_unique"`         // Derived field
 
+    // DomainName names the domain a column is declared with, empty for every
+    // column whose declared type is not a domain (PostgreSQL only today).
+    //
+    // It is a separate fact rather than something read back out of
+    // FormattedType, because FormattedType is filled for arrays as well and the
+    // two shapes want opposite answers: an array's spelling is a TYPE, which may
+    // be compared and normalized like any other, while a domain's spelling is an
+    // IDENTIFIER its author chose and must only ever be compared by identity.
+    // Nothing but the catalog can tell them apart -- a domain over an array is
+    // reported with data_type "ARRAY" exactly like a plain array column
+    // (stokaro/ptah#1138).
+    DomainName string `json:"domain_name,omitempty"`
+
     // GeneratedExpression holds the generated-column expression. Nil for plain
     // columns.
     GeneratedExpression *string `json:"generated_expression,omitempty"`

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5320,6 +5320,25 @@ type DBColumn struct {
     // (stokaro/ptah#1138).
     DomainName string `json:"domain_name,omitempty"`
 
+    // DomainSchema names the schema holding that domain, empty for every column
+    // whose declared type is not a domain.
+    //
+    // A domain's identity is (schema, name), and the name alone is not it:
+    // public.status and other.status are two different types with different
+    // CHECK constraints over possibly different base types. A comparator handed
+    // only "status" for both calls a column that must be converted unchanged,
+    // while the plan still drops the domain the desired schema no longer
+    // declares -- so DROP DOMAIN ... CASCADE takes the column and its data with
+    // nothing having converted it first (stokaro/ptah#1138).
+    //
+    // It is recorded raw, exactly as information_schema.columns.domain_schema
+    // reports it, rather than blanked for the schema being read: the domain a
+    // column is declared with may live in a schema the read never visits, and
+    // blanking it there erases the very distinction this field exists for.
+    // FormattedType cannot stand in, because the server writes a qualifier
+    // there only when the search path forces one.
+    DomainSchema string `json:"domain_schema,omitempty"`
+
     // GeneratedExpression holds the generated-column expression. Nil for plain
     // columns.
     GeneratedExpression *string `json:"generated_expression,omitempty"`

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -152,6 +152,48 @@ community binary applies on a schema-bound URL. A pattern too deep for any
 scope, such as `*.*.*.*`, is refused before a database is contacted, so its
 message carries no schema prefix.
 
+### How an inspected column type is written
+
+A column read out of a database carries no record of how anyone spelled it, so
+inspection decides. A type the Atlas HCL schema models is written bare and
+lower case, and every other type is written as a `sql("...")` call carrying the
+server's own spelling:
+
+```hcl
+column "price"   { type = numeric(10,2) }
+column "prices"  { type = sql("numeric(10,2)[]") }
+column "kind"    { type = sql("cube") }
+```
+
+The split is not cosmetic. The pinned Atlas community binary refuses a type it
+does not model in every spelling except the call — `type = USER_DEFINED` comes
+back as `Unknown column.type`, and `type = "numeric(10,2)[]"` as
+`set field "type": unexpected type string` — so a bare or quoted unmodeled type
+produces a document that binary cannot read at all. Which names are modeled is
+measured against it per dialect by the Atlas CE Oracle job rather than copied
+from a table, and the list errs short: wrapping a type that did not need it
+round-trips, while leaving one bare that did need it does not.
+
+**Arrays always take the call.** No array is one HCL type expression, whatever
+its element type is, so `text[]`, `numeric(10,2)[]` and
+`timestamp(3) with time zone[]` are all written as `sql(...)`. PostgreSQL drops
+an array's declared dimensions itself — `varchar(100)[10][]` is stored and
+reported as `character varying(100)[]` — so the inspected spelling is the
+server's, not the author's.
+
+**A domain is named, not resolved.** A column typed by a domain is written with
+the domain's own name, including when the domain is built on a type Atlas does
+not model:
+
+```sql
+CREATE DOMAIN point3d AS cube CHECK (cube_dim(VALUE) = 3);
+CREATE TABLE scalars (c_point3d point3d NOT NULL);
+```
+
+inspects as `type = sql("point3d")`. Writing the base type there would apply
+back as a bare `cube` column and take the domain's `CHECK` with it, so the
+domain name is what survives the round trip (stokaro/ptah#1138).
+
 ### Blocks the compatibility surface leaves out by default
 
 `ptah-compat schema inspect` omits three top-level HCL block types on

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -616,9 +616,24 @@ precision is reported in both directions.
 **A domain is compared by identity, never by its name's spelling.** A column
 whose declared type is a PostgreSQL domain agrees only with a desired type that
 names the same domain; a base type, a different domain, or any other spelling
-is a change and is planned as one. Whether the server qualifies the name is a
-property of the search path, so `alt.alt_dom` and `alt_dom` are one domain,
-while `other.alt_dom` is a different one.
+is a change and is planned as one.
+
+A domain's identity is its schema and its name together, and the name alone is
+not it: `public.status` and `other.status` are two types, with two `CHECK`
+constraints over possibly different base types. Both halves are read from
+`information_schema.columns` — `domain_name` and `domain_schema` — and both are
+compared. A desired type that qualifies its schema is held to that schema
+exactly. A desired type that does not is resolved through the domain the desired
+schema declares by that name, and when nothing declares it the name alone
+decides, because which domain an unqualified name reaches is a search-path
+question Ptah does not answer for the server. That is why `alt.alt_dom` and a
+bare `alt_dom` that no `CREATE DOMAIN` accounts for still name one domain, while
+`other.alt_dom` never does.
+
+Two declarations that share a bare name in different schemas leave an
+unqualified reference to the name as well: a change between them is reported
+only when one side spells its schema. That is a known gap rather than a claim —
+nothing is dropped in that shape, so the cost is drift and not data loss.
 
 The rule exists because normalization matches by substring, and a domain's name
 belongs to whoever wrote the schema rather than to any type vocabulary:

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -606,6 +606,49 @@ block. `diff.skip.drop_schema` is
 accepted and type-checked, but changes no plan: Ptah's schema diff has no
 removed-schema list, so there is no `DROP SCHEMA` for the suppression to omit.
 
+### How a column type is compared
+
+Type spellings are compared after normalization, so a difference that is only
+cosmetic — `INT` against `integer`, `VARCHAR(255)` against
+`character varying(255)` — plans nothing, while a change in width, length, or
+precision is reported in both directions.
+
+**A domain is compared by identity, never by its name's spelling.** A column
+whose declared type is a PostgreSQL domain agrees only with a desired type that
+names the same domain; a base type, a different domain, or any other spelling
+is a change and is planned as one. Whether the server qualifies the name is a
+property of the search path, so `alt.alt_dom` and `alt_dom` are one domain,
+while `other.alt_dom` is a different one.
+
+The rule exists because normalization matches by substring, and a domain's name
+belongs to whoever wrote the schema rather than to any type vocabulary:
+
+```sql
+CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
+CREATE DOMAIN context  AS integer;
+CREATE TABLE t (id serial PRIMARY KEY, a waypoint NOT NULL, b context NOT NULL);
+```
+
+`waypoint` contains `int` and `context` contains `text`. Compared by spelling,
+a column of either would match a desired `bigint` and `text` respectively and
+no `ALTER COLUMN ... TYPE` would be planned — while the plan still carries the
+`DROP DOMAIN ... CASCADE` that removing the domain requires, so applying it
+would drop the columns and their data instead of converting them
+(stokaro/ptah#1138). The same rule is what `ptah schema compare` reports on the
+native surface.
+
+The rule holds in the other direction too. A plain `integer` column against a
+desired schema that declares `waypoint` and types the column with it is planned
+as `ALTER TABLE "t" ALTER COLUMN "a" TYPE waypoint`, which is what the pinned
+Atlas community binary v1.3.0 plans for the same pair. The desired side must
+declare the domain for this: a bare type name that no `CREATE DOMAIN` in the
+desired schema introduces is an ordinary type name, and every schema source
+Ptah reads carries the declaration alongside the column.
+
+An array is not a domain: its spelling is a type, and it keeps normalizing like
+one. `format_type` writes every array with a trailing `[]`, including an array
+of a domain, so the two are told apart by the catalog rather than by the name.
+
 ### Scope the comparison with `--schema` and `--include`
 
 `--schema/-s` and `--include` positively select what both comparison sides

--- a/internal/atlashclrender/modeled_types.go
+++ b/internal/atlashclrender/modeled_types.go
@@ -206,6 +206,9 @@ func modeledColumnType(dialect, columnType string) (string, bool) {
 	if trimmed == "" {
 		return trimmed, true
 	}
+	if isArrayColumnType(trimmed) {
+		return "", false
+	}
 	name, argument := trimmed, ""
 	if open := strings.IndexByte(trimmed, '('); open >= 0 {
 		name, argument = strings.TrimSpace(trimmed[:open]), trimmed[open:]
@@ -215,4 +218,44 @@ func modeledColumnType(dialect, columnType string) (string, bool) {
 		return "", false
 	}
 	return lowered + argument, true
+}
+
+// isArrayColumnType reports whether a column type is an array of another type,
+// which the Atlas HCL schema models in no bare spelling at all.
+//
+// The element type being modeled does not help, and reading the modeled set
+// through the element name is what made this wrong. `numeric` is modeled, so
+// splitting `numeric(10,2)[]` at its first parenthesis found `numeric` in the
+// set and put the rest back untouched -- and `numeric(10,2)[]` is not one HCL
+// expression, so typeExpr fell through to its quoted branch and the file
+// carried `type = "numeric(10,2)[]"`. An element type NOT in the set escaped by
+// accident: `text[]` is absent from it as a whole string, so it was wrapped.
+// That accident is why half the array columns of one table were readable and
+// half were not.
+//
+// Measured on the pinned Atlas community binary v1.3.0 against a PostgreSQL 17
+// dev database, one column varied and nothing else:
+//
+//	type = "bit(8)[]"                       exit 1  set field "type": unexpected type string
+//	type = "character(5)[]"                 exit 1  the same
+//	type = "numeric(10,2)[]"                exit 1  the same
+//	type = "timestamp(3) with time zone[]"  exit 1  the same
+//	type = text[]                           exit 1  Invalid expression
+//	type = sql("bit(8)[]")                  exit 0
+//	type = sql("character(5)[]")            exit 0
+//	type = sql("numeric(10,2)[]")           exit 0
+//	type = sql("timestamp(3) with time zone[]") exit 0
+//
+// So there is no bare or quoted spelling to prefer: every array reaches that
+// binary through sql() or not at all. Its own `schema inspect` writes them the
+// same way, `sql("numeric(10,2)[]")` included.
+//
+// The suffix test is deliberately the whole rule. PostgreSQL's own
+// format_type reports an array as the element spelling followed by `[]`, and
+// drops the declared dimensions on the way -- `varchar(100)[10][]` is stored
+// and reported as `character varying(100)[]` -- so a trailing bracket is the
+// only shape the reader can produce, and a type name that ends in one does not
+// otherwise exist.
+func isArrayColumnType(columnType string) bool {
+	return strings.HasSuffix(columnType, "]")
 }

--- a/internal/atlashclrender/modeled_types_oracle_internal_test.go
+++ b/internal/atlashclrender/modeled_types_oracle_internal_test.go
@@ -181,6 +181,71 @@ func TestOracleAcceptsTheWrapItFallsBackTo(t *testing.T) {
 			expr:     `sql("character varying(100)[]")`,
 			wantZero: true,
 		},
+		// The array rows below are the measurement isArrayColumnType rests on:
+		// an array is unreadable to that binary in every spelling but the call,
+		// whether or not its element type is one the HCL schema models.
+		//
+		// The quoted rows are not decoration. They are the exact text Ptah
+		// emitted for these four columns before stokaro/ptah#1138, reached
+		// through typeExpr's quoted fallback, and each is asserted to be
+		// REFUSED -- so a change that puts an array back on the modeled path
+		// reddens here rather than in a user's file.
+		{
+			name:     "postgres wraps a sized array whose element name is modeled",
+			dialect:  platform.Postgres,
+			expr:     `sql("numeric(10,2)[]")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres refuses that same array quoted",
+			dialect:  platform.Postgres,
+			expr:     `"numeric(10,2)[]"`,
+			wantZero: false,
+		},
+		{
+			name:     "postgres wraps a bit array",
+			dialect:  platform.Postgres,
+			expr:     `sql("bit(8)[]")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres refuses a bit array quoted",
+			dialect:  platform.Postgres,
+			expr:     `"bit(8)[]"`,
+			wantZero: false,
+		},
+		{
+			name:     "postgres wraps a character array",
+			dialect:  platform.Postgres,
+			expr:     `sql("character(5)[]")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres refuses a character array quoted",
+			dialect:  platform.Postgres,
+			expr:     `"character(5)[]"`,
+			wantZero: false,
+		},
+		{
+			name:     "postgres wraps a sized multi-word array",
+			dialect:  platform.Postgres,
+			expr:     `sql("timestamp(3) with time zone[]")`,
+			wantZero: true,
+		},
+		{
+			name:     "postgres refuses a sized multi-word array quoted",
+			dialect:  platform.Postgres,
+			expr:     `"timestamp(3) with time zone[]"`,
+			wantZero: false,
+		},
+		{
+			// The remaining spelling, and the reason the fallback cannot be
+			// "leave it bare": an array is not one HCL expression at all.
+			name:     "postgres refuses an array written bare",
+			dialect:  platform.Postgres,
+			expr:     `text[]`,
+			wantZero: false,
+		},
 		{
 			name:     "postgres wrapping a modeled type is still readable",
 			dialect:  platform.Postgres,

--- a/internal/atlashclrender/modeled_types_test.go
+++ b/internal/atlashclrender/modeled_types_test.go
@@ -141,6 +141,86 @@ func TestRenderForDialectKeepsAnAuthoredSQLCall(t *testing.T) {
 	}
 }
 
+// TestRenderForDialectWrapsEveryArrayColumnType pins that an array reaches HCL
+// through sql() whatever its element type is (stokaro/ptah#1138).
+//
+// Before this the modeled set was consulted through the element name, so an
+// array split in half by an accident: `text[]` is absent from the set as a
+// whole string and was wrapped, while `numeric(10,2)[]` found `numeric` in it
+// and came out as the quoted string `"numeric(10,2)[]"` -- which the pinned
+// Atlas community binary v1.3.0 refuses to read at all.
+//
+// The rows are the four spellings PostgreSQL's format_type produces for a sized
+// element, each measured against that binary bare, quoted and wrapped, plus the
+// unsized ones that were already right and must stay right. The scalar controls
+// at the end are what keeps this from being "wrap everything": drop the
+// bracket and the same name goes out bare, exactly as it did before.
+func TestRenderForDialectWrapsEveryArrayColumnType(t *testing.T) {
+	tests := []struct {
+		name       string
+		columnType string
+		want       string
+	}{
+		{
+			name:       "a sized element type whose name is modeled",
+			columnType: "numeric(10,2)[]",
+			want:       `    type = sql("numeric(10,2)[]")` + "\n",
+		},
+		{
+			name:       "a bit array",
+			columnType: "bit(8)[]",
+			want:       `    type = sql("bit(8)[]")` + "\n",
+		},
+		{
+			name:       "a character array",
+			columnType: "character(5)[]",
+			want:       `    type = sql("character(5)[]")` + "\n",
+		},
+		{
+			name:       "a sized multi-word element type",
+			columnType: "timestamp(3) with time zone[]",
+			want:       `    type = sql("timestamp(3) with time zone[]")` + "\n",
+		},
+		{
+			name:       "an unsized element type whose name is modeled",
+			columnType: "integer[]",
+			want:       `    type = sql("integer[]")` + "\n",
+		},
+		{
+			name:       "an element type that is not modeled at all",
+			columnType: "text[]",
+			want:       `    type = sql("text[]")` + "\n",
+		},
+		{
+			name:       "an enum element type",
+			columnType: "status[]",
+			want:       `    type = sql("status[]")` + "\n",
+		},
+		{
+			name:       "the same name without the bracket still goes out bare",
+			columnType: "numeric(10,2)",
+			want:       "    type = numeric(10,2)\n",
+		},
+		{
+			name:       "and so does an unsized one",
+			columnType: "integer",
+			want:       "    type = integer\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderForDialect(inspectedColumn(test.columnType), platform.Postgres)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, test.want)
+		})
+	}
+}
+
 // TestRenderIgnoresTheDialect pins that the plain entry point is unchanged, so
 // every caller that parses HCL and renders it back keeps the behavior it had.
 func TestRenderIgnoresTheDialect(t *testing.T) {

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -555,14 +555,11 @@ func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
 	if serialType := postgresSerialType(dbColumn); serialType != "" {
 		return serialType
 	}
-	if strings.EqualFold(dbColumn.DataType, "USER-DEFINED") && dbColumn.UDTName != "" {
-		return dbColumn.UDTName
-	}
 	// The server's own spelling wins wherever the reader had to ask for it,
-	// which today means PostgreSQL array columns. DataType there is the bare
-	// category "ARRAY" -- a word no engine accepts as a type, so a schema read
-	// back out of a database rendered DDL that could not be executed
-	// (stokaro/ptah#1138).
+	// which today means PostgreSQL array and domain columns. DataType for an
+	// array is the bare category "ARRAY" -- a word no engine accepts as a type,
+	// so a schema read back out of a database rendered DDL that could not be
+	// executed (stokaro/ptah#1138).
 	//
 	// It is read from FormattedType rather than from ColumnType deliberately.
 	// ColumnType is also what the Atlas-compatible JSON inspect output prints,
@@ -571,8 +568,35 @@ func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
 	// today. Routing the fix through ColumnType would have made that surface
 	// disagree with the binary in order to fix a surface the binary does not
 	// have.
+	//
+	// It stays AHEAD of the USER-DEFINED branch below, and that order is the
+	// whole content of one half of #1138. A domain whose base type is itself
+	// user-defined is reported by information_schema with data_type
+	// "USER-DEFINED" and udt_name naming the BASE, while domain_name names the
+	// domain -- so with the branches the other way round the domain was
+	// flattened to its base and the CHECK it carries was silently dropped.
+	// Measured on PostgreSQL 17, one cluster, two domains that differ only in
+	// what they are built on:
+	//
+	//	CREATE DOMAIN point3d AS cube CHECK (cube_dim(VALUE) = 3);
+	//	CREATE DOMAIN positive_int AS integer CHECK (VALUE > 0);
+	//
+	//	column      data_type      udt_name   domain_name   format_type
+	//	c_point3d   USER-DEFINED   cube       point3d       point3d
+	//	c_domain    integer        int4       positive_int  positive_int
+	//
+	// Before this, c_point3d inspected as `cube` and c_domain as
+	// `positive_int`: applying that document back built the column as a bare
+	// cube, so the domain and its constraint were gone from the database with
+	// nothing reported. The pinned community binary v1.3.0 renders
+	// `sql("point3d")` for the same column, so this is also the compatible
+	// answer. The same split is visible on stock extension domains -- `lo`
+	// (over oid) survived while `earth` (over cube) did not.
 	if dbColumn.FormattedType != "" {
 		return dbColumn.FormattedType
+	}
+	if strings.EqualFold(dbColumn.DataType, "USER-DEFINED") && dbColumn.UDTName != "" {
+		return dbColumn.UDTName
 	}
 	if dbColumn.ColumnType != "" {
 		return dbColumn.ColumnType

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -306,6 +306,86 @@ func TestConvertDBSchemaToGoSchema_PostgresArrayColumnUsesTheServerSpelling(t *t
 	}
 }
 
+// A PostgreSQL domain is reported by information_schema under its BASE type,
+// and the base is what decides which branch of the converter used to run first.
+// A domain over a built-in base survived; a domain over a user-defined base was
+// flattened to that base and the CHECK it carries went with it
+// (stokaro/ptah#1138).
+//
+// The catalog rows are copied from PostgreSQL 17, one cluster, four columns:
+//
+//	column      data_type      udt_name   domain_name   format_type
+//	c_domain    integer        int4       positive_int  positive_int
+//	c_point3d   USER-DEFINED   cube       point3d       point3d
+//	c_tags      ARRAY          _text      tags          tags
+//	c_cube      USER-DEFINED   cube       (null)        (not read)
+//
+// The reader fills FormattedType for the first three and leaves it empty for
+// the fourth, which is what keeps the last row a control rather than a
+// duplicate: an ordinary user-defined column is not a domain and must still be
+// named by UDTName.
+func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsTheDomain(t *testing.T) {
+	tests := []struct {
+		name     string
+		column   types.DBColumn
+		wantType string
+	}{
+		{
+			name: "a domain over a built-in base",
+			column: types.DBColumn{
+				Name:          "c_domain",
+				DataType:      "integer",
+				UDTName:       "int4",
+				FormattedType: "positive_int",
+			},
+			wantType: "positive_int",
+		},
+		{
+			name: "a domain over a user-defined base",
+			column: types.DBColumn{
+				Name:          "c_point3d",
+				DataType:      "USER-DEFINED",
+				UDTName:       "cube",
+				FormattedType: "point3d",
+			},
+			wantType: "point3d",
+		},
+		{
+			name: "a domain over an array",
+			column: types.DBColumn{
+				Name:          "c_tags",
+				DataType:      "ARRAY",
+				UDTName:       "_text",
+				FormattedType: "tags",
+			},
+			wantType: "tags",
+		},
+		{
+			name: "a user-defined column that is not a domain still uses UDTName",
+			column: types.DBColumn{
+				Name:     "c_cube",
+				DataType: "USER-DEFINED",
+				UDTName:  "cube",
+			},
+			wantType: "cube",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbSchema := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "scalars", Columns: []types.DBColumn{test.column}}},
+			}
+
+			result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+			c.Assert(result.Fields, qt.HasLen, 1)
+			c.Assert(result.Fields[0].Type, qt.Equals, test.wantType)
+		})
+	}
+}
+
 func TestConvertDBSchemaToGoSchema_SchemaQualifiedObjectOwnersUseTableStructName(t *testing.T) {
 	c := qt.New(t)
 	checkClause := "tenant_id > 0"

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -202,8 +202,8 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 		tableName := fmt.Sprintf("table_%02d", i)
 		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
 		columnRows = append(columnRows,
-			[]driver.Value{tableName, "id", "integer", "int4", "", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
-			[]driver.Value{tableName, "name", "character varying", "varchar", "", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
+			[]driver.Value{tableName, "id", "integer", "int4", "", "", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
+			[]driver.Value{tableName, "name", "character varying", "varchar", "", "", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
 		)
 	}
 
@@ -218,6 +218,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 					"udt_name",
 					"formatted_type",
 					"domain_name",
+					"domain_schema",
 					"is_nullable",
 					"column_default",
 					"character_maximum_length",

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -202,8 +202,8 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 		tableName := fmt.Sprintf("table_%02d", i)
 		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
 		columnRows = append(columnRows,
-			[]driver.Value{tableName, "id", "integer", "int4", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
-			[]driver.Value{tableName, "name", "character varying", "varchar", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
+			[]driver.Value{tableName, "id", "integer", "int4", "", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
+			[]driver.Value{tableName, "name", "character varying", "varchar", "", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
 		)
 	}
 
@@ -217,6 +217,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 					"data_type",
 					"udt_name",
 					"formatted_type",
+					"domain_name",
 					"is_nullable",
 					"column_default",
 					"character_maximum_length",

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -321,6 +321,15 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 				THEN format_type(a.atttypid, a.atttypmod)
 				ELSE ''
 			END AS formatted_type,
+			-- The same format_type answer means two different things, and only
+			-- this column separates them: for an array it is a TYPE, and for a
+			-- domain it is the IDENTIFIER its author picked. A comparator that
+			-- normalizes the two the same way lets a name decide whether a
+			-- column changed -- a domain named "waypoint" contains "int" and one
+			-- named "context" contains "text". A domain over an array is
+			-- reported with data_type 'ARRAY' just like a plain array column, so
+			-- the distinction cannot be recovered downstream (stokaro/ptah#1138).
+			COALESCE(col.domain_name, '') AS domain_name,
 			is_nullable,
 			column_default,
 			character_maximum_length,
@@ -368,6 +377,7 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			&col.DataType,
 			&col.UDTName,
 			&col.FormattedType,
+			&col.DomainName,
 			&col.IsNullable,
 			&col.ColumnDefault,
 			&col.CharacterMaxLength,

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -330,6 +330,15 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			-- reported with data_type 'ARRAY' just like a plain array column, so
 			-- the distinction cannot be recovered downstream (stokaro/ptah#1138).
 			COALESCE(col.domain_name, '') AS domain_name,
+			-- And the schema that holds it, because the name is only half of a
+			-- domain's identity. public.status and other.status are two types;
+			-- a comparator given "status" for both reports no change for a
+			-- column that must be converted, and the DROP DOMAIN ... CASCADE
+			-- the plan keeps then takes the column. Read raw rather than
+			-- through outputSchema: the domain may live outside the schemas
+			-- being read, and blanking it there is exactly the erasure this
+			-- projection exists to prevent (stokaro/ptah#1138).
+			COALESCE(col.domain_schema, '') AS domain_schema,
 			is_nullable,
 			column_default,
 			character_maximum_length,
@@ -378,6 +387,7 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			&col.UDTName,
 			&col.FormattedType,
 			&col.DomainName,
+			&col.DomainSchema,
 			&col.IsNullable,
 			&col.ColumnDefault,
 			&col.CharacterMaxLength,

--- a/internal/dbschema/postgres/reader_columns_internal_test.go
+++ b/internal/dbschema/postgres/reader_columns_internal_test.go
@@ -38,6 +38,11 @@ type pgColumnCatalog struct {
 	// domainName is information_schema.columns.domain_name: how the catalog
 	// records that the declared type was a domain. Empty for a plain column.
 	domainName string
+	// domainSchema is information_schema.columns.domain_schema, the other half
+	// of the domain's identity. public.status and other.status are two types,
+	// and a reader that drops this hands the comparator a name both of them
+	// answer to.
+	domainSchema string
 }
 
 // domainColumnCatalog is CREATE DOMAIN positive_int AS integer CHECK (VALUE > 0)
@@ -50,7 +55,18 @@ func domainColumnCatalog() pgColumnCatalog {
 		udtName:       "int4",
 		formattedType: "positive_int",
 		domainName:    "positive_int",
+		domainSchema:  "public",
 	}
+}
+
+// offSearchPathDomainColumnCatalog is the same column for a domain that lives
+// in another schema: format_type qualifies it because the search path does not
+// reach it, while information_schema reports the two halves separately.
+func offSearchPathDomainColumnCatalog() pgColumnCatalog {
+	catalog := domainColumnCatalog()
+	catalog.formattedType = "other.positive_int"
+	catalog.domainSchema = "other"
+	return catalog
 }
 
 // plainColumnCatalog is a plain integer column: same base type, no domain. It
@@ -62,6 +78,7 @@ func plainColumnCatalog() pgColumnCatalog {
 	catalog.columnName = "id"
 	catalog.formattedType = "integer"
 	catalog.domainName = ""
+	catalog.domainSchema = ""
 	return catalog
 }
 
@@ -79,7 +96,7 @@ func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult
 	if asksAboutDomains && catalog.domainName != "" {
 		formattedType = catalog.formattedType
 	}
-	readsDomainName, err := queryReadsDomainName(query)
+	readsDomainName, err := queryReadsCatalogColumn(query, "domain_name")
 	if err != nil {
 		return dbtest.QueryResult{}, err
 	}
@@ -87,17 +104,25 @@ func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult
 	if readsDomainName {
 		domainName = catalog.domainName
 	}
+	readsDomainSchema, err := queryReadsCatalogColumn(query, "domain_schema")
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	domainSchema := ""
+	if readsDomainSchema {
+		domainSchema = catalog.domainSchema
+	}
 	return dbtest.QueryResult{
 		Columns: []string{
 			"table_name", "column_name", "data_type", "udt_name", "formatted_type",
-			"domain_name", "is_nullable", "column_default", "character_maximum_length",
+			"domain_name", "domain_schema", "is_nullable", "column_default", "character_maximum_length",
 			"numeric_precision", "numeric_scale", "ordinal_position",
 			"generated_kind", "generated_expression", "identity_kind",
 			"owned_sequence_name",
 		},
 		Rows: [][]driver.Value{{
 			catalog.tableName, catalog.columnName, catalog.dataType, catalog.udtName, formattedType,
-			domainName, "YES", nil, nil,
+			domainName, domainSchema, "YES", nil, nil,
 			nil, nil, int64(1),
 			"", "", "",
 			"",
@@ -121,24 +146,25 @@ func queryAsksAboutDomains(query string) (bool, error) {
 	return strings.Contains(projection, "domain_name"), nil
 }
 
-// queryReadsDomainName reports whether the domain_name projection reads
-// information_schema's domain_name column rather than answering a constant.
+// queryReadsCatalogColumn reports whether the projection aliased column reads
+// the information_schema column of that name rather than answering a constant.
 //
-// The alias is cut off before the expression is inspected, since the alias
-// itself is spelled domain_name: a projection of an empty SQL string literal
-// aliased domain_name names the column without reading it, and a comparator
-// handed that empty string cannot tell a domain column from a plain one of the
-// same base type.
-func queryReadsDomainName(query string) (bool, error) {
-	projection, ok := selectListItem(query, "domain_name", "FROM information_schema.columns")
+// The alias is cut off before the expression is inspected, since the alias is
+// spelled like the column: a projection of an empty SQL string literal aliased
+// domain_name names the column without reading it, and a comparator handed that
+// empty string cannot tell a domain column from a plain one of the same base
+// type -- nor, for domain_schema, one domain from another of the same name in a
+// different schema.
+func queryReadsCatalogColumn(query, column string) (bool, error) {
+	projection, ok := selectListItem(query, column, "FROM information_schema.columns")
 	if !ok {
-		return false, fmt.Errorf("query has no projection aliased domain_name:\n%s", query)
+		return false, fmt.Errorf("query has no projection aliased %s:\n%s", column, query)
 	}
 	expression := projection
 	if alias := strings.LastIndex(strings.ToLower(projection), " as "); alias >= 0 {
 		expression = projection[:alias]
 	}
-	return strings.Contains(expression, "domain_name"), nil
+	return strings.Contains(expression, column), nil
 }
 
 // TestReadColumnsForSchema_KeepsTheDeclaredDomainType guards the last of the
@@ -166,18 +192,33 @@ func TestReadColumnsForSchema_KeepsTheDeclaredDomainType(t *testing.T) {
 		// contains "text", so with this empty the name decides whether a
 		// column changed at all (stokaro/ptah#1138).
 		expectedDomainName string
+		// expectedDomainSchema is the other half of that fact. Without it a
+		// column of public.status and a desired other.status compare equal,
+		// the required ALTER COLUMN ... TYPE is never planned, and the
+		// DROP DOMAIN ... CASCADE the plan keeps takes the column and its data
+		// (stokaro/ptah#1138).
+		expectedDomainSchema string
 	}{
 		{
 			name:                  "domain column keeps the domain",
 			catalog:               domainColumnCatalog,
 			expectedFormattedType: "positive_int",
 			expectedDomainName:    "positive_int",
+			expectedDomainSchema:  "public",
+		},
+		{
+			name:                  "a domain off the search path keeps its schema",
+			catalog:               offSearchPathDomainColumnCatalog,
+			expectedFormattedType: "other.positive_int",
+			expectedDomainName:    "positive_int",
+			expectedDomainSchema:  "other",
 		},
 		{
 			name:                  "plain column is left alone",
 			catalog:               plainColumnCatalog,
 			expectedFormattedType: "",
 			expectedDomainName:    "",
+			expectedDomainSchema:  "",
 		},
 	}
 
@@ -193,6 +234,7 @@ func TestReadColumnsForSchema_KeepsTheDeclaredDomainType(t *testing.T) {
 			c.Assert(columnsByTable["t"], qt.HasLen, 1)
 			c.Assert(columnsByTable["t"][0].FormattedType, qt.Equals, test.expectedFormattedType)
 			c.Assert(columnsByTable["t"][0].DomainName, qt.Equals, test.expectedDomainName)
+			c.Assert(columnsByTable["t"][0].DomainSchema, qt.Equals, test.expectedDomainSchema)
 			// The base type stays available; the fix adds a spelling rather
 			// than replacing one.
 			c.Assert(columnsByTable["t"][0].DataType, qt.Equals, "integer")

--- a/internal/dbschema/postgres/reader_columns_internal_test.go
+++ b/internal/dbschema/postgres/reader_columns_internal_test.go
@@ -65,11 +65,11 @@ func plainColumnCatalog() pgColumnCatalog {
 	return catalog
 }
 
-// serveColumnQuery answers the column query. formatted_type is answered from
-// the catalog only when the projection asks whether the column's declared type
-// was a domain; a projection that does not ask cannot distinguish the two
-// fixtures above on a real server either, and gets the empty string the CASE's
-// ELSE branch returns.
+// serveColumnQuery answers the column query. formatted_type and domain_name are
+// answered from the catalog only when their projections actually read
+// information_schema's domain_name; a projection that does not ask cannot
+// distinguish the two fixtures above on a real server either, and gets the empty
+// string the CASE's ELSE branch returns.
 func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult, error) {
 	asksAboutDomains, err := queryAsksAboutDomains(query)
 	if err != nil {
@@ -79,17 +79,25 @@ func serveColumnQuery(catalog pgColumnCatalog, query string) (dbtest.QueryResult
 	if asksAboutDomains && catalog.domainName != "" {
 		formattedType = catalog.formattedType
 	}
+	readsDomainName, err := queryReadsDomainName(query)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	domainName := ""
+	if readsDomainName {
+		domainName = catalog.domainName
+	}
 	return dbtest.QueryResult{
 		Columns: []string{
 			"table_name", "column_name", "data_type", "udt_name", "formatted_type",
-			"is_nullable", "column_default", "character_maximum_length",
+			"domain_name", "is_nullable", "column_default", "character_maximum_length",
 			"numeric_precision", "numeric_scale", "ordinal_position",
 			"generated_kind", "generated_expression", "identity_kind",
 			"owned_sequence_name",
 		},
 		Rows: [][]driver.Value{{
 			catalog.tableName, catalog.columnName, catalog.dataType, catalog.udtName, formattedType,
-			"YES", nil, nil,
+			domainName, "YES", nil, nil,
 			nil, nil, int64(1),
 			"", "", "",
 			"",
@@ -113,6 +121,26 @@ func queryAsksAboutDomains(query string) (bool, error) {
 	return strings.Contains(projection, "domain_name"), nil
 }
 
+// queryReadsDomainName reports whether the domain_name projection reads
+// information_schema's domain_name column rather than answering a constant.
+//
+// The alias is cut off before the expression is inspected, since the alias
+// itself is spelled domain_name: a projection of an empty SQL string literal
+// aliased domain_name names the column without reading it, and a comparator
+// handed that empty string cannot tell a domain column from a plain one of the
+// same base type.
+func queryReadsDomainName(query string) (bool, error) {
+	projection, ok := selectListItem(query, "domain_name", "FROM information_schema.columns")
+	if !ok {
+		return false, fmt.Errorf("query has no projection aliased domain_name:\n%s", query)
+	}
+	expression := projection
+	if alias := strings.LastIndex(strings.ToLower(projection), " as "); alias >= 0 {
+		expression = projection[:alias]
+	}
+	return strings.Contains(expression, "domain_name"), nil
+}
+
 // TestReadColumnsForSchema_KeepsTheDeclaredDomainType guards the last of the
 // #1242 introspection gaps. Measured on PostgreSQL 17.10, a reader that takes
 // information_schema's data_type for a domain column emits
@@ -131,16 +159,25 @@ func TestReadColumnsForSchema_KeepsTheDeclaredDomainType(t *testing.T) {
 		// it builds the field type, so this is the value that decides whether
 		// the emitted DDL says positive_int or integer.
 		expectedFormattedType string
+		// expectedDomainName is the FACT that the declared type was a domain.
+		// The comparator decides a domain column by identity instead of
+		// normalizing its name, and a name is all it would otherwise have: a
+		// domain named "waypoint" contains "int" and one named "context"
+		// contains "text", so with this empty the name decides whether a
+		// column changed at all (stokaro/ptah#1138).
+		expectedDomainName string
 	}{
 		{
 			name:                  "domain column keeps the domain",
 			catalog:               domainColumnCatalog,
 			expectedFormattedType: "positive_int",
+			expectedDomainName:    "positive_int",
 		},
 		{
 			name:                  "plain column is left alone",
 			catalog:               plainColumnCatalog,
 			expectedFormattedType: "",
+			expectedDomainName:    "",
 		},
 	}
 
@@ -155,6 +192,7 @@ func TestReadColumnsForSchema_KeepsTheDeclaredDomainType(t *testing.T) {
 			c.Assert(err, qt.IsNil)
 			c.Assert(columnsByTable["t"], qt.HasLen, 1)
 			c.Assert(columnsByTable["t"][0].FormattedType, qt.Equals, test.expectedFormattedType)
+			c.Assert(columnsByTable["t"][0].DomainName, qt.Equals, test.expectedDomainName)
 			// The base type stays available; the fix adds a spelling rather
 			// than replacing one.
 			c.Assert(columnsByTable["t"][0].DataType, qt.Equals, "integer")

--- a/migration/schemadiff/array_domain_self_compare_test.go
+++ b/migration/schemadiff/array_domain_self_compare_test.go
@@ -1,0 +1,83 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompareWithDialect_PostgresArrayAndDomainColumnsCompareEqualToThemselves
+// compares a PostgreSQL schema against ITSELF (stokaro/ptah#1138).
+//
+// The desired side is not written out by hand -- it is the same *types.DBSchema
+// put through the database-to-schema converter, which is the path
+// `ptah-compat schema diff --from <db> --to <db>` takes. That is what makes the
+// assertion meaningful: any column the two sides read out of different fields
+// shows up as a change from a database to itself.
+//
+// The columns and their catalog values are copied from PostgreSQL 17. The
+// comparator used to read ColumnType/UDTName while the converter read the
+// server's own format_type, and the run reported seven ALTER COLUMN ... TYPE
+// statements retyping each column to the type it already had, e.g.
+//
+//	arrays.a_bit    type: _bit    -> bit(8)[]
+//	scalars.c_tags  type: text    -> tags
+//
+// The scalar rows are here so the test would notice a fix that simply stopped
+// comparing types: an ordinary varchar and an ordinary user-defined column go
+// down the untouched path and must still match.
+func TestCompareWithDialect_PostgresArrayAndDomainColumnsCompareEqualToThemselves(t *testing.T) {
+	c := qt.New(t)
+
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "arrays",
+				Type: "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "a_bit", DataType: "ARRAY", UDTName: "_bit", FormattedType: "bit(8)[]", IsNullable: "NO"},
+					{Name: "a_char", DataType: "ARRAY", UDTName: "_bpchar", FormattedType: "character(5)[]", IsNullable: "NO"},
+					{Name: "a_cube", DataType: "ARRAY", UDTName: "_cube", FormattedType: "cube[]", IsNullable: "NO"},
+					{Name: "a_enum", DataType: "ARRAY", UDTName: "_status", FormattedType: "status[]", IsNullable: "NO"},
+					{Name: "a_numeric", DataType: "ARRAY", UDTName: "_numeric", FormattedType: "numeric(10,2)[]", IsNullable: "NO"},
+					{
+						Name:          "a_varchar",
+						DataType:      "ARRAY",
+						UDTName:       "_varchar",
+						FormattedType: "character varying(100)[]",
+						IsNullable:    "NO",
+					},
+					{
+						Name:          "a_timestamptz",
+						DataType:      "ARRAY",
+						UDTName:       "_timestamptz",
+						FormattedType: "timestamp(3) with time zone[]",
+						IsNullable:    "NO",
+					},
+				},
+			},
+			{
+				Name: "scalars",
+				Type: "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "c_domain", DataType: "integer", UDTName: "int4", FormattedType: "positive_int", IsNullable: "NO"},
+					{Name: "c_point3d", DataType: "USER-DEFINED", UDTName: "cube", FormattedType: "point3d", IsNullable: "NO"},
+					{Name: "c_tags", DataType: "ARRAY", UDTName: "_text", FormattedType: "tags", IsNullable: "NO"},
+					{Name: "c_cube", DataType: "USER-DEFINED", UDTName: "cube", IsNullable: "NO"},
+					{Name: "c_varchar", DataType: "character varying", UDTName: "varchar", CharacterMaxLength: new(100), IsNullable: "NO"},
+				},
+			},
+		},
+	}
+
+	diff := schemadiff.CompareWithDialect(dbschematogo.ConvertDBSchemaToGoSchema(database), database, platform.Postgres)
+
+	c.Assert(diff.TablesModified, qt.HasLen, 0, qt.Commentf("a database compared against itself reported %+v", diff.TablesModified))
+	c.Assert(diff.TablesAdded, qt.HasLen, 0)
+	c.Assert(diff.TablesRemoved, qt.HasLen, 0)
+}

--- a/migration/schemadiff/domain_column_identity_test.go
+++ b/migration/schemadiff/domain_column_identity_test.go
@@ -1,0 +1,208 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// assertTypeChange returns an assertion that the comparator reported exactly
+// one modified column and that its only change is the given type row.
+func assertTypeChange(expected string) func(c *qt.C, modified []difftypes.TableDiff) {
+	return func(c *qt.C, modified []difftypes.TableDiff) {
+		c.Assert(modified, qt.HasLen, 1, qt.Commentf("the desired type is a real change and must be reported"))
+		c.Assert(modified[0].ColumnsModified, qt.HasLen, 1)
+		c.Assert(modified[0].ColumnsModified[0].Changes, qt.DeepEquals, map[string]string{"type": expected})
+	}
+}
+
+// assertNoChange returns an assertion that the two sides describe one column.
+func assertNoChange() func(c *qt.C, modified []difftypes.TableDiff) {
+	return func(c *qt.C, modified []difftypes.TableDiff) {
+		c.Assert(modified, qt.HasLen, 0, qt.Commentf("reported %+v for a column that did not change", modified))
+	}
+}
+
+// TestCompareWithDialect_PostgresDomainColumnComparesByIdentity pins how a
+// column typed by a PostgreSQL domain is compared: by the domain's IDENTITY,
+// never through normalize.Type.
+//
+// normalize.Type matches by substring -- anything containing "int" is
+// "integer", anything containing "text" is "text" -- which is right for type
+// names and wrong for an identifier a schema author picked. Routing a domain
+// name through it let the NAME decide whether a column changed, and the miss is
+// destructive rather than cosmetic: the plan keeps the DROP DOMAIN ... CASCADE
+// for the domain the column uses, so with no ALTER COLUMN ... TYPE ahead of it
+// the CASCADE takes the column and its data. Measured on PostgreSQL 17.10,
+// `ptah-compat schema apply --auto-approve` exited 0 and left a two-column
+// table with neither column (stokaro/ptah#1138).
+//
+// The rows are catalog values as PostgreSQL 17.10 reports them. A domain column
+// is recorded by information_schema under its BASE type, with domain_name
+// naming the domain; format_type spells the domain the way the server does and
+// qualifies it when the search path needs that.
+func TestCompareWithDialect_PostgresDomainColumnComparesByIdentity(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// column is the database side: one column of table t.
+		column types.DBColumn
+		// desiredType is what the desired schema declares for that column.
+		desiredType string
+		// desiredDomains are the domains the desired schema declares. It is the
+		// only thing that can tell the comparator a desired type name belongs
+		// to a domain, since a goschema field carries a type string and nothing
+		// else.
+		desiredDomains []goschema.Domain
+		assert         func(c *qt.C, modified []difftypes.TableDiff)
+	}{
+		{
+			// CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
+			// "waypoint" contains "int", so the normalizer called this equal to
+			// a desired BIGINT and planned nothing.
+			name:        "a domain whose name contains a type name is still a change",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", DomainName: "waypoint", IsNullable: "NO"},
+			desiredType: "BIGINT",
+			assert:      assertTypeChange("waypoint -> BIGINT"),
+		},
+		{
+			// CREATE DOMAIN context AS integer; "context" contains "text".
+			name:        "a domain named context is not text",
+			column:      types.DBColumn{Name: "b", DataType: "integer", UDTName: "int4", FormattedType: "context", DomainName: "context", IsNullable: "NO"},
+			desiredType: "TEXT",
+			assert:      assertTypeChange("context -> TEXT"),
+		},
+		{
+			name:        "the same domain is not a change",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", DomainName: "waypoint", IsNullable: "NO"},
+			desiredType: "waypoint",
+			assert:      assertNoChange(),
+		},
+		{
+			name:        "another domain over the same base type is a change",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", DomainName: "waypoint", IsNullable: "NO"},
+			desiredType: "milestone",
+			assert:      assertTypeChange("waypoint -> milestone"),
+		},
+		{
+			// A domain off the search path: format_type qualifies it, while
+			// information_schema.domain_name stays bare. Whether the server
+			// qualifies a name is a property of the search path, not of the
+			// domain, so the two spellings name one domain.
+			name:        "a qualified spelling and a bare one name one domain",
+			column:      types.DBColumn{Name: "c", DataType: "USER-DEFINED", UDTName: "cube", FormattedType: "alt.alt_dom", DomainName: "alt_dom", IsNullable: "NO"},
+			desiredType: "alt_dom",
+			assert:      assertNoChange(),
+		},
+		{
+			name:        "the same bare name in another schema is a different domain",
+			column:      types.DBColumn{Name: "c", DataType: "USER-DEFINED", UDTName: "cube", FormattedType: "alt.alt_dom", DomainName: "alt_dom", IsNullable: "NO"},
+			desiredType: "other.alt_dom",
+			assert:      assertTypeChange("alt.alt_dom -> other.alt_dom"),
+		},
+		{
+			// CREATE DOMAIN waypoints AS integer[]; a domain over an array is
+			// reported with data_type ARRAY exactly like a plain array column,
+			// and "waypoints" normalizes to "integer" just like the desired
+			// BIGINT[] does.
+			name:        "a domain over an array is a domain, not an array",
+			column:      types.DBColumn{Name: "d", DataType: "ARRAY", UDTName: "_int4", FormattedType: "waypoints", DomainName: "waypoints", IsNullable: "NO"},
+			desiredType: "BIGINT[]",
+			assert:      assertTypeChange("waypoints -> BIGINT[]"),
+		},
+		{
+			// The catalog fact on its own is enough: a caller that carries
+			// DomainName without format_type still gets identity comparison.
+			// The desired INTEGER is the discriminating spelling here -- it is
+			// the domain's own base type, so normalization calls it equal and
+			// the width rule sees nothing to report either.
+			name:        "the domain name alone decides",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", DomainName: "waypoint", IsNullable: "NO"},
+			desiredType: "INTEGER",
+			assert:      assertTypeChange("int4 -> INTEGER"),
+		},
+		{
+			// And so is the server's spelling on its own, which is what a
+			// caller built before domain_name was read carries.
+			name:        "the server's spelling alone decides",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", IsNullable: "NO"},
+			desiredType: "BIGINT",
+			assert:      assertTypeChange("waypoint -> BIGINT"),
+		},
+		{
+			// An array is not an identifier: its spelling is a type and must
+			// keep normalizing like one, or every array column would report a
+			// change against a desired schema that spells it differently.
+			name:        "a plain array still compares as a type",
+			column:      types.DBColumn{Name: "e", DataType: "ARRAY", UDTName: "_varchar", FormattedType: "character varying(100)[]", IsNullable: "NO"},
+			desiredType: "character varying(100)[]",
+			assert:      assertNoChange(),
+		},
+		{
+			name:        "a plain array that really changed is reported",
+			column:      types.DBColumn{Name: "e", DataType: "ARRAY", UDTName: "_varchar", FormattedType: "character varying(100)[]", IsNullable: "NO"},
+			desiredType: "TEXT[]",
+			assert:      assertTypeChange("character varying(100)[] -> text"),
+		},
+		{
+			name:        "a plain column is untouched",
+			column:      types.DBColumn{Name: "id", DataType: "integer", UDTName: "int4", IsNullable: "NO"},
+			desiredType: "INTEGER",
+			assert:      assertNoChange(),
+		},
+		{
+			// The other direction of the same rule, and the pinned Atlas
+			// community binary v1.3.0 plans it too: measured on two PostgreSQL
+			// 17.10 databases that differ only in this column,
+			// `ALTER TABLE "t" ALTER COLUMN "a" TYPE waypoint;`. Both sides
+			// normalize to "integer", so without the declaration the desired
+			// domain is invisible here.
+			name:           "a plain column against a desired domain is a change",
+			column:         types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", IsNullable: "NO"},
+			desiredType:    "waypoint",
+			desiredDomains: []goschema.Domain{{Name: "waypoint", BaseType: "INTEGER", Check: "VALUE > 0"}},
+			assert:         assertTypeChange("int4 -> waypoint"),
+		},
+		{
+			// And the boundary: with no domain declared anywhere, "waypoint" is
+			// an ordinary type name on both sides and normalization decides. A
+			// desired schema that means the domain has to declare it, which is
+			// what every source Ptah reads does.
+			name:        "an undeclared name is not a domain",
+			column:      types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", IsNullable: "NO"},
+			desiredType: "waypoint",
+			assert:      assertNoChange(),
+		},
+		{
+			name:           "a domain declared on both sides is not a change",
+			column:         types.DBColumn{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", DomainName: "waypoint", IsNullable: "NO"},
+			desiredType:    "waypoint",
+			desiredDomains: []goschema.Domain{{Name: "waypoint", BaseType: "INTEGER", Check: "VALUE > 0"}},
+			assert:         assertNoChange(),
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "t", Type: "TABLE", Columns: []types.DBColumn{test.column}}},
+			}
+			desired := &goschema.Database{
+				Tables:  []goschema.Table{{StructName: "T", Name: "t"}},
+				Fields:  []goschema.Field{{StructName: "T", Name: test.column.Name, Type: test.desiredType}},
+				Domains: test.desiredDomains,
+			}
+
+			diff := schemadiff.CompareWithDialect(desired, database, platform.Postgres)
+
+			test.assert(c, diff.TablesModified)
+		})
+	}
+}

--- a/migration/schemadiff/domain_column_identity_test.go
+++ b/migration/schemadiff/domain_column_identity_test.go
@@ -92,10 +92,85 @@ func TestCompareWithDialect_PostgresDomainColumnComparesByIdentity(t *testing.T)
 			assert:      assertTypeChange("waypoint -> milestone"),
 		},
 		{
+			// The reviewer's shape for stokaro/ptah#1138. A domain's identity
+			// is (schema, name); the name alone is not it. The database column
+			// is declared with public.status and the desired schema types it
+			// with other.status -- two different domains, with two different
+			// CHECK constraints. Measured on PostgreSQL 17.10 with the name
+			// alone reaching the comparator, `schema diff` emitted
+			// DROP DOMAIN IF EXISTS "status" CASCADE and no ALTER, and
+			// `schema apply --auto-approve` exited 0, said "Schema apply
+			// completed successfully", and left the table with only its id
+			// column.
+			name:        "a domain in another schema is a different domain",
+			column:      types.DBColumn{Name: "s", DataType: "text", UDTName: "text", FormattedType: "status", DomainName: "status", DomainSchema: "public", IsNullable: "NO"},
+			desiredType: "other.status",
+			assert:      assertTypeChange("status -> other.status"),
+		},
+		{
+			// The same miss the other way round: the column is declared with
+			// the domain in another schema and the desired schema declares its
+			// own. Measured on the same server, that one is silent drift rather
+			// than data loss -- the column is never converted and re-running
+			// never converges.
+			name:           "a column from another schema against the declared one is a change",
+			column:         types.DBColumn{Name: "s", DataType: "text", UDTName: "text", FormattedType: "other.status", DomainName: "status", DomainSchema: "other", IsNullable: "NO"},
+			desiredType:    "status",
+			desiredDomains: []goschema.Domain{{Name: "status", BaseType: "TEXT"}},
+			assert:         assertTypeChange("other.status -> status"),
+		},
+		{
+			// And the boundary that keeps this from becoming "any domain is a
+			// change": one domain, spelled qualified on the desired side and
+			// reported by the catalog as the schema it is in.
+			name:        "the same domain named with its schema is not a change",
+			column:      types.DBColumn{Name: "s", DataType: "text", UDTName: "text", FormattedType: "status", DomainName: "status", DomainSchema: "public", IsNullable: "NO"},
+			desiredType: "public.status",
+			assert:      assertNoChange(),
+		},
+		{
+			// A domain declared with no schema of its own lives in the schema
+			// the connection reads, which is the schema the database side
+			// reports for it. This is the ordinary single-schema case and it
+			// must stay a no-op.
+			name:           "a domain declared without a schema is the one in the default schema",
+			column:         types.DBColumn{Name: "s", DataType: "text", UDTName: "text", FormattedType: "status", DomainName: "status", DomainSchema: "public", IsNullable: "NO"},
+			desiredType:    "status",
+			desiredDomains: []goschema.Domain{{Name: "status", BaseType: "TEXT"}},
+			assert:         assertNoChange(),
+		},
+		{
+			// An unqualified reference resolves through the declaration, so a
+			// desired schema that declares its status in another schema means
+			// that one even when the column spells the name bare.
+			name:           "an unqualified reference means the domain that is declared",
+			column:         types.DBColumn{Name: "s", DataType: "text", UDTName: "text", FormattedType: "status", DomainName: "status", DomainSchema: "public", IsNullable: "NO"},
+			desiredType:    "status",
+			desiredDomains: []goschema.Domain{{Name: "status", Schema: "other", BaseType: "TEXT"}},
+			assert:         assertTypeChange("status -> status"),
+		},
+		{
+			// The residual gap, pinned so it is visible rather than assumed
+			// away: two declarations share the bare name in different schemas,
+			// so an unqualified reference is left to the name. Measured on
+			// PostgreSQL 17.10, one database whose column b is other.status
+			// against one whose column b is public.status, read with both
+			// schemas selected, reports "Schemas are synced" -- drift rather
+			// than data loss, since neither domain is dropped. Closing it needs
+			// the desired column to carry its domain's schema rather than a
+			// type string, which is a model change (stokaro/ptah#1138).
+			name:           "two same-named domains leave an unqualified reference undecided",
+			column:         types.DBColumn{Name: "b", DataType: "integer", UDTName: "int4", FormattedType: "other.status", DomainName: "status", DomainSchema: "other", IsNullable: "NO"},
+			desiredType:    "status",
+			desiredDomains: []goschema.Domain{{Name: "status", BaseType: "TEXT"}, {Name: "status", Schema: "other", BaseType: "INTEGER"}},
+			assert:         assertNoChange(),
+		},
+		{
 			// A domain off the search path: format_type qualifies it, while
 			// information_schema.domain_name stays bare. Whether the server
 			// qualifies a name is a property of the search path, not of the
-			// domain, so the two spellings name one domain.
+			// domain, so with nothing on the desired side to resolve the bare
+			// spelling the two name one domain.
 			name:        "a qualified spelling and a bare one name one domain",
 			column:      types.DBColumn{Name: "c", DataType: "USER-DEFINED", UDTName: "cube", FormattedType: "alt.alt_dom", DomainName: "alt_dom", IsNullable: "NO"},
 			desiredType: "alt_dom",

--- a/migration/schemadiff/domain_named_like_a_type_test.go
+++ b/migration/schemadiff/domain_named_like_a_type_test.go
@@ -1,0 +1,72 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompareWithDialect_PostgresDomainNamedLikeATypeStillReportsARealChange
+// pins that a domain's NAME never stands in for its base type when the
+// comparator decides whether a column changed.
+//
+// The comparator reads a column's type spelling and hands it to
+// normalize.Type, which matches by SUBSTRING: anything containing "int" is
+// "integer" and anything containing "text" is "text". Feeding it a domain name
+// therefore makes the name's spelling decide the answer. Both domains below are
+// built on integer and carry ordinary names a schema author would pick:
+//
+//	CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
+//	CREATE DOMAIN context  AS integer;
+//
+// "waypoint" contains "int" and "context" contains "text", so a column of
+// either compares EQUAL to a desired BIGINT and TEXT respectively, and the
+// ALTER COLUMN ... TYPE the desired schema asks for is dropped from the plan.
+// The plan still carries DROP DOMAIN ... CASCADE for the domain the column
+// uses, so applying it destroys the column and its data instead of converting
+// it.
+//
+// Measured on PostgreSQL 17.10, two databases, `schema diff --from P --to Q`
+// and `ptah schema compare --root-dir <models> --db-url P`.
+//
+// The catalog values are copied from that server: information_schema reports a
+// domain column under its BASE type, so DataType is "integer" and UDTName is
+// "int4" while format_type names the domain.
+func TestCompareWithDialect_PostgresDomainNamedLikeATypeStillReportsARealChange(t *testing.T) {
+	c := qt.New(t)
+
+	database := &types.DBSchema{
+		Tables: []types.DBTable{
+			{
+				Name: "t",
+				Type: "TABLE",
+				Columns: []types.DBColumn{
+					{Name: "a", DataType: "integer", UDTName: "int4", FormattedType: "waypoint", IsNullable: "NO"},
+					{Name: "b", DataType: "integer", UDTName: "int4", FormattedType: "context", IsNullable: "NO"},
+				},
+			},
+		},
+	}
+
+	desired := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "a", Type: "BIGINT"},
+			{StructName: "T", Name: "b", Type: "TEXT"},
+		},
+	}
+
+	diff := schemadiff.CompareWithDialect(desired, database, platform.Postgres)
+
+	c.Assert(diff.TablesModified, qt.HasLen, 1,
+		qt.Commentf("a column of domain waypoint (over integer) against a desired BIGINT, and one of domain context "+
+			"(over integer) against a desired TEXT, are both real changes; reporting none leaves the plan with only "+
+			"DROP DOMAIN ... CASCADE, which drops the columns"))
+	c.Assert(diff.TablesModified[0].ColumnsModified, qt.HasLen, 2,
+		qt.Commentf("got %+v", diff.TablesModified[0].ColumnsModified))
+}

--- a/migration/schemadiff/domain_schema_identity_plan_test.go
+++ b/migration/schemadiff/domain_schema_identity_plan_test.go
@@ -1,0 +1,99 @@
+package schemadiff_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/planner"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// crossSchemaDomainColumn is the shape from stokaro/ptah#1138: the database
+// column is declared with public.status and the desired schema declares its own
+// status in another schema and types the column with it. Two domains, two CHECK
+// constraints, one name.
+//
+// Built as PostgreSQL 17.10 reports it: information_schema records a domain
+// column under its BASE type with domain_name/domain_schema naming the domain,
+// and the reader blanks a domain's own schema for the schema it is reading, so
+// the current side's domain carries no schema of its own.
+func crossSchemaDomainColumn() (*goschema.Database, *types.DBSchema) {
+	database := &types.DBSchema{
+		Domains: []types.DBDomain{{Name: "status", BaseType: "text", Check: "VALUE IN ('open','closed')"}},
+		Tables: []types.DBTable{{
+			Name: "t",
+			Type: "TABLE",
+			Columns: []types.DBColumn{
+				{Name: "id", DataType: "integer", UDTName: "int4", IsNullable: "NO", IsPrimaryKey: true, IsAutoIncrement: true},
+				{
+					Name: "s", DataType: "text", UDTName: "text",
+					FormattedType: "status", DomainName: "status", DomainSchema: "public",
+					IsNullable: "NO",
+				},
+			},
+		}},
+	}
+	desired := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "id", Type: "SERIAL", Primary: true},
+			{StructName: "T", Name: "s", Type: "other.status"},
+		},
+		Domains: []goschema.Domain{{
+			StructName: "Status", Name: "status", Schema: "other",
+			BaseType: "TEXT", Check: "VALUE IN ('open','closed')",
+		}},
+	}
+	return desired, database
+}
+
+// TestGenerateSchemaDiffSQL_DomainColumnIsConvertedBeforeTheOldDomainIsDropped
+// is the executable half of the identity rule: it is not enough for the
+// comparator to see the change, the plan must convert the column BEFORE the
+// domain it uses is dropped.
+//
+// The plan drops a domain the desired schema no longer declares, and PostgreSQL
+// drops it with CASCADE, which takes every column still declared with it.
+// Measured on PostgreSQL 17.10 against a table holding one row, with the
+// comparator seeing only the domain's NAME:
+//
+//	ptah-compat schema diff --from <public.status> --to <other.status>
+//	  DROP DOMAIN IF EXISTS "status" CASCADE;        <- and no ALTER
+//	ptah-compat schema apply --url <copy> --to <other.status> --auto-approve
+//	  rc=0, "Schema apply completed successfully"
+//	  table t = id only; the column and its row were gone
+//
+// The merge-base, same command and an identical copy of the same database,
+// planned ALTER TABLE "t" ALTER COLUMN "s" TYPE other.status ahead of the drop
+// and left the row intact. Ordering alone is not the fix and the ALTER alone is
+// not either; this asserts both, so a change that restores one without the
+// other is red (stokaro/ptah#1138).
+func TestGenerateSchemaDiffSQL_DomainColumnIsConvertedBeforeTheOldDomainIsDropped(t *testing.T) {
+	c := qt.New(t)
+
+	desired, database := crossSchemaDomainColumn()
+
+	diff := schemadiff.CompareWithDialect(desired, database, platform.Postgres)
+
+	c.Assert(diff.DomainsRemoved, qt.DeepEquals, []string{"status"},
+		qt.Commentf("the desired schema no longer declares public.status, so the plan drops it"))
+
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, desired, platform.Postgres)
+	c.Assert(err, qt.IsNil)
+
+	sql := strings.Join(statements, "\n")
+	conversion := strings.Index(sql, `ALTER COLUMN "s" TYPE other.status`)
+	removal := strings.Index(sql, `DROP DOMAIN IF EXISTS "status" CASCADE`)
+
+	c.Assert(conversion >= 0, qt.IsTrue,
+		qt.Commentf("the column must be converted off public.status, or the CASCADE below takes it\n%s", sql))
+	c.Assert(removal >= 0, qt.IsTrue,
+		qt.Commentf("the plan is expected to drop the domain the desired schema dropped\n%s", sql))
+	c.Assert(conversion < removal, qt.IsTrue,
+		qt.Commentf("the conversion must come first, or the CASCADE takes the column with it\n%s", sql))
+}

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -148,6 +148,8 @@ func tableColumnsWithSemantics(
 		dbColumns[semantics.ColumnIdentityKey(col.Name)] = col
 	}
 
+	desiredDomains := desiredDomainNames(generated)
+
 	// Find added and removed columns
 	for identity, column := range genColumns {
 		if _, exists := dbColumns[identity]; !exists {
@@ -178,7 +180,7 @@ func tableColumnsWithSemantics(
 				genCol.Unique = false
 				dbCol.IsUnique = false
 			}
-			colDiff := ColumnsWithDialect(genCol, dbCol, dialect)
+			colDiff := columnsWithDesiredDomains(genCol, dbCol, dialect, desiredDomains)
 			if len(colDiff.Changes) > 0 {
 				tableDiff.ColumnsModified = append(tableDiff.ColumnsModified, colDiff)
 			}
@@ -284,7 +286,21 @@ func Columns(genCol goschema.Field, dbCol types.DBColumn) difftypes.ColumnDiff {
 
 // ColumnsWithDialect compares two columns using dialect-specific expression
 // normalization where catalog readback rewrites equivalent SQL.
+//
+// It knows nothing about which type names the desired schema declares as
+// domains, so it decides a domain from the DATABASE column alone. Every
+// comparison that has a desired schema to consult goes through
+// tableColumnsWithSemantics, which passes that set down.
 func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect string) difftypes.ColumnDiff {
+	return columnsWithDesiredDomains(genCol, dbCol, dialect, nil)
+}
+
+func columnsWithDesiredDomains(
+	genCol goschema.Field,
+	dbCol types.DBColumn,
+	dialect string,
+	desiredDomains map[string]struct{},
+) difftypes.ColumnDiff {
 	colDiff := difftypes.ColumnDiff{
 		ColumnName: genCol.Name,
 		Changes:    make(map[string]string),
@@ -300,10 +316,8 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 	dbRawType := rawDBColumnType(dbCol)
 	genType, dbType := normalizeColumnTypesForDialect(genCol.Type, dbRawType, dialect)
 
-	if genType != dbType {
-		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbType, genType)
-	} else if shouldReportSizedTypeChange(dbRawType, genCol.Type, dialect) {
-		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
+	if change := columnTypeChange(genCol, dbCol, dbRawType, dialect, desiredDomains); change != "" {
+		colDiff.Changes["type"] = change
 	}
 
 	// Compare nullable. On the engines that enforce it, a primary key column is
@@ -412,6 +426,162 @@ func sqliteKeyColumnImpliesNotNull(
 		return false
 	}
 	return sqlitekey.ImpliesNotNull(table, keyColumns, field)
+}
+
+// columnTypeChange returns the "database -> desired" row for a column's type,
+// or "" when the two sides describe the same type.
+//
+// A column whose declared type is a DOMAIN is decided by identity and never by
+// normalize.Type. That matcher works by substring -- anything containing "int"
+// is "integer" and anything containing "text" is "text" -- which is safe for
+// type names and wrong for a name a schema author picked. Measured on
+// PostgreSQL 17.10:
+//
+//	CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
+//	CREATE DOMAIN context  AS integer;
+//	CREATE TABLE t (id serial PRIMARY KEY, a waypoint NOT NULL, b context NOT NULL);
+//
+// "waypoint" contains "int" and "context" contains "text", so against a desired
+// `a bigint, b text` both columns compared EQUAL and neither
+// ALTER COLUMN ... TYPE was planned -- while the plan kept its
+// DROP DOMAIN ... CASCADE. Applying it exited 0, said "Schema apply completed
+// successfully", and left the table with only its id column: the CASCADE took
+// the two columns and their data because nothing had converted them first
+// (stokaro/ptah#1138).
+//
+// A domain therefore agrees only with a desired type that names the SAME
+// domain. Anything else -- a base type, a different domain, a plain type that
+// happens to share a substring with the name -- is a change and is reported.
+//
+// The rule holds when only the DESIRED side names a domain, too. A plain
+// integer column against a desired schema that declares `waypoint` and types
+// the column with it is a change the pinned Atlas community binary v1.3.0 also
+// plans, measured on the same two databases:
+//
+//	ALTER TABLE "t" ALTER COLUMN "a" TYPE waypoint;
+//
+// where both sides of this comparator's normalization say "integer" and Ptah
+// reported the schemas synced.
+func columnTypeChange(
+	genCol goschema.Field,
+	dbCol types.DBColumn,
+	dbRawType, dialect string,
+	desiredDomains map[string]struct{},
+) string {
+	dbDomain := domainColumnSpelling(dbCol)
+	if dbDomain != "" || namesADesiredDomain(genCol.Type, desiredDomains) {
+		if domainColumnTypeMatches(genCol.Type, dbDomain) {
+			return ""
+		}
+		return fmt.Sprintf("%s -> %s", dbRawType, strings.TrimSpace(genCol.Type))
+	}
+
+	genType, dbType := normalizeColumnTypesForDialect(genCol.Type, dbRawType, dialect)
+	switch {
+	case genType != dbType:
+		return fmt.Sprintf("%s -> %s", dbType, genType)
+	case shouldReportSizedTypeChange(dbRawType, genCol.Type, dialect):
+		return fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
+	}
+	return ""
+}
+
+// domainColumnSpelling returns the name of the DOMAIN a column is declared
+// with, and "" when the column's declared type is not a domain.
+//
+// DomainName is the fact: information_schema records it for exactly the columns
+// whose declared type is a domain, and nothing else in a column's catalog row
+// separates a domain from a plain column of the same base type. FormattedType
+// is the server's own format_type of the same domain, and it is preferred
+// because it is the fuller spelling -- it carries the schema qualifier when the
+// search path needs one, where information_schema's name is always bare.
+//
+// FormattedType on its own still counts, because the reader fills it for a
+// domain column whether or not the caller carried DomainName along, and because
+// the failure it guards is destructive while its cost is not: reading a
+// spelling as an identity can only ever REPORT a change that normalization
+// would have folded away, never hide one. The one shape it must not claim is an
+// array, whose spelling is a type rather than an identifier -- and format_type
+// spells every array with a trailing "[]", including an array of a domain,
+// while a column whose declared type IS a domain is spelled with the domain's
+// own name (stokaro/ptah#1138).
+func domainColumnSpelling(dbCol types.DBColumn) string {
+	if formatted := strings.TrimSpace(dbCol.FormattedType); formatted != "" && !strings.HasSuffix(formatted, "[]") {
+		return formatted
+	}
+	return strings.TrimSpace(dbCol.DomainName)
+}
+
+// desiredDomainNames indexes, by lower-case bare name, the domains the desired
+// schema declares. It is what lets the comparator see a domain on the side
+// where a type is only a string: goschema.Field carries a type name and nothing
+// that says the name belongs to a domain.
+func desiredDomainNames(generated *goschema.Database) map[string]struct{} {
+	if generated == nil {
+		return nil
+	}
+	names := make(map[string]struct{}, len(generated.Domains))
+	for _, domain := range generated.Domains {
+		if name := unquoteIdentifier(domain.Name); name != "" {
+			names[strings.ToLower(name)] = struct{}{}
+		}
+	}
+	return names
+}
+
+// namesADesiredDomain reports whether a desired column type names one of those
+// domains. The qualifier is dropped before the lookup because a domain is
+// declared once and may be referenced either way.
+func namesADesiredDomain(genType string, desiredDomains map[string]struct{}) bool {
+	if len(desiredDomains) == 0 {
+		return false
+	}
+	_, bare := splitQualifiedTypeName(strings.TrimSpace(genType))
+	_, declared := desiredDomains[strings.ToLower(bare)]
+	return declared
+}
+
+// domainColumnTypeMatches reports whether the desired type names the same
+// domain as the spelling the database side carries.
+//
+// A database compared against itself arrives here with the desired side holding
+// FormattedType verbatim, because that is the field the database-to-schema
+// converter reads for a domain column.
+func domainColumnTypeMatches(genType, spelling string) bool {
+	return sameDomainSpelling(strings.TrimSpace(genType), spelling)
+}
+
+// sameDomainSpelling reports whether two spellings name one domain. A qualified
+// spelling agrees with an unqualified one, because whether the server qualifies
+// a name is a property of the search path rather than of the domain; two
+// DIFFERENT qualifiers name two different domains and never agree.
+func sameDomainSpelling(left, right string) bool {
+	if left == "" || right == "" {
+		return false
+	}
+	if strings.EqualFold(left, right) {
+		return true
+	}
+	leftSchema, leftName := splitQualifiedTypeName(left)
+	rightSchema, rightName := splitQualifiedTypeName(right)
+	if !strings.EqualFold(leftName, rightName) {
+		return false
+	}
+	return leftSchema == "" || rightSchema == ""
+}
+
+// splitQualifiedTypeName splits schema.name and drops the quotes PostgreSQL
+// writes around an identifier that needs them.
+func splitQualifiedTypeName(name string) (schema, bare string) {
+	if dot := strings.LastIndex(name, "."); dot >= 0 {
+		schema = unquoteIdentifier(name[:dot])
+		name = name[dot+1:]
+	}
+	return schema, unquoteIdentifier(name)
+}
+
+func unquoteIdentifier(name string) string {
+	return strings.Trim(strings.TrimSpace(name), `"`)
 }
 
 func normalizeColumnTypesForDialect(genType, dbType, dialect string) (generatedType, databaseType string) {

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -148,7 +148,7 @@ func tableColumnsWithSemantics(
 		dbColumns[semantics.ColumnIdentityKey(col.Name)] = col
 	}
 
-	desiredDomains := desiredDomainNames(generated)
+	desiredDomains := desiredDomainIdentities(generated, semantics)
 
 	// Find added and removed columns
 	for identity, column := range genColumns {
@@ -299,7 +299,7 @@ func columnsWithDesiredDomains(
 	genCol goschema.Field,
 	dbCol types.DBColumn,
 	dialect string,
-	desiredDomains map[string]struct{},
+	desiredDomains map[string]domainIdentity,
 ) difftypes.ColumnDiff {
 	colDiff := difftypes.ColumnDiff{
 		ColumnName: genCol.Name,
@@ -462,15 +462,27 @@ func sqliteKeyColumnImpliesNotNull(
 //
 // where both sides of this comparator's normalization say "integer" and Ptah
 // reported the schemas synced.
+//
+// A domain's identity is (schema, name), and the name alone is not it. Measured
+// on the same server, one database holding public.status and one holding
+// other.status, with a row in the table:
+//
+//	ptah-compat schema diff --from <public.status> --to <other.status>
+//	  DROP DOMAIN IF EXISTS "status" CASCADE;      <- and no ALTER
+//
+// so `schema apply --auto-approve` exited 0, said "Schema apply completed
+// successfully", and left the table with only its id column. Comparing the two
+// halves of the identity is what makes that a reported change.
 func columnTypeChange(
 	genCol goschema.Field,
 	dbCol types.DBColumn,
 	dbRawType, dialect string,
-	desiredDomains map[string]struct{},
+	desiredDomains map[string]domainIdentity,
 ) string {
-	dbDomain := domainColumnSpelling(dbCol)
-	if dbDomain != "" || namesADesiredDomain(genCol.Type, desiredDomains) {
-		if domainColumnTypeMatches(genCol.Type, dbDomain) {
+	dbDomain, dbIsDomain := dbColumnDomainIdentity(dbCol)
+	desiredDomain, desiredIsDomain := desiredColumnDomainIdentity(genCol.Type, desiredDomains)
+	if dbIsDomain || desiredIsDomain {
+		if dbIsDomain && domainIdentitiesMatch(dbDomain, desiredDomain) {
 			return ""
 		}
 		return fmt.Sprintf("%s -> %s", dbRawType, strings.TrimSpace(genCol.Type))
@@ -486,88 +498,152 @@ func columnTypeChange(
 	return ""
 }
 
-// domainColumnSpelling returns the name of the DOMAIN a column is declared
-// with, and "" when the column's declared type is not a domain.
-//
-// DomainName is the fact: information_schema records it for exactly the columns
-// whose declared type is a domain, and nothing else in a column's catalog row
-// separates a domain from a plain column of the same base type. FormattedType
-// is the server's own format_type of the same domain, and it is preferred
-// because it is the fuller spelling -- it carries the schema qualifier when the
-// search path needs one, where information_schema's name is always bare.
-//
-// FormattedType on its own still counts, because the reader fills it for a
-// domain column whether or not the caller carried DomainName along, and because
-// the failure it guards is destructive while its cost is not: reading a
-// spelling as an identity can only ever REPORT a change that normalization
-// would have folded away, never hide one. The one shape it must not claim is an
-// array, whose spelling is a type rather than an identifier -- and format_type
-// spells every array with a trailing "[]", including an array of a domain,
-// while a column whose declared type IS a domain is spelled with the domain's
-// own name (stokaro/ptah#1138).
-func domainColumnSpelling(dbCol types.DBColumn) string {
-	if formatted := strings.TrimSpace(dbCol.FormattedType); formatted != "" && !strings.HasSuffix(formatted, "[]") {
-		return formatted
-	}
-	return strings.TrimSpace(dbCol.DomainName)
+// domainIdentity is what a domain IS: the schema that holds it and its own
+// name, both case-folded. An empty schema means "not said, and nothing here can
+// resolve it" -- never "the default schema", which is a value this type carries
+// spelled out.
+type domainIdentity struct {
+	schema string
+	name   string
 }
 
-// desiredDomainNames indexes, by lower-case bare name, the domains the desired
+// foldDomainPart canonicalizes one half of an identity. PostgreSQL folds an
+// unquoted identifier to lower case on the way in, so the catalog spelling and
+// the spelling a schema author typed differ in case and name one domain.
+func foldDomainPart(value string) string {
+	return strings.ToLower(unquoteIdentifier(value))
+}
+
+// dbColumnDomainIdentity returns the identity of the DOMAIN a database column
+// is declared with, and false when its declared type is not a domain.
+//
+// DomainName/DomainSchema are the fact: information_schema records them for
+// exactly the columns whose declared type is a domain, and nothing else in a
+// column's catalog row separates a domain from a plain column of the same base
+// type. They are read together, because half an identity is not one: a
+// comparator holding only "status" for a column of public.status calls it equal
+// to a desired other.status, reports no change, and lets the plan's
+// DROP DOMAIN ... CASCADE take the column (stokaro/ptah#1138).
+//
+// FormattedType is the server's own format_type of the same domain. It is
+// consulted for the schema qualifier the server writes when the search path
+// forces one, and it still counts on its own, because a caller may carry it
+// without the catalog columns and because the failure it guards is destructive
+// while its cost is not: reading a spelling as an identity can only ever REPORT
+// a change that normalization would have folded away, never hide one. The one
+// shape it must not claim is an array, whose spelling is a type rather than an
+// identifier -- and format_type spells every array with a trailing "[]",
+// including an array of a domain, while a column whose declared type IS a
+// domain is spelled with the domain's own name.
+func dbColumnDomainIdentity(dbCol types.DBColumn) (domainIdentity, bool) {
+	qualifier, spelled := domainColumnSpelling(dbCol)
+	if name := foldDomainPart(dbCol.DomainName); name != "" {
+		schema := foldDomainPart(dbCol.DomainSchema)
+		if schema == "" {
+			schema = foldDomainPart(qualifier)
+		}
+		return domainIdentity{schema: schema, name: name}, true
+	}
+	if name := foldDomainPart(spelled); name != "" {
+		return domainIdentity{schema: foldDomainPart(qualifier), name: name}, true
+	}
+	return domainIdentity{}, false
+}
+
+// domainColumnSpelling splits the server's own spelling of a domain column's
+// declared type, and returns an empty name for every column that has none --
+// including an array, whose spelling is a type.
+func domainColumnSpelling(dbCol types.DBColumn) (schema, name string) {
+	formatted := strings.TrimSpace(dbCol.FormattedType)
+	if formatted == "" || strings.HasSuffix(formatted, "[]") {
+		return "", ""
+	}
+	return splitQualifiedTypeName(formatted)
+}
+
+// desiredDomainIdentities indexes, by folded bare name, the domains the desired
 // schema declares. It is what lets the comparator see a domain on the side
 // where a type is only a string: goschema.Field carries a type name and nothing
 // that says the name belongs to a domain.
-func desiredDomainNames(generated *goschema.Database) map[string]struct{} {
+//
+// The index is by BARE name because that is how a column references a domain
+// declared in the same schema, and its value carries the declared schema so an
+// unqualified reference resolves to the domain it actually names rather than to
+// any domain of that name. A name two declarations share is left unresolved:
+// which one an unqualified reference means is a search-path question this
+// comparator has no answer for, and guessing one would be the miss again.
+//
+// semantics.DefaultSchema is the explicit default rule. A domain declared with
+// no schema of its own lives in the schema the connection reads, which is the
+// same schema the database side reports for it.
+func desiredDomainIdentities(
+	generated *goschema.Database,
+	semantics identifier.Semantics,
+) map[string]domainIdentity {
 	if generated == nil {
 		return nil
 	}
-	names := make(map[string]struct{}, len(generated.Domains))
+	identities := make(map[string]domainIdentity, len(generated.Domains))
+	ambiguous := make(map[string]struct{})
 	for _, domain := range generated.Domains {
-		if name := unquoteIdentifier(domain.Name); name != "" {
-			names[strings.ToLower(name)] = struct{}{}
+		name := foldDomainPart(domain.Name)
+		if name == "" {
+			continue
 		}
+		schema := foldDomainPart(domain.Schema)
+		if schema == "" {
+			schema = foldDomainPart(semantics.DefaultSchema)
+		}
+		if declared, seen := identities[name]; seen && declared.schema != schema {
+			ambiguous[name] = struct{}{}
+		}
+		identities[name] = domainIdentity{schema: schema, name: name}
 	}
-	return names
+	for name := range ambiguous {
+		identities[name] = domainIdentity{name: name}
+	}
+	return identities
 }
 
-// namesADesiredDomain reports whether a desired column type names one of those
-// domains. The qualifier is dropped before the lookup because a domain is
-// declared once and may be referenced either way.
-func namesADesiredDomain(genType string, desiredDomains map[string]struct{}) bool {
-	if len(desiredDomains) == 0 {
-		return false
-	}
-	_, bare := splitQualifiedTypeName(strings.TrimSpace(genType))
-	_, declared := desiredDomains[strings.ToLower(bare)]
-	return declared
-}
-
-// domainColumnTypeMatches reports whether the desired type names the same
-// domain as the spelling the database side carries.
+// desiredColumnDomainIdentity returns the identity a desired column type names,
+// and whether the desired schema declares that name as a domain.
 //
-// A database compared against itself arrives here with the desired side holding
-// FormattedType verbatim, because that is the field the database-to-schema
-// converter reads for a domain column.
-func domainColumnTypeMatches(genType, spelling string) bool {
-	return sameDomainSpelling(strings.TrimSpace(genType), spelling)
+// A qualified spelling says its own schema. An unqualified one is resolved
+// through the declaration when there is exactly one, and otherwise left with an
+// empty schema -- the search path decides it, and this comparator does not read
+// the search path.
+func desiredColumnDomainIdentity(
+	genType string,
+	desiredDomains map[string]domainIdentity,
+) (domainIdentity, bool) {
+	schema, bare := splitQualifiedTypeName(strings.TrimSpace(genType))
+	identity := domainIdentity{schema: foldDomainPart(schema), name: foldDomainPart(bare)}
+	if identity.name == "" {
+		return identity, false
+	}
+	declared, isDomain := desiredDomains[identity.name]
+	if isDomain && identity.schema == "" {
+		identity.schema = declared.schema
+	}
+	return identity, isDomain
 }
 
-// sameDomainSpelling reports whether two spellings name one domain. A qualified
-// spelling agrees with an unqualified one, because whether the server qualifies
-// a name is a property of the search path rather than of the domain; two
-// DIFFERENT qualifiers name two different domains and never agree.
-func sameDomainSpelling(left, right string) bool {
-	if left == "" || right == "" {
+// domainIdentitiesMatch reports whether two identities name one domain.
+//
+// Both halves must agree when both are known. An empty schema on either side is
+// a spelling that did not say and that nothing resolved, which the search path
+// decides at the server; it is matched by name so that a database compared
+// against itself stays synced. Two DIFFERENT schemas name two different
+// domains and never agree -- that is the half whose absence lost a column.
+func domainIdentitiesMatch(dbDomain, desiredDomain domainIdentity) bool {
+	if dbDomain.name == "" || desiredDomain.name == "" {
 		return false
 	}
-	if strings.EqualFold(left, right) {
-		return true
-	}
-	leftSchema, leftName := splitQualifiedTypeName(left)
-	rightSchema, rightName := splitQualifiedTypeName(right)
-	if !strings.EqualFold(leftName, rightName) {
+	if dbDomain.name != desiredDomain.name {
 		return false
 	}
-	return leftSchema == "" || rightSchema == ""
+	return dbDomain.schema == "" || desiredDomain.schema == "" ||
+		dbDomain.schema == desiredDomain.schema
 }
 
 // splitQualifiedTypeName splits schema.name and drops the quotes PostgreSQL

--- a/migration/schemadiff/internal/compare/shared.go
+++ b/migration/schemadiff/internal/compare/shared.go
@@ -51,7 +51,7 @@ func nonEmptyNames(names []string) []string {
 // or a domain, and because the desired side reads the same field -- see
 // goSchemaFieldType in internal/convert/dbschematogo. The reader fills it from
 // the server's own format_type for exactly those two shapes and leaves it empty
-// for every other column, so this changes nothing else.
+// for every other column.
 //
 // With ColumnType and UDTName first the two sides read different fields for the
 // same column, and the comparator reported a change between a database and
@@ -68,6 +68,11 @@ func nonEmptyNames(names []string) []string {
 //
 // Every one of them proposed an ALTER COLUMN ... TYPE to the type the column
 // already had. None survive this (stokaro/ptah#1138).
+//
+// What this string may then be USED for is not uniform, and the difference is
+// the whole of #1138's comparator half. An array's spelling is a type. A
+// domain's spelling is the identifier its author chose, and columnTypeChange
+// keeps it away from normalize.Type for that reason.
 func rawDBColumnType(dbCol types.DBColumn) string {
 	rawType := strings.TrimSpace(dbCol.FormattedType)
 	if rawType == "" {

--- a/migration/schemadiff/internal/compare/shared.go
+++ b/migration/schemadiff/internal/compare/shared.go
@@ -44,8 +44,35 @@ func nonEmptyNames(names []string) []string {
 	return filtered
 }
 
+// rawDBColumnType is the type spelling the comparator holds the desired schema
+// against.
+//
+// FormattedType comes first because it is the only field that survives an array
+// or a domain, and because the desired side reads the same field -- see
+// goSchemaFieldType in internal/convert/dbschematogo. The reader fills it from
+// the server's own format_type for exactly those two shapes and leaves it empty
+// for every other column, so this changes nothing else.
+//
+// With ColumnType and UDTName first the two sides read different fields for the
+// same column, and the comparator reported a change between a database and
+// ITSELF. Measured on PostgreSQL 17, `ptah-compat schema diff` with --from and
+// --to naming one database, seven phantom rows:
+//
+//	arrays.a_bit          type: _bit    -> bit(8)[]
+//	arrays.a_char         type: _bpchar -> character(5)[]
+//	arrays.a_cube         type: _cube   -> cube[]
+//	arrays.a_enum         type: _status -> status[]
+//	arrays.a_varchar      type: varchar -> character varying(100)[]
+//	arrays.a_varchar_dim  type: varchar -> character varying(100)[]
+//	scalars.c_tags        type: text    -> tags
+//
+// Every one of them proposed an ALTER COLUMN ... TYPE to the type the column
+// already had. None survive this (stokaro/ptah#1138).
 func rawDBColumnType(dbCol types.DBColumn) string {
-	rawType := strings.TrimSpace(dbCol.ColumnType)
+	rawType := strings.TrimSpace(dbCol.FormattedType)
+	if rawType == "" {
+		rawType = strings.TrimSpace(dbCol.ColumnType)
+	}
 	if rawType == "" && dbCol.UDTName != "" {
 		rawType = strings.TrimSpace(dbCol.UDTName)
 	}


### PR DESCRIPTION
`ptah-compat schema inspect` wrote HCL the pinned Atlas community binary v1.3.0 refuses to read for four of the six array columns of one PostgreSQL table, and it described a domain column as the domain's base type, so applying its own output rebuilt the column without the domain and without the `CHECK` the domain carries.

Both defects are on the database-to-render path. The parse-to-render half was already correct and is untouched.

Everything below is measured on PostgreSQL 17.10 against the pinned community binary by absolute path. The binary reports `atlas community version v1.3.0`.

## What was already fixed, and is not claimed here

Measured on `origin/master` `9820496e` before touching anything.

- **Cluster A's own completion criterion holds.** `ptah-compat schema inspect --url file://schema.v1.hcl --dev-url "sqlite://dev?mode=memory"` prints `type = sql("USER_DEFINED")`, and feeding that file to the pinned binary exits 0 and inspects back the same call. #1140 and #1233 did that.
- **Six of eleven array shapes were already right.** `text[]`, `integer[]`, `character varying(100)[]`, `status[]`, `positive_int[]` and `cube[]` already rendered as `sql(...)`, byte-identical to what that binary renders for the same columns. #1220 did that.
- **`varchar(100)[10][]` losing its dimensions is PostgreSQL, not Ptah.** The server stores and reports `character varying(100)[]`. Nothing to fix.
- **The fixed point itself already held.** `render -> parse -> render` was byte-identical on master for every column in this PR. What did not hold is the other half of the property — the described type surviving — and that is exactly what a round trip which only re-renders cannot see.

## Family 1 — a type rendered as `sql(...)`

`information_schema` reports a domain column under its **base** type. `goSchemaFieldType` tested `data_type = 'USER-DEFINED'` before the server's `format_type`, so a domain over a built-in base survived and a domain over a user-defined base did not:

```
column      data_type      udt_name   domain_name   format_type
c_domain    integer        int4       positive_int  positive_int
c_point3d   USER-DEFINED   cube       point3d       point3d
```

| shape | Ptah, master | pinned v1.3.0 |
| --- | --- | --- |
| `positive_int` (domain over `integer`) | `sql("positive_int")` | `sql("positive_int")` |
| `tags` (domain over `text[]`) | `sql("tags")` | `sql("tags")` |
| `point3d` (domain over `cube`) | **`sql("cube")`** | `sql("point3d")` |
| `lo` (stock, domain over `oid`) | `sql("lo")` | `sql("lo")` |
| `earth` (stock, domain over `cube`) | **`sql("cube")`** | `sql("earth")` |

`lo` and `earth` differ in nothing but what they are built on. Applying Ptah's own output built `c_point3d` as a bare `cube`, so the domain and its `cube_dim(VALUE) = 3` constraint were gone from the database with nothing reported.

Reading the server's spelling first fixes all of them, and it is also the compatible answer.

## Family 2 — array types

`modeledColumnType` consulted the modeled-type set through the **element** name, splitting at the first parenthesis. `numeric(10,2)[]` found `numeric` in the set, put `(10,2)[]` back untouched, and `typeExpr` fell through to its quoted branch. `text[]` escaped only by accident, being absent from the set as a whole string — which is why one table came out half readable.

One column varied and nothing else, `atlas schema inspect --url file://p.hcl --dev-url <clean postgres 17>`:

```
type = "bit(8)[]"                           exit 1  set field "type": unexpected type string
type = "character(5)[]"                     exit 1  the same
type = "numeric(10,2)[]"                    exit 1  the same
type = "timestamp(3) with time zone[]"      exit 1  the same
type = text[]                               exit 1  Invalid expression
type = sql("bit(8)[]")                      exit 0
type = sql("character(5)[]")                exit 0
type = sql("numeric(10,2)[]")               exit 0
type = sql("timestamp(3) with time zone[]") exit 0
```

There is no bare or quoted spelling to prefer: an array is not one HCL type expression, whatever its element type is. So an array is never modeled and always takes the call — which is what that binary's own inspect writes for all six columns.

Feeding the whole document to it, an arrays-only table:

```
master:      atlas schema inspect --url file://<ptah output>  exit 1
this branch: the same command                                 exit 0, and inspects back the same six calls
```

## The comparator was reading the same column out of a different field

`rawDBColumnType` read `ColumnType`/`UDTName` while the desired side read `format_type`, so `ptah-compat schema diff --from <db> --to <db>` reported a change between a database and **itself**:

```
arrays.a_bit          type: _bit    -> bit(8)[]
arrays.a_char         type: _bpchar -> character(5)[]
arrays.a_cube         type: _cube   -> cube[]
arrays.a_enum         type: _status -> status[]
arrays.a_varchar      type: varchar -> character varying(100)[]
arrays.a_varchar_dim  type: varchar -> character varying(100)[]
scalars.c_tags        type: text    -> tags
```

Every row proposed an `ALTER COLUMN ... TYPE` to the type the column already had. Fixing the domain read alone would have added an eighth (`c_point3d cube -> integer`); preferring `FormattedType` there removes all eight and keeps both sides on one field.

## The round trip, against a live database

One PostgreSQL 17 cluster, two tables, 23 columns, `cube` and `hstore` extensions, an enum, and three domains.

1. `ptah-compat schema inspect ptah_test` → document A
2. `ptah-compat schema apply --to file://A --url <empty database> --dev-url <clean dev> --auto-approve` → exit 0
3. `ptah-compat schema inspect <that database>` → document B

| | master | this branch |
| --- | --- | --- |
| `diff A B` | identical | identical |
| catalog of source vs round trip | `scalars.c_point3d` comes back as **`cube`** | identical, all 23 columns |
| `schema diff --from source --to round trip` | `Modify column scalars.c_point3d: type: integer -> cube` | `Schemas are synced, no changes to be made.` |
| self-diff of one database | 7 phantom rows | synced |

Master's document was a byte-identical fixed point too. That is the whole reason this survived the round-trip tests that already existed.

## Tests

- `TestRenderForDialectWrapsEveryArrayColumnType` — nine rows: the four sized spellings, the three unsized ones that were already right, and two scalar controls that must still go out bare.
- `TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsTheDomain` — four rows, with the ordinary user-defined column kept as a control so this cannot become "always prefer `format_type`".
- `TestCompareWithDialect_PostgresArrayAndDomainColumnsCompareEqualToThemselves` — compares a schema against itself through the converter, the same path the CLI takes.
- Nine new rows in `TestOracleAcceptsTheWrapItFallsBackTo`, each measured against the pinned binary. The refusal rows are asserted as refusals, so a change that puts an array back on the modeled path reddens the Atlas CE Oracle job rather than a user's file. Three of them are named in `.github/workflows/atlas-oracle.yml` so a selection that stopped matching cannot leave that job green.

Each was seen red both ways. Reverting the array guard reddens exactly the four sized rows and leaves the unsized ones green; over-correcting to wrap every type reddens the bare-type rows in the pre-existing suite. Reverting the branch order reddens only the domain-over-user-defined row; dropping the `USER-DEFINED` branch entirely reddens the control. Reverting the comparator reproduces the seven phantom rows verbatim in the failure message.

## Behavior change

An array or domain column's `type` attribute changes spelling in `schema inspect` HCL output. Pre-v1, so no compatibility with Ptah's own previous output is owed; the new spelling is the one the pinned community binary accepts and the one it writes itself. No capability is removed and nothing is gated. `--format sql` and `--format json` output is unchanged.

Documentation: a new "How an inspected column type is written" section in the schema-commands page states the rule, both refusals, and why a domain is named rather than resolved.

Refs #1138, #1220, #1233, #1140.

---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

REFUTED. Two of the three changes hold and are better than claimed. The third — the comparator hunk in /Users/buster/Work/denis/ptah/.claude/worktrees/wf_b394c0e2-0e4-8/migration/schemadiff/internal/compare/shared.go — silently DESTROYS COLUMNS AND DATA on an adjacent shape the author never built.

SETUP. My own container r1138x-pg (postgres:17, port 15738, removed at the end), CI role shape (ptah_user SUPERUSER + bootstrap postgres), my own fixtures, oracle at /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas ("atlas community version v1.3.0"). Head 1d03cdac in my worktree; merge-base 9820496e in a second worktree at /private/tmp/claude-501/-Users-buster-Work-denis-ptah/2fc9aeb4-cb03-4375-ae0a-82e5047f1051/scratchpad/r1138base. `git log --oneline -1` verified in each before every build.

=== THE REFUTATION ===

rawDBColumnType now returns FormattedType, which for a PostgreSQL domain column is the DOMAIN'S NAME. That string is handed to normalize.Type (migration/schemadiff/internal/normalize/normalize.go:51), which matches by SUBSTRING: anything containing "int" is "integer", anything containing "text" is "text". The name a schema author picked now decides whether the comparator sees a change at all.

FAILING SHAPE, PostgreSQL 17.10:
  DB P: CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
        CREATE DOMAIN context  AS integer;
        CREATE TABLE t (id serial PRIMARY KEY, a waypoint NOT NULL, b context NOT NULL);
        INSERT INTO t (a,b) VALUES (7,42);
  DB Q: CREATE TABLE t (id serial PRIMARY KEY, a bigint NOT NULL, b text NOT NULL);

  ptah-compat schema diff --from <P> --to <Q>
    9820496e: -- Modify column t.a: type: int4 -> bigint --
              -- Modify column t.b: type: integer -> text --
              DROP DOMAIN IF EXISTS "context" CASCADE;  DROP DOMAIN IF EXISTS "waypoint" CASCADE;
    1d03cdac: DROP DOMAIN IF EXISTS "context" CASCADE;  DROP DOMAIN IF EXISTS "waypoint" CASCADE;   <- no ALTERs

  ptah-compat schema apply --url <live copy of P> --to <Q> --dev-url <clean> --auto-approve
  (two identical live copies, one per binary)
    9820496e: rc=0, table t = id | a bigint | b text, row 1|7|42 intact          (3 columns)
    1d03cdac: rc=0, "Schema apply completed successfully", table t = id only     (1 COLUMN)
  DROP DOMAIN ... CASCADE takes the columns because no ALTER was planned. Exit 0, nothing reported.

  Native surface, same defect:
  ptah schema compare --root-dir <Go models: a BIGINT, b TEXT> --db-url <P>
    9820496e: "Differences detected (2 categories): tables_modified (1): t / domains_removed (2)" + both ALTERs
    1d03cdac: "Differences detected (1 category): domains_removed (2)"

  Role-independent: identical output as ptah_user and as the bootstrap postgres superuser.
  ISOLATED: reverting ONLY the rawDBColumnType hunk on 1d03cdac (rebuild, same two databases) restores both ALTERs. The renderer and converter halves are not implicated.

REGRESSION TEST COMMITTED (red on purpose) at
/Users/buster/Work/denis/ptah/.claude/worktrees/wf_b394c0e2-0e4-8/migration/schemadiff/domain_named_like_a_type_test.go
  go test ./migration/schemadiff/ -run DomainNamedLikeAType   1d03cdac: FAIL   9820496e: ok
The branch's own TestCompareWithDialect_PostgresArrayAndDomainColumnsCompareEqualToThemselves still PASSES alongside it, so a correct fix must satisfy both.

WHY THEIR MUTATION SWEEP MISSED IT. Their revert mutant reddened only their new self-compare test, whose fixture names (positive_int, point3d, tags, short_text) all normalize to the same token on both sides. The fingerprint is already in their own report and they read past it: "schema diff --from ptah_test --to ptah_rt_base -> 'Modify column scalars.c_point3d: type: integer -> cube'". point3d is not integer — that "integer" IS normalize.Type matching the substring "int".

THE CLAIM THAT IS NOT CODE. The doc comment they added on rawDBColumnType asserts "...leaves it empty for every other column, so this changes nothing else." The premise is true; the inference is false. It changes the comparator's verdict for every domain column, and for a domain whose name collides with a type substring it changes it from "report the change" to "report nothing".

=== WHAT HOLDS (re-measured, my fixtures) ===
1. ARRAYS. Confirmed and broader than claimed. All 20 array columns of my fixture render byte-identical to the pinned binary's own `schema inspect` of the same database (diff rc=0). Base emitted the quoted spelling for SIX sized shapes, not four — they never built interval(3)[] or time(2) without time zone[]. Oracle probes: quoted `"numeric(10,2)[]"` rc=1 (`set field "type": unexpected type string`); all eight wrapped spellings rc=0, including my two extra ones. SQLite improves too: a column declared `VARCHAR(10)[]` was `type = "varchar(10)[]"` on base (oracle rc=1) and is `sql("VARCHAR(10)[]")` on head (oracle rc=0). MySQL byte-identical on inspect and self-diff, as predicted (no modeled set, early return).
2. DOMAINS. Confirmed. c_point3d, c_earth and my extra alt.alt_dom_over_ud all now match the oracle exactly. Live round trip (inspect -> apply to empty DB via clean dev -> inspect): head documents byte-identical and point3d_check CHECK ((cube_dim(VALUE) = 3)) survives on the column; base rebuilds c_point3d as bare cube with the domain gone.
3. SELF-DIFF. On my fixture base emitted 15 phantom rows (they reported 7); head emits "Schemas are synced". Control built: head still reports real differences against a deliberately-altered database (a_varchar 100->200, c_point3d, c_tags).
4. Oracle tests execute: 15/15 subtests PASS, 0 SKIP, `go test -list '^TestOracle'` still lists exactly 5, all three workflow-named rows present.

=== GATES (in my worktree, exit code on its own line) ===
go build ./...                                0
go vet ./...                                  0
go vet -tags integration ./integration/...    0
go test ./... -count=1                        1  -- cmd/ptah-compat "panic: test timed o

### What it says must change

Keep the renderer half (internal/atlashclrender/modeled_types.go) and the converter half (internal/convert/dbschematogo/dbschematogo.go) — both are measured against the pinned binary and both are right. Drop or rework the third hunk.

The defect is that a domain's NAME reaches normalize.Type, whose matching is substring-based and was only ever safe for real type names. Two shapes that fix the phantom self-diff without introducing the miss:

(a) Compare a domain-typed column by exact identity on BOTH sides and never send the name through normalize.Type: carry a "this column is a domain" bit (the reader already has domain_name), and when both sides carry it compare the domain names verbatim; when only one side does, that IS a change and must be reported.

(b) Or fix the phantom rows on the desired side instead: leave rawDBColumnType reading ColumnType/UDTName and make goSchemaFieldType's output for a domain column resolve to the same field, so the two sides agree without a user-chosen identifier ever reaching a substring matcher.

Either way, the branch needs a fixture whose domain name collides with a type substring. The one committed at /Users/buster/Work/denis/ptah/.claude/worktrees/wf_b394c0e2-0e4-8/migration/schemadiff/domain_named_like_a_type_test.go uses `waypoint` (over integer) and `context` (over integer) and must go green alongside the existing self-compare test.

PR title:
  Pin the domain a comparator change stopped seeing (#1138)

PR body:
  `stokaro/ptah#1138`'s comparator hunk makes `schema diff`, `schema apply` and
  `ptah schema compare` drop a required `ALTER COLUMN ... TYPE` whenever the
  column's type is a PostgreSQL domain whose NAME contains a type substring. The
  plan keeps its `DROP DOMAIN ... CASCADE`, so applying it destroys the column
  instead of converting it. This adds the fixture that fails on that branch and
  passes on its merge-base.

  `rawDBColumnType` now prefers `FormattedType`, which for a domain column is the
  domain's own name rather than the base type `information_schema` reports. That
  string is handed to `normalize.Type`, which matches by SUBSTRING: anything
  containing "int" is "integer", anything containing "text" is "text". A schema
  author's choice of name now decides whether the comparator sees a change.

  Measured on PostgreSQL 17.10, one cluster, two domains over integer:

      CREATE DOMAIN waypoint AS integer CHECK (VALUE > 0);
      CREATE DOMAIN context  AS integer;
      CREATE TABLE t (id serial PRIMARY KEY, a waypoint NOT NULL, b context NOT NULL);

  against a desired `a bigint, b text`:

      merge-base   ALTER TABLE "t" ALTER COLUMN "a" TYPE bigint;
                   ALTER TABLE "t" ALTER COLUMN "b" TYPE text;
                   DROP DOMAIN IF EXISTS "context" CASCADE;
                   DROP DOMAIN IF EXISTS "waypoint" CASCADE;

      that branch  DROP DOMAIN IF EXISTS "context" CASCADE;
                   DROP DOMAIN IF EXISTS "waypoint" CASCADE;

  Applied to a live database holding one row, `schema apply --auto-approve`
  exited 0, printed "Schema apply completed successfully", and left table `t`
  with only `id`. The merge-base binary, same command and an identical copy of
  the same database, left `a bigint` and `b text` with the row intact. The same
  miss reaches the native surface: `ptah schema compare --root-dir <models>
  --db-url <db>` reports only `domains_removed`.

  Reverting just the `rawDBColumnType` hunk restores both ALTERs, so the renderer
  and converter halves of that branch are not implicated; they are measured
  against the pinned Atlas community binary v1.3.0 and both are right.

  This test is RED on `issue-1138-hcl-roundtrip` and green on `9820496e`. It is
  meant to be satisfied alongside that branch's own
  `TestCompareWithDialect_PostgresArrayAndDomainColumnsCompareEqualToThemselves`:
  a database must equal itself AND a real change must still be reported.