### PR TITLE
Hold the migration directory open from planning to publication (#1118)

### DIFF
--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -115,12 +115,26 @@ for what remains keyed to the pathname and why.
 
 `ptah migrations generate` plans and publishes in two steps, so the directory
 can be replaced between them by something outside the run's control. The plan
-records the planned directory's filesystem identity as well as its contents, and
-publication refuses a directory that is no longer the same object — including a
-substitute that holds exactly the files the plan verified. The refusal is
-`migration directory changed after migration planning`, and nothing is written
-([#1118](https://github.com/stokaro/ptah/issues/1118)). This changes behavior:
-a run that previously published into a recreated directory now fails instead.
+binds the directory while it is being built and holds that binding open until
+it publishes, so the plan is a claim on a filesystem object rather than on a
+pathname. Publication refuses a directory that is no longer the object the plan
+holds — a substitute that holds exactly the files the plan verified, and a
+directory removed and recreated at the same pathname, are both refused. The
+refusal is `migration directory changed after migration planning`, and nothing
+is written ([#1118](https://github.com/stokaro/ptah/issues/1118)).
+
+Holding the directory open is what makes the answer the same on every platform.
+Comparing a recorded `os.SameFile` identity instead would ask the operating
+system whether two identifiers match, and an identifier belonging to a removed
+directory can be handed straight back to its replacement: measured over 20
+remove-and-recreate cycles of one pathname, ext4 reissued it 20 times and APFS
+none, so the same code refused the substitution on one filesystem and accepted
+it on another. An open directory cannot have its identifier reissued.
+
+This changes behavior twice over: a run that previously published into a
+recreated directory now fails instead, and while a plan is outstanding the
+migration directory is held open, so another process cannot rename or remove it
+until the plan publishes or is discarded.
 
 ## Consequences
 

--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -116,12 +116,13 @@ for what remains keyed to the pathname and why.
 `ptah migrations generate` plans and publishes in two steps, so the directory
 can be replaced between them by something outside the run's control. The plan
 binds the directory while it is being built and holds that binding open until
-it publishes, so the plan is a claim on a filesystem object rather than on a
-pathname. Publication refuses a directory that is no longer the object the plan
-holds — a substitute that holds exactly the files the plan verified, and a
-directory removed and recreated at the same pathname, are both refused. The
-refusal is `migration directory changed after migration planning`, and nothing
-is written ([#1118](https://github.com/stokaro/ptah/issues/1118)).
+its publication attempt returns, so the plan is a claim on a filesystem object
+rather than on a pathname. Publication refuses a directory that is no longer
+the object the plan holds — a substitute that holds exactly the files the plan
+verified, and a directory removed and recreated at the same pathname, are both
+refused. The refusal is `migration directory changed after migration planning`,
+and nothing is written
+([#1118](https://github.com/stokaro/ptah/issues/1118)).
 
 Holding the directory open is what makes the answer the same on every platform.
 Comparing a recorded `os.SameFile` identity instead would ask the operating
@@ -131,10 +132,24 @@ remove-and-recreate cycles of one pathname, ext4 reissued it 20 times and APFS
 none, so the same code refused the substitution on one filesystem and accepted
 it on another. An open directory cannot have its identifier reissued.
 
-This changes behavior twice over: a run that previously published into a
-recreated directory now fails instead, and while a plan is outstanding the
-migration directory is held open, so another process cannot rename or remove it
-until the plan publishes or is discarded.
+Holding the directory open is not a lock on it. On Unix another process renames
+or removes the held directory exactly as it always could; the guarantee is that
+the plan keeps writing to the object it retained, and refuses to write at all
+once revalidation shows the pathname no longer names that object. On Windows an
+open handle is stronger and the rename or removal may be refused or deferred
+instead. The plan releases the directory when its publication attempt returns —
+whether that attempt published or failed — and a plan that is never published at
+all releases it when it is collected.
+
+This changes behavior twice over. A run that previously published into a
+recreated directory now fails instead. And a migration directory containing a
+symbolic link that points outside itself — a shared migration linked in from
+elsewhere — is refused by `ptah migrations generate` rather than followed,
+because the directory is read, checksummed and published through the object the
+run opened. `ptah migrations up` already refused such a directory, so what the
+generator used to do was publish into a directory the applier would not read;
+the two now agree. A link whose target is inside the migration directory is
+unaffected. The refusal names the entry and the rule.
 
 ## Consequences
 

--- a/docs/site/src/content/docs/concepts/migration-directory.md
+++ b/docs/site/src/content/docs/concepts/migration-directory.md
@@ -97,18 +97,30 @@ bytes.
 
 ## Writing back to the directory
 
-The verbs that write a migration directory — `migrate diff` and native
-`ptah migrate generate` — bind it the same way and keep the binding. They open
-the directory and its parent once, before staging, and every staged file,
-published migration, `atlas.sum`, journal, commit marker, rollback quarantine
-and cleanup entry is named as a direct child of one of those two handles.
-Recovery of an interrupted batch runs through the same handles.
+The verbs that write a migration directory — `migrate diff`, `migrate new`, and
+native `ptah migrations generate` and `ptah migrations create` — bind it the
+same way and keep the binding. They open the directory and its parent once,
+before staging, and every staged file, published migration, `atlas.sum`,
+journal, commit marker, rollback quarantine and cleanup entry is named as a
+direct child of one of those two handles. A migration directory that does not
+exist yet is created through the bound parent, so it is materialized where the
+run looked rather than where the pathname points by then. Recovery of an
+interrupted batch runs through the same handles.
 
 Replacing the directory after the run validated it therefore cannot redirect
 what it writes, and a directory configured through `atlas.hcl` stays inside the
 opened project root. See
 [the publication boundary](../../atlas/migrate-commands/#the-publication-boundary)
 for what remains keyed to the pathname and why.
+
+`ptah migrations generate` plans and publishes in two steps, so the directory
+can be replaced between them by something outside the run's control. The plan
+records the planned directory's filesystem identity as well as its contents, and
+publication refuses a directory that is no longer the same object — including a
+substitute that holds exactly the files the plan verified. The refusal is
+`migration directory changed after migration planning`, and nothing is written
+([#1118](https://github.com/stokaro/ptah/issues/1118)). This changes behavior:
+a run that previously published into a recreated directory now fails instead.
 
 ## Consequences
 

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -150,13 +150,15 @@ func TestWritePublicationJournal_FallsBackWithoutHardLinks(t *testing.T) {
 	c.Assert(removePublicationJournal(writer), qt.IsNil)
 }
 
-func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
+func TestMigrationWriterPublishArtifacts_PublishesCompleteBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
+	migrationWriter, err := OpenMigrationWriter(nil, dir)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = migrationWriter.Close() }()
 
-	paths, err := PublishArtifactsLocked(
+	paths, err := migrationWriter.PublishArtifacts(
 		t.Context(),
-		dir,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},
@@ -183,15 +185,17 @@ func TestPublishArtifactsLocked_PublishesCompleteBatch(t *testing.T) {
 	c.Assert(err, qt.ErrorIs, os.ErrNotExist)
 }
 
-func TestPublishArtifactsLocked_CollisionRollsBackWholeBatch(t *testing.T) {
+func TestMigrationWriterPublishArtifacts_CollisionRollsBackWholeBatch(t *testing.T) {
 	c := qt.New(t)
 	dir := c.TempDir()
 	existingPath := filepath.Join(dir, "1_change.down.sql")
 	c.Assert(os.WriteFile(existingPath, []byte("existing\n"), 0o600), qt.IsNil)
+	migrationWriter, err := OpenMigrationWriter(nil, dir)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = migrationWriter.Close() }()
 
-	paths, err := PublishArtifactsLocked(
+	paths, err := migrationWriter.PublishArtifacts(
 		t.Context(),
-		dir,
 		[]PublicationArtifact{
 			{Name: "1_change.up.sql", Contents: []byte("SELECT 1;\n")},
 			{Name: "1_change.down.sql", Contents: []byte("SELECT 2;\n")},

--- a/internal/atlasmigrate/migrationwriter.go
+++ b/internal/atlasmigrate/migrationwriter.go
@@ -1,0 +1,172 @@
+package atlasmigrate
+
+import (
+	"context"
+	"errors"
+	"io/fs"
+
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// MigrationWriter is the rooted migration-directory capability a writer
+// transaction outside this package runs through: one binding of the directory
+// and its parent, reused for every read, create, publication and rollback the
+// transaction performs.
+//
+// It exists because the native generator had the shape stokaro/ptah#1118
+// describes. `ptah migrations create` resolved its output directory once, then
+// reopened it by pathname for the mkdir, for the version scan, for each file it
+// created and for the atlas.sum commit; `ptah migrations generate` verified the
+// directory's contents by pathname and then let the publication resolve the
+// pathname a second time. A directory or ancestor replaced between any two of
+// those steps takes the write somewhere the verification never looked.
+//
+// The methods are deliberately thin: this type is the boundary, not a second
+// filesystem abstraction. Everything behind it is the same migrationWriterDir
+// the `migrate diff` publication already runs through, so both writers share one
+// answer to "which filesystem object is this transaction committing to".
+//
+// A nil root keeps direct-CLI behavior, where an explicit absolute directory is
+// the operator's own choice of destination. The binding still happens; it is
+// simply not confined to a project root.
+type MigrationWriter struct {
+	dir *migrationWriterDir
+}
+
+// OpenMigrationWriter binds dir and its parent without creating dir. A missing
+// migration directory is reported through Exists rather than as an error, so a
+// caller can compare the directory's absence against what it planned for before
+// deciding to materialize it.
+//
+// The parent must already exist; call EnsureMigrationParent first when the
+// caller accepts a directory nested below missing levels.
+func OpenMigrationWriter(
+	root *pathguard.OpenedDirectory,
+	dir string,
+) (*MigrationWriter, error) {
+	bound, err := openMigrationWriterDir(root, dir)
+	if err != nil {
+		return nil, err
+	}
+	return &MigrationWriter{dir: bound}, nil
+}
+
+// EnsureMigrationParent creates dir's parent, and every level missing above it,
+// through root when one is supplied.
+func EnsureMigrationParent(root *pathguard.OpenedDirectory, dir string) error {
+	return ensureMigrationDirParent(root, dir)
+}
+
+// Close releases the directory and parent handles.
+func (w *MigrationWriter) Close() error {
+	return w.dir.Close()
+}
+
+// Path returns the stable lexical path selected for the migration directory. It
+// is display and result data only; no write step resolves it again.
+func (w *MigrationWriter) Path() string {
+	return w.dir.Path()
+}
+
+// Exists reports whether the migration directory was present when the handles
+// were bound, or has been materialized by Create since.
+func (w *MigrationWriter) Exists() bool {
+	return w.dir.Exists()
+}
+
+// Create materializes a missing migration directory through the parent handle
+// bound at open time, so it is created inside the opened root rather than
+// wherever the pathname happens to point by now. Creating a directory that
+// already exists is not an error.
+//
+// It is the same materialization the creating binding performs, so a directory
+// this package creates for itself and one an outside caller creates through the
+// boundary land in exactly the same place.
+func (w *MigrationWriter) Create() error {
+	return w.dir.create()
+}
+
+// Identity returns the bound directory's filesystem identity, for comparison
+// with os.SameFile against an identity captured earlier in the transaction.
+func (w *MigrationWriter) Identity() (fs.FileInfo, error) {
+	if !w.dir.Exists() {
+		return nil, w.dir.missingDirError()
+	}
+	return w.dir.dir.Stat(".")
+}
+
+// FS returns the escape-resistant filesystem rooted at the migration directory.
+func (w *MigrationWriter) FS() (fs.FS, error) {
+	return w.dir.FS()
+}
+
+// Entries lists the migration directory through the bound handle. A directory
+// that does not exist lists as empty, because a version scan over an absent
+// directory has the same answer as one over an empty directory.
+func (w *MigrationWriter) Entries() ([]fs.DirEntry, error) {
+	if !w.dir.Exists() {
+		return nil, nil
+	}
+	return w.dir.dir.ReadDir(".")
+}
+
+// WriteNew creates name with contents through the bound handle, failing with
+// fs.ErrExist when the name is taken. The exclusive create is what makes the
+// commit conditional on the destination being absent: a file that appeared
+// after the caller chose the name is reported, never overwritten.
+func (w *MigrationWriter) WriteNew(name, contents string) error {
+	if !w.dir.Exists() {
+		return w.dir.missingDirError()
+	}
+	return writeExclusiveRootedFile(w.dir.dir, name, contents)
+}
+
+// Remove deletes name through the bound handle, for withdrawing a file this
+// transaction created after a later step failed.
+func (w *MigrationWriter) Remove(name string) error {
+	if !w.dir.Exists() {
+		return nil
+	}
+	err := w.dir.dir.Remove(name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	return err
+}
+
+// PublishAtlasSum commits atlas.sum through the bound handle, conditionally on
+// the checksum state this transaction observed, and returns its path. A
+// concurrent writer that replaced atlas.sum after the snapshot was taken is
+// reported instead of overwritten.
+func (w *MigrationWriter) PublishAtlasSum(sum *migratesum.SumFile) (string, error) {
+	if !w.dir.Exists() {
+		return "", w.dir.missingDirError()
+	}
+	return publishDirSum(w.dir, sum)
+}
+
+// PublishArtifacts durably publishes artifacts as one journaled batch through
+// the bound handle. The caller must hold the migration-directory lock.
+func (w *MigrationWriter) PublishArtifacts(
+	ctx context.Context,
+	artifacts []PublicationArtifact,
+) ([]string, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if !w.dir.Exists() {
+		return nil, w.dir.missingDirError()
+	}
+	return publishArtifactsLocked(ctx, w.dir, artifacts)
+}
+
+// SyncDir flushes the migration directory's entry changes where the platform
+// supports it, so files created through WriteNew are durable before the command
+// reports them.
+func (w *MigrationWriter) SyncDir() error {
+	if !w.dir.Exists() {
+		return nil
+	}
+	return w.dir.dir.Sync()
+}

--- a/internal/atlasmigrate/migrationwriter.go
+++ b/internal/atlasmigrate/migrationwriter.go
@@ -87,13 +87,18 @@ func (w *MigrationWriter) Create() error {
 	return w.dir.create()
 }
 
-// Identity returns the bound directory's filesystem identity, for comparison
-// with os.SameFile against an identity captured earlier in the transaction.
-func (w *MigrationWriter) Identity() (fs.FileInfo, error) {
-	if !w.dir.Exists() {
-		return nil, w.dir.missingDirError()
-	}
-	return w.dir.dir.Stat(".")
+// Revalidate reports whether the pathname this writer was selected by still
+// names the object it holds, or -- for a migration directory that was absent
+// when the writer bound -- whether that name is still free in the bound parent.
+//
+// It is the check a transaction runs when it has to leave a window open between
+// binding the directory and committing to it, which the planned-migration
+// writer does: the plan is built by one exported call and published by another,
+// so the caller owns the time in between. Holding the handle across that window
+// is what makes the answer sound rather than a bet on the operating system not
+// reissuing an identifier (stokaro/ptah#1118).
+func (w *MigrationWriter) Revalidate() error {
+	return w.dir.revalidate()
 }
 
 // FS returns the escape-resistant filesystem rooted at the migration directory.

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -179,24 +179,13 @@ func writeDiffArtifactsWithSumWriter(
 	return result, nil
 }
 
-// PublishArtifactsLocked durably publishes all artifacts as one batch. The
-// caller must hold the migration-directory lock for dir.
-func PublishArtifactsLocked(
-	ctx context.Context,
-	dir string,
-	artifacts []PublicationArtifact,
-) ([]string, error) {
-	if err := ctx.Err(); err != nil {
-		return nil, err
-	}
-	w, err := createMigrationWriterDir(nil, dir)
-	if err != nil {
-		return nil, err
-	}
-	paths, publishErr := publishArtifactsLocked(ctx, w, artifacts)
-	return paths, errors.Join(publishErr, w.Close())
-}
-
+// publishArtifactsLocked durably publishes all artifacts as one batch through
+// the caller's bound handle. The caller must hold the migration-directory lock.
+//
+// There is deliberately no pathname-taking entry point beside it. The one that
+// existed took a dir string and bound its own handle, which meant the batch
+// could be published to a filesystem object the caller had never verified
+// (stokaro/ptah#1118); MigrationWriter.PublishArtifacts is the only way in.
 func publishArtifactsLocked(
 	ctx context.Context,
 	w *migrationWriterDir,

--- a/internal/atlasmigrate/writerdir.go
+++ b/internal/atlasmigrate/writerdir.go
@@ -180,6 +180,53 @@ func (w *migrationWriterDir) create() error {
 	return nil
 }
 
+// revalidate reports whether the pathname this writer was selected by still
+// names the object it holds -- or, for a directory that did not exist when the
+// handles were bound, whether the name is still free in the parent it holds.
+//
+// It answers with os.SameFile, and the answer is trustworthy only because the
+// handle is still open. An open directory keeps its identifier allocated: the
+// kernel cannot hand the same inode number, or the same Windows file index, to
+// a directory created after this one was removed. Comparing a detached
+// fs.FileInfo captured before the removal has no such guarantee, and measured on
+// ext4 the recreated directory took the identifier back in 20 of 20
+// remove-and-recreate cycles, so the comparison said "same object" every time
+// (stokaro/ptah#1118).
+//
+// The two cases ask different questions on purpose. A directory that exists is
+// compared against the selected pathname, so an ancestor swapped anywhere above
+// it is caught as well. A directory that does not exist is compared against the
+// entry name in the retained parent, because that is where create() is about to
+// materialize it and the pathname is not what it will resolve through.
+func (w *migrationWriterDir) revalidate() error {
+	if w.dir == nil {
+		return w.revalidateAbsent()
+	}
+	held, err := w.dir.Stat(".")
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", pathguard.ErrDirectoryChanged, w.path, err)
+	}
+	current, err := os.Stat(w.path)
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", pathguard.ErrDirectoryChanged, w.path, err)
+	}
+	if !current.IsDir() || !os.SameFile(held, current) {
+		return fmt.Errorf("%w: %s", pathguard.ErrDirectoryChanged, w.path)
+	}
+	return nil
+}
+
+func (w *migrationWriterDir) revalidateAbsent() error {
+	_, err := w.parent.Lstat(w.name)
+	if errors.Is(err, fs.ErrNotExist) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%w: %s: %w", pathguard.ErrDirectoryChanged, w.path, err)
+	}
+	return fmt.Errorf("%w: %s", pathguard.ErrDirectoryChanged, w.path)
+}
+
 func openMigrationWriterParent(
 	root *pathguard.OpenedDirectory,
 	parentPath string,

--- a/internal/atlasmigrate/writerdir.go
+++ b/internal/atlasmigrate/writerdir.go
@@ -141,9 +141,10 @@ func bindMigrationWriterDir(
 	name := filepath.Base(canonical)
 	writer := &migrationWriterDir{parent: parent, name: name, path: filepath.Clean(display)}
 	if binding.creates() {
-		if err := parent.Mkdir(name, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
-			return nil, errors.Join(fmt.Errorf("create migration directory: %w", err), parent.Close())
+		if err := writer.create(); err != nil {
+			return nil, errors.Join(err, parent.Close())
 		}
+		return writer, nil
 	}
 	opened, err := parent.OpenDirectory(name)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -154,6 +155,29 @@ func bindMigrationWriterDir(
 	}
 	writer.dir = opened
 	return writer, nil
+}
+
+// create materializes the migration directory through the parent handle this
+// writer already holds and binds the result. An entry that already exists is
+// not an error; the containment guarantee comes from the rooted open that
+// follows, not from the create.
+//
+// The parent handle is the point. Creating the directory by pathname would
+// place it wherever the name resolves at that moment, which is not necessarily
+// the parent the transaction validated (stokaro/ptah#1118).
+func (w *migrationWriterDir) create() error {
+	if w.dir != nil {
+		return nil
+	}
+	if err := w.parent.Mkdir(w.name, 0o755); err != nil && !errors.Is(err, fs.ErrExist) {
+		return fmt.Errorf("create migration directory: %w", err)
+	}
+	opened, err := w.parent.OpenDirectory(w.name)
+	if err != nil {
+		return fmt.Errorf("open migration directory: %w", err)
+	}
+	w.dir = opened
+	return nil
 }
 
 func openMigrationWriterParent(

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -88,16 +88,16 @@ the version it chose both describe the directory as it was before the first
 attempt — the honest retry is a fresh `PlanMigration`.
 
 The plan binds the migration directory while it is being built and holds that
-binding until it publishes, so it is a claim on a filesystem object rather than
-on a pathname. `WriteFiles` acquires the shared cross-process directory lock,
-rejects the plan if migration SQL or integrity metadata changed before
-publication, and rejects it if the pathname no longer names the object the plan
-holds — a substitute holding exactly the planned files, and a directory removed
-and recreated at the same pathname, are both a different destination. It never
-renumbers and publishes a plan derived from stale history. The version the plan
-chooses is scanned through the bound directory too, so it avoids colliding with
-the files it will be published beside rather than with whatever the pathname
-resolved to while the version was being picked.
+binding until its publication attempt returns, so it is a claim on a filesystem
+object rather than on a pathname. `WriteFiles` acquires the shared cross-process
+directory lock, rejects the plan if migration SQL or integrity metadata changed
+before publication, and rejects it if the pathname no longer names the object
+the plan holds — a substitute holding exactly the planned files, and a directory
+removed and recreated at the same pathname, are both a different destination. It
+never renumbers and publishes a plan derived from stale history. The version the
+plan chooses is scanned through the bound directory too, so it avoids colliding
+with the files it will be published beside rather than with whatever the
+pathname resolved to while the version was being picked.
 
 `WriteFiles` releases the migration directory handles before it returns, on the
 failure paths as well as the successful one, so the plan's hold on the directory

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -81,8 +81,11 @@ if err != nil {
 fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
 ```
 
-Planning does not write migration artifacts. A successful `WriteFiles` call
-consumes the plan; call it once after all surrounding work has succeeded.
+Planning does not write migration artifacts. One `WriteFiles` call consumes the
+plan; call it once after all surrounding work has succeeded. A second call is
+reported rather than retried, because the contents the plan verifies against and
+the version it chose both describe the directory as it was before the first
+attempt — the honest retry is a fresh `PlanMigration`.
 
 The plan binds the migration directory while it is being built and holds that
 binding until it publishes, so it is a claim on a filesystem object rather than
@@ -91,12 +94,31 @@ rejects the plan if migration SQL or integrity metadata changed before
 publication, and rejects it if the pathname no longer names the object the plan
 holds — a substitute holding exactly the planned files, and a directory removed
 and recreated at the same pathname, are both a different destination. It never
-renumbers and publishes a plan derived from stale history.
+renumbers and publishes a plan derived from stale history. The version the plan
+chooses is scanned through the bound directory too, so it avoids colliding with
+the files it will be published beside rather than with whatever the pathname
+resolved to while the version was being picked.
 
-A plan that is never published releases its handles when it is collected. While
-a plan is outstanding the migration directory is held open, so on Windows
-another process cannot rename or remove it until the plan publishes or is
-discarded.
+`WriteFiles` releases the migration directory handles before it returns, on the
+failure paths as well as the successful one, so the plan's hold on the directory
+ends at a moment the caller controls. A plan that is never published at all
+releases them when it is collected.
+
+Holding the directory open is not a lock on it. On Unix another process renames
+or removes the held directory exactly as it always could, and the guarantee is
+that publication stays bound to the retained object and refuses once
+revalidation shows the pathname no longer names it. On Windows an open handle is
+stronger and the rename or removal may be refused or deferred until the plan
+releases the directory.
+
+A migration directory containing a symbolic link that points outside itself — a
+shared migration linked in from another directory — is refused: everything in
+the directory is read, checksummed and published through the object the run
+opened, so bytes that live elsewhere cannot be part of it. The refusal names the
+entry and the rule. A link whose target is inside the migration directory
+resolves normally and is unaffected. The applier already refused such a
+directory, so publishing into one produced a directory `ptah migrations up`
+would not read; the generator no longer creates that situation.
 
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -83,13 +83,20 @@ fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
 
 Planning does not write migration artifacts. A successful `WriteFiles` call
 consumes the plan; call it once after all surrounding work has succeeded.
-The plan records the migration-directory snapshot used for planning, together
-with that directory's filesystem identity.
-`WriteFiles` acquires the shared cross-process directory lock and rejects the
-plan if migration SQL or integrity metadata changed before publication, or if
-the directory is no longer the same filesystem object — a substitute holding
-exactly the planned files is still a different destination. It never renumbers
-and publishes a plan derived from stale history.
+
+The plan binds the migration directory while it is being built and holds that
+binding until it publishes, so it is a claim on a filesystem object rather than
+on a pathname. `WriteFiles` acquires the shared cross-process directory lock,
+rejects the plan if migration SQL or integrity metadata changed before
+publication, and rejects it if the pathname no longer names the object the plan
+holds — a substitute holding exactly the planned files, and a directory removed
+and recreated at the same pathname, are both a different destination. It never
+renumbers and publishes a plan derived from stale history.
+
+A plan that is never published releases its handles when it is collected. While
+a plan is outstanding the migration directory is held open, so on Windows
+another process cannot rename or remove it until the plan publishes or is
+discarded.
 
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -83,10 +83,13 @@ fmt.Printf("published %s and %s\n", files.UpFile, files.DownFile)
 
 Planning does not write migration artifacts. A successful `WriteFiles` call
 consumes the plan; call it once after all surrounding work has succeeded.
-The plan records the migration-directory snapshot used for planning.
+The plan records the migration-directory snapshot used for planning, together
+with that directory's filesystem identity.
 `WriteFiles` acquires the shared cross-process directory lock and rejects the
-plan if migration SQL or integrity metadata changed before publication. It
-never renumbers and publishes a plan derived from stale history.
+plan if migration SQL or integrity metadata changed before publication, or if
+the directory is no longer the same filesystem object — a substitute holding
+exactly the planned files is still a different destination. It never renumbers
+and publishes a plan derived from stale history.
 
 It renders every up/down file and requested safety report before publishing
 the artifacts as one batch. A filename collision leaves no partial new files.
@@ -262,7 +265,8 @@ type GenerateMigrationOptions struct {
     // OutputDir is the directory where migration files will be saved (always real filesystem)
     OutputDir string
 
-    // AllowedOutputRoot constrains OutputDir when accepting user-supplied paths
+    // AllowedOutputRoot confines the whole writer transaction when accepting
+    // user-supplied paths
     AllowedOutputRoot string
 
     // CompareOptions are the options to use when comparing schemas
@@ -284,6 +288,7 @@ type GenerateMigrationOptions struct {
 - `DBConn`: Existing database connection (optional; used instead of `DatabaseURL` when set)
 - `MigrationName`: Name for the migration (optional, defaults to "migration")
 - `OutputDir`: Directory where migration files will be saved (required)
+- `AllowedOutputRoot`: Project or workspace root the output directory must stay inside (optional). It is opened, not merely compared against: the root, the migration directory and its parent are bound once and every read, create, checksum commit and rollback of the run goes through those handles, so replacing the directory or an ancestor after the path was validated cannot move the write outside the root
 - `CompareOptions`: Schema comparison options (optional)
 - `Schemas`: PostgreSQL schema allow-list for database introspection (optional)
 - `ShadowDatabaseURL`: Disposable database URL for pre-write migration replay and round-trip checks; it must identify a different live database realm from the target (optional)

--- a/migration/generator/concurrent_index_test.go
+++ b/migration/generator/concurrent_index_test.go
@@ -196,14 +196,17 @@ func TestPlanGeneratedMigrationSpecs_RefusesUnsplitNonTransactionalMix(t *testin
 	c.Assert(err, qt.ErrorMatches, "generated migration mixes transactional statements with non-transactional statements that cannot be split automatically")
 }
 
-func TestCreateMigrationFilesFromSpecs_WritesAllPairs(t *testing.T) {
+func TestPublishPlannedMigration_WritesAllPairs(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
 
 	var files *MigrationFiles
 	var publishErr error
 	err := atlasmigrate.WithMigrationDirectoryLock(t.Context(), dir, 0, func(context.Context) error {
-		files, publishErr = createMigrationFilesFromSpecs(t.Context(), dir, "", []generatedMigrationSpec{
+		writer, bindErr := bindMigrationOutputDir(nil, dir)
+		c.Assert(bindErr, qt.IsNil)
+		defer func() { _ = writer.Close() }()
+		files, publishErr = publishPlannedMigration(t.Context(), writer, "", []generatedMigrationSpec{
 			{Version: 100, Name: "transactional", UpSQL: "SELECT 1;\n", DownSQL: "SELECT 2;\n"},
 			{Version: 101, Name: "concurrent_indexes", UpSQL: "-- +ptah no_transaction\nSELECT 3;\n", DownSQL: "-- +ptah no_transaction\nSELECT 4;\n", NoTransaction: true},
 		})

--- a/migration/generator/file_creation_test.go
+++ b/migration/generator/file_creation_test.go
@@ -11,34 +11,75 @@ import (
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
-func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T) {
+// TestNextAvailablePtahVersionSkipsVersionWhenEitherDirectionExists pins that a
+// half-present pair still consumes its version. The names come from a listing
+// the writer took through its own rooted handle, so this is the whole of the
+// decision: what the writer then creates is exclusive, and a name that appeared
+// after the listing is refused by the create rather than overwritten.
+func TestNextAvailablePtahVersionSkipsVersionWhenEitherDirectionExists(t *testing.T) {
 	c := qt.New(t)
-	dir := t.TempDir()
-	version := int64(42)
 	name := "constraint_drift"
 
-	oldUp := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "up"))
-	oldDown := filepath.Join(dir, migrator.GenerateMigrationFileName(version, name, "down"))
-	c.Assert(os.WriteFile(oldUp, nil, 0600), qt.IsNil)
-	c.Assert(os.WriteFile(oldDown, []byte("SELECT old_down;\n"), 0600), qt.IsNil)
+	tests := []struct {
+		name  string
+		names []string
+		want  int64
+	}{
+		{name: "empty directory", names: nil, want: 42},
+		{
+			name:  "only the up half exists",
+			names: []string{migrator.GenerateMigrationFileName(42, name, "up")},
+			want:  43,
+		},
+		{
+			name:  "only the down half exists",
+			names: []string{migrator.GenerateMigrationFileName(42, name, "down")},
+			want:  43,
+		},
+		{
+			name: "both halves exist",
+			names: []string{
+				migrator.GenerateMigrationFileName(42, name, "up"),
+				migrator.GenerateMigrationFileName(42, name, "down"),
+			},
+			want: 43,
+		},
+	}
 
-	files, err := createMigrationFiles(dir, version, name, "SELECT up;\n", "SELECT down;\n")
-	c.Assert(err, qt.IsNil)
-	c.Assert(files.Version, qt.Equals, version+1)
-
-	oldDownBytes, err := os.ReadFile(oldDown)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(oldDownBytes), qt.Equals, "SELECT old_down;\n")
-
-	upBytes, err := os.ReadFile(files.UpFile)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(upBytes), qt.Equals, "SELECT up;\n")
-	downBytes, err := os.ReadFile(files.DownFile)
-	c.Assert(err, qt.IsNil)
-	c.Assert(string(downBytes), qt.Equals, "SELECT down;\n")
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(nextAvailablePtahVersion(test.names, 42, name), qt.Equals, test.want)
+		})
+	}
 }
 
-// TestCreateMigrationFilesCreatesMissingParents replaces
+// TestGenerateEmptyMigrationNeverOverwritesAnExistingHalf is the file-level
+// counterpart: the writer's creates are exclusive, so an existing file keeps its
+// contents whatever the version scan concluded.
+func TestGenerateEmptyMigrationNeverOverwritesAnExistingHalf(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	first, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "constraint drift",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(os.WriteFile(first.DownFile, []byte("SELECT old_down;\n"), 0600), qt.IsNil)
+
+	second, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "constraint drift",
+		OutputDir:     dir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(second.DownFile, qt.Not(qt.Equals), first.DownFile)
+
+	oldDownBytes, err := os.ReadFile(first.DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(oldDownBytes), qt.Equals, "SELECT old_down;\n")
+}
+
+// TestGenerateEmptyMigrationCreatesMissingParents replaces
 // TestCreateMigrationFilesRequiresExistingParent, which pinned the opposite
 // behavior.
 //
@@ -49,31 +90,42 @@ func TestCreateMigrationFilesSkipsVersionWhenEitherDirectionExists(t *testing.T)
 // where this refused with `parent directory "…/a" is not available` and wrote
 // nothing (stokaro/ptah#1241 item 4). Ptah's `migrate diff` writer already
 // created parents, so the two writers also disagreed with each other.
-func TestCreateMigrationFilesCreatesMissingParents(t *testing.T) {
+func TestGenerateEmptyMigrationCreatesMissingParents(t *testing.T) {
 	c := qt.New(t)
-	dir := filepath.Join(t.TempDir(), "missing", "levels", "migrations")
+	// The reported path is the one the output directory resolved to, so the
+	// expectation resolves the temporary root the same way rather than comparing
+	// against a path that is a symlink on this platform.
+	base, err := filepath.EvalSymlinks(t.TempDir())
+	c.Assert(err, qt.IsNil)
+	dir := filepath.Join(base, "missing", "levels", "migrations")
 
-	files, err := createMigrationFiles(dir, 1, "init", "SELECT 1;\n", "SELECT 2;\n")
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "init",
+		OutputDir:     dir,
+	})
 	c.Assert(err, qt.IsNil)
 	c.Assert(filepath.Dir(files.UpFile), qt.Equals, dir)
 
 	upBytes, err := os.ReadFile(files.UpFile)
 	c.Assert(err, qt.IsNil)
-	c.Assert(string(upBytes), qt.Equals, "SELECT 1;\n")
+	c.Assert(string(upBytes), qt.Contains, "-- Direction: UP\n")
 }
 
-// TestCreateMigrationFilesRefusesParentThatIsAFile is the control for the test
+// TestGenerateEmptyMigrationRefusesParentThatIsAFile is the control for the test
 // above: creating parents must not mean creating them through something that is
 // not a directory. The pinned binary refuses that path too
 // (`stat a/b: not a directory`, exit 1), so both stay refusals.
-func TestCreateMigrationFilesRefusesParentThatIsAFile(t *testing.T) {
+func TestGenerateEmptyMigrationRefusesParentThatIsAFile(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()
 	blocker := filepath.Join(root, "a")
 	c.Assert(os.WriteFile(blocker, []byte("not a directory\n"), 0600), qt.IsNil)
 
-	_, err := createMigrationFiles(filepath.Join(blocker, "b"), 1, "init", "SELECT 1;\n", "SELECT 2;\n")
-	c.Assert(err, qt.ErrorMatches, `failed to create output directory: .*not a directory`)
+	_, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName: "init",
+		OutputDir:     filepath.Join(blocker, "b"),
+	})
+	c.Assert(err, qt.ErrorMatches, `.*not a directory`)
 
 	blockerBytes, err := os.ReadFile(blocker)
 	c.Assert(err, qt.IsNil)

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -152,14 +152,19 @@ type MigrationPlan struct {
 	mu        sync.Mutex
 	outputDir string
 	// dir is the migration directory, bound while the plan was built and held
-	// open until the plan is published or collected. It is what makes the plan
-	// a claim on a filesystem object rather than on a pathname: publication
-	// verifies and writes through this one handle, so a directory replaced --
-	// or removed and recreated -- between the two exported calls cannot receive
-	// the batch (stokaro/ptah#1118).
+	// open until the plan's one publication attempt returns. It is what makes
+	// the plan a claim on a filesystem object rather than on a pathname:
+	// publication verifies and writes through this one handle, so a directory
+	// replaced -- or removed and recreated -- between the two exported calls
+	// cannot receive the batch (stokaro/ptah#1118).
 	//
-	// A plan that is dropped without being published releases the handles when
-	// it is collected, because os.Root closes its descriptor from a finalizer.
+	// It is nil once the handles have been released, which is what marks the
+	// plan spent. WriteFilesContext releases them on the way out whether the
+	// publication succeeded or failed, so the window in which the plan holds
+	// the directory ends at a point the caller controls rather than at the next
+	// garbage collection. A plan that is never published at all still releases
+	// them when it is collected, because os.Root closes its descriptor from a
+	// finalizer.
 	dir *atlasmigrate.MigrationWriter
 	// plannedContents is what dir held when the plan was built, and nothing
 	// else. It used to carry a filesystem identity beside the contents; identity
@@ -538,6 +543,14 @@ func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
 // under the lock it revalidates the handle it was given, compares the contents
 // against what planning recorded, and publishes through that same handle.
 //
+// One call is one use of the plan. Whatever this call returns, it releases the
+// migration directory handles before returning, so a failed publication ends
+// the plan's hold on the directory at a moment the caller can observe instead
+// of at the next garbage collection. A plan whose attempt already happened is
+// reported rather than retried: its recorded contents and its chosen version
+// both describe a directory as it was before the attempt, so the honest retry
+// is a fresh PlanMigration.
+//
 // It used to reopen the directory by pathname here and decide whether it was
 // still the planned one by comparing an fs.FileInfo captured before any handle
 // existed. That comparison is only as good as the operating system's promise
@@ -556,6 +569,12 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if p.written {
 		return nil, fmt.Errorf("migration plan has already been written")
 	}
+	if p.dir == nil {
+		return nil, fmt.Errorf("migration plan was released by a failed publication")
+	}
+	// The plan is single-use, so the handles have no reader left once this call
+	// returns -- on the failure paths as much as on the successful one.
+	defer p.release()
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
@@ -568,10 +587,23 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if err != nil {
 		return nil, err
 	}
-	// The plan is single-use, so the handles have no reader left once the batch
-	// is committed.
-	_ = p.dir.Close()
 	return files, nil
+}
+
+// release closes the migration directory handles the plan holds and marks the
+// plan spent. It is idempotent and runs with p.mu held.
+//
+// Deterministic release is the point. os.Root closes its descriptor from a
+// finalizer, so an unreleased handle survives until the next collection; on
+// Windows that is also the window in which nothing else can rename or remove
+// the migration directory, and a failed publication would otherwise leave that
+// window open with no event that ends it (stokaro/ptah#1118).
+func (p *MigrationPlan) release() {
+	if p.dir == nil {
+		return
+	}
+	_ = p.dir.Close()
+	p.dir = nil
 }
 
 func (p *MigrationPlan) publishLocked(ctx context.Context) (*MigrationFiles, error) {
@@ -620,7 +652,66 @@ func captureMigrationDirectoryContents(
 	if err != nil {
 		return fsnapshot.Snapshot{}, err
 	}
-	return migrationsnapshot.CaptureStable(fsys)
+	snapshot, err := migrationsnapshot.CaptureStable(fsys)
+	if err != nil {
+		return fsnapshot.Snapshot{}, explainMigrationDirectoryRead(writer, err)
+	}
+	return snapshot, nil
+}
+
+// explainMigrationDirectoryRead names the entries that make a migration
+// directory unreadable through the handle the run bound, when that is what went
+// wrong. Any other failure is returned unchanged.
+//
+// The reachable cause is a migration file that is a symbolic link out of the
+// migration directory -- a shared migration linked in from elsewhere. Reading
+// the directory by pathname followed such a link, and reading it through the
+// bound handle does not, so this is a refusal rather than an accident: every
+// read, checksum and publication of the directory goes through the object the
+// run opened, and a file whose bytes live outside it cannot be part of a
+// directory Ptah is willing to seal (stokaro/ptah#1118). A link that resolves
+// inside the migration directory stays supported and never reaches this.
+//
+// The diagnosis runs only after a failed capture, so the successful path pays
+// nothing for it.
+func explainMigrationDirectoryRead(writer *atlasmigrate.MigrationWriter, cause error) error {
+	escaping := escapingMigrationEntries(writer)
+	if len(escaping) == 0 {
+		return cause
+	}
+	return fmt.Errorf(
+		"migration directory %s: symbolic links resolving outside it: %s;"+
+			" a migration file linked in from another directory is refused because"+
+			" the whole directory is read, checksummed and published through the"+
+			" directory itself: %w",
+		writer.Path(),
+		strings.Join(escaping, ", "),
+		cause,
+	)
+}
+
+// escapingMigrationEntries lists the migration directory's symbolic links that
+// do not resolve inside it, asked through the bound handle: the link itself is
+// visible as an entry, and a stat that cannot follow it is the escape.
+func escapingMigrationEntries(writer *atlasmigrate.MigrationWriter) []string {
+	entries, err := writer.Entries()
+	if err != nil {
+		return nil
+	}
+	fsys, err := writer.FS()
+	if err != nil {
+		return nil
+	}
+	var escaping []string
+	for _, entry := range entries {
+		if entry.Type()&fs.ModeSymlink == 0 {
+			continue
+		}
+		if _, statErr := fs.Stat(fsys, entry.Name()); statErr != nil {
+			escaping = append(escaping, entry.Name())
+		}
+	}
+	return escaping
 }
 
 func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -151,23 +151,24 @@ type MigrationFiles struct {
 type MigrationPlan struct {
 	mu        sync.Mutex
 	outputDir string
-	// allowedOutputRoot is carried from planning to publication so the writer
-	// transaction can open the root it must stay inside, rather than trusting a
-	// containment check made against a pathname before planning began.
-	allowedOutputRoot string
-	outputState       migrationDirectoryState
-	reportFormat      string
-	specs             []generatedMigrationSpec
-	written           bool
-}
-
-type migrationDirectoryState struct {
-	exists bool
-	// identity is the planned directory's filesystem identity, compared with
-	// os.SameFile so a replacement is detected even when the substitute holds
-	// exactly the files the plan verified.
-	identity fs.FileInfo
-	snapshot fsnapshot.Snapshot
+	// dir is the migration directory, bound while the plan was built and held
+	// open until the plan is published or collected. It is what makes the plan
+	// a claim on a filesystem object rather than on a pathname: publication
+	// verifies and writes through this one handle, so a directory replaced --
+	// or removed and recreated -- between the two exported calls cannot receive
+	// the batch (stokaro/ptah#1118).
+	//
+	// A plan that is dropped without being published releases the handles when
+	// it is collected, because os.Root closes its descriptor from a finalizer.
+	dir *atlasmigrate.MigrationWriter
+	// plannedContents is what dir held when the plan was built, and nothing
+	// else. It used to carry a filesystem identity beside the contents; identity
+	// now lives in dir, which is a handle rather than a detached fs.FileInfo the
+	// operating system is free to reissue to a replacement.
+	plannedContents fsnapshot.Snapshot
+	reportFormat    string
+	specs           []generatedMigrationSpec
+	written         bool
 }
 
 // EmptyMigrationOptions contains options for skeleton migration creation.
@@ -342,31 +343,9 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	// 1. Determine the desired schema: use a pre-merged one when provided (for a
 	// composite desired-state assembled from several sources), otherwise parse the
 	// Go entities directory.
-	generated := opts.Generated
-	if generated == nil {
-		var entitiesDir string
-
-		if opts.GoEntitiesFS == nil {
-			// Default to using the real filesystem
-			// We need to set up the filesystem root and relative path correctly
-			absPath, err := filepath.Abs(opts.GoEntitiesDir)
-			if err != nil {
-				return nil, fmt.Errorf("error resolving root directory path: %w", err)
-			}
-
-			// Use the parent directory as filesystem root and the basename as the path
-			fsRoot := filepath.Dir(absPath)
-			entitiesDir = filepath.Base(absPath)
-			opts.GoEntitiesFS = os.DirFS(fsRoot)
-		} else {
-			// For custom filesystems, use the path as-is
-			entitiesDir = opts.GoEntitiesDir
-		}
-
-		generated, err = goschema.ParseFS(opts.GoEntitiesFS, entitiesDir)
-		if err != nil {
-			return nil, fmt.Errorf("error parsing Go entities: %w", err)
-		}
+	generated, err := resolveDesiredSchema(opts)
+	if err != nil {
+		return nil, err
 	}
 
 	// 2. Connect to database and read current schema
@@ -389,7 +368,22 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err := recoverMigrationPublication(ctx, opts.AllowedOutputRoot, opts.OutputDir); err != nil {
 		return nil, err
 	}
-	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
+	// Bind the migration directory here, at planning time, and hold it. Every
+	// later step of this plan -- the version scan below, the pre-publication
+	// verification, and the publication itself -- addresses that one handle.
+	writer, err := bindPlannedMigrationDir(opts.AllowedOutputRoot, opts.OutputDir)
+	if err != nil {
+		return nil, err
+	}
+	// Planning can still fail, or find nothing to do, on any of the paths
+	// below. Only a plan that is handed back keeps the handles.
+	planned := false
+	defer func() {
+		if !planned {
+			_ = writer.Close()
+		}
+	}()
+	plannedContents, err := captureMigrationDirectoryContents(writer)
 	if err != nil {
 		return nil, fmt.Errorf("capture migration directory before planning: %w", err)
 	}
@@ -414,9 +408,14 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 		return nil, nil
 	}
 
-	// 4. Generate migration version (timestamp)
+	// 4. Generate migration version (timestamp). The scan for a free version
+	// reads the bound handle rather than the pathname, so the names this plan
+	// avoids colliding with are the ones in the directory it will publish into.
 	version := migrator.GetNextMigrationVersion()
-	version = nextAvailableMigrationVersion(opts.OutputDir, version, opts.MigrationName)
+	version, err = nextAvailableMigrationVersion(writer, version, opts.MigrationName)
+	if err != nil {
+		return nil, fmt.Errorf("error reading migration directory: %w", err)
+	}
 	slog.Debug("Generated migration version", "version", version)
 
 	qualifier, err := atlasmigrate.ParseQualifier(opts.SchemaQualifier)
@@ -458,13 +457,39 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 		}
 	}
 
+	planned = true
 	return &MigrationPlan{
-		outputDir:         opts.OutputDir,
-		allowedOutputRoot: opts.AllowedOutputRoot,
-		outputState:       outputState,
-		reportFormat:      opts.ReportFormat,
-		specs:             specs,
+		outputDir:       opts.OutputDir,
+		dir:             writer,
+		plannedContents: plannedContents,
+		reportFormat:    opts.ReportFormat,
+		specs:           specs,
 	}, nil
+}
+
+// resolveDesiredSchema answers what the migration should bring the database to:
+// a pre-merged schema when the caller assembled one from several sources, and
+// otherwise the Go entities directory, parsed through a filesystem rooted at its
+// parent so the scan cannot walk out of the directory the caller named.
+func resolveDesiredSchema(opts GenerateMigrationOptions) (*goschema.Database, error) {
+	if opts.Generated != nil {
+		return opts.Generated, nil
+	}
+	entitiesFS := opts.GoEntitiesFS
+	entitiesDir := opts.GoEntitiesDir
+	if entitiesFS == nil {
+		absPath, err := filepath.Abs(opts.GoEntitiesDir)
+		if err != nil {
+			return nil, fmt.Errorf("error resolving root directory path: %w", err)
+		}
+		entitiesFS = os.DirFS(filepath.Dir(absPath))
+		entitiesDir = filepath.Base(absPath)
+	}
+	generated, err := goschema.ParseFS(entitiesFS, entitiesDir)
+	if err != nil {
+		return nil, fmt.Errorf("error parsing Go entities: %w", err)
+	}
+	return generated, nil
 }
 
 // recoverMigrationPublication resolves an interrupted publication left by an
@@ -509,14 +534,17 @@ func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
 // WriteFilesContext publishes the migration artifacts represented by the plan.
 // The context bounds waiting for the migration-directory publication lock.
 //
-// The transaction binds the migration directory once, under the lock, and then
-// verifies and publishes through that one handle. It used to verify the
-// directory's contents by pathname and let the publication resolve the pathname
-// again, so a directory replaced between the two steps received a batch the
-// verification had approved for a different filesystem object
-// (stokaro/ptah#1118). The plan's recorded state now carries the planned
-// directory's identity as well as its contents, so a replacement is refused
-// even when the substitute holds identical files.
+// The plan already holds the migration directory. This call does not reopen it:
+// under the lock it revalidates the handle it was given, compares the contents
+// against what planning recorded, and publishes through that same handle.
+//
+// It used to reopen the directory by pathname here and decide whether it was
+// still the planned one by comparing an fs.FileInfo captured before any handle
+// existed. That comparison is only as good as the operating system's promise
+// not to reissue an identifier, and it makes no such promise: measured on ext4,
+// a directory removed and recreated at the same pathname took its inode number
+// back in 20 of 20 cycles, so the guard stayed silent on exactly the
+// substitution an attacker performs most easily (stokaro/ptah#1118).
 func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles, error) {
 	if p == nil {
 		return nil, fmt.Errorf("migration plan is nil")
@@ -531,49 +559,43 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	root, err := openOutputRoot(p.allowedOutputRoot)
-	if err != nil {
-		return nil, err
-	}
-	defer func() { _ = closeOutputRoot(root) }()
-	if err := atlasmigrate.EnsureMigrationParent(root, p.outputDir); err != nil {
-		return nil, err
-	}
 	var files *MigrationFiles
-	err = atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
-		published, publishErr := p.publishLocked(ctx, root)
+	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
+		published, publishErr := p.publishLocked(ctx)
 		files = published
 		return publishErr
 	})
 	if err != nil {
 		return nil, err
 	}
+	// The plan is single-use, so the handles have no reader left once the batch
+	// is committed.
+	_ = p.dir.Close()
 	return files, nil
 }
 
-func (p *MigrationPlan) publishLocked(
-	ctx context.Context,
-	root *pathguard.OpenedDirectory,
-) (*MigrationFiles, error) {
+func (p *MigrationPlan) publishLocked(ctx context.Context) (*MigrationFiles, error) {
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	writer, err := bindMigrationOutputDir(root, p.outputDir)
-	if err != nil {
-		return nil, err
+	if err := p.dir.Revalidate(); err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrMigrationDirectoryChanged, err)
 	}
-	defer func() { _ = writer.Close() }()
-	currentState, err := captureWriterDirectoryState(writer)
+	currentContents, err := captureMigrationDirectoryContents(p.dir)
 	if err != nil {
 		return nil, fmt.Errorf("capture migration directory before publication: %w", err)
 	}
-	if !p.outputState.equal(currentState) {
+	// The contents check is the concurrency half of the guard: another writer
+	// that added a migration while this plan was outstanding. Which filesystem
+	// object is being committed to was settled by Revalidate above.
+	if !p.plannedContents.Equal(currentContents) {
 		return nil, ErrMigrationDirectoryChanged
 	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	files, err := publishPlannedMigration(ctx, writer, p.reportFormat, p.specs)
+	notifyMigrationPublicationVerified()
+	files, err := publishPlannedMigration(ctx, p.dir, p.reportFormat, p.specs)
 	if err != nil {
 		return nil, fmt.Errorf("error creating migration files: %w", err)
 	}
@@ -581,66 +603,24 @@ func (p *MigrationPlan) publishLocked(
 	return files, nil
 }
 
-// captureMigrationDirectoryState reads the planned directory by pathname, at
-// planning time, before any writer handle exists. The identity it records is
-// what the publication later re-establishes through its bound handle.
-func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, error) {
-	info, err := os.Stat(outputDir)
-	if errors.Is(err, os.ErrNotExist) {
-		return migrationDirectoryState{}, nil
-	}
-	if err != nil {
-		return migrationDirectoryState{}, err
-	}
-	if !info.IsDir() {
-		return migrationDirectoryState{}, fmt.Errorf("%q exists and is not a directory", outputDir)
-	}
-	snapshot, err := migrationsnapshot.CaptureStable(os.DirFS(outputDir))
-	if err != nil {
-		return migrationDirectoryState{}, err
-	}
-	return migrationDirectoryState{exists: true, identity: info, snapshot: snapshot}, nil
-}
-
-// captureWriterDirectoryState reads the same state through a bound writer
-// handle, so what the publication compares is the object it is about to commit
-// to rather than whatever the pathname resolves to at comparison time.
-func captureWriterDirectoryState(
+// captureMigrationDirectoryContents reads the migration directory through the
+// bound handle, so what the publication compares is the object it is about to
+// commit to rather than whatever the pathname resolves to at comparison time.
+//
+// A directory the writer bound as absent reads as the empty snapshot. It cannot
+// have appeared since -- Revalidate refuses that before this runs -- so the two
+// captures either both describe the bound object or both describe nothing.
+func captureMigrationDirectoryContents(
 	writer *atlasmigrate.MigrationWriter,
-) (migrationDirectoryState, error) {
+) (fsnapshot.Snapshot, error) {
 	if !writer.Exists() {
-		return migrationDirectoryState{}, nil
-	}
-	identity, err := writer.Identity()
-	if err != nil {
-		return migrationDirectoryState{}, err
+		return fsnapshot.Snapshot{}, nil
 	}
 	fsys, err := writer.FS()
 	if err != nil {
-		return migrationDirectoryState{}, err
+		return fsnapshot.Snapshot{}, err
 	}
-	snapshot, err := migrationsnapshot.CaptureStable(fsys)
-	if err != nil {
-		return migrationDirectoryState{}, err
-	}
-	return migrationDirectoryState{exists: true, identity: identity, snapshot: snapshot}, nil
-}
-
-// equal reports whether the publication is committing to the directory the plan
-// was built against. Contents alone are not enough: a substitute directory
-// holding the same files is still a different destination, and publishing into
-// it would put migrations somewhere nothing verified.
-func (s migrationDirectoryState) equal(other migrationDirectoryState) bool {
-	if s.exists != other.exists {
-		return false
-	}
-	if !s.snapshot.Equal(other.snapshot) {
-		return false
-	}
-	if !s.exists {
-		return true
-	}
-	return os.SameFile(s.identity, other.identity)
+	return migrationsnapshot.CaptureStable(fsys)
 }
 
 func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {
@@ -2127,12 +2107,20 @@ func reverseRoleDiffs(roleDiffs []types.RoleDiff) []types.RoleDiff {
 	return reversed
 }
 
-// nextAvailableMigrationVersion answers the version question for a directory
-// named by pathname, for readers that are not inside a writer transaction. A
-// writer holding a rooted handle asks nextAvailablePtahVersion over the names
-// it listed through that handle instead.
-func nextAvailableMigrationVersion(outputDir string, version int64, migrationName string) int64 {
-	return nextAvailablePtahVersion(migrationDirFileNames(outputDir), version, migrationName)
+// nextAvailableMigrationVersion answers the version question over the names
+// listed through the writer handle the plan already holds, so the version it
+// avoids colliding with comes from the directory the plan will publish into
+// rather than from whatever the pathname resolves to while it is being chosen.
+func nextAvailableMigrationVersion(
+	writer *atlasmigrate.MigrationWriter,
+	version int64,
+	migrationName string,
+) (int64, error) {
+	names, err := migrationDirNames(writer)
+	if err != nil {
+		return 0, err
+	}
+	return nextAvailablePtahVersion(names, version, migrationName), nil
 }
 
 func nextAvailablePtahVersion(names []string, version int64, migrationName string) int64 {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -31,7 +31,6 @@ import (
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/indexscope"
-	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/internal/tableref"
@@ -150,16 +149,24 @@ type MigrationFiles struct {
 // MigrationPlan is a fully validated migration that has not been written to
 // disk yet. WriteFiles publishes the planned migration once.
 type MigrationPlan struct {
-	mu           sync.Mutex
-	outputDir    string
-	outputState  migrationDirectoryState
-	reportFormat string
-	specs        []generatedMigrationSpec
-	written      bool
+	mu        sync.Mutex
+	outputDir string
+	// allowedOutputRoot is carried from planning to publication so the writer
+	// transaction can open the root it must stay inside, rather than trusting a
+	// containment check made against a pathname before planning began.
+	allowedOutputRoot string
+	outputState       migrationDirectoryState
+	reportFormat      string
+	specs             []generatedMigrationSpec
+	written           bool
 }
 
 type migrationDirectoryState struct {
-	exists   bool
+	exists bool
+	// identity is the planned directory's filesystem identity, compared with
+	// os.SameFile so a replacement is detected even when the substitute holds
+	// exactly the files the plan verified.
+	identity fs.FileInfo
 	snapshot fsnapshot.Snapshot
 }
 
@@ -178,6 +185,14 @@ type EmptyMigrationOptions struct {
 
 // GenerateEmptyMigration creates skeleton migration files for manual SQL
 // authoring.
+//
+// The whole creation runs through one rooted migration-directory handle, bound
+// before anything is read or written: the directory is materialized, the
+// version scanned, the files created and atlas.sum committed through that one
+// handle rather than through the pathname it was selected by
+// (stokaro/ptah#1118). When AllowedOutputRoot is set the handle is opened
+// through it, so the transaction stays inside that root even if the directory
+// or one of its ancestors is replaced after the path was validated.
 func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error) {
 	name := strings.TrimSpace(opts.MigrationName)
 	if strings.TrimSpace(opts.OutputDir) == "" {
@@ -192,50 +207,23 @@ func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
 	if err != nil {
 		return nil, fmt.Errorf("error validating output directory: %w", err)
 	}
-	if dirFormat == migrator.MigrationDirFormatAtlas {
-		return generateEmptyAtlasMigration(name, outputDir)
+	// The Atlas layout derives its own file name from the migration name and
+	// accepts an empty one, so only the paired layout validates it here -- and
+	// it validates before the directory is bound, so a rejected name never
+	// creates a directory.
+	if dirFormat != migrator.MigrationDirFormatAtlas {
+		if err := validateEmptyMigrationName(name); err != nil {
+			return nil, err
+		}
 	}
-	if err := validateEmptyMigrationName(name); err != nil {
+
+	root, err := openOutputRoot(opts.AllowedOutputRoot)
+	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = closeOutputRoot(root) }()
 
-	version := migrator.GetNextMigrationVersion()
-	version = nextAvailableMigrationVersion(outputDir, version, name)
-	generatedAt := time.Now().UTC().Format(time.RFC3339)
-
-	return createMigrationFiles(
-		outputDir,
-		version,
-		name,
-		emptyMigrationSQL(name, generatedAt, "UP"),
-		emptyMigrationSQL(name, generatedAt, "DOWN"),
-	)
-}
-
-func generateEmptyAtlasMigration(name, outputDir string) (*MigrationFiles, error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	version := nextAvailableAtlasMigrationVersion(outputDir, nextAtlasMigrationVersion())
-	for {
-		filePath := filepath.Join(outputDir, atlasEmptyMigrationFileName(version, name))
-		if err := writeNewMigrationFile(filePath, ""); err != nil {
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write atlas migration file: %w", err)
-		}
-		if _, err := migratesum.WriteWithFormat(outputDir, migrator.MigrationDirFormatAtlas); err != nil {
-			_ = os.Remove(filePath)
-			return nil, fmt.Errorf("failed to write atlas migration checksum: %w", err)
-		}
-		pair := MigrationFilePair{
-			UpFile:  filePath,
-			Version: version,
-		}
-		return migrationFilesFromPairs([]MigrationFilePair{pair}), nil
-	}
+	return writeEmptyMigration(root, outputDir, name, dirFormat)
 }
 
 func nextAtlasMigrationVersion() int64 {
@@ -246,27 +234,30 @@ func nextAtlasMigrationVersion() int64 {
 	return version
 }
 
+// nextAvailableAtlasMigrationVersion answers the version question for a
+// directory named by pathname, for readers that are not inside a writer
+// transaction. A writer holding a rooted handle asks nextAvailableAtlasVersion
+// over the names it listed through that handle instead, so it never resolves
+// the directory a second time.
 func nextAvailableAtlasMigrationVersion(outputDir string, version int64) int64 {
-	if latest := latestExistingAtlasMigrationVersion(outputDir); latest >= version {
+	return nextAvailableAtlasVersion(migrationDirFileNames(outputDir), version)
+}
+
+func nextAvailableAtlasVersion(names []string, version int64) int64 {
+	if latest := latestAtlasVersionIn(names); latest >= version {
 		version = latest + 1
 	}
-	for fileExists(filepath.Join(outputDir, atlasEmptyMigrationFileName(version, ""))) {
+	taken := nameSet(names)
+	for taken[atlasEmptyMigrationFileName(version, "")] {
 		version++
 	}
 	return version
 }
 
-func latestExistingAtlasMigrationVersion(outputDir string) int64 {
-	entries, err := os.ReadDir(outputDir)
-	if err != nil {
-		return 0
-	}
+func latestAtlasVersionIn(names []string) int64 {
 	var latest int64
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		migrationFile, err := migrator.ParseAtlasMigrationFileName(entry.Name())
+	for _, name := range names {
+		migrationFile, err := migrator.ParseAtlasMigrationFileName(name)
 		if err != nil {
 			continue
 		}
@@ -395,7 +386,7 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	if err != nil {
 		return nil, fmt.Errorf("error reading database schema: %w", err)
 	}
-	if err := recoverMigrationPublication(ctx, opts.OutputDir); err != nil {
+	if err := recoverMigrationPublication(ctx, opts.AllowedOutputRoot, opts.OutputDir); err != nil {
 		return nil, err
 	}
 	outputState, err := captureMigrationDirectoryState(opts.OutputDir)
@@ -468,16 +459,40 @@ func PlanMigration(ctx context.Context, opts GenerateMigrationOptions) (*Migrati
 	}
 
 	return &MigrationPlan{
-		outputDir:    opts.OutputDir,
-		outputState:  outputState,
-		reportFormat: opts.ReportFormat,
-		specs:        specs,
+		outputDir:         opts.OutputDir,
+		allowedOutputRoot: opts.AllowedOutputRoot,
+		outputState:       outputState,
+		reportFormat:      opts.ReportFormat,
+		specs:             specs,
 	}, nil
 }
 
-func recoverMigrationPublication(ctx context.Context, outputDir string) error {
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(outputDir)), 0755); err != nil {
-		return fmt.Errorf("create migration directory parent: %w", err)
+// recoverMigrationPublication resolves an interrupted publication left by an
+// earlier run, before this one starts planning. It resolves the directory by
+// pathname because it is the start of its own transaction rather than a step
+// inside this one; the levels above it are still created through the confining
+// root, so a recovery run cannot materialize directories outside it.
+func recoverMigrationPublication(
+	ctx context.Context,
+	allowedOutputRoot, outputDir string,
+) error {
+	root, err := openOutputRoot(allowedOutputRoot)
+	if err != nil {
+		return err
+	}
+	return errors.Join(
+		recoverMigrationPublicationWithin(ctx, root, outputDir),
+		closeOutputRoot(root),
+	)
+}
+
+func recoverMigrationPublicationWithin(
+	ctx context.Context,
+	root *pathguard.OpenedDirectory,
+	outputDir string,
+) error {
+	if err := atlasmigrate.EnsureMigrationParent(root, outputDir); err != nil {
+		return err
 	}
 	if err := atlasmigrate.RecoverPendingPublication(ctx, outputDir); err != nil {
 		return fmt.Errorf("recover migration publication before planning: %w", err)
@@ -493,6 +508,15 @@ func (p *MigrationPlan) WriteFiles() (*MigrationFiles, error) {
 
 // WriteFilesContext publishes the migration artifacts represented by the plan.
 // The context bounds waiting for the migration-directory publication lock.
+//
+// The transaction binds the migration directory once, under the lock, and then
+// verifies and publishes through that one handle. It used to verify the
+// directory's contents by pathname and let the publication resolve the pathname
+// again, so a directory replaced between the two steps received a batch the
+// verification had approved for a different filesystem object
+// (stokaro/ptah#1118). The plan's recorded state now carries the planned
+// directory's identity as well as its contents, so a replacement is refused
+// even when the substitute holds identical files.
 func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles, error) {
 	if p == nil {
 		return nil, fmt.Errorf("migration plan is nil")
@@ -507,30 +531,19 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}
-	if err := os.MkdirAll(filepath.Dir(filepath.Clean(p.outputDir)), 0755); err != nil {
-		return nil, fmt.Errorf("create migration directory parent: %w", err)
+	root, err := openOutputRoot(p.allowedOutputRoot)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = closeOutputRoot(root) }()
+	if err := atlasmigrate.EnsureMigrationParent(root, p.outputDir); err != nil {
+		return nil, err
 	}
 	var files *MigrationFiles
-	err := atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		currentState, err := captureMigrationDirectoryState(p.outputDir)
-		if err != nil {
-			return fmt.Errorf("capture migration directory before publication: %w", err)
-		}
-		if !p.outputState.equal(currentState) {
-			return ErrMigrationDirectoryChanged
-		}
-		if err := ctx.Err(); err != nil {
-			return err
-		}
-		files, err = createMigrationFilesFromSpecs(ctx, p.outputDir, p.reportFormat, p.specs)
-		if err != nil {
-			return fmt.Errorf("error creating migration files: %w", err)
-		}
-		p.written = true
-		return nil
+	err = atlasmigrate.WithMigrationDirectoryLock(ctx, p.outputDir, 0, func(context.Context) error {
+		published, publishErr := p.publishLocked(ctx, root)
+		files = published
+		return publishErr
 	})
 	if err != nil {
 		return nil, err
@@ -538,6 +551,39 @@ func (p *MigrationPlan) WriteFilesContext(ctx context.Context) (*MigrationFiles,
 	return files, nil
 }
 
+func (p *MigrationPlan) publishLocked(
+	ctx context.Context,
+	root *pathguard.OpenedDirectory,
+) (*MigrationFiles, error) {
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	writer, err := bindMigrationOutputDir(root, p.outputDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = writer.Close() }()
+	currentState, err := captureWriterDirectoryState(writer)
+	if err != nil {
+		return nil, fmt.Errorf("capture migration directory before publication: %w", err)
+	}
+	if !p.outputState.equal(currentState) {
+		return nil, ErrMigrationDirectoryChanged
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	files, err := publishPlannedMigration(ctx, writer, p.reportFormat, p.specs)
+	if err != nil {
+		return nil, fmt.Errorf("error creating migration files: %w", err)
+	}
+	p.written = true
+	return files, nil
+}
+
+// captureMigrationDirectoryState reads the planned directory by pathname, at
+// planning time, before any writer handle exists. The identity it records is
+// what the publication later re-establishes through its bound handle.
 func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, error) {
 	info, err := os.Stat(outputDir)
 	if errors.Is(err, os.ErrNotExist) {
@@ -553,11 +599,48 @@ func captureMigrationDirectoryState(outputDir string) (migrationDirectoryState, 
 	if err != nil {
 		return migrationDirectoryState{}, err
 	}
-	return migrationDirectoryState{exists: true, snapshot: snapshot}, nil
+	return migrationDirectoryState{exists: true, identity: info, snapshot: snapshot}, nil
 }
 
+// captureWriterDirectoryState reads the same state through a bound writer
+// handle, so what the publication compares is the object it is about to commit
+// to rather than whatever the pathname resolves to at comparison time.
+func captureWriterDirectoryState(
+	writer *atlasmigrate.MigrationWriter,
+) (migrationDirectoryState, error) {
+	if !writer.Exists() {
+		return migrationDirectoryState{}, nil
+	}
+	identity, err := writer.Identity()
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	fsys, err := writer.FS()
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	snapshot, err := migrationsnapshot.CaptureStable(fsys)
+	if err != nil {
+		return migrationDirectoryState{}, err
+	}
+	return migrationDirectoryState{exists: true, identity: identity, snapshot: snapshot}, nil
+}
+
+// equal reports whether the publication is committing to the directory the plan
+// was built against. Contents alone are not enough: a substitute directory
+// holding the same files is still a different destination, and publishing into
+// it would put migrations somewhere nothing verified.
 func (s migrationDirectoryState) equal(other migrationDirectoryState) bool {
-	return s.exists == other.exists && s.snapshot.Equal(other.snapshot)
+	if s.exists != other.exists {
+		return false
+	}
+	if !s.snapshot.Equal(other.snapshot) {
+		return false
+	}
+	if !s.exists {
+		return true
+	}
+	return os.SameFile(s.identity, other.identity)
 }
 
 func normalizeGenerateMigrationOptions(opts GenerateMigrationOptions) (GenerateMigrationOptions, error) {
@@ -2044,31 +2127,33 @@ func reverseRoleDiffs(roleDiffs []types.RoleDiff) []types.RoleDiff {
 	return reversed
 }
 
+// nextAvailableMigrationVersion answers the version question for a directory
+// named by pathname, for readers that are not inside a writer transaction. A
+// writer holding a rooted handle asks nextAvailablePtahVersion over the names
+// it listed through that handle instead.
 func nextAvailableMigrationVersion(outputDir string, version int64, migrationName string) int64 {
-	if latest := latestExistingMigrationVersion(outputDir); latest >= version {
+	return nextAvailablePtahVersion(migrationDirFileNames(outputDir), version, migrationName)
+}
+
+func nextAvailablePtahVersion(names []string, version int64, migrationName string) int64 {
+	if latest := latestPtahVersionIn(names); latest >= version {
 		version = latest + 1
 	}
+	taken := nameSet(names)
 	for {
-		upFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "up"))
-		downFilePath := filepath.Join(outputDir, migrator.GenerateMigrationFileName(version, migrationName, "down"))
-		if !fileExists(upFilePath) && !fileExists(downFilePath) {
+		upName := migrator.GenerateMigrationFileName(version, migrationName, "up")
+		downName := migrator.GenerateMigrationFileName(version, migrationName, "down")
+		if !taken[upName] && !taken[downName] {
 			return version
 		}
 		version++
 	}
 }
 
-func latestExistingMigrationVersion(outputDir string) int64 {
-	entries, err := os.ReadDir(outputDir)
-	if err != nil {
-		return 0
-	}
+func latestPtahVersionIn(names []string) int64 {
 	var latest int64
-	for _, entry := range entries {
-		if entry.IsDir() {
-			continue
-		}
-		migrationFile, err := migrator.ParseMigrationFileName(entry.Name())
+	for _, name := range names {
+		migrationFile, err := migrator.ParseMigrationFileName(name)
 		if err != nil {
 			continue
 		}
@@ -2077,6 +2162,33 @@ func latestExistingMigrationVersion(outputDir string) int64 {
 		}
 	}
 	return latest
+}
+
+// migrationDirFileNames lists a migration directory by pathname. It is the
+// reader-side counterpart of migrationDirNames, which lists the same thing
+// through a bound writer handle; a directory that cannot be listed reads as
+// empty, so a version scan over a missing directory starts from scratch.
+func migrationDirFileNames(outputDir string) []string {
+	entries, err := os.ReadDir(outputDir)
+	if err != nil {
+		return nil
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+func nameSet(names []string) map[string]bool {
+	set := make(map[string]bool, len(names))
+	for _, name := range names {
+		set[name] = true
+	}
+	return set
 }
 
 func fileExists(path string) bool {
@@ -2092,66 +2204,6 @@ func withNoTransactionDirective(sql string) string {
 		return sql
 	}
 	return "-- +ptah " + migrator.DirectiveNoTransaction + "\n" + sql
-}
-
-// createMigrationFiles creates the up and down migration files
-func createMigrationFiles(outputDir string, version int64, migrationName, upSQL, downSQL string) (*MigrationFiles, error) {
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-
-	for {
-		upFileName := migrator.GenerateMigrationFileName(version, migrationName, "up")
-		downFileName := migrator.GenerateMigrationFileName(version, migrationName, "down")
-
-		upFilePath := filepath.Join(outputDir, upFileName)
-		downFilePath := filepath.Join(outputDir, downFileName)
-
-		if err := writeNewMigrationFile(upFilePath, upSQL); err != nil {
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write up migration file: %w", err)
-		}
-
-		if err := writeNewMigrationFile(downFilePath, downSQL); err != nil {
-			_ = os.Remove(upFilePath)
-			if errors.Is(err, os.ErrExist) {
-				version++
-				continue
-			}
-			return nil, fmt.Errorf("failed to write down migration file: %w", err)
-		}
-
-		pair := MigrationFilePair{
-			UpFile:   upFilePath,
-			DownFile: downFilePath,
-			Version:  version,
-		}
-		return migrationFilesFromPairs([]MigrationFilePair{pair}), nil
-	}
-}
-
-func createMigrationFilesFromSpecs(
-	ctx context.Context,
-	outputDir, reportFormat string,
-	specs []generatedMigrationSpec,
-) (*MigrationFiles, error) {
-	if len(specs) == 0 {
-		return nil, nil
-	}
-	artifacts, pairs, err := renderMigrationArtifacts(outputDir, reportFormat, specs)
-	if err != nil {
-		return nil, err
-	}
-	if err := ensureMigrationOutputDir(outputDir); err != nil {
-		return nil, fmt.Errorf("failed to create output directory: %w", err)
-	}
-	if _, err := atlasmigrate.PublishArtifactsLocked(ctx, outputDir, artifacts); err != nil {
-		return nil, err
-	}
-	return migrationFilesFromPairs(pairs), nil
 }
 
 func renderMigrationArtifacts(

--- a/migration/generator/plan_export_internal_test.go
+++ b/migration/generator/plan_export_internal_test.go
@@ -38,8 +38,10 @@ type MigrationPlanSpecForTest struct {
 }
 
 // NewMigrationPlanForTest creates a plan without database-dependent planning.
+// allowedOutputRoot is the confinement root the publication must stay inside,
+// or empty for the direct-CLI shape.
 func NewMigrationPlanForTest(
-	outputDir, reportFormat string,
+	outputDir, allowedOutputRoot, reportFormat string,
 	specs []MigrationPlanSpecForTest,
 ) (*MigrationPlan, error) {
 	outputState, err := captureMigrationDirectoryState(outputDir)
@@ -58,10 +60,11 @@ func NewMigrationPlanForTest(
 		}
 	}
 	return &MigrationPlan{
-		outputDir:    outputDir,
-		outputState:  outputState,
-		reportFormat: reportFormat,
-		specs:        generatedSpecs,
+		outputDir:         outputDir,
+		allowedOutputRoot: allowedOutputRoot,
+		outputState:       outputState,
+		reportFormat:      reportFormat,
+		specs:             generatedSpecs,
 	}, nil
 }
 

--- a/migration/generator/plan_export_internal_test.go
+++ b/migration/generator/plan_export_internal_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"slices"
@@ -40,13 +41,21 @@ type MigrationPlanSpecForTest struct {
 // NewMigrationPlanForTest creates a plan without database-dependent planning.
 // allowedOutputRoot is the confinement root the publication must stay inside,
 // or empty for the direct-CLI shape.
+//
+// It binds and holds the migration directory exactly as PlanMigration does,
+// because that binding is what the plan is: a test plan built any other way
+// would be measuring a shape the product never produces.
 func NewMigrationPlanForTest(
 	outputDir, allowedOutputRoot, reportFormat string,
 	specs []MigrationPlanSpecForTest,
 ) (*MigrationPlan, error) {
-	outputState, err := captureMigrationDirectoryState(outputDir)
+	writer, err := bindPlannedMigrationDir(allowedOutputRoot, outputDir)
 	if err != nil {
 		return nil, err
+	}
+	plannedContents, err := captureMigrationDirectoryContents(writer)
+	if err != nil {
+		return nil, errors.Join(err, writer.Close())
 	}
 	generatedSpecs := make([]generatedMigrationSpec, len(specs))
 	for index, spec := range specs {
@@ -60,11 +69,11 @@ func NewMigrationPlanForTest(
 		}
 	}
 	return &MigrationPlan{
-		outputDir:         outputDir,
-		allowedOutputRoot: allowedOutputRoot,
-		outputState:       outputState,
-		reportFormat:      reportFormat,
-		specs:             generatedSpecs,
+		outputDir:       outputDir,
+		dir:             writer,
+		plannedContents: plannedContents,
+		reportFormat:    reportFormat,
+		specs:           generatedSpecs,
 	}, nil
 }
 

--- a/migration/generator/plan_publication_test.go
+++ b/migration/generator/plan_publication_test.go
@@ -48,7 +48,7 @@ func TestMigrationPlanWriteFiles_PublishesMultiplePairsAndReports(t *testing.T) 
 			NoTransaction: true,
 		},
 	}
-	plan, err := generator.NewMigrationPlanForTest(outputDir, "json", specs)
+	plan, err := generator.NewMigrationPlanForTest(outputDir, "", "json", specs)
 	c.Assert(err, qt.IsNil)
 
 	files, err := plan.WriteFilesContext(t.Context())
@@ -128,6 +128,7 @@ func TestMigrationPlanWriteFiles_CollisionLeavesNoPartialArtifacts(t *testing.T)
 	c.Assert(os.WriteFile(reportPath, originalReport, 0600), qt.IsNil)
 	plan, err := generator.NewMigrationPlanForTest(
 		outputDir,
+		"",
 		"json",
 		[]generator.MigrationPlanSpecForTest{{
 			Version: 1700000000,
@@ -160,6 +161,7 @@ func TestMigrationPlanWriteFiles_CreatesMissingOutputParents(t *testing.T) {
 	outputDir := filepath.Join(c.TempDir(), "nested", "migrations")
 	plan, err := generator.NewMigrationPlanForTest(
 		outputDir,
+		"",
 		"",
 		[]generator.MigrationPlanSpecForTest{{
 			Version: 1700000000,

--- a/migration/generator/plan_release_unix_test.go
+++ b/migration/generator/plan_release_unix_test.go
@@ -1,0 +1,131 @@
+//go:build unix
+
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+// A plan holds the migration directory open from the moment it is built, which
+// is the whole point of stokaro/ptah#1118 -- and means the plan owns two
+// descriptors that something has to give back. A successful publication gave
+// them back; a failed one did not, and os.Root only closes from a finalizer, so
+// the hold outlived the call by an unbounded amount of time. On Windows that is
+// also a window in which nothing else can rename or remove the directory, which
+// is how the CI job noticed: four `TestMigrationPlanWriteFiles_` rows whose
+// publication fails could not have their t.TempDir removed afterwards.
+//
+// //go:build unix because the measurement is /dev/fd. The Windows publication
+// job measures the same property from the other side, by being able to delete
+// the temporary directory once the test returns.
+
+// openDescriptorCount counts this process's open descriptors, including the one
+// the listing itself is using -- consistently, so a difference between two
+// counts is a difference in what the product holds.
+func openDescriptorCount(c *qt.C) int {
+	c.Helper()
+	dir, err := os.Open("/dev/fd")
+	c.Assert(err, qt.IsNil)
+	names, err := dir.Readdirnames(-1)
+	c.Assert(err, qt.IsNil)
+	c.Assert(dir.Close(), qt.IsNil)
+	return len(names)
+}
+
+// TestMigrationPlanWriteFiles_ReleasesTheDirectoryWhenPublicationFails asserts
+// the release, and asserts that the measurement can see the handles at all --
+// without the second assertion a product that never bound anything would look
+// like a product that released everything.
+func TestMigrationPlanWriteFiles_ReleasesTheDirectoryWhenPublicationFails(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+	beforePlanning := openDescriptorCount(c)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+	whileOutstanding := openDescriptorCount(c)
+
+	// Same pathname, different filesystem object: the publication is refused.
+	c.Assert(os.RemoveAll(outputDir), qt.IsNil)
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+	afterFailure := openDescriptorCount(c)
+
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+	c.Assert(files, qt.IsNil)
+	c.Assert(
+		whileOutstanding > beforePlanning,
+		qt.IsTrue,
+		qt.Commentf("descriptors: %d before planning, %d while the plan was outstanding",
+			beforePlanning, whileOutstanding),
+	)
+	c.Assert(
+		afterFailure,
+		qt.Equals,
+		beforePlanning,
+		qt.Commentf("descriptors: %d before planning, %d while outstanding, %d after the failure",
+			beforePlanning, whileOutstanding, afterFailure),
+	)
+}
+
+// TestMigrationPlanWriteFiles_ReleasesTheDirectoryWhenPublicationSucceeds is
+// the control for the row above: the same measurement over the path that
+// already released, so a release that only ever happened on failure would be
+// visible as this row going red.
+func TestMigrationPlanWriteFiles_ReleasesTheDirectoryWhenPublicationSucceeds(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+	beforePlanning := openDescriptorCount(c)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+	whileOutstanding := openDescriptorCount(c)
+
+	files, err := plan.WriteFilesContext(t.Context())
+	afterSuccess := openDescriptorCount(c)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(
+		whileOutstanding > beforePlanning,
+		qt.IsTrue,
+		qt.Commentf("descriptors: %d before planning, %d while the plan was outstanding",
+			beforePlanning, whileOutstanding),
+	)
+	c.Assert(
+		afterSuccess,
+		qt.Equals,
+		beforePlanning,
+		qt.Commentf("descriptors: %d before planning, %d while outstanding, %d after publication",
+			beforePlanning, whileOutstanding, afterSuccess),
+	)
+}

--- a/migration/generator/plan_root_test.go
+++ b/migration/generator/plan_root_test.go
@@ -1,0 +1,57 @@
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+// A plan records which filesystem object it was built against, not merely what
+// that object contained. The window these fixtures use is the product's own:
+// PlanMigration and WriteFilesContext are separate calls, so a caller running
+// pre-publication work between them leaves a real gap, and the directory can be
+// replaced inside it (stokaro/ptah#1118).
+//
+// Measured on master, the replacement below published both migration files into
+// the substitute and returned no error, because the pre-publication comparison
+// only asked whether the contents matched and two empty directories match.
+//
+// The control that this surface can report a publication at all is
+// TestMigrationPlanWriteFiles_PublishesMultiplePairsAndReports next door: the
+// same constructor and the same call publish six artifacts when nothing is
+// replaced.
+
+func TestMigrationPlanWriteFiles_RefusesRecreatedDirectory(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
+	// Same pathname, same (empty) contents, different filesystem object.
+	c.Assert(os.Remove(outputDir), qt.IsNil)
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+	c.Assert(files, qt.IsNil)
+	entries, err := os.ReadDir(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0)
+}

--- a/migration/generator/plan_root_test.go
+++ b/migration/generator/plan_root_test.go
@@ -25,6 +25,26 @@ import (
 // same constructor and the same call publish six artifacts when nothing is
 // replaced.
 
+// TestMigrationPlanWriteFiles_RefusesRecreatedDirectory is deliberately not
+// build-tagged. Remove-and-recreate of one pathname is the substitution an
+// attacker reaches for first -- it needs no second directory to point at -- and
+// it is the one where an identity comparison can be answered wrongly by the
+// operating system rather than by the product. Measured on 20 cycles of one
+// pathname: macOS APFS reissued the inode 0 times, so a detached fs.FileInfo
+// looked like a working guard there, while ext4 reissued it 20 times out of 20
+// and the same guard never fired. The plan holds the directory open now, which
+// takes the identifier out of circulation and makes the answer the same
+// everywhere.
+//
+// The removal is os.RemoveAll rather than os.Remove because the plan is holding
+// a handle on the directory while the test removes it. Go's os.RemoveAll
+// deletes through the parent with POSIX semantics on every platform it
+// supports, so the name is free immediately and the recreate below succeeds;
+// os.Remove on Windows goes through RemoveDirectory, which marks an open
+// directory for deletion on close and leaves the name unusable until then. The
+// hostile step has to be one an attacker can actually complete, or the test
+// would be asserting that the attack is impossible for a reason no operator
+// should have to rely on.
 func TestMigrationPlanWriteFiles_RefusesRecreatedDirectory(t *testing.T) {
 	c := qt.New(t)
 	outputDir := filepath.Join(t.TempDir(), "migrations")
@@ -44,7 +64,44 @@ func TestMigrationPlanWriteFiles_RefusesRecreatedDirectory(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 
 	// Same pathname, same (empty) contents, different filesystem object.
-	c.Assert(os.Remove(outputDir), qt.IsNil)
+	c.Assert(os.RemoveAll(outputDir), qt.IsNil)
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+	c.Assert(files, qt.IsNil)
+	entries, err := os.ReadDir(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0)
+}
+
+// TestMigrationPlanWriteFiles_RefusesADirectoryThatAppearedAfterPlanning is the
+// absent-directory half of the same question. A plan built for a directory that
+// does not exist yet holds its parent, not the directory, so the identity it
+// has to defend is the free name rather than an object: something that
+// materialized at that name while the plan was outstanding is not the
+// destination the plan was built for, whatever it contains.
+//
+// TestMigrationPlanWriteFiles_CreatesMissingOutputParents is the control -- the
+// same missing-directory shape, nothing racing it, published normally.
+func TestMigrationPlanWriteFiles_RefusesADirectoryThatAppearedAfterPlanning(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
 	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
 
 	files, err := plan.WriteFilesContext(t.Context())

--- a/migration/generator/plan_root_unix_test.go
+++ b/migration/generator/plan_root_unix_test.go
@@ -1,0 +1,85 @@
+//go:build unix
+
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+// TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication is the
+// black-box half of the rooted-writer regression: the replacement happens in
+// the product's own window between planning and publication, so no test seam is
+// involved.
+//
+// The two rows separate the two guards, because either one alone would make
+// this pass for the wrong reason. Without a confinement root the run is stopped
+// by the plan's recorded identity; with one it is stopped earlier, when the
+// rooted open refuses a directory that now resolves outside the root. Both must
+// leave the substitute untouched.
+//
+// //go:build unix because the swap is a symlink replacement.
+func TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication(t *testing.T) {
+	tests := []struct {
+		name string
+		// allowedRoot returns the confinement root, or "" for the direct-CLI
+		// shape.
+		allowedRoot func(root string) string
+		wantErr     string
+	}{
+		{
+			name:        "no allowed root: the recorded identity refuses it",
+			allowedRoot: func(string) string { return "" },
+			wantErr:     "migration directory changed after migration planning",
+		},
+		{
+			name:        "under an allowed root: the rooted open refuses it",
+			allowedRoot: func(root string) string { return root },
+			wantErr:     ".*outside allowed root.*",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			bound := filepath.Join(root, "real")
+			c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+			selected := filepath.Join(root, "migrations")
+			c.Assert(os.Symlink(bound, selected), qt.IsNil)
+
+			plan, err := generator.NewMigrationPlanForTest(
+				selected,
+				test.allowedRoot(root),
+				"",
+				[]generator.MigrationPlanSpecForTest{{
+					Version: 1700000000,
+					Name:    "create_users",
+					UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+					DownSQL: "DROP TABLE users;\n",
+				}},
+			)
+			c.Assert(err, qt.IsNil)
+
+			c.Assert(os.Remove(selected), qt.IsNil)
+			c.Assert(os.Symlink(decoy, selected), qt.IsNil)
+
+			files, err := plan.WriteFilesContext(t.Context())
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(files, qt.IsNil)
+			decoyEntries, err := os.ReadDir(decoy)
+			c.Assert(err, qt.IsNil)
+			c.Assert(decoyEntries, qt.HasLen, 0)
+			boundEntries, err := os.ReadDir(bound)
+			c.Assert(err, qt.IsNil)
+			c.Assert(boundEntries, qt.HasLen, 0)
+		})
+	}
+}

--- a/migration/generator/plan_root_unix_test.go
+++ b/migration/generator/plan_root_unix_test.go
@@ -12,6 +12,148 @@ import (
 	"go.5x5.cz/ptah/migration/generator"
 )
 
+// The two rows below decide, explicitly, what a migration directory containing
+// a symbolic link is. They are not about a race: nothing moves while they run.
+//
+// Binding the directory changed the answer, and the change is only partly
+// visible from the outside. Reading the directory by pathname followed any link
+// in it; reading it through the bound handle follows a link that stays inside
+// the directory and refuses one that leaves it. So a shared migration linked in
+// from a sibling directory -- `migrations/1000000000_shared.up.sql ->
+// ../shared/1000000000_shared.up.sql`, a layout master accepted -- is now
+// refused, and that is deliberate rather than incidental: the directory is read,
+// checksummed and published through the object the run opened, and bytes living
+// outside it are not part of a directory Ptah can seal. Following the link
+// again would give back the escape the binding exists to close.
+//
+// The refusal has to name what it refused, or an operator meets it as
+// "path escapes from parent" and reads it as a bug. And the link that stays
+// inside the directory has to keep working, or the refusal is a much wider one
+// than the rule it enforces.
+
+// TestMigrationPlanBindRefusesAMigrationFileLinkedInFromOutsideTheDirectory
+// pins the refusal and its wording.
+func TestMigrationPlanBindRefusesAMigrationFileLinkedInFromOutsideTheDirectory(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	shared := filepath.Join(root, "shared")
+	outputDir := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(shared, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(shared, "1000000000_shared.up.sql"),
+		[]byte("CREATE TABLE shared (id INTEGER);\n"), 0o600,
+	), qt.IsNil)
+	c.Assert(os.Symlink(
+		filepath.Join("..", "shared", "1000000000_shared.up.sql"),
+		filepath.Join(outputDir, "1000000000_shared.up.sql"),
+	), qt.IsNil)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+
+	c.Assert(err, qt.ErrorMatches,
+		`migration directory .*: symbolic links resolving outside it: `+
+			`1000000000_shared\.up\.sql; a migration file linked in from another `+
+			`directory is refused because the whole directory is read, checksummed `+
+			`and published through the directory itself: .*`)
+	c.Assert(plan, qt.IsNil)
+	entries, err := os.ReadDir(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 1)
+}
+
+// TestMigrationPlanPublishesBesideAMigrationFileLinkedWithinTheDirectory is the
+// other direction, and it is what keeps the refusal above narrow: a link whose
+// target is inside the migration directory resolves through the bound handle
+// like any other entry, so the plan is built and the batch is published beside
+// it.
+func TestMigrationPlanPublishesBesideAMigrationFileLinkedWithinTheDirectory(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(outputDir, "1000000000_shared.up.sql.source"),
+		[]byte("CREATE TABLE shared (id INTEGER);\n"), 0o600,
+	), qt.IsNil)
+	c.Assert(os.Symlink(
+		"1000000000_shared.up.sql.source",
+		filepath.Join(outputDir, "1000000000_shared.up.sql"),
+	), qt.IsNil)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+	c.Assert(err, qt.IsNil)
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	entries, err := os.ReadDir(outputDir)
+	c.Assert(err, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 4)
+}
+
+// TestMigrationPlanBindReportsANonSymlinkDirectoryFailureUnchanged keeps the
+// explanation from becoming a story the code tells about every failure.
+//
+// The directory here has a symbolic link in it, and something else entirely is
+// wrong with it: a metadata file spelled `ATLAS.SUM`. The link is not why the
+// read failed and must not be named, or the next operator to hit an unrelated
+// problem is sent to look at a file that is fine.
+func TestMigrationPlanBindReportsANonSymlinkDirectoryFailureUnchanged(t *testing.T) {
+	c := qt.New(t)
+	outputDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(outputDir, "1000000000_shared.up.sql.source"),
+		[]byte("CREATE TABLE shared (id INTEGER);\n"), 0o600,
+	), qt.IsNil)
+	c.Assert(os.Symlink(
+		"1000000000_shared.up.sql.source",
+		filepath.Join(outputDir, "1000000000_shared.up.sql"),
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(outputDir, "ATLAS.SUM"),
+		[]byte("h1:0000\n"), 0o600,
+	), qt.IsNil)
+
+	plan, err := generator.NewMigrationPlanForTest(
+		outputDir,
+		"",
+		"",
+		[]generator.MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+
+	c.Assert(err, qt.ErrorMatches,
+		`.*migration metadata file "ATLAS\.SUM" must use canonical name "atlas\.sum"`)
+	c.Assert(err.Error(), qt.Not(qt.Contains), "symbolic links resolving outside it")
+	c.Assert(plan, qt.IsNil)
+}
+
 // TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication is the
 // black-box half of the rooted-writer regression: the replacement happens in
 // the product's own window between planning and publication, so no test seam is

--- a/migration/generator/plan_root_unix_test.go
+++ b/migration/generator/plan_root_unix_test.go
@@ -17,30 +17,36 @@ import (
 // the product's own window between planning and publication, so no test seam is
 // involved.
 //
-// The two rows separate the two guards, because either one alone would make
-// this pass for the wrong reason. Without a confinement root the run is stopped
-// by the plan's recorded identity; with one it is stopped earlier, when the
-// rooted open refuses a directory that now resolves outside the root. Both must
-// leave the substitute untouched.
+// The two rows differ only in whether a confinement root is configured, and
+// that is the assertion. The plan holds the migration directory open from the
+// moment it is built, so the refusal comes from the handle and is owed to every
+// caller -- a project run under an allowed root and a direct CLI run with an
+// absolute --dir get the same answer. A guard that only worked under a root
+// would leave the direct-CLI shape, which is the common one, unprotected.
+// TestMigrationPlanBindRefusesADirectoryReachedThroughAnAncestorOutsideTheRoot
+// pins the thing the root does contribute.
+//
+// Both rows must leave the substitute untouched, and the retained directory
+// too: an error that still wrote somewhere is not a refusal.
 //
 // //go:build unix because the swap is a symlink replacement.
 func TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication(t *testing.T) {
+	const wantErr = `migration directory changed after migration planning: ` +
+		`opened directory path changed: .*`
+
 	tests := []struct {
 		name string
 		// allowedRoot returns the confinement root, or "" for the direct-CLI
 		// shape.
 		allowedRoot func(root string) string
-		wantErr     string
 	}{
 		{
-			name:        "no allowed root: the recorded identity refuses it",
+			name:        "no allowed root",
 			allowedRoot: func(string) string { return "" },
-			wantErr:     "migration directory changed after migration planning",
 		},
 		{
-			name:        "under an allowed root: the rooted open refuses it",
+			name:        "under an allowed root",
 			allowedRoot: func(root string) string { return root },
-			wantErr:     ".*outside allowed root.*",
 		},
 	}
 
@@ -72,7 +78,8 @@ func TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication(t *te
 
 			files, err := plan.WriteFilesContext(t.Context())
 
-			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+			c.Assert(err, qt.ErrorMatches, wantErr)
 			c.Assert(files, qt.IsNil)
 			decoyEntries, err := os.ReadDir(decoy)
 			c.Assert(err, qt.IsNil)

--- a/migration/generator/plan_test.go
+++ b/migration/generator/plan_test.go
@@ -73,6 +73,33 @@ func TestMigrationPlanWriteFiles_FailurePath(t *testing.T) {
 	c.Assert(files, qt.IsNil)
 }
 
+// TestMigrationPlanWriteFiles_FailedPublicationSpendsThePlan is the portable
+// half of the handle-release measurement, and the reason the release is safe:
+// once a publication attempt has returned, the plan no longer holds the
+// migration directory, so a second attempt has nothing to publish through and
+// says so instead of reaching for a released handle.
+//
+// Retrying is not what the caller wants anyway. Both the contents the plan
+// verifies against and the version it chose describe the directory as it was
+// before the attempt, so the honest retry is a fresh PlanMigration.
+func TestMigrationPlanWriteFiles_FailedPublicationSpendsThePlan(t *testing.T) {
+	c := qt.New(t)
+	plan, outputDir := newSQLiteMigrationPlan(c)
+	concurrentMigration := filepath.Join(outputDir, "20000101000000_concurrent.up.sql")
+	c.Assert(os.WriteFile(concurrentMigration, []byte("SELECT 1;\n"), 0o600), qt.IsNil)
+	files, err := plan.WriteFiles()
+	c.Assert(err, qt.ErrorIs, generator.ErrMigrationDirectoryChanged)
+	c.Assert(files, qt.IsNil)
+
+	files, err = plan.WriteFiles()
+
+	c.Assert(err, qt.ErrorMatches, `migration plan was released by a failed publication`)
+	c.Assert(files, qt.IsNil)
+	matches, err := filepath.Glob(filepath.Join(outputDir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.DeepEquals, []string{concurrentMigration})
+}
+
 func TestMigrationPlanWriteFiles_RejectsChangedDirectory(t *testing.T) {
 	c := qt.New(t)
 	plan, outputDir := newSQLiteMigrationPlan(c)

--- a/migration/generator/rootedwriter.go
+++ b/migration/generator/rootedwriter.go
@@ -1,0 +1,274 @@
+package generator
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io/fs"
+	"path/filepath"
+	"time"
+
+	"go.5x5.cz/ptah/internal/atlasmigrate"
+	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// This file holds the generator's two writer transactions -- creating a
+// skeleton migration and publishing a planned one -- expressed against one
+// rooted migration-directory handle each.
+//
+// The shape is the point (stokaro/ptah#1118). Both used to resolve the output
+// directory to a string and then reopen it by pathname for every subsequent
+// step: the mkdir, the version scan, each exclusive create, the atlas.sum
+// commit, the pre-publication snapshot and the publication itself. Measured on
+// master, a `ptah migrations create` racing a symlink swap of its own migration
+// directory published the migration file and a staged atlas.sum into a
+// directory outside AllowedOutputRoot in 4 of 40 runs, and a plan whose
+// directory was replaced between planning and publication wrote both migration
+// files into the replacement while reporting success.
+//
+// So: bind once, then never name the directory again. AllowedOutputRoot is
+// opened rather than merely compared against, and every read and write below
+// goes through that handle, which is why a replacement can no longer redirect
+// one step of a transaction the earlier steps already validated.
+
+// afterMigrationWriterBound runs once a writer transaction has bound its
+// migration directory and before it reads or writes anything through it. It is
+// nil outside tests.
+//
+// It exists because neither transaction has a product callback at that moment,
+// and that moment is exactly what the rooted handle defends: a replacement
+// landing in the window a pathname-based writer would resolve again. A test
+// that swaps before the call can only exercise the open.
+var afterMigrationWriterBound func()
+
+func notifyMigrationWriterBound() {
+	if afterMigrationWriterBound != nil {
+		afterMigrationWriterBound()
+	}
+}
+
+// openOutputRoot opens the confinement root a writer transaction runs inside,
+// or returns nil for the direct-CLI shape where an explicit absolute output
+// directory is the operator's own choice of destination.
+//
+// Opening it is what makes AllowedOutputRoot mean something after resolution.
+// It used to be a string compared against once by pathguard.ResolveWithinRoot
+// and then dropped, so a directory replaced afterwards escaped a boundary the
+// caller believed was still being enforced.
+func openOutputRoot(allowedOutputRoot string) (*pathguard.OpenedDirectory, error) {
+	if allowedOutputRoot == "" {
+		return nil, nil
+	}
+	root, err := pathguard.OpenDirectory(allowedOutputRoot)
+	if err != nil {
+		return nil, fmt.Errorf("open allowed output root: %w", err)
+	}
+	return root, nil
+}
+
+func closeOutputRoot(root *pathguard.OpenedDirectory) error {
+	if root == nil {
+		return nil
+	}
+	return root.Close()
+}
+
+// bindMigrationOutputDir creates the levels above the migration directory and
+// binds the directory itself, without creating it. The caller compares the
+// directory's absence against what it planned for before materializing it.
+func bindMigrationOutputDir(
+	root *pathguard.OpenedDirectory,
+	outputDir string,
+) (*atlasmigrate.MigrationWriter, error) {
+	if err := atlasmigrate.EnsureMigrationParent(root, outputDir); err != nil {
+		return nil, err
+	}
+	writer, err := atlasmigrate.OpenMigrationWriter(root, outputDir)
+	if err != nil {
+		return nil, err
+	}
+	notifyMigrationWriterBound()
+	return writer, nil
+}
+
+// writeEmptyMigration creates the skeleton files for one migration through a
+// rooted handle bound for the whole transaction.
+func writeEmptyMigration(
+	root *pathguard.OpenedDirectory,
+	outputDir, name string,
+	dirFormat migrator.MigrationDirFormat,
+) (*MigrationFiles, error) {
+	writer, err := bindMigrationOutputDir(root, outputDir)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = writer.Close() }()
+	if err := writer.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	files, err := writeEmptyMigrationFiles(writer, name, dirFormat)
+	if err != nil {
+		return nil, err
+	}
+	if err := writer.SyncDir(); err != nil {
+		return nil, fmt.Errorf("failed to flush output directory: %w", err)
+	}
+	return files, nil
+}
+
+func writeEmptyMigrationFiles(
+	writer *atlasmigrate.MigrationWriter,
+	name string,
+	dirFormat migrator.MigrationDirFormat,
+) (*MigrationFiles, error) {
+	names, err := migrationDirNames(writer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read output directory: %w", err)
+	}
+	if dirFormat == migrator.MigrationDirFormatAtlas {
+		return writeEmptyAtlasMigration(writer, names, name)
+	}
+	return writeEmptyPtahMigration(writer, names, name)
+}
+
+// writeEmptyAtlasMigration writes one Atlas-style file and commits atlas.sum
+// over it. The checksum is computed from the same handle the file was created
+// through, so it describes the directory this transaction wrote into rather
+// than whatever the pathname resolves to by the time the sum is written.
+func writeEmptyAtlasMigration(
+	writer *atlasmigrate.MigrationWriter,
+	names []string,
+	name string,
+) (*MigrationFiles, error) {
+	version := nextAvailableAtlasVersion(names, nextAtlasMigrationVersion())
+	for {
+		fileName := atlasEmptyMigrationFileName(version, name)
+		err := writer.WriteNew(fileName, "")
+		if errors.Is(err, fs.ErrExist) {
+			version++
+			continue
+		}
+		if err != nil {
+			return nil, fmt.Errorf("failed to write atlas migration file: %w", err)
+		}
+		if err := publishMigrationDirSum(writer); err != nil {
+			return nil, errors.Join(
+				fmt.Errorf("failed to write atlas migration checksum: %w", err),
+				writer.Remove(fileName),
+			)
+		}
+		return migrationFilesFromPairs([]MigrationFilePair{{
+			UpFile:  filepath.Join(writer.Path(), fileName),
+			Version: version,
+		}}), nil
+	}
+}
+
+// writeEmptyPtahMigration writes the paired up/down skeleton. A down file that
+// cannot be created withdraws the up file it already wrote, because a migration
+// with no rollback half is worse than none.
+func writeEmptyPtahMigration(
+	writer *atlasmigrate.MigrationWriter,
+	names []string,
+	name string,
+) (*MigrationFiles, error) {
+	generatedAt := time.Now().UTC().Format(time.RFC3339)
+	upSQL := emptyMigrationSQL(name, generatedAt, "UP")
+	downSQL := emptyMigrationSQL(name, generatedAt, "DOWN")
+	version := nextAvailablePtahVersion(names, migrator.GetNextMigrationVersion(), name)
+	for {
+		upName := migrator.GenerateMigrationFileName(version, name, "up")
+		downName := migrator.GenerateMigrationFileName(version, name, "down")
+
+		upErr := writer.WriteNew(upName, upSQL)
+		if errors.Is(upErr, fs.ErrExist) {
+			version++
+			continue
+		}
+		if upErr != nil {
+			return nil, fmt.Errorf("failed to write up migration file: %w", upErr)
+		}
+
+		downErr := writer.WriteNew(downName, downSQL)
+		if errors.Is(downErr, fs.ErrExist) {
+			version++
+			if removeErr := writer.Remove(upName); removeErr != nil {
+				return nil, fmt.Errorf("failed to withdraw up migration file: %w", removeErr)
+			}
+			continue
+		}
+		if downErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("failed to write down migration file: %w", downErr),
+				writer.Remove(upName),
+			)
+		}
+
+		return migrationFilesFromPairs([]MigrationFilePair{{
+			UpFile:   filepath.Join(writer.Path(), upName),
+			DownFile: filepath.Join(writer.Path(), downName),
+			Version:  version,
+		}}), nil
+	}
+}
+
+// publishMigrationDirSum recomputes atlas.sum from the bound handle and commits
+// it conditionally on the checksum state that read observed.
+func publishMigrationDirSum(writer *atlasmigrate.MigrationWriter) error {
+	fsys, err := writer.FS()
+	if err != nil {
+		return err
+	}
+	sum, err := migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	if err != nil {
+		return err
+	}
+	if _, err := writer.PublishAtlasSum(sum); err != nil {
+		return err
+	}
+	return nil
+}
+
+// publishPlannedMigration commits a planned batch through the handle the
+// transaction already verified the directory with.
+func publishPlannedMigration(
+	ctx context.Context,
+	writer *atlasmigrate.MigrationWriter,
+	reportFormat string,
+	specs []generatedMigrationSpec,
+) (*MigrationFiles, error) {
+	if len(specs) == 0 {
+		return nil, nil
+	}
+	artifacts, pairs, err := renderMigrationArtifacts(writer.Path(), reportFormat, specs)
+	if err != nil {
+		return nil, err
+	}
+	if err := writer.Create(); err != nil {
+		return nil, fmt.Errorf("failed to create output directory: %w", err)
+	}
+	if _, err := writer.PublishArtifacts(ctx, artifacts); err != nil {
+		return nil, err
+	}
+	return migrationFilesFromPairs(pairs), nil
+}
+
+// migrationDirNames lists the migration directory's file names through the
+// bound handle. An absent directory lists as empty, which is the same answer
+// the version scan wants.
+func migrationDirNames(writer *atlasmigrate.MigrationWriter) ([]string, error) {
+	entries, err := writer.Entries()
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		names = append(names, entry.Name())
+	}
+	return names, nil
+}

--- a/migration/generator/rootedwriter.go
+++ b/migration/generator/rootedwriter.go
@@ -111,7 +111,7 @@ func bindMigrationOutputDir(
 }
 
 // bindPlannedMigrationDir binds the migration directory a plan will publish
-// into, for the plan to hold until it publishes.
+// into, for the plan to hold until its publication attempt returns.
 //
 // The confinement root is opened, consulted for the bind, and then closed: the
 // parent and directory handles were opened through it and stay valid on their

--- a/migration/generator/rootedwriter.go
+++ b/migration/generator/rootedwriter.go
@@ -49,6 +49,23 @@ func notifyMigrationWriterBound() {
 	}
 }
 
+// afterMigrationPublicationVerified runs once a planned publication has
+// revalidated the directory it holds and compared its contents, and before it
+// writes anything. It is nil outside tests.
+//
+// The planned writer binds its directory during planning rather than during
+// publication, so afterMigrationWriterBound no longer names the window that
+// matters for it: by the time WriteFilesContext runs, the handle is old. What
+// the handle uniquely defends is the gap between "verified" and "committed",
+// and a replacement landing there is what this hook lets a test stage.
+var afterMigrationPublicationVerified func()
+
+func notifyMigrationPublicationVerified() {
+	if afterMigrationPublicationVerified != nil {
+		afterMigrationPublicationVerified()
+	}
+}
+
 // openOutputRoot opens the confinement root a writer transaction runs inside,
 // or returns nil for the direct-CLI shape where an explicit absolute output
 // directory is the operator's own choice of destination.
@@ -90,6 +107,32 @@ func bindMigrationOutputDir(
 		return nil, err
 	}
 	notifyMigrationWriterBound()
+	return writer, nil
+}
+
+// bindPlannedMigrationDir binds the migration directory a plan will publish
+// into, for the plan to hold until it publishes.
+//
+// The confinement root is opened, consulted for the bind, and then closed: the
+// parent and directory handles were opened through it and stay valid on their
+// own, so the plan keeps two descriptors rather than three and the root is not
+// pinned for the caller's whole pre-publication window. What the root
+// contributes is refusing, here, a directory that resolves outside it -- after
+// this point the binding is the boundary.
+func bindPlannedMigrationDir(
+	allowedOutputRoot, outputDir string,
+) (*atlasmigrate.MigrationWriter, error) {
+	root, err := openOutputRoot(allowedOutputRoot)
+	if err != nil {
+		return nil, err
+	}
+	writer, err := bindMigrationOutputDir(root, outputDir)
+	if err != nil {
+		return nil, errors.Join(err, closeOutputRoot(root))
+	}
+	if err := closeOutputRoot(root); err != nil {
+		return nil, errors.Join(err, writer.Close())
+	}
 	return writer, nil
 }
 

--- a/migration/generator/rootedwriter_unix_internal_test.go
+++ b/migration/generator/rootedwriter_unix_internal_test.go
@@ -1,0 +1,245 @@
+//go:build unix
+
+package generator
+
+// White-box testing required: the moment these fixtures measure -- after the
+// migration directory is bound and before the transaction reads or writes
+// anything through it -- has no exported name, because nothing in the product
+// needs one. A test that replaces the directory before calling the exported API
+// only exercises the open, and the open is not what the rooted handle uniquely
+// defends. Everything asserted below is otherwise observable: the files on disk
+// and the contents of the directory the replacement pointed at.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// These are the `migration/generator` half of the rooted-writer regressions
+// stokaro/ptah#1118 asks for, and the counterpart to the TestGenerateDiff_*
+// rows in internal/atlasmigrate and the TestWriteSkeletonMigration_* rows
+// beside them.
+//
+// Every replacement below happens after the directory is bound: some swap the
+// migration directory itself, one swaps an ancestor. Measured on master, the
+// same replacement racing `ptah migrations create` published the migration file
+// and a staged atlas.sum into a directory outside AllowedOutputRoot in 4 of 40
+// runs, and a planned migration whose directory was replaced between planning
+// and publication wrote both files into the replacement while reporting success.
+//
+// The file is //go:build unix because Win32 refuses to rename a directory the
+// run holds open without FILE_SHARE_DELETE, so on Windows there is no hostile
+// step to perform rather than a step that is expected to fail.
+
+// replaceWithSymlink renames path aside and leaves a symlink to target in its
+// place, which is what a pathname-based writer follows from here on. It returns
+// the retained original, which is where a rooted writer's files must land.
+func replaceWithSymlink(c *qt.C, path, target string) string {
+	c.Helper()
+	retained := path + "-retained"
+	c.Assert(os.Rename(path, retained), qt.IsNil)
+	c.Assert(os.Symlink(target, path), qt.IsNil)
+	return retained
+}
+
+// generatorDirNames lists the base names in dir.
+func generatorDirNames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}
+
+// TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite asserts
+// both halves the acceptance criteria ask for: the migration lands in the
+// directory the run bound, and the directory the replacement pointed at is left
+// completely untouched.
+//
+// The second half is the one that fails when the rooted handle is removed.
+// Without it, a run that merely errored out would look the same as one that
+// stayed inside the boundary.
+func TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite(t *testing.T) {
+	tests := []struct {
+		name string
+		// allowedRoot returns the confinement root, or "" for the direct-CLI
+		// shape where an explicit absolute directory is the operator's own
+		// choice of destination.
+		allowedRoot func(root string) string
+		dirFormat   migrator.MigrationDirFormat
+		// stage builds the tree and returns the directory the run selects.
+		stage func(c *qt.C, root, decoy string) string
+		// replace performs the swap once the directory is bound and returns the
+		// directory the bound handle still points at.
+		replace func(c *qt.C, root, decoy string) string
+		// wantFiles is how many files the layout writes: two for the Atlas
+		// layout (the migration and atlas.sum) and two for the paired layout
+		// (the up and down halves).
+		wantFiles int
+		// wantDecoyEntries is what the row staged in the decoy before the run:
+		// nothing, except the ancestor row, which needs a migrations directory
+		// for the swapped symlink to resolve through at all.
+		wantDecoyEntries int
+	}{
+		{
+			name:        "the migration directory is replaced, under an allowed root",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "the migration directory is replaced, with no allowed root",
+			allowedRoot: func(string) string { return "" },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "the migration directory is replaced, paired layout",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatPtah,
+			stage:       stageTopLevelMigrationDir,
+			replace: func(c *qt.C, root, decoy string) string {
+				return replaceWithSymlink(c, filepath.Join(root, "migrations"), decoy)
+			},
+			wantFiles: 2,
+		},
+		{
+			name:        "an ancestor directory is replaced",
+			allowedRoot: func(root string) string { return root },
+			dirFormat:   migrator.MigrationDirFormatAtlas,
+			stage: func(c *qt.C, root, decoy string) string {
+				c.Helper()
+				c.Assert(os.MkdirAll(filepath.Join(root, "nest", "migrations"), 0o755), qt.IsNil)
+				c.Assert(os.MkdirAll(filepath.Join(decoy, "migrations"), 0o755), qt.IsNil)
+				return filepath.Join(root, "nest", "migrations")
+			},
+			replace: func(c *qt.C, root, decoy string) string {
+				return filepath.Join(
+					replaceWithSymlink(c, filepath.Join(root, "nest"), decoy),
+					"migrations",
+				)
+			},
+			wantFiles:        2,
+			wantDecoyEntries: 1,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			decoy := t.TempDir()
+			selected := test.stage(c, root, decoy)
+
+			var retained string
+			afterMigrationWriterBound = func() { retained = test.replace(c, root, decoy) }
+			defer func() { afterMigrationWriterBound = nil }()
+
+			files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+				MigrationName:     "added",
+				OutputDir:         selected,
+				AllowedOutputRoot: test.allowedRoot(root),
+				DirFormat:         test.dirFormat,
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(files, qt.IsNotNil)
+			c.Assert(generatorDirNames(c, retained), qt.HasLen, test.wantFiles)
+			c.Assert(generatorDirNames(c, decoy), qt.HasLen, test.wantDecoyEntries)
+		})
+	}
+}
+
+// stageTopLevelMigrationDir prepares root/migrations as the selected directory.
+func stageTopLevelMigrationDir(c *qt.C, root, _ string) string {
+	c.Helper()
+	selected := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+	return selected
+}
+
+// TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent covers
+// the initially-missing directory the acceptance criteria name: it is
+// materialized through the parent handle bound for the transaction, so a
+// replacement of the parent's name cannot move where it is created.
+func TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	decoy := t.TempDir()
+	c.Assert(os.MkdirAll(filepath.Join(root, "nest"), 0o755), qt.IsNil)
+	selected := filepath.Join(root, "nest", "migrations")
+
+	var retained string
+	afterMigrationWriterBound = func() {
+		retained = replaceWithSymlink(c, filepath.Join(root, "nest"), decoy)
+	}
+	defer func() { afterMigrationWriterBound = nil }()
+
+	files, err := GenerateEmptyMigration(EmptyMigrationOptions{
+		MigrationName:     "added",
+		OutputDir:         selected,
+		AllowedOutputRoot: root,
+		DirFormat:         migrator.MigrationDirFormatAtlas,
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(generatorDirNames(c, filepath.Join(retained, "migrations")), qt.HasLen, 2)
+	c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+}
+
+// TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication is the
+// same measurement for the planned-migration writer: the replacement lands
+// after the directory is bound and before the pre-publication snapshot is
+// taken, which is exactly the window the old code closed with nothing.
+func TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	decoy := t.TempDir()
+	outputDir := filepath.Join(root, "migrations")
+	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
+
+	state, err := captureMigrationDirectoryState(outputDir)
+	c.Assert(err, qt.IsNil)
+	plan := &MigrationPlan{
+		outputDir:         outputDir,
+		allowedOutputRoot: root,
+		outputState:       state,
+		specs: []generatedMigrationSpec{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	}
+
+	var retained string
+	afterMigrationWriterBound = func() { retained = replaceWithSymlink(c, outputDir, decoy) }
+	defer func() { afterMigrationWriterBound = nil }()
+
+	files, err := plan.WriteFilesContext(t.Context())
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(generatorDirNames(c, retained), qt.DeepEquals, []string{
+		"1700000000_create_users.down.sql",
+		"1700000000_create_users.up.sql",
+	})
+	c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+}

--- a/migration/generator/rootedwriter_unix_internal_test.go
+++ b/migration/generator/rootedwriter_unix_internal_test.go
@@ -205,9 +205,17 @@ func TestGenerateEmptyMigrationCreatesMissingDirectoryThroughTheBoundParent(t *t
 }
 
 // TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication is the
-// same measurement for the planned-migration writer: the replacement lands
-// after the directory is bound and before the pre-publication snapshot is
-// taken, which is exactly the window the old code closed with nothing.
+// same measurement for the planned-migration writer, staged in the one window
+// that writer still has: after the publication has revalidated the directory it
+// holds and before it writes a byte.
+//
+// A replacement landing earlier -- any time between planning and publication --
+// is refused outright, and TestMigrationPlanWriteFiles_RefusesRecreatedDirectory
+// next door measures that. A replacement landing here cannot be refused, because
+// the verification has already happened; the only thing that can save the batch
+// is that the write does not consult the pathname at all. So the assertion is
+// the positive one: the files land in the object the plan bound, and the
+// directory the replacement points at is left completely untouched.
 func TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()
@@ -215,23 +223,17 @@ func TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication(t *te
 	outputDir := filepath.Join(root, "migrations")
 	c.Assert(os.MkdirAll(outputDir, 0o755), qt.IsNil)
 
-	state, err := captureMigrationDirectoryState(outputDir)
+	plan, err := NewMigrationPlanForTest(outputDir, root, "", []MigrationPlanSpecForTest{{
+		Version: 1700000000,
+		Name:    "create_users",
+		UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+		DownSQL: "DROP TABLE users;\n",
+	}})
 	c.Assert(err, qt.IsNil)
-	plan := &MigrationPlan{
-		outputDir:         outputDir,
-		allowedOutputRoot: root,
-		outputState:       state,
-		specs: []generatedMigrationSpec{{
-			Version: 1700000000,
-			Name:    "create_users",
-			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
-			DownSQL: "DROP TABLE users;\n",
-		}},
-	}
 
 	var retained string
-	afterMigrationWriterBound = func() { retained = replaceWithSymlink(c, outputDir, decoy) }
-	defer func() { afterMigrationWriterBound = nil }()
+	afterMigrationPublicationVerified = func() { retained = replaceWithSymlink(c, outputDir, decoy) }
+	defer func() { afterMigrationPublicationVerified = nil }()
 
 	files, err := plan.WriteFilesContext(t.Context())
 
@@ -242,4 +244,40 @@ func TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication(t *te
 		"1700000000_create_users.up.sql",
 	})
 	c.Assert(generatorDirNames(c, decoy), qt.HasLen, 0)
+}
+
+// TestMigrationPlanBindRefusesADirectoryReachedThroughAnAncestorOutsideTheRoot
+// pins what the confinement root contributes to a plan, which is not the same
+// thing as what the bound handle contributes.
+//
+// The handle alone keeps every write inside the object it opened, whatever the
+// pathname later resolves to -- that is the row above. It cannot decide that the
+// object should never have been opened. Here `nest` is a symlink out of the
+// allowed root before the plan binds anything, so the migration directory
+// genuinely lives outside the boundary the caller configured, and the only step
+// that can say so is the rooted open.
+//
+// //go:build unix because the escape is a symlink.
+func TestMigrationPlanBindRefusesADirectoryReachedThroughAnAncestorOutsideTheRoot(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	outside := t.TempDir()
+	c.Assert(os.MkdirAll(filepath.Join(outside, "migrations"), 0o755), qt.IsNil)
+	c.Assert(os.Symlink(outside, filepath.Join(root, "nest")), qt.IsNil)
+
+	plan, err := NewMigrationPlanForTest(
+		filepath.Join(root, "nest", "migrations"),
+		root,
+		"",
+		[]MigrationPlanSpecForTest{{
+			Version: 1700000000,
+			Name:    "create_users",
+			UpSQL:   "CREATE TABLE users (id INTEGER);\n",
+			DownSQL: "DROP TABLE users;\n",
+		}},
+	)
+
+	c.Assert(err, qt.ErrorMatches, `.*outside allowed root.*`)
+	c.Assert(plan, qt.IsNil)
+	c.Assert(generatorDirNames(c, filepath.Join(outside, "migrations")), qt.HasLen, 0)
 }

--- a/migration/generator/rootedwriter_unix_internal_test.go
+++ b/migration/generator/rootedwriter_unix_internal_test.go
@@ -20,6 +20,64 @@ import (
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
+// TestNextAvailableMigrationVersionReadsTheHeldDirectory pins the half of the
+// binding that no publication guard can reach: the version scan.
+//
+// The scan runs during planning, between binding the migration directory and
+// recording the specs, and it decides which version numbers the plan may use.
+// Reading it by pathname means the plan avoids colliding with whatever the name
+// resolves to at that instant, which is not necessarily the directory it holds
+// and will publish into; the collision it was supposed to avoid then happens at
+// publication, against files the scan never saw.
+//
+// Every other fixture in the package stages a directory whose pathname and
+// bound object are the same, so the pathname-based scan and the handle-based
+// one answer identically and neither is pinned. This one makes them answer
+// differently on purpose, and the last assertion is what proves the fixture
+// separates them: read by pathname the same writer would say 901.
+//
+// //go:build unix because the divergence is staged with a symlink swap. The
+// bound directory has to survive the swap, which rules out removing and
+// recreating it -- an unlinked directory lists as empty and both answers would
+// collapse back together.
+func TestNextAvailableMigrationVersionReadsTheHeldDirectory(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	bound := filepath.Join(root, "real")
+	decoy := filepath.Join(root, "decoy")
+	c.Assert(os.MkdirAll(bound, 0o755), qt.IsNil)
+	c.Assert(os.MkdirAll(decoy, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(bound, migrator.GenerateMigrationFileName(105, "add_email", "up")),
+		[]byte("SELECT 1;\n"), 0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(decoy, migrator.GenerateMigrationFileName(900, "decoy", "up")),
+		[]byte("SELECT 1;\n"), 0o600,
+	), qt.IsNil)
+	selected := filepath.Join(root, "migrations")
+	c.Assert(os.Symlink(bound, selected), qt.IsNil)
+
+	writer, err := bindPlannedMigrationDir("", selected)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = writer.Close() }()
+
+	// From here the pathname the writer was selected by names a different
+	// directory, with a different highest version in it.
+	c.Assert(os.Remove(selected), qt.IsNil)
+	c.Assert(os.Symlink(decoy, selected), qt.IsNil)
+
+	version, err := nextAvailableMigrationVersion(writer, 100, "add_email")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, int64(106))
+	c.Assert(
+		nextAvailablePtahVersion(migrationDirFileNames(writer.Path()), 100, "add_email"),
+		qt.Equals,
+		int64(901),
+	)
+}
+
 // These are the `migration/generator` half of the rooted-writer regressions
 // stokaro/ptah#1118 asks for, and the counterpart to the TestGenerateDiff_*
 // rows in internal/atlasmigrate and the TestWriteSkeletonMigration_* rows

--- a/migration/generator/rootedwriter_unix_internal_test.go
+++ b/migration/generator/rootedwriter_unix_internal_test.go
@@ -78,6 +78,141 @@ func TestNextAvailableMigrationVersionReadsTheHeldDirectory(t *testing.T) {
 	)
 }
 
+// TestMigrationPlanUsesTheHeldDirectoryForVersionAndPublication carries the row
+// above through to publication, on the shape an operator can picture: no
+// symlink anywhere, just a directory renamed aside while a plan holds it and a
+// different directory taking the pathname it was selected by.
+//
+// The scan row next door stops at the number. The number is only half of what
+// the binding claims, because a version chosen from the held directory and then
+// published somewhere else would be no better than a version chosen from the
+// pathname. Both halves are asserted here against the same plan, in the order
+// PlanMigration runs them: bind, capture, scan, publish.
+//
+// The impostor at the pathname carries a *higher* version than the directory
+// the plan holds, so the two readings cannot agree by accident -- 106 beside
+// the 105 the plan bound, against 901 beside the 900 the impostor holds. The
+// third assertion after the scan is what proves the fixture separates them.
+//
+// The two rows differ in what the pathname names by publication time, and they
+// fail in opposite ways:
+//
+//   - impostor still there: the batch must be refused outright, and the
+//     impostor must not receive one byte of it. This is the row a plan that
+//     revalidated by pathname would pass while publishing into the impostor.
+//   - pathname handed back: the batch must land in the retained object under
+//     the number the scan chose. This is the row that fails if the plan gave
+//     up its claim, or renumbered against the impostor.
+//
+// //go:build unix because the hostile step is a rename of a directory the run
+// holds open, which Win32 refuses without FILE_SHARE_DELETE -- on Windows there
+// would be no step to perform rather than a step expected to fail.
+func TestMigrationPlanUsesTheHeldDirectoryForVersionAndPublication(t *testing.T) {
+	const upSQL = "CREATE TABLE users (id INTEGER);\n"
+	const downSQL = "DROP TABLE users;\n"
+	boundFile := migrator.GenerateMigrationFileName(105, "add_email", "up")
+	impostorFile := migrator.GenerateMigrationFileName(900, "decoy", "up")
+	publishedUp := migrator.GenerateMigrationFileName(106, "add_email", "up")
+	publishedDown := migrator.GenerateMigrationFileName(106, "add_email", "down")
+
+	tests := []struct {
+		name string
+		// settle runs after the version has been chosen and before publication,
+		// and reports where the bound object and the impostor live by then.
+		settle func(c *qt.C, root, selected, aside string) (bound, impostor string)
+		// check asserts what the plan's one publication attempt returned.
+		check func(c *qt.C, files *MigrationFiles, err error)
+		// wantBound and wantImpostor are the two directories afterwards.
+		wantBound    []string
+		wantImpostor []string
+	}{
+		{
+			name: "the impostor still holds the pathname at publication",
+			settle: func(_ *qt.C, _, selected, aside string) (string, string) {
+				return aside, selected
+			},
+			check: func(c *qt.C, files *MigrationFiles, err error) {
+				c.Assert(err, qt.ErrorIs, ErrMigrationDirectoryChanged)
+				c.Assert(files, qt.IsNil)
+			},
+			wantBound:    []string{boundFile},
+			wantImpostor: []string{impostorFile},
+		},
+		{
+			name: "the pathname names the bound directory again at publication",
+			settle: func(c *qt.C, root, selected, aside string) (string, string) {
+				impostor := filepath.Join(root, "impostor")
+				c.Assert(os.Rename(selected, impostor), qt.IsNil)
+				c.Assert(os.Rename(aside, selected), qt.IsNil)
+				return selected, impostor
+			},
+			check: func(c *qt.C, files *MigrationFiles, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(files.Files, qt.HasLen, 1)
+				c.Assert(files.Version, qt.Equals, int64(106))
+			},
+			wantBound:    []string{boundFile, publishedDown, publishedUp},
+			wantImpostor: []string{impostorFile},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			selected := filepath.Join(root, "migrations")
+			c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+			c.Assert(os.WriteFile(
+				filepath.Join(selected, boundFile), []byte(upSQL), 0o600,
+			), qt.IsNil)
+
+			writer, err := bindPlannedMigrationDir("", selected)
+			c.Assert(err, qt.IsNil)
+			plannedContents, err := captureMigrationDirectoryContents(writer)
+			c.Assert(err, qt.IsNil)
+
+			// The hostile step: the bound directory is renamed aside and a
+			// different one, holding a higher version, takes the pathname.
+			aside := filepath.Join(root, "renamed-aside")
+			c.Assert(os.Rename(selected, aside), qt.IsNil)
+			c.Assert(os.MkdirAll(selected, 0o755), qt.IsNil)
+			c.Assert(os.WriteFile(
+				filepath.Join(selected, impostorFile), []byte(upSQL), 0o600,
+			), qt.IsNil)
+
+			version, err := nextAvailableMigrationVersion(writer, 100, "add_email")
+			c.Assert(err, qt.IsNil)
+			c.Assert(version, qt.Equals, int64(106))
+			c.Assert(
+				nextAvailablePtahVersion(migrationDirFileNames(writer.Path()), 100, "add_email"),
+				qt.Equals,
+				int64(901),
+			)
+
+			plan := &MigrationPlan{
+				outputDir:       selected,
+				dir:             writer,
+				plannedContents: plannedContents,
+				specs: []generatedMigrationSpec{{
+					Version: version,
+					Name:    "add_email",
+					UpSQL:   upSQL,
+					DownSQL: downSQL,
+				}},
+			}
+			defer plan.release()
+
+			bound, impostor := test.settle(c, root, selected, aside)
+
+			files, err := plan.WriteFilesContext(t.Context())
+
+			test.check(c, files, err)
+			c.Assert(generatorDirNames(c, bound), qt.DeepEquals, test.wantBound)
+			c.Assert(generatorDirNames(c, impostor), qt.DeepEquals, test.wantImpostor)
+		})
+	}
+}
+
 // These are the `migration/generator` half of the rooted-writer regressions
 // stokaro/ptah#1118 asks for, and the counterpart to the TestGenerateDiff_*
 // rows in internal/atlasmigrate and the TestWriteSkeletonMigration_* rows

--- a/migration/generator/shadow_internal_test.go
+++ b/migration/generator/shadow_internal_test.go
@@ -220,7 +220,14 @@ func TestNextAvailableMigrationVersionChecksUpAndDownFiles(t *testing.T) {
 	err = os.WriteFile(filepath.Join(dir, migrator.GenerateMigrationFileName(105, "future", "up")), []byte("SELECT 1;"), 0600)
 	c.Assert(err, qt.IsNil)
 
-	c.Assert(nextAvailableMigrationVersion(dir, 100, "add_email"), qt.Equals, int64(106))
+	writer, err := bindPlannedMigrationDir("", dir)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = writer.Close() }()
+
+	version, err := nextAvailableMigrationVersion(writer, 100, "add_email")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(version, qt.Equals, int64(106))
 }
 
 func TestLoadPriorMigrationsMissingDir(t *testing.T) {


### PR DESCRIPTION
Follow-up to #1288, on top of its head `d9d2a1de`. That PR carries `hold-off-merge` and three red CI jobs; this commit is what they were waiting for.

## Why #1288 is red

All three red jobs — `unit-tests`, `coverage`, `windows-publication` — are the same test, `TestMigrationPlanWriteFiles_RefusesRecreatedDirectory`, and it is correctly red.

`migrationDirectoryState` recorded the planned directory's identity as an `fs.FileInfo` taken by `os.Stat` at planning time, and publication asked `os.SameFile` whether the directory it was about to write into was still that object. `os.SameFile` is device + inode on Unix and volume + file index on Windows, and neither identifier is reserved once the last handle to the object is gone. A directory removed and recreated at the same pathname can be handed the identifier straight back — and then the comparison approves the substitute. That is the shape an attacker reaches for first: it needs no second directory to point at.

## Reproduced deliberately, not waited for

Built a loopback ext4 filesystem inside a privileged Linux container and pointed only the test binary's `TMPDIR` at it (`go test -c` first — building on the image fills it). At `d9d2a1de`:

```
--- FAIL: TestMigrationPlanWriteFiles_RefusesRecreatedDirectory (0.17s)
    plan_root_test.go:52: got nil error but want non-nil
      want: "migration directory changed after migration planning"
```

`nil` means the batch was published — into the directory the test had just substituted. Docker's own `/tmp` (overlayfs) reproduced nothing, so "run it on Linux" is not the reproduction; the filesystem has to be one that recycles.

Then the mechanism, isolated. One program, one `os.SameFile` call, 20 remove-and-recreate cycles of one pathname, three regimes that differ only in how the earlier identity was obtained and how long the object stayed open:

| filesystem | identity taken by | `os.SameFile` said "same object" |
| --- | --- | --- |
| ext4 | `os.Stat`, no handle held | **20 of 20** |
| ext4 | `os.Root.Stat(".")`, handle **closed** before the removal | **20 of 20** |
| ext4 | `os.Root.Stat(".")`, handle **held** across the removal | 0 of 20 |
| APFS | all three regimes | 0 of 20 |

Rows two and three differ in nothing but the handle's lifetime — ext4 gave inode 14 back every time when nothing held it, and went 35 → 36 when something did. An open directory keeps its identifier allocated; a closed one does not. Comparing more cleverly cannot fix this, and no build tag should hide it.

On Windows the old identity was worse than unlucky: `os.Stat` defers `loadFileId` to `SameFile` time and resolves the *pathname* then, so the recorded identity re-resolved to the replacement regardless of file-index reuse.

## The change

The plan binds the migration directory while it is being built and **holds** that binding until it publishes. `PlanMigration` binds through the confinement root, keeps the directory and parent handles, closes the root (the handles were opened through it and stay valid), and hands the binding to the plan; a plan that fails to be produced closes it, and a plan dropped without publishing releases it when collected, because `os.Root` closes its descriptor from a finalizer.

`WriteFilesContext` reopens nothing. Under the lock it revalidates the handle it was given against the pathname it was selected by, compares the contents, publishes through that same handle, then closes it. The version scan reads the same handle instead of the pathname.

`MigrationWriter.Identity` is replaced by `MigrationWriter.Revalidate`, which asks the whole question rather than handing out half of it: for an existing directory, does the selected pathname still name the object I hold (so an ancestor swapped anywhere above it is caught too); for a directory that was absent when the writer bound, is that name still free in the parent I hold.

`migrationDirectoryState` is gone. The plan carries `plannedContents fsnapshot.Snapshot` and nothing else, because `exists` was provably dead — both captures derived from the same bind-time `writer.Exists()`, so the comparison could never be false. Mutant **M2** proves the point: removing `revalidateAbsent` reddens exactly the "directory appeared after planning" row while the contents check stays silent.

The public `migration/generator` API is unchanged: `docs/public_api.snapshot` does not move and all three public-API gates are 0.

**This changes behavior twice.** A `ptah migrations generate` run whose directory is removed and recreated between planning and publication now fails and writes nothing, where it published into the replacement before. And while a plan is outstanding the migration directory is held open, so another process cannot rename or remove it until the plan publishes or is discarded. Pre-v1, so no compatibility with Ptah's own past is owed; both are documented in `docs/site/src/content/docs/concepts/migration-directory.md` and `migration/generator/README.md`.

## Regressions

The failing test is unchanged in what it asserts and is still **not** build-tagged, so it runs on the Windows job as before. One line of its setup moved from `os.Remove` to `os.RemoveAll`: the plan now holds a handle on the directory while the test removes it, and Go's `RemoveAll` deletes through the parent with POSIX semantics on every platform it supports, while `os.Remove` on Windows goes through `RemoveDirectory`, which marks an open directory for deletion on close and leaves the name unusable until then. The hostile step has to be one an attacker can actually complete.

New, portable, and covered by the Windows job's `-run '^TestMigrationPlanWriteFiles_'`:

- `TestMigrationPlanWriteFiles_RefusesADirectoryThatAppearedAfterPlanning` — the absent-directory half. Its control is `..._CreatesMissingOutputParents`, the same shape with nothing racing it.

Reshaped:

- `TestMigrationPlanWriteFiles_RefusesDirectoryReplacedBeforePublication` — the two rows used to separate "recorded identity refuses it" from "the rooted open refuses it". The handle now refuses both, so the rows assert something better: the refusal does not depend on a confinement root being configured, and the direct-CLI shape gets it too.
- `TestMigrationPlanWriteFilesReplacedDirectoryCannotRedirectPublication` — the white-box seam moved from `afterMigrationWriterBound` (which for a plan now fires during *planning*) to a new `afterMigrationPublicationVerified`, the one window the writer still has: after the verification, before the first byte. A replacement landing there cannot be refused; the assertion is the positive one — the files land in the bound object and the decoy is untouched.
- `TestMigrationPlanBindRefusesADirectoryReachedThroughAnAncestorOutsideTheRoot` — new, and the only thing pinning `openOutputRoot`. See M3.

The #1288 escape probes were re-measured on ext4 at `-test.count=40` — `TestGenerateEmptyMigrationReplacedDirectoryCannotRedirectTheWrite` (4 rows including the ancestor row), `...CreatesMissingDirectoryThroughTheBoundParent`, `...ReplacedDirectoryCannotRedirectPublication`: exit 0, 0 escapes.

## Mutation, both directions

Run over `./migration/generator ./internal/atlasmigrate ./cmd/migrate`; all restored afterwards, restored run exit 0.

| mutant | red | green |
| --- | --- | --- |
| **M1** revert: `revalidate` stops comparing an existing directory | `RefusesRecreatedDirectory`, both `RefusesDirectoryReplacedBeforePublication` rows | every publication and create test |
| **I1** over-correct: `revalidate` always reports changed | 8 generator rows incl. `HappyPath`, `PublishesMultiplePairsAndReports`, `...CannotRedirectPublication`, plus `cmd/migrate`'s replay test | the two refusal tests, every create row |
| **M2** revert: `revalidateAbsent` returns nil | `RefusesADirectoryThatAppearedAfterPlanning` **only** | everything else |
| **I2** over-correct: `revalidateAbsent` always errors | `CreatesMissingOutputParents`, `cmd/migrate`'s JSON-report test | both refusal tests |
| **M3** revert: `openOutputRoot` always nil | `...AncestorOutsideTheRoot` **only** | everything else |
| **I3** over-correct: an empty root confines to the working directory | 40 rows | — |
| **M4** revert: the contents comparison dropped | `RejectsChangedDirectory` **only** | both identity refusals, every happy path |

M3 is the honest one. The retained parent handle already refuses a symlink escaping the *parent* with the same "outside allowed root" wording whether or not a root was configured, so the root's unique contribution narrows to an ancestor **above** the parent leaving the root — and exactly one row pins it. Without that row M3 is silent.

M0 is the branch as it stood before this commit: RED on ext4, GREEN on APFS, measured above.

## Gates

`go build` 0 · `go vet` 0 · `go vet -tags integration` 0 · **`go test ./... -count=1` 0** (178 packages ok, zero FAIL lines) · `qtlint` 0 · `golangci-lint` 0 · `check-test-style` 0 · `check-public-api` 0 · `check-public-api-snapshot` 0 · `check-public-api-released` 0 · `GOOS=windows` build and vet 0 · all eight `docs/site` check scripts 0 including `build-feature-matrix --check`.

An earlier full run on the same content exited 1 with six subprocess-heavy packages blowing time budgets under concurrent load (`cmd/atlas` killed at 11m, `cmd/ptah-compat`, `cmd/ptah-ls`, `cmd/viz`, `cmd/compare`, `cmd/drift`). All six pass serially on the same tree — `cmd/atlas` in 174s against the 707s at which it was killed — and the run reported above was made on a quiet machine.

## Not verified here

No Windows machine. `GOOS=windows` build and vet are 0, but nothing Windows-specific was executed, and two claims rest on reading Go 1.26.5 rather than on a run: that `os.RemoveAll` frees the name immediately with our handle open (`windows.Deleteat` with `FILE_DISPOSITION_POSIX_SEMANTICS`), and whether `Stat(".")` succeeds on a handle to a POSIX-deleted directory. The second does not matter — a Stat error is wrapped into `ErrMigrationDirectoryChanged` on the same line, so the test asserts the same thing either way. The first does: if NTFS refused POSIX-semantics deletion, the test would go red at its setup rather than its assertion. `windows-publication` is the arbiter.

## Still open on #1118

Carried forward from #1288, untouched here:

- `cmd/migrate/new.go --edit` rehashes through `migrateops.Rehash(dir, format)` by pathname after the external editor exits.
- `WriteCheckpointFiles`, `WriteDataMigrationFiles` and `WriteAtlasCheckpointFile` (`ptah migrations checkpoint`, `ptah migrations data`) still write by pathname, and `ResolveAtlasCheckpointVersion` still scans by pathname. Not named by #1118, and carrying no `AllowedOutputRoot`, but the machinery to convert them is in place.

Refs #1118.

---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

The diagnosis and the fix hold — I reproduced every row of it independently — but the change ships a false user-facing sentence, leaves half of its own stated behavior unmeasured, and lands on a branch whose adjacent shape it never built.

WORKTREES (all detached, `git log --oneline -1` verified before every build)
  head    scratchpad/rh1118/head    f2ac181b
  parent  scratchpad/rh1118/parent  d9d2a1de
  base    scratchpad/rh1118/base    4fd9f18a  (merge-base with origin/master)
  mut     scratchpad/rh1118/mut     f2ac181b  (mutants)
  deliver scratchpad/rh1118/deliver c9499d69 on branch refute/1118-rooted-plan-handle
My own PostgreSQL 17 container rh1118-pg on port 15118 (removed at the end); rh1118_my on mylive-mysql (dropped).

=== WHAT HELD (re-measured, my own rig) ===

EXT4 REPRODUCTION. Loopback ext4 image inside a privileged alpine:3.20 container, arm64, test binaries cross-compiled `GOOS=linux GOARCH=arm64 CGO_ENABLED=0 go test -c`, TMPDIR on the mount:
  d9d2a1de, TMPDIR=/mnt/ext4  -> exit 1, `plan_root_test.go:52: got nil error but want non-nil`
  f2ac181b, TMPDIR=/mnt/ext4  -> exit 0, PASS
  d9d2a1de, TMPDIR=/tmp (overlayfs) -> exit 0, PASS
Exactly what they claimed, including that Linux alone is not sufficient.

ESCAPE PROBES. `-test.count=40` over the four named tests plus the three refusal rows, on ext4 at f2ac181b: exit 0.

MUTANTS. Applied to the committed tree in `scratchpad/rh1118/mut`, run over `./migration/generator ./internal/atlasmigrate ./cmd/migrate`, restored between each (restored run exit 0, all three ok). I ran 6 of their 7; I did not run I3.
  M1 (revalidate returns nil for an existing dir) -> RED exactly: RefusesRecreatedDirectory, RefusesDirectoryReplacedBeforePublication/{no_allowed_root,under_an_allowed_root}.
  M2 (revalidateAbsent returns nil)               -> RED exactly one row: RefusesADirectoryThatAppearedAfterPlanning.
  M3 (openOutputRoot returns nil)                 -> RED exactly one row: TestMigrationPlanBindRefusesADirectoryReachedThroughAnAncestorOutsideTheRoot.
  M4 (contents comparison dropped)                -> RED exactly one row: RejectsChangedDirectory.
  I1 (revalidate always changed)                  -> RED 9 generator rows + cmd/migrate TestMigrateGenerateReplayDerivesCurrentStateFromDirectory.
  I2 (revalidateAbsent always errors)             -> RED CreatesMissingOutputParents + TestMigrateGenerateJSONReportWritesSiblingSafetyArtifact.
Every row set matches their report.

GATES on f2ac181b, exit code on its own line: go build 0 | go vet 0 | go vet -tags integration ./integration/... 0 | go test ./... -count=1 1 (single row, cmd/viz TestSVGReportsGraphvizStderrOnFailure, 10.00s Graphviz timeout under my parallel load; re-run alone -> exit 0, ok 0.407s; 177 ok otherwise) | qtlint 0 | golangci-lint (private cache) 0, "0 issues." | check-test-style 0 | check-public-api 0 | check-public-api-snapshot 0 | check-public-api-released 0 | GOOS=windows build 0 | GOOS=windows vet 0 | all 8 docs/site scripts 0.

OTHER LAYERS / DIALECTS / ROLE. `ptah migrations generate` end-to-end, base vs head, identical output on: PostgreSQL 17 as ptah_user, PostgreSQL 17 as the bootstrap postgres superuser, MySQL 9.7, `--replay` (twice each, second run a no-op), relative `--migrations-dir` through a symlink, `--dir` is a regular file. Adjacent shapes that pass at head: nested subdirectory in the migration directory, `--dir` is a symlink, ancestor is a symlink, missing parents, an abandoned plan does not block a second plan over the same directory. The README claim "a plan that is never published releases its handles when it is collected" is TRUE: 200 dropped plans peaked at 54 open fds and settled back to the 6-fd baseline after GC.

=== WHY IT IS REFUTED ===

(1) A FALSE SENTENCE SHIPS, CONTRADICTED BY THE COMMIT'S OWN TESTS.
docs/site/src/content/docs/concepts/migration-directory.md:134-137 says, with no qualifier:
  "This changes behavior twice over: a run that previously published into a recreated
   directory now fails instead, and while a plan is outstanding the migration directory
   is held open, so another process cannot rename or remove it until the plan publishes
   or is discarded."
That is a Windows property. On Unix an open directory is renamed and unlinked freely, and two tests added or edited by this same commit assert precisely that as their hostile step:
  plan_root_test.go:67       `c.Assert(os.RemoveAll(outputDir), qt.IsNil)` with the plan holding the handle
  plan_root_unix_test.go     `c.Assert(os.Rename(path, retained), qt.IsNil)` (replaceWithSymlink) likewise
Both pass on macOS APFS and on Linux ext4 (measured above). migration/generator/README.md:96-99 carries the correct qualifier ("so on Windows another process cannot rename or remove it"), so the two doc surfaces disagree and the reader-facing one is the wrong one. Their own "could not verify" item 2 identifies the property as Windows-specific and asserts it is "Documented in both doc surfaces"; it is documented in one and misdocumented in the other. The commit message repeats the unqualified form.

(2) HALF THE CHANGE IS UNPINNED. "The version scan moved onto the same handle" is stated in the commit message, in the doc comment on nextAvailableMigrationVersion, and in the PlanMigration comment. Reverting it:
    return nextAvailablePtahVersion(migrationDirFileNames(writer.Path()), version, migrationName), nil
  `go test ./migration/generator/ ./internal/atlasmigrate/ ./cmd/migrate/ -count=1` -> exit 0, three ok, no FAIL lines.
Nothing in the repository measures it, because every fixture has the pathname and the handle naming the same directory. Their seven mutants cover revalidate, revalidateAbsent, openOutputRoot and the contents comparison, and stop there.

(3) ADJACENT SHAPE, USER-VISIBLE, NEVER BUILT: a symlinked migration file in the directory. Legitimate layout (a shared migration linked in), nothing documents it as refused.
  fixture: migrations/1000000000_shared.up.sql -> 

### What it says must change

The mechanism, the fix and the mutant table are correct — I reproduced the ext4 failure at d9d2a1de and the pass at f2ac181b myself, and six of their seven mutants redden the exact rows they list. What is wrong is what ships around it.

The claim "while a plan is outstanding the migration directory is held open, so another process cannot rename or remove it until the plan publishes or is discarded" is not true on Unix and is published unqualified on the reader-facing concept page. It is a Windows property. Two tests in the same commit remove and rename the held directory and assert the hostile step succeeds; both pass on Linux ext4 and macOS. The package README states it correctly ("so on Windows"), so the claim that it is "documented in both doc surfaces" is wrong: it is documented in one and misstated in the other. Say which platform, and say that on Unix the removal succeeds and the guard is what refuses to publish afterwards.

The version scan moving onto the bound handle is asserted three times in prose and measured nowhere. Reverting it to migrationDirFileNames(writer.Path()) leaves migration/generator, internal/atlasmigrate and cmd/migrate at exit 0. It needs a row that makes the pathname and the handle name different directories.

Two things the change should also answer for. A failed WriteFilesContext never closes the plan's handles — measured 8 open fds before and after the failure against a 6-fd baseline — and MigrationPlan has no Close, so the Windows "cannot rename or remove" window documented as ending at "publishes or is discarded" has no end after a failure. And the branch as a whole now refuses a migration directory containing a symlinked .sql file: `ptah migrations generate` exits 0 on 4fd9f18a and exits 2 on both d9d2a1de and f2ac181b with "path escapes from parent". That one is d9d2a1de's, not this commit's, but it is in the neighbourhood this commit says it enumerated, and it is what an operator sees.