### PR TITLE
Close three output-shape cells and stop renaming migrations (#1235)

### DIFF
--- a/cmd/atlas/atlas_test.go
+++ b/cmd/atlas/atlas_test.go
@@ -535,7 +535,7 @@ func TestCompatCommand_SchemaApplySchemaShorthandParses(t *testing.T) {
 	// SQLite owns unqualified objects in "main", so a "public" schema scope
 	// selects nothing and the apply reports a synced schema.
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Schema is synced, no changes to be made.")
+	c.Assert(out.String(), qt.Contains, "Schema is synced, no changes to be made")
 }
 
 func TestCompatCommand_SchemaDiffSchemaShorthandParses(t *testing.T) {
@@ -2519,7 +2519,10 @@ CREATE TABLE users (
 	err = second.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(secondOut.String(), qt.Equals, "Schema is synced, no changes to be made.\n")
+	// No trailing period: this is the byte-exact form the pinned community
+	// binary v1.3.0 writes for `schema apply` (stokaro/ptah#1235 finding 9.4).
+	// Its `schema diff` answer keeps its period and already matched.
+	c.Assert(secondOut.String(), qt.Equals, "Schema is synced, no changes to be made\n")
 }
 
 func TestCompatCommand_SchemaApplyDryRunDoesNotApply(t *testing.T) {
@@ -3123,7 +3126,11 @@ func TestCompatCommand_MigrateApplyFormatsNoopResult(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Not(qt.Contains), "No migration files to execute.")
+	// The text printer terminates its line; the same sentence inside the JSON
+	// document is followed by a quote. Asserting on the newline is what keeps
+	// this row meaningful now that the two spellings are the same string
+	// (stokaro/ptah#1235 finding 9.3 removed the text form's trailing period).
+	c.Assert(out.String(), qt.Not(qt.Contains), "No migration files to execute\n")
 	var result atlasMigrateApplyJSONResult
 	c.Assert(json.Unmarshal(out.Bytes(), &result), qt.IsNil)
 	c.Assert(result.Current, qt.Equals, "1")

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -525,7 +525,13 @@ func finishAtlasMigrateApplyFreshNoop(
 	if opts.format != "" {
 		return true, writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
 	}
-	fmt.Fprintln(cmd.OutOrStdout(), "No migration files to execute.")
+	// No trailing period: the pinned community binary v1.3.0 writes
+	// `No migration files to execute\n` on stdout for the same run, 30 bytes,
+	// verified byte for byte with xxd on 2026-08-08 against a directory both
+	// binaries had already applied. Ptah wrote 31 (stokaro/ptah#1235 finding
+	// 9.3). The report model in internal/atlasreport already spells it without
+	// the period, so this line was also the odd one out inside Ptah.
+	fmt.Fprintln(cmd.OutOrStdout(), "No migration files to execute")
 	return true, nil
 }
 

--- a/cmd/atlas/migrate_apply_foreign_flyway.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway.go
@@ -232,7 +232,7 @@ func foreignFlywayRefusal(
 // V1__g1.sql and V3__g3.sql recorded by the other implementation as `1` and `3`
 // with V2__g2.sql added afterwards: the head is V3's 4611686018427551119, and
 // `migrate set 4611686018427551119` reports `(3 set)` — g1, g2 and g3 — so the
-// next `migrate apply` prints `No migration files to execute.` at exit 0 with
+// next `migrate apply` prints `No migration files to execute` at exit 0 with
 // table g2 never created and now unreachable, because its version is recorded.
 // The operator followed the printed instruction and lost a migration; the
 // refusal said nothing about it. That is the shape this clause withdraws on,

--- a/cmd/atlas/migrate_apply_foreign_flyway_test.go
+++ b/cmd/atlas/migrate_apply_foreign_flyway_test.go
@@ -247,7 +247,7 @@ func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing
 
 	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	c.Assert(stdout, qt.Contains, "No migration files to execute")
 	// The seed did not run a second time.
 	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
 }
@@ -264,7 +264,7 @@ func TestCompatMigrateApply_ForeignFlywayRefusalPrintsWorkingRecovery(t *testing
 //
 // Measured with the route still offered there: `migrate set 4611686018427551119`
 // reports `(3 set)` — `+ 4611686018427510315 (g2)` among them — the next
-// `migrate apply` prints `No migration files to execute.` at exit 0, and table
+// `migrate apply` prints `No migration files to execute` at exit 0, and table
 // g2 is absent with its version recorded, so it can never run again. Following
 // the printed instruction lost a migration and the refusal said nothing.
 //
@@ -485,7 +485,7 @@ func TestCompatMigrateApply_ForeignFlywayBaselineOverForeignHistory(t *testing.T
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
 	stdout, stderr, err = compatApplyConverted(dir, "flyway", dbPath)
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	c.Assert(stdout, qt.Contains, "No migration files to execute")
 	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"p", "q"})
 }
 

--- a/cmd/atlas/migrate_apply_integrity_test.go
+++ b/cmd/atlas/migrate_apply_integrity_test.go
@@ -134,7 +134,7 @@ func TestCompatMigrateApply_CheckpointPreCheckpointDatabaseSkips(t *testing.T) {
 	// execute", no new revision row, status stays OK.
 	stdout, _, err = compatApply(fullDir, dbPath)
 	c.Assert(err, qt.IsNil, qt.Commentf("output:\n%s", stdout))
-	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	c.Assert(stdout, qt.Contains, "No migration files to execute")
 	c.Assert(compatRevisionRows(c, dbPath), qt.DeepEquals, seeded)
 
 	statusOut, _, err := runCompat("migrate", "status", "--url", "sqlite://"+dbPath, "--dir", "file://"+fullDir)
@@ -308,7 +308,7 @@ func TestCompatMigrateApply_DirWithoutSQLFilesApplies(t *testing.T) {
 			stdout, stderr, err := compatApply(dir, dbPath)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-			c.Assert(stdout, qt.Contains, "No migration files to execute.")
+			c.Assert(stdout, qt.Contains, "No migration files to execute")
 		})
 	}
 }
