### PR TITLE
Reword the sentence the style gate refuses

### DIFF
--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -537,7 +537,7 @@ ask it rather than the dialect. Before they did, measured on 2026-08-08 at exit
 
 The pinned binary answered `Schemas are synced, no changes to be made.` against
 those databases throughout: the disagreement was Ptah's with itself, between the
-database it had just built and the model it built it from.
+database it had built and the model it built that database from.
 
 ### The uniqueness half
 


### PR DESCRIPTION
The `Docs` workflow is red on `master` since fd4a0c43: `docs/conformance.md:540` carries the banned filler "just".

```
Documentation style check failed:
- docs/conformance.md:540: banned filler "just"; state the action instead
```

One sentence, reworded to say what it meant — the disagreement was between the database Ptah had built and the model it built that database from.

`npm run check:style` in `docs/site` goes from exit 1 with that single finding to exit 0 across 100 documentation files.