### PR TITLE
Let SQLite decide whether a key column is NOT NULL (#1235)

### DIFF
--- a/cmd/atlas/schema_sqlite_key_shape_test.go
+++ b/cmd/atlas/schema_sqlite_key_shape_test.go
@@ -1,0 +1,350 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// This file pins the SQLite key-and-uniqueness output shape of the
+// Atlas-compatible surface, measured against the pinned Atlas community v1.3.0
+// binary for stokaro/ptah#1235 (findings 5.1, 5.2 and 6.3).
+//
+// The three findings share one cause: Ptah folded constraints into the column
+// definition using rules SQLite does not have. A primary key was rendered as
+// `id integer PRIMARY KEY`, swallowing the author's NOT NULL, and every
+// single-column unique index — including one an author created by name — was
+// folded into the column as an inline UNIQUE while the index itself was still
+// emitted.
+//
+// What that cost, measured on 2026-08-08 with each binary in its own directory:
+//
+//   - `schema apply --to file://users.hcl --auto-approve` over an HCL table
+//     whose key column says `null = false` produced a database the pinned
+//     binary answered was NOT in sync with that same file: asked
+//     `schema diff --from sqlite://main.db --to file://users.hcl`, it planned a
+//     full table rebuild (PRAGMA foreign_keys off / CREATE new_users / INSERT /
+//     DROP / RENAME / PRAGMA on). Against its own applied database it answered
+//     `Schemas are synced, no changes to be made.` A `schema apply` hand-off
+//     between the two binaries never reached a fixed point.
+//   - `schema inspect --format '{{ sql . }}'` over
+//     `CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE,
+//     c TEXT); CREATE UNIQUE INDEX ux_t_c ON t(c);` replayed into a fresh
+//     database with four indexes where the source had three. The extra one,
+//     `sqlite_autoindex_t_3`, was a phantom unique index on `c` that the source
+//     never had, backing a constraint the author never wrote.
+//   - `schema inspect --format '{{ json . }}'` reported the key column of
+//     `id INTEGER PRIMARY KEY` as NOT NULL. The pinned binary reports
+//     `"null": true`, and it was the only column in the fixture whose flag the
+//     two disagreed about. SQLite is on the pinned binary's side: on a rowid
+//     table `pragma table_info.notnull` is 0 for that column and an explicit
+//     NULL insert is accepted, with a rowid assigned for it.
+//
+// After the fix, the same `schema apply` fixture makes the pinned binary answer
+// `Schemas are synced, no changes to be made.` at exit 0, and the same inspect
+// fixture replays to exactly the source's three indexes.
+
+// inspectSQLiteFormat runs `atlas schema inspect` over dbPath with an explicit
+// --format template and returns what reached stdout.
+func inspectSQLiteFormat(c *qt.C, dbPath, format string) string {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "inspect",
+		"--url", sqliteURLFromPath(dbPath),
+		"--format", format,
+	})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	return out.String()
+}
+
+// sqliteIndexNames returns every index name the database reports, in name
+// order, so a replayed dump can be compared with the source it came from.
+func sqliteIndexNames(c *qt.C, dbPath string) []string {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), sqliteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	rows, err := conn.QueryContext(
+		context.Background(),
+		"SELECT name FROM sqlite_master WHERE type = 'index' ORDER BY name",
+	)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(rows.Close(), qt.IsNil) }()
+
+	names := []string{}
+	for rows.Next() {
+		var name string
+		c.Assert(rows.Scan(&name), qt.IsNil)
+		names = append(names, name)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return names
+}
+
+// sqliteTableDDL returns the CREATE TABLE text SQLite persisted for table.
+func sqliteTableDDL(c *qt.C, dbPath, table string) string {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), sqliteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var ddl string
+	err = conn.QueryRowContext(
+		context.Background(),
+		"SELECT sql FROM sqlite_master WHERE type = 'table' AND name = ?",
+		table,
+	).Scan(&ddl)
+	c.Assert(err, qt.IsNil)
+	return ddl
+}
+
+// applySQLiteHCL runs `atlas schema apply --auto-approve` from an HCL file and
+// returns the combined output. The dev URL names a path inside the test's own
+// directory: `sqlite://dev?mode=memory` materializes a file called `dev` in the
+// working directory, which for a package test is the package source tree.
+func applySQLiteHCL(c *qt.C, dbPath, hclPath string) string {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", sqliteURLFromPath(dbPath),
+		"--to", "file://" + hclPath,
+		"--dev-url", sqliteURLFromPath(filepath.Join(filepath.Dir(dbPath), "dev.db")),
+		"--auto-approve",
+	})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	return out.String()
+}
+
+const sqliteKeyNotNullHCL = `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    null = false
+    type = integer
+  }
+  column "name" {
+    null = false
+    type = text
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`
+
+const sqliteKeyNullableHCL = `schema "main" {
+}
+
+table "users" {
+  schema = schema.main
+  column "id" {
+    null = true
+    type = integer
+  }
+  column "name" {
+    null = false
+    type = text
+  }
+  primary_key {
+    columns = [column.id]
+  }
+}
+`
+
+// TestSchemaApplySQLiteKeyColumnKeepsDeclaredNullability pins finding 5.1 in
+// both directions: a declared NOT NULL survives onto the key column, and a
+// declared nullable key column does not acquire one.
+//
+// The second row is the over-correction guard. Emitting NOT NULL beside every
+// PRIMARY KEY would make the first row pass while writing a stricter table than
+// the source asked for, which is the same class of defect in the other
+// direction — a restored database that rejects rows the original accepted.
+func TestSchemaApplySQLiteKeyColumnKeepsDeclaredNullability(t *testing.T) {
+	tests := []struct {
+		name        string
+		hcl         string
+		wantNotNull bool
+	}{
+		{
+			name:        "declared not null survives onto the key column",
+			hcl:         sqliteKeyNotNullHCL,
+			wantNotNull: true,
+		},
+		{
+			name:        "declared nullable key column stays nullable",
+			hcl:         sqliteKeyNullableHCL,
+			wantNotNull: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			hclPath := filepath.Join(dir, "users.hcl")
+			c.Assert(os.WriteFile(hclPath, []byte(test.hcl), 0o600), qt.IsNil)
+			dbPath := filepath.Join(dir, "main.db")
+
+			applySQLiteHCL(c, dbPath, hclPath)
+
+			ddl := sqliteTableDDL(c, dbPath, "users")
+			c.Assert(keyColumnIsNotNull(c, dbPath, "users", "id"), qt.Equals, test.wantNotNull,
+				qt.Commentf("persisted DDL: %s", ddl))
+		})
+	}
+}
+
+// keyColumnIsNotNull reports what SQLite itself says about the column, read
+// from pragma table_info rather than from the DDL text, so the assertion is
+// about the database that was built and not about how it was spelled.
+func keyColumnIsNotNull(c *qt.C, dbPath, table, column string) bool {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), sqliteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var notNull int
+	err = conn.QueryRowContext(
+		context.Background(),
+		`SELECT "notnull" FROM pragma_table_info(?) WHERE name = ?`,
+		table, column,
+	).Scan(&notNull)
+	c.Assert(err, qt.IsNil)
+	return notNull != 0
+}
+
+// TestSchemaInspectSQLiteSQLReplaysTheSourceIndexSet pins finding 5.2: the SQL
+// rendering of an inspected database must replay to the index set it was read
+// from, neither adding a constraint nor dropping one.
+//
+// Row one is the reported case, where uniqueness on `c` comes only from a named
+// standalone index. Row two is the companion that keeps the fold from simply
+// being deleted: a column that declares UNIQUE inline still round-trips through
+// its own implicit index.
+func TestSchemaInspectSQLiteSQLReplaysTheSourceIndexSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		schemaSQL string
+		wantNames []string
+	}{
+		{
+			name: "named unique index is not folded into the column",
+			schemaSQL: "CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE, c TEXT);" +
+				"CREATE UNIQUE INDEX ux_t_c ON t(c);",
+			wantNames: []string{"sqlite_autoindex_t_1", "sqlite_autoindex_t_2", "ux_t_c"},
+		},
+		{
+			name:      "declared column UNIQUE still round-trips",
+			schemaSQL: "CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE);",
+			wantNames: []string{"sqlite_autoindex_t_1"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			sourcePath := filepath.Join(dir, "source.db")
+			seedSQLiteSchema(c, sourcePath, test.schemaSQL)
+			c.Assert(sqliteIndexNames(c, sourcePath), qt.DeepEquals, test.wantNames,
+				qt.Commentf("fixture does not have the index set it claims"))
+
+			rendered := inspectSQLiteFormat(c, sourcePath, "{{ sql . }}")
+
+			replayPath := filepath.Join(dir, "replay.db")
+			seedSQLiteSchema(c, replayPath, rendered)
+			c.Assert(sqliteIndexNames(c, replayPath), qt.DeepEquals, test.wantNames,
+				qt.Commentf("rendered SQL: %s", rendered))
+		})
+	}
+}
+
+// TestSchemaInspectSQLiteJSONNullabilityMatchesTheCatalog pins finding 6.3:
+// `{{ json . }}` reports nullability as SQLite reports it, with the key column
+// of a rowid table nullable unless the DDL said otherwise.
+//
+// The pinned Atlas community v1.3.0 binary answers `"null": true` for the first
+// row's `id` and omits the key for the second row's, which is what the two rows
+// assert. `null` is omitted rather than written false when the column is NOT
+// NULL, so the assertion reads the key's presence.
+func TestSchemaInspectSQLiteJSONNullabilityMatchesTheCatalog(t *testing.T) {
+	tests := []struct {
+		name         string
+		schemaSQL    string
+		wantNullable map[string]bool
+	}{
+		{
+			name:      "rowid alias key column is nullable",
+			schemaSQL: "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL, note TEXT);",
+			wantNullable: map[string]bool{
+				"id": true, "name": false, "note": true,
+			},
+		},
+		{
+			name:      "declared NOT NULL key column is not",
+			schemaSQL: "CREATE TABLE t (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, note TEXT);",
+			wantNullable: map[string]bool{
+				"id": false, "name": false, "note": true,
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dbPath := filepath.Join(c.TempDir(), "nullability.db")
+			seedSQLiteSchema(c, dbPath, test.schemaSQL)
+
+			rendered := inspectSQLiteFormat(c, dbPath, "{{ json . }}")
+
+			c.Assert(inspectJSONNullability(c, rendered, "t"), qt.DeepEquals, test.wantNullable,
+				qt.Commentf("rendered JSON: %s", rendered))
+		})
+	}
+}
+
+// inspectJSONNullability decodes the `{{ json . }}` document and returns each
+// column's nullability for one table, reading an absent `null` key as NOT NULL
+// the way the pinned binary writes it.
+func inspectJSONNullability(c *qt.C, document, table string) map[string]bool {
+	c.Helper()
+	var report struct {
+		Schemas []struct {
+			Tables []struct {
+				Name    string `json:"name"`
+				Columns []struct {
+					Name string `json:"name"`
+					Null bool   `json:"null"`
+				} `json:"columns"`
+			} `json:"tables"`
+		} `json:"schemas"`
+	}
+	c.Assert(json.Unmarshal([]byte(document), &report), qt.IsNil)
+	c.Assert(report.Schemas, qt.HasLen, 1)
+
+	nullability := map[string]bool{}
+	for _, reported := range report.Schemas[0].Tables {
+		for _, column := range reported.Columns {
+			nullability[column.Name] = column.Null
+		}
+	}
+	return nullability
+}

--- a/cmd/atlas/schema_sqlite_key_shape_test.go
+++ b/cmd/atlas/schema_sqlite_key_shape_test.go
@@ -283,9 +283,16 @@ func TestSchemaInspectSQLiteSQLReplaysTheSourceIndexSet(t *testing.T) {
 // of a rowid table nullable unless the DDL said otherwise.
 //
 // The pinned Atlas community v1.3.0 binary answers `"null": true` for the first
-// row's `id` and omits the key for the second row's, which is what the two rows
+// row's `id` and omits the key for the second row's, which is what those rows
 // assert. `null` is omitted rather than written false when the column is NOT
 // NULL, so the assertion reads the key's presence.
+//
+// The STRICT and WITHOUT ROWID rows are the other half of the same question. The
+// reader answers from `pragma table_info.notnull` alone, so it already reports
+// them correctly; the rows are here so that a future normalization of key
+// nullability on this path has to disagree with the catalog out loud. Their
+// values are the catalog's: measured, a STRICT or WITHOUT ROWID key column
+// reports notnull=1, and the rowid alias of a STRICT table still reports 0.
 func TestSchemaInspectSQLiteJSONNullabilityMatchesTheCatalog(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -304,6 +311,43 @@ func TestSchemaInspectSQLiteJSONNullabilityMatchesTheCatalog(t *testing.T) {
 			schemaSQL: "CREATE TABLE t (id INTEGER NOT NULL PRIMARY KEY, name TEXT NOT NULL, note TEXT);",
 			wantNullable: map[string]bool{
 				"id": false, "name": false, "note": true,
+			},
+		},
+		{
+			name:      "without rowid key column is not nullable",
+			schemaSQL: "CREATE TABLE t (id TEXT PRIMARY KEY, name TEXT NOT NULL, note TEXT) WITHOUT ROWID;",
+			wantNullable: map[string]bool{
+				"id": false, "name": false, "note": true,
+			},
+		},
+		{
+			name: "without rowid table level composite key is not nullable",
+			schemaSQL: "CREATE TABLE t (team TEXT, member TEXT, note TEXT," +
+				" PRIMARY KEY (team, member)) WITHOUT ROWID;",
+			wantNullable: map[string]bool{
+				"team": false, "member": false, "note": true,
+			},
+		},
+		{
+			name:      "strict key column is not nullable",
+			schemaSQL: "CREATE TABLE t (id TEXT PRIMARY KEY, name TEXT NOT NULL, note TEXT) STRICT;",
+			wantNullable: map[string]bool{
+				"id": false, "name": false, "note": true,
+			},
+		},
+		{
+			name: "strict table level composite key is not nullable",
+			schemaSQL: "CREATE TABLE t (team TEXT, member TEXT, note TEXT," +
+				" PRIMARY KEY (team, member)) STRICT;",
+			wantNullable: map[string]bool{
+				"team": false, "member": false, "note": true,
+			},
+		},
+		{
+			name:      "strict rowid alias key column is still nullable",
+			schemaSQL: "CREATE TABLE t (id INTEGER PRIMARY KEY, name TEXT NOT NULL, note TEXT) STRICT;",
+			wantNullable: map[string]bool{
+				"id": true, "name": false, "note": true,
 			},
 		},
 	}

--- a/cmd/atlas/schema_sqlite_table_shape_test.go
+++ b/cmd/atlas/schema_sqlite_table_shape_test.go
@@ -181,6 +181,19 @@ func TestSchemaApplySQLiteTableShapeConvergesOnKeyNullability(t *testing.T) {
 			source: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL) STRICT;",
 			want:   map[string]bool{"id": false},
 		},
