### PR TITLE
Write a permission block that resolves inside its own document (#1234)

### DIFF
--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -202,11 +202,17 @@ jobs:
           # document unreadable, so both halves of each pair are named. The
           # grant-only document is the one no prediction reaches: it is what an
           # EMPTY database inspects to, with no table anywhere to declare a
-          # schema from.
+          # schema from. The table-and-view document is the one no FILTER
+          # reaches: it is the default invocation on any database carrying a
+          # view, and its pair is what says a permission target names the block
+          # type the document declares rather than the field the name arrived on.
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_with_grants/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_with_grants/unreadable/PUBLIC_written_bare' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_whose_roles_were_excluded/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_whose_roles_were_excluded/unreadable/a_grantee_reference_with_no_role_block_anywhere' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_and_a_view_with_grants_on_both/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_and_a_view_with_grants_on_both/unreadable/a_view_named_as_a_table' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/sqlite/a_table_and_a_view_with_grants_on_both/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/unreadable/a_schema_reference_with_no_block' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/sqlite/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"

--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -140,6 +140,10 @@ jobs:
       # started modeling. The spelling of a table REFERENCE is another
       # (stokaro/ptah#1260): `table.<schema>.<name>` costs the whole document,
       # so the rendered output is put to that binary here rather than trusted.
+      # The last one is the WHOLE inspected document (stokaro/ptah#1234): a
+      # permission body that does not evaluate and a `schema.<name>` reference
+      # nothing declares are properties of the file rather than of any one
+      # attribute, so neither is visible to the runs above.
       # All of them live in internal/atlashclrender and are listed before they
       # are run, for the same reason as above.
       - name: Verify HCL render conformance selection
@@ -152,7 +156,8 @@ jobs:
           grep -Fx 'TestOracleAtlasRefusedBlockTypesMatchTheBinary' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleToleratesTheBlockTypesPtahStillRenders' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleReadsTheReferenceSpellingPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
-          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 5
+          grep -Fx 'TestOracleReadsTheInspectedDocumentPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 6
 
       - name: Run HCL render conformance tests
         run: |
@@ -191,6 +196,20 @@ jobs:
           grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_wraps_a_sized_array_whose_element_name_is_modeled' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_refuses_that_same_array_quoted' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleAcceptsTheWrapItFallsBackTo/postgres_refuses_an_array_written_bare' "$RUNNER_TEMP/atlas-column-type-run"
+
+          # And for the whole-document run (stokaro/ptah#1234). Each `rendered`
+          # row is only a measurement next to the mutation that makes the same
+          # document unreadable, so both halves of each pair are named. The
+          # grant-only document is the one no prediction reaches: it is what an
+          # EMPTY database inspects to, with no table anywhere to declare a
+          # schema from.
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_with_grants/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_with_grants/unreadable/PUBLIC_written_bare' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_whose_roles_were_excluded/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/a_table_whose_roles_were_excluded/unreadable/a_grantee_reference_with_no_role_block_anywhere' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/unreadable/a_schema_reference_with_no_block' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/sqlite/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/.github/workflows/atlas-oracle.yml
+++ b/.github/workflows/atlas-oracle.yml
@@ -26,6 +26,16 @@ jobs:
       # engine does not have -- and those are the two verdicts that run exists to
       # keep apart.
       PTAH_ATLAS_ORACLE_POSTGRES_DEV_URL: 'postgres://postgres:pw@localhost:5432/dev?sslmode=disable&search_path=public'
+      # A second dev database, REALM-scoped: no search_path, so the binary is
+      # willing to materialize a document declaring more than one schema. The
+      # one above is deliberately scoped to `public` and refuses such a document
+      # with `cannot use HCL with more than 1 schema when dev-url is limited to
+      # schema "public"`, which is a verdict about the dev URL rather than about
+      # the document. It is a SEPARATE database because a realm-scoped read
+      # requires a clean one: measured on PostgreSQL 17, a leftover schema makes
+      # the next read fail with `sql/migrate: connected database is not clean:
+      # found schema "other"`, so it must not share with the runs above.
+      PTAH_ATLAS_ORACLE_POSTGRES_REALM_DEV_URL: 'postgres://postgres:pw@localhost:5432/realmdev?sslmode=disable'
 
     services:
       postgres:
@@ -46,6 +56,13 @@ jobs:
 
       - name: Configure oracle path
         run: echo "PTAH_ATLAS_ORACLE=$RUNNER_TEMP/ptah-atlas-ce/atlas" >> "$GITHUB_ENV"
+
+      # The realm-scoped dev database the two-schema document needs. The service
+      # creates only `dev`, and that one is scoped to a single schema on purpose.
+      - name: Create the realm-scoped dev database
+        run: >-
+          PGPASSWORD=pw psql -h localhost -p 5432 -U postgres -d postgres
+          -v ON_ERROR_STOP=1 -c 'CREATE DATABASE realmdev'
 
       - name: Set up Go
         uses: actions/setup-go@v7
@@ -157,7 +174,8 @@ jobs:
           grep -Fx 'TestOracleToleratesTheBlockTypesPtahStillRenders' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleReadsTheReferenceSpellingPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
           grep -Fx 'TestOracleReadsTheInspectedDocumentPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
-          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 6
+          grep -Fx 'TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders' "$RUNNER_TEMP/atlas-column-type-tests"
+          test "$(grep -c '^TestOracle' "$RUNNER_TEMP/atlas-column-type-tests")" -eq 7
 
       - name: Run HCL render conformance tests
         run: |
@@ -216,6 +234,17 @@ jobs:
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/postgres/nothing_but_the_grant_every_database_has/unreadable/a_schema_reference_with_no_block' "$RUNNER_TEMP/atlas-column-type-run"
           grep -Fq 'TestOracleReadsTheInspectedDocumentPtahRenders/sqlite/nothing_but_the_grant_every_database_has/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          # And for the shape a relation LABEL is not unique in: two schemas each
+          # holding a view named `v`, which is a DEFAULT inspect of a
+          # realm-scoped URL. Its three mutations are named for the same reason
+          # -- `rendered` alone would pass on a build that had gone back to
+          # writing an unreadable traversal, since the mutation is what says the
+          # traversal is refused. PostgreSQL only: the binary refuses a
+          # two-schema document on SQLite outright, so there is no SQLite row.
+          grep -Fq 'TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders/rendered' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders/unreadable/a_grant_target_named_as_a_qualified_table' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders/unreadable/a_grant_target_named_as_a_qualified_view' "$RUNNER_TEMP/atlas-column-type-run"
+          grep -Fq 'TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders/unreadable/a_trigger_target_named_as_a_qualified_table' "$RUNNER_TEMP/atlas-column-type-run"
 
       - name: Regenerate Atlas CE corpus
         run: >-

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -527,6 +527,39 @@ rather than a flag because `ptah-compat`'s flag surface is held to parity with
 the pinned binary; see
 [Compatibility never costs you a capability](../overview/#compatibility-never-costs-you-a-capability).
 
+### Every reference the document writes resolves inside it
+
+Inspected output is written so that it evaluates as HCL on its own, whatever
+the selection left behind. Two rules follow from that, and both are visible
+when a filter removes something a `permission` block still points at.
+
+A schema is declared whenever anything in the document references one. That
+includes a document with no tables at all: every PostgreSQL database carries
+`GRANT USAGE ON SCHEMA public TO PUBLIC`, so inspecting an empty database
+renders a `permission` block saying `for = schema.public` and the matching
+`schema "public" {}` beside it. A document that references no schema declares
+none.
+
+A grantee is written as a `role.<name>` reference only where the same document
+declares that `role` block, and as a quoted name otherwise. Grants are children
+of the object granted on rather than of the grantee, so excluding roles keeps
+every grant to them:
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL" --exclude '*[type=role]'
+permission {
+  to = "app_user"
+  for = table.users
+  privileges = ["SELECT"]
+}
+```
+
+The name is preserved either way — Ptah reads both spellings back to the same
+grant, and applying that document issues `GRANT SELECT ON TABLE "public"."users"
+TO "app_user"` — so nothing is lost by the quoted form, while a reference to a
+block the document does not contain would cost the whole file: the pinned Atlas
+community binary refuses it with `There is no variable named "role"`.
+
 ### Select what is inspected with `--include`
 
 `--include` positively selects which top-level resources survive inspection,

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -584,10 +584,44 @@ permission {
 A reference in HCL names a block, and the block type is the first word of it, so
 `table.v` reads as "the `v` attribute of the table object" and the community
 binary refuses the file with `This object does not have an attribute named "v"`.
-A materialized view is `materialized.<name>` for the same reason, and a name the
-document declares no block for keeps the spelling the position implies. The same
-rule applies to a `trigger`'s `on`, which reaches a view whenever the database
-has an `INSTEAD OF` trigger.
+A materialized view is `materialized.<name>` for the same reason. The same rule
+applies to a `trigger`'s `on`, which reaches a view whenever the database has an
+`INSTEAD OF` trigger.
+
+Where the document declares no single block to name, the target is written as a
+quoted name instead — `for = "v"`, or `for = "other.v"` with the schema kept.
+Two cases reach it, and neither is exotic. One is a target the document does not
+contain, which a selection leaves behind. The other is a label the document
+declares TWICE: relations share one namespace per schema, so a realm-scoped
+inspect of a database with a view named `v` in two schemas declares `view "v"`
+twice, and no reference names one of them in particular.
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL" --schema public --schema other
+view "v" {
+  schema = schema.other
+  as = " SELECT id\n   FROM other.t;"
+}
+
+view "v" {
+  as = " SELECT id\n   FROM t;"
+}
+
+permission {
+  to = role.app_user
+  for = "other.v"
+  privileges = ["SELECT"]
+}
+```
+
+A block is named by its labels, so there is no traversal left that both resolves
+and carries the schema: the community binary refuses `for = table.other.v` and
+`for = view.other.v` alike with `This object does not have an attribute named
+"other"`, and reads `for = "other.v"` at exit 0. The short `for = view.v` does
+evaluate there and is still wrong — it means neither of the two blocks, and
+reading it back would drop the schema for good. Ptah reads the quoted form back
+to the same target, so applying that document issues `GRANT SELECT ON TABLE
+"other"."v"`.
 
 ### Select what is inspected with `--include`
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -527,11 +527,14 @@ rather than a flag because `ptah-compat`'s flag surface is held to parity with
 the pinned binary; see
 [Compatibility never costs you a capability](../overview/#compatibility-never-costs-you-a-capability).
 
-### Every reference the document writes resolves inside it
+### Three rules a `permission` block is written by
 
-Inspected output is written so that it evaluates as HCL on its own, whatever
-the selection left behind. Two rules follow from that, and both are visible
-when a filter removes something a `permission` block still points at.
+Each of these is a rule about one position, measured against the pinned Atlas
+community binary on the document `ptah-compat schema inspect` writes. They are
+not a promise that every reference in every document resolves — a sequence block
+is still refused whatever the reference naming it says, and
+[the blocks left out by default](#blocks-the-compatibility-surface-leaves-out-by-default)
+names the shapes that binary cannot read at all.
 
 A schema is declared whenever anything in the document references one. That
 includes a document with no tables at all: every PostgreSQL database carries
@@ -559,6 +562,32 @@ grant, and applying that document issues `GRANT SELECT ON TABLE "public"."users"
 TO "app_user"` — so nothing is lost by the quoted form, while a reference to a
 block the document does not contain would cost the whole file: the pinned Atlas
 community binary refuses it with `There is no variable named "role"`.
+
+A target names the kind of block the document declares for it. PostgreSQL
+reports the owner's implicit privileges on a view exactly as it does on a table,
+so a database with a view in it produces `permission` blocks for the view too,
+and those say `for = view.<name>`:
+
+```console
+$ ptah-compat schema inspect --url "$PG_URL"
+view "v" {
+  as = " SELECT id\n   FROM t;"
+}
+
+permission {
+  to = role.app_user
+  for = view.v
+  privileges = ["SELECT"]
+}
+```
+
+A reference in HCL names a block, and the block type is the first word of it, so
+`table.v` reads as "the `v` attribute of the table object" and the community
+binary refuses the file with `This object does not have an attribute named "v"`.
+A materialized view is `materialized.<name>` for the same reason, and a name the
+document declares no block for keeps the spelling the position implies. The same
+rule applies to a `trigger`'s `on`, which reaches a view whenever the database
+has an `INSTEAD OF` trigger.
 
 ### Select what is inspected with `--include`
 

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -170,10 +170,12 @@ it and the plan that follows removes the object, which is what you asked for.
 The compatibility surface, which does leave blocks out, says so in the document;
 see [The document says what it does not describe](../../atlas/schema-commands/#the-document-says-what-it-does-not-describe).
 
-What both commands share is that the document evaluates on its own: a schema is
-declared whenever anything references one, and a grantee is written as a
-`role.<name>` reference only where the document declares that role block. See
-[Every reference the document writes resolves inside it](../../atlas/schema-commands/#every-reference-the-document-writes-resolves-inside-it).
+Both commands write a `permission` block by the same three rules: a schema is
+declared whenever anything references one, a grantee is a `role.<name>`
+reference only where the document declares that role block, and a target names
+the kind of block the document declares for it — `view.<name>` for a view,
+`materialized.<name>` for a materialized view. See
+[Three rules a permission block is written by](../../atlas/schema-commands/#three-rules-a-permission-block-is-written-by).
 
 `--format sql` and `--format json` select SQL and JSON output. `--schemas`,
 `--include`, and `--exclude` select what is inspected, in that order:

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -170,6 +170,11 @@ it and the plan that follows removes the object, which is what you asked for.
 The compatibility surface, which does leave blocks out, says so in the document;
 see [The document says what it does not describe](../../atlas/schema-commands/#the-document-says-what-it-does-not-describe).
 
+What both commands share is that the document evaluates on its own: a schema is
+declared whenever anything references one, and a grantee is written as a
+`role.<name>` reference only where the document declares that role block. See
+[Every reference the document writes resolves inside it](../../atlas/schema-commands/#every-reference-the-document-writes-resolves-inside-it).
+
 `--format sql` and `--format json` select SQL and JSON output. `--schemas`,
 `--include`, and `--exclude` select what is inspected, in that order:
 `--schemas` names the database schemas, `--include` picks top-level resources

--- a/integration/gonative/schema_boundary_guard_postgres_test.go
+++ b/integration/gonative/schema_boundary_guard_postgres_test.go
@@ -30,6 +30,15 @@
 // re-measured unchanged on 4c4a8a1d, after #1277 and #1278 landed -- #1277 in
 // particular renames a qualified HCL table reference, which is the same defect
 // class as the grant churn pinned below, and it does not move any row here.
+//
+// #1234 moved two rows, and only the two that had no table in them: an inspected
+// document now declares the schema blocks its own body referenced instead of
+// predicting them from the tables it was given, so the two fixtures with nothing
+// to predict from stopped being the exception. Both were re-measured on live
+// PostgreSQL 17.10 with the document put to the pinned Atlas community binary
+// v1.3.0 -- exit 1 `There is no variable named "schema"` before, exit 0 after.
+// Every other row's values are unchanged, which is the claim that the common
+// path did not move.
 
 package gonative_test
 
@@ -192,16 +201,29 @@ func boundaryCases() []boundaryCase {
 			name: "extension_nothing_references",
 			seed: []string{"CREATE EXTENSION pgcrypto"},
 
-			// CORRECT: a database with no tables declares no schema.
-			wantDescribedSchemas: nil,
+			// CORRECT and must stay correct. This row used to read nil, on the
+			// reasoning that a database with no tables declares no schema, and
+			// #1234 showed that reasoning was answering the wrong question.
+			// EVERY PostgreSQL database carries `GRANT USAGE ON SCHEMA public TO
+			// PUBLIC`, so even a database with no tables inspects to a
+			// `permission` block whose `for = schema.public` is a reference. A
+			// document that carries the reference and not the block is
+			// unreadable: measured on the pinned Atlas community binary v1.3.0
+			// against this exact document, exit 1 with `There is no variable
+			// named "schema"` before #1234 and exit 0 after it. What a document
+			// declares is now collected from what it referenced, so the
+			// declaration cannot go missing again.
+			wantDescribedSchemas: []string{"public"},
 			// WRONG (#1276): must become []string{"public"} -- the reader did
 			// read `public`, it just does not say so.
 			wantReadSchemas: nil,
 
-			// CORRECT: property 1 holds here. The native surface omits
-			// nothing, so its document names pgcrypto and the round trip is
-			// clean. The damage is only visible in the plan below.
-			wantDocumentOnly: nil,
+			// WRONG (#1276): must become empty, and for the same reason as every
+			// other row -- the reader reports no schemas while the document
+			// declares the one it references. The extension itself is on neither
+			// side of this difference, which is #1274 holding; the damage this
+			// row exists for is in the plan below.
+			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
 			// CORRECT: the native document declares the extension, so applying
@@ -256,13 +278,18 @@ func boundaryCases() []boundaryCase {
 			// may be planned against a database with nothing in it.
 			name: "empty_database",
 
-			// CORRECT.
-			wantDescribedSchemas: nil,
+			// CORRECT and must stay correct, for the reason spelled out on
+			// `extension_nothing_references` above: the grant every PostgreSQL
+			// database has is a reference to `public`, and #1234 made the
+			// document declare what it references. This is the smallest instance
+			// of that defect -- there is no table here to predict a schema from,
+			// which is how a rule that predicted rather than collected missed it.
+			wantDescribedSchemas: []string{"public"},
 			// WRONG (#1276): must become []string{"public"}.
 			wantReadSchemas: nil,
 
-			// CORRECT: property 1 holds.
-			wantDocumentOnly: nil,
+			// WRONG (#1276): must become empty, as on every other row.
+			wantDocumentOnly: []string{"schema:public"},
 			wantDatabaseOnly: nil,
 
 			// CORRECT: property 2 holds on both surfaces.

--- a/internal/atlashcl/atlashcl_test.go
+++ b/internal/atlashcl/atlashcl_test.go
@@ -1438,7 +1438,7 @@ permission {
   for        = function.get_tenant
   privileges = [EXECUTE]
 }`,
-			match: `.*permission requires table, schema, or sequence target.*`,
+			match: `.*permission requires table, view, schema, or sequence target.*`,
 		},
 		{
 			name: "permission missing privileges",

--- a/internal/atlashcl/document_table_refs.go
+++ b/internal/atlashcl/document_table_refs.go
@@ -119,20 +119,32 @@ func (p *parser) qualifyFromRelationBlock(name string) string {
 // relationBlockSchema is the schema carried by the single view, materialized
 // view or sequence block this document declares under a label, and empty where
 // there is not exactly one.
+//
+// EVERY declaration under the label is counted, including the ones carrying no
+// schema of their own, and that is what makes "exactly one" mean what it says. A
+// block with no schema is not a block that is absent -- it is the one in the
+// schema being read, so a document declaring `view "v"` and `view "v"` in
+// `other` declares the label TWICE and resolves neither. Counting only the
+// qualified ones made that document look unambiguous and moved the bare
+// reference into `other`, where Deduplicate then merged it with the grant that
+// really was on `other.v` and one of the two grants disappeared.
+//
+// A single declaration carrying no schema still restores nothing, because there
+// is nothing to restore: the empty entry falls through the caller's own check.
 func relationBlockSchema(db *goschema.Database, label string) string {
 	var found []string
 	for _, view := range db.Views {
-		if ref, ok := tableref.Parse(view.Name); ok && ref.Qualified && ref.Name == label {
+		if ref, ok := tableref.Parse(view.Name); ok && ref.Name == label {
 			found = append(found, ref.Schema)
 		}
 	}
 	for _, view := range db.MaterializedViews {
-		if ref, ok := tableref.Parse(view.Name); ok && ref.Qualified && ref.Name == label {
+		if ref, ok := tableref.Parse(view.Name); ok && ref.Name == label {
 			found = append(found, ref.Schema)
 		}
 	}
 	for _, sequence := range db.Sequences {
-		if sequence.Name == label && sequence.Schema != "" {
+		if sequence.Name == label {
 			found = append(found, sequence.Schema)
 		}
 	}

--- a/internal/atlashcl/document_table_refs.go
+++ b/internal/atlashcl/document_table_refs.go
@@ -45,6 +45,13 @@ type pendingForeignRef struct {
 //     the shape it emits most.
 //   - A `data` block's table, whose schema goschema.Finalize never touches and
 //     whose block has no owning table to supply one.
+//   - A `permission` target or a `trigger`'s `on` naming a VIEW, a MATERIALIZED
+//     view or a SEQUENCE. Finalize reads a grant's or a trigger's schema off a
+//     TABLE block and does nothing for these, by the note at the end of
+//     goschema.Finalize, so the schema the short form drops would be dropped for
+//     good. The renderer only writes the short form where the document declares
+//     the block, so the block is right there to read it back off
+//     (stokaro/ptah#1234).
 //
 // An ambiguous name is left exactly as written, matching what goschema and
 // [tablelookup.ResolveReference] both do with one: two tables of a name in
@@ -70,6 +77,69 @@ func (p *parser) resolveDocumentTableRefs() {
 		data.Schema = ref.Schema
 		data.Table = ref.Name
 	}
+	for i := range p.db.Grants {
+		grant := &p.db.Grants[i]
+		grant.OnTable = p.qualifyFromRelationBlock(grant.OnTable)
+		grant.OnSequence = p.qualifyFromRelationBlock(grant.OnSequence)
+	}
+	for i := range p.db.Triggers {
+		trigger := &p.db.Triggers[i]
+		trigger.Table = p.qualifyFromRelationBlock(trigger.Table)
+	}
+}
+
+// qualifyFromRelationBlock writes back the schema of the `view`, `materialized`
+// or `sequence` block a bare relation reference names.
+//
+// It answers only for a name no TABLE block claims, so it can never disagree
+// with the resolution goschema.Finalize does for those: a relation name belongs
+// to one namespace per schema, and where a table block carries the label the
+// table path already restores whatever there is to restore.
+//
+// A block that declares no schema of its own restores nothing, which keeps a
+// single-schema document exactly as it was written -- a bare name there is bare
+// because there was never a schema on it, not because a spelling dropped one.
+func (p *parser) qualifyFromRelationBlock(name string) string {
+	ref, ok := tableref.Parse(name)
+	if !ok || ref.Qualified {
+		return name
+	}
+	for _, table := range p.db.Tables {
+		if table.Name == ref.Name {
+			return name
+		}
+	}
+	schema := relationBlockSchema(p.db, ref.Name)
+	if schema == "" {
+		return name
+	}
+	return tableref.Canonical(schema, ref.Name)
+}
+
+// relationBlockSchema is the schema carried by the single view, materialized
+// view or sequence block this document declares under a label, and empty where
+// there is not exactly one.
+func relationBlockSchema(db *goschema.Database, label string) string {
+	var found []string
+	for _, view := range db.Views {
+		if ref, ok := tableref.Parse(view.Name); ok && ref.Qualified && ref.Name == label {
+			found = append(found, ref.Schema)
+		}
+	}
+	for _, view := range db.MaterializedViews {
+		if ref, ok := tableref.Parse(view.Name); ok && ref.Qualified && ref.Name == label {
+			found = append(found, ref.Schema)
+		}
+	}
+	for _, sequence := range db.Sequences {
+		if sequence.Name == label && sequence.Schema != "" {
+			found = append(found, sequence.Schema)
+		}
+	}
+	if len(found) != 1 {
+		return ""
+	}
+	return found[0]
 }
 
 // resolveDocumentTableName reads the schema of an unqualified table reference

--- a/internal/atlashcl/objects.go
+++ b/internal/atlashcl/objects.go
@@ -164,7 +164,7 @@ func (p *parser) parseTrigger(block *hclsyntax.Block) error {
 	if err != nil {
 		return err
 	}
-	table := objectRefName(p.optionalRawExpr(block.Body.Attributes["on"]), "table")
+	table := relationRefName(p.optionalRawExpr(block.Body.Attributes["on"]))
 	if table == "" {
 		return p.blockError(block, "trigger %q requires on", name)
 	}
@@ -367,14 +367,14 @@ func (p *parser) parsePermission(block *hclsyntax.Block) error {
 		return err
 	}
 	grant.WithOption = grantable
-	if table := objectRefName(target, "table"); table != "" {
+	if table := relationRefName(target); table != "" {
 		grant.OnTable = table
 	} else if schema := objectRefName(target, "schema"); schema != "" {
 		grant.OnSchema = schema
 	} else if sequence := objectRefName(target, "sequence"); sequence != "" {
 		grant.OnSequence = sequence
 	} else {
-		return p.blockError(block, "permission requires table, schema, or sequence target")
+		return p.blockError(block, "permission requires table, view, schema, or sequence target")
 	}
 	if grant.Role == "" {
 		return p.blockError(block, "permission requires to")
@@ -667,6 +667,29 @@ func (p *parser) boolAttr(block *hclsyntax.Block, name, label string, fallback b
 		return false, p.blockError(block, "%s attribute %q must be a bool", label, name)
 	}
 	return value.True(), nil
+}
+
+// relationRefName reads the object name out of a reference written from a
+// position that can name any relation -- a `permission` target, a `trigger`'s
+// `on`.
+//
+// A reference in HCL names a block, so the block TYPE is part of the spelling
+// and a grant on a view is `for = view.<name>`: the renderer picks the word
+// from what the document declares, and this reads back every word it can pick.
+// Without that, Ptah could not read its own output for any database carrying a
+// view, which is the failure TestRenderedPermissionRoundTrips exists to catch.
+//
+// The name is the only thing kept. Which relation kind it was is already in the
+// document, in the block that declares it, and goschema keeps a grant's target
+// in Grant.OnTable whatever kind of relation it is -- so this returns a name and
+// not a kind on purpose.
+func relationRefName(raw string) string {
+	for _, kind := range []string{"table", "view", "materialized"} {
+		if name := objectRefName(raw, kind); name != "" {
+			return name
+		}
+	}
+	return ""
 }
 
 func objectRefName(raw, kind string) string {

--- a/internal/atlashcl/permission_sequence_test.go
+++ b/internal/atlashcl/permission_sequence_test.go
@@ -44,15 +44,66 @@ permission {
 	c.Assert(db.Grants[0].OnSequence, qt.Equals, "app.order_seq")
 }
 
+// TestParsePermissionRelationTargets pins that a permission naming a view or a
+// materialized view is read back to the same grant as one naming a table
+// (stokaro/ptah#1234).
+//
+// A reference in HCL names a BLOCK, so the block type is part of the spelling
+// and a grant on a view has to be written `for = view.<name>` -- the pinned
+// Atlas community binary v1.3.0 refuses `for = table.<view>` with
+// `This object does not have an attribute named "<view>"`, measured on the
+// document `ptah-compat schema inspect` writes for an ordinary PostgreSQL
+// database carrying a view. This side is what keeps that from costing Ptah the
+// ability to read its own output.
+//
+// Grant.OnTable stays the home for all three: which relation kind it is, is in
+// the document, in the block that declares it.
+func TestParsePermissionRelationTargets(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{name: "a table", target: "table.reporting", want: "reporting"},
+		{name: "a view", target: "view.reporting", want: "reporting"},
+		{name: "a materialized view", target: "materialized.reporting", want: "reporting"},
+		{name: "a schema-qualified view", target: "view.app.reporting", want: "app.reporting"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db, err := atlashcl.Parse([]byte(`
+permission {
+  to         = role.app_user
+  for        = `+test.target+`
+  privileges = [SELECT]
+}
+`), "schema.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(db.Grants, qt.HasLen, 1)
+			c.Assert(db.Grants[0].OnTable, qt.Equals, test.want)
+			c.Assert(db.Grants[0].OnSchema, qt.Equals, "")
+			c.Assert(db.Grants[0].OnSequence, qt.Equals, "")
+		})
+	}
+}
+
+// TestParsePermissionRejectsUnknownTargetKind is the control for the row above:
+// widening the accepted block types is only safe if a block type Ptah does not
+// model is still refused, rather than every traversal being taken as a name.
 func TestParsePermissionRejectsUnknownTargetKind(t *testing.T) {
 	c := qt.New(t)
 
 	_, err := atlashcl.Parse([]byte(`
 permission {
   to         = role.app_user
-  for        = view.reporting
+  for        = wibble.reporting
   privileges = [SELECT]
 }
 `), "schema.hcl")
-	c.Assert(err, qt.ErrorMatches, `.*permission requires table, schema, or sequence target.*`)
+	c.Assert(err, qt.ErrorMatches, `.*permission requires table, view, schema, or sequence target.*`)
 }

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -13,14 +13,17 @@ import (
 )
 
 // Top-level HCL block spellings an inspected render can emit. Only the ones a
-// refusal list or a diagnostic names are constants: the token has to be spelled
-// identically by the renderer, by [atlasRefusedBlockTypes], and by the
-// conformance run that re-measures that list against the binary, and three
-// string literals drift where one constant cannot.
+// refusal list, a diagnostic, or a reference names are constants: the token has
+// to be spelled identically by the renderer, by [atlasRefusedBlockTypes], by
+// [renderer.documentDeclares], and by the conformance runs that re-measure both
+// against the binary, and string literals drift where one constant cannot.
 const (
-	blockExtension = "extension"
-	blockPolicy    = "policy"
-	blockSequence  = "sequence"
+	blockExtension    = "extension"
+	blockPolicy       = "policy"
+	blockSequence     = "sequence"
+	blockTable        = "table"
+	blockView         = "view"
+	blockMaterialized = "materialized"
 )
 
 // KeepAtlasRefusedBlocksEnvVar restores the full set of blocks Ptah models on
@@ -199,7 +202,11 @@ func (r *renderer) renderCoverageHeader() {
 // not a name at all.
 func (r *renderer) omitRefusedBlock(path, block string, names ...string) bool {
 	return r.omitRefused(path, block, func() blockDependency {
-		if !r.documentNamesAny(names) {
+		// Asked through [renderer.omitsRefusedBlock] rather than of
+		// [renderer.documentNamesAny] directly, so that this decision and the one
+		// [renderer.documentDeclares] makes about a reference to the same block
+		// are one rule with one caller each, not two copies that can drift.
+		if r.omitsRefusedBlock(block, names...) {
 			return blockDependency{}
 		}
 		return blockDependency{
@@ -326,6 +333,27 @@ func (r *renderer) omitRefused(path, block string, dependency func() blockDepend
 		r.dialect, block, KeepAtlasRefusedBlocksEnvVar,
 	))
 	return true
+}
+
+// omitsRefusedBlock is the DECISION [renderer.omitRefusedBlock] reports, with
+// no diagnostic attached, so a second caller can ask the same question without
+// telling the operator twice.
+//
+// [renderer.documentDeclares] is that second caller: what a reference is
+// allowed to name is exactly what the document ends up declaring, and a
+// suppressed block declares nothing. Both go through here rather than each
+// carrying its own copy of the rule, because a `permission` naming a sequence
+// this render left out is the dangling reference the suppression exists to
+// avoid, arriving from the other side.
+//
+// An extension is not asked here. [renderer.omitRefusedExtension] can keep a
+// block for a reason no name in the document carries, and nothing references an
+// extension block by traversal, so a second caller has nothing to ask about it.
+func (r *renderer) omitsRefusedBlock(block string, names ...string) bool {
+	if !r.omitAtlasRefusedBlocks || !atlasRefusesBlock(r.dialect, block) {
+		return false
+	}
+	return !r.documentNamesAny(names)
 }
 
 // documentRequiresExtension reports whether an object the surviving document

--- a/internal/atlashclrender/inspected_document_oracle_internal_test.go
+++ b/internal/atlashclrender/inspected_document_oracle_internal_test.go
@@ -1,0 +1,247 @@
+package atlashclrender
+
+// White-box testing required: this run reuses the oracle harness the other
+// conformance runs in this package define -- oracleVersion, requireTypeOracle,
+// requireDevURL, schemaNameByDialect, and runReferenceOracle, which writes one
+// document to a temp file and returns the binary's output and exit status. A
+// private copy would drift from the pinned version constant, and the whole value
+// of these runs is that they measure the SAME build.
+
+import (
+	"fmt"
+	"maps"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// TestOracleReadsTheInspectedDocumentPtahRenders puts a WHOLE inspected
+// document to the pinned community binary, which is what stokaro/ptah#1234
+// asks for: the column-type half of that issue is measured one column at a
+// time by TestOracleModeledColumnTypesMatchTheBinary, and the two halves left
+// -- a `permission` body that does not evaluate, and a `schema.<name>`
+// reference nothing declares -- are properties of the file as a whole and
+// cannot be seen in one attribute.
+//
+// Each document is rendered through RenderInspectedForAtlasCLI, the entry point
+// `ptah-compat schema inspect` calls, so what is measured is the output a user
+// gets rather than a fixture written to agree with it.
+//
+// The `unreadable` rows are what make the `rendered` row a measurement. Each is
+// produced FROM the accepted document by one textual substitution, so nothing
+// else differs between the pair, and each asserts the binary's MESSAGE and not
+// merely a non-zero status: a document refused for an unrelated reason would
+// otherwise look like confirmation and this run would keep passing after it had
+// stopped measuring anything. Every substitution is asserted to have changed the
+// text, so a spelling that stopped being emitted fails the run instead of
+// silently mutating nothing.
+//
+// The second document is the one no prediction reaches. Every PostgreSQL
+// database carries `GRANT USAGE ON SCHEMA public TO PUBLIC`, so an EMPTY
+// database renders exactly it -- a `permission` block referencing a schema, with
+// no table anywhere to declare that schema from.
+func TestOracleReadsTheInspectedDocumentPtahRenders(t *testing.T) {
+	oracle := requireTypeOracle(t)
+
+	for _, dialect := range slices.Sorted(maps.Keys(schemaNameByDialect)) {
+		t.Run(dialect, func(t *testing.T) {
+			devURL := requireDevURL(t, dialect)
+			schema := schemaNameByDialect[dialect]
+
+			for _, document := range inspectedOracleDocuments {
+				t.Run(document.name, func(t *testing.T) {
+					c := qt.New(t)
+
+					result, err := RenderInspectedForAtlasCLI(document.db(schema), dialect, schema)
+					c.Assert(err, qt.IsNil)
+					rendered := string(result.Data)
+					for _, want := range document.wantContains(schema) {
+						c.Assert(rendered, qt.Contains, want,
+							qt.Commentf("the document no longer carries the spelling this row measures:\n%s", rendered))
+					}
+
+					t.Run("rendered", func(t *testing.T) {
+						c := qt.New(t)
+
+						out, code := runReferenceOracle(c, oracle, devURL, rendered)
+
+						c.Assert(code, qt.Equals, 0,
+							qt.Commentf("the binary refuses the document ptah-compat renders on %s: %s\n%s",
+								dialect, out, rendered))
+					})
+
+					for _, mutation := range document.unreadable(schema) {
+						t.Run("unreadable/"+mutation.name, func(t *testing.T) {
+							c := qt.New(t)
+
+							mutated := strings.Replace(rendered, mutation.from, mutation.to, 1)
+							c.Assert(mutated, qt.Not(qt.Equals), rendered,
+								qt.Commentf("substituting %q changed nothing, so this row measures nothing", mutation.from))
+
+							out, code := runReferenceOracle(c, oracle, devURL, mutated)
+
+							c.Assert(code, qt.Not(qt.Equals), 0,
+								qt.Commentf("the binary now reads %s on %s; the rule this row guards can go: %s",
+									mutation.name, dialect, out))
+							c.Assert(out, qt.Contains, mutation.wantMessage,
+								qt.Commentf("refused for a reason that is not %s, so this row is not measuring it: %s",
+									mutation.name, out))
+						})
+					}
+				})
+			}
+		})
+	}
+}
+
+// inspectedOracleMutation is one operand varied against the accepted document.
+type inspectedOracleMutation struct {
+	name        string
+	from        string
+	to          string
+	wantMessage string
+}
+
+// inspectedOracleDocuments are the inspected shapes put to the binary whole.
+var inspectedOracleDocuments = []struct {
+	name string
+	db   func(schema string) *goschema.Database
+	// wantContains are the spellings this document exists to measure. They are
+	// asserted before the binary runs, so a render that stopped emitting one
+	// fails here rather than passing an oracle row that no longer covers it.
+	wantContains func(schema string) []string
+	unreadable   func(schema string) []inspectedOracleMutation
+}{
+	{
+		name: "a table with grants",
+		db:   inspectedOracleTableDocument,
+		wantContains: func(schema string) []string {
+			return []string{
+				fmt.Sprintf("schema %q {\n}\n", schema),
+				"  schema = schema." + schema + "\n",
+				"  to = \"PUBLIC\"\n",
+				"  privileges = [\"USAGE\"]\n",
+				"  to = role.app\n",
+				"  to = \"reporting\"\n",
+			}
+		},
+		unreadable: func(schema string) []inspectedOracleMutation {
+			return []inspectedOracleMutation{
+				{
+					name:        "a schema reference with no block",
+					from:        fmt.Sprintf("schema %q {\n}\n\n", schema),
+					to:          "",
+					wantMessage: `There is no variable named "schema"`,
+				},
+				{
+					// The document declares `role "app"`, so `role` resolves to
+					// an object and the missing label is reported as a missing
+					// attribute of it. The other spelling of the same defect --
+					// no role block anywhere, which is what excluding roles
+					// leaves -- is the third document below.
+					name:        "a grantee reference to a role this document does not declare",
+					from:        "to = \"reporting\"",
+					to:          "to = role.reporting",
+					wantMessage: `This object does not have an attribute named "reporting"`,
+				},
+				{
+					name:        "PUBLIC written bare",
+					from:        "to = \"PUBLIC\"",
+					to:          "to = PUBLIC",
+					wantMessage: `There is no variable named "PUBLIC"`,
+				},
+				{
+					name:        "a privilege written bare",
+					from:        "privileges = [\"USAGE\"]",
+					to:          "privileges = [USAGE]",
+					wantMessage: `There is no variable named "USAGE"`,
+				},
+			}
+		},
+	},
+	{
+		// What `ptah-compat schema inspect --exclude '*[type=role]'` renders:
+		// the role blocks are gone and every grant to them is still here,
+		// because a grant is a child of the object granted on rather than of the
+		// grantee. This is the shape the `role` traversal used to be written in
+		// unconditionally, and the one the pinned binary answered with
+		// `There is no variable named "role"`.
+		name: "a table whose roles were excluded",
+		db: func(schema string) *goschema.Database {
+			db := inspectedOracleTableDocument(schema)
+			db.Roles = nil
+			return db
+		},
+		wantContains: func(_ string) []string {
+			return []string{"  to = \"app\"\n", "  to = \"reporting\"\n"}
+		},
+		unreadable: func(_ string) []inspectedOracleMutation {
+			return []inspectedOracleMutation{
+				{
+					name:        "a grantee reference with no role block anywhere",
+					from:        "to = \"app\"",
+					to:          "to = role.app",
+					wantMessage: `There is no variable named "role"`,
+				},
+			}
+		},
+	},
+	{
+		name: "nothing but the grant every database has",
+		db:   inspectedOracleGrantOnlyDocument,
+		wantContains: func(schema string) []string {
+			return []string{
+				fmt.Sprintf("schema %q {\n}\n", schema),
+				"  for = schema." + schema + "\n",
+			}
+		},
+		unreadable: func(schema string) []inspectedOracleMutation {
+			return []inspectedOracleMutation{
+				{
+					name:        "a schema reference with no block",
+					from:        fmt.Sprintf("schema %q {\n}\n\n", schema),
+					to:          "",
+					wantMessage: `There is no variable named "schema"`,
+				},
+			}
+		},
+	},
+}
+
+// inspectedOracleTableDocument is the IR a database read produces for a table
+// carrying the three grantee shapes that reach a `permission` body.
+//
+// Nothing declares a schema, which is what a catalog reports: the engine treats
+// the read's own schema as implicit and does not repeat it. `reporting` is a
+// grantee with no role block, which is what `--exclude '*[type=role]'` leaves
+// behind -- grants are children of the object granted on, so excluding roles
+// removes the blocks and keeps every reference to them.
+func inspectedOracleTableDocument(schema string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{StructName: "T", Name: "t"}},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "id", Type: "integer", Primary: true},
+			{StructName: "T", Name: "name", Type: "varchar(100)"},
+		},
+		Roles: []goschema.Role{{Name: "app"}},
+		Grants: []goschema.Grant{
+			{Role: "PUBLIC", OnSchema: schema, Privileges: []string{"USAGE"}},
+			{Role: "app", OnTable: schema + ".t", Privileges: []string{"SELECT"}, WithOption: true},
+			{Role: "reporting", OnTable: schema + ".t", Privileges: []string{"SELECT"}},
+		},
+	}
+}
+
+// inspectedOracleGrantOnlyDocument is what an empty PostgreSQL database
+// inspects to: one grant on the schema, and nothing else at all.
+func inspectedOracleGrantOnlyDocument(schema string) *goschema.Database {
+	return &goschema.Database{
+		Grants: []goschema.Grant{
+			{Role: "PUBLIC", OnSchema: schema, Privileges: []string{"USAGE"}},
+		},
+	}
+}

--- a/internal/atlashclrender/inspected_document_oracle_internal_test.go
+++ b/internal/atlashclrender/inspected_document_oracle_internal_test.go
@@ -10,6 +10,7 @@ package atlashclrender
 import (
 	"fmt"
 	"maps"
+	"os"
 	"slices"
 	"strings"
 	"testing"
@@ -17,6 +18,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
 )
 
 // TestOracleReadsTheInspectedDocumentPtahRenders puts a WHOLE inspected
@@ -95,6 +97,179 @@ func TestOracleReadsTheInspectedDocumentPtahRenders(t *testing.T) {
 				})
 			}
 		})
+	}
+}
+
+// realmDevURLEnv names the environment variable carrying a REALM-scoped
+// PostgreSQL dev database URL -- one with no `search_path`, so the binary is
+// willing to materialize a document declaring more than one schema.
+//
+// It is separate from PTAH_ATLAS_ORACLE_POSTGRES_DEV_URL because that one is
+// scoped to a single schema on purpose, and a two-schema document put to it is
+// refused with `cannot use HCL with more than 1 schema when dev-url is limited
+// to schema "public"` -- a verdict about the dev URL rather than about the
+// document, which would make the run below pass or fail for the wrong reason.
+// Measured: the binary cleans the realm dev database after each read, so the
+// same URL answers three two-schema reads and a one-schema read in a row, each
+// at exit 0, and leaves only `public` behind.
+const realmDevURLEnv = "PTAH_ATLAS_ORACLE_POSTGRES_REALM_DEV_URL"
+
+// TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders is the same
+// whole-document measurement for the shape a relation LABEL is not unique in.
+//
+// Two schemas each holding a relation of one name is an ordinary PostgreSQL
+// database and a DEFAULT `ptah-compat schema inspect` of a realm-scoped URL, and
+// it is where naming the block the document declares stops being possible: with
+// `view "v"` written twice, no traversal names one of them in particular.
+// Measured on the pinned community binary against the rendered document, one
+// operand varied and nothing else touched:
+//
+//	for = table.other.v  exit 1  Unsupported attribute; ... named "other"
+//	for = view.other.v   exit 1  same message
+//	for = "other.v"      exit 0
+//
+// and `on = table.other.v` / `on = "other.v"` the same pair on the trigger. The
+// short form `view.v` does evaluate there, which is why it is not the answer: it
+// means neither block, and Ptah's own reader drops the schema for a label it
+// finds twice, so the quoted name is the only spelling that survives both ends.
+//
+// PostgreSQL only, and not by preference: the binary refuses a two-schema
+// document on SQLite outright -- `cannot use HCL with more than 1 schema when
+// dev-url is limited to schema "main"` -- so there is no SQLite instance of this
+// shape to measure.
+func TestOracleReadsTheTwoSchemaRelationDocumentPtahRenders(t *testing.T) {
+	oracle := requireTypeOracle(t)
+	devURL := requireRealmDevURL(t)
+	schema := schemaNameByDialect[platform.Postgres]
+
+	result, err := RenderInspectedForAtlasCLI(
+		inspectedOracleTwoSchemaDocument(schema), platform.Postgres, schema)
+	c := qt.New(t)
+	c.Assert(err, qt.IsNil)
+	rendered := string(result.Data)
+	for _, want := range []string{
+		"view \"v\" {\n",
+		"  for = \"" + twoSchemaOracleOther + ".v\"\n",
+		"  for = \"v\"\n",
+		"  on = \"" + twoSchemaOracleOther + ".v\"\n",
+	} {
+		c.Assert(rendered, qt.Contains, want,
+			qt.Commentf("the document no longer carries the spelling this row measures:\n%s", rendered))
+	}
+
+	t.Run("rendered", func(t *testing.T) {
+		c := qt.New(t)
+
+		out, code := runReferenceOracle(c, oracle, devURL, rendered)
+
+		c.Assert(code, qt.Equals, 0,
+			qt.Commentf("the binary refuses the two-schema document ptah-compat renders: %s\n%s", out, rendered))
+	})
+
+	for _, mutation := range twoSchemaOracleMutations() {
+		t.Run("unreadable/"+mutation.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			mutated := strings.Replace(rendered, mutation.from, mutation.to, 1)
+			c.Assert(mutated, qt.Not(qt.Equals), rendered,
+				qt.Commentf("substituting %q changed nothing, so this row measures nothing", mutation.from))
+
+			out, code := runReferenceOracle(c, oracle, devURL, mutated)
+
+			c.Assert(code, qt.Not(qt.Equals), 0,
+				qt.Commentf("the binary now reads %s; the rule this row guards can go: %s", mutation.name, out))
+			c.Assert(out, qt.Contains, mutation.wantMessage,
+				qt.Commentf("refused for a reason that is not %s, so this row is not measuring it: %s",
+					mutation.name, out))
+		})
+	}
+}
+
+// requireRealmDevURL returns the realm-scoped dev URL, skipping loudly without
+// one. The Atlas CE Oracle job fails on any SKIPPED line, so an unset variable
+// there is a red job rather than a silently unmeasured shape.
+func requireRealmDevURL(t *testing.T) string {
+	t.Helper()
+
+	url := os.Getenv(realmDevURLEnv)
+	if url == "" {
+		t.Skipf("SKIPPED: set %s to a realm-scoped PostgreSQL dev database (no search_path) to measure the two-schema document",
+			realmDevURLEnv)
+	}
+	return url
+}
+
+// twoSchemaOracleOther is the second schema of the two-schema document. It is
+// not the default one, because the whole point is a label two schemas share.
+const twoSchemaOracleOther = "other"
+
+// twoSchemaOracleMutations are the operands varied against the accepted
+// two-schema document, one substitution each.
+func twoSchemaOracleMutations() []inspectedOracleMutation {
+	return []inspectedOracleMutation{
+		{
+			// The refuted spelling: the field the name arrived on picking the
+			// word, against a document that declares `view "v"` twice.
+			name:        "a grant target named as a qualified table",
+			from:        "for = \"" + twoSchemaOracleOther + ".v\"",
+			to:          "for = table." + twoSchemaOracleOther + ".v",
+			wantMessage: `does not have an attribute named "` + twoSchemaOracleOther + `"`,
+		},
+		{
+			// And the block kind corrected while the traversal is kept, which is
+			// the other thing that looks like a fix and is not: a reference names
+			// a block by its LABELS, so the schema is not addressable either way.
+			name:        "a grant target named as a qualified view",
+			from:        "for = \"" + twoSchemaOracleOther + ".v\"",
+			to:          "for = view." + twoSchemaOracleOther + ".v",
+			wantMessage: `does not have an attribute named "` + twoSchemaOracleOther + `"`,
+		},
+		{
+			name:        "a trigger target named as a qualified table",
+			from:        "on = \"" + twoSchemaOracleOther + ".v\"",
+			to:          "on = table." + twoSchemaOracleOther + ".v",
+			wantMessage: `does not have an attribute named "` + twoSchemaOracleOther + `"`,
+		},
+	}
+}
+
+// inspectedOracleTwoSchemaDocument is the IR a realm-scoped read produces for
+// two schemas each carrying a table `t` and a view `v`, with a grant on each
+// view and a trigger on the one outside the default schema.
+//
+// The grants arrive in Grant.OnTable, which is where a catalog read puts a
+// privilege on a view, and the one in the default schema arrives UNQUALIFIED,
+// which is what a reader does with everything in the schema it is reading. That
+// asymmetry is deliberate: it is the pair that says the rule holds whether or
+// not the name carries a schema.
+func inspectedOracleTwoSchemaDocument(schema string) *goschema.Database {
+	return &goschema.Database{
+		Schemas: []goschema.Schema{{Name: schema}, {Name: twoSchemaOracleOther}},
+		Tables: []goschema.Table{
+			{StructName: "T", Name: "t", Schema: schema},
+			{StructName: "OtherT", Name: "t", Schema: twoSchemaOracleOther},
+		},
+		Fields: []goschema.Field{
+			{StructName: "T", Name: "id", Type: "integer", Primary: true},
+			{StructName: "OtherT", Name: "id", Type: "integer", Primary: true},
+		},
+		Views: []goschema.View{
+			{Name: "v", Body: "SELECT id FROM t"},
+			{Name: twoSchemaOracleOther + ".v", Body: "SELECT id FROM " + twoSchemaOracleOther + ".t"},
+		},
+		Roles: []goschema.Role{{Name: "app"}},
+		Grants: []goschema.Grant{
+			{Role: "app", OnTable: "v", Privileges: []string{"SELECT"}},
+			{Role: "app", OnTable: twoSchemaOracleOther + ".v", Privileges: []string{"SELECT"}},
+		},
+		Triggers: []goschema.Trigger{{
+			Name:    "v_ins",
+			Table:   twoSchemaOracleOther + ".v",
+			Timing:  "INSTEAD OF",
+			Event:   "INSERT",
+			ForEach: "ROW",
+			Body:    "SELECT 1",
+		}},
 	}
 }
 

--- a/internal/atlashclrender/inspected_document_oracle_internal_test.go
+++ b/internal/atlashclrender/inspected_document_oracle_internal_test.go
@@ -191,6 +191,39 @@ var inspectedOracleDocuments = []struct {
 		},
 	},
 	{
+		// What `ptah-compat schema inspect` renders for a database carrying a
+		// VIEW, with no selection and no hand-editing: PostgreSQL reports the
+		// owner's implicit privileges on a view exactly as it does on a table,
+		// so the grant arrives in Grant.OnTable and the target used to be
+		// written `for = table.v` against a document declaring `view "v"`.
+		//
+		// This is the reachable instance the other three miss. They are all
+		// documents a filter left behind; this one is the DEFAULT invocation on
+		// an ordinary database.
+		name: "a table and a view with grants on both",
+		db:   inspectedOracleViewDocument,
+		wantContains: func(_ string) []string {
+			return []string{"view \"v\" {\n", "  for = table.t\n", "  for = view.v\n"}
+		},
+		unreadable: func(_ string) []inspectedOracleMutation {
+			return []inspectedOracleMutation{
+				{
+					// The whole refutation of the first version of this fix, as
+					// one substitution: the block type is part of the spelling,
+					// so naming a view under `table` resolves to nothing. The
+					// document declares `table "t"`, so `table` is an object and
+					// the missing label is reported as a missing attribute of
+					// it -- the same message the sibling rows use, for the same
+					// reason.
+					name:        "a view named as a table",
+					from:        "for = view.v",
+					to:          "for = table.v",
+					wantMessage: `This object does not have an attribute named "v"`,
+				},
+			}
+		},
+	},
+	{
 		name: "nothing but the grant every database has",
 		db:   inspectedOracleGrantOnlyDocument,
 		wantContains: func(schema string) []string {
@@ -234,6 +267,22 @@ func inspectedOracleTableDocument(schema string) *goschema.Database {
 			{Role: "reporting", OnTable: schema + ".t", Privileges: []string{"SELECT"}},
 		},
 	}
+}
+
+// inspectedOracleViewDocument adds a view, and a grant on it, to the same IR.
+//
+// The grant is in OnTable and unqualified, which is what a read produces: the
+// catalog reports privileges on a view through the same table-grant path, and
+// the reader drops the schema of everything in the read's own schema. So the
+// renderer cannot learn the block type from the IR field or from the name -- it
+// has to read it off the block the document declares.
+func inspectedOracleViewDocument(schema string) *goschema.Database {
+	db := inspectedOracleTableDocument(schema)
+	db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+	db.Grants = append(db.Grants, goschema.Grant{
+		Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+	})
+	return db
 }
 
 // inspectedOracleGrantOnlyDocument is what an empty PostgreSQL database

--- a/internal/atlashclrender/inspected_schema_test.go
+++ b/internal/atlashclrender/inspected_schema_test.go
@@ -1,6 +1,7 @@
 package atlashclrender_test
 
 import (
+	"slices"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -382,8 +383,13 @@ func TestRenderedPermissionRoundTrips(t *testing.T) {
 // The last two rows are the controls that keep this from being "call anything
 // with a view in the IR a view". A reference is only allowed to name what this
 // render actually WRITES, so a view the render drops is not a block to name,
-// and a name the document declares nothing under keeps the spelling the
-// position implies.
+// and a name the document declares nothing under is not one either. What those
+// two write instead is a QUOTED name, because a traversal to a block that is
+// not there is refused whichever word it starts with -- measured on the same
+// binary, `for = table.gone` at exit 1 `Unsupported attribute; This object does
+// not have an attribute named "gone"` against `for = "gone"` at exit 0, and
+// with no table block in the document at all the same traversal is refused with
+// `Unknown variable; There is no variable named "table"`.
 func TestRenderNamesTheBlockTypeTheDocumentDeclares(t *testing.T) {
 	tests := []struct {
 		name string
@@ -449,7 +455,7 @@ func TestRenderNamesTheBlockTypeTheDocumentDeclares(t *testing.T) {
 				db.Views = []goschema.View{{Name: "v"}}
 				return db
 			},
-			want: []string{"  for = table.v\n"},
+			want: []string{"  for = \"v\"\n"},
 		},
 		{
 			// A read puts a sequence grant in OnTable -- the catalog reports it
@@ -474,13 +480,62 @@ func TestRenderNamesTheBlockTypeTheDocumentDeclares(t *testing.T) {
 			},
 		},
 		{
-			name: "a name the document declares nothing under keeps the table spelling",
+			name: "a name the document declares nothing under is quoted",
 			db: func() *goschema.Database {
 				return relationTargetDocument(goschema.Grant{
 					Role: "app", OnTable: "gone", Privileges: []string{"SELECT"},
 				})
 			},
-			want: []string{"  for = table.gone\n"},
+			want: []string{"  for = \"gone\"\n"},
+		},
+		{
+			// The shape the review of #1303 refuted: two schemas each holding a
+			// relation of one name. The label is declared TWICE, so no traversal
+			// names one of them in particular -- `view.v` evaluates on the pinned
+			// binary and means neither, and Ptah's own reader drops the schema
+			// for a label it finds twice -- while `table.other.v` and
+			// `view.other.v` are both refused with `This object does not have an
+			// attribute named "other"`. `for = "other.v"` is read at exit 0 and
+			// keeps the schema.
+			name: "a label two schemas both declare is a quoted qualified name",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "other.v", Privileges: []string{"SELECT"},
+				})
+				db.Schemas = append(db.Schemas, goschema.Schema{Name: "other"})
+				db.Views = []goschema.View{
+					{Name: "v", Body: "SELECT id FROM t"},
+					{Name: "other.v", Body: "SELECT id FROM other.t"},
+				}
+				db.Grants = append(db.Grants, goschema.Grant{
+					Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+				})
+				return db
+			},
+			want: []string{
+				"  for = \"other.v\"\n",
+				"  for = \"v\"\n",
+			},
+		},
+		{
+			// Same document, the other position that can name a relation.
+			name: "a trigger on a label two schemas both declare is a quoted qualified name",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "t", Privileges: []string{"SELECT"},
+				})
+				db.Schemas = append(db.Schemas, goschema.Schema{Name: "other"})
+				db.Views = []goschema.View{
+					{Name: "v", Body: "SELECT id FROM t"},
+					{Name: "other.v", Body: "SELECT id FROM other.t"},
+				}
+				db.Triggers = []goschema.Trigger{{
+					Name: "v_ins", Table: "other.v", Timing: "INSTEAD OF", Event: "INSERT",
+					ForEach: "ROW", Body: "RETURN NEW;",
+				}}
+				return db
+			},
+			want: []string{"  on = \"other.v\"\n"},
 		},
 		{
 			// The fallback is the position's own guess, and for a sequence
@@ -659,6 +714,63 @@ func TestRenderedRelationTargetKeepsItsSchema(t *testing.T) {
 			c.Assert(parsed.Grants[0].OnTable, qt.Equals, test.wantTarget)
 		})
 	}
+}
+
+// TestRenderedDuplicateRelationLabelRoundTrips is the round trip for the shape
+// no traversal can spell: two schemas each declaring a relation of one name.
+//
+// It is the half that keeps the quoted fallback from being a way to make the
+// pinned binary happy at Ptah's expense. `view.v` would evaluate there and mean
+// neither block, and relationBlockSchema in internal/atlashcl returns nothing
+// for a label it finds twice -- so the short form would come back as a bare `v`
+// and the schema would be gone. The quoted qualified name comes back as written,
+// on both positions that can name a relation, and the grant on the view in the
+// DEFAULT schema is the paired row: it was bare going in and must stay bare, not
+// acquire a schema on the way through.
+func TestRenderedDuplicateRelationLabelRoundTrips(t *testing.T) {
+	c := qt.New(t)
+
+	db := relationTargetDocument(goschema.Grant{
+		Role: "app", OnTable: "other.v", Privileges: []string{"SELECT"},
+	})
+	db.Schemas = append(db.Schemas, goschema.Schema{Name: "other"})
+	db.Views = []goschema.View{
+		{Name: "v", Body: "SELECT id FROM t"},
+		{Name: "other.v", Body: "SELECT id FROM other.t"},
+	}
+	db.Grants = append(db.Grants, goschema.Grant{
+		Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+	})
+	db.Triggers = []goschema.Trigger{{
+		Name: "v_ins", Table: "other.v", Timing: "INSTEAD OF", Event: "INSERT",
+		ForEach: "ROW", Body: "RETURN NEW;",
+	}}
+
+	result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+	c.Assert(err, qt.IsNil)
+	rendered := string(result.Data)
+	c.Assert(rendered, qt.Contains, "  for = \"other.v\"\n", qt.Commentf("rendered HCL:\n%s", rendered))
+	c.Assert(rendered, qt.Contains, "  for = \"v\"\n", qt.Commentf("rendered HCL:\n%s", rendered))
+	c.Assert(rendered, qt.Contains, "  on = \"other.v\"\n", qt.Commentf("rendered HCL:\n%s", rendered))
+
+	parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("rendered HCL:\n%s", rendered))
+	c.Assert(parsed.Grants, qt.HasLen, 2)
+	c.Assert(grantTargets(parsed.Grants), qt.DeepEquals, []string{"other.v", "v"})
+	c.Assert(parsed.Triggers, qt.HasLen, 1)
+	c.Assert(parsed.Triggers[0].Table, qt.Equals, "other.v")
+}
+
+// grantTargets lists the parsed grant targets in a stable order, so the
+// assertion names the same thing however the render ordered the blocks.
+func grantTargets(grants []goschema.Grant) []string {
+	targets := make([]string, 0, len(grants))
+	for _, grant := range grants {
+		targets = append(targets, grant.OnTable)
+	}
+	slices.Sort(targets)
+	return targets
 }
 
 // TestRenderedSequenceTargetKeepsItsSchema is the same restore for the block

--- a/internal/atlashclrender/inspected_schema_test.go
+++ b/internal/atlashclrender/inspected_schema_test.go
@@ -349,6 +349,370 @@ func TestRenderedPermissionRoundTrips(t *testing.T) {
 	}
 }
 
+// TestRenderNamesTheBlockTypeTheDocumentDeclares pins that a reference to a
+// relation spells the block type the same document writes for it
+// (stokaro/ptah#1234).
+//
+// A reference in HCL names a BLOCK, and the block type is the first word of the
+// traversal, so `table.v` reads as "the v attribute of the table object" and
+// resolves to nothing where the document declares `view "v"`. Measured on the
+// pinned Atlas community binary v1.3.0 against the document
+// `ptah-compat schema inspect` writes for
+//
+//	CREATE TABLE t (id integer PRIMARY KEY);
+//	CREATE VIEW v AS SELECT id FROM t;
+//
+// one operand varied and nothing else touched:
+//
+//	for = table.v   exit 1  Unsupported attribute; This object does not have
+//	                        an attribute named "v"
+//	for = view.v    exit 0
+//	for = "v"       exit 0
+//
+// and on a document declaring `materialized "mv"`, the same pair:
+//
+//	for = table.mv         exit 1  ... an attribute named "mv"
+//	for = materialized.mv  exit 0
+//
+// That is the DEFAULT invocation on any database carrying a view, with no
+// selection involved: PostgreSQL reports the owner's implicit privileges on a
+// view exactly as it does on a table, so the grant reaches the renderer in
+// Grant.OnTable and the field cannot be what picks the word.
+//
+// The last two rows are the controls that keep this from being "call anything
+// with a view in the IR a view". A reference is only allowed to name what this
+// render actually WRITES, so a view the render drops is not a block to name,
+// and a name the document declares nothing under keeps the spelling the
+// position implies.
+func TestRenderNamesTheBlockTypeTheDocumentDeclares(t *testing.T) {
+	tests := []struct {
+		name string
+		db   func() *goschema.Database
+		want []string
+	}{
+		{
+			name: "a grant on a table names the table block",
+			db: func() *goschema.Database {
+				return relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "t", Privileges: []string{"SELECT"},
+				})
+			},
+			want: []string{"  for = table.t\n"},
+		},
+		{
+			name: "a grant on a view names the view block",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+				})
+				db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+				return db
+			},
+			want: []string{"view \"v\" {\n", "  for = view.v\n"},
+		},
+		{
+			name: "a grant on a materialized view names the materialized block",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "mv", Privileges: []string{"SELECT"},
+				})
+				db.MaterializedViews = []goschema.MaterializedView{{Name: "mv", Body: "SELECT id FROM t"}}
+				return db
+			},
+			want: []string{"materialized \"mv\" {\n", "  for = materialized.mv\n"},
+		},
+		{
+			// A trigger's target is a relation too: `INSTEAD OF` triggers only
+			// exist on views, and Trigger.Table is where the reader puts one.
+			// Measured on the same binary, `on = table.v` refused with the same
+			// message and `on = view.v` read at exit 0.
+			name: "a trigger on a view names the view block",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "t", Privileges: []string{"SELECT"},
+				})
+				db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+				db.Triggers = []goschema.Trigger{{
+					Name: "v_ins", Table: "v", Timing: "INSTEAD OF", Event: "INSERT",
+					ForEach: "ROW", Body: "RETURN NEW;",
+				}}
+				return db
+			},
+			want: []string{"  on = view.v\n"},
+		},
+		{
+			name: "a view this render drops is not a block to name",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+				})
+				db.Views = []goschema.View{{Name: "v"}}
+				return db
+			},
+			want: []string{"  for = table.v\n"},
+		},
+		{
+			// A read puts a sequence grant in OnTable -- the catalog reports it
+			// through the same table-grant path -- while a Go annotation puts it
+			// in OnSequence. One reference, so one spelling: both name the block
+			// the document declares.
+			name: "a grant on a sequence names the sequence block whichever field it arrived in",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "order_seq", Privileges: []string{"SELECT"},
+				})
+				db.Grants = append(db.Grants, goschema.Grant{
+					Role: "app", OnSequence: "order_seq", Privileges: []string{"USAGE"},
+				})
+				db.Sequences = []goschema.Sequence{{Name: "order_seq"}}
+				return db
+			},
+			want: []string{
+				"sequence \"order_seq\" {\n",
+				"  for = sequence.order_seq\n  privileges = [\"SELECT\"]\n",
+				"  for = sequence.order_seq\n  privileges = [\"USAGE\"]\n",
+			},
+		},
+		{
+			name: "a name the document declares nothing under keeps the table spelling",
+			db: func() *goschema.Database {
+				return relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "gone", Privileges: []string{"SELECT"},
+				})
+			},
+			want: []string{"  for = table.gone\n"},
+		},
+		{
+			// The fallback is the position's own guess, and for a sequence
+			// target that is `sequence`, not `table`. A reference to a block the
+			// document does not declare is unreadable either way, so the one
+			// that says what the object IS is the one to write.
+			name: "a sequence the document declares no block for keeps the sequence spelling",
+			db: func() *goschema.Database {
+				return relationTargetDocument(goschema.Grant{
+					Role: "app", OnSequence: "gone_seq", Privileges: []string{"USAGE"},
+				})
+			},
+			want: []string{"  for = sequence.gone_seq\n"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(test.db(), platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			for _, want := range test.want {
+				c.Assert(string(result.Data), qt.Contains, want)
+			}
+		})
+	}
+}
+
+// TestRenderedRelationTargetRoundTrips pins that Ptah reads back every block
+// type its own renderer can now write into a target position.
+//
+// Without this the change would be measured only against the other binary, and
+// a document Ptah could no longer read would still look like progress -- which
+// is exactly what emitting `view.<name>` without teaching the parser would be.
+func TestRenderedRelationTargetRoundTrips(t *testing.T) {
+	tests := []struct {
+		name   string
+		db     func() *goschema.Database
+		target string
+	}{
+		{
+			// The table target comes back qualified: goschema.Finalize reads a
+			// grant's schema off the table block it names, which is what it has
+			// always done and what the schema restore for the other two block
+			// types is modeled on.
+			name: "a table",
+			db: func() *goschema.Database {
+				return relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "t", Privileges: []string{"SELECT"},
+				})
+			},
+			target: "public.t",
+		},
+		{
+			name: "a view",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "v", Privileges: []string{"SELECT"},
+				})
+				db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+				return db
+			},
+			target: "v",
+		},
+		{
+			name: "a materialized view",
+			db: func() *goschema.Database {
+				db := relationTargetDocument(goschema.Grant{
+					Role: "app", OnTable: "mv", Privileges: []string{"SELECT"},
+				})
+				db.MaterializedViews = []goschema.MaterializedView{{Name: "mv", Body: "SELECT id FROM t"}}
+				return db
+			},
+			target: "mv",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(test.db(), platform.Postgres, "public")
+			c.Assert(err, qt.IsNil)
+
+			parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(parsed.Grants, qt.HasLen, 1)
+			c.Assert(parsed.Grants[0].OnTable, qt.Equals, test.target)
+			c.Assert(parsed.Grants[0].Role, qt.Equals, "app")
+			c.Assert(parsed.Grants[0].Privileges, qt.DeepEquals, []string{"SELECT"})
+		})
+	}
+}
+
+// TestRenderedTriggerOnAViewRoundTrips is the same round trip for the other
+// position that can name one.
+func TestRenderedTriggerOnAViewRoundTrips(t *testing.T) {
+	c := qt.New(t)
+
+	db := relationTargetDocument(goschema.Grant{
+		Role: "app", OnTable: "t", Privileges: []string{"SELECT"},
+	})
+	db.Views = []goschema.View{{Name: "v", Body: "SELECT id FROM t"}}
+	db.Triggers = []goschema.Trigger{{
+		Name: "v_ins", Table: "v", Timing: "INSTEAD OF", Event: "INSERT",
+		ForEach: "ROW", Body: "RETURN NEW;",
+	}}
+
+	result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(result.Data), qt.Contains, "  on = view.v\n")
+
+	parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(parsed.Triggers, qt.HasLen, 1)
+	c.Assert(parsed.Triggers[0].Table, qt.Equals, "v")
+}
+
+// TestRenderedRelationTargetKeepsItsSchema pins that shortening the reference
+// costs nothing on Ptah's own side in a MULTI-SCHEMA document, which is the
+// only place there is a schema to lose.
+//
+// A reference names a block by its labels, so `view.v` is the only spelling the
+// pinned Atlas community binary v1.3.0 reads -- measured on a two-schema
+// PostgreSQL 17 inspect, `for = table.other.v` refused with
+// `This object does not have an attribute named "other"` and `for = view.v`
+// read at exit 0. goschema.Finalize restores a grant's schema off a TABLE block
+// and says in its own closing note that it does nothing for views, so the
+// restore for these lives in the HCL reader beside the other two positions the
+// same note leaves out.
+//
+// The single-schema row is the control: a bare name there was never carrying a
+// schema, and inventing one would change a document the author controls.
+func TestRenderedRelationTargetKeepsItsSchema(t *testing.T) {
+	tests := []struct {
+		name       string
+		viewName   string
+		wantTarget string
+	}{
+		{
+			name:       "a view outside the default schema",
+			viewName:   "other.v",
+			wantTarget: "other.v",
+		},
+		{
+			name:       "a view the document declares no schema for",
+			viewName:   "v",
+			wantTarget: "v",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := relationTargetDocument(goschema.Grant{
+				Role: "app", OnTable: test.wantTarget, Privileges: []string{"SELECT"},
+			})
+			db.Views = []goschema.View{{Name: test.viewName, Body: "SELECT id FROM t"}}
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, "  for = view.v\n")
+
+			parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(parsed.Grants, qt.HasLen, 1)
+			c.Assert(parsed.Grants[0].OnTable, qt.Equals, test.wantTarget)
+		})
+	}
+}
+
+// TestRenderedSequenceTargetKeepsItsSchema is the same restore for the block
+// type a grant reaches through Grant.OnSequence.
+func TestRenderedSequenceTargetKeepsItsSchema(t *testing.T) {
+	tests := []struct {
+		name           string
+		sequenceSchema string
+		wantTarget     string
+	}{
+		{
+			name:           "a sequence outside the default schema",
+			sequenceSchema: "app",
+			wantTarget:     "app.order_seq",
+		},
+		{
+			name:       "a sequence the document declares no schema for",
+			wantTarget: "order_seq",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			db := relationTargetDocument(goschema.Grant{
+				Role: "app", OnSequence: test.wantTarget, Privileges: []string{"USAGE"},
+			})
+			db.Sequences = []goschema.Sequence{{Name: "order_seq", Schema: test.sequenceSchema}}
+
+			result, err := atlashclrender.RenderInspected(db, platform.Postgres, "public")
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(result.Data), qt.Contains, "  for = sequence.order_seq\n")
+
+			parsed, err := atlashcl.Parse(result.Data, "rendered.hcl")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(parsed.Grants, qt.HasLen, 1)
+			c.Assert(parsed.Grants[0].OnSequence, qt.Equals, test.wantTarget)
+		})
+	}
+}
+
+// relationTargetDocument builds the IR a database read produces for one table
+// plus one grant, with no schema anywhere -- which is what a catalog reports
+// for the read's own schema.
+func relationTargetDocument(grant goschema.Grant) *goschema.Database {
+	db := inspectedTable("")
+	db.Roles = []goschema.Role{{Name: "app"}}
+	db.Grants = []goschema.Grant{grant}
+	return db
+}
+
 // inspectedTable builds the IR a database read produces for one table, with the
 // schema the reader reported -- which is nothing at all wherever the engine
 // treats it as implicit.

