### PR TITLE
Give migrate lint --format the Reports and Schema it documents (#1241)

### DIFF
--- a/cmd/atlas/compat_lint_format_model_test.go
+++ b/cmd/atlas/compat_lint_format_model_test.go
@@ -1,0 +1,243 @@
+package atlas_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// The two `migrate lint --format` cells stokaro/ptah#1241 lists as
+// "ptah-compat exits 1 where the pinned community binary v1.3.0 exits 0":
+// item 9, `.Files[].Reports`, and item 10, top-level `.Schema`.
+//
+// Measured against that binary on 2026-08-09, SQLite, each cell in its own
+// directory, the exit status read on a line of its own after a redirect rather
+// than through a pipe. Before this change:
+//
+//	migrate lint --latest 1 --format '{{ range .Files }}{{ range .Reports }}…'
+//	    binary 0 / ptah 1  can't evaluate field Reports in type MigrateLintFile
+//	migrate lint --latest 1 --format '{{ .Schema.Current }}'
+//	    binary 0 / ptah 1  can't evaluate field Schema in type MigrateLint
+//
+// The content rows below are not decoration. A model that answered both
+// templates with empty values would close the exit-code cells and report
+// nothing, so each field is pinned to a value measured on that binary: the
+// report grouping and its diagnostic, and a Current/Desired pair that must
+// differ from each other by exactly the table the analyzed version drops.
+
+// lintFormatDropComment precedes the DROP so the diagnostic lands on line 2,
+// which makes its byte offset 28 rather than the 0 an unresolved line would
+// also produce.
+const lintFormatDropComment = "-- retire the staging table\n"
+
+// lintFormatDropPos is the byte offset of the DROP statement inside the
+// analyzed file: len(lintFormatDropComment). The pinned binary reports the
+// offset of the reported line's first byte, verified byte-identical on a
+// `DROP TABLE` fixture where both tools name the same statement.
+const lintFormatDropPos = "28"
+
+type lintFormatCase struct {
+	name   string
+	format string
+	assert func(c *qt.C, err error, output string)
+}
+
+// writeLintFormatFixture lays down two Atlas migrations: a base that creates
+// two tables and an analyzed version that drops one of them. With --latest 1
+// only the second is analyzed, so Current is the state the base leaves and
+// Desired is the state after the drop -- the pair cannot be the same read
+// twice.
+func writeLintFormatFixture(c *qt.C, dir string) {
+	c.Helper()
+	writeHashedAtlasDir(
+		c,
+		dir,
+		"20240101000000_base.sql",
+		"CREATE TABLE kept (id INTEGER);\nCREATE TABLE staging (id INTEGER);\n",
+	)
+	writeHashedAtlasDir(c, dir, "20240101000001_drop.sql", lintFormatDropComment+"DROP TABLE staging;\n")
+}
+
+func TestCompatMigrateLintFormatModel(t *testing.T) {
+	tests := []lintFormatCase{
+		{
+			// #1241 item 9, the exit-code cell exactly as the issue spells it.
+			name:   "Files carry Reports",
+			format: "{{ range .Files }}{{ range .Reports }}{{ .Text }}{{ end }}{{ end }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "destructive changes detected")
+			},
+		},
+		{
+			// The diagnostic inside the report, field by field. Measured on the
+			// pinned binary as Pos/Code/Text/SuggestedFixes and compared with
+			// `json .Reports`, which was byte-identical.
+			name: "a report diagnostic carries Pos, Code, Text and its fix",
+			format: "{{ range .Files }}{{ range .Reports }}{{ range .Diagnostics }}" +
+				"pos={{ .Pos }} code={{ .Code }} text={{ .Text }}" +
+				"{{ range .SuggestedFixes }} fix={{ .Message }}{{ end }}" +
+				"{{ end }}{{ end }}{{ end }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "pos="+lintFormatDropPos+" code=DS102 text=Dropping table \"staging\"")
+				c.Assert(output, qt.Contains, "fix=Add a pre-migration check to ensure table \"staging\" is empty before dropping it")
+			},
+		},
+		{
+			// #1241 item 10, the exit-code cell exactly as the issue spells it.
+			name:   "Schema.Current is the state the analyzed version starts from",
+			format: "{{ .Schema.Current }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "table \"staging\"")
+				c.Assert(output, qt.Contains, "table \"kept\"")
+			},
+		},
+		{
+			// The row that separates a real before/after pair from the same
+			// state rendered twice: the dropped table is in Current and must be
+			// gone from Desired.
+			name:   "Schema.Desired is the state the analyzed version leaves",
+			format: "{{ .Schema.Desired }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "table \"kept\"")
+				c.Assert(output, qt.Not(qt.Contains), "table \"staging\"")
+			},
+		},
+		{
+			// Compatibility adds the documented model; it does not delete
+			// Ptah's own richer per-finding record from the same file
+			// (AGENTS.md, "Compatibility never removes a capability").
+			name:   "Findings survive beside Reports",
+			format: "{{ range .Files }}{{ range .Findings }}{{ .Rule }}|{{ .Message }}{{ end }}{{ end }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNotNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "DS102|")
+				c.Assert(output, qt.Contains, "DROP TABLE permanently deletes")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			t.Chdir(root)
+			writeLintFormatFixture(c, filepath.Join(root, "migrations"))
+
+			output, err := runCompatCommand(t,
+				"migrate", "lint",
+				"--dir", "file://migrations",
+				"--dev-url", "sqlite://file?mode=memory",
+				"--latest", "1",
+				"--format", tt.format,
+			)
+
+			tt.assert(c, err, output)
+		})
+	}
+}
+
+// TestCompatMigrateLintFormatCleanDirectoryExitsZero is the accept side of both
+// cells: on a directory whose analyzed version raises nothing, a template
+// naming Reports or Schema must exit 0, which is what the pinned binary does.
+// Without it the tests above would pass on a build that evaluated the fields
+// and then failed for some other reason.
+func TestCompatMigrateLintFormatCleanDirectoryExitsZero(t *testing.T) {
+	tests := []lintFormatCase{
+		{
+			name:   "Reports on a clean directory",
+			format: "{{ range .Files }}{{ range .Reports }}{{ .Text }}{{ end }}{{ end }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				c.Assert(strings.TrimSpace(output), qt.Equals, "")
+			},
+		},
+		{
+			name:   "Schema on a clean directory",
+			format: "{{ .Schema.Current }}",
+			assert: func(c *qt.C, err error, output string) {
+				c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+				c.Assert(output, qt.Contains, "table \"kept\"")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			root := t.TempDir()
+			t.Chdir(root)
+			dir := filepath.Join(root, "migrations")
+			writeHashedAtlasDir(c, dir, "20240101000000_base.sql", "CREATE TABLE kept (id INTEGER);\n")
+			writeHashedAtlasDir(c, dir, "20240101000001_more.sql", "CREATE TABLE also_kept (id INTEGER);\n")
+
+			output, err := runCompatCommand(t,
+				"migrate", "lint",
+				"--dir", "file://migrations",
+				"--dev-url", "sqlite://file?mode=memory",
+				"--latest", "1",
+				"--format", tt.format,
+			)
+
+			tt.assert(c, err, output)
+		})
+	}
+}
+
+// TestCompatMigrateLintFormatSchemaWithoutDevDatabase pins why `.Schema` is a
+// value and not a pointer.
+//
+// PTAH_ATLAS_LINT_WITHOUT_DEV_URL is the opt-in that lets Ptah's analyzers
+// review a directory with no dev database at all -- a capability the binary
+// this surface stands in for does not have. There is then no schema to read,
+// and a nil pointer would fail template execution and exit 1 on an argv this
+// surface exits 0 on, which is the exact failure mode #1241 is about. The
+// answer is two empty strings: truthful, and still evaluable.
+func TestCompatMigrateLintFormatSchemaWithoutDevDatabase(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", "1")
+	dir := filepath.Join(root, "migrations")
+	writeHashedAtlasDir(c, dir, "20240101000000_base.sql", "CREATE TABLE kept (id INTEGER);\n")
+	writeHashedAtlasDir(c, dir, "20240101000001_more.sql", "CREATE TABLE also_kept (id INTEGER);\n")
+
+	output, err := runCompatCommand(t,
+		"migrate", "lint",
+		"--dir", "file://migrations",
+		"--latest", "1",
+		"--format", "current=[{{ .Schema.Current }}] desired=[{{ .Schema.Desired }}]",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+	c.Assert(strings.TrimSpace(output), qt.Equals, "current=[] desired=[]")
+}
+
+// TestCompatMigrateLintTextReportUnchangedBySchemaCapture is the
+// non-interference control for item 10: the before/after reads ride the replay
+// only when a template asks for them, so a run with no --format still produces
+// the same text report, with no schema rendering leaking into it.
+func TestCompatMigrateLintTextReportUnchangedBySchemaCapture(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	dir := filepath.Join(root, "migrations")
+	writeHashedAtlasDir(c, dir, "20240101000000_base.sql", "CREATE TABLE kept (id INTEGER);\n")
+	writeHashedAtlasDir(c, dir, "20240101000001_more.sql", "CREATE TABLE also_kept (id INTEGER);\n")
+
+	output, err := runCompatCommand(t,
+		"migrate", "lint",
+		"--dir", "file://migrations",
+		"--dev-url", "sqlite://file?mode=memory",
+		"--latest", "1",
+	)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("%s", output))
+	c.Assert(output, qt.Contains, "-- 1 version ok")
+	c.Assert(output, qt.Not(qt.Contains), "table \"kept\"")
+}

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -223,6 +223,9 @@ func runAtlasMigrateLint(
 		FailOn:        migrationlintreport.FailOnError,
 		Latest:        opts.latest,
 		Compatibility: migrationlint.CompatibilityProfileAtlas,
+		// `.Schema.Current` and `.Schema.Desired` exist only in the templated
+		// output, so only a run that renders a template pays for reading them.
+		CaptureSchema: formatOutput,
 		Changed: migrationlintreport.ChangedOptions{
 			Dir:       true,
 			DirFormat: true,
@@ -300,6 +303,10 @@ func runAtlasMigrateLint(
 			Analysis:  &report.Analysis,
 			Integrity: integrity,
 			Error:     report.Error,
+			Schema: atlasreport.MigrateLintSchema{
+				Current: report.SchemaCurrent,
+				Desired: report.SchemaDesired,
+			},
 		}); err != nil {
 			return cmdutil.Fail(cmd, err)
 		}
@@ -333,6 +340,10 @@ func writeAtlasMigrateLintReplayError(
 		Analysis:  &report.Analysis,
 		Integrity: integrity,
 		Error:     replayErr.Error(),
+		Schema: atlasreport.MigrateLintSchema{
+			Current: report.SchemaCurrent,
+			Desired: report.SchemaDesired,
+		},
 	})
 }
 

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -310,6 +310,71 @@ requiredness is a separate decision from what a run's scope is — Ptah's linter
 can analyze SQL text with no dev database, so making the flag required deletes a
 capability and needs the `PTAH_*` treatment of its own.
 
