### PR TITLE
Refuse an up run over an index PostgreSQL cannot use (#1101)

### DIFF
--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -924,9 +924,10 @@ parent-traversal path, and a plain relative name that resolves out of the
 directory through a symbolic link. The refusal names which of the three applies
 and points at `getenv()` for passing a value in from outside.
 
-This is the one place `ptah-compat` is deliberately stricter than the binary it
-replaces, and it is stricter rather than looser, so it cannot exit 0 where the
-binary exits 1. The reason is that an `atlas.hcl` is usually repository-controlled
+This is one of two places `ptah-compat` is deliberately stricter than the binary
+it replaces — the other is the invalid-index refusal below — and it is stricter
+rather than looser, so it cannot exit 0 where the binary exits 1. The reason is
+that an `atlas.hcl` is usually repository-controlled
 and `file()` is evaluated before anything is applied: without confinement, a
 config file arriving in a pull request can read any file the process can and
 place the contents somewhere observable, such as a database URL or an error
@@ -940,6 +941,37 @@ scenarios in the conformance repository, so the day a community build starts
 confining `file()` the gate goes red and this divergence can be retired.
 
 **Tracking.** [`stokaro/ptah#1042`](https://github.com/stokaro/ptah/issues/1042)
+
+### A migration that would be recorded over an invalid index
+
+**Type.** Deliberate divergence
+
+**Current boundary.** On PostgreSQL, `ptah-compat migrate apply` refuses a
+migration while an index that migration creates is reported unusable by
+`pg_index` (`indisvalid` or `indisready` false). The pinned community binary
+v1.3.0 applies it and records it.
+
+Measured on PostgreSQL 17.10, identical fixture on both: a `members` table whose
+duplicate rows made an earlier `CREATE UNIQUE INDEX CONCURRENTLY` fail, the
+duplicates then removed, and one migration carrying `-- atlas:txmode none` and
+the same `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` statement.
+
+| | pinned community binary v1.3.0 | `ptah-compat` |
+| --- | --- | --- |
+| `migrate apply --allow-dirty` | exit `0`, `-- ok`, 1 statement | exit `1`, names the index and `REINDEX` |
+| `pg_index` afterwards | `indisvalid=f`, `indisready=f` | unchanged, nothing written |
+| revision row afterwards | `20260808000001` applied 1/1, no error | no row |
+| duplicate `INSERT` afterwards | accepted, 2 rows share the email | n/a |
+| after `REINDEX INDEX CONCURRENTLY` | n/a | exit `0`, `indisvalid=t`, row recorded, duplicate rejected |
+
+The leftover keeps the name, so `IF NOT EXISTS` skips it and the statement
+reports success over an index that enforces nothing. Recording that as applied
+means the tooling reports a constraint the database does not have, and nothing
+will look again. The divergence is stricter, not looser: `ptah-compat` exits `1`
+where the binary exits `0`, never the reverse, so no invocation the binary
+refuses succeeds here.
+
+**Tracking.** [`stokaro/ptah#1101`](https://github.com/stokaro/ptah/issues/1101)
 
 A green docs build only proves the documentation site builds and internal links
 resolve. It is not parity evidence. Use the conformance reports for measured

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -303,12 +303,25 @@ statement's outcome as unknown. Inspect the database before repair. Ptah
 rejects `repair --resume-from` while this marker is present because the SQL may
 already have committed.
 
-**A concurrent index build failed on PostgreSQL.** The invalid index left
-behind keeps the name, so retrying the generated `IF NOT EXISTS` statement is
-skipped rather than retried and reports no error. Ptah refuses to repair the
-migration while the index is unusable and names the `REINDEX INDEX
-CONCURRENTLY` that rebuilds it — `--force` does not bypass that refusal. See
-[Maintain migration history](../maintain-history/).
+**A concurrent index build failed on PostgreSQL** (exit `2`). The invalid index
+left behind keeps the name, so re-issuing the generated `IF NOT EXISTS`
+statement is skipped rather than retried and reports no error. Ptah refuses to
+run the migration while an index it creates is unusable, and names the `REINDEX
+INDEX CONCURRENTLY` that rebuilds it:
+
+```text
+error: error running migrations: migration 1785756328 cannot be applied: PostgreSQL reports index "public"."idx_members_email" (indisvalid=false, indisready=false) unusable, and CREATE INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, so this run would record the migration applied over a constraint that is not enforced; run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", or drop the index, then run the migration again
+```
+
+`--allow-dirty` does not bypass this — retrying the body is what the refusal is
+about. An invalid *unique* index enforces nothing, so without the refusal the
+run would exit `0`, report the database up to date, and keep accepting duplicate
+rows. Rebuild the index with the `REINDEX` the message names, or drop it so the
+name is free and the statement builds it, then run again. Only indexes the
+migration itself creates are checked, and only on PostgreSQL; other dialects
+have no concurrent index build to leave half-finished. A dry run is exempt,
+because it records nothing. `ptah migrations repair` refuses on the same
+grounds — see [Maintain migration history](../maintain-history/).
 
 **A pre-migration check blocked the migration.** Nothing is applied and no
 revision row is written, so the run is recorded as never started. Fix the data

--- a/docs/site/src/content/docs/versioned/maintain-history.md
+++ b/docs/site/src/content/docs/versioned/maintain-history.md
@@ -214,6 +214,9 @@ is `REINDEX`. Only indexes the migration itself creates are checked, so an
 unrelated invalid index elsewhere never blocks a repair. Other dialects have no
 concurrent index build to leave half-finished and are unaffected.
 
+`ptah migrations up` refuses on the same grounds, so `--allow-dirty` cannot be
+used to walk past it either. See [Apply migrations](../apply/#failure-modes).
+
 ## Set the revision boundary (set)
 
 `repair` fixes one dirty row and `baseline` only records existing history as

--- a/integration/gonative/retry_invalid_index_integration_test.go
+++ b/integration/gonative/retry_invalid_index_integration_test.go
@@ -1,0 +1,461 @@
+//go:build integration
+
+package gonative_test
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// A failed CREATE INDEX CONCURRENTLY leaves an invalid index occupying the
+// name, and `migrations up --allow-dirty` re-runs the body over the dirty row
+// the failure left. The generated statement carries IF NOT EXISTS, so the
+// leftover is skipped rather than rebuilt, nothing errors, and the run used to
+// clear the dirty state over an object PostgreSQL will not use. These tests pin
+// what the up path does with that residue, on both halves of the issue -- a
+// unique index whose constraint is then unenforced, and a plain index that is
+// simply never built -- on the same residue reached without a dirty row at all,
+// and on the control where the index is usable and the run has to finish the
+// migration as it always did.
+const (
+	retryInvalidIndexTable   = "ptah_issue1101_retry_members"
+	retryPartitionedTable    = "ptah_issue1101_retry_events"
+	retryInvalidIndexMarker  = "ptah_issue1101_retry_marker"
+	retryInvalidUniqueIndex  = "idx_ptah_issue1101_retry_email"
+	retryInvalidPlainIndex   = "idx_ptah_issue1101_retry_ratio"
+	retryInvalidIndexTracker = "schema_migrations_issue_1101_retry"
+	retryInvalidIndexVersion = int64(1785756329)
+)
+
+// TestPostgreSQLAllowDirtyRetryRefusesOverInvalidUniqueIndexIntegration is the
+// reproduction from the issue, driven through the retry path rather than
+// through repair. The measurement that matters is the last one: a write that
+// duplicates an existing email is accepted while the index is invalid and
+// rejected once it is rebuilt, so the fixture is testing whether the index
+// enforces anything, not whether it exists.
+func TestPostgreSQLAllowDirtyRetryRefusesOverInvalidUniqueIndexIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryInvalidIndexTable(c, db, "'shared@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryInvalidUniqueIndexMigrator(conn)
+
+	// The concurrent build fails on the duplicates and leaves the index behind.
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, "(?s).*could not create unique index.*")
+	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidUniqueIndex)
+	c.Assert(valid, qt.IsFalse)
+	c.Assert(ready, qt.IsFalse)
+	failed := retryInvalidIndexDirtyRevision(c, ctx, mig)
+
+	// The operator fixes the data that broke the build and reaches for the
+	// documented recovery flag instead of repair.
+	_, err = db.ExecContext(ctx, "DELETE FROM "+retryInvalidIndexTable+" WHERE id > 1")
+	c.Assert(err, qt.IsNil)
+
+	err = mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `"public"."`+retryInvalidUniqueIndex+`"`)
+	c.Assert(err.Error(), qt.Contains, "indisvalid=false, indisready=false")
+	c.Assert(err.Error(), qt.Contains, "REINDEX INDEX CONCURRENTLY")
+	c.Assert(err.Error(), qt.Contains, "cannot be applied")
+
+	// The refusal reads the catalog and writes nothing, so the row still carries
+	// the failure that produced it and the progress a later retry resumes from.
+	c.Assert(retryInvalidIndexDirtyRevision(c, ctx, mig), qt.DeepEquals, failed)
+
+	// Why refusing is the conservative direction: nothing is enforced yet.
+	c.Assert(retryInvalidIndexDuplicateInsert(ctx, db), qt.IsNil)
+	_, err = db.ExecContext(ctx, "DELETE FROM "+retryInvalidIndexTable+" WHERE id > 1")
+	c.Assert(err, qt.IsNil)
+
+	// Rebuilding the index is the escape hatch the refusal names, and it works.
+	_, err = db.ExecContext(ctx, `REINDEX INDEX CONCURRENTLY "public"."`+retryInvalidUniqueIndex+`"`)
+	c.Assert(err, qt.IsNil)
+	valid, ready = retryInvalidIndexFlags(c, db, retryInvalidUniqueIndex)
+	c.Assert(valid, qt.IsTrue)
+	c.Assert(ready, qt.IsTrue)
+
+	c.Assert(mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{retryInvalidIndexVersion})
+	c.Assert(retryInvalidIndexDuplicateInsert(ctx, db), qt.IsNotNil)
+}
+
+// TestPostgreSQLAllowDirtyRetryRefusesOverInvalidPlainIndexIntegration is the
+// other half. A plain index carries no constraint, so nothing about a write can
+// reveal that it was never built -- the migration claims an access path the
+// planner can never use, and the only witness is the catalog. The build is made
+// to fail on an expression that divides by zero for one row, which is the
+// deterministic way to leave a non-unique index invalid.
+func TestPostgreSQLAllowDirtyRetryRefusesOverInvalidPlainIndexIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryInvalidIndexTable(c, db, "'user' || g || '@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryInvalidPlainIndexMigrator(conn)
+
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, "(?s).*division by zero.*")
+	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
+	c.Assert(valid, qt.IsFalse)
+	c.Assert(ready, qt.IsFalse)
+	unique := retryInvalidIndexUnique(c, db, retryInvalidPlainIndex)
+	c.Assert(unique, qt.IsFalse)
+	failed := retryInvalidIndexDirtyRevision(c, ctx, mig)
+
+	_, err = db.ExecContext(ctx, "DELETE FROM "+retryInvalidIndexTable+" WHERE id = 3")
+	c.Assert(err, qt.IsNil)
+
+	err = mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `"public"."`+retryInvalidPlainIndex+`"`)
+	c.Assert(err.Error(), qt.Contains, "indisvalid=false, indisready=false")
+	c.Assert(retryInvalidIndexDirtyRevision(c, ctx, mig), qt.DeepEquals, failed)
+
+	// Dropping the leftover is the refusal's other named remedy: with the name
+	// free, IF NOT EXISTS no longer skips and the retry actually builds it.
+	_, err = db.ExecContext(ctx, `DROP INDEX "public"."`+retryInvalidPlainIndex+`"`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+	valid, ready = retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
+	c.Assert(valid, qt.IsTrue)
+	c.Assert(ready, qt.IsTrue)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{retryInvalidIndexVersion})
+}
+
+// TestPostgreSQLAllowDirtyRetryOverValidIndexStillAppliesIntegration is the
+// discriminating control. It is a retry over a dirty row -- the same path both
+// refusals travel -- where the index the migration creates was built and is
+// usable, and the failure was in a later statement. The retry has to resume,
+// finish, and record the migration applied. A probe that refused whenever a
+// migration mentions an index, or whenever a revision row is dirty, fails here.
+func TestPostgreSQLAllowDirtyRetryOverValidIndexStillAppliesIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryInvalidIndexTable(c, db, "'user' || g || '@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryValidIndexThenFailureMigrator(conn)
+
+	// Statement 1 builds the index and commits; statement 2 writes to a table
+	// that does not exist yet and fails.
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, "(?s).*"+retryInvalidIndexMarker+".*")
+	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidUniqueIndex)
+	c.Assert(valid, qt.IsTrue)
+	c.Assert(ready, qt.IsTrue)
+	failed := retryInvalidIndexDirtyRevision(c, ctx, mig)
+	c.Assert(failed.Applied, qt.Equals, 1)
+	c.Assert(failed.Total, qt.Equals, 2)
+
+	// The operator creates the missing table and retries.
+	_, err = db.ExecContext(ctx, "CREATE TABLE "+retryInvalidIndexMarker+" (id INTEGER PRIMARY KEY)")
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{retryInvalidIndexVersion})
+	c.Assert(retryInvalidIndexDuplicateInsert(ctx, db), qt.IsNotNil)
+}
+
+// TestPostgreSQLFirstAttemptRefusesOverPreexistingInvalidIndexIntegration is
+// the same defect reached with no dirty row anywhere.
+//
+// The residue here was not left by a run this migrator is finishing: the index
+// was built by hand and failed, which is also what a restored dump or a revision
+// row cleaned up out of band leaves behind. The migration has never been
+// attempted, so nothing about the revision table hints that anything is wrong --
+// and IF NOT EXISTS skips the leftover exactly as it does on a retry. Scope the
+// refusal to a dirty retry and this test is what goes red: measured on that
+// shape, the run exits 0, records the migration applied, and accepts a duplicate
+// write.
+func TestPostgreSQLFirstAttemptRefusesOverPreexistingInvalidIndexIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryInvalidIndexTable(c, db, "'shared@example.com'")
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryInvalidUniqueIndexMigrator(conn)
+
+	// Nothing here goes through the migrator: the build and its failure happen
+	// out of band, so no revision row exists for the version at all.
+	_, err = db.ExecContext(ctx, fmt.Sprintf(
+		"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q (%q)",
+		retryInvalidUniqueIndex, retryInvalidIndexTable, "email",
+	))
+	c.Assert(err, qt.IsNotNil)
+	_, err = db.ExecContext(ctx, "DELETE FROM "+retryInvalidIndexTable+" WHERE id > 1")
+	c.Assert(err, qt.IsNil)
+	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidUniqueIndex)
+	c.Assert(valid, qt.IsFalse)
+	c.Assert(ready, qt.IsFalse)
+
+	// A dry run is exempt. It records nothing, so it has nothing to be wrong
+	// about, and no surface's dry-run exit code was measured for this refusal.
+	dryConn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(dryConn.Close(), qt.IsNil) })
+	dryConn.SchemaWriter().SetDryRun(true)
+	c.Assert(retryInvalidUniqueIndexMigrator(dryConn).MigrateUp(ctx), qt.IsNil)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, `"public"."`+retryInvalidUniqueIndex+`"`)
+	c.Assert(err.Error(), qt.Contains, "cannot be applied")
+
+	// Refusing before any bookkeeping means the revision table is untouched:
+	// this is a migration that was never started, not one that failed.
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.HasLen, 0)
+
+	// And the remedy still gets the operator all the way through.
+	_, err = db.ExecContext(ctx, `REINDEX INDEX CONCURRENTLY "public"."`+retryInvalidUniqueIndex+`"`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	c.Assert(retryInvalidIndexDuplicateInsert(ctx, db), qt.IsNotNil)
+}
+
+// TestPostgreSQLFirstAttemptOverPartitionedParentIndexStillAppliesIntegration
+// pins that an index which is deliberately invalid does not block the migration
+// that creates it.
+//
+// CREATE INDEX ... ON ONLY a partitioned parent is the documented way to build a
+// partitioned index without locking every partition at once, and PostgreSQL
+// marks the parent invalid on purpose until an index is attached for every
+// partition -- measured here as relkind='I', indisvalid=false, indisready=true.
+// The probe runs before the body, so the index it asks about does not exist yet
+// and the migration applies.
+//
+// The limit is honest, and this test does not pin it: a migration in this shape
+// that failed on a later statement and was run again WOULD be refused, because
+// by then the parent index exists and is invalid. The operator would have to
+// finish or drop it first. Telling a partitioned parent apart from residue is
+// stokaro/ptah#997's partitioned-parent awareness, which is measured there
+// rather than guessed at here.
+func TestPostgreSQLFirstAttemptOverPartitionedParentIndexStillAppliesIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryPartitionedTable(c, db)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryPartitionedParentIndexMigrator(conn)
+
+	c.Assert(mig.MigrateUp(ctx), qt.IsNil)
+	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
+	c.Assert(valid, qt.IsFalse)
+	c.Assert(ready, qt.IsTrue)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{retryInvalidIndexVersion})
+}
+
+func retryInvalidUniqueIndexMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"-- +ptah no_transaction\nCREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q (%q);",
+		retryInvalidUniqueIndex, retryInvalidIndexTable, "email",
+	)
+	down := fmt.Sprintf("-- +ptah no_transaction\nDROP INDEX IF EXISTS %q;", retryInvalidUniqueIndex)
+	return retryInvalidIndexMigrator(conn, up, down)
+}
+
+func retryInvalidPlainIndexMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"-- +ptah no_transaction\nCREATE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q ((10 / (id - 3)));",
+		retryInvalidPlainIndex, retryInvalidIndexTable,
+	)
+	down := fmt.Sprintf("-- +ptah no_transaction\nDROP INDEX IF EXISTS %q;", retryInvalidPlainIndex)
+	return retryInvalidIndexMigrator(conn, up, down)
+}
+
+// retryValidIndexThenFailureMigrator builds the control's two-statement body:
+// an index build that succeeds, then a statement that fails for a reason the
+// operator can fix without touching the index.
+func retryValidIndexThenFailureMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"-- +ptah no_transaction\nCREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q (%q);\nINSERT INTO %s (id) VALUES (1);",
+		retryInvalidUniqueIndex, retryInvalidIndexTable, "email", retryInvalidIndexMarker,
+	)
+	down := fmt.Sprintf(
+		"-- +ptah no_transaction\nDELETE FROM %s WHERE id = 1;\nDROP INDEX IF EXISTS %q;",
+		retryInvalidIndexMarker, retryInvalidUniqueIndex,
+	)
+	return retryInvalidIndexMigrator(conn, up, down)
+}
+
+func retryPartitionedParentIndexMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"CREATE INDEX IF NOT EXISTS %q ON ONLY %q (%q);",
+		retryInvalidPlainIndex, retryPartitionedTable, "email",
+	)
+	down := fmt.Sprintf("DROP INDEX IF EXISTS %q;", retryInvalidPlainIndex)
+	return retryInvalidIndexMigrator(conn, up, down)
+}
+
+func retryInvalidIndexMigrator(conn *dbschema.DatabaseConnection, up, down string) *migrator.Migrator {
+	migration := migrator.CreateMigrationFromSQL(retryInvalidIndexVersion, "add unique email", up, down)
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migration)).
+		WithMigrationsTable("", retryInvalidIndexTracker)
+}
+
+func openRetryInvalidIndexDB(c *qt.C, dsn string) *sql.DB {
+	c.Helper()
+	db, err := sql.Open("pgx", dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(db.Close(), qt.IsNil) })
+	return db
+}
+
+// seedRetryInvalidIndexTable rebuilds the fixture from scratch so a previous run
+// cannot decide this one's outcome. emailExpr is evaluated per generated row: a
+// constant produces the duplicates that break a unique build, and an expression
+// over g produces distinct values that let it succeed.
+func seedRetryInvalidIndexTable(c *qt.C, db *sql.DB, emailExpr string) {
+	c.Helper()
+	cleanup := func() {
+		for _, table := range []string{retryInvalidIndexTable, retryInvalidIndexMarker, retryInvalidIndexTracker} {
+			_, err := db.Exec("DROP TABLE IF EXISTS " + table + " CASCADE")
+			c.Check(err, qt.IsNil)
+		}
+	}
+	cleanup()
+	c.Cleanup(cleanup)
+
+	_, err := db.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, email TEXT NOT NULL)", retryInvalidIndexTable,
+	))
+	c.Assert(err, qt.IsNil)
+	// PostgreSQL only picks a concurrent-build-worthy plan on a table it knows
+	// has rows, so the seed is populated and analyzed before the migration runs.
+	_, err = db.Exec(fmt.Sprintf(
+		"INSERT INTO %s SELECT g, %s FROM generate_series(1, 5000) g", retryInvalidIndexTable, emailExpr,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec("ANALYZE " + retryInvalidIndexTable)
+	c.Assert(err, qt.IsNil)
+}
+
+// seedRetryPartitionedTable builds a partitioned table with one partition, which
+// is what makes CREATE INDEX ... ON ONLY leave a deliberately invalid parent.
+func seedRetryPartitionedTable(c *qt.C, db *sql.DB) {
+	c.Helper()
+	cleanup := func() {
+		for _, table := range []string{retryPartitionedTable, retryInvalidIndexTracker} {
+			_, err := db.Exec("DROP TABLE IF EXISTS " + table + " CASCADE")
+			c.Check(err, qt.IsNil)
+		}
+	}
+	cleanup()
+	c.Cleanup(cleanup)
+
+	_, err := db.Exec(fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER, email TEXT NOT NULL) PARTITION BY RANGE (id)", retryPartitionedTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec(fmt.Sprintf(
+		"CREATE TABLE %s_p1 PARTITION OF %s FOR VALUES FROM (1) TO (100)",
+		retryPartitionedTable, retryPartitionedTable,
+	))
+	c.Assert(err, qt.IsNil)
+}
+
+func retryInvalidIndexFlags(c *qt.C, db *sql.DB, name string) (valid, ready bool) {
+	c.Helper()
+	err := db.QueryRow(`
+		SELECT ix.indisvalid, ix.indisready
+		FROM pg_index ix
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_class t ON t.oid = ix.indrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE n.nspname = 'public' AND i.relname = $1`,
+		name,
+	).Scan(&valid, &ready)
+	c.Assert(err, qt.IsNil)
+	return valid, ready
+}
+
+func retryInvalidIndexUnique(c *qt.C, db *sql.DB, name string) bool {
+	c.Helper()
+	var unique bool
+	err := db.QueryRow(`
+		SELECT ix.indisunique
+		FROM pg_index ix
+		JOIN pg_class i ON i.oid = ix.indexrelid
+		JOIN pg_class t ON t.oid = ix.indrelid
+		JOIN pg_namespace n ON n.oid = t.relnamespace
+		WHERE n.nspname = 'public' AND i.relname = $1`,
+		name,
+	).Scan(&unique)
+	c.Assert(err, qt.IsNil)
+	return unique
+}
+
+// retryInvalidIndexDirtyRevision returns the dirty row as the status command
+// reports it, so a later call can assert the refusal left it alone. Timings are
+// blanked because a revision that was not rewritten still reports the wall clock
+// the failing attempt took, which no assertion should depend on.
+func retryInvalidIndexDirtyRevision(c *qt.C, ctx context.Context, mig *migrator.Migrator) migrator.MigrationRevision {
+	c.Helper()
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+	revision := *status.DirtyRevision
+	revision.ExecutionTime = 0
+	revision.AppliedAt = revision.AppliedAt.UTC().Truncate(0)
+	return revision
+}
+
+// retryInvalidIndexDuplicateInsert returns the error PostgreSQL raises for a
+// second row carrying an email that already exists, or nil when the write is
+// accepted. Nil is the shape of the defect: the index exists and the migration
+// is recorded applied while enforcing nothing.
+func retryInvalidIndexDuplicateInsert(ctx context.Context, db *sql.DB) error {
+	_, err := db.ExecContext(ctx, fmt.Sprintf(
+		"INSERT INTO %s (id, email) SELECT 999999, email FROM %s ORDER BY id LIMIT 1",
+		retryInvalidIndexTable, retryInvalidIndexTable,
+	))
+	return err
+}

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -711,6 +711,24 @@ each unusable index and the `REINDEX INDEX CONCURRENTLY` that rebuilds it.
 revision row, not a fact about the database. Other dialects have no concurrent
 index build to leave half-finished and run no probe.
 
