### PR TITLE
Pass the coverage set to the two comparators the new rows call

### DIFF
--- a/migration/schemadiff/internal/compare/usertypes_test.go
+++ b/migration/schemadiff/internal/compare/usertypes_test.go
@@ -145,8 +145,8 @@ func TestUserTypes_ModifiedCarryTheirCurrentShape(t *testing.T) {
 	}
 	diff := &difftypes.SchemaDiff{}
 
-	compare.Domains(generated, database, diff)
-	compare.CompositeTypes(generated, database, diff)
+	compare.Domains(generated, database, diff, compare.CoverageOf(generated, database))
+	compare.CompositeTypes(generated, database, diff, compare.CoverageOf(generated, database))
 
 	c.Assert(diff.DomainsModified, qt.HasLen, 1)
 	c.Assert(diff.DomainsModified[0].CurrentBaseType, qt.Equals, "integer")
@@ -178,8 +178,8 @@ func TestUserTypes_CurrentShapeKeepsTheCatalogSpelling(t *testing.T) {
 	}
 	diff := &difftypes.SchemaDiff{}
 
-	compare.Domains(generated, database, diff)
-	compare.CompositeTypes(generated, database, diff)
+	compare.Domains(generated, database, diff, compare.CoverageOf(generated, database))
+	compare.CompositeTypes(generated, database, diff, compare.CoverageOf(generated, database))
 
 	c.Assert(diff.DomainsModified, qt.HasLen, 1)
 	c.Assert(diff.DomainsModified[0].CurrentBaseType, qt.Equals, "decimal")


### PR DESCRIPTION
Repairs `master`, which is red on `f0eeb790`.

## What is broken

```
migration/schemadiff/internal/compare/usertypes_test.go:148:43: not enough arguments in call to compare.Domains
  have (*goschema.Database, *types.DBSchema, *difftypes.SchemaDiff)
  want (*goschema.Database, *types.DBSchema, *difftypes.SchemaDiff, compare.Coverage)
```

Four call sites, at lines 148, 149, 181 and 182. It takes down `Go Lint` (qtlint refuses the package), `Go Unit Tests`, and `Go Security` — anything that has to build the package.

## How two green pull requests produced a red master

- **#1298** gave `Domains`, `CompositeTypes` and `Ranges` a trailing `compare.Coverage` parameter and updated every call site that existed when it was written.
- **#1306** was rebased onto master **before** #1298 landed, and added two tests — `TestUserTypes_CurrentShapeIsCarried` and `TestUserTypes_CurrentShapeKeepsTheCatalogSpelling` — whose four calls pass three arguments.

Each branch was green on its own base. GitHub reported both as `CLEAN`, because there is no textual conflict between them: one changes a signature, the other adds new callers of the old signature, and they touch different lines. **A clean merge is not a compiling merge**, and nothing between the two green results ever built the combination.

## The fix

The four calls now pass `compare.CoverageOf(generated, database)`, matching what `migration/schemadiff/schemadiff.go:179` does.

A zero `compare.Coverage{}` would also compile, and the type's own doc comment blesses it — *"a zero Coverage records nothing, which is what a caller comparing two fully authoritative descriptions wants"* — which is exactly what these two fixtures are. `CoverageOf` was chosen anyway so the rows follow production if either fixture ever declares a `NotDescribed` set, rather than silently keeping the empty answer.

## Measured on this tree

| gate | exit |
|---|---|
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go tool qtlint ./...` | 0 |
| `scripts/check-test-style.sh` | 0 |
| `go test ./migration/schemadiff/... -count=1` | ok, all four packages |