### PR TITLE
Take the patched nanoid in the docs lockfile

### DIFF
--- a/docs/site/package-lock.json
+++ b/docs/site/package-lock.json
@@ -5665,9 +5665,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
Closes the open Dependabot alert on `master`.

| | |
|---|---|
| advisory | GHSA-2v37-7h3g-55p8 / CVE-2026-67213 |
| severity | high |
| summary | custom generators can loop indefinitely when size is zero |
| manifest | `docs/site/package-lock.json` |
| was | 3.3.16 |
| patched from | 3.3.17 |
| now | 3.3.18 |

`nanoid` is transitive here — astro pulls it — so this is a **lockfile-only** change. `npm install nanoid@^3.3.17` would have added it to `package.json` as a direct dependency the site does not declare and does not import; `npm update nanoid --package-lock-only` moves the resolution without that.

Verified in a clean checkout: `npm ci` exit 0, `npm run build` exit 0, and `require("nanoid/package.json").version` reports `3.3.18`.