+		{
+			// SQLite's own rule is that DESC defeats the rowid alias, so a
+			// database built from this source *with* the DESC would report
+			// notnull=1. Ptah's SQLite renderer drops DESC from a PRIMARY KEY,
+			// so the table it builds does not have it, and the row asserts what
+			// was actually built. Modelling SQLite's DESC rule instead made this
+			// shape plan a rebuild on every run: the table has the alias, the
+			// model said it did not.
+			name:   "strict table level key ordered DESC follows the table that was built",
+			table:  "users",
+			source: "CREATE TABLE users (id INTEGER, name TEXT NOT NULL, PRIMARY KEY (id DESC)) STRICT;",
+			want:   map[string]bool{"id": false},
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/cmd/atlas/schema_sqlite_table_shape_test.go
+++ b/cmd/atlas/schema_sqlite_table_shape_test.go
@@ -1,0 +1,228 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// This file pins the other half of the SQLite key-nullability rule
+// (stokaro/ptah#1235): SQLite decides it from the table's shape, not from the
+// dialect, and a STRICT or WITHOUT ROWID table does enforce NOT NULL on its key
+// columns.
+//
+// Reading the rule off `pragma table_info` on SQLite 3.51.0, and confirmed
+// against the pinned Atlas community v1.3.0 binary, which reports the same
+// nullability for each shape when it reads the same DDL through a dev database:
+//
+//	shape                                            notnull
+//	id TEXT PRIMARY KEY                              0
+//	id INTEGER PRIMARY KEY                           0
+//	PRIMARY KEY (team, member)                       0, 0
+//	id TEXT PRIMARY KEY            WITHOUT ROWID     1
+//	id INTEGER PRIMARY KEY         WITHOUT ROWID     1
+//	PRIMARY KEY (team, member)     WITHOUT ROWID     1, 1
+//	id TEXT PRIMARY KEY            STRICT            1
+//	id INT PRIMARY KEY             STRICT            1
+//	PRIMARY KEY (team, member)     STRICT            1, 1
+//	id INTEGER PRIMARY KEY         STRICT            0
+//
+// The last row is not an exception: a STRICT table still has a rowid, and
+// `id INTEGER PRIMARY KEY` is still its alias, so `INSERT INTO t (id) VALUES
+// (NULL)` is accepted there and assigns a rowid.
+//
+// What treating every SQLite table as nullable-key cost, measured on 2026-08-08
+// with `ptah-compat` built from this branch's previous head 90a39945: a second
+// `schema apply` of the identical fixture planned a full table rebuild
+// (CREATE __ptah_rebuild_users / INSERT / DROP / RENAME) for the WITHOUT ROWID
+// and STRICT rows and never reached a fixed point, and a second `migrate diff`
+// against the identical desired file wrote a second migration containing that
+// rebuild. Both are permanent: the catalog answers NOT NULL, the desired model
+// answers nullable, and nothing either one does can make them agree.
+
+// applySQLiteSourceFile runs `schema apply --auto-approve` from a desired-state
+// file and returns the combined output.
+//
+// devName names a dev database per call so a second apply is answered from a
+// scratch database of its own rather than out of the first one's leftovers.
+func applySQLiteSourceFile(c *qt.C, dbPath, sourcePath, devName string) string {
+	c.Helper()
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", sqliteURLFromPath(dbPath),
+		"--to", "file://" + sourcePath,
+		"--dev-url", sqliteURLFromPath(filepath.Join(filepath.Dir(dbPath), devName)),
+		"--auto-approve",
+	})
+	err := cmd.Execute()
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", out.String()))
+	return out.String()
+}
+
+// keyColumnNullability returns what SQLite says about every primary key column
+// of table, read from `pragma table_info` rather than from the DDL text, so the
+// assertion is about the database that was built and not about how it was
+// spelled. The map covers the key exactly, so a composite key that lost a
+// column is a failure too.
+func keyColumnNullability(c *qt.C, dbPath, table string) map[string]bool {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), sqliteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	rows, err := conn.QueryContext(
+		context.Background(),
+		`SELECT name, "notnull" FROM pragma_table_info(?) WHERE pk > 0 ORDER BY pk`,
+		table,
+	)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(rows.Close(), qt.IsNil) }()
+
+	nullability := map[string]bool{}
+	for rows.Next() {
+		var name string
+		var notNull int
+		c.Assert(rows.Scan(&name, &notNull), qt.IsNil)
+		nullability[name] = notNull != 0
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return nullability
+}
+
+// TestSchemaApplySQLiteTableShapeConvergesOnKeyNullability applies each table
+// shape and then applies the identical desired state again, which must be a
+// no-op.
+//
+// The DDL is executed rather than only rendered, and the key's nullability is
+// read back out of the catalog, because the whole defect is a disagreement
+// between what Ptah's model says about a key column and what SQLite did with it.
+//
+// The rows are in both directions on purpose. Take the shape out of the rule and
+// the WITHOUT ROWID and STRICT rows report a rebuild; apply the rule to every
+// STRICT table and `strict rowid alias` reports one instead, which is
+// stokaro/ptah#1235's own defect wearing a STRICT table.
+func TestSchemaApplySQLiteTableShapeConvergesOnKeyNullability(t *testing.T) {
+	tests := []struct {
+		name   string
+		table  string
+		source string
+		want   map[string]bool
+	}{
+		{
+			name:   "rowid table key column stays nullable",
+			table:  "users",
+			source: "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL);",
+			want:   map[string]bool{"id": false},
+		},
+		{
+			name:   "rowid alias key column stays nullable",
+			table:  "users",
+			source: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL);",
+			want:   map[string]bool{"id": false},
+		},
+		{
+			name:   "rowid table level composite key stays nullable",
+			table:  "memberships",
+			source: "CREATE TABLE memberships (team TEXT, member TEXT, PRIMARY KEY (team, member));",
+			want:   map[string]bool{"team": false, "member": false},
+		},
+		{
+			name:   "without rowid key column is not null",
+			table:  "users",
+			source: "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL) WITHOUT ROWID;",
+			want:   map[string]bool{"id": true},
+		},
+		{
+			name:   "without rowid integer key column is not null",
+			table:  "users",
+			source: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL) WITHOUT ROWID;",
+			want:   map[string]bool{"id": true},
+		},
+		{
+			name:  "without rowid table level composite key is not null",
+			table: "memberships",
+			source: "CREATE TABLE memberships (team TEXT, member TEXT, PRIMARY KEY (team, member))" +
+				" WITHOUT ROWID;",
+			want: map[string]bool{"team": true, "member": true},
+		},
+		{
+			name:   "strict key column is not null",
+			table:  "users",
+			source: "CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL) STRICT;",
+			want:   map[string]bool{"id": true},
+		},
+		{
+			name:   "strict int key column is not null because INT is no rowid alias",
+			table:  "users",
+			source: "CREATE TABLE users (id INT PRIMARY KEY, name TEXT NOT NULL) STRICT;",
+			want:   map[string]bool{"id": true},
+		},
+		{
+			name:  "strict table level composite key is not null",
+			table: "memberships",
+			source: "CREATE TABLE memberships (team TEXT, member TEXT, PRIMARY KEY (team, member))" +
+				" STRICT;",
+			want: map[string]bool{"team": true, "member": true},
+		},
+		{
+			name:   "strict rowid alias key column stays nullable",
+			table:  "users",
+			source: "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT NOT NULL) STRICT;",
+			want:   map[string]bool{"id": false},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			sourcePath := filepath.Join(dir, "schema.sql")
+			c.Assert(os.WriteFile(sourcePath, []byte(test.source), 0o600), qt.IsNil)
+			dbPath := filepath.Join(dir, "main.db")
+
+			applySQLiteSourceFile(c, dbPath, sourcePath, "dev1.db")
+			c.Assert(keyColumnNullability(c, dbPath, test.table), qt.DeepEquals, test.want,
+				qt.Commentf("persisted DDL: %s", sqliteTableDDL(c, dbPath, test.table)))
+
+			second := applySQLiteSourceFile(c, dbPath, sourcePath, "dev2.db")
+			c.Assert(second, qt.Contains, "Schema is synced, no changes to be made.")
+		})
+	}
+}
+
+// TestSchemaApplySQLiteTableShapeStillPlansGenuineChanges is the companion that
+// keeps the rule above from being satisfied by a comparator that reports
+// nothing. A real difference on a WITHOUT ROWID table is still planned, applied,
+// and converges on the next run.
+func TestSchemaApplySQLiteTableShapeStillPlansGenuineChanges(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	dbPath := filepath.Join(dir, "main.db")
+	before := filepath.Join(dir, "before.sql")
+	after := filepath.Join(dir, "after.sql")
+	c.Assert(os.WriteFile(before, []byte(
+		"CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL) WITHOUT ROWID;",
+	), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(after, []byte(
+		"CREATE TABLE users (id TEXT PRIMARY KEY, name TEXT NOT NULL, note TEXT) WITHOUT ROWID;",
+	), 0o600), qt.IsNil)
+
+	applySQLiteSourceFile(c, dbPath, before, "dev1.db")
+
+	changed := applySQLiteSourceFile(c, dbPath, after, "dev2.db")
+	c.Assert(changed, qt.Contains, `ADD COLUMN "note"`)
+	c.Assert(keyColumnNullability(c, dbPath, "users"), qt.DeepEquals, map[string]bool{"id": true})
+
+	again := applySQLiteSourceFile(c, dbPath, after, "dev3.db")
+	c.Assert(again, qt.Contains, "Schema is synced, no changes to be made.")
+}

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -301,11 +301,20 @@ func (n *ColumnNode) Accept(visitor Visitor) error {
 // NOT NULL its source never wrote, so a dump taken through `schema inspect`
 // restored a stricter table than the one it read. See stokaro/ptah#1235.
 //
-// The dialects that do enforce it say so themselves: the PostgreSQL, MySQL,
-// MariaDB and SQL Server renderers emit their own NOT NULL beside PRIMARY KEY
-// without consulting this flag, and the ClickHouse renderer already excludes a
-// primary-key column from Nullable() wrapping, so their output does not depend
-// on it.
+// The dialects that do enforce it say so in their own renderer, which is where
+// the dialect is known. On the CREATE TABLE path they always have: the
+// PostgreSQL, MySQL, MariaDB and SQL Server renderers write NOT NULL beside
+// PRIMARY KEY without consulting this flag, and the ClickHouse renderer
+// excludes a primary-key column from Nullable() wrapping.
+//
+// The ALTER path is not free of it, and assuming otherwise cost a live
+// regression. The PostgreSQL and SQL Server MODIFY-COLUMN renderers do read
+// this flag, and PostgreSQL refuses `ALTER COLUMN ... DROP NOT NULL` on a key
+// column outright (SQLSTATE 42P16), so leaving the flag set there made every
+// modification of a single-column key column unappliable. Both now take the
+// primary-key branch as well; see the guards in core/renderer, pinned by
+// TestModifyColumn_KeyColumnNeverRendersNullable across every supported
+// dialect. Any new consumer of this flag owes the same decision.
 //
 // Example:
 //

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -316,6 +316,12 @@ func (n *ColumnNode) Accept(visitor Visitor) error {
 // TestModifyColumn_KeyColumnNeverRendersNullable across every supported
 // dialect. Any new consumer of this flag owes the same decision.
 //
+// SQLite's own answer is not "never" either, and a consumer that reads it as
+// such is wrong in the other direction: a STRICT or WITHOUT ROWID table does
+// make its key columns NOT NULL, and the catalog reports them that way. The
+// rule is a property of the table rather than of the dialect, so it lives in
+// internal/sqlitekey with the measured shape table rather than here.
+//
 // Example:
 //
 //	column.SetPrimary()

--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -293,15 +293,25 @@ func (n *ColumnNode) Accept(visitor Visitor) error {
 
 // SetPrimary marks the column as a primary key and returns the column for chaining.
 //
-// Setting a column as primary automatically makes it NOT NULL, as primary keys
-// cannot contain NULL values in SQL.
+// Nullability is left alone. "A primary key is NOT NULL" is a rule of the
+// dialect, not of this AST: SQLite does not enforce it on a rowid table, where
+// `id INTEGER PRIMARY KEY` is a rowid alias whose `pragma table_info.notnull`
+// is 0 and which accepts an explicit NULL insert. Clearing the flag here made
+// every reader of a SQLite database and every parser of SQLite DDL invent a
+// NOT NULL its source never wrote, so a dump taken through `schema inspect`
+// restored a stricter table than the one it read. See stokaro/ptah#1235.
+//
+// The dialects that do enforce it say so themselves: the PostgreSQL, MySQL,
+// MariaDB and SQL Server renderers emit their own NOT NULL beside PRIMARY KEY
+// without consulting this flag, and the ClickHouse renderer already excludes a
+// primary-key column from Nullable() wrapping, so their output does not depend
+// on it.
 //
 // Example:
 //
 //	column.SetPrimary()
 func (n *ColumnNode) SetPrimary() *ColumnNode {
 	n.Primary = true
-	n.Nullable = false // Primary keys are always NOT NULL
 	return n
 }
 

--- a/core/ast/nodes_test.go
+++ b/core/ast/nodes_test.go
@@ -126,7 +126,19 @@ func TestColumnNode_SetPrimary(t *testing.T) {
 	column := ast.NewColumn("id", "INTEGER").SetPrimary()
 
 	c.Assert(column.Primary, qt.IsTrue)
-	c.Assert(column.Nullable, qt.IsFalse) // Primary keys are always NOT NULL
+	// Nullability is a separate statement about the column. SQLite does not
+	// derive NOT NULL from PRIMARY KEY on a rowid table, so SetPrimary leaves
+	// the flag where the caller put it. See stokaro/ptah#1235.
+	c.Assert(column.Nullable, qt.IsTrue)
+}
+
+func TestColumnNode_SetPrimaryKeepsNotNull(t *testing.T) {
+	c := qt.New(t)
+
+	column := ast.NewColumn("id", "INTEGER").SetNotNull().SetPrimary()
+
+	c.Assert(column.Primary, qt.IsTrue)
+	c.Assert(column.Nullable, qt.IsFalse)
 }
 
 func TestColumnNode_SetNotNull(t *testing.T) {
@@ -240,7 +252,7 @@ func TestColumnNode_FluentAPI(t *testing.T) {
 	c.Assert(column.Type, qt.Equals, "INTEGER")
 	c.Assert(column.Primary, qt.IsTrue)
 	c.Assert(column.AutoInc, qt.IsTrue)
-	c.Assert(column.Nullable, qt.IsFalse) // SetPrimary() sets this to false
+	c.Assert(column.Nullable, qt.IsTrue) // SetPrimary() leaves nullability alone
 	c.Assert(column.Comment, qt.Equals, "Auto-incrementing primary key")
 }
 
@@ -425,7 +437,7 @@ func TestComplexTableCreation(t *testing.T) {
 	c.Assert(idCol.Name, qt.Equals, "id")
 	c.Assert(idCol.Primary, qt.IsTrue)
 	c.Assert(idCol.AutoInc, qt.IsTrue)
-	c.Assert(idCol.Nullable, qt.IsFalse)
+	c.Assert(idCol.Nullable, qt.IsTrue) // no SetNotNull() on this column
 	c.Assert(idCol.Comment, qt.Equals, "Primary key")
 
 	// Verify second column (email)

--- a/core/renderer/internal/dialects/mssql/modify_column_nullability_test.go
+++ b/core/renderer/internal/dialects/mssql/modify_column_nullability_test.go
@@ -1,0 +1,90 @@
+package mssql_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/renderer/internal/dialects/mssql"
+)
+
+// TestMSSQL_ModifyColumn_KeyColumnKeepsNotNull guards the SQL Server twin of the
+// PostgreSQL hole measured in stokaro/ptah#1235.
+//
+// renderColumnForAlter is the only SQL Server path that decides nullability
+// from ColumnNode.Nullable alone; the CREATE TABLE path writes PRIMARY KEY and
+// takes the branch that never asks. Once SetPrimary() stopped clearing the flag
+// so SQLite could answer for itself, this path respelled a key column as
+// `[id] BIGINT NULL`, and SQL Server refuses to make a column nullable while a
+// primary key constraint depends on it. PostgreSQL's identical hole was
+// measured live and refused with SQLSTATE 42P16; this dialect is guarded by
+// inspection, with no live SQL Server available to measure against.
+func TestMSSQL_ModifyColumn_KeyColumnKeepsNotNull(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		column *ast.ColumnNode
+		want   string
+	}{
+		{
+			name:   "nullable key column is still not null",
+			column: ast.NewColumn("id", "BIGINT").SetPrimary(),
+			want:   "ALTER TABLE [users] ALTER COLUMN [id] BIGINT NOT NULL;\n",
+		},
+		{
+			name:   "key column declared not null is unchanged",
+			column: ast.NewColumn("id", "BIGINT").SetPrimary().SetNotNull(),
+			want:   "ALTER TABLE [users] ALTER COLUMN [id] BIGINT NOT NULL;\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			alter := &ast.AlterTableNode{
+				Name:       "users",
+				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: test.column}},
+			}
+			sql, err := mssql.New().Render(alter)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestMSSQL_ModifyColumn_OrdinaryColumnStaysNullable pins the opposite
+// direction: over-correcting renderColumnForAlter to always write NOT NULL
+// reddens here.
+func TestMSSQL_ModifyColumn_OrdinaryColumnStaysNullable(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		column *ast.ColumnNode
+		want   string
+	}{
+		{
+			name:   "nullable non-key column stays nullable",
+			column: ast.NewColumn("nickname", "TEXT"),
+			want:   "ALTER TABLE [users] ALTER COLUMN [nickname] NVARCHAR(MAX) NULL;\n",
+		},
+		{
+			name:   "non-key column declared not null stays not null",
+			column: ast.NewColumn("nickname", "TEXT").SetNotNull(),
+			want:   "ALTER TABLE [users] ALTER COLUMN [nickname] NVARCHAR(MAX) NOT NULL;\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			alter := &ast.AlterTableNode{
+				Name:       "users",
+				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: test.column}},
+			}
+			sql, err := mssql.New().Render(alter)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sql, qt.Equals, test.want)
+		})
+	}
+}

