### PR TITLE
Create a user-defined type before the type that names it (#1242)

### DIFF
--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -94,6 +94,16 @@ func QualifyTableName(schema, table string) string {
 // GeneratedKind / GeneratedExpression are populated by readers for dialects
 // that expose generated column metadata. Schema comparison matches these fields
 // when the goschema-side model also carries generated column metadata.
+//
+// DomainName and FormattedType are a pair. DataType reports a domain column's
+// BASE type, so it alone cannot say that the declared type was a domain:
+// DomainName carries that fact and FormattedType carries the spelling the
+// server uses for it, schema-qualified where the search path needs that.
+// Everything that answers "what type is this column declared as" -- the
+// desired-state conversion, the Atlas-compatible JSON inspect output, and the
+// comparator's database side -- must consult DomainName rather than infer the
+// answer from DataType, which reports the base type and drops the domain's
+// constraints with it. See stokaro/ptah#1242.
 type DBColumn struct {
 	Name               string  `json:"name"`
 	DataType           string  `json:"data_type"`

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -372,6 +372,45 @@ folded into the shorthand, and the sequence itself is reported rather than
 treated as the column's implicit backing sequence — without it the emitted DDL
 names a sequence nothing creates, which is measured as psql exit 3.
 
+### A domain over a user-defined base type is a different catalog shape
+
+`CREATE DOMAIN positive AS integer` and `CREATE DOMAIN d_enum AS color` do not
+read back the same way, and the difference decides which code answers the
+question "what type is this column declared as". Measured on PostgreSQL 17.10:
+
+| Column | `data_type` | `udt_name` | `domain_name` | `format_type` |
+| --- | --- | --- | --- | --- |
+| `qty positive`, `positive AS integer` | `integer` | `int4` | `positive` | `positive` |
+| `c d_enum`, `d_enum AS color` | `USER-DEFINED` | `color` | `d_enum` | `d_enum` |
+| `plain color`, no domain | `USER-DEFINED` | `color` | *(null)* | *(not read)* |
+
+For a domain over a built-in base type `data_type` is the base type, so a
+consumer that falls through to `format_type` reaches the domain by accident. For
+a domain over a user-defined base type — an enum, a composite or a range —
+`data_type` is the bare category `USER-DEFINED` and `udt_name` names the BASE
+type, identically to the plain column on the last row. A consumer that answers
+from `udt_name` there flattens `c` to `color` and drops the domain's `CHECK`
+with it, and only `domain_name` separates row two from row three.
+
+Measured with `ptah-compat` against one database holding rows two and three, and
+against the composite and range shapes beside them:
+
+| Probe | Atlas CE v1.3.0 | Ptah |
+| --- | --- | --- |
+| `schema diff --from X --to X`, one database against itself | Schemas are synced | Schemas are synced |
+| `schema apply` of a byte-identical twin | — | Schema is synced, no changes to be made |
+| `schema inspect --format json` | `"type":"d_enum"` | `"type":"d_enum"` |
+| `schema inspect`, HCL | `type = sql("d_enum")` | `type = sql("d_enum")` |
+| `schema inspect`, HCL, plain enum column beside it | `type = enum.color` | `type = enum.color` |
+| `schema diff` from empty, replayed with psql, then compared to the source by CE | — | psql exit 0, Schemas are synced |
+
+The last row is the round trip, and CE is the neutral observer in it: Ptah emits
+`CREATE TYPE`, `CREATE DOMAIN` and a `d_enum` column, the replay runs at psql
+exit 0, and CE then reports the replayed database in sync with the one it was
+described from. A description that spells the column `color` replays at exit 0
+too and CE reports `ALTER TABLE "t" ALTER COLUMN "c" TYPE d_enum;` — the replay
+lost the domain and the exit code did not say so.
+
 ### Reading an attribute and reconciling it are different claims
 
 The table above records what introspection preserves. It does not say what

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -323,7 +323,54 @@ own `schema diff` output fails to replay with
 `ERROR: type "positive_int" does not exist` — measured, psql exit 3. Ptah emits
 both the `CREATE DOMAIN` and the domain-typed column, so closing this gap meant
 keeping both halves rather than matching CE. Ptah's output replays at psql exit
-0 where CE's does not.
+0 where CE's does not. The same divergence reaches `schema apply`: applying this
+source database to an empty target, CE exits 1 with
+`create "t" table: pq: type "positive" does not exist` and Ptah exits 0 with the
+domain created first.
+
+### A domain column has to survive the comparator too, and the JSON surface
+
+Rendering a domain and reconciling one are separate claims, the same way they
+are for indexes below. Reading the domain fixed what `schema inspect` writes as
+HCL and left two other surfaces on the base type. Measured on PostgreSQL 17.10
+against one database holding `CREATE DOMAIN positive AS integer CHECK (VALUE >
+0)` and a column of it:
+
+| Surface | Atlas CE v1.3.0 | Ptah before | Ptah now |
+| --- | --- | --- | --- |
+| `schema inspect`, HCL | `type = sql("positive")` | `type = sql("positive")` | `type = sql("positive")` |
+| `schema inspect --format json` | `"type":"positive"` | `"type":"integer"` | `"type":"positive"` |
+| `schema inspect --format json`, domain off the search path | `"type":"doms.positive"` | `"type":"integer"` | `"type":"doms.positive"` |
+| `schema diff --from X --to X`, one database against itself | Schemas are synced | `ALTER TABLE "t" ALTER COLUMN "qty" TYPE positive;` | Schemas are synced |
+| `schema apply` run twice against the same target | — | plans and executes the same `ALTER` on every run, exit 0 each time | second run reports the schema synced |
+
+The diff row is the one that made the rendered domain worth nothing: the desired
+side answered `positive` and the database side answered `integer`, so a database
+was never in sync with itself and `schema apply` executed an `ALTER COLUMN` on
+every run while reporting success.
+
+Two details decided whether any of this was visible:
+
+- **The name of the domain.** The type comparison folded a spelling into a
+  category by substring, so any domain whose name contains `int` — the issue's
+  own `positive_int` fixture — compared equal to `integer` by accident and the
+  churn did not appear. A domain is now compared as the identifier it is: two
+  domains are the same type when they are the same domain. The reverse follows,
+  and is the point: a column of `positive_int` that a desired schema declares as
+  `bigint` is now reported as drift instead of silently matching.
+- **The array column next to it.** An array column and a domain column both make
+  the reader ask the server for its own spelling of the type, and the two want
+  opposite answers on the JSON surface: CE prints the bare category `ARRAY` for
+  an array and the domain name for a domain. The read carries which one it was,
+  rather than letting each consumer guess from which field happens to be empty.
+
+A domain column that also draws from an owned sequence is not a `SERIAL`
+column. PostgreSQL's `SERIAL` shorthand only ever builds a column of an integer
+type, so writing such a column back as `SERIAL` rebuilds it without the domain.
+The domain wins, the sequence default is written out beside it instead of being
+folded into the shorthand, and the sequence itself is reported rather than
+treated as the column's implicit backing sequence — without it the emitted DDL
+names a sequence nothing creates, which is measured as psql exit 3.
 
 ### Reading an attribute and reconciling it are different claims
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -392,6 +392,24 @@ type, identically to the plain column on the last row. A consumer that answers
 from `udt_name` there flattens `c` to `color` and drops the domain's `CHECK`
 with it, and only `domain_name` separates row two from row three.
 
+The split is not a synthetic one. Two domains arrive with PostgreSQL's own
+contrib modules and land on opposite sides of it: `lo`, from the `lo` module, is
+a domain over the built-in `oid`, and `earth`, from `earthdistance`, is a domain
+over `cube`, a base type the `cube` module supplies. Measured on PostgreSQL
+17.10 against one table holding a column of each, with a plain `cube` column
+beside them as the control:
+
+| Column | Atlas CE v1.3.0 | Answering from `udt_name` | Ptah |
+| --- | --- | --- | --- |
+| `l lo` | `type = sql("lo")` | `type = sql("lo")` | `type = sql("lo")` |
+| `w earth` | `type = sql("earth")` | `type = sql("cube")` | `type = sql("earth")` |
+| `cu cube`, no domain | `type = sql("cube")` | `type = sql("cube")` | `type = sql("cube")` |
+
+The middle column is this same code with the `domain_name` gate taken back out,
+and it is the reason the gate is not optional: two domains a user never wrote
+disagree with each other about whether a domain survives introspection, decided
+by nothing but whether the base type happens to be built-in.
+
 Measured with `ptah-compat` against one database holding rows two and three, and
 against the composite and range shapes beside them:
 
@@ -410,6 +428,30 @@ exit 0, and CE then reports the replayed database in sync with the one it was
 described from. A description that spells the column `color` replays at exit 0
 too and CE reports `ALTER TABLE "t" ALTER COLUMN "c" TYPE d_enum;` — the replay
 lost the domain and the exit code did not say so.
+
+That row carries a second claim, and it is the emitted script's ORDER. Naming a
+domain in a column is worth nothing if the statement that creates the domain
+runs before the statement that creates its base type, and PostgreSQL has no
+forward declaration for a type. The emitter ran kind by kind — every domain,
+then every range, then every composite — so a database holding
+`CREATE DOMAIN d_comp AS addr` was described as `CREATE DOMAIN "d_comp" AS addr;`
+four statements ahead of `CREATE TYPE "addr" AS ("street" text, "city" text);`
+and the replay stopped where it had to. Measured on PostgreSQL 17.10 with the
+enum, composite and range shapes in one database:
+
+| Emitted script | `psql -v ON_ERROR_STOP=1` | CE compares the replay to the source |
+| --- | --- | --- |
+| every domain first | `ERROR: type "addr" does not exist`, exit 3 | not reached |
+| dependency ordered | exit 0 | Schemas are synced |
+
+No fixed order of kinds fixes this, because the three kinds share one namespace
+and name each other in both directions: `CREATE DOMAIN d_comp AS addr` needs the
+composite first and `CREATE TYPE addr AS (f d_int)` needs the domain first.
+Domains, composites and ranges are ordered against each other by what their
+definitions name, and the ones a modification recreates are dropped in the
+reverse of that order, so the deliberately non-CASCADE drop is not blocked by a
+dependent the same plan is about to replace. Enums stay ahead of all three: an
+enum names no other user-defined type, so it has nothing to wait for.
 
 ### Reading an attribute and reconciling it are different claims
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -354,10 +354,8 @@ Two details decided whether any of this was visible:
 - **The name of the domain.** The type comparison folded a spelling into a
   category by substring, so any domain whose name contains `int` — the issue's
   own `positive_int` fixture — compared equal to `integer` by accident and the
-  churn did not appear. A domain is now compared as the identifier it is: two
-  domains are the same type when they are the same domain. The reverse follows,
-  and is the point: a column of `positive_int` that a desired schema declares as
-  `bigint` is now reported as drift instead of silently matching.
+  churn did not appear. A domain is compared as the identifier it is instead,
+  which is the subject of *A domain column is reconciled by identity* below.
 - **The array column next to it.** An array column and a domain column both make
   the reader ask the server for its own spelling of the type, and the two want
   opposite answers on the JSON surface: CE prints the bare category `ARRAY` for

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -448,10 +448,28 @@ No fixed order of kinds fixes this, because the three kinds share one namespace
 and name each other in both directions: `CREATE DOMAIN d_comp AS addr` needs the
 composite first and `CREATE TYPE addr AS (f d_int)` needs the domain first.
 Domains, composites and ranges are ordered against each other by what their
-definitions name, and the ones a modification recreates are dropped in the
-reverse of that order, so the deliberately non-CASCADE drop is not blocked by a
-dependent the same plan is about to replace. Enums stay ahead of all three: an
-enum names no other user-defined type, so it has nothing to wait for.
+definitions name. Enums stay ahead of all three: an enum names no other
+user-defined type, so it has nothing to wait for.
+
+The drops a modification emits are ordered by a different graph, and reversing
+the creation order is not a substitute for it. A `DROP` executes against the
+database as it stands, so only the references that database holds now can block
+it. Measured on PostgreSQL 17.10, one database holding
+`CREATE TYPE cc AS (f integer)` and `CREATE DOMAIN dd AS cc`, reconciled against
+a target of `CREATE DOMAIN dd AS integer` and `CREATE TYPE cc AS (f dd)`:
+
+| Drops ordered by | Emitted order | `schema apply --auto-approve` |
+| --- | --- | --- |
+| the target definitions | `DROP TYPE cc`, `DROP DOMAIN dd` | exit 1, `cannot drop type cc because other objects depend on it` / `DETAIL: type dd depends on type cc` (SQLSTATE 2BP01) |
+| the current definitions | `DROP DOMAIN dd`, `DROP TYPE cc` | exit 0 |
+
+The same root cause shows without a flip in it. A database holding
+`CREATE DOMAIN qty AS integer CHECK (VALUE > 0)` and
+`CREATE TYPE meas AS (q qty, label text)`, reconciled against a target that
+widens `qty` to bigint and gives `meas` a plain bigint field, has no edge at all
+on the target side: `DROP DOMAIN "qty"` came out first and the server answered
+`column q of composite type meas depends on type qty`. The current side still
+has the edge, and dropping `meas` first exits 0.
 
 ### Reading an attribute and reconciling it are different claims
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5294,6 +5294,7 @@ type DBColumn struct {
     DataType           string  `json:"data_type"`
     UDTName            string  `json:"udt_name"`                 // For PostgreSQL enum types
     FormattedType      string  `json:"formatted_type,omitempty"` // Server's own spelling, where the catalog cannot express it
+    DomainName         string  `json:"domain_name,omitempty"`    // Domain this column's declared type names, empty when it is not a domain
     ColumnType         string  `json:"column_type"`              // For MySQL ENUM syntax
     IsNullable         string  `json:"is_nullable"`              // YES/NO
     ColumnDefault      *string `json:"column_default"`           // Can be NULL
@@ -5359,6 +5360,16 @@ type DBColumn struct {
     GeneratedKind / GeneratedExpression are populated by readers for dialects
     that expose generated column metadata. Schema comparison matches these
     fields when the goschema-side model also carries generated column metadata.
+
+    DomainName and FormattedType are a pair. DataType reports a domain column's
+    BASE type, so it alone cannot say that the declared type was a domain:
+    DomainName carries that fact and FormattedType carries the spelling the
+    server uses for it, schema-qualified where the search path needs that.
+    Everything that answers "what type is this column declared as" -- the
+    desired-state conversion, the Atlas-compatible JSON inspect output, and the
+    comparator's database side -- must consult DomainName rather than infer the
+    answer from DataType, which reports the base type and drops the domain's
+    constraints with it. See stokaro/ptah#1242.
 
 
 ### go.5x5.cz/ptah/dbschema/types.DBComposite

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -8389,8 +8389,21 @@ package types // import "go.5x5.cz/ptah/migration/schemadiff/types"
 type CompositeTypeDiff struct {
     TypeName string            `json:"type_name"`
     Changes  map[string]string `json:"changes"`
+
+    // CurrentFieldTypes are the field types the composite has in the database
+    // being compared against, in that catalog's own spellings and in field
+    // order. They order the non-CASCADE DROP the recreate path emits, which
+    // runs against the current shape rather than the desired one.
+    //
+    // Empty when the caller built the diff by hand or the type's from-side is
+    // unknown; the drop ordering then falls back to declaration order.
+    CurrentFieldTypes []string `json:"current_field_types,omitempty"`
 }
     CompositeTypeDiff represents changes to a PostgreSQL composite type.
+
+    Changes is the human-readable "old -> new" payload. CurrentFieldTypes is
+    the from-side of the same comparison kept as type spellings, for the reason
+    given on DomainDiff.CurrentBaseType.
 
 
 ### go.5x5.cz/ptah/migration/schemadiff/types.ConstraintAdditionInfo
@@ -8480,8 +8493,27 @@ package types // import "go.5x5.cz/ptah/migration/schemadiff/types"
 type DomainDiff struct {
     DomainName string            `json:"domain_name"`
     Changes    map[string]string `json:"changes"`
+
+    // CurrentBaseType is the base type the domain has in the database being
+    // compared against, in that catalog's own spelling -- the from-side of the
+    // "type" entry in Changes, structurally rather than as prose.
+    //
+    // A modification is reconciled as a non-CASCADE DROP followed by a CREATE.
+    // The CREATE belongs to the desired definitions, but the DROP executes
+    // against the database as it stands, so only the references it holds now
+    // can block it, and those are the ones recorded here. The two sides
+    // disagree exactly when the modification is what moved a reference.
+    //
+    // Empty when the caller built the diff by hand or the domain's from-side is
+    // unknown; the drop ordering then falls back to declaration order.
+    CurrentBaseType string `json:"current_base_type,omitempty"`
 }
     DomainDiff represents changes to a PostgreSQL domain type.
+
+    Changes is the human-readable "old -> new" payload. CurrentBaseType is the
+    from-side of the same comparison kept as a type spelling rather than prose,
+    because a plan that drops this domain has to be ordered by the shape the
+    database holds now. See the comment on CurrentBaseType.
 
 
 ### go.5x5.cz/ptah/migration/schemadiff/types.EnumDiff

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5294,7 +5294,6 @@ type DBColumn struct {
     DataType           string  `json:"data_type"`
     UDTName            string  `json:"udt_name"`                 // For PostgreSQL enum types
     FormattedType      string  `json:"formatted_type,omitempty"` // Server's own spelling, where the catalog cannot express it
-    DomainName         string  `json:"domain_name,omitempty"`    // Domain this column's declared type names, empty when it is not a domain
     ColumnType         string  `json:"column_type"`              // For MySQL ENUM syntax
     IsNullable         string  `json:"is_nullable"`              // YES/NO
     ColumnDefault      *string `json:"column_default"`           // Can be NULL

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -278,8 +278,12 @@ destructive by the safety gate. Reconciliation is deliberately conservative:
   not by kind: `CREATE TYPE addr AS (...)` precedes `CREATE DOMAIN d AS addr`,
   and `CREATE DOMAIN qty AS integer` precedes a composite with a `qty` field.
   Both directions occur, and PostgreSQL has no forward declaration for a type.
-  Recreations drop in the reverse of that order, so a non-`CASCADE` drop is
-  never blocked by a dependent the same plan is replacing.
+- The drops a recreation emits are ordered by the shape the **database holds**,
+  which is a different graph from the one above and does not have to agree with
+  it. A `DROP` runs against the current schema, so only a reference that schema
+  carries can block it; when the change is what moves the reference, the create
+  order and the drop order are not mirror images. Both orders come out of the
+  same plan.
 - A domain, composite or range type that an **extension** owns is not
   described. `CREATE EXTENSION` creates those types, so they cannot be created
   or dropped independently, and describing one as a user type made the

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -274,6 +274,12 @@ destructive by the safety gate. Reconciliation is deliberately conservative:
   domain, the drop fails loudly instead of dropping the column.
 - Range types are matched by name only; a changed range is dropped and
   recreated.
+- Within the group the three kinds are ordered by what their definitions name,
+  not by kind: `CREATE TYPE addr AS (...)` precedes `CREATE DOMAIN d AS addr`,
+  and `CREATE DOMAIN qty AS integer` precedes a composite with a `qty` field.
+  Both directions occur, and PostgreSQL has no forward declaration for a type.
+  Recreations drop in the reverse of that order, so a non-`CASCADE` drop is
+  never blocked by a dependent the same plan is replacing.
 - A domain, composite or range type that an **extension** owns is not
   described. `CREATE EXTENSION` creates those types, so they cannot be created
   or dropped independently, and describing one as a user type made the

--- a/docs/user_defined_types.md
+++ b/docs/user_defined_types.md
@@ -98,4 +98,8 @@ beside `lo` — is still described in full.
 
 ## Ordering
 
-Ptah emits user-defined types after extensions and enums but before tables, so table columns can reference them. Within the group the order is domains → ranges → composites (composites may reference the others). Drops run after tables, and `DROP TYPE` / `DROP DOMAIN` are classified as destructive by the safety gate.
+Ptah emits user-defined types after extensions and enums but before tables, so table columns can reference them. Within the group the order is derived from what each definition names rather than fixed by kind: a domain over a composite waits for the composite, and a composite whose field is a domain waits for the domain. Both directions occur, so no fixed order of kinds serves them — `domains → ranges → composites` emitted `CREATE DOMAIN d_comp AS addr` ahead of `CREATE TYPE addr`, and PostgreSQL has no forward declaration for a type. A reference the plan does not create, such as a built-in type or a type the database already has, adds no ordering constraint, and a cycle — which PostgreSQL refuses to create anyway — falls back to declaration order rather than dropping a type from the plan.
+
+Enums are emitted ahead of the whole group and take no part in the ordering, because an enum names no other user-defined type.
+
+A domain or composite that changed is dropped and recreated, and the drops run in the reverse of the creation order: the deliberately non-`CASCADE` drop of a composite fails while a domain still names it, so the dependent goes first. Removals of types that are gone from the target schema run after tables, and `DROP TYPE` / `DROP DOMAIN` are classified as destructive by the safety gate.

--- a/docs/user_defined_types.md
+++ b/docs/user_defined_types.md
@@ -102,4 +102,8 @@ Ptah emits user-defined types after extensions and enums but before tables, so t
 
 Enums are emitted ahead of the whole group and take no part in the ordering, because an enum names no other user-defined type.
 
-A domain or composite that changed is dropped and recreated, and the drops run in the reverse of the creation order: the deliberately non-`CASCADE` drop of a composite fails while a domain still names it, so the dependent goes first. Removals of types that are gone from the target schema run after tables, and `DROP TYPE` / `DROP DOMAIN` are classified as destructive by the safety gate.
+A domain or composite that changed is dropped and recreated. The drops are ordered by what the **database currently holds**, not by the target definitions the creations follow. A `DROP` executes against the schema as it stands, so the only reference that can block it is one that schema still carries: the deliberately non-`CASCADE` drop of a composite fails while a domain there still names it, so that domain goes first.
+
+The two orders are the same when a reference survives the change, and they are not when the change is what moves it. Reconciling a database holding `CREATE TYPE cc AS (f integer)` with `CREATE DOMAIN dd AS cc` over it against a target of `CREATE DOMAIN dd AS integer` with `CREATE TYPE cc AS (f dd)` drops `dd` before `cc` and then creates `dd` before `cc` — the reverse of one another in name only. That is not a conflict: only the current schema can refuse a `DROP`, and only the target schema describes what is being built.
+
+Removals of types that are gone from the target schema run after tables, and `DROP TYPE` / `DROP DOMAIN` are classified as destructive by the safety gate.

--- a/integration/gonative/domain_columns_postgres_test.go
+++ b/integration/gonative/domain_columns_postgres_test.go
@@ -46,6 +46,39 @@ func domainColumnSeed() []string {
 	}
 }
 
+// domainOverUserDefinedSeed is the shape the fixture above cannot reach: a
+// domain whose BASE type is itself user-defined.
+//
+// The distinction is a catalog one and it decides which branch of the
+// conversion runs. For `positive` above, information_schema reports data_type
+// 'integer' -- the base type -- so a consumer that only knows about built-in
+// spellings still lands somewhere that can be corrected. For `d_enum` here,
+// measured on PostgreSQL 17.10, it reports data_type 'USER-DEFINED' with
+// udt_name 'color': the BASE type again, but now under the branch that answers
+// from udt_name. Only domain_name and format_type name the domain.
+//
+// The plain `color` column beside it is the control in the other direction: a
+// USER-DEFINED column that is NOT a domain must keep answering with its own
+// type name, so the rule stays gated on the domain rather than on USER-DEFINED.
+// The composite and range columns are the same shape with the other two kinds
+// of user-defined base type PostgreSQL has.
+func domainOverUserDefinedSeed() []string {
+	return []string{
+		"CREATE TYPE color AS ENUM ('r','g','b')",
+		"CREATE TYPE addr AS (street text, city text)",
+		"CREATE TYPE myrange AS RANGE (subtype = integer)",
+		"CREATE DOMAIN d_enum AS color CHECK (VALUE <> 'b')",
+		"CREATE DOMAIN d_comp AS addr",
+		"CREATE DOMAIN d_range AS myrange",
+		"CREATE TABLE t (" +
+			"id integer PRIMARY KEY, " +
+			"c d_enum NOT NULL, " +
+			"a d_comp, " +
+			"r d_range, " +
+			"plain color NOT NULL)",
+	}
+}
+
 // TestPostgreSQLDomainColumn_ReaderKeepsTheDomain asserts what the reader
 // reports, before anything renders or compares.
 func TestPostgreSQLDomainColumn_ReaderKeepsTheDomain(t *testing.T) {
@@ -149,6 +182,143 @@ func TestPostgreSQLDomainColumn_ApplyingItsOwnDescriptionChangesNothing(t *testi
 			plan := boundaryApplyBack(c, conn, document, test.compatibility)
 
 			c.Assert(columnStatements(plan, "qty"), qt.DeepEquals, []string(nil))
+		})
+	}
+}
+
+// TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeKeepsTheDomain is the same
+// claim as TestPostgreSQLDomainColumn_ReaderKeepsTheDomain for the shape whose
+// base type is itself user-defined.
+//
+// This is the shape a fix for the `positive` fixture can silently break. The
+// conversion answers a USER-DEFINED column from udt_name, and for a domain
+// udt_name is the BASE type -- so consulting the domain only where data_type
+// happens to be a built-in spelling flattens `c d_enum` to `color` and takes
+// the domain's CHECK with it. Measured with ptah-compat against PostgreSQL
+// 17.10 before this guard existed: `schema diff --from X --to X` on one
+// database planned `ALTER TABLE "t" ALTER COLUMN "c" TYPE color;`, `schema
+// apply` executed it and reported success, and afterwards
+// information_schema.columns.domain_name for that column was NULL. The pinned
+// community binary v1.3.0 reported the same database synced.
+func TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeKeepsTheDomain(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	dbURL := newBoundaryDatabase(c, dsn, boundaryCase{
+		name:  "domain_over_user_defined_reader",
+		seed:  domainOverUserDefinedSeed(),
+		query: "search_path=public",
+	})
+	conn, err := dbschema.ConnectToDatabase(c.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	live, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	c.Assert(err, qt.IsNil)
+	converted := dbschematogo.ConvertDBSchemaToGoSchema(live)
+
+	tests := []struct {
+		name   string
+		column string
+		// wantDomain is DBColumn.DomainName, empty for the control column.
+		wantDomain string
+		// wantUDTName is the BASE type the catalog reports for a domain
+		// column, and the column's own type for the control. The two being
+		// equal for the control is exactly why the domain rows need the
+		// domain: udt_name cannot tell them apart.
+		wantUDTName string
+		// wantFieldType is what the desired-state model carries, which is what
+		// every renderer and the comparator's desired side then use.
+		wantFieldType string
+	}{
+		{
+			name:          "domain over an enum",
+			column:        "c",
+			wantDomain:    "d_enum",
+			wantUDTName:   "color",
+			wantFieldType: "d_enum",
+		},
+		{
+			name:          "domain over a composite type",
+			column:        "a",
+			wantDomain:    "d_comp",
+			wantUDTName:   "addr",
+			wantFieldType: "d_comp",
+		},
+		{
+			name:          "domain over a range type",
+			column:        "r",
+			wantDomain:    "d_range",
+			wantUDTName:   "myrange",
+			wantFieldType: "d_range",
+		},
+		{
+			name:          "plain enum column is not a domain",
+			column:        "plain",
+			wantDomain:    "",
+			wantUDTName:   "color",
+			wantFieldType: "color",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			column := findLiveColumn(c, live.Tables, "t", test.column)
+			c.Assert(column.DomainName, qt.Equals, test.wantDomain)
+			c.Assert(column.UDTName, qt.Equals, test.wantUDTName)
+			// The catalog reports the same data_type for all four, which is
+			// why nothing downstream can separate them without the domain.
+			c.Assert(column.DataType, qt.Equals, "USER-DEFINED")
+
+			field := findConvertedField(c, converted, test.column)
+			c.Assert(field.Type, qt.Equals, test.wantFieldType)
+		})
+	}
+}
+
+// TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeApplyingItsOwnDescriptionChangesNothing
+// is the round-trip property for the same shape: a database that applies its
+// own inspected description must plan nothing for these columns.
+//
+// The `positive` version of this test next door passed throughout the change
+// that broke this one, which is the whole reason this exists separately.
+func TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeApplyingItsOwnDescriptionChangesNothing(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// compatibility selects the surface, as next door: both must hold it.
+		compatibility bool
+	}{
+		{name: "native surface", compatibility: false},
+		{name: "compatibility surface", compatibility: true},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "domain_over_user_defined_apply",
+				seed:  domainOverUserDefinedSeed(),
+				query: "search_path=public",
+			})
+			conn, err := dbschema.ConnectToDatabase(c.Context(), dbURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+			document := boundaryInspect(c, dbURL, test.compatibility)
+			c.Assert(document, qt.Contains, `type = sql("d_enum")`)
+			// The control's spelling is asserted too, so a change that made
+			// every USER-DEFINED column print sql(...) would not read as a
+			// pass here.
+			c.Assert(document, qt.Contains, `type = enum.color`)
+
+			plan := boundaryApplyBack(c, conn, document, test.compatibility)
+
+			c.Assert(columnStatements(plan, "c"), qt.DeepEquals, []string(nil))
+			c.Assert(columnStatements(plan, "a"), qt.DeepEquals, []string(nil))
+			c.Assert(columnStatements(plan, "r"), qt.DeepEquals, []string(nil))
+			c.Assert(columnStatements(plan, "plain"), qt.DeepEquals, []string(nil))
 		})
 	}
 }

