### PR TITLE
Read every desired-schema source on the API export targets

### DIFF
--- a/cmd/schema/export_source.go
+++ b/cmd/schema/export_source.go
@@ -1,0 +1,153 @@
+package schema
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"go.5x5.cz/ptah/cmd/internal/cmdutil"
+	"go.5x5.cz/ptah/cmd/internal/schemaload"
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/ociartifact"
+	"go.5x5.cz/ptah/internal/pathguard"
+)
+
+// loadExportSchema resolves the desired schema an export projects, from Go
+// annotation roots and/or language-agnostic schema files.
+//
+// It delegates to schemaload, the resolver behind "ptah schema render",
+// "ptah schema compare" and the migration commands, so --schema-file means the
+// same thing on every surface that accepts it. Parsing a schema file here
+// instead would be a second loader free to drift from the first.
+func loadExportSchema(cmd *cobra.Command, opts exportOptions) (*goschema.Database, error) {
+	rootDirs, err := exportRootDirs(opts)
+	if err != nil {
+		return nil, err
+	}
+	// Logf stays nil so the resolver narrates nothing: with --out omitted the
+	// openapi-v3 and graphql targets write the schema itself to stdout.
+	return schemaload.LoadContext(cmd.Context(), schemaload.Options{
+		RootDirs:    rootDirs,
+		SchemaFiles: opts.schemaFiles,
+	})
+}
+
+// exportRootDirs returns the Go entity roots to scan, or none when the desired
+// schema comes from --schema-file alone. The "." default applies only when no
+// schema file was named, so --schema-file never silently merges whatever
+// annotated Go files happen to sit in the working directory.
+func exportRootDirs(opts exportOptions) ([]string, error) {
+	if len(opts.schemaFiles) > 0 && !opts.rootDirExplicit {
+		return nil, nil
+	}
+	rootDir, err := exportGoRootDir(opts)
+	if err != nil {
+		return nil, err
+	}
+	return []string{rootDir}, nil
+}
+
+// exportGoRootDir resolves and validates the single Go annotation root.
+func exportGoRootDir(opts exportOptions) (string, error) {
+	rootDir, err := pathguard.ResolveCLIPath(opts.rootDir)
+	if err != nil {
+		return "", fmt.Errorf("invalid root directory: %w", err)
+	}
+	if err := cmdutil.StatDir(rootDir); err != nil {
+		return "", err
+	}
+	return rootDir, nil
+}
+
+// schemaFileFormat maps a schema file path to the --from value that names its
+// format. The extension is the only declaration a schema file carries, and it
+// is what schemaload dispatches on, so an explicit --from is checked against it
+// rather than against the file's contents.
+func schemaFileFormat(path string) (string, bool) {
+	switch strings.ToLower(filepath.Ext(strings.TrimSpace(path))) {
+	case ".yaml", ".yml":
+		return exportFormatYAML, true
+	case ".hcl":
+		return exportFormatHCL, true
+	case ".sql":
+		return exportFormatSQL, true
+	default:
+		return "", false
+	}
+}
+
+// validateExportSource checks the desired-schema source selection: whether the
+// target can read a schema file at all, and whether an explicit --from agrees
+// with the files named. With --from left at its default the extension decides,
+// which is why the acceptance form of this command is --schema-file alone.
+func validateExportSource(opts exportOptions) error {
+	if opts.to == exportFormatHCL && len(opts.schemaFiles) > 0 {
+		return fmt.Errorf(
+			"--%s is not supported with --%s %s: that target rewrites the Go files it reads "+
+				"(--%s removes their annotations), so its source is --%s; "+
+				"use --%s openapi-v3, graphql, or protobuf to export a schema file",
+			exportSchemaFileFlag, exportToFlag, exportFormatHCL,
+			cleanupGoAnnotationsFlag, exportRootDirFlag, exportToFlag,
+		)
+	}
+	if !opts.fromExplicit {
+		return nil
+	}
+	switch opts.from {
+	case exportFormatGo:
+		if len(opts.schemaFiles) > 0 {
+			return fmt.Errorf(
+				"--%s %s reads Go annotations from --%s: drop --%s, or set it to the format of the --%s value",
+				exportFromFlag, exportFormatGo, exportRootDirFlag, exportFromFlag, exportSchemaFileFlag,
+			)
+		}
+		return nil
+	case exportFormatYAML, exportFormatHCL, exportFormatSQL:
+		return validateSchemaFileFormats(opts)
+	case exportSourceDB:
+		return fmt.Errorf(
+			"--%s %s is not supported: an export reads a schema definition, not a live database; "+
+				"run \"ptah introspect\" to generate annotated Go models from a database URL and export those",
+			exportFromFlag, exportSourceDB,
+		)
+	default:
+		return fmt.Errorf("unsupported --%s %q: expected %s, %s, %s, or %s",
+			exportFromFlag, opts.from, exportFormatGo, exportFormatYAML, exportFormatHCL, exportFormatSQL)
+	}
+}
+
+// validateSchemaFileFormats reports a --from that names a file format without a
+// file to read, or that disagrees with the extension of one it was given.
+func validateSchemaFileFormats(opts exportOptions) error {
+	if len(opts.schemaFiles) == 0 {
+		return fmt.Errorf("--%s %s requires --%s", exportFromFlag, opts.from, exportSchemaFileFlag)
+	}
+	for _, schemaFile := range opts.schemaFiles {
+		// An OCI reference carries its format inside the artifact and has no
+		// extension to check, so it is named here rather than falling into the
+		// extension message below, which would read as "rename your registry
+		// reference". The prefix test matches the one schemaload dispatches on.
+		if strings.HasPrefix(schemaFile, ociartifact.Scheme) {
+			return fmt.Errorf(
+				"--%s cannot declare the format of the %s artifact %q, which records its own; omit --%s",
+				exportFromFlag, ociartifact.Scheme, schemaFile, exportFromFlag,
+			)
+		}
+		format, ok := schemaFileFormat(schemaFile)
+		if !ok {
+			return fmt.Errorf(
+				"--%s %q has no recognized schema file extension: expected .yaml, .yml, .hcl, or .sql",
+				exportSchemaFileFlag, schemaFile,
+			)
+		}
+		if format != opts.from {
+			return fmt.Errorf(
+				"--%s %s does not match --%s %q, which is %s",
+				exportFromFlag, opts.from, exportSchemaFileFlag, schemaFile, format,
+			)
+		}
+	}
+	return nil
+}

