### PR TITLE
Refuse a desired schema that declares a reserved PostgreSQL role (#1312)

### DIFF
--- a/core/renderer/renderer.go
+++ b/core/renderer/renderer.go
@@ -55,6 +55,7 @@ import (
 	"go.5x5.cz/ptah/core/renderer/internal/dialects/sqlite"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/planner/tablelookup"
+	"go.5x5.cz/ptah/internal/reservedrole"
 )
 
 // RenderVisitor defines the interface for rendering AST nodes to SQL statements.
@@ -769,6 +770,18 @@ func prepareDatabaseForRendering(
 	dialect string,
 	caps capability.Capabilities,
 ) (goschema.Database, error) {
+	// A reserved PostgreSQL role name renders into a CREATE ROLE the server is
+	// guaranteed to reject, so it is refused here, in the validation phase both
+	// whole-schema rendering and migration planning run before they emit
+	// anything (stokaro/ptah#1312).
+	if err := reservedrole.ValidateDeclared(dialect, database.Roles); err != nil {
+		return goschema.Database{}, &ptaherr.RenderError{
+			Dialect: dialect,
+			Err:     err,
+			Message: err.Error(),
+		}
+	}
+
 	prepared := *database
 	prepared.Tables = slices.Clone(database.Tables)
 	prepared.Fields = slices.Clone(database.Fields)

--- a/core/renderer/reserved_roles_test.go
+++ b/core/renderer/reserved_roles_test.go
@@ -1,0 +1,128 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/reservedrole"
+)
+
+// TestGetOrderedCreateStatementsRefusesAReservedRole is the regression for
+// stokaro/ptah#1312 on the generate path.
+//
+// Whole-schema rendering and migration planning share this validation phase --
+// migration/planner calls renderer.ValidateSchemaWithCapabilities before it
+// emits an AST node -- so refusing here refuses before any statement exists,
+// which is what the issue asks for. Without it, a declared reserved role is
+// rendered as `CREATE ROLE "pg_monitor" WITH NOLOGIN ...`, a statement
+// PostgreSQL 17.10 refuses at SQLSTATE 42939 whoever runs it.
+func TestGetOrderedCreateStatementsRefusesAReservedRole(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		roles   []goschema.Role
+		wantErr string
+	}{
+		{
+			name:    "the reserved prefix",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor".*SQLSTATE 42939.*`,
+		},
+		{
+			name:    "the bootstrap superuser",
+			roles:   []goschema.Role{{Name: "postgres", Login: true}},
+			wantErr: `.*declares reserved PostgreSQL role "postgres".*SQLSTATE 42710.*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(
+				&goschema.Database{Roles: test.roles},
+				"postgres",
+			)
+
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(statements, qt.IsNil)
+
+			var renderErr *ptaherr.RenderError
+			c.Assert(err, qt.ErrorAs, &renderErr)
+		})
+	}
+}
+
+// TestValidateSchemaRefusesAReservedRole covers the same phase through the
+// entry point migration/planner uses, so the refusal is proven on the path that
+// turns a diff into statements and not only on the whole-schema render.
+func TestValidateSchemaRefusesAReservedRole(t *testing.T) {
+	c := qt.New(t)
+
+	err := renderer.ValidateSchema(
+		&goschema.Database{Roles: []goschema.Role{{Name: "pg_monitor"}}},
+		"postgres",
+	)
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err.Error(), qt.Contains, reservedrole.AllowEnvVar)
+}
+
+// TestGetOrderedCreateStatementsStillRendersAnOrdinaryRole is the control: the
+// statement the refusal exists to prevent is the only one it prevents.
+func TestGetOrderedCreateStatementsStillRendersAnOrdinaryRole(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		role goschema.Role
+		want string
+	}{
+		{
+			name: "an ordinary application role",
+			role: goschema.Role{Name: "app_user", Login: true},
+			want: `CREATE ROLE "app_user" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION;
+`,
+		},
+		{
+			name: "pgbouncer, whose underscore-free name is not the prefix",
+			role: goschema.Role{Name: "pgbouncer", Login: true},
+			want: `CREATE ROLE "pgbouncer" WITH LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOINHERIT NOREPLICATION;
+`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			statements, err := renderer.GetOrderedCreateStatements(
+				&goschema.Database{Roles: []goschema.Role{test.role}},
+				"postgres",
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements, qt.DeepEquals, []string{test.want})
+		})
+	}
+}
+
+// TestGetOrderedCreateStatementsOptInRendersTheReservedRoleAnyway keeps the
+// capability reachable on the same surface, as AGENTS.md requires of a refusal
+// that removes one.
+func TestGetOrderedCreateStatementsOptInRendersTheReservedRoleAnyway(t *testing.T) {
+	c := qt.New(t)
+
+	c.Setenv(reservedrole.AllowEnvVar, "1")
+
+	statements, err := renderer.GetOrderedCreateStatements(
+		&goschema.Database{Roles: []goschema.Role{{Name: "postgres"}}},
+		"postgres",
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(statements, qt.HasLen, 1)
+	c.Assert(statements[0], qt.Contains, `CREATE ROLE "postgres"`)
+}

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -47,11 +47,10 @@ type DBSchema struct {
 	// The partition is over managed roles, not over the whole catalog. A
 	// PostgreSQL reader leaves the reserved pg_ roles and the bootstrap
 	// superuser out of both lists, because Ptah manages neither in either
-	// direction, so a desired schema that names one of them is still compared
-	// against nothing and still planned as a CREATE ROLE the server refuses
-	// (SQLSTATE 42710 for postgres, 42939 for a reserved name). That is
-	// unchanged by this field and is tracked separately; do not read the union
-	// as "every role the server has".
+	// direction, so the union is not every role the server has and must not be
+	// described as if it were. A desired schema that names one of them is
+	// refused before anything is compared or planned, naming the role and the
+	// rule, rather than compared against nothing. See stokaro/ptah#1312.
 	//
 	// This field is not part of the description: it carries role names from
 	// outside the inspected scope, so it is never serialized and never

--- a/docs/POSTGRESQL_ROLES.md
+++ b/docs/POSTGRESQL_ROLES.md
@@ -145,6 +145,32 @@ describe every role Ptah manages on the server, which is what you want when the
 output is meant to reproduce a cluster's roles somewhere else; apply that output
 to a clean target, or reconcile existing roles explicitly before applying it.
 
+### Reserved Role Names
+
+Ptah manages neither the reserved `pg_` roles nor the bootstrap `postgres`
+superuser, in either direction: neither read describes them and neither is ever
+compared. A desired schema declaring one would therefore be compared against
+nothing, read as absent, and planned as a `CREATE ROLE` the server rejects.
+Ptah refuses the declaration instead, before anything is compared or planned,
+on both the compare path and the generate path, naming the role and the rule:
+
+```text
+Error: compare database schema: invalid schema diff: desired schema declares reserved PostgreSQL role "pg_monitor" (PostgreSQL reserves the "pg_" prefix for system roles and refuses CREATE ROLE at SQLSTATE 42939); Ptah manages reserved roles in neither direction, so the declaration is compared against nothing and would be planned as a CREATE ROLE the server refuses; rename the role, or set PTAH_ALLOW_RESERVED_ROLE_NAMES=1 to plan it anyway
+```
+
+Both spellings are covered, and they fail for different reasons: `postgres`
+because the role already exists (SQLSTATE 42710), and any `pg_` name because
+the prefix is reserved (SQLSTATE 42939). The prefix is matched literally, so
+`pgbouncer`, `pgadmin` and `pgpool` are ordinary roles and are planned as
+before, and so is an uppercase `PG_` name, which PostgreSQL also accepts.
+
+Set `PTAH_ALLOW_RESERVED_ROLE_NAMES=1` to plan the declaration anyway, which is
+what Ptah did before the refusal existed. That is not a curiosity: measured on
+PostgreSQL 17.10, a cluster bootstrapped as `admin` rather than `postgres`
+accepts `CREATE ROLE "postgres"` and the role appears in `pg_roles`. The
+variable decides only whether Ptah refuses first or the server does; it changes
+neither read, so a `pg_` name still fails at the server whatever it is set to.
+
 ### Role Modifications
 
 When role attributes change between migrations, Ptah generates ALTER ROLE statements:

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5788,11 +5788,10 @@ type DBSchema struct {
     // The partition is over managed roles, not over the whole catalog. A
     // PostgreSQL reader leaves the reserved pg_ roles and the bootstrap
     // superuser out of both lists, because Ptah manages neither in either
-    // direction, so a desired schema that names one of them is still compared
-    // against nothing and still planned as a CREATE ROLE the server refuses
-    // (SQLSTATE 42710 for postgres, 42939 for a reserved name). That is
-    // unchanged by this field and is tracked separately; do not read the union
-    // as "every role the server has".
+    // direction, so the union is not every role the server has and must not be
+    // described as if it were. A desired schema that names one of them is
+    // refused before anything is compared or planned, naming the role and the
+    // rule, rather than compared against nothing. See stokaro/ptah#1312.
     //
     // This field is not part of the description: it carries role names from
     // outside the inspected scope, so it is never serialized and never

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -174,6 +174,16 @@ only: comparison already treats undescribed roles as present, so the planned
 statements are identical either way. Reserved `pg_` names and the bootstrap
 `postgres` superuser are outside it in both directions.
 
+**`PTAH_ALLOW_RESERVED_ROLE_NAMES`** — by default, a desired schema that
+declares a reserved PostgreSQL role is refused before anything is compared or
+planned, naming the role and the rule, because Ptah manages neither the `pg_`
+roles nor the bootstrap `postgres` superuser in either direction and the
+declaration would otherwise become a `CREATE ROLE` the server rejects at
+SQLSTATE 42939 or 42710. Set it to `1` and the declaration is planned instead,
+as it was before the refusal existed. That is worth having on a cluster
+bootstrapped under a name other than `postgres`, where `CREATE ROLE "postgres"`
+succeeds.
+
 **`PTAH_ALLOW_EXTERNAL_SCHEMA`** — by default, `atlas.hcl`
 `data "external_schema"` is not evaluated, because it runs a
 repository-controlled program. Set it to `1` and the data source is evaluated,

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -139,13 +139,35 @@ on standard error. A role the server does **not** have is still created there,
 so the same document also materializes on a server that has never seen it.
 
 Reserved roles sit outside that rule in both directions. Ptah manages neither
-the `pg_` roles nor the bootstrap `postgres` superuser: it never describes
-them and never compares them, so a desired schema that declares one is compared
-against nothing and is still planned as a `CREATE ROLE` the server refuses —
-`role "postgres" already exists` (SQLSTATE 42710) for the superuser, and
-`role name "pg_monitor" is reserved` (SQLSTATE 42939) for a `pg_` name. Do not
-declare them: Ptah does not yet refuse the declaration up front, and that
-refusal is a known gap rather than something this page describes as working.
+the `pg_` roles nor the bootstrap `postgres` superuser: it never describes them
+and never compares them, so a declaration naming one would be compared against
+nothing and planned as a `CREATE ROLE` the server refuses. Ptah refuses the
+declaration instead, before anything is compared or planned:
+
+```text
+Error: compare database schema: invalid schema diff: desired schema declares reserved PostgreSQL role "pg_monitor" (PostgreSQL reserves the "pg_" prefix for system roles and refuses CREATE ROLE at SQLSTATE 42939); Ptah manages reserved roles in neither direction, so the declaration is compared against nothing and would be planned as a CREATE ROLE the server refuses; rename the role, or set PTAH_ALLOW_RESERVED_ROLE_NAMES=1 to plan it anyway
+```
+
+The two names fail for different reasons and both are covered: the superuser
+because it already exists (`role "postgres" already exists`, SQLSTATE 42710),
+and a `pg_` name because the prefix is reserved (`role name "pg_monitor" is
+reserved`, SQLSTATE 42939). The prefix is matched literally, so `pgbouncer`,
+`pgadmin` and `pgpool` are ordinary roles and are planned as before.
+
+One thing the refusal costs, so it stays reachable rather than being removed:
+on a cluster bootstrapped under another name, `CREATE ROLE "postgres"` succeeds.
+Measured on PostgreSQL 17.10, a cluster whose superuser is `admin` accepts the
+statement and the role appears in `pg_roles`.
+
+```bash
+# Plan a declared reserved role anyway, as Ptah did before the refusal existed.
+PTAH_ALLOW_RESERVED_ROLE_NAMES=1 ptah-compat schema apply --dry-run --url "$PG_URL" --to file://schema.hcl --dev-url "$PG_DEV_URL"
+```
+
+The variable changes only whether Ptah refuses first or the server does. The
+reads are untouched, so a `pg_` name still fails at the server whatever you set
+it to. It is an environment variable rather than a flag because `ptah-compat`
+registers exactly the flags the Atlas community CLI registers.
 
 :::caution
 Ptah never drops a role automatically. A role that disappears from the desired

--- a/integration/gonative/roles_grants_integration_test.go
+++ b/integration/gonative/roles_grants_integration_test.go
@@ -490,8 +490,10 @@ func rolesNamedByDescription(schema *dbschematypes.DBSchema) []string {
 //
 // The reserved roles are outside this test as they are outside the reader: pg_
 // names and the bootstrap superuser are in neither list, so a desired schema
-// naming one is still planned as a CREATE ROLE the server refuses. See
-// compare.TestRolesReservedNameIsNotComparedAgainstAnything.
+// naming one is refused before anything is compared or planned rather than
+// turned into a CREATE ROLE the server refuses. See
+// compare.TestRolesReservedNameIsRefusedBeforeThisComparisonRunsAtAll and
+// go.5x5.cz/ptah/internal/reservedrole.
 func TestPostgreSQLRoleOutOfScopeIsPresentNotAbsentIntegration(t *testing.T) {
 	c := qt.New(t)
 	dsn := skipIfNoPostgreSQL(t)

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -10,6 +10,7 @@ import (
 
 	"go.5x5.cz/ptah/core/platform/capability"
 	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/reservedrole"
 	"go.5x5.cz/ptah/internal/rolescope"
 	"go.5x5.cz/ptah/internal/sqlrunner"
 )
@@ -2477,14 +2478,13 @@ func (r *Reader) readRolesInto(schema *types.DBSchema) error {
 // make a reported role look absent.
 //
 // The partition is over managed roles, not over pg_roles. queryRoles ends both
-// statements with the same `NOT LIKE 'pg\_%' ESCAPE '\'` and `!= 'postgres'`
-// exclusions, so the reserved roles and the bootstrap superuser are in neither
-// list -- Ptah manages neither, in either direction. A desired schema that
-// names one is therefore still compared against nothing and still planned as a
-// CREATE ROLE the server refuses (SQLSTATE 42710 for postgres, 42939 for a
-// reserved name); that predates this method, is unchanged by it, and is a
-// separate refusal to build. Do not restate this as "every role the server
-// has".
+// statements with the exclusion [reservedrole.ExcludeSQL] renders, so the
+// reserved roles and the bootstrap superuser are in neither list -- Ptah
+// manages neither, in either direction. A desired schema that names one is
+// refused before anything is compared or planned, through
+// [reservedrole.ValidateDeclared] over the same definition of "reserved"
+// (stokaro/ptah#1312), rather than being compared against nothing here. Do not
+// restate this as "every role the server has".
 //
 // The escape is load-bearing for both reads at once: an unescaped underscore
 // is a single-character wildcard, so it would drop pgbouncer, pgadmin and
@@ -2541,13 +2541,15 @@ func (r *Reader) queryRoles(membership string) ([]types.DBRole, error) {
 			COALESCE(shobj_description(r.oid, 'pg_authid'), '') AS comment
 		FROM pg_roles r
 		LEFT JOIN pg_authid a ON r.oid = a.oid
-		-- The underscore is escaped because LIKE reads a bare _ as a
-		-- single-character wildcard: 'pg_%' matches pgbouncer, pgadmin and
-		-- pgpool, which are ordinary user roles. PostgreSQL reserves the
-		-- prefix WITH the underscore (stokaro/ptah#1291).
+		-- Reserved system roles and the bootstrap superuser, excluded through
+		-- the same definition the desired-schema refusal tests against, so the
+		-- two cannot drift into disagreeing about what "reserved" means
+		-- (stokaro/ptah#1312). The rendered fragment escapes the underscore,
+		-- because LIKE reads a bare _ as a single-character wildcard: an
+		-- unescaped 'pg_%' matches pgbouncer, pgadmin and pgpool, which are
+		-- ordinary user roles (stokaro/ptah#1291).
 		WHERE ` + membership + `
-		AND r.rolname NOT LIKE 'pg\_%' ESCAPE '\'  -- Exclude system roles
-		AND r.rolname != 'postgres'      -- Exclude postgres superuser
+		AND ` + reservedrole.ExcludeSQL("r.rolname") + `
 		ORDER BY r.rolname`
 
 	rows, err := r.db.Query(rolesQuery, args...)

--- a/internal/dbschema/postgres/reader_roles_internal_test.go
+++ b/internal/dbschema/postgres/reader_roles_internal_test.go
@@ -861,9 +861,11 @@ func TestReadRolesPartitionsEveryManageableRole(t *testing.T) {
 	// It is NOT a partition of pg_roles, and the fixture proves that rather
 	// than footnoting it: fullCluster holds pg_reserved and postgres, both
 	// reads exclude them, and the union below is asserted to be the manageable
-	// names exactly. A desired schema naming a reserved role is therefore still
-	// compared against nothing, which is why the comparator's documentation
-	// says so and TestRolesReservedNameIsNotComparedAgainstAnything pins it.
+	// names exactly. A desired schema naming a reserved role would therefore be
+	// compared against nothing, which is why such a schema is refused before it
+	// reaches the comparator -- see
+	// compare.TestRolesReservedNameIsRefusedBeforeThisComparisonRunsAtAll and
+	// go.5x5.cz/ptah/internal/reservedrole.
 	//
 	// This test alone cannot catch a broken complement predicate: the fake
 	// answers the complement read by negating its own scoped answer. What

--- a/internal/reservedrole/reservedrole.go
+++ b/internal/reservedrole/reservedrole.go
@@ -1,0 +1,174 @@
+// Package reservedrole owns the single definition of a PostgreSQL role name
+// Ptah never manages: the reserved pg_ prefix and the bootstrap superuser. The
+// PostgreSQL reader excludes both from every role read through the SQL fragment
+// this package renders, and the desired-schema surfaces refuse to plan them
+// through the Go predicate this package exports, so the exclusion and the
+// refusal cannot drift into disagreeing about what "reserved" means.
+package reservedrole
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/ptaherr"
+)
+
+const (
+	// Prefix is the role-name prefix PostgreSQL reserves for system roles.
+	// CREATE ROLE fails at SQLSTATE 42939 for any name carrying it, measured on
+	// PostgreSQL 17.10 as a superuser: role name "pg_monitor_x" is reserved.
+	//
+	// The server compares the literal lowercase bytes, so the test here is a
+	// plain prefix test and nothing else. Measured on the same server,
+	// CREATE ROLE "PG_upper" succeeds, and so does CREATE ROLE "pgbouncer" --
+	// the underscore is part of the prefix rather than a wildcard, which is the
+	// defect stokaro/ptah#1291 had to fix at seven SQL sites.
+	Prefix = "pg_"
+
+	// BootstrapSuperuser is the role name a PostgreSQL cluster initialized by
+	// initdb's default carries. It is not reserved by the server, only occupied:
+	// CREATE ROLE "postgres" fails at SQLSTATE 42710 because the role already
+	// exists, and succeeds on a cluster bootstrapped under another name.
+	BootstrapSuperuser = "postgres"
+
+	// likeEscape is the ESCAPE character ExcludeSQL declares, so the underscore
+	// in Prefix is matched literally rather than as LIKE's single-character
+	// wildcard.
+	likeEscape = `\`
+)
+
+// AllowEnvVar plans a declared reserved role instead of refusing it, restoring
+// what Ptah did before the refusal existed.
+//
+// It exists because the refusal removes a capability, and AGENTS.md
+// ("Compatibility never removes a capability. Constitute it, do not discard
+// it.") does not allow that to be the end of the story. Measured on two
+// PostgreSQL 17.10 clusters: on one bootstrapped as "postgres",
+// CREATE ROLE "postgres" fails at SQLSTATE 42710; on one bootstrapped as
+// "admin" the same statement succeeds and the role appears in pg_roles, and
+// Ptah's own dev-database materialization is what created it there. Declaring
+// role "postgres" against a cluster that does not have one is therefore
+// something a user could do before this refusal, so it stays reachable here.
+//
+// It is an environment variable and not a flag for the reason
+// [go.5x5.cz/ptah/internal/rolescope.DescribeAllEnvVar] gives: the conformance
+// cli-surface tier asserts that ptah-compat registers exactly the flags the
+// pinned Atlas community binary registers, so a flag that binary does not have
+// would break the promise the surface exists to keep.
+//
+// Setting it never makes a reserved role succeed that would otherwise fail. The
+// reader still excludes the name from both of its reads, so the role still
+// reads as absent and is still planned as a CREATE ROLE; the variable decides
+// only whether Ptah refuses first or the server does.
+const AllowEnvVar = "PTAH_ALLOW_RESERVED_ROLE_NAMES"
+
+// Is reports whether name is a PostgreSQL role name Ptah never manages.
+//
+// This is the Go spelling of the exclusion [ExcludeSQL] renders, over the same
+// two constants. A role Is reports true for is in neither DBSchema.Roles nor
+// DBSchema.RolesOutOfScope, which is why declaring one has to be refused rather
+// than compared: the comparator would find it in neither list and read it as
+// absent.
+func Is(name string) bool {
+	return strings.HasPrefix(name, Prefix) || name == BootstrapSuperuser
+}
+
+// Rule names, for one role name, the reason the server refuses to create it.
+// The two spellings fail for different reasons and a message that gave only one
+// of them would misdescribe the other.
+func Rule(name string) string {
+	if strings.HasPrefix(name, Prefix) {
+		return fmt.Sprintf(
+			"PostgreSQL reserves the %q prefix for system roles and refuses CREATE ROLE at SQLSTATE 42939",
+			Prefix,
+		)
+	}
+	return "the bootstrap superuser is not a role Ptah manages, and CREATE ROLE for a role that" +
+		" already exists fails at SQLSTATE 42710"
+}
+
+// ExcludeSQL renders the WHERE-clause fragment that keeps reserved role names
+// out of a pg_roles read, for the role-name column named by column.
+//
+// The LIKE pattern is derived from [Prefix] rather than written out, so the
+// escaping cannot be forgotten the way stokaro/ptah#1291 found it forgotten,
+// and so a change to Prefix moves the SQL and [Is] together.
+func ExcludeSQL(column string) string {
+	return column + " NOT LIKE '" + likePattern() + "' ESCAPE '" + likeEscape + "'" +
+		" AND " + column + " != '" + BootstrapSuperuser + "'"
+}
+
+// likePattern escapes every LIKE metacharacter in Prefix and appends the
+// wildcard that makes it a prefix match.
+func likePattern() string {
+	var pattern strings.Builder
+	for _, r := range Prefix {
+		if r == '_' || r == '%' || r == '\\' {
+			pattern.WriteString(likeEscape)
+		}
+		pattern.WriteRune(r)
+	}
+	pattern.WriteString("%")
+	return pattern.String()
+}
+
+// Allowed reports whether the opt-in variable is set to a true boolean value.
+// Unset, empty, false and unparsable values all keep the refusal, mirroring how
+// [go.5x5.cz/ptah/internal/rolescope] and
+// [go.5x5.cz/ptah/internal/atlassource] read their own opt-ins.
+func Allowed() bool {
+	allow, err := strconv.ParseBool(os.Getenv(AllowEnvVar))
+	return err == nil && allow
+}
+
+// ValidateDeclared refuses a desired schema that declares a reserved role,
+// naming every offending role and the rule it breaks.
+//
+// The refusal is the answer AGENTS.md gives to a construct Ptah cannot carry
+// out -- "refuse loudly rather than accept and ignore" -- and it has to happen
+// before anything is planned: a reserved role is in neither of the reader's
+// lists, so the comparator reads it as absent and the plan becomes a CREATE
+// ROLE the server is guaranteed to reject, discovered halfway through an apply
+// rather than up front. See stokaro/ptah#1312.
+//
+// It applies to PostgreSQL-family targets, which are the only ones whose reader
+// excludes these names and whose planner emits CREATE ROLE. dialect is the
+// normalized or raw target dialect; an empty or non-PostgreSQL dialect declares
+// nothing about PostgreSQL role names and is left alone.
+func ValidateDeclared(dialect string, roles []goschema.Role) error {
+	if !platform.IsPostgresFamily(dialect) || Allowed() {
+		return nil
+	}
+	var refused []string
+	for _, role := range roles {
+		if !Is(role.Name) {
+			continue
+		}
+		refused = append(refused, fmt.Sprintf("%q (%s)", role.Name, Rule(role.Name)))
+	}
+	if len(refused) == 0 {
+		return nil
+	}
+	return fmt.Errorf(
+		"%w: desired schema declares reserved PostgreSQL %s %s;"+
+			" Ptah manages reserved roles in neither direction, so the declaration is compared"+
+			" against nothing and would be planned as a CREATE ROLE the server refuses;"+
+			" rename the role, or set %s=1 to plan it anyway",
+		ptaherr.ErrInvalidSchemaDiff,
+		noun(len(refused)),
+		strings.Join(refused, ", "),
+		AllowEnvVar,
+	)
+}
+
+// noun agrees the noun with the number of refused roles.
+func noun(count int) string {
+	if count == 1 {
+		return "role"
+	}
+	return "roles"
+}

--- a/internal/reservedrole/reservedrole_test.go
+++ b/internal/reservedrole/reservedrole_test.go
@@ -1,0 +1,235 @@
+package reservedrole_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/internal/reservedrole"
+)
+
+// TestIsRecognizesBothSpellingsTheServerRefuses covers the two names that fail
+// for different reasons. A check that knew only one of them would let the other
+// through, which is the half stokaro/ptah#1312 names.
+//
+// The negative rows are the ones stokaro/ptah#1291 had to buy back: pgbouncer,
+// pgadmin and pgpool are ordinary user roles, and a test that treated the
+// underscore as a wildcard would refuse all three.
+func TestIsRecognizesBothSpellingsTheServerRefuses(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name string
+		role string
+		want bool
+	}{
+		{name: "the reserved prefix itself", role: "pg_", want: true},
+		{name: "a reserved system role", role: "pg_monitor", want: true},
+		{name: "a name nobody has used yet under the prefix", role: "pg_whatever", want: true},
+		{name: "the bootstrap superuser", role: "postgres", want: true},
+		{name: "pgbouncer is an ordinary role", role: "pgbouncer", want: false},
+		{name: "pgadmin is an ordinary role", role: "pgadmin", want: false},
+		{name: "pgpool is an ordinary role", role: "pgpool", want: false},
+		{name: "the prefix uppercased is not reserved", role: "PG_upper", want: false},
+		{name: "the prefix in the middle is not reserved", role: "app_pg_user", want: false},
+		{name: "a name the superuser shares a stem with", role: "postgres_admin", want: false},
+		{name: "an ordinary application role", role: "app_user", want: false},
+		{name: "the empty name", role: "", want: false},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(reservedrole.Is(test.role), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestExcludeSQLEscapesTheUnderscore pins the rendered fragment byte for byte.
+//
+// This is the half the PostgreSQL reader embeds, and the reason the fragment is
+// rendered rather than written out at each read site: an unescaped underscore
+// is a single-character wildcard, so 'pg_%' matches pgbouncer and drops it from
+// both role reads at once (stokaro/ptah#1291). Pinning the text is what keeps
+// the SQL exclusion and [reservedrole.Is] from drifting apart.
+func TestExcludeSQLEscapesTheUnderscore(t *testing.T) {
+	c := qt.New(t)
+
+	got := reservedrole.ExcludeSQL("r.rolname")
+
+	c.Assert(got, qt.Equals, `r.rolname NOT LIKE 'pg\_%' ESCAPE '\' AND r.rolname != 'postgres'`)
+	c.Assert(got, qt.Not(qt.Contains), `NOT LIKE 'pg_%'`)
+}
+
+// TestValidateDeclaredHappyPath is the control the refusal has to leave alone.
+// A schema whose roles are ordinary is planned exactly as before, and so is one
+// declaring a reserved name for a target whose reader never excluded it.
+func TestValidateDeclaredHappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		roles   []goschema.Role
+	}{
+		{
+			name:    "an ordinary role on postgres",
+			dialect: "postgres",
+			roles:   []goschema.Role{{Name: "app_user", Login: true}},
+		},
+		{
+			name:    "roles whose names merely start like the reserved ones",
+			dialect: "postgres",
+			roles:   []goschema.Role{{Name: "pgbouncer"}, {Name: "postgres_admin"}},
+		},
+		{
+			name:    "no roles at all",
+			dialect: "postgres",
+			roles:   nil,
+		},
+		{
+			name:    "a reserved name on mysql, whose reader excludes nothing",
+			dialect: "mysql",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+		},
+		{
+			name:    "a reserved name with no dialect resolved",
+			dialect: "",
+			roles:   []goschema.Role{{Name: "postgres"}},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Assert(reservedrole.ValidateDeclared(test.dialect, test.roles), qt.IsNil)
+		})
+	}
+}
+
+// TestValidateDeclaredFailurePath is the refusal itself, on every
+// PostgreSQL-family dialect whose reader excludes these names from both of its
+// role reads.
+func TestValidateDeclaredFailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+		roles   []goschema.Role
+		wantErr string
+	}{
+		{
+			name:    "the reserved prefix on postgres",
+			dialect: "postgres",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor" ` +
+				`\(PostgreSQL reserves the "pg_" prefix for system roles and refuses ` +
+				`CREATE ROLE at SQLSTATE 42939\).*`,
+		},
+		{
+			name:    "the bootstrap superuser on postgres",
+			dialect: "postgres",
+			roles:   []goschema.Role{{Name: "postgres"}},
+			wantErr: `.*declares reserved PostgreSQL role "postgres" ` +
+				`\(the bootstrap superuser is not a role Ptah manages, and CREATE ROLE ` +
+				`for a role that already exists fails at SQLSTATE 42710\).*`,
+		},
+		{
+			name:    "both spellings are named at once",
+			dialect: "postgres",
+			roles: []goschema.Role{
+				{Name: "app_user"},
+				{Name: "pg_monitor"},
+				{Name: "postgres"},
+			},
+			wantErr: `.*declares reserved PostgreSQL roles "pg_monitor" \(.*\), "postgres" \(.*\).*`,
+		},
+		{
+			name:    "cockroachdb reads the same catalog",
+			dialect: "cockroachdb",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor".*`,
+		},
+		{
+			name:    "yugabytedb reads the same catalog",
+			dialect: "yugabytedb",
+			roles:   []goschema.Role{{Name: "postgres"}},
+			wantErr: `.*declares reserved PostgreSQL role "postgres".*`,
+		},
+		{
+			name:    "the alias spelling resolves to the same dialect",
+			dialect: "postgresql",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor".*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := reservedrole.ValidateDeclared(test.dialect, test.roles)
+
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(err.Error(), qt.Contains, reservedrole.AllowEnvVar)
+		})
+	}
+}
+
+// TestValidateDeclaredOptInRestoresTheOlderBehavior is the capability half of
+// AGENTS.md: the refusal removes something a user could do, so the fuller
+// behavior stays reachable on the same surface behind a PTAH_ variable rather
+// than being deleted.
+//
+// Measured on PostgreSQL 17.10: on a cluster bootstrapped as "admin" rather
+// than "postgres", CREATE ROLE "postgres" succeeds and the role appears in
+// pg_roles. Refusing it unconditionally would take that away.
+func TestValidateDeclaredOptInRestoresTheOlderBehavior(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "1", value: "1"},
+		{name: "true", value: "true"},
+		{name: "TRUE", value: "TRUE"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Setenv(reservedrole.AllowEnvVar, test.value)
+
+			err := reservedrole.ValidateDeclared("postgres", []goschema.Role{{Name: "postgres"}})
+
+			c.Assert(err, qt.IsNil)
+		})
+	}
+}
+
+// TestValidateDeclaredOptInKeepsTheRefusalForEveryOtherValue mirrors how the
+// other PTAH_ opt-ins read themselves: unset, empty, false and unparsable all
+// keep the default.
+func TestValidateDeclaredOptInKeepsTheRefusalForEveryOtherValue(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name  string
+		value string
+	}{
+		{name: "empty", value: ""},
+		{name: "zero", value: "0"},
+		{name: "false", value: "false"},
+		{name: "unparsable", value: "yes please"},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			c.Setenv(reservedrole.AllowEnvVar, test.value)
+
+			err := reservedrole.ValidateDeclared("postgres", []goschema.Role{{Name: "postgres"}})
+
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+		})
+	}
+}

