### PR TITLE
Identify an RLS policy by the table it names, not by the string it was written as (#1276)

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -262,6 +262,17 @@ jobs:
           go test -v -count=1 ./internal/migrationreplay -tags=integration -run '^TestWithReplayedSnapshot_(ClickHouse|SQLServer)Live$' -timeout 5m
           go test -v -count=1 ./integration -tags=integration -run '^TestAtlasMigrateDiff(MySQLFamilyDatabaseDesiredState|PostgresFamilyDevCleanup)E2E$' -timeout 12m
 
+      # These two skip themselves without a live PostgreSQL, and a skip reads as
+      # a pass, so the log is grepped for the PASS lines afterwards.
+      - name: Run compatibility apply table-spelling tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -v -count=1 ./cmd/atlas -run '^TestSchemaApplyRLS(ReferenceToUndeclaredRelationRefused|DeclaredRelationAccepted)LivePostgres$' -timeout 5m > rls-spelling.log || { cat rls-spelling.log; exit 1; }
+          cat rls-spelling.log
+          grep -q -- '--- PASS: TestSchemaApplyRLSReferenceToUndeclaredRelationRefusedLivePostgres' rls-spelling.log
+          grep -q -- '--- PASS: TestSchemaApplyRLSDeclaredRelationAcceptedLivePostgres' rls-spelling.log
+
       - name: Build integration test binary
         run: |
           go build -race -o ./integration-test ./cmd/integration-test

--- a/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
+++ b/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
@@ -1,0 +1,190 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// livePostgresURLForRLSSpelling gates these tests on the same environment
+// variable as the other live PostgreSQL compatibility tests.
+func livePostgresURLForRLSSpelling(t *testing.T) string {
+	t.Helper()
+	dbURL := os.Getenv("POSTGRES_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN or TEST_DATABASE_URL not set")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		t.Skip("PostgreSQL URL required for RLS table spelling live tests")
+	}
+	return dbURL
+}
+
+// createRLSSpellingDatabases provisions an empty target database and a separate
+// empty dev database, and registers their removal.
+//
+// They must be two databases rather than two schemas: the dev database is reset
+// destructively before the plan is rehearsed on it, and `schema apply` refuses
+// outright when --dev-url may address the target.
+func createRLSSpellingDatabases(t *testing.T, adminURL string) (targetURL, devURL string) {
+	t.Helper()
+	c := qt.New(t)
+	suffix := fmt.Sprintf("%d_%d", os.Getpid(), time.Now().UnixNano()%1_000_000)
+	targetName := "ptah_rls_target_" + suffix
+	devName := "ptah_rls_dev_" + suffix
+	conn, err := dbschema.ConnectToDatabase(context.Background(), adminURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+targetName+" WITH (FORCE)")
+		_, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+devName+" WITH (FORCE)")
+		dbschema.CloseAndWarn(conn)
+	})
+	for _, name := range []string{targetName, devName} {
+		_, err := conn.ExecContext(context.Background(), "CREATE DATABASE "+name)
+		c.Assert(err, qt.IsNil)
+	}
+	return databaseURL(c, adminURL, targetName), databaseURL(c, adminURL, devName)
+}
+
+// databaseURL rewrites the database component of a PostgreSQL URL, keeping
+// credentials, host and query parameters.
+func databaseURL(c *qt.C, adminURL, database string) string {
+	c.Helper()
+	parsed, err := url.Parse(adminURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + database
+	return parsed.String()
+}
+
+// rlsPolicyRows reports the relations carrying a row-level security policy in
+// the public schema, as `relname/polname` pairs.
+func rlsPolicyRows(t *testing.T, dbURL string) []string {
+	t.Helper()
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	rows, err := conn.QueryContext(context.Background(),
+		`SELECT c.relname || '/' || p.polname
+		   FROM pg_policy p
+		   JOIN pg_class c ON c.oid = p.polrelid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		  WHERE n.nspname = 'public'
+		  ORDER BY 1`)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = rows.Close() }()
+	found := []string{}
+	for rows.Next() {
+		var row string
+		c.Assert(rows.Scan(&row), qt.IsNil)
+		found = append(found, row)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return found
+}
+
+// runCompatSchemaApply runs `schema apply` on the compatibility binary's
+// command tree and returns its combined output and error.
+func runCompatSchemaApply(targetURL, devURL, schemaPath string) (string, error) {
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"schema", "apply",
+		"--url", targetURL,
+		"--to", "file://" + schemaPath,
+		"--dev-url", devURL,
+		"--auto-approve",
+	})
+	err := cmd.Execute()
+	return out.String(), err
+}
+
+// TestSchemaApplyRLSReferenceToUndeclaredRelationRefusedLivePostgres is the
+// compatibility floor for a schema file whose row-level security declaration
+// names a relation the file does not declare.
+//
+// `CREATE TABLE "ORDERS"` creates the relation `ORDERS`; `ALTER TABLE orders`
+// names `orders`, which is a different relation and does not exist. Measured on
+// PostgreSQL 17.10 with `-v ON_ERROR_STOP=1`, psql exits 3 on this file with
+// `relation "orders" does not exist`, and the pinned Atlas community v1.3.0
+// binary exits 1 with `read state from "schema.sql": ... pq: relation "orders"
+// does not exist (42P01)`.
+//
+// Ptah must not exit 0 where that binary exits 1. Binding the reference to the
+// case-preserving declaration instead applied cleanly and put the policy on
+// `ORDERS`, leaving the relation the author named with `relrowsecurity = f` and
+// no policy at all — a silently relocated access-control declaration.
+func TestSchemaApplyRLSReferenceToUndeclaredRelationRefusedLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSSpelling(t)
+	targetURL, devURL := createRLSSpellingDatabases(t, adminURL)
+	schemaPath := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		`CREATE TABLE "ORDERS" (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	out, err := runCompatSchemaApply(targetURL, devURL, schemaPath)
+
+	// The rehearsal on the dev database reproduces PostgreSQL's own answer, so
+	// the apply is refused and the target keeps no policy on either spelling.
+	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*relation "orders" does not exist.*the plan was not applied to the target database`)
+	c.Assert(out, qt.Not(qt.Contains), "Schema apply completed successfully.")
+	c.Assert(rlsPolicyRows(t, targetURL), qt.DeepEquals, []string{})
+}
+
+// TestSchemaApplyRLSDeclaredRelationAcceptedLivePostgres is the
+// non-interference control: the same surface, the same command, a file
+// PostgreSQL accepts. The pinned Atlas community v1.3.0 binary exits 0 on it,
+// and so must Ptah — twice, converging on the second run.
+//
+// Every table here is declared in the case the row-level security declarations
+// name, and one of them names it in the other case, which is the fold this
+// resolver exists for: an unquoted `ORDERS` reaches the table declared
+// `orders`. Measured on PostgreSQL 17.10, replaying the render of this file
+// exits 0 with both policies in pg_policy.
+func TestSchemaApplyRLSDeclaredRelationAcceptedLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSSpelling(t)
+	targetURL, devURL := createRLSSpellingDatabases(t, adminURL)
+	schemaPath := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+CREATE TABLE shipments (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE ORDERS ENABLE ROW LEVEL SECURITY;
+ALTER TABLE shipments ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
+CREATE POLICY tenant_isolation ON shipments FOR ALL TO PUBLIC USING (tenant_id = 2);
+`), 0o600), qt.IsNil)
+
+	firstOut, firstErr := runCompatSchemaApply(targetURL, devURL, schemaPath)
+	secondOut, secondErr := runCompatSchemaApply(targetURL, devURL, schemaPath)
+
+	// One policy name per table, both applied, and the second run has nothing
+	// left to do.
+	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", firstOut))
+	c.Assert(firstOut, qt.Contains, "Schema apply completed successfully.")
+	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", secondOut))
+	c.Assert(secondOut, qt.Contains, "Schema is synced, no changes to be made.")
+	c.Assert(rlsPolicyRows(t, targetURL), qt.DeepEquals, []string{
+		"orders/tenant_isolation",
+		"shipments/tenant_isolation",
+	})
+}

--- a/cmd/internal/schemaload/rls_policy_table_spelling_test.go
+++ b/cmd/internal/schemaload/rls_policy_table_spelling_test.go
@@ -1,0 +1,94 @@
+package schemaload_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/schemaload"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+// oneTableTwoPolicySpellings declares a table without a schema and then names
+// that table twice, once bare and once with the default schema. PostgreSQL
+// reads both as `public.orders`, so this is one policy declared twice, not two
+// policies. Measured on PostgreSQL 17.10, replaying these four statements
+// exits 3 with `ERROR:  policy "p" for table "orders" already exists`
+// (stokaro/ptah#1276).
+const oneTableTwoPolicySpellings = `CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON orders        FOR ALL TO PUBLIC USING (tenant_id = 1);
+CREATE POLICY p ON public.orders FOR ALL TO PUBLIC USING (tenant_id = 2);
+`
+
+// TestLoad_SQLSchemaFileFoldsTwoSpellingsOfOnePolicysTable pins the surface
+// where invalid DDL escapes. `ptah schema render --schema-file` renders the
+// loaded schema directly, with no comparison in between, so a schema carrying
+// both spellings emitted two CREATE POLICY statements against one table and
+// the database rejected the second.
+//
+// The survivor must be the first declaration: deduplication keeps the first,
+// and a row-level-security predicate that silently changes from `tenant_id =
+// 1` to `tenant_id = 2` is the same defect wearing a quieter coat.
+func TestLoad_SQLSchemaFileFoldsTwoSpellingsOfOnePolicysTable(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(oneTableTwoPolicySpellings), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Name, qt.Equals, "p")
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "orders")
+	c.Assert(database.RLSPolicies[0].UsingExpression, qt.Equals, "tenant_id = 1")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+}
+
+// TestLoad_SQLSchemaFileKeepsOnePolicyNamePerTable is the control the fold
+// must not swallow: two tables in one schema may each carry a policy called
+// `p`, and PostgreSQL keeps both rows in pg_policy.
+func TestLoad_SQLSchemaFileKeepsOnePolicyNamePerTable(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE alpha_orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+CREATE TABLE zeta_orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE alpha_orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE zeta_orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON alpha_orders FOR ALL TO PUBLIC USING (tenant_id = 1);
+CREATE POLICY p ON zeta_orders  FOR ALL TO PUBLIC USING (tenant_id = 2);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 2)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"alpha_orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+		"CREATE POLICY \"p\" ON \"zeta_orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 2)\n;",
+	})
+}
+
+// createPolicyStatements keeps the rendered CREATE POLICY statements, trimmed,
+// so a fixture asserts on the policies rather than on the whole schema.
+func createPolicyStatements(statements []string) []string {
+	trimmed := make([]string, 0, len(statements))
+	for _, statement := range statements {
+		trimmed = append(trimmed, strings.TrimSpace(statement))
+	}
+	return slices.DeleteFunc(trimmed, func(statement string) bool {
+		return !strings.HasPrefix(statement, "CREATE POLICY ")
+	})
+}

--- a/cmd/internal/schemaload/rls_policy_table_spelling_test.go
+++ b/cmd/internal/schemaload/rls_policy_table_spelling_test.go
@@ -54,6 +54,133 @@ func TestLoad_SQLSchemaFileFoldsTwoSpellingsOfOnePolicysTable(t *testing.T) {
 	})
 }
 
+// oneTableTwoPolicyCases spells the same table three ways: declared as
+// `orders`, enabled as `ORDERS`, and carrying `p` under both spellings. An
+// unquoted PostgreSQL identifier folds to lower case, so all three are
+// `public.orders`. Measured on PostgreSQL 17.10, replaying these four
+// statements exits 3 with `ERROR:  policy "p" for table "orders" already
+// exists` (stokaro/ptah#1276).
+const oneTableTwoPolicyCases = `CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE ORDERS ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON orders  FOR ALL TO PUBLIC USING (tenant_id = 1);
+CREATE POLICY p ON ORDERS  FOR ALL TO PUBLIC USING (tenant_id = 2);
+`
+
+// TestLoad_SQLSchemaFileFoldsACaseVariantOfOnePolicysTable is the case-variant
+// half of the same surface. The SQL reader stores an identifier as it was
+// written, so `ORDERS` arrived as a table of its own: the render carried a
+// second CREATE POLICY and an ALTER TABLE against a table nothing declared,
+// and PostgreSQL answered `relation "ORDERS" does not exist`.
+//
+// Every statement here must name `orders`, because that is the table the
+// schema declares and the only one the render may reach.
+func TestLoad_SQLSchemaFileFoldsACaseVariantOfOnePolicysTable(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(oneTableTwoPolicyCases), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "orders")
+	c.Assert(database.RLSPolicies[0].UsingExpression, qt.Equals, "tenant_id = 1")
+	c.Assert(database.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(database.RLSEnabledTables[0].Table, qt.Equals, "orders")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
+		`ALTER TABLE "orders" ENABLE ROW LEVEL SECURITY;`,
+	})
+}
+
+// TestLoad_SQLSchemaFileKeepsACaseVariantDeclaredFirst pins the half a
+// deduplication key alone cannot reach. Deduplication keeps the first
+// declaration, so when the variant spelling comes first the survivor still has
+// to name the declared table.
+func TestLoad_SQLSchemaFileKeepsACaseVariantDeclaredFirst(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON ORDERS FOR ALL TO PUBLIC USING (tenant_id = 2);
+CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 2)\n;",
+	})
+}
+
+// TestLoad_SQLSchemaFileBindsToTheDeclaredCase shows the rule is "name the
+// declared table", not "lower-case everything". The SQL reader keeps
+// `CREATE TABLE ORDERS` as `ORDERS`, so a policy written `ON orders` has to
+// reach `ORDERS` -- the only table this schema declares. Rendered the other
+// way the statements name a table nothing declared, and PostgreSQL 17.10
+// answers `relation "orders" does not exist`.
+func TestLoad_SQLSchemaFileBindsToTheDeclaredCase(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE ORDERS (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "ORDERS")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"ORDERS\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
+		`ALTER TABLE "ORDERS" ENABLE ROW LEVEL SECURITY;`,
+	})
+}
+
+// TestLoad_SQLSchemaFileKeepsTwoTablesDifferingOnlyInCase is the boundary the
+// case fold must not cross. A quoted identifier keeps its case, so `orders`
+// and `"ORDERS"` are two tables; PostgreSQL 17.10 accepts a policy called `p`
+// on each and reports both rows in pg_policy.
+func TestLoad_SQLSchemaFileKeepsTwoTablesDifferingOnlyInCase(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+CREATE TABLE "ORDERS" (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+ALTER TABLE "ORDERS" ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
+CREATE POLICY p ON "ORDERS" FOR ALL TO PUBLIC USING (tenant_id = 2);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 2)
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+		"CREATE POLICY \"p\" ON \"ORDERS\" FOR ALL TO PUBLIC\n    USING (tenant_id = 2)\n;",
+	})
+}
+
 // TestLoad_SQLSchemaFileKeepsOnePolicyNamePerTable is the control the fold
 // must not swallow: two tables in one schema may each carry a policy called
 // `p`, and PostgreSQL keeps both rows in pg_policy.
