### PR TITLE
Establish native/compat capability parity as a project architecture contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -121,6 +121,207 @@ is "nothing, it is a different spelling of the same outcome", match it -- wordin
 flag names and output shape are worth being identical on, because tooling reads
 them. If the answer is "they lose something they asked for", do not match it.
 
+## Native And Compatibility Capability Ownership
+
+`ptah-compat` is an adapter over Ptah capabilities, not an independent product
+implementation.
+
+When implementing behavior for `ptah-compat`, distinguish between:
+
+1. a general semantic capability; and
+2. Atlas-specific interface or compatibility machinery.
+
+A general semantic capability must live in a reusable Ptah package below the
+CLI layer and, where meaningful to a native Ptah user, must be reachable
+through the native Ptah surface as well.
+
+Do not implement general product behavior exclusively inside `cmd/atlas` or
+another compatibility-only package.
+
+The native surface does not need to reproduce Atlas command names, flags,
+configuration syntax, output shape, URI spelling, or other interface
+conventions. This is functional parity, not interface parity.
+
+Compatibility-only adapters, parsers, codecs, persistence bridges,
+diagnostics, and behavioral shims may remain compat-only when they exist
+solely because of an Atlas contract.
+
+Conversely, when native Ptah already implements a capability that has an
+Atlas-compatible spelling, prefer adapting the compatibility surface to the
+existing capability rather than implementing the behavior again.
+
+CLI and compatibility packages should translate inputs and outputs, resolve
+compatibility policy, and delegate semantic work to reusable
+application/core packages.
+
+The intended architecture:
+
+```text
+                         shared Ptah capabilities
+                        /                        \
+                       /                          \
+             native Ptah surface          compatibility surface
+                  `ptah`                    `ptah-compat`
+```
+
+### Which side of the boundary a change is on
+
+These are general capabilities. They mean something without Atlas, so their
+execution semantics belong in shared Ptah code with a native entry point, even
+when the work that produced them was Atlas compatibility work:
+
+```text
+schema plan testing
+migration testing
+drift detection
+schema security analysis
+migration checkpoints
+pre-apply checks
+schema planning
+schema validation
+artifact publishing/fetching
+migration-directory import
+```
+
+These are compatibility machinery. They exist to interpret, reproduce, or
+bridge an Atlas interface or persisted representation, and they imply no native
+user-facing spelling:
+
+```text
+atlas:// -> OCI resolution
+Atlas CLI flag spelling and precedence
+atlas.hcl compatibility parsing/evaluation
+Atlas .plan.hcl codec
+Atlas .test.hcl adapter
+Atlas revision-table representation compatibility
+Atlas checksum encoding compatibility
+Atlas-compatible stdout/stderr rendering
+Atlas exit-code compatibility
+Atlas-specific refusal diagnostics
+```
+
+A codec feeding a shared capability is the intended shape, not a violation of
+the rule:
+
+```text
+Atlas .test.hcl
+      |
+      v
+compatibility parser
+      |
+      v
+shared test model / runner
+      |
+      +--> ptah
+      |
+      +--> ptah-compat
+```
+
+### How this reads against the compatibility policy
+
+The [compatibility policy](#compatibility-policy) and this rule run in opposite
+directions, and neither one relaxes the other.
+
+- The compatibility policy forbids the compatibility surface from losing a
+  capability native Ptah models. A capability reachable only through `ptah` is
+  no migration path for someone porting an Atlas pipeline.
+- This rule forbids the native surface from losing a capability the
+  compatibility surface gained. A capability reachable only through
+  `ptah-compat` turns the compat tree into a second product.
+
+They are one invariant read from two ends: neither binary is where a generally
+useful capability lives, because both are adapters over the package that
+implements it.
+
+Three consequences are worth naming, because getting them backwards satisfies
+this rule while breaking the older one:
+
+- Exposing a capability natively means a **native** verb or flag. The
+  compatibility surface still takes no new flag: the conformance `cli-surface`
+  tier asserts flag parity with the pinned community binary, so the fuller
+  behavior there stays behind a `PTAH_*` environment variable. Precedent:
+  `PTAH_ALLOW_EXTERNAL_SCHEMA`.
+- Reusing an existing native capability means the compatibility surface adapts
+  to it. It never means narrowing the native capability to whatever the Atlas
+  contract can express.
+- One implementation does not force one behavior. Where the two surfaces
+  deliberately diverge -- Atlas revision bookkeeping on one, recoverable
+  failure state on the other -- the divergence belongs in the shared package as
+  a policy the caller selects, not as a second implementation.
+
+### Dependency direction
+
+```text
+cmd/ptah  --------------------\
+                               \
+                                > shared capability/application/core packages
+                               /
+cmd/atlas / ptah-compat ------/
+```
+
+- Native Ptah code must not depend on the compatibility command layer.
+- Shared semantic packages must not depend on `cmd/atlas`.
+- Atlas-specific codecs and adapters may depend on shared domain models and
+  capabilities.
+
+Conceptually:
+
+```text
+Atlas input/output contract
+          |
+          v
+compat adapter / codec
+          |
+          v
+shared Ptah capability
+          ^
+          |
+native Ptah adapter
+```
+
+Today `cmd/ptah-compat/main.go` is the only non-test file outside `cmd/atlas`
+that imports `cmd/atlas`; native command packages reference it from tests only.
+Keep it that way.
+
+### Classify the change in the PR
+
+Every PR that adds or substantially extends behavior under the compatibility
+surface says which of the two it is:
+
+```text
+GENERAL CAPABILITY
+```
+
+or:
+
+```text
+COMPATIBILITY ADAPTER
+```
+
+A general capability answers three questions in the PR description:
+
+1. Where does the semantic implementation live?
+2. How can native Ptah consume it?
+3. If no native surface is added in the same PR, why is that reasonable, and
+   what issue records the exposure gap?
+
+A compatibility adapter names the external Atlas contract that makes it
+compatibility-specific.
+
+No GitHub PR template is required for this; `AGENTS.md` and normal PR
+self-review are enough. The requirement is that the decision is made
+deliberately rather than made for you by where a file happened to be placed.
+
+### Scope of this rule
+
+The rule is prospective. It governs work written from now on. It does not
+require auditing every capability already implemented on either surface, and it
+does not require refactoring packages that predate it. Add no further
+divergence from here; existing architectural debt may remain for now. The
+repository-wide audit belongs in a separate post-parity issue, and no such
+issue is open yet. See
+[`stokaro/ptah#1213`](https://github.com/stokaro/ptah/issues/1213).
+
 ## Language And Spelling
 
 Use American English spelling in code, comments, documentation, issue/PR text,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -118,6 +118,14 @@ The system is organized into several key packages:
 - Each command is in its own package (generate, migrate, compare, etc.)
 - Main binary entry point in `cmd/ptah/main.go`
 - Root command assembly in `cmd/root/root.go`
+- Atlas-compatible command tree in `cmd/atlas`, shipped by the separate
+  `cmd/ptah-compat` binary
+
+Both command trees are adapters. A generally useful capability belongs in a
+reusable package below the CLI layer and must be reachable from the native
+`ptah` surface, not only from `ptah-compat`; only Atlas-specific interface
+machinery stays compatibility-only. `AGENTS.md` is authoritative for that
+boundary and for the dependency direction it implies.
 
 ### Key Design Patterns
 

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -47,6 +47,30 @@ and the migration fails partway through. Ptah honors it.
 Differences of this kind are listed in the [gap register](#gap-register) with
 the measurement behind them, so you can see which way each one goes.
 
+### Capability parity, not interface parity
+
+Ptah's Atlas compatibility layer does not define a separate feature set.
+
+Capabilities implemented for Atlas compatibility are also available through
+Ptah's native workflows when they are generally useful database-schema or
+migration capabilities.
+
+The interfaces may differ: `ptah-compat` preserves Atlas-shaped commands and
+compatibility contracts, while `ptah` uses Ptah-native commands and
+configuration.
+
+Atlas-specific adapters and compatibility representations — for example
+`atlas://` resolution, Atlas file and config codecs, revision-history
+compatibility, or Atlas-specific CLI and output behavior — are not duplicated
+in the native interface unless they have independent Ptah value.
+
+So the promise is about capabilities, not about command lines. The native
+binary accepts no Atlas CLI aliases, and the two binaries are not
+command-for-command equivalent: Atlas command spellings live only in
+`ptah-compat`. The [command parity table](#command-parity) below shows which
+native verb answers each Atlas one, and the differences in what each verb
+records or refuses are named in the sections that follow it.
+
 ## Command parity
 
 | Task | Native Ptah | `ptah-compat` | Atlas OSS |

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -24,11 +24,16 @@ ptah-compat migrate apply --url "$DATABASE_URL" --dir ./migrations
 Command examples on the Atlas compatibility pages are written as
 `ptah-compat <command> ...` — the name the binary ships under.
 
-Every Atlas-compatible command has a native `ptah` twin — for example
-`ptah-compat migrate apply` and `ptah migrations up`, or `ptah-compat schema inspect` and
-`ptah schema inspect --db-url ...`. Use the native tree for new Ptah-authored
-work and the compat binary for existing Atlas scripts; the per-verb mapping is
-listed in the [Atlas-compatible commands reference](../../reference/atlas-commands/).
+What the two binaries share is capabilities, not command lines. A generally
+useful capability you reach through `ptah-compat` is reachable through native
+`ptah` as well, under native names and flags: `ptah-compat migrate apply` and
+`ptah migrations up`, or `ptah-compat schema inspect` and `ptah schema inspect`.
+Atlas-specific machinery has no native twin at all. See
+[Capability parity, not interface parity](../comparison/#capability-parity-not-interface-parity).
+
+Use the native tree for new Ptah-authored work and the compat binary for
+existing Atlas scripts; the per-verb mapping is listed in the
+[Atlas-compatible commands reference](../../reference/atlas-commands/).
 
 ### Installing under the name `atlas`
 
@@ -141,6 +146,10 @@ This matters most if you are coming from Atlas **Pro** rather than CE. The
 compatibility surface is the migration path for Pro scripts and configuration
 too, not only CE ones — a capability you could only reach by rewriting your
 pipeline against native `ptah` verbs would not be a migration path at all.
+
+The rule runs the other way too. A capability built for Atlas compatibility
+does not stay on the compatibility surface: where it is generally useful for
+schemas or migrations, native `ptah` reaches it under native names.
 
 ### The variables
 


### PR DESCRIPTION
## Classification

`COMPATIBILITY ADAPTER` / `GENERAL CAPABILITY` — neither. This PR changes no
runtime behavior; it writes down the rule that future PRs classify themselves
against.

## What changed

**`AGENTS.md`** gains a `## Native And Compatibility Capability Ownership`
section, placed directly after the compatibility policy it pairs with. It
states the rule the issue asked for: `ptah-compat` is an adapter over Ptah
capabilities rather than an independent product implementation; a general
semantic capability lives in a reusable package below the CLI layer and, where
meaningful to a native Ptah user, is reachable through the native surface;
general product behavior is not implemented exclusively inside `cmd/atlas`; the
native surface reproduces no Atlas command names, flags, configuration syntax,
output shape or URI spelling; compatibility-only adapters, parsers, codecs,
persistence bridges, diagnostics and behavioral shims may stay compat-only when
an Atlas contract is their only reason to exist; and compat work that meets an
existing native capability adapts to it rather than implementing it again.

The section carries the concrete examples for both sides of the boundary, the
codec-feeding-a-shared-capability shape, the dependency direction, the
`GENERAL CAPABILITY` / `COMPATIBILITY ADAPTER` classification a compatibility-surface
PR must state, and an explicit scope note that the rule is prospective.

**How it reads against the existing compatibility policy.** The two rules run
in opposite directions and neither relaxes the other, so the section says so
directly and names three consequences that would otherwise be easy to get
backwards:

- Exposing a capability natively means a *native* verb or flag. The
  compatibility surface still takes no new flag — the conformance
  `cli-surface` tier asserts flag parity with the pinned community binary, so
  the fuller behavior there stays behind a `PTAH_*` environment variable.
- Reusing a native capability means the compatibility surface adapts to it; it
  never means narrowing the native capability to what the Atlas contract can
  express.
- One shared implementation does not force one behavior. Where the surfaces
  deliberately diverge — Atlas revision bookkeeping on one, recoverable failure
  state on the other — the divergence is a policy the caller selects inside the
  shared package, not a second implementation.

**`docs/site/src/content/docs/atlas/comparison.md`** is the canonical home for
the user-facing promise, as a new `### Capability parity, not interface parity`
subsection under "What parity means, and what it does not". It states that the
compatibility layer defines no separate feature set, that capabilities are
available through native workflows when generally useful, that the interfaces
differ, and that Atlas-specific adapters and representations are not duplicated
natively unless they have independent Ptah value. It says plainly that the two
binaries are not command-for-command equivalent.

**`docs/site/src/content/docs/atlas/overview.md`** previously opened with "Every
Atlas-compatible command has a native `ptah` twin", which is exactly the
command-for-command promise the contract rules out — several compat paths
(the `schema plan` registry sub-verbs, for instance) have no native twin and are
not meant to. That paragraph now states the capability promise and links to the
canonical section. The existing "Compatibility never costs you a capability"
section gains one sentence stating the converse direction.

**`CLAUDE.md`** named only the native command packages under `cmd/`, which left
the compatibility tree unmentioned in the file an agent reads first. It now
names `cmd/atlas` and `cmd/ptah-compat`, states the boundary in two sentences,
and points at `AGENTS.md` as authoritative.

Nothing already in the repository contradicts the new rule beyond that overview
sentence. The existing rule that Atlas command paths live only in `ptah-compat`
is untouched.

## Dependency direction, as it stands today

`cmd/ptah-compat/main.go` is the only non-test file outside `cmd/atlas` that
imports `cmd/atlas`; the native command packages reference it from tests only.
The section records that and asks for it to be kept.

## Verification

No Go source changed. Documentation gates, run from the worktree with literal
exit codes:

```text
docs/site  npm ci                             0
docs/site  npm run check:exit-codes           0
docs/site  npm run check:exit-codes:selftest  0
docs/site  npm run check:core-doc-links       0
docs/site  npm run check:page-health          0
docs/site  npm run check:links                0
docs/site  npm run check:links:selftest       0
docs/site  npm run check:redirects            0
docs/site  npm run check:redirects:selftest   0
docs/site  npm run check:style                0
docs/site  npm run check:style:selftest       0
docs/site  npm run check:limitations          0
docs/site  npm run check:limitations:selftest 0
docs/site  npm run versions:selftest          0
docs/site  npm run check:responsive:selftest  0
docs/site  npm run build                      0
docs/site  npm run check:responsive           0
scripts/check-test-style.sh                   0
scripts/check-public-api.sh                   0
scripts/check-public-api-snapshot.sh          0
scripts/check-public-api-released.sh          0
scripts/check-documented-install.sh           0
go build ./...                                0
go vet ./...                                  0
```

`check:responsive` reports `60 routes x 2 viewports`, so it rendered rather
than skipping for a missing browser.

Two gates were driven red before being believed:

- The new anchor in `atlas/overview.md` was pointed at a non-existent id;
  `check:links` exited `1`. Restored, it exits `0`.
- `AGENTS.md` was mutated to read "This is simply functional parity, not
  interface behaviour"; `check:style` exited `1` with two findings against
  `AGENTS.md`, confirming the style gate governs the file this contract lives
  in. Restored, it exits `0`.

Closes #1213