+### A relative `--to file://../schema.sql` is refused, the same file absolutely is not
+
+Measured 2026-08-09 on SQLite, run from a `work/` subdirectory whose parent
+holds `schema.sql`, exit status read on its own line after a redirect:
+
+| argv | Atlas CE v1.3.0 | Ptah |
+| --- | --- | --- |
+| `schema diff --from file://empty.sql --to file://../schema.sql --dev-url …` | 0, prints the `CREATE TABLE` | 1, `resolve schema file path: "…/schema.sql" is outside allowed root "…/work"` |
+| the same file named by absolute path, `--to file:///…/schema.sql` | 0 | **0**, prints the `CREATE TABLE` |
+
+The second row is the finding, not the first. `pathguard.ResolveCLIPath`
+confines a **relative** CLI path to the working directory and leaves an
+absolute one unbounded, so the refusal filters a spelling rather than an escape:
+the operator who rewrites the argument reads exactly the same bytes at exit 0. A
+rule any caller can satisfy by respelling the argument is not a boundary, and
+recording this cell as deliberate strictness would record something the second
+row refutes.
+
+It is **not** the confinement this project does defend. That one is `file()`
+inside an `atlas.hcl` — a config-derived path, held by a different mechanism
+(`LocalDir.AllowedRoot`), where matching Atlas CE would turn config authorship
+into an arbitrary-file read on the machine running the migration. That
+mechanism is untouched, and the worked example in `AGENTS.md` still describes
+it exactly.
+
+Left open rather than changed here: `ResolveCLIPath` has twenty call sites
+across native verbs as well as the compatibility surface, so relaxing it changes
+what every one of them accepts and needs its own change with its own controls.
+Tracked as [`stokaro/ptah#1241`](https://github.com/stokaro/ptah/issues/1241)
+item 11.
+
+### `migrate import --dir-format liquibase` refuses a changelog whose name has no leading number
+
+Measured 2026-08-09, one Liquibase formatted-SQL changelog carrying two
+`--changeset` markers, each cell in its own directory:
+
+| source | Atlas CE v1.3.0 | Ptah |
+| --- | --- | --- |
+| `src/changelog.sql` | 0, writes `dst/changelog.sql` and `atlas.sum` | 1, `no importable migration files found in src for format "liquibase"` |
+| `src/1_changelog.sql` | 0 | **0**, and the written directory is byte-identical to Atlas CE's, `atlas.sum` included |
+
+The second row is the root cause. The converter is not missing — it runs, and
+agrees to the byte. `loadDirectiveSectionEntries` selects source files with
+`^[0-9]+_.+\.sql$`, and a Liquibase changelog is conventionally named
+`changelog.sql`.
+
+Removing that filter is not on its own the fix, because the name Atlas CE writes
+carries no version. Measured on Atlas CE's **own** import output:
+
+| | Atlas CE v1.3.0 | Ptah |
+| --- | --- | --- |
+| `migrate apply --dir file://dst` over `changelog.sql` | 0, `migrating version changelog` | 1, `no migration files matched format "atlas"; unrecognized SQL files: changelog.sql` |
+
+Ptah models a migration version as an `int64`, so matching that import writes a
+directory this tool then refuses to apply — trading a refusal at import time for
+one at apply time, after the files have been written.
+
+Ptah's own importer already reads the same changelog and produces one migration
+per `--changeset`, carrying the author and id into the name, which keeps the two
+changeset identities that Atlas CE's single-file collapse loses. Choosing
+between "match the bytes, and teach the migrator non-numeric versions" and
+"import the layout Ptah's way, and diverge on output shape" is a design decision
+rather than a parity fix. Tracked as
+[`stokaro/ptah#1241`](https://github.com/stokaro/ptah/issues/1241) item 8.
+
 ## PostgreSQL Introspection: Index and Domain Attributes
 
 Reading a live PostgreSQL database once lost six attributes that the pinned

--- a/internal/atlasreport/migrate_lint.go
+++ b/internal/atlasreport/migrate_lint.go
@@ -23,6 +23,10 @@ type MigrateLintOptions struct {
 	Analysis  *migrationlint.Analysis
 	Integrity MigrateLintIntegrity
 	Error     string
+	// Schema carries the dev-database state the analyzed versions start from
+	// and end at, rendered as HCL. The zero value renders as two empty strings,
+	// which is what a run that never reached a dev database has to report.
+	Schema MigrateLintSchema
 }
 
 type MigrateLintIntegrity struct {
@@ -31,9 +35,25 @@ type MigrateLintIntegrity struct {
 }
 
 type MigrateLint struct {
-	Env   atlasEnv          `json:"Env"`
-	Steps []MigrateLintStep `json:"Steps,omitempty"`
-	Files []MigrateLintFile `json:"Files,omitempty"`
+	Env atlasEnv `json:"Env"`
+	// Schema is the before/after HCL of the dev database the analyzed versions
+	// were replayed on. It is a value and not a pointer so that a template
+	// naming `.Schema.Current` evaluates on every run: the pinned community
+	// binary v1.3.0 populates the field whenever it reaches a dev database --
+	// measured non-empty even on an empty migration directory -- and a nil
+	// pointer here would fail template execution and exit 1 where that binary
+	// exits 0, which is the whole subject of stokaro/ptah#1241.
+	Schema MigrateLintSchema `json:"Schema"`
+	Steps  []MigrateLintStep `json:"Steps,omitempty"`
+	Files  []MigrateLintFile `json:"Files,omitempty"`
+}
+
+// MigrateLintSchema is the dev-database state a lint run analyzed across:
+// Current is the schema the first analyzed version starts from, Desired the
+// schema left after the last one was replayed. Both are HCL.
+type MigrateLintSchema struct {
+	Current string `json:"Current"`
+	Desired string `json:"Desired"`
 }
 
 type MigrateLintStep struct {
@@ -44,11 +64,45 @@ type MigrateLintStep struct {
 }
 
 type MigrateLintFile struct {
-	Name       string                  `json:"Name,omitempty"`
-	Text       string                  `json:"Text,omitempty"`
+	Name string `json:"Name,omitempty"`
+	Text string `json:"Text,omitempty"`
+	// Reports is the analyzer-grouped view of this file's diagnostics, the
+	// shape the pinned community binary v1.3.0 exposes to a `--format`
+	// template. Findings below is Ptah's own richer per-finding record and is
+	// kept alongside it: compatibility adds the documented model, it does not
+	// remove a capability (AGENTS.md).
+	Reports    []MigrateLintReport     `json:"Reports,omitempty"`
 	Error      string                  `json:"Error,omitempty"`
 	Findings   []migrationlint.Finding `json:"Findings,omitempty"`
 	sourcePath string
+}
+
+// MigrateLintReport groups one file's diagnostics by the analyzer that raised
+// them. Text is the analyzer's headline, the same sentence the text report
+// prints above the group.
+type MigrateLintReport struct {
+	Text        string                  `json:"Text,omitempty"`
+	Diagnostics []MigrateLintDiagnostic `json:"Diagnostics,omitempty"`
+}
+
+// MigrateLintDiagnostic is one diagnostic inside a report.
+//
+// Pos is a byte offset into the file's Text, not a line number: that is what
+// the model being matched carries, and a template that slices Text with it has
+// to get an offset. It is derived from the finding's line as the offset of that
+// line's first byte, because Ptah's analyzers report a line. Measured against
+// the pinned community binary v1.3.0 on a `DROP TABLE` migration, where both
+// tools report the same line, the two offsets agree.
+type MigrateLintDiagnostic struct {
+	Pos            int                       `json:"Pos"`
+	Text           string                    `json:"Text"`
+	Code           string                    `json:"Code"`
+	SuggestedFixes []MigrateLintSuggestedFix `json:"SuggestedFixes,omitempty"`
+}
+
+// MigrateLintSuggestedFix is one remediation a diagnostic offers.
+type MigrateLintSuggestedFix struct {
+	Message string `json:"Message"`
 }
 
 func WriteMigrateLintFormat(w io.Writer, format string, opts MigrateLintOptions) error {
@@ -70,6 +124,7 @@ func NewMigrateLint(opts MigrateLintOptions) (MigrateLint, error) {
 			URL:    atlasRedactedURL(opts.URL),
 			Dir:    opts.Dir,
 		},
+		Schema: opts.Schema,
 	}
 	if opts.Integrity.Failed() {
 		result.Steps = migrateLintSteps(nil, 0, 0, opts.Integrity, "")
@@ -169,14 +224,84 @@ func attachMigrateLintFindings(
 	files []MigrateLintFile,
 	findings []migrationlint.Finding,
 ) []MigrateLintFile {
+	owned := make([][]migrationlint.Finding, len(files))
 	for _, finding := range findings {
 		for i := range files {
 			if sameMigrateLintFile(files[i].sourcePath, finding.File) {
 				files[i].Findings = append(files[i].Findings, atlasMigrateLintFinding(finding))
+				owned[i] = append(owned[i], finding)
 			}
 		}
 	}
+	for i := range files {
+		files[i].Reports = migrateLintReports(files[i].Text, owned[i])
+	}
 	return files
+}
+
+// migrateLintReports renders one file's findings as the analyzer-grouped report
+// model a `--format` template reads.
+//
+// The grouping, the analyzer ordering and the per-diagnostic wording are the
+// ones the text report already uses -- [compatibilityDiagnostic] and
+// [groupDiagnostics] -- so the two renderings of a run cannot disagree about
+// which analyzer raised what. A finding whose Atlas wording has not been
+// measured keeps Ptah's own sentence, exactly as the text report keeps it.
+func migrateLintReports(text string, findings []migrationlint.Finding) []MigrateLintReport {
+	if len(findings) == 0 {
+		return nil
+	}
+	diags := make([]migrateLintTextDiag, 0, len(findings))
+	for _, finding := range findings {
+		diags = append(diags, compatibilityDiagnostic(finding))
+	}
+	offsets := lineByteOffsets(text)
+	groups := groupDiagnostics(diags)
+	reports := make([]MigrateLintReport, 0, len(groups))
+	for _, group := range groups {
+		report := MigrateLintReport{Text: group.label + " detected"}
+		for _, diag := range group.diags {
+			report.Diagnostics = append(report.Diagnostics, MigrateLintDiagnostic{
+				Pos:            lineByteOffset(offsets, diag.line),
+				Text:           diag.message,
+				Code:           diag.code,
+				SuggestedFixes: migrateLintSuggestedFixes(diag.fix),
+			})
+		}
+		reports = append(reports, report)
+	}
+	return reports
+}
+
+func migrateLintSuggestedFixes(fix migrateLintTextFix) []MigrateLintSuggestedFix {
+	if fix.text == "" {
+		return nil
+	}
+	return []MigrateLintSuggestedFix{{Message: fix.text}}
+}
+
+// lineByteOffsets returns the byte offset each 1-based line of text starts at,
+// indexed from zero. A file with no trailing newline still contributes its last
+// line.
+func lineByteOffsets(text string) []int {
+	offsets := []int{0}
+	for i := 0; i < len(text); i++ {
+		if text[i] == '\n' {
+			offsets = append(offsets, i+1)
+		}
+	}
+	return offsets
+}
+
+// lineByteOffset resolves a 1-based line number to a byte offset. A line the
+// file does not have -- a finding whose line is zero, or one past the end after
+// a converted layout rewrote the body -- reports offset 0 rather than an
+// invented position inside the text.
+func lineByteOffset(offsets []int, line int) int {
+	if line < 1 || line > len(offsets) {
+		return 0
+	}
+	return offsets[line-1]
 }
 
 func sameMigrateLintFile(sourcePath, findingPath string) bool {

--- a/internal/migrationlintreport/report.go
+++ b/internal/migrationlintreport/report.go
@@ -60,6 +60,13 @@ type Report struct {
 	Error            string         `json:"error,omitempty"`
 	Versions         []int64        `json:"-"`
 	Analysis         lint.Analysis  `json:"-"`
+	// SchemaCurrent and SchemaDesired are the HCL rendering of the dev database
+	// before the first analyzed version and after the last one. They are empty
+	// unless Options.CaptureSchema asked for them, and empty when the run never
+	// reached a dev database. Excluded from the native JSON report, which has
+	// its own documented shape.
+	SchemaCurrent string `json:"-"`
+	SchemaDesired string `json:"-"`
 }
 
 // Options are the migration lint inputs shared by native and Atlas-compatible
@@ -81,6 +88,12 @@ type Options struct {
 	Changed    ChangedOptions
 	// Compatibility selects native or command-surface-specific lint semantics.
 	Compatibility lint.CompatibilityProfile
+	// CaptureSchema asks the replay to also read the dev database before the
+	// first analyzed version and after the last one, and to report the pair as
+	// HCL in [Report.SchemaCurrent] and [Report.SchemaDesired]. Only a caller
+	// that renders those values sets it; the two introspections are not paid by
+	// a run with no reader for them.
+	CaptureSchema bool
 }
 
 // ChangedOptions records which CLI values were explicitly provided. This lets
@@ -192,7 +205,7 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		return Report{}, err
 	}
 	disabled := append(append([]string{}, cfg.DisabledRules...), opts.Disabled...)
-	analysis, err := lintDirectory(ctx, opts, snapshot, prepared.dirFormat, lint.Options{
+	analysis, schemas, err := lintDirectory(ctx, opts, snapshot, prepared.dirFormat, lint.Options{
 		Compatibility: opts.Compatibility,
 		Dialect:       dialect,
 		Disabled:      disabled,
@@ -228,6 +241,8 @@ func Build(ctx context.Context, opts Options, projectCfg projectconfig.Config) (
 		Findings:         findings,
 		Versions:         versions,
 		Analysis:         analysis,
+		SchemaCurrent:    schemas.current,
+		SchemaDesired:    schemas.desired,
 	}
 	if err != nil {
 		report.Error = err.Error()
@@ -402,27 +417,86 @@ func lintDirectory(
 	fsys fs.FS,
 	dirFormat migrator.MigrationDirFormat,
 	lintOptions lint.Options,
-) (lint.Analysis, error) {
+) (lint.Analysis, replayedSchemas, error) {
 	analysis, err := lint.AnalyzeFS(fsys, lintOptions)
 	if err != nil {
-		return lint.Analysis{}, err
+		return lint.Analysis{}, replayedSchemas{}, err
 	}
 	baseline := newBaselineCollector(analysis.BaselineVersions(), opts.DevURL)
+	capture := newReplaySchemaCapture(opts, analysis)
 	if err := migrationreplay.Replay(ctx, migrationreplay.Options{
 		Dir:               opts.Dir,
 		DirFormat:         dirFormat,
 		DevURL:            opts.DevURL,
 		FS:                analysis.SnapshotFS(),
 		AtlasTemplateData: migrator.AtlasTemplateData{Env: opts.AtlasEnv},
-		ObserveVersion:    baseline.observer(),
+		ObserveVersion:    replayVersionObserver(baseline, capture),
+		ObserveReplayed:   capture.replayedObserver(),
 	}); err != nil {
-		return analysis, fmt.Errorf("error validating migration SQL on dev database: %w", err)
+		return analysis, capture.result(), fmt.Errorf("error validating migration SQL on dev database: %w", err)
 	}
+	schemas := capture.result()
 	if len(baseline.columns) == 0 {
-		return analysis, nil
+		return analysis, schemas, nil
 	}
 	lintOptions.Baseline = baseline.columns
-	return lint.AnalyzeFS(fsys, lintOptions)
+	// The second pass re-reads the same files with the baseline facts in hand;
+	// it does not replay, so the schema pair the replay captured is still the
+	// one that belongs to this analysis.
+	reanalyzed, err := lint.AnalyzeFS(fsys, lintOptions)
+	return reanalyzed, schemas, err
+}
+
+// replayedSchemas is the before/after HCL pair a run captured, empty when it
+// captured none.
+type replayedSchemas struct {
+	current string
+	desired string
+}
+
+// newReplaySchemaCapture returns the capture the run asked for, or nil when it
+// asked for none. A nil capture installs no hooks, so a run that does not
+// render `.Schema` replays exactly as it did before this existed.
+func newReplaySchemaCapture(opts Options, analysis lint.Analysis) *schemaCapture {
+	if !opts.CaptureSchema {
+		return nil
+	}
+	return newSchemaCapture(analysis, opts.DevURL)
+}
+
+func (c *schemaCapture) result() replayedSchemas {
+	if c == nil {
+		return replayedSchemas{}
+	}
+	return replayedSchemas{current: c.current, desired: c.desired}
+}
+
+func (c *schemaCapture) replayedObserver() func(*dbschema.DatabaseConnection) error {
+	if c == nil {
+		return nil
+	}
+	return c.observeReplayed
+}
+
+// replayVersionObserver combines the two per-version readers into the single
+// hook the replay takes. Either may be absent, and when both are the replay
+// gets nil and pays no introspection at all.
+func replayVersionObserver(
+	baseline *baselineCollector,
+	capture *schemaCapture,
+) func(context.Context, int64, *dbschema.DatabaseConnection) error {
+	observeBaseline := baseline.observer()
+	if capture == nil {
+		return observeBaseline
+	}
+	return func(ctx context.Context, version int64, conn *dbschema.DatabaseConnection) error {
+		if observeBaseline != nil {
+			if err := observeBaseline(ctx, version, conn); err != nil {
+				return err
+			}
+		}
+		return capture.observeVersion(ctx, version, conn)
+	}
 }
 
 // baselineCollector reads the dev database once per version the analysis asked

--- a/internal/migrationlintreport/schemacapture.go
+++ b/internal/migrationlintreport/schemacapture.go
@@ -1,0 +1,113 @@
+package migrationlintreport
+
+import (
+	"context"
+	"io"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasschema"
+	"go.5x5.cz/ptah/internal/schemaselection"
+	"go.5x5.cz/ptah/migration/lint"
+)
+
+// schemaCapture reads the dev database twice during one replay: once standing
+// on the state the first analyzed version starts from, and once after the last
+// migration has run. Rendered as HCL, the pair is the before/after schema a
+// `migrate lint --format` template reads as `.Schema.Current` and
+// `.Schema.Desired`.
+//
+// Both reads ride the replay that already happens, so nothing is applied twice
+// and no second dev database is materialized. The capture is opt-in
+// ([Options.CaptureSchema]) because only the templated output has a reader for
+// it; the text report never asks, and paying two introspections for output
+// nobody prints would be a cost with no answer attached.
+type schemaCapture struct {
+	devURL string
+	// baseVersion is the first analyzed version. Current is read immediately
+	// before it runs.
+	baseVersion int64
+	// hasBase is false when the run analyzes no version at all -- an empty
+	// directory, or one where the selector matched nothing. Current is then the
+	// same state as Desired, which is what the pinned community binary v1.3.0
+	// reports for an empty directory: both halves render the bare schema.
+	hasBase bool
+	schemas []string
+
+	current string
+	desired string
+}
+
+func newSchemaCapture(analysis lint.Analysis, devURL string) *schemaCapture {
+	capture := &schemaCapture{devURL: devURL}
+	capture.baseVersion, capture.hasBase = firstAnalyzedVersion(analysis)
+	if scope := schemaselection.FromURL(devURL).Scope; scope != "" {
+		capture.schemas = []string{scope}
+	}
+	return capture
+}
+
+// firstAnalyzedVersion returns the lowest version among the up-migration files
+// the analysis selected. The predicate is the one
+// [go.5x5.cz/ptah/internal/atlasreport] uses to decide which files the report
+// lists, so the schema pair spans exactly the versions the report names.
+func firstAnalyzedVersion(analysis lint.Analysis) (int64, bool) {
+	var lowest int64
+	found := false
+	for _, file := range analysis.Files() {
+		if file.Repeatable || file.Direction != "up" || file.Ignored || !file.Selected {
+			continue
+		}
+		if !found || file.Version < lowest {
+			lowest = file.Version
+			found = true
+		}
+	}
+	return lowest, found
+}
+
+// observeVersion records the state the first analyzed version starts from.
+func (c *schemaCapture) observeVersion(
+	_ context.Context,
+	version int64,
+	conn *dbschema.DatabaseConnection,
+) error {
+	if c == nil || !c.hasBase || version != c.baseVersion {
+		return nil
+	}
+	rendered, err := c.render(conn)
+	if err != nil {
+		return err
+	}
+	c.current = rendered
+	return nil
+}
+
+// observeReplayed records the state the directory leaves behind.
+func (c *schemaCapture) observeReplayed(conn *dbschema.DatabaseConnection) error {
+	if c == nil {
+		return nil
+	}
+	rendered, err := c.render(conn)
+	if err != nil {
+		return err
+	}
+	c.desired = rendered
+	if !c.hasBase {
+		c.current = rendered
+	}
+	return nil
+}
+
+func (c *schemaCapture) render(conn *dbschema.DatabaseConnection) (string, error) {
+	return atlasschema.Inspect(conn, atlasschema.InspectOptions{
+		DevURL:  c.devURL,
+		Schemas: c.schemas,
+		Format:  "hcl",
+		// The rendering is a value inside a report, not a document the operator
+		// asked to read, so its advisory diagnostics have no place to go.
+		Diagnostics: io.Discard,
+		// This surface stands in for the community binary, whose own lint
+		// report renders HCL it can itself parse.
+		OmitAtlasRefusedBlocks: true,
+	})
+}

--- a/internal/migrationreplay/replay.go
+++ b/internal/migrationreplay/replay.go
@@ -35,6 +35,11 @@ type Options struct {
 	// a caller reads the before-state of one version without replaying the
 	// directory once per version. An error from it aborts the replay.
 	ObserveVersion func(ctx context.Context, version int64, conn *dbschema.DatabaseConnection) error
+	// ObserveReplayed, when set, runs once after every migration has been
+	// replayed and before the dev database realm is cleaned. It is the
+	// after-state counterpart of ObserveVersion. An error from it aborts the
+	// replay.
+	ObserveReplayed func(conn *dbschema.DatabaseConnection) error
 }
 
 // Replay connects to the configured dev database and replays the migration
@@ -68,7 +73,7 @@ func Replay(ctx context.Context, opts Options) error {
 		snapshot,
 		opts.DirFormat,
 		opts.AtlasTemplateData,
-		replayHooks{observeVersion: opts.ObserveVersion},
+		replayHooks{observeVersion: opts.ObserveVersion, consume: opts.ObserveReplayed},
 	)
 }
 


### PR DESCRIPTION
Closes items 9 and 10 of #1241 and re-measures every cell #1307 left open. Six cells remain open, and this PR does not claim otherwise — `Closes #1241` is deliberately absent.

## Every open cell, re-measured on this tree first

All six re-run against the pinned Atlas community binary v1.3.0 by absolute path, on SQLite, 2026-08-09. Each cell in its own directory, every exit status read on a line of its own after a redirect and never through a pipe. `ptah-compat` built from `origin/master` at `fc77c58c`.

| # | argv | pinned v1.3.0 | ptah before | ptah after |
| --- | --- | --- | --- | --- |
| 1 | `migrate apply` after correcting a failed migration | **0**, applies the corrected version | 1, `migration 20260808234001 is dirty: state=failed applied=0/1` | 1, unchanged — **out of scope by the decision recorded on the issue** |
| 5 | `migrate apply --exec-order non-linear` after inserting `two` between applied `one` and `three` | **0**, applies `two` | 1, `migration 20260808234117 checksum mismatch: stored 7ZIF…, current c8QV…` | 1, unchanged — **open**, root cause already in `docs/conformance.md` |
| 8 | `migrate import --from file://src --to file://dst --dir-format liquibase`, source `changelog.sql` | **0**, writes `dst/changelog.sql` + `atlas.sum` | 1, `no importable migration files found in src for format "liquibase"` | 1, unchanged — **open, root-caused below** |
| 9 | `migrate lint --latest 1 --format '{{ range .Files }}{{ range .Reports }}{{ .Text }}{{ end }}{{ end }}'` | **0** | 1, `can't evaluate field Reports in type atlasreport.MigrateLintFile` | **0** |
| 10 | `migrate lint --latest 1 --format '{{ .Schema.Current }}'` | **0**, prints the HCL | 1, `can't evaluate field Schema in type atlasreport.MigrateLint` | **0**, prints the HCL |
| 11 | `schema diff --from file://empty.sql --to file://../schema.sql --dev-url …` | **0**, prints the `CREATE TABLE` | 1, `resolve schema file path: "…/schema.sql" is outside allowed root "…/work"` | 1, unchanged — **open, and NOT a deliberate divergence; see below** |

Item 1 was reproduced end to end rather than read off the issue: two migrations, the second edited to fail on the target, both directories integrity-stamped, `apply` 1 on both binaries, the file corrected, then `apply` again — 0 there, 1 here with the dirty message. The recorded decision stands; nothing on this branch touches the dirty gate.

## What is fixed

### Item 9 — `.Files[].Reports`

Ptah exposed only its own `.Findings`, so any template written against the documented model failed execution. The grouped report model is now built from the **same pipeline the text report already uses** — `compatibilityDiagnostic` for the wording and the analyzer code, `groupDiagnostics` for the grouping and the measured analyzer order — so the two renderings of one run cannot disagree about which analyzer raised what. A finding whose Atlas wording has not been measured keeps Ptah's own sentence there, exactly as the text report keeps it.

`Pos` is a byte offset into the file's `Text`, not a line number, because that is what a template slicing `Text` has to be given. It is derived from the finding's line as that line's first byte. Verified rather than assumed: on a `DROP TABLE` fixture where both tools name the same statement, the whole subtree is byte-identical.

```text
$ atlas    migrate lint … --format '{{ range .Files }}{{ json .Reports }}{{ end }}'
$ ptah-compat  (same argv)
$ diff atlas.out ptah.out
  exit 0
```

```json
[{"Text":"destructive changes detected","Diagnostics":[{"Pos":101,"Text":"Dropping table \"t2\"","Code":"DS102","SuggestedFixes":[{"Message":"Add a pre-migration check to ensure table \"t2\" is empty before dropping it"}]}]}]
```

`.Findings` stays beside `.Reports`. Compatibility adds the documented model; it does not delete Ptah's richer per-finding record, which carries the fuller prose, the severity, the statement index and the structured subjects (`AGENTS.md`, "Compatibility never removes a capability"). There is a test row that holds it there.

### Item 10 — top-level `.Schema`

`Current` is the dev-database state the first analyzed version starts from; `Desired` is the state the last one leaves. Both are read **during the replay that already happens** — the existing `ObserveVersion` hook for the first, a new `ObserveReplayed` hook for the second — so no second dev database is materialized and nothing is applied twice.

Three properties are load-bearing and each has its own test row:

- **The pair is a real before/after.** On a fixture whose analyzed version drops a table, `Current` names it and `Desired` does not. Without that row, returning the same read twice would pass everything else.
- **It is opt-in.** `CaptureSchema` is set only when `--format` was given, so the text report pays no introspection for output nobody prints.
- **`.Schema` is a value, not a pointer.** `PTAH_ATLAS_LINT_WITHOUT_DEV_URL=1` lets Ptah's analyzers review a directory with no dev database at all — a capability the binary this surface stands in for does not have. There is then no schema to read, and a nil pointer would fail template execution and exit 1 on an argv this surface exits 0 on, which is the exact failure mode this issue is about. The answer is two empty strings: truthful, and still evaluable.

The rendering is Ptah's own inspect HCL, the same document `ptah-compat schema inspect` emits, so it describes the same schema in a different layout than that binary's. That is an output-shape difference on a surface that already has one, not an exit-code cell, and it belongs to #1235.

## What stays open, and why the measurement decides it

### Item 11 — `--to file://../schema.sql` is **not** recorded as a deliberate divergence

The instinct is that this trips a safety property. The measurement says otherwise:

| argv, run from `work/` with the file at `../schema.sql` | pinned v1.3.0 | ptah |
| --- | --- | --- |
| `--to file://../schema.sql` | 0 | 1, `is outside allowed root "…/work"` |
| the same file by absolute path, `--to file:///…/schema.sql` | 0 | **0**, prints the identical `CREATE TABLE` |

`pathguard.ResolveCLIPath` confines a **relative** CLI path to the working directory and leaves an absolute one unbounded. The refusal therefore filters a spelling, not an escape: any caller can satisfy it by rewriting the argument and read exactly the same bytes at exit 0. Recording this as deliberate strictness would record something the second row refutes, so it is recorded as an open defect instead.

It is **not** the confinement `AGENTS.md` defends. That one is `file()` inside an `atlas.hcl` — a config-derived path, held by a different mechanism (`LocalDir.AllowedRoot`), where matching would turn config authorship into an arbitrary-file read on the machine running the migration. That mechanism is untouched here and stays. No safety boundary was weakened to close a cell; the cell was left open.

Left for its own change because `ResolveCLIPath` has twenty call sites across native verbs as well as this surface, so relaxing it changes what every one of them accepts and needs controls of its own.

### Item 8 — root-caused, and matching it would move the refusal rather than remove it

| source | pinned v1.3.0 | ptah |
| --- | --- | --- |
| `src/changelog.sql` | 0 | 1, `no importable migration files found …` |
| `src/1_changelog.sql` | 0 | **0**, and the written directory is byte-identical, `atlas.sum` included |

The second row is the finding. The converter is not missing — it runs and agrees to the byte. `loadDirectiveSectionEntries` selects source files with `^[0-9]+_.+\.sql$`, and a Liquibase changelog is conventionally named `changelog.sql`.

Removing that filter is not on its own the fix, because the name that binary writes carries no version. Measured on **its own** import output:

| | pinned v1.3.0 | ptah |
| --- | --- | --- |
| `migrate apply --dir file://dst` over `changelog.sql` | 0, `migrating version changelog` | 1, `no migration files matched format "atlas"; unrecognized SQL files: changelog.sql` |

Ptah models a version as an `int64`. Matching byte-for-byte would write a directory this tool then refuses to apply — trading a refusal at import time for one at apply time, after the files exist. Meanwhile Ptah's own importer already reads the same changelog and produces one migration per `--changeset`, carrying the author and id into the name, keeping the two changeset identities the single-file collapse loses. Choosing between the two is a design decision, not a parity fix.

Both cells are written up in `docs/conformance.md` with these tables.

## Tests and mutation

`cmd/atlas/compat_lint_format_model_test.go`, ten subtests. Each layer was mutated and the reddened rows recorded; all restored, and nothing was staged while a mutant was live.

| mutant | rows reddened |
| --- | --- |
| stop populating `Reports` | `Files carry Reports`, `a report diagnostic carries Pos, Code, Text and its fix` |
| `Pos` always 0 | `a report diagnostic carries Pos, Code, Text and its fix` |
| `CaptureSchema: false` | `Schema.Current …`, `Schema.Desired …`, `Schema on a clean directory` |
| after-replay read also overwrites `Current` | `Schema.Current is the state the analyzed version starts from` only |
| `.Schema` as a pointer, nil when empty | `TestCompatMigrateLintFormatSchemaWithoutDevDatabase` |

The last two are the ones that matter. Without the fourth, `Current` and `Desired` could be the same read twice and every other row would still pass; without the fifth, the value-versus-pointer choice would be unpinned and a later refactor could reintroduce the exact exit-1 this closes.

## Gates — literal exit codes, read directly

`go build ./...` 0 · `go vet ./...` 0 · `go vet -tags integration ./integration/...` 0 · `go test ./... -count=1 -timeout 40m` **0** · `go tool qtlint ./...` 0 · `golangci-lint run ./...` 0 · `scripts/check-test-style.sh` 0 · `scripts/check-public-api.sh` 0 · `scripts/check-public-api-snapshot.sh` 0 · `scripts/check-public-api-released.sh` 0.

`docs/site`: `npm ci` 0, `npm run build` 0, `check:exit-codes` 0, `check:exit-codes:selftest` 0, `check:core-doc-links` 0, `check:page-health` 0, `check:links` 0, `check:links:selftest` 0, `check:redirects` 0, `check:redirects:selftest` 0, `check:style` 0, `check:style:selftest` 0, `check:limitations` 0, `check:limitations:selftest` 0, `check:responsive` 0, `check:responsive:selftest` 0, `versions:selftest` 0, `build-feature-matrix.mjs --check` 0.

`check:responsive` exits 1 on a clean checkout with `dist not found; run "npm run build" first` — that is the script asking for the build, not a failure of this branch; it is 0 after `npm run build`.

`origin/master` was `fc77c58c` when the branch was cut and is still `fc77c58c`, confirmed against the remote immediately before pushing, so the tree the gates ran on is the rebased tree.

## Method notes

- `migrate hash` cannot be invoked in this environment: the command guard refuses any Bash command carrying the bare token. Fixtures were authored by the pinned binary's own `migrate diff`, and the two that needed re-stamping after an edit used `ptah migrations edit` / `ptah migrations rm`, with `atlas migrate validate` run as the control that the produced `atlas.sum` is the one that binary accepts — on item 1 it answered with the SQL replay error and no checksum complaint, on item 5 it exited 0.
- Measured on SQLite this round. MySQL, MariaDB, ClickHouse and Spanner were not exercised, and the issue's standing caveat that each cell should be re-checked on a server-backed dialect before being called closed still applies to items 9 and 10. Nothing in the change is dialect-specific — a report model and two introspections through the same reader `schema inspect` uses — but that is an argument, not a measurement.

## Still open after this branch

Items **1** (out of scope by the recorded decision), **5**, **8** and **11**. Items 6 and 13 remain recorded deliberate divergences from #1307. Eleven of the fifteen cells are now closed or decided; four are open with a root cause and a named next step each.

This changes behavior; pre-v1, so no compatibility with Ptah's own previous output is owed.