### PR TITLE
Re-measure every #1231 cell and pin the two that no test held

### DIFF
--- a/cmd/atlas/migrate_preconditions_test.go
+++ b/cmd/atlas/migrate_preconditions_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"os"
 	"path/filepath"
-	"slices"
 	"strings"
 	"testing"
 
@@ -195,15 +194,52 @@ func TestCompatCommand_MigrateValidateRefusesReorderedChecksum(t *testing.T) {
 // verification shared by all of them, and `migrate apply` is the row that costs
 // something: without it a tampered ordering executes migrations against the
 // target.
+//
+// The last three rows are the verbs that WRITE, re-measured on the pinned
+// binary v1.3.0 on 2026-08-09 over a two-migration directory whose atlas.sum
+// entry lines were swapped, exit status read on a line of its own:
+//
+//	migrate new third   exit 1  checksum mismatch, nothing written
+//	migrate diff third  exit 1  checksum mismatch, nothing written
+//	migrate set <v>     exit 1  checksum mismatch, no revision row
+//
+// They are not decoration on the three the issue named. A refusal that fires
+// only on the reading verbs still lets `migrate new` append a file to a
+// tampered directory and re-hash it, which launders the tampering into a
+// directory that verifies -- the shape stokaro/ptah#1095 records for
+// `migrate import`. The directory census below is what pins that, and it is
+// asserted on every row so the reading verbs cannot drift into writing either.
 func TestCompatCommand_MigrateVerbsRefuseReorderedChecksum(t *testing.T) {
 	tests := []struct {
-		name    string
-		verb    []string
-		withURL bool
+		name string
+		args func(t *testing.T, dir string) []string
 	}{
-		{name: "validate", verb: []string{"migrate", "validate"}},
-		{name: "status", verb: []string{"migrate", "status"}, withURL: true},
-		{name: "apply", verb: []string{"migrate", "apply"}, withURL: true},
+		{name: "validate", args: func(_ *testing.T, dir string) []string {
+			return []string{"migrate", "validate", "--dir", "file://" + dir}
+		}},
+		{name: "status", args: func(t *testing.T, dir string) []string {
+			return append([]string{"migrate", "status", "--dir", "file://" + dir}, atlasTargetURLArgs(t)...)
+		}},
+		{name: "apply", args: func(t *testing.T, dir string) []string {
+			return append([]string{"migrate", "apply", "--dir", "file://" + dir}, atlasTargetURLArgs(t)...)
+		}},
+		{name: "new", args: func(_ *testing.T, dir string) []string {
+			return []string{"migrate", "new", "third", "--dir", "file://" + dir}
+		}},
+		{name: "diff", args: func(t *testing.T, dir string) []string {
+			return []string{
+				"migrate", "diff", "third",
+				"--dir", "file://" + dir,
+				"--to", "sqlite://" + seedSQLiteDB(t, "CREATE TABLE desired_users (id INTEGER PRIMARY KEY)"),
+				"--dev-url", "sqlite://" + filepath.Join(t.TempDir(), "dev.db"),
+			}
+		}},
+		{name: "set", args: func(t *testing.T, dir string) []string {
+			return append(
+				[]string{"migrate", "set", "20260101000000", "--dir", "file://" + dir},
+				atlasTargetURLArgs(t)...,
+			)
+		}},
 	}
 
 	for _, test := range tests {
@@ -211,28 +247,42 @@ func TestCompatCommand_MigrateVerbsRefuseReorderedChecksum(t *testing.T) {
 			c := qt.New(t)
 			dir := seedAtlasPreconditionDir(c, t.TempDir())
 			swapAtlasSumEntryLines(c, dir)
-			args := append(slices.Clone(test.verb), "--dir", "file://"+dir)
-			args = append(args, atlasTargetURLArgs(t, test.withURL)...)
+			before := dirEntryNames(c, dir)
 
-			out, err := runAtlasPrecondition(c, args...)
+			out, err := runAtlasPrecondition(c, test.args(t, dir)...)
 
 			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
 			c.Assert(out, qt.Contains, "Error: checksum mismatch")
+			c.Assert(dirEntryNames(c, dir), qt.DeepEquals, before)
 		})
 	}
 }
 