@@ -380,7 +380,7 @@ func TestCompatMigrateApply_UnhashedDirWithNestedSQLIsNothingToExecute(t *testin
 			stdout, stderr, err := compatApply(dir, dbPath)
 
 			c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-			c.Assert(stdout, qt.Contains, "No migration files to execute.")
+			c.Assert(stdout, qt.Contains, "No migration files to execute")
 			c.Assert(stderr, qt.Equals,
 				"warning: sub/20260801100335_init.sql is not covered by atlas.sum and will not run; "+
 					"Atlas migrations are top-level files named *.sql\n")

--- a/cmd/atlas/migrate_apply_legacy_flyway_test.go
+++ b/cmd/atlas/migrate_apply_legacy_flyway_test.go
@@ -136,7 +136,7 @@ func TestCompatMigrateApply_LegacyFlywayRefusalPrintsWorkingRecovery(t *testing.
 	stdout, stderr, err := runCompat("migrate", "apply", "--url", "sqlite://"+dbPath, "--dir", "file://"+dir+"?format=flyway")
 
 	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-	c.Assert(stdout, qt.Contains, "No migration files to execute.")
+	c.Assert(stdout, qt.Contains, "No migration files to execute")
 	// The seed did not run a second time.
 	c.Assert(countRows(c, dbPath, "seeded"), qt.Equals, 1)
 
@@ -739,7 +739,7 @@ func TestCompatMigrateApply_FlywayBaselineAgainstRecordedHistory(t *testing.T) {
 			// quiet no-op rather than the same refusal a second time.
 			stdout, stderr, err := compatApplyConverted(run.dir, "flyway", run.dbPath)
 			c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
-			c.Assert(stdout, qt.Contains, "No migration files to execute.")
+			c.Assert(stdout, qt.Contains, "No migration files to execute")
 		},
 	}, {
 		// The prefix control: identical token, identical database, only B -> V.

--- a/cmd/atlas/migrate_apply_noop_line_test.go
+++ b/cmd/atlas/migrate_apply_noop_line_test.go
@@ -1,0 +1,43 @@
+package atlas_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// TestCompatMigrateApply_NoopLineIsByteExact pins the whole stdout of a second
+// `migrate apply` over a directory that is already applied.
+//
+// It asserts EQUALITY, not containment, and that is the entire point of the
+// row. Every other assertion on this sentence in the package is
+// `qt.Contains, "No migration files to execute"`, which matches just as
+// happily when the line carries a trailing period — so with the period put
+// back in migrate_apply.go, not one of them fails. Finding 9.3 of
+// stokaro/ptah#1235 is exactly that period, so a `Contains` assertion cannot
+// hold it.
+//
+// Measured against the pinned Atlas community binary v1.3.0, both writing 30
+// bytes and nothing else on stdout at exit 0, read with xxd from an unpiped
+// invocation, on an empty directory and on the shape below:
+//
+//	4e6f 206d 6967 7261 7469 6f6e 2066 696c   No migration fil
+//	6573 2074 6f20 6578 6563 7574 650a        es to execute\n
+func TestCompatMigrateApply_NoopLineIsByteExact(t *testing.T) {
+	c := qt.New(t)
+	tempDir := c.TempDir()
+	dir := filepath.Join(tempDir, "m_noop")
+	dbPath := filepath.Join(tempDir, "noop.db")
+	writeCoveredSetFile(c, dir, "1_a.sql", coveredSetTopLevelSQL)
+	hashCoveredSetDir(c, dir)
+
+	first, firstErr, err := compatApply(dir, dbPath)
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", first, firstErr))
+	c.Assert(userTables(c, dbPath), qt.DeepEquals, []string{"a"})
+
+	second, secondErr, err := compatApply(dir, dbPath)
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", second, secondErr))
+	c.Assert(second, qt.Equals, "No migration files to execute\n")
+}

--- a/cmd/atlas/migrate_apply_skip_checks_env_test.go
+++ b/cmd/atlas/migrate_apply_skip_checks_env_test.go
@@ -430,5 +430,5 @@ func TestMigrateApplySkipChecksEnvStillRecordsRevisions(t *testing.T) {
 		"--dir", "file://"+migrationsDir,
 	)
 	c.Assert(err, qt.IsNil, qt.Commentf("command output:\n%s", out))
-	c.Assert(out, qt.Contains, "No migration files to execute.")
+	c.Assert(out, qt.Contains, "No migration files to execute")
 }

--- a/cmd/atlas/migrate_atlas_covered_set_test.go
+++ b/cmd/atlas/migrate_atlas_covered_set_test.go
@@ -134,7 +134,7 @@ func TestCompatMigrateApply_ExecutesOnlyTheCoveredSet(t *testing.T) {
 				writeCoveredSetFile(c, dir, "sub/2_b.sql", coveredSetNestedSQL)
 				hashCoveredSetDir(c, dir)
 			},
-			wantStdout: "No migration files to execute.",
+			wantStdout: "No migration files to execute",
 			wantStderr: coveredSetNestedWarn,
 			wantTables: []string{},
 		},
@@ -154,7 +154,7 @@ func TestCompatMigrateApply_ExecutesOnlyTheCoveredSet(t *testing.T) {
 				writeCoveredSetFile(c, dir, "1_a.SQL", coveredSetTopLevelSQL)
 				hashCoveredSetDir(c, dir)
 			},
-			wantStdout: "No migration files to execute.",
+			wantStdout: "No migration files to execute",
 			wantStderr: "warning: 1_a.SQL is not covered by atlas.sum and will not run; " +
 				"Atlas migrations are top-level files named *.sql\n",
 			wantTables: []string{},

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -304,7 +304,15 @@ func runAtlasSchemaApply(cmd *cobra.Command, opts atlasSchemaApplyOptions) error
 		if formatOutput {
 			return writeAtlasSchemaApplyFormat(cmd, opts, conn.Info().Dialect, plan.Statements())
 		}
-		fmt.Fprintln(cmd.OutOrStdout(), "Schema is synced, no changes to be made.")
+		// No trailing period, and only on this verb. The pinned community binary
+		// v1.3.0 writes `Schema is synced, no changes to be made\n` here -- 40
+		// bytes against Ptah's 41, read back with xxd and wc -c from an unpiped
+		// second `schema apply --auto-approve` over a synced SQLite database --
+		// while its `schema diff` answer, `Schemas are synced, no changes to be
+		// made.`, does carry one and already matches (stokaro/ptah#1235 9.4).
+		// The native `ptah schema apply` sentence is untouched: no parity is owed
+		// there and it is not this surface.
+		fmt.Fprintln(cmd.OutOrStdout(), "Schema is synced, no changes to be made")
 		return nil
 	}
 

--- a/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
+++ b/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
@@ -212,7 +212,7 @@ CREATE POLICY tenant_isolation ON shipments FOR ALL TO PUBLIC USING (tenant_id =
 	c.Assert(firstErr, qt.IsNil, qt.Commentf("%s", firstOut))
 	c.Assert(firstOut, qt.Contains, "Schema apply completed successfully.")
 	c.Assert(secondErr, qt.IsNil, qt.Commentf("%s", secondOut))
-	c.Assert(secondOut, qt.Contains, "Schema is synced, no changes to be made.")
+	c.Assert(secondOut, qt.Contains, "Schema is synced, no changes to be made")
 	c.Assert(rlsPolicyRows(t, targetURL), qt.DeepEquals, []string{
 		"orders/tenant_isolation",
 		"shipments/tenant_isolation",

--- a/cmd/atlas/schema_scope_test.go
+++ b/cmd/atlas/schema_scope_test.go
@@ -382,5 +382,5 @@ func TestSchemaApplySchemaScopeEmptyMatchReportsSynced(t *testing.T) {
 	err := cmd.Execute()
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(out.String(), qt.Contains, "Schema is synced, no changes to be made.")
+	c.Assert(out.String(), qt.Contains, "Schema is synced, no changes to be made")
 }

--- a/cmd/atlas/schema_sqlite_table_shape_test.go
+++ b/cmd/atlas/schema_sqlite_table_shape_test.go
@@ -208,7 +208,7 @@ func TestSchemaApplySQLiteTableShapeConvergesOnKeyNullability(t *testing.T) {
 				qt.Commentf("persisted DDL: %s", sqliteTableDDL(c, dbPath, test.table)))
 
 			second := applySQLiteSourceFile(c, dbPath, sourcePath, "dev2.db")
-			c.Assert(second, qt.Contains, "Schema is synced, no changes to be made.")
+			c.Assert(second, qt.Contains, "Schema is synced, no changes to be made")
 		})
 	}
 }
