### PR TITLE
Count a DROP INDEX as the schema change it is (#1296)

### DIFF
--- a/core/ast/nodes.go
+++ b/core/ast/nodes.go
@@ -1084,11 +1084,25 @@ func (n *IndexNode) SetIfNotExists() *IndexNode {
 // and dialect-specific features. Different databases have different
 // syntax for dropping indexes (some require table name, others don't).
 type DropIndexNode struct {
-	// Name is the raw, unqualified index identifier. Dialect renderers derive
-	// its namespace from Table.
+	// Name is the index identifier the statement names, and it is the only
+	// place a schema qualifier can live when the statement names no table.
+	//
+	// A planned drop names the index bare and carries the namespace on Table,
+	// which is where every renderer reads it from. A drop recovered from SQL
+	// text may have no table to record: PostgreSQL and SQLite spell the
+	// statement `DROP INDEX app.idx`, putting a schema on the index and naming
+	// no table at all, where MySQL, MariaDB, SQL Server and CockroachDB name
+	// the table and leave the index bare. Name therefore carries whatever
+	// qualifier the source spelled on the index, and nothing more.
+	//
+	// Anything that has to answer "which schema is this index in" reads Table
+	// first and falls back to Name, never the other way round: a bare Name is
+	// unqualified and belongs to its table's schema, so reading it first would
+	// place `DROP INDEX app.idx` inside every schema (stokaro/ptah#1296).
 	Name string
 	// Table is the qualified owning table. It is required for every planned
-	// index drop even when the target SQL names the index by schema.
+	// index drop even when the target SQL names the index by schema, and it is
+	// empty for a drop parsed from a statement that names no table -- see Name.
 	Table string
 	// IfExists indicates whether to use IF EXISTS clause
 	IfExists bool
@@ -1100,6 +1114,12 @@ type DropIndexNode struct {
 	// planners set it only for standalone index drops the caller routes into a
 	// no_transaction migration.
 	Concurrently bool
+	// Cascade requests DROP INDEX ... CASCADE, which also drops the objects
+	// that depend on the index. Only PostgreSQL's grammar has the clause;
+	// every other renderer ignores the flag. RESTRICT, the opposite spelling,
+	// is the default everywhere and is therefore not modeled: a node with
+	// Cascade unset already means it.
+	Cascade bool
 	// EnforcesUniqueConstraint reports that the index being dropped is the one
 	// a UNIQUE constraint of the same name enforces, so the statement removes a
 	// uniqueness protection and not only an access path.
@@ -1168,6 +1188,19 @@ func (n *DropIndexNode) SetIfExists() *DropIndexNode {
 //	dropIndex.SetConcurrently()
 func (n *DropIndexNode) SetConcurrently() *DropIndexNode {
 	n.Concurrently = true
+	return n
+}
+
+// SetCascade marks the drop to use CASCADE.
+//
+// The clause only reaches the SQL on PostgreSQL, whose DROP INDEX is the only
+// one of Ptah's targets that has it.
+//
+// Example:
+//
+//	dropIndex.SetCascade()
+func (n *DropIndexNode) SetCascade() *DropIndexNode {
+	n.Cascade = true
 	return n
 }
 

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -48,6 +48,10 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 
 	parts = append(parts, r.dropIndexTarget(node))
 
+	if node.Cascade {
+		parts = append(parts, "CASCADE")
+	}
+
 	sql := strings.Join(parts, " ") + ";"
 
 	// Add comment if provided
@@ -65,7 +69,11 @@ func (r *Renderer) dropIndexTarget(node *ast.DropIndexNode) string {
 	}
 	tableParts := splitQualifiedIdentifier(node.Table)
 	if len(tableParts) < 2 {
-		return r.escapeIdentifier(node.Name)
+		// No table namespace to borrow, so the index name is the only place a
+		// qualifier can be, and `DROP INDEX app.idx` puts one there. Escaping
+		// it whole would emit "app.idx" as a single identifier and name an
+		// index nobody created. See [ast.DropIndexNode.Name].
+		return r.escapeQualifiedIdentifier(node.Name)
 	}
 	schemaParts := tableParts[:len(tableParts)-1]
 	return r.escapeQualifiedIdentifier(strings.Join(schemaParts, ".")) + "." + r.escapeIdentifier(node.Name)

--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -155,14 +155,29 @@ func (r *Renderer) VisitDropIndex(node *ast.DropIndexNode) error {
 	if node.Comment != "" {
 		r.w.WriteLinef("-- %s", node.Comment)
 	}
-	indexName, _ := sqliteIndexTarget(node.Name, node.Table)
 	parts := []string{"DROP INDEX"}
 	if node.IfExists {
 		parts = append(parts, "IF EXISTS")
 	}
-	parts = append(parts, indexName)
+	parts = append(parts, sqliteDropIndexTarget(node.Name, node.Table))
 	r.w.WriteLinef("%s;", strings.Join(parts, " "))
 	return nil
+}
+
+// sqliteDropIndexTarget renders the index a DROP INDEX names.
+//
+// It is [sqliteIndexTarget]'s index half plus the case CREATE INDEX never has:
+// a drop with no owning table recorded, where the index name is the only place
+// a schema qualifier can live and `DROP INDEX app.idx` puts one there. Escaping
+// it whole would emit "app.idx" as a single identifier and name an index nobody
+// created. See [ast.DropIndexNode.Name].
+func sqliteDropIndexTarget(indexName, tableName string) string {
+	tableParts := splitQualifiedIdentifier(tableName)
+	if len(tableParts) < 2 {
+		return escapeQualifiedIdentifier(indexName)
+	}
+	schema := strings.Join(tableParts[:len(tableParts)-1], ".")
+	return escapeQualifiedIdentifier(schema) + "." + escapeIdentifier(indexName)
 }
 
 func sqliteIndexTarget(indexName, tableName string) (renderedIndexName, renderedTableName string) {

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -1864,11 +1864,25 @@ func (n *DropFunctionNode) SetParameters(parameters string) *DropFunctionNode
 package ast // import "go.5x5.cz/ptah/core/ast"
 
 type DropIndexNode struct {
-    // Name is the raw, unqualified index identifier. Dialect renderers derive
-    // its namespace from Table.
+    // Name is the index identifier the statement names, and it is the only
+    // place a schema qualifier can live when the statement names no table.
+    //
+    // A planned drop names the index bare and carries the namespace on Table,
+    // which is where every renderer reads it from. A drop recovered from SQL
+    // text may have no table to record: PostgreSQL and SQLite spell the
+    // statement `DROP INDEX app.idx`, putting a schema on the index and naming
+    // no table at all, where MySQL, MariaDB, SQL Server and CockroachDB name
+    // the table and leave the index bare. Name therefore carries whatever
+    // qualifier the source spelled on the index, and nothing more.
+    //
+    // Anything that has to answer "which schema is this index in" reads Table
+    // first and falls back to Name, never the other way round: a bare Name is
+    // unqualified and belongs to its table's schema, so reading it first would
+    // place `DROP INDEX app.idx` inside every schema (stokaro/ptah#1296).
     Name string
     // Table is the qualified owning table. It is required for every planned
-    // index drop even when the target SQL names the index by schema.
+    // index drop even when the target SQL names the index by schema, and it is
+    // empty for a drop parsed from a statement that names no table -- see Name.
     Table string
     // IfExists indicates whether to use IF EXISTS clause
     IfExists bool
@@ -1880,6 +1894,12 @@ type DropIndexNode struct {
     // planners set it only for standalone index drops the caller routes into a
     // no_transaction migration.
     Concurrently bool
+    // Cascade requests DROP INDEX ... CASCADE, which also drops the objects
+    // that depend on the index. Only PostgreSQL's grammar has the clause;
+    // every other renderer ignores the flag. RESTRICT, the opposite spelling,
+    // is the default everywhere and is therefore not modeled: a node with
+    // Cascade unset already means it.
+    Cascade bool
     // EnforcesUniqueConstraint reports that the index being dropped is the one
     // a UNIQUE constraint of the same name enforces, so the statement removes a
     // uniqueness protection and not only an access path.
@@ -1902,6 +1922,7 @@ type DropIndexNode struct {
 
 func NewDropIndex(name string) *DropIndexNode
 func (n *DropIndexNode) Accept(visitor Visitor) error
+func (n *DropIndexNode) SetCascade() *DropIndexNode
 func (n *DropIndexNode) SetComment(comment string) *DropIndexNode
 func (n *DropIndexNode) SetConcurrently() *DropIndexNode
 func (n *DropIndexNode) SetEnforcesUniqueConstraint() *DropIndexNode

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -920,10 +920,17 @@ objects the run analyzes. A PostgreSQL-family `--dev-url` carrying
   name;
 - one statement is measured per object: `DROP TABLE users, other.audit_log;`
   under `search_path=public` reports `users` and counts one schema change;
-- an index is measured by the schema of the table it is on, because an index
-  name never carries one: `CREATE INDEX idx ON app.users (id);` under
+- an index is measured by the schema of the table it is on whenever the
+  statement names a table, because the index name is bare there:
+  `CREATE INDEX idx ON app.users (id);` under `search_path=public` counts no
+  schema change and raises no diagnostic, while the same statement on a
+  `public` table counts one and raises `PG101`. `DROP INDEX idx ON app.t;` —
+  MySQL's, MariaDB's and SQL Server's spelling — is measured the same way;
+- a `DROP INDEX` that names no table is measured by the qualifier on the index
+  itself, which is the only one the statement has: `DROP INDEX app.idx;` under
   `search_path=public` counts no schema change and raises no diagnostic, while
-  the same statement on a `public` table counts one and raises `PG101`.
+  `DROP INDEX public.idx;` and the unqualified `DROP INDEX idx;` each count one
+  and raise `PG106`.
 
 A `--dev-url` that names no schema puts the whole connected database under
 review and filters nothing, which is also what every non-PostgreSQL dev URL
@@ -957,14 +964,30 @@ changes for it. A count of zero is not a statement of safety.
 
 Silence is not exclusion. A statement outside Ptah's SQL grammar is left under
 review whatever schema it names, because a boundary that could not be read must
-not be able to drop a diagnostic. `DROP INDEX` is the current example: Ptah's
-parser does not model it, so `DROP INDEX public.idx;` counts no schema change
-even in the reviewed schema — the pinned community binary counts one — while
-its `PG106` diagnostic is reported in every schema. That missing change is a
-parser gap rather than a scope decision, tracked in
-[`stokaro/ptah#1296`](https://github.com/stokaro/ptah/issues/1296). The same
-grammar boundary is why `TRUNCATE app.users;` and `DROP FUNCTION app.recalc();`
-are reported under `search_path=public` while counting no schema change.
+not be able to drop a diagnostic. That grammar boundary is why
+`TRUNCATE app.users;` and `DROP FUNCTION app.recalc();` are reported under
+`search_path=public` while counting no schema change.
+
+`DROP INDEX` used to be the largest example of it and no longer is: the parser
+models the statement, so `DROP INDEX public.idx;` counts one schema change,
+matching the pinned community binary v1.3.0, and `DROP INDEX app.idx;` is
+scoped out whole — no schema change and no `PG106`, which is also what the
+community binary reports. Ptah raised `PG106` for the `app` form before
+[`stokaro/ptah#1296`](https://github.com/stokaro/ptah/issues/1296); nothing
+about the reviewed schema became quieter, since the `public` form still raises
+it.
+
+Two `DROP INDEX` forms are still outside the grammar. Both are refused by the
+parser rather than half-recorded, so each counts no schema change and keeps its
+diagnostics under every scope:
+
+- PostgreSQL's multi-index `DROP INDEX a, b;`, which one `DROP INDEX` node
+  cannot hold;
+- SQL Server's backward-compatible `DROP INDEX t.idx;`, where the qualifier
+  names the table rather than a schema. Reading it the way every other dialect
+  spells the same text would scope the drop to a schema nobody wrote. Ptah
+  renders SQL Server index drops as `DROP INDEX idx ON t`, which is read
+  exactly.
 
 Three constructs are still measured by a name that carries no schema, because
 Ptah's parser records none for them. Measured on PostgreSQL 17.10 under

--- a/internal/parser/drop_index_test.go
+++ b/internal/parser/drop_index_test.go
@@ -1,0 +1,399 @@
+package parser_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/renderer"
+	"go.5x5.cz/ptah/internal/parser"
+)
+
+// dropIndexShape is the whole of what a parsed DROP INDEX has to say. Comparing
+// the struct rather than field by field is what makes a row fail when the parser
+// records a name in the wrong field, which is the defect this file guards:
+// asserting only on Name would pass with the schema silently misfiled on Table.
+type dropIndexShape struct {
+	Name         string
+	Table        string
+	IfExists     bool
+	Concurrently bool
+	Cascade      bool
+}
+
+func shapeOfDropIndex(node *ast.DropIndexNode) dropIndexShape {
+	return dropIndexShape{
+		Name:         node.Name,
+		Table:        node.Table,
+		IfExists:     node.IfExists,
+		Concurrently: node.Concurrently,
+		Cascade:      node.Cascade,
+	}
+}
+
+// TestParser_ParseDropIndex pins that a DROP INDEX parses into an
+// [ast.DropIndexNode] on every dialect Ptah renders one for, and that the schema
+// qualifier ends up where [ast.DropIndexNode.Name] says it does
+// (stokaro/ptah#1296).
+//
+// Before this, `parseDropStatement` refused every target but TABLE, so
+// `DROP INDEX app.idx` came back as `unsupported DROP target: INDEX at position
+// 5` and contributed no schema change to `migration/lint` in any schema -- the
+// community binary v1.3.0 counts one for the reviewed schema.
+//
+// The two grammars are what the rows are really about. PostgreSQL and SQLite
+// name the index in its own namespace and no table; MySQL, MariaDB, SQL Server
+// and CockroachDB name the table and leave the index bare. A row that put
+// `app` on Table for the first shape would read as "the index in schema app" to
+// a renderer and as "the table named app" to the reviewed-schema filter, which
+// treats an unqualified name as in-scope -- so it would put a drop in `app`
+// under review from a run reviewing `public`.
+func TestParser_ParseDropIndex(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		want    dropIndexShape
+	}{
+		{
+			name:    "postgres schema-qualified index",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX app.idx;",
+			want:    dropIndexShape{Name: "app.idx"},
+		},
+		{
+			name:    "postgres unqualified index",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX idx;",
+			want:    dropIndexShape{Name: "idx"},
+		},
+		{
+			name:    "postgres concurrently",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX CONCURRENTLY idx;",
+			want:    dropIndexShape{Name: "idx", Concurrently: true},
+		},
+		{
+			name:    "postgres concurrently if exists qualified",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX CONCURRENTLY IF EXISTS public.idx;",
+			want:    dropIndexShape{Name: "public.idx", IfExists: true, Concurrently: true},
+		},
+		{
+			name:    "postgres cascade",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX app.idx CASCADE;",
+			want:    dropIndexShape{Name: "app.idx", Cascade: true},
+		},
+		{
+			name:    "postgres restrict is the default and records nothing",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX app.idx RESTRICT;",
+			want:    dropIndexShape{Name: "app.idx"},
+		},
+		{
+			name:    "postgres quoted identifiers",
+			dialect: platform.Postgres,
+			sql:     `DROP INDEX "App"."Idx";`,
+			want:    dropIndexShape{Name: `"App"."Idx"`},
+		},
+		{
+			name:    "lowercase keywords",
+			dialect: platform.Postgres,
+			sql:     "drop index concurrently if exists app.idx cascade;",
+			want:    dropIndexShape{Name: "app.idx", IfExists: true, Concurrently: true, Cascade: true},
+		},
+		{
+			name:    "sqlite schema-qualified index",
+			dialect: platform.SQLite,
+			sql:     "DROP INDEX IF EXISTS tenant.idx;",
+			want:    dropIndexShape{Name: "tenant.idx", IfExists: true},
+		},
+		{
+			name:    "mysql names the table",
+			dialect: platform.MySQL,
+			sql:     "DROP INDEX idx ON app.t;",
+			want:    dropIndexShape{Name: "idx", Table: "app.t"},
+		},
+		{
+			name:    "mariadb guards the drop and names the table",
+			dialect: platform.MariaDB,
+			sql:     "DROP INDEX IF EXISTS idx ON app.t;",
+			want:    dropIndexShape{Name: "idx", Table: "app.t", IfExists: true},
+		},
+		{
+			name:    "sqlserver bracketed identifiers",
+			dialect: platform.SQLServer,
+			sql:     "DROP INDEX [idx] ON [dbo].[t];",
+			// Bracketed identifiers keep their brackets through the parser on
+			// every statement; the renderers strip them. Recording them
+			// unbracketed here would make this the one place they do not.
+			want: dropIndexShape{Name: "[idx]", Table: "[dbo].[t]"},
+		},
+		{
+			name:    "cockroachdb joins table and index with @",
+			dialect: platform.CockroachDB,
+			sql:     "DROP INDEX app.t@idx;",
+			want:    dropIndexShape{Name: "idx", Table: "app.t"},
+		},
+		{
+			name:    "cockroachdb if exists and cascade around the @ form",
+			dialect: platform.CockroachDB,
+			sql:     "DROP INDEX IF EXISTS app.t@idx CASCADE;",
+			want:    dropIndexShape{Name: "idx", Table: "app.t", IfExists: true, Cascade: true},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := parser.NewParser(test.sql, parser.WithDialect(test.dialect)).Parse()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+			dropIndex, ok := statements.Statements[0].(*ast.DropIndexNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(shapeOfDropIndex(dropIndex), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestParser_ParseDropIndexWithoutDialect pins that the compatibility mode --
+// no dialect selected, which is what `migration/lint` falls back to when a run
+// names none -- parses the same statements. A grammar wired only under an
+// explicit dialect would leave the change count zero for exactly the callers
+// that have the least information.
+func TestParser_ParseDropIndexWithoutDialect(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want dropIndexShape
+	}{
+		{
+			name: "qualified index",
+			sql:  "DROP INDEX app.idx;",
+			want: dropIndexShape{Name: "app.idx"},
+		},
+		{
+			name: "index on table",
+			sql:  "DROP INDEX idx ON app.t;",
+			want: dropIndexShape{Name: "idx", Table: "app.t"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := parser.NewParser(test.sql).Parse()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+			dropIndex, ok := statements.Statements[0].(*ast.DropIndexNode)
+			c.Assert(ok, qt.IsTrue)
+			c.Assert(shapeOfDropIndex(dropIndex), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestParser_ParseDropIndexRoundTrip pins that a parsed DROP INDEX renders back
+// to the statement it came from.
+//
+// The qualified-index rows are the ones that need saying. With the schema on
+// [ast.DropIndexNode.Name] and no table to take a namespace from, a renderer
+// that escapes the name whole emits `DROP INDEX "app.idx";` -- one identifier,
+// naming an index nobody created, and a statement that would fail against a
+// database rather than drop the wrong thing. Both PostgreSQL and SQLite reach
+// that shape, so both are here.
+func TestParser_ParseDropIndexRoundTrip(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		want    string
+	}{
+		{
+			name:    "postgres keeps the schema on the index name",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX app.idx;",
+			want:    "DROP INDEX \"app\".\"idx\";\n",
+		},
+		{
+			name:    "postgres unqualified index",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX idx;",
+			want:    "DROP INDEX \"idx\";\n",
+		},
+		{
+			name:    "postgres concurrently if exists cascade",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX CONCURRENTLY IF EXISTS app.idx CASCADE;",
+			want:    "DROP INDEX CONCURRENTLY IF EXISTS \"app\".\"idx\" CASCADE;\n",
+		},
+		{
+			name:    "sqlite keeps the schema on the index name",
+			dialect: platform.SQLite,
+			sql:     "DROP INDEX IF EXISTS tenant.idx;",
+			want:    "DROP INDEX IF EXISTS \"tenant\".\"idx\";\n",
+		},
+		{
+			name:    "mysql keeps the table",
+			dialect: platform.MySQL,
+			sql:     "DROP INDEX idx ON app.t;",
+			want:    "DROP INDEX `idx` ON `app`.`t`;\n",
+		},
+		{
+			name:    "cockroachdb keeps the @ form",
+			dialect: platform.CockroachDB,
+			sql:     "DROP INDEX app.t@idx;",
+			want:    "DROP INDEX \"app\".\"t\"@\"idx\";\n",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			statements, err := parser.NewParser(test.sql, parser.WithDialect(test.dialect)).Parse()
+			c.Assert(err, qt.IsNil)
+			c.Assert(statements.Statements, qt.HasLen, 1)
+
+			rendered, err := renderer.RenderSQL(test.dialect, statements.Statements[0])
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(rendered, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestParser_ParseDropIndexRefusesShapesItCannotRecord pins that the forms
+// [ast.DropIndexNode] cannot hold are refused out loud rather than truncated.
+//
+// A silent partial parse is the worse failure here: `DROP INDEX a, b` recorded
+// as one node would report one schema change where two happened, and a reader
+// judging a version by its change count would be told the smaller number with
+// nothing to indicate it. An error costs the count entirely, which is the
+// failure that is at least visible in the parse.
+func TestParser_ParseDropIndexRefusesShapesItCannotRecord(t *testing.T) {
+	tests := []struct {
+		name string
+		sql  string
+		want string
+	}{
+		{
+			name: "several index names",
+			sql:  "DROP INDEX a, b;",
+			want: "unsupported DROP INDEX with multiple index names at position 12",
+		},
+		{
+			name: "several index names after IF EXISTS",
+			sql:  "DROP INDEX IF EXISTS a, b;",
+			want: "unsupported DROP INDEX with multiple index names at position 22",
+		},
+		{
+			name: "no index name",
+			sql:  "DROP INDEX;",
+			want: "expected index name: expected identifier, got Semicolon at position 10",
+		},
+		{
+			name: "ON without a table",
+			sql:  "DROP INDEX idx ON;",
+			want: "expected table name: expected identifier, got Semicolon at position 17",
+		},
+		{
+			name: "@ without an index name",
+			sql:  "DROP INDEX t@;",
+			want: "expected index name after '@': expected identifier, got Semicolon at position 13",
+		},
+		{
+			name: "IF without EXISTS",
+			sql:  "DROP INDEX IF idx;",
+			want: "expected EXISTS after DROP INDEX IF: expected 'EXISTS', got 'idx' at position 14",
+		},
+		{
+			name: "a DROP target that is still unmodeled",
+			sql:  "DROP VIEW users;",
+			want: "unsupported DROP target: VIEW at position 5",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := parser.NewParser(test.sql, parser.WithDialect(platform.Postgres)).Parse()
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.want)
+		})
+	}
+}
+
+// TestParser_ParseDropIndexRefusesSQLServerTableQualifiedName pins the one
+// dialect where a qualified name with no ON means something else.
+//
+// SQL Server has no schema-qualified index names, so `DROP INDEX t.idx` is its
+// backward-compatible spelling of `DROP INDEX idx ON t`. Reading `t` as a schema
+// there -- which is what every other dialect's grammar means -- would measure
+// the drop against a schema nobody wrote and render the name back as the single
+// identifier "t.idx". Ptah never renders that spelling, so refusing it costs
+// only the schema change count of a statement it does not emit, and the control
+// row proves the refusal is scoped to the dialect rather than to the shape.
+func TestParser_ParseDropIndexRefusesSQLServerTableQualifiedName(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		sql     string
+		check   func(c *qt.C, err error)
+	}{
+		{
+			name:    "sqlserver two-part name without ON",
+			dialect: platform.SQLServer,
+			sql:     "DROP INDEX t.idx;",
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Equals,
+					`unsupported SQL Server DROP INDEX "t.idx" without ON: a qualified name there is table.index, not schema.index`)
+			},
+		},
+		{
+			name:    "sqlserver three-part name without ON",
+			dialect: platform.SQLServer,
+			sql:     "DROP INDEX dbo.t.idx;",
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Equals,
+					`unsupported SQL Server DROP INDEX "dbo.t.idx" without ON: a qualified name there is table.index, not schema.index`)
+			},
+		},
+		{
+			name:    "sqlserver bare name without ON is accepted",
+			dialect: platform.SQLServer,
+			sql:     "DROP INDEX idx;",
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.IsNil)
+			},
+		},
+		{
+			name:    "postgres reads the same text as a schema-qualified index",
+			dialect: platform.Postgres,
+			sql:     "DROP INDEX t.idx;",
+			check: func(c *qt.C, err error) {
+				c.Assert(err, qt.IsNil)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := parser.NewParser(test.sql, parser.WithDialect(test.dialect)).Parse()
+
+			test.check(c, err)
+		})
+	}
+}

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -13,6 +13,7 @@ import (
 	"go.5x5.cz/ptah/core/platform/capability"
 	"go.5x5.cz/ptah/core/sqlutil"
 	"go.5x5.cz/ptah/internal/lexer"
+	"go.5x5.cz/ptah/internal/tableref"
 )
 
 // Parser converts SQL tokens into AST nodes.
@@ -3620,6 +3621,8 @@ func (p *Parser) parseDropStatement() (ast.Node, error) {
 	switch target {
 	case "TABLE":
 		return p.parseDropTable()
+	case "INDEX":
+		return p.parseDropIndex()
 	default:
 		return nil, fmt.Errorf("unsupported DROP target: %s at position %d", target, p.current.Start)
 	}
@@ -3681,6 +3684,158 @@ func (p *Parser) parseDropTableNames() ([]string, error) {
 		p.advance()
 		p.skipWhitespace()
 	}
+}
+
+// parseDropIndex parses a DROP INDEX statement into an [ast.DropIndexNode].
+//
+// One grammar covers every dialect Ptah renders a DROP INDEX for, because the
+// forms differ in which optional clauses they use rather than in what a clause
+// means:
+//
+//	PostgreSQL   DROP INDEX [CONCURRENTLY] [IF EXISTS] [schema.]index [CASCADE|RESTRICT]
+//	SQLite       DROP INDEX [IF EXISTS] [schema.]index
+//	MySQL        DROP INDEX index ON [schema.]table
+//	MariaDB      DROP INDEX [IF EXISTS] index ON [schema.]table
+//	SQL Server   DROP INDEX [IF EXISTS] index ON [schema.]table
+//	CockroachDB  DROP INDEX [IF EXISTS] [schema.]table@index [CASCADE|RESTRICT]
+//
+// SQL Server's backward-compatible `DROP INDEX table.index` is the one form
+// where a qualified name with no ON is not a schema-qualified index; see
+// [Parser.rejectSQLServerTableQualifiedIndex] for why it is refused.
+//
+// ClickHouse has no DROP INDEX statement -- Ptah renders its index drops as
+// ALTER TABLE ... DROP INDEX, which [Parser.parseAlterStatement] handles -- so
+// it needs nothing here.
+//
+// The two halves of the grammar decide between them where the schema qualifier
+// lands, which is the whole point of parsing the statement: the first three
+// forms name the index in its own namespace and no table, the last three name
+// the table and leave the index bare. See [ast.DropIndexNode.Name].
+//
+// A statement this function returns an error for contributes no schema change
+// to callers such as migration/lint, so every form it declines is declined
+// loudly rather than half-recorded. PostgreSQL's multi-index `DROP INDEX a, b`
+// is the other one: [ast.DropIndexNode] models a single index, and accepting
+// the list would record only its first name and report one change where two
+// happened.
+func (p *Parser) parseDropIndex() (*ast.DropIndexNode, error) {
+	if err := p.expect(lexer.TokenIdentifier, "INDEX"); err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+
+	concurrently := false
+	if p.current.MatchIdentifierValue("CONCURRENTLY") {
+		concurrently = true
+		p.advance()
+		p.skipWhitespace()
+	}
+
+	ifExists := false
+	if p.current.MatchIdentifierValue("IF") {
+		p.advance()
+		p.skipWhitespace()
+		if err := p.expect(lexer.TokenIdentifier, "EXISTS"); err != nil {
+			return nil, fmt.Errorf("expected EXISTS after DROP INDEX IF: %w", err)
+		}
+		p.skipWhitespace()
+		ifExists = true
+	}
+
+	name, table, err := p.parseDropIndexTarget()
+	if err != nil {
+		return nil, err
+	}
+
+	p.skipWhitespace()
+	if p.current.MatchOperatorValue(",") {
+		return nil, fmt.Errorf("unsupported DROP INDEX with multiple index names at position %d", p.current.Start)
+	}
+
+	dropIndex := ast.NewDropIndex(name)
+	if table != "" {
+		dropIndex.SetTable(table)
+	}
+	if ifExists {
+		dropIndex.SetIfExists()
+	}
+	if concurrently {
+		dropIndex.SetConcurrently()
+	}
+	if p.current.MatchIdentifierValue("CASCADE") {
+		dropIndex.SetCascade()
+		p.advance()
+		return dropIndex, nil
+	}
+	if p.current.MatchIdentifierValue("RESTRICT") {
+		p.advance()
+	}
+	return dropIndex, nil
+}
+
+// parseDropIndexTarget reads the index a DROP INDEX names and, when the
+// statement names one, its owning table. An empty table is the answer for the
+// dialects whose grammar has no place to write one, not a failure to find it.
+func (p *Parser) parseDropIndexTarget() (name, table string, err error) {
+	first, err := p.parseQualifiedIdentifier("index name")
+	if err != nil {
+		return "", "", err
+	}
+
+	p.skipWhitespace()
+
+	// CockroachDB writes the owning table first and joins it to the index with
+	// `@`, so what was read above is the table and the index is still ahead.
+	if p.current.MatchOperatorValue("@") {
+		p.advance()
+		p.skipWhitespace()
+		indexName, err := p.expectIdentifier()
+		if err != nil {
+			return "", "", fmt.Errorf("expected index name after '@': %w", err)
+		}
+		return indexName, first, nil
+	}
+
+	if !p.current.MatchIdentifierValue("ON") {
+		if err := p.rejectSQLServerTableQualifiedIndex(first); err != nil {
+			return "", "", err
+		}
+		return first, "", nil
+	}
+	p.advance()
+	p.skipWhitespace()
+	tableName, err := p.parseQualifiedIdentifier("table name")
+	if err != nil {
+		return "", "", err
+	}
+	return first, tableName, nil
+}
+
+// rejectSQLServerTableQualifiedIndex refuses a qualified DROP INDEX target that
+// named no table, for the one dialect where such a name is not a
+// schema-qualified index.
+//
+// SQL Server has no schema-qualified index names: an index lives in its table's
+// namespace, and `DROP INDEX t.idx` is the backward-compatible spelling of
+// `DROP INDEX idx ON t`. Recording the qualifier as a schema the way every other
+// dialect's grammar means it would name an index `t.idx` that does not exist,
+// render back as the single identifier "t.idx", and measure the drop against a
+// schema called `t` -- a scope decision taken on an object nobody wrote.
+//
+// It is refused rather than decomposed because the change costs only the schema
+// change count of a spelling Ptah never renders, where guessing wrong costs a
+// wrong schema. Ptah renders SQL Server index drops as `DROP INDEX idx ON t`,
+// which the ON branch above reads exactly.
+func (p *Parser) rejectSQLServerTableQualifiedIndex(name string) error {
+	if p.dialect != platform.SQLServer {
+		return nil
+	}
+	if ref, ok := tableref.Parse(name); ok && !ref.Qualified {
+		return nil
+	}
+	return fmt.Errorf(
+		"unsupported SQL Server DROP INDEX %q without ON: a qualified name there is table.index, not schema.index", name)
 }
 
 // parseAlterOperation parses individual ALTER TABLE operations.

--- a/migration/lint/changes.go
+++ b/migration/lint/changes.go
@@ -252,16 +252,21 @@ func alterReferencedTables(alter *ast.AlterTableNode) []string {
 // nodeScopeReference is the reference a change is measured against, which is not
 // always the object it names.
 //
-// An index's own name carries no schema in any dialect Ptah renders --
-// [ast.IndexNode.Name] and [ast.DropIndexNode.Name] both document it as the raw,
-// unqualified index identifier, with the namespace derived from Table -- so
-// measuring an index by its own name puts every index in scope whatever schema
+// A CREATE INDEX names its index bare in every dialect Ptah renders -- the
+// index lands in its table's schema and the grammar has nowhere else to put it
+// -- so measuring one by its own name puts every index in scope whatever schema
 // its table lives in. `CREATE INDEX idx ON app.users (id)` was counted as a
 // change under a run reviewing `public` (stokaro/ptah#1249).
 //
 // The table is the answer because it is where the index actually lives. A node
 // with no table recorded keeps its own name, which is all there is left to
-// measure.
+// measure -- and for a DROP INDEX that is not a fallback but the ordinary case:
+// `DROP INDEX app.idx` names a schema on the index and no table at all, so the
+// name is where the qualifier is and reading it is what puts the statement
+// outside a run reviewing `public` (stokaro/ptah#1296). See
+// [ast.DropIndexNode.Name] for why Table still comes first when it is there:
+// MySQL, MariaDB, SQL Server and CockroachDB spell the same drop the other way
+// round, naming the table and leaving the index bare.
 func nodeScopeReference(node ast.Node, object string) string {
 	switch n := node.(type) {
 	case *ast.IndexNode:
@@ -269,11 +274,6 @@ func nodeScopeReference(node ast.Node, object string) string {
 			return table
 		}
 	case *ast.DropIndexNode:
-		// Unreachable from [extractSchemaChanges] today: Ptah's SQL parser does
-		// not model DROP INDEX, so no run produces this node. The rule is stated
-		// here anyway because the two node types carry the same contract, and
-		// leaving it out would encode the opposite claim about the one that is
-		// taught next.
 		if table := strings.TrimSpace(n.Table); table != "" {
 			return table
 		}

--- a/migration/lint/scope_test.go
+++ b/migration/lint/scope_test.go
@@ -481,18 +481,9 @@ func TestAnalyzeFS_SchemaScopeExcludesOnlyTheScopedOutStatement(t *testing.T) {
 // Ptah's SQL parser cannot model keeps its findings under every scope, and that
 // the scope is not what suppresses its change count.
 //
-// `DROP INDEX` is the measured case. stokaro/ptah#1249 read its `0 changes /
-// 1 finding` as the scope filter reaching the diagnostic but not the change;
-// it is not. `parser.NewParser("DROP INDEX app.idx").Parse()` returns
-// `unsupported DROP target: INDEX at position 5`, so the statement contributes
-// no change in the reviewed schema either. The `public` row is what says so: it
-// is the reviewed schema and it still counts zero, while the `DROP TABLE`
-// control on the same schema counts one. That missing change is a real defect
-// and a wider one, and it belongs to the parser rather than to the scope.
-//
-// The rows are also the guard on the exclusion rule: a statement is excluded
-// only when the scope rejected something it named, never merely because it
-// produced no change. Reading it the other way would silence PG106 here.
+// A statement is excluded only when the scope rejected something it named, never
+// merely because it produced no change. Reading it the other way would silence
+// DS106 here, on a statement whose schema was never established.
 func TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone(t *testing.T) {
 	tests := []struct {
 		name         string
@@ -501,20 +492,6 @@ func TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone(t *testing.T) {
 		wantChanges  []changeProjection
 		wantFindings []string
 	}{
-		{
-			name:         "dropping an index in the reviewed schema counts no change and still reports",
-			base:         "CREATE TABLE public.t (id int);\nCREATE INDEX idx ON public.t (id);\n",
-			sql:          "DROP INDEX public.idx;\n",
-			wantChanges:  []changeProjection{},
-			wantFindings: []string{"PG106"},
-		},
-		{
-			name:         "dropping an index outside the reviewed schema behaves identically",
-			base:         "CREATE SCHEMA app;\nCREATE TABLE app.t (id int);\nCREATE INDEX idx ON app.t (id);\n",
-			sql:          "DROP INDEX app.idx;\n",
-			wantChanges:  []changeProjection{},
-			wantFindings: []string{"PG106"},
-		},
 		{
 			name:         "a statement the parser models as no schema object keeps its finding",
 			base:         "CREATE TABLE public.t (id int);\n",
@@ -540,6 +517,145 @@ func TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone(t *testing.T) {
 
 			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
 			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
+// TestAnalyzeFS_DropIndexCountsAsASchemaChange pins that a DROP INDEX is a
+// schema change, and that the schema it counts in is the one the statement
+// names (stokaro/ptah#1296).
+//
+// Ptah's SQL parser used to refuse every DROP INDEX with `unsupported DROP
+// target: INDEX at position 5`, so the statement contributed no change in ANY
+// schema. stokaro/ptah#1249 read the resulting `0 changes / 1 finding` as the
+// reviewed-schema filter reaching the diagnostic but not the change; it was not
+// that. The `public` row is what separates the two explanations: it is the
+// reviewed schema, its `DROP TABLE` control counts one change, and the
+// `DROP INDEX` beside it counted zero.
+//
+// Measured with `ptah-compat migrate lint --latest 1` against a dev URL carrying
+// `?search_path=public`, PostgreSQL 17.10, oracle = pinned community binary
+// v1.3.0. Each version 2 runs after a version 1 that creates what it touches:
+//
+//	version 2                | community v1.3.0             | ptah-compat now
+//	DROP INDEX public.idx;   | 1 change,  0 diagnostics, rc 0 | 1 change, 1 diagnostic (PG106), rc 0
+//	DROP INDEX app.idx;      | 0 changes, 0 diagnostics, rc 0 | 0 changes, 0 diagnostics, rc 0
+//	DROP TABLE public.t;     | 1 change,  1 diagnostic, rc 1  | 1 change, 1 diagnostic (DS102), rc 1
+//
+// The out-of-schema row is where the qualifier question lands, and it lands
+// there because the qualifier lives on the index name: `app.idx` is a reference
+// the scope can read, so the statement is scoped out whole and takes PG106 with
+// it, by the same rule that removes an out-of-scope ALTER TABLE's finding
+// (stokaro/ptah#1249). Ptah reported PG106 for `app` before this change, which
+// was the permitted stricter direction; it now matches the community binary and
+// nothing about the reviewed schema got quieter -- the `public` row still
+// reports it.
+func TestAnalyzeFS_DropIndexCountsAsASchemaChange(t *testing.T) {
+	const publicBase = "CREATE TABLE public.t (id int);\nCREATE INDEX idx ON public.t (id);\n"
+	const appBase = "CREATE SCHEMA app;\nCREATE TABLE app.t (id int);\nCREATE INDEX idx ON app.t (id);\n"
+
+	tests := []struct {
+		name         string
+		base         string
+		sql          string
+		wantChanges  []changeProjection
+		wantFindings []string
+	}{
+		{
+			name:         "dropping an index in the reviewed schema counts one change",
+			base:         publicBase,
+			sql:          "DROP INDEX public.idx;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "public.idx"}},
+			wantFindings: []string{"PG106"},
+		},
+		{
+			name:         "dropping an unqualified index counts one change",
+			base:         publicBase,
+			sql:          "DROP INDEX idx;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "idx"}},
+			wantFindings: []string{"PG106"},
+		},
+		{
+			// PG106 gives way to PG103 here: the statement took the advice and
+			// dropped concurrently, which then needs a no-transaction file.
+			name:         "CONCURRENTLY IF EXISTS still counts one change",
+			base:         publicBase,
+			sql:          "DROP INDEX CONCURRENTLY IF EXISTS public.idx;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "public.idx"}},
+			wantFindings: []string{"PG103"},
+		},
+		{
+			name:         "CASCADE counts one change",
+			base:         publicBase,
+			sql:          "DROP INDEX public.idx CASCADE;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "public.idx"}},
+			wantFindings: []string{"PG106"},
+		},
+		{
+			name:         "dropping an index outside the reviewed schema counts none and reports none",
+			base:         appBase,
+			sql:          "DROP INDEX app.idx;\n",
+			wantChanges:  []changeProjection{},
+			wantFindings: []string{},
+		},
+		{
+			name:         "the modeled destructive control on the reviewed schema is unchanged",
+			base:         "CREATE TABLE public.t (id int);\n",
+			sql:          "DROP TABLE public.t;\n",
+			wantChanges:  []changeProjection{{lint.SchemaChangeDrop, "public.t"}},
+			wantFindings: []string{"DS101"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, "public")
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
+			c.Assert(rulesOf(analysis.Findings()), qt.DeepEquals, test.wantFindings)
+		})
+	}
+}
+
+// TestAnalyzeFS_DropIndexOnTableFormCountsInItsTableSchema pins the other half
+// of the qualifier rule from stokaro/ptah#1296: MySQL, MariaDB and SQL Server
+// spell the same drop as `DROP INDEX idx ON app.t`, naming the table and leaving
+// the index bare, so the schema that decides the scope is the table's.
+//
+// Reading the bare index name instead would put every such drop in scope, which
+// is the mirror of the CREATE INDEX defect stokaro/ptah#1249 fixed.
+func TestAnalyzeFS_DropIndexOnTableFormCountsInItsTableSchema(t *testing.T) {
+	tests := []struct {
+		name        string
+		base        string
+		sql         string
+		wantChanges []changeProjection
+	}{
+		{
+			name:        "the table under review keeps the change",
+			base:        "CREATE TABLE public.t (id int);\nCREATE INDEX idx ON public.t (id);\n",
+			sql:         "DROP INDEX idx ON public.t;\n",
+			wantChanges: []changeProjection{{lint.SchemaChangeDrop, "idx"}},
+		},
+		{
+			name:        "a table outside the reviewed schema drops the change",
+			base:        "CREATE SCHEMA app;\nCREATE TABLE app.t (id int);\nCREATE INDEX idx ON app.t (id);\n",
+			sql:         "DROP INDEX idx ON app.t;\n",
+			wantChanges: []changeProjection{},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			c := qt.New(t)
+
+			analysis := analyzeScoped(c, test.base, test.sql, "public")
+
+			c.Assert(projectChanges(fileByName(c, analysis, "2.sql").Changes), qt.DeepEquals, test.wantChanges)
 		})
 	}
 }


### PR DESCRIPTION
## Reproduction

Two migration versions, version 2 dropping an index version 1 created, linted
against a dev URL carrying `?search_path=public` on PostgreSQL 17.10:

```
$ cat repro/public/migrations/1.sql
CREATE TABLE public.t (id int);
CREATE INDEX idx ON public.t (id);
$ cat repro/public/migrations/2.sql
DROP INDEX public.idx;

$ ptah-compat migrate lint \
    --dir file://$PWD/repro/public/migrations \
    --dev-url 'postgres://postgres:pw@localhost:16296/devpub?sslmode=disable&search_path=public' \
    --latest 1
Analyzing changes from version 1 to 2 (1 migration in total):

  -- analyzing version 2
    -- diagnostics detected:
      -- L1 [PG106]: DROP INDEX without CONCURRENTLY blocks writes while PostgreSQL removes the
         index; use DROP INDEX CONCURRENTLY outside a transaction for populated tables
  -- ok (96.083µs)

  -------------------------
  -- 119.208µs
  -- 1 version with warnings
  -- 1 diagnostic
; exit 0
```

There is no `-- N schema change` line at all: the count is zero. The pinned
community binary v1.3.0 on the same directory and the same dev URL:

```
  -------------------------
  -- 121.30575ms
  -- 1 version ok
  -- 1 schema change
```

`public` is the schema under review, and its `DROP TABLE public.t;` control
counts one schema change on both tools, so this is not the reviewed-schema
filter.

## Cause

Confirmed against the code rather than assumed. `parseDropStatement` in
`internal/parser/parser.go` accepted exactly one DROP target:

```go
switch target {
case "TABLE":
    return p.parseDropTable()
default:
    return nil, fmt.Errorf("unsupported DROP target: %s at position %d", target, p.current.Start)
}
```

So `parser.NewParser("DROP INDEX app.idx").Parse()` returned
`unsupported DROP target: INDEX at position 5`,
`migration/lint.statementSchemaChanges` took its `err != nil` branch, and the
statement contributed no change in **any** schema. `nodeScopeReference` and
`File.scopeExcluded` from #1249 were never reached — the `DropIndexNode` case in
`nodeScopeReference` even carried a comment saying it was unreachable. #1249
attributed this shape to the scope filter; it was a parser gap, and a wider one.

## Fix

`internal/parser` now models `DROP INDEX` on every dialect Ptah renders one for:

| dialect | grammar |
| --- | --- |
| PostgreSQL | `DROP INDEX [CONCURRENTLY] [IF EXISTS] [schema.]index [CASCADE\|RESTRICT]` |
| SQLite | `DROP INDEX [IF EXISTS] [schema.]index` |
| MySQL | `DROP INDEX index ON [schema.]table` |
| MariaDB | `DROP INDEX [IF EXISTS] index ON [schema.]table` |
| SQL Server | `DROP INDEX [IF EXISTS] index ON [schema.]table` |
| CockroachDB | `DROP INDEX [IF EXISTS] [schema.]table@index [CASCADE\|RESTRICT]` |

**Where the qualifier lives.** It lives on `ast.DropIndexNode.Name`, and the doc
comment now says so. `Table` is still read first when the statement names one.
That is the only answer that puts `DROP INDEX app.idx` outside a run reviewing
`public`: recording `app` on `Table` instead makes it an unqualified table
reference, and `schemaScope.allowsObject` treats an unqualified reference as
resolving into the reviewed schema, so the drop would stay in scope.

**Where the out-of-schema row landed, written down rather than left to an `if`.**
`DROP INDEX app.idx` is now scoped out whole: 0 schema changes and 0
diagnostics, which is exactly what the community binary reports. The `PG106` it
used to raise there goes with the statement the scope removed, by the same rule
#1249 established for an out-of-scope `ALTER TABLE`. Nothing about the reviewed
schema got quieter — the `public` form still raises it.

**Renderers.** PostgreSQL and SQLite escape the index name as a *qualified*
identifier when there is no table namespace to borrow. Escaping it whole emitted
`DROP INDEX "app.idx";` — one identifier naming an index nobody created:

```
postgres=# DROP INDEX "public.idx";
ERROR:  index "public.idx" does not exist
```

`CASCADE` becomes `ast.DropIndexNode.Cascade` and is rendered, rather than being
accepted and silently discarded. `RESTRICT` is the default everywhere, so an
unset `Cascade` already means it and no field is needed.

## Measured result

`ptah-compat migrate lint --latest 1`, PostgreSQL 17.10, dev URL with
`?search_path=public`, oracle = pinned community binary v1.3.0. Each version 2
runs after a version 1 that creates what it touches. Dev databases dropped and
recreated between runs.

| version 2 | community v1.3.0 | ptah-compat before | ptah-compat after |
| --- | --- | --- | --- |
| `DROP INDEX public.idx;` (reviewed schema) | 1 change, 0 diagnostics, rc 0 | **0 changes**, 1 diagnostic (PG106), rc 0 | **1 change**, 1 diagnostic (PG106), rc 0 |
| `DROP INDEX app.idx;` (outside review) | 0 changes, 0 diagnostics, rc 0 | 0 changes, 1 diagnostic (PG106), rc 0 | 0 changes, 0 diagnostics, rc 0 |
| `DROP TABLE public.t;` (control) | 1 change, 1 diagnostic, rc 1 | 1 change, 1 diagnostic (DS102), rc 1 | 1 change, 1 diagnostic (DS102), rc 1 |

The control does not move. `ptah-compat` still never exits 0 where the community
binary exits 1.

Rendered SQL executed against the live database rather than only inspected —
two indexes named `idx`, one per schema:

```
postgres=# DROP INDEX "app"."idx";
DROP INDEX
postgres=# SELECT schemaname, indexname FROM pg_indexes WHERE indexname = 'idx';
 schemaname | indexname
------------+-----------
 public     | idx
```

MySQL 9.7, same check: ``DROP INDEX `idx` ON `db`.`t`;`` executes and
`SHOW INDEX FROM t` comes back empty.

## Red/green evidence

Every test below was watched fail before it was watched pass. Each mutation was
applied to the fixed tree and then reverted.

| mutation | tests that went RED |
| --- | --- |
| remove `case "INDEX": return p.parseDropIndex()` | all 14 rows of `TestParser_ParseDropIndex`, both rows of `TestParser_ParseDropIndexWithoutDialect`, all 6 rows of `TestParser_ParseDropIndexRoundTrip`, 6 rows of `TestParser_ParseDropIndexRefusesShapesItCannotRecord`, 5 rows of `TestAnalyzeFS_DropIndexCountsAsASchemaChange`, 1 row of `TestAnalyzeFS_DropIndexOnTableFormCountsInItsTableSchema` |
| renderers back to `escapeIdentifier(node.Name)` | 3 rows of `TestParser_ParseDropIndexRoundTrip` (postgres qualified, postgres CONCURRENTLY/CASCADE, sqlite qualified) |
| `nodeScopeReference` stops reading `DropIndexNode.Table` | `TestAnalyzeFS_DropIndexOnTableFormCountsInItsTableSchema/a_table_outside_the_reviewed_schema_drops_the_change` — the row the first mutation leaves vacuous |
| drop `SetCascade()` from the parser | 3 rows of `TestParser_ParseDropIndex`, 1 row of `TestParser_ParseDropIndexRoundTrip` |
| disarm the SQL Server refusal | 2 rows of `TestParser_ParseDropIndexRefusesSQLServerTableQualifiedName` |

The two rows of the old `TestAnalyzeFS_SchemaScopeLeavesUnmodeledStatementsAlone`
that pinned the defect were red against the fix before they were rewritten —
that is how the behavior change was first observed. The test keeps its remaining
rows (`DELETE FROM pg_enum`, the `DROP TABLE` control), which still pin that
silence is not exclusion.

## Per-dialect findings

The defect applied to every dialect, because the refusal was in the shared DROP
dispatch and named no dialect.

- **PostgreSQL** — `DROP INDEX [schema.]idx`, no table. Qualifier on the index
  name. `CONCURRENTLY`, `IF EXISTS`, `CASCADE`, `RESTRICT` all parsed.
- **SQLite** — same shape, `IF EXISTS` only. Same qualifier rule. The renderer
  needed the same qualified-name fix as PostgreSQL.
- **MySQL** — `DROP INDEX idx ON [schema.]t`. The syntax does differ: the table
  is named and the index is bare, so the scope reads `Table`. Verified by
  `TestAnalyzeFS_DropIndexOnTableFormCountsInItsTableSchema`, whose two rows
  separate an in-scope table from an out-of-scope one.
- **MariaDB** — MySQL's shape plus `IF EXISTS`.
- **SQL Server** — modern `DROP INDEX idx ON [schema.]t` parsed, brackets
  preserved as everywhere else. Its backward-compatible `DROP INDEX t.idx` is
  **refused explicitly**: there the qualifier names the table, not a schema, and
  reading it the way every other dialect spells the same text would scope the
  drop to a schema nobody wrote. Ptah never renders that spelling.
- **CockroachDB** — `DROP INDEX [schema.]t@idx`, which the PostgreSQL renderer
  emits for that target. Parsed into `Table` + `Name` and round-trips.
- **ClickHouse** — has no `DROP INDEX` statement; Ptah renders its index drops
  as `ALTER TABLE … DROP INDEX`, which the ALTER parser already handles. Nothing
  was needed and nothing was added.

## Gates

Run from the worktree root on the rebased branch. Exit codes read directly, not
through a pipe.

| gate | exit code |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1 -timeout 40m` | **1** — see below |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci` + every `check:*` script | 0 |

The `go test` 1 is reported literally rather than rounded down. On the final
tree two packages failed, neither of which this change touches, and both
failures are spawned-process-budget shaped:

- `cmd/ptah-ls` — `process did not exit within 20s`, `signal: killed`
- `cmd/viz` — `render SVG with Graphviz dot: signal: killed`, where the test's
  fake `dot` should have printed its own message

(An earlier run on the same branch also reddened `internal/atlasschema` with
`connect to --dev-url: failed to ping database: context deadline exceeded`
before the lock step the test asserts on; it is green in the final run and green
when run alone.)

Both remaining packages were run in a `git archive origin/master` extraction —
this branch's changes absent, same machine, same moment — and failed identically
there:

```
--- FAIL: TestPtahLSArgumentHandling (44.74s)
    --- FAIL: TestPtahLSArgumentHandling/version_positional_answers (20.00s)
    --- FAIL: TestPtahLSArgumentHandling/version_flag_answers (20.00s)
--- FAIL: TestPtahLSVersionSpellingsPrintIdenticalBytes (20.16s)
FAIL    go.5x5.cz/ptah/cmd/ptah-ls
--- FAIL: TestSVGReportsGraphvizStderrOnFailure (10.03s)
FAIL    go.5x5.cz/ptah/cmd/viz
```

So they are this machine's load (~35 concurrent full suites, load average 30+
killing spawned child processes), not this branch. Every package this change
touches — `internal/parser`, `core/ast`, `core/renderer/...`, `migration/lint` —
is green.

`docs/public_api.snapshot` is regenerated for the new `Cascade` field and
`SetCascade` method. Both are additive, so `check-public-api-released.sh` reports
no new incompatibility and needs no approval entry.

## Documentation

`docs/site/src/content/docs/atlas/migrate-commands.md` described `DROP INDEX` as
the standing example of "a statement outside Ptah's SQL grammar", with the
measured `0 changes / PG106 in every schema` behavior and a pointer to this
issue. That section is rewritten to the new behavior, including where the
out-of-schema row landed and the two forms still refused. The "an index is
measured by the schema of the table it is on, because an index name never
carries one" bullet is split, since a `DROP INDEX app.idx` name does carry one.

## Residual risk

- **PostgreSQL's `DROP INDEX a, b;` still counts no schema change.**
  `ast.DropIndexNode` models one index and the renderers emit one, so the parser
  refuses the list rather than recording only its first name. The count is the
  same zero it was before this change; the difference is that the refusal is
  explicit and tested. Giving `DropIndexNode` a `Names` slice the way
  `DropTableNode` has one would fix it and touches all five renderers — worth a
  follow-up issue, not this PR.
- **SQL Server's `DROP INDEX t.idx` is refused, so it also counts no change.**
  Deliberate: guessing the qualifier wrong there costs a wrong schema, where
  refusing costs the count of a spelling Ptah does not emit.
- **MySQL's trailing `ALGORITHM=`/`LOCK=` options on `DROP INDEX` still fail the
  parse**, now at the option keyword rather than at `DROP INDEX`. Same outcome as
  before (no change counted, diagnostics kept), no regression.
- **`ptah sql lint` behavior shift.** A `DROP INDEX` used to produce a
  parse-error finding there and now parses cleanly, so its rules run on the node
  instead. Strictly better, and no test pinned the old finding.
- **Schema-source loading.** `internal/convert/toschema.ToDatabase` has no case
  for `DropIndexNode`, so a `DROP INDEX` inside a SQL *schema* file is now
  ignored instead of erroring. That is exactly what already happens to
  `DROP TABLE` in the same position, so no new inconsistency.
- **The red packages are the machine, not the branch** — proven against an
  unmodified `origin/master` extraction; see the Gates section. Worth confirming
  on CI, where the load profile is different.

Closes #1296