-// atlasTargetURLArgs returns the --url pair for the verbs that register one and
-// nothing for the verbs that do not. `migrate validate` reads the directory
-// alone and rejects --url as an unknown flag, which would fail the row above
-// for a reason that is not the checksum.
-func atlasTargetURLArgs(t *testing.T, wanted bool) []string {
+// atlasTargetURLArgs returns the --url pair for the verbs that register one.
+// `migrate validate` reads the directory alone and rejects --url as an unknown
+// flag, which would fail its row above for a reason that is not the checksum,
+// so that row does not call this.
+func atlasTargetURLArgs(t *testing.T) []string {
 	t.Helper()
-	urls := map[bool][]string{
-		false: nil,
-		true:  {"--url", "sqlite://" + filepath.Join(t.TempDir(), "target.db")},
-	}
-	return urls[wanted]
+	return []string{"--url", "sqlite://" + filepath.Join(t.TempDir(), "target.db")}
+}
+
+// TestCompatCommand_MigrateSetAcceptsAnUntouchedDirectory is the inverse
+// control for the `set` row above, and it is the row that keeps that row
+// honest: a build where `migrate set` failed for any reason at all would
+// satisfy a refusal-only table.
+//
+// Measured on the pinned binary v1.3.0 on 2026-08-09 over the same untampered
+// directory, both implementations exit 0 and print the same two lines.
+func TestCompatCommand_MigrateSetAcceptsAnUntouchedDirectory(t *testing.T) {
+	c := qt.New(t)
+	dir := seedAtlasPreconditionDir(c, t.TempDir())
+
+	args := append([]string{"migrate", "set", "20260101000000", "--dir", "file://" + dir}, atlasTargetURLArgs(t)...)
+	out, err := runAtlasPrecondition(c, args...)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", out))
+	c.Assert(out, qt.Contains, "Current version is 20260101000000")
 }
 
 // TestCompatCommand_MigrateValidateAcceptsAnUntouchedDirectory is the control
@@ -466,18 +516,43 @@ func TestCompatCommand_SchemaApplyAppliesWithAutoApproveAlone(t *testing.T) {
 // of a write it did not expect to fail, and reproducing it would import the
 // defect with the exit code. What must match is the direction and the fact that
 // no file appears.
+// The second row exists because "create the directory instead" is the cheaper
+// fix somebody will reach for, and it would be wrong. The binary composes
+// `<version>_<name>.sql` and the version prefixes the FIRST element, so the
+// open it fails is `migrations/<version>_sub/dir_name.sql` -- a directory named
+// after a timestamp nobody can create in advance. Re-measured on the pinned
+// binary v1.3.0 on 2026-08-09 with `migrations/sub` already present: still
+// exit 1, still the same open failure, still nothing written. Relaxing the
+// refusal for an existing subdirectory would therefore exit 0 where that binary
+// exits 1, which is the violation this cell is about.
 func TestCompatCommand_MigrateNewRefusesPathSeparatorName(t *testing.T) {
-	c := qt.New(t)
-	dir := seedAtlasPreconditionDir(c, t.TempDir())
-	before := dirEntryNames(c, dir)
+	tests := []struct {
+		name    string
+		prepare func(c *qt.C, dir string)
+	}{
+		{name: "no such subdirectory", prepare: func(_ *qt.C, _ string) {}},
+		{name: "subdirectory already exists", prepare: func(c *qt.C, dir string) {
+			c.Helper()
+			c.Assert(os.MkdirAll(filepath.Join(filepath.Clean(dir), "sub"), 0o750), qt.IsNil)
+		}},
+	}
 
-	out, err := runAtlasPrecondition(c, "migrate", "new", "sub/dir_name", "--dir", "file://"+dir)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := seedAtlasPreconditionDir(c, t.TempDir())
+			test.prepare(c, dir)
+			before := dirEntryNames(c, dir)
 
-	c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-	c.Assert(out, qt.Contains,
-		`Error: atlas migrate new "sub/dir_name": migration name must be a single file name element,`+
-			` without a path separator`)
-	c.Assert(dirEntryNames(c, dir), qt.DeepEquals, before)
+			out, err := runAtlasPrecondition(c, "migrate", "new", "sub/dir_name", "--dir", "file://"+dir)
+
+			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
+			c.Assert(out, qt.Contains,
+				`Error: atlas migrate new "sub/dir_name": migration name must be a single file name element,`+
+					` without a path separator`)
+			c.Assert(dirEntryNames(c, dir), qt.DeepEquals, before)
+		})
+	}
 }
 
 // TestCompatCommand_MigrateNewAcceptsNamesTheBinaryAccepts pins the other side

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -65,12 +65,20 @@ migration directory does not match ptah.sum:
   changed: 0000000002_add_posts.up.sql
 ```
 
-`ptah-compat migrate apply`, `migrate status`, and `migrate set` enforce the
-same gate on `atlas.sum` directories with Atlas's own checksum output, matching
-official Atlas behavior. Reporting is not exempt: on a hashed directory whose
-only migration was deleted, an ungated `migrate status` announced
-"Database is up to date"
+`ptah-compat migrate validate`, `apply`, `status`, `set`, `new` and `diff`
+enforce the same gate on `atlas.sum` directories with Atlas's own checksum
+output, matching official Atlas behavior. Reporting is not exempt: on a hashed
+directory whose only migration was deleted, an ungated `migrate status`
+announced "Database is up to date"
 ([#974](https://github.com/stokaro/ptah/issues/974)).
+
+The verbs that **write** are on that list for a reason of their own. A gate that
+fired only on the reading verbs would still let `migrate new` append a file to a
+tampered directory and re-hash it on the way out, so the tampering would end up
+inside a directory that verifies clean — the laundering shape recorded for
+`migrate import` in [#1095](https://github.com/stokaro/ptah/issues/1095). All
+six verbs refuse before anything is written, which is what the pinned Atlas
+community binary v1.3.0 does on the same directory.
 
 ### The sum file has to agree with itself, too
 


### PR DESCRIPTION
Closes #1231.

Every one of the eight cells was re-measured against the pinned Atlas community
binary v1.3.0 (`/…/ptah-atlas-conformance/bin/atlas`, self-reporting
`atlas community version v1.3.0`) rather than read off the issue table, which
predates #1252, #1257, #1299 and #1307. One directory or database per cell, exit
status read from an unpiped invocation.

**All eight refuse where that binary refuses.** No cell needed a new gate, so
this branch changes no behavior. What it does change is the two places where a
measurement was not held by any test, and both are the kind that only surfaces
once somebody relaxes a rule for a plausible-looking reason.

Every row below was then re-measured a second time, independently, on fixtures
built from scratch by a different reader — see **Independent verification**.

## The eight cells, re-measured

"before" and "after" are identical on every row because the branch changes no
behavior; the column is kept so the table can be read as a claim rather than as
a summary.

| # | argv | pinned v1.3.0 | ptah-compat before | after |
| --- | --- | --- | --- | --- |
| 1 | `migrate apply --dir file://migrations --url sqlite://app.db?_fk=1`, one unrelated table | 1 `sql/migrate: connected database is not clean: found multiple tables: 2. baseline version or allow-dirty is required` | **1**, byte-identical | 1 |
| 1r | same, `--url postgres://…/db?sslmode=disable` (no `search_path`), one empty extra schema | 1 `… not clean: found schema "extra". baseline version or allow-dirty is required` | **1**, byte-identical | 1 |
| 1s | same, `--url postgres://…/db?sslmode=disable&search_path=public`, one unrelated table | 1 `… not clean: found table "atlas_schema_revisions" in schema "public". baseline version or allow-dirty is required` | **1**, byte-identical | 1 |
| 2 | `migrate lint --dir file://migrations --latest 1` | 1 `Error: required flag(s) "dev-url" not set` | **1**, byte-identical | 1 |
| 3 | `migrate lint --dir file://migrations --dev-url sqlite://dv?mode=memory` | 1 `Error: --latest or --git-base is required` | **1**, byte-identical | 1 |
| 4 | `migrate validate --dir file://migrations`, entry lines swapped | 1 `checksum mismatch` + guidance block | **1**, byte-identical | 1 |
| 5 | `schema apply --url … --to … --dry-run --auto-approve` | 1 `if any flags in the group [dry-run auto-approve] are set none of the others can be; [auto-approve dry-run] were all set` | **1**, byte-identical | 1 |
| 6 | `migrate new "sub/dir_name" --dir file://migrations` | 1 `open migrations/<version>_sub/dir_name.sql: no such file or directory`, nothing written | **1** `migration name must be a single file name element, without a path separator`, nothing written | 1 |
| 7 | `migrate status --url … --dir … --var novalue` | 1 `invalid argument "novalue" for "--var" flag: variables must be format as key=value, got: "novalue"` | **1**, byte-identical | 1 |
| 8 | `migrate diff --dir … --to … --dev-url … one two` | 1 `accepts at most 1 arg(s), received 2` | **1**, byte-identical | 1 |