@@ -237,5 +237,5 @@ func TestSchemaApplySQLiteTableShapeStillPlansGenuineChanges(t *testing.T) {
 	c.Assert(keyColumnNullability(c, dbPath, "users"), qt.DeepEquals, map[string]bool{"id": true})
 
 	again := applySQLiteSourceFile(c, dbPath, after, "dev3.db")
-	c.Assert(again, qt.Contains, "Schema is synced, no changes to be made.")
+	c.Assert(again, qt.Contains, "Schema is synced, no changes to be made")
 }

--- a/docs/conformance.md
+++ b/docs/conformance.md
@@ -260,7 +260,7 @@ entry is a running hash over the preceding files, so editing one file changes
 the recorded hash of every file below it. Measured on the two-migration fixture
 above, repairing only the edited version moved the refusal to the next one, and
 repairing both returned `migrate apply` to exit 0 with
-`No migration files to execute.`
+`No migration files to execute`
 
 The refusal is exit 1 in the direction the rules allow, and it is stricter than
 Atlas CE, never looser. See
@@ -877,9 +877,9 @@ ask it rather than the dialect. Before they did, measured on 2026-08-08 at exit
 
 | Command | Table | Before | After |
 | --- | --- | --- | --- |
-| `schema apply --to file://schema.sql --auto-approve`, run twice | `WITHOUT ROWID` | second run planned a full table rebuild, and so would every run after it | `Schema is synced, no changes to be made.` |
-| the same | `STRICT` | second run planned a full table rebuild | `Schema is synced, no changes to be made.` |
-| the same | rowid | `Schema is synced, no changes to be made.` | unchanged |
+| `schema apply --to file://schema.sql --auto-approve`, run twice | `WITHOUT ROWID` | second run planned a full table rebuild, and so would every run after it | `Schema is synced, no changes to be made` |
+| the same | `STRICT` | second run planned a full table rebuild | `Schema is synced, no changes to be made` |
+| the same | rowid | `Schema is synced, no changes to be made` | unchanged |
 | `migrate diff <name> --to file://schema.sql`, run twice | `WITHOUT ROWID` | wrote a second migration file containing that rebuild | `The migration directory is synced with the desired state, no changes to be made` |
 
 The pinned binary answered `Schemas are synced, no changes to be made.` against
@@ -977,6 +977,82 @@ Ptah was silent. A plain `integer` column against a desired schema that declares
 A desired type names a domain when the desired schema declares one by that
 name, which is how every source Ptah reads carries it. A bare name with no
 declaration behind it stays an ordinary type name.
