### PR TITLE
Leave an extension's own types to the extension (#1294)

### DIFF
--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -252,6 +252,13 @@ destructive by the safety gate. Reconciliation is deliberately conservative:
   domain, the drop fails loudly instead of dropping the column.
 - Range types are matched by name only; a changed range is dropped and
   recreated.
+- A domain, composite or range type that an **extension** owns is not
+  described. `CREATE EXTENSION` creates those types, so they cannot be created
+  or dropped independently, and describing one as a user type made the
+  description declare something the extension already makes — replaying it
+  failed with `type "lo" already exists`. Ownership is read from `pg_depend`,
+  so a type of your own named close to an extension's is unaffected. The same
+  rule has always applied to extension-owned functions.
 
 ## Concurrent index creation
 

--- a/docs/user_defined_types.md
+++ b/docs/user_defined_types.md
@@ -75,6 +75,27 @@ Renders `CREATE TYPE "floatrange" AS RANGE (SUBTYPE = float8, SUBTYPE_DIFF = flo
 
 Range types have no in-place `ALTER`, so a changed range is dropped and recreated, and range comparison matches by name only.
 
+## Extension-owned types
+
+Reading a PostgreSQL database describes only the domains, composite types and
+range types the user declared. One that an extension owns is left to the
+extension, for the same reason extension-owned functions always have been: it
+is created by `CREATE EXTENSION` and cannot be created or dropped
+independently.
+
+Describing one made the description declare a type the extension already
+creates, and replaying such a description failed — measured on PostgreSQL
+17.10 against `CREATE EXTENSION lo`, which supplies the domain `lo`:
+
+```text
+ERROR: type "lo" already exists (SQLSTATE 42710)
+SQL: CREATE DOMAIN "lo" AS oid;
+```
+
+Ownership is read from `pg_depend` (`deptype = 'e'`) rather than from the type
+name, so a type of your own named closely after an extension's — `lo_own`
+beside `lo` — is still described in full.
+
 ## Ordering
 
 Ptah emits user-defined types after extensions and enums but before tables, so table columns can reference them. Within the group the order is domains → ranges → composites (composites may reference the others). Drops run after tables, and `DROP TYPE` / `DROP DOMAIN` are classified as destructive by the safety gate.

--- a/integration/atlas_compat_extension_owned_types_e2e_test.go
+++ b/integration/atlas_compat_extension_owned_types_e2e_test.go
@@ -1,0 +1,231 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+	_ "github.com/jackc/pgx/v5/stdlib"
+)
+
+// extensionOwnedTypeCase is one database shape and the type blocks its
+// description must and must not carry.
+type extensionOwnedTypeCase struct {
+	name string
+	// extensions are installed with CASCADE, in order, before seed runs.
+	extensions []string
+	// seed is the shape's DDL. It creates the user's own types alongside the
+	// extension's, so both directions are measured on one document.
+	seed string
+	// absentBlocks are block spellings the description must NOT carry, because
+	// CREATE EXTENSION already creates what they would declare.
+	absentBlocks []string
+	// presentBlocks are block spellings the description MUST carry: the user's
+	// own types, and the extension blocks without which the document names a
+	// type nothing creates.
+	presentBlocks []string
+	// unreplayable, when set, is the reason this row's fixture cannot be
+	// materialized on a fresh dev database whatever the renderer emits. See
+	// [atlasCompatExtensionRoundTripCase.unreplayable].
+	unreplayable string
+	// why records the measurement behind the row.
+	why string
+}
+
+// TestAtlasCompatExtensionOwnedTypesE2E pins that a domain, composite or range
+// type an extension owns is not described as a user type, and that a type the
+// user declared still is.
+//
+// `CREATE EXTENSION` creates the extension's own types, so a description that
+// declares both the extension and the type cannot be replayed: the second
+// declaration collides with what the first already made. Measured on
+// PostgreSQL 17.10 against `lo`, which supplies the domain `lo`, with a
+// `lo`-typed column so the extension block survives suppression:
+//
+//	before  domain "lo" declared, extension "lo" declared, replay exit 1
+//	        ERROR: type "lo" already exists (SQLSTATE 42710)
+//	        SQL: CREATE DOMAIN "lo" AS oid;
+//	after   domain "lo" absent, extension "lo" declared, replay exit 0
+//
+// The reader already excluded extension-owned FUNCTIONS for exactly this
+// reason -- its comment says they "cannot be dropped independently and should
+// be managed by the extension" -- and the three type reads were never given
+// that filter (stokaro/ptah#1294).
+//
+// Both directions are asserted on every row, on ONE document, because the
+// cheap wrong fix is a name filter. The user's types are named as closely to
+// the extension's as PostgreSQL allows -- `lo` beside `lo_own` -- so a
+// `NOT LIKE 'lo_%'` written without an ESCAPE clause, which is the mistake this
+// reader has already had to correct for roles (stokaro/ptah#1291), takes the
+// user's type with it and this test says so.
+//
+// Which extensions can carry a row at all was measured rather than assumed.
+// Over every extension the postgres:17 image ships, exactly six extension-owned
+// types reach these three reads:
+//
+//	dblink         dblink_pkey_results     composite
+//	earthdistance  earth                   domain
+//	lo             lo                      domain
+//	tablefunc      tablefunc_crosstab_2/3/4 composite
+//
+// pg_buffercache and pg_stat_statements also own composites, but those are the
+// row types of their views, and readComposites joins pg_class on relkind = 'c',
+// so they never reached a description. NO shipped extension supplies a range
+// type, which is why the range row below builds its member with
+// `ALTER EXTENSION ... ADD` and asserts the blocks rather than the round trip.
+//
+// The earthdistance row is a second, independent reproduction and is kept
+// because its column does NOT name the type: an `earth` column renders as
+// `sql("cube")`, the domain flattened to its base type (stokaro/ptah#1242). So
+// after the fix nothing names anything earthdistance supplies and its extension
+// block is legitimately omitted too -- and the document still replays, because
+// what the column now names is `cube`, which the cube extension declares. That
+// row is what distinguishes "stopped describing the domain" from "stopped
+// describing the domain and lost the column with it".
+func TestAtlasCompatExtensionOwnedTypesE2E(t *testing.T) {
+	adminURL := requirePostgresE2EDatabaseURL(t)
+
+	tests := []extensionOwnedTypeCase{
+		{
+			name:       "a domain the extension's install script creates",
+			extensions: []string{"lo"},
+			seed: "CREATE DOMAIN lo_own AS text;" +
+				" CREATE TABLE docs (id integer PRIMARY KEY, payload lo, own_payload lo_own)",
+			absentBlocks:  []string{`domain "lo"`},
+			presentBlocks: []string{`extension "lo"`, `domain "lo_own"`},
+			why: "lo supplies the domain lo and a lo-typed column keeps the extension in the" +
+				" document, so the collision is reachable; lo_own is the user's and must survive",
+		},
+		{
+			name:       "a composite the extension's install script creates",
+			extensions: []string{"dblink"},
+			seed: "CREATE TYPE dblink_pkey_results_own AS (position integer, colname text);" +
+				" CREATE TABLE keys (id integer PRIMARY KEY, k dblink_pkey_results," +
+				" own_k dblink_pkey_results_own)",
+			absentBlocks:  []string{`composite "dblink_pkey_results"`},
+			presentBlocks: []string{`extension "dblink"`, `composite "dblink_pkey_results_own"`},
+			why: "dblink supplies the composite dblink_pkey_results; the user's type differs from" +
+				" it by a suffix an unescaped LIKE underscore would swallow",
+		},
+		{
+			name:       "a range type an extension owns",
+			extensions: []string{"lo"},
+			seed: "CREATE TYPE ptahspan AS RANGE (subtype = integer);" +
+				" ALTER EXTENSION lo ADD TYPE ptahspan;" +
+				" CREATE TYPE ptahspan_own AS RANGE (subtype = integer);" +
+				" CREATE TABLE spans (id integer PRIMARY KEY, s ptahspan, own_s ptahspan_own)",
+			absentBlocks:  []string{`range "ptahspan"`},
+			presentBlocks: []string{`extension "lo"`, `range "ptahspan_own"`},
+			unreplayable: "lo owns ptahspan through ALTER EXTENSION ... ADD, so no CREATE EXTENSION" +
+				" recreates it and the spans table can never be built on a fresh dev database",
+			why: "no extension the postgres:17 image ships supplies a range type, so the only way to" +
+				" reach the range arm is to write the membership row directly",
+		},
+		{
+			name:       "a domain whose column flattens to its base type",
+			extensions: []string{"earthdistance"},
+			seed: "CREATE DOMAIN earth_own AS text;" +
+				" CREATE TABLE places (id integer PRIMARY KEY, loc earth NOT NULL, own_loc earth_own)",
+			absentBlocks:  []string{`domain "earth"`},
+			presentBlocks: []string{`extension "cube"`, `domain "earth_own"`},
+			why: "an earth column renders as sql(\"cube\"), so nothing names earthdistance once its" +
+				" domain is no longer declared and its block is legitimately omitted -- the" +
+				" document still replays, because cube is what the column now names",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+			defer cancel()
+
+			adminDB, err := sql.Open("pgx", adminURL)
+			c.Assert(err, qt.IsNil)
+			defer adminDB.Close()
+
+			stamp := time.Now().UnixNano()
+			sourceName := fmt.Sprintf("ptah_ext_type_src_%d", stamp)
+			devName := fmt.Sprintf("ptah_ext_type_dev_%d", stamp)
+			createE2EDatabase(c, ctx, adminDB, sourceName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, sourceName)
+			createE2EDatabase(c, ctx, adminDB, devName)
+			defer dropE2EDatabase(c, context.Background(), adminDB, devName)
+
+			sourceURL := replaceDatabaseName(c, adminURL, sourceName)
+			devURL := replaceDatabaseName(c, adminURL, devName)
+
+			seedExtensionOwnedTypeDB(c, ctx, sourceURL, test)
+
+			rendered := runAtlasCompatInspect(c, sourceURL, "")
+
+			for _, block := range test.presentBlocks {
+				c.Assert(rendered, qt.Contains, block, qt.Commentf("%s", test.why))
+			}
+			for _, block := range test.absentBlocks {
+				c.Assert(rendered, qt.Not(qt.Contains), block,
+					qt.Commentf("the document declares a type CREATE EXTENSION already makes: %s", test.why))
+			}
+
+			assertExtensionOwnedTypeRoundTrip(c, test, rendered, devURL)
+		})
+	}
+}
+
+// seedExtensionOwnedTypeDB installs the row's extensions and runs its DDL, then
+// verifies through pg_depend that an extension really does own a domain,
+// composite or range type here. Without that check a row whose membership never
+// landed would assert the absence of a block that was never going to be there.
+func seedExtensionOwnedTypeDB(c *qt.C, ctx context.Context, dbURL string, test extensionOwnedTypeCase) {
+	c.Helper()
+
+	db, err := sql.Open("pgx", dbURL)
+	c.Assert(err, qt.IsNil)
+	defer db.Close()
+
+	for _, extension := range test.extensions {
+		_, err = db.ExecContext(ctx, "CREATE EXTENSION "+quoteE2EIdent(extension)+" CASCADE")
+		c.Assert(err, qt.IsNil)
+	}
+	_, err = db.ExecContext(ctx, test.seed)
+	c.Assert(err, qt.IsNil)
+
+	var owned int
+	c.Assert(db.QueryRowContext(ctx, `
+		SELECT count(*)
+		  FROM pg_depend d
+		  JOIN pg_type t ON t.oid = d.objid
+		  JOIN pg_namespace n ON n.oid = t.typnamespace
+		 WHERE d.deptype = 'e'
+		   AND d.classid = 'pg_type'::regclass
+		   AND t.typtype IN ('d', 'c', 'r')
+		   AND n.nspname = 'public'`,
+	).Scan(&owned), qt.IsNil)
+	c.Assert(owned > 0, qt.IsTrue,
+		qt.Commentf("no extension owns a domain, composite or range type here, so this row asserts nothing"))
+}
+
+// assertExtensionOwnedTypeRoundTrip materializes the description on a fresh dev
+// database, unless the row recorded a reason its fixture can never be
+// materialized at all.
+func assertExtensionOwnedTypeRoundTrip(c *qt.C, test extensionOwnedTypeCase, rendered, devURL string) {
+	c.Helper()
+
+	if test.unreplayable != "" {
+		c.Logf("round trip not asserted: %s", test.unreplayable)
+		return
+	}
+
+	documentPath := filepath.Join(c.TempDir(), "inspected.hcl")
+	c.Assert(os.WriteFile(documentPath, []byte(rendered), 0o600), qt.IsNil)
+	readBack := runAtlasCompatInspect(c, "file://"+documentPath, devURL)
+	c.Assert(readBack, qt.Not(qt.Equals), "",
+		qt.Commentf("the round trip produced an empty document"))
+}

--- a/integration/atlas_compat_extension_owned_types_e2e_test.go
+++ b/integration/atlas_compat_extension_owned_types_e2e_test.go
@@ -81,14 +81,24 @@ type extensionOwnedTypeCase struct {
 // type, which is why the range row below builds its member with
 // `ALTER EXTENSION ... ADD` and asserts the blocks rather than the round trip.
 //
-// The earthdistance row is a second, independent reproduction and is kept
-// because its column does NOT name the type: an `earth` column renders as
-// `sql("cube")`, the domain flattened to its base type (stokaro/ptah#1242). So
-// after the fix nothing names anything earthdistance supplies and its extension
-// block is legitimately omitted too -- and the document still replays, because
-// what the column now names is `cube`, which the cube extension declares. That
-// row is what distinguishes "stopped describing the domain" from "stopped
-// describing the domain and lost the column with it".
+// `earthdistance` reproduces the defect too and is deliberately NOT a row here.
+// Its column spelling is not stable across environments, and the divergence is
+// measured rather than suspected. On a database holding
+//
+//	CREATE EXTENSION earthdistance CASCADE;
+//	CREATE TABLE places (id integer PRIMARY KEY, loc earth NOT NULL);
+//
+// this suite's own assertions rendered `column "loc" { type = sql("cube") }`
+// with an `extension "cube"` block on PostgreSQL 17.10 AND on 18.4 locally, and
+// `type = sql("earth")` with an `extension "earthdistance"` block on CI, from
+// the same catalog answer -- `format_type` reports `earth` and
+// `information_schema.columns.domain_name` reports `earth` on both. Which
+// spelling appears decides which extension the reference scan keeps, so an
+// assertion about either is really an assertion about stokaro/ptah#1242's
+// flattening and about which block survives, neither of which this change is
+// for. A fixture that answers differently in CI than on every server it was
+// written against is not a regression test; it is a second finding, and it is
+// reported as one rather than pinned here.
 func TestAtlasCompatExtensionOwnedTypesE2E(t *testing.T) {
 	adminURL := requirePostgresE2EDatabaseURL(t)
 
@@ -127,17 +137,6 @@ func TestAtlasCompatExtensionOwnedTypesE2E(t *testing.T) {
 				" recreates it and the spans table can never be built on a fresh dev database",
 			why: "no extension the postgres:17 image ships supplies a range type, so the only way to" +
 				" reach the range arm is to write the membership row directly",
-		},
-		{
-			name:       "a domain whose column flattens to its base type",
-			extensions: []string{"earthdistance"},
-			seed: "CREATE DOMAIN earth_own AS text;" +
-				" CREATE TABLE places (id integer PRIMARY KEY, loc earth NOT NULL, own_loc earth_own)",
-			absentBlocks:  []string{`domain "earth"`},
-			presentBlocks: []string{`extension "cube"`, `domain "earth_own"`},
-			why: "an earth column renders as sql(\"cube\"), so nothing names earthdistance once its" +
-				" domain is no longer declared and its block is legitimately omitted -- the" +
-				" document still replays, because cube is what the column now names",
 		},
 	}
 

--- a/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
+++ b/integration/atlas_compat_inspect_extension_roundtrip_e2e_test.go
@@ -33,6 +33,28 @@ type atlasCompatExtensionRoundTripCase struct {
 	wantBlock bool
 	// why records the measurement behind the expectation.
 	why string
+	// unreplayable, when set, is the reason this row's fixture cannot be
+	// materialized on a fresh dev database no matter what the renderer emits,
+	// so the round trip below is not an assertion about Ptah for this row. An
+	// empty string means the round trip is asserted, which is the default and
+	// what every row that builds its extension from an install script gets.
+	//
+	// Only a fixture whose membership comes from `ALTER EXTENSION ... ADD` can
+	// need this, and only when the added member is a TYPE. `ALTER EXTENSION`
+	// writes the pg_depend membership row without adding anything to the
+	// extension's install script, so it builds a catalog state no
+	// `CREATE EXTENSION` can reproduce. Measured on PostgreSQL 17.10 against a
+	// clean database:
+	//
+	//	CREATE EXTENSION pgcrypto;
+	//	SELECT count(*) FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
+	//	 WHERE n.nspname = 'public' AND t.typname = 'box';   -> 0
+	//
+	// against `CREATE EXTENSION lo` answering 1 for its own domain `lo`. A
+	// function member is not affected, because the bodies that call one are
+	// plpgsql and PostgreSQL does not resolve them at creation time; a type
+	// member is resolved when the column is created, so the replay stops there.
+	unreplayable string
 }
 
 // TestAtlasCompatInspectExtensionRoundTripE2E pins the property that
@@ -98,10 +120,20 @@ type atlasCompatExtensionRoundTripCase struct {
 // Both rows build that shape through `ALTER EXTENSION ... ADD`, which writes
 // the same pg_depend membership rows an extension's install script writes, so
 // no fixture control file has to be installed on the server for CI to run them.
-// The dependent call therefore lives in a plpgsql body, which PostgreSQL does
-// not resolve at creation time, so the document still materializes on a dev
-// database that has the extension but not the added member -- the assertion
-// that carries these two rows is the block, not the round trip. The word in
+// The assertion that carries these two rows is therefore the block, not the
+// round trip: `ALTER EXTENSION` adds nothing to the extension's install script,
+// so `CREATE EXTENSION` on a fresh dev database does not recreate the added
+// member and the fixture is one no replay can rebuild.
+//
+// Whether that costs the round trip depends on WHAT was added, and the two rows
+// differ on exactly this. A function member does not: the dependent call lives
+// in a plpgsql body, which PostgreSQL does not resolve at creation time, so the
+// first row still materializes. A TYPE member does, because a column's type is
+// resolved when the table is created -- so the second row records the reason in
+// `unreplayable` and asserts the block alone. Before stokaro/ptah#1294 that row
+// materialized only because the reader described the extension's own domain as
+// a user domain, which is the defect that issue is about; the round trip was
+// passing because of the bug, not despite it. The word in
 // that body is also indistinguishable from the false positives above, which is
 // the whole point: the decision cannot be made from the word, only from what
 // the extension is the only supplier of.
@@ -301,6 +333,9 @@ func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 			why: "the type in merge's signature is named box, which pg_catalog also supplies," +
 				" so the type arm already dropped it and it cannot answer for anything;" +
 				" excluding merge as well leaves this document with no evidence either",
+			unreplayable: "pgcrypto owns public.box through ALTER EXTENSION ... ADD, so no" +
+				" CREATE EXTENSION recreates it and the labels table can never be built on a" +
+				" fresh dev database (stokaro/ptah#1294)",
 		},
 		{
 			name:      "index resting on an operator class the extension supplies as the default",
@@ -423,13 +458,33 @@ func TestAtlasCompatInspectExtensionRoundTripE2E(t *testing.T) {
 			// The round trip. A fresh dev database has none of these
 			// extensions, so materializing the document is what proves it
 			// carries everything it depends on.
-			documentPath := filepath.Join(t.TempDir(), "inspected.hcl")
-			c.Assert(os.WriteFile(documentPath, []byte(rendered), 0o600), qt.IsNil)
-			readBack := runAtlasCompatInspect(c, "file://"+documentPath, devURL)
-			c.Assert(readBack, qt.Not(qt.Equals), "",
-				qt.Commentf("the round trip produced an empty document"))
+			assertAtlasCompatRoundTrip(c, test, rendered, devURL)
 		})
 	}
+}
+
+// assertAtlasCompatRoundTrip materializes the rendered document on a fresh dev
+// database, unless the row has recorded a reason its fixture can never be
+// materialized at all.
+//
+// The skip is per row and carries its reason with it rather than being a flag,
+// because "this document is unreadable" and "this fixture is unbuildable" are
+// different findings and only the first is about Ptah. Every row that builds
+// its extension from an install script is asserted, which is all of them but
+// one.
+func assertAtlasCompatRoundTrip(c *qt.C, test atlasCompatExtensionRoundTripCase, rendered, devURL string) {
+	c.Helper()
+
+	if test.unreplayable != "" {
+		c.Logf("round trip not asserted: %s", test.unreplayable)
+		return
+	}
+
+	documentPath := filepath.Join(c.TempDir(), "inspected.hcl")
+	c.Assert(os.WriteFile(documentPath, []byte(rendered), 0o600), qt.IsNil)
+	readBack := runAtlasCompatInspect(c, "file://"+documentPath, devURL)
+	c.Assert(readBack, qt.Not(qt.Equals), "",
+		qt.Commentf("the round trip produced an empty document"))
 }
 
 // seedAtlasCompatExtensionDB installs the extension and runs the shape's DDL,

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -505,6 +505,46 @@ func (r *Reader) readUserTypesInto(schema *types.DBSchema) error {
 	return nil
 }
 
+// extensionOwnedTypeExclusion is the correlated NOT EXISTS that keeps a type an
+// extension owns out of a description. It is written once and shared by the
+// domain, composite and range reads because the three ask the same question of
+// the same catalog and three copies drift.
+//
+// The predicate correlates on `t`, which every one of those queries spells for
+// its pg_type row.
+//
+// The reasoning is the one [Reader.readFunctionsForSchema] already carries for
+// functions -- an extension's members "cannot be dropped independently and
+// should be managed by the extension" -- and it was never applied to its types.
+// A description that declares both `extension "lo"` and `domain "lo"` cannot be
+// replayed, because CREATE EXTENSION makes the domain and the second
+// declaration collides with it. Measured on PostgreSQL 17.10 (stokaro/ptah#1294):
+//
+//	CREATE EXTENSION lo;
+//	CREATE TABLE docs (id integer PRIMARY KEY, payload lo);
+//
+//	Error: materialize schema on dev database: ... ERROR: type "lo" already
+//	exists (SQLSTATE 42710)  SQL: CREATE DOMAIN "lo" AS oid;
+//
+// classid is part of the predicate rather than left to objid alone: a pg_depend
+// row names its object by (classid, objid), and OIDs are drawn from one counter
+// shared by every catalog, so objid on its own can collide with a row of another
+// class.
+//
+// Ownership is asked of pg_depend rather than of the type's NAME. A user type
+// named close to an extension's -- `lo_own` beside `lo` -- is a user type, and a
+// name filter would have to spell `NOT LIKE` with an ESCAPE clause to avoid
+// treating its underscore as a wildcard, a mistake this reader has already had
+// to correct elsewhere (stokaro/ptah#1291). The catalog edge has no such
+// failure mode.
+const extensionOwnedTypeExclusion = `
+		AND NOT EXISTS (
+			SELECT 1 FROM pg_depend extdep
+			WHERE extdep.classid = 'pg_type'::regclass
+			  AND extdep.objid = t.oid
+			  AND extdep.deptype = 'e'
+		)`
+
 // readDomains reads PostgreSQL domain types (typtype='d').
 func (r *Reader) readDomains() ([]types.DBDomain, error) {
 	var domains []types.DBDomain
@@ -533,7 +573,8 @@ func (r *Reader) readDomainsForSchema(schemaName string) ([]types.DBDomain, erro
 			), '') AS check_expr
 		FROM pg_type t
 		JOIN pg_namespace n ON n.oid = t.typnamespace
-		WHERE t.typtype = 'd' AND n.nspname = $1
+		WHERE t.typtype = 'd' AND n.nspname = $1` +
+		extensionOwnedTypeExclusion + `
 		ORDER BY t.typname`
 
 	rows, err := r.db.Query(query, schemaName)