--- a/migration/schemadiff/internal/compare/compare_roles_test.go
+++ b/migration/schemadiff/internal/compare/compare_roles_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/reservedrole"
 	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
 )
@@ -312,24 +313,33 @@ func TestRolesAnswerIsTheSameWhicheverListTheRoleWasReadInto(t *testing.T) {
 		qt.Commentf("describing a role instead of carrying it out of scope changed the plan"))
 }
 
-func TestRolesReservedNameIsNotComparedAgainstAnything(t *testing.T) {
+func TestRolesReservedNameIsRefusedBeforeThisComparisonRunsAtAll(t *testing.T) {
 	c := qt.New(t)
 
-	// A KNOWN GAP, pinned so it cannot be lost or silently claimed fixed.
+	// This is what TestRolesReservedNameIsNotComparedAgainstAnything pinned as
+	// a known gap, rewritten now that stokaro/ptah#1312 closed it. The behavior
+	// asserted below is UNCHANGED, and deliberately so: the gap was never in
+	// this function, and moving the refusal into it would give the comparator
+	// an error return every caller would have to plumb.
 	//
 	// Roles and RolesOutOfScope partition the roles Ptah MANAGES, not the
 	// cluster's role set: a PostgreSQL reader excludes the reserved pg_ roles
 	// and the bootstrap superuser from both reads, in either direction. So a
-	// desired schema naming one is compared against nothing and is planned as
-	// a CREATE ROLE the server refuses. Measured on PostgreSQL 17.10 with
-	// ptah-compat schema apply --auto-approve: `role "postgres"` exits 1 on
-	// SQLSTATE 42710, `role "pg_monitor"` exits 1 on SQLSTATE 42939, both
-	// identically before and after stokaro/ptah#1267's reader scoping.
+	// reserved name reaching this comparison is compared against nothing and
+	// reads as absent, which is exactly why the declaration has to be refused
+	// before it gets here rather than repaired once it has.
 	//
-	// Refusing such a desired state up front is the right answer and is a
-	// separate change: schemadiff.Compare has no error to return, and the
-	// refusal has to cover the generate path too. When it lands, this test
-	// changes with it.
+	// The refusal lives at the two surfaces that accept a desired schema and
+	// can return an error -- schemadiff.CompareWithDatabaseInfo on the compare
+	// path, and the renderer validation phase migration/planner runs before it
+	// emits any node on the generate path. See
+	// schemadiff.TestCompareWithDatabaseInfoRefusesAReservedRole and
+	// renderer.TestGetOrderedCreateStatementsRefusesAReservedRole.
+	//
+	// The second assertion is what keeps this from becoming decorative: every
+	// name this comparison would read as absent is a name reservedrole.Is
+	// recognizes, so there is no reserved spelling that slips past the refusal
+	// and lands here.
 	generated := &goschema.Database{
 		Roles: []goschema.Role{
 			{Name: "postgres", Login: true, Superuser: true},
@@ -348,6 +358,12 @@ func TestRolesReservedNameIsNotComparedAgainstAnything(t *testing.T) {
 	c.Assert(diff.RolesAdded, qt.DeepEquals, []string{"pg_monitor", "postgres"},
 		qt.Commentf("reserved names are in neither database list, so they read as absent"))
 	c.Assert(diff.RolesModified, qt.HasLen, 0)
+	for _, roleName := range diff.RolesAdded {
+		c.Assert(reservedrole.Is(roleName), qt.IsTrue,
+			qt.Commentf("%q read as absent but the refusal would not have caught it", roleName))
+	}
+	c.Assert(reservedrole.ValidateDeclared("postgres", generated.Roles), qt.IsNotNil,
+		qt.Commentf("the desired schema this comparison received should never have reached it"))
 }
 
 func TestRoleDefinitionsComparison(t *testing.T) {

--- a/migration/schemadiff/internal/compare/roles.go
+++ b/migration/schemadiff/internal/compare/roles.go
@@ -45,14 +45,17 @@ import (
 // The union is not every role the server has, and this comparison must not be
 // described as if it were. A PostgreSQL reader excludes the reserved pg_ roles
 // and the bootstrap superuser from both lists, because Ptah manages neither in
-// either direction. A desired schema naming one of them therefore still lands
-// in RolesAdded and the server still refuses the statement -- measured on
-// PostgreSQL 17.10, `role "postgres"` in the desired state gives
-// `CREATE ROLE "postgres" ...` and SQLSTATE 42710, and `role "pg_monitor"`
-// gives SQLSTATE 42939. That is identical before and after this change;
-// refusing such a desired state up front is a separate change, and until it
-// lands TestRolesReservedNameIsNotComparedAgainstAnything pins the gap so it
-// cannot be lost or silently claimed fixed.
+// either direction, so a reserved name reaching this function would land in
+// RolesAdded and be planned as a statement the server refuses -- measured on
+// PostgreSQL 17.10, `role "postgres"` gave `CREATE ROLE "postgres" ...` and
+// SQLSTATE 42710, and `role "pg_monitor"` gave SQLSTATE 42939.
+//
+// A reserved name therefore never reaches this function: the desired schema is
+// refused first, at the surfaces that accept one and can return an error
+// (stokaro/ptah#1312). This comparison keeps no opinion about reserved names,
+// which is why it still needs no error return. The single definition of
+// "reserved" lives in [go.5x5.cz/ptah/internal/reservedrole], shared with the
+// reader's own exclusion so the two cannot disagree.
 //
 // # Role Modification Detection
 //

--- a/migration/schemadiff/reserved_roles_test.go
+++ b/migration/schemadiff/reserved_roles_test.go
@@ -1,0 +1,155 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/reservedrole"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// postgresInfo is the connection metadata a PostgreSQL comparison carries.
+func postgresInfo() types.DBInfo {
+	return types.DBInfo{Dialect: "postgres", Schema: "public"}
+}
+
+// emptyPostgresDatabase is the target the reproduction used: an empty database
+// whose reader reported no role in either list, which is also what a reader
+// reports for a reserved role that does exist on the server.
+func emptyPostgresDatabase() *types.DBSchema {
+	return &types.DBSchema{
+		Roles:           []types.DBRole{{Name: "app_user", Login: true}},
+		RolesOutOfScope: []types.DBRole{{Name: "other_tenant_user", Login: true}},
+	}
+}
+
+// TestCompareWithDatabaseInfoRefusesAReservedRole is the regression for
+// stokaro/ptah#1312 on the compare path.
+//
+// Reproduced before the fix with ptah-compat schema apply --auto-approve
+// against PostgreSQL 17.10: a desired state declaring role "pg_monitor" printed
+// `CREATE ROLE "pg_monitor" WITH NOLOGIN ...` and then exited 1 on
+// `role name "pg_monitor" is reserved (SQLSTATE 42939)`; declaring role
+// "postgres" printed the same shape and exited 1 on SQLSTATE 42710. Neither
+// name is in DBSchema.Roles or DBSchema.RolesOutOfScope, because the reader
+// excludes both from both reads, so the comparison read them as absent.
+func TestCompareWithDatabaseInfoRefusesAReservedRole(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name    string
+		roles   []goschema.Role
+		wantErr string
+	}{
+		{
+			name:    "the reserved prefix",
+			roles:   []goschema.Role{{Name: "pg_monitor"}},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor".*SQLSTATE 42939.*`,
+		},
+		{
+			name:    "the bootstrap superuser",
+			roles:   []goschema.Role{{Name: "postgres", Login: true, Superuser: true}},
+			wantErr: `.*declares reserved PostgreSQL role "postgres".*SQLSTATE 42710.*`,
+		},
+		{
+			name: "a reserved role alongside ordinary ones",
+			roles: []goschema.Role{
+				{Name: "app_user", Login: true},
+				{Name: "pg_monitor"},
+			},
+			wantErr: `.*declares reserved PostgreSQL role "pg_monitor".*`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				&goschema.Database{Roles: test.roles},
+				emptyPostgresDatabase(),
+				postgresInfo(),
+				nil,
+			)
+
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+			c.Assert(diff, qt.IsNil)
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfoStillComparesAnOrdinaryRole is the control. The
+// refusal must not cost the comparison a role it was always right to plan, and
+// a name that merely starts like a reserved one is an ordinary role
+// (stokaro/ptah#1291).
+func TestCompareWithDatabaseInfoStillComparesAnOrdinaryRole(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name       string
+		roles      []goschema.Role
+		wantAdded  []string
+		wantSynced bool
+	}{
+		{
+			name:      "a role the database does not have is still added",
+			roles:     []goschema.Role{{Name: "brand_new", Login: true}},
+			wantAdded: []string{"brand_new"},
+		},
+		{
+			name:      "pgbouncer is an ordinary role, not a reserved one",
+			roles:     []goschema.Role{{Name: "pgbouncer", Login: true}},
+			wantAdded: []string{"pgbouncer"},
+		},
+		{
+			name:      "postgres_admin is an ordinary role, not the superuser",
+			roles:     []goschema.Role{{Name: "postgres_admin", Login: true}},
+			wantAdded: []string{"postgres_admin"},
+		},
+		{
+			name:       "a role the database already has is not added",
+			roles:      []goschema.Role{{Name: "app_user", Login: true}},
+			wantAdded:  nil,
+			wantSynced: true,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			diff, err := schemadiff.CompareWithDatabaseInfo(
+				&goschema.Database{Roles: test.roles},
+				emptyPostgresDatabase(),
+				postgresInfo(),
+				nil,
+			)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(diff.RolesAdded, qt.DeepEquals, test.wantAdded)
+			c.Assert(diff.RolesModified, qt.HasLen, 0)
+		})
+	}
+}
+
+// TestCompareWithDatabaseInfoOptInPlansTheReservedRoleAnyway pins the
+// capability the refusal would otherwise remove. Measured on PostgreSQL 17.10:
+// against a cluster bootstrapped as "admin" rather than "postgres",
+// CREATE ROLE "postgres" succeeds, so declaring it is something a user could do
+// before the refusal existed and stays reachable behind the variable.
+func TestCompareWithDatabaseInfoOptInPlansTheReservedRoleAnyway(t *testing.T) {
+	c := qt.New(t)
+
+	c.Setenv(reservedrole.AllowEnvVar, "1")
+
+	diff, err := schemadiff.CompareWithDatabaseInfo(
+		&goschema.Database{Roles: []goschema.Role{{Name: "postgres"}, {Name: "pg_monitor"}}},
+		emptyPostgresDatabase(),
+		postgresInfo(),
+		nil,
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(diff.RolesAdded, qt.DeepEquals, []string{"pg_monitor", "postgres"})
+}

--- a/migration/schemadiff/schemadiff.go
+++ b/migration/schemadiff/schemadiff.go
@@ -12,6 +12,7 @@ import (
 	"go.5x5.cz/ptah/core/ptaherr"
 	"go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
+	"go.5x5.cz/ptah/internal/reservedrole"
 	"go.5x5.cz/ptah/migration/internal/identifiervalidation"
 	"go.5x5.cz/ptah/migration/schemadiff/internal/compare"
 	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
@@ -52,6 +53,15 @@ func CompareWithDatabaseInfo(
 		merged.IgnoredExtensions = slices.Clone(opts.IgnoredExtensions)
 	}
 	merged.Dialect = info.Dialect
+	// A reserved PostgreSQL role is in neither DBSchema.Roles nor
+	// DBSchema.RolesOutOfScope, so comparing it would read it as absent and
+	// plan a CREATE ROLE the server always refuses. Refuse the declaration
+	// here instead, before anything is compared (stokaro/ptah#1312).
+	if generated != nil {
+		if err := reservedrole.ValidateDeclared(info.Dialect, generated.Roles); err != nil {
+			return nil, err
+		}
+	}
 	generated = fromschema.AssignDefaultForeignKeyNames(generated, info.Dialect)
 	semantics := info.IdentifierSemantics.Normalize(info.Dialect)
 	if !info.IdentifierSemantics.IsZero() &&


### PR DESCRIPTION
`GENERAL CAPABILITY`

The semantic implementation lives in `internal/reservedrole`, below the CLI layer. Native `ptah` reaches it through `ptah schema render`, `ptah schema compare`, `ptah migrate` and every other verb that compares or plans; `ptah-compat` reaches the same package through the same two seams. No flag was added on either surface.

## Reproduced first, before any code was touched

PostgreSQL 17.10 in a private container (`postgres:17.10`, own port, removed afterwards), `ptah_user` created `LOGIN SUPERUSER` and both databases owned by it — the CI shape. Desired state is a schema file declaring one role and nothing else; target is an empty database. `ptah-compat` built from `master`.

```
$ ptah-compat schema apply --auto-approve --url ".../ptah_test" \
    --to file://reserved_prefix.hcl --dev-url ".../ptah_dev"
Planned schema changes:
CREATE ROLE "pg_monitor" WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
Error: dev database simulation failed during plan: failed to execute SQL statement: SQL execution
failed: ERROR: role name "pg_monitor" is reserved (SQLSTATE 42939)
EXIT=1

$ ptah-compat schema apply --auto-approve ... --to file://bootstrap_superuser.hcl ...
Planned schema changes:
CREATE ROLE "postgres" WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
Error: ... ERROR: role "postgres" already exists (SQLSTATE 42710)
EXIT=1
```

The worse one is `schema diff`, which does not touch the target at all and so never learns the statement is impossible:

```
$ ptah-compat schema diff --from file://normal_role.hcl --to file://reserved_prefix.hcl --dev-url ...
CREATE ROLE "pg_monitor" WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
EXIT=0
```

That statement is what a user would paste into a migration file. It cannot succeed anywhere.

The cause is the one #1312 names: `queryRoles` excludes the `pg_` prefix and the bootstrap superuser from **both** of its reads, so a reserved name is in neither `DBSchema.Roles` nor `DBSchema.RolesOutOfScope`. Those two lists partition the roles Ptah manages, not the catalog, and the comparator takes existence from their union — so a reserved name reads as absent, and absent means `CREATE ROLE`.

## What the pinned community binary does

`/Users/buster/Work/denis/ptah-atlas-conformance/bin/atlas`, self-reporting `atlas community version v1.3.0`, against the same cluster with its own pair of databases:

| desired state | pinned binary |
| --- | --- |
| `role "pg_monitor" { inherit = true }`, `schema apply --auto-approve` | `Schema is synced, no changes to be made` — **exit 0** |
| `role "pg_monitor" { inherit = true }`, `schema diff` | `Schemas are synced, no changes to be made.` — **exit 0** |
| `zzz_not_a_real_object "zzz_nonsense" { inherit = true }` (control), `schema apply --auto-approve` | `Schema is synced, no changes to be made` — **exit 0** |

The control is the reason the first two rows are not evidence of acceptance: the pinned binary answers identically for a block type that does not exist, so `role` is not a block it models — it is dropped by a permissive HCL parser, not understood. Ptah models roles and the pinned binary does not, so there is no behavior here to match.

Policy (a) — `ptah-compat` must never exit 0 where the pinned binary exits 1 — is untouched in the direction that matters: the pinned binary exits 0, and refusing makes Ptah **stricter**. That is the "never be looser" half of AGENTS.md, and the answer it already gives for a construct Ptah cannot carry out: refuse loudly rather than accept and ignore.

## The fix

**One definition of "reserved"**, in `internal/reservedrole`. The package exports the Go predicate the refusal tests with **and renders the SQL fragment the reader embeds**, both from the same two constants, so the read and the refusal cannot drift into disagreeing:

```go
reservedrole.ExcludeSQL("r.rolname")
// r.rolname NOT LIKE 'pg\_%' ESCAPE '\' AND r.rolname != 'postgres'
```

`queryRoles` now uses that rather than spelling the exclusion out. The pattern's underscore escape is derived from the prefix constant rather than typed, which is the class of bug #1291 had to fix at seven SQL sites.

The Go side is a plain prefix test on the literal `pg_`, never a `LIKE`. Measured on the same server, both of these succeed, which is exactly why:

```
CREATE ROLE "PG_upper";   -- CREATE ROLE   (the reservation is case-sensitive)
CREATE ROLE "pgbouncer";  -- CREATE ROLE   (the underscore is not a wildcard)
```

**Two refusal seams**, both already returning an error, and both ahead of any statement:

- `schemadiff.CompareWithDatabaseInfo` — the compare path. Every database-backed comparison reaches it through `CompareWithDatabase`.
- `renderer.prepareDatabaseForRendering` — the generate path. `migration/planner` calls `renderer.ValidateSchemaWithCapabilities` before it emits a single AST node, and whole-schema rendering runs the same phase, so this one seam covers `ptah schema render`, `ptah-compat schema diff`, and any library caller of `schemadiff.Compare` who then plans.

Both spellings are covered and named separately, because they fail for different reasons and a check that knew only one would let the other through. It is gated to PostgreSQL-family dialects, which are exactly the ones whose reader excludes these names and whose renderer emits `CREATE ROLE`.

After:

```
$ ptah-compat schema apply --auto-approve ... --to file://reserved_prefix.hcl ...
Error: compare database schema: invalid schema diff: desired schema declares reserved PostgreSQL
role "pg_monitor" (PostgreSQL reserves the "pg_" prefix for system roles and refuses CREATE ROLE at
SQLSTATE 42939); Ptah manages reserved roles in neither direction, so the declaration is compared
against nothing and would be planned as a CREATE ROLE the server refuses; rename the role, or set
PTAH_ALLOW_RESERVED_ROLE_NAMES=1 to plan it anyway
EXIT=1

$ ptah-compat schema diff --from file://normal_role.hcl --to file://reserved_prefix.hcl --dev-url ...
Error: generate schema diff SQL: invalid schema diff: desired schema declares reserved PostgreSQL role "pg_monitor" ...
EXIT=1

$ ptah schema render --schema-file reserved_prefix.hcl --dialect postgres
error: error rendering postgres schema: invalid schema diff: desired schema declares reserved
PostgreSQL role "pg_monitor" ...
EXIT=2
```

No statement is planned or printed in any of them.

## The capability the refusal removes, kept rather than deleted

`pg_` never succeeds anywhere. `postgres` does. Measured on a **second** PostgreSQL 17.10 cluster bootstrapped as `admin` rather than `postgres`:

```
$ psql -U admin -c "SELECT rolname FROM pg_roles WHERE rolname='postgres';"
(0 rows)
$ psql -U admin -c 'CREATE ROLE "postgres" WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;'
CREATE ROLE
$ psql -U admin -c "SELECT rolname FROM pg_roles WHERE rolname='postgres';"
 postgres
```

Ptah planned that statement before this change, and its own dev materialization executed it successfully on that cluster. So the refusal takes something away, and AGENTS.md does not allow that to be the end of the story. `PTAH_ALLOW_RESERVED_ROLE_NAMES=1` restores the older behavior on the same surface:

```
$ PTAH_ALLOW_RESERVED_ROLE_NAMES=1 ptah-compat schema apply --dry-run \
    --url ".../ptah_test" --to file://bootstrap_superuser.hcl --dev-url ".../ptah_dev"   # cluster bootstrapped as admin
Planned schema changes:
CREATE ROLE "postgres" WITH NOLOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT NOREPLICATION;
EXIT=0
```

An environment variable and not a flag, because the conformance `cli-surface` tier asserts flag parity — `ptah-compat schema apply --help` is byte-identical before and after apart from the binary's own name. It decides only whether Ptah refuses first or the server does: both reads are untouched, so a `pg_` name still fails at the server with the variable set (verified: exit 1, SQLSTATE 42939).

## `compare.Roles` is unchanged, deliberately

#1312 anticipated a signature change across `schemadiff.Compare`'s callers. It turned out not to be needed and not to be right: the gap was never inside that function. A reserved name no longer reaches it, so it still needs no error return, and `Compare`'s signature is untouched.

`TestRolesReservedNameIsNotComparedAgainstAnything` is rewritten rather than deleted, as the issue requires. It is now `TestRolesReservedNameIsRefusedBeforeThisComparisonRunsAtAll`, asserts the same unchanged behavior, and adds the assertion that keeps it from being decorative: every name the comparison would read as absent is one `reservedrole.Is` recognizes, so no reserved spelling can slip past the refusal and land there.

## Red/green

Mutation 1 — `reservedrole.Is` always false:

```
--- FAIL: TestIsRecognizesBothSpellingsTheServerRefuses (4 subtests)
--- FAIL: TestValidateDeclaredFailurePath (6 subtests)
--- FAIL: TestValidateDeclaredOptInKeepsTheRefusalForEveryOtherValue (4 subtests)
--- FAIL: TestGetOrderedCreateStatementsRefusesAReservedRole (2 subtests)
--- FAIL: TestValidateSchemaRefusesAReservedRole
--- FAIL: TestCompareWithDatabaseInfoRefusesAReservedRole (3 subtests)
--- FAIL: TestRolesReservedNameIsRefusedBeforeThisComparisonRunsAtAll
FAIL  internal/reservedrole, core/renderer, migration/schemadiff, migration/schemadiff/internal/compare
```

Mutation 2 — drop the `_` from the escaped LIKE metacharacters:

```
--- FAIL: TestExcludeSQLEscapesTheUnderscore
--- FAIL: TestReadRolesKeepsOrdinaryRolesTheReservedPrefixWouldSwallow (2 subtests)
--- FAIL: TestReadRolesPartitionsEveryManageableRole (4 subtests)
--- FAIL: TestReadRolesOutOfScopeReportsWhatTheDescriptionLeavesOut (3 subtests)
   ... and 4 more in internal/dbschema/postgres
```

The second mutation reddening the existing #1291 guards is the proof that the reader really consumes the rendered fragment rather than a copy of it.

Restored, all green. Controls, which must not move:

- `CompareWithDatabaseInfo` still adds `brand_new`, `pgbouncer` and `postgres_admin` to `RolesAdded`, and still adds nothing for a role the database already has.
- `GetOrderedCreateStatements` still renders `CREATE ROLE "app_user" ...` and `CREATE ROLE "pgbouncer" ...` byte for byte.
- Live: `ptah-compat schema apply --dry-run` with `role "app_user"` plans `CREATE ROLE "app_user" ...` at exit 0, and `ptah schema render` emits it at exit 0.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci`, `build`, and every `check:*` script incl. selftests | 0 |
| every package this change touches, `-count=1` | 0 |

`go test ./...` exits 1 on this machine, in `cmd/atlas`, `cmd/ptah-ls` and `cmd/viz`, on `panic: test timed out after 10m0s`, `process did not exit within 20s` and `signal: killed`. Nine other `go test` invocations were running concurrently on the same host. **Measured on `master` with this branch's changes absent, the same packages fail identically at exit 1**, so these are host contention rather than a regression. No package this change touches is among them.

## Documentation

- `docs/POSTGRESQL_ROLES.md` gains a "Reserved Role Names" section.
- `docs/site/.../databases/postgresql.md`: the paragraph that described the refusal as a known gap now describes the refusal.
- `docs/site/.../atlas/overview.md`: `PTAH_ALLOW_RESERVED_ROLE_NAMES` added to the environment-variable catalog.
- `dbschema/types/types.go`, `compare/roles.go`, `postgres/reader.go` and the two tests that cross-referenced the pinned gap are updated so nothing still claims it is open.

## Residual risk

- `schemadiff.Compare`, `CompareWithOptions` and `CompareWithDialect` still return a diff containing the reserved name in `RolesAdded`. Nothing turns that into SQL without the planner, which refuses — but a library consumer reading `RolesAdded` directly and rendering it themselves would not be stopped. Giving those three an error return is a public API change that buys little; it is noted rather than done.
- The dialect gate uses `platform.IsPostgresFamily`, which includes Spanner. Spanner is served by the PostgreSQL renderer, so it would have emitted the same rejected statement, but the reservation itself was measured on PostgreSQL only.
- The reserved-role and dev-materialization interaction is unchanged: with the opt-in set, a reserved role planned against a cluster that has it still fails at the server, exactly as before.

Closes #1312