### PR TITLE
Tell a caller when a server is past the newest measured version line (#916)

### DIFF
--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -839,6 +839,10 @@ func ForDialect(dialect string) Capabilities {
 // exactly there, so a caller can tell "inside a measured line" from "past the
 // newest line this package knows".
 //
+// Above these numbers the preset that comes back is byte-identical to
+// ForDialect's, which is the definition of "no version-specific preset could be
+// selected", so VersionSpecific is false there too.
+//
 // Raising one of these numbers is the deliberate act of claiming a newer
 // server line behaves like the preset it lands on. Do it in the change that
 // measures that line, together with the preset it deserves — never as a side
@@ -857,15 +861,16 @@ const (
 )
 
 // VersionResolution reports how a server version string was mapped onto a
-// capability preset. It is what ForServerVersionResult's boolean cannot say on
-// its own: that boolean answers "did a parsed version select this preset", and
-// stays true for a version far newer than anything this package has a preset
-// for.
+// capability preset.
 //
-// Saturated distinguishes those two cases. It is true when the version parsed,
-// selected the newest preset in its dialect's ladder, and is itself newer than
-// the newest line that ladder was measured against — so the preset is a
-// stand-in and any capability the newer server gained or lost is unmodeled.
+// Saturated names the case the resolver used to answer wrongly: the version
+// parsed, it selected the newest preset in its dialect's ladder, and it is
+// itself newer than the newest line that ladder was measured against — so the
+// preset is a stand-in and any capability the newer server gained or lost is
+// unmodeled. That is not a version-specific answer, so VersionSpecific is
+// false whenever Saturated is true, and the two fields together say which of
+// the two ways a caller ended up on the dialect default: the version could not
+// be parsed at all, or it parsed and ran off the top of the ladder.
 //
 // Saturation is only defined where this package has a version ladder: MySQL,
 // MariaDB and PostgreSQL. CockroachDB, YugabyteDB and Spanner are resolved
@@ -878,11 +883,14 @@ type VersionResolution struct {
 	Capabilities Capabilities
 	// VersionSpecific is false when no version-specific preset could be
 	// selected and the dialect default was used instead. It carries exactly
-	// the meaning of ForServerVersionResult's second return value.
+	// the meaning of ForServerVersionResult's second return value, and it is
+	// false for a saturated version because the preset such a version lands
+	// on is exactly ForDialect's.
 	VersionSpecific bool
 	// Saturated is true when the resolved preset is the top of a version
 	// ladder and the server is newer than the newest line that ladder was
-	// measured against.
+	// measured against. It is the reason VersionSpecific is false, and is
+	// never true at the same time as VersionSpecific.
 	Saturated bool
 	// NewestMeasured names the newest measured version line for the dialect,
 	// for example "9.x". It is empty for dialects with no version ladder.
@@ -905,8 +913,10 @@ func ForServerVersion(dialect, version string) Capabilities {
 // the dialect default was used instead. Callers with a live connection can log
 // that degradation while offline callers can keep using ForDialect.
 //
-// The boolean says nothing about whether the server is newer than the newest
-// preset this package holds; ResolveServerVersion answers that.
+// A version newer than the newest measured line for its dialect is one of
+// those fallbacks: the ladder's open-topped arm hands back exactly ForDialect's
+// preset, so the boolean is false. ResolveServerVersion separates that case
+// from a version that could not be parsed at all.
 func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 	resolution := ResolveServerVersion(dialect, version)
 	return resolution.Capabilities, resolution.VersionSpecific
@@ -914,9 +924,10 @@ func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
 
 // ResolveServerVersion is ForServerVersionResult with the saturation answer
 // attached. It selects exactly the same preset and reports exactly the same
-// VersionSpecific value; the extra fields describe how far the mapping was
-// trusted. See VersionResolution for what saturation means and which dialects
-// can report it.
+// VersionSpecific value; Saturated and NewestMeasured say why a saturated
+// version is not version-specific and which line it was planned as. See
+// VersionResolution for what saturation means and which dialects can report
+// it.
 func ResolveServerVersion(dialect, version string) VersionResolution {
 	normalized := platform.NormalizeDialect(dialect)
 	versionLower := strings.ToLower(version)
@@ -959,36 +970,40 @@ func measuredLine(major int) string {
 	return strconv.Itoa(major) + ".x"
 }
 
-func mysqlResolution(v serverVersion) VersionResolution {
+// ladderResolution assembles the answer for a dialect that has a version
+// ladder. saturated is the single place VersionSpecific and Saturated are tied
+// together: a version past the top of the ladder receives ForDialect's preset,
+// so it is a fallback and not a version-specific selection.
+func ladderResolution(caps Capabilities, newestMeasuredMajor int, saturated bool) VersionResolution {
 	return VersionResolution{
-		Capabilities:    mysqlForVersion(v),
-		VersionSpecific: true,
-		Saturated:       v.major > newestMeasuredMySQLMajor,
-		NewestMeasured:  measuredLine(newestMeasuredMySQLMajor),
+		Capabilities:    caps,
+		VersionSpecific: !saturated,
+		Saturated:       saturated,
+		NewestMeasured:  measuredLine(newestMeasuredMajor),
 	}
+}
+
+func mysqlResolution(v serverVersion) VersionResolution {
+	return ladderResolution(mysqlForVersion(v), newestMeasuredMySQLMajor, v.major > newestMeasuredMySQLMajor)
 }
 
 func mariaDBResolution(version string) VersionResolution {
-	resolution := VersionResolution{
-		Capabilities:   mariaDBForVersion(version),
-		NewestMeasured: measuredLine(newestMeasuredMariaDBMajor),
-	}
 	v, ok := parseVersion(strings.TrimPrefix(version, mariaDBReplicationPrefix))
 	if !ok {
-		return resolution
+		return VersionResolution{
+			Capabilities:   mariaDBForVersion(version),
+			NewestMeasured: measuredLine(newestMeasuredMariaDBMajor),
+		}
 	}
-	resolution.VersionSpecific = true
-	resolution.Saturated = v.major > newestMeasuredMariaDBMajor
-	return resolution
+	return ladderResolution(
+		mariaDBForVersion(version),
+		newestMeasuredMariaDBMajor,
+		v.major > newestMeasuredMariaDBMajor,
+	)
 }
 
 func postgresResolution(v serverVersion) VersionResolution {
-	return VersionResolution{
-		Capabilities:    postgresForVersion(v),
-		VersionSpecific: true,
-		Saturated:       v.major > newestMeasuredPostgresMajor,
-		NewestMeasured:  measuredLine(newestMeasuredPostgresMajor),
-	}
+	return ladderResolution(postgresForVersion(v), newestMeasuredPostgresMajor, v.major > newestMeasuredPostgresMajor)
 }
 
 func mysqlForVersion(v serverVersion) Capabilities {

--- a/core/platform/capability/capability.go
+++ b/core/platform/capability/capability.go
@@ -41,6 +41,7 @@ package capability
 import (
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 
 	"go.5x5.cz/ptah/core/platform"
@@ -828,6 +829,66 @@ func ForDialect(dialect string) Capabilities {
 	}
 }
 
+// Newest measured major version line per refined dialect.
+//
+// Each ladder in this file ends in an open-topped arm: MySQL sends everything
+// above 8.4 to MySQL84, MariaDB everything above 10.2 to MariaDB1011, and
+// PostgreSQL everything at or above 17 to Postgres17. That arm is a stand-in,
+// not a measurement — a server newer than the line below was never observed
+// behaving like the preset it receives. VersionResolution.Saturated is true
+// exactly there, so a caller can tell "inside a measured line" from "past the
+// newest line this package knows".
+//
+// Raising one of these numbers is the deliberate act of claiming a newer
+// server line behaves like the preset it lands on. Do it in the change that
+// measures that line, together with the preset it deserves — never as a side
+// effect of bumping a container tag.
+const (
+	// MySQL84 covers 8.4 LTS through the 9.x LTS line, which is the newest
+	// MySQL the integration matrix runs (mysql:9.7).
+	newestMeasuredMySQLMajor = 9
+	// MariaDB1011 covers 10.2 through the 11.x lines; the integration matrix
+	// runs mariadb:10.11.
+	newestMeasuredMariaDBMajor = 11
+	// Postgres17 covers 17 only. The integration matrix already runs
+	// postgres:18, which therefore resolves saturated: Ptah has no measured
+	// PostgreSQL 18 capability line yet.
+	newestMeasuredPostgresMajor = 17
+)
+
+// VersionResolution reports how a server version string was mapped onto a
+// capability preset. It is what ForServerVersionResult's boolean cannot say on
+// its own: that boolean answers "did a parsed version select this preset", and
+// stays true for a version far newer than anything this package has a preset
+// for.
+//
+// Saturated distinguishes those two cases. It is true when the version parsed,
+// selected the newest preset in its dialect's ladder, and is itself newer than
+// the newest line that ladder was measured against — so the preset is a
+// stand-in and any capability the newer server gained or lost is unmodeled.
+//
+// Saturation is only defined where this package has a version ladder: MySQL,
+// MariaDB and PostgreSQL. CockroachDB, YugabyteDB and Spanner are resolved
+// from the banner without consulting a version at all, and ClickHouse, SQLite
+// and SQL Server have no ladder to saturate; all six report Saturated=false
+// and an empty NewestMeasured. Refining those dialects is the remaining scope
+// of issue #916 and is deliberately not answered here.
+type VersionResolution struct {
+	// Capabilities is the resolved preset, never nil for a known dialect.
+	Capabilities Capabilities
+	// VersionSpecific is false when no version-specific preset could be
+	// selected and the dialect default was used instead. It carries exactly
+	// the meaning of ForServerVersionResult's second return value.
+	VersionSpecific bool
+	// Saturated is true when the resolved preset is the top of a version
+	// ladder and the server is newer than the newest line that ladder was
+	// measured against.
+	Saturated bool
+	// NewestMeasured names the newest measured version line for the dialect,
+	// for example "9.x". It is empty for dialects with no version ladder.
+	NewestMeasured string
+}
+
 // ForServerVersion refines ForDialect using a live server version string —
 // typically the result of SELECT version() — so callers can map a concrete
 // server to the closest preset at connect time. Recognized shapes include
@@ -836,53 +897,97 @@ func ForDialect(dialect string) Capabilities {
 // over the MySQL protocol) and "PostgreSQL 16.3 (Debian ...)". When the
 // version cannot be parsed, the dialect's default preset is returned.
 func ForServerVersion(dialect, version string) Capabilities {
-	caps, _ := ForServerVersionResult(dialect, version)
-	return caps
+	return ResolveServerVersion(dialect, version).Capabilities
 }
 
 // ForServerVersionResult is ForServerVersion plus an explicit fallback signal.
 // The boolean is false when no version-specific preset could be selected and
 // the dialect default was used instead. Callers with a live connection can log
 // that degradation while offline callers can keep using ForDialect.
+//
+// The boolean says nothing about whether the server is newer than the newest
+// preset this package holds; ResolveServerVersion answers that.
 func ForServerVersionResult(dialect, version string) (Capabilities, bool) {
+	resolution := ResolveServerVersion(dialect, version)
+	return resolution.Capabilities, resolution.VersionSpecific
+}
+
+// ResolveServerVersion is ForServerVersionResult with the saturation answer
+// attached. It selects exactly the same preset and reports exactly the same
+// VersionSpecific value; the extra fields describe how far the mapping was
+// trusted. See VersionResolution for what saturation means and which dialects
+// can report it.
+func ResolveServerVersion(dialect, version string) VersionResolution {
 	normalized := platform.NormalizeDialect(dialect)
 	versionLower := strings.ToLower(version)
 
 	switch {
 	case strings.Contains(versionLower, "cockroachdb"):
-		return CockroachDB23(), true
+		return VersionResolution{Capabilities: CockroachDB23(), VersionSpecific: true}
 	case strings.Contains(versionLower, "yugabytedb") || strings.Contains(versionLower, "yugabyte") || strings.Contains(versionLower, "-yb-"):
-		return YugabyteDB25(), true
+		return VersionResolution{Capabilities: YugabyteDB25(), VersionSpecific: true}
 	case strings.Contains(versionLower, "spanner"):
-		return SpannerPostgres(), true
+		return VersionResolution{Capabilities: SpannerPostgres(), VersionSpecific: true}
 	}
 
 	// MariaDB announces itself in the version string even when connected via
 	// the mysql dialect/driver; trust the string over the declared dialect.
 	if strings.Contains(versionLower, "mariadb") {
-		return mariaDBForVersion(version), parseableMariaDBVersion(version)
+		return mariaDBResolution(version)
 	}
 
 	v, ok := parseVersion(version)
 	if !ok {
-		return ForDialect(dialect), false
+		return VersionResolution{Capabilities: ForDialect(dialect)}
 	}
 
 	switch normalized {
 	case platform.MySQL:
-		return mysqlForVersion(v), true
+		return mysqlResolution(v)
 	case platform.MariaDB:
-		return mariaDBForVersion(version), parseableMariaDBVersion(version)
+		return mariaDBResolution(version)
 	case platform.Postgres:
-		if v.major >= 17 {
-			return Postgres17(), true
-		}
-		if v.major >= 14 {
-			return Postgres16(), true
-		}
-		return Postgres13(), true
+		return postgresResolution(v)
 	default:
-		return ForDialect(dialect), false
+		return VersionResolution{Capabilities: ForDialect(dialect)}
+	}
+}
+
+// measuredLine renders a major version number as the version line label
+// reported in VersionResolution.NewestMeasured.
+func measuredLine(major int) string {
+	return strconv.Itoa(major) + ".x"
+}
+
+func mysqlResolution(v serverVersion) VersionResolution {
+	return VersionResolution{
+		Capabilities:    mysqlForVersion(v),
+		VersionSpecific: true,
+		Saturated:       v.major > newestMeasuredMySQLMajor,
+		NewestMeasured:  measuredLine(newestMeasuredMySQLMajor),
+	}
+}
+
+func mariaDBResolution(version string) VersionResolution {
+	resolution := VersionResolution{
+		Capabilities:   mariaDBForVersion(version),
+		NewestMeasured: measuredLine(newestMeasuredMariaDBMajor),
+	}
+	v, ok := parseVersion(strings.TrimPrefix(version, mariaDBReplicationPrefix))
+	if !ok {
+		return resolution
+	}
+	resolution.VersionSpecific = true
+	resolution.Saturated = v.major > newestMeasuredMariaDBMajor
+	return resolution
+}
+
+func postgresResolution(v serverVersion) VersionResolution {
+	return VersionResolution{
+		Capabilities:    postgresForVersion(v),
+		VersionSpecific: true,
+		Saturated:       v.major > newestMeasuredPostgresMajor,
+		NewestMeasured:  measuredLine(newestMeasuredPostgresMajor),
 	}
 }
 
@@ -899,6 +1004,21 @@ func mysqlForVersion(v serverVersion) Capabilities {
 	}
 }
 
+func postgresForVersion(v serverVersion) Capabilities {
+	switch {
+	case v.major >= 17:
+		return Postgres17()
+	case v.major >= 14:
+		return Postgres16()
+	default:
+		return Postgres13()
+	}
+}
+
+// mariaDBReplicationPrefix is the fake version prefix MariaDB servers prepend
+// when speaking the MySQL protocol ("5.5.5-10.11.6-MariaDB").
+const mariaDBReplicationPrefix = "5.5.5-"
+
 // mariaDBForVersion picks the MariaDB preset for a server version string.
 // MariaDB servers speaking the MySQL protocol prepend a fake "5.5.5-"
 // replication-compatibility prefix ("5.5.5-10.11.6-MariaDB"); that prefix is
@@ -907,7 +1027,7 @@ func mysqlForVersion(v serverVersion) Capabilities {
 // anything older — or an unparseable string — degrades to MariaDBLegacy /
 // the modern preset respectively.
 func mariaDBForVersion(version string) Capabilities {
-	trimmed := strings.TrimPrefix(version, "5.5.5-")
+	trimmed := strings.TrimPrefix(version, mariaDBReplicationPrefix)
 	v, ok := parseVersion(trimmed)
 	if !ok {
 		return MariaDB1011()
@@ -916,11 +1036,6 @@ func mariaDBForVersion(version string) Capabilities {
 		return MariaDB1011()
 	}
 	return MariaDBLegacy()
-}
-
-func parseableMariaDBVersion(version string) bool {
-	_, ok := parseVersion(strings.TrimPrefix(version, "5.5.5-"))
-	return ok
 }
 
 // serverVersion is a parsed dotted server version.

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -406,6 +406,101 @@ func TestForServerVersionResultReportsFallback(t *testing.T) {
 	c.Assert(caps.Has(capability.DropConstraintIfExists), qt.Equals, true)
 }
 
+// TestResolveServerVersionReportsSaturation pins the version-saturation
+// answer for every refined dialect: one row per (dialect, version) below the
+// newest measured line, inside it, exactly at it, and above it.
+//
+// The "above" rows are the point of the test. Each ladder ends in an
+// open-topped arm, so a server newer than anything Ptah measured still lands
+// on the newest preset; Saturated is the only signal that separates that
+// stand-in from a real match, and #791 (MySQL 26.x) and #108 (MariaDB 12.x)
+// unblock on exactly these rows. The wantCaps column pins the preset at the
+// same time, so a row cannot go green by resolving to some other set.
+func TestResolveServerVersionReportsSaturation(t *testing.T) {
+	tests := []struct {
+		name                string
+		dialect             string
+		version             string
+		wantCaps            capability.Capabilities
+		wantVersionSpecific bool
+		wantSaturated       bool
+		wantNewestMeasured  string
+	}{
+		// MySQL: the ladder tops out at MySQL84, measured through the 9.x line.
+		{"mysql below", "mysql", "5.7.44", capability.MySQLLegacy(), true, false, "9.x"},
+		{"mysql inside", "mysql", "8.0.42-log", capability.MySQL8019(), true, false, "9.x"},
+		{"mysql at the newest measured line", "mysql", "9.7.1", capability.MySQL84(), true, false, "9.x"},
+		{"mysql at the top of the newest measured major", "mysql", "9.99.0", capability.MySQL84(), true, false, "9.x"},
+		{"mysql above (#791 bumps CI to 26.x)", "mysql", "26.7.0", capability.MySQL84(), true, true, "9.x"},
+		{"mysql far above", "mysql", "99.0", capability.MySQL84(), true, true, "9.x"},
+
+		// MariaDB: MariaDB1011 is measured through the 11.x lines.
+		{"mariadb below", "mariadb", "10.1.48-MariaDB", capability.MariaDBLegacy(), true, false, "11.x"},
+		{"mariadb inside", "mariadb", "10.11.6-MariaDB", capability.MariaDB1011(), true, false, "11.x"},
+		{"mariadb at the newest measured line", "mariadb", "11.8.2-MariaDB", capability.MariaDB1011(), true, false, "11.x"},
+		{"mariadb above (#108 bumps CI to 12.x)", "mariadb", "12.3.0-MariaDB", capability.MariaDB1011(), true, true, "11.x"},
+		{"mariadb far above", "mariadb", "99.0.0-MariaDB", capability.MariaDB1011(), true, true, "11.x"},
+		{
+			"mariadb above over the mysql replication prefix",
+			"mysql", "5.5.5-12.3.0-MariaDB", capability.MariaDB1011(), true, true, "11.x",
+		},
+
+		// PostgreSQL: Postgres17 is the top preset and covers 17 only, while
+		// the integration matrix already runs postgres:18.
+		{"postgres below", "postgres", "PostgreSQL 13.14 (Debian)", capability.Postgres13(), true, false, "17.x"},
+		{"postgres inside", "postgres", "PostgreSQL 16.3 (Debian)", capability.Postgres16(), true, false, "17.x"},
+		{"postgres at the newest measured line", "postgres", "PostgreSQL 17.5", capability.Postgres17(), true, false, "17.x"},
+		{"postgres above (CI runs postgres:18)", "postgres", "PostgreSQL 18.4 (Debian)", capability.Postgres17(), true, true, "17.x"},
+		{"postgres far above", "postgres", "PostgreSQL 99.0", capability.Postgres17(), true, true, "17.x"},
+
+		// Controls. An unparseable version never reports saturation, and a
+		// dialect with no version ladder reports neither a ceiling nor
+		// saturation — refining those is the rest of issue #916.
+		{"mysql unparseable", "mysql", "who knows", capability.MySQL84(), false, false, ""},
+		{"mariadb unparseable", "mariadb", "MariaDB something", capability.MariaDB1011(), false, false, "11.x"},
+		{"postgres empty", "postgres", "", capability.Postgres17(), false, false, ""},
+		{
+			"cockroachdb resolves from the banner, no ladder",
+			"postgres", "CockroachDB CCL v26.2.4 (x86_64-pc-linux-gnu)", capability.CockroachDB23(), true, false, "",
+		},
+		{
+			"yugabytedb resolves from the banner, no ladder",
+			"postgres", "PostgreSQL 15.2-YB-2026.1.0.0-b0 on x86_64-pc-linux-gnu", capability.YugabyteDB25(), true, false, "",
+		},
+		{
+			"spanner is intentionally version-free",
+			"postgres", "Cloud Spanner PostgreSQL interface", capability.SpannerPostgres(), true, false, "",
+		},
+		{"clickhouse has no ladder", "clickhouse", "25.3.1.100", capability.ClickHouse24(), false, false, ""},
+		{"sqlite has no ladder", "sqlite", "3.53.0", capability.SQLite3(), false, false, ""},
+		{
+			"sqlserver has no ladder",
+			"sqlserver", "Microsoft SQL Server 2022 (RTM-CU12) - 16.0.4115.5", capability.SQLServer2022(), false, false, "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got := capability.ResolveServerVersion(tt.dialect, tt.version)
+
+			comment := qt.Commentf("dialect=%s version=%q", tt.dialect, tt.version)
+			c.Assert(got.Capabilities.Validate(), qt.IsNil, comment)
+			c.Assert(got.Capabilities, qt.DeepEquals, tt.wantCaps, comment)
+			c.Assert(got.VersionSpecific, qt.Equals, tt.wantVersionSpecific, comment)
+			c.Assert(got.Saturated, qt.Equals, tt.wantSaturated, comment)
+			c.Assert(got.NewestMeasured, qt.Equals, tt.wantNewestMeasured, comment)
+
+			// The two older entry points must keep answering exactly what they
+			// answered before saturation existed, on every row above.
+			caps, versionSpecific := capability.ForServerVersionResult(tt.dialect, tt.version)
+			c.Assert(caps, qt.DeepEquals, tt.wantCaps, comment)
+			c.Assert(versionSpecific, qt.Equals, tt.wantVersionSpecific, comment)
+			c.Assert(capability.ForServerVersion(tt.dialect, tt.version), qt.DeepEquals, tt.wantCaps, comment)
+		})
+	}
+}
+
 func TestDoc(t *testing.T) {
 	c := qt.New(t)
 

--- a/core/platform/capability/capability_test.go
+++ b/core/platform/capability/capability_test.go
@@ -1,6 +1,7 @@
 package capability_test
 
 import (
+	"maps"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -412,10 +413,12 @@ func TestForServerVersionResultReportsFallback(t *testing.T) {
 //
 // The "above" rows are the point of the test. Each ladder ends in an
 // open-topped arm, so a server newer than anything Ptah measured still lands
-// on the newest preset; Saturated is the only signal that separates that
-// stand-in from a real match, and #791 (MySQL 26.x) and #108 (MariaDB 12.x)
-// unblock on exactly these rows. The wantCaps column pins the preset at the
-// same time, so a row cannot go green by resolving to some other set.
+// on the newest preset — which is byte-identical to ForDialect's. Those rows
+// therefore assert wantVersionSpecific=false: nothing version-specific was
+// selected, and saying otherwise is the silent saturation completion criterion
+// 3 of issue #916 rejects. #791 (MySQL 26.x) and #108 (MariaDB 12.x) unblock
+// on exactly these rows. The wantCaps column pins the preset at the same time,
+// so a row cannot go green by resolving to some other set.
 func TestResolveServerVersionReportsSaturation(t *testing.T) {
 	tests := []struct {
 		name                string
@@ -431,18 +434,18 @@ func TestResolveServerVersionReportsSaturation(t *testing.T) {
 		{"mysql inside", "mysql", "8.0.42-log", capability.MySQL8019(), true, false, "9.x"},
 		{"mysql at the newest measured line", "mysql", "9.7.1", capability.MySQL84(), true, false, "9.x"},
 		{"mysql at the top of the newest measured major", "mysql", "9.99.0", capability.MySQL84(), true, false, "9.x"},
-		{"mysql above (#791 bumps CI to 26.x)", "mysql", "26.7.0", capability.MySQL84(), true, true, "9.x"},
-		{"mysql far above", "mysql", "99.0", capability.MySQL84(), true, true, "9.x"},
+		{"mysql above (#791 bumps CI to 26.x)", "mysql", "26.7.0", capability.MySQL84(), false, true, "9.x"},
+		{"mysql far above", "mysql", "99.0", capability.MySQL84(), false, true, "9.x"},
 
 		// MariaDB: MariaDB1011 is measured through the 11.x lines.
 		{"mariadb below", "mariadb", "10.1.48-MariaDB", capability.MariaDBLegacy(), true, false, "11.x"},
 		{"mariadb inside", "mariadb", "10.11.6-MariaDB", capability.MariaDB1011(), true, false, "11.x"},
 		{"mariadb at the newest measured line", "mariadb", "11.8.2-MariaDB", capability.MariaDB1011(), true, false, "11.x"},
-		{"mariadb above (#108 bumps CI to 12.x)", "mariadb", "12.3.0-MariaDB", capability.MariaDB1011(), true, true, "11.x"},
-		{"mariadb far above", "mariadb", "99.0.0-MariaDB", capability.MariaDB1011(), true, true, "11.x"},
+		{"mariadb above (#108 bumps CI to 12.x)", "mariadb", "12.3.0-MariaDB", capability.MariaDB1011(), false, true, "11.x"},
+		{"mariadb far above", "mariadb", "99.0.0-MariaDB", capability.MariaDB1011(), false, true, "11.x"},
 		{
 			"mariadb above over the mysql replication prefix",
-			"mysql", "5.5.5-12.3.0-MariaDB", capability.MariaDB1011(), true, true, "11.x",
+			"mysql", "5.5.5-12.3.0-MariaDB", capability.MariaDB1011(), false, true, "11.x",
 		},
 
 		// PostgreSQL: Postgres17 is the top preset and covers 17 only, while
@@ -450,8 +453,8 @@ func TestResolveServerVersionReportsSaturation(t *testing.T) {
 		{"postgres below", "postgres", "PostgreSQL 13.14 (Debian)", capability.Postgres13(), true, false, "17.x"},
 		{"postgres inside", "postgres", "PostgreSQL 16.3 (Debian)", capability.Postgres16(), true, false, "17.x"},
 		{"postgres at the newest measured line", "postgres", "PostgreSQL 17.5", capability.Postgres17(), true, false, "17.x"},
-		{"postgres above (CI runs postgres:18)", "postgres", "PostgreSQL 18.4 (Debian)", capability.Postgres17(), true, true, "17.x"},
-		{"postgres far above", "postgres", "PostgreSQL 99.0", capability.Postgres17(), true, true, "17.x"},
+		{"postgres above (CI runs postgres:18)", "postgres", "PostgreSQL 18.4 (Debian)", capability.Postgres17(), false, true, "17.x"},
+		{"postgres far above", "postgres", "PostgreSQL 99.0", capability.Postgres17(), false, true, "17.x"},
 
 		// Controls. An unparseable version never reports saturation, and a
 		// dialect with no version ladder reports neither a ceiling nor
@@ -491,12 +494,74 @@ func TestResolveServerVersionReportsSaturation(t *testing.T) {
 			c.Assert(got.Saturated, qt.Equals, tt.wantSaturated, comment)
 			c.Assert(got.NewestMeasured, qt.Equals, tt.wantNewestMeasured, comment)
 
-			// The two older entry points must keep answering exactly what they
-			// answered before saturation existed, on every row above.
+			// Saturated and VersionSpecific are two readings of one fact and
+			// must never both be true: a preset reached by running off the top
+			// of the ladder is the dialect default, not a version-specific
+			// selection.
+			c.Assert(got.Saturated && got.VersionSpecific, qt.IsFalse, comment)
+
+			// The two older entry points answer from the same resolution, so
+			// the boolean ForServerVersionResult hands an existing caller is
+			// the one asserted above.
 			caps, versionSpecific := capability.ForServerVersionResult(tt.dialect, tt.version)
 			c.Assert(caps, qt.DeepEquals, tt.wantCaps, comment)
 			c.Assert(versionSpecific, qt.Equals, tt.wantVersionSpecific, comment)
 			c.Assert(capability.ForServerVersion(tt.dialect, tt.version), qt.DeepEquals, tt.wantCaps, comment)
+		})
+	}
+}
+
+// TestForServerVersionResultDoesNotSaturateSilently is completion criterion 3
+// of issue #916, transcribed:
+//
+//	ForServerVersionResult("mysql", "26.7.0") no longer returns a set
+//	identical to ("mysql", "8.4.0"), OR it returns versionSpecific=false.
+//	Same for mariadb 12.3.0 vs 10.11.6. Silently saturating while returning
+//	true is what fails. #791 and #108 unblock on exactly this row.
+//
+// The criterion permits either outcome, so the assertion is on the conjunction
+// the criterion forbids — an identical set *and* a true boolean — rather than
+// on the branch this change happens to take. A later change that gives MySQL
+// 26.x, MariaDB 12.x or PostgreSQL 18 a measured preset of its own satisfies
+// the criterion the other way and must keep this test green without editing
+// it.
+//
+// wantIdenticalSet records which branch is live today, so the test also fails
+// if a preset silently starts differing and nobody notices the criterion is
+// now met for a different reason. The postgres row is not named in the
+// criterion; it is here because the integration matrix runs postgres:18, which
+// makes it the row a reader will hit first.
+func TestForServerVersionResultDoesNotSaturateSilently(t *testing.T) {
+	tests := []struct {
+		name              string
+		dialect           string
+		above             string
+		inside            string
+		wantIdenticalSet  bool
+		wantAboveSpecific bool
+	}{
+		{"mysql 26.7.0 against 8.4.0 (#791)", "mysql", "26.7.0", "8.4.0", true, false},
+		{"mariadb 12.3.0 against 10.11.6 (#108)", "mariadb", "12.3.0-MariaDB", "10.11.6-MariaDB", true, false},
+		{"postgres 18.4 against 17.5 (CI runs postgres:18)", "postgres", "PostgreSQL 18.4", "PostgreSQL 17.5", true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			comment := qt.Commentf("dialect=%s above=%q inside=%q", tt.dialect, tt.above, tt.inside)
+			aboveCaps, aboveSpecific := capability.ForServerVersionResult(tt.dialect, tt.above)
+			insideCaps, insideSpecific := capability.ForServerVersionResult(tt.dialect, tt.inside)
+
+			identicalSet := maps.Equal(aboveCaps, insideCaps)
+			c.Assert(identicalSet && aboveSpecific, qt.IsFalse, comment)
+
+			c.Assert(identicalSet, qt.Equals, tt.wantIdenticalSet, comment)
+			c.Assert(aboveSpecific, qt.Equals, tt.wantAboveSpecific, comment)
+
+			// The control: the version inside the measured line is what a true
+			// boolean is for. Without it a resolver that answered false for
+			// every input would pass the assertion above.
+			c.Assert(insideSpecific, qt.IsTrue, comment)
 		})
 	}
 }

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -182,30 +182,41 @@ func getDatabaseInfoWithCapabilities(
 	return info, resolution, nil
 }
 
-// reportCapabilityResolution tells the operator how the live server version
-// was mapped onto a capability preset, in the two cases where the mapping is
-// not a plain match.
+// reportCapabilityResolution records how the live server version was mapped
+// onto a capability preset, in the two cases where the mapping is not a plain
+// match: the version could not be parsed at all, or it parsed and ran off the
+// top of its dialect's ladder.
 //
-// A version that could not be parsed at all is routine — several dialects
-// have no version ladder yet — so it stays at DEBUG. Saturation is not
-// routine: the version parsed, it is newer than the newest line Ptah has a
-// preset for, and the plan is being built from that line's preset as a
-// stand-in. Nothing further along the path can notice, so this is the only
-// place it can be said (issue #916).
+// Both stay at DEBUG, and that level is the point. The default logger
+// cmd/internal/cliobs installs keeps WARN and above precisely because a clean
+// run against a supported server emits nothing there; anything it does emit is
+// a diagnostic that exists nowhere else. Connecting to a server Ptah supports
+// and runs in CI is not such an event. A saturated resolution fires on every
+// single connection to that server — the integration matrix runs postgres:18,
+// which is saturated against the PostgreSQL 17 line — so reporting it at WARN
+// wrote a line to stderr on every command and broke every test that asserts a
+// clean error stream.
+//
+// The fact itself is not lost. capability.ResolveServerVersion returns
+// Saturated and NewestMeasured to any caller that wants to act on them, and
+// `--log-level debug` prints these lines. Surfacing an unrefined version to
+// the user on a channel of its own is criterion 6 of issue #916 and belongs
+// with the CLI work that owns that channel.
 func reportCapabilityResolution(info types.DBInfo, resolution capability.VersionResolution) {
+	if resolution.Saturated {
+		slog.Debug(
+			"server is newer than the newest measured capability line; planning with that line's preset",
+			"dialect", info.Dialect,
+			"version", info.Version,
+			"newest_measured", resolution.NewestMeasured,
+		)
+		return
+	}
 	if !resolution.VersionSpecific {
 		slog.Debug(
 			"falling back to dialect default capabilities",
 			"dialect", info.Dialect,
 			"version", info.Version,
-		)
-	}
-	if resolution.Saturated {
-		slog.Warn(
-			"server is newer than the newest measured capability line; planning with that line's preset",
-			"dialect", info.Dialect,
-			"version", info.Version,
-			"newest_measured", resolution.NewestMeasured,
 		)
 	}
 }
@@ -217,8 +228,8 @@ func resolveDatabaseCapabilities(info types.DBInfo) capability.VersionResolution
 	// connection that will plan and execute the statements.
 	//
 	// The resolution carries more than the preset: a server newer than the
-	// newest measured version line resolves saturated, and ConnectToDatabase
-	// reports that rather than swallowing it.
+	// newest measured version line resolves saturated and not
+	// version-specific, which is what ConnectToDatabase records.
 	return capability.ResolveServerVersion(info.Dialect, info.Version)
 }
 

--- a/dbschema/connection.go
+++ b/dbschema/connection.go
@@ -84,7 +84,7 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 	}
 
 	// Get database info
-	info, versionSpecific, err := getDatabaseInfoWithCapabilities(
+	info, resolution, err := getDatabaseInfoWithCapabilities(
 		ctx,
 		db,
 		dialect,
@@ -95,13 +95,7 @@ func ConnectToDatabase(ctx context.Context, dbURL string) (*DatabaseConnection, 
 		_ = db.Close()
 		return nil, fmt.Errorf("failed to get database info: %w", err)
 	}
-	if !versionSpecific {
-		slog.Debug(
-			"falling back to dialect default capabilities",
-			"dialect", info.Dialect,
-			"version", info.Version,
-		)
-	}
+	reportCapabilityResolution(info, resolution)
 
 	var newReader schemaReaderFactory
 	var newWriter schemaWriterFactory
@@ -178,22 +172,54 @@ func getDatabaseInfoWithCapabilities(
 	dialect string,
 	parsedURL *url.URL,
 	dbURL string,
-) (types.DBInfo, bool, error) {
+) (types.DBInfo, capability.VersionResolution, error) {
 	info, err := getDatabaseInfo(ctx, db, dialect, parsedURL, dbURL)
 	if err != nil {
-		return types.DBInfo{}, false, err
+		return types.DBInfo{}, capability.VersionResolution{}, err
 	}
-	caps, versionSpecific := resolveDatabaseCapabilities(info)
-	info.Capabilities = caps
-	return info, versionSpecific, nil
+	resolution := resolveDatabaseCapabilities(info)
+	info.Capabilities = resolution.Capabilities
+	return info, resolution, nil
 }
 
-func resolveDatabaseCapabilities(info types.DBInfo) (capability.Capabilities, bool) {
+// reportCapabilityResolution tells the operator how the live server version
+// was mapped onto a capability preset, in the two cases where the mapping is
+// not a plain match.
+//
+// A version that could not be parsed at all is routine — several dialects
+// have no version ladder yet — so it stays at DEBUG. Saturation is not
+// routine: the version parsed, it is newer than the newest line Ptah has a
+// preset for, and the plan is being built from that line's preset as a
+// stand-in. Nothing further along the path can notice, so this is the only
+// place it can be said (issue #916).
+func reportCapabilityResolution(info types.DBInfo, resolution capability.VersionResolution) {
+	if !resolution.VersionSpecific {
+		slog.Debug(
+			"falling back to dialect default capabilities",
+			"dialect", info.Dialect,
+			"version", info.Version,
+		)
+	}
+	if resolution.Saturated {
+		slog.Warn(
+			"server is newer than the newest measured capability line; planning with that line's preset",
+			"dialect", info.Dialect,
+			"version", info.Version,
+			"newest_measured", resolution.NewestMeasured,
+		)
+	}
+}
+
+func resolveDatabaseCapabilities(info types.DBInfo) capability.VersionResolution {
 	// Root metadata must describe the conservative server-version baseline.
 	// Session variables can differ between pooled physical connections, so
 	// session-specific relaxations are detected only after WithSession pins the
 	// connection that will plan and execute the statements.
-	return capability.ForServerVersionResult(info.Dialect, info.Version)
+	//
+	// The resolution carries more than the preset: a server newer than the
+	// newest measured version line resolves saturated, and ConnectToDatabase
+	// reports that rather than swallowing it.
+	return capability.ResolveServerVersion(info.Dialect, info.Version)
 }
 
 func databaseDriverConfig(dialect, dbURL string) (driverName, dataSourceName string) {

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -182,62 +182,84 @@ func TestResolveDatabaseCapabilities_MySQLKeepsVersionBaseline(t *testing.T) {
 	c.Assert(got.Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
 }
 
+// defaultCLILogLevel is the threshold cmd/internal/cliobs.QuietDefaultLogger
+// installs before any command runs, and therefore the level at which library
+// slog calls reach a user's stderr on a default invocation. It is duplicated
+// rather than imported because cliobs lives under cmd/internal and this
+// package cannot reach it.
+const defaultCLILogLevel = slog.LevelWarn
+
+// captureResolutionReport runs the reporter with a default logger writing to a
+// buffer at the given threshold, and returns everything it wrote.
+func captureResolutionReport(t *testing.T, level slog.Level, info types.DBInfo) string {
+	t.Helper()
+	var output bytes.Buffer
+	previousLogger := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: level})))
+	defer slog.SetDefault(previousLogger)
+	reportCapabilityResolution(info, resolveDatabaseCapabilities(info))
+	return output.String()
+}
+
 // TestReportCapabilityResolution covers the one production caller of the
-// version-aware selector: a server past the newest measured version line is
-// planned with that line's preset, and this is the only place that fact
-// reaches an operator. The rows pin what is said and, just as importantly,
-// that nothing is said for a server inside a measured line.
+// version-aware selector.
+//
+// Every row asserts the same thing first: nothing is written at the level a
+// default command runs at. A saturated resolution is not an incident — the
+// integration matrix runs postgres:18, which is saturated against the
+// PostgreSQL 17 line, so a WARN there fires on every connection to a server
+// Ptah supports. It did, and it broke 25 subtests that assert a clean error
+// stream. cliobs.QuietDefaultLogger's contract is that a clean run emits
+// nothing at WARN or above; a supported server is a clean run.
+//
+// The debug column is the other half: the fact is recorded, not dropped, and
+// `--log-level debug` shows it. The quiet row is the non-interference control
+// — without it, a reporter that said nothing at any level would pass.
 func TestReportCapabilityResolution(t *testing.T) {
 	tests := []struct {
-		name       string
-		info       types.DBInfo
-		wantLogged []string
-		wantQuiet  bool
+		name           string
+		info           types.DBInfo
+		wantDebug      []string
+		wantDebugQuiet bool
 	}{
 		{
-			name: "mysql inside the measured line stays quiet",
+			name: "mysql inside the measured line says nothing at all",
 			info: types.DBInfo{Dialect: "mysql", Version: "9.7.1"},
-			// The integration matrix runs mysql:9.7; a warning here would fire
-			// on every connection and train operators to ignore it.
-			wantQuiet: true,
+			// The integration matrix runs mysql:9.7.
+			wantDebugQuiet: true,
 		},
 		{
-			name:       "mysql past the newest measured line warns",
-			info:       types.DBInfo{Dialect: "mysql", Version: "26.7.0"},
-			wantLogged: []string{"level=WARN", "newest measured capability line", "dialect=mysql", "version=26.7.0", "newest_measured=9.x"},
+			name:      "mysql past the newest measured line is recorded at debug",
+			info:      types.DBInfo{Dialect: "mysql", Version: "26.7.0"},
+			wantDebug: []string{"level=DEBUG", "newest measured capability line", "dialect=mysql", "version=26.7.0", "newest_measured=9.x"},
 		},
 		{
-			name:       "mariadb past the newest measured line warns",
-			info:       types.DBInfo{Dialect: "mariadb", Version: "12.3.0-MariaDB"},
-			wantLogged: []string{"level=WARN", "dialect=mariadb", "version=12.3.0-MariaDB", "newest_measured=11.x"},
+			name:      "mariadb past the newest measured line is recorded at debug",
+			info:      types.DBInfo{Dialect: "mariadb", Version: "12.3.0-MariaDB"},
+			wantDebug: []string{"level=DEBUG", "dialect=mariadb", "version=12.3.0-MariaDB", "newest_measured=11.x"},
 		},
 		{
-			name:       "postgres past the newest measured line warns",
-			info:       types.DBInfo{Dialect: "postgres", Version: "PostgreSQL 18.4 (Debian)"},
-			wantLogged: []string{"level=WARN", "dialect=postgres", "newest_measured=17.x"},
+			name:      "postgres past the newest measured line is recorded at debug",
+			info:      types.DBInfo{Dialect: "postgres", Version: "PostgreSQL 18.4 (Debian)"},
+			wantDebug: []string{"level=DEBUG", "dialect=postgres", "newest_measured=17.x"},
 		},
 		{
-			name:       "an unparseable version stays a debug-level fallback",
-			info:       types.DBInfo{Dialect: "mysql", Version: "who knows"},
-			wantLogged: []string{"level=DEBUG", "falling back to dialect default capabilities"},
+			name:      "an unparseable version stays a debug-level fallback",
+			info:      types.DBInfo{Dialect: "mysql", Version: "who knows"},
+			wantDebug: []string{"level=DEBUG", "falling back to dialect default capabilities"},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := qt.New(t)
 
-			var output bytes.Buffer
-			previousLogger := slog.Default()
-			slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelDebug})))
-			t.Cleanup(func() {
-				slog.SetDefault(previousLogger)
-			})
+			atDefault := captureResolutionReport(t, defaultCLILogLevel, tt.info)
+			c.Assert(atDefault, qt.Equals, "", qt.Commentf("emitted on default stderr: %q", atDefault))
 
-			reportCapabilityResolution(tt.info, resolveDatabaseCapabilities(tt.info))
-
-			c.Assert(output.String() == "", qt.Equals, tt.wantQuiet, qt.Commentf("logged: %q", output.String()))
-			for _, want := range tt.wantLogged {
-				c.Assert(output.String(), qt.Contains, want)
+			atDebug := captureResolutionReport(t, slog.LevelDebug, tt.info)
+			c.Assert(atDebug == "", qt.Equals, tt.wantDebugQuiet, qt.Commentf("logged: %q", atDebug))
+			for _, want := range tt.wantDebug {
+				c.Assert(atDebug, qt.Contains, want)
 			}
 		})
 	}

--- a/dbschema/connection_internal_test.go
+++ b/dbschema/connection_internal_test.go
@@ -5,9 +5,11 @@ package dbschema
 // the public connection API alone.
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"database/sql/driver"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -168,15 +170,77 @@ func TestDatabaseConnectionWithSession_RebindsAllDatabaseOperations(t *testing.T
 func TestResolveDatabaseCapabilities_MySQLKeepsVersionBaseline(t *testing.T) {
 	c := qt.New(t)
 
-	got, versionSpecific := resolveDatabaseCapabilities(types.DBInfo{
+	got := resolveDatabaseCapabilities(types.DBInfo{
 		Dialect: "mysql",
 		Version: "8.4.0",
 	})
 
-	c.Assert(versionSpecific, qt.IsTrue)
-	c.Assert(got, qt.DeepEquals, capability.MySQL84())
-	c.Assert(got.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
-	c.Assert(got.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+	c.Assert(got.VersionSpecific, qt.IsTrue)
+	c.Assert(got.Saturated, qt.IsFalse)
+	c.Assert(got.Capabilities, qt.DeepEquals, capability.MySQL84())
+	c.Assert(got.Capabilities.Has(capability.ForeignKeysRequireUniqueReference), qt.IsTrue)
+	c.Assert(got.Capabilities.Has(capability.ForeignKeysRequireIndexedReference), qt.IsFalse)
+}
+
+// TestReportCapabilityResolution covers the one production caller of the
+// version-aware selector: a server past the newest measured version line is
+// planned with that line's preset, and this is the only place that fact
+// reaches an operator. The rows pin what is said and, just as importantly,
+// that nothing is said for a server inside a measured line.
+func TestReportCapabilityResolution(t *testing.T) {
+	tests := []struct {
+		name       string
+		info       types.DBInfo
+		wantLogged []string
+		wantQuiet  bool
+	}{
+		{
+			name: "mysql inside the measured line stays quiet",
+			info: types.DBInfo{Dialect: "mysql", Version: "9.7.1"},
+			// The integration matrix runs mysql:9.7; a warning here would fire
+			// on every connection and train operators to ignore it.
+			wantQuiet: true,
+		},
+		{
+			name:       "mysql past the newest measured line warns",
+			info:       types.DBInfo{Dialect: "mysql", Version: "26.7.0"},
+			wantLogged: []string{"level=WARN", "newest measured capability line", "dialect=mysql", "version=26.7.0", "newest_measured=9.x"},
+		},
+		{
+			name:       "mariadb past the newest measured line warns",
+			info:       types.DBInfo{Dialect: "mariadb", Version: "12.3.0-MariaDB"},
+			wantLogged: []string{"level=WARN", "dialect=mariadb", "version=12.3.0-MariaDB", "newest_measured=11.x"},
+		},
+		{
+			name:       "postgres past the newest measured line warns",
+			info:       types.DBInfo{Dialect: "postgres", Version: "PostgreSQL 18.4 (Debian)"},
+			wantLogged: []string{"level=WARN", "dialect=postgres", "newest_measured=17.x"},
+		},
+		{
+			name:       "an unparseable version stays a debug-level fallback",
+			info:       types.DBInfo{Dialect: "mysql", Version: "who knows"},
+			wantLogged: []string{"level=DEBUG", "falling back to dialect default capabilities"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			var output bytes.Buffer
+			previousLogger := slog.Default()
+			slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{Level: slog.LevelDebug})))
+			t.Cleanup(func() {
+				slog.SetDefault(previousLogger)
+			})
+
+			reportCapabilityResolution(tt.info, resolveDatabaseCapabilities(tt.info))
+
+			c.Assert(output.String() == "", qt.Equals, tt.wantQuiet, qt.Commentf("logged: %q", output.String()))
+			for _, want := range tt.wantLogged {
+				c.Assert(output.String(), qt.Contains, want)
+			}
+		})
+	}
 }
 
 func TestDatabaseConnectionWithSession_MySQLRelaxationIsCallbackScoped(t *testing.T) {

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -182,18 +182,28 @@ anything Ptah measured still resolves to the newest preset in its dialect. That
 is a stand-in, not a match: whatever the newer release gained or lost is
 unmodeled.
 
-`ForServerVersionResult`'s boolean cannot express this — it answers "did a
-parsed version select this preset", and stays `true` for a major nobody has
-measured. `ResolveServerVersion` returns a `VersionResolution` that adds the
-missing answer:
+The preset such a server receives is byte-identical to `ForDialect`'s, which is
+exactly what `ForServerVersionResult`'s boolean means by "no version-specific
+preset could be selected". So the boolean is `false` there:
+
+```go
+caps, versionSpecific := capability.ForServerVersionResult("mysql", "26.7.0")
+// caps            == capability.MySQL84() == capability.ForDialect("mysql")
+// versionSpecific == false   (26.x ran off the top of the ladder)
+```
+
+`ResolveServerVersion` separates that fallback from the other one — a version
+that could not be parsed at all — and names the line the server was planned as:
 
 ```go
 resolution := capability.ResolveServerVersion("mysql", "26.7.0")
 // resolution.Capabilities    == capability.MySQL84()
-// resolution.VersionSpecific == true    (a parsed version selected it)
+// resolution.VersionSpecific == false   (the dialect default was used)
 // resolution.Saturated       == true    (26.x is past the newest measured line)
 // resolution.NewestMeasured  == "9.x"
 ```
+
+`Saturated` and `VersionSpecific` are never both true.
 
 The newest measured line per refined dialect:
 
@@ -218,10 +228,18 @@ report `Saturated=false` and an empty `NewestMeasured`. Refining those dialects
 is the remaining scope of issue #916.
 
 `dbschema.ConnectToDatabase` is the one production caller of the version-aware
-selector. It logs a saturated resolution at `WARN`, naming the dialect, the
-server version, and the line it was planned as. An unparseable version stays at
-`DEBUG`, because several dialects have no ladder and would warn on every
-connection.
+selector. It records a saturated resolution at `DEBUG`, naming the dialect, the
+server version, and the line it was planned as; an unparseable version is
+recorded at `DEBUG` too. Neither reaches a default run's stderr, and that is
+deliberate: the CLI's default logger keeps `WARN` and above so that a clean run
+emits nothing, and connecting to a supported server is a clean run. The
+integration matrix runs `postgres:18`, so a saturated resolution there fires on
+every connection — a warning would be noise on every command rather than a
+diagnostic. Use `--log-level debug` to see it, or read `Saturated` and
+`NewestMeasured` from `ResolveServerVersion` directly.
+
+Surfacing an unrefined version to the user on a channel of its own is
+criterion 6 of issue #916 and belongs with the CLI work that owns that channel.
 
 ### Composition
 

--- a/docs/capabilities.md
+++ b/docs/capabilities.md
@@ -161,7 +161,7 @@ Version lines: `MySQL84()` covers MySQL 8.4+ and 9.x; `MySQL8019()` covers
 older. `MariaDB1011()` covers the
 supported MariaDB lines (10.6+/11.x); `MariaDBLegacy()` is the conservative
 floor `ForServerVersion` assigns to pre-10.2 servers. `Postgres17()` covers
-PostgreSQL 17+; `Postgres16()` covers 14–16; `Postgres13()` covers 12–13 (no
+PostgreSQL 17; `Postgres16()` covers 14–16; `Postgres13()` covers 12–13 (no
 `CREATE OR REPLACE TRIGGER`).
 
 `CockroachDB23()` and `YugabyteDB25()` are PostgreSQL-family presets for the
@@ -174,6 +174,54 @@ schemas, tables, `IDENTITY`, enforced CHECK/UNIQUE/FK constraints, basic
 indexes, raw-SQL view/trigger rendering, and `XML` columns. Standalone
 sequence objects and drift-safe normalization for SQL Server-specific view,
 trigger, and index metadata are outside the initial SQL Server subset.
+
+### Saturation: servers newer than the newest measured line
+
+Every version ladder above ends in an open-topped arm, so a server newer than
+anything Ptah measured still resolves to the newest preset in its dialect. That
+is a stand-in, not a match: whatever the newer release gained or lost is
+unmodeled.
+
+`ForServerVersionResult`'s boolean cannot express this — it answers "did a
+parsed version select this preset", and stays `true` for a major nobody has
+measured. `ResolveServerVersion` returns a `VersionResolution` that adds the
+missing answer:
+
+```go
+resolution := capability.ResolveServerVersion("mysql", "26.7.0")
+// resolution.Capabilities    == capability.MySQL84()
+// resolution.VersionSpecific == true    (a parsed version selected it)
+// resolution.Saturated       == true    (26.x is past the newest measured line)
+// resolution.NewestMeasured  == "9.x"
+```
+
+The newest measured line per refined dialect:
+
+| Dialect | Newest measured line | Saturates above major |
+| --- | --- | --- |
+| MySQL | 9.x (`MySQL84()`) | 9 |
+| MariaDB | 11.x (`MariaDB1011()`) | 11 |
+| PostgreSQL | 17.x (`Postgres17()`) | 17 |
+
+PostgreSQL 18 therefore resolves saturated even though the integration matrix
+already runs `postgres:18`: Ptah has no measured PostgreSQL 18 capability line
+yet, so 18 is planned with the PostgreSQL 17 preset and says so.
+
+Raising one of those numbers is the deliberate act of claiming a newer server
+line behaves like the preset it lands on. Do it in the change that measures
+that line — never as a side effect of bumping a container tag.
+
+Saturation is only defined where this package has a version ladder. ClickHouse,
+SQLite and SQL Server have no ladder at all, and CockroachDB, YugabyteDB and
+Spanner are resolved from the banner without consulting a version; all six
+report `Saturated=false` and an empty `NewestMeasured`. Refining those dialects
+is the remaining scope of issue #916.
+
+`dbschema.ConnectToDatabase` is the one production caller of the version-aware
+selector. It logs a saturated resolution at `WARN`, naming the dialect, the
+server version, and the line it was planned as. An unparseable version stays at
+`DEBUG`, because several dialects have no ladder and would warn on every
+connection.
 
 ### Composition
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -4882,26 +4882,30 @@ type VersionResolution struct {
     Capabilities Capabilities
     // VersionSpecific is false when no version-specific preset could be
     // selected and the dialect default was used instead. It carries exactly
-    // the meaning of ForServerVersionResult's second return value.
+    // the meaning of ForServerVersionResult's second return value, and it is
+    // false for a saturated version because the preset such a version lands
+    // on is exactly ForDialect's.
     VersionSpecific bool
     // Saturated is true when the resolved preset is the top of a version
     // ladder and the server is newer than the newest line that ladder was
-    // measured against.
+    // measured against. It is the reason VersionSpecific is false, and is
+    // never true at the same time as VersionSpecific.
     Saturated bool
     // NewestMeasured names the newest measured version line for the dialect,
     // for example "9.x". It is empty for dialects with no version ladder.
     NewestMeasured string
 }
     VersionResolution reports how a server version string was mapped onto a
-    capability preset. It is what ForServerVersionResult's boolean cannot say
-    on its own: that boolean answers "did a parsed version select this preset",
-    and stays true for a version far newer than anything this package has a
-    preset for.
+    capability preset.
 
-    Saturated distinguishes those two cases. It is true when the version parsed,
-    selected the newest preset in its dialect's ladder, and is itself newer
-    than the newest line that ladder was measured against — so the preset is a
-    stand-in and any capability the newer server gained or lost is unmodeled.
+    Saturated names the case the resolver used to answer wrongly: the version
+    parsed, it selected the newest preset in its dialect's ladder, and it is
+    itself newer than the newest line that ladder was measured against — so the
+    preset is a stand-in and any capability the newer server gained or lost
+    is unmodeled. That is not a version-specific answer, so VersionSpecific is
+    false whenever Saturated is true, and the two fields together say which of
+    the two ways a caller ended up on the dialect default: the version could not
+    be parsed at all, or it parsed and ran off the top of the ladder.
 
     Saturation is only defined where this package has a version ladder: MySQL,
     MariaDB and PostgreSQL. CockroachDB, YugabyteDB and Spanner are resolved

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -4827,6 +4827,8 @@ type Capabilities map[Capability]bool
 type Capability string
     const DropConstraintGeneric Capability = "drop_constraint_generic" ...
     func All() []Capability
+type VersionResolution struct{ ... }
+    func ResolveServerVersion(dialect, version string) VersionResolution
 
 ### go.5x5.cz/ptah/core/platform/capability.Capabilities
 
@@ -4870,6 +4872,45 @@ type Capability string
 
 const DropConstraintGeneric Capability = "drop_constraint_generic" ...
 func All() []Capability
+
+### go.5x5.cz/ptah/core/platform/capability.VersionResolution
+
+package capability // import "go.5x5.cz/ptah/core/platform/capability"
+
+type VersionResolution struct {
+    // Capabilities is the resolved preset, never nil for a known dialect.
+    Capabilities Capabilities
+    // VersionSpecific is false when no version-specific preset could be
+    // selected and the dialect default was used instead. It carries exactly
+    // the meaning of ForServerVersionResult's second return value.
+    VersionSpecific bool
+    // Saturated is true when the resolved preset is the top of a version
+    // ladder and the server is newer than the newest line that ladder was
+    // measured against.
+    Saturated bool
+    // NewestMeasured names the newest measured version line for the dialect,
+    // for example "9.x". It is empty for dialects with no version ladder.
+    NewestMeasured string
+}
+    VersionResolution reports how a server version string was mapped onto a
+    capability preset. It is what ForServerVersionResult's boolean cannot say
+    on its own: that boolean answers "did a parsed version select this preset",
+    and stays true for a version far newer than anything this package has a
+    preset for.
+
+    Saturated distinguishes those two cases. It is true when the version parsed,
+    selected the newest preset in its dialect's ladder, and is itself newer
+    than the newest line that ladder was measured against — so the preset is a
+    stand-in and any capability the newer server gained or lost is unmodeled.
+
+    Saturation is only defined where this package has a version ladder: MySQL,
+    MariaDB and PostgreSQL. CockroachDB, YugabyteDB and Spanner are resolved
+    from the banner without consulting a version at all, and ClickHouse, SQLite
+    and SQL Server have no ladder to saturate; all six report Saturated=false
+    and an empty NewestMeasured. Refining those dialects is the remaining scope
+    of issue #916 and is deliberately not answered here.
+
+func ResolveServerVersion(dialect, version string) VersionResolution
 
 ## go.5x5.cz/ptah/core/platform/identifier
 

--- a/integration/capability_resolution_stderr_e2e_test.go
+++ b/integration/capability_resolution_stderr_e2e_test.go
@@ -1,0 +1,102 @@
+//go:build integration
+
+package integration_test
+
+import (
+	"bytes"
+	"context"
+	"database/sql"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// capabilityReportDefaultLogLevel is the threshold
+// cmd/internal/cliobs.QuietDefaultLogger installs before any command runs, and
+// therefore the level at which a library slog call reaches a user's stderr on
+// a default invocation. It is duplicated rather than imported because cliobs
+// lives under cmd/internal.
+const capabilityReportDefaultLogLevel = slog.LevelWarn
+
+// TestLiveCapabilityResolutionStaysOffDefaultStderrE2E pins that connecting to
+// a supported server writes nothing to the error stream.
+//
+// It has to run against a live server because the defect is a function of the
+// banner the server reports. `postgres:18` is what
+// .github/workflows/go-integration-tests.yml and docker-compose.yaml pin, and
+// PostgreSQL 18 is past the newest measured capability line (17), so the
+// resolution is saturated on exactly the image CI runs. A diagnostic emitted
+// for that condition fires on every single connection, and every test that
+// asserts a clean error stream goes red — which is what happened: 25 subtests
+// across four migrate-lint E2E files.
+//
+// The test is written to hold on any supported PostgreSQL, not only 18: the
+// contract is "a clean run against a server Ptah supports emits nothing at the
+// default level", saturated or not. The resolution is asserted to have seen
+// the real banner so the assertion cannot pass by never connecting.
+func TestLiveCapabilityResolutionStaysOffDefaultStderrE2E(t *testing.T) {
+	dbURL := requirePostgresE2EDatabaseURL(t)
+
+	c := qt.New(t)
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	c.Run("the library writes nothing at the default log level", func(c *qt.C) {
+		var output bytes.Buffer
+		previousLogger := slog.Default()
+		slog.SetDefault(slog.New(slog.NewTextHandler(&output, &slog.HandlerOptions{
+			Level: capabilityReportDefaultLogLevel,
+		})))
+		defer slog.SetDefault(previousLogger)
+
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer conn.Close()
+
+		info := conn.Info()
+		c.Assert(output.String(), qt.Equals, "",
+			qt.Commentf("emitted on default stderr for %s %q", info.Dialect, info.Version))
+
+		// Non-vacuity: the buffer being empty means something only if a live
+		// banner was actually resolved.
+		c.Assert(info.Version, qt.Not(qt.Equals), "")
+		resolution := capability.ResolveServerVersion(info.Dialect, info.Version)
+		c.Assert(resolution.Capabilities, qt.Not(qt.IsNil))
+		c.Assert(resolution.Saturated && resolution.VersionSpecific, qt.IsFalse,
+			qt.Commentf("version %q", info.Version))
+	})
+
+	c.Run("a clean binary run writes nothing to stderr", func(c *qt.C) {
+		repoRoot := e2eRepoRoot(t)
+		binaryPath := filepath.Join(c.TempDir(), "ptah-compat")
+		buildPtahCompat(c, ctx, repoRoot, binaryPath)
+
+		adminDB, err := sql.Open("pgx", dbURL)
+		c.Assert(err, qt.IsNil)
+		defer adminDB.Close()
+
+		testDBName := fmt.Sprintf("ptah_caps_stderr_e2e_%d", time.Now().UnixNano())
+		createE2EDatabase(c, ctx, adminDB, testDBName)
+		defer dropE2EDatabase(c, context.Background(), adminDB, testDBName)
+
+		migrationsDir := c.TempDir()
+		writeLintE2EFile(c, migrationsDir, "1.sql", "CREATE TABLE widgets (id int);\n")
+
+		stdout, stderr, err := runLintE2EBinary(ctx, binaryPath,
+			"migrate", "lint",
+			"--dir", "file://"+migrationsDir,
+			"--dev-url", replaceDatabaseName(c, dbURL, testDBName),
+			"--latest", "1",
+		)
+
+		c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+		c.Assert(stderr, qt.Equals, "")
+	})
+}


### PR DESCRIPTION
Narrow slice of #916: the **version-saturation criterion** only (criterion 3 of the completion criteria in https://github.com/stokaro/ptah/issues/916#issuecomment-5169436377). Everything else in that issue is deliberately untouched — see "What this deliberately leaves" at the bottom.

> **This branch was force-pushed to repair two defects an independent verifier reproduced in the previous revision.** Both are described in "What was wrong with the previous revision" below, along with the claims this body used to make that were false. The first revision resolved saturation as an *additional* signal while leaving the existing boolean answering `true` and reporting saturation at `WARN`; both of those turned out to be wrong, and the sections that argued for them have been replaced rather than edited.

## The item: saturation is silent, and the boolean says the opposite

`ForServerVersionResult`'s boolean exists to tell a caller "this capability set was chosen for your version". Every ladder in `core/platform/capability` ends in an open-topped arm — `mysqlForVersion` is `v.major > 8 ... return MySQL84()` with no upper bound, `mariaDBForVersion` saturates the same way at `major > 10`, and the PostgreSQL branch at `v.major >= 17`. So the boolean answered `true` for a major nobody has ever measured, and a caller could not tell *inside a measured version line* from *past the newest line we know*.

That is what blocks #791 (`mysql:9.7 → 26.7`) and #108 (`mariadb:10.11 → 12.3`): each would model a brand-new major with an old preset, silently.

## Criterion 3, verbatim, and the outcome taken

> `ForServerVersionResult("mysql", "26.7.0")` no longer returns a set identical to `("mysql", "8.4.0")`, **or** it returns `versionSpecific=false`. Same for `("mariadb", "12.3.0-MariaDB")` vs `("mariadb", "10.11.6-MariaDB")`. Silently saturating while returning `true` is what fails. #791 and #108 unblock on exactly this row.

This takes the **second** outcome. The preset a saturated version receives is byte-identical to `ForDialect(dialect)`'s — that is precisely what the boolean's own documentation means by "no version-specific preset could be selected and the dialect default was used instead" — so the boolean is `false` there.

Measured with a small program against the library (the defect has no CLI surface — no command outside `ptah sql lint` accepts a server version, which is scope item 5 of #916 and is not in this PR), comparing each above-the-line version against one inside the line:

```go
aboveCaps, aboveSpecific := capability.ForServerVersionResult(dialect, above)
insideCaps, _ := capability.ForServerVersionResult(dialect, inside)
identicalSet := maps.Equal(aboveCaps, insideCaps)
```

Before, on `ffcd4029` (the previous head of this branch):

```
mysql     "26.7.0"     vs "8.4.0"        identicalSet=true  versionSpecific=true
mariadb   "12.3.0"     vs "10.11.6"      identicalSet=true  versionSpecific=true
postgres  "18.4"       vs "17.5"         identicalSet=true  versionSpecific=true
```

Neither permitted outcome. After:

```
mysql     "26.7.0"     vs "8.4.0"        identicalSet=true  versionSpecific=false
mariadb   "12.3.0"     vs "10.11.6"      identicalSet=true  versionSpecific=false
postgres  "18.4"       vs "17.5"         identicalSet=true  versionSpecific=false
```

## The fix

`ResolveServerVersion(dialect, version) VersionResolution` — the preset, `VersionSpecific`, a new `Saturated` bool, and `NewestMeasured`, the newest measured version line for the dialect. `ForServerVersion` and `ForServerVersionResult` delegate to it.

`Saturated` and `VersionSpecific` are two readings of one fact and are tied together in exactly one place, `ladderResolution`:

```go
func ladderResolution(caps Capabilities, newestMeasuredMajor int, saturated bool) VersionResolution {
	return VersionResolution{
		Capabilities:    caps,
		VersionSpecific: !saturated,
		Saturated:       saturated,
		NewestMeasured:  measuredLine(newestMeasuredMajor),
	}
}
```

They are never both true. Together they say *which* of the two ways a caller reached the dialect default: the version could not be parsed at all (`VersionSpecific=false`, `Saturated=false`), or it parsed and ran off the top of the ladder (`VersionSpecific=false`, `Saturated=true`, with `NewestMeasured` naming the line it was planned as).

### The ceilings are declared, not inferred

```go
const (
	newestMeasuredMySQLMajor    = 9
	newestMeasuredMariaDBMajor  = 11
	newestMeasuredPostgresMajor = 17
)
```

with a doc comment saying that raising one is the deliberate act of claiming a newer server line behaves like the preset below it — "never as a side effect of bumping a container tag". That is the mechanism #791 and #108 unblock through: each bump must either move its ceiling (a reviewed claim, with the measurement that backs it) or accept a resolution that reports itself saturated and not version-specific. It can no longer happen by accident.

The numbers come from what the presets document and what the matrix runs: `MySQL84()` covers 8.4 through 9.x (`mysql:9.7`), `MariaDB1011()` covers 10.2 through 11.x (`mariadb:10.11`), `Postgres17()` covers 17 — and `postgres:18` therefore resolves **saturated today**, which is the honest answer: there is no measured PostgreSQL 18 capability line, so 18 is planned as 17 and says so.

### The one production caller, and why it is quiet

`dbschema/connection.go` is the single production caller of the version-aware selector. Reporting is a named function, `reportCapabilityResolution`. Both cases — saturated, and unparseable — are recorded at `DEBUG`.

`DEBUG` is the point, not an oversight. `cmd/internal/cliobs.QuietDefaultLogger` installs a default logger that keeps `WARN` and above, and its own doc comment states the contract: *"a clean run emits nothing at either level: the diagnostics only appear when something is genuinely wrong"*. Connecting to a server Ptah supports and runs in CI is not something being wrong. The integration matrix runs `postgres:18`, which is saturated against the PostgreSQL 17 line, so a `WARN` there fires on **every single connection** — noise on every command rather than a diagnostic.

Nothing is lost. `ResolveServerVersion` returns `Saturated` and `NewestMeasured` to any caller that wants to act on them, and `--log-level debug` prints these lines. Surfacing an unrefined version to the user on a channel of its own is criterion **6** of #916, which is a CLI change and is not in this PR.

`resolveDatabaseCapabilities` and `getDatabaseInfoWithCapabilities` (both unexported) carry the resolution instead of a bare bool.

### Public API

`docs/public_api.snapshot` is regenerated: one new type (`VersionResolution`), one new function (`ResolveServerVersion`), plus the doc-comment text of the type. `scripts/check-public-api-released.sh` reports only the four pre-existing approved incompatibilities and exits 0 — `ForServerVersionResult`'s *signature* is unchanged; what changed is its answer on versions above a ladder's top, which no API gate can see and which the tests below pin instead.

## What was wrong with the previous revision

An independent verifier measured `ffcd4029` and found two blockers. Both reproduced here before anything was changed.

### Blocker 1 — the `WARN` reddened 25 integration subtests on the image CI itself runs

`.github/workflows/go-integration-tests.yml` and `docker-compose.yaml` both pin `postgres:18`. Against live PostgreSQL 18.4 the warning fired on every connection, and every test asserting `c.Assert(stderr, qt.Equals, "")` failed. Reproduced on `ffcd4029` against a dedicated `postgres:18` container:

```
--- FAIL: TestAtlasMigrateLintMultiTargetDropE2E/single_target (1.01s)
    got:
      "time=... level=WARN msg=\"server is newer than the newest measured capability line; planning
       with that line's preset\" dialect=postgres version=\"PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)
       on aarch64-unknown-linux-gnu, ...\" newest_measured=17.x\n"
    want:
      ""
```

Across the four affected files — `TestAtlasMigrateLintMultiTargetDropE2E`, `TestAtlasMigrateLintRenameAddSideE2E`, `TestAtlasMigrateLintRenameE2E`, `TestAtlasMigrateLintSchemaScopeE2E` — the run produced 29 `--- FAIL` lines, 4 of them the parent tests: **25 failing subtests**, exit 1.

After the fix, the same four tests plus the new one on the same database: 32 `--- PASS` subtests, zero `FAIL`, exit 0.

### Blocker 2 — the criterion was not met, and the test pinned the opposite

Measured above. `core/platform/capability/capability_test.go` asserted `wantVersionSpecific: true` on the `mysql 26.7.0` row, locking in the state criterion 3 rejects. Those rows now assert `false`, and a second test transcribes the criterion itself.

### Claims in the previous body that were false, and are corrected here

| Previous claim | Correction |
| --- | --- |
| "the existing `VersionSpecific` bool unchanged" | It is now `false` for a saturated version. That is the change criterion 3 asked for. |
| The 16-row before/after table showing `VERSPEC true` on every saturated row after the fix | Replaced by the measured three-row criterion probe above. Saturated rows answer `false`. |
| A whole section, "Why additive, and not a new meaning for the existing boolean" | Removed. Its argument — that `true` for `mysql 99.0` is "genuinely true" — is exactly what the criterion forbids. |
| "adds a `WARN` for saturation" | Both reports are at `DEBUG`. A supported server must not write to stderr. |
| "the `dbschema` mysql **warn** row" in the mutant table | The mutant table is replaced; the rows now assert silence at the default level. |
| "Rebased onto the current `origin/master` (`d81b6d84` …) — no rebase was needed" | Stale. This revision is rebased onto `1b17999a`, fetched immediately before, and the rebase did replay. |
| "all 13 `check:*` scripts" | There are 14 in `docs/site/package.json`. All 14 were run. |
| "this closes the saturation criterion of #916" | It did not, on the previous revision. It does now. |
| A note about a `cmd/viz` timeout flake on the first full `go test` run | Not observed on this revision: `go test ./... -count=1` exited 0 on the first run of the rebased tree. |

## Red/green evidence

Three tests. Every observation below was made by mutating the working tree, running, and restoring.

**`core/platform/capability`: `TestResolveServerVersionReportsSaturation`** — one row per (dialect, version) below / inside / at / above the newest measured line for MySQL, MariaDB and PostgreSQL, plus controls for unparseable versions and for the six dialects with no ladder. Each row pins the preset, the boolean, the saturation answer and the measured line, and asserts `Saturated && VersionSpecific` is never true.

**`core/platform/capability`: `TestForServerVersionResultDoesNotSaturateSilently`** — criterion 3 transcribed. It asserts the conjunction the criterion *forbids* (`identicalSet && aboveSpecific`) rather than the branch this change happens to take, so a later change that gives MySQL 26.x or MariaDB 12.x a measured preset of its own satisfies the criterion the other way and keeps this test green without editing it. The version inside the measured line is the control: without it, a resolver answering `false` for everything would pass.

**`integration`: `TestLiveCapabilityResolutionStaysOffDefaultStderrE2E`** (build tag `integration`) — the blocker-1 regression, and it has to be live: the defect is a function of the banner the server reports, and `postgres:18` is what CI runs. Two subtests, both surfaces the verifier used: the library (`dbschema.ConnectToDatabase` with a default logger at the `WARN` threshold `cliobs` installs, writing to a buffer) and the built `ptah-compat` binary (a clean `migrate lint` against a fresh dev database, stderr captured separately from stdout). It also asserts the resolution saw a non-empty live banner, so an empty buffer cannot pass by never connecting.

| Mutant | What went red | Restored |
| --- | --- | --- |
| saturation report `slog.Debug` → `slog.Warn` | `TestLiveCapabilityResolutionStaysOffDefaultStderrE2E` — **both** subtests, library and binary, each quoting the literal PG 18.4 `level=WARN` line; and `TestReportCapabilityResolution` on 3 of 5 rows, all on the default-level assertion | green |
| `VersionSpecific: !saturated` → `true` | `TestResolveServerVersionReportsSaturation` on all 7 above-the-line rows (`got: bool(true) / want: bool(false)`), and `TestForServerVersionResultDoesNotSaturateSilently` on all 3 rows at `c.Assert(identicalSet && aboveSpecific, qt.IsFalse, …)` | green |
| `VersionSpecific: !saturated` → `false` (inverse) | `TestResolveServerVersionReportsSaturation` on all 10 below/inside/at rows, and `TestForServerVersionResultDoesNotSaturateSilently` on the `insideSpecific` control in all 3 rows | green |

The inverse mutant matters because a guard that only ever fires can never redden its non-interference control: the below/inside/at rows, the "says nothing at all" row and the `insideSpecific` control are what pin the ceiling from the other side.

Whole-suite red/green for blocker 1, on a dedicated `postgres:18` container (`PostgreSQL 18.4 (Debian 18.4-1.pgdg13+1)`), role `ptah_user` owning `ptah_test`:

| Tree | Result |
| --- | --- |
| `ffcd4029` (previous head) | 25 subtests red across 4 files, exit 1 |
| this revision | 32 subtests pass, 0 `FAIL`, exit 0 |

## Gates

Rebased onto the current `origin/master` — `1b17999a`, fetched immediately before the rebase and re-fetched immediately before the push, with the remote branch tip confirmed still at `ffcd4029` (what this work started from) before force-pushing. The rebase replayed cleanly; the tree was checked for conflict markers afterwards and the diff against `origin/master` confirmed to contain only this change's lines. Literal exit codes, read directly:

| Gate | Exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1` | 0 |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (`teststyle: OK (175 conditional groups, 45 white-box files)`) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 (four pre-existing approved incompatibilities) |
| `docs/site`: `npm ci` | 0 |
| `docs/site`: each of the 14 `check:*` scripts | 0 each |

`check:responsive` needs `npm run build` first (it reports `dist not found` otherwise); the build was run (exit 0) and the check then passed.

Live integration, against the `postgres:18` container described above: the four previously-red lint E2E files plus the new test, exit 0.

## What this deliberately leaves

Untouched, and each belongs in its own change:

- The **three renderers that take no capabilities** — ClickHouse, SQLite, SQL Server — and `core/renderer/renderer.go` discarding `caps` for them.
- The **planners that discard `opts`** — ClickHouse and SQLite.
- The **five hand-rolled version gates** (ClickHouse `CHECK GRANT`, MySQL `VIEW_TABLE_USAGE`, MySQL `SHOW_ROUTINE` and its fail-open defect, MySQL/MariaDB `CHECK_CONSTRAINTS`, SQLite `RENAME COLUMN`).
- **Refining the other six dialects.** ClickHouse, SQLite and SQL Server have no version ladder; CockroachDB, YugabyteDB and Spanner resolve from the banner without consulting a version. All six report `Saturated=false` and an empty `NewestMeasured`, and `VersionResolution`'s doc comment says so explicitly rather than leaving a reader to infer it. Fixing `parseVersion` for SQL Server marketing-year banners is part of that work, not this one.
- **The offline `--server-version` pin** (criterion 4/5) and **making an unrefined version user-visible on its own channel** (criterion 6), including `ptah sql lint --version` reporting what it actually applied. Criterion 6 is the reason the saturation report here sits at `DEBUG` rather than being deleted: the fact is available, and the channel that should show it does not exist yet.

Because of that, this closes the saturation criterion of #916, not the issue — no `Closes` line.

`docs/capabilities.md` gains a "Saturation" section with the per-dialect table, the PostgreSQL 18 consequence, the rule for raising a ceiling, the statement that the other six dialects are unrefined, and the explanation of why the report is at `DEBUG`.