@@ -584,7 +625,8 @@ func (r *Reader) readCompositesForSchema(schemaName string) ([]types.DBComposite
 		JOIN pg_namespace n ON n.oid = t.typnamespace
 		JOIN pg_class c ON c.oid = t.typrelid AND c.relkind = 'c'
 		JOIN pg_attribute a ON a.attrelid = c.oid AND a.attnum > 0 AND NOT a.attisdropped
-		WHERE t.typtype = 'c' AND n.nspname = $1
+		WHERE t.typtype = 'c' AND n.nspname = $1` +
+		extensionOwnedTypeExclusion + `
 		ORDER BY t.typname, a.attnum`
 
 	rows, err := r.db.Query(query, schemaName)
@@ -644,7 +686,8 @@ func (r *Reader) readRangesForSchema(schemaName string) ([]types.DBRange, error)
 		FROM pg_type t
 		JOIN pg_namespace n ON n.oid = t.typnamespace
 		JOIN pg_range rng ON rng.rngtypid = t.oid
-		WHERE t.typtype = 'r' AND n.nspname = $1
+		WHERE t.typtype = 'r' AND n.nspname = $1` +
+		extensionOwnedTypeExclusion + `
 		ORDER BY t.typname`
 
 	rows, err := r.db.Query(query, schemaName)

--- a/internal/dbschema/postgres/reader_types_internal_test.go
+++ b/internal/dbschema/postgres/reader_types_internal_test.go
@@ -1,0 +1,413 @@
+package postgres
+
+// White-box testing required: the whole of stokaro/ptah#1294 is the SQL that
+// readDomainsForSchema, readCompositesForSchema and readRangesForSchema send.
+// Whether a type is owned by an extension is a pg_depend fact that no exported
+// reader API exposes -- a described domain looks the same either way -- so the
+// difference is only observable against a server that answers the ownership
+// question. All three methods are unexported and the query text has no other
+// source.
+//
+// The fake server below EVALUATES the ownership predicate against its own
+// pg_depend rows rather than recognizing a token in the query. It holds its own
+// literal copy of the conjuncts it knows how to evaluate, and a predicate it
+// does not know is an error, never a guess. That is what stops the guard being
+// true by construction of the fake: the two mutants that matter here are
+// dropping `extdep.objid = t.oid` -- which makes the NOT EXISTS drop EVERY type
+// as soon as the database holds any extension member -- and changing
+// `extdep.deptype` or `extdep.classid` to some other edge, which silently stops
+// excluding anything. Both are refused by name instead of being answered, so
+// every test in this file turns red rather than one of them passing.
+//
+// A query carrying no pg_depend clause at all is a different fact, and a real
+// one: it is the read as it stood before this change, and the fake answers it
+// with every type the server has, which is exactly what master did.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// catalogType is one pg_type row on the simulated server together with the one
+// fact this file is about: whether pg_depend records an extension owning it.
+type catalogType struct {
+	// name is the type name pg_type reports.
+	name string
+	// kind is pg_type.typtype: 'd' domain, 'c' composite, 'r' range.
+	kind string
+	// ownedByExtension is whether pg_depend holds a deptype='e' row naming
+	// this type. That row is written by CREATE EXTENSION and by
+	// ALTER EXTENSION ... ADD, and by nothing else.
+	ownedByExtension bool
+}
+
+// The conjuncts of the ownership exclusion this fake knows how to evaluate,
+// spelled out here rather than read from the reader's own constant: a guard
+// that imports the value it is checking agrees with every mutation of it.
+//
+// Each one is load-bearing and each is separately fatal to leave out:
+//
+//	ownershipCatalog      the edge lives in pg_depend and nowhere else
+//	ownershipClass        a pg_depend row names its object by (classid, objid),
+//	                      and OIDs come from one counter shared by every
+//	                      catalog, so objid alone can match another class's row
+//	ownershipCorrelation  without it the subquery is uncorrelated and the
+//	                      NOT EXISTS is false for every row the moment the
+//	                      database holds one extension member -- the read then
+//	                      describes nothing at all
+//	ownershipEdge         'e' is extension membership; 'n', 'a' and 'i' are
+//	                      ordinary, automatic and internal dependencies, which
+//	                      every user type has
+const (
+	ownershipNotExists   = "NOT EXISTS"
+	ownershipCatalog     = "FROM pg_depend extdep"
+	ownershipClass       = "extdep.classid = 'pg_type'::regclass"
+	ownershipCorrelation = "extdep.objid = t.oid"
+	ownershipEdge        = "extdep.deptype = 'e'"
+)
+
+// ownershipConjuncts is the exclusion taken apart, so a refusal can name the
+// piece that is missing instead of reporting "not the predicate I know".
+var ownershipConjuncts = []string{
+	ownershipNotExists,
+	ownershipCatalog,
+	ownershipClass,
+	ownershipCorrelation,
+	ownershipEdge,
+}
+
+// stripTypeSQLComments removes `-- ...` comments so the reader's prose cannot
+// stand in for the catalog expression it describes. The exclusion is documented
+// at length right above itself, and every conjunct's name appears in that
+// prose.
+func stripTypeSQLComments(query string) string {
+	lines := strings.Split(query, "\n")
+	for i, line := range lines {
+		lines[i], _, _ = strings.Cut(line, "--")
+	}
+	return strings.Join(lines, "\n")
+}
+
+// typeFilter reports whether the server hands a type back for the statement it
+// was resolved from. The statement is turned into a predicate rather than into
+// a boolean so that "which types does this query select" stays one idea.
+type typeFilter func(catalogType) bool
+
+// everyType is what a statement carrying no ownership clause selects: all of
+// them. That is the read as it stood before stokaro/ptah#1294.
+func everyType(catalogType) bool { return true }
+
+// onlyUserDeclared is what the exclusion selects.
+func onlyUserDeclared(entry catalogType) bool { return !entry.ownedByExtension }
+
+// describedTypes resolves the statement's ownership clause into the predicate
+// the server evaluates, and refuses any pg_depend clause this fake cannot
+// evaluate.
+func describedTypes(stripped string) (typeFilter, error) {
+	missing := missingConjuncts(stripped)
+	if len(missing) == len(ownershipConjuncts) {
+		return everyType, nil
+	}
+	if len(missing) > 0 {
+		return nil, fmt.Errorf(
+			"this fake evaluates the extension-ownership exclusion only in full, and the query is "+
+				"missing %s. A reader that changes the exclusion on purpose updates ownershipConjuncts "+
+				"and the tests in this file",
+			strings.Join(missing, ", "),
+		)
+	}
+	return onlyUserDeclared, nil
+}
+
+// missingConjuncts lists the pieces of the exclusion the statement does not
+// carry.
+func missingConjuncts(stripped string) []string {
+	var missing []string
+	for _, conjunct := range ownershipConjuncts {
+		missing = appendWhenAbsent(missing, stripped, conjunct)
+	}
+	return missing
+}
+
+func appendWhenAbsent(missing []string, stripped, conjunct string) []string {
+	if strings.Contains(stripped, conjunct) {
+		return missing
+	}
+	return append(missing, conjunct)
+}
+
+// typeKindRead returns the pg_type.typtype the statement selects, so one fake
+// can answer all three reads and a read asking for the wrong kind is visible as
+// a wrong answer rather than being waved through.
+func typeKindRead(stripped string) (string, error) {
+	for _, kind := range []string{"d", "c", "r"} {
+		if strings.Contains(stripped, fmt.Sprintf("t.typtype = '%s'", kind)) {
+			return kind, nil
+		}
+	}
+	return "", fmt.Errorf("the query restricts no pg_type.typtype, so this fake cannot tell which read it is")
+}
+
+// answerTypes plays PostgreSQL for the three type reads.
+func answerTypes(query string, args []driver.NamedValue, catalog []catalogType) (dbtest.QueryResult, error) {
+	stripped := stripTypeSQLComments(query)
+
+	kind, err := typeKindRead(stripped)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	described, err := describedTypes(stripped)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	schema, err := boundSchema(stripped, args)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+
+	return typeRows(kind, schema, described, catalog), nil
+}
+
+// boundSchema returns the schema name the statement binds, refusing a read that
+// binds a placeholder it never spells.
+func boundSchema(stripped string, args []driver.NamedValue) (string, error) {
+	if len(args) == 0 {
+		return "", fmt.Errorf("the query binds no schema")
+	}
+	arg := args[0]
+	placeholder := fmt.Sprintf("$%d", arg.Ordinal)
+	if !strings.Contains(stripped, placeholder) {
+		return "", fmt.Errorf("argument %v is bound but %s never appears in the query", arg.Value, placeholder)
+	}
+	name, ok := arg.Value.(string)
+	if !ok {
+		return "", fmt.Errorf("argument %s is not a schema name", placeholder)
+	}
+	return name, nil
+}
+
+// typeRows builds the answer for one read. Composites carry a field so the
+// reader has something to group, and the column sets differ per kind because
+// the three statements select different things.
+func typeRows(kind, schema string, described typeFilter, catalog []catalogType) dbtest.QueryResult {
+	result := dbtest.QueryResult{Columns: typeColumns(kind)}
+	for _, entry := range catalog {
+		result.Rows = appendTypeRow(result.Rows, entry, kind, schema, described)
+	}
+	return result
+}
+
+func typeColumns(kind string) []string {
+	return map[string][]string{
+		"d": {"schema_name", "domain_name", "base_type", "not_null", "default_value", "check_expr"},
+		"c": {"schema_name", "type_name", "field_name", "field_type", "attnum"},
+		"r": {"schema_name", "range_name", "subtype"},
+	}[kind]
+}
+
+func appendTypeRow(
+	rows [][]driver.Value,
+	entry catalogType,
+	kind, schema string,
+	described typeFilter,
+) [][]driver.Value {
+	if entry.kind != kind || !described(entry) {
+		return rows
+	}
+	return append(rows, map[string][]driver.Value{
+		"d": {schema, entry.name, "text", false, "", ""},
+		"c": {schema, entry.name, "lo", "integer", int64(1)},
+		"r": {schema, entry.name, "integer"},
+	}[kind])
+}
+
+// newTypesServer returns a Reader backed by a server holding catalog.
+func newTypesServer(tb interface{ Cleanup(func()) }, catalog []catalogType) *Reader {
+	db := dbtest.Open(tb, func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+		return answerTypes(query, args, catalog)
+	})
+	reader := NewPostgreSQLReaderWithCapabilities(db.SQL, "public", capability.Postgres16())
+	reader.SetSchemas([]string{"public"})
+	return reader
+}
+
+// mixedCatalog is a server holding, for each of the three kinds, one type an
+// extension owns and one the user declared -- named as closely as PostgreSQL
+// allows, so a filter matching on the NAME rather than on the pg_depend edge
+// catches the user's type too.
+//
+// The underscore is the point of the pairing. A `NOT LIKE 'lo_%'` written
+// without an ESCAPE clause reads that underscore as a single-character
+// wildcard, which is how this reader lost ordinary pg-prefixed roles in
+// stokaro/ptah#1291. Ownership is a catalog edge and has no such failure mode,
+// and these rows are what says so.
+func mixedCatalog() []catalogType {
+	return []catalogType{
+		{name: "lo", kind: "d", ownedByExtension: true},
+		{name: "lo_own", kind: "d", ownedByExtension: false},
+		{name: "dblink_pkey_results", kind: "c", ownedByExtension: true},
+		{name: "dblink_pkey_results_own", kind: "c", ownedByExtension: false},
+		{name: "ptahspan", kind: "r", ownedByExtension: true},
+		{name: "ptahspan_own", kind: "r", ownedByExtension: false},
+	}
+}
+
+// readTypeNames is the three reads behind one signature, so a table row can name
+// the read it exercises instead of the test body choosing between them.
+var (
+	readDomainNames = func(r *Reader) ([]string, error) {
+		domains, err := r.readDomains()
+		names := make([]string, 0, len(domains))
+		for _, domain := range domains {
+			names = append(names, domain.Name)
+		}
+		return names, err
+	}
+	readCompositeNames = func(r *Reader) ([]string, error) {
+		composites, err := r.readComposites()
+		names := make([]string, 0, len(composites))
+		for _, composite := range composites {
+			names = append(names, composite.Name)
+		}
+		return names, err
+	}
+	readRangeNames = func(r *Reader) ([]string, error) {
+		ranges, err := r.readRanges()
+		names := make([]string, 0, len(ranges))
+		for _, rangeType := range ranges {
+			names = append(names, rangeType.Name)
+		}
+		return names, err
+	}
+)
+
+func TestReadTypesLeavesExtensionOwnedTypesToTheExtension(t *testing.T) {
+	c := qt.New(t)
+
+	// The headline of stokaro/ptah#1294. CREATE EXTENSION creates these types,
+	// so a description that declares both the extension and the type cannot be
+	// replayed -- the second declaration collides with what the first already
+	// made. Measured on PostgreSQL 17.10 against a database holding
+	// `CREATE EXTENSION lo` and a `lo`-typed column:
+	//
+	//	Error: materialize schema on dev database: ... ERROR: type "lo"
+	//	already exists (SQLSTATE 42710)  SQL: CREATE DOMAIN "lo" AS oid;
+	//
+	// The reader already excluded extension-owned FUNCTIONS for exactly this
+	// reason and the three type reads were never given that filter.
+	tests := []struct {
+		name string
+		read func(*Reader) ([]string, error)
+		want []string
+	}{
+		{name: "domains", read: readDomainNames, want: []string{"lo_own"}},
+		{name: "composites", read: readCompositeNames, want: []string{"dblink_pkey_results_own"}},
+		{name: "ranges", read: readRangeNames, want: []string{"ptahspan_own"}},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newTypesServer(c.TB, mixedCatalog())
+
+			names, err := test.read(reader)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(names, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestReadTypesStillDescribesWhatTheUserDeclared(t *testing.T) {
+	c := qt.New(t)
+
+	// The control in the other direction, and the reason the exclusion is a fix
+	// rather than a deletion. A server whose types are all the user's own must
+	// be described in full, whatever else is installed alongside -- including
+	// types named as closely as PostgreSQL allows to an extension's.
+	//
+	// This row stays green when the exclusion is reverted, which is what a
+	// non-interference control is for. What stops it being vacuous is the
+	// inverse mutant: dropping the correlation `extdep.objid = t.oid` makes the
+	// exclusion swallow every type on the server, and the fake refuses that
+	// predicate by name, so this test reddens for it.
+	tests := []struct {
+		name string
+		read func(*Reader) ([]string, error)
+		want []string
+	}{
+		{name: "domains", read: readDomainNames, want: []string{"lo", "lo_own"}},
+		{
+			name: "composites",
+			read: readCompositeNames,
+			want: []string{"dblink_pkey_results", "dblink_pkey_results_own"},
+		},
+		{name: "ranges", read: readRangeNames, want: []string{"ptahspan", "ptahspan_own"}},
+	}
+
+	userDeclared := make([]catalogType, 0, len(mixedCatalog()))
+	for _, entry := range mixedCatalog() {
+		entry.ownedByExtension = false
+		userDeclared = append(userDeclared, entry)
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			reader := newTypesServer(c.TB, userDeclared)
+
+			names, err := test.read(reader)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(names, qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestReadTypesAsksPgDependRatherThanTheName(t *testing.T) {
+	c := qt.New(t)
+
+	// The property of the three STATEMENTS, which is where the defect would
+	// live, stated separately from the property of the answers. A read that
+	// excluded by name -- `NOT LIKE 'lo\_%'`, an allow-list of contrib type
+	// names -- could satisfy every assertion above on this fixture and be wrong
+	// on the next database. The correlation is asserted explicitly because
+	// without it the subquery is uncorrelated: the exclusion then withholds
+	// every type as soon as the server holds one extension member, and a
+	// database with nothing installed would still pass the tests above.
+	tests := []struct {
+		name string
+		read func(*Reader) ([]string, error)
+	}{
+		{name: "domains", read: readDomainNames},
+		{name: "composites", read: readCompositeNames},
+		{name: "ranges", read: readRangeNames},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			var sent []string
+			db := dbtest.Open(c.TB, func(query string, args []driver.NamedValue) (dbtest.QueryResult, error) {
+				sent = append(sent, query)
+				return answerTypes(query, args, mixedCatalog())
+			})
+			reader := NewPostgreSQLReaderWithCapabilities(db.SQL, "public", capability.Postgres16())
+			reader.SetSchemas([]string{"public"})
+
+			_, err := test.read(reader)
+			c.Assert(err, qt.IsNil)
+			c.Assert(sent, qt.HasLen, 1)
+
+			stripped := stripTypeSQLComments(sent[0])
+			c.Assert(missingConjuncts(stripped), qt.HasLen, 0,
+				qt.Commentf("the ownership exclusion is not carried in full"))
+			c.Assert(stripped, qt.Not(qt.Contains), "LIKE",
+				qt.Commentf("ownership is a pg_depend edge, not a name pattern"))
+		})
+	}
+}


### PR DESCRIPTION
The PostgreSQL reader describes domains, composite types and range types, and none of the three queries excluded the ones an extension owns.

**The held attempt's blocker was a fixture artifact, not a design gap.** #1294's second comment reported this as unlandable until #1276/#1298 lands. That diagnosis is refuted below, by measurement. This PR lands on its own.

## Reproduction

PostgreSQL 17.10, connected as `ptah_user`, source and dev databases created fresh, exit status read from a bare command.

```sql
CREATE EXTENSION lo;      -- supplies the DOMAIN    lo
CREATE EXTENSION dblink;  -- supplies the COMPOSITE dblink_pkey_results

CREATE TYPE ptahspan AS RANGE (subtype = integer);
ALTER EXTENSION lo ADD TYPE ptahspan;

-- the control: the user's own, named a suffix apart
CREATE DOMAIN lo_own AS text;
CREATE TYPE dblink_pkey_results_own AS (position integer, colname text);
CREATE TYPE ptahspan_own AS RANGE (subtype = integer);

CREATE TABLE docs (id integer PRIMARY KEY, payload lo, keys dblink_pkey_results,
    span ptahspan, own_payload lo_own, own_keys dblink_pkey_results_own,
    own_span ptahspan_own);
```

The catalog is unambiguous about ownership:

```
        typname          | kind | owned_by_extension
-------------------------+------+--------------------
 dblink_pkey_results     | c    | t
 dblink_pkey_results_own | c    | f
 lo                      | d    | t
 lo_own                  | d    | f
 ptahspan                | r    | t
 ptahspan_own            | r    | f
```

`ptah-compat schema inspect` on master declares all six, alongside both extensions:

```
extension "dblink"
extension "lo"
domain "lo"                            <- lo's own
domain "lo_own"
composite "dblink_pkey_results"        <- dblink's own
composite "dblink_pkey_results_own"
range "ptahspan"                       <- lo's own
range "ptahspan_own"
table "docs"
```

Reading that document back against a clean dev database:

```
Error: materialize schema on dev database: failed to execute SQL statement:
SQL execution failed: ERROR: type "lo" already exists (SQLSTATE 42710)
SQL: CREATE DOMAIN "lo" AS oid;
```

exit 1.

### The destructive half

Same live database, diffed against a desired state declaring nothing:

```console
$ ptah-compat schema diff --from "$SRC" --to file://desired-empty.hcl --dev-url "$DEV"
ALTER TABLE "docs" DROP CONSTRAINT IF EXISTS "docs_pkey";
DROP TABLE IF EXISTS "docs" CASCADE;
DROP DOMAIN IF EXISTS "lo" CASCADE;                    <- lo's own
DROP DOMAIN IF EXISTS "lo_own" CASCADE;
DROP TYPE IF EXISTS "dblink_pkey_results" CASCADE;     <- dblink's own
DROP TYPE IF EXISTS "dblink_pkey_results_own" CASCADE;
DROP TYPE IF EXISTS "ptahspan_own" CASCADE;
DROP EXTENSION IF EXISTS "dblink";
DROP EXTENSION IF EXISTS "lo";
```

That is the issue's title as a plan: three types an extension owns, proposed for dropping as if a user had declared them.

## The fix

One correlated `NOT EXISTS` on `pg_depend`, shared by `readDomainsForSchema`, `readCompositesForSchema` and `readRangesForSchema` — written once because the three ask the same question of the same catalog and three copies drift:

```sql
AND NOT EXISTS (
    SELECT 1 FROM pg_depend extdep
    WHERE extdep.classid = 'pg_type'::regclass
      AND extdep.objid = t.oid
      AND extdep.deptype = 'e'
)
```

`readFunctionsForSchema` already carries this reasoning — its comment says extension functions "cannot be dropped independently and should be managed by the extension" — and it was never applied to types.

`classid` is part of the predicate rather than left to `objid` alone: a `pg_depend` row names its object by `(classid, objid)`, and OIDs come from one counter shared by every catalog.

Ownership is asked of `pg_depend` and never of the type NAME. Every fixture pairs an extension-owned type with one of the user's a suffix apart, because `NOT LIKE 'lo_%'` without an `ESCAPE` clause reads the underscore as a wildcard and takes the user's type with it — the mistake this reader already had to correct for roles (#1291).

### After

```
extension "dblink"
extension "lo"
domain "lo_own"
composite "dblink_pkey_results_own"
range "ptahspan_own"
table "docs"
```

Replay against a clean dev database: **exit 0**. The diff plans neither extension-owned drop; the three `_own` types still drop.

## The survey #1294 asked for

Over every extension the `postgres:17` image ships, exactly six extension-owned types reach these three reads:

| extension | type | kind | shadowed by pg_catalog |
| --- | --- | --- | --- |
| dblink | dblink_pkey_results | composite | no |
| earthdistance | earth | domain | no |
| lo | lo | domain | no |
| tablefunc | tablefunc_crosstab_2/3/4 | composite | no |

`pg_buffercache` and `pg_stat_statements` own composites too, but those are their views' row types and `readComposites` joins `pg_class` on `relkind = 'c'`, so they never reached a description. **No shipped extension supplies a range type**, which is why the range row builds its member with `ALTER EXTENSION ... ADD` and asserts the blocks rather than the round trip.

## Refuting the held blocker

#1294's second comment parked an earlier attempt because the #1281 suite row *"keyword-named extension function whose answering type pg_catalog shadows"* went red, and read that as: `box` is dropped from `Provides` as shadowed → nothing keeps the extension → the block is omitted → nothing declares `box`.

Measured, the block is **not** omitted:

```console
$ grep -c 'extension "pgcrypto"' base.hcl   -> 1
$ grep -c 'extension "pgcrypto"' head.hcl   -> 1
```

and in the failing run the block assertion passes; only the blanket round trip at the end of the loop fails. The real cause is the fixture. `ALTER EXTENSION pgcrypto ADD DOMAIN public.box` writes the `pg_depend` membership row without adding anything to pgcrypto's install script, so it builds a catalog state no `CREATE EXTENSION` can reproduce:

```console
$ psql -c "CREATE EXTENSION pgcrypto" \
       -c "SELECT count(*) FROM pg_type t JOIN pg_namespace n ON n.oid = t.typnamespace
            WHERE n.nspname = 'public' AND t.typname = 'box'"
 0
$ psql -c "CREATE EXTENSION lo" -c "... AND t.typname = 'lo'"
 1
```

That row's round trip was passing only because the reader described the extension's own domain as a user domain — green *because of* this defect, not despite it. Its load-bearing assertion, the extension block, is unchanged and still passes; the round trip now carries a per-row `unreplayable` reason. Whether that costs the round trip depends on **what** was added: a function member is fine, because plpgsql bodies are not resolved at creation time, and that sibling row still asserts its round trip. A type member is not, because a column's type is resolved at `CREATE TABLE`. Nothing else in that suite moves — `TestAtlasCompatInspectExtensionRoundTripE2E` is green on CI on this branch.

## Red/green, both directions

### Unit — `internal/dbschema/postgres/reader_types_internal_test.go`

A fake server that **evaluates** the ownership predicate against its own `pg_depend` rows rather than recognizing a token, and refuses any predicate it cannot evaluate instead of answering one it invented.

| mutant | red |
| --- | --- |
| exclusion removed (revert the fix) | `LeavesExtensionOwnedTypes` 3/3, `AsksPgDependRatherThanTheName` 3/3; the control `StillDescribesWhatTheUserDeclared` stays **green** |
| `extdep.objid = t.oid` → `extdep.objid = extdep.objid` | **9/9**, control included |
| exclusion dropped from the ranges arm only | exactly the two `ranges` subtests, nothing else |

The second is the inverse mutant that keeps the non-interference control from being vacuous; the third is what says each of the three arms is separately covered. All three were re-run after the fake was refactored for a lint finding, and still kill it.

### Live — `integration/atlas_compat_extension_owned_types_e2e_test.go`

Three rows, one per type kind, both directions asserted on one document per row.

Reverting the exclusion, each row red on its own reason:

```
--- FAIL: .../a_domain_the_extension's_install_script_creates
--- FAIL: .../a_composite_the_extension's_install_script_creates
--- FAIL: .../a_range_type_an_extension_owns
```

With the fix, all three PASS, on PostgreSQL 17.10, on 18.4 (the version CI runs), and on CI itself.

## A second finding, reported rather than pinned

An `earthdistance` row was written as an independent reproduction and then **removed**, because its column spelling is not stable across environments. On

```sql
CREATE EXTENSION earthdistance CASCADE;
CREATE TABLE places (id integer PRIMARY KEY, loc earth NOT NULL);
```

the same commit rendered `column "loc" { type = sql("cube") }` with an `extension "cube"` block on PostgreSQL 17.10 **and** on 18.4 locally, and `type = sql("earth")` with an `extension "earthdistance"` block on CI. The catalog answers identically on both — `format_type` reports `earth`, and `information_schema.columns.domain_name` reports `earth` — so the divergence is in what Ptah does with that answer, which is #1242's flattening.

Which spelling appears decides which extension the reference scan keeps, so every assertion that row could make is really an assertion about #1242 and about which block survives suppression. Neither is what this change is for, and a fixture that answers differently in CI than on every server it was written against is not a regression test. The measurement is kept in the suite's doc comment so it is not re-added blind. **It likely deserves its own issue.**

Note that `earthdistance` on PostgreSQL 17.10 does reproduce #1294 exactly as `lo` does — master's document declares `domain "earth"` alongside `extension "earthdistance"` and fails to replay with `ERROR: type "earth" already exists (SQLSTATE 42710)`, and with the fix it replays at exit 0. It is the *assertion* that is unstable, not the defect.

## Gates

Each run bare, exit code read directly — never through a pipe.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (175 conditional groups, 45 white-box files) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci` + all 14 `check:*` scripts | 0 |
| `go test ./... -count=1` | 1 locally, see note; **green on CI** |
| `go test -tags integration ./integration/ -run 'TestAtlasCompat...'` | 0, on PostgreSQL 17.10 and on 18.4 |

**Note on the local `go test ./...`.** One run reported two failing packages, `cmd/ptah-ls` and `cmd/viz`, on a machine carrying load average 47 from three concurrent full Go test suites. Both failures are starvation signatures — `process did not exit within 20s`, `signal: killed`, and a fake graphviz killed before it could print its message — and both pass in isolation:

```console
$ go test ./cmd/ptah-ls/ ./cmd/viz/ -count=1
ok  	go.5x5.cz/ptah/cmd/ptah-ls	20.613s
ok  	go.5x5.cz/ptah/cmd/viz	13.030s
```

Neither reaches the changed code — `go list -deps` for both returns 0 hits for `internal/dbschema/postgres`. **CI's Go Unit Tests workflow is green on this branch**, which is the authoritative run.

### CI on the first push

10 of 11 workflows green, including Atlas CE Oracle, Go Lint, Go Unit Tests, Go Security, Go Fuzz, Export Acceptance and Docs. Integration Tests failed on exactly one subtest, the `earthdistance` row, which the second commit removes.

## Documentation

- `docs/user_defined_types.md` gains an *Extension-owned types* section with the measurement and the "ownership is a catalog edge, not a name" rule.
- `docs/site/src/content/docs/databases/postgresql.md` gains the same point in its *User-defined types* list.

## Residual risk

- **A shadowed extension type in a document whose extension block is omitted.** If an extension supplied a type into `public` with a name `pg_catalog` also supplies, `format_type` would render the column schema-qualified, the shadowed-name filter would keep that name out of `Extension.Provides`, and the extension block could be omitted — leaving a document naming a type nothing declares. Measured: **none** of the six shipped extension-owned types has a name `pg_catalog` supplies, so this is unreachable with any extension the image ships. It is #1276's shape and is what #1298's coverage record would express. I did not add a reader→renderer signal for it, because no available fixture can make it red, and an unmeasurable mechanism is worse than a named gap.
- **A desired state that explicitly declares a type an extension owns** now diffs against a read that reports nothing, so it plans a `CREATE` that fails with `already exists`. Before this change it silently compared against the extension's type as though the user owned it. Both are wrong; the new one fails loudly.
- `readFunctionsForSchema`'s own extension filter matches `d.objid = p.oid AND d.deptype = 'e'` with **no** `classid`, unlike the new type predicate. Since OIDs come from one counter shared by every catalog, `objid` alone can match a row of another class. Not touched here — no reproduction, and narrowing it is a separate change.
- The `earthdistance` rendering divergence above is unexplained and outlives this PR.

## Not verified

PostgreSQL only. No MySQL, MariaDB, ClickHouse or SQL Server target has these three reads. No conformance run of my own; no flags added, no public API change.

Closes #1294