+
+## Output Shape: Three Cells From The #1235 Register
+
+[`stokaro/ptah#1235`](https://github.com/stokaro/ptah/issues/1235) registers 51
+places where `ptah-compat` and the pinned community binary v1.3.0 agree on the
+exit code and disagree on the bytes. Three of them are closed here. Every row was
+measured with each binary in its own directory, every exit code read from an
+unpiped invocation.
+
+| Finding | Command | Pinned binary | Ptah, before | Ptah, now |
+| --- | --- | --- | --- | --- |
+| 6.2 | `schema inspect --format '{{ json . }}'` over `a TEXT UNIQUE, b TEXT UNIQUE` plus `CREATE UNIQUE INDEX ux_t_c` | 3 indexes | 5 — each implicit autoindex listed twice | 3 |
+| 9.3 | `migrate apply` over an already-applied directory | `No migration files to execute\n` | the same plus a period | byte-identical |
+| 9.4 | `schema apply --auto-approve` against a synced database | `Schema is synced, no changes to be made\n` | the same plus a period | byte-identical |
+
+**6.2 is not SQLite-specific, though the register is.** It reproduces on
+PostgreSQL 17: a plain `email text UNIQUE` column printed `users_email_key`
+twice. A UNIQUE constraint and the index that backs it are one entry in
+`indexes`, deduplicated by index name — the constraint branch still runs for a
+reader that reports a UNIQUE constraint with no index row of its own.
+
+**6.1 — an empty schema is still a schema — is closed elsewhere and stays
+closed.** The same divergence is
+[`stokaro/ptah#1264`](https://github.com/stokaro/ptah/issues/1264), and the
+realm document has named the schemas its READER described since that landed, so
+an empty database answers `{"schemas":[{"name":"main"}]}` on SQLite and
+`{"schemas":[{"name":"public","comment":"standard public schema"}]}` on
+PostgreSQL 17, byte-identically to the pinned binary. Seeding the CONNECTED
+schema instead would close the same cell one line earlier and reopen two shapes
+that already matched — measured live on PostgreSQL 17, `--schema extra` on a
+realm URL gained a second, empty `{"name":"public"}` entry that binary never
+prints, and `--schema nosuch` answered `{"schemas":[{"name":"public"}]}` where
+it answers `{}`. Which schemas exist is the reader's answer, not the
+connection's.
+
+**9.4 changes one verb only.** The pinned binary's `schema diff` answer,
+`Schemas are synced, no changes to be made.`, does carry a period and already
+matched; only the `apply` spelling grew one. The native `ptah schema apply`
+sentence is untouched: no parity is owed on that surface.
+
+### `migrate new` writes the name it was given
+
+Findings 8.6 and 8.7 of the same register: the Atlas-layout file name is
+`<version>_<name>.sql` composed from the name verbatim on that binary, and Ptah
+mapped spaces to hyphens and dropped every character outside `[-_0-9A-Za-z]`.
+The name is covered by `atlas.sum`, so a rewritten name is also a different
+checksum for the same command. Measured, each binary in its own directory:
+
+| `migrate new …` | Pinned binary | Ptah, before | Ptah, now |
+| --- | --- | --- | --- |
+| `"add users table"` | `<version>_add users table.sql` | `<version>_add-users-table.sql` | matches |
+| `"add_users.sql"` | `<version>_add_users.sql.sql` | `<version>_add_userssql.sql` | matches |
+
+That binary reads a directory Ptah writes this way at exit 0, and Ptah reads its
+own back at exit 0.
+
+Two rules survive, and both are deliberate:
+
+- Leading and trailing whitespace is still trimmed. That binary keeps it —
+  `migrate new "  padded  "` writes `<version>_  padded  .sql` — but a file name
+  with trailing spaces does not survive every filesystem this tool writes into,
+  and no finding in the register asks for one.
+- A name whose composed file name Ptah's own reader would classify as something
+  other than a new up migration is refused before anything is written. Exactly
+  one suffix does that today: `migrator.ParseAtlasMigrationFileName` reads
+  `<version>_x.down.sql` as the down half of a pair, because Atlas importers emit
+  that spelling for golang-migrate directories.
+
+That second rule is stricter than the pinned binary, which writes
+`<version>_x.down.sql` at exit 0 and reads it back as a pending migration at exit
+0. Refusing to write it does **not** close the reader gap: measured on
+2026-08-08, a directory that binary wrote that way makes `ptah-compat migrate
+status` exit 1 with `Atlas migration version <version> has down migration but no
+up migration`, where it exits 0. That divergence is in the
+"Ptah exits 1, the binary exits 0" direction the register lists as unfiled, and
+it is reported here rather than closed.
 
 ## Reports
 

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -861,7 +861,7 @@ An **empty** migration directory is the one shape where a missing `atlas.sum`
 is not drift: there is nothing for it to cover, so `ptah-compat migrate validate`
 exits `0` with no output, matching the pinned Atlas community binary v1.3.0 and
 matching what `ptah-compat migrate apply` already does on the same directory
-(`No migration files to execute.`). The moment the directory holds a migration
+(`No migration files to execute`). The moment the directory holds a migration
 file the refusal returns, byte-identically. `ptah-compat migrate lint --latest`
 follows the same rule: an empty directory selects nothing and exits `0`, which
 is what a repository linting its migrations in CI does before the first

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -431,7 +431,7 @@ $ head -3 out/public.hcl
 // ptah:not-described policy
 // ptah:not-described sequence
 $ ptah-compat schema apply --url "$PG_URL" --to file://out/public.hcl --dev-url "$DEV_URL" --dry-run
-Schema is synced, no changes to be made.
+Schema is synced, no changes to be made
 ```
 
 All three split strategies do this — per object (the default), `split "schema"`,

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -459,7 +459,7 @@ it, run or not:
   *ran*, and the covered migrations below it need not all be among them.
   Measured on `V1__g1.sql` and `V3__g3.sql` recorded as `1` and `3` with
   `V2__g2.sql` added afterwards: `migrate set 4611686018427551119` reports
-  `(3 set)`, the next apply prints `No migration files to execute.` at exit 0,
+  `(3 set)`, the next apply prints `No migration files to execute` at exit 0,
   and table `g2` is absent with its version recorded — it can never run again.
   The refusal names that file and the version the command would assert, so
   nothing is lost by following the printed instruction.

--- a/internal/atlasreport/schema_inspect.go
+++ b/internal/atlasreport/schema_inspect.go
@@ -336,6 +336,14 @@ func atlasSchemaInspectBase64URL(value any) string {
 // Tables still contribute their schema, so a reader that describes no schemas
 // keeps rendering what it did before rather than losing its tables to a
 // missing row.
+//
+// The connected schema is deliberately NOT seeded here. Seeding it would close
+// the empty-database cell on its own, and it was measured reopening two shapes
+// that already matched: `--schema extra` on a realm PostgreSQL URL gained a
+// second, empty `{"name":"public"}` entry the binary never prints, and
+// `--schema nosuch` answered `{"schemas":[{"name":"public"}]}` where that
+// binary answers `{}`. Which schemas exist is the reader's answer, not the
+// connection's; see [go.5x5.cz/ptah/internal/schemaselection].
 func atlasSchemaInspectJSON(schema *dbschematypes.DBSchema, info dbschematypes.DBInfo) atlasSchemaInspectJSONRealm {
 	schemasByName := make(map[string]*atlasSchemaInspectJSONSchema)
 	indexesByTable := atlasSchemaInspectIndexesByTable(schema.Indexes)
@@ -396,12 +404,23 @@ func atlasSchemaInspectTable(
 	for _, column := range table.Columns {
 		jsonTable.Columns = append(jsonTable.Columns, atlasSchemaInspectColumn(column))
 	}
+	// A UNIQUE constraint whose backing index the reader already reported is one
+	// index, not two. SQLite reports both: `pragma index_list` names the implicit
+	// `sqlite_autoindex_<table>_<n>` and the constraint carries that same name, so
+	// `CREATE TABLE t (…, a TEXT UNIQUE, b TEXT UNIQUE, …)` printed five indexes
+	// where the pinned community binary v1.3.0 printed three, each autoindex
+	// listed twice (stokaro/ptah#1235 finding 6.2). The constraint branch still
+	// has to run for readers that report a UNIQUE constraint with no index row of
+	// its own, which is why the duplicate is dropped by name here rather than by
+	// deleting the branch.
+	indexNames := make(map[string]struct{}, len(indexesByTable[table.QualifiedName()]))
 	for _, index := range indexesByTable[table.QualifiedName()] {
 		jsonIndex := atlasSchemaInspectIndex(index)
 		if index.IsPrimary {
 			jsonTable.PrimaryKey = atlasSchemaInspectPrimaryKey(jsonIndex.Parts)
 			continue
 		}
+		indexNames[jsonIndex.Name] = struct{}{}
 		jsonTable.Indexes = append(jsonTable.Indexes, jsonIndex)
 	}
 	for _, constraint := range constraintsByTable[table.QualifiedName()] {
@@ -411,7 +430,12 @@ func atlasSchemaInspectTable(
 				jsonTable.PrimaryKey = atlasSchemaInspectPrimaryKey(atlasSchemaInspectConstraintIndexParts(constraint))
 			}
 		case "UNIQUE":
-			jsonTable.Indexes = append(jsonTable.Indexes, atlasSchemaInspectUniqueConstraintIndex(constraint))
+			jsonIndex := atlasSchemaInspectUniqueConstraintIndex(constraint)
+			if _, alreadyReported := indexNames[jsonIndex.Name]; alreadyReported {
+				continue
+			}
+			indexNames[jsonIndex.Name] = struct{}{}
+			jsonTable.Indexes = append(jsonTable.Indexes, jsonIndex)
 		case "FOREIGN KEY":
 			jsonTable.ForeignKeys = append(jsonTable.ForeignKeys, atlasSchemaInspectForeignKey(constraint))
 		}

--- a/internal/atlasreport/schema_inspect_json_shape_test.go
+++ b/internal/atlasreport/schema_inspect_json_shape_test.go
@@ -1,0 +1,179 @@
+package atlasreport_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasreport"
+)
+
+// TestSchemaInspectJSONNeverInventsTheConnectedSchema pins that the realm
+// document names the schemas the READER described and never the one the
+// connection happens to sit in.
+//
+// The distinction has a price attached. Seeding the connected schema into the
+// document closes the empty-database cell of stokaro/ptah#1235 (finding 6.1) on
+// its own, and it was measured reopening two shapes that already matched. All
+// four rows below were run against the pinned Atlas community binary v1.3.0 on
+// live PostgreSQL 17 and SQLite, each at exit 0, with `schema inspect --format
+// '{{ json . }}'`:
+//
+//	sqlite, empty database                  {"schemas":[{"name":"main"}]}
+//	postgres, empty public                  {"schemas":[{"name":"public",…}]}
+//	postgres, realm URL, --schema extra     {"schemas":[{"name":"extra",…}]}
+//	postgres, realm URL, --schema nosuch    {}
+//
+// With the connected schema seeded, the third answered a second, empty
+// `{"name":"public"}` entry that binary never prints, and the fourth answered
+// `{"schemas":[{"name":"public"}]}` where it answers `{}` — a schema described
+// to an operator who had just been told it does not exist.
+//
+// So the seed is the cheaper wrong implementation of finding 6.1, and these
+// rows are what refuse it. The empty-database rows are here in the same table
+// on purpose: they are the cell the seed was reaching for, and they hold
+// without it because the reader describes the schema itself.
+func TestSchemaInspectJSONNeverInventsTheConnectedSchema(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema *types.DBSchema
+		info   types.DBInfo
+		want   string
+	}{
+		{
+			name: "an empty sqlite database reports the schema its reader described",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{{Name: "main"}},
+			},
+			info: types.DBInfo{Dialect: "sqlite", Schema: "main"},
+			want: `{"schemas":[{"name":"main"}]}`,
+		},
+		{
+			name: "an empty postgres database reports the schema its reader described",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{{Name: "public", Comment: "standard public schema"}},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want: `{"schemas":[{"name":"public","comment":"standard public schema"}]}`,
+		},
+		{
+			name: "a schema selection on a realm URL does not gain the connected schema",
+			schema: &types.DBSchema{
+				Schemas: []types.DBSchemaInfo{{Name: "extra"}},
+				Tables: []types.DBTable{{
+					Name:    "ext_t",
+					Schema:  "extra",
+					Columns: []types.DBColumn{{Name: "id", DataType: "integer"}},
+				}},
+			},
+			info: types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want: `{"schemas":[{"name":"extra","tables":[{"name":"ext_t",` +
+				`"columns":[{"name":"id","type":"integer"}]}]}]}`,
+		},
+		{
+			name:   "a selection naming a schema that does not exist stays empty",
+			schema: &types.DBSchema{},
+			info:   types.DBInfo{Dialect: "postgres", Schema: "public"},
+			want:   `{}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			report := atlasreport.NewSchemaInspectReport(
+				&goschema.Database{},
+				test.schema,
+				test.info,
+				nil,
+				false,
+				true,
+			)
+			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestSchemaInspectJSONReportsABackedUniqueConstraintOnce pins that a UNIQUE
+// constraint and the index that backs it are one entry in `indexes`, not two.
+//
+// SQLite reports both halves: `pragma index_list` names the implicit
+// `sqlite_autoindex_<table>_<n>` and the table's UNIQUE constraint carries that
+// same name. Measured over
+// `CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE, c TEXT)`
+// plus `CREATE UNIQUE INDEX ux_t_c ON t (c)`, the pinned community binary
+// v1.3.0 printed three indexes and Ptah printed five, with each autoindex
+// listed twice (stokaro/ptah#1235 finding 6.2).
+//
+// It is not a SQLite-only fold. Measured live on PostgreSQL 17, a plain
+// `email text UNIQUE` column printed `users_email_key` twice with the
+// deduplication reverted in place, and once with it.
+//
+// The second row is the control the fix must not break: a reader that reports a
+// UNIQUE constraint with no index row of its own -- which is why the constraint
+// branch exists at all -- must still produce an index entry.
+func TestSchemaInspectJSONReportsABackedUniqueConstraintOnce(t *testing.T) {
+	tests := []struct {
+		name    string
+		indexes []types.DBIndex
+		want    string
+	}{
+		{
+			name: "the backing index is reported and the constraint is not repeated",
+			indexes: []types.DBIndex{{
+				Name:      "sqlite_autoindex_t_1",
+				TableName: "t",
+				Columns:   []string{"a"},
+				IsUnique:  true,
+			}},
+			want: `{"schemas":[{"name":"main","tables":[{"name":"t",` +
+				`"columns":[{"name":"a","type":"TEXT","null":true}],` +
+				`"indexes":[{"name":"sqlite_autoindex_t_1","unique":true,"parts":[{"column":"a"}]}]}]}]}`,
+		},
+		{
+			name:    "a constraint with no backing index row still becomes an index",
+			indexes: nil,
+			want: `{"schemas":[{"name":"main","tables":[{"name":"t",` +
+				`"columns":[{"name":"a","type":"TEXT","null":true}],` +
+				`"indexes":[{"name":"sqlite_autoindex_t_1","unique":true,"parts":[{"column":"a"}]}]}]}]}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			report := atlasreport.NewSchemaInspectReport(
+				&goschema.Database{},
+				&types.DBSchema{
+					Schemas: []types.DBSchemaInfo{{Name: "main"}},
+					Tables: []types.DBTable{{
+						Name:    "t",
+						Columns: []types.DBColumn{{Name: "a", DataType: "TEXT", IsNullable: "YES"}},
+					}},
+					Indexes: test.indexes,
+					Constraints: []types.DBConstraint{{
+						Name:        "sqlite_autoindex_t_1",
+						TableName:   "t",
+						Type:        "UNIQUE",
+						ColumnNames: []string{"a"},
+					}},
+				},
+				types.DBInfo{Dialect: "sqlite", Schema: "main"},
+				nil,
+				false,
+				true,
+			)
+			output, err := atlasreport.RenderSchemaInspect(`{{ json . }}`, report)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(output.Text, qt.Equals, test.want)
+		})
+	}
+}