--- a/integration/gonative/domain_columns_postgres_test.go
+++ b/integration/gonative/domain_columns_postgres_test.go
@@ -33,7 +33,9 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+	"go.5x5.cz/ptah/migration/migrator"
 )
 
 // domainColumnSeed is the fixture from the issue, plus a plain column of the
@@ -319,6 +321,74 @@ func TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeApplyingItsOwnDescription
 			c.Assert(columnStatements(plan, "a"), qt.DeepEquals, []string(nil))
 			c.Assert(columnStatements(plan, "r"), qt.DeepEquals, []string(nil))
 			c.Assert(columnStatements(plan, "plain"), qt.DeepEquals, []string(nil))
+		})
+	}
+}
+
+// TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeDescriptionReplaysOnAnEmptyDatabase
+// is the round trip in its other direction: not "applying a database's own
+// description changes nothing", but "the description RUNS at all".
+//
+// The two are different claims and only this one can see a statement ORDER
+// defect. A self-apply plans nothing, so it executes nothing and any order is
+// vacuously fine. Creating the same schema from empty has to name every type
+// before the type that uses it, and PostgreSQL has no forward declaration:
+// measured on 17.10 before this guard existed, ptah-compat emitted
+// `CREATE DOMAIN "d_comp" AS addr;` five statements ahead of
+// `CREATE TYPE "addr" AS ("street" text, "city" text);` and psql -v
+// ON_ERROR_STOP=1 stopped at `ERROR: type "addr" does not exist`, exit 3.
+//
+// The plan is EXECUTED rather than inspected, because a text assertion on the
+// order is a restatement of the emitter and would agree with it whatever it
+// says. The server is the judge. What is asserted afterwards is the shape, not
+// only the exit status: a script that ran but flattened the domains would
+// otherwise pass.
+func TestPostgreSQLDomainColumn_OverUserDefinedBaseTypeDescriptionReplaysOnAnEmptyDatabase(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	sourceURL := newBoundaryDatabase(c, dsn, boundaryCase{
+		name:  "domain_over_user_defined_replay_source",
+		seed:  domainOverUserDefinedSeed(),
+		query: "search_path=public",
+	})
+	targetURL := newBoundaryDatabase(c, dsn, boundaryCase{
+		name:  "domain_over_user_defined_replay_target",
+		query: "search_path=public",
+	})
+
+	target, err := dbschema.ConnectToDatabase(c.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(target) })
+
+	plan, err := atlasschema.PrepareApply(c.Context(), target, atlasschema.ApplyRuntimeOptions{
+		ToURLs: []string{sourceURL},
+		// The default the CLI parses out of an unset --tx-mode. One
+		// transaction per statement list is also what makes a failure
+		// unambiguous: the target is left empty rather than half built.
+		TxMode: migrator.MigrationTxModeFile,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(plan.HasChanges(), qt.IsTrue)
+	c.Assert(plan.Execute(c.Context()), qt.IsNil, qt.Commentf("emitted script:\n%s", plan.SQL()))
+
+	replayed, err := dbschema.ReadSchemaWithSchemas(target, nil)
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		name       string
+		column     string
+		wantDomain string
+	}{
+		{name: "domain over an enum", column: "c", wantDomain: "d_enum"},
+		{name: "domain over a composite type", column: "a", wantDomain: "d_comp"},
+		{name: "domain over a range type", column: "r", wantDomain: "d_range"},
+		{name: "plain enum column is not a domain", column: "plain", wantDomain: ""},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(findLiveColumn(c, replayed.Tables, "t", test.column).DomainName, qt.Equals, test.wantDomain)
 		})
 	}
 }

--- a/integration/gonative/domain_columns_postgres_test.go
+++ b/integration/gonative/domain_columns_postgres_test.go
@@ -1,0 +1,193 @@
+//go:build integration
+
+// Live guard for the last item of stokaro/ptah#1242: a column whose declared
+// type is a PostgreSQL DOMAIN.
+//
+// The catalog subtlety this is about: information_schema.columns.data_type
+// reports a domain column's BASE type -- "integer" for a column of
+// `CREATE DOMAIN positive AS integer CHECK (VALUE > 0)` -- and records the
+// domain separately in domain_name/domain_schema. pg_attribute joined to
+// pg_type names the domain directly, with typtype = 'd'. A reader that trusts
+// data_type therefore hands the rest of the pipeline a column that never had
+// the domain, and no pure function downstream can notice.
+//
+// It takes a LIVE server to see this. Every fixture below is one throwaway
+// database, so a failure names one shape.
+//
+// The domain is named `positive`, not `positive_int`, deliberately. The
+// comparator folded a type spelling into a category by substring, so any name
+// containing "int" compared equal to the base type by accident: measured on
+// PostgreSQL 17.10 with ptah-compat, `schema diff --from X --to X` planned
+// `ALTER TABLE "t" ALTER COLUMN "qty" TYPE positive` on the `positive` fixture
+// and reported "Schemas are synced" on the `positive_int` one. The name of the
+// domain decided whether the defect was visible.
+
+package gonative_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+)
+
+// domainColumnSeed is the fixture from the issue, plus a plain column of the
+// domain's base type. The plain column is the control: it keeps a fix that
+// reports every integer column as a domain from passing.
+func domainColumnSeed() []string {
+	return []string{
+		"CREATE DOMAIN positive AS integer CHECK (VALUE > 0)",
+		"CREATE TABLE t (id integer PRIMARY KEY, qty positive NOT NULL)",
+	}
+}
+
+// TestPostgreSQLDomainColumn_ReaderKeepsTheDomain asserts what the reader
+// reports, before anything renders or compares.
+func TestPostgreSQLDomainColumn_ReaderKeepsTheDomain(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	dbURL := newBoundaryDatabase(c, dsn, boundaryCase{
+		name:  "domain_reader",
+		seed:  domainColumnSeed(),
+		query: "search_path=public",
+	})
+	conn, err := dbschema.ConnectToDatabase(c.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+	live, err := dbschema.ReadSchemaWithSchemas(conn, nil)
+	c.Assert(err, qt.IsNil)
+	converted := dbschematogo.ConvertDBSchemaToGoSchema(live)
+
+	tests := []struct {
+		name   string
+		column string
+		// wantDomain is DBColumn.DomainName: the fact information_schema
+		// records and data_type erases.
+		wantDomain string
+		// wantFieldType is what the desired-state model carries, which is what
+		// every renderer writes out.
+		wantFieldType string
+	}{
+		{
+			name:          "domain column",
+			column:        "qty",
+			wantDomain:    "positive",
+			wantFieldType: "positive",
+		},
+		{
+			name:          "plain column of the domain's base type",
+			column:        "id",
+			wantDomain:    "",
+			wantFieldType: "integer",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			column := findLiveColumn(c, live.Tables, "t", test.column)
+			c.Assert(column.DomainName, qt.Equals, test.wantDomain)
+			// The base type stays available either way: the read adds a
+			// spelling rather than replacing one.
+			c.Assert(column.DataType, qt.Equals, "integer")
+
+			field := findConvertedField(c, converted, test.column)
+			c.Assert(field.Type, qt.Equals, test.wantFieldType)
+		})
+	}
+}
+
+// TestPostgreSQLDomainColumn_ApplyingItsOwnDescriptionChangesNothing is the
+// round-trip property, and the one that makes a rendered domain worth
+// something.
+//
+// Before this change the document said `type = sql("positive")` while the
+// comparator read the same column back as `integer`, so a database was never in
+// sync with itself: applying its own description planned
+// `ALTER TABLE "t" ALTER COLUMN "qty" TYPE positive`, and `schema apply`
+// executed it on every run and reported success.
+//
+// The assertion is on statements that touch the COLUMN rather than on an empty
+// plan, because these fixtures also carry the owner-grant churn of #1276, which
+// is a different issue with its own guard next door and is not this test's
+// business.
+func TestPostgreSQLDomainColumn_ApplyingItsOwnDescriptionChangesNothing(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		// compatibility selects the surface: the compatibility binary omits
+		// blocks the tool it stands in for refuses and tolerates names Ptah
+		// does not model. Both surfaces must hold this property.
+		compatibility bool
+	}{
+		{name: "native surface", compatibility: false},
+		{name: "compatibility surface", compatibility: true},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "domain_apply",
+				seed:  domainColumnSeed(),
+				query: "search_path=public",
+			})
+			conn, err := dbschema.ConnectToDatabase(c.Context(), dbURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() { dbschema.CloseAndWarn(conn) })
+
+			document := boundaryInspect(c, dbURL, test.compatibility)
+			c.Assert(document, qt.Contains, `type = sql("positive")`)
+
+			plan := boundaryApplyBack(c, conn, document, test.compatibility)
+
+			c.Assert(columnStatements(plan, "qty"), qt.DeepEquals, []string(nil))
+		})
+	}
+}
+
+// columnStatements keeps the planned statements that name a column, which for
+// these fixtures means the type churn and nothing else: the grant statements
+// name a table and a role.
+func columnStatements(statements []string, column string) []string {
+	var out []string
+	for _, statement := range statements {
+		if strings.Contains(statement, `"`+column+`"`) {
+			out = append(out, statement)
+		}
+	}
+	return out
+}
+
+func findLiveColumn(c *qt.C, tables []dbschematypes.DBTable, table, column string) dbschematypes.DBColumn {
+	c.Helper()
+
+	for _, candidate := range tables {
+		for _, columnCandidate := range candidate.Columns {
+			if candidate.Name == table && columnCandidate.Name == column {
+				return columnCandidate
+			}
+		}
+	}
+	c.Fatalf("table %q has no column %q in the read schema", table, column)
+	return dbschematypes.DBColumn{}
+}
+
+func findConvertedField(c *qt.C, converted *goschema.Database, column string) goschema.Field {
+	c.Helper()
+
+	for _, field := range converted.Fields {
+		if field.Name == column {
+			return field
+		}
+	}
+	c.Fatalf("converted schema has no field %q", column)
+	return goschema.Field{}
+}

--- a/integration/gonative/user_type_recreate_order_postgres_test.go
+++ b/integration/gonative/user_type_recreate_order_postgres_test.go
@@ -157,6 +157,101 @@ func TestPostgreSQLUserTypeRecreate_DropsAgainstTheCurrentShape(t *testing.T) {
 	}
 }
 