Row 6 is the one place the wording diverges on purpose, and the reason is
already in `migrate_name.go`: that binary's message is the raw failure of a
write it did not expect to fail, so it leaks an internal path and never says
what to change. Reproducing it would import a defect along with the exit code —
rule (b), matching is the floor. **The exit codes match (1 and 1), the direction
matches, and the directory census afterwards matches**; only the sentence
differs, deliberately, and that divergence is recorded here and in the code.

Row 1r is the realm-scope half that #1257 split out, on a plain PostgreSQL 17
URL with no `search_path` — the shape that made the original miss invisible.
Row 1s is the schema-scoped half on the same server, added by the verification
pass so the two scopes are pinned side by side rather than one standing for
both.

## Neighbors measured on the way, all already closed

None of these is one of the eight; each is a branch of a cell that a fix could
plausibly have landed on only one side of.

| argv | pinned v1.3.0 | ptah-compat |
| --- | --- | --- |
| `migrate status`, reordered sum | 1 checksum mismatch | 1, byte-identical |
| `migrate new third`, reordered sum | 1 | 1, byte-identical, nothing written |
| `migrate diff third --to … --dev-url …`, reordered sum | 1 | 1, byte-identical, nothing written |
| `migrate set <version> --url …`, reordered sum | 1 | 1, byte-identical |
| `migrate set <version> --url …`, untouched sum | 0, `Current version is …` | 0, identical output |
| `migrate new one two` | 1 `accepts at most 1 arg(s), received 2` | 1, byte-identical |
| `migrate new "sub/dir_name"` with `migrations/sub` present | 1, same open failure, nothing written | 1, nothing written |
| `migrate apply` on a schema-scoped MySQL 9.7 URL, one unrelated table | 1 | 1 |

