### PR TITLE
fix(projectconfig): validate Atlas envs consistently

### DIFF
--- a/cmd/atlas/atlas.go
+++ b/cmd/atlas/atlas.go
@@ -949,6 +949,9 @@ func atlasArgMapper(group string, verb atlasVerb) cmdadapter.ArgMapper {
 		if err != nil {
 			return nil, nil, err
 		}
+		if err := dbcli.ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), project.project.Config); err != nil {
+			return nil, nil, err
+		}
 		args = project.args
 		if err := rejectNativeOnlyAtlasFlags(group, verb, args); err != nil {
 			return nil, nil, err

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -123,7 +123,7 @@ func runAtlasMigrateDownFormat(
 	if err != nil {
 		return err
 	}
-	loadedProject, err := applyAtlasMigrateDownFormatProjectConfig(opts, project)
+	loadedProject, err := applyAtlasMigrateDownFormatProjectConfig(cmd.ErrOrStderr(), opts, project)
 	if err != nil {
 		return err
 	}
@@ -349,6 +349,7 @@ func atlasVerbFlag(verb atlasVerb, name string) (atlasargs.Flag, bool) {
 // commands use: an explicitly changed flag wins, an unset flag falls back to
 // the selected env.
 func applyAtlasMigrateDownFormatProjectConfig(
+	diagnostics io.Writer,
 	opts *atlasMigrateDownFormatOptions,
 	projectArgs atlasProjectArgValues,
 ) (
@@ -364,6 +365,9 @@ func applyAtlasMigrateDownFormatProjectConfig(
 	}
 	defer closeAtlasProjectOnError(&project, &returnErr)
 	cfg := project.Config
+	if err := dbcli.ReportIgnoredAtlasConstructs(diagnostics, cfg); err != nil {
+		return atlasProject{}, err
+	}
 	opts.url = atlasDownEffective(
 		opts.flagSet,
 		"url",

--- a/cmd/atlas/migrate_down_format_test.go
+++ b/cmd/atlas/migrate_down_format_test.go
@@ -524,7 +524,8 @@ func TestCompatCommand_MigrateDownFormatUsesAtlasProjectConfig(t *testing.T) {
 	c.Assert(os.MkdirAll(outsideDir, 0o755), qt.IsNil)
 	t.Chdir(outsideDir)
 	c.Assert(os.WriteFile(filepath.Join(projectDir, "atlas.hcl"), []byte(`env "local" {
-  url = "sqlite://`+dbPath+`"
+  url     = "sqlite://`+dbPath+`"
+  project = "ignored"
   migration {
     dir = "file://migrations"
   }
@@ -551,6 +552,11 @@ func TestCompatCommand_MigrateDownFormatUsesAtlasProjectConfig(t *testing.T) {
 	// the apply report's behavior with a config-supplied dir.
 	c.Assert(err, qt.IsNil, qt.Commentf("stderr=%s", errOut.String()))
 	c.Assert(out.String(), qt.Equals, "migrations|2")
+	c.Assert(
+		errOut.String(),
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at "+filepath.Join(projectDir, "atlas.hcl")+":3 is ignored for Atlas compatibility and has no effect\n",
+	)
 }
 
 func TestCompatCommand_MigrateDownFormatValidation(t *testing.T) {

--- a/cmd/atlas/migrate_integrity.go
+++ b/cmd/atlas/migrate_integrity.go
@@ -98,6 +98,9 @@ func newAtlasMigrateIntegrityCommand(
 		if atlasmigrate.ReadsNativeAtlasDir(source.format) {
 			return forward(cmd, source.forwardArgs)
 		}
+		if err := dbcli.ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), source.project.Config); err != nil {
+			return err
+		}
 		// The forwarding path above lets the native command reject an unknown
 		// flag or a stray positional. This path executes directly, so it has to
 		// reject them itself instead of silently dropping them. It belongs to

--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -9,6 +9,7 @@ import (
 
 	"go.5x5.cz/ptah/cmd/internal/cmdadapter"
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
+	"go.5x5.cz/ptah/cmd/internal/dbcli"
 	"go.5x5.cz/ptah/cmd/migrate"
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
@@ -45,6 +46,9 @@ func newAtlasMigrateNewCommand() *cobra.Command {
 			return err
 		}
 		if !atlasmigrate.ReadsNativeAtlasDir(source.format) {
+			if err := dbcli.ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), source.project.Config); err != nil {
+				return err
+			}
 			return runAtlasMigrateNewConverted(cmd, verb, source)
 		}
 		if source.dir == "" {

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -228,12 +228,6 @@ func loadOptionalAtlasProjectConfigForCommand(
 	return loadAtlasProjectConfigForCommand(cmd, ignoreMissingEnvSelection)
 }
 
-func loadRequiredAtlasProjectConfigForCommand(
-	cmd *cobra.Command,
-) (projectconfig.Config, bool, error) {
-	return loadAtlasProjectConfigForCommand(cmd, reportMissingEnvSelection)
-}
-
 func atlasProjectConfigSchemaURLs(cmd *cobra.Command, raw []string) ([]string, error) {
 	flags, _, err := atlasProjectFlagsFromCommand(cmd)
 	if err != nil {
@@ -314,15 +308,21 @@ func openAtlasProjectForCommand(
 	if err != nil {
 		return atlasProject{}, false, err
 	}
+	requirement := optionalAtlasProject
 	if changed {
-		return openAtlasProject(flags, requiredAtlasProject)
+		requirement = requiredAtlasProject
 	}
-	project, loaded, err := openAtlasProject(flags, optionalAtlasProject)
+	project, loaded, err := openAtlasProject(flags, requirement)
 	if err != nil {
 		if isAtlasEnvSelectionRequired(err) && mode == ignoreMissingEnvSelection {
 			return atlasProject{}, false, nil
 		}
 		return atlasProject{}, false, err
+	}
+	if loaded {
+		if err := dbcli.ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), project.Config); err != nil {
+			return atlasProject{}, false, errors.Join(err, project.Close())
+		}
 	}
 	return project, loaded, nil
 }

--- a/cmd/atlas/project_config_ignored_test.go
+++ b/cmd/atlas/project_config_ignored_test.go
@@ -1,0 +1,124 @@
+package atlas_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+)
+
+func TestCompatDirectCommandReportsIgnoredAtlasConstructs(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  url     = "sqlite://`+filepath.Join(dir, "inspect.db")+`"
+  project = "ignored"
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"schema", "inspect", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		stderr.String(),
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at atlas.hcl:3 is ignored for Atlas compatibility and has no effect\n",
+	)
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "warning: atlas.hcl")
+}
+
+func TestCompatAdapterCommandReportsIgnoredAtlasConstructs(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	c.Assert(os.Mkdir("migrations", 0o700), qt.IsNil)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  project = "ignored"
+  migration {
+    dir = "file://migrations"
+  }
+}
+`), 0o600), qt.IsNil)
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"migrate", "hash", "--env", "local"})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		stderr.String(),
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect\n",
+	)
+	c.Assert(stdout.String(), qt.Not(qt.Contains), "warning: atlas.hcl")
+}
+
+func TestCompatConvertedIntegrityCommandReportsIgnoredAtlasConstructs(t *testing.T) {
+	c := qt.New(t)
+	configPath, migrationsDir := writeIntegrityProject(c, "goose")
+	c.Assert(os.WriteFile(configPath, []byte(`env "local" {
+  project = "ignored"
+  migration {
+    dir    = "file://migrations"
+    format = goose
+  }
+}
+`), 0o600), qt.IsNil)
+
+	stdout, stderr, err := runCompatExit(
+		"migrate", "hash", "--config", "file://"+configPath, "--env", "local",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(
+		stderr,
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at "+configPath+":2 is ignored for Atlas compatibility and has no effect\n",
+	)
+	c.Assert(sumEntryNames(c, migrationsDir), qt.DeepEquals, sqlSuffixCoveredSet)
+}
+
+func TestCompatConvertedMigrateNewReportsIgnoredAtlasConstructs(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	c.Assert(os.WriteFile("atlas.hcl", []byte(`env "local" {
+  project = "ignored"
+  migration {
+    dir    = "file://migrations"
+    format = goose
+  }
+}
+`), 0o600), qt.IsNil)
+
+	stdout, stderr, err := runCompatExit("migrate", "new", "add_users", "--env", "local")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(stdout, qt.Contains, "Generated empty migration file:")
+	c.Assert(
+		stderr,
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect\n",
+	)
+	created, err := filepath.Glob(filepath.Join("migrations", "*_add_users.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(created, qt.HasLen, 1)
+}

--- a/cmd/atlas/project_config_root_unix_internal_test.go
+++ b/cmd/atlas/project_config_root_unix_internal_test.go
@@ -7,6 +7,7 @@ package atlas
 // no exported API exposes a deterministic hook at that point.
 
 import (
+	"io"
 	"io/fs"
 	"os"
 	"path/filepath"
@@ -179,7 +180,7 @@ func TestAtlasMigrateDownFormatPreservesProjectRoot(t *testing.T) {
 		[]string{"--format", "{{ .Dir }}"},
 	)
 	c.Assert(err, qt.IsNil)
-	project, err := applyAtlasMigrateDownFormatProjectConfig(opts, atlasProjectArgValues{
+	project, err := applyAtlasMigrateDownFormatProjectConfig(io.Discard, opts, atlasProjectArgValues{
 		flags: atlasProjectFlagValues{
 			configPath: "file://" + filepath.ToSlash(filepath.Join(projectDir, "atlas.hcl")),
 			envName:    "local",

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -141,10 +141,11 @@ has no lint pass to skip, so --skip-lint changes nothing there.`,
 func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error {
 	formatOutput := cmd.Flags().Changed("format")
 	policy := atlasschema.DiffPolicy{}
-	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
+	mode := ignoreMissingEnvSelection
 	if needsAtlasSchemaApplyConfig(cmd) {
-		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
+		mode = reportMissingEnvSelection
 	}
+	projectCfg, loaded, err := loadAtlasProjectConfigForCommand(cmd, mode)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/atlas/schema_diff.go
+++ b/cmd/atlas/schema_diff.go
@@ -81,10 +81,11 @@ func runAtlasSchemaDiff(cmd *cobra.Command, opts atlasSchemaDiffOptions) error {
 	}
 	formatConfigured := cmd.Flags().Changed("format")
 	policy := atlasschema.DiffPolicy{}
-	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
+	mode := ignoreMissingEnvSelection
 	if needsAtlasSchemaDiffConfig(cmd) {
-		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
+		mode = reportMissingEnvSelection
 	}
+	projectCfg, loaded, err := loadAtlasProjectConfigForCommand(cmd, mode)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -113,10 +113,11 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 		return cmdutil.Fail(cmd, err)
 	}
 	formatConfigured := cmd.Flags().Changed("format")
-	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
+	mode := ignoreMissingEnvSelection
 	if needsAtlasSchemaInspectConfig(cmd) {
-		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
+		mode = reportMissingEnvSelection
 	}
+	projectCfg, loaded, err := loadAtlasProjectConfigForCommand(cmd, mode)
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}

--- a/cmd/atlas/schema_plan_transition.go
+++ b/cmd/atlas/schema_plan_transition.go
@@ -73,10 +73,11 @@ func resolveAtlasSchemaPlanTransitionConfig(
 	in atlasSchemaPlanTransitionFlags,
 ) (atlasSchemaPlanTransitionFlags, atlasschema.DiffPolicy, error) {
 	policy := atlasschema.DiffPolicy{}
-	projectCfg, loaded, err := loadOptionalAtlasProjectConfigForCommand(cmd)
+	mode := ignoreMissingEnvSelection
 	if needsAtlasSchemaPlanConfig(cmd) {
-		projectCfg, loaded, err = loadRequiredAtlasProjectConfigForCommand(cmd)
+		mode = reportMissingEnvSelection
 	}
+	projectCfg, loaded, err := loadAtlasProjectConfigForCommand(cmd, mode)
 	if err != nil {
 		return in, policy, err
 	}

--- a/cmd/internal/dbcli/project_config.go
+++ b/cmd/internal/dbcli/project_config.go
@@ -3,6 +3,7 @@ package dbcli
 import (
 	"context"
 	"fmt"
+	"io"
 	"slices"
 	"strings"
 
@@ -157,12 +158,39 @@ func LoadProjectConfig(cmd *cobra.Command, ptahConfigPath string) (projectconfig
 	if err != nil {
 		return projectconfig.Config{}, err
 	}
-	return projectconfig.Load(projectconfig.LoadOptions{
+	config, err := projectconfig.Load(projectconfig.LoadOptions{
 		PtahPath:  ptahConfigPath,
 		AtlasPath: atlasPath,
 		EnvName:   envName,
 		AtlasVars: atlasVars,
 	})
+	if err != nil {
+		return projectconfig.Config{}, err
+	}
+	if err := ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), config); err != nil {
+		return projectconfig.Config{}, err
+	}
+	return config, nil
+}
+
+// ReportIgnoredAtlasConstructs writes one warning for every atlas.hcl name
+// that Atlas CE accepts without acting on. Ptah preserves this compatibility
+// behavior, but makes the resulting no-op visible instead of silently hiding
+// a likely typo or unsupported policy.
+func ReportIgnoredAtlasConstructs(out io.Writer, config projectconfig.Config) error {
+	for _, construct := range config.IgnoredConstructs {
+		if _, err := fmt.Fprintf(
+			out,
+			"warning: atlas.hcl %s %q at %s:%d is ignored for Atlas compatibility and has no effect\n",
+			construct.Kind,
+			construct.Name,
+			construct.Filename,
+			construct.Line,
+		); err != nil {
+			return fmt.Errorf("write ignored atlas.hcl construct warning: %w", err)
+		}
+	}
+	return nil
 }
 
 // projectVars resolves the atlas.hcl variable overrides for a command. The

--- a/cmd/internal/dbcli/project_config_test.go
+++ b/cmd/internal/dbcli/project_config_test.go
@@ -1,6 +1,8 @@
 package dbcli_test
 
 import (
+	"bytes"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -96,6 +98,52 @@ migration:
 	c.Assert(cfg.Migration.Dir, qt.Equals, "atlas-migrations")
 	c.Assert(cfg.Migration.Format, qt.Equals, "atlas")
 	c.Assert(cfg.Migration.RevisionFormat, qt.Equals, "atlas")
+}
+
+func TestLoadProjectConfigReportsIgnoredAtlasConstructs(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	c.Assert(os.WriteFile(projectconfig.AtlasFileName, []byte(`env "local" {
+  project = "ignored"
+}
+`), 0o600), qt.IsNil)
+
+	cmd := &cobra.Command{Use: "test"}
+	cmd.Flags().String(dbcli.EnvFlagName, "local", "")
+	var stderr bytes.Buffer
+	cmd.SetErr(&stderr)
+	cfg, err := dbcli.LoadProjectConfig(cmd, "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.IgnoredConstructs, qt.HasLen, 1)
+	c.Assert(
+		stderr.String(),
+		qt.Equals,
+		"warning: atlas.hcl attribute \"project\" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect\n",
+	)
+}
+
+func TestReportIgnoredAtlasConstructsReturnsWriterError(t *testing.T) {
+	c := qt.New(t)
+	writeErr := errors.New("diagnostics unavailable")
+
+	err := dbcli.ReportIgnoredAtlasConstructs(
+		failingDiagnosticsWriter{err: writeErr},
+		projectconfig.Config{IgnoredConstructs: []projectconfig.IgnoredAtlasConstruct{
+			{Name: "project", Kind: "attribute", Filename: "atlas.hcl", Line: 2},
+		}},
+	)
+
+	c.Assert(err, qt.ErrorIs, writeErr)
+}
+
+type failingDiagnosticsWriter struct {
+	err error
+}
+
+func (w failingDiagnosticsWriter) Write([]byte) (int, error) {
+	return 0, w.err
 }
 
 func TestLoadProjectConfigReadsInternalAtlasProjectFlags(t *testing.T) {
@@ -213,6 +261,9 @@ schemas: [public]
 			Exclude:  []string{"migrations/legacy/*"},
 		},
 	}
+	snapshot.IgnoredConstructs = []projectconfig.IgnoredAtlasConstruct{
+		{Name: "project", Kind: "attribute", Filename: "atlas.hcl", Line: 2},
+	}
 	cmd := &cobra.Command{Use: "test"}
 	cmd.SetContext(dbcli.WithProjectConfig(cmd.Context(), snapshot))
 	snapshot.DatabaseURL = "postgres://mutated/db"
@@ -222,6 +273,7 @@ schemas: [public]
 		Severity: "error",
 		Exclude:  []string{"mutated/*"},
 	}
+	snapshot.IgnoredConstructs[0].Name = "mutated"
 
 	first, err := dbcli.LoadProjectConfig(cmd, filepath.Join(t.TempDir(), "missing.yaml"))
 
@@ -233,10 +285,14 @@ schemas: [public]
 		Severity: "warning",
 		Exclude:  []string{"migrations/legacy/*"},
 	})
+	c.Assert(first.IgnoredConstructs, qt.DeepEquals, []projectconfig.IgnoredAtlasConstruct{
+		{Name: "project", Kind: "attribute", Filename: "atlas.hcl", Line: 2},
+	})
 	first.DatabaseURL = "postgres://consumer-mutation/db"
 	first.Schemas[0] = "consumer-mutation"
 	*first.Lint.Latest = 12
 	first.Lint.RuleConfigs["DS"] = projectconfig.LintRuleConfig{Severity: "off"}
+	first.IgnoredConstructs[0].Name = "consumer-mutation"
 
 	second, err := dbcli.LoadProjectConfig(cmd, filepath.Join(t.TempDir(), "missing.yaml"))
 
@@ -247,6 +303,9 @@ schemas: [public]
 	c.Assert(second.Lint.RuleConfigs["DS"], qt.DeepEquals, projectconfig.LintRuleConfig{
 		Severity: "warning",
 		Exclude:  []string{"migrations/legacy/*"},
+	})
+	c.Assert(second.IgnoredConstructs, qt.DeepEquals, []projectconfig.IgnoredAtlasConstruct{
+		{Name: "project", Kind: "attribute", Filename: "atlas.hcl", Line: 2},
 	})
 }
 

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -170,17 +170,24 @@ type atlasParser struct {
 	// ignored records the constructs tolerated under Atlas CE's
 	// unknown-name policy, so the caller can report them. Pointer for the same
 	// reason as sensitiveValues: the parser is passed by value.
-	ignored *[]IgnoredAtlasConstruct
+	ignored     *[]IgnoredAtlasConstruct
+	ignoredSeen map[ignoredAtlasConstructKey]struct{}
+}
+
+type ignoredAtlasConstructKey struct {
+	kind     string
+	name     string
+	filename string
+	line     int
+	column   int
 }
 
 // IgnoredAtlasConstruct is an atlas.hcl name that was accepted and not acted
 // on, matching what Atlas CE does with a name it does not recognize.
 //
-// CE reports nothing at all. Ptah records them so the caller can say one line
-// per construct on stderr: CE's silence is a footgun -- a typo'd block name
-// does nothing and looks fine -- and stdout, the exit code, and every error
-// diagnostic stay byte-identical, so nothing that reads those can tell the
-// difference.
+// Atlas CE reports nothing for these names. Ptah records them so callers can
+// make the no-op visible; the Ptah CLIs warn on stderr while preserving the
+// command's stdout and exit code.
 type IgnoredAtlasConstruct struct {
 	// Name is the construct's name as written.
 	Name string
@@ -200,6 +207,7 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 	return atlasParser{
 		sensitiveValues: &[]string{},
 		ignored:         &[]IgnoredAtlasConstruct{},
+		ignoredSeen:     map[ignoredAtlasConstructKey]struct{}{},
 		ctx: &hcl.EvalContext{
 			Variables: map[string]cty.Value{},
 			Functions: map[string]function.Function{
@@ -366,8 +374,8 @@ func enforcedByCE(scope, name string) bool {
 // scope is the dotted path of the enclosing body, used to keep names CE really
 // enforces out of the tolerance -- see ceEnforcedConstructs.
 func (p atlasParser) tolerateUnknownAttr(scope, name string, attr *hclsyntax.Attribute) error {
-	if enforcedByCE(scope, name) {
-		return unsupported(name, attr.NameRange)
+	if err := rejectEnforcedConstruct(scope, name, attr.NameRange); err != nil {
+		return err
 	}
 	if _, diags := attr.Expr.Value(p.ctx); diags.HasErrors() {
 		return p.evaluationFailed(name, attr, diags)
@@ -379,8 +387,8 @@ func (p atlasParser) tolerateUnknownAttr(scope, name string, attr *hclsyntax.Att
 // tolerateUnknownBlock accepts a block name Atlas CE does not recognize, with
 // the same name-level and enforced-name rules as tolerateUnknownAttr.
 func (p atlasParser) tolerateUnknownBlock(scope string, block *hclsyntax.Block) error {
-	if enforcedByCE(scope, block.Type) {
-		return unsupported(block.Type, block.TypeRange)
+	if err := rejectEnforcedConstruct(scope, block.Type, block.TypeRange); err != nil {
+		return err
 	}
 	if err := p.evaluateIgnoredBody(block.Body); err != nil {
 		return err
@@ -389,10 +397,43 @@ func (p atlasParser) tolerateUnknownBlock(scope string, block *hclsyntax.Block) 
 	return nil
 }
 
+func (p atlasParser) recordIgnoredAttr(scope, name string, attr *hclsyntax.Attribute) error {
+	if err := rejectEnforcedConstruct(scope, name, attr.NameRange); err != nil {
+		return err
+	}
+	p.noteIgnored("attribute", name, attr.NameRange)
+	return nil
+}
+
+func (p atlasParser) recordIgnoredBlock(scope string, block *hclsyntax.Block) error {
+	if err := rejectEnforcedConstruct(scope, block.Type, block.TypeRange); err != nil {
+		return err
+	}
+	p.noteIgnored("block", block.Type, block.TypeRange)
+	return nil
+}
+
+func rejectEnforcedConstruct(scope, name string, rng hcl.Range) error {
+	if enforcedByCE(scope, name) {
+		return unsupported(name, rng)
+	}
+	return nil
+}
+
 // noteIgnored records a construct tolerated under the unknown-name policy.
 func (p atlasParser) noteIgnored(kind, name string, rng hcl.Range) {
 	if p.ignored == nil {
 		return
+	}
+	key := ignoredAtlasConstructKey{
+		kind: kind, name: name, filename: rng.Filename,
+		line: rng.Start.Line, column: rng.Start.Column,
+	}
+	if p.ignoredSeen != nil {
+		if _, ok := p.ignoredSeen[key]; ok {
+			return
+		}
+		p.ignoredSeen[key] = struct{}{}
 	}
 	*p.ignored = append(*p.ignored, IgnoredAtlasConstruct{
 		Name: name, Kind: kind, Filename: rng.Filename, Line: rng.Start.Line,
@@ -627,6 +668,14 @@ func (p atlasParser) parseSchemaMode(block *hclsyntax.Block, cfg *Config) error 
 		return unsupportedBlock(block)
 	}
 	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "funcs", "objects", "permissions", "roles", "sensitive", "tables", "triggers", "types", "views":
+		default:
+			if err := p.tolerateUnknownAttr("env.schema.mode", attrName, attr); err != nil {
+				return err
+			}
+			continue
+		}
 		value, err := p.schemaModeAttr(attrName, attr)
 		if err != nil {
 			return err
@@ -653,10 +702,6 @@ func (p atlasParser) parseSchemaMode(block *hclsyntax.Block, cfg *Config) error 
 				if err := p.tolerateUnknownAttr("env.schema.mode", attrName, attr); err != nil {
 					return err
 				}
-			}
-		default:
-			if err := p.tolerateUnknownAttr("env.schema.mode", attrName, attr); err != nil {
-				return err
 			}
 		}
 	}
@@ -788,7 +833,8 @@ func (p atlasParser) parseLint(block *hclsyntax.Block, cfg *Config) error {
 	if len(block.Labels) > 0 {
 		return unsupportedBlock(block)
 	}
-	for attrName, attr := range block.Body.Attributes {
+	for _, attrName := range sortedAttributeNames(block.Body.Attributes) {
+		attr := block.Body.Attributes[attrName]
 		if err := p.parseLintAttr(attrName, attr, cfg); err != nil {
 			return err
 		}
@@ -926,7 +972,8 @@ func (p atlasParser) parseLintAnalyzer(block *hclsyntax.Block, cfg *Config, code
 	if len(block.Labels) > 0 {
 		return unsupportedBlock(block)
 	}
-	for attrName, attr := range block.Body.Attributes {
+	for _, attrName := range sortedAttributeNames(block.Body.Attributes) {
+		attr := block.Body.Attributes[attrName]
 		switch attrName {
 		case "error":
 			value, err := p.boolAttr(attrName, attr)
@@ -982,7 +1029,8 @@ func (p atlasParser) parseLintGit(block *hclsyntax.Block, cfg *Config) error {
 	if len(block.Labels) > 0 {
 		return unsupportedBlock(block)
 	}
-	for attrName, attr := range block.Body.Attributes {
+	for _, attrName := range sortedAttributeNames(block.Body.Attributes) {
+		attr := block.Body.Attributes[attrName]
 		switch attrName {
 		case "base":
 			value, err := p.stringAttr(attrName, attr)
@@ -1122,6 +1170,14 @@ func (p atlasParser) parseDiffSkip(block *hclsyntax.Block, cfg *Config) error {
 		return unsupportedBlock(block)
 	}
 	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "drop_table", "drop_schema":
+		default:
+			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
+				return err
+			}
+			continue
+		}
 		value, err := p.configBoolAttr(attrName, attr)
 		if err != nil {
 			return err
@@ -1131,10 +1187,6 @@ func (p atlasParser) parseDiffSkip(block *hclsyntax.Block, cfg *Config) error {
 			cfg.Diff.Skip.DropTable = value
 		case "drop_schema":
 			cfg.Diff.Skip.DropSchema = value
-		default:
-			if err := p.tolerateUnknownAttr("diff.skip", attrName, attr); err != nil {
-				return err
-			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {
@@ -1148,6 +1200,14 @@ func (p atlasParser) parseDiffConcurrentIndex(block *hclsyntax.Block, cfg *Confi
 		return unsupportedBlock(block)
 	}
 	for attrName, attr := range block.Body.Attributes {
+		switch attrName {
+		case "create", "drop":
+		default:
+			if err := p.tolerateUnknownAttr("diff.concurrent_index", attrName, attr); err != nil {
+				return err
+			}
+			continue
+		}
 		value, err := p.configBoolAttr(attrName, attr)
 		if err != nil {
 			return err
@@ -1157,10 +1217,6 @@ func (p atlasParser) parseDiffConcurrentIndex(block *hclsyntax.Block, cfg *Confi
 			cfg.Diff.ConcurrentIndex.Create = value
 		case "drop":
 			cfg.Diff.ConcurrentIndex.Drop = value
-		default:
-			if err := p.tolerateUnknownAttr("diff.concurrent_index", attrName, attr); err != nil {
-				return err
-			}
 		}
 	}
 	if len(block.Body.Blocks) > 0 {

--- a/config/projectconfig/atlas_structure.go
+++ b/config/projectconfig/atlas_structure.go
@@ -7,8 +7,10 @@ import (
 )
 
 type atlasBodyStructure struct {
-	attributes []string
-	blocks     map[string]atlasBlockStructure
+	attributes             []string
+	blocks                 map[string]atlasBlockStructure
+	allowUnknownAttributes bool
+	allowUnknownBlocks     bool
 }
 
 type atlasBlockStructure struct {
@@ -18,76 +20,102 @@ type atlasBlockStructure struct {
 
 func atlasEnvBodyStructure() atlasBodyStructure {
 	return atlasBodyStructure{
-		attributes: []string{"dev", "exclude", "src", "url"},
+		attributes:             []string{"dev", "exclude", "src", "url"},
+		allowUnknownAttributes: true,
+		allowUnknownBlocks:     true,
 		blocks: map[string]atlasBlockStructure{
 			"diff": {
-				body: atlasBodyStructure{blocks: map[string]atlasBlockStructure{
-					"concurrent_index": {
-						body: atlasBodyStructure{attributes: []string{"create", "drop"}},
+				body: atlasBodyStructure{
+					allowUnknownAttributes: true,
+					allowUnknownBlocks:     true,
+					blocks: map[string]atlasBlockStructure{
+						"concurrent_index": {
+							body: atlasBodyStructure{
+								attributes:             []string{"create", "drop"},
+								allowUnknownAttributes: true,
+							},
+						},
+						"skip": {
+							body: atlasBodyStructure{
+								attributes:             []string{"drop_schema", "drop_table"},
+								allowUnknownAttributes: true,
+							},
+						},
 					},
-					"skip": {
-						body: atlasBodyStructure{attributes: []string{"drop_schema", "drop_table"}},
-					},
-				}},
+				},
 			},
 			"format": {
-				body: atlasBodyStructure{blocks: map[string]atlasBlockStructure{
-					"migrate": {
-						body: atlasBodyStructure{attributes: []string{"apply", "diff", "lint", "status"}},
+				body: atlasBodyStructure{
+					allowUnknownAttributes: true,
+					allowUnknownBlocks:     true,
+					blocks: map[string]atlasBlockStructure{
+						"migrate": {
+							body: atlasBodyStructure{attributes: []string{"apply", "diff", "lint", "status"}},
+						},
+						"schema": {
+							body: atlasBodyStructure{attributes: []string{"apply", "clean", "diff", "inspect"}},
+						},
 					},
-					"schema": {
-						body: atlasBodyStructure{attributes: []string{"apply", "clean", "diff", "inspect"}},
-					},
-				}},
+				},
 			},
 			"lint": {
 				body: atlasBodyStructure{
-					attributes: []string{"latest", "log"},
+					attributes:             []string{"latest", "log"},
+					allowUnknownAttributes: true,
+					allowUnknownBlocks:     true,
 					blocks: map[string]atlasBlockStructure{
-						"concurrent_index": {body: atlasBodyStructure{attributes: []string{"error"}}},
-						"condrop":          {body: atlasBodyStructure{attributes: []string{"error"}}},
-						"data_depend":      {body: atlasBodyStructure{attributes: []string{"error"}}},
-						"destructive":      {body: atlasBodyStructure{attributes: []string{"error"}}},
-						"git":              {body: atlasBodyStructure{attributes: []string{"base", "dir"}}},
-						"incompatible":     {body: atlasBodyStructure{attributes: []string{"error"}}},
-						"nestedtx":         {body: atlasBodyStructure{attributes: []string{"error"}}},
+						"concurrent_index": {body: atlasTolerantLeafStructure("error")},
+						"condrop":          {body: atlasTolerantLeafStructure("error")},
+						"data_depend":      {body: atlasTolerantLeafStructure("error")},
+						"destructive":      {body: atlasTolerantLeafStructure("error")},
+						"git":              {body: atlasTolerantLeafStructure("base", "dir")},
+						"incompatible":     {body: atlasTolerantLeafStructure("error")},
+						"nestedtx":         {body: atlasTolerantLeafStructure("error")},
 					},
 				},
 			},
 			"migration": {
-				body: atlasBodyStructure{attributes: []string{
+				body: atlasTolerantLeafStructure(
 					"dir",
 					"exec_order",
 					"format",
 					"lock_timeout",
 					"revisions_schema",
 					"tx_mode",
-				}},
+				),
 			},
 			"schema": {
 				body: atlasBodyStructure{
-					attributes: []string{"src"},
+					attributes:             []string{"src"},
+					allowUnknownAttributes: true,
+					allowUnknownBlocks:     true,
 					blocks: map[string]atlasBlockStructure{
 						"mode": {
-							body: atlasBodyStructure{attributes: []string{
+							body: atlasTolerantLeafStructure(
 								"funcs",
 								"objects",
 								"permissions",
 								"roles",
-								"sensitive",
 								"tables",
 								"triggers",
 								"types",
 								"views",
-							}},
+							),
 						},
 						"repo": {
-							body: atlasBodyStructure{attributes: []string{"name"}},
+							body: atlasTolerantLeafStructure("name"),
 						},
 					},
 				},
 			},
 		},
+	}
+}
+
+func atlasTolerantLeafStructure(attributes ...string) atlasBodyStructure {
+	return atlasBodyStructure{
+		attributes:             attributes,
+		allowUnknownAttributes: true,
 	}
 }
 
@@ -110,7 +138,10 @@ func (p atlasParser) validateAtlasBodyStructure(scope string, body *hclsyntax.Bo
 	// parsers' own switch defaults would have changed nothing here.
 	for _, name := range sortedAttributeNames(body.Attributes) {
 		if !slices.Contains(structure.attributes, name) {
-			if err := p.tolerateUnknownAttr(scope, name, body.Attributes[name]); err != nil {
+			if !structure.allowUnknownAttributes {
+				return unsupportedAttr(name, body.Attributes[name])
+			}
+			if err := p.recordIgnoredAttr(scope, name, body.Attributes[name]); err != nil {
 				return err
 			}
 			continue
@@ -121,7 +152,10 @@ func (p atlasParser) validateAtlasBodyStructure(scope string, body *hclsyntax.Bo
 	for _, block := range body.Blocks {
 		blockStructure, ok := structure.blocks[block.Type]
 		if !ok {
-			if err := p.tolerateUnknownBlock(scope, block); err != nil {
+			if !structure.allowUnknownBlocks {
+				return unsupportedBlock(block)
+			}
+			if err := p.recordIgnoredBlock(scope, block); err != nil {
 				return err
 			}
 			continue

--- a/config/projectconfig/atlas_structure_test.go
+++ b/config/projectconfig/atlas_structure_test.go
@@ -1,0 +1,484 @@
+package projectconfig_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+func TestParseAtlasProjectConfigRejectsUnsupportedEnvStructureRegardlessOfSelection(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name: "migration nested block",
+			body: `migration {
+    remote {}
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "remote" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "schema mode nested block",
+			body: `schema {
+    mode {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "schema repo nested block",
+			body: `schema {
+    repo {
+      cloud {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "cloud" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "migrate format unknown attribute",
+			body: `format {
+    migrate {
+      custom = "template"
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "migrate format nested block",
+			body: `format {
+    migrate {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "schema format unknown attribute",
+			body: `format {
+    schema {
+      custom = "template"
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "schema format nested block",
+			body: `format {
+    schema {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint concurrent index nested block",
+			body: `lint {
+    concurrent_index {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint constraint drop nested block",
+			body: `lint {
+    condrop {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint data dependency nested block",
+			body: `lint {
+    data_depend {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint destructive nested block",
+			body: `lint {
+    destructive {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint incompatible nested block",
+			body: `lint {
+    incompatible {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint nested transaction nested block",
+			body: `lint {
+    nestedtx {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "lint git nested block",
+			body: `lint {
+    git {
+      remote {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "remote" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "diff skip nested block",
+			body: `diff {
+    skip {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+		{
+			name: "diff concurrent index nested block",
+			body: `diff {
+    concurrent_index {
+      custom {}
+    }
+  }`,
+			wantErr: `unsupported atlas\.hcl construct "custom" at atlas\.hcl:[0-9]+`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env "selected" {
+  url = "sqlite://selected.db"
+}
+env "other" {
+  ` + test.body + `
+}
+`)
+
+			_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+
+			_, err = projectconfig.ParseAtlas(raw, "atlas.hcl", "other")
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigSkipsIgnoredExpressionEvaluationInUnselectedEnv(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "attribute",
+			body: `project = missing.value`,
+		},
+		{
+			name: "block body",
+			body: `cloud {
+    value = missing.value
+  }`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env "selected" {
+	  url = "sqlite://selected.db"
+	}
+	env "other" {
+	  ` + test.body + `
+}
+`)
+
+			cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://selected.db")
+			c.Assert(cfg.IgnoredConstructs, qt.HasLen, 1)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigToleratesOpenEnvBodiesRegardlessOfSelection(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "env attribute", body: `custom = "literal"`},
+		{name: "env block", body: `custom {}`},
+		{name: "diff attribute", body: `diff { custom = "literal" }`},
+		{name: "diff block", body: `diff {
+    custom {}
+  }`},
+		{name: "format attribute", body: `format { custom = "literal" }`},
+		{name: "format block", body: `format {
+    custom {}
+  }`},
+		{name: "lint attribute", body: `lint { custom = "literal" }`},
+		{name: "lint block", body: `lint {
+    custom {}
+  }`},
+		{name: "schema attribute", body: `schema { custom = "literal" }`},
+		{name: "schema block", body: `schema {
+    custom {}
+  }`},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env "selected" {
+  url = "sqlite://selected.db"
+}
+env "other" {
+  ` + test.body + `
+}
+`)
+
+			selected, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "other")
+			c.Assert(err, qt.IsNil)
+			c.Assert(selected.IgnoredConstructs, qt.HasLen, 1)
+
+			unselected, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+			c.Assert(err, qt.IsNil)
+			c.Assert(unselected.IgnoredConstructs, qt.HasLen, 1)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigToleratesUnknownLeafAttributesRegardlessOfSelection(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{
+			name: "schema mode",
+			body: `schema {
+    mode {
+      custom = "literal"
+    }
+  }`,
+		},
+		{
+			name: "diff skip",
+			body: `diff {
+    skip {
+      custom = "literal"
+    }
+  }`,
+		},
+		{
+			name: "diff concurrent index",
+			body: `diff {
+    concurrent_index {
+      custom = "literal"
+    }
+  }`,
+		},
+		{
+			name: "lint analyzer",
+			body: `lint {
+    destructive {
+      custom = "literal"
+    }
+  }`,
+		},
+		{
+			name: "lint git",
+			body: `lint {
+    git {
+      custom = "literal"
+    }
+  }`,
+		},
+		{
+			name: "migration",
+			body: `migration {
+    custom = "literal"
+  }`,
+		},
+		{
+			name: "schema repository",
+			body: `schema {
+    repo {
+      custom = "literal"
+    }
+  }`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env "selected" {
+  url = "sqlite://selected.db"
+}
+env "other" {
+  ` + test.body + `
+}
+`)
+
+			selected, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "other")
+			c.Assert(err, qt.IsNil)
+			c.Assert(selected.IgnoredConstructs, qt.HasLen, 1)
+
+			unselected, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+			c.Assert(err, qt.IsNil)
+			c.Assert(unselected.IgnoredConstructs, qt.HasLen, 1)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigClassifiesSensitiveModeRegardlessOfSelection(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "selected" {
+  schema {
+    mode {
+      sensitive = "ALLOW"
+    }
+  }
+}
+env "other" {
+  schema {
+    mode {
+      sensitive = DENY
+    }
+  }
+}
+`)
+	want := []projectconfig.IgnoredAtlasConstruct{
+		{Name: "sensitive", Kind: "attribute", Filename: "atlas.hcl", Line: 4},
+		{Name: "sensitive", Kind: "attribute", Filename: "atlas.hcl", Line: 11},
+	}
+
+	selected, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+	c.Assert(err, qt.IsNil)
+	c.Assert(selected.IgnoredConstructs, qt.DeepEquals, want)
+
+	other, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "other")
+	c.Assert(err, qt.IsNil)
+	c.Assert(other.IgnoredConstructs, qt.DeepEquals, want)
+}
+
+func TestParseAtlasProjectConfigEvaluatesIgnoredExpressionsInSelectedEnv(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "attribute",
+			body:    `project = missing.value`,
+			wantErr: `cannot evaluate atlas\.hcl "project" at atlas\.hcl:[0-9]+: .*Unknown variable.*`,
+		},
+		{
+			name: "block body",
+			body: `cloud {
+    value = missing.value
+  }`,
+			wantErr: `cannot evaluate atlas\.hcl "value" at atlas\.hcl:[0-9]+: .*Unknown variable.*`,
+		},
+		{
+			name: "schema mode attribute",
+			body: `schema {
+    mode {
+      custom = missing.value
+    }
+  }`,
+			wantErr: `cannot evaluate atlas\.hcl "custom" at atlas\.hcl:[0-9]+: .*Unknown variable.*`,
+		},
+		{
+			name: "diff skip attribute",
+			body: `diff {
+    skip {
+      custom = missing.value
+    }
+  }`,
+			wantErr: `cannot evaluate atlas\.hcl "custom" at atlas\.hcl:[0-9]+: .*Unknown variable.*`,
+		},
+		{
+			name: "diff concurrent index attribute",
+			body: `diff {
+    concurrent_index {
+      custom = missing.value
+    }
+  }`,
+			wantErr: `cannot evaluate atlas\.hcl "custom" at atlas\.hcl:[0-9]+: .*Unknown variable.*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env "selected" {
+  url = "sqlite://selected.db"
+}
+env "other" {
+  ` + test.body + `
+}
+`)
+
+			_, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "other")
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestParseAtlasProjectConfigRecordsIgnoredConstructsOnceAcrossAllEnvs(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "selected" {
+  url     = "sqlite://selected.db"
+  project = "local"
+}
+env "other" {
+  cloud {}
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "selected")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.IgnoredConstructs, qt.DeepEquals, []projectconfig.IgnoredAtlasConstruct{
+		{Name: "project", Kind: "attribute", Filename: "atlas.hcl", Line: 3},
+		{Name: "cloud", Kind: "block", Filename: "atlas.hcl", Line: 6},
+	})
+}
+
+func TestParseAtlasProjectConfigOrdersIgnoredGlobalLintAttributesDeterministically(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`lint {
+  zebra = "last"
+  alpha = "first"
+}
+`)
+
+	cfg, err := projectconfig.ParseAtlas(raw, "atlas.hcl", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.IgnoredConstructs, qt.DeepEquals, []projectconfig.IgnoredAtlasConstruct{
+		{Name: "alpha", Kind: "attribute", Filename: "atlas.hcl", Line: 3},
+		{Name: "zebra", Kind: "attribute", Filename: "atlas.hcl", Line: 2},
+	})
+}

--- a/config/projectconfig/config.go
+++ b/config/projectconfig/config.go
@@ -42,11 +42,9 @@ type Config struct {
 	// IgnoredConstructs lists the atlas.hcl names that were accepted and not
 	// acted on, under Atlas CE's unknown-name policy.
 	//
-	// It exists so a caller can say something. CE reports nothing at all, and
-	// that silence is a footgun: a typo'd block name does nothing and looks
-	// fine. Everything the conformance tiers measure -- exit code, stdout, the
-	// text of every error -- is unchanged whether or not a caller reports
-	// these, so drop-in fidelity does not depend on it.
+	// Atlas CE reports nothing for these names. Ptah records them so callers can
+	// make the no-op visible; the Ptah CLIs warn on stderr while preserving the
+	// command's stdout and exit code.
 	IgnoredConstructs []IgnoredAtlasConstruct
 	// EnvName is the selected project env name, when the source had one.
 	EnvName string
@@ -691,6 +689,7 @@ func appendDisabledMode(patterns []string, option ConfigBool, pattern string) []
 // non-zero programmatic values from override.
 func Merge(base, override Config) Config {
 	result := base
+	result.IgnoredConstructs = slices.Concat(base.IgnoredConstructs, override.IgnoredConstructs)
 	result.presence = base.presence.clone()
 	result.EnvName = mergeStringValue(
 		base.EnvName,

--- a/config/projectconfig/load_test.go
+++ b/config/projectconfig/load_test.go
@@ -2,6 +2,7 @@ package projectconfig_test
 
 import (
 	"io/fs"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -40,4 +41,29 @@ func TestLoadPtahFileMissingRemainsOptional(t *testing.T) {
 	c.Assert(err, qt.IsNil)
 	c.Assert(cfg.DatabaseURL, qt.Equals, "")
 	c.Assert(cfg.OnlineDDL, qt.DeepEquals, projectconfig.OnlineDDLConfig{})
+}
+
+func TestLoadPreservesIgnoredAtlasConstructsAfterMerge(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	ptahPath := filepath.Join(dir, projectconfig.PtahFileName)
+	atlasPath := filepath.Join(dir, projectconfig.AtlasFileName)
+	c.Assert(os.WriteFile(ptahPath, []byte("url: sqlite://ptah.db\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(atlasPath, []byte(`env "local" {
+  url     = "sqlite://atlas.db"
+  project = "ignored"
+}
+`), 0o600), qt.IsNil)
+
+	cfg, err := projectconfig.Load(projectconfig.LoadOptions{
+		PtahPath:  ptahPath,
+		AtlasPath: atlasPath,
+		EnvName:   "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(cfg.DatabaseURL, qt.Equals, "sqlite://atlas.db")
+	c.Assert(cfg.IgnoredConstructs, qt.DeepEquals, []projectconfig.IgnoredAtlasConstruct{
+		{Name: "project", Kind: "attribute", Filename: atlasPath, Line: 3},
+	})
 }

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -196,7 +196,9 @@ explicit `--exclude` flag is provided.
 matching Atlas-style resource exclusions for object kinds represented in Ptah's
 schema IR. `sensitive = DENY` is accepted as a no-op because Ptah does not emit
 sensitive values through the supported local workflows. `sensitive = ALLOW` is
-rejected until Ptah has explicit sensitive-value semantics.
+also accepted as a no-op, matching Atlas CE's project-config decoding. Both
+values produce the ignored-construct warning because Ptah has no
+sensitive-value behavior to enable or disable.
 
 `env.schema.repo` names a schema repository in a hosted registry. Its `name` is
 accepted and type-checked as a string, and nothing reads it afterwards — the
@@ -503,30 +505,45 @@ supported `diff` policy.
 `ptah-compat migrate diff` reads `env.schema.src`, `env.dev`, `migration.dir`,
 `format.migrate.diff`, and supported `diff` policy.
 
-## Unsupported constructs
+## Structural contract and ignored names
 
-Ptah intentionally rejects everything outside the documented subset. Unsupported
-attributes, unsupported data sources, unsupported lint policy blocks or attributes,
-Cloud or registry URLs such as `atlas://`, unsupported format blocks,
-unsupported diff policy fields, duplicate `migration` or `lint` blocks,
-variables without defaults that are not supplied through `--var` fail with a
+Ptah classifies every `atlas.hcl` name into one of three outcomes:
+
+| Outcome | Behavior |
+| --- | --- |
+| Supported | Ptah parses the value into project config and evaluates its expression when the containing environment is selected. |
+| Structurally unsupported | Ptah rejects the file with a location-aware error, even when the construct is in an unselected environment. |
+| Ignored by Atlas CE | Ptah accepts the name for compatibility, records it in `Config.IgnoredConstructs`, and the CLI warns that it has no effect. |
+
+Structurally unsupported attributes, data sources, lint policy shapes, format
+fields, diff policy fields, labels, and duplicate supported blocks fail with a
 location-aware error:
 
 ```text
 unsupported atlas.hcl construct "src" at atlas.hcl:2
 ```
 
-This hard-fail policy prevents partially interpreted Atlas project configs from
-silently changing migration behavior.
+Ptah does not turn a construct that Atlas CE decodes or enforces into a no-op.
+The ignored category is limited to names that Atlas CE itself accepts without
+acting on. The CLI writes one warning per ignored source location:
+
+```text
+warning: atlas.hcl attribute "project" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect
+```
+
+This distinction preserves Atlas CE's unknown-name behavior without hiding a
+likely typo or a policy that does nothing. The warning goes to stderr; stdout
+and the success exit code remain unchanged.
 
 Structural validation covers every `env` block, including environments that
 are not selected for the current command. An unsupported attribute, nested
 block, label, or duplicate therefore fails even when it appears in another
-environment. Expressions inside `env` blocks are evaluated only in the selected
-environment, so an unselected environment may still refer to variables, files,
-or environment values that are unavailable in the current invocation. Global
-`variable`, `locals`, and `data` blocks are evaluated separately to build the
-shared context before environment selection.
+environment. Expressions inside `env` blocks, including bodies and values of
+ignored names, are evaluated only in the selected environment. An unselected
+environment may therefore refer to variables, files, or environment values
+unavailable in the current invocation. Global `variable`, `locals`, and `data`
+blocks are evaluated separately to build the shared context before environment
+selection.
 
 Non-local URI schemes in `migration.dir` and `schema.src` fail explicitly when
 a command needs that configured value. An explicit CLI path flag still wins over

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -35,6 +35,10 @@ is recorded as a deliberate divergence, with the measurement that establishes
 which behavior is the defective one, and the report says which of the two rules
 it falls under.
 
+An unknown name that the community binary itself accepts without acting on is
+not a refused construct under rule 1. Ptah can accept the same no-op for
+compatibility, but reports its source location so the behavior is not silent.
+
 The distinction is not academic. `-- atlas:txmode none` written directly above
 its statement, with no blank line between them, is silently dropped by the
 community binary; the statement then runs inside the transaction it asked to

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -50,7 +50,10 @@ online-DDL policy is parsed, merged, validated, and then passed to migration
 execution without a second configuration-file read.
 `ParseAtlasFSWithOptions` lets embedders evaluate `atlas.hcl` against an
 already anchored or immutable `fs.FS`; `file()` and `fileset()` resolve only
-through that filesystem.
+through that filesystem. `Config.IgnoredConstructs` identifies names that
+Atlas CE accepts without acting on, with kind and source location. `Merge`
+preserves this diagnostic metadata from both inputs. Ptah's command layer warns
+for each entry; embedders can choose their own reporting policy.
 
 `core/renderer.GetOrderedCreateStatements` and its capability-aware variant
 render complete schema DDL fail-closed. Non-SQLite targets return all table

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -196,11 +196,9 @@ type Config struct {
     // IgnoredConstructs lists the atlas.hcl names that were accepted and not
     // acted on, under Atlas CE's unknown-name policy.
     //
-    // It exists so a caller can say something. CE reports nothing at all, and
-    // that silence is a footgun: a typo'd block name does nothing and looks
-    // fine. Everything the conformance tiers measure -- exit code, stdout, the
-    // text of every error -- is unchanged whether or not a caller reports
-    // these, so drop-in fidelity does not depend on it.
+    // Atlas CE reports nothing for these names. Ptah records them so callers can
+    // make the no-op visible; the Ptah CLIs warn on stderr while preserving the
+    // command's stdout and exit code.
     IgnoredConstructs []IgnoredAtlasConstruct
     // EnvName is the selected project env name, when the source had one.
     EnvName string
@@ -375,11 +373,9 @@ type IgnoredAtlasConstruct struct {
     IgnoredAtlasConstruct is an atlas.hcl name that was accepted and not acted
     on, matching what Atlas CE does with a name it does not recognize.
 
-    CE reports nothing at all. Ptah records them so the caller can say one line
-    per construct on stderr: CE's silence is a footgun -- a typo'd block name
-    does nothing and looks fine -- and stdout, the exit code, and every error
-    diagnostic stay byte-identical, so nothing that reads those can tell the
-    difference.
+    Atlas CE reports nothing for these names. Ptah records them so callers can
+    make the no-op visible; the Ptah CLIs warn on stderr while preserving the
+    command's stdout and exit code.
 
 
 ### go.5x5.cz/ptah/config/projectconfig.LintConfig

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -86,8 +86,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema.",
-    "evidence": "config/projectconfig/atlas.go:214 (collectAtlasTopBlock default -> unsupportedBlock), :402 (parseEnvAttr default), :475 (parseMigration default); each rejection reproduced with /tmp/pc-audit at exit 1; Atlas-side block inventory from https://atlasgo.io/atlas-schema/projects (top-level variable, locals, atlas, env, script, lint, diff, exporter, deployment)"
+    "note": "Whole-document structural validation rejects unsupported shapes in every env. Names Atlas CE accepts as no-ops are preserved and warned once per source location.",
+    "evidence": "config/projectconfig/atlas_structure.go (open/closed body contract), config/projectconfig/atlas.go (selected-env evaluation and IgnoredConstructs), config/projectconfig/atlas_structure_test.go, cmd/atlas/project_config_ignored_test.go"
   },
   {
     "area": "Project config",
@@ -104,8 +104,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected.",
-    "evidence": "config/projectconfig/atlas.go:126-133 (five-function eval context), parseVariableBlock/convertAtlasVariableOverride (type constraints with typed --var conversion, sensitive redaction, validation rejected), :402 (for_each hits the env attribute default). Repro: `dev = urlsetpath(\"sqlite://file.db\",\"x\")` -> `error: unsupported atlas.hcl construct \"dev\" at atlas.hcl:2`; upper, lower, join, split, concat, trimspace, coalesce, toupper, abspath, urlescape, urlqueryset, print all fail the same way, while file, fileset, format, getenv, jsonencode evaluate; `variable \"schema_file\" { type = string }` + `--var schema_file=schema.sql` inspects on both binaries"
+    "note": "file, fileset, format, getenv, and jsonencode evaluate. Variables support string, number, bool, list(string), and sensitive; validation blocks fail. `for_each` is accepted and warned.",
+    "evidence": "config/projectconfig/atlas.go newAtlasParser, parseVariableBlock, convertAtlasVariableOverride, tolerateUnknownAttr; config/projectconfig/atlas_structure_test.go selected-only evaluation cases"
   },
   {
     "area": "Project config",
@@ -878,7 +878,7 @@
     "ptah": "partial",
     "atlas_oss": "no",
     "atlas_pro": "yes",
-    "note": "Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail.",
+    "note": "Custom rules run only through Go registration. Atlas project rule, review, naming, non_linear, and force names are accepted as Atlas CE no-ops and reported as having no effect.",
     "evidence": "migration/lint/rules.go:20 Register, migration/lint/lint.go:107 Options.ExtraRules; migration/lint/config.go Config has only Dialect/DisabledRules/Rules{severity,exclude} — no rule definition. config/projectconfig/atlas.go parseLintPolicyBlocks accepts only concurrent_index, condrop, data_depend, destructive, git, nestedtx, incompatible; parseLintAnalyzer tolerates `force` without acting on it. Atlas features page classifies \"Custom linting rules\" as Pro. `lint { rule \"hcl\" \"custom\" { src = [...] } }` accepted and the rules execute during migrate lint; rule severity is only `error=true/false` (measured; observation study, scenario, lint-test-pro)"
   },
   {

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -188,10 +188,10 @@ Atlas-side rows are the recorded transcripts, so behavior beyond those inputs is
 
 There is no `atlas.hcl` spelling of this selector. Atlas documents `exclude`
 but no `include` attribute on the `env` block; CE accepts `include = [...]`
-there only because it accepts any unknown env attribute — a run with
+there only because it accepts any unknown env attribute. A run with
 `not_a_real = [...]` is likewise accepted and prints the full schema. Ptah
-rejects unknown `atlas.hcl` constructs instead of ignoring them, so
-`env.include` fails explicitly.
+accepts `env.include` under the same unknown-name rule, leaves it without
+effect, and writes a location-aware warning to stderr.
 
 **Atlas OSS.** `atlas schema inspect` is documented as an open CLI feature for inspecting a database schema with HCL, SQL, JSON, template output forms, split/write file exports, and resource exclusion filters. The pinned Atlas CE flag surface does not register `schema inspect --include`.
 
@@ -507,7 +507,9 @@ Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `
 
 Ptah also composes a desired-schema schema from multiple sources — several Go roots, or a mix of Go annotations, YAML, HCL, and SQL — via repeatable `--root-dir` and `--schema-file` flags on `ptah schema render`, `ptah schema compare`, `ptah migrations plan`, and `ptah migrations generate`, an open, local, no-account counterpart to Atlas's Pro `composite_schema` data source.
 
-Unsupported constructs fail explicitly rather than being silently ignored.
+Structurally unsupported constructs fail explicitly. Names that Atlas CE
+accepts without acting on are accepted for compatibility and reported as
+having no effect.
 
 **Atlas OSS.** Atlas OSS supports SQL and HCL schema sources. The community binary rejects the `data "external_schema"` project data source (measured 2026-08-01, Atlas CE v1.2.0: exit 1, `Error: data.external_schema is not supported by the community version of Atlas.`); Ptah evaluates it in the open build behind the external-schema opt-in.
 
@@ -644,7 +646,9 @@ Each area below states the current status and links the evidence behind it.
 
 Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff` policy, and supported lint analyzer severity policy can feed `ptah-compat ... --env` commands, including local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`), repeated string/list `--var name=value` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, and `data.hcl_schema.<name>.url`.
 
-Unsupported constructs fail explicitly instead of being ignored.
+Structurally unsupported constructs fail explicitly. Names that Atlas CE
+accepts without acting on are accepted and reported once per source location
+instead of becoming silent no-ops.
 
 **Evidence.** [Atlas project config](../project-config/)
 

--- a/docs/site/src/content/docs/atlas/docs-coverage.md
+++ b/docs/site/src/content/docs/atlas/docs-coverage.md
@@ -235,11 +235,20 @@ The native OCI source is available to `schema compare` and `drift` through `--sc
 
 **Implementation status.** Partial.
 
-Ptah reads a documented subset into project config IR, including local env settings, `schema.src`, `schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff.skip.drop_table` and `diff.concurrent_index.create` policy, supported migration-lint analyzer severity policy for `destructive`, `concurrent_index`, `data_depend`, `incompatible`, and `nestedtx`, local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`) with `sensitive` support, string/list variable overrides through repeated `--var name=value` with conversion to the declared type, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, and migration-lint changeset selectors such as `lint.latest` and `lint.git`, and rejects unsupported constructs.
+Ptah reads a documented subset into project config IR, including local env settings, `schema.src`, `schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff.skip.drop_table` and `diff.concurrent_index.create` policy, supported migration-lint analyzer severity policy for `destructive`, `concurrent_index`, `data_depend`, `incompatible`, and `nestedtx`, local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`) with `sensitive` support, string/list variable overrides through repeated `--var name=value` with conversion to the declared type, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, and migration-lint changeset selectors such as `lint.latest` and `lint.git`.
+
+Whole-document structural validation classifies every environment before one is
+selected. Unsupported shapes fail in selected and unselected environments.
+Names that Atlas CE accepts without acting on are preserved in project config
+and reported once per source location; only the selected environment's
+expressions are evaluated.
 
 Cloud, registry, data sources beyond the local subset, variable `validation` blocks, other variable type constraints such as `object(...)`, Atlas check-level lint policy, custom lint rules, unsupported lint analyzer options, unsupported format blocks, unsupported diff policy fields, and remote directory behavior are not implemented.
 
-**Conformance status.** Partially measured with parser, direct command, compatibility-wrapper, and live SQLite command tests for the supported local subset.
+**Conformance status.** Partially measured. As of 2026-08-08, parser, merge,
+direct-command, adapter, and live SQLite tests cover the supported local subset,
+whole-document structural decisions, selected-environment evaluation, and
+ignored-name warnings.
 
 **Follow-up.** [`stokaro/ptah#582`](https://github.com/stokaro/ptah/issues/582), [`stokaro/ptah#583`](https://github.com/stokaro/ptah/issues/583), [`stokaro/ptah#581`](https://github.com/stokaro/ptah/issues/581), [`stokaro/ptah#619`](https://github.com/stokaro/ptah/issues/619).
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -206,7 +206,7 @@ seven of them as open capabilities regardless.
 | Atlas web reports (`--web`) | ❌ | ❌ | ✅ | Not registered on migrate lint or schema diff; rejected as an unknown flag. Pinned Atlas CE v1.2.0 does not register it either. |
 | Check bypass on the compat surface | ✅ | ❌ | ❌ | No Atlas build registers `--skip-checks` on migrate apply, so the compat bypass is PTAH_SKIP_CHECKS. Explicit-only on migrate down. |
 | CI integration (GitHub Action, annotations) | ✅ | 🟡 | ✅ | stokaro/ptah-action@v1 posts a sticky PR comment; `--format` github-actions emits annotations. The community binary has no annotation mode; its lint `--format` takes a Go template only. |
-| Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules only from Go (lint.Register, Options.ExtraRules); atlas.hcl rule, review, naming, non_linear blocks and force all fail. |
+| Custom lint rules and check-level policy | 🟡 | ❌ | ✅ | Custom rules run only through Go registration. Atlas project rule, review, naming, non_linear, and force names are accepted as Atlas CE no-ops and reported as having no effect. |
 | Default-firing Atlas analyzer concern mapping | ✅ | ➖ | ➖ | lint-analyzer-catalog maps every default-firing Atlas concern to a covering Ptah rule, severity and line; 0 gap on the committed corpus. |
 | Dev-URL schema scope on `migrate lint` | ✅ | ✅ | ✅ | `ptah-compat migrate lint` reviews only the schema the dev URL's search_path names, matching the pinned CE binary. Native `ptah migrations lint` reads SQL text and deliberately does not scope. |
 | Generation-time destructive-change gate | ✅ | ❌ | ❌ | migrations generate and plan fail with `--check-destructive` when the generated SQL contains destructive statements; `--allow-destructive` reopens the gate. Distinct from the apply-time gate row. |
@@ -234,7 +234,7 @@ seven of them as open capabilities regardless.
 
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
-| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Rejects atlas, script, exporter, deployment; env for_each and schemas; migration baseline, skip_report, repo; data blocks but hcl_schema and external_schema. |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Whole-document structural validation rejects unsupported shapes in every env. Names Atlas CE accepts as no-ops are preserved and warned once per source location. |
 | atlas.hcl file() and fileset() path confinement | ✅ | ❌ | ❌ | Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today. |
 | atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl in the working directory; `--var name=value` supplies a variable with no default on every env-aware verb; `--config` still takes ptah.yaml only. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input is rejected by name, and an absolute path or a non-file:// scheme is rejected by its rule rather than as an unsupported construct. |
@@ -243,7 +243,7 @@ seven of them as open capabilities regardless.
 | Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. An unknown key fails, naming the key, its line, and the accepted keys. |
 | PTAH_* environment-variable flag equivalents | ✅ | ❌ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
-| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | Only file, fileset, format, getenv, jsonencode evaluate; variable type (string, number, bool, list(string)) and sensitive are honored; validation and env for_each are rejected. |
+| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | file, fileset, format, getenv, and jsonencode evaluate. Variables support string, number, bool, list(string), and sensitive; validation blocks fail. `for_each` is accepted and warned. |
 
 ## Databases and schema objects
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -407,22 +407,23 @@ one plain SQL stream. Atlas CE `v1.3.0` instead ignores section-local modes and
 can classify that malformed outer-header shape as plain SQL, so this contour is
 an intentional safety difference rather than a parity claim.
 
-A successful `ptah-compat migrate apply` writes nothing to stderr, matching
-Atlas CE: there is no progress narration, in a dry run or otherwise, so
-`--format` output survives the usual CI idiom of folding both streams together.
+A clean successful `ptah-compat migrate apply` writes nothing to stderr,
+matching Atlas CE: there is no progress narration, in a dry run or otherwise,
+so `--format` output survives the usual CI idiom of folding both streams
+together.
 
 ```bash
 ptah-compat migrate apply --url "$DATABASE_URL" --dir file://migrations \
   --dry-run --format '{{ json . }}' 2>&1 | jq
 ```
 
-Two things still reach stderr, by design. A command that fails prints its
-`Error: …` diagnostic there and exits `1`. And a Warn-level diagnostic that
+Three things still reach stderr, by design. A command that fails prints its
+`Error: …` diagnostic there and exits `1`. A Warn-level runtime diagnostic that
 exists on no other channel — such as function ordering or a dev database that
-would not close — is still reported, because dropping it would let an apply
-claim success while quietly degrading. Valid circular foreign keys are rendered
-in two phases and do not produce a warning. Neither diagnostic appears on a
-clean run.
+would not close — is still reported. An `atlas.hcl` name that Atlas CE accepts
+without acting on also produces a location-aware warning that the construct has
+no effect. Valid circular foreign keys are rendered in two phases and do not
+produce a warning. None of these diagnostics appears on a clean run.
 
 `ptah-compat migrate down` holds the same contract, with or without `--format`.
 Without `--format` it forwards to the native `ptah migrations down`, which

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -152,6 +152,11 @@ resources inside it, and the configured exclusions subtract from that
 selection last, exactly like CLI `--exclude`. See
 [Scope the comparison with `--schema` and `--include`](../schema-commands/#scope-the-comparison-with---schema-and---include).
 
+`env.schema.mode.sensitive` accepts Atlas's `DENY` and `ALLOW` values. Both are
+no-ops because Ptah does not emit sensitive values through the supported local
+workflows. Ptah records either spelling as an ignored compatibility construct
+and warns that it has no effect.
+
 Ptah accepts Atlas's `atlas`, `golang-migrate`, `goose`, `flyway`,
 `liquibase`, and `dbmate` values while evaluating `atlas.hcl`, and
 `ptah-compat migrate apply` executes all of them.
@@ -373,17 +378,30 @@ use it as the default. Atlas-compatible `migrate apply` does not need to select
 an environment when both `--url` and `--dir` are explicit. Other ambiguous or
 unsupported environment layouts fail instead of guessing.
 
-## Unsupported means error
+## Structural validation and ignored names
 
-Ptah intentionally rejects unsupported project config constructs. This prevents
-a dangerous half-configured state where a user believes an Atlas setting is in
-effect but Ptah silently ignored it.
+Ptah gives each project-config name one of three outcomes:
+
+| Outcome | Result |
+| --- | --- |
+| Supported | Parsed into project config; expressions are evaluated for the selected environment. |
+| Structurally unsupported | Fails with `unsupported atlas.hcl construct ...`, including in an unselected environment. |
+| Ignored by Atlas CE | Accepted for compatibility and reported on stderr as having no effect. |
+
+The ignored category contains only names that Atlas CE itself accepts without
+acting on. Ptah does not silently discard them. A successful command reports
+each ignored source location once:
+
+```text
+warning: atlas.hcl attribute "project" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect
+```
 
 Structural validation covers every `env` block, including environments that
 are not selected for the current command. An unsupported attribute, nested
 block, label, or duplicate therefore fails even when it appears in another
-environment. Expressions inside `env` blocks are evaluated only in the selected
-environment, so an unselected environment may still refer to variables, files,
-or environment values that are unavailable in the current invocation. Global
-`variable`, `locals`, and `data` blocks are evaluated separately to build the
-shared context before environment selection.
+environment. Expressions inside `env` blocks, including ignored attributes and
+block bodies, are evaluated only in the selected environment. An unselected
+environment may therefore refer to variables, files, or environment values
+unavailable in the current invocation. Global `variable`, `locals`, and `data`
+blocks are evaluated separately to build the shared context before environment
+selection.

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -50,6 +50,10 @@ its case model and [Database test commands](../../reference/test-cases/) for CLI
 `projectconfig.ParseAtlasFSWithOptions` evaluates `atlas.hcl` against a
 caller-provided `fs.FS`. Use it when project config and its `file()` or
 `fileset()` inputs must come from one anchored or immutable filesystem view.
+`projectconfig.Config.IgnoredConstructs` carries every Atlas CE-compatible
+no-op name with its kind and source location, and `projectconfig.Merge`
+preserves the collection. Ptah's CLI reports each entry; embedders decide how
+to expose the same metadata.
 
 `renderer.ValidateSchema` and `renderer.ValidateSchemaWithCapabilities` check
 a complete `goschema.Database` without rendering SQL. They use the same

--- a/docs/site/src/content/docs/operate/troubleshooting.md
+++ b/docs/site/src/content/docs/operate/troubleshooting.md
@@ -98,6 +98,21 @@ unsupported atlas.hcl construct ...
 
 Reference: [Atlas project config subset](../../atlas/project-config/).
 
+## `atlas.hcl` says a construct has no effect
+
+Ptah accepted a name that Atlas CE also accepts without acting on:
+
+```text
+warning: atlas.hcl attribute "project" at atlas.hcl:2 is ignored for Atlas compatibility and has no effect
+```
+
+The command can still succeed, but the named setting changed nothing. Remove a
+typo, replace the construct with a supported setting, or remove it when Atlas
+compatibility requires the no-op. Re-run the command and verify that the
+warning is gone.
+
+Reference: [Atlas project config subset](../../atlas/project-config/).
+
 ## Atlas-compatible command is registered but not implemented
 
 Some Atlas-compatible paths exist so scripts fail in the right namespace before

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -171,5 +171,5 @@ Continue with [Atlas project config](../../atlas/project-config/) for the suppor
 `atlas.hcl` subset.
 
 :::note
-Ptah config parsing is intentionally strict. Unknown `ptah.yaml` keys and unsupported `atlas.hcl` constructs fail instead of being ignored. A rejected `ptah.yaml` key is reported by name, with its line and the keys that section accepts — never by the Go type the decoder was filling.
+Ptah config parsing is intentionally explicit. Unknown `ptah.yaml` keys and structurally unsupported `atlas.hcl` constructs fail with their source location. Names that Atlas CE accepts without acting on are the exception: Ptah accepts them for compatibility and warns that they have no effect. A rejected `ptah.yaml` key is reported by name, with its line and the keys that section accepts — never by the Go type the decoder was filling.
 :::


### PR DESCRIPTION
Closes #276

## Summary

- validate the structural contract of every `env` block before selecting an environment, while evaluating expressions only in the selected environment
- distinguish supported, structurally unsupported, and Atlas CE-ignored names; preserve ignored metadata through merge/context snapshots
- report ignored compatibility constructs exactly once on stderr across native, direct compat, adapter, converted integrity, formatted down, and converted migrate-new paths
- document the contract, warnings, conformance implications, and public API behavior; regenerate the feature matrix and API snapshot

## Coverage

- black-box selected/unselected matrices cover every open container and closed leaf policy
- special `schema.mode.sensitive` classification is identical across environment selection
- warning tests cover native loading, direct commands, adapter forwarding, converted integrity, formatted down, and converted migrate-new
- writer failures, merge preservation, immutable snapshots, deterministic ordering, and duplicate suppression are covered

## Verification

- `go test -count=1 -timeout 30m ./...`
- `go test -race -count=1 -timeout 30m ./config/projectconfig ./cmd/internal/dbcli ./cmd/atlas`
- `go vet ./...`
- `golangci-lint run --fix ./...`
- `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- public API guard, snapshot guard, and released API guard
- all documentation style, limitation, link, redirect, page-health, exit-code, feature-matrix, build, and responsive checks

## Self-review

Two independent review passes found and this PR fixes the remaining environment-dependent `sensitive` classification, nondeterministic global-lint warning order, missing bespoke warning paths, and stale documentation. A final call-path audit also found and covered converted `migrate new`.