@@ -84,11 +211,22 @@ CREATE POLICY p ON zeta_orders  FOR ALL TO PUBLIC USING (tenant_id = 2);
 // createPolicyStatements keeps the rendered CREATE POLICY statements, trimmed,
 // so a fixture asserts on the policies rather than on the whole schema.
 func createPolicyStatements(statements []string) []string {
+	return statementsWithPrefix(statements, "CREATE POLICY ")
+}
+
+// rowLevelSecurityStatements keeps the rendered RLS enablement statements. The
+// policy and the enablement name the same table, and a render is only
+// replayable when both spell it the way the schema declares it.
+func rowLevelSecurityStatements(statements []string) []string {
+	return statementsWithPrefix(statements, "ALTER TABLE ")
+}
+
+func statementsWithPrefix(statements []string, prefix string) []string {
 	trimmed := make([]string, 0, len(statements))
 	for _, statement := range statements {
 		trimmed = append(trimmed, strings.TrimSpace(statement))
 	}
 	return slices.DeleteFunc(trimmed, func(statement string) bool {
-		return !strings.HasPrefix(statement, "CREATE POLICY ")
+		return !strings.HasPrefix(statement, prefix)
 	})
 }

--- a/cmd/internal/schemaload/rls_policy_table_spelling_test.go
+++ b/cmd/internal/schemaload/rls_policy_table_spelling_test.go
@@ -123,17 +123,25 @@ CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
 	})
 }
 
-// TestLoad_SQLSchemaFileBindsToTheDeclaredCase shows the rule is "name the
-// declared table", not "lower-case everything". The SQL reader keeps
-// `CREATE TABLE ORDERS` as `ORDERS`, so a policy written `ON orders` has to
-// reach `ORDERS` -- the only table this schema declares. Rendered the other
-// way the statements name a table nothing declared, and PostgreSQL 17.10
-// answers `relation "orders" does not exist`.
-func TestLoad_SQLSchemaFileBindsToTheDeclaredCase(t *testing.T) {
+// TestLoad_SQLSchemaFileDoesNotFoldOntoACasePreservingTable is the direction
+// the fold must not run. The SQL reader keeps `CREATE TABLE "ORDERS"` as
+// `ORDERS` and discards the quoting, so a declaration spelled `ORDERS` is
+// indistinguishable from one written `"ORDERS"` -- and to PostgreSQL those are
+// two different relations, only one of which a reference written `orders`
+// reaches. Folding the declaration up to meet the reference therefore has to be
+// wrong for one of two inputs Ptah cannot tell apart, and being wrong for the
+// quoted one moves an access-control declaration onto a relation the author did
+// not name.
+//
+// Measured on PostgreSQL 17.10 with `-v ON_ERROR_STOP=1`, this exact file exits
+// 3 with `relation "orders" does not exist`. The render must say the same thing:
+// every statement keeps `orders`, so replaying it reproduces the database's own
+// answer instead of quietly succeeding against `ORDERS`.
+func TestLoad_SQLSchemaFileDoesNotFoldOntoACasePreservingTable(t *testing.T) {
 	c := qt.New(t)
 
 	path := filepath.Join(t.TempDir(), "schema.sql")
-	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE ORDERS (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE "ORDERS" (id INTEGER PRIMARY KEY, tenant_id INTEGER);
 ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
 CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
 `), 0o600), qt.IsNil)
@@ -141,15 +149,49 @@ CREATE POLICY p ON orders FOR ALL TO PUBLIC USING (tenant_id = 1);
 	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
 	c.Assert(err, qt.IsNil)
 	c.Assert(database.RLSPolicies, qt.HasLen, 1)
-	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "ORDERS")
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "orders")
+	c.Assert(database.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(database.RLSEnabledTables[0].Table, qt.Equals, "orders")
 
 	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
 	c.Assert(err, qt.IsNil)
 	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
-		"CREATE POLICY \"p\" ON \"ORDERS\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
 	})
 	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
-		`ALTER TABLE "ORDERS" ENABLE ROW LEVEL SECURITY;`,
+		`ALTER TABLE "orders" ENABLE ROW LEVEL SECURITY;`,
+	})
+}
+
+// TestLoad_SQLSchemaFileFoldsOntoALowerCaseTableDeclaredUnquoted is the other
+// half of the same boundary, and the reason the fold exists at all. The
+// declaration here is already its own folded form, so a reference written
+// `ORDERS` reaches it exactly as PostgreSQL says it does, and the render names
+// the declared table. The two tests differ only in the case of the CREATE
+// TABLE, which is what makes the rule one-directional rather than absent.
+func TestLoad_SQLSchemaFileFoldsOntoALowerCaseTableDeclaredUnquoted(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE ORDERS ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "orders")
+	c.Assert(database.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(database.RLSEnabledTables[0].Table, qt.Equals, "orders")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
+		`ALTER TABLE "orders" ENABLE ROW LEVEL SECURITY;`,
 	})
 }
 

--- a/core/goschema/parser.go
+++ b/core/goschema/parser.go
@@ -837,19 +837,29 @@ func (s *schemaParseState) processAllFileComments(f *ast.File) error {
 	return nil
 }
 
+// rlsPolicyKey identifies an RLS policy the way PostgreSQL does: by the table
+// that owns it together with its name. A policy name is scoped to its table,
+// not to the schema, so two tables may each carry one called
+// "tenant_isolation". Recording only the name here dropped the second of the
+// two before anything downstream could see it (stokaro/ptah#1276).
+type rlsPolicyKey struct {
+	table  string
+	policy string
+}
+
 type rlsCommentSet struct {
-	policies      map[string]struct{}
+	policies      map[rlsPolicyKey]struct{}
 	enabledTables map[string]struct{}
 }
 
 func (s *schemaParseState) newRLSCommentSet() rlsCommentSet {
 	seen := rlsCommentSet{
-		policies:      make(map[string]struct{}, len(s.rlsPolicies)),
+		policies:      make(map[rlsPolicyKey]struct{}, len(s.rlsPolicies)),
 		enabledTables: make(map[string]struct{}, len(s.rlsEnabledTables)),
 	}
 
 	for _, policy := range s.rlsPolicies {
-		seen.policies[policy.Name] = struct{}{}
+		seen.policies[rlsPolicyKey{table: policy.Table, policy: policy.Name}] = struct{}{}
 	}
 	for _, table := range s.rlsEnabledTables {
 		seen.enabledTables[table.Table] = struct{}{}
@@ -881,7 +891,8 @@ func (s *schemaParseState) parseFileScopedRLSPolicyComment(comment *ast.Comment,
 	if policyName == "" || tableName == "" {
 		return nil
 	}
-	if _, exists := seen.policies[policyName]; exists {
+	key := rlsPolicyKey{table: tableName, policy: policyName}
+	if _, exists := seen.policies[key]; exists {
 		return nil
 	}
 
@@ -900,7 +911,7 @@ func (s *schemaParseState) parseFileScopedRLSPolicyComment(comment *ast.Comment,
 		WithCheckExpression: kv["with_check"],
 		Comment:             kv["comment"],
 	})
-	seen.policies[policyName] = struct{}{}
+	seen.policies[key] = struct{}{}
 	return nil
 }
 

--- a/core/goschema/rls_policy_identity_encoding_test.go
+++ b/core/goschema/rls_policy_identity_encoding_test.go
@@ -1,0 +1,107 @@
+package goschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// dottedPolicyCase is one pair of (table, policy name) that a delimiter-joined
+// identity cannot tell apart.
+type dottedPolicyCase struct {
+	name     string
+	tables   []goschema.Table
+	policies []goschema.RLSPolicy
+	wantKept int
+}
+
+// TestDeduplicate_KeepsPoliciesADelimiterWouldCollapse pins that the (table,
+// policy name) identity is injective.
+//
+// Keying by the policy name alone dropped the second of two identically named
+// policies on different tables (stokaro/ptah#1276). Repairing that by joining
+// the resolved table and the policy name with a "." reintroduced the same loss
+// through a different door: both components are independently valid PostgreSQL
+// identifiers that may contain a literal dot, and Table.QualifiedName already
+// spends the dot structurally.
+//
+// Measured on PostgreSQL 17.10 -- both of these exist in one database at once,
+// so the pair is a real catalog state rather than a synthetic one:
+//
+//	CREATE TABLE a (...);      CREATE POLICY "b.c" ON a ...   -- public | a | b.c
+//	CREATE SCHEMA a;
+//	CREATE TABLE a.b (...);    CREATE POLICY c ON a.b ...     -- a      | b | c
+//
+// Joined with a dot both become `a.b.c`, and deduplication keeps one.
+func TestDeduplicate_KeepsPoliciesADelimiterWouldCollapse(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []dottedPolicyCase{
+		{
+			// The shape the reviewer reproduced.
+			name: "a dotted policy name against a schema-qualified table",
+			tables: []goschema.Table{
+				{StructName: "A", Name: "a"},
+				{StructName: "B", Name: "b", Schema: "a"},
+			},
+			policies: []goschema.RLSPolicy{
+				{StructName: "A", Name: "b.c", Table: "a", PolicyFor: "SELECT", UsingExpression: "true"},
+				{StructName: "B", Name: "c", Table: "a.b", PolicyFor: "SELECT", UsingExpression: "true"},
+			},
+			wantKept: 2,
+		},
+		{
+			// The same collision with no schema in play, so the fix cannot be
+			// "always qualify the table".
+			name: "a dotted table name against a dotted policy name",
+			tables: []goschema.Table{
+				{StructName: "X", Name: "x.y"},
+				{StructName: "Y", Name: "x"},
+			},
+			policies: []goschema.RLSPolicy{
+				{StructName: "X", Name: "z", Table: "x.y", PolicyFor: "SELECT", UsingExpression: "true"},
+				{StructName: "Y", Name: "y.z", Table: "x", PolicyFor: "SELECT", UsingExpression: "true"},
+			},
+			wantKept: 2,
+		},
+		{
+			// The control against the fix becoming "never deduplicate": one
+			// policy declared twice on one table is still one policy.
+			name: "the same policy on the same table is still one",
+			tables: []goschema.Table{
+				{StructName: "A", Name: "a"},
+			},
+			policies: []goschema.RLSPolicy{
+				{StructName: "A", Name: "p", Table: "a", PolicyFor: "SELECT", UsingExpression: "true"},
+				{StructName: "A", Name: "p", Table: "a", PolicyFor: "SELECT", UsingExpression: "true"},
+			},
+			wantKept: 1,
+		},
+		{
+			// And the row the original fix exists to protect.
+			name: "one policy name on two tables survives whole",
+			tables: []goschema.Table{
+				{StructName: "A", Name: "alpha"},
+				{StructName: "B", Name: "beta"},
+			},
+			policies: []goschema.RLSPolicy{
+				{StructName: "A", Name: "tenant_isolation", Table: "alpha", PolicyFor: "SELECT", UsingExpression: "true"},
+				{StructName: "B", Name: "tenant_isolation", Table: "beta", PolicyFor: "SELECT", UsingExpression: "true"},
+			},
+			wantKept: 2,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			database := &goschema.Database{Tables: test.tables, RLSPolicies: test.policies}
+
+			goschema.Deduplicate(database)
+
+			c.Assert(database.RLSPolicies, qt.HasLen, test.wantKept,
+				qt.Commentf("kept %d of %d policies", len(database.RLSPolicies), len(test.policies)))
+		})
+	}
+}

--- a/core/goschema/rls_policy_identity_test.go
+++ b/core/goschema/rls_policy_identity_test.go
@@ -178,6 +178,54 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			},
 		},
 		{
+			// The direction the fold must not run. Ptah discards quoting, so
+			// a table declared `ORDERS` is indistinguishable from one written
+			// `"ORDERS"` -- and PostgreSQL reads those as two different
+			// relations, only one of which a reference written `orders`
+			// reaches. Measured on PostgreSQL 17.10, a file declaring
+			// `CREATE TABLE "ORDERS"` and then `CREATE POLICY p ON orders`
+			// exits 3 with `relation "orders" does not exist`. Folding the
+			// declaration up to meet the reference would instead protect
+			// `ORDERS` and leave the named relation unprotected, so the
+			// reference keeps its spelling and nothing binds.
+			name:   "a case-preserving declared table does not capture a lower-case reference",
+			tables: []goschema.Table{{Name: "ORDERS", StructName: "OrdersTable"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
+			// The schema half of a qualified name is an identifier too, and
+			// answers the same question. Measured on PostgreSQL 17.10, a file
+			// declaring `CREATE SCHEMA "App"` and then naming `app.ledger`
+			// exits 3 with `schema "app" does not exist`.
+			name:   "a case-preserving declared schema does not capture a folded reference",
+			tables: []goschema.Table{{Name: "orders", Schema: "App", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "app.orders", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "app.orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
+			// The pair to the row above, differing only in the case of the
+			// declared schema. `CREATE SCHEMA app` is its own folded form, so
+			// PostgreSQL 17.10 accepts `CREATE POLICY row_guard ON APP.LEDGER`
+			// against `app.ledger` with exit 0, and the fold runs.
+			name:   "a folded reference reaches a schema declared in lower case",
+			tables: []goschema.Table{{Name: "orders", Schema: "app", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "APP.ORDERS", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "app.orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
 			// The control that bounds the case fold: a quoted identifier keeps
 			// its case, so `orders` and `"ORDERS"` are two tables. PostgreSQL
 			// 17.10 accepts a policy called `p` on each and reports both rows

--- a/core/goschema/rls_policy_identity_test.go
+++ b/core/goschema/rls_policy_identity_test.go
@@ -75,13 +75,20 @@ type AlphaOrder struct {
 }
 
 func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
+	twoTables := []goschema.Table{
+		{Name: "alpha_orders", StructName: "AlphaOrder"},
+		{Name: "zeta_orders", StructName: "ZetaOrder"},
+	}
+
 	tests := []struct {
 		name     string
+		tables   []goschema.Table
 		policies []goschema.RLSPolicy
 		want     []goschema.RLSPolicy
 	}{
 		{
-			name: "one name on two tables survives whole",
+			name:   "one name on two tables survives whole",
+			tables: twoTables,
 			policies: []goschema.RLSPolicy{
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
 				{Name: "tenant_isolation", Table: "zeta_orders", UsingExpression: "tenant_id = 2"},
@@ -92,7 +99,8 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			},
 		},
 		{
-			name: "the same name on the same table collapses",
+			name:   "the same name on the same table collapses",
+			tables: twoTables,
 			policies: []goschema.RLSPolicy{
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
@@ -106,7 +114,8 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			// refuse the second CREATE POLICY outright, so two declarations of
 			// one policy still collapse to the first even when their
 			// definitions disagree.
-			name: "the same name on the same table collapses despite a different definition",
+			name:   "the same name on the same table collapses despite a different definition",
+			tables: twoTables,
 			policies: []goschema.RLSPolicy{
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 2"},
@@ -115,16 +124,52 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
 			},
 		},
+		{
+			// A table declared without a schema is reached both as `orders`
+			// and as `public.orders`, and PostgreSQL treats those as one
+			// table: measured on PostgreSQL 17.10, `CREATE POLICY p ON orders`
+			// followed by `CREATE POLICY p ON public.orders` is refused with
+			// `policy "p" for table "orders" already exists`. Keying the two
+			// spellings apart kept both, and `ptah schema render` then emitted
+			// a pair of CREATE POLICY statements the database rejects. The
+			// survivor is the first, so the applied USING expression is the
+			// one written first rather than whichever spelling came last.
+			name:   "two spellings of one unqualified table collapse onto the first",
+			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "public.orders", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
+			// The control that separates the fold above from folding every
+			// qualified spelling together: two tables of the same name in two
+			// schemas are two tables, and one policy name on each is two
+			// policies. PostgreSQL accepts both.
+			name: "one name on the same table name in two schemas survives whole",
+			tables: []goschema.Table{
+				{Name: "orders", Schema: "tenanta", StructName: "TenantAOrder"},
+				{Name: "orders", Schema: "tenantb", StructName: "TenantBOrder"},
+			},
+			policies: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "tenanta.orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "tenantb.orders", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "tenanta.orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "tenantb.orders", UsingExpression: "tenant_id = 2"},
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
 			database := &goschema.Database{
-				Tables: []goschema.Table{
-					{Name: "alpha_orders", StructName: "AlphaOrder"},
-					{Name: "zeta_orders", StructName: "ZetaOrder"},
-				},
+				Tables:      test.tables,
 				RLSPolicies: test.policies,
 			}
 

--- a/core/goschema/rls_policy_identity_test.go
+++ b/core/goschema/rls_policy_identity_test.go
@@ -1,0 +1,136 @@
+package goschema_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+)
+
+// A PostgreSQL RLS policy name is scoped to its table, not to the schema.
+// Measured on PostgreSQL 17.10: CREATE POLICY tenant_isolation succeeds on
+// public.alpha_orders and again on public.zeta_orders, leaving two rows in
+// pg_policy, and is refused only when repeated on the same table. Recording a
+// policy by name alone therefore threw one of the two away before anything
+// downstream could compare it (stokaro/ptah#1276).
+const sharedPolicyNameSource = `package entities
+
+//ptah:schema:rls:enable table="alpha_orders"
+//ptah:schema:rls:policy name="tenant_isolation" table="alpha_orders" for="ALL" to="PUBLIC" using="tenant_id = 1"
+
+//ptah:schema:table name="alpha_orders"
+type AlphaOrder struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+
+//ptah:schema:rls:enable table="zeta_orders"
+//ptah:schema:rls:policy name="tenant_isolation" table="zeta_orders" for="ALL" to="PUBLIC" using="tenant_id = 2"
+
+//ptah:schema:table name="zeta_orders"
+type ZetaOrder struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+`
+
+func TestParseSource_KeepsOnePolicyNamePerTable(t *testing.T) {
+	c := qt.New(t)
+
+	database := mustParseSource(c, "fixture.go", sharedPolicyNameSource)
+
+	c.Assert(database.RLSPolicies, qt.HasLen, 2)
+	c.Assert(database.RLSPolicies[0].Name, qt.Equals, "tenant_isolation")
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "alpha_orders")
+	c.Assert(database.RLSPolicies[0].UsingExpression, qt.Equals, "tenant_id = 1")
+	c.Assert(database.RLSPolicies[1].Name, qt.Equals, "tenant_isolation")
+	c.Assert(database.RLSPolicies[1].Table, qt.Equals, "zeta_orders")
+	c.Assert(database.RLSPolicies[1].UsingExpression, qt.Equals, "tenant_id = 2")
+}
+
+// TestParseSource_RecordsAStructAttachedPolicyOnce is the control the
+// table-scoped key must not break: a policy annotation attached to its struct
+// is also visible to the file-wide comment scan, and it must still be recorded
+// exactly once.
+func TestParseSource_RecordsAStructAttachedPolicyOnce(t *testing.T) {
+	c := qt.New(t)
+
+	source := `package entities
+
+//ptah:schema:rls:enable table="alpha_orders"
+//ptah:schema:rls:policy name="tenant_isolation" table="alpha_orders" for="ALL" to="PUBLIC" using="tenant_id = 1"
+//ptah:schema:table name="alpha_orders"
+type AlphaOrder struct {
+	//ptah:schema:field name="id" type="INTEGER" primary="true"
+	ID int64
+}
+`
+
+	database := mustParseSource(c, "fixture.go", source)
+
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Name, qt.Equals, "tenant_isolation")
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "alpha_orders")
+}
+
+func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
+	tests := []struct {
+		name     string
+		policies []goschema.RLSPolicy
+		want     []goschema.RLSPolicy
+	}{
+		{
+			name: "one name on two tables survives whole",
+			policies: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "zeta_orders", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "zeta_orders", UsingExpression: "tenant_id = 2"},
+			},
+		},
+		{
+			name: "the same name on the same table collapses",
+			policies: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
+			// The key is the identity, not the definition: PostgreSQL would
+			// refuse the second CREATE POLICY outright, so two declarations of
+			// one policy still collapse to the first even when their
+			// definitions disagree.
+			name: "the same name on the same table collapses despite a different definition",
+			policies: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			database := &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "alpha_orders", StructName: "AlphaOrder"},
+					{Name: "zeta_orders", StructName: "ZetaOrder"},
+				},
+				RLSPolicies: test.policies,
+			}
+
+			goschema.Deduplicate(database)
+
+			c.Assert(database.RLSPolicies, qt.DeepEquals, test.want)
+		})
+	}
+}

--- a/core/goschema/rls_policy_identity_test.go
+++ b/core/goschema/rls_policy_identity_test.go
@@ -145,6 +145,72 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			},
 		},
 		{
+			// The schema is not the only part of a table that has more than
+			// one spelling. An unquoted PostgreSQL identifier folds to lower
+			// case, so `ORDERS` names the table declared as `orders`: measured
+			// on PostgreSQL 17.10, `CREATE POLICY p ON orders` followed by
+			// `CREATE POLICY p ON ORDERS` is refused with `policy "p" for
+			// table "orders" already exists`.
+			name:   "a case variant of one unqualified table collapses onto the first",
+			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
+			// Collapsing onto the first declaration is only half an answer if
+			// the first declaration is the variant spelling. The survivor has
+			// to name the declared table, because the renderer quotes what it
+			// is given and `CREATE POLICY "p" ON "ORDERS"` is answered by
+			// `relation "ORDERS" does not exist`.
+			name:   "a case variant declared first still names the declared table",
+			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 2"},
+			},
+		},
+		{
+			// The control that bounds the case fold: a quoted identifier keeps
+			// its case, so `orders` and `"ORDERS"` are two tables. PostgreSQL
+			// 17.10 accepts a policy called `p` on each and reports both rows
+			// in pg_policy. An ambiguous fold must resolve to nothing rather
+			// than pick one.
+			name: "two tables differing only in case keep one policy each",
+			tables: []goschema.Table{
+				{Name: "orders", StructName: "Order"},
+				{Name: "ORDERS", StructName: "ORDERSTable"},
+			},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
+			},
+		},
+		{
+			// A policy on a table nothing declares keeps its spelling. The
+			// resolver maps a reference onto a declared table or leaves it
+			// alone; it does not invent one.
+			name:   "a policy on an undeclared table keeps its spelling",
+			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+			policies: []goschema.RLSPolicy{
+				{Name: "p", Table: "archive.SHIPMENTS", UsingExpression: "tenant_id = 1"},
+			},
+			want: []goschema.RLSPolicy{
+				{Name: "p", Table: "archive.SHIPMENTS", UsingExpression: "tenant_id = 1"},
+			},
+		},
+		{
 			// The control that separates the fold above from folding every
 			// qualified spelling together: two tables of the same name in two
 			// schemas are two tables, and one policy name on each is two

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1150,7 +1150,9 @@ func deduplicateDatabase(
 	})
 
 	deduplicateSchemaObjects(r)