## What this branch adds

### `migrate new`, `diff` and `set` join the reordered-sum table

They were measured refusing, and the code path is shared, but
`TestCompatCommand_MigrateVerbsRefuseReorderedChecksum` asserted only
`validate`, `status` and `apply` — the three the issue named. A gate that fired
only on the verbs that READ would still let `migrate new` append a file to a
tampered directory and re-hash it on the way out, so the tampering would end up
inside a directory that verifies clean. That is the laundering shape #1095
records for `migrate import`, reachable through a different door.

The table now walks all six and censuses the directory on every row, so a future
change that let a write through would fail on the census even if it kept the
exit code. `migrate set` also gets an inverse control
(`TestCompatCommand_MigrateSetAcceptsAnUntouchedDirectory`, exit 0 and
`Current version is …`), because a refusal-only table is satisfied by a build
where the verb fails for any reason at all.

The three new rows do not all rest on the same code, and the verification pass
established which code holds each — see the mutant table below. `new` is held by
the `verifyAtlasWriteDirChecksum` preflight; `diff` is held by
`DiffOptions.VerifyDir`, the recheck inside `GenerateDiff` that runs against the
LOCKED snapshot, and survives removal of the preflight on its own; `set` is held
by `verifyAtlasApplyChecksum`, the same gate `apply` and `status` use, because
`set` writes revision rows to the database rather than files to the directory.
Three rows, three distinct load-bearing gates.