--- a/migration/generator/atlas_migration_name_test.go
+++ b/migration/generator/atlas_migration_name_test.go
@@ -1,0 +1,113 @@
+package generator_test
+
+import (
+	"fmt"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/generator"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestGenerateEmptyMigrationKeepsTheAtlasNameVerbatim pins the file name
+// `migrate new` writes into an Atlas-layout directory against the pinned Atlas
+// community binary v1.3.0, which composes `<version>_<name>.sql` from the name
+// it was given without rewriting it.
+//
+// Measured on that binary on 2026-08-08, each row run in its own directory:
+//
+//	migrate new "add users table"    -> <version>_add users table.sql
+//	migrate new "add_users.sql"      -> <version>_add_users.sql.sql
+//	migrate new "caps-AND.dots+plus" -> <version>_caps-AND.dots+plus.sql
+//	migrate new "x.up"               -> <version>_x.up.sql
+//
+// Ptah wrote `<version>_add-users-table.sql` and `<version>_add_userssql.sql`
+// for the first two, because it mapped spaces to hyphens and dropped every
+// character outside [-_0-9A-Za-z] (stokaro/ptah#1235 findings 8.6 and 8.7). The
+// file name is covered by atlas.sum, so the two tools produced different
+// checksums for the same command.
+//
+// The `x.up` row is not decoration: the guard added alongside this change
+// refuses a name whose file name reads back as the down half of a pair, and this
+// row is what keeps that guard from widening into every dotted suffix.
+func TestGenerateEmptyMigrationKeepsTheAtlasNameVerbatim(t *testing.T) {
+	tests := []struct {
+		name          string
+		migrationName string
+		wantSuffix    string
+	}{
+		{
+			name:          "interior spaces survive",
+			migrationName: "add users table",
+			wantSuffix:    "_add users table.sql",
+		},
+		{
+			name:          "a dot survives, extension and all",
+			migrationName: "add_users.sql",
+			wantSuffix:    "_add_users.sql.sql",
+		},
+		{
+			name:          "case and punctuation survive",
+			migrationName: "caps-AND.dots+plus",
+			wantSuffix:    "_caps-AND.dots+plus.sql",
+		},
+		{
+			name:          "an up suffix is a name, not a direction",
+			migrationName: "x.up",
+			wantSuffix:    "_x.up.sql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			files, err := generator.GenerateEmptyMigration(generator.EmptyMigrationOptions{
+				MigrationName: tt.migrationName,
+				OutputDir:     t.TempDir(),
+				DirFormat:     migrator.MigrationDirFormatAtlas,
+			})
+			c.Assert(err, qt.IsNil)
+			c.Assert(files.Files, qt.HasLen, 1)
+
+			want := fmt.Sprintf("%d%s", files.Files[0].Version, tt.wantSuffix)
+			c.Assert(filepath.Base(files.Files[0].UpFile), qt.Equals, want)
+		})
+	}
+}
+
+// TestGenerateEmptyMigrationRefusesAnAtlasNameItCannotReadBack is the guard that
+// keeps writing the name verbatim from producing a directory Ptah's own reader
+// rejects.
+//
+// `migrator.ParseAtlasMigrationFileName` classifies `<version>_x.down.sql` as
+// the down half of a pair, because Atlas importers emit that spelling for
+// golang-migrate directories. Without this refusal `migrate new "x.down"` wrote
+// a file `migrate status` then answered `Atlas migration version <version> has
+// down migration but no up migration` on, exit 1 -- one verb producing a
+// directory another verb cannot read.
+//
+// This is stricter than the pinned binary, which writes that file at exit 0 and
+// reads it back as pending at exit 0. Refusing to write it does not close the
+// reader gap, which is reported separately; it only keeps Ptah from opening the
+// gap on itself.
+func TestGenerateEmptyMigrationRefusesAnAtlasNameItCannotReadBack(t *testing.T) {
+	c := qt.New(t)
+	dir := t.TempDir()
+
+	_, err := generator.GenerateEmptyMigration(generator.EmptyMigrationOptions{
+		MigrationName: "x.down",
+		OutputDir:     dir,
+		DirFormat:     migrator.MigrationDirFormatAtlas,
+	})
+	c.Assert(err, qt.ErrorMatches,
+		`migration name "x.down" composes the file name <version>_x\.down\.sql, `+
+			`which this tool does not read back as a new migration`)
+
+	// The refusal runs before the directory is bound, so nothing is left behind.
+	entries, readErr := filepath.Glob(filepath.Join(dir, "*"))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(entries, qt.HasLen, 0)
+}