--- a/internal/atlashclrender/inspected_schema_test.go
+++ b/internal/atlashclrender/inspected_schema_test.go
@@ -145,14 +145,22 @@ func TestRenderForDialectSynthesizesNoSchema(t *testing.T) {
 // so both attributes had to move, and the third row is why quoting only the
 // grantee was not enough.
 //
-// A named role stays a reference: `to = role.app` with the matching `role`
-// block present is measured to evaluate on that binary, so quoting it would
-// lose a reference and buy nothing.
+// A named role stays a reference only where the document declares the matching
+// `role` block. The last two rows are that pair, and they are the half the
+// original fix asserted in prose and never enforced: a `permission` block is a
+// child of the object granted on, so `--exclude '*[type=role]'` takes the role
+// blocks away and leaves every grant to them behind. Measured on the same
+// binary, one operand varied:
+//
+//	role "app" declared, to = role.app   exit 0
+//	role "app" absent,   to = role.app   exit 1  There is no variable named "role"
+//	role "app" absent,   to = "app"      exit 0
 func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
 	tests := []struct {
-		name string
-		role string
-		want string
+		name  string
+		role  string
+		roles []goschema.Role
+		want  string
 	}{
 		{
 			name: "PUBLIC is a quoted string, not a variable",
@@ -165,9 +173,15 @@ func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
 			want: "  to = \"PUBLIC\"\n",
 		},
 		{
-			name: "a named role stays a reference",
+			name:  "a named role the document declares stays a reference",
+			role:  "app",
+			roles: []goschema.Role{{Name: "app"}},
+			want:  "  to = role.app\n",
+		},
+		{
+			name: "a named role the document does not declare is a string",
 			role: "app",
-			want: "  to = role.app\n",
+			want: "  to = \"app\"\n",
 		},
 	}
 
@@ -177,6 +191,7 @@ func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
 			c := qt.New(t)
 
 			db := inspectedTable("public")
+			db.Roles = test.roles
 			db.Grants = []goschema.Grant{{
 				Role:       test.role,
 				OnSchema:   "public",
@@ -192,6 +207,100 @@ func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
 	}
 }
 
+// TestRenderInspectedDeclaresTheSchemaAGrantReferences pins the other half of
+// the same document: the schema blocks are the ones the body turned out to
+// reference, whatever wrote the reference.
+//
+// Every PostgreSQL database carries `GRANT USAGE ON SCHEMA public TO PUBLIC`,
+// so the first row is what an EMPTY database renders as. Its `permission` block
+// says `for = schema.public` with nothing to resolve it to, and the pinned
+// Atlas community binary v1.3.0 refuses the file with `There is no variable
+// named "schema"` -- with no table anywhere to predict the declaration from.
+//
+// The last row is the control that keeps this from being satisfied by
+// declaring the default unconditionally: a document that references no schema
+// declares none, which is what the empty-include-selection contract needs.
+func TestRenderInspectedDeclaresTheSchemaAGrantReferences(t *testing.T) {
+	tests := []struct {
+		name        string
+		db          func() *goschema.Database
+		wantPresent []string
+		wantAbsent  []string
+	}{
+		{
+			name: "a grant on the schema is the only thing referencing it",
+			db: func() *goschema.Database {
+				return &goschema.Database{Grants: []goschema.Grant{{
+					Role:       "PUBLIC",
+					OnSchema:   "public",
+					Privileges: []string{"USAGE"},
+				}}}
+			},
+			wantPresent: []string{"schema \"public\" {\n}\n", "  for = schema.public\n"},
+		},
+		{
+			name: "a table references it as well",
+			db: func() *goschema.Database {
+				db := inspectedTable("")
+				db.Grants = []goschema.Grant{{
+					Role:       "PUBLIC",
+					OnSchema:   "public",
+					Privileges: []string{"USAGE"},
+				}}
+				return db
+			},
+			wantPresent: []string{
+				"schema \"public\" {\n}\n",
+				"  schema = schema.public\n",
+				"  for = schema.public\n",
+			},
+		},
+		{
+			name: "nothing references it",
+			db: func() *goschema.Database {
+				return &goschema.Database{Roles: []goschema.Role{{Name: "app"}}}
+			},
+			wantPresent: []string{"role \"app\" {\n"},
+			wantAbsent:  []string{"schema \"public\"", "schema."},
+		},
+		{
+			// A grant conferring no privilege is dropped with a diagnostic, so
+			// its target reference is never written -- and a schema block
+			// declared for it would be a declaration of nothing.
+			//
+			// The grantee is present on purpose. The completeness check reads
+			// left to right, so a row missing the ROLE would short-circuit
+			// before the target is computed and could not tell whether asking
+			// for the target had declared anything.
+			name: "a grant too incomplete to render",
+			db: func() *goschema.Database {
+				return &goschema.Database{Grants: []goschema.Grant{{
+					Role:     "app",
+					OnSchema: "public",
+				}}}
+			},
+			wantAbsent: []string{"schema \"public\"", "schema.", "permission {"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			result, err := atlashclrender.RenderInspected(test.db(), platform.Postgres, "public")
+
+			c.Assert(err, qt.IsNil)
+			for _, want := range test.wantPresent {
+				c.Assert(string(result.Data), qt.Contains, want)
+			}
+			for _, unwanted := range test.wantAbsent {
+				c.Assert(string(result.Data), qt.Not(qt.Contains), unwanted)
+			}
+		})
+	}
+}
+
 // TestRenderedPermissionRoundTrips pins that quoting cost nothing on Ptah's own
 // side: the parser reads the quoted spelling back to the same grant.
 //
@@ -199,11 +308,18 @@ func TestRenderWritesPermissionBodiesThatEvaluate(t *testing.T) {
 // a rendering Ptah itself could no longer read would still look like progress.
 func TestRenderedPermissionRoundTrips(t *testing.T) {
 	tests := []struct {
-		name string
-		role string
+		name  string
+		role  string
+		roles []goschema.Role
 	}{
-		{name: "PUBLIC", role: "PUBLIC"},
-		{name: "a named role", role: "app"},
+		{name: "PUBLIC", role: "PUBLIC", roles: []goschema.Role{{Name: "app"}}},
+		{name: "a named role", role: "app", roles: []goschema.Role{{Name: "app"}}},
+		{
+			// The spelling the fix introduces. Quoting is only free if the
+			// grantee survives it, and this row is what says it does.
+			name: "a named role the document does not declare",
+			role: "app",
+		},
 	}
 
 	for _, test := range tests {
@@ -212,7 +328,7 @@ func TestRenderedPermissionRoundTrips(t *testing.T) {
 			c := qt.New(t)
 
 			db := inspectedTable("public")
-			db.Roles = []goschema.Role{{Name: "app"}}
+			db.Roles = test.roles
 			db.Grants = []goschema.Grant{{
 				Role:       test.role,
 				OnSchema:   "public",

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -384,7 +384,13 @@ func (r *renderer) renderTrigger(trigger goschema.Trigger) {
 		return
 	}
 	r.linef(`trigger %s {`, quote(trigger.Name))
-	r.rawAttr(1, "on", r.tableRef(trigger.Table))
+	// A trigger's target is a relation, not a table: `INSTEAD OF` triggers only
+	// exist on views, and Trigger.Table is where the reader puts one. Measured
+	// on PostgreSQL 17, `CREATE TRIGGER v_ins INSTEAD OF INSERT ON v` inspected
+	// whole and put to the pinned Atlas community binary v1.3.0,
+	// `on = table.v` is refused with `This object does not have an attribute
+	// named "v"` and `on = view.v` is read at exit 0.
+	r.rawAttr(1, "on", r.relationRef(blockTable, trigger.Table))
 	r.linef("  %s {", timing)
 	r.rawAttr(2, event, "true")
 	r.line("  }")
@@ -689,20 +695,61 @@ func grantTargetName(grant goschema.Grant) string {
 	return cmp.Or(grant.OnSchema, grant.OnTable, grant.OnSequence)
 }
 
+// grantTarget renders the object a `permission` block is about.
+//
+// The IR names the object; the document decides how to spell it. A grant on a
+// view arrives in OnTable -- PostgreSQL reports the owner's implicit privileges
+// on a view exactly as it does on a table, and the reader keeps that shape --
+// so the field it came in on cannot be what picks the block type, or every
+// database carrying a view writes `for = table.<view>` against a document
+// declaring `view "<view>"`. That is [renderer.relationRef]'s question, and the
+// field is only the fallback for a name the document does not declare at all.
 func (r *renderer) grantTarget(grant goschema.Grant) string {
 	if grant.OnSchema != "" {
 		return r.schemaRef(grant.OnSchema)
 	}
 	if grant.OnTable != "" {
-		return r.tableRef(grant.OnTable)
+		return r.relationRef(blockTable, grant.OnTable)
 	}
 	if grant.OnSequence != "" {
-		return objectRef("sequence", grant.OnSequence)
+		return r.relationRef(blockSequence, grant.OnSequence)
 	}
 	return ""
 }
 
-// tableRef renders a reference to a table block.
+// relationRef renders a reference from a position that can name any relation:
+// a `permission` target and a `trigger`'s `on`, both of which reach a view on
+// an ordinary PostgreSQL database.
+//
+// The block type comes from [renderer.documentDeclares] -- from what this
+// document writes -- rather than from the IR field the name arrived on or from
+// the position doing the referring. fallback is the spelling for a name the
+// document declares nothing under, or declares twice: it is the position's own
+// guess, which is all there is left, and it is what Ptah wrote for every
+// reference before this rule existed.
+//
+// A reference the document CAN resolve loses the schema for the same reason
+// [renderer.tableRef] drops it -- the block is named by its labels alone -- and
+// keeps it otherwise, because there would be no block to read it back off.
+func (r *renderer) relationRef(fallback, name string) string {
+	ref, ok := tableref.Parse(name)
+	if !ok {
+		return objectRef(fallback, name)
+	}
+	block, declared := r.documentDeclares(ref.Name)
+	if !declared || (ref.Qualified && block.schema != ref.Schema) {
+		return objectRef(fallback, name)
+	}
+	return block.kind + objectRefPart(ref.Name)
+}
+
+// tableRef renders a reference from a position that can only be about a table:
+// a foreign key's `ref_columns`, a row-level security `policy`'s `on`, and a
+// `data` block's `table`. No engine Ptah renders for lets a foreign key or an
+// RLS policy name a view, and a `data` block is Ptah's own construct for seeding
+// rows, so there is no second block type for these to resolve to and the kind is
+// not a question. A position that CAN name one goes through
+// [renderer.relationRef] instead.
 //
 // A reference in HCL names a BLOCK, and a block is named by its labels. Ptah
 // writes a table block with one label, so `table.<schema>.<name>` does not read
@@ -739,21 +786,23 @@ func (r *renderer) grantTarget(grant goschema.Grant) string {
 func (r *renderer) tableRef(name string) string {
 	ref, ok := tableref.Parse(name)
 	if !ok || !ref.Qualified || !r.documentResolvesTableRef(ref.Schema, ref.Name) {
-		return objectRef("table", name)
+		return objectRef(blockTable, name)
 	}
-	return "table" + objectRefPart(ref.Name)
+	return blockTable + objectRefPart(ref.Name)
 }
 
-// objectRef renders a reference to a block, with whatever schema the name
-// carries.
+// objectRef renders a reference to a block of a named kind, with whatever
+// schema the name carries.
 //
-// Only [renderer.tableRef] shortens a reference, and only table positions call
-// it, so a sequence target keeps `sequence.<schema>.<name>`. That is a
-// structural guarantee rather than a policy: a permission naming a sequence
-// keeps that sequence block in the document, and the pinned binary refuses any
-// PostgreSQL file declaring one with `postgres: sequences are not supported by
-// this version` before any reference is resolved, so nothing measured says
-// which spelling it would take there.
+// It is the fallback both [renderer.tableRef] and [renderer.relationRef] reach
+// for, and the only thing that writes a two-part reference. A grant on a
+// sequence therefore keeps `sequence.<schema>.<name>` where the schema is
+// spelled out and the document declares no block to read it back off. Nothing
+// measured says which spelling the pinned binary would take there in any case:
+// it refuses any PostgreSQL file declaring a sequence block at all, with
+// `postgres: sequences are not supported by this version`, so both
+// `for = sequence.order_seq` and `for = "order_seq"` reach that same message
+// while the block is kept -- measured on PostgreSQL 17.
 func objectRef(kind, name string) string {
 	if name == "" {
 		return quote("")

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -389,8 +389,11 @@ func (r *renderer) renderTrigger(trigger goschema.Trigger) {
 	// on PostgreSQL 17, `CREATE TRIGGER v_ins INSTEAD OF INSERT ON v` inspected
 	// whole and put to the pinned Atlas community binary v1.3.0,
 	// `on = table.v` is refused with `This object does not have an attribute
-	// named "v"` and `on = view.v` is read at exit 0.
-	r.rawAttr(1, "on", r.relationRef(blockTable, trigger.Table))
+	// named "v"` and `on = view.v` is read at exit 0. Where the document
+	// declares no single block to name, the quoted name is what evaluates --
+	// measured on the same binary, `on = "other.v"` at exit 0 against a document
+	// carrying `view "v"` in two schemas, where `on = table.other.v` is refused.
+	r.rawAttr(1, "on", r.relationRef(trigger.Table, quote(trigger.Table)))
 	r.linef("  %s {", timing)
 	r.rawAttr(2, event, "true")
 	r.line("  }")
@@ -703,16 +706,22 @@ func grantTargetName(grant goschema.Grant) string {
 // so the field it came in on cannot be what picks the block type, or every
 // database carrying a view writes `for = table.<view>` against a document
 // declaring `view "<view>"`. That is [renderer.relationRef]'s question, and the
-// field is only the fallback for a name the document does not declare at all.
+// field only decides what to write when the document declares no single block
+// to name.
 func (r *renderer) grantTarget(grant goschema.Grant) string {
 	if grant.OnSchema != "" {
 		return r.schemaRef(grant.OnSchema)
 	}
 	if grant.OnTable != "" {
-		return r.relationRef(blockTable, grant.OnTable)
+		return r.relationRef(grant.OnTable, quote(grant.OnTable))
 	}
 	if grant.OnSequence != "" {
-		return r.relationRef(blockSequence, grant.OnSequence)
+		// A sequence keeps a traversal even unresolved, because the word is the
+		// only thing that says which OBJECT this grant is about: Ptah's own
+		// reader takes `for = "order_seq"` as a grant on a relation and would
+		// emit `GRANT ... ON TABLE`. See [objectRef] for what the pinned binary
+		// does with a sequence block in either spelling.
+		return r.relationRef(grant.OnSequence, objectRef(blockSequence, grant.OnSequence))
 	}
 	return ""
 }
@@ -723,22 +732,44 @@ func (r *renderer) grantTarget(grant goschema.Grant) string {
 //
 // The block type comes from [renderer.documentDeclares] -- from what this
 // document writes -- rather than from the IR field the name arrived on or from
-// the position doing the referring. fallback is the spelling for a name the
-// document declares nothing under, or declares twice: it is the position's own
-// guess, which is all there is left, and it is what Ptah wrote for every
-// reference before this rule existed.
+// the position doing the referring. A reference the document CAN resolve loses
+// the schema for the same reason [renderer.tableRef] drops it: the block is
+// named by its labels alone.
 //
-// A reference the document CAN resolve loses the schema for the same reason
-// [renderer.tableRef] drops it -- the block is named by its labels alone -- and
-// keeps it otherwise, because there would be no block to read it back off.
-func (r *renderer) relationRef(fallback, name string) string {
+// unresolved is what to write when there is no single block to name -- because
+// the document declares nothing under the label, or because it declares the
+// label TWICE, which two schemas holding a relation of one name is all it
+// takes. For a relation that is a QUOTED name, and the quoting is the whole
+// point: a traversal has no spelling left that both evaluates and keeps the
+// schema. Measured on the pinned Atlas community binary v1.3.0 against one
+// document declaring `view "v"` in `other` and `view "v"` in `public`, one
+// operand varied and nothing else touched:
+//
+//	for = table.other.v  exit 1  Unsupported attribute; This object does not
+//	                             have an attribute named "other"
+//	for = view.other.v   exit 1  same message
+//	for = table.gone     exit 1  ... an attribute named "gone"
+//	for = "other.v"      exit 0
+//	for = "gone"         exit 0
+//
+// and against the same document with the two table blocks removed, so that no
+// `table` block is declared at all, `for = table.other.v` is refused with
+// `Unknown variable; There is no variable named "table"` instead.
+//
+// The short form view.v evaluates there (exit 0) and is still wrong: two blocks
+// carry that label, so it names neither in particular, and Ptah's own reader
+// refuses to guess -- relationBlockSchema in internal/atlashcl returns nothing
+// for a label it finds twice -- so the schema would be dropped for good. The
+// quoted name is the only spelling that both evaluates and survives the round
+// trip; relationRefName reads it straight back.
+func (r *renderer) relationRef(name, unresolved string) string {
 	ref, ok := tableref.Parse(name)
 	if !ok {
-		return objectRef(fallback, name)
+		return unresolved
 	}
 	block, declared := r.documentDeclares(ref.Name)
 	if !declared || (ref.Qualified && block.schema != ref.Schema) {
-		return objectRef(fallback, name)
+		return unresolved
 	}
 	return block.kind + objectRefPart(ref.Name)
 }
@@ -794,8 +825,9 @@ func (r *renderer) tableRef(name string) string {
 // objectRef renders a reference to a block of a named kind, with whatever
 // schema the name carries.
 //
-// It is the fallback both [renderer.tableRef] and [renderer.relationRef] reach
-// for, and the only thing that writes a two-part reference. A grant on a
+// It is what [renderer.tableRef] falls back to, and what
+// [renderer.grantTarget] hands [renderer.relationRef] for a SEQUENCE target,
+// and the only thing that writes a two-part reference. A grant on a
 // sequence therefore keeps `sequence.<schema>.<name>` where the schema is
 // spelled out and the document declares no block to read it back off. Nothing
 // measured says which spelling the pinned binary would take there in any case:

--- a/internal/atlashclrender/objects.go
+++ b/internal/atlashclrender/objects.go
@@ -42,7 +42,7 @@ func (r *renderer) renderSequences() {
 		sequence.Canonicalize()
 		r.linef(`sequence %s {`, quote(sequence.Name))
 		if sequence.Schema != "" {
-			r.rawAttr(1, "schema", schemaRef(sequence.Schema))
+			r.rawAttr(1, "schema", r.schemaRef(sequence.Schema))
 		}
 		// A quoted string, not the bare word `bigint`. Bare, it is an HCL
 		// variable reference with nothing behind it and the pinned Atlas
@@ -106,7 +106,7 @@ func (r *renderer) renderDomain(domain goschema.Domain) {
 	domain.Canonicalize()
 	r.linef(`domain %s {`, quote(domain.Name))
 	if domain.Schema != "" {
-		r.rawAttr(1, "schema", schemaRef(domain.Schema))
+		r.rawAttr(1, "schema", r.schemaRef(domain.Schema))
 	}
 	r.rawAttr(1, "type", userTypeExpr(domain.BaseType))
 	if domain.NotNull {
@@ -129,7 +129,7 @@ func (r *renderer) renderComposite(composite goschema.CompositeType) {
 	composite.Canonicalize()
 	r.linef(`composite %s {`, quote(composite.Name))
 	if composite.Schema != "" {
-		r.rawAttr(1, "schema", schemaRef(composite.Schema))
+		r.rawAttr(1, "schema", r.schemaRef(composite.Schema))
 	}
 	r.stringAttr(1, "comment", composite.Comment)
 	for _, field := range composite.Fields {
@@ -145,7 +145,7 @@ func (r *renderer) renderRange(rangeType goschema.Range) {
 	rangeType.Canonicalize()
 	r.linef(`range %s {`, quote(rangeType.Name))
 	if rangeType.Schema != "" {
-		r.rawAttr(1, "schema", schemaRef(rangeType.Schema))
+		r.rawAttr(1, "schema", r.schemaRef(rangeType.Schema))
 	}
 	r.rawAttr(1, "subtype", userTypeExpr(rangeType.Subtype))
 	r.stringAttr(1, "subtype_opclass", rangeType.SubtypeOpClass)
@@ -249,7 +249,7 @@ func (r *renderer) renderFunction(function goschema.Function) {
 	name := objectNameFromQualified(function.Name)
 	r.linef(`function %s {`, quote(name))
 	if schema := schemaNameFromQualified(function.Name); schema != "" {
-		r.rawAttr(1, "schema", schemaRef(schema))
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	// Every one of these four is a quoted string rather than a bare word.
 	// Measured on the pinned Atlas community binary v1.3.0, one attribute varied
@@ -311,7 +311,7 @@ func (r *renderer) renderViews() {
 		name := objectNameFromQualified(view.Name)
 		r.linef(`view %s {`, quote(name))
 		if schema := schemaNameFromQualified(view.Name); schema != "" {
-			r.rawAttr(1, "schema", schemaRef(schema))
+			r.rawAttr(1, "schema", r.schemaRef(schema))
 		}
 		r.stringAttr(1, "as", view.Body)
 		if view.WithCheck {
@@ -342,7 +342,7 @@ func (r *renderer) renderMaterializedView(view goschema.MaterializedView) {
 	name := objectNameFromQualified(view.Name)
 	r.linef(`materialized %s {`, quote(name))
 	if schema := schemaNameFromQualified(view.Name); schema != "" {
-		r.rawAttr(1, "schema", schemaRef(schema))
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.stringAttr(1, "as", view.Body)
 	// Emit refresh_strategy only when it differs from the canonical default so
@@ -437,7 +437,7 @@ func (r *renderer) renderRLSPolicies() {
 		// PolicyFor.
 		r.stringAttr(1, "for", firstNonEmpty(strings.ToUpper(policy.PolicyFor), "ALL"))
 		if policy.ToRoles != "" {
-			r.rawAttr(1, "to", roleTargets(policy.ToRoles))
+			r.rawAttr(1, "to", r.roleTargets(policy.ToRoles))
 		}
 		r.stringAttr(1, "using", policy.UsingExpression)
 		r.stringAttr(1, "check", policy.WithCheckExpression)
@@ -448,7 +448,21 @@ func (r *renderer) renderRLSPolicies() {
 }
 
 func (r *renderer) renderGrants() {
-	grants := append([]goschema.Grant(nil), r.db.Grants...)
+	// Incomplete grants are dropped BEFORE the sort, because the sort key is
+	// [renderer.grantTarget] and rendering a target records the schema
+	// reference it writes. Asking it about a grant that is then skipped would
+	// declare a `schema` block for a `permission` block the document does not
+	// contain -- a declaration of nothing, which is the failure this render's
+	// collected schema set exists to avoid in the other direction.
+	grants := make([]goschema.Grant, 0, len(r.db.Grants))
+	for _, grant := range r.db.Grants {
+		grant.Canonicalize()
+		if grant.Role == "" || grantTargetName(grant) == "" || len(grant.Privileges) == 0 {
+			r.warn("grants."+grant.Role, "grant requires role, table, schema, or sequence target, and at least one privilege")
+			continue
+		}
+		grants = append(grants, grant)
+	}
 	slices.SortFunc(grants, func(a, b goschema.Grant) int {
 		return cmp.Or(
 			cmp.Compare(a.Role, b.Role),
@@ -457,14 +471,9 @@ func (r *renderer) renderGrants() {
 		)
 	})
 	for _, grant := range grants {
-		grant.Canonicalize()
 		target := r.grantTarget(grant)
-		if grant.Role == "" || target == "" || len(grant.Privileges) == 0 {
-			r.warn("grants."+grant.Role, "grant requires role, table, schema, or sequence target, and at least one privilege")
-			continue
-		}
 		r.line("permission {")
-		r.rawAttr(1, "to", roleTarget(grant.Role))
+		r.rawAttr(1, "to", r.roleTarget(grant.Role))
 		r.rawAttr(1, "for", target)
 		r.rawAttr(1, "privileges", privilegeList(grant.Privileges))
 		if grant.WithOption {
@@ -625,14 +634,14 @@ func atlasLanguage(language string) string {
 	}
 }
 
-func roleTargets(value string) string {
+func (r *renderer) roleTargets(value string) string {
 	roles, ok := splitTopLevelComma(value)
 	if !ok {
 		return stringList([]string{value})
 	}
 	targets := make([]string, 0, len(roles))
 	for _, role := range roles {
-		targets = append(targets, roleTarget(role))
+		targets = append(targets, r.roleTarget(role))
 	}
 	return "[" + strings.Join(targets, ", ") + "]"
 }
@@ -645,24 +654,44 @@ func roleTargets(value string) string {
 // `There is no variable named "PUBLIC"` -- it drops a block whose name it does
 // not model, but only after the body evaluates (stokaro/ptah#1234).
 //
-// A named role stays a `role.<name>` traversal, which is measured to evaluate
-// on that binary when the file also declares the matching `role` block, so
-// quoting it would lose a reference for nothing. Ptah's own parser reads either
-// spelling through rawIdentifierOrString, so the round trip is unaffected.
-func roleTarget(value string) string {
+// A named role is a `role.<name>` traversal only where the document declares
+// the matching block. That precondition was written down when PUBLIC was fixed
+// and never enforced, and a grantee is exactly where it fails: a `permission`
+// block is a child of the object granted on, so `--exclude '*[type=role]'`
+// takes away the role blocks and leaves every grant to them behind. Measured on
+// PostgreSQL 17, one operand varied against an otherwise identical document:
+//
+//	role "app" declared, to = role.app   exit 0
+//	role "app" absent,   to = role.app   exit 1  There is no variable named "role"
+//	role "app" absent,   to = "app"      exit 0
+//
+// Quoting where the block is absent loses nothing, which is what separates this
+// from [renderer.tableRef]: there, the short form would destroy the schema the
+// qualified name carried, so an unresolvable reference keeps the qualified
+// spelling. A grantee carries no second part to lose, and Ptah's own parser
+// reads either spelling back to the same role through roleTargetName, so the
+// round trip is unaffected either way.
+func (r *renderer) roleTarget(value string) string {
 	value = strings.TrimSpace(value)
 	if strings.EqualFold(value, "PUBLIC") {
 		return quote("PUBLIC")
 	}
-	if value == "" {
+	if value == "" || !r.documentDeclaresRole(value) {
 		return quote(value)
 	}
 	return "role" + objectRefPart(value)
 }
 
+// grantTargetName is the raw name a grant targets, with no reference rendered
+// and nothing recorded. It answers "is this grant complete" without asking
+// [renderer.grantTarget], which has the side effect of declaring a schema.
+func grantTargetName(grant goschema.Grant) string {
+	return cmp.Or(grant.OnSchema, grant.OnTable, grant.OnSequence)
+}
+
 func (r *renderer) grantTarget(grant goschema.Grant) string {
 	if grant.OnSchema != "" {
-		return schemaRef(grant.OnSchema)
+		return r.schemaRef(grant.OnSchema)
 	}
 	if grant.OnTable != "" {
 		return r.tableRef(grant.OnTable)

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -258,7 +258,12 @@ type declaredBlock struct {
 // per schema in every engine Ptah renders for, so two blocks under one label
 // are two schemas' worth, and which of them an unqualified reference means is
 // exactly the question [renderer.documentResolvesTableRef] refuses to guess.
-// The caller falls back to the spelling its own position implies.
+// Saying no here is therefore routine rather than exotic -- two schemas each
+// holding a view named `v` is all it takes, and that is a DEFAULT inspect of a
+// realm-scoped URL -- so what the caller writes instead has to be a spelling
+// the pinned binary reads. For a relation that is a quoted name; see
+// [renderer.relationRef] for the measurement and for why the short form is not
+// it.
 func (r *renderer) documentDeclares(label string) (declaredBlock, bool) {
 	if r.relationBlocks == nil {
 		r.relationBlocks = r.declaredRelationBlocks()

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -177,8 +177,39 @@ type renderer struct {
 	// distinguishable from "built and empty" because a document with no tables
 	// still answers every lookup. See [renderer.documentResolvesTableRef].
 	tableSchemas map[string][]string
-	builder      strings.Builder
-	diagnostics  []Diagnostic
+	// roleBlocks caches the `role` block labels this render will write. Nil
+	// means not yet built, which is distinguishable from "built and empty"
+	// because a document with no roles still answers every lookup. See
+	// [renderer.documentDeclaresRole].
+	roleBlocks map[string]bool
+	// schemaRefs collects the name of every `schema.<name>` reference the body
+	// wrote, filled by [renderer.schemaRef] as the body is rendered and read
+	// afterwards by [renderer.referencedSchemas].
+	schemaRefs  map[string]bool
+	builder     strings.Builder
+	diagnostics []Diagnostic
+}
+
+// documentDeclaresRole reports whether this document writes a `role` block
+// labeled with this name.
+//
+// A `role.<name>` traversal names a BLOCK, so without one it is an HCL variable
+// reference with nothing behind it and the pinned Atlas community binary v1.3.0
+// refuses the whole file with `There is no variable named "role"`. Every render
+// writes a block for every role in the IR, so the IR is the list of labels.
+//
+// Matching is exact rather than case-insensitive: [renderer.renderRoles] writes
+// the label as a quoted string, so `role "App"` and `role "app"` are two
+// different blocks and a traversal resolves to neither of the other's.
+func (r *renderer) documentDeclaresRole(name string) bool {
+	if r.roleBlocks == nil {
+		blocks := make(map[string]bool, len(r.db.Roles))
+		for _, role := range r.db.Roles {
+			blocks[role.Name] = true
+		}
+		r.roleBlocks = blocks
+	}
+	return r.roleBlocks[name]
 }
 
 // documentResolvesTableRef reports whether an unqualified `table.<name>`
@@ -220,48 +251,55 @@ func (r *renderer) schemaFor(schema string) string {
 	return r.defaultSchema
 }
 
-// referencedSchemas lists, in a stable order, every schema this render will
-// write a `schema.<name>` reference to. It is empty outside an inspected
-// render, because nothing is synthesized there.
+// referencedSchemas lists, in a stable order, every schema the body of this
+// render actually wrote a `schema.<name>` reference to. It is empty outside an
+// inspected render, because nothing is synthesized there.
+//
+// The set is COLLECTED from the rendered body rather than predicted from the
+// IR, and that is the whole point. Predicting it has now been wrong three
+// times, each time in the same direction and each time reaching the pinned
+// Atlas community binary v1.3.0 as `There is no variable named "schema"`: the
+// first version declared only the default and missed a table outside it, the
+// second missed the enum block's own reference, and the third missed the
+// `permission { for = schema.public }` that every PostgreSQL database has --
+// visible on an EMPTY database, where there is no table to predict from at all
+// (stokaro/ptah#1234). A reference and its declaration cannot disagree when one
+// is derived from the other.
+//
+// Collecting also gets the suppressed blocks right for free. A block the
+// Atlas-compatible surface leaves out never reaches [renderer.schemaRef], so an
+// omitted sequence no longer conjures a schema block declaring nothing.
 func (r *renderer) referencedSchemas() []string {
 	if r.defaultSchema == "" {
 		return nil
 	}
-	// Nothing to attach a schema to means nothing to declare. An inspect whose
-	// selection matched no object renders an empty document, and a lone schema
-	// block there would be a declaration of nothing -- which is what the
-	// empty-include-selection contract already pins.
-	//
-	// Enums count as something to attach. They now carry a schema reference of
-	// their own (see renderEnums), so a read that matched enums but no table
-	// still has to declare the block that reference points at.
-	if len(r.db.Tables) == 0 && len(r.db.Enums) == 0 {
-		return nil
-	}
-	seen := map[string]bool{}
-	var names []string
-	add := func(name string) {
-		if name == "" || seen[name] {
-			return
-		}
-		seen[name] = true
-		names = append(names, name)
-	}
-	for _, table := range r.db.Tables {
-		add(r.schemaFor(table.Schema))
-	}
-	if len(r.db.Enums) > 0 {
-		add(r.defaultSchema)
-	}
-	slices.Sort(names)
-	return names
+	return sortedMapKeys(r.schemaRefs)
 }
 
+// render assembles the document in two passes. The body is rendered first and
+// held aside, then the header and the schema blocks that body turned out to
+// reference are written, then the body goes back on the end.
+//
+// Two things force that. Every schema a reference names has to be declared
+// somewhere in the file, and Ptah writes the declarations at the top -- so the
+// only way to declare exactly the set the body references is to have rendered
+// the body before writing them.
 func (r *renderer) render() {
+	r.renderBody()
+	body := r.builder.String()
+	r.builder.Reset()
+
+	// The coverage header must be written AFTER the body snapshot is taken and
+	// the builder reset, or it lands inside body and is re-emitted below the
+	// schema blocks instead of at the top of the document.
 	r.builder.WriteString("// Code generated by ptah; DO NOT EDIT.\n")
 	r.renderCoverageHeader()
 	r.builder.WriteString("\n")
 	r.renderSchemas()
+	r.builder.WriteString(body)
+}
+
+func (r *renderer) renderBody() {
 	r.renderExtensions()
 	r.renderSequences()
 	r.renderUserTypes()
@@ -280,15 +318,13 @@ func (r *renderer) render() {
 func (r *renderer) renderSchemas() {
 	schemas := append([]goschema.Schema(nil), r.db.Schemas...)
 	// An inspected read reports no schema block at all, so every schema the
-	// file is about to reference has to be declared here or the reference
-	// resolves to nothing. A read that DID report one keeps what it reported,
-	// comment, charset and collation included.
+	// file references has to be declared here or the reference resolves to
+	// nothing. A read that DID report one keeps what it reported, comment,
+	// charset and collation included.
 	//
-	// It is not enough to declare the default. A reader looking at more than
-	// one schema reports each table's own, so a table in `reporting` emits
-	// `schema = schema.reporting` and needs that block too -- the first version
-	// of this declared only the default, and a test row with a table outside it
-	// is what caught the dangling reference.
+	// Which schemas those are is answered by the body that was already
+	// rendered, not guessed from the IR; see [renderer.referencedSchemas] for
+	// the three guesses that were wrong.
 	for _, name := range r.referencedSchemas() {
 		if !slices.ContainsFunc(schemas, func(s goschema.Schema) bool { return s.Name == name }) {
 			schemas = append(schemas, goschema.Schema{Name: name})
@@ -330,7 +366,7 @@ func (r *renderer) renderEnums() {
 		// own schema as implicit, which is the same reason renderTable falls
 		// back to it.
 		if schema := r.schemaFor(""); schema != "" {
-			r.rawAttr(1, "schema", schemaRef(schema))
+			r.rawAttr(1, "schema", r.schemaRef(schema))
 		}
 		r.rawAttr(1, "values", stringList(enum.Values))
 		r.line("}")
@@ -377,7 +413,7 @@ func (r *renderer) renderTable(
 ) {
 	r.linef(`table %s {`, quote(table.Name))
 	if schema := r.schemaFor(table.Schema); schema != "" {
-		r.rawAttr(1, "schema", schemaRef(schema))
+		r.rawAttr(1, "schema", r.schemaRef(schema))
 	}
 	r.stringAttr(1, "engine", table.Engine)
 	r.stringAttr(1, "charset", table.Charset)
@@ -1195,7 +1231,20 @@ func columnRef(name string) string {
 	return "column" + objectRefPart(name)
 }
 
-func schemaRef(name string) string {
+// schemaRef renders a reference to a schema block and records that this
+// document now needs one, which is what [renderer.renderSchemas] declares.
+//
+// Every position that writes `schema.<name>` goes through here so that no
+// position can be added without its declaration following. That is the property
+// the previous shape lacked: a reference was written in one place and predicted
+// in another, and the two drifted apart every time a new position was added.
+func (r *renderer) schemaRef(name string) string {
+	if name != "" {
+		if r.schemaRefs == nil {
+			r.schemaRefs = map[string]bool{}
+		}
+		r.schemaRefs[name] = true
+	}
 	return "schema" + objectRefPart(name)
 }
 

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -182,6 +182,11 @@ type renderer struct {
 	// because a document with no roles still answers every lookup. See
 	// [renderer.documentDeclaresRole].
 	roleBlocks map[string]bool
+	// relationBlocks caches, per block label this render will write, every
+	// relation block carrying it. Nil means not yet built, which is
+	// distinguishable from "built and empty" because a document with no
+	// relations still answers every lookup. See [renderer.documentDeclares].
+	relationBlocks map[string][]declaredBlock
 	// schemaRefs collects the name of every `schema.<name>` reference the body
 	// wrote, filled by [renderer.schemaRef] as the body is rendered and read
 	// afterwards by [renderer.referencedSchemas].
@@ -210,6 +215,91 @@ func (r *renderer) documentDeclaresRole(name string) bool {
 		r.roleBlocks = blocks
 	}
 	return r.roleBlocks[name]
+}
+
+// declaredBlock is one relation block this render writes, described the way a
+// reference to it has to be spelled: the block KIND the traversal names, and
+// the schema the block belongs to.
+type declaredBlock struct {
+	kind   string
+	schema string
+}
+
+// documentDeclares reports the single relation block this document writes under
+// this label, when there is exactly one.
+//
+// A reference in HCL names a BLOCK, and the block TYPE is the first word of the
+// traversal, so `table.v` is "the v attribute of the table object" and resolves
+// to nothing when the document declares `view "v"`. The pinned Atlas community
+// binary v1.3.0 refuses the whole file over it. Measured on PostgreSQL 17
+// against the document `ptah-compat schema inspect` writes for
+//
+//	CREATE TABLE t (id integer PRIMARY KEY);
+//	CREATE VIEW v AS SELECT id FROM t;
+//
+// with one operand varied and nothing else touched:
+//
+//	for = table.v   exit 1  Unsupported attribute; This object does not have
+//	                        an attribute named "v"
+//	for = view.v    exit 0
+//	for = "v"       exit 0
+//
+// PostgreSQL reports the owner's implicit grants on a view exactly as it does
+// on a table, so that is the DEFAULT invocation on any database carrying a
+// view, with no selection involved (stokaro/ptah#1234).
+//
+// The set is what this render WRITES, not what the IR holds: a view with no
+// body is warned about and skipped, and a sequence the Atlas-compatible surface
+// omits is not there to be named either -- both asked through the same
+// predicate the render itself uses, so the answer cannot drift from the
+// document.
+//
+// "Exactly one" is what makes the kind knowable. Relations share one namespace
+// per schema in every engine Ptah renders for, so two blocks under one label
+// are two schemas' worth, and which of them an unqualified reference means is
+// exactly the question [renderer.documentResolvesTableRef] refuses to guess.
+// The caller falls back to the spelling its own position implies.
+func (r *renderer) documentDeclares(label string) (declaredBlock, bool) {
+	if r.relationBlocks == nil {
+		r.relationBlocks = r.declaredRelationBlocks()
+	}
+	blocks := r.relationBlocks[label]
+	if len(blocks) != 1 {
+		return declaredBlock{}, false
+	}
+	return blocks[0], true
+}
+
+func (r *renderer) declaredRelationBlocks() map[string][]declaredBlock {
+	blocks := make(map[string][]declaredBlock, len(r.db.Tables)+len(r.db.Views)+len(r.db.MaterializedViews))
+	declare := func(kind, label, schema string) {
+		blocks[label] = append(blocks[label], declaredBlock{kind: kind, schema: r.schemaFor(schema)})
+	}
+	for _, table := range r.db.Tables {
+		declare(blockTable, table.Name, table.Schema)
+	}
+	for _, view := range r.db.Views {
+		if view.Body == "" {
+			continue
+		}
+		declare(blockView, objectNameFromQualified(view.Name), schemaNameFromQualified(view.Name))
+	}
+	for _, view := range r.db.MaterializedViews {
+		if view.Body == "" {
+			continue
+		}
+		declare(blockMaterialized, objectNameFromQualified(view.Name), schemaNameFromQualified(view.Name))
+	}
+	for _, sequence := range r.db.Sequences {
+		if r.omitsRefusedBlock(blockSequence, sequence.Name) {
+			continue
+		}
+		// The label [renderer.renderSequences] writes is the canonical name, so
+		// that is the label a reference has to match.
+		sequence.Canonicalize()
+		declare(blockSequence, sequence.Name, sequence.Schema)
+	}
+	return blocks
 }
 
 // documentResolvesTableRef reports whether an unqualified `table.<name>`

--- a/internal/atlashclrender/table_reference_test.go
+++ b/internal/atlashclrender/table_reference_test.go
@@ -159,6 +159,20 @@ func TestRenderCrossSchemaReferencesRoundTripToTheSameIR(t *testing.T) {
 // TestRenderKeepsQualifiedReferenceWhenDocumentCannotResolveIt covers the cases
 // where dropping the schema would destroy it or point the reference somewhere
 // else. Each row is a document the short form would be wrong for.
+//
+// The schema is kept in both spellings this rule can write, and which one a
+// position gets is decided by what that position is allowed to be. A
+// `ref_columns`, a `policy`'s `on` and a `data` block's `table` go on naming a
+// table through a traversal: `ref_columns` has to reach a column through the
+// same expression, so a quoted name is not a spelling available there at all,
+// and the other two are rendered the same way because Ptah's reader has to
+// agree with itself. A `permission` target and a `trigger`'s `on` are quoted,
+// because the pinned Atlas community binary v1.3.0 evaluates those two without
+// resolving them and reads a quoted name at exit 0 where it refuses every
+// traversal to a block the document does not declare -- `for = "gone"` exit 0
+// against `for = table.gone` exit 1 `Unsupported attribute; This object does
+// not have an attribute named "gone"`, and `Unknown variable; There is no
+// variable named "table"` where the document declares no table block at all.
 func TestRenderKeepsQualifiedReferenceWhenDocumentCannotResolveIt(t *testing.T) {
 	tests := []struct {
 		name string
@@ -209,11 +223,17 @@ func TestRenderKeepsQualifiedReferenceWhenDocumentCannotResolveIt(t *testing.T) 
 			for _, want := range []string{
 				`ref_columns = [table.other.users.column.id]`,
 				`on = table.other.users`,
-				`for = table.other.users`,
 				`table = table.other.users`,
+				`on = "other.users"`,
+				`for = "other.users"`,
 			} {
 				c.Assert(hcl, qt.Contains, want, qt.Commentf("%s\nrendered HCL:\n%s", test.why, hcl))
 			}
+			// Two positions spell `on`, and this rule sends them to different
+			// spellings, so counting is what says the policy kept the traversal
+			// rather than the trigger's quoted name satisfying both.
+			c.Assert(strings.Count(hcl, `on = table.other.users`), qt.Equals, 1,
+				qt.Commentf("%s\nrendered HCL:\n%s", test.why, hcl))
 		})
 	}
 }

--- a/internal/goannotationexport/parity_test.go
+++ b/internal/goannotationexport/parity_test.go
@@ -62,7 +62,14 @@ func TestExport_HappyPath_PreservesGoAnnotationSemantics(t *testing.T) {
 	c.Assert(hclText, qt.Contains, `composite "postal_address"`)
 	c.Assert(hclText, qt.Contains, `range "price_range"`)
 	c.Assert(hclText, qt.Contains, `password = "SCRAM-SHA-256$fixture"`)
-	c.Assert(hclText, qt.Contains, `for = sequence.app.order_seq`)
+	// The annotation writes on_sequence="app.order_seq" and the export writes
+	// `for = sequence.order_seq`, for the same reason `ref_columns` below drops
+	// its schema: an HCL reference names a BLOCK, and the block is named by its
+	// labels alone. This is the same rule the reader's side of a permission
+	// target now follows, so one sequence reference has one spelling whichever
+	// frontend produced the grant (stokaro/ptah#1234). Nothing is lost: the
+	// round trip below reads `app.order_seq` back off the sequence block.
+	c.Assert(hclText, qt.Contains, `for = sequence.order_seq`)
 	c.Assert(hclText, qt.Contains, "data {")
 	c.Assert(hclText, qt.Contains, `checks = ["id > 0"]`)
 	c.Assert(hclText, qt.Contains, `custom = "WITHOUT OIDS"`)


### PR DESCRIPTION
Closes #1234.

Both reasons in that issue are still live, in instances the fix in #1248 did not
reach. Neither needs a hand-edited fixture: each is what `ptah-compat schema
inspect` writes, fed straight back to the pinned Atlas community binary v1.3.0.

## Reason 2 — the missing schema declaration

Every PostgreSQL database carries `GRANT USAGE ON SCHEMA public TO PUBLIC`, so
an **empty** database inspects to one `permission` block and nothing else:

```console
$ ptah-compat schema inspect -u "postgres://.../empty?sslmode=disable&search_path=public" > out.hcl
$ cat out.hcl
// Code generated by ptah; DO NOT EDIT.

role "ptah_user" {
  login = true
  superuser = true
  inherit = true
}

permission {
  to = "PUBLIC"
  for = schema.public
  privileges = ["USAGE"]
}

$ atlas schema inspect -u file://out.hcl --dev-url "$DEV_URL"
Error: out.hcl:11,9-15: Unknown variable; There is no variable named "schema".
exit 1
```

The declaration was **predicted** from the IR — the schemas the tables carry,
plus the default when there are enums — while the reference was **written**
somewhere else. That prediction has now been wrong three times in the same
direction: it declared only the default and missed a table outside it, it missed
the enum block's own reference, and it misses this, where there is no table to
predict from at all.

So it is replaced by collection. The body is rendered first, every
`schema.<name>` goes through one recording helper, and the blocks declared are
exactly the set that came back. A reference and its declaration cannot disagree
when one is derived from the other, and a position added later declares itself.

Collecting fixes the other direction for free: a block the Atlas-compatible
surface omits never reaches the helper, so an omitted sequence no longer
conjures a schema block declaring nothing, and a document that references no
schema still declares none.

## Reason 1 — a permission body that does not evaluate

`to = PUBLIC` was fixed. `to = role.<name>` was not. That spelling is valid only
where the document declares the matching `role` block — which the comment on it
said and nothing enforced. A grantee is exactly where the precondition fails,
because a grant is a child of the object granted on rather than of the grantee,
so excluding roles takes the blocks away and leaves every reference to them:

```console
$ ptah-compat schema inspect -u "$PG_URL" --exclude '*[type=role]' > out.hcl
$ atlas schema inspect -u file://out.hcl --dev-url "$DEV_URL"
Error: out.hcl:52,8-12: Unknown variable; There is no variable named "role".
exit 1
```

Measured on that binary, one operand varied against an otherwise identical
document:

| grantee | role block | result |
| --- | --- | --- |
| `to = role.app` | declared | exit 0 |
| `to = role.app` | absent | exit 1 `There is no variable named "role"` |
| `to = "app"` | absent | exit 0 |

So a grantee is a reference only where the block is there, and a quoted name
otherwise. Quoting costs nothing here, which is what separates it from
`tableRef`: an unresolvable table reference keeps its qualified spelling because
the short form would destroy the schema it carried, and a grantee has no second
part to lose. Ptah reads both spellings back to the same grant, and applying the
document against a live PostgreSQL 17 issues `GRANT ... TO "ptah_user"` at exit
0 — executed, not merely rendered.

## Measured result

| document | master | branch |
| --- | --- | --- |
| inspect of an empty database | 1 `There is no variable named "schema"` | **0** |
| inspect `--exclude '*[type=role]'` | 1 `There is no variable named "role"` | **0** |
| inspect `--exclude 't'` (grants outlive the table) | 1 `There is no variable named "schema"` | **0** |
| inspect, unfiltered | 0 | 0, **byte-identical** |
| inspect, SQLite | 0 | 0, **byte-identical** |

The common path does not move. Only documents that were unreadable change.

## The test the issue asked for

`TestOracleModeledColumnTypesMatchTheBinary` measures one column at a time, and
neither of these defects is visible in one attribute. `TestOracleReadsThe
InspectedDocumentPtahRenders` puts three whole inspected documents to the pinned
binary — a table with grants, the same table with its roles excluded, and the
grant-only document an empty database produces — on PostgreSQL and SQLite, each
rendered through `RenderInspectedForAtlasCLI`, the entry point `ptah-compat
schema inspect` calls.

Each `rendered` row is paired with `unreadable` rows one substitution away from
the accepted document, each asserting the binary's **message** rather than a
bare non-zero status, so a document refused for an unrelated reason cannot pass
as confirmation; every substitution is asserted to have changed the text, so a
spelling that stopped being emitted fails the run instead of mutating nothing.
The Atlas CE Oracle job names those rows rather than counting them, for the same
reason the other runs there do.

## Also in this change

Incomplete grants are now dropped before the sort rather than inside the render
loop. The sort key is the rendered target, and rendering a target is what
records the schema reference, so asking about a grant that is then skipped would
declare a block for a permission that is not in the document.

## Not in this change

The ordering difference #1235 tracks — that binary writes `schema "public" {}`
at the end of its file and Ptah writes it at the top — is untouched. The
two-pass render makes moving it a one-line change if that front wants it.


---

## The review's findings are answered, and the branch was rebased past a destructive trap

An adversarial review refuted head `47f65146`. Two later commits answered it, and this head is three commits past the one that section described — so it has been replaced with what is true now.

### Why this pull request had zero checks

Not a scheduler backlog and not a missing push. The head **was** pushed; the branch was **conflicting**, and GitHub creates no merge ref for a conflicting pull request. Every workflow here is declared `on: {push: {branches: [master]}, pull_request:}` — push events are filtered to `master`, and the `pull_request` events had no merge ref to run against. Zero was the only number possible, and it is easy to misread as "CI has not got to it yet".

### The trap inside the rebase

Both sides had rewritten the same seven-line orchestrator in `internal/atlashclrender/render.go`. `master` had gained a coverage header:

```go
r.builder.WriteString("// Code generated by ptah; DO NOT EDIT.\n")
r.renderCoverageHeader()
r.builder.WriteString("\n")
```

while this branch restructured into a two-pass render that snapshots the body first:

```go
r.renderBody()
body := r.builder.String()
r.builder.Reset()
r.builder.WriteString("// Code generated by ptah; DO NOT EDIT.\n\n")
```

This branch never deleted `renderCoverageHeader()` — it restructured around a function that did not exist on its base. Taking this side wholesale, which is the instinctive resolution since it is "the change", drops the only call site of the `// ptah:not-described` header, and `ptah-compat schema inspect > file` followed by `schema apply --to file://file` starts planning `DROP EXTENSION`, `DROP SEQUENCE` and `DROP POLICY` again — the exact destructive regression #1298 closed.

Resolved as a union, and the placement is load-bearing: the header call sits **after** the builder `Reset()`, or its output is captured into the snapshotted `body` and re-emitted below the schema blocks instead of at the top. `master`'s three-statement form is kept over this branch's `\n\n`, so output stays byte-identical when there is no header. A comment in the code now says why.

The other two conflicts were resolved on their own merits rather than by one rule:

| file | shape | resolution |
| --- | --- | --- |
| `internal/atlashclrender/render.go` | both sides rewrote one function, neither deleted the other's work | union, header after the reset |
| `.github/workflows/atlas-oracle.yml` | additive — the two sides assert different tests | both assertion sets kept |
| `docs/site/src/content/docs/direct/inspect.md` | **superseding** — this branch's second commit replaces a paragraph its own first commit added | `master`'s paragraph kept, plus this branch's *newer* paragraph; the intermediate one dropped |

A blind union on the third file would have left two paragraphs where the branch itself intends one.

### The red integration test, and why it needed no code change

`TestPostgreSQLSchemaBoundaryGuardIntegration` failed on two of six rows — `extension_nothing_references` and `empty_database`, exactly the two fixtures with no table in them:

```
got: []string{"public"}        want: []string(nil)
got: []string{"schema:public"} want: []string(nil)
```

That is this branch working: the renderer now declares the schema blocks its body referenced, so a database with no tables finally emits `schema "public" {}`. It does not reproduce on `master`, where Integration Tests is green. The branch's own fourth commit moved those two characterization rows to the values the four table-bearing rows already carried, kept both assertions as exact equality against a named value, and re-labelled `wantDocumentOnly` as `WRONG (#1276)` rather than pretending the reader gap had closed. Nothing was weakened — the test needed to *run*.

### Verified on the rebased tree

`go build ./...` 0 · `go vet ./...` 0 · `go vet -tags integration ./integration/...` 0 · `go tool qtlint ./...` 0 · `go test ./internal/atlashclrender/... ./internal/atlashcl/... -count=1` ok · a tree-wide conflict-marker grep is empty · `renderCoverageHeader()` still has exactly one call site.