### `migrate new "sub/dir_name"` is pinned with the subdirectory present

"Create the directory instead" is the cheaper fix somebody will reach for, and
it would be wrong: that binary prefixes the version to the FIRST element, so the
open it fails is `migrations/<version>_sub/dir_name.sql` — a directory named
after a timestamp nobody can create in advance. Re-measured with
`migrations/sub` already there: still exit 1, still the same failure, still
nothing written. Relaxing the refusal for an existing subdirectory would exit 0
where that binary exits 1, which is the violation this cell is about.

The `integrity-and-safety` page is corrected to name all six verbs — it listed
`apply`, `status` and `set` — and says why the writing verbs are on the list.

## Both directions, per gate

Each of the eight refusals was removed on the tree and the suite re-run, then
restored. `git status` is clean and nothing was staged during the sweep.

| mutant | rows reddened |
| --- | --- |
| `checkConnectedDatabaseClean` returns nil | `MigrateApplyRefusesUncleanDatabase`, `…UncleanCountReportsEveryTable`, `…DryRunRefusesUncleanDatabase`, `…RefusesUncleanDatabaseWithEmptyDirectory` |
| `requireAtlasMigrateLintDevURL` returns nil | `MigrateLintRefusesWithoutDevURL`, all four `MigrateLintOptInIgnoresNonBooleanValues` rows |
| `requireAtlasMigrateLintScope` returns nil | two `CompatOverstrictCellsStillRefused` lint rows, `CompatMigrateLintScopeOptInIgnoresNonBoolean` |
| `FailAtlasChecksumMismatch` returns nil | `MigrateValidateRefusesReorderedChecksum` and **all six** `MigrateVerbsRefuseReorderedChecksum` rows — including the three added here, while `MigrateSetAcceptsAnUntouchedDirectory` stayed green |
| `PreRunE` drops `MutuallyExclusiveOnCommandLine` | both `SchemaApplyRefusesDryRunWithAutoApprove` rows |
| `checkAtlasMigrationName` returns nil | **both** `MigrateNewRefusesPathSeparatorName` rows and `MigrateDiffRefusesPathSeparatorName` |
| `validateAtlasVarFlagValue` returns nil | `SchemaDiffRejectsMalformedVariableOverride` and nine `CompatOverstrictCellsStillRefused` `--var` rows |
| `migrate diff` arity set to nil | `MigrateDiffRefusesASecondPositional` |

Those are deletion mutants, and a row that only catches deletion is decoration.
The verification pass therefore re-killed the two new pins with the CHEAPER
WRONG implementation instead — the fix somebody would actually write — one
mutant at a time, each restored before the next:

| mutant (the plausible wrong fix) | reddens | stays green |
| --- | --- | --- |
| M1 `verifyAtlasWriteDirChecksum` returns nil, and `DiffOptions.VerifyDir` returns nil — "gate only the verbs that READ" | `MigrateVerbsRefuseReorderedChecksum/new`, `/diff` | `/validate`, `/status`, `/apply`, `/set`, `MigrateSetAcceptsAnUntouchedDirectory` |
| M1 with the preflight alone removed | `/new` only | `/diff` — held independently by the locked-snapshot `VerifyDir` |
| M2 `migrate set` skips `verifyAtlasApplyChecksum` — "gate only the three verbs the issue named" | `MigrateVerbsRefuseReorderedChecksum/set` | the other five rows, `MigrateSetAcceptsAnUntouchedDirectory` |
| M3 `migrate new` accepts a name whose leading element already exists as a directory under `--dir` — "create the directory instead" | `MigrateNewRefusesPathSeparatorName/subdirectory_already_exists`, on `exitcode.Code(err, 0)` reading 0 where 1 is wanted | `/no_such_subdirectory`, all three `MigrateNewAcceptsNamesTheBinaryAccepts` rows, `MigrateDiffRefusesPathSeparatorName` |