--- a/migration/generator/checkpoint.go
+++ b/migration/generator/checkpoint.go
@@ -212,7 +212,7 @@ func WriteAtlasCheckpointFile(outputDir string, version int64, description, upSQ
 // `migrate new` uses. The contents are the measured Atlas layout: the
 // directive on the first line, a blank separator line, then the SQL.
 func AtlasCheckpointArtifact(version int64, description, upSQL string) (name, contents string) {
-	stem := atlasEmptyMigrationName(description)
+	stem := atlasCheckpointNameStem(description)
 	if stem == "" {
 		stem = "checkpoint"
 	}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -218,6 +218,8 @@ func GenerateEmptyMigration(opts EmptyMigrationOptions) (*MigrationFiles, error)
 		if err := validateEmptyMigrationName(name); err != nil {
 			return nil, err
 		}
+	} else if err := checkAtlasEmptyMigrationNameReadable(name); err != nil {
+		return nil, err
 	}
 
 	root, err := openOutputRoot(opts.AllowedOutputRoot)
@@ -271,15 +273,51 @@ func latestAtlasVersionIn(names []string) int64 {
 	return latest
 }
 
+// atlasEmptyMigrationFileName composes the Atlas-layout file name `migrate new`
+// writes, and it carries the caller's name unchanged.
+//
+// It used to rewrite the name first: spaces became hyphens and every character
+// outside [-_0-9A-Za-z] was dropped, so `migrate new "add users table"` wrote
+// `<version>_add-users-table.sql` and `migrate new "add_users.sql"` wrote
+// `<version>_add_userssql.sql`. The Atlas layout is not ours to rename in: the
+// pinned community binary v1.3.0 composes `<version>_<name>.sql` from the name
+// verbatim, so the same two commands write `<version>_add users table.sql` and
+// `<version>_add_users.sql.sql` there (measured 2026-08-08). The file name is
+// covered by atlas.sum, so a rewritten name is also a different checksum for the
+// same command (stokaro/ptah#1235 findings 8.6 and 8.7).
+//
+// Two rules still apply and are deliberate, not leftovers:
+//
+//   - [GenerateEmptyMigration] trims leading and trailing whitespace off the
+//     name for every layout. That binary keeps it -- `migrate new "  padded  "`
+//     writes `<version>_  padded  .sql` -- but a file name with trailing spaces
+//     does not survive every filesystem this tool writes into, and no finding in
+//     that register asks for one.
+//   - A path separator is refused rather than stripped, on the compatibility
+//     surface by checkAtlasMigrationName and here by the rooted writer, which
+//     cannot open a path outside the directory it holds.
+//
+// [atlasCheckpointNameStem] keeps the old rewriting for `migrate checkpoint`.
+// That verb has no measured counterpart on the pinned binary, and its writer
+// resolves the file by pathname rather than through a rooted handle.
 func atlasEmptyMigrationFileName(version int64, name string) string {
-	name = atlasEmptyMigrationName(name)
 	if name == "" {
 		return fmt.Sprintf("%d.sql", version)
 	}
 	return fmt.Sprintf("%d_%s.sql", version, name)
 }
 
-func atlasEmptyMigrationName(name string) string {
+// atlasCheckpointNameStem maps a checkpoint description onto a conservative file
+// name stem: spaces to hyphens, everything outside [-_0-9A-Za-z] dropped.
+//
+// This is what every Atlas-layout name used to go through. `migrate new` no
+// longer does, because that binary was measured writing the name verbatim there.
+// `migrate checkpoint` keeps it: the register that prompted the change records
+// no cell for the verb, so there is nothing measured to move towards, and
+// [WriteAtlasCheckpointFile] joins the stem onto a pathname instead of opening
+// it through a rooted directory handle, so a stem carrying a separator would
+// name a file outside the directory the caller asked for.
+func atlasCheckpointNameStem(name string) string {
 	name = strings.TrimSpace(name)
 	name = strings.ReplaceAll(name, " ", "-")
 	var b strings.Builder
@@ -296,6 +334,45 @@ func isAtlasMigrationNameChar(r rune) bool {
 		('0' <= r && r <= '9') ||
 		('A' <= r && r <= 'Z') ||
 		('a' <= r && r <= 'z')
+}
+
+// checkAtlasEmptyMigrationNameReadable refuses a migration name whose composed
+// file name this tool would read back as something other than the new up
+// migration it just wrote.
+//
+// Writing the name verbatim means it can now reach the Atlas file-name grammar,
+// and one suffix collides with it: [migrator.ParseAtlasMigrationFileName]
+// classifies `<version>_x.down.sql` as the down half of a pair, because Atlas
+// importers emit that spelling for golang-migrate directories. So `migrate new
+// "x.down"` would write a file `migrate status` then refuses with `Atlas
+// migration version <version> has down migration but no up migration`, exit 1 --
+// one verb producing a directory another verb cannot read.
+//
+// The check is a round trip rather than a list of banned suffixes, so a later
+// change to that grammar cannot reopen the hole silently.
+//
+// This refusal is stricter than the pinned community binary v1.3.0, which
+// writes `<version>_x.down.sql` at exit 0 and reads it back as a pending
+// migration at exit 0. Ptah refusing to WRITE it does not fix Ptah's reader:
+// that binary can still hand us such a directory, and `migrate status` still
+// exits 1 on it. That reader gap is a separate divergence and is reported, not
+// closed, by the change that introduced this guard.
+func checkAtlasEmptyMigrationNameReadable(name string) error {
+	// The version is a stand-in: the grammar this probes keys on the name's
+	// suffix, not on the digits in front of it, and the message quotes the shape
+	// rather than a version no caller asked for.
+	const probeVersion = 1
+	fileName := atlasEmptyMigrationFileName(probeVersion, name)
+	parsed, err := migrator.ParseAtlasMigrationFileName(fileName)
+	if err == nil && parsed.Version == probeVersion && parsed.Direction == "up" {
+		return nil
+	}
+	shape := "<version>" + strings.TrimPrefix(fileName, strconv.FormatInt(probeVersion, 10))
+	return fmt.Errorf(
+		"migration name %q composes the file name %s, which this tool does not read back as a new migration",
+		name,
+		shape,
+	)
 }
 
 func validateEmptyMigrationName(name string) error {


### PR DESCRIPTION
Refs [#1235](https://github.com/stokaro/ptah/issues/1235). **Not** `Closes` — five of the register's 51 cells are closed here, three more are confirmed closed elsewhere, one is reported unmeasurable, and the rest are still open. The open inventory is at the bottom so the next pass starts from a list rather than from 51 re-readings.

## What changed in this revision

The previous revision of this branch closed **6.1** by seeding the CONNECTED schema into the realm document before any table was placed in it. That is one line shorter than the alternative and it was **measured reopening two shapes on the same verb that already matched**. It is gone. 6.1 is closed on `master` by [#1264](https://github.com/stokaro/ptah/issues/1264) / [#1275](https://github.com/stokaro/ptah/pull/1275), which builds the realm from the schemas the READER described, and that fix survives this branch untouched.

The branch is now rebased onto `origin/master` `71a7d7f2`, which is where #1275 lives.

### Every shape `schema inspect --format '{{ json . }}'` can be given

Live PostgreSQL 17 in a throwaway container created for this run, one database per shape, dropped and recreated between the "before" and "after" passes; each binary built into a directory inside this worktree; every exit code read from an unpiped invocation; every cell compared with `cmp` against the pinned Atlas community binary v1.3.0's own stdout. Every invocation exits 0 — the table is about bytes, not status.

| Shape | `cmp` vs pinned binary, previous head `03dd0116` | `cmp` vs pinned binary, this head |
| --- | --- | --- |
| realm URL, empty database | **1** — `{"schemas":[{"name":"public"}]}` vs `…,"comment":"standard public schema"}` | **0** |
| realm URL, one schema with two tables | **1** — no schema `comment`, and `users_email_key` listed twice | **0** |
| realm URL, `public` + `extra`, both with tables | **1** — `extra` absent entirely | **0** |
| schema-bound URL (`?search_path=public`) | **1** — no schema `comment` | **0** |
| realm URL + `--schema extra` | **1** — a second, empty `{"name":"public"}` entry the binary never prints | **0** |
| realm URL + `--schema nosuch` | **1** — `{"schemas":[{"name":"public"}]}` where the binary answers `{}` | **0** |

The last two rows are the blocker. They are the shapes the seed **broke**: on `master` alone, without this branch, both already matched the binary byte for byte. Row two is the shape this branch still has to fix — it is finding 6.2, and `master` alone misses it.

SQLite, same discipline:

| Shape | pinned binary | this head |
| --- | --- | --- |
| empty database | `{"schemas":[{"name":"main"}]}` | identical |
| `--exclude` every table | `{"schemas":[{"name":"main"}]}` | identical |
| `a TEXT UNIQUE, b TEXT UNIQUE, c TEXT` + `CREATE UNIQUE INDEX ux_t_c` | 3 index entries | 3, same set — **order still differs**, which is 4.8 and stays open |

## What this closes

### 6.2 — a UNIQUE constraint and its index are one entry

SQLite reports both halves: `pragma index_list` names the implicit `sqlite_autoindex_<table>_<n>` and the table's UNIQUE constraint carries that same name. Over `CREATE TABLE t (id INTEGER PRIMARY KEY, a TEXT UNIQUE, b TEXT UNIQUE, c TEXT)` plus `CREATE UNIQUE INDEX ux_t_c ON t(c)`, the pinned binary printed **3** index entries and Ptah printed **5**, each autoindex listed twice.

Deduplicated by index name. The constraint branch still runs — it exists for readers that report a UNIQUE constraint with no index row of its own — which is why the duplicate is dropped rather than the branch deleted.

**Not SQLite-only, though the register is.** On live PostgreSQL 17 a plain `email text UNIQUE` column printed `users_email_key` twice on `master` and once here; that is the "one schema with two tables" row above, and it is the last thing standing between `master` and a byte-identical answer on all six PostgreSQL shapes.

### 8.6 and 8.7 — `migrate new` writes the name it was given

The Atlas layout is not ours to rename in. That binary composes `<version>_<name>.sql` from the name verbatim; Ptah mapped spaces to hyphens and dropped every character outside `[-_0-9A-Za-z]`. The name is covered by `atlas.sum`, so a rewritten name is also a different checksum for the same command.

Re-measured on this head, each row in its own directory:

| `migrate new …` | Pinned binary | Ptah, before | Ptah, now |
| --- | --- | --- | --- |
| `"add users table"` | `<version>_add users table.sql` | `<version>_add-users-table.sql` | matches |
| `"add_users.sql"` | `<version>_add_users.sql.sql` | `<version>_add_userssql.sql` | matches |
| `"caps-AND.dots+plus"` | `<version>_caps-AND.dots+plus.sql` | `<version>_capsANDdotsplus.sql` | matches |

Cross-read on this head: the pinned binary answers `migrate validate` exit 0 on the directory Ptah wrote, and Ptah answers exit 0 on the directory that binary wrote.

**Two rules survive, both deliberate.**

`GenerateEmptyMigration` still trims leading and trailing whitespace. That binary keeps it — `migrate new "  padded  "` writes `<version>_  padded  .sql` — but a file name with trailing spaces does not survive every filesystem this tool writes into, and no finding in the register asks for one. Recorded as a remaining divergence rather than silently closed.

And writing the name verbatim lets it reach the Atlas file-name grammar, where exactly one suffix collides today. `migrator.ParseAtlasMigrationFileName` reads `<version>_x.down.sql` as the down half of a pair, because Atlas importers emit that spelling for golang-migrate directories. So `migrate new` now refuses a name whose composed file name does not round-trip back to a new **up** migration, before the directory is bound. It is a round trip rather than a list of banned suffixes, so a later change to that grammar cannot reopen the hole silently.

**That refusal does not close the reader gap, and is not claimed to.** Measured on this head:

```console
$ atlas migrate new "x.down" --dir file://down_a      # pinned binary
exit 0, writes 20260809032118_x.down.sql
$ ptah-compat migrate new "x.down" --dir file://down_b
Error: migration name "x.down" composes the file name <version>_x.down.sql, which this tool does not read back as a new migration
exit 1
```

A directory the pinned binary wrote that way still makes `ptah-compat migrate status` exit 1 where that binary exits 0. That is a divergence in the "Ptah exits 1, the binary exits 0" direction the register lists as unfiled. It is written down in `docs/conformance.md` and belongs in that unfiled set, not in this PR — fixing it means changing the shared Atlas file-name parser that golang-migrate imports depend on.

`migrate checkpoint` keeps the old rewriting, now under its own name `atlasCheckpointNameStem`. The verb has no measured counterpart on that binary, and `WriteAtlasCheckpointFile` joins the stem onto a pathname instead of opening it through a rooted directory handle, so a stem carrying a separator would name a file outside the directory the caller asked for.

### 9.3 and 9.4 — two periods

Read with `xxd`, unpiped, on this head:

| Probe | pinned binary | Ptah, before | Ptah, now |
| --- | --- | --- | --- |
| `migrate apply` over an already-applied directory | `…execute\n` — 30 bytes, and stdout holds nothing else | `…execute.\n` (31) | `cmp` against the binary's stdout exits 0 |
| `migrate apply` over an empty directory | the same 30 bytes | 31 | `cmp` exits 0 |
| `schema apply --auto-approve` against a synced database | `…be made\n` (40) | `…be made.\n` (41) | `cmp` exits 0 |

The byte counts for the third row are 40 and 41, not the 41 and 42 an earlier revision of this description claimed; they were re-read with `xxd` and `wc -c` on this head, and the code comment in `cmd/atlas/schema_apply.go` is corrected too.

Only the `apply` verb moves. That binary's `schema diff` answer, `Schemas are synced, no changes to be made.`, does carry a period and already matched — the control that keeps this from becoming a blanket period-stripping. The native `ptah schema apply` sentence in `cmd/schema/apply.go` is untouched: no parity is owed on that surface.

**9.3 had no assertion that could see its own defect, and now it does.** Every existing assertion on that sentence reads `qt.Contains, "No migration files to execute"` — which matches just as happily with the period back. Putting the period back into `migrate_apply.go` reddened **nothing**. `TestCompatMigrateApply_NoopLineIsByteExact` asserts the whole stdout of a second apply equals the measured 30 bytes. 9.4 already had such an assertion in `TestCompatCommand_SchemaApplyAppliesLocalSchemaToSQLite`, confirmed red the same way.

## Seeing it red

Six mutants, each applied to the working tree, run, and reverted; `git diff --stat` empty after each. Exit codes read directly, never through a pipe.

| Mutant (the cheaper wrong implementation, not a deletion) | Reddens |
| --- | --- |
| the connected-schema seed put back | `TestSchemaInspectJSONNeverInventsTheConnectedSchema` rows 3 and 4, **and** `TestRenderSchemaInspect_JSONRealmDocument/a_selection_that_matched_nothing_stays_empty` — while both empty-database rows stayed GREEN, which is what shows the seed buys nothing |
| the index deduplication reduced to bookkeeping only | the backed-constraint row only |
| the UNIQUE constraint branch emits nothing (over-correction) | the no-backing-index row only |
| `atlasEmptyMigrationFileName` sanitizes again | all 4 verbatim-name rows **and** the `.down` refusal |
| the `.down` round-trip guard returns nil | the refusal row only |
| the trailing period restored, one line at a time | `…NoopLineIsByteExact` for 9.3; `…SchemaApplyAppliesLocalSchemaToSQLite` for 9.4 |

The third is the inverse guard: without it, "deduplicate" could be traded for "drop the branch" and the suite would stay green. The first is the blocker's guard: it is the exact code the previous revision shipped.

## Rebase

Rebased from `03dd0116` onto `origin/master` `71a7d7f2`. Two files conflicted, and one of them is the reason a clean merge is not a correct merge:

- `internal/atlasreport/schema_inspect.go` — git auto-merged the **body** of `atlasSchemaInspectJSON`, keeping master's `schema.Schemas` loop *and* the seed, and conflicted only on the doc comment. Taking either side of that comment would have left a tree that compiles, passes `go build`, and reintroduces the divergence. Resolved by keeping master's construction and deleting the seed; the net diff of that file against `master` is now the 6.2 deduplication and one doc paragraph.
- `cmd/atlas/atlas_test.go` — both sides had reached the same assertion by different routes; master's comment is the accurate one and was kept.

Conflict-marker grep over the tree is empty. `go build ./...` and `go vet ./...` were run on the rebased tree before anything else.

## Gates

Every one run from the worktree root on the rebased tree, exit codes read directly and never through a pipe.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1 -timeout 40m` | 0 — 187 packages `ok`, zero `FAIL` lines |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci`, every `check:*`, every `*:selftest`, `npm run build` | 0 |

None of these can see a parity defect, which is why every behavior claim above comes from a live database and the pinned binary instead.

## What could not be measured

**8.5, the orphan revision row, is not in this PR and was not measured.** Its fixture needs a hand-written three-migration directory carrying a valid `atlas.sum`, and the only way to produce one on the command line is `migrate hash`, which this session's command guard refuses on every spelling. Confirmed the fixture is unreachable rather than assumed: both binaries refuse an unhashed directory with `checksum file not found`, exit 1. 8.2 (goose zero padding) is blocked by the same constraint, exactly as PR #1308 recorded.

## Group 7 is untouched, on purpose

7.1 and 7.2 need a decision the owner has not made: whether a two-part `--exclude` selector means `schema.table` (Ptah) or `table.column` (the pinned binary). The issue itself flags that the binary's reading arguably *is* the defect and Ptah's is more useful, so matching it would be reproducing one. Left alone and left open.

## Still open in the register

Closed **here**: **6.2, 8.6, 8.7, 9.3, 9.4**.

Closed **elsewhere**, confirmed rather than assumed: **6.1** by #1264 / #1275 on `master` — re-measured on this head, an empty database answers `{"schemas":[{"name":"main"}]}` on SQLite and `{"schemas":[{"name":"public","comment":"standard public schema"}]}` on PostgreSQL 17, byte-identically. **5.1** and **5.2** by #1308, measured at `fc77c58c` in the previous session on this branch and not re-measured on this head. 2.2 and 9.9 were recorded closed by #1308's own re-measurement.

Open, by number, so the next pass has an inventory:

- **Group 1** — 1.1, 1.2, 1.3, 1.4. No default Atlas report-envelope renderer; `--dry-run` still shows no SQL.
- **Group 2** — 2.1 (MF101 not implemented). 2.2 closed earlier.
- **Group 3** — 3.1, 3.2 (progress chatter on `migrate new` stdout; still reproduces on this head — the pinned binary writes 0 bytes and `ptah-compat` writes `Generated empty migration file: …`), 3.3, 3.4.
- **Group 4** — 4.1, 4.2 (the missing `PRAGMA foreign_keys` bracketing, the one correctness gap in that group), 4.3, 4.4, 4.5, 4.6, 4.7, 4.8 (index ordering; the 6.2 fixture still shows Ptah's index order differing from the binary's now that the *set* matches — measured on this head).
- **Group 6** — 6.4, 6.5, 6.6, 6.7. 6.3 landed earlier; 6.1 is closed on master; 6.2 closes here.
- **Group 7** — 7.1, 7.2. Blocked on an owner decision, see above.
- **Group 8** — 8.1, 8.3, 8.4, 8.5, 8.8. 8.2 not measurable in this session. 8.8 was triaged by #1308 as a case where the binary is the destructive one and rule (b) keeps Ptah's behavior.
- **Group 9** — 9.1, 9.2 (triaged by #1308 as the binary's slip), 9.5, 9.6, 9.7, 9.8, 9.10, 9.11, 9.12 `[carried over]`, 9.13, 9.14.

Plus the one this branch found and did not fix: `migrate status` exits 1 on a `<version>_x.down.sql` file the pinned binary writes and reads at exit 0.

## Compatibility

Nothing here makes `ptah-compat` exit 0 where the pinned binary exits 1. The one new refusal goes the other way and is argued above. `migrate new` file names change for anyone relying on Ptah's rewriting — pre-v1, so no compatibility with older Ptah is owed, and the compatibility that matters improves. No native `ptah` behavior is weakened: the native `schema apply` sentence, the native paired migration layout and `migrate checkpoint` are all unchanged.