+// TestPostgreSQLUserTypeRecreate_DropsAgainstTheCurrentShapeWithinOneKind is the
+// same live guard for a dependent pair of the SAME kind, which is where no order
+// of kinds can help at all.
+//
+// Every row of the table above pairs a domain with a composite, so a rule as
+// crude as "composites before domains" would pass all three. Here the two types
+// are both domains, or both composites, and the reference between them lives
+// inside one kind. The comparator hands the planner each modified list sorted by
+// name, and both rows are named so that order is the failing one: the base type
+// comes first alphabetically, and dropping it while its dependent still stands
+// draws `cannot drop type ... because other objects depend on it`.
+//
+// Neither desired side names the other type, so the desired graph is empty here
+// as well. Only the current definitions can place these statements.
+func TestPostgreSQLUserTypeRecreate_DropsAgainstTheCurrentShapeWithinOneKind(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name            string
+		current         []string
+		desired         []string
+		assertConverged func(c *qt.C, applied *dbschematypes.DBSchema)
+	}{
+		{
+			name: "both types are domains",
+			current: []string{
+				"CREATE DOMAIN d_base AS integer",
+				"CREATE DOMAIN d_over AS d_base",
+			},
+			desired: []string{
+				"CREATE DOMAIN d_base AS text",
+				"CREATE DOMAIN d_over AS text",
+			},
+			assertConverged: func(c *qt.C, applied *dbschematypes.DBSchema) {
+				c.Assert(findLiveDomain(c, applied.Domains, "d_base").BaseType, qt.Equals, "text")
+				c.Assert(findLiveDomain(c, applied.Domains, "d_over").BaseType, qt.Equals, "text")
+			},
+		},
+		{
+			name: "both types are composites",
+			current: []string{
+				"CREATE TYPE c_base AS (f integer)",
+				"CREATE TYPE c_over AS (g c_base)",
+			},
+			desired: []string{
+				"CREATE TYPE c_base AS (f text)",
+				"CREATE TYPE c_over AS (g text)",
+			},
+			assertConverged: func(c *qt.C, applied *dbschematypes.DBSchema) {
+				c.Assert(liveCompositeFieldTypes(c, applied.Composites, "c_base"), qt.DeepEquals, []string{"text"})
+				c.Assert(liveCompositeFieldTypes(c, applied.Composites, "c_over"), qt.DeepEquals, []string{"text"})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			desiredURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "user_type_one_kind_desired",
+				seed:  test.desired,
+				query: "search_path=public",
+			})
+			currentURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "user_type_one_kind_current",
+				seed:  test.current,
+				query: "search_path=public",
+			})
+
+			target, err := dbschema.ConnectToDatabase(c.Context(), currentURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() { dbschema.CloseAndWarn(target) })
+
+			plan, err := atlasschema.PrepareApply(c.Context(), target, atlasschema.ApplyRuntimeOptions{
+				ToURLs: []string{desiredURL},
+				TxMode: migrator.MigrationTxModeFile,
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(plan.HasChanges(), qt.IsTrue)
+			c.Assert(plan.Execute(c.Context()), qt.IsNil, qt.Commentf("emitted script:\n%s", plan.SQL()))
+
+			applied, err := dbschema.ReadSchemaWithSchemas(target, nil)
+			c.Assert(err, qt.IsNil)
+			test.assertConverged(c, applied)
+
+			settled, err := atlasschema.PrepareApply(c.Context(), target, atlasschema.ApplyRuntimeOptions{
+				ToURLs: []string{desiredURL},
+				TxMode: migrator.MigrationTxModeFile,
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(settled.HasChanges(), qt.IsFalse, qt.Commentf("second plan:\n%s", settled.SQL()))
+		})
+	}
+}
+
 func findLiveDomain(c *qt.C, domains []dbschematypes.DBDomain, name string) dbschematypes.DBDomain {
 	c.Helper()
 

--- a/integration/gonative/user_type_recreate_order_postgres_test.go
+++ b/integration/gonative/user_type_recreate_order_postgres_test.go
@@ -1,0 +1,187 @@
+//go:build integration
+
+// Live guard for the drop half of the user-defined type ordering added for
+// stokaro/ptah#1242.
+//
+// A modified domain or composite has no in-place ALTER, so it is reconciled as
+// a non-CASCADE DROP followed by a CREATE. The two halves are ordered by
+// different graphs and have to be: the CREATE builds the desired shape, while
+// the DROP executes against the database as it stands, where only the
+// references it holds now can block it.
+//
+// Nothing short of a live server settles this. Every emitted order is
+// self-consistent, so a text assertion just restates the emitter; a self-apply
+// plans no statements and executes nothing; and a replay from empty drops
+// nothing. Each case below seeds the CURRENT shape into one throwaway database,
+// reconciles it against a second database holding the DESIRED shape, and lets
+// PostgreSQL judge.
+
+package gonative_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestPostgreSQLUserTypeRecreate_DropsAgainstTheCurrentShape reconciles a
+// database whose user-defined types have to be recreated, and asserts the plan
+// runs.
+//
+// The three rows differ only in where the reference between the two types sits
+// on each side, which is the axis that decides whether one order can serve
+// both:
+//
+//   - it inverts: the domain names the composite now, the composite will name
+//     the domain. Ordering the drops by the desired side takes the composite
+//     first and PostgreSQL answers `cannot drop type cc because other objects
+//     depend on it / DETAIL: type dd depends on type cc`.
+//   - it disappears: the composite names the domain now and will name a
+//     built-in. The desired side has no edge at all, so the order degrades to
+//     the caller's -- domains first -- and the server answers `column q of
+//     composite type meas depends on type qty`.
+//   - it survives: both sides agree, and the two orders are mirror images.
+//     This is the row that was already green before the drop graph was
+//     separated from the create graph, and it is here so a fix for the first
+//     two cannot be had by giving this one up.
+func TestPostgreSQLUserTypeRecreate_DropsAgainstTheCurrentShape(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+
+	tests := []struct {
+		name             string
+		current          []string
+		desired          []string
+		wantDomain       string
+		wantBaseType     string
+		wantComposite    string
+		wantCompositeSQL []string
+	}{
+		{
+			name: "the reference between the two types inverts",
+			current: []string{
+				"CREATE TYPE cc AS (f integer)",
+				"CREATE DOMAIN dd AS cc",
+			},
+			desired: []string{
+				"CREATE DOMAIN dd AS integer",
+				"CREATE TYPE cc AS (f dd)",
+			},
+			wantDomain:       "dd",
+			wantBaseType:     "integer",
+			wantComposite:    "cc",
+			wantCompositeSQL: []string{"dd"},
+		},
+		{
+			name: "the desired shape stops naming the domain",
+			current: []string{
+				"CREATE DOMAIN qty AS integer CHECK (VALUE > 0)",
+				"CREATE TYPE meas AS (q qty, label text)",
+			},
+			desired: []string{
+				"CREATE DOMAIN qty AS bigint CHECK (VALUE > 0)",
+				"CREATE TYPE meas AS (q bigint, label text)",
+			},
+			wantDomain:       "qty",
+			wantBaseType:     "bigint",
+			wantComposite:    "meas",
+			wantCompositeSQL: []string{"bigint", "text"},
+		},
+		{
+			name: "the reference survives the modification",
+			current: []string{
+				"CREATE DOMAIN qty AS integer CHECK (VALUE > 0)",
+				"CREATE TYPE meas AS (q qty, label text)",
+			},
+			desired: []string{
+				"CREATE DOMAIN qty AS bigint CHECK (VALUE > 0)",
+				"CREATE TYPE meas AS (q qty, label text, extra text)",
+			},
+			wantDomain:       "qty",
+			wantBaseType:     "bigint",
+			wantComposite:    "meas",
+			wantCompositeSQL: []string{"qty", "text", "text"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			desiredURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "user_type_recreate_desired",
+				seed:  test.desired,
+				query: "search_path=public",
+			})
+			currentURL := newBoundaryDatabase(c, dsn, boundaryCase{
+				name:  "user_type_recreate_current",
+				seed:  test.current,
+				query: "search_path=public",
+			})
+
+			target, err := dbschema.ConnectToDatabase(c.Context(), currentURL)
+			c.Assert(err, qt.IsNil)
+			c.Cleanup(func() { dbschema.CloseAndWarn(target) })
+
+			plan, err := atlasschema.PrepareApply(c.Context(), target, atlasschema.ApplyRuntimeOptions{
+				ToURLs: []string{desiredURL},
+				TxMode: migrator.MigrationTxModeFile,
+			})
+			c.Assert(err, qt.IsNil)
+			// Without this the row would pass on a planner that emitted
+			// nothing, which is the cheapest way to make a drop order look
+			// correct.
+			c.Assert(plan.HasChanges(), qt.IsTrue)
+			c.Assert(plan.Execute(c.Context()), qt.IsNil, qt.Commentf("emitted script:\n%s", plan.SQL()))
+
+			// Exit status alone is not convergence: a plan could run and leave
+			// the types on their old shape.
+			applied, err := dbschema.ReadSchemaWithSchemas(target, nil)
+			c.Assert(err, qt.IsNil)
+			c.Assert(findLiveDomain(c, applied.Domains, test.wantDomain).BaseType, qt.Equals, test.wantBaseType)
+			c.Assert(liveCompositeFieldTypes(c, applied.Composites, test.wantComposite), qt.DeepEquals, test.wantCompositeSQL)
+
+			// The other direction: the converged database plans nothing
+			// against the same target, so the plan above was not a churn that
+			// happens to be executable.
+			settled, err := atlasschema.PrepareApply(c.Context(), target, atlasschema.ApplyRuntimeOptions{
+				ToURLs: []string{desiredURL},
+				TxMode: migrator.MigrationTxModeFile,
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(settled.HasChanges(), qt.IsFalse, qt.Commentf("second plan:\n%s", settled.SQL()))
+		})
+	}
+}
+
+func findLiveDomain(c *qt.C, domains []dbschematypes.DBDomain, name string) dbschematypes.DBDomain {
+	c.Helper()
+
+	for _, candidate := range domains {
+		if candidate.Name == name {
+			return candidate
+		}
+	}
+	c.Fatalf("the read schema has no domain %q", name)
+	return dbschematypes.DBDomain{}
+}
+
+func liveCompositeFieldTypes(c *qt.C, composites []dbschematypes.DBComposite, name string) []string {
+	c.Helper()
+
+	for _, candidate := range composites {
+		if candidate.Name != name {
+			continue
+		}
+		fieldTypes := make([]string, len(candidate.Fields))
+		for i, field := range candidate.Fields {
+			fieldTypes[i] = field.Type
+		}
+		return fieldTypes
+	}
+	c.Fatalf("the read schema has no composite type %q", name)
+	return nil
+}

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -347,10 +347,7 @@ func atlasSchemaInspectTable(
 }
 
 func atlasSchemaInspectColumn(column dbschematypes.DBColumn) atlasSchemaInspectJSONColumn {
-	columnType := column.ColumnType
-	if columnType == "" {
-		columnType = column.DataType
-	}
+	columnType := atlasSchemaInspectColumnType(column)
 	return atlasSchemaInspectJSONColumn{
 		Name: column.Name,
 		Type: columnType,
@@ -360,6 +357,33 @@ func atlasSchemaInspectColumn(column dbschematypes.DBColumn) atlasSchemaInspectJ
 			Collate: column.Collate,
 		},
 	}
+}
+
+// atlasSchemaInspectColumnType spells a column's type the way the pinned
+// community binary v1.3.0 spells it in `schema inspect --format '{{ json . }}'`.
+//
+// A domain column is the one place where DataType is not that spelling:
+// information_schema reports the domain's BASE type there and puts the domain
+// in domain_name, so a column of `positive` printed as "integer" and lost the
+// domain's CHECK with it. Measured on PostgreSQL 17.10, both against the same
+// database:
+//
+//	column of domain positive   binary: "positive"       Ptah before: "integer"
+//	column of doms.positive     binary: "doms.positive"  Ptah before: "integer"
+//	column of varchar(100)[]    binary: "ARRAY"          Ptah:        "ARRAY"
+//
+// The array row is why this reads DomainName rather than FormattedType, which
+// both kinds of column fill: preferring FormattedType outright would print
+// "character varying(100)[]" where the binary prints "ARRAY" and trade one
+// disagreement for another. See stokaro/ptah#1242.
+func atlasSchemaInspectColumnType(column dbschematypes.DBColumn) string {
+	if column.DomainName != "" && column.FormattedType != "" {
+		return column.FormattedType
+	}
+	if column.ColumnType != "" {
+		return column.ColumnType
+	}
+	return column.DataType
 }
 
 func atlasSchemaInspectIndex(index dbschematypes.DBIndex) atlasSchemaInspectJSONIndex {

--- a/internal/atlasreport/schema_inspect_test.go
+++ b/internal/atlasreport/schema_inspect_test.go
@@ -323,6 +323,91 @@ func TestRenderSchemaInspect_SplitRejectsNonSchemaOutput(t *testing.T) {
 	}
 }
 
+// TestRenderSchemaInspect_JSONColumnTypeMatchesThePinnedBinary pins the type
+// spelling the Atlas-compatible JSON inspect surface prints per column class.
+//
+// Every want below was measured on PostgreSQL 17.10 by running
+// `schema inspect --format '{{ json . }}'` on the pinned community binary
+// v1.3.0 and on ptah-compat against the same database. The domain rows are
+// where the two disagreed: information_schema reports a domain column's BASE
+// type in data_type, so Ptah printed "integer" for a column of `positive` and
+// dropped the domain's CHECK with it, while the binary printed the domain.
+//
+// The array row is why this reads DomainName rather than FormattedType, which
+// an array column fills too. There the binary prints the bare category "ARRAY"
+// and Ptah already agreed; preferring FormattedType outright would print
+// "character varying(100)[]" there and trade one disagreement for another.
+// See stokaro/ptah#1242.
+func TestRenderSchemaInspect_JSONColumnTypeMatchesThePinnedBinary(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		column types.DBColumn
+		want   string
+	}{
+		{
+			name: "domain column names the domain",
+			column: types.DBColumn{
+				Name: "qty", DataType: "integer", UDTName: "int4",
+				FormattedType: "positive", DomainName: "positive", IsNullable: "NO",
+			},
+			want: `{"name":"qty","type":"positive"}`,
+		},
+		{
+			name: "domain outside the search path keeps its qualifier",
+			column: types.DBColumn{
+				Name: "qty", DataType: "integer", UDTName: "int4",
+				FormattedType: "doms.positive", DomainName: "positive", IsNullable: "NO",
+			},
+			want: `{"name":"qty","type":"doms.positive"}`,
+		},
+		{
+			name: "array column stays the bare category",
+			column: types.DBColumn{
+				Name: "tags", DataType: "ARRAY", UDTName: "_varchar",
+				FormattedType: "character varying(100)[]", IsNullable: "NO",
+			},
+			want: `{"name":"tags","type":"ARRAY"}`,
+		},
+		{
+			name:   "plain column is untouched",
+			column: types.DBColumn{Name: "id", DataType: "integer", IsNullable: "NO"},
+			want:   `{"name":"id","type":"integer"}`,
+		},
+		{
+			name: "a dialect that reports its own full spelling keeps it",
+			column: types.DBColumn{
+				Name: "mood", DataType: "enum", ColumnType: "enum('sad','ok')", IsNullable: "NO",
+			},
+			want: `{"name":"mood","type":"enum('sad','ok')"}`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			report := atlasreport.NewSchemaInspectReport(
+				&goschema.Database{},
+				&types.DBSchema{
+					Tables: []types.DBTable{{
+						Name:    "t",
+						Schema:  "public",
+						Columns: []types.DBColumn{test.column},
+					}},
+				},
+				types.DBInfo{Dialect: "postgres", Schema: "public"},
+				nil,
+				false,
+			)
+
+			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Contains, test.want)
+		})
+	}
+}
+
 func sampleSchemaInspectReport() *atlasreport.SchemaInspectReport {
 	return atlasreport.NewSchemaInspectReport(
 		&goschema.Database{

--- a/internal/convert/dbschematogo/dbschematogo.go
+++ b/internal/convert/dbschematogo/dbschematogo.go
@@ -607,7 +607,23 @@ func goSchemaFieldType(dbColumn dbschematypes.DBColumn) string {
 	return dbColumn.DataType
 }
 
+// postgresSerialType reports the SERIAL shorthand a column can be written back
+// as, or "" when it cannot.
+//
+// A domain column can never be written back as SERIAL. PostgreSQL's SERIAL
+// shorthand only ever builds a column of an integer type, so spelling a column
+// of domain `positive` as SERIAL rebuilds it as a plain integer and drops the
+// domain's CHECK with it. The domain wins, and the sequence default it was
+// drawing from is then carried as an ordinary default rather than folded into
+// the shorthand. Measured on PostgreSQL 17.10 against `id positive DEFAULT
+// nextval('s')` with the sequence OWNED BY that column: the pinned binary
+// v1.3.0 reports `type = sql("positive")` with the nextval default beside it,
+// and Ptah reported `type = serial` with no default at all. See
+// stokaro/ptah#1242.
 func postgresSerialType(dbColumn dbschematypes.DBColumn) string {
+	if dbColumn.DomainName != "" {
+		return ""
+	}
 	if !dbColumn.IsAutoIncrement || dbColumn.ColumnDefault == nil ||
 		!strings.Contains(strings.ToLower(*dbColumn.ColumnDefault), "nextval(") {
 		return ""

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -401,6 +401,17 @@ func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsTheDomain(t *testing
 // ever builds an integer column, so the shorthand would silently undo the
 // domain. The domain wins, and the sequence default it was folding away is
 // carried explicitly instead.
+//
+// The enum, composite and range rows are the shape where a domain does NOT put
+// its base type in data_type. When the base type is itself user-defined the
+// catalog reports data_type = 'USER-DEFINED' with udt_name naming the BASE type
+// -- measured on PostgreSQL 17.10, `c d_enum` where `CREATE DOMAIN d_enum AS
+// color` reads back as data_type 'USER-DEFINED', udt_name 'color', domain_name
+// 'd_enum', format_type 'd_enum'. Answering udt_name there rebuilds the column
+// as the bare enum and drops the domain's CHECK, which is the same loss the
+// `positive` rows above pin, on the branch that reaches USER-DEFINED first.
+// TestConvertDBSchemaToGoSchema_PostgresUserDefinedColumnUsesUDTName is the
+// control: a USER-DEFINED column with no domain still answers with udt_name.
 func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsItsDomain(t *testing.T) {
 	nextval := "nextval('s'::regclass)"
 
@@ -445,6 +456,50 @@ func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsItsDomain(t *testing
 			},
 			wantType:        "positive",
 			wantDefaultExpr: nextval,
+		},
+		{
+			name: "a domain over an enum keeps the domain, not the enum",
+			column: types.DBColumn{
+				Name:          "c",
+				DataType:      "USER-DEFINED",
+				UDTName:       "color",
+				FormattedType: "d_enum",
+				DomainName:    "d_enum",
+			},
+			wantType: "d_enum",
+		},
+		{
+			name: "a domain over a composite type keeps the domain",
+			column: types.DBColumn{
+				Name:          "a",
+				DataType:      "USER-DEFINED",
+				UDTName:       "addr",
+				FormattedType: "d_comp",
+				DomainName:    "d_comp",
+			},
+			wantType: "d_comp",
+		},
+		{
+			name: "a domain over a range type keeps the domain",
+			column: types.DBColumn{
+				Name:          "r",
+				DataType:      "USER-DEFINED",
+				UDTName:       "myrange",
+				FormattedType: "d_range",
+				DomainName:    "d_range",
+			},
+			wantType: "d_range",
+		},
+		{
+			name: "a domain over an enum outside the search path keeps its qualifier",
+			column: types.DBColumn{
+				Name:          "c",
+				DataType:      "USER-DEFINED",
+				UDTName:       "color",
+				FormattedType: "doms.d_enum",
+				DomainName:    "d_enum",
+			},
+			wantType: "doms.d_enum",
 		},
 	}
 

--- a/internal/convert/dbschematogo/dbschematogo_test.go
+++ b/internal/convert/dbschematogo/dbschematogo_test.go
@@ -386,6 +386,109 @@ func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsTheDomain(t *testing
 	}
 }
 
+// TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsItsDomain pins the
+// desired-state side of stokaro/ptah#1242.
+//
+// information_schema reports a domain column's BASE type in data_type and puts
+// the domain in domain_name, so a conversion that trusts data_type rebuilds the
+// column as `integer` and drops every constraint the domain carries. Measured
+// on the pinned community binary v1.3.0 against PostgreSQL 17.10, the binary
+// reports `type = sql("positive")` for such a column.
+//
+// The SERIAL row is the case where two rules meet. A domain column that also
+// draws from an owned sequence satisfies the SERIAL detection -- data_type is
+// the domain's base type and pg_get_serial_sequence answers -- and SERIAL only
+// ever builds an integer column, so the shorthand would silently undo the
+// domain. The domain wins, and the sequence default it was folding away is
+// carried explicitly instead.
+func TestConvertDBSchemaToGoSchema_PostgresDomainColumnKeepsItsDomain(t *testing.T) {
+	nextval := "nextval('s'::regclass)"
+
+	tests := []struct {
+		name            string
+		column          types.DBColumn
+		wantType        string
+		wantDefaultExpr string
+	}{
+		{
+			name: "domain column keeps the domain, not its base type",
+			column: types.DBColumn{
+				Name:          "qty",
+				DataType:      "integer",
+				UDTName:       "int4",
+				FormattedType: "positive",
+				DomainName:    "positive",
+			},
+			wantType: "positive",
+		},
+		{
+			name: "a domain outside the search path keeps its qualifier",
+			column: types.DBColumn{
+				Name:          "qty",
+				DataType:      "integer",
+				UDTName:       "int4",
+				FormattedType: "doms.positive",
+				DomainName:    "positive",
+			},
+			wantType: "doms.positive",
+		},
+		{
+			name: "a domain column drawing from a sequence is not a SERIAL",
+			column: types.DBColumn{
+				Name:            "id",
+				DataType:        "integer",
+				UDTName:         "int4",
+				FormattedType:   "positive",
+				DomainName:      "positive",
+				ColumnDefault:   &nextval,
+				IsAutoIncrement: true,
+			},
+			wantType:        "positive",
+			wantDefaultExpr: nextval,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbSchema := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "t", Columns: []types.DBColumn{test.column}}},
+			}
+
+			result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+			c.Assert(result.Fields, qt.HasLen, 1)
+			c.Assert(result.Fields[0].Type, qt.Equals, test.wantType)
+			c.Assert(result.Fields[0].DefaultExpr, qt.Equals, test.wantDefaultExpr)
+		})
+	}
+}
+
+// TestConvertDBSchemaToGoSchema_SerialDetectionSurvivesTheDomainRule is the
+// control for the SERIAL row above: a plain integer column with the same
+// sequence default must still be written back as the SERIAL shorthand, with the
+// default folded into it rather than restated.
+func TestConvertDBSchemaToGoSchema_SerialDetectionSurvivesTheDomainRule(t *testing.T) {
+	c := qt.New(t)
+	nextval := "nextval('t_id_seq'::regclass)"
+
+	dbSchema := &types.DBSchema{
+		Tables: []types.DBTable{{Name: "t", Columns: []types.DBColumn{{
+			Name:            "id",
+			DataType:        "integer",
+			UDTName:         "int4",
+			ColumnDefault:   &nextval,
+			IsAutoIncrement: true,
+		}}}},
+	}
+
+	result := dbschematogo.ConvertDBSchemaToGoSchema(dbSchema)
+
+	c.Assert(result.Fields, qt.HasLen, 1)
+	c.Assert(result.Fields[0].Type, qt.Equals, "SERIAL")
+	c.Assert(result.Fields[0].DefaultExpr, qt.Equals, "")
+}
+
 func TestConvertDBSchemaToGoSchema_SchemaQualifiedObjectOwnersUseTableStructName(t *testing.T) {
 	c := qt.New(t)
 	checkClause := "tenant_id > 0"

--- a/internal/convert/fromschema/fromschema.go
+++ b/internal/convert/fromschema/fromschema.go
@@ -62,6 +62,7 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/planner/tablelookup"
 	"go.5x5.cz/ptah/internal/sqlident"
 )
