### PR TITLE
fix(lint): enforce policy consistently

### DIFF
--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -802,6 +802,32 @@ func TestRunLint_ConfigRuleSeverityAndExclude(t *testing.T) {
 	c.Assert(report.Findings[0].File, qt.Contains, "main/0000000002_main.up.sql")
 }
 
+func TestRunLint_MalformedExclusionGlobFailsBeforeAnalysis(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, migrationlint.ConfigFileName),
+		[]byte("rules:\n  DS101:\n    exclude:\n      - '[legacy/**'\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	stdout, stderr, err := execute("--dir", dir)
+
+	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+	c.Assert(stdout, qt.Equals, "")
+	c.Assert(stderr, qt.Contains, `rule DS101 has invalid exclude pattern "[legacy/**": syntax error in pattern`)
+}
+
 func TestRunLint_FailOnThresholds(t *testing.T) {
 	c := qt.New(t)
 
@@ -853,7 +879,7 @@ func TestRunLint_InvalidFlagValuesExitCode2(t *testing.T) {
 
 	_, stderr, err = execute("--dir", "testdata/bad", "--config", "testdata/invalid-dialect.yaml")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
-	c.Assert(stderr, qt.Contains, `invalid dialect "oracle" in lint config`)
+	c.Assert(stderr, qt.Contains, `unsupported lint dialect "oracle"`)
 
 	_, stderr, err = execute("--dir", "testdata/bad", "--no-such-flag")
 	c.Assert(exitcode.Code(err, 0), qt.Equals, 2)

--- a/cmd/migratebaseline/migratebaseline_test.go
+++ b/cmd/migratebaseline/migratebaseline_test.go
@@ -1,11 +1,15 @@
 package migratebaseline_test
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/cmd/migratebaseline"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/generator"
 )
 
 func TestMigrateBaselineCommandCreation(t *testing.T) {
@@ -22,4 +26,54 @@ func TestMigrateBaselineCommandCreation(t *testing.T) {
 	c.Assert(cmd.Flag("shadow-db"), qt.IsNotNil)
 	c.Assert(cmd.Flag("dir-format"), qt.IsNotNil)
 	c.Assert(cmd.Flag("migration-lock-timeout"), qt.IsNotNil)
+}
+
+func TestMigrateBaselineCommand_PreservesStructuredShadowFailure(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	dbURL := "sqlite://" + filepath.Join(dir, "target.db")
+	target, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+	dbschema.CloseAndWarn(target)
+
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	cmd := migratebaseline.NewMigrateBaselineCommand()
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", migrationsDir,
+		"--shadow-db", dbURL,
+	})
+
+	err = cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: shadow database must be distinct from target database`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "realm-check")
+	c.Assert(shadowErr.Result.Mismatches, qt.DeepEquals, []generator.ShadowMismatch{{
+		Kind:    "target_shadow_same_realm",
+		Message: "shadow database must be distinct from target database",
+	}})
+
+	target, err = dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	var count int
+	err = target.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'schema_migrations'").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 0)
 }

--- a/cmd/migrateup/lint_config_external_test.go
+++ b/cmd/migrateup/lint_config_external_test.go
@@ -1,0 +1,173 @@
+package migrateup_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/migrateup"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+func TestMigrateUp_InvalidLintPolicyPreventsExecution(t *testing.T) {
+	tests := []struct {
+		name    string
+		policy  string
+		args    []string
+		wantErr string
+	}{
+		{
+			name:    "unsupported configured dialect",
+			policy:  "dialect: oracle\n",
+			wantErr: `.*unsupported lint dialect "oracle": expected postgres.*`,
+		},
+		{
+			name:    "configured dialect differs from database",
+			policy:  "dialect: postgres\n",
+			wantErr: `.*lint dialect "postgres" does not match database dialect "sqlite".*`,
+		},
+		{
+			name:    "bypass still validates policy",
+			policy:  "dialect: oracle\n",
+			args:    []string{"--allow-destructive"},
+			wantErr: `.*unsupported lint dialect "oracle": expected postgres.*`,
+		},
+		{
+			name:    "bypass still validates registered selectors",
+			policy:  "disabled-rules:\n  - ZZ404\n",
+			args:    []string{"--allow-destructive"},
+			wantErr: `.*rule selector "ZZ404" does not match any registered rule.*`,
+		},
+		{
+			name:    "malformed exclusion glob",
+			policy:  "rules:\n  DS101:\n    exclude:\n      - '[legacy/**'\n",
+			wantErr: `.*rule DS101 has invalid exclude pattern "\[legacy/\*\*": syntax error in pattern.*`,
+		},
+		{
+			name:    "non-normalized exclusion glob",
+			policy:  "rules:\n  DS101:\n    exclude:\n      - '**/../**'\n",
+			wantErr: `.*rule DS101 has invalid exclude pattern "\*\*/\.\./\*\*": pattern must be a normalized slash-separated path.*`,
+		},
+		{
+			name:    "parent-directory exclusion glob",
+			policy:  "rules:\n  DS101:\n    exclude:\n      - '../legacy/**'\n",
+			wantErr: `.*rule DS101 has invalid exclude pattern "\.\./legacy/\*\*": pattern must not contain \. or \.\. path segments.*`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := c.TempDir()
+			c.Assert(os.WriteFile(filepath.Join(dir, ".ptah-lint.yaml"), []byte(test.policy), 0o600), qt.IsNil)
+			c.Assert(os.WriteFile(
+				filepath.Join(dir, "0000000001_create_users.up.sql"),
+				[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+				0o600,
+			), qt.IsNil)
+			c.Assert(os.WriteFile(
+				filepath.Join(dir, "0000000001_create_users.down.sql"),
+				[]byte("DROP TABLE users;\n"),
+				0o600,
+			), qt.IsNil)
+
+			dbURL := "sqlite://" + filepath.Join(c.TempDir(), "target.db")
+			cmd := migrateup.NewMigrateUpCommand()
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			args := []string{
+				"--db-url", dbURL,
+				"--migrations-dir", dir,
+			}
+			cmd.SetArgs(append(args, test.args...))
+
+			err := cmd.Execute()
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+			c.Assert(err, qt.IsNil)
+			defer dbschema.CloseAndWarn(conn)
+			var count int
+			err = conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&count)
+			c.Assert(err, qt.IsNil)
+			c.Assert(count, qt.Equals, 0)
+		})
+	}
+}
+
+func TestMigrateUp_ValidLintPolicyAppliesMigration(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	c.Assert(os.WriteFile(filepath.Join(dir, ".ptah-lint.yaml"), []byte("dialect: sqlite\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	dbURL := "sqlite://" + filepath.Join(c.TempDir(), "target.db")
+	cmd := migrateup.NewMigrateUpCommand()
+	var stdout, stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{
+		"--db-url", dbURL,
+		"--migrations-dir", dir,
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.IsNil)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+}
+
+func TestMigrateUp_InvalidLintSelectorRejectedWithoutPendingMigrations(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	configPath := filepath.Join(dir, ".ptah-lint.yaml")
+	c.Assert(os.WriteFile(configPath, []byte("dialect: sqlite\n"), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "0000000001_create_users.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+	dbURL := "sqlite://" + filepath.Join(c.TempDir(), "target.db")
+
+	first := migrateup.NewMigrateUpCommand()
+	first.SetArgs([]string{"--db-url", dbURL, "--migrations-dir", dir})
+	c.Assert(first.Execute(), qt.IsNil)
+	c.Assert(os.WriteFile(configPath, []byte("rules:\n  ZZ404:\n    severity: error\n"), 0o600), qt.IsNil)
+
+	second := migrateup.NewMigrateUpCommand()
+	second.SetArgs([]string{"--db-url", dbURL, "--migrations-dir", dir})
+	err := second.Execute()
+
+	c.Assert(err, qt.ErrorMatches, `.*rule selector "ZZ404" does not match any registered rule.*`)
+	conn, err := dbschema.ConnectToDatabase(t.Context(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	var count int
+	err = conn.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&count)
+	c.Assert(err, qt.IsNil)
+	c.Assert(count, qt.Equals, 1)
+}

--- a/cmd/migrateup/lint_internal_test.go
+++ b/cmd/migrateup/lint_internal_test.go
@@ -14,6 +14,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/cmd/internal/migrationsource"
+	"go.5x5.cz/ptah/internal/migrationlintgate"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/migration/lint"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -105,6 +106,26 @@ func TestLintPendingDestructive_HonorsDirectoryPrefixedExclusion(t *testing.T) {
 	c.Assert(findings, qt.HasLen, 0)
 }
 
+func TestLintPendingDestructive_RejectsConfiguredDialectMismatch(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("dialect: mysql\n"),
+		},
+		"0000000001_hash_comment.up.sql": {
+			Data: []byte("# decoy; DROP TABLE users;\nCREATE TABLE current_users (id INTEGER);\n"),
+		},
+		"0000000001_hash_comment.down.sql": {
+			Data: []byte("DROP TABLE current_users;\n"),
+		},
+	}
+
+	findings, err := lintPendingDestructive(fsys, []int64{1}, "sqlite", "")
+
+	c.Assert(err, qt.ErrorMatches, `lint dialect "mysql" does not match database dialect "sqlite"`)
+	c.Assert(findings, qt.IsNil)
+}
+
 func TestLintPathPrefixForSource_PreservesLocalSpelling(t *testing.T) {
 	c := qt.New(t)
 
@@ -177,9 +198,11 @@ func TestLockedDestructiveLintHookUsesLockedPlanVersions(t *testing.T) {
 			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
 		},
 	}
-	hook := lockedDestructiveLintHook(fsys, "sqlite", "")
+	policy, err := migrationlintgate.LoadPolicy(fsys, "sqlite")
+	c.Assert(err, qt.IsNil)
+	hook := lockedDestructiveLintHook(fsys, policy, "")
 
-	err := hook(context.Background(), migrator.MigrationPlan{
+	err = hook(context.Background(), migrator.MigrationPlan{
 		Versions: []int64{2},
 	})
 
@@ -202,9 +225,11 @@ func TestLockedDestructiveLintHookAllowsSafeLockedPlan(t *testing.T) {
 			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
 		},
 	}
-	hook := lockedDestructiveLintHook(fsys, "sqlite", "")
+	policy, err := migrationlintgate.LoadPolicy(fsys, "sqlite")
+	c.Assert(err, qt.IsNil)
+	hook := lockedDestructiveLintHook(fsys, policy, "")
 
-	err := hook(context.Background(), migrator.MigrationPlan{
+	err = hook(context.Background(), migrator.MigrationPlan{
 		Versions: []int64{1},
 	})
 

--- a/cmd/migrateup/migrateup.go
+++ b/cmd/migrateup/migrateup.go
@@ -23,11 +23,11 @@ import (
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/deploymentreport"
 	"go.5x5.cz/ptah/internal/migratesum"
+	"go.5x5.cz/ptah/internal/migrationlintgate"
 	"go.5x5.cz/ptah/internal/onlineddl"
 	"go.5x5.cz/ptah/internal/preflight"
 	"go.5x5.cz/ptah/migration/lint"
 	"go.5x5.cz/ptah/migration/migrator"
-	"go.5x5.cz/ptah/migration/risk"
 )
 
 const (
@@ -355,6 +355,10 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 		return fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
+	lintPolicy, err := migrationlintgate.LoadPolicy(migrationsFS, conn.Info().Dialect)
+	if err != nil {
+		return fmt.Errorf("error loading migration lint policy: %w", err)
+	}
 
 	// Set dry run mode if requested
 	conn.SchemaWriter().SetDryRun(opts.dryRun)
@@ -452,7 +456,7 @@ func migrateUpCommand(cmd *cobra.Command, opts *options) error {
 	}, emit, cliobs.NewOutputWriter(cmd.OutOrStdout(), runtime, "pre-flight output"))
 	if !opts.allowDestructive {
 		preflightHook = dbcli.CombineMigrationHooks(
-			lockedDestructiveLintHook(migrationsFS, conn.Info().Dialect, lintPathPrefix),
+			lockedDestructiveLintHook(migrationsFS, lintPolicy, lintPathPrefix),
 			preflightHook,
 		)
 	}
@@ -731,35 +735,16 @@ func lintPendingDestructive(
 	dialect string,
 	pathPrefix string,
 ) ([]lint.Finding, error) {
-	cfg, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
-	if err != nil {
-		return nil, err
-	}
-	findings, err := lint.LintFS(fsys, lint.Options{
-		Dialect:    dialect,
-		Disabled:   append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
-		PathPrefix: pathPrefix,
-		Selection: lint.VersionSelection{
-			Versions:   pending,
-			Restricted: true,
-		},
-		RuleConfigs: cfg.Rules,
-	})
-	if err != nil {
-		return nil, err
-	}
-	var destructive []lint.Finding
-	for _, finding := range findings {
-		if strings.HasPrefix(finding.Rule, "DS") && risk.IsBlocking(finding.Severity) {
-			destructive = append(destructive, finding)
-		}
-	}
-	return destructive, nil
+	return migrationlintgate.Analyze(fsys, pending, dialect, pathPrefix)
 }
 
-func lockedDestructiveLintHook(fsys fs.FS, dialect, pathPrefix string) migrator.PreMigrationHook {
+func lockedDestructiveLintHook(
+	fsys fs.FS,
+	policy migrationlintgate.Policy,
+	pathPrefix string,
+) migrator.PreMigrationHook {
 	return func(_ context.Context, plan migrator.MigrationPlan) error {
-		findings, err := lintPendingDestructive(fsys, plan.Versions, dialect, pathPrefix)
+		findings, err := migrationlintgate.AnalyzeWithPolicy(fsys, plan.Versions, policy, pathPrefix)
 		if err != nil {
 			return fmt.Errorf("error checking pending migration safety: %w", err)
 		}

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -92,8 +92,14 @@ integrity metadata, and `.ptah-lint.yaml`. It returns deep-copy views of
 prepared files and findings together with a read-only source snapshot. Capture
 does not apply the lint policy automatically: embedders call `LoadConfigFS`
 and pass its `Dialect`, `DisabledRules`, and `Rules` through `lint.Options`.
+
 Configuration decoding rejects unknown keys and noncanonical rule selectors,
-including selectors with leading or trailing whitespace.
+including selectors with leading or trailing whitespace. It also rejects
+unsupported dialects and empty, malformed, or non-normalized exclusion globs
+instead of silently weakening the effective policy. `lint.ValidateOptions`
+checks selectors against the active rule registry without reading migration
+files; call it before a no-work return or an execution override that can skip
+`LintFS` or `AnalyzeFS`.
 
 Finding contexts identify the exact statement and affected tables or columns;
 column subjects can also carry the parent table and declared data type. Each
@@ -213,13 +219,18 @@ risk, destructive verdict, and rendered statement assessments. The native
 output. `GenerateMigrationOptions.ReportFormat: "json"` instead publishes one
 `.safety.json` file beside each generated migration pair.
 
-Candidate shadow failures preserve a typed
+Candidate and baseline shadow failures preserve a typed
 `*generator.ShadowVerificationError` through `PlanMigration`,
-`GenerateMigration`, and command wrappers. Use `errors.As` to inspect
-`Result.Stage` and the structured `Result.Mismatches`; operational failures
-also expose their underlying error through `Unwrap`. A schema mismatch carries
-the complete, deterministically ordered mismatch list without a wrapped
-execution error.
+`GenerateMigration`, `VerifyBaselineShadow`, and command wrappers. Use
+`errors.As` to inspect `Result.Stage` and the structured `Result.Mismatches`;
+operational failures also expose their underlying error through `Unwrap`. A
+schema mismatch carries the complete, deterministically ordered mismatch list
+without a wrapped execution error. Baseline failures retain the
+`baseline shadow check failed:` display prefix while preserving this typed
+contract. Candidate and baseline verification share stage names at common
+boundaries. Baseline verification can additionally report `target-introspect`,
+`reset-schemas`, and `drop-metadata`; candidate-only `round-trip-down` and
+`round-trip-up` stages do not occur during baseline verification.
 
 `migration/generator.VerifyRollbackFromShadow` requires the caller's open
 target `dbschema.DatabaseConnection`. It checks the target and shadow's live

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6659,13 +6659,14 @@ func Normalize(migrations []SourceMigration) ([]SourceMigration, error)
 const ConfigFileName = ".ptah-lint.yaml"
 func Describe(f Finding) string
 func Register(rule Rule) error
+func ValidateOptions(opts Options) error
 type Analysis struct{ ... }
     func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error)
 type BaselineColumn struct{ ... }
 type CompatibilityProfile string
     const CompatibilityProfileNative CompatibilityProfile = "" ...
 type Config struct{ ... }
-    func LoadConfig(path string) (*Config, error)
+    func LoadConfig(configPath string) (*Config, error)
     func LoadConfigFS(fsys fs.FS, name string) (*Config, error)
 type File struct{ ... }
 type Finding struct{ ... }
@@ -6781,7 +6782,7 @@ type Config struct {
             exclude:
               - legacy/**
 
-func LoadConfig(path string) (*Config, error)
+func LoadConfig(configPath string) (*Config, error)
 func LoadConfigFS(fsys fs.FS, name string) (*Config, error)
 
 ### go.5x5.cz/ptah/migration/lint.File

--- a/docs/site/src/content/docs/extend/components.md
+++ b/docs/site/src/content/docs/extend/components.md
@@ -368,11 +368,12 @@ if dialect == "" {
 	dialect = "postgres"
 }
 
-findings, err := lint.LintFS(fsys, lint.Options{
+lintOptions := lint.Options{
 	Dialect:     dialect,
 	Disabled:    lintConfig.DisabledRules,
 	RuleConfigs: lintConfig.Rules,
-})
+}
+findings, err := lint.LintFS(fsys, lintOptions)
 if err != nil {
 	return err
 }
@@ -383,6 +384,12 @@ if len(findings) > 0 {
 	return fmt.Errorf("migration lint failed")
 }
 ```
+
+`LintFS` and `AnalyzeFS` validate `lint.Options` before reading migrations. A
+host that can return early when no work is pending, or that offers an execution
+override which skips analysis, should call `lint.ValidateOptions(lintOptions)`
+before that branch. This rejects unknown selectors against the active built-in,
+registered, and per-run rule set even when no migration is analyzed.
 
 Use `lint.AnalyzeFS` when more than findings are needed. It captures every SQL
 file plus migration metadata (`atlas.sum`, `ptah.sum`, and

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -47,6 +47,12 @@ commands, including regular-expression case selection through `FilterCases`.
 See [Test migrations and schemas](../../testing/migrations-and-schema/) for
 its case model and [Database test commands](../../reference/test-cases/) for CLI behavior.
 
+`migration/lint.ValidateOptions` checks rule definitions, configured selectors,
+severity and path overrides, compatibility mode, and migration-directory format
+without reading migration files. Host applications that can skip analysis on a
+no-work or explicit-override path should validate first so policy errors cannot
+bypass the gate.
+
 `projectconfig.ParseAtlasFSWithOptions` evaluates `atlas.hcl` against a
 caller-provided `fs.FS`. Use it when project config and its `file()` or
 `fileset()` inputs must come from one anchored or immutable filesystem view.
@@ -207,8 +213,9 @@ API when an embedder needs the same machine-readable contract as
 `generator.GenerateMigrationOptions.ReportFormat` to `json` instead publishes
 one `.safety.json` artifact beside each generated migration pair.
 
-When candidate shadow verification fails, `generator.PlanMigration` and
-`generator.GenerateMigration` preserve a typed
+When candidate or baseline shadow verification fails,
+`generator.PlanMigration`, `generator.GenerateMigration`, and
+`generator.VerifyBaselineShadow` preserve a typed
 `*generator.ShadowVerificationError`. Inspect it with `errors.As` instead of
 parsing `Error()`:
 
@@ -221,10 +228,17 @@ if errors.As(err, &shadowErr) {
 }
 ```
 
-`Result.Stage` identifies the failed boundary, such as `connect`, `replay`,
-`schema-match`, `round-trip-down`, or `round-trip-up`. A schema-match result
-contains every mismatch in deterministic category and object order, not only
-the first.
+`Result.Stage` identifies the failed boundary, such as `connect`, `replay`, or
+`schema-match`. Candidate and baseline verification use the same names at
+shared boundaries. Baseline verification can additionally report
+`target-introspect`, `reset-schemas`, and `drop-metadata`; candidate-only
+`round-trip-down` and `round-trip-up` stages do not occur during baseline
+verification.
+
+Baseline display text keeps the
+`baseline shadow check failed:` prefix expected by CLI users. A schema-match
+result contains every mismatch in deterministic category and object order, not
+only the first.
 Each `ShadowMismatch` has a stable `Kind`, a human-readable `Message`, and the
 available object, table, column, constraint, or changed-property fields.
 Operational failures also preserve their underlying error through `Unwrap`;
@@ -243,7 +257,7 @@ the error:
   `ptaherr.ErrUnsupportedDialect`;
 - invalid schema diffs rejected during planning should support `errors.Is` with
   `ptaherr.ErrInvalidSchemaDiff`;
-- shadow candidate verification should support `errors.As` with
+- shadow candidate and baseline verification should support `errors.As` with
   `*generator.ShadowVerificationError`;
 - command wrappers should preserve typed errors instead of replacing them with
   string-only errors.

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -524,8 +524,10 @@ Useful controls, all designed for CI:
   scanners and PR annotations. The SARIF output is a SARIF 2.1.0 document
   that GitHub code scanning ingests — [CI](../../testing/ci/) shows the
   upload step.
-- `--dialect` gates dialect-specific rules; `--dev-url` infers the dialect
-  and additionally replays the directory on the dev database.
+- `--dialect` gates dialect-specific rules; accepted values are `postgres`,
+  `mysql`, `mariadb`, `sqlite`, `clickhouse`, `cockroachdb`, `yugabytedb`, and
+  `spanner`. `--dev-url` infers the dialect and additionally replays the
+  directory on the dev database.
 - `--disable DS101` (or a family such as `MY`) skips rules ad hoc; a
   committed `.ptah-lint.yaml` does it persistently and adds per-rule
   severity and path scoping — see below.
@@ -570,12 +572,18 @@ rules:
   directory, such as `legacy/**`; these match regardless of how `--dir` was
   spelled. A directory-prefixed pattern such as `migrations/legacy/**`
   matches only when the command path has that prefix, for example
-  `--dir migrations`, and need not match an absolute `--dir` path.
+  `--dir migrations`, and need not match an absolute `--dir` path. Patterns
+  must already be normalized: repeated separators, `.` or `..` segments, and
+  trailing separators are configuration errors rather than being rewritten
+  into a broader match. Empty patterns and malformed glob syntax are also
+  errors; Ptah reports the rule and pattern instead of silently weakening the
+  policy.
 
 Configuration decoding is strict. Unknown keys, misspelled keys such as
-`severty`, lowercase or whitespace-padded selectors, selectors that match no registered rule,
-unsupported severities, and multiple YAML documents fail before linting or
-migration execution instead of silently weakening policy.
+`severty`, lowercase or whitespace-padded selectors, selectors that match no
+registered rule, unsupported dialects or severities, empty or malformed
+or non-normalized exclusion globs, and multiple YAML documents fail before
+linting or migration execution instead of silently weakening policy.
 
 Precedence: a rule listed in `disabled-rules` never runs, regardless of its
 `rules` entry; then `exclude` skips the matching files; then `severity`
@@ -637,22 +645,28 @@ error: error running migrations: pending migrations contain destructive statemen
 Use `--allow-destructive` only after the plan has been reviewed and the
 rollback path is understood.
 
-The apply-time gate always loads the conventional
-`<migrations-dir>/.ptah-lint.yaml` and blocks on error-severity `DS`
-data-safety findings. The `--config` flag on `ptah migrations up` selects
-`ptah.yaml`; it does not select a lint policy. This distinction prevents a
-project configuration path from silently replacing the policy shipped with
-the migration directory.
+`ptah migrations up` always loads and validates the conventional
+`<migrations-dir>/.ptah-lint.yaml`; when the apply-time gate is active, it
+blocks on error-severity `DS` data-safety findings. A nonempty policy `dialect`
+must match the connected database and selects the same scanner used by
+`ptah migrations lint`; otherwise the gate uses the connected database's
+dialect. A mismatch fails before migration analysis or execution. On the
+standalone lint command, an explicit `--dialect` still overrides the policy.
+The `--config` flag on `ptah migrations up` selects `ptah.yaml`; it does not
+select a lint policy. This distinction prevents a project configuration path
+from silently replacing the policy shipped with the migration directory.
 
-The gate otherwise uses the same rule configuration and path matching as
-`ptah migrations lint`. That makes the escape hatch proportional: a rule downgraded with
+The gate otherwise uses the same dialect selection, rule configuration, and
+path matching as `ptah migrations lint`. That makes the escape hatch
+proportional: a rule downgraded with
 `severity: warning`, listed under `disabled-rules`, or excluded for a path
 stops blocking exactly that reviewed pattern — a widening
 `ALTER COLUMN ... TYPE` under `rules: {DS103: {severity: warning}}` applies
 without `--allow-destructive` — while a `DROP TABLE` in another pending
 file of the same batch still aborts the apply. `--allow-destructive`
 remains the all-or-nothing per-run override rather than the only way past
-a single warning-grade finding.
+a single warning-grade finding. `--allow-destructive` bypasses the findings
+gate, but it does not bypass loading or validating the lint policy.
 
 Lint-policy severities are `warning` and `error`. Generated safety reports use
 the operational vocabulary `safe`, `warning`, and `destructive`; an `error`

--- a/internal/lintdialect/dialect.go
+++ b/internal/lintdialect/dialect.go
@@ -1,0 +1,17 @@
+// Package lintdialect defines the SQL dialects accepted by migration linting.
+// It keeps lint-policy and command validation on one compatibility boundary.
+package lintdialect
+
+// Expected is the user-facing list of supported lint dialects.
+const Expected = "postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner"
+
+// Valid reports whether dialect is supported. The empty value means that the
+// hybrid lint scanner should run every dialect-independent rule.
+func Valid(dialect string) bool {
+	switch dialect {
+	case "", "postgres", "mysql", "mariadb", "sqlite", "clickhouse", "cockroachdb", "yugabytedb", "spanner":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/lintdialect/dialect_test.go
+++ b/internal/lintdialect/dialect_test.go
@@ -1,0 +1,39 @@
+package lintdialect_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/lintdialect"
+)
+
+func TestValid_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{
+		"",
+		"postgres",
+		"mysql",
+		"mariadb",
+		"sqlite",
+		"clickhouse",
+		"cockroachdb",
+		"yugabytedb",
+		"spanner",
+	} {
+		c.Run(dialect, func(c *qt.C) {
+			c.Assert(lintdialect.Valid(dialect), qt.IsTrue)
+		})
+	}
+}
+
+func TestValid_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	for _, dialect := range []string{"oracle", "POSTGRES", " postgres"} {
+		c.Run(dialect, func(c *qt.C) {
+			c.Assert(lintdialect.Valid(dialect), qt.IsFalse)
+		})
+	}
+}

--- a/internal/migrationlintgate/gate.go
+++ b/internal/migrationlintgate/gate.go
@@ -1,0 +1,97 @@
+// Package migrationlintgate applies migration lint policy to pending database
+// migrations before execution.
+package migrationlintgate
+
+import (
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"go.5x5.cz/ptah/migration/lint"
+	"go.5x5.cz/ptah/migration/risk"
+)
+
+// Policy is a validated apply-time lint policy resolved for a live database.
+type Policy struct {
+	dialect  string
+	disabled []string
+	rules    map[string]lint.RuleConfig
+}
+
+// LoadPolicy loads the conventional lint policy and resolves it against the
+// connected database dialect.
+func LoadPolicy(fsys fs.FS, databaseDialect string) (Policy, error) {
+	cfg, err := lint.LoadConfigFS(fsys, lint.ConfigFileName)
+	if err != nil {
+		return Policy{}, err
+	}
+	if cfg.Dialect != "" {
+		if cfg.Dialect != databaseDialect {
+			return Policy{}, fmt.Errorf(
+				"lint dialect %q does not match database dialect %q",
+				cfg.Dialect,
+				databaseDialect,
+			)
+		}
+		databaseDialect = cfg.Dialect
+	}
+	policy := Policy{
+		dialect:  databaseDialect,
+		disabled: append([]string{"MF", "BC", "PG", "MY"}, cfg.DisabledRules...),
+		rules:    cfg.Rules,
+	}
+	if err := lint.ValidateOptions(policy.options("")); err != nil {
+		return Policy{}, err
+	}
+	return policy, nil
+}
+
+// Analyze loads policy and returns blocking data-safety findings for the
+// selected pending migration versions.
+func Analyze(
+	fsys fs.FS,
+	pending []int64,
+	databaseDialect string,
+	pathPrefix string,
+) ([]lint.Finding, error) {
+	policy, err := LoadPolicy(fsys, databaseDialect)
+	if err != nil {
+		return nil, err
+	}
+	return AnalyzeWithPolicy(fsys, pending, policy, pathPrefix)
+}
+
+// AnalyzeWithPolicy returns blocking data-safety findings using a policy that
+// was loaded before migration planning.
+func AnalyzeWithPolicy(
+	fsys fs.FS,
+	pending []int64,
+	policy Policy,
+	pathPrefix string,
+) ([]lint.Finding, error) {
+	options := policy.options(pathPrefix)
+	options.Selection = lint.VersionSelection{
+		Versions:   pending,
+		Restricted: true,
+	}
+	findings, err := lint.LintFS(fsys, options)
+	if err != nil {
+		return nil, err
+	}
+	blocking := make([]lint.Finding, 0, len(findings))
+	for _, finding := range findings {
+		if strings.HasPrefix(finding.Rule, "DS") && risk.IsBlocking(finding.Severity) {
+			blocking = append(blocking, finding)
+		}
+	}
+	return blocking, nil
+}
+
+func (p Policy) options(pathPrefix string) lint.Options {
+	return lint.Options{
+		Dialect:     p.dialect,
+		Disabled:    p.disabled,
+		PathPrefix:  pathPrefix,
+		RuleConfigs: p.rules,
+	}
+}

--- a/internal/migrationlintgate/gate_test.go
+++ b/internal/migrationlintgate/gate_test.go
@@ -1,0 +1,106 @@
+package migrationlintgate_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/migrationlintgate"
+	"go.5x5.cz/ptah/migration/lint"
+)
+
+func TestAnalyze_HappyPath_AppliesPolicy(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("dialect: sqlite\ndisabled-rules:\n  - DS102\n"),
+		},
+		"0000000001_drop_column.up.sql": {
+			Data: []byte("ALTER TABLE users DROP COLUMN legacy;\n"),
+		},
+		"0000000001_drop_column.down.sql": {
+			Data: []byte("ALTER TABLE users ADD COLUMN legacy TEXT;\n"),
+		},
+	}
+
+	findings, err := migrationlintgate.Analyze(fsys, []int64{1}, "sqlite", "")
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(findings, qt.HasLen, 0)
+}
+
+func TestLoadPolicy_FailurePath_DialectMismatch(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("dialect: postgres\n"),
+		},
+	}
+
+	_, err := migrationlintgate.LoadPolicy(fsys, "sqlite")
+
+	c.Assert(err, qt.ErrorMatches, `lint dialect "postgres" does not match database dialect "sqlite"`)
+}
+
+func TestAnalyze_FailurePath_InvalidPolicy(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("rules:\n  DS101:\n    exclude:\n      - '[legacy/**'\n"),
+		},
+		"0000000001_drop.up.sql": {
+			Data: []byte("DROP TABLE users;\n"),
+		},
+		"0000000001_drop.down.sql": {
+			Data: []byte("CREATE TABLE users (id INTEGER);\n"),
+		},
+	}
+
+	findings, err := migrationlintgate.Analyze(fsys, []int64{1}, "sqlite", "")
+
+	c.Assert(err, qt.ErrorMatches, `.*rule DS101 has invalid exclude pattern "\[legacy/\*\*": syntax error in pattern`)
+	c.Assert(findings, qt.IsNil)
+}
+
+func TestLoadPolicy_FailurePath_UnregisteredRuleSelectors(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name   string
+		config string
+	}{
+		{
+			name:   "disabled rule selector",
+			config: "disabled-rules:\n  - ZZ404\n",
+		},
+		{
+			name:   "configured rule selector",
+			config: "rules:\n  ZZ404:\n    severity: error\n",
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			fsys := fstest.MapFS{
+				lint.ConfigFileName: {Data: []byte(test.config)},
+			}
+
+			_, err := migrationlintgate.LoadPolicy(fsys, "sqlite")
+
+			c.Assert(err, qt.ErrorMatches, `rule selector "ZZ404" does not match any registered rule`)
+		})
+	}
+}
+
+func TestLoadPolicy_FailurePath_NonNormalizedExclusionGlob(t *testing.T) {
+	c := qt.New(t)
+	fsys := fstest.MapFS{
+		lint.ConfigFileName: {
+			Data: []byte("rules:\n  DS101:\n    exclude:\n      - '**/../**'\n"),
+		},
+	}
+
+	_, err := migrationlintgate.LoadPolicy(fsys, "sqlite")
+
+	c.Assert(err, qt.ErrorMatches, `.*rule DS101 has invalid exclude pattern "\*\*/\.\./\*\*": pattern must be a normalized slash-separated path`)
+}

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -22,6 +22,7 @@ import (
 	"go.5x5.cz/ptah/config/projectconfig"
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/internal/lintdialect"
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/internal/schemaselection"
@@ -354,8 +355,8 @@ func loadEffectiveConfig(
 		cfg.DisabledRules = append([]string{}, projectCfg.Lint.DisabledRules...)
 	}
 	cfg.Rules = effectiveLintRuleConfigs(projectCfg.Lint.RuleConfigs, cfg.Rules)
-	if !isValidDialect(cfg.Dialect) {
-		msg := fmt.Sprintf("invalid dialect %q in lint config: expected postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner", cfg.Dialect)
+	if !lintdialect.Valid(cfg.Dialect) {
+		msg := fmt.Sprintf("invalid dialect %q in lint config: expected %s", cfg.Dialect, lintdialect.Expected)
 		return nil, errors.New(msg)
 	}
 	return cfg, nil
@@ -1064,19 +1065,10 @@ func ValidateFailOn(failOn string) error {
 }
 
 func validateDialect(dialect string) error {
-	if isValidDialect(dialect) {
+	if lintdialect.Valid(dialect) {
 		return nil
 	}
-	return fmt.Errorf("invalid --dialect value %q: expected postgres, mysql, mariadb, sqlite, clickhouse, cockroachdb, yugabytedb, or spanner", dialect)
-}
-
-func isValidDialect(dialect string) bool {
-	switch dialect {
-	case "", "postgres", "mysql", "mariadb", "sqlite", "clickhouse", "cockroachdb", "yugabytedb", "spanner":
-		return true
-	default:
-		return false
-	}
+	return fmt.Errorf("invalid --dialect value %q: expected %s", dialect, lintdialect.Expected)
 }
 
 func validateDir(dir string) error {

--- a/migration/generator/README.md
+++ b/migration/generator/README.md
@@ -172,8 +172,8 @@ shadow check failed: missing column users.email
 Ptah also runs an `up -> down -> up` round-trip on the candidate migration and
 aborts if either direction fails.
 
-Shadow failures preserve structured diagnostics. Use `errors.As` rather than
-parsing the display message:
+Candidate generation and `VerifyBaselineShadow` preserve structured shadow
+diagnostics. Use `errors.As` rather than parsing the display message:
 
 ```go
 var shadowErr *generator.ShadowVerificationError
@@ -187,7 +187,12 @@ if errors.As(err, &shadowErr) {
 
 Operational failures also unwrap to the underlying database or migration
 error. Structural schema mismatches carry the complete, deterministically
-ordered mismatch list without an underlying error.
+ordered mismatch list without an underlying error. Baseline verification keeps
+the `baseline shadow check failed:` display prefix while exposing the same
+typed result. It shares stage names with candidate verification at common
+boundaries, can additionally report `target-introspect`, `reset-schemas`, and
+`drop-metadata`, and never reports the candidate-only `round-trip-down` or
+`round-trip-up` stages.
 
 ### File Naming Convention
 

--- a/migration/generator/baseline_shadow.go
+++ b/migration/generator/baseline_shadow.go
@@ -3,7 +3,6 @@ package generator
 import (
 	"context"
 	"fmt"
-	"maps"
 	"strings"
 	"time"
 
@@ -12,7 +11,6 @@ import (
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/convert/dbschematogo"
-	"go.5x5.cz/ptah/internal/devlock"
 	"go.5x5.cz/ptah/migration/migrator"
 	"go.5x5.cz/ptah/migration/schemadiff"
 )
@@ -33,21 +31,30 @@ type BaselineShadowVerifyOptions struct {
 }
 
 // VerifyBaselineShadow replays migrations up to Version on the shadow database
-// and compares the resulting schema with the target database.
+// and compares the resulting schema with the target database. Failures support
+// errors.As with [ShadowVerificationError], including the complete structured
+// mismatch list for schema drift.
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error {
-	if opts.TargetConn == nil {
-		return fmt.Errorf("baseline shadow check failed: target database connection is required")
+	if err := targetConnectionRequiredError(opts.TargetConn, "target database connection is required"); err != nil {
+		return wrapBaselineShadowError(err)
 	}
 	connectCtx, cancelConnect := baselineShadowConnectContext(ctx, opts.ConnectTimeout)
 	shadowConn, err := dbschema.ConnectToDatabase(connectCtx, opts.ShadowDatabaseURL)
 	cancelConnect()
 	if err != nil {
-		return fmt.Errorf("baseline shadow check failed: connect to shadow database: %w", err)
+		return baselineShadowError("connect", "connect_error", "connect to shadow database", err)
 	}
 	defer dbschema.CloseAndWarn(shadowConn)
 
-	if err := validateBaselineShadowConnection(ctx, opts, shadowConn); err != nil {
-		return err
+	if err := validateShadowConnection(
+		ctx,
+		opts.TargetConn,
+		shadowConn,
+		opts.Dialect,
+		opts.Capabilities,
+		"target database connection is required",
+	); err != nil {
+		return wrapBaselineShadowError(err)
 	}
 
 	targetSchema, err := validateBaselineTargetIdentifierSemantics(
@@ -59,7 +66,7 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 		return err
 	}
 	if err := shadowConn.SchemaWriter().DropAllTables(ctx); err != nil {
-		return fmt.Errorf("baseline shadow check failed: drop all objects: %w", err)
+		return baselineShadowError("drop-all", "drop_all_error", "drop all objects", err)
 	}
 	if err := resetBaselineShadowSchemas(ctx, shadowConn, opts.Schemas); err != nil {
 		return err
@@ -67,19 +74,24 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 
 	migrations, err := loadPriorMigrations(opts.MigrationsDir, opts.ProviderOptions...)
 	if err != nil {
-		return fmt.Errorf("baseline shadow check failed: load migrations: %w", err)
+		return baselineShadowError("load-prior", "load_prior_error", "load migrations", err)
 	}
 	migrations = migrationsAtOrBelow(migrations, opts.Version)
 	if len(migrations) == 0 {
-		return fmt.Errorf("baseline shadow check failed: no migrations found at or below version %d", opts.Version)
+		return baselineShadowError(
+			"load-prior",
+			"no_migrations",
+			fmt.Sprintf("no migrations found at or below version %d", opts.Version),
+			nil,
+		)
 	}
 
 	mig := migrator.NewMigrator(shadowConn, migrator.NewRegisteredMigrationProvider(migrations...))
 	if err := mig.MigrateUp(ctx); err != nil {
 		if description := describeReplayError(err); description != "" {
-			return fmt.Errorf("baseline shadow check failed: %s", description)
+			return baselineShadowErrorWithDisplayMessage("replay", "replay_error", description, err)
 		}
-		return fmt.Errorf("baseline shadow check failed: replay migrations: %w", err)
+		return baselineShadowError("replay", "replay_error", "replay migrations", err)
 	}
 	if err := dropBaselineShadowMetadata(ctx, shadowConn, mig.MigrationsTableIdentifier()); err != nil {
 		return err
@@ -87,7 +99,7 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 
 	shadowSchema, err := dbschema.ReadSchemaWithSchemas(shadowConn, opts.Schemas)
 	if err != nil {
-		return fmt.Errorf("baseline shadow check failed: read shadow schema: %w", err)
+		return baselineShadowError("re-introspect", "re_introspect_error", "read shadow schema", err)
 	}
 	diff, err := schemadiff.CompareWithDatabase(
 		ctx,
@@ -97,8 +109,10 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 		opts.CompareOptions,
 	)
 	if err != nil {
-		return fmt.Errorf(
-			"baseline shadow check failed: resolve target identifier semantics: %w",
+		return baselineShadowError(
+			"schema-match",
+			"identifier_resolution_error",
+			"resolve target identifier semantics",
 			err,
 		)
 	}
@@ -109,43 +123,37 @@ func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions)
 		*diff.IdentifierSemantics,
 	)
 	if err != nil {
-		return fmt.Errorf(
-			"baseline shadow check failed: resolve replayed shadow identifier semantics: %w",
+		return baselineShadowError(
+			"identifier-semantics-check",
+			"identifier_semantics_resolution_error",
+			"resolve replayed shadow identifier semantics",
 			err,
 		)
 	}
 	if !identifierSemanticsMatch {
-		return fmt.Errorf("baseline shadow check failed: replayed shadow identifier semantics do not match target %s catalog semantics", opts.Dialect)
+		return baselineShadowError(
+			"identifier-semantics-check",
+			"identifier_semantics_mismatch",
+			fmt.Sprintf("replayed shadow identifier semantics do not match target %s catalog semantics", opts.Dialect),
+			nil,
+		)
 	}
 	if !diff.HasChanges() {
 		return nil
 	}
-	return fmt.Errorf("baseline shadow check failed: %s", describeShadowDiff(diff))
+	return wrapBaselineShadowError(newShadowSchemaMismatchError(diff))
 }
 
-func validateBaselineShadowConnection(
-	ctx context.Context,
-	opts BaselineShadowVerifyOptions,
-	shadowConn *dbschema.DatabaseConnection,
-) error {
-	if !sameDialect(opts.Dialect, shadowConn.Info().Dialect) {
-		return fmt.Errorf(
-			"baseline shadow check failed: shadow database dialect %q does not match target dialect %q",
-			shadowConn.Info().Dialect,
-			opts.Dialect,
-		)
-	}
-	sameRealm, err := devlock.SameRealm(ctx, opts.TargetConn, shadowConn)
-	if err != nil {
-		return fmt.Errorf("baseline shadow check failed: compare target and shadow database realms: %w", err)
-	}
-	if sameRealm {
-		return fmt.Errorf("baseline shadow check failed: shadow database must be distinct from target database")
-	}
-	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, shadowConn.Info().Capabilities) {
-		return fmt.Errorf("baseline shadow check failed: shadow database capabilities do not match target %s capabilities", opts.Dialect)
-	}
-	return nil
+func baselineShadowError(stage, kind, message string, err error) error {
+	return wrapBaselineShadowError(newShadowVerificationError(stage, kind, message, err))
+}
+
+func baselineShadowErrorWithDisplayMessage(stage, kind, message string, err error) error {
+	return wrapBaselineShadowError(newShadowVerificationErrorWithDisplayMessage(stage, kind, message, err))
+}
+
+func wrapBaselineShadowError(err *ShadowVerificationError) error {
+	return fmt.Errorf("baseline %w", err)
 }
 
 func validateBaselineTargetIdentifierSemantics(
@@ -155,7 +163,7 @@ func validateBaselineTargetIdentifierSemantics(
 ) (*dbschematypes.DBSchema, error) {
 	targetSchema, err := dbschema.ReadSchemaWithSchemas(opts.TargetConn, opts.Schemas)
 	if err != nil {
-		return nil, fmt.Errorf("baseline shadow check failed: read target schema: %w", err)
+		return nil, baselineShadowError("target-introspect", "target_introspection_error", "read target schema", err)
 	}
 	targetGenerated := dbschematogo.ConvertDBSchemaToGoSchema(targetSchema)
 	targetDiff, err := schemadiff.CompareWithDatabase(
@@ -166,8 +174,10 @@ func validateBaselineTargetIdentifierSemantics(
 		opts.CompareOptions,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"baseline shadow check failed: resolve target identifier semantics: %w",
+		return nil, baselineShadowError(
+			"identifier-semantics-check",
+			"target_identifier_semantics_resolution_error",
+			"resolve target identifier semantics",
 			err,
 		)
 	}
@@ -178,15 +188,22 @@ func validateBaselineTargetIdentifierSemantics(
 		*targetDiff.IdentifierSemantics,
 	)
 	if err != nil {
-		return nil, fmt.Errorf(
-			"baseline shadow check failed: resolve shadow identifier semantics: %w",
+		return nil, baselineShadowError(
+			"identifier-semantics-check",
+			"identifier_semantics_resolution_error",
+			"resolve shadow identifier semantics",
 			err,
 		)
 	}
 	if !identifierSemanticsMatch {
-		return nil, fmt.Errorf(
-			"baseline shadow check failed: shadow database identifier semantics do not match target %s catalog semantics",
-			opts.Dialect,
+		return nil, baselineShadowError(
+			"identifier-semantics-check",
+			"identifier_semantics_mismatch",
+			fmt.Sprintf(
+				"shadow database identifier semantics do not match target %s catalog semantics",
+				opts.Dialect,
+			),
+			nil,
 		)
 	}
 	return targetSchema, nil
@@ -219,7 +236,12 @@ func resetBaselineShadowSchemas(ctx context.Context, conn *dbschema.DatabaseConn
 		}
 		_, err := conn.ExecContext(ctx, "DROP SCHEMA IF EXISTS "+quoteBaselinePostgresIdentifier(schema)+" CASCADE")
 		if err != nil {
-			return fmt.Errorf("baseline shadow check failed: drop schema %q: %w", schema, err)
+			return baselineShadowError(
+				"reset-schemas",
+				"schema_reset_error",
+				fmt.Sprintf("drop schema %q", schema),
+				err,
+			)
 		}
 	}
 	return nil
@@ -228,7 +250,7 @@ func resetBaselineShadowSchemas(ctx context.Context, conn *dbschema.DatabaseConn
 func dropBaselineShadowMetadata(ctx context.Context, conn *dbschema.DatabaseConnection, tableIdentifier string) error {
 	_, err := conn.ExecContext(ctx, "DROP TABLE IF EXISTS "+tableIdentifier)
 	if err != nil {
-		return fmt.Errorf("baseline shadow check failed: drop metadata table: %w", err)
+		return baselineShadowError("drop-metadata", "drop_metadata_error", "drop metadata table", err)
 	}
 	return nil
 }

--- a/migration/generator/shadow.go
+++ b/migration/generator/shadow.go
@@ -66,6 +66,15 @@ func newShadowVerificationError(stage, kind, message string, err error) *ShadowV
 	if err != nil {
 		message = fmt.Sprintf("%s: %v", message, err)
 	}
+	return newShadowVerificationErrorWithDisplayMessage(stage, kind, message, err)
+}
+
+func newShadowVerificationErrorWithDisplayMessage(
+	stage,
+	kind,
+	message string,
+	err error,
+) *ShadowVerificationError {
 	return &ShadowVerificationError{
 		Result: ShadowVerificationResult{
 			Stage: stage,
@@ -76,6 +85,68 @@ func newShadowVerificationError(stage, kind, message string, err error) *ShadowV
 		},
 		Err: err,
 	}
+}
+
+func targetConnectionRequiredError(
+	target *dbschema.DatabaseConnection,
+	message string,
+) *ShadowVerificationError {
+	if target != nil {
+		return nil
+	}
+	return newShadowVerificationError(
+		"realm-check",
+		"target_connection_required",
+		message,
+		nil,
+	)
+}
+
+func validateShadowConnection(
+	ctx context.Context,
+	target *dbschema.DatabaseConnection,
+	shadow *dbschema.DatabaseConnection,
+	dialect string,
+	capabilities capability.Capabilities,
+	targetRequiredMessage string,
+) *ShadowVerificationError {
+	if !sameDialect(dialect, shadow.Info().Dialect) {
+		return newShadowVerificationError(
+			"dialect-check",
+			"dialect_mismatch",
+			fmt.Sprintf("shadow database dialect %q does not match target dialect %q", shadow.Info().Dialect, dialect),
+			nil,
+		)
+	}
+	if err := targetConnectionRequiredError(target, targetRequiredMessage); err != nil {
+		return err
+	}
+	sameRealm, err := devlock.SameRealm(ctx, target, shadow)
+	if err != nil {
+		return newShadowVerificationError(
+			"realm-check",
+			"realm_comparison_error",
+			"compare target and shadow database realms",
+			err,
+		)
+	}
+	if sameRealm {
+		return newShadowVerificationError(
+			"realm-check",
+			"target_shadow_same_realm",
+			"shadow database must be distinct from target database",
+			nil,
+		)
+	}
+	if capabilities != nil && !maps.Equal(capabilities, shadow.Info().Capabilities) {
+		return newShadowVerificationError(
+			"capability-check",
+			"capability_mismatch",
+			fmt.Sprintf("shadow database capabilities do not match target %s capabilities", dialect),
+			nil,
+		)
+	}
+	return nil
 }
 
 type shadowMigrationOptions struct {
@@ -106,46 +177,15 @@ func verifyShadowMigration(ctx context.Context, opts shadowMigrationOptions) err
 	defer database.CloseAndWarn()
 	conn := database.Connection()
 
-	if !sameDialect(opts.Dialect, conn.Info().Dialect) {
-		return newShadowVerificationError(
-			"dialect-check",
-			"dialect_mismatch",
-			fmt.Sprintf("shadow database dialect %q does not match target dialect %q", conn.Info().Dialect, opts.Dialect),
-			nil,
-		)
-	}
-	if opts.TargetConnection == nil {
-		return newShadowVerificationError(
-			"realm-check",
-			"target_connection_required",
-			"compare target and shadow database realms: target connection is required",
-			nil,
-		)
-	}
-	sameRealm, err := devlock.SameRealm(ctx, opts.TargetConnection, conn)
-	if err != nil {
-		return newShadowVerificationError(
-			"realm-check",
-			"realm_comparison_error",
-			"compare target and shadow database realms",
-			err,
-		)
-	}
-	if sameRealm {
-		return newShadowVerificationError(
-			"realm-check",
-			"target_shadow_same_realm",
-			"shadow database must be distinct from target database",
-			nil,
-		)
-	}
-	if opts.Capabilities != nil && !maps.Equal(opts.Capabilities, conn.Info().Capabilities) {
-		return newShadowVerificationError(
-			"capability-check",
-			"capability_mismatch",
-			fmt.Sprintf("shadow database capabilities do not match target %s capabilities", opts.Dialect),
-			nil,
-		)
+	if err := validateShadowConnection(
+		ctx,
+		opts.TargetConnection,
+		conn,
+		opts.Dialect,
+		opts.Capabilities,
+		"compare target and shadow database realms: target connection is required",
+	); err != nil {
+		return err
 	}
 	identifierSemanticsMatch, err := shadowIdentifierSemanticsMatch(
 		ctx,
@@ -299,8 +339,5 @@ func assertShadowSchemaMatches(
 	if !diff.HasChanges() {
 		return nil
 	}
-	return &ShadowVerificationError{Result: ShadowVerificationResult{
-		Stage:      "schema-match",
-		Mismatches: collectShadowMismatches(diff),
-	}}
+	return newShadowSchemaMismatchError(diff)
 }

--- a/migration/generator/shadow_external_test.go
+++ b/migration/generator/shadow_external_test.go
@@ -13,6 +13,103 @@ import (
 	"go.5x5.cz/ptah/migration/generator"
 )
 
+func TestVerifyBaselineShadow_MissingTargetReturnsStructuredError(t *testing.T) {
+	c := qt.New(t)
+
+	err := generator.VerifyBaselineShadow(t.Context(), generator.BaselineShadowVerifyOptions{})
+
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: target database connection is required`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result, qt.DeepEquals, generator.ShadowVerificationResult{
+		Stage: "realm-check",
+		Mismatches: []generator.ShadowMismatch{{
+			Kind:    "target_connection_required",
+			Message: "target database connection is required",
+		}},
+	})
+}
+
+func TestVerifyBaselineShadow_ConnectFailureReturnsStructuredError(t *testing.T) {
+	c := qt.New(t)
+	targetURL := "sqlite://" + filepath.Join(c.TempDir(), "target.db")
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	err = generator.VerifyBaselineShadow(t.Context(), generator.BaselineShadowVerifyOptions{
+		ShadowDatabaseURL: "unsupported://shadow",
+		TargetConn:        target,
+		Dialect:           "sqlite",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: connect to shadow database: .*`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "connect")
+	c.Assert(shadowErr.Result.Mismatches, qt.HasLen, 1)
+	c.Assert(shadowErr.Result.Mismatches[0].Kind, qt.Equals, "connect_error")
+	c.Assert(shadowErr.Err, qt.IsNotNil)
+}
+
+func TestVerifyBaselineShadow_SchemaMismatchReturnsAllStructuredDifferences(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+	targetURL := "sqlite://" + filepath.Join(dir, "target.db")
+	shadowURL := "sqlite://" + filepath.Join(dir, "shadow.db")
+	target, err := dbschema.ConnectToDatabase(t.Context(), targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	_, err = target.ExecContext(t.Context(), "CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)")
+	c.Assert(err, qt.IsNil)
+
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE users (id INTEGER PRIMARY KEY, legacy TEXT);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	err = generator.VerifyBaselineShadow(t.Context(), generator.BaselineShadowVerifyOptions{
+		ShadowDatabaseURL: shadowURL,
+		TargetConn:        target,
+		MigrationsDir:     migrationsDir,
+		Version:           1,
+		Dialect:           "sqlite",
+		Capabilities:      target.Info().Capabilities,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: missing column users\.legacy`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Err, qt.IsNil)
+	c.Assert(shadowErr.Result, qt.DeepEquals, generator.ShadowVerificationResult{
+		Stage: "schema-match",
+		Mismatches: []generator.ShadowMismatch{
+			{
+				Kind:    "missing_column",
+				Object:  "users.legacy",
+				Table:   "users",
+				Column:  "legacy",
+				Message: "missing column users.legacy",
+			},
+			{
+				Kind:    "extra_column",
+				Object:  "users.name",
+				Table:   "users",
+				Column:  "name",
+				Message: "extra column users.name",
+			},
+		},
+	})
+}
+
 func TestGenerateMigration_ShadowSchemaMismatchReturnsStructuredError(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -262,6 +359,13 @@ func assertBaselineShadowRealmRejected(
 ) {
 	c.Helper()
 	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: shadow database must be distinct from target database`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result.Stage, qt.Equals, "realm-check")
+	c.Assert(shadowErr.Result.Mismatches, qt.DeepEquals, []generator.ShadowMismatch{{
+		Kind:    "target_shadow_same_realm",
+		Message: "shadow database must be distinct from target database",
+	}})
 	var tableCount int64
 	c.Assert(target.QueryRow("SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name = 'users'").Scan(&tableCount), qt.IsNil)
 	c.Assert(tableCount, qt.Equals, int64(1))

--- a/migration/generator/shadow_mismatch.go
+++ b/migration/generator/shadow_mismatch.go
@@ -17,6 +17,13 @@ func describeShadowDiff(diff *types.SchemaDiff) string {
 	return "schema differs"
 }
 
+func newShadowSchemaMismatchError(diff *types.SchemaDiff) *ShadowVerificationError {
+	return &ShadowVerificationError{Result: ShadowVerificationResult{
+		Stage:      "schema-match",
+		Mismatches: collectShadowMismatches(diff),
+	}}
+}
+
 func collectModifiedTableMismatches(table types.TableDiff) []ShadowMismatch {
 	var mismatches []ShadowMismatch
 	for _, columnName := range sortedStrings(table.ColumnsAdded) {

--- a/migration/generator/shadow_postgres_live_test.go
+++ b/migration/generator/shadow_postgres_live_test.go
@@ -1,0 +1,112 @@
+package generator_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/sqlident"
+	"go.5x5.cz/ptah/migration/generator"
+)
+
+func TestVerifyBaselineShadow_ReplayErrorWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	dbURL := requireBaselineShadowPostgresURL(t)
+	target, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+	c.Assert(platform.NormalizeDialect(target.Info().Dialect), qt.Equals, platform.Postgres)
+	shadowURL, shadowDatabase := createBaselineShadowPostgres(c, target, dbURL)
+	defer dropBaselineShadowPostgres(c, target, shadowDatabase)
+
+	migrationsDir := filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.up.sql"),
+		[]byte("CREATE TABLE users (id SERIAL PRIMARY KEY);\nALTER TABLE users DROP COLUMN name;\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(migrationsDir, "0000000001_init.down.sql"),
+		[]byte("DROP TABLE IF EXISTS users;\n"),
+		0o600,
+	), qt.IsNil)
+
+	err = generator.VerifyBaselineShadow(ctx, generator.BaselineShadowVerifyOptions{
+		ShadowDatabaseURL: shadowURL,
+		TargetConn:        target,
+		MigrationsDir:     migrationsDir,
+		Version:           1,
+		Dialect:           platform.Postgres,
+		Capabilities:      target.Info().Capabilities,
+	})
+
+	c.Assert(err, qt.ErrorMatches, `baseline shadow check failed: missing column users\.name`)
+	var shadowErr *generator.ShadowVerificationError
+	c.Assert(err, qt.ErrorAs, &shadowErr)
+	c.Assert(shadowErr.Result, qt.DeepEquals, generator.ShadowVerificationResult{
+		Stage: "replay",
+		Mismatches: []generator.ShadowMismatch{
+			{
+				Kind:    "replay_error",
+				Message: "missing column users.name",
+			},
+		},
+	})
+	c.Assert(shadowErr.Err, qt.IsNotNil)
+	c.Assert(shadowErr.Err.Error(), qt.Contains, `column "name" of relation "users" does not exist`)
+	c.Assert(err, qt.ErrorIs, shadowErr.Err)
+}
+
+func requireBaselineShadowPostgresURL(t *testing.T) string {
+	t.Helper()
+	for _, name := range []string{"POSTGRES_TEST_DSN", "POSTGRES_URL", "TEST_DATABASE_URL", "TEST_DB_URL"} {
+		if value := os.Getenv(name); value != "" {
+			return value
+		}
+	}
+	t.Skip("POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set")
+	return ""
+}
+
+func createBaselineShadowPostgres(
+	c *qt.C,
+	admin *dbschema.DatabaseConnection,
+	baseURL string,
+) (shadowURL, database string) {
+	c.Helper()
+	database = fmt.Sprintf("ptah_baseline_shadow_%d", time.Now().UnixNano())
+	_, err := admin.ExecContext(
+		c.Context(),
+		"CREATE DATABASE "+sqlident.Quote(platform.Postgres, database),
+	)
+	c.Assert(err, qt.IsNil)
+	parsed, err := url.Parse(baseURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + database
+	parsed.RawPath = ""
+	return parsed.String(), database
+}
+
+func dropBaselineShadowPostgres(c *qt.C, admin *dbschema.DatabaseConnection, database string) {
+	c.Helper()
+	_, _ = admin.ExecContext(
+		context.Background(),
+		"SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = $1 AND pid <> pg_backend_pid()",
+		database,
+	)
+	_, err := admin.ExecContext(
+		context.Background(),
+		"DROP DATABASE IF EXISTS "+sqlident.Quote(platform.Postgres, database),
+	)
+	c.Assert(err, qt.IsNil)
+}

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -272,27 +272,39 @@ func cloneFindings(findings []Finding) []Finding {
 	return cloned
 }
 
+// ValidateOptions checks a lint policy without reading migration files. Apply
+// gates should call it before any early return or bypass that can skip analysis.
+func ValidateOptions(opts Options) error {
+	_, _, err := validateOptions(opts)
+	return err
+}
+
+func validateOptions(opts Options) (migrator.MigrationDirFormat, []Rule, error) {
+	if err := validateCompatibilityProfile(opts.Compatibility); err != nil {
+		return "", nil, err
+	}
+	rules := rulesForOptions(opts)
+	if err := validateRules(rules); err != nil {
+		return "", nil, err
+	}
+	if err := validateRuleConfigs(opts.RuleConfigs); err != nil {
+		return "", nil, err
+	}
+	if err := validateRuleSelectors(opts.Disabled); err != nil {
+		return "", nil, err
+	}
+	if err := validateConfiguredRuleSelectors(rules, opts); err != nil {
+		return "", nil, err
+	}
+	dirFormat, err := migrator.ParseMigrationDirFormat(string(opts.DirFormat))
+	return dirFormat, rules, err
+}
+
 // AnalyzeFS captures and analyzes every *.sql file under fsys recursively.
 // Input file contents are read exactly once; template rendering, linting,
 // replay, and reporting can all consume the returned immutable snapshot.
 func AnalyzeFS(fsys fs.FS, opts Options) (Analysis, error) {
-	if err := validateCompatibilityProfile(opts.Compatibility); err != nil {
-		return Analysis{}, err
-	}
-	rules := rulesForOptions(opts)
-	if err := validateRules(rules); err != nil {
-		return Analysis{}, err
-	}
-	if err := validateRuleConfigs(opts.RuleConfigs); err != nil {
-		return Analysis{}, err
-	}
-	if err := validateRuleSelectors(opts.Disabled); err != nil {
-		return Analysis{}, err
-	}
-	if err := validateConfiguredRuleSelectors(rules, opts); err != nil {
-		return Analysis{}, err
-	}
-	dirFormat, err := migrator.ParseMigrationDirFormat(string(opts.DirFormat))
+	dirFormat, rules, err := validateOptions(opts)
 	if err != nil {
 		return Analysis{}, err
 	}

--- a/migration/lint/config.go
+++ b/migration/lint/config.go
@@ -8,10 +8,13 @@ import (
 	"io/fs"
 	"maps"
 	"os"
+	"path"
 	"slices"
 	"strings"
 
 	yaml "go.yaml.in/yaml/v3"
+
+	"go.5x5.cz/ptah/internal/lintdialect"
 )
 
 // ConfigFileName is the conventional per-project lint configuration file,
@@ -44,13 +47,14 @@ type Config struct {
 }
 
 // LoadConfig reads an explicit lint configuration file. Missing, unreadable,
-// malformed, and unknown configuration fields are errors.
-func LoadConfig(path string) (*Config, error) {
-	raw, err := os.ReadFile(path)
+// malformed, and unknown configuration fields are errors, as are unsupported
+// dialects and invalid rule exclusion globs.
+func LoadConfig(configPath string) (*Config, error) {
+	raw, err := os.ReadFile(configPath)
 	if err != nil {
-		return nil, fmt.Errorf("failed to read lint config %s: %w", path, err)
+		return nil, fmt.Errorf("failed to read lint config %s: %w", configPath, err)
 	}
-	cfg, err := parseConfig(raw, path)
+	cfg, err := parseConfig(raw, configPath)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +62,8 @@ func LoadConfig(path string) (*Config, error) {
 }
 
 // LoadConfigFS reads a conventional lint configuration from fsys. A missing
-// file is not an error; malformed and unknown configuration fields are errors.
+// file is not an error; the same strict validation as [LoadConfig] applies to
+// a present file.
 func LoadConfigFS(fsys fs.FS, name string) (*Config, error) {
 	raw, err := fs.ReadFile(fsys, name)
 	if errors.Is(err, fs.ErrNotExist) {
@@ -95,6 +100,9 @@ func parseConfig(raw []byte, name string) (*Config, error) {
 }
 
 func validateConfig(cfg Config) error {
+	if !lintdialect.Valid(cfg.Dialect) {
+		return fmt.Errorf("unsupported lint dialect %q: expected %s", cfg.Dialect, lintdialect.Expected)
+	}
 	if err := validateRuleSelectors(cfg.DisabledRules); err != nil {
 		return err
 	}
@@ -112,8 +120,31 @@ func validateRuleConfigs(configs map[string]RuleConfig) error {
 		default:
 			return fmt.Errorf("rule %s has unsupported severity %q", code, rule.Severity)
 		}
+		for _, pattern := range rule.Exclude {
+			if err := validateExcludePattern(pattern); err != nil {
+				return fmt.Errorf("rule %s has invalid exclude pattern %q: %w", code, pattern, err)
+			}
+		}
 	}
 	return nil
+}
+
+func validateExcludePattern(pattern string) error {
+	if strings.TrimSpace(pattern) == "" {
+		return errors.New("pattern must not be empty")
+	}
+	if strings.TrimSpace(pattern) != pattern {
+		return errors.New("pattern must not contain surrounding whitespace")
+	}
+	if path.Clean(pattern) != pattern {
+		return errors.New("pattern must be a normalized slash-separated path")
+	}
+	segments := strings.Split(pattern, "/")
+	if slices.Contains(segments, ".") || slices.Contains(segments, "..") {
+		return errors.New("pattern must not contain . or .. path segments")
+	}
+	_, err := path.Match(pattern, "")
+	return err
 }
 
 func validateConfiguredRuleSelectors(rules []Rule, opts Options) error {

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -290,7 +290,6 @@ func fileFindingSuppressed(file *File, finding Finding) bool {
 }
 
 func pathGlobMatches(pattern, value string) bool {
-	pattern = path.Clean(strings.TrimSpace(pattern))
 	value = path.Clean(value)
 	if pattern == "." || value == "." {
 		return false

--- a/migration/lint/lint_test.go
+++ b/migration/lint/lint_test.go
@@ -1,7 +1,9 @@
 package lint_test
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 	"testing/fstest"
 
@@ -1170,6 +1172,30 @@ func TestLoadConfig_FailurePath(t *testing.T) {
 		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported severity "fatal".*`)
 	})
 
+	c.Assert(writeFile(dir+"/bad-dialect.yaml", "dialect: oracle\n"), qt.IsNil)
+	c.Run("unsupported dialect", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/bad-dialect.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*unsupported lint dialect "oracle": expected postgres.*`)
+	})
+
+	c.Assert(writeFile(dir+"/bad-exclude.yaml", "rules:\n  DS102:\n    exclude:\n      - '[legacy/**'\n"), qt.IsNil)
+	c.Run("malformed exclude glob", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/bad-exclude.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule DS102 has invalid exclude pattern "\[legacy/\*\*": syntax error in pattern`)
+	})
+
+	c.Assert(writeFile(dir+"/empty-exclude.yaml", "rules:\n  DS102:\n    exclude:\n      - '  '\n"), qt.IsNil)
+	c.Run("empty exclude glob", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/empty-exclude.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule DS102 has invalid exclude pattern "  ": pattern must not be empty`)
+	})
+
+	c.Assert(writeFile(dir+"/non-normalized-exclude.yaml", "rules:\n  DS102:\n    exclude:\n      - '**/../**'\n"), qt.IsNil)
+	c.Run("non-normalized exclude glob", func(c *qt.C) {
+		_, err := lint.LoadConfig(dir + "/non-normalized-exclude.yaml")
+		c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*rule DS102 has invalid exclude pattern "\*\*/\.\./\*\*": pattern must be a normalized slash-separated path`)
+	})
+
 	c.Assert(writeFile(dir+"/unknown-top-level.yaml", "severty: error\n"), qt.IsNil)
 	c.Run("unknown top-level key", func(c *qt.C) {
 		_, err := lint.LoadConfig(dir + "/unknown-top-level.yaml")
@@ -1208,6 +1234,92 @@ func TestLoadConfigFS_MissingConventionalFileReturnsEmptyConfig(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(cfg, qt.DeepEquals, &lint.Config{})
+}
+
+func TestLintFS_FailurePath_InvalidProgrammaticExclusionGlob(t *testing.T) {
+	c := qt.New(t)
+	fsys := fixture(map[string]string{
+		"0000000001_drop.up.sql":   "DROP TABLE users;\n",
+		"0000000001_drop.down.sql": "CREATE TABLE users (id INTEGER);\n",
+	})
+
+	findings, err := lint.LintFS(fsys, lint.Options{
+		RuleConfigs: map[string]lint.RuleConfig{
+			"DS101": {Exclude: []string{"[legacy/**"}},
+		},
+	})
+
+	c.Assert(err, qt.ErrorMatches, `rule DS101 has invalid exclude pattern "\[legacy/\*\*": syntax error in pattern`)
+	c.Assert(findings, qt.IsNil)
+}
+
+func TestValidateOptions_FailurePath_InvalidProgrammaticExclusionGlob(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		pattern string
+		wantErr string
+	}{
+		{
+			name:    "non-normalized parent segment",
+			pattern: "**/../**",
+			wantErr: `rule DS101 has invalid exclude pattern "\*\*/\.\./\*\*": pattern must be a normalized slash-separated path`,
+		},
+		{
+			name:    "current directory",
+			pattern: ".",
+			wantErr: `rule DS101 has invalid exclude pattern "\.": pattern must not contain \. or \.\. path segments`,
+		},
+		{
+			name:    "parent directory",
+			pattern: "..",
+			wantErr: `rule DS101 has invalid exclude pattern "\.\.": pattern must not contain \. or \.\. path segments`,
+		},
+		{
+			name:    "leading parent directory",
+			pattern: "../legacy/**",
+			wantErr: `rule DS101 has invalid exclude pattern "\.\./legacy/\*\*": pattern must not contain \. or \.\. path segments`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := lint.ValidateOptions(lint.Options{
+				RuleConfigs: map[string]lint.RuleConfig{
+					"DS101": {Exclude: []string{test.pattern}},
+				},
+			})
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestLoadConfig_FailurePath_DotSegmentExclusionGlobs(t *testing.T) {
+	c := qt.New(t)
+	dir := c.TempDir()
+
+	tests := []struct {
+		name    string
+		pattern string
+	}{
+		{name: "current directory", pattern: "."},
+		{name: "parent directory", pattern: ".."},
+		{name: "leading parent directory", pattern: "../legacy/**"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			configPath := filepath.Join(dir, test.name+".yaml")
+			contents := fmt.Sprintf("rules:\n  DS101:\n    exclude:\n      - %q\n", test.pattern)
+			c.Assert(writeFile(configPath, contents), qt.IsNil)
+
+			_, err := lint.LoadConfig(configPath)
+
+			c.Assert(err, qt.ErrorMatches, `failed to parse lint config .*pattern must not contain \. or \.\. path segments`)
+		})
+	}
 }
 
 func TestRules_EveryRuleHasCodeTitleAndOneChecker(t *testing.T) {


### PR DESCRIPTION
## Summary

- reject unsupported lint dialects and malformed, non-normalized, or dot-segment exclusion globs before analysis
- load one validated migrate-up lint policy, honor its configured dialect, and validate it even on destructive-override and no-pending paths
- preserve structured `ShadowVerificationError` results and wrapped causes for baseline shadow verification without changing the CLI display prefix
- document the stricter policy and public error contracts

## Validation

- `go test -race -count=1 ./... -timeout=15m`
- affected-package race tests after rebasing onto current `master`
- live PostgreSQL migrate-up severity/error gate tests
- live PostgreSQL black-box baseline replay error test
- `golangci-lint run --fix --allow-parallel-runners ./...`
- `golangci-lint run --allow-parallel-runners ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- `go vet ./...`
- `go build ./...`
- `node docs/site/scripts/check-style.mjs`
- public API snapshot and released-API guards

Closes #270