--- a/cmd/schema/export_source_test.go
+++ b/cmd/schema/export_source_test.go
@@ -1,0 +1,436 @@
+package schema_test
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/internal/exitcode"
+)
+
+// The four spellings of one desired schema. They declare the same two tables,
+// the same foreign key, and the same named enum, so an export taken from any of
+// them describes the same contract and must produce the same bytes. The enum and
+// the foreign key are what make the comparison worth making: they are the two
+// places where an API export invents names of its own.
+const (
+	gridGoModels = `package models
+
+//ptah:schema:table name="categories"
+type Category struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//ptah:schema:field name="name" type="VARCHAR(120)" not_null="true"
+	Name string
+}
+
+//ptah:schema:table name="products"
+type Product struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//ptah:schema:field name="name" type="VARCHAR(255)" not_null="true"
+	Name string
+
+	//ptah:schema:field name="price" type="DECIMAL(10,2)" not_null="true"
+	Price float64
+
+	//ptah:schema:field name="description" type="TEXT"
+	Description string
+
+	//ptah:schema:field name="category_id" type="INTEGER" not_null="true" foreign="categories(id)"
+	CategoryID int64
+
+	//ptah:schema:field name="status" type="product_status" not_null="true"
+	Status string
+}
+
+//ptah:schema:enum name="product_status" values="active,inactive"
+type ProductStatus struct{}
+`
+
+	gridYAMLSchema = `tables:
+  categories:
+    columns:
+      id:
+        type: SERIAL
+        primary: true
+      name:
+        type: VARCHAR(120)
+        not_null: true
+  products:
+    columns:
+      id:
+        type: SERIAL
+        primary: true
+      name:
+        type: VARCHAR(255)
+        not_null: true
+      price:
+        type: DECIMAL(10,2)
+        not_null: true
+      description:
+        type: TEXT
+      category_id:
+        type: INTEGER
+        not_null: true
+        foreign: categories(id)
+      status:
+        type: product_status
+        not_null: true
+enums:
+  product_status:
+    values: [active, inactive]
+`
+
+	gridHCLSchema = `schema "public" {}
+
+enum "product_status" {
+  values = ["active", "inactive"]
+}
+
+table "categories" {
+  schema = schema.public
+
+  column "id" {
+    type = serial
+  }
+
+  column "name" {
+    type = varchar(120)
+    null = false
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+}
+
+table "products" {
+  schema = schema.public
+
+  column "id" {
+    type = serial
+  }
+
+  column "name" {
+    type = varchar(255)
+    null = false
+  }
+
+  column "price" {
+    type = decimal(10, 2)
+    null = false
+  }
+
+  column "description" {
+    type = text
+    null = true
+  }
+
+  column "category_id" {
+    type = integer
+    null = false
+  }
+
+  column "status" {
+    type = product_status
+    null = false
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "products_category_id_fkey" {
+    columns     = [column.category_id]
+    ref_columns = [table.categories.column.id]
+  }
+}
+`
+
+	gridSQLSchema = `CREATE TYPE product_status AS ENUM ('active', 'inactive');
+
+CREATE TABLE categories (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(120) NOT NULL
+);
+
+CREATE TABLE products (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL,
+    price DECIMAL(10,2) NOT NULL,
+    description TEXT,
+    category_id INTEGER NOT NULL REFERENCES categories(id),
+    status product_status NOT NULL
+);
+`
+
+	// strayGoModel is annotated Go in a directory nobody named as a source.
+	strayGoModel = `package stray
+
+//ptah:schema:table name="audit_log"
+type AuditLog struct {
+	//ptah:schema:field name="id" type="SERIAL" primary="true"
+	ID int64
+
+	//ptah:schema:field name="actor" type="VARCHAR(64)" not_null="true"
+	Actor string
+}
+`
+)
+
+// gridFixture writes the four source spellings into one directory and returns
+// it. The Go models live in a "models" subdirectory so a schema-file export can
+// be shown not to pick them up.
+func gridFixture(c *qt.C) string {
+	c.Helper()
+	dir := resolvedTempDir(c)
+	modelsDir := filepath.Join(dir, "models")
+	c.Assert(os.MkdirAll(modelsDir, 0o750), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(modelsDir, "model.go"), []byte(gridGoModels), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema.yaml"), []byte(gridYAMLSchema), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema.hcl"), []byte(gridHCLSchema), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "schema.sql"), []byte(gridSQLSchema), 0o600), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("not a schema\n"), 0o600), qt.IsNil)
+	return dir
+}
+
+// exportTarget is one API export target: how to run it, and a token its output
+// must carry. Without the token a cell could pass by comparing one empty
+// artifact with another.
+type exportTarget struct {
+	name   string
+	marker string
+	run    func(c *qt.C, sourceArgs []string) string
+}
+
+func apiExportTargets() []exportTarget {
+	return []exportTarget{
+		{name: "openapi-v3", marker: "        - inactive\n", run: stdoutExport("openapi-v3")},
+		{name: "graphql", marker: "enum ProductStatus {\n", run: stdoutExport("graphql")},
+		{name: "protobuf", marker: "PRODUCT_STATUS_INACTIVE = 2;\n", run: protobufExport},
+	}
+}
+
+// stdoutExport runs a stateless target with --out omitted, which writes the
+// schema itself to stdout.
+func stdoutExport(target string) func(c *qt.C, sourceArgs []string) string {
+	return func(c *qt.C, sourceArgs []string) string {
+		c.Helper()
+		stdout, stderr, err := runSchemaExport(append([]string{"--to", target}, sourceArgs...)...)
+		c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr))
+		return stdout
+	}
+}
+
+// protobufExport runs the stateful target, which requires --out. Every run gets
+// its own output directory so no run reads another run's compatibility state.
+func protobufExport(c *qt.C, sourceArgs []string) string {
+	c.Helper()
+	outPath := filepath.Join(c.TempDir(), "schema.proto")
+	args := append([]string{
+		"--to", "protobuf",
+		"--out", outPath,
+		"--proto-package", "acme.inventory.v1",
+	}, sourceArgs...)
+
+	stdout, stderr, err := runSchemaExport(args...)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	data, err := os.ReadFile(outPath)
+	c.Assert(err, qt.IsNil)
+	return string(data)
+}
+
+// schemaSource is one non-Go desired-schema source: the --from value that names
+// its format, and the file that carries it.
+type schemaSource struct {
+	name string
+	path string
+}
+
+func nonGoSchemaSources(dir string) []schemaSource {
+	return []schemaSource{
+		{name: "yaml", path: filepath.Join(dir, "schema.yaml")},
+		{name: "hcl", path: filepath.Join(dir, "schema.hcl")},
+		{name: "sql", path: filepath.Join(dir, "schema.sql")},
+	}
+}
+
+// TestSchemaExportReadsEveryNonGoSource walks the whole grid of API export
+// targets against non-Go desired-schema sources. Each cell is checked in both
+// spellings: --schema-file alone, where the extension names the format, and an
+// explicit --from beside it.
+func TestSchemaExportReadsEveryNonGoSource(t *testing.T) {
+	c := qt.New(t)
+	dir := gridFixture(c)
+	goSource := []string{"--root-dir", filepath.Join(dir, "models")}
+
+	for _, target := range apiExportTargets() {
+		for _, source := range nonGoSchemaSources(dir) {
+			c.Run(target.name+"/"+source.name, func(c *qt.C) {
+				baseline := target.run(c, goSource)
+				c.Assert(baseline, qt.Contains, target.marker)
+
+				inferred := target.run(c, []string{"--schema-file", source.path})
+				declared := target.run(c, []string{"--from", source.name, "--schema-file", source.path})
+
+				c.Assert(inferred, qt.Equals, baseline)
+				c.Assert(declared, qt.Equals, baseline)
+			})
+		}
+	}
+}
+
+// TestSchemaExportAcceptsTheYamlExtensionAlias covers .yml, which schemaload
+// reads as YAML. An explicit --from yaml has to agree with it, or the alias
+// would be readable only by leaving --from unset.
+func TestSchemaExportAcceptsTheYamlExtensionAlias(t *testing.T) {
+	c := qt.New(t)
+	dir := gridFixture(c)
+	aliasPath := filepath.Join(dir, "schema.yml")
+	c.Assert(os.WriteFile(aliasPath, []byte(gridYAMLSchema), 0o600), qt.IsNil)
+	target := apiExportTargets()[1]
+
+	baseline := target.run(c, []string{"--root-dir", filepath.Join(dir, "models")})
+	alias := target.run(c, []string{"--from", "yaml", "--schema-file", aliasPath})
+
+	c.Assert(alias, qt.Equals, baseline)
+}
+
+// TestSchemaExportComposesGoRootsWithSchemaFiles pins the composite case: an
+// explicit --root-dir beside --schema-file exports both, as it does on
+// "ptah schema render", which shares this resolver.
+func TestSchemaExportComposesGoRootsWithSchemaFiles(t *testing.T) {
+	c := qt.New(t)
+	dir := gridFixture(c)
+	strayDir := filepath.Join(dir, "stray")
+	c.Assert(os.MkdirAll(strayDir, 0o750), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(strayDir, "stray.go"), []byte(strayGoModel), 0o600), qt.IsNil)
+
+	stdout, stderr, err := runSchemaExport(
+		"--to", "graphql",
+		"--root-dir", strayDir,
+		"--schema-file", filepath.Join(dir, "schema.yaml"),
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr))
+	c.Assert(stdout, qt.Contains, "type Product {")
+	c.Assert(stdout, qt.Contains, "type AuditLog {")
+}
+
+// TestSchemaExportSchemaFileDoesNotAddTheWorkingDirectory holds the --root-dir
+// default to Go-only exports. The flag defaults to ".", and passing that default
+// to the resolver alongside --schema-file would merge whatever annotated Go
+// files happen to sit in the working directory into the published contract.
+func TestSchemaExportSchemaFileDoesNotAddTheWorkingDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := gridFixture(c)
+	c.Assert(os.WriteFile(filepath.Join(dir, "stray.go"), []byte(strayGoModel), 0o600), qt.IsNil)
+	t.Chdir(dir)
+
+	stdout, stderr, err := runSchemaExport("--to", "graphql", "--schema-file", "schema.yaml")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stderr:\n%s", stderr))
+	c.Assert(stdout, qt.Contains, "type Product {")
+	c.Assert(stdout, qt.Not(qt.Contains), "AuditLog")
+}
+
+// TestSchemaExportRefusesSourcesItCannotRead covers every refusal on the source
+// selection: the one source deliberately out of scope, a format nothing reads,
+// and each way a declared --from can disagree with the file beside it.
+func TestSchemaExportRefusesSourcesItCannotRead(t *testing.T) {
+	c := qt.New(t)
+	dir := gridFixture(c)
+	yamlPath := filepath.Join(dir, "schema.yaml")
+	sqlPath := filepath.Join(dir, "schema.sql")
+	notesPath := filepath.Join(dir, "notes.txt")
+
+	tests := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{
+			name: "a live database",
+			args: []string{"--to", "graphql", "--from", "db"},
+			wantErr: `--from db is not supported: an export reads a schema definition, not a live database; ` +
+				`run "ptah introspect" to generate annotated Go models from a database URL and export those`,
+		},
+		{
+			name:    "a format nothing reads",
+			args:    []string{"--to", "graphql", "--from", "toml"},
+			wantErr: `unsupported --from "toml": expected go, yaml, hcl, or sql`,
+		},
+		{
+			name:    "a declared format with no file",
+			args:    []string{"--to", "graphql", "--from", "yaml", "--root-dir", filepath.Join(dir, "models")},
+			wantErr: `--from yaml requires --schema-file`,
+		},
+		{
+			name:    "a declared format the file contradicts",
+			args:    []string{"--to", "graphql", "--from", "yaml", "--schema-file", sqlPath},
+			wantErr: fmt.Sprintf(`--from yaml does not match --schema-file %q, which is sql`, sqlPath),
+		},
+		{
+			name: "a declared format on a file with no schema extension",
+			args: []string{"--to", "graphql", "--from", "yaml", "--schema-file", notesPath},
+			wantErr: fmt.Sprintf(
+				`--schema-file %q has no recognized schema file extension: expected .yaml, .yml, .hcl, or .sql`,
+				notesPath,
+			),
+		},
+		{
+			name: "a declared format on a registry artifact",
+			args: []string{"--to", "graphql", "--from", "yaml", "--schema-file", "oci://ghcr.io/acme/app-schema:v1"},
+			wantErr: `--from cannot declare the format of the oci:// artifact "oci://ghcr.io/acme/app-schema:v1", ` +
+				`which records its own; omit --from`,
+		},
+		{
+			name: "an inferred format on a file with no schema extension",
+			args: []string{"--to", "graphql", "--schema-file", notesPath},
+			wantErr: `unsupported schema file extension ".txt": ` +
+				`only .yaml, .yml, .hcl, and .sql are supported`,
+		},
+		{
+			name: "Go annotations and a schema file at once",
+			args: []string{"--to", "graphql", "--from", "go", "--schema-file", yamlPath},
+			wantErr: `--from go reads Go annotations from --root-dir: ` +
+				`drop --from, or set it to the format of the --schema-file value`,
+		},
+		{
+			// --to defaults to hcl, so a user who names a schema file and forgets
+			// --to lands here. The message has to name the way out.
+			name: "a schema file with no target named",
+			args: []string{"--out", filepath.Join(dir, "out.hcl"), "--schema-file", yamlPath},
+			wantErr: `--schema-file is not supported with --to hcl: that target rewrites the Go files it reads ` +
+				`(--cleanup-go-annotations removes their annotations), so its source is --root-dir; ` +
+				`use --to openapi-v3, graphql, or protobuf to export a schema file`,
+		},
+		{
+			name: "a schema file for the target that rewrites its source",
+			args: []string{"--to", "hcl", "--out", filepath.Join(dir, "out.hcl"), "--schema-file", yamlPath},
+			wantErr: `--schema-file is not supported with --to hcl: that target rewrites the Go files it reads ` +
+				`(--cleanup-go-annotations removes their annotations), so its source is --root-dir; ` +
+				`use --to openapi-v3, graphql, or protobuf to export a schema file`,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			stdout, stderr, err := runSchemaExport(tt.args...)
+
+			c.Assert(err, qt.ErrorMatches, regexp.QuoteMeta(tt.wantErr), qt.Commentf("stdout:\n%s", stdout))
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 2)
+			c.Assert(stderr, qt.Contains, "error: "+tt.wantErr+"\n")
+			// A refused source must not have produced a schema either.
+			c.Assert(stdout, qt.Equals, "")
+		})
+	}
+}