+The up path runs the same probe, because repair is not the only way that
+revision gets written. `MigrateUpWithOptions` with `AllowDirty` re-runs the body
+over the dirty row instead, meets the same leftover through the same
+`IF NOT EXISTS`, and would clear the dirty state over an index that enforces
+nothing. The probe is not scoped to that retry: an invalid index left by any
+other route — a hand-run build, a restored dump, a revision row cleaned up out
+of band — is skipped by the same statement on a first attempt with no dirty row
+in sight.
+
+The up probe runs before any revision bookkeeping, so a refusal leaves the
+revision table exactly as it found it: a dirty row keeps the earlier attempt's
+own error and `applied/total`, and a version that was never started stays
+absent. A dry run is exempt, since it records nothing to be wrong about. No flag
+relaxes either refusal; the remedy is `REINDEX INDEX CONCURRENTLY`, or dropping
+the index so the name is free. One shape is knowingly refused: an index left
+invalid on purpose — `CREATE INDEX ... ON ONLY` a partitioned parent — blocks a
+second attempt at the migration that created it (stokaro/ptah#997).
+
 Atlas-format down execution is the deliberate exception. It leaves the
 revision row unchanged before and during the down body to reproduce Atlas's
 measured bookkeeping. A non-transactional Atlas-format down can therefore

--- a/migration/migrator/invalid_index.go
+++ b/migration/migrator/invalid_index.go
@@ -44,59 +44,141 @@ func (i postgresUnusableIndex) quotedName() string {
 // as applied over a constraint the database is not enforcing. Refusing leaves
 // the operator with a dirty state they can still see.
 //
-// The probe is PostgreSQL-only by nature: no other supported dialect has a
-// concurrent index build that can be left half-finished, so every other dialect
-// returns here before any query runs and keeps its existing code path. This
-// deliberately ignores opts.Force. --force is documented as "Rewrite or create
-// the revision row even when it is not dirty" -- it relaxes a precondition
-// about the metadata, not a fact about the database. The escape hatch is
-// REINDEX INDEX CONCURRENTLY, which fixes the database rather than the
-// bookkeeping about it.
+// The probe is PostgreSQL-only by nature -- see
+// [Migrator.unusableIndexesCreatedBy]. This deliberately ignores opts.Force.
+// --force is documented as "Rewrite or create the revision row even when it is
+// not dirty" -- it relaxes a precondition about the metadata, not a fact about
+// the database. The escape hatch is REINDEX INDEX CONCURRENTLY, which fixes the
+// database rather than the bookkeeping about it. No flag on any surface relaxes
+// either refusal, for the same reason: a flag can only change what Ptah records
+// about the database, and the problem is the database.
+//
+// [Migrator.refuseUpOverUnusableIndex] is the same refusal on the up path.
 func (m *Migrator) refuseRepairOverUnusableIndex(ctx context.Context, migration *Migration) error {
-	if m.conn == nil || platform.NormalizeDialect(m.conn.Info().Dialect) != platform.Postgres {
-		return nil
-	}
-	refs := postgresCreatedIndexNames(migration.UpSQL)
-	if len(refs) == 0 {
-		return nil
-	}
-	unusable, err := m.postgresUnusableIndexes(ctx, refs)
-	if err != nil {
+	unusable, err := m.unusableIndexesCreatedBy(ctx, migration)
+	if err != nil || len(unusable) == 0 {
 		return err
-	}
-	if len(unusable) == 0 {
-		return nil
 	}
 	return unusableIndexRepairError(migration.Version, unusable)
 }
 
-// unusableIndexRepairError renders the refusal. It names every index that is
-// unusable together with the catalog flags that say so, and points at the
+// refuseUpOverUnusableIndex refuses to run a migration while PostgreSQL already
+// reports an index that migration creates as unusable.
+//
+// This is the automatic half of the defect refuseRepairOverUnusableIndex covers.
+// An operator does not have to reach for repair at all: `migrations up
+// --allow-dirty` (and `ptah-compat migrate apply --allow-dirty`, which reaches
+// the same code) re-runs the body over the dirty row a failed concurrent build
+// left, and meets the leftover on exactly the same terms -- the generated
+// statement is CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS, the invalid index
+// still occupies the name, PostgreSQL skips it with a notice, nothing errors,
+// and the run clears the dirty state over an index that enforces nothing.
+//
+// It is not restricted to that retry. Measured on PostgreSQL 17.10 with the
+// refusal scoped to a dirty retry: an invalid index left behind by any other
+// route -- a hand-run build, a restored dump, a migration whose revision row was
+// cleaned up out of band -- is skipped by the same IF NOT EXISTS on a FIRST
+// attempt, the migration is recorded applied, and a duplicate write is accepted.
+// The question worth asking is whether the object the migration creates is
+// usable, and a revision row cannot answer it.
+//
+// Two limits are deliberate. A dry run is exempt, because it records nothing to
+// be wrong about and no surface's dry-run exit code was measured for this. And
+// an index deliberately left invalid -- CREATE INDEX ON ONLY a partitioned
+// parent, which stays invalid until every partition's index is attached -- is
+// refused if a later attempt at the same migration meets it. Telling that shape
+// apart from residue is stokaro/ptah#997's partitioned-parent awareness, which
+// is measured there rather than guessed at here.
+//
+// Nothing is written when it refuses. The probe runs before any revision
+// bookkeeping, so a dirty row still holds the failed attempt's own error and its
+// applied/total counters: `migrations status` reports the same state it did
+// before, and a later retry resumes from the same statement. Recording a second
+// failure over it would reset those counters from something that is not a
+// statement failure, and the next retry would re-run SQL that already committed.
+func (m *Migrator) refuseUpOverUnusableIndex(ctx context.Context, migration *Migration) error {
+	if m.conn == nil || m.conn.Writer().IsDryRun() {
+		return nil
+	}
+	unusable, err := m.unusableIndexesCreatedBy(ctx, migration)
+	if err != nil || len(unusable) == 0 {
+		return err
+	}
+	return unusableIndexApplyError(migration.Version, unusable)
+}
+
+// unusableIndexesCreatedBy returns the indexes migration's up SQL creates that
+// PostgreSQL currently reports as unusable.
+//
+// It is empty on every other dialect before any query runs: no other supported
+// dialect has a concurrent index build that can be left half-finished, so they
+// keep their existing code paths rather than growing a no-op probe.
+func (m *Migrator) unusableIndexesCreatedBy(ctx context.Context, migration *Migration) ([]postgresUnusableIndex, error) {
+	if m.conn == nil || platform.NormalizeDialect(m.conn.Info().Dialect) != platform.Postgres {
+		return nil, nil
+	}
+	refs := postgresCreatedIndexNames(migration.UpSQL)
+	if len(refs) == 0 {
+		return nil, nil
+	}
+	return m.postgresUnusableIndexes(ctx, refs)
+}
+
+// unusableIndexRepairError renders the repair refusal. It names every index that
+// is unusable together with the catalog flags that say so, and points at the
 // PostgreSQL command that rebuilds one without holding writes.
 func unusableIndexRepairError(version int64, unusable []postgresUnusableIndex) error {
-	details := make([]string, 0, len(unusable))
-	rebuild := make([]string, 0, len(unusable))
-	for _, index := range unusable {
-		details = append(details, fmt.Sprintf(
-			"%s (indisvalid=%t, indisready=%t)",
-			index.quotedName(), index.Valid, index.Ready,
-		))
-		rebuild = append(rebuild, "REINDEX INDEX CONCURRENTLY "+index.quotedName())
-	}
-	noun := "index"
-	if len(unusable) > 1 {
-		noun = "indexes"
-	}
+	details, rebuild, noun := unusableIndexPhrases(unusable)
 	return fmt.Errorf(
 		"migration %d cannot be repaired: PostgreSQL reports %s %s unusable, "+
 			"so recording the migration applied would report a constraint that is not enforced; "+
 			"run %s, or drop the %s and rerun the migration, then repair again",
 		version,
 		noun,
-		strings.Join(details, ", "),
-		strings.Join(rebuild, "; "),
+		details,
+		rebuild,
 		noun,
 	)
+}
+
+// unusableIndexApplyError renders the up-path refusal. It says why running the
+// body is not itself the fix, which is what separates this refusal from an
+// ordinary migration failure the operator could simply run again -- and running
+// it again is exactly what an operator holding --allow-dirty has already chosen
+// to do.
+func unusableIndexApplyError(version int64, unusable []postgresUnusableIndex) error {
+	details, rebuild, noun := unusableIndexPhrases(unusable)
+	return fmt.Errorf(
+		"migration %d cannot be applied: PostgreSQL reports %s %s unusable, "+
+			"and CREATE INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, "+
+			"so this run would record the migration applied over a constraint that is not enforced; "+
+			"run %s, or drop the %s, then run the migration again",
+		version,
+		noun,
+		details,
+		rebuild,
+		noun,
+	)
+}
+
+// unusableIndexPhrases renders the three parts both refusals share: the named
+// indexes with the catalog flags that condemn them, the REINDEX commands that
+// rebuild them, and the noun that agrees with how many there are.
+func unusableIndexPhrases(unusable []postgresUnusableIndex) (details, rebuild, noun string) {
+	detailParts := make([]string, 0, len(unusable))
+	rebuildParts := make([]string, 0, len(unusable))
+	for _, index := range unusable {
+		detailParts = append(detailParts, fmt.Sprintf(
+			"%s (indisvalid=%t, indisready=%t)",
+			index.quotedName(), index.Valid, index.Ready,
+		))
+		rebuildParts = append(rebuildParts, "REINDEX INDEX CONCURRENTLY "+index.quotedName())
+	}
+	noun = "index"
+	if len(unusable) > 1 {
+		noun = "indexes"
+	}
+	return strings.Join(detailParts, ", "), strings.Join(rebuildParts, "; "), noun
 }
 
 // postgresUnusableIndexes returns the subset of refs the catalog reports as

--- a/migration/migrator/invalid_index_internal_test.go
+++ b/migration/migrator/invalid_index_internal_test.go
@@ -1,13 +1,14 @@
 package migrator
 
-// White-box testing required: postgresCreatedIndexNames and
-// unusableIndexRepairError are the pure halves of a refusal whose other half is
-// a live pg_index query. Reaching them through RepairMigration needs a
-// PostgreSQL connection and a half-built concurrent index, so the boundary
-// cases exercised here -- substring near-misses, quoted and unquoted spellings,
-// comments and string literals, the name-less CREATE INDEX form -- are only
-// observable directly. The end-to-end behavior is covered against a live
-// database in integration/gonative.
+// White-box testing required: postgresCreatedIndexNames,
+// unusableIndexRepairError and unusableIndexApplyError are the pure halves of a
+// refusal whose other half is a live pg_index query. Reaching them through
+// RepairMigration or MigrateUpWithOptions needs a PostgreSQL connection and a
+// half-built concurrent index, so the boundary cases exercised here --
+// substring near-misses, quoted and unquoted spellings, comments and string
+// literals, the name-less CREATE INDEX form, and the plural rendering that no
+// single-index fixture reaches -- are only observable directly. The end-to-end
+// behavior is covered against a live database in integration/gonative.
 
 import (
 	"testing"
@@ -159,6 +160,65 @@ func TestUnusableIndexRepairError(t *testing.T) {
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
 			err := unusableIndexRepairError(1785756328, tt.unusable)
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestUnusableIndexApplyError pins the refusal the up path renders. It has to
+// say something the repair refusal does not: why running the body is not itself
+// the fix, because running it is the action an operator reaching for
+// --allow-dirty has already chosen.
+func TestUnusableIndexApplyError(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name     string
+		unusable []postgresUnusableIndex
+		want     string
+	}{
+		{
+			name: "one index names it, its flags, and the rebuild command",
+			unusable: []postgresUnusableIndex{
+				{Schema: "public", Name: "idx_members_email"},
+			},
+			want: `migration 1785756328 cannot be applied: PostgreSQL reports index ` +
+				`"public"."idx_members_email" (indisvalid=false, indisready=false) unusable, ` +
+				`and CREATE INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, ` +
+				`so this run would record the migration applied over a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", or drop the index, then run the migration again`,
+		},
+		{
+			name: "a ready but invalid index reports both flags as measured",
+			unusable: []postgresUnusableIndex{
+				{Schema: "public", Name: "idx_members_email", Ready: true},
+			},
+			want: `migration 1785756328 cannot be applied: PostgreSQL reports index ` +
+				`"public"."idx_members_email" (indisvalid=false, indisready=true) unusable, ` +
+				`and CREATE INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, ` +
+				`so this run would record the migration applied over a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "public"."idx_members_email", or drop the index, then run the migration again`,
+		},
+		{
+			name: "two indexes are both named and both get a rebuild command",
+			unusable: []postgresUnusableIndex{
+				{Schema: "app", Name: "idx_a"},
+				{Schema: "public", Name: "idx_b", Valid: true},
+			},
+			want: `migration 1785756328 cannot be applied: PostgreSQL reports indexes ` +
+				`"app"."idx_a" (indisvalid=false, indisready=false), ` +
+				`"public"."idx_b" (indisvalid=true, indisready=false) unusable, ` +
+				`and CREATE INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, ` +
+				`so this run would record the migration applied over a constraint that is not enforced; ` +
+				`run REINDEX INDEX CONCURRENTLY "app"."idx_a"; REINDEX INDEX CONCURRENTLY "public"."idx_b", ` +
+				`or drop the indexes, then run the migration again`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			err := unusableIndexApplyError(1785756328, tt.unusable)
 			c.Assert(err, qt.IsNotNil)
 			c.Assert(err.Error(), qt.Equals, tt.want)
 		})

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1680,6 +1680,12 @@ func (m *Migrator) applyUpMigrationsInSingleTransaction(ctx context.Context, mig
 	// read would deadlock. See [Migrator.planUpRetry].
 	plans := make(map[int64]upRetryPlan, len(migrations))
 	for _, migration := range migrations {
+		// Same reason the plans are read here: the probe queries the catalog, so
+		// it has to run before the batch transaction takes the connection. See
+		// [Migrator.refuseUpOverUnusableIndex].
+		if err := m.refuseUpOverUnusableIndex(ctx, migration); err != nil {
+			return nil, err
+		}
 		plan, err := m.planUpRetry(ctx, migration)
 		if err != nil {
 			return nil, err
@@ -1816,6 +1822,12 @@ func (m *Migrator) applyUpMigrationObserved(
 	}
 	checksDeferred, err = m.runPreMigrationChecks(ctx, migration, observesApplyState)
 	if err != nil {
+		return false, err
+	}
+	// Read-only, and before the revision row is touched: a refusal has to leave
+	// whatever an earlier attempt recorded exactly as it found it. See
+	// [Migrator.refuseUpOverUnusableIndex].
+	if err := m.refuseUpOverUnusableIndex(ctx, migration); err != nil {
 		return false, err
 	}
 	plan, err := m.planUpRetry(ctx, migration)


### PR DESCRIPTION
`ptah migrations repair` already refuses to record a migration applied while an index it creates is invalid. Repair is not the only way that revision row gets written, and the other ways were unguarded — which is what reopened this issue.

## Reproduction

Live PostgreSQL 17.10 in a container of its own, CI-shaped role `ptah_user` owning `ptah_test`. Table `members`, 5000 rows all carrying `shared@example.com`, `ANALYZE`d. One migration carrying `-- +ptah no_transaction` and the statement Ptah generates.

```
$ ptah migrations up --db-url ... --migrations-dir ...                                exit 2
  error: error running migrations: failed to apply migration 1785756328: failed to execute
  migration SQL: ERROR: could not create unique index "idx_members_email" (SQLSTATE 23505)
  SQL: CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email")
```

```
$ psql -v ON_ERROR_STOP=1 -c "SELECT indexrelid::regclass AS index, indisvalid, indisready,
                              indisunique FROM pg_index WHERE NOT indisvalid;"
       index       | indisvalid | indisready | indisunique
-------------------+------------+------------+-------------
 idx_members_email | f          | f          | t
(1 row)
```

The operator fixes the data and reaches for the documented recovery flag:

```
$ psql -v ON_ERROR_STOP=1 -c "DELETE FROM members WHERE id > 1;"                 DELETE 4999

$ ptah migrations up --allow-dirty --db-url ... --migrations-dir ...                  exit 0
  Migrations completed successfully!
  Database is now at version: 1785756328

$ psql -v ON_ERROR_STOP=1 -c "... FROM pg_index WHERE NOT indisvalid;"
       index       | indisvalid | indisready | indisunique
-------------------+------------+------------+-------------
 idx_members_email | f          | f          | t          <-- STILL invalid
(1 row)

$ ptah migrations status ...                          Status: Database is up to date

$ psql -v ON_ERROR_STOP=1 -c "INSERT INTO members VALUES (99,'shared@example.com');"
  INSERT 0 1, exit 0
$ psql -c "SELECT count(*) FROM members WHERE email='shared@example.com';"    shared_rows = 2
```

The invalid index occupies the name, so `CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS` is skipped with a notice, nothing errors, and the run clears the dirty state over a constraint the database is not enforcing.

## The fix, and why this shape

Before any revision bookkeeping, on all three up paths, Ptah reads `pg_index.indisvalid` and `indisready` for the index names the migration's up SQL creates — the same probe `repair` already uses, resolving an unqualified name through the same search path the statement used. If any is unusable it **refuses**, naming each index, its catalog flags, and the command that rebuilds it:

```
error: error running migrations: migration 1785756328 cannot be applied: PostgreSQL reports
index "public"."idx_members_email" (indisvalid=false, indisready=false) unusable, and CREATE
INDEX ... IF NOT EXISTS finds the name taken and skips it rather than rebuilding it, so this
run would record the migration applied over a constraint that is not enforced; run REINDEX
INDEX CONCURRENTLY "public"."idx_members_email", or drop the index, then run the migration again
```

**Refuse rather than drop and rebuild.** Refusing leaves the operator with a state they can still see; rebuilding silently would have Ptah issue a `DROP INDEX` nobody asked for, against an object it cannot prove it created. It is also what `repair` already does, so the two paths give the same answer to the same question.

**Not scoped to the dirty retry.** The reopening named `--allow-dirty`. Measured with the refusal scoped there, the identical defect is still reachable with no dirty row anywhere: build the index by hand, let it fail, remove the duplicates, and a **first** `ptah migrations up` exits `0`, records the migration applied, and accepts the duplicate write. That is also what a restored dump or a revision row cleaned up out of band leaves behind. The question worth asking is whether the object the migration creates is usable, and a revision row cannot answer it.

**A refusal writes nothing.** The probe runs before `recordPendingMigrationRevisionOn`, so a dirty row keeps the failed attempt's own error and its `applied`/`total` counters — `status` reports the same state it did before, and a later retry resumes from the same statement. A version that was never started stays absent. Recording a second failure over it would reset those counters from something that is not a statement failure, and the next retry would re-run SQL that already committed.

**No flag relaxes it**, matching what `repair` already does with `--force`. A flag can only change what Ptah records about the database; the problem is the database.

**The uniqueness half.** An invalid unique index enforces nothing, so this is not cosmetic: the fixture accepts a duplicate write while the index is invalid and rejects it after `REINDEX`. A plain index is the quieter half — no write can reveal it was never built, and the catalog is the only witness. Both are covered.

## Deliberately stricter than the pinned community binary

Measured on PostgreSQL 17.10, identical fixture on both sides, one migration carrying `-- atlas:txmode none`:

| | pinned community binary v1.3.0 | `ptah-compat` |
| --- | --- | --- |
| `migrate apply --allow-dirty` | exit `0`, `-- ok`, 1 statement | exit `1`, names the index and `REINDEX` |
| `pg_index` afterwards | `indisvalid=f`, `indisready=f` | unchanged, nothing written |
| revision row afterwards | `20260808000001` applied 1/1, no error | no row |
| duplicate `INSERT` afterwards | accepted, 2 rows share the email | n/a |
| after `REINDEX INDEX CONCURRENTLY` | n/a | exit `0`, `indisvalid=t`, row recorded, duplicate rejected |

Stricter, never looser: `ptah-compat` exits `1` where the binary exits `0` and never the reverse, so no invocation the binary refuses succeeds here. This changes behavior; pre-v1, so no compatibility is owed.

## Red/green evidence

All tests live against PostgreSQL 17.10, in `integration/gonative`. Each mutant applied alone, then restored.

| test | with the fix | probe disabled | scoped to a dirty retry | every named index treated as unusable | dry-run exemption removed |
| --- | --- | --- | --- | --- | --- |
| invalid **unique** index, `--allow-dirty` retry | PASS | **FAIL** | PASS | **FAIL** | PASS |
| invalid **plain** index, `--allow-dirty` retry | PASS | **FAIL** | PASS | PASS | PASS |
| pre-existing residue, **first attempt** | PASS | **FAIL** | **FAIL** | **FAIL** | **FAIL** (at the dry-run assertion, `retry_invalid_index_integration_test.go:234`) |
| control — retry over a **usable** index resumes and records | PASS | PASS | PASS | **FAIL** | PASS |
| control — partitioned parent built `ON ONLY` still applies | PASS | PASS | PASS | PASS | PASS |
| existing — repair refuses over an invalid unique index | PASS | PASS | PASS | **FAIL** | PASS |
| existing — repair leaves a usable index alone | PASS | PASS | PASS | **FAIL** | PASS |

The plain-index fixture fails its build on an expression that divides by zero for exactly one row, which is the deterministic way to leave a non-unique index invalid: measured `indisvalid=f, indisready=f, indisunique=f`, and re-issuing the statement answers `NOTICE: relation "..." already exists, skipping`.

The partitioned-parent control is honest about what it does not pin: it passes under every mutant, because the probe runs before the body and the parent index does not exist yet. It is there to state the boundary, not to defend it.

White-box: `TestUnusableIndexApplyError` pins the rendered message including the plural form no single-index fixture reaches.

## Gates

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (`175 conditional groups, 45 white-box files`) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `go test ./migration/... -count=1` | 0 (all 20 packages `ok`) |
| `go test ./... -count=1` | **1** — see below |
| docs/site `npm ci` + all 13 `check:*` scripts | 0 |

`go test ./...` exits 1 on three subtests in `cmd/ptah-ls` and `cmd/viz`, all of them subprocesses reporting `signal: killed` or `context deadline exceeded` on this loaded host. They reproduce when run alone, and neither package — including test dependencies — imports `go.5x5.cz/ptah/migration/migrator`: `go list -deps -test ./cmd/viz ./cmd/ptah-ls | grep -c 'migration/migrator$'` answers `0`. Environmental, not this change, and not hidden.

## Residual risk

- **A partitioned parent built `ON ONLY` blocks a second attempt at its own migration.** The first attempt is fine; if that migration fails on a later statement, the operator must finish or drop the parent index before running it again. Telling a deliberately invalid parent apart from residue is #997's partitioned-parent awareness, measured there rather than guessed at here.
- **A dry run does not warn.** `--dry-run` records nothing, so it has nothing to be wrong about, and no surface's dry-run exit code was measured for this refusal. It is asserted as an exemption rather than left to chance.
- **A concurrent build running in another session** shows `indisvalid=false` for its duration, so a migration creating that same name would be refused mid-build. That is already a conflict, and the migration advisory lock rules out two Ptah runs racing.
- **PostgreSQL only.** No other supported dialect has a concurrent index build that can be left half-finished; they return before any query runs.

Closes #1101