@@ -2071,20 +2072,11 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 		}
 	}
 
-	// 3b. Add PostgreSQL user-defined types (domains, ranges, then composites)
-	// before tables so columns can reference them. Ordering within the group:
-	// domains and ranges reference base subtypes; composites may reference
-	// domains/enums, so they come last.
+	// 3b. Add PostgreSQL user-defined types before tables so columns can
+	// reference them, ordered by what each definition names rather than by
+	// kind. Enums are already out, above, and reference nothing.
 	if isPostgreSQLFamilyPlatform(targetPlatform) {
-		for _, domain := range database.Domains {
-			statements.Statements = append(statements.Statements, FromDomain(domain))
-		}
-		for _, rangeType := range database.Ranges {
-			statements.Statements = append(statements.Statements, FromRange(rangeType))
-		}
-		for _, composite := range database.CompositeTypes {
-			statements.Statements = append(statements.Statements, FromCompositeType(composite))
-		}
+		statements.Statements = append(statements.Statements, orderedUserTypeStatements(database)...)
 	}
 
 	// 4. Add table definitions (they may be referenced by indexes)
@@ -2125,6 +2117,49 @@ func FromDatabase(database goschema.Database, targetPlatform string) *ast.Statem
 	}
 
 	return statements
+}
+
+// orderedUserTypeStatements returns CREATE DOMAIN / CREATE TYPE for every
+// domain, range and composite the schema declares, ordered so a type is created
+// before whatever names it.
+//
+// The three kinds share one namespace and reference each other in both
+// directions -- `CREATE DOMAIN d AS addr` needs the composite `addr` first,
+// `CREATE TYPE addr AS (f d_int)` needs the domain `d_int` first -- so emitting
+// kind by kind gets one direction wrong whichever kind goes first, and
+// PostgreSQL has no forward declaration for a type. This is the same ordering
+// the migration planner applies to the types a diff adds; a schema rendered
+// whole has to hold it too, or `ptah generate` writes a script that stops at
+// `ERROR: type "addr" does not exist`.
+func orderedUserTypeStatements(database goschema.Database) []ast.Node {
+	total := len(database.Domains) + len(database.Ranges) + len(database.CompositeTypes)
+	byName := make(map[string]ast.Node, total)
+	userTypes := make([]deporder.UserType, 0, total)
+
+	for _, domain := range database.Domains {
+		byName[domain.QualifiedName()] = FromDomain(domain)
+		userTypes = append(userTypes, deporder.UserType{Name: domain.QualifiedName(), References: []string{domain.BaseType}})
+	}
+	for _, rangeType := range database.Ranges {
+		byName[rangeType.QualifiedName()] = FromRange(rangeType)
+		userTypes = append(userTypes, deporder.UserType{Name: rangeType.QualifiedName(), References: []string{rangeType.Subtype}})
+	}
+	for _, composite := range database.CompositeTypes {
+		references := make([]string, 0, len(composite.Fields))
+		for _, field := range composite.Fields {
+			references = append(references, field.Type)
+		}
+		byName[composite.QualifiedName()] = FromCompositeType(composite)
+		userTypes = append(userTypes, deporder.UserType{Name: composite.QualifiedName(), References: references})
+	}
+
+	nodes := make([]ast.Node, 0, len(userTypes))
+	for _, name := range deporder.UserTypesForCreate(userTypes) {
+		if node, ok := byName[name]; ok {
+			nodes = append(nodes, node)
+		}
+	}
+	return nodes
 }
 
 func appendTableStatements(

--- a/internal/convert/fromschema/user_type_order_test.go
+++ b/internal/convert/fromschema/user_type_order_test.go
@@ -1,0 +1,90 @@
+package fromschema_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+)
+
+// userTypeOrderDatabase declares one type of each kind naming another kind, in
+// both directions, so a whole-schema render that emits kind by kind gets one
+// direction wrong whichever kind it puts first.
+func userTypeOrderDatabase() goschema.Database {
+	return goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "d_comp", BaseType: "addr"},
+			{Name: "d_range", BaseType: "myrange"},
+			{Name: "d_int", BaseType: "integer", Check: "VALUE > 0"},
+		},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "addr", Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}}},
+			{Name: "measure", Fields: []goschema.CompositeTypeField{{Name: "qty", Type: "d_int"}}},
+		},
+		Ranges: []goschema.Range{
+			{Name: "myrange", Subtype: "integer"},
+			{Name: "posrange", Subtype: "d_int"},
+		},
+	}
+}
+
+// TestFromDatabase_CreatesUserTypesBeforeTheTypesThatNameThem is the ordering
+// property for the whole-schema render, the one `ptah generate` writes out.
+//
+// The migration planner has the same property with its own guard. Both are
+// needed: they are separate emitters over the same three kinds, and the planner
+// only ever sees the types a diff adds.
+func TestFromDatabase_CreatesUserTypesBeforeTheTypesThatNameThem(t *testing.T) {
+	c := qt.New(t)
+
+	statements := fromschema.FromDatabase(userTypeOrderDatabase(), "postgres")
+	sql, err := renderer.RenderSQL("postgres", statements.Statements...)
+	c.Assert(err, qt.IsNil)
+
+	tests := []struct {
+		name    string
+		earlier string
+		later   string
+	}{
+		{
+			name:    "a composite precedes the domain over it",
+			earlier: `CREATE TYPE "addr" AS`,
+			later:   `CREATE DOMAIN "d_comp" AS`,
+		},
+		{
+			name:    "a range precedes the domain over it",
+			earlier: `CREATE TYPE "myrange" AS RANGE`,
+			later:   `CREATE DOMAIN "d_range" AS`,
+		},
+		{
+			name:    "a domain precedes the composite whose field uses it",
+			earlier: `CREATE DOMAIN "d_int" AS`,
+			later:   `CREATE TYPE "measure" AS`,
+		},
+		{
+			name:    "a domain precedes the range whose subtype uses it",
+			earlier: `CREATE DOMAIN "d_int" AS`,
+			later:   `CREATE TYPE "posrange" AS RANGE`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			assertRenderedBefore(c, sql, test.earlier, test.later)
+		})
+	}
+}
+
+func assertRenderedBefore(c *qt.C, sql, earlier, later string) {
+	c.Helper()
+
+	earlierIndex := strings.Index(sql, earlier)
+	laterIndex := strings.Index(sql, later)
+	c.Assert(earlierIndex, qt.Not(qt.Equals), -1, qt.Commentf("missing %q in:\n%s", earlier, sql))
+	c.Assert(laterIndex, qt.Not(qt.Equals), -1, qt.Commentf("missing %q in:\n%s", later, sql))
+	c.Assert(earlierIndex < laterIndex, qt.IsTrue, qt.Commentf("expected %q before %q in:\n%s", earlier, later, sql))
+}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -330,6 +330,15 @@ func (r *Reader) readColumnsForSchema(schemaName string) (map[string][]types.DBC
 			-- named "context" contains "text". A domain over an array is
 			-- reported with data_type 'ARRAY' just like a plain array column, so
 			-- the distinction cannot be recovered downstream (stokaro/ptah#1138).
+			--
+			-- The Atlas-compatible JSON inspect surface reads the same fact for
+			-- the same reason: measured against the pinned binary v1.3.0, an
+			-- array column prints "type":"ARRAY" while a domain column prints
+			-- "type":"positive", schema-qualified to "doms.positive" when the
+			-- domain is off the search path. Carrying the fact separately is
+			-- what lets each consumer pick, instead of every consumer
+			-- re-deriving it from a coincidence of which other field is empty
+			-- (stokaro/ptah#1242).
 			COALESCE(col.domain_name, '') AS domain_name,
 			-- And the schema that holds it, because the name is only half of a
 			-- domain's identity. public.status and other.status are two types;
@@ -1823,6 +1832,18 @@ func (r *Reader) readSequencesForSchema(schemaName string) ([]types.DBSequence, 
 			CASE
 				WHEN dep.refobjid IS NULL THEN false
 				WHEN dep.deptype = 'i' THEN true
+				-- A sequence a DOMAIN column draws from is not implicit, however
+				-- the catalog edges look. "Implicit" here means "writing the
+				-- owning column back recreates this sequence on its own", and
+				-- only the SERIAL shorthand and an identity column do that.
+				-- Neither is available to a domain column: SERIAL always builds
+				-- an integer column, so the column is written back as its domain
+				-- with an ordinary nextval default, and the sequence that
+				-- default names has to be created too. Calling it implicit
+				-- omitted the CREATE SEQUENCE and the emitted DDL failed on
+				-- replay with ERROR: relation "s" does not exist. See
+				-- stokaro/ptah#1242, and #657 for the rest of this rule.
+				WHEN owner_col_type.typtype = 'd' THEN false
 				ELSE EXISTS (
 					SELECT 1
 					FROM pg_attrdef ad
@@ -1845,6 +1866,7 @@ func (r *Reader) readSequencesForSchema(schemaName string) ([]types.DBSequence, 
 		LEFT JOIN pg_class owner_tbl ON owner_tbl.oid = dep.refobjid
 		LEFT JOIN pg_namespace owner_ns ON owner_ns.oid = owner_tbl.relnamespace
 		LEFT JOIN pg_attribute owner_col ON owner_col.attrelid = dep.refobjid AND owner_col.attnum = dep.refobjsubid
+		LEFT JOIN pg_type owner_col_type ON owner_col_type.oid = owner_col.atttypid
 		WHERE n.nspname = $1
 		ORDER BY n.nspname, c.relname`
 

--- a/internal/dbschema/postgres/reader_sequences_internal_test.go
+++ b/internal/dbschema/postgres/reader_sequences_internal_test.go
@@ -1,0 +1,179 @@
+package postgres
+
+// White-box testing required: readSequencesForSchema decides whether a sequence
+// is standalone or a backing sequence of its owning column entirely inside the
+// SQL it issues, and drops the backing ones before anything exported can see
+// them. The decision has no other source, so there is nothing to assert on
+// without either a live server or this fake one.
+//
+// The fake server follows the same rule as the column and index guards next
+// door: a projection is answered from the fixture catalog only when the query
+// actually reads the catalog column the answer comes from.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// pgSequenceCatalog is one sequence as PostgreSQL 17.10 reports it, reduced to
+// the three facts the is_implicit decision rests on.
+type pgSequenceCatalog struct {
+	name string
+	// ownedColumn is the column the sequence is OWNED BY, empty when it is
+	// owned by nothing.
+	ownedColumn string
+	// ownerDefaultDrawsFromSequence is whether that column's DEFAULT calls
+	// nextval on this sequence. Ownership alone does not make a sequence
+	// implicit -- a lifecycle-only OWNED BY sequence is standalone (#657).
+	ownerDefaultDrawsFromSequence bool
+	// ownerColumnTypeCategory is pg_type.typtype for the owning column's type:
+	// "b" for a base type such as integer, "d" for a domain.
+	ownerColumnTypeCategory string
+}
+
+// serialSequenceCatalog is `id SERIAL PRIMARY KEY`: the sequence is owned by an
+// integer column whose default draws from it, and writing that column back as
+// SERIAL recreates it. It must stay implicit.
+func serialSequenceCatalog() pgSequenceCatalog {
+	return pgSequenceCatalog{
+		name:                          "t_id_seq",
+		ownedColumn:                   "id",
+		ownerDefaultDrawsFromSequence: true,
+		ownerColumnTypeCategory:       "b",
+	}
+}
+
+// domainSequenceCatalog is the same shape over a domain column:
+//
+//	CREATE DOMAIN positive AS integer CHECK (VALUE > 0);
+//	CREATE SEQUENCE s;
+//	CREATE TABLE t (id positive DEFAULT nextval('s'));
+//	ALTER SEQUENCE s OWNED BY t.id;
+//
+// Measured on PostgreSQL 17.10: pg_get_serial_sequence answers for this column
+// and the catalog edges are indistinguishable from the SERIAL case above. They
+// are not the same case. SERIAL only ever builds an integer column, so the
+// column is written back as its domain with an ordinary nextval default, and
+// nothing recreates the sequence that default names unless this reader reports
+// it. See stokaro/ptah#1242.
+func domainSequenceCatalog() pgSequenceCatalog {
+	catalog := serialSequenceCatalog()
+	catalog.name = "s"
+	catalog.ownerColumnTypeCategory = "d"
+	return catalog
+}
+
+// lifecycleSequenceCatalog is a sequence OWNED BY a column that does not draw
+// from it. It is standalone on both builds, and it is here so a fix that widens
+// the domain case cannot be confused with a fix that widens ownership (#657).
+func lifecycleSequenceCatalog() pgSequenceCatalog {
+	catalog := serialSequenceCatalog()
+	catalog.name = "lifecycle_seq"
+	catalog.ownerDefaultDrawsFromSequence = false
+	return catalog
+}
+
+// serveSequenceQuery answers the sequence query the way PostgreSQL would, with
+// one restriction: the owning column's type category is available only to a
+// query that reads it. A CASE that never joins pg_type cannot tell the SERIAL
+// fixture from the domain one on a real server either.
+func serveSequenceQuery(catalog pgSequenceCatalog, query string) (dbtest.QueryResult, error) {
+	implicit, err := sequenceIsImplicit(catalog, query)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	return dbtest.QueryResult{
+		Columns: []string{
+			"schema_name", "sequence_name", "data_type",
+			"start_value", "increment_by", "min_value", "max_value", "cache_size", "is_cycled",
+			"owned_schema", "owned_table", "owned_column", "comment", "is_implicit",
+		},
+		Rows: [][]driver.Value{{
+			"public", catalog.name, "bigint",
+			int64(1), int64(1), int64(1), int64(9223372036854775807), int64(1), false,
+			"public", "t", catalog.ownedColumn, nil, implicit,
+		}},
+	}, nil
+}
+
+// sequenceIsImplicit models the CASE the reader issues.
+//
+// The projection has to name pg_type.typtype AND the domain code 'd' before the
+// fixture's type category is made available to it. Naming typtype alone is not
+// enough: a CASE that reads the column but branches on `IS NOT NULL` classifies
+// every owned sequence as standalone, which un-hides the backing sequence of
+// every SERIAL column in every database. That over-correction was applied and
+// this guard stayed green against a check that only asked for "typtype".
+func sequenceIsImplicit(catalog pgSequenceCatalog, query string) (bool, error) {
+	projection, ok := selectListItem(query, "is_implicit", "FROM pg_sequence")
+	if !ok {
+		return false, fmt.Errorf("query has no projection aliased is_implicit:\n%s", query)
+	}
+	body := stripSQLLineComments(projection)
+	asksForDomains := strings.Contains(body, "typtype") && strings.Contains(body, "'d'")
+	if asksForDomains && catalog.ownerColumnTypeCategory == "d" {
+		return false, nil
+	}
+	return catalog.ownerDefaultDrawsFromSequence, nil
+}
+
+// TestReadSequencesForSchema_DomainBackedSequenceIsStandalone pins which
+// sequences survive the read.
+//
+// Measured end to end on PostgreSQL 17.10 with ptah-compat: before this change,
+// `schema diff` against the domain fixture emitted the table with the domain
+// column and no CREATE SEQUENCE, and replaying it into a fresh database failed
+// at psql exit 3 with `ERROR: relation "s" does not exist`. After it, the same
+// replay is exit 0 and the pinned binary v1.3.0 reports the replayed database
+// synced with the source.
+func TestReadSequencesForSchema_DomainBackedSequenceIsStandalone(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		catalog func() pgSequenceCatalog
+		// wantNames is the sequences the reader reports. Empty means the
+		// sequence was classified as its column's backing sequence and dropped.
+		wantNames []string
+	}{
+		{
+			name:      "sequence a domain column draws from is reported",
+			catalog:   domainSequenceCatalog,
+			wantNames: []string{"s"},
+		},
+		{
+			name:      "SERIAL backing sequence stays hidden",
+			catalog:   serialSequenceCatalog,
+			wantNames: nil,
+		},
+		{
+			name:      "lifecycle-only owned sequence stays reported",
+			catalog:   lifecycleSequenceCatalog,
+			wantNames: []string{"lifecycle_seq"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			catalog := test.catalog()
+			db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+				return serveSequenceQuery(catalog, query)
+			})
+
+			sequences, err := NewPostgreSQLReader(db.SQL, "public").readSequencesForSchema("public")
+			c.Assert(err, qt.IsNil)
+
+			var names []string
+			for _, sequence := range sequences {
+				names = append(names, sequence.Name)
+			}
+			c.Assert(names, qt.DeepEquals, test.wantNames)
+		})
+	}
+}

--- a/internal/deporder/deporder.go
+++ b/internal/deporder/deporder.go
@@ -22,6 +22,119 @@ type ViewLike struct {
 	Materialized bool
 }
 
+// UserType is a PostgreSQL user-defined type -- a domain, a composite type or a
+// range type -- named together with the type spellings its own definition
+// mentions: a domain's base type, a composite's field types, a range's subtype.
+//
+// The three kinds share one namespace and can name each other in either
+// direction, so they have to be ordered together rather than kind by kind.
+// `CREATE DOMAIN d AS addr` needs the composite `addr` first, and
+// `CREATE TYPE addr AS (f d)` needs the domain `d` first.
+type UserType struct {
+	// Name is the qualified name the caller uses to look the type back up.
+	Name string
+	// References are the type spellings the definition names, in the caller's
+	// own spelling. Anything outside the set is ignored, so a reference to a
+	// built-in type or to a type the database already has costs nothing.
+	References []string
+}
+
+// UserTypesForCreate returns user-defined type names in creation order: a type
+// another one names comes first. A cycle degrades to caller order, which is
+// what PostgreSQL itself refuses to create anyway.
+func UserTypesForCreate(userTypes []UserType) []string {
+	return StableTopologicalSort(userTypeNames(userTypes), UserTypeDependencies(userTypes))
+}
+
+// UserTypesForDrop returns user-defined type names in drop order: a type that
+// names another is dropped first, so a non-CASCADE drop is not blocked by a
+// dependent the same plan is about to remove.
+func UserTypesForDrop(userTypes []UserType) []string {
+	return StableReverseDependencySort(userTypeNames(userTypes), UserTypeDependencies(userTypes))
+}
+
+// UserTypeDependencies resolves each type's references against the names in the
+// set and returns the edges the two sorts above run on.
+func UserTypeDependencies(userTypes []UserType) map[string][]string {
+	dependencies := make(map[string][]string, len(userTypes))
+	for _, userType := range userTypes {
+		for _, reference := range userType.References {
+			name, ok := resolveUserTypeReference(userTypes, reference)
+			if !ok || name == userType.Name || slices.Contains(dependencies[userType.Name], name) {
+				continue
+			}
+			dependencies[userType.Name] = append(dependencies[userType.Name], name)
+		}
+	}
+	return dependencies
+}
+
+func userTypeNames(userTypes []UserType) []string {
+	names := make([]string, 0, len(userTypes))
+	for _, userType := range userTypes {
+		names = append(names, userType.Name)
+	}
+	return names
+}
+
+// resolveUserTypeReference maps one type spelling onto a name in the set. A
+// qualified spelling must match a qualified name; an unqualified one falls back
+// to the single type carrying that bare name, and stays unresolved when two
+// schemas offer it, because guessing there would order the plan around a type
+// the column does not use.
+func resolveUserTypeReference(userTypes []UserType, reference string) (string, bool) {
+	key := NormalizeTypeReference(reference)
+	if key == "" {
+		return "", false
+	}
+	for _, userType := range userTypes {
+		if NormalizeTypeReference(userType.Name) == key {
+			return userType.Name, true
+		}
+	}
+	if strings.Contains(key, ".") {
+		return "", false
+	}
+
+	var match string
+	for _, userType := range userTypes {
+		ref, ok := tableref.Parse(strings.TrimSpace(userType.Name))
+		if !ok || !strings.EqualFold(ref.Name, key) {
+			continue
+		}
+		if match != "" {
+			return "", false
+		}
+		match = userType.Name
+	}
+	return match, match != ""
+}
+
+// NormalizeTypeReference reduces a SQL type spelling to the bare type name it
+// points at: it drops array markers and a length/precision modifier, unquotes
+// each part of a qualified name, and lowercases the result. `"app"."Addr"[]`
+// and `app.addr` normalize alike, and `character varying(255)` becomes
+// `character varying`.
+func NormalizeTypeReference(reference string) string {
+	value := strings.TrimSpace(reference)
+	for strings.HasSuffix(value, "]") {
+		open := strings.LastIndex(value, "[")
+		if open < 0 {
+			break
+		}
+		value = strings.TrimSpace(value[:open])
+	}
+	if open := strings.Index(value, "("); open >= 0 {
+		value = strings.TrimSpace(value[:open])
+	}
+
+	parts := strings.Split(value, ".")
+	for i, part := range parts {
+		parts[i] = strings.Trim(strings.TrimSpace(part), `"`)
+	}
+	return strings.ToLower(strings.Join(parts, "."))
+}
+
 // StableTopologicalSort returns nodes ordered so dependencies come first while
 // preserving caller order for otherwise independent nodes. Cycles degrade
 // deterministically by appending remaining nodes in caller order.

--- a/internal/deporder/deporder.go
+++ b/internal/deporder/deporder.go
@@ -49,6 +49,12 @@ func UserTypesForCreate(userTypes []UserType) []string {
 // UserTypesForDrop returns user-defined type names in drop order: a type that
 // names another is dropped first, so a non-CASCADE drop is not blocked by a
 // dependent the same plan is about to remove.
+//
+// The References the caller passes must be the ones the database holds NOW.
+// A DROP executes against the current schema, so passing the definitions a plan
+// intends to create instead orders the statements by a graph the server is not
+// consulting, and the two differ whenever the change is what moves a reference.
+// UserTypesForCreate is the call that takes the desired definitions.
 func UserTypesForDrop(userTypes []UserType) []string {
 	return StableReverseDependencySort(userTypeNames(userTypes), UserTypeDependencies(userTypes))
 }

--- a/internal/deporder/user_types_test.go
+++ b/internal/deporder/user_types_test.go
@@ -1,0 +1,216 @@
+package deporder_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/deporder"
+)
+
+// TestUserTypesForCreate_OrdersEachKindAgainstTheOthers pins the property the
+// three kinds share: a domain, a composite and a range live in one namespace
+// and can name each other in either direction, so no fixed order of kinds
+// serves them. Every row here is a pair that a kind-by-kind emitter gets wrong
+// in one direction or the other.
+func TestUserTypesForCreate_OrdersEachKindAgainstTheOthers(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		input []deporder.UserType
+		want  []string
+	}{
+		{
+			name: "domain over a composite waits for the composite",
+			input: []deporder.UserType{
+				{Name: "d_comp", References: []string{"addr"}},
+				{Name: "addr", References: []string{"text"}},
+			},
+			want: []string{"addr", "d_comp"},
+		},
+		{
+			name: "composite over a domain waits for the domain",
+			input: []deporder.UserType{
+				{Name: "addr", References: []string{"d_int", "text"}},
+				{Name: "d_int", References: []string{"integer"}},
+			},
+			want: []string{"d_int", "addr"},
+		},
+		{
+			name: "domain over a range waits for the range",
+			input: []deporder.UserType{
+				{Name: "d_range", References: []string{"myrange"}},
+				{Name: "myrange", References: []string{"integer"}},
+			},
+			want: []string{"myrange", "d_range"},
+		},
+		{
+			name: "range over a domain waits for the domain",
+			input: []deporder.UserType{
+				{Name: "myrange", References: []string{"d_int"}},
+				{Name: "d_int", References: []string{"integer"}},
+			},
+			want: []string{"d_int", "myrange"},
+		},
+		{
+			name: "domain over a domain waits for the domain",
+			input: []deporder.UserType{
+				{Name: "d_outer", References: []string{"d_inner"}},
+				{Name: "d_inner", References: []string{"integer"}},
+			},
+			want: []string{"d_inner", "d_outer"},
+		},
+		{
+			name: "a chain across all three kinds",
+			input: []deporder.UserType{
+				{Name: "d_comp", References: []string{"addr"}},
+				{Name: "addr", References: []string{"d_range", "text"}},
+				{Name: "d_range", References: []string{"myrange"}},
+				{Name: "myrange", References: []string{"integer"}},
+			},
+			want: []string{"myrange", "d_range", "addr", "d_comp"},
+		},
+		{
+			name: "types that name nothing in the set keep caller order",
+			input: []deporder.UserType{
+				{Name: "d_two", References: []string{"integer"}},
+				{Name: "d_one", References: []string{"text"}},
+			},
+			want: []string{"d_two", "d_one"},
+		},
+		{
+			name: "an array of a composite is still a reference to it",
+			input: []deporder.UserType{
+				{Name: "d_comp", References: []string{"addr[]"}},
+				{Name: "addr", References: []string{"text"}},
+			},
+			want: []string{"addr", "d_comp"},
+		},
+		{
+			name: "a length modifier does not hide the base type",
+			input: []deporder.UserType{
+				{Name: "d_text", References: []string{"short_text(20)"}},
+				{Name: "short_text", References: []string{"character varying(255)"}},
+			},
+			want: []string{"short_text", "d_text"},
+		},
+		{
+			name: "a qualified reference matches a qualified name",
+			input: []deporder.UserType{
+				{Name: "app.d_comp", References: []string{`"app"."addr"`}},
+				{Name: "app.addr", References: []string{"text"}},
+			},
+			want: []string{"app.addr", "app.d_comp"},
+		},
+		{
+			name: "an unqualified reference matches the one type carrying that name",
+			input: []deporder.UserType{
+				{Name: "app.d_comp", References: []string{"addr"}},
+				{Name: "app.addr", References: []string{"text"}},
+			},
+			want: []string{"app.addr", "app.d_comp"},
+		},
+		{
+			name: "a bare name two schemas both offer stays unresolved",
+			input: []deporder.UserType{
+				{Name: "app.d_comp", References: []string{"addr"}},
+				{Name: "other.addr", References: []string{"text"}},
+				{Name: "app.addr", References: []string{"text"}},
+			},
+			want: []string{"app.d_comp", "other.addr", "app.addr"},
+		},
+		{
+			name: "a cycle degrades to caller order rather than dropping a type",
+			input: []deporder.UserType{
+				{Name: "a", References: []string{"b"}},
+				{Name: "b", References: []string{"a"}},
+			},
+			want: []string{"a", "b"},
+		},
+		{
+			name: "a self reference is not a dependency",
+			input: []deporder.UserType{
+				{Name: "d_self", References: []string{"d_self"}},
+				{Name: "addr", References: []string{"text"}},
+			},
+			want: []string{"d_self", "addr"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(deporder.UserTypesForCreate(test.input), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+// TestUserTypesForDrop_ReversesTheCreateOrder is the other half: a non-CASCADE
+// drop of a composite fails while a domain still names it, so the dependent
+// goes first.
+func TestUserTypesForDrop_ReversesTheCreateOrder(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		input []deporder.UserType
+		want  []string
+	}{
+		{
+			name: "the domain over a composite is dropped before the composite",
+			input: []deporder.UserType{
+				{Name: "addr", References: []string{"text"}},
+				{Name: "d_comp", References: []string{"addr"}},
+			},
+			want: []string{"d_comp", "addr"},
+		},
+		{
+			name: "the composite over a domain is dropped before the domain",
+			input: []deporder.UserType{
+				{Name: "d_int", References: []string{"integer"}},
+				{Name: "addr", References: []string{"d_int"}},
+			},
+			want: []string{"addr", "d_int"},
+		},
+		{
+			name: "independent types keep caller order",
+			input: []deporder.UserType{
+				{Name: "d_two", References: []string{"integer"}},
+				{Name: "d_one", References: []string{"text"}},
+			},
+			want: []string{"d_two", "d_one"},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(deporder.UserTypesForDrop(test.input), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestNormalizeTypeReference_ReducesASpellingToItsTypeName(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		reference string
+		want      string
+	}{
+		{name: "a bare name is lowercased", reference: "Addr", want: "addr"},
+		{name: "surrounding space is dropped", reference: "  addr  ", want: "addr"},
+		{name: "quotes are removed part by part", reference: `"app"."Addr"`, want: "app.addr"},
+		{name: "one array marker is dropped", reference: "addr[]", want: "addr"},
+		{name: "nested array markers are dropped", reference: "addr[][]", want: "addr"},
+		{name: "a length modifier is dropped", reference: "character varying(255)", want: "character varying"},
+		{name: "a precision modifier is dropped", reference: "numeric(10,2)", want: "numeric"},
+		{name: "a modifier under an array marker is dropped", reference: "varchar(10)[]", want: "varchar"},
+		{name: "an empty spelling normalizes to empty", reference: "   ", want: ""},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(deporder.NormalizeTypeReference(test.reference), qt.Equals, test.want)
+		})
+	}
+}

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -1182,22 +1182,28 @@ func (p *Planner) removeUserTypes(result []ast.Node, diff *types.SchemaDiff) []a
 // is in use requires a manual migration (PostgreSQL offers ALTER DOMAIN /
 // ALTER TYPE for the in-place cases).
 //
-// The order is the reverse of the one addNewUserTypes creates in, for the same
-// reason and in the same direction: a domain over a composite has to go before
-// the composite it names, or the non-CASCADE drop fails on a dependency this
-// very plan is about to replace.
-func (p *Planner) dropModifiedUserTypes(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+// The order comes from the CURRENT definitions the diff carries, not from the
+// desired ones addNewUserTypes creates in. A DROP executes against the database
+// as it stands, so the only references that can block it are the ones that
+// database holds now: `DROP TYPE cc` fails while `CREATE DOMAIN dd AS cc` is
+// still on disk, whatever the desired schema says either type should become.
+//
+// The two graphs disagree exactly when the modification is what moved the
+// reference, and no single order serves both. That is not a conflict to
+// resolve, because they answer different questions: the create graph is the
+// shape being built, the drop graph is the shape being taken apart.
+func (p *Planner) dropModifiedUserTypes(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
 	byName := make(map[string]ast.Node, len(diff.DomainsModified)+len(diff.CompositeTypesModified))
 	deps := make([]deporder.UserType, 0, len(diff.DomainsModified)+len(diff.CompositeTypesModified))
 	for _, domainDiff := range diff.DomainsModified {
 		byName[domainDiff.DomainName] = ast.NewDropType(domainDiff.DomainName).SetDomain().SetIfExists().
 			SetComment("Recreate modified domain; drop is non-CASCADE and fails if the domain is in use")
-		deps = append(deps, deporder.UserType{Name: domainDiff.DomainName, References: modifiedDomainReferences(generated, domainDiff.DomainName)})
+		deps = append(deps, deporder.UserType{Name: domainDiff.DomainName, References: currentDomainReferences(domainDiff)})
 	}
 	for _, compositeDiff := range diff.CompositeTypesModified {
 		byName[compositeDiff.TypeName] = ast.NewDropType(compositeDiff.TypeName).SetIfExists().
 			SetComment("Recreate modified composite type; drop is non-CASCADE and fails if the type is in use")
-		deps = append(deps, deporder.UserType{Name: compositeDiff.TypeName, References: modifiedCompositeReferences(generated, compositeDiff.TypeName)})
+		deps = append(deps, deporder.UserType{Name: compositeDiff.TypeName, References: compositeDiff.CurrentFieldTypes})
 	}
 
 	for _, name := range deporder.UserTypesForDrop(deps) {
@@ -1208,18 +1214,15 @@ func (p *Planner) dropModifiedUserTypes(result []ast.Node, diff *types.SchemaDif
 	return result
 }
 
-func modifiedDomainReferences(generated *goschema.Database, name string) []string {
-	if domain := findDomain(generated.Domains, name); domain != nil {
-		return []string{domain.BaseType}
+// currentDomainReferences reports the from-side base type of a modified domain,
+// or nothing when the diff does not carry one. It never reads Changes: that map
+// is a human-readable "old -> new" rendering, and recovering a type name by
+// splitting prose is not a basis for statement ordering.
+func currentDomainReferences(domainDiff types.DomainDiff) []string {
+	if domainDiff.CurrentBaseType == "" {
+		return nil
 	}
-	return nil
-}
-
-func modifiedCompositeReferences(generated *goschema.Database, name string) []string {
-	if composite := findCompositeType(generated.CompositeTypes, name); composite != nil {
-		return compositeFieldTypes(*composite)
-	}
-	return nil
+	return []string{domainDiff.CurrentBaseType}
 }
 
 func findDomain(domains []goschema.Domain, name string) *goschema.Domain {
@@ -1378,7 +1381,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 
 	// 3c. Recreate changed user-defined types (drop then create), then create
 	// new domains/ranges/composites before tables can reference them.
-	result = p.dropModifiedUserTypes(result, diff, generated)
+	result = p.dropModifiedUserTypes(result, diff)
 	result = p.addNewUserTypes(result, diff, generated)
 
 	// 4. Modify existing enums

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -1054,37 +1054,104 @@ func (p *Planner) removeEnums(result []ast.Node, diff *types.SchemaDiff) []ast.N
 	return result
 }
 
+// plannedUserType pairs a user-defined type's dependency identity with the node
+// that creates it, so one ordering covers domains, ranges and composites
+// together.
+type plannedUserType struct {
+	dep  deporder.UserType
+	node ast.Node
+}
+
 // addNewUserTypes emits CREATE DOMAIN / CREATE TYPE for newly added domains,
-// ranges, and composite types (in dependency order). It runs before tables so
-// columns can reference them.
+// ranges, and composite types. It runs before tables so columns can reference
+// them, and orders the three kinds against each other so a type is created
+// before whatever names it.
+//
+// Emitting kind by kind is not enough, because the three kinds name each other
+// in both directions. `CREATE DOMAIN d_comp AS addr` needs the composite `addr`
+// first and `CREATE TYPE addr AS (f d_int)` needs the domain `d_int` first, so
+// no fixed order of kinds can serve both. Emitting domains first sent
+// `CREATE DOMAIN "d_comp" AS addr;` out ahead of `CREATE TYPE "addr" AS (...)`
+// and the script stopped at `ERROR: type "addr" does not exist` -- measured on
+// PostgreSQL 17.10 with psql -v ON_ERROR_STOP=1, exit 3.
+//
+// Enums are not in the set: they carry no reference to another user-defined
+// type and are already emitted before this runs.
 func (p *Planner) addNewUserTypes(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	planned := p.plannedUserTypes(diff, generated)
+	byName := make(map[string]ast.Node, len(planned))
+	deps := make([]deporder.UserType, 0, len(planned))
+	for _, userType := range planned {
+		byName[userType.dep.Name] = userType.node
+		deps = append(deps, userType.dep)
+	}
+
+	for _, name := range deporder.UserTypesForCreate(deps) {
+		if node, ok := byName[name]; ok {
+			result = append(result, node)
+		}
+	}
+	return result
+}
+
+// plannedUserTypes collects every domain, range and composite this plan
+// creates, newly added ones first and then the ones recreated in place of a
+// modification, each with the type spellings its definition names.
+func (p *Planner) plannedUserTypes(diff *types.SchemaDiff, generated *goschema.Database) []plannedUserType {
+	var planned []plannedUserType
 	for _, name := range diff.DomainsAdded {
 		if domain := findDomain(generated.Domains, name); domain != nil {
-			result = append(result, fromschema.FromDomain(*domain))
+			planned = append(planned, plannedUserType{
+				dep:  deporder.UserType{Name: name, References: []string{domain.BaseType}},
+				node: fromschema.FromDomain(*domain),
+			})
 		}
 	}
 	for _, name := range diff.RangesAdded {
 		if rangeType := findRange(generated.Ranges, name); rangeType != nil {
-			result = append(result, fromschema.FromRange(*rangeType))
+			planned = append(planned, plannedUserType{
+				dep:  deporder.UserType{Name: name, References: []string{rangeType.Subtype}},
+				node: fromschema.FromRange(*rangeType),
+			})
 		}
 	}
 	for _, name := range diff.CompositeTypesAdded {
 		if composite := findCompositeType(generated.CompositeTypes, name); composite != nil {
-			result = append(result, fromschema.FromCompositeType(*composite))
+			planned = append(planned, plannedUserType{
+				dep:  deporder.UserType{Name: name, References: compositeFieldTypes(*composite)},
+				node: fromschema.FromCompositeType(*composite),
+			})
 		}
 	}
-	// A modification with no in-place ALTER is handled as drop + recreate.
+	// A modification with no in-place ALTER is handled as drop + recreate. The
+	// recreations join the same ordering: a new domain over a recreated
+	// composite has to wait for the recreation, which dropModifiedUserTypes has
+	// already removed by this point.
 	for _, domainDiff := range diff.DomainsModified {
 		if domain := findDomain(generated.Domains, domainDiff.DomainName); domain != nil {
-			result = append(result, fromschema.FromDomain(*domain).SetComment(fmt.Sprintf("Recreate domain %s", domainDiff.DomainName)))
+			planned = append(planned, plannedUserType{
+				dep:  deporder.UserType{Name: domainDiff.DomainName, References: []string{domain.BaseType}},
+				node: fromschema.FromDomain(*domain).SetComment(fmt.Sprintf("Recreate domain %s", domainDiff.DomainName)),
+			})
 		}
 	}
 	for _, compositeDiff := range diff.CompositeTypesModified {
 		if composite := findCompositeType(generated.CompositeTypes, compositeDiff.TypeName); composite != nil {
-			result = append(result, fromschema.FromCompositeType(*composite).SetComment(fmt.Sprintf("Recreate composite type %s", compositeDiff.TypeName)))
+			planned = append(planned, plannedUserType{
+				dep:  deporder.UserType{Name: compositeDiff.TypeName, References: compositeFieldTypes(*composite)},
+				node: fromschema.FromCompositeType(*composite).SetComment(fmt.Sprintf("Recreate composite type %s", compositeDiff.TypeName)),
+			})
 		}
 	}
-	return result
+	return planned
+}
+
+func compositeFieldTypes(composite goschema.CompositeType) []string {
+	references := make([]string, 0, len(composite.Fields))
+	for _, field := range composite.Fields {
+		references = append(references, field.Type)
+	}
+	return references
 }
 
 // removeUserTypes emits DROP DOMAIN / DROP TYPE for removed and modified
@@ -1114,16 +1181,45 @@ func (p *Planner) removeUserTypes(result []ast.Node, diff *types.SchemaDiff) []a
 // silently dropping dependent columns. Reconciling a modification while the type
 // is in use requires a manual migration (PostgreSQL offers ALTER DOMAIN /
 // ALTER TYPE for the in-place cases).
-func (p *Planner) dropModifiedUserTypes(result []ast.Node, diff *types.SchemaDiff) []ast.Node {
+//
+// The order is the reverse of the one addNewUserTypes creates in, for the same
+// reason and in the same direction: a domain over a composite has to go before
+// the composite it names, or the non-CASCADE drop fails on a dependency this
+// very plan is about to replace.
+func (p *Planner) dropModifiedUserTypes(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+	byName := make(map[string]ast.Node, len(diff.DomainsModified)+len(diff.CompositeTypesModified))
+	deps := make([]deporder.UserType, 0, len(diff.DomainsModified)+len(diff.CompositeTypesModified))
 	for _, domainDiff := range diff.DomainsModified {
-		result = append(result, ast.NewDropType(domainDiff.DomainName).SetDomain().SetIfExists().
-			SetComment("Recreate modified domain; drop is non-CASCADE and fails if the domain is in use"))
+		byName[domainDiff.DomainName] = ast.NewDropType(domainDiff.DomainName).SetDomain().SetIfExists().
+			SetComment("Recreate modified domain; drop is non-CASCADE and fails if the domain is in use")
+		deps = append(deps, deporder.UserType{Name: domainDiff.DomainName, References: modifiedDomainReferences(generated, domainDiff.DomainName)})
 	}
 	for _, compositeDiff := range diff.CompositeTypesModified {
-		result = append(result, ast.NewDropType(compositeDiff.TypeName).SetIfExists().
-			SetComment("Recreate modified composite type; drop is non-CASCADE and fails if the type is in use"))
+		byName[compositeDiff.TypeName] = ast.NewDropType(compositeDiff.TypeName).SetIfExists().
+			SetComment("Recreate modified composite type; drop is non-CASCADE and fails if the type is in use")
+		deps = append(deps, deporder.UserType{Name: compositeDiff.TypeName, References: modifiedCompositeReferences(generated, compositeDiff.TypeName)})
+	}
+
+	for _, name := range deporder.UserTypesForDrop(deps) {
+		if node, ok := byName[name]; ok {
+			result = append(result, node)
+		}
 	}
 	return result
+}
+
+func modifiedDomainReferences(generated *goschema.Database, name string) []string {
+	if domain := findDomain(generated.Domains, name); domain != nil {
+		return []string{domain.BaseType}
+	}
+	return nil
+}
+
+func modifiedCompositeReferences(generated *goschema.Database, name string) []string {
+	if composite := findCompositeType(generated.CompositeTypes, name); composite != nil {
+		return compositeFieldTypes(*composite)
+	}
+	return nil
 }
 
 func findDomain(domains []goschema.Domain, name string) *goschema.Domain {
@@ -1282,7 +1378,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 
 	// 3c. Recreate changed user-defined types (drop then create), then create
 	// new domains/ranges/composites before tables can reference them.
-	result = p.dropModifiedUserTypes(result, diff)
+	result = p.dropModifiedUserTypes(result, diff, generated)
 	result = p.addNewUserTypes(result, diff, generated)
 
 	// 4. Modify existing enums

--- a/internal/planner/dialects/postgres/user_type_drop_order_test.go
+++ b/internal/planner/dialects/postgres/user_type_drop_order_test.go
@@ -1,0 +1,152 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesAgainstTheCurrentShape
+// pins the side of the diff a DROP is ordered by.
+//
+// The recreate path emits a non-CASCADE DROP and then creates the type again.
+// The CREATE order follows the desired definitions, because that is the shape
+// being built. The DROP order cannot: those statements run against the database
+// as it stands, so the only references that can block them are the ones the
+// CURRENT definitions carry.
+//
+// Here the modification is what moves the reference. The database holds
+// `CREATE TYPE cc AS (f integer)` with `CREATE DOMAIN dd AS cc` over it, and
+// the desired schema turns that around: `dd` becomes a plain integer domain and
+// `cc` gains a field of `dd`. Ordering the drops by the desired references
+// takes `cc` away first, and PostgreSQL 17.10 answers `ERROR: cannot drop type
+// cc because other objects depend on it / DETAIL: type dd depends on type cc`
+// (SQLSTATE 2BP01) -- measured through `ptah-compat schema apply
+// --auto-approve`, exit 1, the target left on the old shape. Ordering them by
+// the current references drops `dd` first and the same apply exits 0.
+func TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesAgainstTheCurrentShape(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	desired := &goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "dd", BaseType: "integer"},
+		},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "cc", Fields: []goschema.CompositeTypeField{{Name: "f", Type: "dd"}}},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		DomainsModified: []difftypes.DomainDiff{
+			{DomainName: "dd", Changes: map[string]string{"type": "cc -> integer"}, CurrentBaseType: "cc"},
+		},
+		CompositeTypesModified: []difftypes.CompositeTypeDiff{
+			{TypeName: "cc", Changes: map[string]string{"fields": "f integer -> f dd"}, CurrentFieldTypes: []string{"integer"}},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, desired)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	// The current shape: dd names cc, so dd goes first.
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS dd", "DROP TYPE IF EXISTS cc")
+	// The desired shape: cc names dd, so dd is created first. The two orders
+	// are not mirror images here, and they do not have to be.
+	assertBefore(t, sql, "CREATE DOMAIN dd AS", "CREATE TYPE cc AS")
+	// A recreation never runs against the shape it replaces.
+	assertBefore(t, sql, "DROP TYPE IF EXISTS cc", "CREATE TYPE cc AS")
+}
+
+// TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesTheDesiredShapeNoLongerNames
+// is the same root cause on a shape with no flip in it: the modification simply
+// stops using the domain.
+//
+// The database holds `CREATE DOMAIN qty AS integer CHECK (VALUE > 0)` and
+// `CREATE TYPE meas AS (q qty, label text)`; the desired schema widens `qty` to
+// bigint and gives `meas` a plain bigint field. Read from the desired side
+// `meas` names nothing, so there is no edge to reverse and the order falls back
+// to the caller's -- domains first. PostgreSQL 17.10 answers `ERROR: cannot
+// drop type qty because other objects depend on it / DETAIL: column q of
+// composite type meas depends on type qty`, exit 1. The current side still has
+// the edge, and dropping `meas` first exits 0.
+func TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesTheDesiredShapeNoLongerNames(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	desired := &goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "qty", BaseType: "bigint", Check: "VALUE > 0"},
+		},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "meas", Fields: []goschema.CompositeTypeField{{Name: "q", Type: "bigint"}, {Name: "label", Type: "text"}}},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		DomainsModified: []difftypes.DomainDiff{
+			{DomainName: "qty", Changes: map[string]string{"type": "integer -> bigint"}, CurrentBaseType: "integer"},
+		},
+		CompositeTypesModified: []difftypes.CompositeTypeDiff{
+			{
+				TypeName:          "meas",
+				Changes:           map[string]string{"fields": "q qty, label text -> q bigint, label text"},
+				CurrentFieldTypes: []string{"qty", "text"},
+			},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, desired)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP TYPE IF EXISTS meas", "DROP DOMAIN IF EXISTS qty")
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS qty", "CREATE DOMAIN qty AS")
+	assertBefore(t, sql, "DROP TYPE IF EXISTS meas", "CREATE TYPE meas AS")
+}
+
+// TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesInCallerOrderWithoutACurrentShape
+// covers a diff assembled by hand, which carries no from-side at all.
+//
+// There is nothing to order by then, and inventing edges out of the desired
+// definitions is what this whole file exists to rule out, so the drops keep the
+// caller's order. Emitting them is still right: the recreate path has to drop
+// before it creates.
+func TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesInCallerOrderWithoutACurrentShape(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	desired := &goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "dd", BaseType: "integer"},
+		},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "cc", Fields: []goschema.CompositeTypeField{{Name: "f", Type: "dd"}}},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		DomainsModified: []difftypes.DomainDiff{
+			{DomainName: "dd", Changes: map[string]string{"type": "cc -> integer"}},
+		},
+		CompositeTypesModified: []difftypes.CompositeTypeDiff{
+			{TypeName: "cc", Changes: map[string]string{"fields": "f integer -> f dd"}},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, desired)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS dd", "DROP TYPE IF EXISTS cc")
+	assertBefore(t, sql, "DROP TYPE IF EXISTS cc", "CREATE DOMAIN dd AS")
+}

--- a/internal/planner/dialects/postgres/user_type_drop_order_test.go
+++ b/internal/planner/dialects/postgres/user_type_drop_order_test.go
@@ -113,6 +113,46 @@ func TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesTheDesiredShapeNoLon
 	assertBefore(t, sql, "DROP TYPE IF EXISTS meas", "CREATE TYPE meas AS")
 }
 
+// TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesWithinOneKind pairs two
+// types of the SAME kind, which is the case no order of kinds can reach.
+//
+// The two tests above each pair a domain with a composite, so a rule as crude as
+// "composites before domains" would satisfy them. Here both types are domains:
+// `CREATE DOMAIN d_base AS integer` with `CREATE DOMAIN d_over AS d_base` over
+// it, and the desired schema makes both plain text. The comparator sorts
+// DomainsModified by name, so caller order emits `DROP DOMAIN d_base` first and
+// PostgreSQL 17.10 answers `ERROR: cannot drop type d_base because other objects
+// depend on it / DETAIL: type d_over depends on type d_base` (SQLSTATE 2BP01) --
+// measured through `ptah-compat schema apply --auto-approve`. The desired side
+// has no edge to reverse either, since neither domain still names the other, so
+// only the current definitions place these two statements.
+func TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesWithinOneKind(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	desired := &goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "d_base", BaseType: "text"},
+			{Name: "d_over", BaseType: "text"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{
+		DomainsModified: []difftypes.DomainDiff{
+			{DomainName: "d_base", Changes: map[string]string{"type": "integer -> text"}, CurrentBaseType: "integer"},
+			{DomainName: "d_over", Changes: map[string]string{"type": "d_base -> text"}, CurrentBaseType: "d_base"},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, desired)
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS d_over", "DROP DOMAIN IF EXISTS d_base")
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS d_base", "CREATE DOMAIN d_base AS")
+}
+
 // TestPlanner_GenerateMigrationAST_DropsModifiedUserTypesInCallerOrderWithoutACurrentShape
 // covers a diff assembled by hand, which carries no from-side at all.
 //

--- a/internal/planner/dialects/postgres/user_type_order_test.go
+++ b/internal/planner/dialects/postgres/user_type_order_test.go
@@ -72,18 +72,23 @@ func TestPlanner_GenerateMigrationAST_CreatesUserTypesBeforeTheTypesThatNameThem
 // The drops are non-CASCADE on purpose, so their order is not cosmetic: a
 // composite still named by a domain cannot be dropped, and the plan that
 // recreates both has to take the dependent away first and put it back last.
+//
+// Here the references survive the modification -- the current shapes the diff
+// carries name the same types the desired ones do -- so the two orders are
+// mirror images of each other. The file next door pins what happens when they
+// are not.
 func TestPlanner_GenerateMigrationAST_RecreatesUserTypesInDependencyOrder(t *testing.T) {
 	c := qt.New(t)
 	planner := postgres.New()
 
 	diff := &difftypes.SchemaDiff{
 		DomainsModified: []difftypes.DomainDiff{
-			{DomainName: "d_comp", Changes: map[string]string{"base_type": "old -> addr"}},
-			{DomainName: "d_int", Changes: map[string]string{"check": "old -> new"}},
+			{DomainName: "d_comp", Changes: map[string]string{"not_null": "false -> true"}, CurrentBaseType: "addr"},
+			{DomainName: "d_int", Changes: map[string]string{"type": "smallint -> integer"}, CurrentBaseType: "smallint"},
 		},
 		CompositeTypesModified: []difftypes.CompositeTypeDiff{
-			{TypeName: "addr", Changes: map[string]string{"fields": "old -> new"}},
-			{TypeName: "measure", Changes: map[string]string{"fields": "old -> new"}},
+			{TypeName: "addr", Changes: map[string]string{"fields": "street text -> street text, city text"}, CurrentFieldTypes: []string{"text"}},
+			{TypeName: "measure", Changes: map[string]string{"fields": "qty d_int -> qty d_int, note text"}, CurrentFieldTypes: []string{"d_int"}},
 		},
 	}
 

--- a/internal/planner/dialects/postgres/user_type_order_test.go
+++ b/internal/planner/dialects/postgres/user_type_order_test.go
@@ -1,0 +1,131 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// userTypeOrderSchema holds one type of each kind that names another kind, in
+// both directions, so a plan that emits kind by kind gets at least one of them
+// wrong whichever kind it puts first.
+func userTypeOrderSchema() *goschema.Database {
+	return &goschema.Database{
+		Domains: []goschema.Domain{
+			{Name: "d_comp", BaseType: "addr"},
+			{Name: "d_range", BaseType: "myrange"},
+			{Name: "d_int", BaseType: "integer", Check: "VALUE > 0"},
+		},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "addr", Fields: []goschema.CompositeTypeField{{Name: "street", Type: "text"}, {Name: "city", Type: "text"}}},
+			{Name: "measure", Fields: []goschema.CompositeTypeField{{Name: "qty", Type: "d_int"}}},
+		},
+		Ranges: []goschema.Range{
+			{Name: "myrange", Subtype: "integer"},
+			{Name: "posrange", Subtype: "d_int"},
+		},
+	}
+}
+
+// TestPlanner_GenerateMigrationAST_CreatesUserTypesBeforeTheTypesThatNameThem
+// is the ordering the round trip depends on.
+//
+// A description a database gives of itself is worth nothing if it cannot be
+// replayed. Emitting every domain before every composite and range put
+// `CREATE DOMAIN "d_comp" AS addr;` ahead of `CREATE TYPE "addr" AS (...)`, and
+// the replay stopped at `ERROR: type "addr" does not exist` -- measured on
+// PostgreSQL 17.10 with psql -v ON_ERROR_STOP=1, exit 3, on the script
+// ptah-compat produced for a database holding exactly these types.
+func TestPlanner_GenerateMigrationAST_CreatesUserTypesBeforeTheTypesThatNameThem(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	diff := &difftypes.SchemaDiff{
+		DomainsAdded:        []string{"d_comp", "d_range", "d_int"},
+		CompositeTypesAdded: []string{"addr", "measure"},
+		RangesAdded:         []string{"myrange", "posrange"},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, userTypeOrderSchema())
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	// A domain over a composite and a domain over a range: the named type first.
+	assertBefore(t, sql, "CREATE TYPE addr AS", "CREATE DOMAIN d_comp AS")
+	assertBefore(t, sql, "CREATE TYPE myrange AS RANGE", "CREATE DOMAIN d_range AS")
+	// The other direction, which a fixed "composites and ranges first" order
+	// would break in place of the one it fixed.
+	assertBefore(t, sql, "CREATE DOMAIN d_int AS", "CREATE TYPE measure AS")
+	assertBefore(t, sql, "CREATE DOMAIN d_int AS", "CREATE TYPE posrange AS RANGE")
+}
+
+// TestPlanner_GenerateMigrationAST_RecreatesUserTypesInDependencyOrder covers
+// the drop + recreate path a modification takes, in both directions at once.
+//
+// The drops are non-CASCADE on purpose, so their order is not cosmetic: a
+// composite still named by a domain cannot be dropped, and the plan that
+// recreates both has to take the dependent away first and put it back last.
+func TestPlanner_GenerateMigrationAST_RecreatesUserTypesInDependencyOrder(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	diff := &difftypes.SchemaDiff{
+		DomainsModified: []difftypes.DomainDiff{
+			{DomainName: "d_comp", Changes: map[string]string{"base_type": "old -> addr"}},
+			{DomainName: "d_int", Changes: map[string]string{"check": "old -> new"}},
+		},
+		CompositeTypesModified: []difftypes.CompositeTypeDiff{
+			{TypeName: "addr", Changes: map[string]string{"fields": "old -> new"}},
+			{TypeName: "measure", Changes: map[string]string{"fields": "old -> new"}},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, userTypeOrderSchema())
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	// Drop dependents first.
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS d_comp", "DROP TYPE IF EXISTS addr")
+	assertBefore(t, sql, "DROP TYPE IF EXISTS measure", "DROP DOMAIN IF EXISTS d_int")
+	// Recreate them last.
+	assertBefore(t, sql, "CREATE TYPE addr AS", "CREATE DOMAIN d_comp AS")
+	assertBefore(t, sql, "CREATE DOMAIN d_int AS", "CREATE TYPE measure AS")
+	// Every drop precedes every recreation, so a recreation never runs against
+	// the shape it is replacing.
+	assertBefore(t, sql, "DROP TYPE IF EXISTS addr", "CREATE TYPE addr AS")
+	assertBefore(t, sql, "DROP DOMAIN IF EXISTS d_int", "CREATE DOMAIN d_int AS")
+}
+
+// TestPlanner_GenerateMigrationAST_CreatesRecreatedUserTypesBeforeNewDependents
+// is the case the two paths share: a brand new domain over a composite the same
+// plan is recreating. The composite does not exist when the new domain is
+// created, because this plan dropped it a few statements earlier.
+func TestPlanner_GenerateMigrationAST_CreatesRecreatedUserTypesBeforeNewDependents(t *testing.T) {
+	c := qt.New(t)
+	planner := postgres.New()
+
+	diff := &difftypes.SchemaDiff{
+		DomainsAdded: []string{"d_comp"},
+		CompositeTypesModified: []difftypes.CompositeTypeDiff{
+			{TypeName: "addr", Changes: map[string]string{"fields": "old -> new"}},
+		},
+	}
+
+	nodes, err := planner.GenerateMigrationASTChecked(diff, userTypeOrderSchema())
+	c.Assert(err, qt.IsNil)
+	sql, err := renderer.RenderSQL("postgres", nodes...)
+	c.Assert(err, qt.IsNil)
+	sql = legacyRenderedSQL(sql)
+
+	assertBefore(t, sql, "DROP TYPE IF EXISTS addr", "CREATE TYPE addr AS")
+	assertBefore(t, sql, "CREATE TYPE addr AS", "CREATE DOMAIN d_comp AS")
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1563,10 +1563,10 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		// Reverse user-defined type operations
 		DomainsAdded:           diff.DomainsRemoved,
 		DomainsRemoved:         diff.DomainsAdded,
-		DomainsModified:        reverseDomainDiffs(diff.DomainsModified),
+		DomainsModified:        reverseDomainDiffs(diff.DomainsModified, schema),
 		CompositeTypesAdded:    diff.CompositeTypesRemoved,
 		CompositeTypesRemoved:  diff.CompositeTypesAdded,
-		CompositeTypesModified: reverseCompositeTypeDiffs(diff.CompositeTypesModified),
+		CompositeTypesModified: reverseCompositeTypeDiffs(diff.CompositeTypesModified, schema),
 		RangesAdded:            diff.RangesRemoved,
 		RangesRemoved:          diff.RangesAdded,
 
@@ -2183,20 +2183,65 @@ func reverseChangeMap(changes map[string]string) map[string]string {
 	return reversed
 }
 
-func reverseDomainDiffs(domainDiffs []types.DomainDiff) []types.DomainDiff {
+// reverseDomainDiffs turns each modified domain around for the down direction.
+//
+// CurrentBaseType has to be re-derived rather than carried over: it names the
+// shape the DROP will run against, and a down migration runs against the shape
+// the up migration created. schema is the up direction's target, so that is
+// where the down direction's from-side lives. A nil schema leaves it empty and
+// the drop ordering falls back to declaration order.
+func reverseDomainDiffs(domainDiffs []types.DomainDiff, schema *goschema.Database) []types.DomainDiff {
 	reversed := make([]types.DomainDiff, len(domainDiffs))
 	for i, domainDiff := range domainDiffs {
-		reversed[i] = types.DomainDiff{DomainName: domainDiff.DomainName, Changes: reverseChangeMap(domainDiff.Changes)}
+		reversed[i] = types.DomainDiff{
+			DomainName:      domainDiff.DomainName,
+			Changes:         reverseChangeMap(domainDiff.Changes),
+			CurrentBaseType: targetDomainBaseType(schema, domainDiff.DomainName),
+		}
 	}
 	return reversed
 }
 
-func reverseCompositeTypeDiffs(compositeDiffs []types.CompositeTypeDiff) []types.CompositeTypeDiff {
+// reverseCompositeTypeDiffs mirrors reverseDomainDiffs for composite types.
+func reverseCompositeTypeDiffs(compositeDiffs []types.CompositeTypeDiff, schema *goschema.Database) []types.CompositeTypeDiff {
 	reversed := make([]types.CompositeTypeDiff, len(compositeDiffs))
 	for i, compositeDiff := range compositeDiffs {
-		reversed[i] = types.CompositeTypeDiff{TypeName: compositeDiff.TypeName, Changes: reverseChangeMap(compositeDiff.Changes)}
+		reversed[i] = types.CompositeTypeDiff{
+			TypeName:          compositeDiff.TypeName,
+			Changes:           reverseChangeMap(compositeDiff.Changes),
+			CurrentFieldTypes: targetCompositeFieldTypes(schema, compositeDiff.TypeName),
+		}
 	}
 	return reversed
+}
+
+func targetDomainBaseType(schema *goschema.Database, name string) string {
+	if schema == nil {
+		return ""
+	}
+	for _, domain := range schema.Domains {
+		if domain.QualifiedName() == name {
+			return domain.BaseType
+		}
+	}
+	return ""
+}
+
+func targetCompositeFieldTypes(schema *goschema.Database, name string) []string {
+	if schema == nil {
+		return nil
+	}
+	for _, composite := range schema.CompositeTypes {
+		if composite.QualifiedName() != name {
+			continue
+		}
+		fieldTypes := make([]string, len(composite.Fields))
+		for i, field := range composite.Fields {
+			fieldTypes[i] = field.Type
+		}
+		return fieldTypes
+	}
+	return nil
 }
 
 // reverseRLSPolicyDiffs reverses RLS policy modifications for down migrations

--- a/migration/generator/user_type_reverse_diff_internal_test.go
+++ b/migration/generator/user_type_reverse_diff_internal_test.go
@@ -1,0 +1,75 @@
+package generator
+
+// White-box testing required: reverseSchemaDiffWithSchema is unexported and the
+// property under test is a field of the diff it returns, not a statement in the
+// SQL. Going through the exported generator would need a live database on both
+// ends and would still only show the ordering indirectly.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestReverseSchemaDiff_ModifiedUserTypesCarryTheDownDirectionsCurrentShape
+// pins where the reversed diff's from-side comes from.
+//
+// CurrentBaseType and CurrentFieldTypes order the non-CASCADE DROP the recreate
+// path emits, and that DROP runs against whatever the database holds when the
+// statement executes. For a down migration that is the shape the up migration
+// created, which is the up direction's TARGET -- so the values are re-derived
+// from the target schema rather than carried across from the forward diff,
+// where they describe the shape the up migration replaced.
+func TestReverseSchemaDiff_ModifiedUserTypesCarryTheDownDirectionsCurrentShape(t *testing.T) {
+	c := qt.New(t)
+
+	target := &goschema.Database{
+		Domains: []goschema.Domain{{Name: "dd", BaseType: "integer"}},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "cc", Fields: []goschema.CompositeTypeField{{Name: "f", Type: "dd"}}},
+		},
+	}
+	forward := &types.SchemaDiff{
+		DomainsModified: []types.DomainDiff{
+			{DomainName: "dd", Changes: map[string]string{"type": "cc -> integer"}, CurrentBaseType: "cc"},
+		},
+		CompositeTypesModified: []types.CompositeTypeDiff{
+			{TypeName: "cc", Changes: map[string]string{"fields": "f integer -> f dd"}, CurrentFieldTypes: []string{"integer"}},
+		},
+	}
+
+	reversed := reverseSchemaDiffWithSchema(forward, target, nil)
+
+	c.Assert(reversed.DomainsModified, qt.HasLen, 1)
+	c.Assert(reversed.DomainsModified[0].CurrentBaseType, qt.Equals, "integer")
+	c.Assert(reversed.DomainsModified[0].Changes["type"], qt.Equals, "integer -> cc")
+	c.Assert(reversed.CompositeTypesModified, qt.HasLen, 1)
+	c.Assert(reversed.CompositeTypesModified[0].CurrentFieldTypes, qt.DeepEquals, []string{"dd"})
+}
+
+// TestReverseSchemaDiff_ModifiedUserTypesWithoutATargetSchema covers the
+// deprecated nil-schema caller: there is no shape to derive a from-side from,
+// so the reversed diff carries none and the drops fall back to declaration
+// order rather than to a graph nobody measured.
+func TestReverseSchemaDiff_ModifiedUserTypesWithoutATargetSchema(t *testing.T) {
+	c := qt.New(t)
+
+	forward := &types.SchemaDiff{
+		DomainsModified: []types.DomainDiff{
+			{DomainName: "dd", Changes: map[string]string{"type": "cc -> integer"}, CurrentBaseType: "cc"},
+		},
+		CompositeTypesModified: []types.CompositeTypeDiff{
+			{TypeName: "cc", Changes: map[string]string{"fields": "f integer -> f dd"}, CurrentFieldTypes: []string{"integer"}},
+		},
+	}
+
+	reversed := reverseSchemaDiff(forward)
+
+	c.Assert(reversed.DomainsModified, qt.HasLen, 1)
+	c.Assert(reversed.DomainsModified[0].CurrentBaseType, qt.Equals, "")
+	c.Assert(reversed.CompositeTypesModified, qt.HasLen, 1)
+	c.Assert(reversed.CompositeTypesModified[0].CurrentFieldTypes, qt.IsNil)
+}

--- a/migration/schemadiff/domain_column_self_diff_test.go
+++ b/migration/schemadiff/domain_column_self_diff_test.go
@@ -1,0 +1,186 @@
+package schemadiff_test
+
+// A database must be in sync with ITSELF. See stokaro/ptah#1242.
+//
+// `ptah-compat schema diff --from X --to X` reads one database once, converts
+// one copy of the read to the desired-state model through dbschematogo and
+// leaves the other as the reader produced it. Every column therefore has to
+// reach the same spelling down both paths, or the comparison plans an ALTER
+// that will never converge and `schema apply` executes it on every run while
+// reporting success.
+//
+// The two paths live in different packages and neither package's own tests can
+// see the disagreement: dbschematogo's tests assert what the desired side
+// answers and compare's tests supply a desired side by hand. This file joins
+// them, which is the only place the property is a property. Every DBColumn
+// below is one column as the PostgreSQL 17.10 reader reports it, values
+// measured from information_schema.columns and pg_catalog rather than invented.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestCompare_DomainColumnSelfDiffPlansNothing is the no-churn property for
+// every domain column shape PostgreSQL can produce.
+//
+// A domain over a BUILT-IN base type reports that base type in data_type. A
+// domain over a USER-DEFINED base type -- an enum, a composite, a range --
+// reports data_type 'USER-DEFINED' with udt_name naming the BASE type, and only
+// domain_name and format_type name the domain. The second shape reaches a
+// different branch of the conversion than the first, so a fix that reads the
+// domain on only one of them re-creates on the enum column exactly the churn it
+// removed from the integer one -- and `schema apply` then drops the domain off
+// the column for real.
+func TestCompare_DomainColumnSelfDiffPlansNothing(t *testing.T) {
+	tests := []struct {
+		name   string
+		column types.DBColumn
+	}{
+		{
+			// CREATE DOMAIN positive AS integer CHECK (VALUE > 0);
+			name: "domain over a built-in base type",
+			column: types.DBColumn{
+				Name:          "qty",
+				DataType:      "integer",
+				UDTName:       "int4",
+				FormattedType: "positive",
+				DomainName:    "positive",
+				IsNullable:    "NO",
+			},
+		},
+		{
+			// CREATE DOMAIN doms.positive AS integer; a domain off the search
+			// path keeps its qualifier on both sides or neither.
+			name: "domain outside the search path",
+			column: types.DBColumn{
+				Name:          "qty",
+				DataType:      "integer",
+				UDTName:       "int4",
+				FormattedType: "doms.positive",
+				DomainName:    "positive",
+				IsNullable:    "NO",
+			},
+		},
+		{
+			// CREATE TYPE color AS ENUM ('r','g','b');
+			// CREATE DOMAIN d_enum AS color CHECK (VALUE <> 'b');
+			name: "domain over an enum",
+			column: types.DBColumn{
+				Name:          "c",
+				DataType:      "USER-DEFINED",
+				UDTName:       "color",
+				FormattedType: "d_enum",
+				DomainName:    "d_enum",
+				IsNullable:    "NO",
+			},
+		},
+		{
+			// CREATE TYPE addr AS (street text, city text);
+			// CREATE DOMAIN d_comp AS addr;
+			name: "domain over a composite type",
+			column: types.DBColumn{
+				Name:          "a",
+				DataType:      "USER-DEFINED",
+				UDTName:       "addr",
+				FormattedType: "d_comp",
+				DomainName:    "d_comp",
+				IsNullable:    "YES",
+			},
+		},
+		{
+			// CREATE TYPE myrange AS RANGE (subtype=integer);
+			// CREATE DOMAIN d_range AS myrange;
+			name: "domain over a range type",
+			column: types.DBColumn{
+				Name:          "r",
+				DataType:      "USER-DEFINED",
+				UDTName:       "myrange",
+				FormattedType: "d_range",
+				DomainName:    "d_range",
+				IsNullable:    "YES",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			database := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "t", Columns: []types.DBColumn{test.column}}},
+			}
+
+			diff := schemadiff.CompareWithDialect(
+				dbschematogo.ConvertDBSchemaToGoSchema(database), database, "postgres",
+			)
+
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+			c.Assert(diff.HasChanges(), qt.IsFalse)
+		})
+	}
+}
+
+// TestCompare_NonDomainColumnSelfDiffPlansNothing is the control. The rule that
+// keeps a domain column quiet is gated on the reader having reported a domain,
+// so the columns that carry none must stay quiet for their own reasons -- an
+// enum column answering with its type name, a composite column with its own, a
+// plain integer through the ordinary catalog-spelling fold.
+//
+// Without this, reading the domain unconditionally -- answering FormattedType
+// for every column that has one -- would look like a fix and would silently
+// change what a plain enum column compares as.
+func TestCompare_NonDomainColumnSelfDiffPlansNothing(t *testing.T) {
+	tests := []struct {
+		name   string
+		column types.DBColumn
+	}{
+		{
+			name: "plain enum column",
+			column: types.DBColumn{
+				Name:       "m",
+				DataType:   "USER-DEFINED",
+				UDTName:    "mood",
+				IsNullable: "NO",
+			},
+		},
+		{
+			name: "plain composite column",
+			column: types.DBColumn{
+				Name:       "p",
+				DataType:   "USER-DEFINED",
+				UDTName:    "pt",
+				IsNullable: "YES",
+			},
+		},
+		{
+			name: "plain integer column under its catalog spelling",
+			column: types.DBColumn{
+				Name:       "id",
+				DataType:   "integer",
+				UDTName:    "int4",
+				IsNullable: "NO",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			database := &types.DBSchema{
+				Tables: []types.DBTable{{Name: "t", Columns: []types.DBColumn{test.column}}},
+			}
+
+			diff := schemadiff.CompareWithDialect(
+				dbschematogo.ConvertDBSchemaToGoSchema(database), database, "postgres",
+			)
+
+			c.Assert(diff.TablesModified, qt.HasLen, 0)
+			c.Assert(diff.HasChanges(), qt.IsFalse)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -317,8 +317,23 @@ func columnsWithDesiredDomains(
 
 	// The default comparison below asks what CATEGORY each side's type is, so it
 	// keeps using the normalizer even where the type comparison above does not:
-	// a default is normalized as a boolean or a number, and a domain's base type
-	// is the right answer to that question.
+	// a default is normalized as a boolean or a number.
+	//
+	// For a domain column both sides receive the DOMAIN NAME, not the domain's
+	// base type, because rawDBColumnType answers with the domain and the desired
+	// side spells the column as the domain too. So `d_bool` reaches the
+	// normalizer, which folds by substring and lands on "boolean" by luck, while
+	// `positive` folds to nothing and the boolean/decimal/temporal branches of
+	// normalize.DefaultValue are skipped for that column.
+	//
+	// Passing the base type on the database side alone would be worse, not
+	// better: the desired side is a goschema.Field carrying only a type name and
+	// has no base type to reach for, so the two sides would land in different
+	// categories and a database would stop being in sync with itself -- the
+	// asymmetry stokaro/ptah#1242 is about. Both sides receiving the same
+	// category, right or wrong, is what keeps a self-diff quiet, and no live
+	// churn from the folding has been measured. Fixing it properly means giving
+	// the desired side a base type to answer with.
 	genType, dbType := normalizeColumnTypesForDialect(genCol.Type, dbRawType, dialect)
 
 	if change := columnTypeChange(genCol, dbCol, dbRawType, dialect, desiredDomains); change != "" {

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -314,6 +314,11 @@ func columnsWithDesiredDomains(
 	}
 
 	dbRawType := rawDBColumnType(dbCol)
+
+	// The default comparison below asks what CATEGORY each side's type is, so it
+	// keeps using the normalizer even where the type comparison above does not:
+	// a default is normalized as a boolean or a number, and a domain's base type
+	// is the right answer to that question.
 	genType, dbType := normalizeColumnTypesForDialect(genCol.Type, dbRawType, dialect)
 
 	if change := columnTypeChange(genCol, dbCol, dbRawType, dialect, desiredDomains); change != "" {

--- a/migration/schemadiff/internal/compare/domain_columns_test.go
+++ b/migration/schemadiff/internal/compare/domain_columns_test.go
@@ -1,0 +1,187 @@
+package compare_test
+
+// Domain columns, database side. See stokaro/ptah#1242.
+//
+// Every fixture below is one PostgreSQL 17.10 column as the reader reports it.
+// The values are measured, not invented: information_schema.columns.data_type
+// for a column of domain `positive` is the domain's BASE type "integer",
+// udt_name is "int4", and only format_type and domain_name name the domain.
+//
+// Both sides of a comparison are often the same database -- `schema diff`
+// converts one side to the desired-state model and leaves the other as read --
+// so the two must reach the same spelling for the same column or a database is
+// never in sync with itself.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+)
+
+// domainColumn is the reader's report of `qty positive` where
+// CREATE DOMAIN positive AS integer CHECK (VALUE > 0).
+func domainColumn() types.DBColumn {
+	return types.DBColumn{
+		Name:          "qty",
+		DataType:      "integer",
+		UDTName:       "int4",
+		FormattedType: "positive",
+		DomainName:    "positive",
+		IsNullable:    "YES",
+	}
+}
+
+// TestColumns_DomainColumnHappyPath is the no-churn property: a desired column
+// that names the domain the database column is declared as must produce no
+// change at all.
+//
+// Measured before this fix with ptah-compat against PostgreSQL 17.10:
+// `schema diff --from X --to X` on one database holding this column planned
+// `ALTER TABLE "t" ALTER COLUMN "qty" TYPE positive;` -- forever, on every run,
+// and `schema apply` executed it every time and reported success. The pinned
+// community binary v1.3.0 reported the same database "Schemas are synced, no
+// changes to be made."
+func TestColumns_DomainColumnHappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		genType string
+		dbCol   types.DBColumn
+	}{
+		{
+			name:    "desired names the domain the column is declared as",
+			genType: "positive",
+			dbCol:   domainColumn(),
+		},
+		{
+			name:    "a domain outside the search path keeps its qualifier on both sides",
+			genType: "doms.positive",
+			dbCol: func() types.DBColumn {
+				column := domainColumn()
+				column.FormattedType = "doms.positive"
+				return column
+			}(),
+		},
+		{
+			// The desired side comes from HCL, where an author may have written
+			// the domain in any case. Domain names are identifiers, and
+			// PostgreSQL folds an unquoted one to lower case.
+			name:    "case does not make two spellings of one domain differ",
+			genType: "POSITIVE",
+			dbCol:   domainColumn(),
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			genCol := goschema.Field{Name: "qty", Type: test.genType, Nullable: true}
+
+			result := compare.Columns(genCol, test.dbCol)
+
+			c.Assert(result.Changes, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestColumns_DomainColumnFailurePath is the other half: a domain column whose
+// declared type really did change must still report it.
+//
+// The `bigint` row is why the comparison asks whether two domains are the SAME
+// DOMAIN rather than running both spellings through the type-category
+// normalizer. That normalizer folds by substring -- anything containing "int"
+// becomes "integer" -- so a domain named `positive_int` compared equal to a
+// desired `bigint` column and the drift was invisible, while the same fixture
+// named `positive` reported it. The name of the domain decided whether the
+// comparator worked.
+func TestColumns_DomainColumnFailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		genType    string
+		dbCol      types.DBColumn
+		wantChange string
+	}{
+		{
+			name:       "desired asks for the base type where the database has the domain",
+			genType:    "integer",
+			dbCol:      domainColumn(),
+			wantChange: "positive -> integer",
+		},
+		{
+			name:       "desired names a different domain",
+			genType:    "nonnegative",
+			dbCol:      domainColumn(),
+			wantChange: "positive -> nonnegative",
+		},
+		{
+			name:    "a domain whose name contains a type keyword is still compared as a domain",
+			genType: "bigint",
+			dbCol: func() types.DBColumn {
+				column := domainColumn()
+				column.FormattedType = "positive_int"
+				column.DomainName = "positive_int"
+				return column
+			}(),
+			wantChange: "positive_int -> bigint",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			genCol := goschema.Field{Name: "qty", Type: test.genType, Nullable: true}
+
+			result := compare.Columns(genCol, test.dbCol)
+
+			c.Assert(result.Changes["type"], qt.Equals, test.wantChange)
+		})
+	}
+}
+
+// TestColumns_NonDomainColumnKeepsCategoryComparison is the control. The domain
+// rule is gated on the reader having reported a domain, and a column that is not
+// one must keep comparing through the type-category normalizer, which is what
+// makes "int4" and "integer" -- the same type under two catalog spellings --
+// compare equal.
+func TestColumns_NonDomainColumnKeepsCategoryComparison(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		genType    string
+		dbCol      types.DBColumn
+		wantChange string
+	}{
+		{
+			name:    "catalog spelling of a plain column still folds to its category",
+			genType: "integer",
+			dbCol: types.DBColumn{
+				Name: "qty", DataType: "integer", UDTName: "int4", IsNullable: "YES",
+			},
+			wantChange: "",
+		},
+		{
+			name:    "a plain column of the domain's base type is not the domain",
+			genType: "positive",
+			dbCol: types.DBColumn{
+				Name: "qty", DataType: "integer", UDTName: "int4", IsNullable: "YES",
+			},
+			wantChange: "integer -> positive",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			genCol := goschema.Field{Name: "qty", Type: test.genType, Nullable: true}
+
+			result := compare.Columns(genCol, test.dbCol)
+
+			c.Assert(result.Changes["type"], qt.Equals, test.wantChange)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/domain_columns_test.go
+++ b/migration/schemadiff/internal/compare/domain_columns_test.go
@@ -35,6 +35,26 @@ func domainColumn() types.DBColumn {
 	}
 }
 
+// domainOverEnumColumn is the reader's report of `qty d_enum` where
+// CREATE TYPE color AS ENUM (...) and CREATE DOMAIN d_enum AS color.
+//
+// A domain over a USER-DEFINED base type does not report its base type in
+// data_type the way `positive` above does. Measured on PostgreSQL 17.10, the
+// catalog answers data_type 'USER-DEFINED', udt_name 'color' -- the BASE type --
+// domain_name 'd_enum' and format_type 'd_enum'. Nothing in the tree built this
+// shape until stokaro/ptah#1242 landed, so the branch that answers from udt_name
+// before consulting the domain was invisible to every test.
+func domainOverEnumColumn() types.DBColumn {
+	return types.DBColumn{
+		Name:          "qty",
+		DataType:      "USER-DEFINED",
+		UDTName:       "color",
+		FormattedType: "d_enum",
+		DomainName:    "d_enum",
+		IsNullable:    "YES",
+	}
+}
+
 // TestColumns_DomainColumnHappyPath is the no-churn property: a desired column
 // that names the domain the database column is declared as must produce no
 // change at all.
@@ -74,6 +94,22 @@ func TestColumns_DomainColumnHappyPath(t *testing.T) {
 			name:    "case does not make two spellings of one domain differ",
 			genType: "POSITIVE",
 			dbCol:   domainColumn(),
+		},
+		{
+			name:    "a domain over an enum is the domain on this side too",
+			genType: "d_enum",
+			dbCol:   domainOverEnumColumn(),
+		},
+		{
+			name:    "a domain over a composite type",
+			genType: "d_comp",
+			dbCol: func() types.DBColumn {
+				column := domainOverEnumColumn()
+				column.UDTName = "addr"
+				column.FormattedType = "d_comp"
+				column.DomainName = "d_comp"
+				return column
+			}(),
 		},
 	}
 
@@ -130,6 +166,12 @@ func TestColumns_DomainColumnFailurePath(t *testing.T) {
 			}(),
 			wantChange: "positive_int -> bigint",
 		},
+		{
+			name:       "desired asks for the base enum where the database has the domain",
+			genType:    "color",
+			dbCol:      domainOverEnumColumn(),
+			wantChange: "d_enum -> color",
+		},
 	}
 
 	for _, test := range tests {
@@ -172,6 +214,17 @@ func TestColumns_NonDomainColumnKeepsCategoryComparison(t *testing.T) {
 				Name: "qty", DataType: "integer", UDTName: "int4", IsNullable: "YES",
 			},
 			wantChange: "integer -> positive",
+		},
+		{
+			// The inverse of the domain-over-enum rows: a USER-DEFINED column
+			// with no domain must keep answering with its own type name, so the
+			// gate stays on DomainName rather than on DataType.
+			name:    "a plain enum column with no domain compares as the enum",
+			genType: "color",
+			dbCol: types.DBColumn{
+				Name: "qty", DataType: "USER-DEFINED", UDTName: "color", IsNullable: "YES",
+			},
+			wantChange: "",
 		},
 	}
 

--- a/migration/schemadiff/internal/compare/usertypes.go
+++ b/migration/schemadiff/internal/compare/usertypes.go
@@ -30,7 +30,15 @@ func Domains(generated *goschema.Database, database *types.DBSchema, diff *difft
 	for name, target := range generatedDomains {
 		if current, exists := databaseDomains[name]; exists {
 			if changes := domainChanges(target, current); len(changes) > 0 {
-				diff.DomainsModified = append(diff.DomainsModified, difftypes.DomainDiff{DomainName: name, Changes: changes})
+				// CurrentBaseType is the from-side of the comparison carried as
+				// a type spelling: the recreate path's non-CASCADE DROP runs
+				// against this database, so it is these references that can
+				// block it, not the target's.
+				diff.DomainsModified = append(diff.DomainsModified, difftypes.DomainDiff{
+					DomainName:      name,
+					Changes:         changes,
+					CurrentBaseType: current.BaseType,
+				})
 			}
 		}
 	}
@@ -122,9 +130,12 @@ func CompositeTypes(generated *goschema.Database, database *types.DBSchema, diff
 			continue
 		}
 		if targetFields, currentFields := compositeFieldList(target), dbCompositeFieldList(current); targetFields != currentFields {
+			// CurrentFieldTypes is the from-side of the comparison carried as
+			// type spellings, for the reason given on the domain branch above.
 			diff.CompositeTypesModified = append(diff.CompositeTypesModified, difftypes.CompositeTypeDiff{
-				TypeName: name,
-				Changes:  map[string]string{"fields": fmt.Sprintf("%s -> %s", currentFields, targetFields)},
+				TypeName:          name,
+				Changes:           map[string]string{"fields": fmt.Sprintf("%s -> %s", currentFields, targetFields)},
+				CurrentFieldTypes: dbCompositeFieldTypes(current),
 			})
 		}
 	}
@@ -142,6 +153,19 @@ func compositeFieldList(composite goschema.CompositeType) string {
 		parts[i] = strings.ToLower(field.Name) + " " + canonicalizePostgresType(field.Type)
 	}
 	return strings.Join(parts, ", ")
+}
+
+// dbCompositeFieldTypes returns the field types the database holds for a
+// composite, in field order and in the catalog's own spelling. Unlike
+// dbCompositeFieldList these are not normalized: they are resolved against
+// other type names later, and canonicalization would rewrite a user-defined
+// name that happens to collide with a built-in alias.
+func dbCompositeFieldTypes(composite types.DBComposite) []string {
+	fieldTypes := make([]string, len(composite.Fields))
+	for i, field := range composite.Fields {
+		fieldTypes[i] = field.Type
+	}
+	return fieldTypes
 }
 
 func dbCompositeFieldList(composite types.DBComposite) string {

--- a/migration/schemadiff/internal/compare/usertypes_test.go
+++ b/migration/schemadiff/internal/compare/usertypes_test.go
@@ -115,6 +115,78 @@ func TestCompositeTypes_UnchangedNoChurn(t *testing.T) {
 	c.Assert(diff.CompositeTypesModified, qt.IsNil)
 }
 
+// TestUserTypes_ModifiedCarryTheirCurrentShape pins the from-side the planner
+// orders a non-CASCADE DROP by.
+//
+// The recreate path drops a modified domain or composite before creating it
+// again, and that DROP executes against this database rather than against the
+// target, so the references it can trip over are the ones recorded here. The
+// planner is forbidden from recovering them out of Changes, which is prose, so
+// if the comparator stops carrying them the ordering silently degrades to
+// declaration order and PostgreSQL refuses the plan.
+//
+// The pairs below are the shape where the two sides disagree: the target
+// composite names no user-defined type at all, while the current one still has
+// a field of the domain being recreated.
+func TestUserTypes_ModifiedCarryTheirCurrentShape(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Domains: []goschema.Domain{{Name: "qty", BaseType: "bigint"}},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "meas", Fields: []goschema.CompositeTypeField{{Name: "q", Type: "bigint"}, {Name: "label", Type: "TEXT"}}},
+		},
+	}
+	database := &types.DBSchema{
+		Domains: []types.DBDomain{{Name: "qty", BaseType: "integer"}},
+		Composites: []types.DBComposite{
+			{Name: "meas", Fields: []types.DBCompositeField{{Name: "q", Type: "qty"}, {Name: "label", Type: "text"}}},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Domains(generated, database, diff)
+	compare.CompositeTypes(generated, database, diff)
+
+	c.Assert(diff.DomainsModified, qt.HasLen, 1)
+	c.Assert(diff.DomainsModified[0].CurrentBaseType, qt.Equals, "integer")
+	c.Assert(diff.CompositeTypesModified, qt.HasLen, 1)
+	c.Assert(diff.CompositeTypesModified[0].CurrentFieldTypes, qt.DeepEquals, []string{"qty", "text"})
+}
+
+// TestUserTypes_CurrentShapeKeepsTheCatalogSpelling asserts the carried types
+// are not run through the churn canonicalization the Changes payload uses.
+//
+// That mapping rewrites alias spellings such as int4 into integer, which is
+// right for deciding whether a domain changed and wrong for a name that is
+// resolved against other type names: a user-defined type called `decimal` would
+// come back as `numeric` and its edge would vanish.
+func TestUserTypes_CurrentShapeKeepsTheCatalogSpelling(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Domains: []goschema.Domain{{Name: "d", BaseType: "text"}},
+		CompositeTypes: []goschema.CompositeType{
+			{Name: "holder", Fields: []goschema.CompositeTypeField{{Name: "v", Type: "TEXT"}}},
+		},
+	}
+	database := &types.DBSchema{
+		Domains: []types.DBDomain{{Name: "d", BaseType: "decimal"}},
+		Composites: []types.DBComposite{
+			{Name: "holder", Fields: []types.DBCompositeField{{Name: "v", Type: "decimal"}}},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.Domains(generated, database, diff)
+	compare.CompositeTypes(generated, database, diff)
+
+	c.Assert(diff.DomainsModified, qt.HasLen, 1)
+	c.Assert(diff.DomainsModified[0].CurrentBaseType, qt.Equals, "decimal")
+	c.Assert(diff.CompositeTypesModified, qt.HasLen, 1)
+	c.Assert(diff.CompositeTypesModified[0].CurrentFieldTypes, qt.DeepEquals, []string{"decimal"})
+}
+
 func TestRanges_AddRemoveByNameOnly(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -729,15 +729,47 @@ type FunctionDiff struct {
 }
 
 // DomainDiff represents changes to a PostgreSQL domain type.
+//
+// Changes is the human-readable "old -> new" payload. CurrentBaseType is the
+// from-side of the same comparison kept as a type spelling rather than prose,
+// because a plan that drops this domain has to be ordered by the shape the
+// database holds now. See the comment on CurrentBaseType.
 type DomainDiff struct {
 	DomainName string            `json:"domain_name"`
 	Changes    map[string]string `json:"changes"`
+
+	// CurrentBaseType is the base type the domain has in the database being
+	// compared against, in that catalog's own spelling -- the from-side of the
+	// "type" entry in Changes, structurally rather than as prose.
+	//
+	// A modification is reconciled as a non-CASCADE DROP followed by a CREATE.
+	// The CREATE belongs to the desired definitions, but the DROP executes
+	// against the database as it stands, so only the references it holds now
+	// can block it, and those are the ones recorded here. The two sides
+	// disagree exactly when the modification is what moved a reference.
+	//
+	// Empty when the caller built the diff by hand or the domain's from-side is
+	// unknown; the drop ordering then falls back to declaration order.
+	CurrentBaseType string `json:"current_base_type,omitempty"`
 }
 
 // CompositeTypeDiff represents changes to a PostgreSQL composite type.
+//
+// Changes is the human-readable "old -> new" payload. CurrentFieldTypes is the
+// from-side of the same comparison kept as type spellings, for the reason given
+// on DomainDiff.CurrentBaseType.
 type CompositeTypeDiff struct {
 	TypeName string            `json:"type_name"`
 	Changes  map[string]string `json:"changes"`
+
+	// CurrentFieldTypes are the field types the composite has in the database
+	// being compared against, in that catalog's own spellings and in field
+	// order. They order the non-CASCADE DROP the recreate path emits, which
+	// runs against the current shape rather than the desired one.
+	//
+	// Empty when the caller built the diff by hand or the type's from-side is
+	// unknown; the drop ordering then falls back to declaration order.
+	CurrentFieldTypes []string `json:"current_field_types,omitempty"`
 }
 
 // SequenceDiff represents changes to a standalone sequence definition.


### PR DESCRIPTION
## What this changes

`internal/planner/dialects/postgres` and `internal/convert/fromschema` emit
PostgreSQL's three kinds of user-defined type -- domains, composite types and
range types -- ordered by what each definition names, instead of kind by kind.
The non-`CASCADE` drops a modification produces run in the reverse of that
order. Enums are unaffected and stay ahead of the group.

## Why

The branch's own `docs/conformance.md` section claims a round trip for a
database holding a domain over an enum, a domain over a composite and a domain
over a range: Ptah describes it, psql replays the description at exit 0, and the
pinned Atlas CE v1.3.0 binary then reports the replay in sync with the source.
The claim was true for the enum shape and false for the other two, because the
emitter put every domain ahead of every composite and range and PostgreSQL has
no forward declaration for a type.

Measured on PostgreSQL 17.10, one database holding `CREATE TYPE addr AS (...)`,
`CREATE TYPE myrange AS RANGE (...)`, `CREATE DOMAIN d_comp AS addr` and
`CREATE DOMAIN d_range AS myrange`:

| Probe | before | now |
| --- | --- | --- |
| `schema diff --from <empty> --to X`, statement 2 | `CREATE DOMAIN "d_comp" AS addr;`, four statements ahead of `CREATE TYPE "addr"` | `CREATE TYPE "addr" AS (...)` precedes it |
| that script under `psql -v ON_ERROR_STOP=1` | `ERROR: type "addr" does not exist`, exit 3 | exit 0 |
| CE compares the replay to the source | not reached | Schemas are synced |

## Why not simply swap the kinds

Emitting composites and ranges first is the same defect pointed the other way. A
composite field and a range subtype can each be a domain, and both are legal
PostgreSQL (verified on the server). Built as a mutant and measured: the swap
emitted `CREATE TYPE "posrange" AS RANGE (SUBTYPE = d_int);` first and psql
stopped at `ERROR: type "d_int" does not exist`, exit 3. No fixed order of kinds
serves both directions, so the ordering runs through the stable topological sort
already in `internal/deporder`. A reference the plan does not create adds no
edge, and a cycle -- which PostgreSQL refuses to create anyway -- degrades to
declaration order rather than dropping a type from the plan.

Two emitters carried the defect and both are fixed: the migration planner (which
also folds in the recreations a modification produces, because a new domain over
a recreated composite has to wait for the recreation) and
`fromschema.FromDatabase`, the whole-schema render behind `ptah generate`.

## Tests

- `internal/deporder` covers each pair of kinds in both directions plus the
  spellings a reference arrives in: `addr[]`, `short_text(20)`, `"app"."Addr"`,
  a bare name two schemas both offer (deliberately unresolved), a cycle, and a
  self-reference.
- The planner and `fromschema` each assert the emitted order on one schema
  holding a domain over a composite, a domain over a range, a composite over a
  domain and a range over a domain, so a fix in either direction alone reddens
  the file.
- `integration/gonative` EXECUTES the emitted script against an empty database
  and asserts it runs, then asserts the replayed columns still carry their
  domains. A text assertion on the order would only restate the emitter. The
  self-apply guard next door cannot see this: a plan with no statements executes
  nothing, so any order is vacuously fine there.

Mutants, each applied to the working tree, built, measured and restored:
reverting the planner to kind order reddens all three planner rows and the live
guard with `type "addr" does not exist` in the output; the static swap reddens
the composite-over-domain and range-over-domain rows only; reverting the drop
order reddens the recreate row alone; reverting the whole-schema emitter reddens
the `fromschema` rows and nothing else.

## Incidental, and recorded in `docs/conformance.md`

`lo` (contrib `lo`) and `earth` (contrib `earthdistance`) are both domains, over
`oid` and over `cube`. Answering a column's type from `udt_name` keeps the first
and flattens the second to `sql("cube")`, decided by nothing but whether the base
type happens to be built-in. With the `domain_name` gate this branch adds, both
print what the pinned CE v1.3.0 binary prints -- `sql("lo")` and `sql("earth")`
-- with a plain `cube` column beside them still `sql("cube")`. Removing the gate
again reproduces the split, which is the control the table records.

## Not verified

PostgreSQL 18 (17.x only); MySQL, MariaDB, SQLite, ClickHouse, MSSQL, Spanner
and CockroachDB, none of which model these three kinds; a composite whose field
type is a range, or a range whose subtype is a composite; a base type in another
schema, live.

---

## The review's regression is fixed, and the fix is pinned by the failure it caused

An adversarial review refuted an earlier head. It was right, and the finding was precise: `dropModifiedUserTypes` built its `deporder.UserType` references from `generated` — the **desired** schema — and reversed that order. The CREATE order rightly follows the desired definitions; the DROP order cannot, because those statements execute against the database **as it stands**, so only the current definitions can block them. The two disagree exactly when the modification is what moved the reference.

Its fixture, reproduced verbatim:

```sql
-- current:  CREATE TYPE cc AS (f integer);   CREATE DOMAIN dd AS cc;
-- desired:  CREATE DOMAIN dd AS integer;     CREATE TYPE cc AS (f dd);
```

| binary | emitted drop order | apply exit |
| --- | --- | --- |
| before | `DROP DOMAIN "dd"` then `DROP TYPE "cc"` | 0 |
| the refuted head | `DROP TYPE "cc"` then `DROP DOMAIN "dd"` | **1**, `cannot drop type cc because other objects depend on it … type dd depends on type cc (SQLSTATE 2BP01)` |

The review also noted why the branch's own mutant could not see it: the ordering test fed a single `generated` in which the desired references were also the current ones, so no fixture separated the two sides.

Both are closed. The drop order is now derived from the current shape through `deporder.UserTypesForDrop`, and the create order keeps its own graph — two graphs, pinned separately. The proof is the review's own failure, turned into a mutant:

| mutation | result |
| --- | --- |
| `UserTypesForDrop(deps)` → `UserTypesForCreate(deps)` | **RED** on 4 planner rows; **RED** on all 5 live integration rows with `cannot drop type cc/qty/d_base/c_base because other objects depend on it (SQLSTATE 2BP01)`, 5 occurrences |
| restored | GREEN, unit and live |
| topological sort replaced by caller order | **RED** on exactly the 3 create rows, every drop row green |
| `postgresSerialType` domain refusal disabled | **RED** on the domain-column-with-a-sequence row only |

The four prose sentences the review called false are gone — `grep -n "reverse of that order|reverse of the creation|never blocked"` across `docs/site/src/content/docs/databases/postgresql.md`, `docs/conformance.md` and `docs/user_defined_types.md` returns nothing.

## Rebase notes, because one hazard here is silent

This branch was rebased through three successive masters. Two things are worth recording.

`546c7247` (#1302) landed a **more complete implementation of the same domain-column work** this branch carried: `DBColumn.DomainName` *plus* `DomainSchema`, and a full `(schema, name)` identity comparator rather than this branch's name-only one. A naive rebase auto-merged a **duplicate `DomainName` field** into `DBColumn` — reported as no conflict at all, and it does not compile. Everywhere the two overlapped, master's implementation was kept and this branch's was dropped: the field, `rawDBColumnType`'s FormattedType preference, `columnTypeChange` / `domainColumnTypeChange`, `goSchemaFieldType`'s domain-over-base branch, and the reader's fake-server helpers. The now-unused `serveDomainName` / `projectionBody` helpers were deleted so `unused` would not fire.

Everything PR-unique is intact: the whole ordering story (`internal/deporder`, planner create and drop ordering, `fromschema`, `DomainDiff.CurrentBaseType`, `CompositeTypeDiff.CurrentFieldTypes`, generator reverse-diff re-derivation), the rule that a domain column's owned sequence is not implicit, `postgresSerialType`'s domain refusal, the Atlas-compatible JSON inspect surface, and the live integration guards.

Both conflicts had the shared-closing-brace shape that has cut a function mid-body in this repo before (`sqliteKeyColumnImpliesNotNull` and `domainColumnTypeChange` shared one `}`). Each resolved file was diffed against **both** parents and came out as exactly master plus exactly this branch's delta, with no third content; `gofmt -l` is clean; a tree-wide grep for conflict markers is empty; and the first rebase's `--stat` was byte-identical to the pre-rebase `--stat`.

## Gates — literal exit codes

`go build ./...` 0 · `go vet ./...` 0 · `go vet -tags integration ./integration/...` 0 · `go tool qtlint ./...` 0 · `golangci-lint run ./...` 0 (v2.12.2, CI's pin) · `scripts/check-test-style.sh` 0 · `scripts/check-public-api.sh` 0 · `scripts/check-public-api-snapshot.sh` 0 · `scripts/check-public-api-released.sh` 0 · every `docs/site` `check:*` and `*:selftest` 0 · `npm run build` 0 · `build-feature-matrix.mjs --check` 0 · the live `integration/gonative` domain and user-type-order guards 0.

`docs/public_api.snapshot` was broken deliberately and watched go to **1**, then restored and watched go to **0** — it is not a gate that reports without running.

## Still open

- `docs/conformance.md` now carries two adjacent sections on domain comparison, this one and #1138's. They do not contradict; consolidating them is a follow-up.
- A full `go test ./...` on the final tree did not finish locally: the machine was at load ~30 with roughly 75 foreign test binaries from parallel work. An earlier full run on the first rebase was 0 across the board. CI's `unit-tests` job is the authoritative answer for this head.