-	r.RLSPolicies = deduplicateRLSPolicies(r.RLSPolicies, resolver)
+	rlsResolver := newRLSTableResolver(r.Tables, resolver)
+	bindRLSTables(r, rlsResolver)
+	r.RLSPolicies = deduplicateRLSPolicies(r.RLSPolicies, rlsResolver)
 	r.RLSEnabledTables = deduplicateNamedDefinitions(r.RLSEnabledTables, func(table RLSEnabledTable) string {
 		return table.Table
 	})
@@ -1195,10 +1197,112 @@ func deduplicateExtensions(extensions []Extension) []Extension {
 	return deduplicated
 }
 
-// rlsPolicyTableSemantics are the identifier rules the owning table of an RLS
-// policy is folded with. Row-level security is a PostgreSQL-family construct,
-// so the default schema an unqualified table lands in is `public`.
-var rlsPolicyTableSemantics = identifier.ForDialect(platform.Postgres)
+// rlsTableSemantics are the identifier rules the owning table of a row-level
+// security declaration is folded with. Row-level security is a
+// PostgreSQL-family construct, so the default schema an unqualified table
+// lands in is `public`.
+var rlsTableSemantics = identifier.ForDialect(platform.Postgres)
+
+// rlsTableResolver answers one question: which declared table does this
+// row-level security declaration name?
+//
+// One table has more than one spelling, and PostgreSQL reaches it through all
+// of them. A table declared as `orders` is named by `orders`, by
+// `public.orders`, and by `ORDERS`, because an unquoted identifier folds to
+// lower case. Measured on PostgreSQL 17.10, `CREATE POLICY p ON orders`
+// followed by either `CREATE POLICY p ON public.orders` or
+// `CREATE POLICY p ON ORDERS` exits 3 with `policy "p" for table "orders"
+// already exists`: one policy declared twice, not two policies.
+//
+// Answering that question in one place is the point. Keying deduplication by
+// the string each declaration happened to use kept both, and `ptah schema
+// render` then emitted a pair of CREATE POLICY statements the database rejects
+// (stokaro/ptah#1276).
+//
+// Resolution never invents a name. It maps a reference onto a table that is
+// declared, or leaves the reference alone:
+//
+//   - the exact spelling wins, through [tableScopeResolver.resolve];
+//   - failing that, the table identity wins, which is what folds
+//     `public.orders` onto a table declared without a schema;
+//   - failing that, an ASCII case fold wins, and only when exactly one declared
+//     table matches. Two tables declared as `orders` and `"ORDERS"` are two
+//     tables -- PostgreSQL keeps a policy called `p` on each -- so an ambiguous
+//     fold resolves to nothing and the reference keeps its spelling.
+type rlsTableResolver struct {
+	scopes     tableScopeResolver
+	byIdentity map[string]string
+	byFolded   map[string]string
+}
+
+func newRLSTableResolver(tables []Table, scopes tableScopeResolver) rlsTableResolver {
+	resolver := rlsTableResolver{
+		scopes:     scopes,
+		byIdentity: make(map[string]string, len(tables)),
+		byFolded:   make(map[string]string, len(tables)),
+	}
+	for _, table := range tables {
+		qualifiedName := table.QualifiedName()
+		identity := rlsTableSemantics.QualifiedTableIdentityKey(qualifiedName)
+		addTableScope(resolver.byIdentity, identity, qualifiedName)
+		addTableScope(resolver.byFolded, foldedRLSTableIdentity(identity), qualifiedName)
+	}
+	return resolver
+}
+
+// foldedRLSTableIdentity folds the ASCII case an unquoted PostgreSQL identifier
+// loses on its way into the catalog.
+func foldedRLSTableIdentity(identity string) string {
+	return identifier.ComparisonASCIIInsensitive.IdentityKey(identity)
+}
+
+func (r rlsTableResolver) resolve(structName, table string) string {
+	scoped := r.scopes.resolve(structName, table)
+	identity := rlsTableSemantics.QualifiedTableIdentityKey(scoped)
+	if declared := resolvedTableScope(r.byIdentity, identity, ""); declared != "" {
+		return declared
+	}
+	if declared := resolvedTableScope(r.byFolded, foldedRLSTableIdentity(identity), ""); declared != "" {
+		return declared
+	}
+	return scoped
+}
+
+// bindRLSTables rewrites the table every row-level security declaration names
+// onto the declared table it reaches, so the rest of the pipeline sees one
+// spelling.
+//
+// Deduplicating on the resolved table is not enough on its own, because
+// deduplication keeps the first declaration and the first one may be the
+// variant spelling. On a table declared as `orders`, a schema whose first
+// policy says `ON ORDERS` rendered `CREATE POLICY "p" ON "ORDERS"` -- a table
+// nothing declared -- and PostgreSQL answered `relation "ORDERS" does not
+// exist`. That predates the table-scoped key and it is what "make every
+// spelling reach one answer" has to mean for a renderer that quotes what it is
+// given.
+//
+// A declaration whose table matches nothing declared keeps its spelling: it is
+// not this function's business to guess at a table it cannot see.
+func bindRLSTables(r *Database, resolver rlsTableResolver) {
+	for index := range r.RLSPolicies {
+		policy := &r.RLSPolicies[index]
+		policy.Table = boundRLSTable(resolver, policy.StructName, policy.Table)
+	}
+	for index := range r.RLSEnabledTables {
+		enabled := &r.RLSEnabledTables[index]
+		enabled.Table = boundRLSTable(resolver, enabled.StructName, enabled.Table)
+	}
+}
+
+// boundRLSTable leaves an omitted table alone. A declaration attached to a Go
+// struct names its table through that struct, and the renderer resolves it
+// there.
+func boundRLSTable(resolver rlsTableResolver, structName, table string) string {
+	if strings.TrimSpace(table) == "" {
+		return table
+	}
+	return resolver.resolve(structName, table)
+}
 
 // deduplicateRLSPolicies keeps one policy per (table, policy name) pair.
 //