--- a/cmd/schema/schema.go
+++ b/cmd/schema/schema.go
@@ -29,6 +29,7 @@ const (
 	exportFromFlag           = "from"
 	exportToFlag             = "to"
 	exportRootDirFlag        = "root-dir"
+	exportSchemaFileFlag     = "schema-file"
 	exportOutFlag            = "out"
 	exportIncludeTablesFlag  = "include-tables"
 	exportExcludeTablesFlag  = "exclude-tables"
@@ -37,11 +38,17 @@ const (
 	cleanupDryRunFlag        = "cleanup-dry-run"
 	cleanupDiffFlag          = "cleanup-diff"
 	exportFormatGo           = "go"
+	exportFormatYAML         = "yaml"
+	exportFormatSQL          = "sql"
 	exportFormatHCL          = "hcl"
 	exportFormatLegacyHCL    = "atlas-hcl"
 	exportFormatOpenAPI      = "openapi-v3"
 	exportFormatGraphQL      = "graphql"
 	exportFormatProtobuf     = "protobuf"
+
+	// exportSourceDB is named so --from db is refused with the reason and the
+	// command that does read a live database, rather than with a bare list.
+	exportSourceDB = "db"
 
 	protoPackageFlag              = "proto-package"
 	protoGoPackageFlag            = "go-package"
@@ -148,6 +155,7 @@ func newSchemaExportCommand() *cobra.Command {
 	var from string
 	var to string
 	var rootDir string
+	var schemaFiles []string
 	var outPath string
 	var includeTables []string
 	var excludeTables []string
@@ -169,7 +177,7 @@ func newSchemaExportCommand() *cobra.Command {
 		Short: "Export one schema source format to another",
 		Long: `Export a Ptah schema to another format.
 
-Convert Go annotations to an HCL schema, an OpenAPI 3.0 component schema, a
+Convert a desired schema to an HCL schema, an OpenAPI 3.0 component schema, a
 GraphQL SDL, or a Protobuf definition:
 
   ptah schema export --to hcl         --root-dir ./models --out schema.hcl
@@ -177,6 +185,17 @@ GraphQL SDL, or a Protobuf definition:
   ptah schema export --to graphql     --root-dir ./models --out schema.graphql
   ptah schema export --to protobuf    --root-dir ./models \
     --out ./proto/acme/inventory/v1/schema.proto --proto-package acme.inventory.v1
+
+The source is Go annotations under --root-dir by default. The openapi-v3,
+graphql, and protobuf targets also read a YAML, HCL, or SQL schema file, which
+--schema-file names as "ptah schema render" does:
+
+  ptah schema export --to protobuf --schema-file schema.yaml \
+    --out ./proto/acme/inventory/v1/schema.proto --proto-package acme.inventory.v1
+
+--from declares that file's format and is checked against its extension; leave
+it unset to take the format from the extension. The hcl target reads Go
+annotations only, because it rewrites the files it reads.
 
 For openapi-v3 and graphql, --out is optional; the schema is written to stdout
 when omitted. Use --include-tables / --exclude-tables to select which tables are
@@ -195,8 +214,11 @@ part of the compatibility state, so all of them must be committed together.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runExport(cmd, exportOptions{
 				from:                      from,
+				fromExplicit:              cmd.Flags().Changed(exportFromFlag),
 				to:                        to,
 				rootDir:                   rootDir,
+				rootDirExplicit:           cmd.Flags().Changed(exportRootDirFlag),
+				schemaFiles:               schemaFiles,
 				outPath:                   outPath,
 				includeTables:             includeTables,
 				excludeTables:             excludeTables,
@@ -217,9 +239,13 @@ part of the compatibility state, so all of them must be committed together.`,
 	}
 
 	flags := cmd.Flags()
-	flags.StringVar(&from, exportFromFlag, exportFormatGo, "Source schema format: go")
+	flags.StringVar(&from, exportFromFlag, exportFormatGo, "Source schema format: go, yaml, hcl, or sql")
 	flags.StringVar(&to, exportToFlag, exportFormatHCL, "Target schema format: hcl, openapi-v3, graphql, or protobuf")
 	flags.StringVar(&rootDir, exportRootDirFlag, ".", "Root directory to scan for Go annotations")
+	flags.StringArrayVar(&schemaFiles, exportSchemaFileFlag, nil,
+		"YAML, HCL, or SQL schema file to export instead of Go annotations (repeatable; "+
+			"merged with --root-dir into one composite schema when both are given; "+
+			"not supported for --to hcl)")
 	flags.StringVar(&outPath, exportOutFlag, "", "Output file (optional for openapi-v3/graphql; required for protobuf)")
 	flags.StringSliceVar(&includeTables, exportIncludeTablesFlag, nil, "Only export these tables (comma-separated); applies to openapi-v3/graphql/protobuf")
 	flags.StringSliceVar(&excludeTables, exportExcludeTablesFlag, nil, "Exclude these tables (comma-separated); applies to openapi-v3/graphql/protobuf")
@@ -246,9 +272,18 @@ part of the compatibility state, so all of them must be committed together.`,
 }
 
 type exportOptions struct {
-	from               string
-	to                 string
-	rootDir            string
+	from string
+	// fromExplicit records whether --from was passed. The flag defaults to "go",
+	// so without this an explicit "--from go" and an unset --from are the same
+	// value, and --schema-file could not infer its format from the extension
+	// without contradicting the default.
+	fromExplicit bool
+	to           string
+	rootDir      string
+	// rootDirExplicit records whether --root-dir was passed, so its "." default
+	// is not merged into a schema-file export as a second source.
+	rootDirExplicit    bool
+	schemaFiles        []string
 	outPath            string
 	includeTables      []string
 	excludeTables      []string
@@ -286,21 +321,17 @@ func runExport(cmd *cobra.Command, opts exportOptions) error {
 		fmt.Fprintf(cmd.ErrOrStderr(),
 			"warning: --%s is ignored for --%s %s\n", exportTitleFlag, exportToFlag, exportFormatProtobuf)
 	}
-	rootDir, err := pathguard.ResolveCLIPath(opts.rootDir)
-	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("invalid root directory: %w", err))
-	}
-	if err := cmdutil.StatDir(rootDir); err != nil {
-		return cmdutil.Fail(cmd, err)
-	}
-
 	if opts.to == exportFormatHCL {
+		rootDir, err := exportGoRootDir(opts)
+		if err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 		return runHCLExport(cmd, opts, rootDir)
 	}
 
-	db, err := goschema.ParseDir(rootDir)
+	db, err := loadExportSchema(cmd, opts)
 	if err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("parse Go annotations: %w", err))
+		return cmdutil.Fail(cmd, err)
 	}
 	switch opts.to {
 	case exportFormatOpenAPI:
@@ -425,8 +456,8 @@ func normalizeExportFormat(format string) string {
 }
 
 func validateExportOptions(opts exportOptions) error {
-	if opts.from != exportFormatGo {
-		return fmt.Errorf("unsupported --from %q: expected %s", opts.from, exportFormatGo)
+	if err := validateExportSource(opts); err != nil {
+		return err
 	}
 	switch opts.to {
 	case exportFormatHCL, exportFormatOpenAPI, exportFormatGraphQL, exportFormatProtobuf:

--- a/docs/api_schema_export.md
+++ b/docs/api_schema_export.md
@@ -1,9 +1,14 @@
 # API schema export (OpenAPI / GraphQL)
 
-Ptah exports the schema it parses from Go annotations to API-facing formats:
-OpenAPI 3.0 component schemas, GraphQL SDL, and Protobuf definitions. The parsed
+Ptah exports a desired schema to API-facing formats: OpenAPI 3.0 component
+schemas, GraphQL SDL, and Protobuf definitions. The parsed
 `goschema.Database` already carries types, nullability, enums and foreign keys,
 so each format is a direct projection of that intermediate representation.
+That intermediate representation is also what makes the source format
+interchangeable: `--root-dir` reads Go annotations and `--schema-file` reads a
+YAML, HCL, or SQL schema file through `cmd/internal/schemaload`, the resolver
+behind `ptah schema render`, and the two produce the same artifact for the same
+tables.
 This is contract generation, not database publication: Ptah emits no runtime
 server, data access, authentication, or authorization.
 
@@ -37,13 +42,17 @@ ptah schema export --to graphql --root-dir ./models --out schema.graphql
 
 # Omit --out to write the schema to stdout for piping into a validator
 ptah schema export --to graphql --root-dir ./models > schema.graphql
+
+# Read the desired schema from a YAML, HCL, or SQL file instead
+ptah schema export --to openapi-v3 --schema-file schema.yaml --out openapi.yaml
 ```
 
 | Flag | Applies to | Meaning |
 | --- | --- | --- |
-| `--from` | all | Source format. Only `go` is supported. |
+| `--from` | all | Format of the `--schema-file` value: `go` (default), `yaml`, `hcl`, or `sql`. Checked against the file extension; unset takes the format from the extension. `db` is refused — run `ptah introspect` first. |
 | `--to` | all | Target format: `hcl`, `openapi-v3`, `graphql`, or [`protobuf`](./site/src/content/docs/schema/protobuf.md). The old `atlas-hcl` value is accepted as an alias. |
 | `--root-dir` | all | Directory scanned for Go annotations. |
+| `--schema-file` | `openapi-v3`, `graphql`, `protobuf` | YAML, HCL, or SQL schema file to export instead of Go annotations. Repeatable; merged with `--root-dir` when both are given. Refused for `hcl`, whose export rewrites the Go files it reads. |
 | `--out` | all | Output file. Optional for `openapi-v3`/`graphql` (stdout when omitted); required for `hcl` and for [`protobuf`](./site/src/content/docs/schema/protobuf.md), where it is also the compatibility state read back on the next run. |
 | `--include-tables` | `openapi-v3`, `graphql`, `protobuf` | Comma-separated allowlist of tables. |
 | `--exclude-tables` | `openapi-v3`, `graphql`, `protobuf` | Comma-separated denylist, applied after the allowlist. |

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -185,8 +185,8 @@
     "ptah": "yes",
     "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list.",
-    "evidence": "ptah schema export --help (--to openapi-v3|graphql); docs/site/src/content/docs/schema/export.md; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
+    "note": "Go annotations, or a YAML, HCL or SQL schema file, to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list.",
+    "evidence": "ptah schema export --help (--to openapi-v3|graphql, --from, --schema-file); docs/site/src/content/docs/schema/export.md; cmd/schema/export_source_test.go TestSchemaExportReadsEveryNonGoSource pins each target against yaml/hcl/sql for byte-identical output; conformance cli-surface.md CE inventory; docs/site/src/content/docs/atlas/comparison.md (atlasgo.io/features Pro list)"
   },
   {
     "area": "API schema export",
@@ -194,8 +194,8 @@
     "ptah": "yes",
     "atlas_oss": "no",
     "atlas_pro": "no",
-    "note": "Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory.",
-    "evidence": "ptah schema export --help (--proto-type-removal, --proto-on-name-reuse, --proto-on-incompatible-change); internal/protobufrender/render.go; docs/site/src/content/docs/schema/protobuf.md; conformance cli-surface.md CE inventory"
+    "note": "Edition 2023 output from Go annotations or a YAML, HCL or SQL schema file; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory.",
+    "evidence": "ptah schema export --help (--proto-type-removal, --proto-on-name-reuse, --proto-on-incompatible-change, --schema-file); internal/protobufrender/render.go; docs/site/src/content/docs/schema/protobuf.md; cmd/schema/export_source_test.go TestSchemaExportReadsEveryNonGoSource pins the protobuf target against yaml/hcl/sql; conformance cli-surface.md CE inventory"
   },
   {
     "area": "API schema export",

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -274,11 +274,11 @@ seven of them as open capabilities regardless.
 | Capability | Ptah | CE | Pro | Difference |
 | --- | :-: | :-: | :-: | --- |
 | Annotation metadata as JSON Schema | ✅ | ➖ | ➖ | Emits a JSON Schema describing every //ptah directive and attribute; Atlas has no //ptah annotation set for the concept to apply to. |
-| API schema export: OpenAPI 3.0 and GraphQL | ✅ | ❌ | ❌ | Go annotations to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list. |
+| API schema export: OpenAPI 3.0 and GraphQL | ✅ | ❌ | ❌ | Go annotations, or a YAML, HCL or SQL schema file, to OpenAPI components or GraphQL SDL; no handlers or resolvers. Absent from the CE inventory and the cited Pro list. |
 | Concurrency-guarded migration plan publication | ✅ | ➖ | ➖ | generator.PlanMigration binds a plan to a directory snapshot; WriteFiles rejects changed history (ErrMigrationDirectoryChanged) under a cross-process lock; concurrent reuse fails (ErrMigrationPlanInUs |
 | Go annotations to HCL export with cleanup | ✅ | ➖ | ➖ | Writes HCL from Go annotations; cleanup requires zero diagnostics and refuses unparsed directives. Opaque function, view, materialized-view, and trigger bodies are reported and block cleanup. |
 | Pinned database sessions (WithSession) | ✅ | ➖ | ➖ | `WithSession` on `DatabaseConnection` pins one physical session for a callback, rebinding reader/writer/SQL runner, and discards the connection so session state cannot leak. |
-| Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
+| Protobuf schema export with pinned field numbers | ✅ | ❌ | ❌ | Edition 2023 output from Go annotations or a YAML, HCL or SQL schema file; `--out` pins field numbers, with policies for type removal, name reuse and incompatible change. Not in CE inventory. |
 | ptah-ls annotation language server | ✅ | ➖ | ➖ | stdio LSP over //ptah annotations: hover, completion, diagnostics, plus a VS Code extension. Tied to Ptah's own annotation syntax. |
 | Public API compatibility gate | ✅ | ➖ | ➖ | check-public-api.sh keeps the committed API baseline and the package tree in sync; pre-v1 breaks need a per-baseline approval line. |
 | Query builder for parameterized SQL | 🟡 | ➖ | ➖ | Joins, DISTINCT, GROUP BY, HAVING and RETURNING work; no subqueries, CTEs, LIKE or upsert; SQL Server and ClickHouse error. |

--- a/docs/site/src/content/docs/schema/export.md
+++ b/docs/site/src/content/docs/schema/export.md
@@ -3,10 +3,14 @@ title: API schema export
 description: Project selected Go entities into OpenAPI or GraphQL contract candidates and review their trust-boundary limitations.
 ---
 
-Ptah projects the schema it parses from Go annotations into API-facing formats:
-OpenAPI 3.0 component schemas, GraphQL SDL, and Protobuf definitions. Use these
-artifacts when the selected database entities intentionally match your transport
-model, or as input to a separately designed contract.
+Ptah projects a desired schema into API-facing formats: OpenAPI 3.0 component
+schemas, GraphQL SDL, and Protobuf definitions. Use these artifacts when the
+selected database entities intentionally match your transport model, or as input
+to a separately designed contract.
+
+The source can be Go annotations under `--root-dir` or a YAML, HCL, or SQL
+schema file named by `--schema-file` — the same desired-schema sources
+`ptah schema render` reads.
 
 The export does not expose database rows or create a working API. It does not
 generate handlers, resolvers, Protobuf services, authentication, authorization,
@@ -32,12 +36,17 @@ ptah schema export --to graphql --root-dir ./models --out schema.graphql
 
 # Omit --out to write the schema to stdout (for piping into a validator)
 ptah schema export --to graphql --root-dir ./models > schema.graphql
+
+# Export a YAML, HCL, or SQL schema file instead of Go annotations
+ptah schema export --to openapi-v3 --schema-file schema.yaml --out openapi.yaml
 ```
 
 | Flag | Applies to | Meaning |
 | --- | --- | --- |
 | `--to` | all | `hcl`, `openapi-v3`, `graphql`, or [`protobuf`](../protobuf/). The old `atlas-hcl` value is accepted as an alias. |
+| `--from` | all | Format of the `--schema-file` value: `go` (default), `yaml`, `hcl`, or `sql`. |
 | `--root-dir` | all | Directory scanned for Go annotations. |
+| `--schema-file` | `openapi-v3`, `graphql`, `protobuf` | YAML, HCL, or SQL schema file to export instead of Go annotations. Repeatable. |
 | `--out` | all | Output file. Optional for `openapi-v3`/`graphql` (stdout when omitted); required for `hcl` and for [`protobuf`](../protobuf/), where it is also the compatibility state read back on the next run. |
 | `--include-tables` | `openapi-v3`, `graphql`, `protobuf` | Comma-separated allowlist of tables. |
 | `--exclude-tables` | `openapi-v3`, `graphql`, `protobuf` | Comma-separated denylist, applied after the allowlist. |
@@ -45,6 +54,42 @@ ptah schema export --to graphql --root-dir ./models > schema.graphql
 
 Export warnings (for example an enum whose values cannot be resolved) are written
 to stderr, so a schema piped from stdout is never corrupted.
+
+## Sources
+
+`--schema-file` is read by the same resolver as `ptah schema render`, so a
+desired schema is spelled the same way on both commands. The `openapi-v3`,
+`graphql`, and `protobuf` targets read all four sources below:
+
+- **Go annotations** — the directory named by `--root-dir`, which defaults to
+  `.`. This is `--from go`.
+- **[YAML schema](../yaml/)** — a `--schema-file` whose extension is `.yaml` or
+  `.yml`. This is `--from yaml`.
+- **[HCL schema](../hcl/)** — a `--schema-file` whose extension is `.hcl`. This
+  is `--from hcl`.
+- **[SQL schema](../sql/)** — a `--schema-file` whose extension is `.sql`. This
+  is `--from sql`.
+
+An export taken from a schema file is byte-identical to the export taken from
+annotated Go models describing the same tables, so a project can change how it
+spells its schema without republishing a different contract.
+
+`--from` declares the file's format and is checked against its extension:
+`--from yaml --schema-file schema.sql` is refused rather than parsed as YAML.
+Leave `--from` unset and the extension decides. Naming both `--root-dir` and
+`--schema-file` merges them into one
+[composite desired schema](../composite/); `--root-dir` alone keeps its `.`
+default, which a schema-file export never picks up.
+
+Two combinations are refused rather than approximated:
+
+- `--to hcl` with `--schema-file`. That target rewrites the Go files it reads —
+  `--cleanup-go-annotations` removes their annotations after a lossless export —
+  so its source is `--root-dir`. Converting a schema file to HCL is a different
+  operation from migrating annotations out of Go code.
+- `--from db`. An export reads a schema definition, not a live database. Run
+  [`ptah introspect`](../../start/adopt-an-existing-database/) to generate
+  annotated models from a database URL, review them, then export those.
 
 ## OpenAPI
 

--- a/docs/site/src/content/docs/schema/hcl.md
+++ b/docs/site/src/content/docs/schema/hcl.md
@@ -64,8 +64,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "accounts_email_key" ON "public"."accounts" ("
 ```
 
 `--schema-file` is accepted wherever Ptah needs a desired schema:
-`ptah schema render`, `ptah schema compare`, `ptah schema drift`, and the
-migration commands (`ptah migrations plan` / `ptah migrations generate`).
+`ptah schema render`, `ptah schema compare`, `ptah schema drift`, the
+migration commands (`ptah migrations plan` / `ptah migrations generate`), and
+the API targets of [`ptah schema export`](../export/#sources).
 
 To replace Go annotations with an HCL source, use the review-aware one-time
 export workflow in [Go annotations](../go-annotations/#move-the-schema-to-hcl).

--- a/docs/site/src/content/docs/schema/protobuf.md
+++ b/docs/site/src/content/docs/schema/protobuf.md
@@ -3,7 +3,8 @@ title: Protobuf schema export
 description: Export Go entities to a Protobuf Edition 2023 definition whose field numbers stay wire compatible as the schema changes.
 ---
 
-Project the schema Ptah parses from Go annotations into a Protobuf definition:
+Project the desired schema Ptah parses — Go annotations under `--root-dir`, or a
+YAML, HCL, or SQL file named by `--schema-file` — into a Protobuf definition:
 one message per table, one enum per enum column, and scalar fields for foreign
 keys. Unlike the OpenAPI and GraphQL targets on
 [API schema export](../export/), this one is stateful. Protobuf field numbers
@@ -17,9 +18,9 @@ and column names, translated types, and enum values. It does **not** carry the
 comments the source schema supplies unless you ask for them with
 [`--proto-comments all`](#control-what-the-contract-says).
 
-Prerequisites: a built `ptah` binary and a directory of annotated Go models.
-`buf` and `protoc` are needed only if you want to lint or compatibility-check
-the result yourself.
+Prerequisites: a built `ptah` binary and a desired schema — a directory of
+annotated Go models, or a YAML, HCL, or SQL schema file. `buf` and `protoc` are
+needed only if you want to lint or compatibility-check the result yourself.
 
 :::caution[Wire compatibility is not API safety]
 Compatibility checks prevent accidental field-number reuse and detect selected
@@ -174,13 +175,36 @@ Ptah protects that state in both directions:
 - The write is atomic. A refusal, a render failure, or an invalid generated
   file leaves the previous version byte-identical on disk.
 
+## Export from a schema file
+
+The desired schema does not have to be Go. `--schema-file` names a YAML, HCL, or
+SQL schema file, exactly as it does on
+[`ptah schema render`](../../reference/native-commands/):
+
+```bash
+ptah schema export --to protobuf \
+  --schema-file schema.yaml \
+  --out ./proto/acme/inventory/v1/schema.proto \
+  --proto-package acme.inventory.v1
+```
+
+The source format never reaches the generated file: a schema file and the
+annotated Go models describing the same tables produce the same `.proto`, down
+to the field numbers and the content digest. Moving a project from Go
+annotations to a schema file therefore does not restart its numbering history.
+
+`--from` declares the file's format and is checked against its extension, so
+`--from yaml --schema-file schema.sql` is refused rather than parsed as the
+wrong format. Leave `--from` unset and the extension decides.
+
 ## Flags
 
 | Flag | Required | Meaning |
 | --- | --- | --- |
 | `--to protobuf` | yes | Selects this target. |
-| `--from` | no | Source format. Only `go` is supported, and it is the default. |
+| `--from` | no | Format of the `--schema-file` value: `go` (default), `yaml`, `hcl`, or `sql`. Checked against the file extension; leave it unset to take the format from the extension. |
 | `--root-dir` | no | Directory scanned for Go annotations (default `.`). |
+| `--schema-file` | no | YAML, HCL, or SQL schema file to export instead of Go annotations. Repeatable; merged with `--root-dir` when both are given. |
 | `--out` | yes | Destination `.proto`. Also the compatibility state read back on the next run. |
 | `--proto-package` | yes | Protobuf package, `lower_snake.case` segments, for example `acme.inventory.v1`. |
 | `--go-package` | no | Emitted as `option go_package`. |
@@ -648,10 +672,13 @@ Every check below runs before anything is written, and each exits with code
 Every bullet below ends with either the issue that tracks it or the reason it is
 permanent, so nothing on this list is an unowned gap.
 
-- The source is Go annotations only. There is no `--schema-file` or database
-  URL for this target; run [`ptah introspect`](../../start/adopt-an-existing-database/)
-  first to generate annotated models from an existing database. Tracked by
-  [#1144](https://github.com/stokaro/ptah/issues/1144).
+- A live database is not a source. `--root-dir` and `--schema-file` cover Go
+  annotations, YAML, HCL, and SQL; there is no database URL for this target, so
+  run [`ptah introspect`](../../start/adopt-an-existing-database/) first to
+  generate annotated models from an existing database and export those. That
+  split is permanent because a wire contract is reviewed from a file in version
+  control, and introspection is the reviewable step that turns a database into
+  one.
 - Table selection is the narrowest available projection. There are no
   field-level allowlists, read/write visibility rules, sensitive-field markers,
   or API-specific aliases. Use a curated annotation source or wrapper messages

--- a/docs/site/src/content/docs/schema/sql.md
+++ b/docs/site/src/content/docs/schema/sql.md
@@ -36,8 +36,9 @@ CREATE TABLE "users" (
 Rendering SQL back out of a SQL file is not a no-op: it proves the parser
 understood every statement, and it can retarget the schema at another dialect.
 `--schema-file` is accepted wherever Ptah needs a desired schema:
-`ptah schema render`, `ptah schema compare`, `ptah schema drift`, and the
-migration commands (`ptah migrations plan` / `ptah migrations generate`).
+`ptah schema render`, `ptah schema compare`, `ptah schema drift`, the
+migration commands (`ptah migrations plan` / `ptah migrations generate`), and
+the API targets of [`ptah schema export`](../export/#sources).
 
 ## Diff two SQL files locally
 

--- a/docs/site/src/content/docs/schema/yaml.md
+++ b/docs/site/src/content/docs/schema/yaml.md
@@ -48,8 +48,9 @@ CREATE UNIQUE INDEX IF NOT EXISTS "accounts_email_key" ON "accounts" ("email");
 
 The rendered SQL proves Ptah understood the desired schema. `--schema-file` is
 accepted wherever Ptah needs a desired schema: `ptah schema render`,
-`ptah schema compare`, `ptah schema drift`, and the migration commands
-(`ptah migrations plan` / `ptah migrations generate`).
+`ptah schema compare`, `ptah schema drift`, the migration commands
+(`ptah migrations plan` / `ptah migrations generate`), and the API targets of
+[`ptah schema export`](../export/#sources).
 
 ## Use it for migrations
 


### PR DESCRIPTION
`ptah schema export` rejected any `--from` but `go` and registered no
`--schema-file`, so the three API export targets could only project Go
annotations. The loader they needed already existed and is what
`ptah schema render` reads `--schema-file` with, so this is wiring rather than a
second reader.

## The grid

Established from the issue's Acceptance section and confirmed against the code
rather than taken on faith. `validateExportOptions` in `cmd/schema/schema.go`
registers four `--to` targets, of which `hcl` is not an API target and converts
Go annotations in place. `cmd/internal/schemaload` dispatches a `--schema-file`
on its extension and accepts exactly `.yaml`/`.yml`, `.hcl` and `.sql`. Three API
targets x three non-Go sources = nine cells. A database URL is out of scope by
the issue's own statement.

| # | Target | Source | Before | After |
| --- | --- | --- | --- | --- |
| 1 | `openapi-v3` | YAML | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 2 | `openapi-v3` | HCL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 3 | `openapi-v3` | SQL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 4 | `graphql` | YAML | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 5 | `graphql` | HCL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 6 | `graphql` | SQL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 7 | `protobuf` | YAML | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 8 | `protobuf` | HCL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| 9 | `protobuf` | SQL | exit 2, `unknown flag: --schema-file` | exit 0, byte-identical to the Go export |
| — | `hcl` | any schema file | exit 2, `unknown flag: --schema-file` | exit 2, refused with the reason (below) |
| — | any | live database | exit 2, `unsupported --from "db": expected go` | exit 2, refused with the reason (below) |

Each cell is checked in both spellings: `--schema-file` alone, where the
extension names the format, and an explicit `--from` beside it.

## Reproduction on the base commit

Built from `d797d15`, `models/` holding annotated Go and `schema.yaml` the same
schema in YAML.

```
$ ptah schema export --to protobuf --root-dir models --out out/schema.proto --proto-package acme.b1.v1
Exported Protobuf schema to .../out/schema.proto        # exit 0, positive control

$ ptah schema export --to protobuf --root-dir models --out out/schema.proto \
    --proto-package acme.b1.v1 --definitely-not-a-flag x
error: unknown flag: --definitely-not-a-flag           # exit 2, negative control

$ ptah schema export --to protobuf --root-dir models --out out/schema.proto \
    --proto-package acme.b1.v1 --from yaml
error: unsupported --from "yaml": expected go          # exit 2

$ ptah schema export --to graphql --from hcl --root-dir models
error: unsupported --from "hcl": expected go           # exit 2

$ ptah schema export --to protobuf --schema-file schema.yaml \
    --out out/schema.proto --proto-package acme.inventory.v1
error: unknown flag: --schema-file                     # exit 2

$ ptah schema export --to openapi-v3 --schema-file schema.yaml
error: unknown flag: --schema-file                     # exit 2
```

## What changed

The export path resolves its source through `cmd/internal/schemaload` instead of
calling `goschema.ParseDir` itself. That is the resolver behind
`ptah schema render`, `ptah schema compare` and the migration commands, so
`--schema-file` means the same thing everywhere and no parallel loader can drift
from it. For a single Go root the resolver reduces to the same `ParseDir` call,
so the Go-only path is unchanged.

`--from` gains `yaml`, `hcl` and `sql`. It declares the named file's format and
is checked against its extension, so `--from yaml --schema-file schema.sql` is
refused rather than parsed as the wrong format. Left unset the extension decides,
which is the form the issue's acceptance command uses.

`--root-dir` keeps its `.` default for a Go-only export and enters a schema-file
export only when it was passed, so `--schema-file` never merges whatever
annotated Go files happen to sit in the working directory. Passing both merges
them into one composite schema, as on `render`.

## Cells that are refused, and why

- **`--to hcl` with `--schema-file`.** That target is not a projection: it
  rewrites the Go files it reads, and `--cleanup-go-annotations` removes their
  annotations after a lossless export. Its source stays `--root-dir`. The
  message names `--to openapi-v3, graphql, or protobuf` as the way out, which
  also covers the operator who names a schema file and forgets `--to`, since
  `--to` defaults to `hcl`.
- **`--from db`.** An export reads a schema definition, not a live database.
  The message names `ptah introspect`, the reviewable step that turns a database
  into source. This replaces the previous bare `expected go`.
- **`--from` beside an `oci://` reference.** A registry artifact records its own
  format and has no extension to check against, so `--from` is refused with that
  reason instead of the "no recognized extension" message, which would read as
  "rename your registry reference".

## Byte-identity

The fixture is two tables, a foreign key, and a named enum — the foreign key and
the enum being the two places an API export invents names of its own. Every one
of the nine cells produces output equal to the Go export byte for byte.

Measured through the built binary for the issue's own command:

```
$ ptah schema export --to protobuf --root-dir models --out go/schema.proto  --proto-package acme.inventory.v1
$ ptah schema export --to protobuf --schema-file schema.yaml --out yaml/schema.proto --proto-package acme.inventory.v1
$ diff go/schema.proto yaml/schema.proto      # no output
$ shasum -a 256 go/schema.proto yaml/schema.proto
ea225f18eac10e8e66b0c1c687f385eebf213977e460657544893aad8053d02e  go/schema.proto
ea225f18eac10e8e66b0c1c687f385eebf213977e460657544893aad8053d02e  yaml/schema.proto
```

Identical bytes include the `ptah:content-sha256` header and every field number,
so moving a project from Go annotations onto a schema file does not restart its
protobuf numbering history.

## Red/green evidence

Every assertion below was seen red before it was trusted. Each mutation was
applied to the implementation, the named subtests were run, and the mutation was
reverted.

| Mutation | Expected red | Observed |
| --- | --- | --- |
| Drop `SchemaFiles` from the `schemaload.Options` the export builds | all nine cells | 9 FAIL, 0 PASS |
| Remove `.yaml`/`.yml` from the resolver's accepted extensions | the three YAML cells | 3 FAIL (yaml), 6 PASS |
| Remove `.hcl` from the resolver's accepted extensions | the three HCL cells | 3 FAIL (hcl), 6 PASS |
| Remove `.sql` from the resolver's accepted extensions | the three SQL cells | 3 FAIL (sql), 6 PASS |
| Drop `.yml` from the `--from` extension map | the `.yml` alias test | FAIL |
| Always pass the `--root-dir` default to the resolver | the working-directory test | FAIL; the nine cells stayed PASS, which is why that test exists separately |
| Ignore an explicit `--root-dir` beside `--schema-file` | the composite test | FAIL |
| Return `nil` from the `--from` validation switch | six of the ten refusal rows | 6 FAIL; the two rows answered before the switch and the inferred-extension row stayed PASS |
| Disable the `--to hcl` guard and the `oci://` branch | the three rows they own | 3 FAIL, 7 PASS |

The nine cells stayed green under the `--root-dir` mutation because the grid
names an absolute `--schema-file` from a working directory that holds no
annotations. That is a real hole in the grid, and
`TestSchemaExportSchemaFileDoesNotAddTheWorkingDirectory` uses `t.Chdir` into a
directory that does hold one to close it.

## Documentation

- `docs/site/src/content/docs/schema/export.md` — a `Sources` section listing
  what each target reads, the byte-identity property, and both refused
  combinations; `--from` and `--schema-file` added to the flag table.
- `docs/site/src/content/docs/schema/protobuf.md` — the first `Limitations`
  bullet was this issue and now records what remains: a live database is not a
  source, with the reason. A new `Export from a schema file` section and two
  flag-table rows.
- `docs/site/src/content/docs/schema/{yaml,hcl,sql}.md` — the list of surfaces
  that accept `--schema-file` now includes the API export targets.
- `docs/api_schema_export.md` and the feature-matrix evidence rows.
  `feature-matrix.md` is regenerated from `feature-matrix-rows.json`;
  `build-feature-matrix.mjs --check` is OK.

## Gates

Read bare, never through a pipe.

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci` and every `check:*` plus every `*:selftest` | 0 |
| `docs/site`: `npm run build`, `build-feature-matrix.mjs --check` | 0 |
| `go test ./... -count=1` | 1 locally, see below; the `unit-tests` job on this PR is green |

`go test ./... -count=1` exited 1 on the development machine, twice, with one
package failing: `FAIL go.5x5.cz/ptah/cmd/atlas 699.130s`, a SIGQUIT from the
10-minute per-package timeout with the goroutine dump parked on `t.Parallel()`
and on an `os/exec` wait inside `cmd/internal/editor`. The machine was running
several unrelated test suites concurrently (58 `go test` processes at the time).
`cmd/atlas` is not in this change's blast radius — it consumes `cmd/schema` only
for `NewSchemaTestCommand` — and every package this change does touch passes:

```
ok  go.5x5.cz/ptah/cmd/schema             83.527s
ok  go.5x5.cz/ptah/cmd/internal/schemaload 84.043s
ok  go.5x5.cz/ptah/cmd/generate           83.418s
ok  go.5x5.cz/ptah/cmd/ptah              293.025s
```

The `unit-tests` job on this pull request runs the same suite on an unloaded
runner and is green, as are `integration-tests`, `export-acceptance`,
`differential and corpus` and the documentation jobs.

`check:responsive` caught a first draft of the `Sources` section: a seven-column
table overflowed its container by 19px on the `/schema/export/` page. It is a
list now.

Closes #1144