--- a/core/renderer/internal/dialects/mssql/mssql.go
+++ b/core/renderer/internal/dialects/mssql/mssql.go
@@ -445,12 +445,23 @@ func renderColumn(column *ast.ColumnNode) (string, error) {
 	return strings.Join(parts, " "), nil
 }
 
+// renderColumnForAlter renders the column body of `ALTER TABLE ... ALTER COLUMN`.
+//
+// SQL Server makes a primary key column NOT NULL and will not let it go: an
+// ALTER COLUMN that respells a key column as NULL is refused because the
+// primary key constraint depends on it. ast.ColumnNode.Nullable no longer
+// carries "a key column is NOT NULL" for the AST, because SQLite does not have
+// that rule (stokaro/ptah#1235), so this renderer applies it where the dialect
+// is known -- the same branch renderColumn takes on the CREATE TABLE path.
+// Measured live on PostgreSQL, whose ALTER path had the identical hole and
+// planned an unappliable `DROP NOT NULL`; this dialect is guarded by
+// inspection, with no live SQL Server to measure against.
 func renderColumnForAlter(column *ast.ColumnNode) (string, error) {
 	if column == nil {
 		return "", fmt.Errorf("nil column")
 	}
 	parts := []string{escapeIdentifier(column.Name), mapColumnType(column.Type)}
-	if !column.Nullable {
+	if !column.Nullable || column.Primary {
 		parts = append(parts, "NOT NULL")
 	} else {
 		parts = append(parts, "NULL")

--- a/core/renderer/internal/dialects/postgres/modify_column_nullability_test.go
+++ b/core/renderer/internal/dialects/postgres/modify_column_nullability_test.go
@@ -1,0 +1,97 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+)
+
+// TestPostgres_ModifyColumn_KeyColumnKeepsNotNull pins the renderer itself,
+// below the preparation and validation layers that core/renderer wraps around
+// it, because this is where the regression lived.
+//
+// The CREATE TABLE path writes PRIMARY KEY and NOT NULL together and never
+// reads ColumnNode.Nullable for a key column. This ALTER path did read it, and
+// when SetPrimary() stopped clearing the flag so that SQLite could answer the
+// question for itself (stokaro/ptah#1235), it began planning
+// `ALTER COLUMN "id" DROP NOT NULL` for a key column. PostgreSQL refuses that
+// outright -- `column "id" is in a primary key`, SQLSTATE 42P16 -- so the whole
+// apply failed rather than merely reading oddly. Measured live on PostgreSQL
+// 17.10 through both `ptah-compat schema apply` and `ptah schema apply`.
+func TestPostgres_ModifyColumn_KeyColumnKeepsNotNull(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		column *ast.ColumnNode
+		want   string
+		absent string
+	}{
+		{
+			name:   "nullable key column is still set not null",
+			column: ast.NewColumn("id", "BIGINT").SetPrimary(),
+			want:   "ALTER TABLE users ALTER COLUMN id SET NOT NULL;",
+			absent: "DROP NOT NULL",
+		},
+		{
+			name:   "key column declared not null is unchanged",
+			column: ast.NewColumn("id", "BIGINT").SetPrimary().SetNotNull(),
+			want:   "ALTER TABLE users ALTER COLUMN id SET NOT NULL;",
+			absent: "DROP NOT NULL",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			alter := &ast.AlterTableNode{
+				Name:       "users",
+				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: test.column}},
+			}
+			out := legacyPostgresSQL(renderPG(t, alter))
+			c.Assert(out, qt.Contains, test.want)
+			c.Assert(out, qt.Not(qt.Contains), test.absent)
+		})
+	}
+}
+
+// TestPostgres_ModifyColumn_OrdinaryColumnStillDropsNotNull is the other half of
+// the guard. Without it, "never emit DROP NOT NULL" would be satisfied by a
+// renderer that emits SET NOT NULL for every column, which would silently
+// re-introduce a constraint the author removed.
+func TestPostgres_ModifyColumn_OrdinaryColumnStillDropsNotNull(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		column *ast.ColumnNode
+		want   string
+		absent string
+	}{
+		{
+			name:   "nullable non-key column drops not null",
+			column: ast.NewColumn("nickname", "TEXT"),
+			want:   "ALTER TABLE users ALTER COLUMN nickname DROP NOT NULL;",
+			absent: "SET NOT NULL",
+		},
+		{
+			name:   "nullable unique non-key column drops not null",
+			column: ast.NewColumn("nickname", "TEXT").SetUnique(),
+			want:   "ALTER TABLE users ALTER COLUMN nickname DROP NOT NULL;",
+			absent: "SET NOT NULL",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			alter := &ast.AlterTableNode{
+				Name:       "users",
+				Operations: []ast.AlterOperation{&ast.ModifyColumnOperation{Column: test.column}},
+			}
+			out := legacyPostgresSQL(renderPG(t, alter))
+			c.Assert(out, qt.Contains, test.want)
+			c.Assert(out, qt.Not(qt.Contains), test.absent)
+		})
+	}
+}

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -1151,8 +1151,19 @@ func (r *Renderer) renderPostgreSQLModifyColumn(tableName string, column *ast.Co
 		}
 	}
 
-	// Change nullability
-	if column.Nullable {
+	// Change nullability.
+	//
+	// A primary key column is NOT NULL on every engine this renderer serves --
+	// PostgreSQL, CockroachDB, YugabyteDB and Spanner -- and PostgreSQL refuses
+	// to take that away: `ALTER TABLE "users" ALTER COLUMN "id" DROP NOT NULL`
+	// on a key column fails with `column "id" is in a primary key`
+	// (SQLSTATE 42P16), so emitting it makes the whole plan unappliable rather
+	// than merely verbose. ast.ColumnNode.Nullable no longer carries the rule
+	// for the AST, because SQLite does not have it (stokaro/ptah#1235), so the
+	// dialects that do have it apply it where the dialect is known. The
+	// CREATE TABLE path above writes PRIMARY KEY and NOT NULL together for the
+	// same reason.
+	if column.Nullable && !column.Primary {
 		r.w.WriteLinef("ALTER TABLE %s ALTER COLUMN %s DROP NOT NULL;", r.escapeQualifiedIdentifier(tableName), r.escapeIdentifier(column.Name))
 	} else {
 		r.updateNullValuesBeforeNotNull(tableName, column)

--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -419,10 +419,22 @@ func renderColumn(column *ast.ColumnNode) (string, error) {
 	if column.AutoInc && !column.Primary {
 		return "", unsupportedFeaturef("AUTOINCREMENT requires an INTEGER PRIMARY KEY column")
 	}
+	// NOT NULL is written even when the column is the primary key. SQLite does
+	// not derive one from the other: `id integer PRIMARY KEY` is a rowid alias
+	// whose `pragma table_info.notnull` is 0 and which accepts an explicit NULL
+	// insert, so folding an author's NOT NULL into PRIMARY KEY drops a
+	// constraint the source declared. Measured against the pinned Atlas
+	// community v1.3.0 binary: applying an HCL table with `null = false` on the
+	// key column and then asking that binary whether the result matches the
+	// same file answered `Schemas are synced, no changes to be made.` only once
+	// the NOT NULL survived; without it the binary planned a full table rebuild
+	// against a database Ptah had just applied from that file. See
+	// stokaro/ptah#1235 group 5.
+	if !column.Nullable {
+		parts = append(parts, "NOT NULL")
+	}
 	if column.Primary {
 		parts = append(parts, "PRIMARY KEY")
-	} else if !column.Nullable {
-		parts = append(parts, "NOT NULL")
 	}
 	if column.AutoInc {
 		parts = append(parts, "AUTOINCREMENT")

--- a/core/renderer/modify_column_key_nullability_test.go
+++ b/core/renderer/modify_column_key_nullability_test.go
@@ -1,0 +1,265 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+// keyColumnModifyAlter is the shape that regressed: a single-column primary key
+// whose ast.ColumnNode still says Nullable, handed to ALTER TABLE rather than
+// CREATE TABLE.
+//
+// SetPrimary() stopped clearing Nullable when SQLite was given its own answer
+// to "is a key column NOT NULL" (stokaro/ptah#1235), because SQLite's answer is
+// no. Every CREATE TABLE renderer writes NOT NULL beside PRIMARY KEY itself and
+// so was unaffected, but the PostgreSQL and SQL Server ALTER paths read the
+// flag, and a plan that asks PostgreSQL to drop NOT NULL from a key column is
+// refused outright with `column "id" is in a primary key` (SQLSTATE 42P16).
+// Measured live on PostgreSQL 17: `schema apply` over a key column widened from
+// integer to bigint planned DROP NOT NULL and exited 1 where it had applied.
+func keyColumnModifyAlter() *ast.AlterTableNode {
+	return &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.ModifyColumnOperation{Column: ast.NewColumn("id", "BIGINT").SetPrimary()},
+		},
+	}
+}
+
+// ordinaryColumnModifyAlter is the same operation on a column that is genuinely
+// nullable and is not part of the primary key. It exists so that the guard
+// above cannot be satisfied by never making any column nullable: over-correct
+// the renderers to always write NOT NULL and these rows redden.
+func ordinaryColumnModifyAlter() *ast.AlterTableNode {
+	return &ast.AlterTableNode{
+		Name: "users",
+		Operations: []ast.AlterOperation{
+			&ast.ModifyColumnOperation{Column: ast.NewColumn("nickname", "TEXT")},
+		},
+	}
+}
+
+type modifyColumnNullabilityCase struct {
+	name    string
+	dialect string
+	// key asserts the rendering of a nullable single-column primary key.
+	key func(c *qt.C, out string, err error)
+	// ordinary asserts the rendering of a nullable non-key column, pinning the
+	// opposite direction so the key guard cannot pass by blanket NOT NULL.
+	ordinary func(c *qt.C, out string, err error)
+}
+
+// modifyColumnNullabilityCases carries one row per dialect in
+// renderer.SupportedDialects(). TestModifyColumn_KeyNullabilityCoversEveryDialect
+// asserts the correspondence, so a dialect added without a row here reddens
+// rather than silently inheriting the hole this table was written to close.
+var modifyColumnNullabilityCases = []modifyColumnNullabilityCase{
+	{
+		name:    "postgresql",
+		dialect: "postgresql",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "id" SET NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "DROP NOT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "nickname" DROP NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "SET NOT NULL")
+		},
+	},
+	{
+		name:    "postgres alias",
+		dialect: "postgres",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "id" SET NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "DROP NOT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "nickname" DROP NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "SET NOT NULL")
+		},
+	},
+	{
+		name:    "cockroachdb",
+		dialect: "cockroachdb",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "id" SET NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "DROP NOT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "nickname" DROP NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "SET NOT NULL")
+		},
+	},
+	{
+		name:    "yugabytedb",
+		dialect: "yugabytedb",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "id" SET NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "DROP NOT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "nickname" DROP NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "SET NOT NULL")
+		},
+	},
+	{
+		name:    "spanner",
+		dialect: "spanner",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "id" SET NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "DROP NOT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, `ALTER TABLE "users" ALTER COLUMN "nickname" DROP NOT NULL;`)
+			c.Assert(out, qt.Not(qt.Contains), "SET NOT NULL")
+		},
+	},
+	{
+		name:    "sqlserver",
+		dialect: "sqlserver",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE [users] ALTER COLUMN [id] BIGINT NOT NULL;")
+			c.Assert(out, qt.Not(qt.Contains), "[id] BIGINT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE [users] ALTER COLUMN [nickname] NVARCHAR(MAX) NULL;")
+			c.Assert(out, qt.Not(qt.Contains), "NVARCHAR(MAX) NOT NULL")
+		},
+	},
+	{
+		name:    "mssql alias",
+		dialect: "mssql",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE [users] ALTER COLUMN [id] BIGINT NOT NULL;")
+			c.Assert(out, qt.Not(qt.Contains), "[id] BIGINT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE [users] ALTER COLUMN [nickname] NVARCHAR(MAX) NULL;")
+			c.Assert(out, qt.Not(qt.Contains), "NVARCHAR(MAX) NOT NULL")
+		},
+	},
+	{
+		// MySQL reaches the key column through the branch that writes
+		// PRIMARY KEY and never looks at Nullable, so it renders exactly as it
+		// did before SetPrimary() stopped clearing the flag.
+		name:    "mysql",
+		dialect: "mysql",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE `users` MODIFY COLUMN `id` BIGINT PRIMARY KEY;")
+			c.Assert(out, qt.Not(qt.Contains), "`id` BIGINT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE `users` MODIFY COLUMN `nickname` TEXT;")
+			c.Assert(out, qt.Not(qt.Contains), "NOT NULL")
+		},
+	},
+	{
+		name:    "mariadb",
+		dialect: "mariadb",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE `users` MODIFY COLUMN `id` BIGINT PRIMARY KEY;")
+			c.Assert(out, qt.Not(qt.Contains), "`id` BIGINT NULL")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE `users` MODIFY COLUMN `nickname` TEXT;")
+			c.Assert(out, qt.Not(qt.Contains), "NOT NULL")
+		},
+	},
+	{
+		// ClickHouse rejects Nullable() on a sorting/primary key column, so its
+		// type renderer has always excluded a key column from the wrapping.
+		name:    "clickhouse",
+		dialect: "clickhouse",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE users MODIFY COLUMN id Int64;")
+			c.Assert(out, qt.Not(qt.Contains), "Nullable(")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.IsNil)
+			c.Assert(out, qt.Contains, "ALTER TABLE users MODIFY COLUMN nickname Nullable(String);")
+		},
+	},
+	{
+		// SQLite cannot ALTER a column at all: the operation is refused and the
+		// caller is expected to plan a table rebuild, so no nullability is
+		// rendered for either column and the flag is never read here.
+		name:    "sqlite",
+		dialect: "sqlite",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.ErrorMatches, `.*requires a table rebuild plan.*`)
+			c.Assert(out, qt.Equals, "")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.ErrorMatches, `.*requires a table rebuild plan.*`)
+			c.Assert(out, qt.Equals, "")
+		},
+	},
+	{
+		name:    "sqlite3 alias",
+		dialect: "sqlite3",
+		key: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.ErrorMatches, `.*requires a table rebuild plan.*`)
+			c.Assert(out, qt.Equals, "")
+		},
+		ordinary: func(c *qt.C, out string, err error) {
+			c.Assert(err, qt.ErrorMatches, `.*requires a table rebuild plan.*`)
+			c.Assert(out, qt.Equals, "")
+		},
+	},
+}
+
+func TestModifyColumn_KeyColumnNeverRendersNullable(t *testing.T) {
+	c := qt.New(t)
+
+	for _, test := range modifyColumnNullabilityCases {
+		c.Run(test.name, func(c *qt.C) {
+			out, err := renderer.RenderSQL(test.dialect, keyColumnModifyAlter())
+			test.key(c, out, err)
+		})
+	}
+}
+
+func TestModifyColumn_OrdinaryColumnStillRendersNullable(t *testing.T) {
+	c := qt.New(t)
+
+	for _, test := range modifyColumnNullabilityCases {
+		c.Run(test.name, func(c *qt.C) {
+			out, err := renderer.RenderSQL(test.dialect, ordinaryColumnModifyAlter())
+			test.ordinary(c, out, err)
+		})
+	}
+}
+
+func TestModifyColumn_KeyNullabilityCoversEveryDialect(t *testing.T) {
+	c := qt.New(t)
+
+	covered := make([]string, 0, len(modifyColumnNullabilityCases))
+	for _, test := range modifyColumnNullabilityCases {
+		covered = append(covered, test.dialect)
+	}
+
+	c.Assert(covered, qt.ContentEquals, renderer.SupportedDialects())
+}

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -274,6 +274,61 @@ YugabyteDB and Spanner keep the comparison they had, because what makes two
 indexes the same index is a per-dialect question and only PostgreSQL was
 measured.
 