M3 is the one that matters most: the single-row test this branch replaced would
have stayed green under it, and the surviving build exits 0 exactly where the
pinned binary exits 1.

## Independent verification

A second pass re-measured this branch end to end without reusing any fixture,
binary or database from the first. `ptah-compat` was built from the branch head
into a directory inside its own worktree, never a shared one. The migration
fixtures were authored by the pinned binary itself (`migrate diff` against a
SQLite and a PostgreSQL desired state), so the `atlas.sum` under test is the
binary's own output rather than a hand-written file. PostgreSQL cells ran on a
private PostgreSQL 17.10 container, one freshly created database per cell.

All ten rows of the cell table and all of the reordered-sum neighbors reproduced
with identical exit codes and identical text, and the catalogs were read after
each PostgreSQL and SQLite refusal to confirm neither implementation had created
`users` or `posts`. The three mutants above were applied and reverted on that
same tree.

Not re-measured in that pass, and therefore carried forward on the first
measurement alone: the MySQL 9.7 neighbor row, `migrate new one two`, and the
two entries under **Measured but not claimed here**.

## Gates

Head `eb006039`. `origin/master` has since moved from `fc77c58c` to `71a7d7f2`;
GitHub reports the pull request `clean` against it, and neither file this branch
touches was modified on master in between, so the rebase is an exact replay.
Every gate below was run on the REBASED tree — the branch's two files replayed
onto `71a7d7f2`, whose diff against master is byte-identical to this pull
request's — from the worktree root, exit codes read directly and never through a
pipe.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1 -timeout 40m` | 0, 187 packages `ok`, none failed |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (175 conditional groups, 42 white-box files) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci`, `npm run build`, every `check:*` and `*:selftest` | 0 |

The full unit suite is green on this machine, including `cmd/ptah-ls` and
`cmd/viz`, which earlier branches recorded as locally flaky on a process budget.

## Measured but not claimed here

- **`schema clean --dry-run`.** `ptah-compat schema clean --url sqlite://c.db
  --dry-run --auto-approve` exits 0 and prints the cleanup plan; the pinned
  binary exits 1 with `Abort: 'atlas schema clean --dry-run' is not supported by
  the community version.` It is a capability gate and not a safety
  precondition — it refuses the SAFE mode while accepting the destructive one —
  so it is the default-refuse-plus-`PTAH_*` shape already filed off #1299 rather
  than one of #1231's cells, and it is not folded in here.
- **Revision bookkeeping placement at PostgreSQL realm scope.** On a URL pinning
  no `search_path`, both implementations refuse the unclean database at exit 1
  with the same sentence, but the bookkeeping table each created on the way to
  the check lands in a different place: the pinned binary puts it in a dedicated
  schema (`atlas_schema_revisions.atlas_schema_revisions`), ptah-compat puts it
  in `public`. Same exit code, same message, same untouched user tables, so this
  is not a #1231 cell and not a parity rule (a) violation; it belongs with the
  same-exit output-shape register in #1235. Recorded here because it is what a
  realm-scope reader will hit next.
- **MySQL realm scope.** `migrate apply` on a MySQL URL pinning no database is 1
  on both, but that binary says `found multiple schemas: 66` while ptah-compat
  leaks a driver error (`converting NULL to string is unsupported`). Direction
  holds. On a server holding exactly one schema the two could disagree in the
  OTHER direction, and that cell could not be measured here: the only MySQL
  reachable from this environment is shared and holds 66 schemas.
- **MariaDB, ClickHouse and Spanner** were not exercised. `migrateclean.Governs`
  includes MariaDB by inference from the shared MySQL code path, which is
  recorded in its own doc comment as inferred.

Pre-v1, so no compatibility with Ptah's own previous behavior is owed; nothing
here changes behavior in any case.