@@ -1209,20 +1313,11 @@ var rlsPolicyTableSemantics = identifier.ForDialect(platform.Postgres)
 // dropped the second of two identically named policies before the comparator
 // ever saw it (stokaro/ptah#1276).
 //
-// The table component is that table's identity, not the string the policy was
-// written with, because one table has more than one spelling. A table declared
-// without a schema is reached both as `orders` and as `public.orders`, and
-// PostgreSQL treats those as one table: `CREATE POLICY p ON orders` followed by
-// `CREATE POLICY p ON public.orders` is refused with `policy "p" for table
-// "orders" already exists`. Keying the two spellings apart kept both, and
-// `ptah schema render` then emitted a pair of CREATE POLICY statements the
-// database rejects. [identifier.Semantics.QualifiedTableIdentityKey] is the
-// same fold the comparator applies through newQualifiedTableIdentity, so
-// deduplication and comparison agree on which table owns a policy.
-func deduplicateRLSPolicies(policies []RLSPolicy, resolver tableScopeResolver) []RLSPolicy {
+// The table component is the declared table the policy names rather than the
+// string it was written with, which is [rlsTableResolver]'s subject.
+func deduplicateRLSPolicies(policies []RLSPolicy, resolver rlsTableResolver) []RLSPolicy {
 	return deduplicateNamedDefinitions(policies, func(policy RLSPolicy) string {
-		table := compositeDeduplicationScope(resolver, policy.StructName, policy.Table)
-		return rlsPolicyTableSemantics.QualifiedTableIdentityKey(table) + "." + policy.Name
+		return resolver.resolve(policy.StructName, policy.Table) + "." + policy.Name
 	})
 }
 

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1225,10 +1225,20 @@ var rlsTableSemantics = identifier.ForDialect(platform.Postgres)
 //   - the exact spelling wins, through [tableScopeResolver.resolve];
 //   - failing that, the table identity wins, which is what folds
 //     `public.orders` onto a table declared without a schema;
-//   - failing that, an ASCII case fold wins, and only when exactly one declared
-//     table matches. Two tables declared as `orders` and `"ORDERS"` are two
-//     tables -- PostgreSQL keeps a policy called `p` on each -- so an ambiguous
-//     fold resolves to nothing and the reference keeps its spelling.
+//   - failing that, an ASCII case fold wins, and only downwards, onto a table
+//     whose declared name is already its own folded form ([foldTarget]), and
+//     only when exactly one declared table matches. Two tables declared as
+//     `orders` and `"ORDERS"` are two tables -- PostgreSQL keeps a policy
+//     called `p` on each -- so an ambiguous fold resolves to nothing and the
+//     reference keeps its spelling.
+//
+// The fold is one-directional because Ptah does not retain whether an
+// identifier was quoted. `CREATE TABLE ORDERS` and `CREATE TABLE "ORDERS"` are
+// two different instructions to PostgreSQL -- the first creates `orders`, the
+// second creates `ORDERS` -- and both reach this resolver as the string
+// `ORDERS`. Folding in both directions therefore has to be wrong for one of
+// two indistinguishable inputs, and being wrong for the quoted one relocates an
+// access-control declaration onto a relation the author did not name.
 type rlsTableResolver struct {
 	scopes     tableScopeResolver
 	byIdentity map[string]string
@@ -1245,9 +1255,34 @@ func newRLSTableResolver(tables []Table, scopes tableScopeResolver) rlsTableReso
 		qualifiedName := table.QualifiedName()
 		identity := rlsTableSemantics.QualifiedTableIdentityKey(qualifiedName)
 		addTableScope(resolver.byIdentity, identity, qualifiedName)
-		addTableScope(resolver.byFolded, foldedRLSTableIdentity(identity), qualifiedName)
+		if foldTarget(identity) {
+			addTableScope(resolver.byFolded, foldedRLSTableIdentity(identity), qualifiedName)
+		}
 	}
 	return resolver
+}
+
+// foldTarget reports whether a reference in some other case may be folded onto
+// a table declared under this identity.
+//
+// Only a table whose declared name is already its own folded form qualifies. A
+// table declared `orders` is indistinguishable from an unquoted lower-case
+// declaration, so folding `ORDERS` onto it is exactly what PostgreSQL does. A
+// table declared `ORDERS` or `Orders` may have been written `"ORDERS"` or
+// `"Orders"`, and Ptah cannot tell, so it is not a fold target: the reference
+// keeps its spelling and the render reproduces the database's own answer.
+//
+// Measured on PostgreSQL 17.10, on a file declaring `CREATE TABLE "ORDERS"` and
+// then writing `ALTER TABLE orders ENABLE ROW LEVEL SECURITY`, psql with
+// `-v ON_ERROR_STOP=1` exits 3 with `relation "orders" does not exist`, and the
+// pinned Atlas community v1.3.0 binary exits 1 on the same file. Folding the
+// declaration up instead bound both statements to `ORDERS`, applied cleanly,
+// and left the relation the file named with `relrowsecurity = f` and no policy.
+//
+// The schema half of the identity is an identifier too, and answers the same
+// question: `app` may be folded onto, `App` may not.
+func foldTarget(identity string) bool {
+	return identity == foldedRLSTableIdentity(identity)
 }
 
 // foldedRLSTableIdentity folds the ASCII case an unquoted PostgreSQL identifier