+## SQLite: A Primary Key Is Not A NOT NULL
+
+Ptah applied "a primary key column is NOT NULL" as if it were a rule of SQL. It
+is a rule of most engines, and SQLite is not one of them. On a rowid table
+`id INTEGER PRIMARY KEY` is an alias for the rowid: `pragma table_info.notnull`
+reports 0, an explicit `INSERT INTO t (id) VALUES (NULL)` is accepted, and a
+rowid is assigned for it. Ptah folded the two together in six places — the AST
+node, the HCL reader, the HCL writer, the SQL-DDL parser's shared node, the
+comparator, and the SQLite renderer — so the assumption survived being fixed
+anywhere less than all of them.
+
+Two things followed, both at exit 0, measured on 2026-08-08 against the pinned
+Atlas CE v1.3.0 binary with each binary in its own directory
+([`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235), findings
+5.1 and 6.3):
+
+| Command | Before | Pinned Atlas CE v1.3.0 |
+| --- | --- | --- |
+| `schema apply --to file://users.hcl --auto-approve`, key column `null = false` | wrote `"id" integer PRIMARY KEY`, dropping the declared NOT NULL. Asked whether that database matched the file it came from, the pinned binary planned a **full table rebuild** | wrote `` `id` integer NOT NULL ``, and answered `Schemas are synced, no changes to be made.` |
+| `schema inspect --format '{{ json . }}'` over `id INTEGER PRIMARY KEY` | `"null"` omitted, meaning NOT NULL — the only column in the fixture whose flag the two binaries disagreed about | `"null": true` |
+
+Both directions are now the source's answer, and both are pinned: a declared
+NOT NULL survives onto the key column, and a key column declared `null = true`
+does not acquire one. After the fix the pinned binary answers
+`Schemas are synced, no changes to be made.` at exit 0 for either document
+against the database `ptah-compat schema apply` built from it.
+
+The dialects that do imply NOT NULL from PRIMARY KEY keep doing so. Their
+renderers write it themselves without consulting the flag, and the comparator
+normalizes the generated side for every dialect except SQLite, so a PostgreSQL
+or MySQL key column still compares and renders exactly as before.
+
+### The uniqueness half
+
+The same fold applied to uniqueness, and there it invented a constraint rather
+than dropping one. `reconcileColumnUniqueness` marked a column UNIQUE from *any*
+single-column unique index, including one an author had created by name, while
+leaving that index in the schema. Rendering the result emitted both.
+
+Measured on the same day, `schema inspect --format '{{ sql . }}'` over
+
+```sql
+CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE, c TEXT);
+CREATE UNIQUE INDEX ux_t_c ON t(c);
+```
+
+replayed into a fresh database with **four** indexes where the source had three.
+The extra one, `sqlite_autoindex_t_3`, was a phantom unique index on `c` backing
+a constraint the author never wrote — a dump-and-restore that silently tightened
+the schema. SQLite distinguishes the two cases itself: `pragma index_list`
+reports `origin` `u` for the implicit index behind a declared UNIQUE constraint
+and `c` for a standalone `CREATE UNIQUE INDEX`. Only the first is part of the
+column's declaration, and only the first is folded now. A declared column
+`UNIQUE` still round-trips through its own implicit index.
+
 ## Reports
 
 - Offline corpus report:

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -277,13 +277,14 @@ measured.
 ## SQLite: A Primary Key Is Not A NOT NULL
 
 Ptah applied "a primary key column is NOT NULL" as if it were a rule of SQL. It
-is a rule of most engines, and SQLite is not one of them. On a rowid table
-`id INTEGER PRIMARY KEY` is an alias for the rowid: `pragma table_info.notnull`
-reports 0, an explicit `INSERT INTO t (id) VALUES (NULL)` is accepted, and a
-rowid is assigned for it. Ptah folded the two together in six places — the AST
-node, the HCL reader, the HCL writer, the SQL-DDL parser's shared node, the
-comparator, and the SQLite renderer — so the assumption survived being fixed
-anywhere less than all of them.
+is a rule of most engines. In SQLite it is a rule of the **table**, and on the
+ordinary rowid table it does not hold: `id INTEGER PRIMARY KEY` is an alias for
+the rowid, `pragma table_info.notnull` reports 0, an explicit
+`INSERT INTO t (id) VALUES (NULL)` is accepted, and a rowid is assigned for it.
+Ptah folded the two together in six places — the AST node, the HCL reader, the
+HCL writer, the SQL-DDL parser's shared node, the comparator, and the SQLite
+renderer — so the assumption survived being fixed anywhere less than all of
+them.
 
 Two things followed, both at exit 0, measured on 2026-08-08 against the pinned
 Atlas CE v1.3.0 binary with each binary in its own directory
@@ -295,9 +296,12 @@ Atlas CE v1.3.0 binary with each binary in its own directory
 | `schema apply --to file://users.hcl --auto-approve`, key column `null = false` | wrote `"id" integer PRIMARY KEY`, dropping the declared NOT NULL. Asked whether that database matched the file it came from, the pinned binary planned a **full table rebuild** | wrote `` `id` integer NOT NULL ``, and answered `Schemas are synced, no changes to be made.` |
 | `schema inspect --format '{{ json . }}'` over `id INTEGER PRIMARY KEY` | `"null"` omitted, meaning NOT NULL — the only column in the fixture whose flag the two binaries disagreed about | `"null": true` |
 
-Both directions are now the source's answer, and both are pinned: a declared
-NOT NULL survives onto the key column, and a key column declared `null = true`
-does not acquire one. After the fix the pinned binary answers
+Both directions are now the source's answer on a rowid table, and both are
+pinned: a declared NOT NULL survives onto the key column, and a key column
+declared `null = true` does not acquire one. (On a `STRICT` or `WITHOUT ROWID`
+table SQLite itself supplies the NOT NULL, whatever the document said; see
+[the table's shape decides](#the-tables-shape-decides-not-the-dialect) below.)
+After the fix the pinned binary answers
 `Schemas are synced, no changes to be made.` at exit 0 for either document
 against the database `ptah-compat schema apply` built from it.
 
@@ -333,6 +337,51 @@ because both predate the change and reproduce identically without it:
 - MySQL plans `ALTER TABLE users MODIFY COLUMN id BIGINT PRIMARY KEY` for a key
   column type change, which MySQL rejects with `Multiple primary key defined`
   when the key already exists.
+
+### The table's shape decides, not the dialect
+
+"SQLite key columns are nullable" is the rowid table's answer, and reading it as
+SQLite's answer is the same mistake in the other direction. A `STRICT` or
+`WITHOUT ROWID` table does enforce NOT NULL on its key columns, and the catalog
+reports them that way. Measured with `pragma table_info` on SQLite 3.51.0, and
+confirmed against the pinned Atlas CE v1.3.0 binary, which models the same
+nullability for each shape when it reads the same DDL through a dev database:
+
+| Table | `notnull` on the key column(s) | Pinned Atlas CE v1.3.0 `{{ json . }}` |
+| --- | --- | --- |
+| `id TEXT PRIMARY KEY` | 0 | `"null": true` |
+| `id INTEGER PRIMARY KEY` | 0 | `"null": true` |
+| `PRIMARY KEY (team, member)` | 0, 0 | `"null": true` |
+| `id TEXT PRIMARY KEY` + `WITHOUT ROWID` | 1 | `"null": false` |
+| `id INTEGER PRIMARY KEY` + `WITHOUT ROWID` | 1 | `"null": false` |
+| `PRIMARY KEY (team, member)` + `WITHOUT ROWID` | 1, 1 | `"null": false` |
+| `id TEXT PRIMARY KEY` + `STRICT` | 1 | `"null": false` |
+| `id INT PRIMARY KEY` + `STRICT` | 1 | `"null": false` |
+| `PRIMARY KEY (team, member)` + `STRICT` | 1, 1 | `"null": false` |
+| `id INTEGER PRIMARY KEY` + `STRICT` | 0 | `"null": true` |
+
+The last row is not an exception to the rule but an instance of it: a `STRICT`
+table still has a rowid, `id INTEGER PRIMARY KEY` is still its alias, and only
+that exact declared type is — `INT` in the same position reports 1. A blanket
+"`STRICT` or `WITHOUT ROWID` implies NOT NULL" would be wrong there, and
+measurably so: it turns `CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT
+NOT NULL) STRICT` back into a permanent rebuild, which is this section's own
+defect wearing a `STRICT` table.
+
+The rule lives in `internal/sqlitekey`, and the comparator and the HCL writer
+ask it rather than the dialect. Before they did, measured on 2026-08-08 at exit
+0 with each binary in its own directory:
+
+| Command | Table | Before | After |
+| --- | --- | --- | --- |
+| `schema apply --to file://schema.sql --auto-approve`, run twice | `WITHOUT ROWID` | second run planned a full table rebuild, and so would every run after it | `Schema is synced, no changes to be made.` |
+| the same | `STRICT` | second run planned a full table rebuild | `Schema is synced, no changes to be made.` |
+| the same | rowid | `Schema is synced, no changes to be made.` | unchanged |
+| `migrate diff <name> --to file://schema.sql`, run twice | `WITHOUT ROWID` | wrote a second migration file containing that rebuild | `The migration directory is synced with the desired state, no changes to be made` |
+
+The pinned binary answered `Schemas are synced, no changes to be made.` against
+those databases throughout: the disagreement was Ptah's with itself, between the
+database it had just built and the model it built it from.
 
 ### The uniqueness half
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -301,10 +301,38 @@ does not acquire one. After the fix the pinned binary answers
 `Schemas are synced, no changes to be made.` at exit 0 for either document
 against the database `ptah-compat schema apply` built from it.
 
-The dialects that do imply NOT NULL from PRIMARY KEY keep doing so. Their
-renderers write it themselves without consulting the flag, and the comparator
-normalizes the generated side for every dialect except SQLite, so a PostgreSQL
-or MySQL key column still compares and renders exactly as before.
+The dialects that do imply NOT NULL from PRIMARY KEY keep doing so, but the rule
+moved rather than vanished: it now lives in each renderer and in the comparator,
+where the dialect is known. Their CREATE TABLE renderers had always applied it
+themselves. Their **MODIFY COLUMN** renderers had not — PostgreSQL and SQL
+Server read the flag — so a first version of this change made any modification
+of a single-column key column plan `ALTER COLUMN "id" DROP NOT NULL`, which
+PostgreSQL refuses outright with `column "id" is in a primary key`
+(SQLSTATE 42P16). Both renderers take the primary-key branch now, and every
+dialect in `renderer.SupportedDialects()` is pinned in both directions by
+`TestModifyColumn_KeyColumnNeverRendersNullable` and
+`TestModifyColumn_OrdinaryColumnStillRendersNullable`.
+
+What that cost each engine, measured rather than reasoned about:
+
+| Dialect | How it was established | Result |
+| --- | --- | --- |
+| PostgreSQL 17.10 | live: `ptah-compat schema apply` from SQL and from HCL, `ptah schema apply` from Go annotations, and `ptah-compat migrate apply` over a key column widened `integer` → `bigint`, with the catalog read back afterwards | plan byte-identical to before the change; applies at exit 0 |
+| MySQL 9.7.1 | live: the same Go-model fixture through `ptah schema compare` | rendered SQL byte-identical to before the change |
+| SQL Server | inspection only — no live server was available here | guarded in `renderColumnForAlter`; pinned by a renderer test, not by an engine |
+| ClickHouse | inspection only | unaffected: its type renderer already excluded a key column from `Nullable()` wrapping on both paths |
+| CockroachDB, YugabyteDB, Spanner | inspection only; they share the PostgreSQL renderer | inherit the PostgreSQL guard |
+
+Two adjacent defects were found while measuring this and are **not** fixed here,
+because both predate the change and reproduce identically without it:
+
+- A composite PRIMARY KEY whose columns are not spelled NOT NULL in the source
+  plans `ALTER COLUMN ... DROP NOT NULL` for each key column on PostgreSQL, and
+  is refused the same way. Only a single-column key reaches the flag this
+  section is about.
+- MySQL plans `ALTER TABLE users MODIFY COLUMN id BIGINT PRIMARY KEY` for a key
+  column type change, which MySQL rejects with `Multiple primary key defined`
+  when the key already exists.
 
 ### The uniqueness half
 

--- a/internal/astbuilder/columnbuilder.go
+++ b/internal/astbuilder/columnbuilder.go
@@ -45,9 +45,10 @@ type ColumnBuilder struct {
 
 // Primary marks the column as a primary key and returns the ColumnBuilder for chaining.
 //
-// Setting a column as primary key automatically makes it NOT NULL, as primary keys
-// cannot contain NULL values in SQL. This follows standard SQL semantics where
-// primary key columns are implicitly NOT NULL.
+// Nullability is left where the caller put it. Whether a key column is also
+// NOT NULL is the dialect's rule, and SQLite does not have it: on a rowid table
+// `id INTEGER PRIMARY KEY` is a rowid alias that accepts an explicit NULL. Use
+// NotNull() to state it. See stokaro/ptah#1235.
 //
 // Example:
 //
@@ -294,9 +295,10 @@ type SchemaColumnBuilder struct {
 
 // Primary marks the column as a primary key and returns the SchemaColumnBuilder for chaining.
 //
-// Setting a column as primary key automatically makes it NOT NULL, as primary keys
-// cannot contain NULL values in SQL. This follows standard SQL semantics where
-// primary key columns are implicitly NOT NULL.
+// Nullability is left where the caller put it. Whether a key column is also
+// NOT NULL is the dialect's rule, and SQLite does not have it: on a rowid table
+// `id INTEGER PRIMARY KEY` is a rowid alias that accepts an explicit NULL. Use
+// NotNull() to state it. See stokaro/ptah#1235.
 //
 // Example:
 //

--- a/internal/astbuilder/columnbuilder_test.go
+++ b/internal/astbuilder/columnbuilder_test.go
@@ -19,7 +19,11 @@ func TestColumnBuilder_Primary(t *testing.T) {
 	c.Assert(result.Columns, qt.HasLen, 1)
 	column := result.Columns[0]
 	c.Assert(column.Primary, qt.IsTrue)
-	c.Assert(column.Nullable, qt.IsFalse) // Primary keys are automatically NOT NULL
+	// Primary() states the key and nothing else. Whether a key column is also
+	// NOT NULL is the dialect's rule and SQLite does not have it, so the
+	// builder leaves the flag for the caller and the renderer to settle. See
+	// stokaro/ptah#1235.
+	c.Assert(column.Nullable, qt.IsTrue)
 }
 
 func TestColumnBuilder_NotNull(t *testing.T) {
@@ -261,18 +265,43 @@ func TestColumnBuilder_MultipleColumns(t *testing.T) {
 	c.Assert(createdAtCol.Default.Expression, qt.Equals, "NOW()")
 }
 
-func TestColumnBuilder_PrimaryKeyOverridesNullable(t *testing.T) {
+// TestColumnBuilder_PrimaryKeyKeepsNullable pins that Primary() does not undo
+// an explicit Nullable(). A builder call that silently reverses one the caller
+// already made is the coupling stokaro/ptah#1235 removed: it is right on
+// PostgreSQL and MySQL and wrong on SQLite, where a rowid key column is
+// nullable, so the dialect settles it and the builder records what was asked.
+func TestColumnBuilder_PrimaryKeyKeepsNullable(t *testing.T) {
 	c := qt.New(t)
 
-	table := astbuilder.NewTable("test").
-		Column("id", "INTEGER").Nullable().Primary().End()
+	tests := []struct {
+		name         string
+		build        func() *astbuilder.TableBuilder
+		wantNullable bool
+	}{
+		{
+			name: "nullable stated before the key",
+			build: func() *astbuilder.TableBuilder {
+				return astbuilder.NewTable("test").
+					Column("id", "INTEGER").Nullable().Primary().End()
+			},
+			wantNullable: true,
+		},
+		{
+			name: "not null stated before the key",
+			build: func() *astbuilder.TableBuilder {
+				return astbuilder.NewTable("test").
+					Column("id", "INTEGER").NotNull().Primary().End()
+			},
+			wantNullable: false,
+		},
+	}
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			result := test.build().Build()
 
-	result := table.Build()
-
-	c.Assert(result.Columns, qt.HasLen, 1)
-	column := result.Columns[0]
-
-	// Primary key should override nullable setting
-	c.Assert(column.Primary, qt.IsTrue)
-	c.Assert(column.Nullable, qt.IsFalse)
+			c.Assert(result.Columns, qt.HasLen, 1)
+			c.Assert(result.Columns[0].Primary, qt.IsTrue)
+			c.Assert(result.Columns[0].Nullable, qt.Equals, test.wantNullable)
+		})
+	}
 }

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -1707,6 +1707,14 @@ func (p *parser) rejectNestedBlocks(block *hclsyntax.Block, label string) error 
 	return nil
 }
 
+// markPrimaryFields moves a single-column table-level primary key onto the
+// column so it renders inline. The column's `null` attribute is left as the
+// document wrote it: measured on the pinned Atlas community v1.3.0 binary,
+// `schema apply` from a table whose key column says `null = true` builds a
+// SQLite table whose `pragma table_info.notnull` is 0 for that column, so
+// clearing the flag here would apply a stricter table than the document asked
+// for. Where the flag is absent the HCL parser already defaults it to NOT NULL.
+// See stokaro/ptah#1235.
 func markPrimaryFields(fields []goschema.Field, columns []string) {
 	if len(columns) != 1 {
 		return
@@ -1714,7 +1722,6 @@ func markPrimaryFields(fields []goschema.Field, columns []string) {
 	for i := range fields {
 		if fields[i].Name == columns[0] {
 			fields[i].Primary = true
-			fields[i].Nullable = false
 			return
 		}
 	}

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -16,15 +16,19 @@ import (
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/sqlitekey"
 	"go.5x5.cz/ptah/internal/tableref"
 )
 
 // primaryKeyImpliesNotNull reports whether the dialect makes a primary key
 // column NOT NULL on its own.
 //
-// SQLite does not: on a rowid table `id INTEGER PRIMARY KEY` is a rowid alias
-// whose `pragma table_info.notnull` is 0 and which accepts an explicit NULL
-// insert. See stokaro/ptah#1235.
+// SQLite does not decide it from the dialect: on a rowid table
+// `id INTEGER PRIMARY KEY` is a rowid alias whose `pragma table_info.notnull` is
+// 0 and which accepts an explicit NULL insert, while a STRICT or WITHOUT ROWID
+// table does enforce NOT NULL on its key columns. This predicate answers for the
+// ordinary rowid table, and [renderer.keyColumnIsNotNull] adds the table's shape
+// where the dialect is SQLite. See stokaro/ptah#1235.
 func primaryKeyImpliesNotNull(dialect string) bool {
 	return platform.NormalizeDialect(dialect) != platform.SQLite
 }
@@ -385,11 +389,13 @@ func (r *renderer) renderTable(
 		return fields[i].Name < fields[j].Name
 	})
 	for _, field := range fields {
-		// A key column is written NOT NULL only where the dialect makes it so.
+		// A key column is written NOT NULL only where the engine makes it so.
 		// SQLite does not on a rowid table, and writing `null = false` there
 		// made this document disagree with the same schema's `{{ json . }}`,
-		// which reports the catalog's answer. See stokaro/ptah#1235.
-		if fieldIsPrimary(table, field) && primaryKeyImpliesNotNull(r.dialect) {
+		// which reports the catalog's answer. It does on a STRICT or
+		// WITHOUT ROWID table, so the decision needs the table and not only the
+		// dialect. See stokaro/ptah#1235.
+		if fieldIsPrimary(table, field) && r.keyColumnIsNotNull(table, fields, field) {
 			field.Nullable = false
 		}
 		r.renderColumn(field)
@@ -454,6 +460,25 @@ func (r *renderer) renderColumn(field goschema.Field) {
 	r.stringAttr(2, "comment", field.Comment)
 	r.renderPlatformOverrides(2, field.Overrides)
 	r.line("  }")
+}
+
+// keyColumnIsNotNull reports whether the engine writes this key column NOT NULL
+// on its own.
+//
+// For SQLite that is a property of the table rather than of the dialect, so the
+// answer comes from the table's shape; every other dialect answers from the
+// dialect. An empty dialect keeps answering yes, which is what the
+// parse-and-re-render callers of [Render] want: their input was HCL and its
+// nullability is already the author's.
+func (r *renderer) keyColumnIsNotNull(
+	table goschema.Table,
+	fields []goschema.Field,
+	field goschema.Field,
+) bool {
+	if platform.NormalizeDialect(r.dialect) != platform.SQLite {
+		return primaryKeyImpliesNotNull(r.dialect)
+	}
+	return sqlitekey.ImpliesNotNull(table, sqlitekey.KeyColumns(table, fields), field)
 }
 
 func fieldIsPrimary(table goschema.Table, field goschema.Field) bool {

--- a/internal/atlashclrender/render.go
+++ b/internal/atlashclrender/render.go
@@ -15,8 +15,19 @@ import (
 	"github.com/zclconf/go-cty/cty"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/internal/tableref"
 )
+
+// primaryKeyImpliesNotNull reports whether the dialect makes a primary key
+// column NOT NULL on its own.
+//
+// SQLite does not: on a rowid table `id INTEGER PRIMARY KEY` is a rowid alias
+// whose `pragma table_info.notnull` is 0 and which accepts an explicit NULL
+// insert. See stokaro/ptah#1235.
+func primaryKeyImpliesNotNull(dialect string) bool {
+	return platform.NormalizeDialect(dialect) != platform.SQLite
+}
 
 // Severity is the diagnostic severity emitted by the exporter.
 type Severity string
@@ -374,7 +385,11 @@ func (r *renderer) renderTable(
 		return fields[i].Name < fields[j].Name
 	})
 	for _, field := range fields {
-		if fieldIsPrimary(table, field) {
+		// A key column is written NOT NULL only where the dialect makes it so.
+		// SQLite does not on a rowid table, and writing `null = false` there
+		// made this document disagree with the same schema's `{{ json . }}`,
+		// which reports the catalog's answer. See stokaro/ptah#1235.
+		if fieldIsPrimary(table, field) && primaryKeyImpliesNotNull(r.dialect) {
 			field.Nullable = false
 		}
 		r.renderColumn(field)

--- a/internal/atlashclrender/sqlite_key_nullability_test.go
+++ b/internal/atlashclrender/sqlite_key_nullability_test.go
@@ -1,0 +1,92 @@
+package atlashclrender_test
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashclrender"
+)
+
+// TestRenderSQLiteKeyColumnNullabilityFollowsTheTableShape pins what this
+// document may claim about a SQLite key column.
+//
+// The rule is SQLite's, not SQL's: a key column is NOT NULL unless it is the
+// rowid alias, and the leniency that lets a key column hold NULL at all survives
+// only on an ordinary rowid table that is not STRICT (stokaro/ptah#1235).
+// Writing `null = true` for the key of a STRICT or WITHOUT ROWID table describes
+// a database SQLite will not build, and the document then disagrees with the
+// `{{ json . }}` rendering of the very database it was applied to.
+//
+// The rows run in both directions. Drop the table's shape from the decision and
+// the STRICT and WITHOUT ROWID rows write `null = true`; force NOT NULL onto
+// every SQLite key column and the two rowid rows lose theirs.
+func TestRenderSQLiteKeyColumnNullabilityFollowsTheTableShape(t *testing.T) {
+	tests := []struct {
+		name        string
+		table       goschema.Table
+		fields      []goschema.Field
+		wantNullSet bool
+	}{
+		{
+			name:        "rowid table keeps its nullable key column",
+			table:       goschema.Table{StructName: "T", Name: "users"},
+			fields:      []goschema.Field{{StructName: "T", Name: "id", Type: "text", Primary: true, Nullable: true}},
+			wantNullSet: true,
+		},
+		{
+			name:        "without rowid table writes the key column NOT NULL",
+			table:       goschema.Table{StructName: "T", Name: "users", WithoutRowID: true},
+			fields:      []goschema.Field{{StructName: "T", Name: "id", Type: "text", Primary: true, Nullable: true}},
+			wantNullSet: false,
+		},
+		{
+			name:        "strict table writes the key column NOT NULL",
+			table:       goschema.Table{StructName: "T", Name: "users", Strict: true},
+			fields:      []goschema.Field{{StructName: "T", Name: "id", Type: "text", Primary: true, Nullable: true}},
+			wantNullSet: false,
+		},
+		{
+			name:        "strict rowid alias keeps its nullable key column",
+			table:       goschema.Table{StructName: "T", Name: "users", Strict: true},
+			fields:      []goschema.Field{{StructName: "T", Name: "id", Type: "integer", Primary: true, Nullable: true}},
+			wantNullSet: true,
+		},
+		{
+			name: "strict table level composite key writes both columns NOT NULL",
+			table: goschema.Table{
+				StructName: "T",
+				Name:       "memberships",
+				Strict:     true,
+				PrimaryKey: []string{"team", "member"},
+			},
+			fields: []goschema.Field{
+				{StructName: "T", Name: "team", Type: "text", Nullable: true},
+				{StructName: "T", Name: "member", Type: "text", Nullable: true},
+			},
+			wantNullSet: false,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			db := &goschema.Database{
+				Tables: []goschema.Table{test.table},
+				Fields: test.fields,
+			}
+			goschema.Finalize(db)
+
+			rendered, err := atlashclrender.RenderInspected(db, "sqlite", "main")
+			c.Assert(err, qt.IsNil)
+
+			// Every fixture declares exactly its key columns as nullable, and
+			// the attribute is written only for a nullable column -- NOT NULL
+			// is the absence of it -- so one answer covers the whole table.
+			hcl := string(rendered.Data)
+			c.Assert(strings.Contains(hcl, "null = true"), qt.Equals, test.wantNullSet,
+				qt.Commentf("rendered HCL:\n%s", hcl))
+		})
+	}
+}

--- a/internal/convert/toschema/toschema.go
+++ b/internal/convert/toschema/toschema.go
@@ -721,6 +721,13 @@ func appendAlterTableConstraints(database *goschema.Database, node *ast.AlterTab
 // markPrimaryFields marks the field backing a single-column table-level primary
 // key as the column primary key, so it renders inline. Composite keys (len != 1)
 // are left on Table.PrimaryKey and render as a table constraint.
+//
+// Moving the key onto the column does not change what the source said about
+// NULL. Clearing the nullability here turned an HCL or DDL source that declared
+// its key column nullable into a NOT NULL one, which SQLite would then enforce
+// on a table the source never asked to be strict. The dialects that do imply
+// NOT NULL from PRIMARY KEY apply that rule in their own renderer and in the
+// comparator, where it can be applied per dialect. See stokaro/ptah#1235.
 func markPrimaryFields(fields []goschema.Field, columns []string) {
 	if len(columns) != 1 {
 		return
@@ -728,7 +735,6 @@ func markPrimaryFields(fields []goschema.Field, columns []string) {
 	for i := range fields {
 		if fields[i].Name == columns[0] {
 			fields[i].Primary = true
-			fields[i].Nullable = false
 			return
 		}
 	}

--- a/internal/dbschema/sqlite/reader.go
+++ b/internal/dbschema/sqlite/reader.go
@@ -266,7 +266,7 @@ func (r *Reader) readColumnsByTable() (map[string][]types.DBColumn, error) {
 			Name:                name,
 			DataType:            normalizeSQLiteType(dataType),
 			ColumnType:          dataType,
-			IsNullable:          sqliteNullable(notNull, pkOrdinal),
+			IsNullable:          sqliteNullable(notNull),
 			OrdinalPosition:     cid + 1,
 			IsPrimaryKey:        pkOrdinal > 0,
 			IsAutoIncrement:     strings.EqualFold(name, ddlMetadata.autoIncrementColumn),
@@ -288,8 +288,19 @@ func (r *Reader) readColumnsByTable() (map[string][]types.DBColumn, error) {
 	return columnsByTable, nil
 }
 
-func sqliteNullable(notNull, pkOrdinal int) string {
-	if notNull != 0 || pkOrdinal > 0 {
+// sqliteNullable reports the column's nullability as SQLite itself reports it,
+// from `pragma table_info.notnull` alone.
+//
+// Primary-key membership is deliberately not consulted. SQLite does not imply
+// NOT NULL from PRIMARY KEY on a rowid table: `id INTEGER PRIMARY KEY` is a
+// rowid alias with `notnull` 0 that accepts an explicit NULL insert and assigns
+// a rowid for it. Measured on the pinned Atlas community v1.3.0 binary,
+// `schema inspect --format '{{ json . }}'` over such a column reports
+// `"null": true`, and it is the only column in the fixture whose flag Ptah
+// disagreed about. Reading the flag from the key instead of from the catalog
+// inverted it. See stokaro/ptah#1235 finding 6.3.
+func sqliteNullable(notNull int) string {
+	if notNull != 0 {
 		return "NO"
 	}
 	return "YES"
@@ -764,16 +775,34 @@ func first(values []string) string {
 	return values[0]
 }
 
+// reconcileColumnUniqueness marks a column UNIQUE when the table declares a
+// single-column UNIQUE **constraint** over it.
+//
+// The distinction is the whole point. SQLite's `pragma index_list` reports an
+// `origin` for every index: `u` for the implicit index behind a declared UNIQUE
+// constraint, and `c` for one an author created with `CREATE UNIQUE INDEX`.
+// Only the first is part of the column's declaration; the reader turns those
+// into [types.DBConstraint] rows of type UNIQUE, which is the signal used here.
+//
+// Keying off `schema.Indexes` instead folded a standalone `CREATE UNIQUE INDEX`
+// into the column while leaving the index itself in the schema, so rendering the
+// result emitted both the inline UNIQUE and the index. Measured against the
+// pinned Atlas community v1.3.0 binary, replaying
+// `schema inspect --format '{{ sql . }}'` over a table whose only uniqueness on
+// a column came from a named index produced four indexes where the source had
+// three: the extra one was a phantom `sqlite_autoindex` the source never had.
+// See stokaro/ptah#1235 finding 5.2.
 func reconcileColumnUniqueness(schema *types.DBSchema) {
 	uniqueColumns := make(map[tableColumnKey]struct{})
-	for _, index := range schema.Indexes {
-		if index.IsPrimary || !index.IsUnique || len(index.Columns) != 1 {
+	for _, constraint := range schema.Constraints {
+		if constraint.Type != "UNIQUE" {
 			continue
 		}
-		if strings.Contains(strings.ToUpper(index.Definition), " WHERE ") {
+		columns := constraint.ColumnNamesOrDefault()
+		if len(columns) != 1 {
 			continue
 		}
-		uniqueColumns[tableColumnKey{table: index.QualifiedTableName(), column: index.Columns[0]}] = struct{}{}
+		uniqueColumns[tableColumnKey{table: constraint.QualifiedTableName(), column: columns[0]}] = struct{}{}
 	}
 	for tableIdx := range schema.Tables {
 		table := &schema.Tables[tableIdx]

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -64,7 +64,10 @@ func TestParser_ParseCreateTable_Basic(t *testing.T) {
 	c.Assert(idColumn.Name, qt.Equals, "id")
 	c.Assert(idColumn.Type, qt.Equals, "INTEGER")
 	c.Assert(idColumn.Primary, qt.IsTrue)
-	c.Assert(idColumn.Nullable, qt.IsFalse) // Primary keys are NOT NULL
+	// The DDL said PRIMARY KEY, not NOT NULL, and the parser reports what it
+	// read. Inventing the second one here made every SQLite source claim a
+	// constraint it never wrote; see stokaro/ptah#1235.
+	c.Assert(idColumn.Nullable, qt.IsTrue)
 
 	// Check second column (name)
 	nameColumn := createTable.Columns[1]

--- a/internal/sqlitekey/sqlitekey.go
+++ b/internal/sqlitekey/sqlitekey.go
@@ -28,6 +28,10 @@
 // catalog answers NOT NULL, the desired model answers nullable, and every plan
 // is another full table rebuild. Treating every SQLite table as NOT NULL-key is
 // the defect #1235 closed. Both halves need the table.
+//
+// One shape SQLite distinguishes is deliberately not modeled here: a DESC key
+// ordering defeats the rowid alias, and this package does not ask, because
+// Ptah's SQLite renderer drops DESC from a PRIMARY KEY. See [isRowidAlias].
 package sqlitekey
 
 import (
@@ -54,7 +58,7 @@ func ImpliesNotNull(table goschema.Table, keyColumns []string, field goschema.Fi
 	if !table.Strict {
 		return false
 	}
-	return !isRowidAlias(table, keyColumns, field)
+	return !isRowidAlias(keyColumns, field)
 }
 
 // KeyColumns returns every column table's primary key covers, reading the
@@ -92,26 +96,24 @@ func tableLevelKeyColumns(table goschema.Table) []string {
 }
 
 // isRowidAlias reports whether field is the table's rowid under another name,
-// which is the one key column SQLite still lets hold NULL in a STRICT table.
+// which is the one key column SQLite still lets hold NULL in a STRICT table. The
+// alias exists only for a single-column key of declared type INTEGER on a table
+// that has a rowid.
 //
-// The alias exists only for a single-column key of declared type INTEGER on a
-// table that has a rowid, and DESC ordering defeats it: measured, a STRICT
-// `id INTEGER PRIMARY KEY DESC` reports notnull=1 while the same key without
-// DESC reports 0.
-func isRowidAlias(table goschema.Table, keyColumns []string, field goschema.Field) bool {
+// A DESC key ordering defeats the alias in SQLite -- measured, a STRICT
+// `id INTEGER PRIMARY KEY DESC` reports notnull=1 where the same key without
+// DESC reports 0 -- and this function deliberately does not ask, because Ptah's
+// SQLite renderer does not write DESC into a PRIMARY KEY at all. Asking would
+// describe a table Ptah never builds: measured, `PRIMARY KEY (id DESC)` in a
+// STRICT source is applied as `PRIMARY KEY ("id")`, whose catalog answer is 0,
+// so a model that answered NOT NULL for it would plan a rebuild on every run and
+// never converge. The DESC that goes missing is its own defect, in the renderer,
+// and it has to be fixed there rather than modeled around here.
+func isRowidAlias(keyColumns []string, field goschema.Field) bool {
 	if len(keyColumns) != 1 {
 		return false
 	}
-	if keyOrdersColumnDesc(table, field.Name) {
-		return false
-	}
 	return rendersAsSQLiteInteger(field.Type)
-}
-
-func keyOrdersColumnDesc(table goschema.Table, column string) bool {
-	return slices.ContainsFunc(table.PrimaryKeyParts, func(part goschema.PrimaryKeyPart) bool {
-		return strings.EqualFold(strings.TrimSpace(part.Name), column) && part.Desc
-	})
 }
 
 // rendersAsSQLiteInteger reports whether the SQLite renderer writes rawType as

--- a/internal/sqlitekey/sqlitekey.go
+++ b/internal/sqlitekey/sqlitekey.go
@@ -1,0 +1,149 @@
+// Package sqlitekey answers whether SQLite enforces NOT NULL on a primary key
+// column. Every other engine Ptah renders for decides that from the dialect
+// alone; SQLite decides it from the table's shape.
+//
+// Measured with `pragma table_info` on SQLite 3.51.0, and confirmed against the
+// pinned Atlas community v1.3.0 binary, which reports the same nullability for
+// each shape when it reads the same DDL through a dev database:
+//
+//	CREATE TABLE t (id TEXT PRIMARY KEY, ...)                    notnull=0
+//	CREATE TABLE t (id INTEGER PRIMARY KEY, ...)                 notnull=0
+//	CREATE TABLE t (a TEXT, b TEXT, PRIMARY KEY (a, b))          notnull=0, 0
+//	CREATE TABLE t (id TEXT PRIMARY KEY, ...) WITHOUT ROWID      notnull=1
+//	CREATE TABLE t (id INTEGER PRIMARY KEY, ...) WITHOUT ROWID   notnull=1
+//	CREATE TABLE t (id TEXT PRIMARY KEY, ...) STRICT             notnull=1
+//	CREATE TABLE t (id INT PRIMARY KEY, ...) STRICT              notnull=1
+//	CREATE TABLE t (a TEXT, b TEXT, PRIMARY KEY (a, b)) STRICT   notnull=1, 1
+//	CREATE TABLE t (id INTEGER PRIMARY KEY, ...) STRICT          notnull=0
+//
+// The rule behind those rows: a primary key column is NOT NULL unless it is the
+// rowid alias, and the historical leniency that lets a key column hold NULL at
+// all survives only on an ordinary rowid table that is not STRICT. The last row
+// is not an exception to that rule but an instance of it -- a STRICT table still
+// has a rowid, and `id INTEGER PRIMARY KEY` is still its alias, so an explicit
+// `INSERT INTO t (id) VALUES (NULL)` is accepted there and assigns a rowid.
+//
+// Treating every SQLite table as nullable-key (stokaro/ptah#1235) makes a STRICT
+// or WITHOUT ROWID table drift forever against the DDL that created it: the
+// catalog answers NOT NULL, the desired model answers nullable, and every plan
+// is another full table rebuild. Treating every SQLite table as NOT NULL-key is
+// the defect #1235 closed. Both halves need the table.
+package sqlitekey
+
+import (
+	"slices"
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// ImpliesNotNull reports whether SQLite makes field NOT NULL because table's
+// primary key covers it.
+//
+// keyColumns is every column that key covers, which [KeyColumns] derives. It is
+// a parameter rather than something recomputed here so a caller that already
+// knows the key -- because it just resolved embedded fields, say -- does not
+// have to spell the table's key twice.
+func ImpliesNotNull(table goschema.Table, keyColumns []string, field goschema.Field) bool {
+	if !coversColumn(keyColumns, field.Name) {
+		return false
+	}
+	if table.WithoutRowID {
+		return true
+	}
+	if !table.Strict {
+		return false
+	}
+	return !isRowidAlias(table, keyColumns, field)
+}
+
+// KeyColumns returns every column table's primary key covers, reading the
+// table-level key where the table declares one and the columns that declare
+// `primary` themselves otherwise. It returns nil for a table with no key.
+func KeyColumns(table goschema.Table, fields []goschema.Field) []string {
+	if columns := tableLevelKeyColumns(table); len(columns) > 0 {
+		return columns
+	}
+	var columns []string
+	for _, field := range fields {
+		if field.Primary {
+			columns = append(columns, field.Name)
+		}
+	}
+	return columns
+}
+
+func tableLevelKeyColumns(table goschema.Table) []string {
+	var columns []string
+	for _, part := range table.PrimaryKeyParts {
+		if name := strings.TrimSpace(part.Name); name != "" {
+			columns = append(columns, name)
+		}
+	}
+	if len(columns) > 0 {
+		return columns
+	}
+	for _, name := range table.PrimaryKey {
+		if trimmed := strings.TrimSpace(name); trimmed != "" {
+			columns = append(columns, trimmed)
+		}
+	}
+	return columns
+}
+
+// isRowidAlias reports whether field is the table's rowid under another name,
+// which is the one key column SQLite still lets hold NULL in a STRICT table.
+//
+// The alias exists only for a single-column key of declared type INTEGER on a
+// table that has a rowid, and DESC ordering defeats it: measured, a STRICT
+// `id INTEGER PRIMARY KEY DESC` reports notnull=1 while the same key without
+// DESC reports 0.
+func isRowidAlias(table goschema.Table, keyColumns []string, field goschema.Field) bool {
+	if len(keyColumns) != 1 {
+		return false
+	}
+	if keyOrdersColumnDesc(table, field.Name) {
+		return false
+	}
+	return rendersAsSQLiteInteger(field.Type)
+}
+
+func keyOrdersColumnDesc(table goschema.Table, column string) bool {
+	return slices.ContainsFunc(table.PrimaryKeyParts, func(part goschema.PrimaryKeyPart) bool {
+		return strings.EqualFold(strings.TrimSpace(part.Name), column) && part.Desc
+	})
+}
+
+// rendersAsSQLiteInteger reports whether the SQLite renderer writes rawType as
+// exactly `INTEGER`, which is what makes a single-column key the rowid alias.
+//
+// The rest of the integer family is not a rowid alias even though SQLite gives
+// it INTEGER affinity, because the alias is keyed on the declared type name:
+// measured, `CREATE TABLE t (id INT PRIMARY KEY, a TEXT) STRICT` reports
+// notnull=1 where the same table spelled INTEGER reports 0.
+//
+// The list mirrors mapColumnType in core/renderer/internal/dialects/sqlite.
+// sqlitekey_internal_test.go pins the correspondence by rendering each type
+// through the public renderer, so a change there reddens here.
+func rendersAsSQLiteInteger(rawType string) bool {
+	switch baseTypeName(rawType) {
+	case "INTEGER", "BOOLEAN", "BOOL", "SERIAL", "BIGSERIAL", "SMALLSERIAL", "AUTO_INCREMENT":
+		return true
+	}
+	return false
+}
+
+func baseTypeName(rawType string) string {
+	base := strings.ToUpper(strings.TrimSpace(rawType))
+	if idx := strings.Index(base, "("); idx >= 0 {
+		base = strings.TrimSpace(base[:idx])
+	}
+	return base
+}
+
+// coversColumn compares column names the way SQLite does, case-insensitively.
+func coversColumn(keyColumns []string, column string) bool {
+	return slices.ContainsFunc(keyColumns, func(name string) bool {
+		return strings.EqualFold(strings.TrimSpace(name), strings.TrimSpace(column))
+	})
+}

--- a/internal/sqlitekey/sqlitekey_internal_test.go
+++ b/internal/sqlitekey/sqlitekey_internal_test.go
@@ -1,0 +1,86 @@
+package sqlitekey
+
+// White-box testing required: rendersAsSQLiteInteger is a copy of a decision
+// that belongs to the SQLite renderer -- which declared types it writes as
+// exactly `INTEGER`, since that spelling and no other makes a single-column key
+// the rowid alias. The list is unexported because nothing outside this package
+// should ask the question, but a copy that drifts from the renderer is exactly
+// how this rule would go wrong silently, so the guard has to reach the
+// unexported function.
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+// TestRendersAsSQLiteIntegerMatchesTheRenderer renders a one-column table for
+// each declared type and asserts that rendersAsSQLiteInteger agrees with whether
+// the SQLite renderer wrote the type as `INTEGER`.
+//
+// Change mapColumnType in core/renderer/internal/dialects/sqlite -- add a type
+// that now renders as INTEGER, or stop mapping one -- and the row for that type
+// reddens here rather than quietly turning a rowid alias into a NOT NULL key
+// column, or the reverse.
+func TestRendersAsSQLiteIntegerMatchesTheRenderer(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawType string
+	}{
+		{name: "integer", rawType: "INTEGER"},
+		{name: "lower case integer", rawType: "integer"},
+		{name: "int", rawType: "INT"},
+		{name: "bigint", rawType: "BIGINT"},
+		{name: "smallint", rawType: "SMALLINT"},
+		{name: "serial", rawType: "SERIAL"},
+		{name: "bigserial", rawType: "BIGSERIAL"},
+		{name: "smallserial", rawType: "SMALLSERIAL"},
+		{name: "boolean", rawType: "BOOLEAN"},
+		{name: "bool", rawType: "BOOL"},
+		{name: "text", rawType: "TEXT"},
+		{name: "varchar", rawType: "VARCHAR(255)"},
+		{name: "blob", rawType: "BLOB"},
+		{name: "real", rawType: "REAL"},
+		{name: "numeric", rawType: "NUMERIC(10,2)"},
+		{name: "any", rawType: "ANY"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			table := &ast.CreateTableNode{
+				Name:    "t",
+				Columns: []*ast.ColumnNode{ast.NewColumn("id", test.rawType)},
+			}
+			sql, err := renderer.RenderSQL("sqlite", table)
+			c.Assert(err, qt.IsNil)
+
+			renderedType := renderedColumnType(sql, `"id"`)
+			c.Assert(renderedType, qt.Not(qt.Equals), "",
+				qt.Commentf("no column line found in: %s", sql))
+			// Case-insensitively, because SQLite reads the declared type that
+			// way: measured, `id integer PRIMARY KEY` and `id InTeGeR PRIMARY
+			// KEY` in a STRICT table both report notnull=0, so both are the
+			// rowid alias.
+			c.Assert(rendersAsSQLiteInteger(test.rawType), qt.Equals,
+				strings.EqualFold(renderedType, "INTEGER"),
+				qt.Commentf("rendered SQL: %s", sql))
+		})
+	}
+}
+
+// renderedColumnType returns the type the renderer wrote for the column named by
+// quotedName, read out of the rendered CREATE TABLE text, or "" when no such
+// column line is there.
+func renderedColumnType(sql, quotedName string) string {
+	for line := range strings.SplitSeq(sql, "\n") {
+		parts := strings.Fields(strings.TrimSuffix(strings.TrimSpace(line), ","))
+		if len(parts) >= 2 && parts[0] == quotedName {
+			return parts[1]
+		}
+	}
+	return ""
+}

--- a/internal/sqlitekey/sqlitekey_test.go
+++ b/internal/sqlitekey/sqlitekey_test.go
@@ -1,0 +1,198 @@
+package sqlitekey_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/sqlitekey"
+)
+
+// TestImpliesNotNull is the shape table measured with `pragma table_info` on
+// SQLite 3.51.0, one row per shape, plus the two rows that are not key columns at
+// all. Each `want` is the notnull the catalog reports for that DDL, so a row that
+// disagrees with SQLite is a failing row rather than a redefinition of the rule.
+func TestImpliesNotNull(t *testing.T) {
+	tests := []struct {
+		name       string
+		table      goschema.Table
+		keyColumns []string
+		field      goschema.Field
+		want       bool
+	}{
+		{
+			name:       "rowid table text key is nullable",
+			table:      goschema.Table{Name: "t"},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "TEXT", Primary: true},
+			want:       false,
+		},
+		{
+			name:       "rowid table integer key is nullable",
+			table:      goschema.Table{Name: "t"},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INTEGER", Primary: true},
+			want:       false,
+		},
+		{
+			name:       "rowid table composite key is nullable",
+			table:      goschema.Table{Name: "t", PrimaryKey: []string{"a", "b"}},
+			keyColumns: []string{"a", "b"},
+			field:      goschema.Field{Name: "a", Type: "TEXT"},
+			want:       false,
+		},
+		{
+			name:       "without rowid text key is not null",
+			table:      goschema.Table{Name: "t", WithoutRowID: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "TEXT", Primary: true},
+			want:       true,
+		},
+		{
+			name:       "without rowid integer key is not null",
+			table:      goschema.Table{Name: "t", WithoutRowID: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INTEGER", Primary: true},
+			want:       true,
+		},
+		{
+			name:       "without rowid composite key is not null",
+			table:      goschema.Table{Name: "t", WithoutRowID: true, PrimaryKey: []string{"a", "b"}},
+			keyColumns: []string{"a", "b"},
+			field:      goschema.Field{Name: "b", Type: "TEXT"},
+			want:       true,
+		},
+		{
+			name:       "strict text key is not null",
+			table:      goschema.Table{Name: "t", Strict: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "TEXT", Primary: true},
+			want:       true,
+		},
+		{
+			name:       "strict integer key is the rowid alias and stays nullable",
+			table:      goschema.Table{Name: "t", Strict: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INTEGER", Primary: true},
+			want:       false,
+		},
+		{
+			name:       "strict INT key is not the rowid alias",
+			table:      goschema.Table{Name: "t", Strict: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INT", Primary: true},
+			want:       true,
+		},
+		{
+			name:       "strict composite key is not null",
+			table:      goschema.Table{Name: "t", Strict: true, PrimaryKey: []string{"a", "b"}},
+			keyColumns: []string{"a", "b"},
+			field:      goschema.Field{Name: "a", Type: "TEXT"},
+			want:       true,
+		},
+		{
+			name: "strict integer key ordered DESC is not the rowid alias",
+			table: goschema.Table{
+				Name:            "t",
+				Strict:          true,
+				PrimaryKeyParts: []goschema.PrimaryKeyPart{{Name: "id", Desc: true}},
+			},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INTEGER"},
+			want:       true,
+		},
+		{
+			name:       "strict and without rowid together answer not null",
+			table:      goschema.Table{Name: "t", Strict: true, WithoutRowID: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "id", Type: "INTEGER", Primary: true},
+			want:       true,
+		},
+		{
+			name:       "a column outside the key is never touched",
+			table:      goschema.Table{Name: "t", Strict: true, WithoutRowID: true},
+			keyColumns: []string{"id"},
+			field:      goschema.Field{Name: "note", Type: "TEXT", Nullable: true},
+			want:       false,
+		},
+		{
+			name:       "a table with no key at all",
+			table:      goschema.Table{Name: "t", Strict: true},
+			keyColumns: nil,
+			field:      goschema.Field{Name: "note", Type: "TEXT", Nullable: true},
+			want:       false,
+		},
+		{
+			name:       "key columns are matched the way SQLite compares names",
+			table:      goschema.Table{Name: "t", WithoutRowID: true},
+			keyColumns: []string{"ID"},
+			field:      goschema.Field{Name: "id", Type: "TEXT", Primary: true},
+			want:       true,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(sqlitekey.ImpliesNotNull(test.table, test.keyColumns, test.field), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestKeyColumns pins where the key is read from, because "is this column in the
+// key" and "is the key one column" are both answers the nullability rule needs.
+func TestKeyColumns(t *testing.T) {
+	tests := []struct {
+		name   string
+		table  goschema.Table
+		fields []goschema.Field
+		want   []string
+	}{
+		{
+			name:   "no key",
+			table:  goschema.Table{Name: "t"},
+			fields: []goschema.Field{{Name: "a"}},
+			want:   nil,
+		},
+		{
+			name:   "field level key",
+			table:  goschema.Table{Name: "t"},
+			fields: []goschema.Field{{Name: "a"}, {Name: "id", Primary: true}},
+			want:   []string{"id"},
+		},
+		{
+			name:   "two field level key columns are a composite key",
+			table:  goschema.Table{Name: "t"},
+			fields: []goschema.Field{{Name: "a", Primary: true}, {Name: "b", Primary: true}},
+			want:   []string{"a", "b"},
+		},
+		{
+			name:   "table level key",
+			table:  goschema.Table{Name: "t", PrimaryKey: []string{"a", "b"}},
+			fields: []goschema.Field{{Name: "a"}, {Name: "b"}},
+			want:   []string{"a", "b"},
+		},
+		{
+			name: "table level key parts win over the plain name list",
+			table: goschema.Table{
+				Name:            "t",
+				PrimaryKey:      []string{"ignored"},
+				PrimaryKeyParts: []goschema.PrimaryKeyPart{{Name: "a"}, {Name: "b", Desc: true}},
+			},
+			fields: []goschema.Field{{Name: "a"}, {Name: "b"}},
+			want:   []string{"a", "b"},
+		},
+		{
+			name:   "an empty name in the key list is not a column",
+			table:  goschema.Table{Name: "t", PrimaryKey: []string{"a", "  "}},
+			fields: []goschema.Field{{Name: "a"}},
+			want:   []string{"a"},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			c.Assert(sqlitekey.KeyColumns(test.table, test.fields), qt.DeepEquals, test.want)
+		})
+	}
+}

--- a/internal/sqlitekey/sqlitekey_test.go
+++ b/internal/sqlitekey/sqlitekey_test.go
@@ -92,7 +92,14 @@ func TestImpliesNotNull(t *testing.T) {
 			want:       true,
 		},
 		{
-			name: "strict integer key ordered DESC is not the rowid alias",
+			// SQLite would answer notnull=1 here, because DESC defeats the
+			// rowid alias. Ptah answers 0 on purpose: its SQLite renderer drops
+			// DESC from a PRIMARY KEY, so the table it actually builds from this
+			// schema does have the alias, and answering SQLite's DESC rule would
+			// plan a rebuild against that table on every run. Measured:
+			// `PRIMARY KEY (id DESC)` in a STRICT source is applied as
+			// `PRIMARY KEY ("id")` and the catalog reports notnull=0.
+			name: "strict integer key ordered DESC follows what the renderer builds",
 			table: goschema.Table{
 				Name:            "t",
 				Strict:          true,
@@ -100,7 +107,7 @@ func TestImpliesNotNull(t *testing.T) {
 			},
 			keyColumns: []string{"id"},
 			field:      goschema.Field{Name: "id", Type: "INTEGER"},
-			want:       true,
+			want:       false,
 		},
 		{
 			name:       "strict and without rowid together answer not null",

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -162,7 +162,7 @@ func tableColumnsWithSemantics(
 	for identity, genCol := range genColumns {
 		if dbCol, exists := dbColumns[identity]; exists {
 			if columnInTablePrimaryKey(genTable, genCol.Name) {
-				genCol = normalizeTablePrimaryKeyColumn(genCol, dbCol)
+				genCol = normalizeTablePrimaryKeyColumn(genCol, dbCol, dialect)
 			}
 			columnKey := columnIdentity{
 				table:  newTableIdentity(genTable.Schema, genTable.Name, semantics),
@@ -300,10 +300,13 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 		colDiff.Changes["type"] = fmt.Sprintf("%s -> %s", dbRawType, genCol.Type)
 	}
 
-	// Compare nullable (primary keys are always NOT NULL regardless of the field definition)
+	// Compare nullable. On the engines that enforce it, a primary key column is
+	// NOT NULL whatever the field says, and the reader reports it that way, so
+	// the generated side is normalized to match or every primary key would show
+	// a permanent diff.
 	genNullable := genCol.Nullable
-	if genCol.Primary {
-		genNullable = false // Primary keys are always NOT NULL
+	if genCol.Primary && primaryKeyImpliesNotNull(dialect) {
+		genNullable = false
 	}
 	dbNullable := dbCol.IsNullable == "YES"
 	if genNullable != dbNullable {
@@ -366,6 +369,19 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 	return colDiff
 }
 
+// primaryKeyImpliesNotNull reports whether the dialect makes a primary key
+// column NOT NULL on its own, so the comparator may normalize the generated
+// side to the reader's answer.
+//
+// SQLite does not. On a rowid table `id INTEGER PRIMARY KEY` is a rowid alias:
+// `pragma table_info.notnull` is 0, an explicit NULL insert is accepted, and a
+// rowid is assigned for it. Normalizing anyway made a schema whose key column
+// SQLite reports as nullable diff forever against the very DDL that created it.
+// See stokaro/ptah#1235.
+func primaryKeyImpliesNotNull(dialect string) bool {
+	return platform.NormalizeDialect(dialect) != platform.SQLite
+}
+
 func normalizeColumnTypesForDialect(genType, dbType, dialect string) (generatedType, databaseType string) {
 	switch platform.NormalizeDialect(dialect) {
 	case platform.SQLite:
@@ -414,8 +430,10 @@ func sqliteRenderedColumnType(rawType string) string {
 	}
 }
 
-func normalizeTablePrimaryKeyColumn(genCol goschema.Field, dbCol types.DBColumn) goschema.Field {
-	genCol.Nullable = false
+func normalizeTablePrimaryKeyColumn(genCol goschema.Field, dbCol types.DBColumn, dialect string) goschema.Field {
+	if primaryKeyImpliesNotNull(dialect) {
+		genCol.Nullable = false
+	}
 	genCol.Primary = dbCol.IsPrimaryKey
 	return genCol
 }

--- a/migration/schemadiff/internal/compare/columns.go
+++ b/migration/schemadiff/internal/compare/columns.go
@@ -10,6 +10,7 @@ import (
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/sqlitekey"
 	"go.5x5.cz/ptah/migration/internal/generatedschema"
 	"go.5x5.cz/ptah/migration/internal/typechange"
 	"go.5x5.cz/ptah/migration/schemadiff/internal/normalize"
@@ -135,10 +136,12 @@ func tableColumnsWithSemantics(
 	tableDiff := difftypes.TableDiff{TableName: genTable.QualifiedName()}
 
 	// Create maps for quick lookup
+	genFields := generatedschema.FieldsForTable(generated, genTable)
 	genColumns := make(map[string]goschema.Field)
-	for _, field := range generatedschema.FieldsForTable(generated, genTable) {
+	for _, field := range genFields {
 		genColumns[semantics.ColumnIdentityKey(field.Name)] = field
 	}
+	keyColumns := sqlitekey.KeyColumns(genTable, genFields)
 
 	dbColumns := make(map[string]types.DBColumn)
 	for _, col := range dbTable.Columns {
@@ -163,6 +166,9 @@ func tableColumnsWithSemantics(
 		if dbCol, exists := dbColumns[identity]; exists {
 			if columnInTablePrimaryKey(genTable, genCol.Name) {
 				genCol = normalizeTablePrimaryKeyColumn(genCol, dbCol, dialect)
+			}
+			if sqliteKeyColumnImpliesNotNull(dialect, genTable, keyColumns, genCol) {
+				genCol.Nullable = false
 			}
 			columnKey := columnIdentity{
 				table:  newTableIdentity(genTable.Schema, genTable.Name, semantics),
@@ -373,13 +379,39 @@ func ColumnsWithDialect(genCol goschema.Field, dbCol types.DBColumn, dialect str
 // column NOT NULL on its own, so the comparator may normalize the generated
 // side to the reader's answer.
 //
-// SQLite does not. On a rowid table `id INTEGER PRIMARY KEY` is a rowid alias:
-// `pragma table_info.notnull` is 0, an explicit NULL insert is accepted, and a
-// rowid is assigned for it. Normalizing anyway made a schema whose key column
-// SQLite reports as nullable diff forever against the very DDL that created it.
-// See stokaro/ptah#1235.
+// SQLite does not decide this from the dialect at all. On a rowid table
+// `id INTEGER PRIMARY KEY` is a rowid alias: `pragma table_info.notnull` is 0,
+// an explicit NULL insert is accepted, and a rowid is assigned for it.
+// Normalizing anyway made a schema whose key column SQLite reports as nullable
+// diff forever against the very DDL that created it (stokaro/ptah#1235).
+//
+// SQLite's answer depends on the table's shape, which this predicate cannot see,
+// so it answers with the shape that has no NOT NULL to normalize -- the ordinary
+// rowid table. [sqliteKeyColumnImpliesNotNull] carries the STRICT and
+// WITHOUT ROWID halves, where SQLite does enforce NOT NULL on a key column, and
+// the caller applies both.
 func primaryKeyImpliesNotNull(dialect string) bool {
 	return platform.NormalizeDialect(dialect) != platform.SQLite
+}
+
+// sqliteKeyColumnImpliesNotNull reports whether SQLite -- not SQL in general --
+// enforces NOT NULL on this key column because of the table's shape.
+//
+// A STRICT or WITHOUT ROWID table makes its key columns NOT NULL, and the reader
+// reports them that way from `pragma table_info`, so the generated side has to
+// be normalized to match or the table drifts against the DDL that created it and
+// every plan is another full table rebuild. The rowid alias of a STRICT table
+// stays nullable; see [sqlitekey] for the measured shape table.
+func sqliteKeyColumnImpliesNotNull(
+	dialect string,
+	table goschema.Table,
+	keyColumns []string,
+	field goschema.Field,
+) bool {
+	if platform.NormalizeDialect(dialect) != platform.SQLite {
+		return false
+	}
+	return sqlitekey.ImpliesNotNull(table, keyColumns, field)
 }
 
 func normalizeColumnTypesForDialect(genType, dbType, dialect string) (generatedType, databaseType string) {


### PR DESCRIPTION
Closes findings 5.1, 5.2 and 6.3 of the [#1235](https://github.com/stokaro/ptah/issues/1235) register, and re-measures and triages the other 48.

## The register, re-measured

The issue is a register, not a defect, so the first deliverable is a re-measurement rather than a patch. All 51 rows were re-run at `origin/master` `9820496e` against the pinned community binary v1.3.0, fixtures rebuilt fresh, each binary in its own directory, every exit code read from an unpiped invocation.

| Outcome | Rows |
| --- | --- |
| Still open, reproduced | 43 |
| Already closed before this branch | 2 |
| Closed by this PR | 3 |
| Could not be re-measured | 3 |

**Already closed, named rather than re-fixed.** Both were confirmed against a `ptah-compat` built at `92213b39` — the sweep's own base commit — in a second worktree, so "it was open then and is closed now" is measured rather than assumed.

- **2.2**, `RENAME COLUMN` of a NOT NULL column emits DS103 but not MF103. At `92213b39` Ptah emitted BC101 only, one diagnostic, exit 0. At HEAD it emits DS103 and MF103, `2 diagnostics`, exit 1 — byte-identical to the pinned binary. Closed by `7b1f0d42` (#1247).
- **9.9**, the checksum-mismatch detail block on `migrate new`. At HEAD stdout and stderr are byte-identical to the pinned binary on both streams. Closed by `30ce8c9a` (#1135). Note the base build did not print a *smaller* report as the register says — it did not fail at all, writing the file at exit 0, which is a rule-(a) violation rather than an output-shape one.

**Could not be re-measured, and not claimed either way.** 8.2 (goose zero padding) and the `migrate validate` shape of 9.7 both need a hand-named migration directory carrying a valid integrity file, which this session could not construct; the same 9.7 divergence does reproduce on `migrate lint --dev-url` over the identical files. 9.12 stays `[carried over]` exactly as the issue left it.

## Fifty-one symptoms, ten causes

The register is organized by symptom. Grouped by cause, the 46 rows that are not closed look like this:

| Cause | Rows | What it is |
| --- | --- | --- |
| **C1** | 9 | The compat surface renders DDL and plans through Ptah's native SQL writer instead of an Atlas-shaped one — no per-change `-- comment` header, double quotes, schema qualification, alphabetical ordering, a stray bare `;`, `DROP TABLE IF EXISTS`, no `PRAGMA foreign_keys` bracketing, views in SQL but not JSON, the indent on every line |
| **C2** | 13 | The compat surface answers with Ptah's diagnostic wording where the Atlas surface has a fixed spelling |
| **C5** | 6 | The inspect report model is not Atlas's `cmdlog.SchemaInspect` |
| **C3** | 4 | No Atlas report-envelope renderer; the `--format` template model already matches byte for byte, only the built-in default is missing |
| **C6** | 4 | A foreign-format migration's version identity is a synthesized `int64` ordering key, not the source's version token |
| **C4** | 3 | Progress chatter on stdout where the pinned binary writes zero bytes |
| **C8** | 3 | `migrate new` sanitizes the name and bumps past a collision |
| **C9** | 2 | `--exclude` selector arity, and how far a column exclusion propagates |
| **C7** | 1 | The revision write escapes the migration transaction |
| **C10** | 1 | MF101 is not implemented |

C2 has the most rows, but it is ten independent strings rather than one decision. **C1 is the largest single cause**: at re-measurement it was twelve rows, and 5.1, 5.2 and 6.3 were its correctness core — the two the issue calls "the most serious thing in this register", plus the one flag the two binaries disagreed about. Those three are what this PR closes. Its remaining nine rows are cosmetics and one correctness gap (4.2, the missing rebuild bracketing) and want their own change.

## What was wrong

Ptah applied "a primary key column is NOT NULL" as a rule of SQL. It is a rule of most engines, and SQLite is not one of them. On a rowid table `id INTEGER PRIMARY KEY` is an alias for the rowid: `pragma table_info.notnull` reports 0, an explicit `INSERT INTO t (id) VALUES (NULL)` is accepted, and a rowid is assigned for it.

The assumption lived in six places — the AST node, the HCL reader, the HCL writer, the shared node the SQL-DDL parser builds, the comparator, and the SQLite renderer. Fixing anywhere less than all six leaves it intact, and fixing only the renderer creates the inverse defect: a dump that restores a *stricter* table than it read.

Measured on 2026-08-08:

| Command | Before | Pinned binary v1.3.0 |
| --- | --- | --- |
| `schema apply --to file://users.hcl --auto-approve`, key column `null = false` | wrote `"id" integer PRIMARY KEY`. Asked whether that database matched the file it came from, the pinned binary planned a **full table rebuild** | wrote `` `id` integer NOT NULL ``, and answered `Schemas are synced, no changes to be made.` |
| `schema inspect --format '{{ json . }}'` over `id INTEGER PRIMARY KEY` | `"null"` omitted, meaning NOT NULL — the only column in the fixture whose flag differed | `"null": true` |

The same fold applied to uniqueness, and there it invented a constraint rather than dropping one. `reconcileColumnUniqueness` marked a column UNIQUE from *any* single-column unique index — including one an author created by name — while leaving that index in the schema, so rendering emitted both. `schema inspect --format '{{ sql . }}'` over

```sql
CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE, c TEXT);
CREATE UNIQUE INDEX ux_t_c ON t(c);
```

replayed into **four** indexes where the source had three; `sqlite_autoindex_t_3` was a phantom unique index on `c` backing a constraint nobody wrote.

## What changed

`SetPrimary()` now sets only the key. Nullability is settled where the dialect is known: the PostgreSQL, MySQL, MariaDB and SQL Server renderers already write their own NOT NULL beside PRIMARY KEY without reading the flag, ClickHouse already excludes a key column from `Nullable()` wrapping, and the comparator and the HCL writer normalize the generated side for every dialect except SQLite. PostgreSQL and MySQL output and comparisons are unchanged.

The SQLite reader reports nullability from `pragma table_info.notnull` alone, and `reconcileColumnUniqueness` folds only a declared single-column UNIQUE **constraint** — SQLite distinguishes the two itself, reporting `origin` `u` for the implicit index behind a constraint and `c` for a standalone `CREATE UNIQUE INDEX`.

After the fix the pinned binary answers `Schemas are synced, no changes to be made.` at exit 0 against the database `ptah-compat schema apply` built, for a key column declared either way, and the rendered SQL replays to exactly the source's index set.

## Tests, and seeing them red

`cmd/atlas/schema_sqlite_key_shape_test.go` carries a row per cell, and each has a companion in the opposite direction so the fix cannot be traded for its mirror image. Five mutants, each reddening only what it should:

| Mutant | Reddens |
| --- | --- |
| Renderer back to `else if` (the shipped defect) | the declared-NOT-NULL row only |
| Renderer always emitting NOT NULL beside a key | the declared-nullable row only |
| Reader consulting the key ordinal again | the JSON nullability row only |
| Uniqueness keyed on indexes again | the named-index row only |
| Uniqueness folding nothing | both uniqueness rows |

The over-correction guard is not decoration: with only the renderer and the reader fixed it was red, which is how the HCL reader, the HCL writer and the comparator were found.

## Triage of every row not fixed

- **Ptah is wrong, fix owed (39).** All of C1's remainder, C3, C4, C5, C6, C7, C10, 7.2, 8.6, 8.7, and eleven of C2.
- **The binary is wrong; rule (b) keeps our behavior (5).** 9.1 and 9.2, where the trailing space is already argued in `internal/atlasargs/args.go` as a slip in one format string rather than a convention. 8.8, where the pinned binary truncates a pre-existing migration file to zero bytes at exit 0 and Ptah's max+1 bump must not be traded for that. 7.1, where the pinned binary reads a two-part selector as `table.column`, so `--exclude main.posts` hides nothing. Half of 4.7, where Ptah's SQL keeping views is right and its JSON dropping them is the defect.
- **Cosmetic, accepted, recorded (2).** The exposed Go type name in 6.7 — `*atlasreport.SchemaInspectReport` cannot read as `*cmdlog.SchemaInspect` without naming a Ptah type after an Atlas internal one, though the `parse --format template:` prefix is still worth removing — and the absolute-versus-relative path inside 9.13's otherwise byte-identical HCL diagnostic.

## Compatibility

This changes behavior for anyone reading `ast.ColumnNode.Nullable` after `SetPrimary()`, and a SQLite database an older Ptah wrote as `id INTEGER PRIMARY KEY` now reads back as nullable, because that is what it is. Pre-v1, so no compatibility with older Ptah is owed; the compatibility that matters here is with the pinned binary, and it improves in both directions. Nothing here makes `ptah-compat` exit 0 where the pinned binary exits 1.

## Scope

SQLite only, as the register is. `docs/conformance.md` gains a section recording the rule, the measurement, and the uniqueness half.

---

## Independent review found a problem — read before merging

This branch was reviewed adversarially by an agent that re-measured every row on its own fixtures and databases. It **refuted** the change. Posting the PR anyway rather than sitting on the work: the reasoning below is what review needs, and CI is the real gate.

### What it found

REFUTED by a live PostgreSQL regression that the branch's own doc comment and conformance page explicitly deny.

The three SQLite claims (5.1, 5.2, 6.3) do reproduce and do hold on my own fixtures. The refutation is elsewhere: this PR decouples Nullable from Primary in six dialect-independent places (ast.ColumnNode.SetPrimary, internal/convert/toschema.markPrimaryFields, internal/atlashcl.markPrimaryFields, the SQL-DDL parser via SetPrimary, plus the two renderers), then argues the other engines are unaffected because "their renderers write NOT NULL themselves without consulting this flag". That is true only of the CREATE TABLE path. The PostgreSQL MODIFY-COLUMN path does consult the flag and has no Primary branch:

  core/renderer/internal/dialects/postgres/postgres.go:1155
      if column.Nullable {
          ... ALTER COLUMN %s DROP NOT NULL;
      } else {
          ... ALTER COLUMN %s SET NOT NULL;
      }

So the moment a single-column primary key column is touched by any column modification, HEAD now emits ALTER TABLE ... ALTER COLUMN "id" DROP NOT NULL, which PostgreSQL refuses outright.

=== ORACLE / SUT / CONTROL ===
ORACLE  /Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas -> "atlas community version v1.3.0"
CONTROL worktree /private/tmp/.../scratchpad/r1235/base, `git log --oneline -1` = 9820496e (the true merge-base of 643bc98d with origin/master; the PR text calls the base 92213b39, which is a different branch's head)
SUT     worktree /private/tmp/.../scratchpad/r1235/head, `git log --oneline -1` = 643bc98d
Binaries built fresh into separate directories bin-base/ bin-head/, chmod +x, every exit code read from an unpiped invocation.
DB: my own container `docker run -d --name r1235pgx -e POSTGRES_PASSWORD=pw -p 15982:5432 postgres:17`, CREATE ROLE ptah_user LOGIN PASSWORD 'ptah_password' SUPERUSER; CREATE DATABASE ptah_test OWNER ptah_user; CREATE DATABASE r1235_dev OWNER ptah_user. Removed at the end. MySQL databases r1235_my/r1235_mydev dropped at the end.

=== FAILING SHAPE 1 (compat surface, SQL source) — RENDERED *AND* APPLIED ===
Fixture (mine, not theirs):
  psql: CREATE TABLE users (id integer PRIMARY KEY, name text NOT NULL); INSERT INTO users VALUES (1,'a');
  v2.sql: CREATE TABLE users (id bigint PRIMARY KEY, name text NOT NULL);

  bin-base/ptah-compat schema apply --url "postgres://ptah_user:ptah_password@localhost:15982/ptah_test?sslmode=disable" --to file://.../v2.sql --auto-approve
    -> ALTER COLUMN "id" TYPE bigint; ... ALTER COLUMN "id" SET NOT NULL;  "Schema apply completed successfully."  exit 0
  (database reset to the identical fixture)
  bin-head/ptah-compat schema apply  <same arguments>
    -> ALTER COLUMN "id" TYPE bigint; ALTER COLUMN "id" DROP NOT NULL; ...
       Error: apply schema changes: failed to execute SQL statement: SQL execution failed:
       ERROR: column "id" is in a primary key (SQLSTATE 42P16)
       SQL: ALTER TABLE "users" ALTER COLUMN "id" DROP NOT NULL
       exit 1

Same failure as the bootstrap superuser (`postgres://postgres:pw@...`) -> exit 1. Not role-dependent. Engine-level control, ON_ERROR_STOP=1:
  psql -c 'ALTER TABLE "users" ALTER COLUMN "id" DROP NOT NULL;' -> ERROR: column "id" is in a primary key, exit 1.

The pinned v1.3.0 binary on the identical pair emits only:
  atlas schema diff --from "postgres://.../ptah_test?...&search_path=public" --to file://v2.sql --dev-url "postgres://.../r1235_dev?...&search_path=public"
  -> ALTER TABLE "users" ALTER COLUMN "id" TYPE bigint;
So HEAD is not merely different from the oracle here, it is unappliable where CONTROL and the oracle both succeed.

=== FAILING SHAPE 2 (compat surface, HCL source) — second independent entry point ===
v3null.hcl: table "users" { column "id" { null = true, type = bigint } ... primary_key { columns = [column.id] } }
  base -> ... ALTER COLUMN "id" SET NOT NULL;
  head -> ALTER TABLE "public"."users" ALTER COLUMN "id" DROP NOT NULL;
This one comes through internal/atlashcl/atlashcl.go markPrimaryFields, not the DDL parser, so the two entry points fail independently.

=== FAILING SHAPE 3 (native ptah, Go annotations — the flagship path) ===
models/user.go, verbatim in the shape CLAUDE.md documents:
  //ptah:schema:field name="id" type="BIGINT" primary="true"      (no not_null, so goschema.Field.Nullable = true)
  bin-base/ptah schema apply --root-dir models --db-url postgres://... --auto-approve -> exit 0 "Schema apply completed successfully."
  bin-head/ptah schema apply --root-dir models --db-url postgres://... --auto-approve -> exit 2
     error: ... ERROR: column "id" is in a primary key (SQLSTATE 42P16)
     SQL: ALTER TABLE "users" ALTER COLUMN "id" DROP NOT NULL

=== FAILING SHAPE 4 (migrate diff writes an unappliable file) ===
  bin-head/ptah-compat migrate diff init  --dir file://... --to file://v1.sql --dev-url postgres://.../r1235_dev
  bin-head/ptah-compat migrate diff widen --dir file://... --to file://v2.sql --dev-url postgres://.../r1235_dev
  -> 20260808073554_widen.sql contains: ALTER TABLE "users" ALTER COLUMN "id" DROP NOT NULL;
  The same two commands on bin-base write ... SET NOT NULL;. HEAD commits a migration file, with a valid atlas.sum, that PostgreSQL will refuse.

=== THE CLAIM THAT IS NOT CODE (item 8) ===
Two shipped sentences are false as measured:
- core/ast/nodes.go SetPrimary doc: "the PostgreSQL, MySQL, MariaDB and SQL Server renderers emit their own NOT NULL beside PRIMARY KEY without consulting this flag ... so their output does not depend on it."
- docs/conformance.md, new section: "The dialects that do imply NOT NULL from PRIMARY KEY keep doing so. Their renderers write it themselves without consulting the flag, and the comparator normalizes the generated side for every dialect except SQLite, so a PostgreSQL or MySQL key column still compares and renders exactly as before."
PostgreSQL renders differently and no longer applies. The comparator normalization (migration/schemadiff/internal/compare/columns.go

### What it says must change

Land the SQLite work, but not without closing the PostgreSQL (and SQL Server) MODIFY-COLUMN hole in the same commit, and correct the two false sentences.

1. Minimal fix, verified here. In core/renderer/internal/dialects/postgres/postgres.go:1155:
     -   if column.Nullable {
     +   if column.Nullable && !column.Primary {
   Built as bin-mut from a third worktree at 643bc98d; the failing shape 1 then plans `... ALTER COLUMN "id" SET NOT NULL;` and applies at exit 0 against my container, and `go test ./cmd/atlas/ ./core/renderer/... ./migration/... ./internal/... -count=1` stays exit 0 (so it does not disturb the three new SQLite tests). The edit was reverted and `git status --short` in that worktree is empty. Prefer expressing it as the same `primaryKeyImpliesNotNull(dialect)` predicate the branch already introduced twice, rather than a bare `!column.Primary`, so the rule lives in one place — but note that renderer is dialect-fixed, so `!column.Primary` is equivalent there.

2. Do the same for core/renderer/internal/dialects/mssql/mssql.go renderColumnForAlter (line 448): it writes bare `NULL` for a nullable column with no Primary branch and is reached from the ModifyColumnOperation case at line 131. Unmeasured here for lack of a live SQL Server, so either fix it by inspection and say it is unmeasured, or measure it.

3. Add the guard test at the layer that broke, not at the AST layer: a PostgreSQL case asserting that a ModifyColumnOperation on a single-column primary key renders SET NOT NULL and never DROP NOT NULL, with the inverse mutant recorded (revert the guard -> that row reddens; over-correct to always SET NOT NULL -> a non-key nullable column's DROP NOT NULL row reddens). The existing five mutants only exercise SQLite and could never have caught this.

4. Fix the two false claims:
   - core/ast/nodes.go SetPrimary doc: it is the CREATE TABLE renderers that ignore the flag; the PostgreSQL and SQL Server ALTER renderers read it, and decoupling here required changing them.
   - docs/conformance.md, the sentence "so a PostgreSQL or MySQL key column still compares and renders exactly as before". MySQL renders as before (measured, byte-identical). PostgreSQL did not, until the guard above. Say what was measured live rather than what was read: "PostgreSQL measured live on 17.x, MySQL measured live on 9.x; SQL Server and ClickHouse by inspection only."

5. Also worth recording while the area is open, since it was found next door and is NOT this PR's fault: a composite PRIMARY KEY whose columns are not spelled NOT NULL in the source produces `ALTER COLUMN ... DROP NOT NULL` on both 9820496e and 643bc98d, and PostgreSQL refuses that identically. It deserves its own issue rather than being folded in silently.

Reproduction, exactly as run:
  ORACLE=/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas   # "atlas community version v1.3.0"
  git worktree add --detach $SD/base 9820496e ; cd $SD/base ; git log --oneline -1
  go build -o $SD/bin-base/ptah-compat ./cmd/ptah-compat ; go build -o $SD/bin-base/ptah ./cmd/ptah ; chmod +x $SD/bin-base/*
  git worktree add --detach $SD/head 643bc98d ; cd $SD/head ; git log --oneline -1
  go build -o $SD/bin-head/ptah-compat ./cmd/ptah-compat ; go build -o $SD/bin-head/ptah ./cmd/ptah ; chmod +x $SD/bin-head/*
  docker run -d --name r1235pgx -e POSTGRES_PASSWORD=pw -p 15982:5432 postgres:17
  psql -U postgres -c "CREATE ROLE ptah_user LOGIN PASSWORD 'ptah_password' SUPERUSER;" -c "CREATE DATABASE ptah_test OWNER ptah_user;" -c "CREATE DATABASE r1235_dev OWNER ptah_user;"
  psql -U ptah_user -d ptah_test -v ON_ERROR_STOP=1 -c "CREATE TABLE users (id integer PRIMARY KEY, name text NOT NULL);" -c "INSERT INTO users VALUES (1,'a');"
  printf 'CREATE TABLE users (\n  id bigint PRIMARY KEY,\n  name text NOT NULL\n);\n' > $SD/fx/pg/v2.sql
  $SD/bin-base/ptah-compat schema apply --url "postgres://ptah_user:ptah_password@localhost:15982/ptah_test?sslmode=disable" --to "file://$SD/fx/pg/v2.sql"