@@ -1282,7 +1317,11 @@ func (r rlsTableResolver) resolve(structName, table string) string {
 // given.
 //
 // A declaration whose table matches nothing declared keeps its spelling: it is
-// not this function's business to guess at a table it cannot see.
+// not this function's business to guess at a table it cannot see. "Matches" is
+// [rlsTableResolver.resolve]'s answer, and the case fold inside it only runs
+// downwards, so a file declaring `"ORDERS"` and naming `orders` does not match:
+// the render keeps `orders`, and PostgreSQL answers `relation "orders" does not
+// exist` exactly as it answers the source file.
 func bindRLSTables(r *Database, resolver rlsTableResolver) {
 	for index := range r.RLSPolicies {
 		policy := &r.RLSPolicies[index]

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1343,6 +1343,18 @@ func boundRLSTable(resolver rlsTableResolver, structName, table string) string {
 	return resolver.resolve(structName, table)
 }
 
+// rlsPolicyIdentity is what makes two row-level security policies the same
+// policy: the table that owns it, and its own name.
+//
+// It is a struct rather than a joined string because both components are
+// PostgreSQL identifiers and either may contain a dot when quoted, while
+// Table.QualifiedName already spends the dot structurally. Any separator is
+// therefore ambiguous; a struct key cannot be.
+type rlsPolicyIdentity struct {
+	table  string
+	policy string
+}
+
 // deduplicateRLSPolicies keeps one policy per (table, policy name) pair.
 //
 // The table has to be part of the key. A PostgreSQL policy name is scoped to
@@ -1355,13 +1367,25 @@ func boundRLSTable(resolver rlsTableResolver, structName, table string) string {
 // The table component is the declared table the policy names rather than the
 // string it was written with, which is [rlsTableResolver]'s subject.
 func deduplicateRLSPolicies(policies []RLSPolicy, resolver rlsTableResolver) []RLSPolicy {
-	return deduplicateNamedDefinitions(policies, func(policy RLSPolicy) string {
-		return resolver.resolve(policy.StructName, policy.Table) + "." + policy.Name
+	return deduplicateNamedDefinitions(policies, func(policy RLSPolicy) rlsPolicyIdentity {
+		return rlsPolicyIdentity{
+			table:  resolver.resolve(policy.StructName, policy.Table),
+			policy: policy.Name,
+		}
 	})
 }
 
-func deduplicateNamedDefinitions[T any](definitions []T, identity func(T) string) []T {
-	seen := make(map[string]struct{}, len(definitions))
+// deduplicateNamedDefinitions keeps the first definition per identity.
+//
+// The key type is a parameter rather than a string so a caller whose identity
+// has SEVERAL components can use a struct instead of joining them with a
+// separator. Joining is not safe here: every component is a PostgreSQL
+// identifier, quoting lets any of them contain the separator, and the encoding
+// then stops being injective -- table `a` with policy `"b.c"` and table `a.b`
+// with policy `c` both render as `a.b.c`, and one of two distinct policies is
+// dropped (stokaro/ptah#1276). Single-component callers keep passing strings.
+func deduplicateNamedDefinitions[T any, K comparable](definitions []T, identity func(T) K) []T {
+	seen := make(map[K]struct{}, len(definitions))
 	deduplicated := make([]T, 0, len(definitions))
 	for _, definition := range definitions {
 		key := identity(definition)

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/internal/tableref"
 )
 
@@ -1193,6 +1195,11 @@ func deduplicateExtensions(extensions []Extension) []Extension {
 	return deduplicated
 }
 
+// rlsPolicyTableSemantics are the identifier rules the owning table of an RLS
+// policy is folded with. Row-level security is a PostgreSQL-family construct,
+// so the default schema an unqualified table lands in is `public`.
+var rlsPolicyTableSemantics = identifier.ForDialect(platform.Postgres)
+
 // deduplicateRLSPolicies keeps one policy per (table, policy name) pair.
 //
 // The table has to be part of the key. A PostgreSQL policy name is scoped to
@@ -1201,9 +1208,21 @@ func deduplicateExtensions(extensions []Extension) []Extension {
 // The single-source path used to key on the policy name alone, which silently
 // dropped the second of two identically named policies before the comparator
 // ever saw it (stokaro/ptah#1276).
+//
+// The table component is that table's identity, not the string the policy was
+// written with, because one table has more than one spelling. A table declared
+// without a schema is reached both as `orders` and as `public.orders`, and
+// PostgreSQL treats those as one table: `CREATE POLICY p ON orders` followed by
+// `CREATE POLICY p ON public.orders` is refused with `policy "p" for table
+// "orders" already exists`. Keying the two spellings apart kept both, and
+// `ptah schema render` then emitted a pair of CREATE POLICY statements the
+// database rejects. [identifier.Semantics.QualifiedTableIdentityKey] is the
+// same fold the comparator applies through newQualifiedTableIdentity, so
+// deduplication and comparison agree on which table owns a policy.
 func deduplicateRLSPolicies(policies []RLSPolicy, resolver tableScopeResolver) []RLSPolicy {
 	return deduplicateNamedDefinitions(policies, func(policy RLSPolicy) string {
-		return compositeDeduplicationScope(resolver, policy.StructName, policy.Table) + "." + policy.Name
+		table := compositeDeduplicationScope(resolver, policy.StructName, policy.Table)
+		return rlsPolicyTableSemantics.QualifiedTableIdentityKey(table) + "." + policy.Name
 	})
 }
 

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1085,6 +1085,7 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 //   - Grants: Deduplicated by role + privileges + grant option + (table or schema) target
 //   - Roles: Deduplicated by role name
 //   - Schemas: Deduplicated by schema name
+//   - RLS policies: Deduplicated by resolved table + policy name combination
 //
 // Composite finalization additionally deduplicates sequences, domains,
 // composite types, ranges, and exact managed-data declarations. Grants retain
@@ -1096,11 +1097,11 @@ func isFunctionInSorted(function Function, sorted []Function) bool {
 // slices with deduplicated versions. The order of entities may change during
 // this process, but dependency ordering is handled separately.
 func Deduplicate(r *Database) {
-	deduplicateDatabase(r, structDeduplicationScope, unscopedDeduplication)
+	deduplicateDatabase(r, structDeduplicationScope)
 }
 
 func deduplicateComposite(r *Database) {
-	deduplicateDatabase(r, compositeDeduplicationScope, compositeDeduplicationScope)
+	deduplicateDatabase(r, compositeDeduplicationScope)
 	r.Sequences = deduplicateNamedDefinitions(r.Sequences, func(sequence Sequence) string {
 		return sequence.QualifiedName()
 	})
@@ -1122,10 +1123,6 @@ func structDeduplicationScope(_ tableScopeResolver, structName, _ string) string
 	return structName
 }
 
-func unscopedDeduplication(_ tableScopeResolver, _, _ string) string {
-	return ""
-}
-
 func compositeDeduplicationScope(resolver tableScopeResolver, structName, tableName string) string {
 	return resolver.resolve(structName, tableName)
 }
@@ -1133,7 +1130,6 @@ func compositeDeduplicationScope(resolver tableScopeResolver, structName, tableN
 func deduplicateDatabase(
 	r *Database,
 	resolveScope deduplicationScope,
-	resolvePolicyScope deduplicationScope,
 ) {
 	resolver := newTableScopeResolver(r.Tables)
 	r.Schemas = deduplicateSchemas(r.Schemas)
@@ -1152,7 +1148,7 @@ func deduplicateDatabase(
 	})
 
 	deduplicateSchemaObjects(r)
-	r.RLSPolicies = deduplicateRLSPolicies(r.RLSPolicies, resolver, resolvePolicyScope)
+	r.RLSPolicies = deduplicateRLSPolicies(r.RLSPolicies, resolver)
 	r.RLSEnabledTables = deduplicateNamedDefinitions(r.RLSEnabledTables, func(table RLSEnabledTable) string {
 		return table.Table
 	})
@@ -1197,13 +1193,17 @@ func deduplicateExtensions(extensions []Extension) []Extension {
 	return deduplicated
 }
 
-func deduplicateRLSPolicies(
-	policies []RLSPolicy,
-	resolver tableScopeResolver,
-	resolveScope deduplicationScope,
-) []RLSPolicy {
+// deduplicateRLSPolicies keeps one policy per (table, policy name) pair.
+//
+// The table has to be part of the key. A PostgreSQL policy name is scoped to
+// its table: `CREATE POLICY tenant_isolation` succeeds once on each of two
+// tables in one schema and is refused only when repeated on the same table.
+// The single-source path used to key on the policy name alone, which silently
+// dropped the second of two identically named policies before the comparator
+// ever saw it (stokaro/ptah#1276).
+func deduplicateRLSPolicies(policies []RLSPolicy, resolver tableScopeResolver) []RLSPolicy {
 	return deduplicateNamedDefinitions(policies, func(policy RLSPolicy) string {
-		return resolveScope(resolver, policy.StructName, policy.Table) + "." + policy.Name
+		return compositeDeduplicationScope(resolver, policy.StructName, policy.Table) + "." + policy.Name
 	})
 }
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -8506,10 +8506,11 @@ type RLSPolicyRef struct {
     RLSPolicyRef represents a reference to an RLS policy with its table
     information.
 
-    This structure is used to identify RLS policies that need to be dropped,
-    providing both the policy name and the table it belongs to. This is
-    necessary because PostgreSQL requires both pieces of information for DROP
-    POLICY statements.
+    This structure identifies an RLS policy on both sides of a diff -- policies
+    added as well as policies dropped. The table is not decoration: a PostgreSQL
+    policy name is scoped to its table, so two tables in one schema may each
+    carry a policy called "tenant_isolation", and both CREATE POLICY and DROP
+    POLICY need the table to say which one is meant.
 
     # Example Usage
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -8685,9 +8685,14 @@ type SchemaDiff struct {
     // TriggersModified contains detailed information about changed triggers.
     TriggersModified []TriggerDiff `json:"triggers_modified"`
 
-    // RLSPoliciesAdded contains names of RLS policies that exist in the target schema
-    // but not in the current database schema
-    RLSPoliciesAdded []string `json:"rls_policies_added"`
+    // RLSPoliciesAdded contains RLS policies that exist in the target schema
+    // but not in the current database schema.
+    //
+    // A policy name is scoped to its table, not to the schema, so the name on
+    // its own does not identify a policy: two tables may each carry one called
+    // "tenant_isolation". The table travels with the name for the same reason
+    // it does in TriggersAdded.
+    RLSPoliciesAdded []RLSPolicyRef `json:"rls_policies_added"`
 
     // RLSPoliciesRemoved contains RLS policies that exist in the current database
     // but not in the target schema (may remove an access-control protection)

--- a/docs/public_api_approvals.txt
+++ b/docs/public_api_approvals.txt
@@ -59,3 +59,17 @@ v0.1.2 go.5x5.cz/ptah/migration/seeder
 # existing field altered.
 v0.2.0 go.5x5.cz/ptah/core/goschema
 v0.2.0 go.5x5.cz/ptah/dbschema/types
+
+# A PostgreSQL RLS policy name is scoped to its table, not to the schema:
+# CREATE POLICY tenant_isolation succeeds once on each of two tables in one
+# schema and is refused only when repeated on the same table. SchemaDiff
+# reported additions as bare names, so a caller could not tell which of two
+# identically named policies was missing and neither could the planner -- it
+# resolved the name against the desired schema and emitted the wrong table's
+# policy. RLSPoliciesAdded therefore becomes []RLSPolicyRef, the shape
+# RLSPoliciesRemoved and TriggersAdded already have.
+#
+# The cost is that consumers reading rls_policies_added get objects with
+# policy_name and table_name instead of strings. Nothing was removed and no
+# other field changed.
+v0.2.0 go.5x5.cz/ptah/migration/schemadiff/types

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -101,6 +101,15 @@ identifies each policy by its table and its name together, so two tables can
 each carry a `tenant_isolation` policy and both are rendered, compared, and
 migrated independently.
 
+The owning table is that table's identity rather than the string you spelled
+it with. A table declared without a schema is reached both as `orders` and as
+`public.orders`, and PostgreSQL treats those as one table: declaring `p` on
+each spelling is one policy declared twice, and the second `CREATE POLICY` is
+refused with `policy "p" for table "orders" already exists`. Ptah keeps the
+first declaration and renders it once. Two tables of the same name in
+different schemas — `tenanta.orders` and `tenantb.orders` — remain two tables,
+and a policy name on each remains two policies.
+
 ## Extensions
 
 `//ptah:schema:extension` manages `CREATE EXTENSION`. Some extensions are

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -110,6 +110,17 @@ first declaration and renders it once. Two tables of the same name in
 different schemas — `tenanta.orders` and `tenantb.orders` — remain two tables,
 and a policy name on each remains two policies.
 
+Letter case is the other spelling that reaches one table. An unquoted
+PostgreSQL identifier folds to lower case, so a SQL schema file declaring
+`CREATE TABLE orders` and then naming `ORDERS` in `CREATE POLICY` or in
+`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` is naming that same table. Ptah
+binds each declaration to the table it names and renders the declared
+spelling, so a policy or an enablement written as `ORDERS` no longer renders
+`ON "ORDERS"` — a table nothing declared, answered by `relation "ORDERS" does
+not exist`. A quoted identifier keeps its case: when a schema declares both
+`orders` and `"ORDERS"`, they are two tables and a policy on each is two
+policies.
+
 ## Extensions
 
 `//ptah:schema:extension` manages `CREATE EXTENSION`. Some extensions are

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -110,16 +110,25 @@ first declaration and renders it once. Two tables of the same name in
 different schemas — `tenanta.orders` and `tenantb.orders` — remain two tables,
 and a policy name on each remains two policies.
 
-Letter case is the other spelling that reaches one table. An unquoted
-PostgreSQL identifier folds to lower case, so a SQL schema file declaring
-`CREATE TABLE orders` and then naming `ORDERS` in `CREATE POLICY` or in
-`ALTER TABLE ... ENABLE ROW LEVEL SECURITY` is naming that same table. Ptah
-binds each declaration to the table it names and renders the declared
-spelling, so a policy or an enablement written as `ORDERS` no longer renders
-`ON "ORDERS"` — a table nothing declared, answered by `relation "ORDERS" does
-not exist`. A quoted identifier keeps its case: when a schema declares both
-`orders` and `"ORDERS"`, they are two tables and a policy on each is two
-policies.
+Letter case is the other spelling that reaches one table, and it folds in one
+direction only. An unquoted PostgreSQL identifier folds to lower case, so a SQL
+schema file declaring `CREATE TABLE orders` and then naming `ORDERS` in
+`CREATE POLICY` or in `ALTER TABLE ... ENABLE ROW LEVEL SECURITY` is naming
+that same table. Ptah binds each declaration to the table it names and renders
+the declared spelling, so a policy or an enablement written as `ORDERS` no
+longer renders `ON "ORDERS"` — a table nothing declared, answered by
+`relation "ORDERS" does not exist`.
+
+The rule is that a reference folds down onto a table declared in lower case,
+and a declaration that preserves case is never a fold target. Ptah does not
+record whether an identifier was quoted, so `CREATE TABLE ORDERS` and
+`CREATE TABLE "ORDERS"` reach it as the same declaration while PostgreSQL reads
+them as two different relations — `orders` and `ORDERS`. A schema that declares
+only `"ORDERS"` and then writes `ON orders` therefore names a relation it does
+not declare, and Ptah keeps that spelling rather than guessing: the render
+reproduces PostgreSQL's own `relation "orders" does not exist` instead of
+quietly moving the policy onto `ORDERS`. Declaring both `orders` and `"ORDERS"`
+gives two tables, and a policy on each is two policies.
 
 ## Extensions
 

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -94,6 +94,13 @@ declares a policy without declaring enablement is enabled with the table,
 because `CREATE POLICY` on a table whose row-level security is off protects
 nothing.
 
+A policy name is scoped to its table rather than to the schema, which is what
+PostgreSQL itself enforces: `CREATE POLICY tenant_isolation` succeeds on two
+tables in one schema and is refused only when repeated on the same table. Ptah
+identifies each policy by its table and its name together, so two tables can
+each carry a `tenant_isolation` policy and both are rendered, compared, and
+migrated independently.
+
 ## Extensions
 
 `//ptah:schema:extension` manages `CREATE EXTENSION`. Some extensions are

--- a/docs/site/src/content/docs/direct/compare-and-drift.md
+++ b/docs/site/src/content/docs/direct/compare-and-drift.md
@@ -121,6 +121,24 @@ Three flags shape the check:
 - `--format` selects `text`, `json` (the findings plus the full structured
   diff, for tooling), or `github-actions` (workflow annotations).
 
+In the JSON document, a PostgreSQL row-level-security policy is reported by the
+table that owns it together with its name, because a policy name is scoped to
+its table and two tables may each carry one called `tenant_isolation`. Both
+`diff.rls_policies_added` and `diff.rls_policies_removed` hold objects:
+
+```json
+{
+  "diff": {
+    "rls_policies_added": [
+      { "policy_name": "tenant_isolation", "table_name": "zeta_orders" }
+    ]
+  }
+}
+```
+
+`rls_policies_added` held bare policy-name strings before Ptah v0.2.0. A
+consumer reading that field reads `.policy_name` now; nothing was removed.
+
 ## Plan-only runs
 
 When the drift check fails, the next question is what SQL would fix it.

--- a/integration/gonative/multi_schema_postgres_test.go
+++ b/integration/gonative/multi_schema_postgres_test.go
@@ -53,7 +53,9 @@ func TestPostgreSQLMultiSchemaGenerateApplyReadDiffIntegration(t *testing.T) {
 
 	diff := &difftypes.SchemaDiff{
 		TablesAdded:           []string{"ptah_ms_accounts", "ptah_ms_auth.ptah_ms_users", "ptah_ms_billing.ptah_ms_invoices"},
-		RLSPoliciesAdded:      []string{"ptah_ms_users_visible"},
+		RLSPoliciesAdded: []difftypes.RLSPolicyRef{
+			{PolicyName: "ptah_ms_users_visible", TableName: "ptah_ms_auth.ptah_ms_users"},
+		},
 		RLSEnabledTablesAdded: []string{"ptah_ms_auth.ptah_ms_users"},
 	}
 	nodes, err := planner.GenerateSchemaDiffAST(diff, generated, "postgres")

--- a/internal/planner/dialects/postgres/capability_gating_test.go
+++ b/internal/planner/dialects/postgres/capability_gating_test.go
@@ -33,7 +33,9 @@ func TestPlanner_CapabilityGatesRLSAndRoleManagement(t *testing.T) {
 		GrantsAdded: []types.GrantRef{
 			{Role: "app_role", Privilege: "SELECT", ObjectType: "TABLE", ObjectName: "users"},
 		},
-		RLSPoliciesAdded: []string{"tenant_policy"},
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "tenant_policy", TableName: "users"},
+		},
 		RLSPoliciesRemoved: []types.RLSPolicyRef{
 			{PolicyName: "old_policy", TableName: "users"},
 		},

--- a/internal/planner/dialects/postgres/category_rendering_test.go
+++ b/internal/planner/dialects/postgres/category_rendering_test.go
@@ -207,7 +207,7 @@ func diffCategoryFixtures() []categoryFixture {
 		},
 		{
 			"RLSPoliciesAdded",
-			&types.SchemaDiff{RLSPoliciesAdded: []string{"pol"}},
+			&types.SchemaDiff{RLSPoliciesAdded: []types.RLSPolicyRef{{PolicyName: "pol", TableName: "t"}}},
 			&goschema.Database{RLSPolicies: []goschema.RLSPolicy{{Name: "pol", Table: "t", PolicyFor: "ALL", ToRoles: "app"}}},
 		},
 		{

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -1956,17 +1956,18 @@ func (p *Planner) disableRLSOnTables(result []ast.Node, diff *types.SchemaDiff) 
 }
 
 func (p *Planner) addNewRLSPolicies(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	for _, policyName := range diff.RLSPoliciesAdded {
-		// Find the policy definition
-		for _, policy := range generated.RLSPolicies {
-			if policy.Name == policyName {
-				policyNode := fromschema.FromRLSPolicy(policy)
-				// Set Replace flag to handle conflicts gracefully during migrations
-				policyNode.Replace = true
-				result = append(result, policyNode)
-				break
-			}
+	for _, policyRef := range diff.RLSPoliciesAdded {
+		// Find the policy definition. The name alone does not identify it:
+		// two tables may each carry a policy called "tenant_isolation", and
+		// matching on the name picked whichever was declared first.
+		policy := findRLSPolicy(generated.RLSPolicies, policyRef.TableName, policyRef.PolicyName)
+		if policy == nil {
+			continue
 		}
+		policyNode := fromschema.FromRLSPolicy(*policy)
+		// Set Replace flag to handle conflicts gracefully during migrations
+		policyNode.Replace = true
+		result = append(result, policyNode)
 	}
 	return result
 }

--- a/internal/planner/dialects/postgres/rls_enablement_test.go
+++ b/internal/planner/dialects/postgres/rls_enablement_test.go
@@ -66,7 +66,7 @@ func TestPlannerRendersRLSEnablementFromDiff(t *testing.T) {
 			name: "a new table carrying a policy is enabled without a diff entry",
 			diff: &types.SchemaDiff{
 				TablesAdded:      []string{"tenants"},
-				RLSPoliciesAdded: []string{"tenant_isolation"},
+				RLSPoliciesAdded: []types.RLSPolicyRef{{PolicyName: "tenant_isolation", TableName: "tenants"}},
 			},
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{Name: "tenants", StructName: "Tenant"}},
@@ -93,7 +93,9 @@ func TestPlannerRendersRLSEnablementFromDiff(t *testing.T) {
 			diff: &types.SchemaDiff{
 				TablesAdded:           []string{"tenants"},
 				RLSEnabledTablesAdded: []string{"tenants"},
-				RLSPoliciesAdded:      []string{"tenant_isolation"},
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "tenants"},
+				},
 			},
 			generated: &goschema.Database{
 				Tables: []goschema.Table{{Name: "tenants", StructName: "Tenant"}},

--- a/internal/planner/dialects/postgres/rls_policy_ref_test.go
+++ b/internal/planner/dialects/postgres/rls_policy_ref_test.go
@@ -1,0 +1,100 @@
+package postgres_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// generatedSharedPolicyName is a desired schema where one policy name is
+// carried by two tables, which PostgreSQL permits: a policy name is scoped to
+// its table, so tenant_isolation can exist on alpha_orders and zeta_orders at
+// once. The planner therefore cannot resolve an addition by name alone.
+func generatedSharedPolicyName() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "alpha_orders", StructName: "AlphaOrder"},
+			{Name: "zeta_orders", StructName: "ZetaOrder"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+			{Name: "tenant_isolation", Table: "zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 2"},
+		},
+	}
+}
+
+func TestPlanner_RLSPolicyRefs_CreatesThePolicyOnTheNamedTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		added     []types.RLSPolicyRef
+		wantTable []string
+		wantUsing []string
+	}{
+		{
+			name:      "only the second table is missing its policy",
+			added:     []types.RLSPolicyRef{{PolicyName: "tenant_isolation", TableName: "zeta_orders"}},
+			wantTable: []string{"zeta_orders"},
+			wantUsing: []string{"tenant_id = 2"},
+		},
+		{
+			name:      "only the first table is missing its policy",
+			added:     []types.RLSPolicyRef{{PolicyName: "tenant_isolation", TableName: "alpha_orders"}},
+			wantTable: []string{"alpha_orders"},
+			wantUsing: []string{"tenant_id = 1"},
+		},
+		{
+			name: "both tables are missing their policy",
+			added: []types.RLSPolicyRef{
+				{PolicyName: "tenant_isolation", TableName: "alpha_orders"},
+				{PolicyName: "tenant_isolation", TableName: "zeta_orders"},
+			},
+			wantTable: []string{"alpha_orders", "zeta_orders"},
+			wantUsing: []string{"tenant_id = 1", "tenant_id = 2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &types.SchemaDiff{RLSPoliciesAdded: test.added}
+
+			nodes, err := postgres.New().GenerateMigrationASTChecked(diff, generatedSharedPolicyName())
+			c.Assert(err, qt.IsNil)
+
+			var tables []string
+			var usings []string
+			for _, node := range nodes {
+				policy, ok := node.(*ast.CreatePolicyNode)
+				c.Assert(ok, qt.IsTrue)
+				c.Assert(policy.Name, qt.Equals, "tenant_isolation")
+				tables = append(tables, policy.Table)
+				usings = append(usings, policy.UsingExpression)
+			}
+			c.Assert(tables, qt.DeepEquals, test.wantTable)
+			c.Assert(usings, qt.DeepEquals, test.wantUsing)
+		})
+	}
+}
+
+// TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold is the
+// control for the lookup becoming exact: a reference the desired schema cannot
+// resolve must produce nothing rather than fall back to a same-named policy on
+// some other table, which is what the name-only lookup did on a down
+// migration.
+func TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold(t *testing.T) {
+	c := qt.New(t)
+	diff := &types.SchemaDiff{
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "tenant_isolation", TableName: "omega_orders"},
+		},
+	}
+
+	nodes, err := postgres.New().GenerateMigrationASTChecked(diff, generatedSharedPolicyName())
+	c.Assert(err, qt.IsNil)
+	c.Assert(nodes, qt.HasLen, 0)
+}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1409,9 +1409,12 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		SequencesRemoved:  diff.SequencesAdded,   // Sequences to add become sequences to remove
 		SequencesModified: reverseSequenceDiffs(diff.SequencesModified),
 
-		// Reverse RLS policy operations
-		RLSPoliciesAdded:    convertRLSPolicyRefsToNames(diff.RLSPoliciesRemoved),                 // Policies to remove become policies to add (convert RLSPolicyRef to string)
-		RLSPoliciesRemoved:  convertRLSPolicyNamesToRefsWithSchema(diff.RLSPoliciesAdded, schema), // Policies to add become policies to remove (convert string to RLSPolicyRef with table resolution)
+		// Reverse RLS policy operations. Both directions carry the owning
+		// table, so reversing is a swap and no name-to-table resolution is
+		// needed -- the resolution that used to happen here keyed a map by
+		// policy name and lost one of two policies that shared one.
+		RLSPoliciesAdded:    slices.Clone(diff.RLSPoliciesRemoved), // Policies to remove become policies to add
+		RLSPoliciesRemoved:  slices.Clone(diff.RLSPoliciesAdded),   // Policies to add become policies to remove
 		RLSPoliciesModified: reverseRLSPolicyDiffs(diff.RLSPoliciesModified),
 
 		// Reverse RLS table enablement operations
@@ -1944,53 +1947,6 @@ func reverseCompositeTypeDiffs(compositeDiffs []types.CompositeTypeDiff) []types
 		reversed[i] = types.CompositeTypeDiff{TypeName: compositeDiff.TypeName, Changes: reverseChangeMap(compositeDiff.Changes)}
 	}
 	return reversed
-}
-
-// convertRLSPolicyRefsToNames converts RLSPolicyRef slice to policy names for down migrations
-func convertRLSPolicyRefsToNames(policyRefs []types.RLSPolicyRef) []string {
-	names := make([]string, len(policyRefs))
-	for i, policyRef := range policyRefs {
-		names[i] = policyRef.PolicyName
-	}
-	return names
-}
-
-// convertRLSPolicyNamesToRefs converts policy names to RLSPolicyRef for down migrations
-// This is needed because RLSPoliciesAdded contains policy names (strings) but
-// RLSPoliciesRemoved needs RLSPolicyRef (with both policy name and table name)
-//
-// Deprecated: Use convertRLSPolicyNamesToRefsWithSchema for proper table name resolution
-func convertRLSPolicyNamesToRefs(policyNames []string) []types.RLSPolicyRef {
-	return convertRLSPolicyNamesToRefsWithSchema(policyNames, nil)
-}
-
-// convertRLSPolicyNamesToRefsWithSchema converts policy names to RLSPolicyRef for down migrations
-// with proper table name resolution using the provided schema context
-func convertRLSPolicyNamesToRefsWithSchema(policyNames []string, schema *goschema.Database) []types.RLSPolicyRef {
-	refs := make([]types.RLSPolicyRef, len(policyNames))
-
-	// Create a lookup map for policy name to table name if schema is provided
-	policyToTable := make(map[string]string)
-	if schema != nil {
-		for _, policy := range schema.RLSPolicies {
-			policyToTable[policy.Name] = policy.Table
-		}
-	}
-
-	for i, policyName := range policyNames {
-		tableName := ""
-		if schema != nil {
-			if table, found := policyToTable[policyName]; found {
-				tableName = table
-			}
-		}
-
-		refs[i] = types.RLSPolicyRef{
-			PolicyName: policyName,
-			TableName:  tableName,
-		}
-	}
-	return refs
 }
 
 // reverseRLSPolicyDiffs reverses RLS policy modifications for down migrations

--- a/migration/generator/reverse_diff_test.go
+++ b/migration/generator/reverse_diff_test.go
@@ -97,8 +97,11 @@ func TestGenerateDownMigrationSQL_Issue43_RLSPolicyTableNames(t *testing.T) {
 
 	// Create a schema diff that adds RLS policies (simulating an up migration)
 	upDiff := &types.SchemaDiff{
-		RLSPoliciesAdded: []string{"area_user_isolation", "commodity_user_isolation"},
-		TablesAdded:      []string{"areas", "commodities"},
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "area_user_isolation", TableName: "areas"},
+			{PolicyName: "commodity_user_isolation", TableName: "commodities"},
+		},
+		TablesAdded: []string{"areas", "commodities"},
 	}
 
 	// Create a database schema that includes the RLS policies with table names
@@ -182,8 +185,12 @@ func TestGenerateDownMigrationSQL_Issue57_MissingTableNames(t *testing.T) {
 
 	// Create a schema diff that adds RLS policies (simulating an up migration)
 	upDiff := &types.SchemaDiff{
-		RLSPoliciesAdded: []string{"area_tenant_isolation", "area_user_isolation", "commodity_tenant_isolation"},
-		TablesAdded:      []string{"areas", "commodities"},
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "area_tenant_isolation", TableName: "areas"},
+			{PolicyName: "area_user_isolation", TableName: "areas"},
+			{PolicyName: "commodity_tenant_isolation", TableName: "commodities"},
+		},
+		TablesAdded: []string{"areas", "commodities"},
 	}
 
 	// Create a database schema that includes the tables but NOT the RLS policies
@@ -270,7 +277,10 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 		ExtensionsRemoved: []string{"postgis"},
 		FunctionsAdded:    []string{"get_tenant_id", "set_tenant_context"},
 		FunctionsRemoved:  []string{"old_function"},
-		RLSPoliciesAdded:  []string{"user_policy", "tenant_policy"},
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "user_policy", TableName: "users"},
+			{PolicyName: "tenant_policy", TableName: "posts"},
+		},
 		RLSPoliciesRemoved: []types.RLSPolicyRef{
 			{PolicyName: "old_policy", TableName: "old_table"},
 		},
@@ -309,12 +319,17 @@ func TestReverseSchemaDiff_CompleteReversal(t *testing.T) {
 	c.Assert(result.FunctionsRemoved, qt.DeepEquals, input.FunctionsAdded)
 
 	// Verify RLS policy reversals
-	expectedRLSPoliciesAdded := []string{"old_policy"}
+	expectedRLSPoliciesAdded := []types.RLSPolicyRef{
+		{PolicyName: "old_policy", TableName: "old_table"},
+	}
 	c.Assert(result.RLSPoliciesAdded, qt.DeepEquals, expectedRLSPoliciesAdded)
 
+	// The reversal carries each policy's own table through instead of
+	// re-deriving it from the policy name, which is why these are no longer
+	// empty.
 	expectedRLSPoliciesRemoved := []types.RLSPolicyRef{
-		{PolicyName: "user_policy", TableName: ""},
-		{PolicyName: "tenant_policy", TableName: ""},
+		{PolicyName: "user_policy", TableName: "users"},
+		{PolicyName: "tenant_policy", TableName: "posts"},
 	}
 	c.Assert(result.RLSPoliciesRemoved, qt.DeepEquals, expectedRLSPoliciesRemoved)
 
@@ -633,72 +648,6 @@ func TestReverseSchemaDiff_RoleModifications(t *testing.T) {
 	c.Assert(reversedRole.Changes["password"], qt.Equals, "new_hash -> old_hash")
 }
 
-func TestConvertRLSPolicyRefsToNames(t *testing.T) {
-	c := qt.New(t)
-
-	input := []types.RLSPolicyRef{
-		{PolicyName: "user_policy", TableName: "users"},
-		{PolicyName: "tenant_policy", TableName: "tenants"},
-	}
-
-	result := convertRLSPolicyRefsToNames(input)
-
-	expected := []string{"user_policy", "tenant_policy"}
-	c.Assert(result, qt.DeepEquals, expected)
-}
-
-func TestConvertRLSPolicyNamesToRefs(t *testing.T) {
-	c := qt.New(t)
-
-	input := []string{"user_policy", "tenant_policy"}
-
-	result := convertRLSPolicyNamesToRefs(input)
-
-	expected := []types.RLSPolicyRef{
-		{PolicyName: "user_policy", TableName: ""},
-		{PolicyName: "tenant_policy", TableName: ""},
-	}
-	c.Assert(result, qt.DeepEquals, expected)
-}
-
-func TestConvertRLSPolicyNamesToRefsWithSchema(t *testing.T) {
-	c := qt.New(t)
-
-	input := []string{"user_policy", "tenant_policy", "unknown_policy"}
-
-	// Create a mock schema with RLS policies
-	schema := &goschema.Database{
-		RLSPolicies: []goschema.RLSPolicy{
-			{Name: "user_policy", Table: "users"},
-			{Name: "tenant_policy", Table: "tenants"},
-			// Note: unknown_policy is not in the schema
-		},
-	}
-
-	result := convertRLSPolicyNamesToRefsWithSchema(input, schema)
-
-	expected := []types.RLSPolicyRef{
-		{PolicyName: "user_policy", TableName: "users"},
-		{PolicyName: "tenant_policy", TableName: "tenants"},
-		{PolicyName: "unknown_policy", TableName: ""}, // Table name not found, remains empty
-	}
-	c.Assert(result, qt.DeepEquals, expected)
-}
-
-func TestConvertRLSPolicyNamesToRefsWithSchema_NilSchema(t *testing.T) {
-	c := qt.New(t)
-
-	input := []string{"user_policy", "tenant_policy"}
-
-	result := convertRLSPolicyNamesToRefsWithSchema(input, nil)
-
-	expected := []types.RLSPolicyRef{
-		{PolicyName: "user_policy", TableName: ""},
-		{PolicyName: "tenant_policy", TableName: ""},
-	}
-	c.Assert(result, qt.DeepEquals, expected)
-}
-
 func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 	c := qt.New(t)
 
@@ -712,7 +661,10 @@ func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 		FunctionsAdded: []string{"get_current_tenant_id", "set_tenant_context"},
 
 		// Add some RLS policies
-		RLSPoliciesAdded: []string{"user_tenant_isolation", "area_tenant_isolation"},
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{PolicyName: "user_tenant_isolation", TableName: "users"},
+			{PolicyName: "area_tenant_isolation", TableName: "areas"},
+		},
 
 		// Enable RLS on tables
 		RLSEnabledTablesAdded: []string{"users", "areas"},
@@ -735,8 +687,8 @@ func TestReverseSchemaDiff_Issue39_Integration(t *testing.T) {
 
 	// RLS policies should be removed in down migration
 	expectedPolicyRefs := []types.RLSPolicyRef{
-		{PolicyName: "user_tenant_isolation", TableName: ""},
-		{PolicyName: "area_tenant_isolation", TableName: ""},
+		{PolicyName: "user_tenant_isolation", TableName: "users"},
+		{PolicyName: "area_tenant_isolation", TableName: "areas"},
 	}
 	c.Assert(downDiff.RLSPoliciesRemoved, qt.DeepEquals, expectedPolicyRefs)
 	c.Assert(downDiff.RLSPoliciesAdded, qt.HasLen, 0)

--- a/migration/generator/shadow_internal_test.go
+++ b/migration/generator/shadow_internal_test.go
@@ -211,6 +211,51 @@ func mismatchKinds(mismatches []ShadowMismatch) []string {
 	return kinds
 }
 
+// TestCollectShadowMismatchesNamesTheTableOwningAnRLSPolicy pins the shape of
+// the two policy-reference mismatches, not only their kinds. ShadowMismatch is
+// serialized into the shadow verification report, so a reader of that JSON is
+// told which policy is missing and which table it belongs to. Reporting a bare
+// name could not distinguish two tables that each carry a policy called
+// tenant_isolation, which PostgreSQL permits (stokaro/ptah#1276).
+//
+// Ordering is part of the contract too: the refs are sorted by table first, so
+// alpha_orders leads zeta_orders regardless of the order the comparison put
+// them in.
+func TestCollectShadowMismatchesNamesTheTableOwningAnRLSPolicy(t *testing.T) {
+	c := qt.New(t)
+
+	diff := &types.SchemaDiff{
+		RLSPoliciesAdded: []types.RLSPolicyRef{
+			{TableName: "zeta_orders", PolicyName: "tenant_isolation"},
+			{TableName: "alpha_orders", PolicyName: "tenant_isolation"},
+		},
+		RLSPoliciesRemoved: []types.RLSPolicyRef{
+			{TableName: "zeta_orders", PolicyName: "legacy_isolation"},
+		},
+	}
+
+	c.Assert(collectShadowMismatches(diff), qt.DeepEquals, []ShadowMismatch{
+		{
+			Kind:    "missing_rls_policy",
+			Table:   "alpha_orders",
+			Object:  "alpha_orders.tenant_isolation",
+			Message: "missing RLS policy alpha_orders.tenant_isolation",
+		},
+		{
+			Kind:    "missing_rls_policy",
+			Table:   "zeta_orders",
+			Object:  "zeta_orders.tenant_isolation",
+			Message: "missing RLS policy zeta_orders.tenant_isolation",
+		},
+		{
+			Kind:    "extra_rls_policy",
+			Table:   "zeta_orders",
+			Object:  "zeta_orders.legacy_isolation",
+			Message: "extra RLS policy zeta_orders.legacy_isolation",
+		},
+	})
+}
+
 func TestNextAvailableMigrationVersionChecksUpAndDownFiles(t *testing.T) {
 	c := qt.New(t)
 

--- a/migration/generator/shadow_internal_test.go
+++ b/migration/generator/shadow_internal_test.go
@@ -118,7 +118,7 @@ func TestCollectShadowMismatchesCoversEverySchemaDiffCategory(t *testing.T) {
 		TriggersAdded:             []types.TriggerRef{{TableName: "users", TriggerName: "missing_trigger"}},
 		TriggersRemoved:           []types.TriggerRef{{TableName: "users", TriggerName: "extra_trigger"}},
 		TriggersModified:          []types.TriggerDiff{{TableName: "users", TriggerName: "changed_trigger", Changes: changes}},
-		RLSPoliciesAdded:          []string{"missing_policy"},
+		RLSPoliciesAdded:          []types.RLSPolicyRef{{TableName: "users", PolicyName: "missing_policy"}},
 		RLSPoliciesRemoved:        []types.RLSPolicyRef{{TableName: "users", PolicyName: "extra_policy"}},
 		RLSPoliciesModified:       []types.RLSPolicyDiff{{TableName: "users", PolicyName: "changed_policy", Changes: changes}},
 		RLSEnabledTablesAdded:     []string{"missing_rls_table"},

--- a/migration/generator/shadow_mismatch.go
+++ b/migration/generator/shadow_mismatch.go
@@ -165,7 +165,10 @@ func collectTriggerMismatches(diff *types.SchemaDiff) []ShadowMismatch {
 
 func collectAccessControlMismatches(diff *types.SchemaDiff) []ShadowMismatch {
 	var mismatches []ShadowMismatch
-	mismatches = append(mismatches, namedMismatches(diff.RLSPoliciesAdded, "missing_rls_policy", "missing RLS policy")...)
+	for _, ref := range sortedRLSPolicyRefs(diff.RLSPoliciesAdded) {
+		object := qualifiedObject(ref.TableName, ref.PolicyName)
+		mismatches = append(mismatches, ShadowMismatch{Kind: "missing_rls_policy", Table: ref.TableName, Object: object, Message: "missing RLS policy " + object})
+	}
 	for _, ref := range sortedRLSPolicyRefs(diff.RLSPoliciesRemoved) {
 		object := qualifiedObject(ref.TableName, ref.PolicyName)
 		mismatches = append(mismatches, ShadowMismatch{Kind: "extra_rls_policy", Table: ref.TableName, Object: object, Message: "extra RLS policy " + object})

--- a/migration/schemadiff/internal/compare/rls.go
+++ b/migration/schemadiff/internal/compare/rls.go
@@ -15,7 +15,8 @@ import (
 //
 // This function handles the comparison of Row-Level Security policies, which are
 // PostgreSQL-specific security features used for multi-tenant data isolation and
-// fine-grained access control. Policies are compared by name and their complete definition.
+// fine-grained access control. Policies are matched by the table they belong to
+// together with their name, and then compared on their complete definition.
 //
 // # RLS Policy Comparison Logic
 //
@@ -38,17 +39,17 @@ import (
 // # Example Scenarios
 //
 // **Policy addition**:
-//   - Generated schema defines "user_tenant_isolation" policy
-//   - Database doesn't have this policy
-//   - Result: "user_tenant_isolation" added to diff.RLSPoliciesAdded
+//   - Generated schema defines "user_tenant_isolation" on "users"
+//   - Database doesn't have that policy on that table
+//   - Result: RLSPolicyRef added to diff.RLSPoliciesAdded
 //
 // **Policy removal**:
-//   - Database has "old_security_policy" policy
-//   - Generated schema doesn't define this policy
-//   - Result: "old_security_policy" added to diff.RLSPoliciesRemoved
+//   - Database has "old_security_policy" on "users"
+//   - Generated schema doesn't define that policy on that table
+//   - Result: RLSPolicyRef added to diff.RLSPoliciesRemoved
 //
 // **Policy modification**:
-//   - Both have "tenant_isolation" policy
+//   - Both have "tenant_isolation" on "users"
 //   - Generated: different USING expression or target roles
 //   - Result: RLSPolicyDiff added to diff.RLSPoliciesModified
 //
@@ -67,31 +68,65 @@ import (
 //
 // # Output Consistency
 //
-// Results are sorted alphabetically for consistent output across multiple runs.
+// Results are sorted by table and then by policy name for consistent output
+// across multiple runs.
 func RLSPolicies(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff) {
-	// Build lookup maps for RLS policy comparison
-	generatedPolicyMap := make(map[string]goschema.RLSPolicy)
+	RLSPoliciesWithSemantics(generated, database, diff, identifier.ForDialect(""))
+}
+
+// RLSPoliciesWithSemantics is [RLSPolicies] told which identifier rules the
+// target actually has, so the two sides' spellings of the owning table resolve
+// to one identity.
+//
+// A PostgreSQL policy name is scoped to its table, not to the schema. Measured
+// on PostgreSQL 17.10: `CREATE POLICY tenant_isolation` succeeds on
+// `public.alpha_orders` and again on `public.zeta_orders`, leaving two rows in
+// `pg_policy`, and is refused only when repeated on the same table
+// ("policy \"tenant_isolation\" for table \"alpha_orders\" already exists").
+// Keying either side by the policy name alone therefore collapses distinct
+// policies into one entry, and the loser is compared against the wrong
+// counterpart or disappears (stokaro/ptah#1276).
+//
+// The table component goes through [tableMemberKey] rather than the raw string
+// for the reason recorded on that type: the database reports a table's schema
+// as empty wherever the engine treats it as implicit, while the desired schema
+// carries it explicitly, so `alpha_orders` and `public.alpha_orders` are two
+// spellings of one table. Only the MATCHING is normalized -- what each side is
+// reported as stays the string that side supplied, because the planner renders
+// those names.
+func RLSPoliciesWithSemantics(
+	generated *goschema.Database,
+	database *types.DBSchema,
+	diff *difftypes.SchemaDiff,
+	semantics identifier.Semantics,
+) {
+	// Build lookup maps for RLS policy comparison, keyed by the owning table
+	// and the policy name together.
+	generatedPolicyMap := make(map[tableMemberKey]goschema.RLSPolicy, len(generated.RLSPolicies))
 	for _, rlsPolicy := range generated.RLSPolicies {
-		generatedPolicyMap[rlsPolicy.Name] = rlsPolicy
+		generatedPolicyMap[newTableMemberKey(rlsPolicy.Table, rlsPolicy.Name, semantics)] = rlsPolicy
 	}
 
-	databasePolicyMap := make(map[string]types.DBRLSPolicy)
+	databasePolicyMap := make(map[tableMemberKey]types.DBRLSPolicy, len(database.RLSPolicies))
 	for _, rlsPolicy := range database.RLSPolicies {
-		databasePolicyMap[rlsPolicy.Name] = rlsPolicy
+		databasePolicyMap[newTableMemberKey(rlsPolicy.Table, rlsPolicy.Name, semantics)] = rlsPolicy
 	}
 
 	// Find added policies (inline logic to avoid duplication detection)
-	for policyName := range generatedPolicyMap {
-		if _, exists := databasePolicyMap[policyName]; !exists {
-			diff.RLSPoliciesAdded = append(diff.RLSPoliciesAdded, policyName)
+	for key, generatedPolicy := range generatedPolicyMap {
+		if _, exists := databasePolicyMap[key]; !exists {
+			diff.RLSPoliciesAdded = append(diff.RLSPoliciesAdded, difftypes.RLSPolicyRef{
+				PolicyName: generatedPolicy.Name,
+				TableName:  generatedPolicy.Table,
+			})
 		}
 	}
 
 	// Find removed policies
-	for policyName, dbPolicy := range databasePolicyMap {
-		if _, exists := generatedPolicyMap[policyName]; !exists {
+	for key, dbPolicy := range databasePolicyMap {
+		if _, exists := generatedPolicyMap[key]; !exists {
 			policyRef := difftypes.RLSPolicyRef{
-				PolicyName: policyName,
+				PolicyName: dbPolicy.Name,
 				TableName:  dbPolicy.Table,
 			}
 			diff.RLSPoliciesRemoved = append(diff.RLSPoliciesRemoved, policyRef)
@@ -99,8 +134,8 @@ func RLSPolicies(generated *goschema.Database, database *types.DBSchema, diff *d
 	}
 
 	// Detect policy definition modifications
-	for policyName, generatedPolicy := range generatedPolicyMap {
-		if databasePolicy, policyExists := databasePolicyMap[policyName]; policyExists {
+	for key, generatedPolicy := range generatedPolicyMap {
+		if databasePolicy, policyExists := databasePolicyMap[key]; policyExists {
 			policyComparison := RLSPolicyDefinitions(generatedPolicy, databasePolicy)
 			if len(policyComparison.Changes) > 0 {
 				diff.RLSPoliciesModified = append(diff.RLSPoliciesModified, policyComparison)
@@ -108,13 +143,24 @@ func RLSPolicies(generated *goschema.Database, database *types.DBSchema, diff *d
 		}
 	}
 
-	// Ensure consistent ordering of results
-	sort.Strings(diff.RLSPoliciesAdded)
-	sort.Slice(diff.RLSPoliciesRemoved, func(i, j int) bool {
-		return diff.RLSPoliciesRemoved[i].PolicyName < diff.RLSPoliciesRemoved[j].PolicyName
-	})
+	// Ensure consistent ordering of results. The policy name alone is not a
+	// total order once two tables may share one, so the table leads.
+	sortRLSPolicyRefs(diff.RLSPoliciesAdded)
+	sortRLSPolicyRefs(diff.RLSPoliciesRemoved)
 	sort.Slice(diff.RLSPoliciesModified, func(i, j int) bool {
-		return diff.RLSPoliciesModified[i].PolicyName < diff.RLSPoliciesModified[j].PolicyName
+		if diff.RLSPoliciesModified[i].TableName == diff.RLSPoliciesModified[j].TableName {
+			return diff.RLSPoliciesModified[i].PolicyName < diff.RLSPoliciesModified[j].PolicyName
+		}
+		return diff.RLSPoliciesModified[i].TableName < diff.RLSPoliciesModified[j].TableName
+	})
+}
+
+func sortRLSPolicyRefs(refs []difftypes.RLSPolicyRef) {
+	sort.Slice(refs, func(i, j int) bool {
+		if refs[i].TableName == refs[j].TableName {
+			return refs[i].PolicyName < refs[j].PolicyName
+		}
+		return refs[i].TableName < refs[j].TableName
 	})
 }
 

--- a/migration/schemadiff/internal/compare/table_qualified_rls_policies_test.go
+++ b/migration/schemadiff/internal/compare/table_qualified_rls_policies_test.go
@@ -237,3 +237,48 @@ func TestRLSPolicies_DelegatesWithDialectlessSemantics(t *testing.T) {
 	c.Assert(diff.RLSPoliciesRemoved, qt.HasLen, 0)
 	c.Assert(diff.RLSPoliciesModified, qt.HasLen, 0)
 }
+
+// TestRLSPoliciesWithSemantics_OrdersRefsByTableFirst pins the sort key. The
+// policy name alone stopped being a total order the moment two tables could
+// share one, so the table leads and the name breaks ties within it. This
+// fixture separates the two orders: sorting by the name alone would lead with
+// `alpha_policy` on `zeta_orders`, while the shipped order groups the refs
+// under the table that owns them.
+//
+// Order is what a caller diffs between runs -- the shadow report, the drift
+// JSON, and the planned SQL all read these slices in sequence -- so an order
+// nothing pins shows up later as churn in artifacts nothing changed in.
+func TestRLSPoliciesWithSemantics_OrdersRefsByTableFirst(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "alpha_orders", StructName: "AlphaOrder"},
+			{Name: "zeta_orders", StructName: "ZetaOrder"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "zeta_policy", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+			{Name: "alpha_policy", Table: "zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 2"},
+			{Name: "alpha_policy", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 3"},
+		},
+	}
+	database := &types.DBSchema{
+		RLSPolicies: []types.DBRLSPolicy{
+			{Name: "zeta_policy", Table: "public.zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 4"},
+			{Name: "alpha_extra", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 5"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.RLSPoliciesWithSemantics(generated, database, diff, identifier.ForDialect("postgres"))
+
+	c.Assert(diff.RLSPoliciesAdded, qt.DeepEquals, []difftypes.RLSPolicyRef{
+		{PolicyName: "alpha_policy", TableName: "alpha_orders"},
+		{PolicyName: "zeta_policy", TableName: "alpha_orders"},
+		{PolicyName: "alpha_policy", TableName: "zeta_orders"},
+	})
+	c.Assert(diff.RLSPoliciesRemoved, qt.DeepEquals, []difftypes.RLSPolicyRef{
+		{PolicyName: "alpha_extra", TableName: "public.alpha_orders"},
+		{PolicyName: "zeta_policy", TableName: "public.zeta_orders"},
+	})
+}

--- a/migration/schemadiff/internal/compare/table_qualified_rls_policies_test.go
+++ b/migration/schemadiff/internal/compare/table_qualified_rls_policies_test.go
@@ -1,0 +1,239 @@
+package compare_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// generatedSharedPolicyName is the desired schema used by the addition and
+// removal tables below: one policy name carried by two different tables, which
+// PostgreSQL permits because a policy name is scoped to its table. Measured on
+// PostgreSQL 17.10, CREATE POLICY tenant_isolation succeeds on both
+// public.alpha_orders and public.zeta_orders and leaves two rows in pg_policy.
+func generatedSharedPolicyName() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "alpha_orders", StructName: "AlphaOrder"},
+			{Name: "zeta_orders", StructName: "ZetaOrder"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+			{Name: "tenant_isolation", Table: "zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+}
+
+func TestRLSPoliciesWithSemantics_TableQualifiedAdditions(t *testing.T) {
+	tests := []struct {
+		name     string
+		database *types.DBSchema
+		want     []difftypes.RLSPolicyRef
+	}{
+		{
+			name:     "both policies missing",
+			database: &types.DBSchema{},
+			want: []difftypes.RLSPolicyRef{
+				{PolicyName: "tenant_isolation", TableName: "alpha_orders"},
+				{PolicyName: "tenant_isolation", TableName: "zeta_orders"},
+			},
+		},
+		{
+			name: "one table has the policy",
+			database: &types.DBSchema{
+				RLSPolicies: []types.DBRLSPolicy{
+					{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+				},
+			},
+			want: []difftypes.RLSPolicyRef{
+				{PolicyName: "tenant_isolation", TableName: "zeta_orders"},
+			},
+		},
+		{
+			name: "both tables have the policy",
+			database: &types.DBSchema{
+				RLSPolicies: []types.DBRLSPolicy{
+					{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+					{Name: "tenant_isolation", Table: "public.zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &difftypes.SchemaDiff{}
+
+			compare.RLSPoliciesWithSemantics(
+				generatedSharedPolicyName(),
+				test.database,
+				diff,
+				identifier.ForDialect("postgres"),
+			)
+
+			c.Assert(diff.RLSPoliciesAdded, qt.DeepEquals, test.want)
+			c.Assert(diff.RLSPoliciesRemoved, qt.HasLen, 0)
+			c.Assert(diff.RLSPoliciesModified, qt.HasLen, 0)
+		})
+	}
+}
+
+func TestRLSPoliciesWithSemantics_TableQualifiedRemovals(t *testing.T) {
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "alpha_orders", StructName: "AlphaOrder"},
+			{Name: "zeta_orders", StructName: "ZetaOrder"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+
+	tests := []struct {
+		name     string
+		database *types.DBSchema
+		want     []difftypes.RLSPolicyRef
+	}{
+		{
+			name: "same name on an undeclared table is removed",
+			database: &types.DBSchema{
+				RLSPolicies: []types.DBRLSPolicy{
+					{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+					{Name: "tenant_isolation", Table: "public.zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+				},
+			},
+			want: []difftypes.RLSPolicyRef{
+				{PolicyName: "tenant_isolation", TableName: "public.zeta_orders"},
+			},
+		},
+		{
+			name: "distinct name on an undeclared table is removed",
+			database: &types.DBSchema{
+				RLSPolicies: []types.DBRLSPolicy{
+					{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+					{Name: "zeta_only", Table: "public.zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+				},
+			},
+			want: []difftypes.RLSPolicyRef{
+				{PolicyName: "zeta_only", TableName: "public.zeta_orders"},
+			},
+		},
+		{
+			name: "the declared policy alone is kept",
+			database: &types.DBSchema{
+				RLSPolicies: []types.DBRLSPolicy{
+					{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+				},
+			},
+			want: nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &difftypes.SchemaDiff{}
+
+			compare.RLSPoliciesWithSemantics(generated, test.database, diff, identifier.ForDialect("postgres"))
+
+			c.Assert(diff.RLSPoliciesRemoved, qt.DeepEquals, test.want)
+			c.Assert(diff.RLSPoliciesAdded, qt.HasLen, 0)
+			c.Assert(diff.RLSPoliciesModified, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestRLSPoliciesWithSemantics_ModificationMatchesTheSameTable is the row the
+// name-only key got backwards rather than merely incomplete: the desired
+// policy on alpha_orders was compared against the database's policy on
+// zeta_orders, the two agreed, and a stale USING expression on alpha_orders
+// was reported as no change at all.
+func TestRLSPoliciesWithSemantics_ModificationMatchesTheSameTable(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "alpha_orders", StructName: "AlphaOrder"},
+			{Name: "zeta_orders", StructName: "ZetaOrder"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+	database := &types.DBSchema{
+		RLSPolicies: []types.DBRLSPolicy{
+			{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 99"},
+			{Name: "tenant_isolation", Table: "public.zeta_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.RLSPoliciesWithSemantics(generated, database, diff, identifier.ForDialect("postgres"))
+
+	c.Assert(diff.RLSPoliciesModified, qt.HasLen, 1)
+	c.Assert(diff.RLSPoliciesModified[0].PolicyName, qt.Equals, "tenant_isolation")
+	c.Assert(diff.RLSPoliciesModified[0].TableName, qt.Equals, "alpha_orders")
+	c.Assert(diff.RLSPoliciesModified[0].Changes["using_expression"], qt.Equals, "tenant_id = 99 -> tenant_id = 1")
+	c.Assert(diff.RLSPoliciesRemoved, qt.DeepEquals, []difftypes.RLSPolicyRef{
+		{PolicyName: "tenant_isolation", TableName: "public.zeta_orders"},
+	})
+	c.Assert(diff.RLSPoliciesAdded, qt.HasLen, 0)
+}
+
+// TestRLSPoliciesWithSemantics_ImplicitSchemaStillMatches is the control for
+// the normalization itself: the database reports the table without a schema
+// where the engine treats it as implicit, and that must still match the
+// desired schema's qualified spelling rather than reading as a removal plus an
+// addition.
+func TestRLSPoliciesWithSemantics_ImplicitSchemaStillMatches(t *testing.T) {
+	c := qt.New(t)
+
+	generated := &goschema.Database{
+		Tables: []goschema.Table{{Name: "alpha_orders", Schema: "public", StructName: "AlphaOrder"}},
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "public.alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+	database := &types.DBSchema{
+		RLSPolicies: []types.DBRLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.RLSPoliciesWithSemantics(generated, database, diff, identifier.ForDialect("postgres"))
+
+	c.Assert(diff.RLSPoliciesAdded, qt.HasLen, 0)
+	c.Assert(diff.RLSPoliciesRemoved, qt.HasLen, 0)
+	c.Assert(diff.RLSPoliciesModified, qt.HasLen, 0)
+}
+
+// TestRLSPolicies_DelegatesWithDialectlessSemantics pins the thin wrapper to
+// the same behavior the package's other name-scoped comparisons expose, so a
+// caller that has no dialect still gets table-scoped matching.
+func TestRLSPolicies_DelegatesWithDialectlessSemantics(t *testing.T) {
+	c := qt.New(t)
+
+	database := &types.DBSchema{
+		RLSPolicies: []types.DBRLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", PolicyFor: "ALL", ToRoles: "PUBLIC", UsingExpression: "tenant_id = 1"},
+		},
+	}
+	diff := &difftypes.SchemaDiff{}
+
+	compare.RLSPolicies(generatedSharedPolicyName(), database, diff)
+
+	c.Assert(diff.RLSPoliciesAdded, qt.DeepEquals, []difftypes.RLSPolicyRef{
+		{PolicyName: "tenant_isolation", TableName: "zeta_orders"},
+	})
+	c.Assert(diff.RLSPoliciesRemoved, qt.HasLen, 0)
+	c.Assert(diff.RLSPoliciesModified, qt.HasLen, 0)
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -166,7 +166,7 @@ func CompareWithOptions(generated *goschema.Database, database *types.DBSchema, 
 	compare.TriggersWithDialect(generated, database, diff, opts.Dialect)
 
 	// Compare RLS policies (PostgreSQL-specific feature)
-	compare.RLSPolicies(generated, database, diff)
+	compare.RLSPoliciesWithSemantics(generated, database, diff, identifierSemantics)
 
 	// Compare RLS enabled tables (PostgreSQL-specific feature)
 	compare.RLSEnabledTablesWithSemantics(generated, database, diff, identifierSemantics)

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -243,9 +243,14 @@ type SchemaDiff struct {
 	// TriggersModified contains detailed information about changed triggers.
 	TriggersModified []TriggerDiff `json:"triggers_modified"`
 
-	// RLSPoliciesAdded contains names of RLS policies that exist in the target schema
-	// but not in the current database schema
-	RLSPoliciesAdded []string `json:"rls_policies_added"`
+	// RLSPoliciesAdded contains RLS policies that exist in the target schema
+	// but not in the current database schema.
+	//
+	// A policy name is scoped to its table, not to the schema, so the name on
+	// its own does not identify a policy: two tables may each carry one called
+	// "tenant_isolation". The table travels with the name for the same reason
+	// it does in TriggersAdded.
+	RLSPoliciesAdded []RLSPolicyRef `json:"rls_policies_added"`
 
 	// RLSPoliciesRemoved contains RLS policies that exist in the current database
 	// but not in the target schema (may remove an access-control protection)

--- a/migration/schemadiff/types/types.go
+++ b/migration/schemadiff/types/types.go
@@ -703,9 +703,11 @@ type TriggerDiff struct {
 
 // RLSPolicyRef represents a reference to an RLS policy with its table information.
 //
-// This structure is used to identify RLS policies that need to be dropped,
-// providing both the policy name and the table it belongs to. This is necessary
-// because PostgreSQL requires both pieces of information for DROP POLICY statements.
+// This structure identifies an RLS policy on both sides of a diff -- policies
+// added as well as policies dropped. The table is not decoration: a PostgreSQL
+// policy name is scoped to its table, so two tables in one schema may each carry
+// a policy called "tenant_isolation", and both CREATE POLICY and DROP POLICY
+// need the table to say which one is meant.
 //
 // # Example Usage
 //


### PR DESCRIPTION
Refs #1276. One more instance of its identity class: `compare.RLSPolicies` keyed both sides by the policy **name alone**, but a PostgreSQL policy name is scoped to its **table**, so two tables each carrying `tenant_isolation` collapsed into one entry — one policy silently won, the other was compared against the wrong counterpart or vanished.

Premise confirmed against a live catalog before any code changed: PostgreSQL accepts the same policy name on two tables in one schema, so the collision is real rather than assumed.

## Two independent reviews, both addressed

This branch was reviewed adversarially twice; each review found a shape the previous author had not built, and both are closed on the current head.

**First review.** Keying by `(table identity, policy name)` fixed the collapse, and then `deduplicateRLSPolicies` in `core/goschema/utils.go` resolved the owning table *differently from the comparator* — so `ptah schema render`, `schema apply` and `migrations generate` produced DDL PostgreSQL refuses. A naive revert was not available: it reddens the row the change exists to protect.

**Second review.** The ASCII case fold was applied to the **declared** table name, and Ptah does not retain quoting — so a case-preserving declared table silently captured a lower-case row-level-security reference naming a *different* PostgreSQL relation. A wrong-object match, not a cosmetic one.

The fix folds a reference **down** to the declaration, never a declaration **up**, which is the asymmetry the second review's counterexample requires. The commit titles record the sequence:

```
52f4bf0c Identify an RLS policy by its table, not by its name alone (#1276)
28d0936a Fold the two spellings of one table when deduplicating RLS policies
2519773d Bind a row-level security declaration to the table it names
8e4393da Fold a row-level security reference down, never a declaration up
```

## What to check on review

- a quoted mixed-case table and a lower-case one differing only by case stay **distinct**;
- two tables in one schema each carrying a policy of the same name stay **two** policies;
- the row the change exists to protect — one policy name on two tables surviving whole — is still green;
- reported names stay the strings each side supplied, because the planner renders them; only the matching is normalized.

## Process note

This branch was pushed in a batch and left without a PR for a while — my oversight, not a deliberate hold. The branch also carried a machine-generated name and has been renamed to `issue-1276-rls-policy-identity`.

Not yet reviewed by the independent reviewer that has been going through the rest of this PR set; treat its findings on the sibling PRs as likely to apply here too, particularly the domain/identity ones.
