### PR TITLE
Let migrate diff write the layout its --dir names (#1013)

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -246,6 +246,19 @@ jobs:
           go test -tags=integration ./migration/generator -list '^TestReverseViewLikeObjects_DownRoundTrip_Integration$' | grep -q '^TestReverseViewLikeObjects_DownRoundTrip_Integration$'
           go test -v -count=1 -tags=integration ./migration/generator -run '^TestReverseViewLikeObjects_DownRoundTrip_Integration$' -timeout 5m
 
+      # The rollback of a migration that DROPS a table has to re-create it, and
+      # the version this gate was added for rendered a perfectly good CREATE
+      # TABLE and was then refused at `ALTER TABLE ... ADD PRIMARY KEY` because
+      # the re-created table already carried one. Only a server can say that.
+      # The -list line is the same guard the step above uses: a test that stopped
+      # existing must fail here rather than be silently not run.
+      - name: Run dropped-table rollback round trip
+        env:
+          POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test -tags=integration ./migration/generator -list '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$' | grep -q '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$'
+          go test -v -count=1 -tags=integration ./migration/generator -run '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$' -timeout 5m
+
       - name: Run database-realm cleanup and replay tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/cmd/atlas/migrate_diff.go
+++ b/cmd/atlas/migrate_diff.go
@@ -19,6 +19,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/migration/generator"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -74,7 +75,7 @@ diff policy values.`,
 	flags.StringArrayVar(&opts.toURLs, "to", nil, "Desired schema target URL")
 	flags.StringVar(&opts.devURL, "dev-url", "", "Dev database URL used to replay migrations and compute the diff")
 	flags.StringVar(&opts.dirURL, "dir", "file://migrations", "Migration directory URL")
-	flags.StringVar(&opts.dirFormat, "dir-format", "atlas", "Migration directory format; only atlas is implemented")
+	flags.StringVar(&opts.dirFormat, "dir-format", "atlas", "Migration directory format")
 	flags.StringVar(&opts.format, "format", "", "Atlas Go template output format")
 	registerAtlasSchemaFlag(flags, &opts.schemas, "Schemas to diff")
 	flags.StringVar(&opts.lockTimeout, "lock-timeout", "", "Timeout for acquiring Atlas migration directory locks")
@@ -177,20 +178,18 @@ func runAtlasMigrateDiff(
 			err,
 		))
 	}
-	// A foreign layout named by the QUERY stays refused, because this verb
-	// WRITES and Ptah plans no reverse SQL for the layouts that carry one
-	// (stokaro/ptah#1013 section 1). Named by `--dir-format` it is refused too,
-	// but after the gate, in [prepareAtlasMigrateDiffSource].
-	if err := checkWritingVerbDirQuery(dirFormat, localDir.Query); err != nil {
-		return cmdutil.Fail(cmd, fmt.Errorf("atlas migrate diff --dir: %w", err))
-	}
-	// Positioned after both format refusals above and before the atlas.sum gate
+	// Positioned after the format refusal above and before the atlas.sum gate
 	// below, which is where every verb that reads a `--dir` query reports it;
 	// see [reportIgnoredDirQuery] for the two rules that fix the position.
 	if err := reportIgnoredDirQuery(cmd.ErrOrStderr(), "diff", localDir.Query); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	if err := verifyAtlasWriteDirChecksum(cmd, project, localDir); err != nil {
+	// The gate runs over the SELECTED layout's covered set. On a foreign layout
+	// that is not the Atlas set — golang-migrate's atlas.sum covers the
+	// `.up.sql` halves alone — so verifying the Atlas one here would refuse a
+	// directory the community binary, and this binary's own `migrate hash`,
+	// both call clean.
+	if err := verifyAtlasWriteDirChecksum(cmd, project, localDir, dirFormat); err != nil {
 		return err
 	}
 	migrationsDir, err := resolveMigrateDiffDirectory(localDir)
@@ -261,13 +260,24 @@ func runAtlasMigrateDiff(
 		SourceConnectTimeout: dbcli.DefaultConnectTimeout,
 		Name:                 name,
 		Format:               format,
-		Schemas:              opts.schemas,
-		LockTimeout:          lockTimeout,
-		Policy:               policy,
-		Qualifier:            qualifier,
-		DryRun:               opts.dryRun,
-		Vars:                 schemaVars,
-		PreparePublication:   preparePublication,
+		// The layout both spellings resolved to, carried through as one value.
+		// The writer converts the existing directory through it, names and
+		// composes the new files in it, and hashes its covered set.
+		DirFormat: dirFormat,
+		// The reverse rule `migration/generator` has always applied to its own
+		// `.down.sql` half, injected rather than imported: that package imports
+		// this command tree's library half in ten places, so the dependency
+		// cannot be pointed the other way (stokaro/ptah#1013). Every layout but
+		// the native Atlas one carries a rollback half, and this is what fills
+		// it.
+		PlanReverse:        generator.ReverseSchemaDiff,
+		Schemas:            opts.schemas,
+		LockTimeout:        lockTimeout,
+		Policy:             policy,
+		Qualifier:          qualifier,
+		DryRun:             opts.dryRun,
+		Vars:               schemaVars,
+		PreparePublication: preparePublication,
 		// The same predicate the preflight above already applied, re-applied to
 		// the locked snapshot. Passing it in is what keeps this verb from
 		// carrying a second definition of a verified directory: without it the
@@ -275,7 +285,7 @@ func runAtlasMigrateDiff(
 		// lost its sum between the preflight and the lock would be written to
 		// and re-hashed.
 		VerifyDir: func(fsys fs.FS) error {
-			return checkNativeAtlasDirChecksum(cmd, fsys)
+			return checkAtlasWriteDirChecksum(cmd, fsys, dirFormat)
 		},
 		// Checked here rather than on the way in, because that is where the
 		// community binary decides it: a name it cannot turn into a file refuses
@@ -355,10 +365,17 @@ func needsAtlasMigrateDiffConfig(cmd *cobra.Command) bool {
 //
 // dirFormat arrives already resolved from both spellings rather than being
 // re-derived from opts.dirFormat here, so "which layout is this run writing"
-// has one answer. The refusal of a foreign layout stays at this position — after
-// the atlas.sum gate — because that is where the community binary refuses it:
-// measured on the pinned v1.3.0, an unhashed directory with `--dir-format goose`
-// prints the checksum error, not a format complaint.
+// has one answer.
+//
+// A foreign layout used to be refused at this position. It is not any more:
+// stokaro/ptah#1013 taught this verb to write the five external layouts, so the
+// value is now carried into the writer instead. What did NOT move is the
+// position of the value's own validation — an unparsable `--dir-format ATLAS`
+// is still refused ahead of the atlas.sum gate by
+// [resolveWritingVerbDirFormat], and a parsable foreign one still reaches the
+// gate first, which is where the community binary answers it: measured on the
+// pinned v1.3.0, an unhashed directory with `--dir-format goose` prints the
+// checksum error, not a format complaint.
 func prepareAtlasMigrateDiffSource(
 	opts atlasMigrateDiffOptions,
 	dirFormat atlasmigrateimport.Format,
@@ -370,8 +387,15 @@ func prepareAtlasMigrateDiffSource(
 	if strings.TrimSpace(opts.devURL) == "" {
 		return atlassource.Set{}, fmt.Errorf("--dev-url is required")
 	}
-	if !atlasmigrate.ReadsNativeAtlasDir(dirFormat) {
-		return atlassource.Set{}, fmt.Errorf("atlas migrate diff currently writes Atlas-format migration directories only")
+	if opts.edit && !atlasmigrate.ReadsNativeAtlasDir(dirFormat) {
+		// `migrate new` draws the same line, for the same reason: the editor
+		// opens the staged files and the operator's edits are then hashed, and
+		// on a layout whose rollback half is a second file or a directive
+		// section that promise is one this surface has not measured.
+		return atlassource.Set{}, fmt.Errorf(
+			"atlas migrate diff --edit: --edit applies only to an atlas directory, but this directory is read as %s",
+			dirFormat,
+		)
 	}
 	if opts.edit && opts.dryRun {
 		return atlassource.Set{}, fmt.Errorf("atlas migrate diff --edit cannot be combined with --dry-run: dry runs write no migration file to edit")

--- a/cmd/atlas/migrate_diff_dir_format_test.go
+++ b/cmd/atlas/migrate_diff_dir_format_test.go
@@ -162,8 +162,17 @@ func TestCompatMigrateDiff_DirFormatValueIsParsedVerbatim(t *testing.T) {
 // green result would also be produced by "any query at all disables
 // --dir-format", which is a different and wrong rule: an unrecognized key
 // selects no layout, so the flag still decides and its refusal stands.
+//
+// The REASON those two exit 1 changed with stokaro/ptah#1013, while the exit
+// code did not. `--dir-format golang-migrate` used to be refused as a layout
+// this verb could not write; it is now honored, and the refusal comes from the
+// gate instead — read as golang-migrate this hashed Atlas directory covers no
+// file, so its atlas.sum entry reads as removed. Measured on the pinned
+// community binary v1.3.0 on 2026-08-08, that binary answers the same two rows
+// with `checksum mismatch` and `L2: …_init.sql was removed`, which is the
+// message below.
 func TestCompatMigrateDiff_DirQueryFormatOutranksDirFormatFlag(t *testing.T) {
-	const refused = `atlas migrate diff currently writes Atlas-format migration directories only`
+	const refused = `checksum mismatch`
 
 	tests := []struct {
 		name      string
@@ -214,58 +223,70 @@ func TestCompatMigrateDiff_DirQueryFormatOutranksDirFormatFlag(t *testing.T) {
 	}
 }
 
-// TestCompatMigrateDiff_ForeignQueryFormatStaysRefusedOnEveryLayout pins the one
-// cell of stokaro/ptah#1013 that is still open, across the whole format axis
-// rather than on the single layout the issue names.
+// TestCompatMigrateDiff_QueryFormatDecidesHowTheDirIsRead pins what `?format=`
+// does to a NATIVE Atlas directory on this verb, across the whole format axis.
 //
-// Measured on the pinned community binary v1.3.0 on 2026-08-07, running
-// `migrate diff` into an empty directory once per layout, the binary exits 0 and
-// writes REVERSE SQL as well as forward SQL in every one of them — a second file
-// for golang-migrate (`.down.sql`) and flyway (`U…__….sql`), a directive section
-// in the same file for goose (`-- +goose Down`) and dbmate (`-- migrate:down`),
-// and one `--rollback:` line per forward statement for liquibase. Ptah's
-// `migrate diff` plans forward statements only, so honoring the query would
-// write a directory whose rollback half is missing or empty. Refusing is the
-// strict side and never exits 0 where the community binary exits 1.
+// It used to pin the opposite — every foreign value refused with one message —
+// and that refusal is what stokaro/ptah#1013 closed. What replaces it is not
+// "all six accepted": the layout decides how the existing directory is READ, so
+// on a directory whose files are Atlas-shaped the answer differs per layout, and
+// each row below was measured on the pinned community binary v1.3.0 on
+// 2026-08-08 against a PostgreSQL dev database, on this fixture's shape.
 //
-// All five rows are here because the layouts do not close together: the paired
-// ones are the cheap half, and a change that taught this verb golang-migrate
-// alone would leave the other four silently refusing while a single-layout test
-// stayed green. The `?format=atlas` control is what shows the refusal turns on
-// the layout and not on the query's presence.
-func TestCompatMigrateDiff_ForeignQueryFormatStaysRefusedOnEveryLayout(t *testing.T) {
+//	?format=          community        ptah-compat
+//	golang-migrate    1, mismatch      1, mismatch      covered set is *.up.sql: none, so atlas.sum's entry is "removed"
+//	flyway            1, mismatch      1, mismatch      same, for V…__… names
+//	goose             0, WROTE         0, WROTE         covered set is *.sql, and the file parses as one Goose migration
+//	liquibase         0, WROTE         0, WROTE         same, as one Liquibase changelog
+//	dbmate            0, WROTE         1, refused       see below — the one deliberate divergence
+//	atlas             0, WROTE         0, WROTE         the control
+//
+// The dbmate row is the strict direction and is deliberate. The community
+// binary reads a file carrying no `-- migrate:up` as a migration with NO up
+// SQL: measured, it then plans BOTH tables — the one the existing migration
+// already creates and the new one — so the migration in the directory is
+// silently dropped from the replay. Ptah's dbmate reader refuses that rather
+// than record a migration that can never be re-run, which is older than this
+// change and shared with `migrate apply`, `lint` and `new`. Reproducing it here
+// would be reproducing a defect on the verb that WRITES the file.
+//
+// The `?format=atlas` control is what shows the per-layout answers turn on the
+// layout and not on the query's presence.
+func TestCompatMigrateDiff_QueryFormatDecidesHowTheDirIsRead(t *testing.T) {
 	tests := []struct {
 		name   string
 		format string
 		check  func(c *qt.C, err error, wrote bool)
 	}{
 		{
-			name:   "golang-migrate",
+			name:   "golang-migrate covers no file here",
 			format: "golang-migrate",
-			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("golang-migrate")),
+			check:  refusedWithoutWriting(`checksum mismatch`),
 		},
 		{
-			name:   "goose",
-			format: "goose",
-			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("goose")),
-		},
-		{
-			name:   "flyway",
+			name:   "flyway covers no file here",
 			format: "flyway",
-			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("flyway")),
+			check:  refusedWithoutWriting(`checksum mismatch`),
 		},
 		{
-			name:   "liquibase",
+			name:   "goose reads the file and writes",
+			format: "goose",
+			check:  acceptedAndWrote,
+		},
+		{
+			name:   "liquibase reads the file and writes",
 			format: "liquibase",
-			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("liquibase")),
+			check:  acceptedAndWrote,
 		},
 		{
-			name:   "dbmate",
+			name:   "dbmate refuses a file its directives do not cover",
 			format: "dbmate",
-			check:  refusedWithoutWriting(compatDiffForeignFormatRefusal("dbmate")),
+			check: refusedWithoutWriting(
+				`read migration directory as dbmate: migration file [^ ]+ carries no "-- migrate:up" directive.*`,
+			),
 		},
 		{
-			name:   "atlas is not refused",
+			name:   "atlas",
 			format: "atlas",
 			check:  acceptedAndWrote,
 		},
@@ -280,11 +301,6 @@ func TestCompatMigrateDiff_ForeignQueryFormatStaysRefusedOnEveryLayout(t *testin
 			tt.check(c, err, wrote)
 		})
 	}
-}
-
-func compatDiffForeignFormatRefusal(format string) string {
-	return `atlas migrate diff --dir: Atlas accepts \?format=` + format +
-		`, but Ptah does not implement that directory format for this command yet`
 }
 
 // refusedWithoutWriting builds the assertion for a row the compat surface must

--- a/cmd/atlas/migrate_diff_foreign_layout_rollback_test.go
+++ b/cmd/atlas/migrate_diff_foreign_layout_rollback_test.go
@@ -1,0 +1,182 @@
+package atlas_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// This file is the DROP half of stokaro/ptah#1013's coverage. Every other
+// fixture in this package's `migrate diff` tests is CREATE-only, and the
+// reverse of a create is a DROP TABLE against either schema — so none of them
+// can tell a reverse planned against the pre-change state from one planned
+// against the desired state, and none of them exercises what a rollback has to
+// REBUILD.
+//
+// The fixture here starts from a directory that already created two tables and
+// asks for one of them to go away. That makes the forward half a DROP and the
+// rollback half a CREATE, which is the only shape where the two ways of getting
+// the reverse wrong become visible:
+//
+//   - planned against `desired`, the rollback has nothing to re-create and the
+//     `.down.sql` is written EMPTY; and
+//   - planned without the rule that a re-created table brings its own
+//     constraints, the rollback repeats them and the server refuses it.
+
+// compatDroppedTableFixture writes a hashed golang-migrate directory that
+// already created `widgets` and `gadgets` — the latter with a primary key and a
+// foreign key — and returns it with a desired-state file that no longer
+// declares `gadgets`.
+func compatDroppedTableFixture(c *qt.C) (dir, target string) {
+	c.Helper()
+	dir = filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_init.up.sql"),
+		[]byte(compatDroppedTableSchema),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_init.down.sql"),
+		[]byte("DROP TABLE gadgets;\nDROP TABLE widgets;\n"),
+		0o600,
+	), qt.IsNil)
+	_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir+"?format=golang-migrate")
+	c.Assert(err, qt.IsNil)
+
+	target = filepath.Join(c.TempDir(), "target.sql")
+	c.Assert(os.WriteFile(
+		target,
+		[]byte("CREATE TABLE widgets (id INTEGER NOT NULL PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	return dir, target
+}
+
+const compatDroppedTableSchema = "CREATE TABLE widgets (id INTEGER NOT NULL PRIMARY KEY);\n" +
+	"CREATE TABLE gadgets (\n" +
+	"  id INTEGER NOT NULL PRIMARY KEY,\n" +
+	"  widget_id INTEGER CONSTRAINT gadgets_widget_fk REFERENCES widgets (id)\n" +
+	");\n"
+
+// TestCompatMigrateDiff_ForeignLayoutRollbackRebuildsTheDroppedTable is the
+// completion criterion for the rollback half of `migrate diff` on a foreign
+// layout, and it is applied rather than read.
+//
+// The forward half drops `gadgets`. The rollback half therefore has to CREATE
+// it, and the assertion is that a database taken through both halves ends up
+// holding the table again, with the foreign key it had. A rollback planned
+// against the desired state leaves an empty `.down.sql` here, which the
+// execution step reports as the table never coming back.
+func TestCompatMigrateDiff_ForeignLayoutRollbackRebuildsTheDroppedTable(t *testing.T) {
+	c := qt.New(t)
+	dir, target := compatDroppedTableFixture(c)
+
+	_, _, err := runCompat("migrate", "diff", "drop",
+		"--dir", "file://"+dir+"?format=golang-migrate",
+		"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+		"--to", "file://"+target)
+	c.Assert(err, qt.IsNil)
+
+	names := atlasDirEntryNames(c, dir)
+	forward := compatReadMigrationFile(c, dir, compatNewestNameWithSuffix(c, names, ".up.sql"))
+	c.Assert(strings.ToUpper(forward), qt.Contains, "DROP TABLE",
+		qt.Commentf("the forward half must be the drop this fixture asks for"))
+
+	rollbackName := compatNewestNameWithSuffix(c, names, ".down.sql")
+	rollback := compatReadMigrationFile(c, dir, rollbackName)
+	c.Assert(strings.ToUpper(rollback), qt.Contains, "CREATE TABLE",
+		qt.Commentf("%s carries no rebuild; a reverse planned against the desired "+
+			"state has nothing to re-create:\n%s", rollbackName, rollback))
+
+	// Rendered is not applied. Take a database through the whole history and
+	// then through the rollback, and read the catalog back.
+	dbPath := filepath.Join(c.TempDir(), "target.db")
+	compatExecSQL(c, dbPath, compatDroppedTableSchema, "SEED")
+	compatExecSQL(c, dbPath, forward, "FORWARD")
+	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "gadgets",
+		qt.Commentf("the forward half must really drop the table, or the rollback proves nothing"))
+
+	compatExecSQL(c, dbPath, rollback, "ROLLBACK")
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "gadgets",
+		qt.Commentf("rollback SQL:\n%s", rollback))
+	c.Assert(compatForeignKeyNames(c, dbPath, "gadgets"), qt.Contains, "gadgets_widget_fk",
+		qt.Commentf("the rollback must restore the table's foreign key:\n%s", rollback))
+}
+
+func compatReadMigrationFile(c *qt.C, dir, name string) string {
+	c.Helper()
+	contents, err := os.ReadFile(filepath.Join(dir, name))
+	c.Assert(err, qt.IsNil)
+	return string(contents)
+}
+
+// compatExecSQL applies every statement of a migration half to a SQLite
+// database, failing on the first one the engine refuses. A half that renders
+// and does not apply is the failure this test exists to catch.
+func compatExecSQL(c *qt.C, dbPath, sqlText, label string) {
+	c.Helper()
+	conn := compatConnect(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+	for _, statement := range migrator.SplitSQLStatements(sqlText) {
+		compatExecStatement(c, conn, statement, label)
+	}
+}
+
+func compatExecStatement(c *qt.C, conn *dbschema.DatabaseConnection, statement, label string) {
+	c.Helper()
+	trimmed := strings.TrimSpace(statement)
+	c.Assert(compatExecNonEmpty(conn, trimmed), qt.IsNil,
+		qt.Commentf("%s statement must apply cleanly:\n%s", label, trimmed))
+}
+
+func compatExecNonEmpty(conn *dbschema.DatabaseConnection, statement string) error {
+	if statement == "" {
+		return nil
+	}
+	_, err := conn.Exec(statement)
+	return err
+}
+
+func compatConnect(c *qt.C, dbPath string) *dbschema.DatabaseConnection {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), atlasurl.SQLiteURLFromPath(dbPath))
+	c.Assert(err, qt.IsNil)
+	return conn
+}
+
+func compatForeignKeyNames(c *qt.C, dbPath, table string) []string {
+	c.Helper()
+	var names []string
+	for _, constraint := range compatReadSchema(c, dbPath).Constraints {
+		names = append(names, compatForeignKeyName(constraint, table)...)
+	}
+	slices.Sort(names)
+	return names
+}
+
+func compatForeignKeyName(constraint dbschematypes.DBConstraint, table string) []string {
+	if constraint.Type != "FOREIGN KEY" || constraint.TableName != table {
+		return nil
+	}
+	return []string{constraint.Name}
+}
+
+func compatReadSchema(c *qt.C, dbPath string) *dbschematypes.DBSchema {
+	c.Helper()
+	conn := compatConnect(c, dbPath)
+	defer dbschema.CloseAndWarn(conn)
+	schema, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	return schema
+}

--- a/cmd/atlas/migrate_diff_foreign_layout_test.go
+++ b/cmd/atlas/migrate_diff_foreign_layout_test.go
@@ -1,0 +1,287 @@
+package atlas_test
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// These tests pin the last cell of stokaro/ptah#1013: `migrate diff` writing a
+// migration directory in a layout other than the native Atlas one.
+//
+// Measured against the pinned community binary v1.3.0 on 2026-08-08, against a
+// PostgreSQL dev database, running `migrate diff` into an EMPTY directory once
+// per layout. That binary exits 0 on all five and writes reverse SQL as well as
+// forward SQL, in three different shapes:
+//
+//	golang-migrate  20260808232952_demo.up.sql + 20260808232952_demo.down.sql
+//	flyway          V20260808233006__demo.sql  + U20260808233006__demo.sql
+//	goose           one file: "-- +goose Up" … "-- +goose Down" …
+//	dbmate          one file: "-- migrate:up" … "-- migrate:down" …
+//	liquibase       one file: "--changeset atlas:<v>-1" … "--rollback: …"
+//
+// Ptah refused every one of them until this change, because its `migrate diff`
+// planned forward statements only. It now injects the reverse rule
+// `migration/generator` has always applied to its own `.down.sql` half, so the
+// plan carries both directions and each layout composes its own files.
+//
+// The SQL text is Ptah's own renderer's on every layout, including the native
+// one, and always was. Matching the LAYOUT is what these close.
+
+// compatGolangMigrateFixture writes a golang-migrate migration directory
+// holding one hashed migration, and returns it with a desired-state .sql file
+// that adds a second table.
+//
+// The layout is what makes the flip visible rather than an exit 0 that could
+// have happened anyway: `atlas.sum` is written over the golang-migrate covered
+// set, which is the `.up.sql` half alone, so the SAME directory read as native
+// Atlas is a checksum error. Every row below therefore turns on the layout
+// selection and nothing else, and the control row proves it.
+func compatGolangMigrateFixture(c *qt.C) (dir, target string) {
+	c.Helper()
+	dir = filepath.Join(c.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_init.up.sql"),
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	c.Assert(os.WriteFile(
+		filepath.Join(dir, "1_init.down.sql"),
+		[]byte("DROP TABLE widgets;\n"),
+		0o600,
+	), qt.IsNil)
+	_, _, err := runCompat("migrate", "hash", "--dir", "file://"+dir+"?format=golang-migrate")
+	c.Assert(err, qt.IsNil)
+
+	target = filepath.Join(c.TempDir(), "target.sql")
+	c.Assert(os.WriteFile(
+		target,
+		[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\nCREATE TABLE gadgets (id INTEGER PRIMARY KEY);\n"),
+		0o600,
+	), qt.IsNil)
+	return dir, target
+}
+
+// TestCompatMigrateDiff_GolangMigrateQueryWritesThatLayout is the completion
+// criterion stokaro/ptah#1013 states, with its control.
+//
+// On a golang-migrate directory, `migrate diff demo --dir 'file://gm?format=golang-migrate'`
+// must exit 0 and add a migration in that layout with a refreshed atlas.sum over
+// that layout's covered file set. It exited 1 and wrote nothing before this
+// change. The control must stay red: the same directory with no layout
+// selection keeps exiting 1 with the checksum error, writing nothing, on both
+// tools.
+func TestCompatMigrateDiff_GolangMigrateQueryWritesThatLayout(t *testing.T) {
+	c := qt.New(t)
+	dir, target := compatGolangMigrateFixture(c)
+
+	_, _, err := runCompat("migrate", "diff", "more",
+		"--dir", "file://"+dir+"?format=golang-migrate",
+		"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+		"--to", "file://"+target)
+
+	c.Assert(err, qt.IsNil)
+	names := atlasDirEntryNames(c, dir)
+	c.Assert(compatNamesWithSuffix(names, ".up.sql"), qt.HasLen, 2)
+	c.Assert(compatNamesWithSuffix(names, ".down.sql"), qt.HasLen, 2)
+	// The rollback half of the new migration is real SQL, not the empty file
+	// `migrate new` leaves. A pair whose down half is empty would satisfy the
+	// layout and still hand the operator a migration nothing can roll back.
+	written := compatNewestNameWithSuffix(c, names, ".down.sql")
+	rollback, readErr := os.ReadFile(filepath.Join(dir, written))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(strings.ToUpper(string(rollback)), qt.Contains, "DROP TABLE",
+		qt.Commentf("rollback file %s", written))
+	// atlas.sum covers the forward halves only, which is what the community
+	// binary writes for this layout and what its own `migrate validate` then
+	// accepts. Covering the pair would produce a sum both tools refuse.
+	sum, readErr := os.ReadFile(filepath.Join(dir, "atlas.sum"))
+	c.Assert(readErr, qt.IsNil)
+	c.Assert(strings.Count(string(sum), ".up.sql"), qt.Equals, 2)
+	c.Assert(string(sum), qt.Not(qt.Contains), ".down.sql")
+}
+
+// TestCompatMigrateDiff_GolangMigrateDirIsRefusedWithoutTheLayout is the
+// control arm of the test above, and it is what makes that one a flip rather
+// than an exit 0 that could have happened anyway.
+//
+// The same fixture, the same command, no layout selection: read as native
+// Atlas the covered set includes the `.down.sql` half that atlas.sum never
+// recorded, so both tools report a checksum error and neither writes.
+func TestCompatMigrateDiff_GolangMigrateDirIsRefusedWithoutTheLayout(t *testing.T) {
+	c := qt.New(t)
+	dir, target := compatGolangMigrateFixture(c)
+	before := atlasDirEntryNames(c, dir)
+
+	_, _, err := runCompat("migrate", "diff", "more",
+		"--dir", "file://"+dir,
+		"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+		"--to", "file://"+target)
+
+	c.Assert(err, qt.ErrorMatches, `checksum mismatch`)
+	c.Assert(atlasDirEntryNames(c, dir), qt.DeepEquals, before)
+}
+
+// TestCompatMigrateDiff_DirFormatFlagWritesTheSelectedLayout pins the same
+// completion criterion through the other spelling.
+//
+// The issue's criterion names both: `?format=golang-migrate` and
+// `--dir-format golang-migrate` must reach the same place. They resolve through
+// one function ([resolveWritingVerbDirFormat]) precisely so they cannot drift,
+// and this is the row that would notice if they did.
+func TestCompatMigrateDiff_DirFormatFlagWritesTheSelectedLayout(t *testing.T) {
+	c := qt.New(t)
+	dir, target := compatGolangMigrateFixture(c)
+
+	_, _, err := runCompat("migrate", "diff", "more",
+		"--dir", "file://"+dir,
+		"--dir-format", "golang-migrate",
+		"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+		"--to", "file://"+target)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(compatNamesWithSuffix(atlasDirEntryNames(c, dir), ".up.sql"), qt.HasLen, 2)
+}
+
+// TestCompatMigrateDiff_ForeignLayoutComposesEachLayoutsFiles pins what each
+// layout WRITES, across the whole format axis rather than on the one layout the
+// issue names.
+//
+// All five rows are here because the layouts do not close together: the paired
+// ones (golang-migrate, flyway) put the rollback in a second file, the
+// directive ones (goose, dbmate) put it under a header in the same file, and
+// liquibase attaches it to a changeset. A change that taught this verb
+// golang-migrate alone would leave the other four writing a directory with no
+// rollback half at all while a single-layout test stayed green.
+//
+// Each row asserts the file NAMES the layout requires and a marker of the
+// rollback half, because the exit code alone cannot tell a composed layout from
+// a native Atlas file that happened to be written under a foreign name.
+func TestCompatMigrateDiff_ForeignLayoutComposesEachLayoutsFiles(t *testing.T) {
+	tests := []struct {
+		name   string
+		format string
+		check  func(c *qt.C, dir string, names []string)
+	}{
+		{
+			name:   "golang-migrate writes a pair",
+			format: "golang-migrate",
+			check: func(c *qt.C, dir string, names []string) {
+				c.Assert(compatNamesWithSuffix(names, ".up.sql"), qt.HasLen, 1)
+				assertCompatRollbackSection(c, dir, compatNewestNameWithSuffix(c, names, ".down.sql"), "")
+			},
+		},
+		{
+			name:   "flyway writes a V and a U file",
+			format: "flyway",
+			check: func(c *qt.C, dir string, names []string) {
+				c.Assert(compatNamesWithPrefix(names, "V"), qt.HasLen, 1)
+				assertCompatRollbackSection(c, dir, compatNewestNameWithPrefix(c, names, "U"), "")
+			},
+		},
+		{
+			name:   "goose writes both halves under its directives",
+			format: "goose",
+			check: func(c *qt.C, dir string, names []string) {
+				assertCompatRollbackSection(c, dir, compatNewestNameWithSuffix(c, names, "_demo.sql"), "-- +goose Down")
+			},
+		},
+		{
+			name:   "dbmate writes both halves under its directives",
+			format: "dbmate",
+			check: func(c *qt.C, dir string, names []string) {
+				assertCompatRollbackSection(c, dir, compatNewestNameWithSuffix(c, names, "_demo.sql"), "-- migrate:down")
+			},
+		},
+		{
+			name:   "liquibase attaches the rollback to a changeset",
+			format: "liquibase",
+			check: func(c *qt.C, dir string, names []string) {
+				assertCompatRollbackSection(c, dir, compatNewestNameWithSuffix(c, names, "_demo.sql"), "--rollback: ")
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := filepath.Join(c.TempDir(), "migrations")
+			c.Assert(os.MkdirAll(dir, 0o755), qt.IsNil)
+			target := filepath.Join(c.TempDir(), "target.sql")
+			c.Assert(os.WriteFile(
+				target,
+				[]byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"),
+				0o600,
+			), qt.IsNil)
+
+			_, _, err := runCompat("migrate", "diff", "demo",
+				"--dir", "file://"+dir+"?format="+tt.format,
+				"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
+				"--to", "file://"+target)
+
+			c.Assert(err, qt.IsNil)
+			tt.check(c, dir, atlasDirEntryNames(c, dir))
+		})
+	}
+}
+
+// assertCompatRollbackSection asserts that the named file opens the layout's
+// rollback container AND that real reverse SQL follows it.
+//
+// Both halves are the assertion. The container alone is emitted whether or not
+// anything was planned — an empty `.down.sql`, a bare `-- +goose Down` — so a
+// row that stopped at the container would stay green on a run that planned no
+// reverse at all, which is precisely the state this change moved away from.
+// Measured: with the reverse rule stubbed out to plan nothing, the container
+// assertions still passed on goose and dbmate, and only the DROP TABLE half
+// below failed.
+//
+// opener is "" for the two layouts whose rollback is a file of its own, where
+// the container IS the file.
+func assertCompatRollbackSection(c *qt.C, dir, name, opener string) {
+	c.Helper()
+	contents, err := os.ReadFile(filepath.Join(dir, name))
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(contents), qt.Contains, opener,
+		qt.Commentf("%s does not open the layout's rollback container", name))
+	_, rollback, _ := strings.Cut(string(contents), opener)
+	c.Assert(strings.ToUpper(rollback), qt.Contains, "DROP TABLE",
+		qt.Commentf("%s carries no reverse SQL after %q", name, opener))
+}
+
+func compatNamesWithSuffix(names []string, suffix string) []string {
+	return compatFilterNames(names, func(name string) bool {
+		return strings.HasSuffix(name, suffix)
+	})
+}
+
+func compatNamesWithPrefix(names []string, prefix string) []string {
+	return compatFilterNames(names, func(name string) bool {
+		return strings.HasPrefix(name, prefix) && strings.HasSuffix(name, ".sql")
+	})
+}
+
+func compatFilterNames(names []string, keep func(string) bool) []string {
+	return slices.DeleteFunc(slices.Clone(names), func(name string) bool {
+		return !keep(name)
+	})
+}
+
+func compatNewestNameWithSuffix(c *qt.C, names []string, suffix string) string {
+	c.Helper()
+	matched := compatNamesWithSuffix(names, suffix)
+	c.Assert(len(matched) > 0, qt.IsTrue, qt.Commentf("no file ending %q in %v", suffix, names))
+	return matched[len(matched)-1]
+}
+
+func compatNewestNameWithPrefix(c *qt.C, names []string, prefix string) string {
+	c.Helper()
+	matched := compatNamesWithPrefix(names, prefix)
+	c.Assert(len(matched) > 0, qt.IsTrue, qt.Commentf("no file starting %q in %v", prefix, names))
+	return matched[len(matched)-1]
+}

--- a/cmd/atlas/migrate_dir_query.go
+++ b/cmd/atlas/migrate_dir_query.go
@@ -69,43 +69,28 @@ func atlasDirFormatSpelling(query url.Values) string {
 	return "--dir-format"
 }
 
-// checkWritingVerbDirQuery refuses a foreign layout that the `--dir` QUERY
-// named, for the one verb that WRITES into the directory: `migrate diff`.
+// WHERE THE FOREIGN-LAYOUT REFUSAL WENT. A `checkWritingVerbDirQuery` used to
+// stand here and refuse a foreign layout the `--dir` QUERY named, for the one
+// verb that WRITES into the directory: `migrate diff`. It was the strict side —
+// exit 1 where the community binary exits 0 — and it was there because writing
+// a foreign layout is a different problem from reading one. The reading verbs
+// (hash, validate, lint, status, set) convert a layout in memory and report on
+// it, which is what #992, #1002 and #1133 built; `migrate diff` has to write
+// reverse SQL as well as forward SQL, in five different shapes, and planned no
+// reverse at all.
 //
-// `migrate new` used to share this refusal. It no longer calls here at all —
-// it grew a converted path in stokaro/ptah#845 and honors `?format=goose`
-// today, exit 0 with files in that layout, matching the community binary.
+// stokaro/ptah#1013 closed that. `migration/generator.ReverseSchemaDiff` is now
+// injected into the writer as [go.5x5.cz/ptah/internal/atlasmigrate.DiffOptions.PlanReverse],
+// the plan carries both directions, and each layout composes its own files. The
+// refusal is gone because the capability it stood in for arrived, which is the
+// only reason to remove a refusal of this kind.
 //
-// Writing a foreign layout is a different problem from reading one. The reading
-// verbs — hash, validate, lint, status, set — convert a foreign layout in
-// memory and report on it, which is what #992, #1002 and #1133 built. Measured
-// against the pinned community binary v1.3.0 on 2026-08-07, `migrate diff` in a
-// foreign layout writes reverse SQL as well as forward SQL, in five different
-// shapes: golang-migrate and flyway put it in a second file, goose and dbmate
-// put it under a directive in the same file, and liquibase interleaves one
-// `--rollback:` line per forward statement. Ptah's `migrate diff` plans forward
-// statements only, so honoring the query here would write a directory whose
-// rollback half is missing or empty. Refusing is the strict side: it never
-// exits 0 where the community binary exits 1. stokaro/ptah#1013 tracks the gap.
-//
-// The refusal is limited to the query spelling deliberately. `--dir-format`
-// naming a foreign layout is refused too, but AFTER the atlas.sum gate, because
-// that is where the community binary refuses it: on an unhashed directory
-// `migrate diff demo --dir file://d --dir-format goose` prints the checksum
-// error there, not a format complaint, while `--dir-format ATLAS` — a value it
-// cannot parse at all — prints `unknown dir format` ahead of the gate.
-//
-// An empty `?format=` value selects the native Atlas layout and passes, which
-// is what the community binary does with it too.
-func checkWritingVerbDirQuery(format atlasmigrateimport.Format, query url.Values) error {
-	if atlasmigrate.ReadsNativeAtlasDir(format) || !atlasmigrate.DirFormatFromQuery(query) {
-		return nil
-	}
-	return fmt.Errorf(
-		"Atlas accepts ?format=%s, but Ptah does not implement that directory format for this command yet",
-		format,
-	)
-}
+// What did NOT change is the position of the two checks around it:
+// [resolveWritingVerbDirFormat] still refuses an unparsable value ahead of the
+// atlas.sum gate, and a parsable foreign one still reaches the gate first —
+// measured on the pinned community binary v1.3.0, an unhashed directory with
+// `--dir-format goose` prints the checksum error there, not a format complaint,
+// while `--dir-format ATLAS` prints `unknown dir format` ahead of the gate.
 
 // dirQueryStrictEnvVar turns the report below into a refusal.
 //

--- a/cmd/atlas/migrate_dir_query_test.go
+++ b/cmd/atlas/migrate_dir_query_test.go
@@ -148,57 +148,21 @@ func TestCompatMigrateDirQuery_IgnoresUnknownKeysOnEveryVerb(t *testing.T) {
 	}
 }
 
-// TestCompatMigrateDirQuery_FailurePathForeignFormat pins the part of the query
-// that is NOT ignored on the one verb that still refuses a foreign layout.
+// WHERE THE `migrate diff` FOREIGN-FORMAT REFUSAL WENT. A
+// TestCompatMigrateDirQuery_FailurePathForeignFormat used to stand here and pin
+// the one verb that still refused a `?format=goose` outright. It was the guard
+// on the unknown-key relaxation: once an unrecognized key is dropped, nothing
+// else stops a `?format=goose` from being dropped with it and the directory
+// being read as Atlas, which on a writing verb would gate the wrong covered set
+// and then write.
 //
-// The community binary honors `?format=` on every verb. Ptah converts a foreign
-// layout for every verb that READS one — hash and validate since #992, status
-// and set since #1002, lint since #1133 — and, since stokaro/ptah#845, for
-// `migrate new`, which WRITES one. `migrate diff` is the last verb that refuses,
-// because it emits a planned migration and nothing writes SQL in a foreign
-// tool's convention yet; refusing is the strict side of the divergence, and it
-// never exits 0 where the community binary exits 1.
-//
-// The refusal has to survive the relaxation above, which is why it is pinned:
-// once unknown keys are ignored, nothing else stops a `?format=goose` from
-// being ignored too and the directory being silently read as Atlas — which on a
-// writing verb would gate the wrong covered file set and then write.
-//
-// Reverted, this row still passes; it is the guard on the relaxation, not on
-// the #845 change. The `migrate new` half moved to
-// TestCompatMigrateNewConverted_QuerySpellingWritesTheSelectedLayout.
-func TestCompatMigrateDirQuery_FailurePathForeignFormat(t *testing.T) {
-	const want = `atlas migrate \w+ --dir: Atlas accepts \?format=goose, ` +
-		`but Ptah does not implement that directory format for this command yet`
-
-	tests := []struct {
-		name string
-		run  func(c *qt.C, dir string) error
-	}{
-		{
-			name: "diff",
-			run: func(c *qt.C, dir string) error {
-				target := filepath.Join(c.TempDir(), "target.sql")
-				c.Assert(os.WriteFile(target, []byte("CREATE TABLE widgets (id INTEGER PRIMARY KEY);\n"), 0o600), qt.IsNil)
-				_, _, err := runCompat("migrate", "diff", "dd",
-					"--dir", "file://"+dir+"?format=goose",
-					"--dev-url", "sqlite://"+filepath.Join(c.TempDir(), "dev.db"),
-					"--to", "file://"+target)
-				return err
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			c := qt.New(t)
-
-			err := tt.run(c, writeQueryFixtureDir(c))
-
-			c.Assert(err, qt.ErrorMatches, want)
-		})
-	}
-}
+// stokaro/ptah#1013 closed that cell — `migrate diff` writes the five external
+// layouts now — so the refusal it pinned no longer exists. The guard it
+// provided did not go with it: TestCompatMigrateDirQuery_RejectsUnknownFormatValue
+// below still fires if the format KEY's value stops being read, and
+// TestCompatMigrateDiff_GolangMigrateQueryWritesThatLayout in
+// migrate_diff_foreign_layout_test.go fires if the value stops SELECTING the
+// layout, with a control row that stays red when no layout is named.
 
 // TestCompatMigrateDirQuery_RejectsUnknownFormatValue pins the part of the
 // query that is NOT ignored: the `format` key's value.

--- a/cmd/atlas/migrate_dir_source.go
+++ b/cmd/atlas/migrate_dir_source.go
@@ -32,15 +32,16 @@ import (
 // it honors `?format=goose` today, exit 0, files in that layout, matching the
 // community binary.
 //
-// What keeps `migrate diff` out is narrower and is what remains of
-// stokaro/ptah#1013: the verbs in this file READ a foreign layout, and reading
-// one is a conversion in memory. `migrate diff` WRITES one, and measured on the
-// pinned community binary v1.3.0 every foreign layout it writes carries reverse
-// SQL -- a second file for golang-migrate and flyway, a directive section for
-// goose and dbmate, and one `--rollback:` line per forward statement for
-// liquibase. Ptah's diff plans forward statements only, so routing it through
-// here would write a directory whose rollback half is missing. Refusing is the
-// strict side; see [checkWritingVerbDirQuery].
+// `migrate diff` is out for a reason that no longer has anything to do with
+// refusing a layout. It honors `?format=goose` too since stokaro/ptah#1013 --
+// exit 0, files in that layout, atlas.sum over that layout's covered set. What
+// keeps it out of THIS file is that the verbs here READ a directory, and
+// reading one is a conversion in memory; `migrate diff` also WRITES one, so it
+// resolves the same value through [resolveWritingVerbDirFormat] and then
+// carries it into the writer, which converts, names, composes and hashes per
+// layout. Both spellings and both resolvers land on
+// [atlasmigrate.ResolveApplyDirFormat], so the two paths cannot drift on which
+// spelling wins or on which values are accepted.
 
 // resolveAtlasVerbDirFormat resolves the directory layout a compat verb reads,
 // from both spellings that can carry it, and blames the one that did.

--- a/cmd/atlas/migrate_integrity_gate.go
+++ b/cmd/atlas/migrate_integrity_gate.go
@@ -11,6 +11,7 @@ import (
 
 	"go.5x5.cz/ptah/cmd/migratevalidate"
 	"go.5x5.cz/ptah/internal/atlasargs"
+	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -178,7 +179,18 @@ func checkCoveredAtlasEntriesReadable(cmd *cobra.Command, fsys fs.FS, names []st
 // nothing to verify and says so by returning nil. The remaining exemptions —
 // an empty directory, one holding no top-level *.sql — belong to
 // [failUnhashedAtlasDir] and are shared with every other verb.
-func verifyAtlasWriteDirChecksum(cmd *cobra.Command, project atlasProject, dir atlasargs.LocalDir) error {
+// The format parameter is the layout the run SELECTED, and the gate runs over
+// that layout's covered set rather than the Atlas one. `migrate diff` can be
+// pointed at a foreign layout since stokaro/ptah#1013; verifying a
+// golang-migrate directory as if it were an Atlas one would refuse the pair it
+// legitimately holds — atlas.sum covers the `.up.sql` halves alone there — and
+// then rewrite the sum over the wrong set.
+func verifyAtlasWriteDirChecksum(
+	cmd *cobra.Command,
+	project atlasProject,
+	dir atlasargs.LocalDir,
+	format atlasmigrateimport.Format,
+) error {
 	source, err := project.captureLocal(dir)
 	if errors.Is(err, fs.ErrNotExist) {
 		return nil
@@ -186,7 +198,27 @@ func verifyAtlasWriteDirChecksum(cmd *cobra.Command, project atlasProject, dir a
 	if err != nil {
 		return err
 	}
-	return verifyNativeAtlasDirChecksum(cmd, source.FileSystem)
+	if atlasmigrate.ReadsNativeAtlasDir(format) {
+		return verifyNativeAtlasDirChecksum(cmd, source.FileSystem)
+	}
+	return verifyCoveredAtlasDirChecksum(cmd, source.FileSystem, format, requireAtlasSum)
+}
+
+// checkAtlasWriteDirChecksum is the refusal half of the writing gate for an
+// already-captured filesystem, dispatched on the selected layout.
+//
+// It is what a writing verb re-checks the LOCKED snapshot with, so the
+// predicate that refused before the lock and the predicate that refuses under
+// it are one definition rather than two that have to agree.
+func checkAtlasWriteDirChecksum(
+	cmd *cobra.Command,
+	fsys fs.FS,
+	format atlasmigrateimport.Format,
+) error {
+	if atlasmigrate.ReadsNativeAtlasDir(format) {
+		return checkNativeAtlasDirChecksum(cmd, fsys)
+	}
+	return verifyCoveredAtlasDirChecksum(cmd, fsys, format, requireAtlasSum)
 }
 
 // verifyNativeAtlasDirChecksum enforces the atlas.sum integrity gate on a

--- a/cmd/atlas/migrate_new.go
+++ b/cmd/atlas/migrate_new.go
@@ -58,7 +58,7 @@ func newAtlasMigrateNewCommand() *cobra.Command {
 			// verify here would change that message and verify nothing.
 			return forward(cmd, source.forwardArgs)
 		}
-		if err := verifyAtlasWriteDirChecksum(cmd, source.project, source.localDir); err != nil {
+		if err := verifyAtlasWriteDirChecksum(cmd, source.project, source.localDir, source.format); err != nil {
 			return err
 		}
 		if err := checkAtlasMigrateNewName(cmd, verb, source.projectArgs); err != nil {

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6548,6 +6548,7 @@ func GenerateCheckpointFromShadow(ctx context.Context, opts CheckpointFromShadow
 func GenerateCheckpointWithDatabase(ctx context.Context, conn *dbschema.DatabaseConnection, ...) (upSQL, downSQL string, err error)
 func GenerateCheckpointWithDatabaseInfo(schema *goschema.Database, info dbschematypes.DBInfo) (upSQL, downSQL string, err error)
 func ResolveAtlasCheckpointVersion(outputDir string) int64
+func ReverseSchemaDiff(diff *types.SchemaDiff, desired *goschema.Database, ...) *types.SchemaDiff
 func VerifyBaselineShadow(ctx context.Context, opts BaselineShadowVerifyOptions) error
 func VerifyRollbackFromShadow(ctx context.Context, opts RollbackFromShadowOptions) error
 func WriteAtlasCheckpointFile(outputDir string, version int64, description, upSQL string) (path string, err error)

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -237,10 +237,22 @@ with `migrate apply`, so relaxing one widens what the integrity gate accepts.
 directory read through `?format=` over the same per-layout file set `hash`
 writes, so what `migrate hash` writes is what `migrate apply` verifies.
 
-`migrate new` writes the selected layout, gating the directory over that
-layout's covered file set first. `migrate diff` is the one verb that still
-refuses a non-`atlas` layout under both spellings: it emits planned migration
-SQL, and nothing writes a migration body in a foreign tool's convention yet.
+`migrate new` and `migrate diff` both write the selected layout, gating the
+directory over that layout's covered file set first. `migrate diff` composes
+each layout's own files: a forward and a rollback file for `golang-migrate`
+(`.up.sql` / `.down.sql`) and `flyway` (`V…` / `U…`), both halves under
+directives in one file for `goose` and `dbmate`, and a changeset carrying
+`--rollback:` lines for `liquibase`. `atlas.sum` is written over that layout's
+covered file set, so the community binary's own `migrate validate` reads back
+what Ptah wrote.
+
+The generated SQL is Ptah's renderer's, on every layout including `atlas` — the
+layout is what these follow, not the DDL text. On `liquibase`, Ptah writes ONE
+changeset carrying the whole migration and all of its `--rollback:` lines, where
+the community binary writes one changeset per statement; rolling the migration
+back is exact either way, but Ptah does not offer per-statement rollback there,
+because pairing each forward statement with a reverse statement would be a guess
+about a reverse plan that is computed for the run as a whole.
 
 ### `ptah-compat migrate lint`
 

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -254,6 +254,21 @@ back is exact either way, but Ptah does not offer per-statement rollback there,
 because pairing each forward statement with a reverse statement would be a guess
 about a reverse plan that is computed for the run as a whole.
 
+The rollback half is planned against the state the migration starts from, not
+the state it produces, so a forward migration that DROPS a table rolls back into
+the CREATE TABLE that puts it back. That re-created table carries its own
+primary key and its single-column foreign keys, and the rollback does not repeat
+them; a rollback that did is refused by the server outright. A CHECK constraint
+is not in the table body at all, so it is restored by its own statement.
+
+Two differences survive that round trip, on this verb and on
+`ptah migrations generate` alike. The restored primary key takes the server's
+default name rather than the name it had, because the table body has nowhere to
+put one. A column that was UNIQUE comes back both from the table body and from
+the named constraint, so the restored table holds two unique constraints where
+it held one. Neither stops the rollback from applying; both mean a
+`schema diff` immediately after a rollback can report work to do.
+
 ### `ptah-compat migrate lint`
 
 Runs Ptah migration linting with Atlas `--dir-format` defaulting to `atlas`.

--- a/internal/atlasmigrate/artifactlayout.go
+++ b/internal/atlasmigrate/artifactlayout.go
@@ -1,0 +1,236 @@
+package atlasmigrate
+
+import (
+	"fmt"
+	"strings"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// This file is the write half of `migrate diff`'s layout rules: given the
+// planned migrations of one run, the FILES they become in each directory
+// convention the verb can be pointed at.
+//
+// It is deliberately the naming [atlasmigrateimport.SkeletonFiles] already
+// emits for `migrate new`, and for the same reason that file states: a name
+// this composes has to be a name [atlasmigrateimport.SumFileNames] covers and
+// the loader accepts, or the run would hand the operator a directory its own
+// `migrate hash` does not cover and its own `migrate apply` cannot read.
+// TestComposeMigrationArtifactsAreCoveredAndLoadable states that over both.
+//
+// Every shape below was measured against the pinned community binary v1.3.0 on
+// 2026-08-08, by running `migrate diff demo --dir 'file://<empty>?format=<f>'`
+// against a PostgreSQL dev database with one CREATE TABLE as the desired state:
+//
+//	golang-migrate  20260808232952_demo.up.sql    "-- create \"orders\" table\nCREATE TABLE …"
+//	                20260808232952_demo.down.sql  "-- reverse: create \"orders\" table\nDROP TABLE …"
+//	flyway          V20260808233006__demo.sql     forward
+//	                U20260808233006__demo.sql     reverse
+//	goose           20260808233014_demo.sql       "-- +goose Up\n…\n\n-- +goose Down\n…"
+//	dbmate          20260808233023_demo.sql       "-- migrate:up\n…\n\n-- migrate:down\n…"
+//	liquibase       20260808233032_demo.sql       "--liquibase formatted sql\n--changeset atlas:<v>-1\n…\n--rollback: …"
+//
+// In every case that binary's atlas.sum covered only the forward half — the
+// `.up.sql`, the `V…` file, or the single file — which is what
+// [atlasmigrateimport.SumFileNames] already computes per layout.
+//
+// The SQL text itself is Ptah's own renderer's, not that binary's, on every
+// layout including the native one. Matching the layout is what this closes;
+// matching the generated DDL byte for byte never was, and is not, the contract.
+const (
+	// gooseUpDirective and gooseDownDirective are the annotations Goose needs
+	// to recognize the two halves of a migration. A Goose file without them is
+	// not an empty migration, it is an unparseable one.
+	gooseUpDirective   = "-- +goose Up"
+	gooseDownDirective = "-- +goose Down"
+	// dbmateUpDirective and dbmateDownDirective are dbmate's equivalents.
+	dbmateUpDirective   = "-- migrate:up"
+	dbmateDownDirective = "-- migrate:down"
+	// liquibaseHeader is the first line of a Liquibase formatted-SQL changelog.
+	liquibaseHeader = "--liquibase formatted sql"
+	// liquibaseChangesetAuthor is the author half of the `author:id` pair on
+	// the changeset line.
+	//
+	// It is `atlas` rather than `ptah` because the value identifies the FORMAT
+	// convention a reader of this directory has to recognize, not the program
+	// that wrote the line: a directory this verb writes is meant to be one the
+	// community binary's own `migrate hash`, `validate` and `apply` read back,
+	// and that binary writes `--changeset atlas:<version>-<n>`.
+	liquibaseChangesetAuthor = "atlas"
+	// liquibaseRollbackPrefix introduces one line of a changeset's rollback.
+	// Liquibase concatenates consecutive rollback lines into one rollback
+	// statement, which is why a multi-line statement is emitted as several of
+	// these rather than as one line carrying newlines.
+	liquibaseRollbackPrefix = "--rollback: "
+)
+
+// composeMigrationArtifacts turns the planned migrations of one `migrate diff`
+// run into the files a directory read as format consists of, in creation order.
+//
+// version is the first version of the run; a plan split into several files
+// takes version, version+1, ... exactly as the native Atlas layout always has,
+// so a caller's collision check over `len(contents)` consecutive versions
+// stays correct for every layout.
+//
+// The forward file is emitted before the rollback file of the same migration.
+// The order is the caller's, not the layout's: staging writes them in this
+// order, so an interrupted run leaves behind the file atlas.sum would have
+// covered rather than an orphaned rollback half the integrity file cannot see.
+func composeMigrationArtifacts(
+	format atlasmigrateimport.Format,
+	name string,
+	version int64,
+	contents []MigrationFileContent,
+) ([]PublicationArtifact, error) {
+	if len(contents) == 0 {
+		return nil, fmt.Errorf("migration SQL is empty")
+	}
+	artifacts := make([]PublicationArtifact, 0, 2*len(contents))
+	for i, content := range contents {
+		fileVersion := version + int64(i)
+		slug := migrationSlug(name + content.NameSuffix)
+		composed, err := composeMigrationArtifact(format, slug, fileVersion, content)
+		if err != nil {
+			return nil, err
+		}
+		artifacts = append(artifacts, composed...)
+	}
+	return artifacts, nil
+}
+
+func composeMigrationArtifact(
+	format atlasmigrateimport.Format,
+	slug string,
+	version int64,
+	content MigrationFileContent,
+) ([]PublicationArtifact, error) {
+	switch format {
+	case atlasmigrateimport.FormatAtlas, "":
+		return []PublicationArtifact{{
+			Name:     fmt.Sprintf("%d_%s.sql", version, slug),
+			Contents: []byte(content.SQL),
+		}}, nil
+	case atlasmigrateimport.FormatGolangMigrate:
+		stem := fmt.Sprintf("%d_%s", version, slug)
+		return pairedArtifacts(stem+".up.sql", stem+".down.sql", content), nil
+	case atlasmigrateimport.FormatFlyway:
+		stem := fmt.Sprintf("%d__%s", version, slug)
+		return pairedArtifacts("V"+stem+".sql", "U"+stem+".sql", content), nil
+	case atlasmigrateimport.FormatGoose:
+		return directiveArtifact(
+			fmt.Sprintf("%d_%s.sql", version, slug),
+			gooseUpDirective,
+			gooseDownDirective,
+			content,
+		), nil
+	case atlasmigrateimport.FormatDBMate:
+		return directiveArtifact(
+			fmt.Sprintf("%d_%s.sql", version, slug),
+			dbmateUpDirective,
+			dbmateDownDirective,
+			content,
+		), nil
+	case atlasmigrateimport.FormatLiquibase:
+		return composeLiquibaseArtifact(fmt.Sprintf("%d_%s.sql", version, slug), version, content), nil
+	default:
+		return nil, fmt.Errorf("unknown migration import format %q", format)
+	}
+}
+
+// pairedArtifacts composes the two layouts that keep the rollback in a file of
+// its own.
+//
+// The rollback file is written even when the run planned no reverse, and it is
+// then empty. That is what the community binary's `migrate new` writes on these
+// two layouts, and it is what keeps the pair complete: a golang-migrate
+// migration whose `.down.sql` is missing is a migration the source tool cannot
+// roll back past, while an empty one is a no-op it can.
+func pairedArtifacts(upName, downName string, content MigrationFileContent) []PublicationArtifact {
+	return []PublicationArtifact{
+		{Name: upName, Contents: []byte(content.SQL)},
+		{Name: downName, Contents: []byte(content.DownSQL)},
+	}
+}
+
+// directiveArtifact composes the two layouts that keep both halves in one file
+// under a directive each.
+//
+// The down section is emitted even when it is empty, because the directive is
+// what makes the file parseable rather than what makes it useful: a Goose file
+// carrying only `-- +goose Up` is a migration the source tool cannot roll back
+// past, and both readers expect the pair.
+func directiveArtifact(
+	name, upDirective, downDirective string,
+	content MigrationFileContent,
+) []PublicationArtifact {
+	var body strings.Builder
+	body.WriteString(upDirective)
+	body.WriteString("\n")
+	body.WriteString(ensureTrailingNewline(content.SQL))
+	body.WriteString("\n")
+	body.WriteString(downDirective)
+	body.WriteString("\n")
+	body.WriteString(ensureTrailingNewline(content.DownSQL))
+	return []PublicationArtifact{{Name: name, Contents: []byte(body.String())}}
+}
+
+// composeLiquibaseArtifact composes the one layout whose rollback is attached
+// to a changeset rather than appended as a block.
+//
+// # One changeset, where the community binary writes one per statement
+//
+// Measured on the pinned v1.3.0, a two-table diff produces two changesets there
+// — `atlas:<version>-1` and `atlas:<version>-2` — each carrying its own
+// forward statement and its own `--rollback:` line. This writes one changeset
+// carrying the whole migration and every rollback line for it, and the
+// difference is deliberate.
+//
+// Pairing forward statement i with reverse statement i would be a guess. Ptah
+// plans the reverse of the RUN — [DiffOptions.PlanReverse] answers a whole
+// diff with a whole diff, and the planner then orders it by reverse dependency
+// — so the two lists are not index-aligned and need not even be the same
+// length: one added table with two indexes reverses into one DROP TABLE.
+// Emitting a changeset per forward statement would therefore attach some
+// statement's rollback to a different statement, and rolling back a single
+// changeset would run SQL that does not undo it. One changeset per migration is
+// the granularity Ptah can state truthfully: rolling it back runs the reverse
+// of exactly what applying it ran.
+//
+// The cost is per-changeset rollback granularity, which is the ability to undo
+// part of one migration. Nothing else moves: the file name, the covered set,
+// the header and the changeset syntax are the layout's, and the rollback is
+// complete.
+//
+// A statement spanning several lines becomes several `--rollback:` lines, which
+// Liquibase concatenates into one rollback statement. Emitting it as a single
+// line carrying newlines would end the rollback at the first one and silently
+// drop the rest.
+func composeLiquibaseArtifact(
+	name string,
+	version int64,
+	content MigrationFileContent,
+) []PublicationArtifact {
+	var body strings.Builder
+	body.WriteString(liquibaseHeader)
+	body.WriteString("\n")
+	fmt.Fprintf(&body, "--changeset %s:%d-1\n", liquibaseChangesetAuthor, version)
+	for _, statement := range content.Statements {
+		body.WriteString(strings.TrimRight(statement, "\n"))
+		body.WriteString(";\n")
+	}
+	for _, statement := range content.ReverseStatements {
+		for line := range strings.SplitSeq(strings.TrimRight(statement, "\n")+";", "\n") {
+			body.WriteString(liquibaseRollbackPrefix)
+			body.WriteString(line)
+			body.WriteString("\n")
+		}
+	}
+	return []PublicationArtifact{{Name: name, Contents: []byte(body.String())}}
+}
+
+func ensureTrailingNewline(sql string) string {
+	if sql == "" || strings.HasSuffix(sql, "\n") {
+		return sql
+	}
+	return sql + "\n"
+}

--- a/internal/atlasmigrate/artifactlayout_internal_test.go
+++ b/internal/atlasmigrate/artifactlayout_internal_test.go
@@ -1,0 +1,148 @@
+package atlasmigrate
+
+// White-box testing required: composeMigrationArtifacts is the unexported step
+// between planning and staging, and the property under test — that every name
+// it composes is one atlas.sum covers and the loader accepts — cannot be stated
+// through GenerateDiff without a dev database per layout.
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+)
+
+// TestComposeMigrationArtifactsAreCoveredAndLoadable states, over every layout
+// at once, the agreement the write path depends on: a file
+// [composeMigrationArtifacts] names must be a file
+// [atlasmigrateimport.SumFileNames] covers for that layout, and the directory
+// it produces must be one [atlasmigrateimport.LoadFS] reads back.
+//
+// Both halves matter and they fail in opposite directions. A name outside the
+// covered set produces an atlas.sum that omits the migration just written, so
+// the community binary's own `migrate validate` reports it as added; a
+// directory the loader cannot read is one `migrate apply` refuses after this
+// verb has already reported success. Stating the property over the composer
+// rather than checking the two by inspection is what keeps them from drifting
+// when either side moves — the same reason
+// atlasmigrateimport.TestSkeletonFilesAreCoveredAndLoadable exists beside
+// SkeletonFiles.
+//
+// The forward half is what must be covered, and the rollback half must NOT be
+// on the two layouts that keep it in a file of its own: golang-migrate's
+// atlas.sum covers `*.up.sql` and flyway's covers the `V…` file, which is
+// measured behavior of the community binary rather than a choice made here.
+func TestComposeMigrationArtifactsAreCoveredAndLoadable(t *testing.T) {
+	tests := []struct {
+		name    string
+		format  atlasmigrateimport.Format
+		files   int
+		covered int
+	}{
+		{name: "atlas", format: atlasmigrateimport.FormatAtlas, files: 1, covered: 1},
+		{name: "golang-migrate", format: atlasmigrateimport.FormatGolangMigrate, files: 2, covered: 1},
+		{name: "flyway", format: atlasmigrateimport.FormatFlyway, files: 2, covered: 1},
+		{name: "goose", format: atlasmigrateimport.FormatGoose, files: 1, covered: 1},
+		{name: "dbmate", format: atlasmigrateimport.FormatDBMate, files: 1, covered: 1},
+		{name: "liquibase", format: atlasmigrateimport.FormatLiquibase, files: 1, covered: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			artifacts, err := composeMigrationArtifacts(tt.format, "addcol", 20240102030405, []MigrationFileContent{{
+				SQL:               "CREATE TABLE widgets (id INTEGER);",
+				DownSQL:           "DROP TABLE widgets;",
+				Statements:        []string{"CREATE TABLE widgets (id INTEGER)"},
+				ReverseStatements: []string{"DROP TABLE widgets"},
+			}})
+			c.Assert(err, qt.IsNil)
+			c.Assert(artifacts, qt.HasLen, tt.files)
+
+			dir := fstest.MapFS{}
+			for _, artifact := range artifacts {
+				dir[artifact.Name] = &fstest.MapFile{Data: artifact.Contents}
+			}
+
+			names, err := atlasmigrateimport.SumFileNames(dir, tt.format)
+			c.Assert(err, qt.IsNil)
+			c.Assert(names, qt.HasLen, tt.covered)
+			c.Assert(names[0], qt.Equals, artifacts[0].Name)
+
+			loaded, err := atlasmigrateimport.LoadFS(dir, "composed", tt.format)
+			c.Assert(err, qt.IsNil)
+			c.Assert(loaded.Entries, qt.HasLen, 1)
+			c.Assert(string(loaded.Entries[0].Data), qt.Contains, "CREATE TABLE widgets")
+		})
+	}
+}
+
+// TestComposeMigrationArtifactsCarriesTheRollbackHalf pins that each layout's
+// rollback actually reaches the file, in the shape that layout reads it from.
+//
+// The test above would pass on a composer that dropped the reverse entirely:
+// the covered set and the loader both look only at the forward half. This is
+// the arm that fails when the rollback goes missing, which is the failure the
+// refusal this change removed was standing in for.
+func TestComposeMigrationArtifactsCarriesTheRollbackHalf(t *testing.T) {
+	tests := []struct {
+		name   string
+		format atlasmigrateimport.Format
+		// index of the artifact carrying the rollback, and the marker that
+		// proves the layout's own rollback container is present rather than the
+		// SQL merely being in the file somewhere.
+		artifact int
+		marker   string
+	}{
+		{name: "golang-migrate", format: atlasmigrateimport.FormatGolangMigrate, artifact: 1, marker: "DROP TABLE widgets;"},
+		{name: "flyway", format: atlasmigrateimport.FormatFlyway, artifact: 1, marker: "DROP TABLE widgets;"},
+		{name: "goose", format: atlasmigrateimport.FormatGoose, artifact: 0, marker: "-- +goose Down\nDROP TABLE widgets;"},
+		{name: "dbmate", format: atlasmigrateimport.FormatDBMate, artifact: 0, marker: "-- migrate:down\nDROP TABLE widgets;"},
+		{name: "liquibase", format: atlasmigrateimport.FormatLiquibase, artifact: 0, marker: "--rollback: DROP TABLE widgets;"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			artifacts, err := composeMigrationArtifacts(tt.format, "addcol", 20240102030405, []MigrationFileContent{{
+				SQL:               "CREATE TABLE widgets (id INTEGER);",
+				DownSQL:           "DROP TABLE widgets;",
+				Statements:        []string{"CREATE TABLE widgets (id INTEGER)"},
+				ReverseStatements: []string{"DROP TABLE widgets"},
+			}})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(string(artifacts[tt.artifact].Contents), qt.Contains, tt.marker)
+		})
+	}
+}
+
+// TestComposeMigrationArtifactsKeepsTheAtlasLayoutUnchanged is the control on
+// the whole file: the native layout's file name and bytes are what they were
+// before any of this existed.
+//
+// It is here because the atlas branch runs on every native `migrate diff`, and
+// a composer that quietly renamed or re-wrapped that file would move every
+// existing migration directory while all five foreign rows above stayed green.
+func TestComposeMigrationArtifactsKeepsTheAtlasLayoutUnchanged(t *testing.T) {
+	c := qt.New(t)
+
+	artifacts, err := composeMigrationArtifacts(
+		atlasmigrateimport.FormatAtlas,
+		"add col",
+		20240102030405,
+		[]MigrationFileContent{
+			{SQL: "SELECT 1;", NameSuffix: "_transactional"},
+			{SQL: "SELECT 2;", NameSuffix: "_concurrent_indexes", DownSQL: "SELECT 3;"},
+		},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(artifacts, qt.DeepEquals, []PublicationArtifact{
+		{Name: "20240102030405_add_col_transactional.sql", Contents: []byte("SELECT 1;")},
+		{Name: "20240102030406_add_col_concurrent_indexes.sql", Contents: []byte("SELECT 2;")},
+	})
+}

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -12,9 +12,11 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/migrationreplay"
@@ -48,11 +50,40 @@ type DiffOptions struct {
 	SourceConnectTimeout time.Duration
 	Name                 string
 	Format               string
-	Schemas              []string
-	LockTimeout          time.Duration
-	Policy               atlasschema.DiffPolicy
-	Qualifier            Qualifier
-	DryRun               bool
+	// DirFormat names the directory convention this run reads the existing
+	// migrations in and writes the new ones in. The empty value is the native
+	// Atlas layout, which is what every caller outside the Atlas-compatible
+	// `migrate diff` wants.
+	//
+	// A foreign layout changes four things and only four: the existing
+	// directory is converted before it is replayed, the next version is chosen
+	// from that converted view, the files are named and composed in that
+	// layout, and atlas.sum is computed over that layout's covered set.
+	DirFormat atlasmigrateimport.Format
+	// PlanReverse computes the diff that undoes a forward diff, so the layouts
+	// carrying a rollback half can be given one.
+	//
+	// It is a hook rather than a call because of an import edge:
+	// [go.5x5.cz/ptah/migration/generator] — which owns the reverse rule and
+	// has since long before this verb existed — imports THIS package in ten
+	// places, so this package cannot import it back. The compatibility surface
+	// imports both and supplies
+	// [go.5x5.cz/ptah/migration/generator.ReverseSchemaDiff] here, the same way
+	// it already supplies VerifyDir and PreparePublication.
+	//
+	// Leaving it nil plans no reverse. Every rollback half is then empty, which
+	// is exactly right for the native Atlas layout: its migration files carry
+	// no rollback half at all.
+	PlanReverse func(
+		diff *difftypes.SchemaDiff,
+		desired *goschema.Database,
+		current *dbschematypes.DBSchema,
+	) *difftypes.SchemaDiff
+	Schemas     []string
+	LockTimeout time.Duration
+	Policy      atlasschema.DiffPolicy
+	Qualifier   Qualifier
+	DryRun      bool
 	// Vars supplies values for HCL schema-file `variable` blocks, as `--var`
 	// spells them; see [go.5x5.cz/ptah/internal/schemafile.Options].
 	Vars []string
@@ -187,18 +218,31 @@ func generateDiff(
 		desiredDefaultSchema = devDefaultSchema
 	}
 	desired := schemascope.FilterGeneratedWithDefaultSchema(desiredState.Schema, schemas, desiredDefaultSchema)
-	var diff *difftypes.SchemaDiff
+	// The directory is replayed as native Atlas in every case, but a foreign
+	// layout is CONVERTED into that shape first rather than parsed as if it
+	// already were one. The conversion is the same one every reading verb runs
+	// (`migrate apply`, `hash`, `validate`, `lint`), so the state this run
+	// diffs against is the state those verbs report.
+	replaySource, err := diffReplaySource(migrationSnapshot, opts)
+	if err != nil {
+		return DiffResult{}, err
+	}
+	var (
+		diff    *difftypes.SchemaDiff
+		current *dbschematypes.DBSchema
+	)
 	if err := runtime.withReplayedSnapshot(
 		ctx,
 		conn,
-		migrationSnapshot,
+		replaySource,
 		migrator.MigrationDirFormatAtlas,
 		func(replayConn *dbschema.DatabaseConnection) error {
-			current, err := runtime.readDevSchema(replayConn, schemas, devDefaultSchema)
+			replayed, err := runtime.readDevSchema(replayConn, schemas, devDefaultSchema)
 			if err != nil {
 				return err
 			}
-			diff, err = schemadiff.CompareWithDatabase(ctx, replayConn, desired, current, nil)
+			current = replayed
+			diff, err = schemadiff.CompareWithDatabase(ctx, replayConn, desired, replayed, nil)
 			if err != nil {
 				return fmt.Errorf("compare dev database schema: %w", err)
 			}
@@ -215,7 +259,7 @@ func generateDiff(
 		return DiffResult{Synced: true}, nil
 	}
 
-	contents, err := planDiffFileContents(diff, desired, info, format, opts)
+	contents, err := planDiffFileContents(diff, desired, current, info, format, opts)
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -240,7 +284,43 @@ func generateDiff(
 		contents,
 		migrationSnapshot,
 		opts.PreparePublication,
+		diffWriteLayout{format: opts.dirFormat(), versionFS: replaySource},
 	)
+}
+
+// dirFormat is the layout this run reads and writes, with the zero value
+// resolved to the native Atlas one.
+func (o DiffOptions) dirFormat() atlasmigrateimport.Format {
+	if o.DirFormat == "" {
+		return atlasmigrateimport.FormatAtlas
+	}
+	return o.DirFormat
+}
+
+// diffReplaySource returns the Atlas-shaped view of the migration directory
+// this run replays and picks its next version from.
+//
+// A native Atlas directory is already that view. A foreign one is converted
+// through the shared reader, which is deliberately the same conversion
+// `migrate apply` and `migrate lint` run: a directory whose replayed state
+// differed between "what apply would do" and "what diff planned against" would
+// generate a migration for changes that are not there.
+//
+// Integrity is NOT re-checked here. The compatibility surface gates the
+// directory over the selected layout's covered set before this package is
+// entered, and [DiffOptions.VerifyDir] re-checks the locked snapshot with that
+// same predicate; converting first and gating after is the ordering
+// stokaro/ptah#973 forbids.
+func diffReplaySource(snapshot fsnapshot.Snapshot, opts DiffOptions) (fs.FS, error) {
+	format := opts.dirFormat()
+	if ReadsNativeAtlasDir(format) {
+		return snapshot, nil
+	}
+	loaded, err := atlasmigrateimport.LoadFS(snapshot, opts.Dir, format)
+	if err != nil {
+		return nil, fmt.Errorf("read migration directory as %s: %w", format, err)
+	}
+	return loaded.FS(), nil
 }
 
 // openVerifiedMigrationDir binds the migration directory once and returns it
@@ -341,10 +421,11 @@ func resolveDesiredState(
 }
 
 // planDiffFileContents plans the migration AST, applies the typed qualifier,
-// and renders the Atlas migration file contents for one diff run.
+// and renders the migration file contents for one diff run — both directions.
 func planDiffFileContents(
 	diff *difftypes.SchemaDiff,
 	desired *goschema.Database,
+	current *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	format string,
 	opts DiffOptions,
@@ -360,7 +441,52 @@ func planDiffFileContents(
 	if err := opts.Qualifier.ApplyToPlan(info.Dialect, desired, upNodes); err != nil {
 		return nil, err
 	}
-	return BuildMigrationFileContents(info.Dialect, info.Capabilities, format, upNodes)
+	contents, err := BuildMigrationFileContents(info.Dialect, info.Capabilities, format, upNodes)
+	if err != nil {
+		return nil, err
+	}
+	reverse, err := planDiffReverseStatements(diff, desired, current, info, opts)
+	if err != nil {
+		return nil, err
+	}
+	return attachReversePlan(contents, reverse, format)
+}
+
+// planDiffReverseStatements renders the statements that undo this run, or none
+// when the caller supplied no reverse rule.
+//
+// The reverse is planned against the PRE-CHANGE state — the replayed database
+// converted back to a schema — and not against the desired one, because that is
+// the state a rollback restores. Planning it against `desired` would describe
+// the world the up file creates and produce a rollback that undoes nothing.
+func planDiffReverseStatements(
+	diff *difftypes.SchemaDiff,
+	desired *goschema.Database,
+	current *dbschematypes.DBSchema,
+	info dbschematypes.DBInfo,
+	opts DiffOptions,
+) ([]string, error) {
+	if opts.PlanReverse == nil || current == nil {
+		return nil, nil
+	}
+	reverseDiff := opts.PlanReverse(diff, desired, current)
+	if reverseDiff == nil {
+		return nil, nil
+	}
+	priorSchema := dbschematogo.ConvertDBSchemaToGoSchema(current)
+	downNodes, err := planner.GenerateSchemaDiffASTWithOptions(
+		reverseDiff,
+		priorSchema,
+		info.Dialect,
+		planner.Options{Capabilities: info.Capabilities},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("generate rollback SQL: %w", err)
+	}
+	if err := opts.Qualifier.ApplyToPlan(info.Dialect, priorSchema, downNodes); err != nil {
+		return nil, err
+	}
+	return renderMigrationStatements(info.Dialect, info.Capabilities, downNodes)
 }
 
 func joinFileContentSQL(contents []MigrationFileContent) string {

--- a/internal/atlasmigrate/diff_internal_test.go
+++ b/internal/atlasmigrate/diff_internal_test.go
@@ -20,6 +20,7 @@ import (
 
 	"go.5x5.cz/ptah/dbschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/atlassource"
 	"go.5x5.cz/ptah/internal/atlasurl"
 	"go.5x5.cz/ptah/internal/migratesum"
@@ -227,6 +228,7 @@ func TestStageMigrationBatch_FallsBackToExclusiveCopy(t *testing.T) {
 		"copy",
 		1,
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
+		atlasmigrateimport.FormatAtlas,
 		func(d *pathguard.OpenedDirectory, stagedName string) (publicationMode, error) {
 			return detectPublicationModeWithLink(
 				d,
@@ -266,6 +268,7 @@ func TestWriteDiffArtifacts_SumPublishFailureRollsBackMigrations(t *testing.T) {
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
 		nil,
+		diffWriteLayout{},
 	)
 
 	c.Assert(err, qt.ErrorMatches, `write atlas\.sum: .*`)
@@ -659,6 +662,7 @@ func TestWriteDiffArtifacts_CommitUncertainRetainsRecoverableBatch(t *testing.T)
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
 		nil,
+		diffWriteLayout{},
 		func(w *migrationWriterDir, sum *migratesum.SumFile) (string, error) {
 			path, writeErr := publishDirSum(w, sum)
 			c.Assert(writeErr, qt.IsNil)
@@ -713,6 +717,7 @@ func TestWriteDiffArtifacts_RejectsUnreplayedConcurrentMigration(t *testing.T) {
 		[]MigrationFileContent{{SQL: "SELECT 1;"}},
 		baseSnapshot,
 		nil,
+		diffWriteLayout{},
 	)
 
 	c.Assert(err, qt.ErrorMatches, `migration directory changed during migrate diff planning`)
@@ -738,7 +743,7 @@ func beginTestPublication(
 	c.Assert(err, qt.IsNil)
 	baseSnapshot, err := migrationsnapshot.CaptureStable(fsys)
 	c.Assert(err, qt.IsNil)
-	_, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents)
+	_, sum, err := preparePublicationSnapshot(baseSnapshot, batch, contents, atlasmigrateimport.FormatAtlas)
 	c.Assert(err, qt.IsNil)
 	journal, err := beginPublication(writer, batch, sum.Bytes())
 	c.Assert(err, qt.IsNil)

--- a/internal/atlasmigrate/filecontent.go
+++ b/internal/atlasmigrate/filecontent.go
@@ -17,14 +17,40 @@ import (
 // migrator and Atlas's migrate apply both honor this form.
 const AtlasTxModeNoneDirective = "-- atlas:txmode none"
 
-// MigrationFileContent is one planned Atlas-format migration file produced by
-// a single migrate diff run.
+// MigrationFileContent is one planned migration produced by a single migrate
+// diff run.
+//
+// It is named for a FILE because the native Atlas layout writes one, but a
+// planned migration is not a file on every layout this verb can be pointed at:
+// golang-migrate and flyway split it into a forward file and a rollback file,
+// goose and dbmate keep both halves under directives in one file, and liquibase
+// wraps them in a changeset. [composeMigrationArtifacts] is what turns this
+// into the files of a given layout; everything below is what those five
+// compositions need, rendered once here rather than five times there.
 type MigrationFileContent struct {
 	// NameSuffix is appended to the operator-chosen migration name when the
 	// plan splits into several files ("" for a single-file plan).
 	NameSuffix string
-	// SQL is the complete file content, including any Atlas file directives.
+	// SQL is the complete forward file content, including any Atlas file
+	// directives.
 	SQL string
+	// DownSQL is the complete rollback file content, rendered exactly as SQL
+	// is. It is empty when the run planned no reverse — which is every run on
+	// the native Atlas layout, whose migration files carry no rollback half at
+	// all, and any run whose caller supplied no
+	// [DiffOptions.PlanReverse].
+	DownSQL string
+	// Statements are the forward statements SQL renders, in apply order, each
+	// carrying whatever leading comment the planner emitted for it.
+	//
+	// It exists for liquibase, the one layout that cannot take the rendered
+	// body: its rollback is attached to a changeset rather than appended as a
+	// block, so that layout composes the file from the statements instead of
+	// from SQL (see [composeLiquibaseArtifact]).
+	Statements []string
+	// ReverseStatements are the statements that undo Statements, in the order
+	// they must run. Empty exactly when DownSQL is.
+	ReverseStatements []string
 	// NoTransaction reports whether the file carries the
 	// `-- atlas:txmode none` directive.
 	NoTransaction bool
@@ -107,7 +133,38 @@ func renderMigrationFileContent(
 	if err != nil {
 		return MigrationFileContent{}, err
 	}
-	return MigrationFileContent{SQL: sql}, nil
+	return MigrationFileContent{SQL: sql, Statements: statements}, nil
+}
+
+// attachReversePlan records the reverse of the whole plan on the LAST file of
+// it, and renders that reverse the same way the forward half was rendered.
+//
+// The last file, and not each file, because a rollback runs newest-first: the
+// files of one diff run are staged at consecutive versions, so the last one is
+// the first to be undone and undoing it has to undo the whole run. Splitting
+// the reverse across the files of a plan would require knowing which forward
+// statement each reverse statement answers, which the planner does not report —
+// it plans the reverse of the run, in reverse dependency order, as one set.
+//
+// A plan that produced no reverse leaves every file's DownSQL empty, which is
+// what the native Atlas layout wants in every case: its migration files carry
+// no rollback half.
+func attachReversePlan(
+	contents []MigrationFileContent,
+	reverse []string,
+	format string,
+) ([]MigrationFileContent, error) {
+	if len(contents) == 0 || len(reverse) == 0 {
+		return contents, nil
+	}
+	sql, err := renderMigrationDiffSQL(reverse, format)
+	if err != nil {
+		return nil, err
+	}
+	last := len(contents) - 1
+	contents[last].DownSQL = sql
+	contents[last].ReverseStatements = reverse
+	return contents, nil
 }
 
 // withTxModeNoneDirective tags one planned file with the Atlas

--- a/internal/atlasmigrate/publication.go
+++ b/internal/atlasmigrate/publication.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"go.5x5.cz/ptah/internal/atlasmigrateimport"
 	"go.5x5.cz/ptah/internal/fsdurable"
 	"go.5x5.cz/ptah/internal/fsnapshot"
 	"go.5x5.cz/ptah/internal/migratesum"
@@ -91,6 +92,7 @@ func writeDiffArtifacts(
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
+	layout diffWriteLayout,
 ) (DiffResult, error) {
 	return writeDiffArtifactsWithSumWriter(
 		ctx,
@@ -99,8 +101,42 @@ func writeDiffArtifacts(
 		contents,
 		baseSnapshot,
 		prepare,
+		layout,
 		publishDirSum,
 	)
+}
+
+// diffWriteLayout carries the two things one `migrate diff` write needs to know
+// about the directory's layout that the file contents themselves do not say.
+//
+// versionFS is separate from the base snapshot on purpose. The next version is
+// chosen by looking at the versions the directory already holds, and on a
+// foreign layout those are only readable through the converter — a
+// golang-migrate `3_init.up.sql` is version 3 to a reader that knows the
+// layout and nothing at all to the Atlas file-name parser. The caller passes
+// the CONVERTED view here and the real directory as baseSnapshot, so the
+// version comes from what the directory means while the checksum comes from
+// what it contains.
+//
+// A zero value is the native Atlas layout with no separate version view, which
+// is what every caller outside `migrate diff` wants.
+type diffWriteLayout struct {
+	format    atlasmigrateimport.Format
+	versionFS fs.FS
+}
+
+func (l diffWriteLayout) dirFormat() atlasmigrateimport.Format {
+	if l.format == "" {
+		return atlasmigrateimport.FormatAtlas
+	}
+	return l.format
+}
+
+func (l diffWriteLayout) versionSource(base fsnapshot.Snapshot) fs.FS {
+	if l.versionFS != nil {
+		return l.versionFS
+	}
+	return base
 }
 
 func writeDiffArtifactsWithSumWriter(
@@ -110,6 +146,7 @@ func writeDiffArtifactsWithSumWriter(
 	contents []MigrationFileContent,
 	baseSnapshot fsnapshot.Snapshot,
 	prepare func([]string) error,
+	layout diffWriteLayout,
 	writeSum func(*migrationWriterDir, *migratesum.SumFile) (string, error),
 ) (DiffResult, error) {
 	if err := ctx.Err(); err != nil {
@@ -118,11 +155,11 @@ func writeDiffArtifactsWithSumWriter(
 	if err := recoverPendingPublication(w); err != nil {
 		return DiffResult{}, fmt.Errorf("recover previous migration artifact publication: %w", err)
 	}
-	version, err := nextMigrationVersionFS(baseSnapshot, len(contents))
+	version, err := nextMigrationVersionFS(layout.versionSource(baseSnapshot), len(contents))
 	if err != nil {
 		return DiffResult{}, err
 	}
-	batch, err := stageMigrationBatchAt(w, name, version, contents)
+	batch, err := stageMigrationBatchAtInFormat(w, name, version, contents, layout.dirFormat())
 	if err != nil {
 		return DiffResult{}, err
 	}
@@ -137,6 +174,7 @@ func writeDiffArtifactsWithSumWriter(
 		baseSnapshot,
 		batch,
 		stagedContents,
+		layout.dirFormat(),
 	)
 	if err != nil {
 		return DiffResult{}, errors.Join(err, removeStagedFiles(w, batch.stagedNames))
@@ -324,10 +362,19 @@ func contentDigest(contents []byte) string {
 	return hex.EncodeToString(sum[:])
 }
 
+// preparePublicationSnapshot builds the directory as publication will leave it
+// and the atlas.sum that covers it.
+//
+// The sum is computed over the covered set of the layout the files were written
+// in, not of the Atlas one. On a golang-migrate directory that is the `.up.sql`
+// halves alone: hashing the Atlas set there would cover both halves of every
+// pair and produce a sum the community binary — and this binary's own
+// `migrate hash` — then refuse.
 func preparePublicationSnapshot(
 	baseSnapshot fsnapshot.Snapshot,
 	batch migrationBatch,
 	contents []MigrationFileContent,
+	format atlasmigrateimport.Format,
 ) (fsnapshot.Snapshot, *migratesum.SumFile, error) {
 	files := make(map[string][]byte, len(batch.names))
 	for i, name := range batch.names {
@@ -337,14 +384,32 @@ func preparePublicationSnapshot(
 	if err != nil {
 		return fsnapshot.Snapshot{}, nil, fmt.Errorf("build published migration snapshot: %w", err)
 	}
-	sum, err := migratesum.ComputeWithFormat(
-		publishedSnapshot,
-		migrator.MigrationDirFormatAtlas,
-	)
+	sum, err := computePublicationSum(publishedSnapshot, format)
 	if err != nil {
 		return fsnapshot.Snapshot{}, nil, fmt.Errorf("compute published migration checksum: %w", err)
 	}
 	return publishedSnapshot, sum, nil
+}
+
+// computePublicationSum hashes a published directory as format's own reader
+// selects it.
+//
+// The native Atlas layout keeps going through [migratesum.ComputeWithFormat],
+// which is the computation every other native-layout path in this repository
+// already runs; only the foreign layouts take the covered-set route, so this
+// change cannot move an atlas.sum the Atlas layout was already producing.
+func computePublicationSum(
+	fsys fs.FS,
+	format atlasmigrateimport.Format,
+) (*migratesum.SumFile, error) {
+	if ReadsNativeAtlasDir(format) {
+		return migratesum.ComputeWithFormat(fsys, migrator.MigrationDirFormatAtlas)
+	}
+	names, err := atlasmigrateimport.SumFileNames(fsys, format)
+	if err != nil {
+		return nil, err
+	}
+	return migratesum.ComputeAtlasFiles(fsys, names)
 }
 
 func beginPublication(
@@ -1279,11 +1344,28 @@ func stageMigrationBatchAt(
 	version int64,
 	contents []MigrationFileContent,
 ) (migrationBatch, error) {
+	return stageMigrationBatchAtInFormat(
+		w,
+		name,
+		version,
+		contents,
+		atlasmigrateimport.FormatAtlas,
+	)
+}
+
+func stageMigrationBatchAtInFormat(
+	w *migrationWriterDir,
+	name string,
+	version int64,
+	contents []MigrationFileContent,
+	format atlasmigrateimport.Format,
+) (migrationBatch, error) {
 	return stageMigrationBatchAtWithModeDetector(
 		w,
 		name,
 		version,
 		contents,
+		format,
 		detectPublicationMode,
 	)
 }
@@ -1293,24 +1375,26 @@ func stageMigrationBatchAtWithModeDetector(
 	name string,
 	version int64,
 	contents []MigrationFileContent,
+	format atlasmigrateimport.Format,
 	detectMode func(*pathguard.OpenedDirectory, string) (publicationMode, error),
 ) (migrationBatch, error) {
 	if !w.Exists() {
 		return migrationBatch{}, w.missingDirError()
 	}
-	batch := migrationBatch{
-		paths:       make([]string, 0, len(contents)),
-		names:       make([]string, 0, len(contents)),
-		stagedNames: make([]string, 0, len(contents)),
+	artifacts, err := composeMigrationArtifacts(format, name, version, contents)
+	if err != nil {
+		return migrationBatch{}, err
 	}
-	for i, content := range contents {
-		fileVersion := version + int64(i)
-		slug := migrationSlug(name + content.NameSuffix)
-		fileName := fmt.Sprintf("%d_%s.sql", fileVersion, slug)
+	batch := migrationBatch{
+		paths:       make([]string, 0, len(artifacts)),
+		names:       make([]string, 0, len(artifacts)),
+		stagedNames: make([]string, 0, len(artifacts)),
+	}
+	for _, artifact := range artifacts {
 		stagedName, err := stageRootedFile(
 			w.dir,
 			stagedMigrationPattern,
-			[]byte(content.SQL),
+			artifact.Contents,
 			publishedFileMode,
 		)
 		if err != nil {
@@ -1319,8 +1403,8 @@ func stageMigrationBatchAtWithModeDetector(
 				removeStagedFiles(w, batch.stagedNames),
 			)
 		}
-		batch.paths = append(batch.paths, filepath.Join(w.path, fileName))
-		batch.names = append(batch.names, fileName)
+		batch.paths = append(batch.paths, filepath.Join(w.path, artifact.Name))
+		batch.names = append(batch.names, artifact.Name)
 		batch.stagedNames = append(batch.stagedNames, stagedName)
 	}
 	mode, err := detectMode(w.dir, batch.stagedNames[0])

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1677,6 +1677,12 @@ func reverseSchemaDiffWithSchema(diff *types.SchemaDiff, schema *goschema.Databa
 		ConstraintsRemovedWithTables: reverseConstraintRemovals(diff, schema),
 		ConstraintsAddedWithTables:   reverseConstraintAdditions(diff, dbSchema),
 	}
+	// A re-created table brings its own primary key and field-level foreign keys
+	// back with it, so listing those a second time as constraint additions is
+	// how a rollback of a DROP TABLE became unexecutable. This runs before the
+	// index-removal restorations are appended purely for readability: those are
+	// UNIQUE constraints, which the rule deliberately never drops.
+	dropReverseConstraintsRestoredByTableCreation(reversed, diff.ConstraintsRemovedWithTables, dbSchema)
 	indexAdditions, constraintRestorations := reverseIndexRemovals(diff, dbSchema)
 	reversed.SetIndexAdditions(indexAdditions)
 	reversed.SetIndexRemovals(diff.IndexAdditions())

--- a/migration/generator/reverse_export.go
+++ b/migration/generator/reverse_export.go
@@ -41,6 +41,14 @@ import (
 // [goschema.Database] — because the reverse restores that state rather than the
 // desired one.
 //
+// A table the reverse RE-CREATES is restored by that CREATE TABLE, so the
+// result deliberately does not also list the constraints the re-created body
+// brings back with it: its primary key, and the field-level foreign keys the
+// planner's new-table pass re-adds. Repeating them is not merely redundant —
+// PostgreSQL refuses the second primary key outright, so a rollback carrying
+// both aborts part-applied (stokaro/ptah#1013). Everything the re-created body
+// does NOT restore, a CHECK above all, is still listed and still rendered.
+//
 // Two refinements this package applies to its own down direction are NOT
 // included, because neither is expressible without the dialect, which this
 // signature deliberately does not take:

--- a/migration/generator/reverse_export.go
+++ b/migration/generator/reverse_export.go
@@ -1,0 +1,66 @@
+package generator
+
+import (
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// ReverseSchemaDiff returns the diff that undoes diff: the plan input a caller
+// renders to obtain rollback SQL for a forward migration it has already
+// planned.
+//
+// It is the rule this package has always applied to its own `.down.sql` half,
+// exported so that a second writer of migration files can reach it. There is
+// exactly one caller outside this package today —
+// [go.5x5.cz/ptah/internal/atlasmigrate.DiffOptions.PlanReverse], which the
+// Atlas-compatible `migrate diff` fills in — and the reason it cannot call the
+// unexported original is an import edge rather than taste: `migration/generator`
+// imports `internal/atlasmigrate` in ten places (the migration-directory lock,
+// the publication primitives, the qualifier), so the dependency cannot be
+// pointed the other way without moving those primitives out first
+// (stokaro/ptah#1013).
+//
+// # Arguments
+//
+// diff is the FORWARD comparison, desired the schema it was computed against,
+// and current the introspected database state it was computed FROM. All three
+// are what a diff run already holds; nothing here needs recomputing.
+//
+// current is what makes the reverse restorable rather than merely opposite. A
+// forward diff that widens a column records the new type only, so the reverse
+// of it has to read the old one back off the pre-change database state; the
+// same is true of a constraint the forward direction replaced. desired resolves
+// object names the forward diff carries in reference form, such as an RLS
+// policy's owning table.
+//
+// # What the caller still owes
+//
+// The result is a diff, not SQL. Rendering it is the caller's step, and the
+// schema to render it AGAINST is the pre-change one — `current` converted to a
+// [goschema.Database] — because the reverse restores that state rather than the
+// desired one.
+//
+// Two refinements this package applies to its own down direction are NOT
+// included, because neither is expressible without the dialect, which this
+// signature deliberately does not take:
+//
+//   - the MySQL-family backing index a dropped FOREIGN KEY leaves behind, and
+//   - the concurrent-index refs a down file inherits from the up file's policy.
+//
+// A caller that needs either has to add it, and a caller on a dialect where
+// neither applies — PostgreSQL, SQLite — needs neither.
+//
+// The returned diff is freshly allocated, but it shares slices with diff: the
+// reversal is largely a swap of the added and removed lists. Callers must treat
+// both as read-only.
+func ReverseSchemaDiff(
+	diff *types.SchemaDiff,
+	desired *goschema.Database,
+	current *dbschematypes.DBSchema,
+) *types.SchemaDiff {
+	if diff == nil {
+		return nil
+	}
+	return reverseSchemaDiffWithSchema(diff, desired, current)
+}

--- a/migration/generator/reverse_recreated_tables.go
+++ b/migration/generator/reverse_recreated_tables.go
@@ -1,0 +1,256 @@
+package generator
+
+import (
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/convert/dbschematogo"
+	"go.5x5.cz/ptah/internal/convert/fromschema"
+	"go.5x5.cz/ptah/internal/deporder"
+	"go.5x5.cz/ptah/internal/planner/tablelookup"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// dropReverseConstraintsRestoredByTableCreation removes, from a reverse plan,
+// the constraint additions that the plan's own CREATE TABLE already restores.
+//
+// # Why the reverse needs this and the forward direction does not
+//
+// The comparator applies one rule going forward: a table it is CREATING carries
+// its own constraints, so it never also lists them as constraint additions —
+// "new tables/columns get their FK inline via CREATE TABLE / ALTER TABLE ADD
+// CONSTRAINT, so emitting an ADD CONSTRAINT here would double-create it in the
+// same migration step" (migration/schemadiff/internal/compare/constraints.go).
+// A table it is DROPPING gets no such treatment: the constraints go into
+// ConstraintsRemoved alongside the table, which is harmless going forward
+// because every drop is IF EXISTS and the DROP TABLE follows.
+//
+// Reversing that diff swaps both lists at once, and the asymmetry turns into a
+// rollback that says the same thing twice: the re-created table is rendered
+// from the pre-change schema WITH its primary key inline and its foreign keys
+// re-added by the planner's new-table pass, and then the swapped constraint
+// lists ADD both a second time. PostgreSQL 17.10 answers the second primary key
+// with `multiple primary keys for table "gadgets" are not allowed` (SQLSTATE
+// 42P16) and the second foreign key with `constraint … already exists` (42710),
+// so the rollback half aborts part-applied — measured on both writers of down
+// files, `ptah migrations generate` and the Atlas-compatible `migrate diff`
+// (stokaro/ptah#1013).
+//
+// # What is dropped, and what deliberately is not
+//
+// Only what the re-created table demonstrably brings back on its own:
+//
+//   - PRIMARY KEY, when the restored table body carries one — single-column via
+//     the field, composite via [goschema.Table.PrimaryKey]. Both render inline,
+//     and neither renders the constraint's NAME, so the separate ALTER carried
+//     no information the CREATE TABLE loses.
+//   - FOREIGN KEY, when the restored table has a field-level reference the
+//     planner's new-table pass re-adds under the same constraint name. A
+//     SELF-referencing reference is excluded because that pass skips it, and a
+//     multi-column foreign key is excluded because the introspected schema
+//     cannot express it field-level; in both cases the ALTER is the only
+//     emission there is.
+//
+// CHECK and UNIQUE additions are left alone. The CREATE TABLE restores neither
+// by name — a CHECK is not rendered at all, and a UNIQUE comes back as the
+// column's anonymous inline uniqueness — so dropping them here would trade a
+// rollback that fails loudly for one that silently restores less than it
+// should. Those two remain as they were before this change.
+//
+// Nothing is dropped when there is no introspected pre-change schema to read
+// the restored body from: the caller then has no table bodies to compare
+// against and the conservative answer is the behavior that was there before.
+func dropReverseConstraintsRestoredByTableCreation(
+	reversed *types.SchemaDiff,
+	removedWithTables []types.ConstraintRemovalInfo,
+	dbSchema *dbschematypes.DBSchema,
+) {
+	if reversed == nil || dbSchema == nil || len(reversed.TablesAdded) == 0 {
+		return
+	}
+	restored := tableCreationRestores(dbschematogo.ConvertDBSchemaToGoSchema(dbSchema), reversed.TablesAdded)
+	if len(restored) == 0 {
+		return
+	}
+
+	keptNames := make(map[string]struct{}, len(reversed.ConstraintsAddedWithTables))
+	keptAdditions := make([]types.ConstraintAdditionInfo, 0, len(reversed.ConstraintsAddedWithTables))
+	for _, addition := range reversed.ConstraintsAddedWithTables {
+		if restored.covers(addition.TableName, addition.Name, addition.Type) {
+			continue
+		}
+		keptAdditions = append(keptAdditions, addition)
+		keptNames[addition.Name] = struct{}{}
+	}
+	if len(keptAdditions) != len(reversed.ConstraintsAddedWithTables) {
+		reversed.ConstraintsAddedWithTables = keptAdditions
+	}
+
+	// The bare name list has to lose the same entries. Left behind, a name whose
+	// table-qualified addition was dropped falls through to the planners'
+	// name-only add path and re-emits exactly the statement this function set
+	// out to remove.
+	//
+	// A name is only dropped when EVERY host the comparator recorded for it is
+	// one of the re-created tables that restores it. A constraint name shared
+	// across host tables — the mixin case ConstraintsAddedWithTables exists for
+	// — keeps its name whenever any host still needs it.
+	hostsByName := make(map[string][]types.ConstraintRemovalInfo, len(removedWithTables))
+	for _, removal := range removedWithTables {
+		hostsByName[removal.Name] = append(hostsByName[removal.Name], removal)
+	}
+	keptBareNames := make([]string, 0, len(reversed.ConstraintsAdded))
+	for _, name := range reversed.ConstraintsAdded {
+		if restored.coversEveryHost(name, keptNames, hostsByName[name]) {
+			continue
+		}
+		keptBareNames = append(keptBareNames, name)
+	}
+	if len(keptBareNames) != len(reversed.ConstraintsAdded) {
+		// Freshly allocated on purpose: ConstraintsAdded is the caller's
+		// ConstraintsRemoved slice, and reverseSchemaDiffWithSchema promises to
+		// leave the forward diff untouched.
+		reversed.ConstraintsAdded = keptBareNames
+	}
+}
+
+// recreatedTableRestores answers, per table the reverse re-creates, which of
+// its constraints the CREATE TABLE step puts back without help.
+type recreatedTableRestores []recreatedTableRestore
+
+type recreatedTableRestore struct {
+	table goschema.Table
+	// hasPrimaryKey is true when the rendered table body declares a primary
+	// key, in either spelling the renderer accepts.
+	hasPrimaryKey bool
+	// foreignKeyNames holds the constraint names the planner's new-table
+	// foreign-key pass emits for this table.
+	foreignKeyNames map[string]struct{}
+}
+
+// tableCreationRestores resolves the re-created tables exactly as the planners
+// do — through [deporder.TablesForCreate], the same call
+// `addNewTables`/`addForeignKeyConstraintsForNewTables` make — so this
+// function's idea of "this plan creates that table" cannot drift from theirs.
+func tableCreationRestores(prior *goschema.Database, tablesAdded []string) recreatedTableRestores {
+	created := deporder.TablesForCreate(prior, tablesAdded)
+	if len(created) == 0 {
+		return nil
+	}
+	restores := make(recreatedTableRestores, 0, len(created))
+	for _, table := range created {
+		restore := recreatedTableRestore{
+			table:           table,
+			hasPrimaryKey:   len(table.PrimaryKey) > 0,
+			foreignKeyNames: make(map[string]struct{}),
+		}
+		for _, field := range prior.Fields {
+			if field.StructName != table.StructName {
+				continue
+			}
+			if field.Primary {
+				restore.hasPrimaryKey = true
+			}
+			if name, ok := recreatedForeignKeyName(prior, table, field); ok {
+				restore.foreignKeyNames[name] = struct{}{}
+			}
+		}
+		restores = append(restores, restore)
+	}
+	return restores
+}
+
+// recreatedForeignKeyName mirrors the planners' new-table foreign-key pass:
+// which field-level references it emits, and under which constraint name.
+//
+// A reference that resolves back to its own table is not emitted there — the
+// planners route self-references through a separate list the introspected
+// schema does not populate — so it is reported as not restored, and its ALTER
+// stays.
+func recreatedForeignKeyName(prior *goschema.Database, table goschema.Table, field goschema.Field) (string, bool) {
+	if strings.TrimSpace(field.Foreign) == "" {
+		return "", false
+	}
+	ref := fromschema.ParseForeignKeyReference(field.Foreign)
+	if ref == nil {
+		return "", false
+	}
+	if tablelookup.ResolveReference(prior.Tables, table, ref.Table) == table.QualifiedName() {
+		return "", false
+	}
+	if field.ForeignKeyName != "" {
+		return field.ForeignKeyName, true
+	}
+	return fromschema.GenerateForeignKeyName(table.Name, field.Name), true
+}
+
+// covers reports whether the named constraint on tableName is put back by that
+// table's own CREATE TABLE.
+func (r recreatedTableRestores) covers(tableName, constraintName, constraintType string) bool {
+	restore, ok := r.lookup(tableName)
+	if !ok {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(constraintType)) {
+	case "PRIMARY KEY":
+		return restore.hasPrimaryKey
+	case "FOREIGN KEY":
+		_, restored := restore.foreignKeyNames[constraintName]
+		return restored
+	default:
+		return false
+	}
+}
+
+// coversEveryHost reports whether a bare constraint name is fully accounted for
+// by table creation: no table-qualified addition of that name survived, at
+// least one host was recorded for it, and every recorded host restores it.
+func (r recreatedTableRestores) coversEveryHost(
+	name string,
+	keptNames map[string]struct{},
+	hosts []types.ConstraintRemovalInfo,
+) bool {
+	if _, kept := keptNames[name]; kept {
+		return false
+	}
+	if len(hosts) == 0 {
+		return false
+	}
+	for _, host := range hosts {
+		if !r.covers(host.TableName, name, host.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+// lookup matches a comparator-recorded table name against the re-created
+// tables. The comparator qualifies its host names and a hand-built diff may
+// not, so the qualified spelling is tried first and the bare one only when it
+// picks out a single table; an ambiguous bare name resolves to nothing, which
+// leaves the constraint addition in place.
+func (r recreatedTableRestores) lookup(tableName string) (recreatedTableRestore, bool) {
+	tableName = strings.TrimSpace(tableName)
+	if tableName == "" {
+		return recreatedTableRestore{}, false
+	}
+	for _, restore := range r {
+		if restore.table.QualifiedName() == tableName {
+			return restore, true
+		}
+	}
+	var match recreatedTableRestore
+	found := false
+	for _, restore := range r {
+		if restore.table.Name != tableName {
+			continue
+		}
+		if found {
+			return recreatedTableRestore{}, false
+		}
+		match = restore
+		found = true
+	}
+	return match, found
+}

--- a/migration/generator/reverse_recreated_tables_internal_test.go
+++ b/migration/generator/reverse_recreated_tables_internal_test.go
@@ -1,0 +1,235 @@
+package generator
+
+// White-box testing required: the subject is the unexported reverse plan
+// builder (reverseSchemaDiffWithSchema -> dropReverseConstraintsRestoredByTableCreation)
+// as it is rendered by the unexported generateDownMigrationSQL. The exported
+// migration-file API reaches the same code only through a filesystem and a live
+// connection, which would put the failure somewhere other than the rule under
+// test.
+
+import (
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// TestGenerateDownMigration_DropTable_RollbackSaysEachConstraintOnce covers the
+// rollback of a migration that DROPS a table, on the two dialect families whose
+// planner emits ALTER TABLE ... ADD CONSTRAINT.
+//
+// The reverse re-creates the table, and the re-created body already carries the
+// primary key inline and has its field-level foreign key re-added by the
+// planner's new-table pass. Before stokaro/ptah#1013 the swapped constraint
+// lists said both a second time, and the rollback was refused at the second
+// statement — measured on PostgreSQL 17.10
+// (`multiple primary keys for table "gadgets" are not allowed`, exit 3) and on
+// MySQL 9.7 (`ERROR 1068 (42000): Multiple primary key defined`, exit 1),
+// through `ptah migrations generate` and through the Atlas-compatible
+// `migrate diff` alike.
+//
+// Both halves of every row are the assertion, and they fail to different
+// mutants. The "exactly once" counts fail when the rule is removed. The CHECK
+// and UNIQUE lines fail to the cheaper rule that drops EVERY constraint
+// addition whose host table is re-created: that one also produces a rollback
+// that applies, and silently restores a table without its CHECK — which is why
+// this test asserts what the rollback KEEPS as loudly as what it stops
+// repeating.
+func TestGenerateDownMigration_DropTable_RollbackSaysEachConstraintOnce(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		// inlinePrimaryKey is the primary key as the re-created table's own
+		// CREATE TABLE spells it, which differs per renderer. The rollback must
+		// contain this and no separate ADD PRIMARY KEY.
+		inlinePrimaryKey string
+		// wantOnce are the statements the rollback must carry exactly one of.
+		wantOnce []string
+		// wantNone are the statements a correct rollback never repeats.
+		wantNone []string
+	}{
+		{
+			name:             "postgres",
+			dialect:          "postgres",
+			inlinePrimaryKey: "id integer PRIMARY KEY NOT NULL",
+			wantOnce: []string{
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_widget_fk FOREIGN KEY (widget_id)",
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_qty_ck CHECK",
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_code_uq UNIQUE",
+			},
+			wantNone: []string{"ADD PRIMARY KEY"},
+		},
+		{
+			name:             "mysql",
+			dialect:          "mysql",
+			inlinePrimaryKey: "id int PRIMARY KEY",
+			wantOnce: []string{
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_widget_fk FOREIGN KEY (widget_id)",
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_qty_ck CHECK",
+				"ALTER TABLE gadgets ADD CONSTRAINT gadgets_code_uq UNIQUE",
+			},
+			wantNone: []string{"ADD PRIMARY KEY"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			target, prior := droppedTableFixtures(tt.dialect)
+
+			upDiff := schemadiff.CompareWithDialect(target, prior, tt.dialect)
+			c.Assert(upDiff.TablesRemoved, qt.DeepEquals, []string{"gadgets"})
+
+			down, err := generateDownMigrationSQL(upDiff, target, prior, tt.dialect)
+			c.Assert(err, qt.IsNil)
+			down = legacyRenderedSQL(down)
+
+			c.Assert(strings.Count(down, "CREATE TABLE gadgets"), qt.Equals, 1,
+				qt.Commentf("the rollback must put the dropped table back:\n%s", down))
+			c.Assert(strings.Count(down, tt.inlinePrimaryKey), qt.Equals, 1,
+				qt.Commentf("the re-created table carries its own primary key:\n%s", down))
+			for _, statement := range tt.wantOnce {
+				c.Assert(strings.Count(down, statement), qt.Equals, 1,
+					qt.Commentf("want exactly one %q in:\n%s", statement, down))
+			}
+			for _, statement := range tt.wantNone {
+				c.Assert(strings.Count(down, statement), qt.Equals, 0,
+					qt.Commentf("want no %q in:\n%s", statement, down))
+			}
+		})
+	}
+}
+
+// TestGenerateDownMigration_DropTable_KeepsWhatTableCreationCannotRestore is the
+// other side of the same rule, on the two references the re-created table does
+// NOT bring back on its own.
+//
+// A self-referencing foreign key is routed through a list the introspected
+// schema never populates, and a multi-column foreign key cannot be expressed as
+// a field-level reference at all, so for both of them the ALTER is the only
+// emission there is. Dropping them along with the rest would turn an
+// unexecutable rollback into one that applies and restores a table missing its
+// references, which is the worse of the two failures.
+func TestGenerateDownMigration_DropTable_KeepsWhatTableCreationCannotRestore(t *testing.T) {
+	c := qt.New(t)
+	target, prior := selfAndCompositeForeignKeyFixtures()
+
+	upDiff := schemadiff.CompareWithDialect(target, prior, "postgres")
+	c.Assert(upDiff.TablesRemoved, qt.Contains, "nodes")
+	c.Assert(upDiff.TablesRemoved, qt.Contains, "pairs")
+
+	down, err := generateDownMigrationSQL(upDiff, target, prior, "postgres")
+	c.Assert(err, qt.IsNil)
+	down = legacyRenderedSQL(down)
+
+	kept := []string{
+		"ALTER TABLE nodes ADD CONSTRAINT nodes_parent_fk FOREIGN KEY (parent_id)",
+		"ALTER TABLE pairs ADD CONSTRAINT pairs_owner_fk FOREIGN KEY (owner_a, owner_b)",
+	}
+	for _, statement := range kept {
+		c.Assert(strings.Count(down, statement), qt.Equals, 1,
+			qt.Commentf("want exactly one %q in:\n%s", statement, down))
+	}
+	c.Assert(strings.Count(down, "PRIMARY KEY (a, b)"), qt.Equals, 1,
+		qt.Commentf("the composite primary key is restored inline, once:\n%s", down))
+	c.Assert(strings.Count(down, "ADD PRIMARY KEY"), qt.Equals, 0,
+		qt.Commentf("want no separate ADD PRIMARY KEY in:\n%s", down))
+}
+
+// droppedTableFixtures returns the target schema that no longer declares
+// `gadgets` and the introspected pre-change database that still holds it, with
+// one constraint of every kind the reverse has to decide about: a primary key
+// and a single-column foreign key (both restored by the re-created table), and
+// a CHECK and a named UNIQUE (neither of which is).
+func droppedTableFixtures(dialect string) (*goschema.Database, *dbschematypes.DBSchema) {
+	target := &goschema.Database{
+		Tables: []goschema.Table{{Name: "widgets", StructName: "Widget"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: droppedTableIntType(dialect), StructName: "Widget", Primary: true},
+		},
+	}
+	check := "qty > 0"
+	prior := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{Name: "widgets", Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: droppedTableIntType(dialect), IsNullable: "NO", IsPrimaryKey: true},
+			}},
+			{Name: "gadgets", Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: droppedTableIntType(dialect), IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "code", DataType: "text", IsNullable: "NO"},
+				{Name: "qty", DataType: droppedTableIntType(dialect), IsNullable: "NO"},
+				{Name: "widget_id", DataType: droppedTableIntType(dialect), IsNullable: "YES"},
+			}},
+		},
+		Constraints: []dbschematypes.DBConstraint{
+			{Name: "gadgets_pk", TableName: "gadgets", Type: "PRIMARY KEY", ColumnName: "id", ColumnNames: []string{"id"}},
+			{Name: "gadgets_code_uq", TableName: "gadgets", Type: "UNIQUE", ColumnName: "code", ColumnNames: []string{"code"}},
+			{Name: "gadgets_qty_ck", TableName: "gadgets", Type: "CHECK", ColumnName: "qty", CheckClause: &check},
+			{
+				Name: "gadgets_widget_fk", TableName: "gadgets", Type: "FOREIGN KEY",
+				ColumnName: "widget_id", ColumnNames: []string{"widget_id"},
+				ForeignTable: new("widgets"), ForeignColumn: new("id"), ForeignColumns: []string{"id"},
+				DeleteRule: new("NO ACTION"), UpdateRule: new("NO ACTION"),
+			},
+		},
+	}
+	return target, prior
+}
+
+// droppedTableIntType names the integer type each dialect's introspection
+// reports, so the fixture is the shape the comparator really receives rather
+// than a spelling only this test uses.
+func droppedTableIntType(dialect string) string {
+	return map[string]string{"postgres": "integer", "mysql": "int"}[dialect]
+}
+
+// selfAndCompositeForeignKeyFixtures returns a target schema holding neither
+// table and a pre-change database holding two the re-created CREATE TABLE
+// cannot fully restore: `nodes` with a self-referencing foreign key, and
+// `pairs` with a composite primary key and a two-column foreign key.
+func selfAndCompositeForeignKeyFixtures() (*goschema.Database, *dbschematypes.DBSchema) {
+	target := &goschema.Database{
+		Tables: []goschema.Table{{Name: "widgets", StructName: "Widget"}},
+		Fields: []goschema.Field{
+			{Name: "id", Type: "integer", StructName: "Widget", Primary: true},
+		},
+	}
+	prior := &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{Name: "widgets", Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+			}},
+			{Name: "nodes", Columns: []dbschematypes.DBColumn{
+				{Name: "id", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "parent_id", DataType: "integer", IsNullable: "YES"},
+			}},
+			{Name: "pairs", Columns: []dbschematypes.DBColumn{
+				{Name: "a", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "b", DataType: "integer", IsNullable: "NO", IsPrimaryKey: true},
+				{Name: "owner_a", DataType: "integer", IsNullable: "YES"},
+				{Name: "owner_b", DataType: "integer", IsNullable: "YES"},
+			}},
+		},
+		Constraints: []dbschematypes.DBConstraint{
+			{Name: "nodes_pk", TableName: "nodes", Type: "PRIMARY KEY", ColumnName: "id", ColumnNames: []string{"id"}},
+			{
+				Name: "nodes_parent_fk", TableName: "nodes", Type: "FOREIGN KEY",
+				ColumnName: "parent_id", ColumnNames: []string{"parent_id"},
+				ForeignTable: new("nodes"), ForeignColumn: new("id"), ForeignColumns: []string{"id"},
+				DeleteRule: new("NO ACTION"), UpdateRule: new("NO ACTION"),
+			},
+			{Name: "pairs_pk", TableName: "pairs", Type: "PRIMARY KEY", ColumnName: "a", ColumnNames: []string{"a", "b"}},
+			{
+				Name: "pairs_owner_fk", TableName: "pairs", Type: "FOREIGN KEY",
+				ColumnName: "owner_a", ColumnNames: []string{"owner_a", "owner_b"},
+				ForeignTable: new("pairs"), ForeignColumn: new("a"), ForeignColumns: []string{"a", "b"},
+				DeleteRule: new("NO ACTION"), UpdateRule: new("NO ACTION"),
+			},
+		},
+	}
+	return target, prior
+}

--- a/migration/generator/reverse_recreated_tables_live_internal_test.go
+++ b/migration/generator/reverse_recreated_tables_live_internal_test.go
@@ -1,0 +1,185 @@
+//go:build integration
+
+package generator
+
+// White-box testing required: the subject is the unexported down path
+// (generateDownMigrationSQL over reverseSchemaDiffWithSchema) applied to a live
+// PostgreSQL server. Driving it through the exported migration-file API would
+// add a filesystem and a migration directory to a test whose whole point is
+// what the server accepts.
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+const (
+	rrtWidgets = "ptah_rrt_widgets"
+	rrtGadgets = "ptah_rrt_gadgets"
+)
+
+// TestReverseRecreatedTable_DropTableRollbackApplies_Integration is the live
+// gate for the rollback half of a migration that DROPS a table.
+//
+// Rendering that rollback proves a CREATE TABLE exists; it does not prove the
+// server accepts what follows it. The version this replaces rendered perfectly
+// and was refused at its third statement, because the re-created table already
+// carried the primary key the plan then added again — PostgreSQL 17.10,
+// `multiple primary keys for table "ptah_rrt_gadgets" are not allowed`. The
+// same shape on MySQL 9.7 is `ERROR 1068 (42000): Multiple primary key
+// defined`.
+//
+// The test seeds the pre-up state with Ptah's own planner, applies the up
+// migration, applies the down migration, and then asserts that the dropped
+// table is back with the constraints it had. Applying is the gate; the catalog
+// compare is what stops a rollback that applies from restoring less than it
+// should.
+func TestReverseRecreatedTable_DropTableRollbackApplies_Integration(t *testing.T) {
+	c := qt.New(t)
+
+	url := revIntRequireURL(t)
+	conn := revIntConnect(t, url)
+	rrtDropAll(conn)
+	t.Cleanup(func() { rrtDropAll(conn) })
+
+	// 1. The pre-up state, installed through Ptah so the catalog holds what
+	//    Ptah writes rather than a hand-typed approximation of it.
+	prior := rrtSchema(true)
+	seedDiff := schemadiff.CompareWithDialect(prior, &dbschematypes.DBSchema{}, "postgres")
+	seedSQL, err := generateUpMigrationSQL(seedDiff, prior, "postgres")
+	c.Assert(err, qt.IsNil)
+	execScript(c, conn, seedSQL, "SEED")
+
+	dbPrior, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	priorCatalog := rrtCatalog(dbPrior)
+	c.Assert(priorCatalog, qt.Not(qt.HasLen), 0,
+		qt.Commentf("the seed must leave constraints behind, or the compare proves nothing"))
+
+	// 2. The up migration under test: the table goes away.
+	target := rrtSchema(false)
+	upDiff := schemadiff.CompareWithDialect(target, dbPrior, "postgres")
+	c.Assert(upDiff.TablesRemoved, qt.DeepEquals, []string{rrtGadgets})
+
+	upSQL, err := generateUpMigrationSQL(upDiff, target, "postgres")
+	c.Assert(err, qt.IsNil)
+	execScript(c, conn, upSQL, "UP")
+
+	dbAfterUp, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rrtHasTable(dbAfterUp), qt.IsFalse,
+		qt.Commentf("the up migration must really drop the table, or the down proves nothing"))
+
+	// 3. THE GATE. Every statement of the rollback has to be accepted.
+	downSQL, err := generateDownMigrationSQL(upDiff, target, dbPrior, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(strings.ToUpper(downSQL), qt.Contains, "CREATE TABLE",
+		qt.Commentf("a rollback planned against the desired state instead of the "+
+			"pre-change one has nothing to re-create:\n%s", downSQL))
+	execScript(c, conn, downSQL, "DOWN")
+
+	// 4. Applying is not arriving: the table has to be back, with its
+	//    constraints, and not with more of them than it started with.
+	dbAfterDown, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	c.Assert(rrtHasTable(dbAfterDown), qt.IsTrue, qt.Commentf("down SQL:\n%s", downSQL))
+	c.Assert(rrtCatalog(dbAfterDown), qt.DeepEquals, priorCatalog,
+		qt.Commentf("down SQL:\n%s", downSQL))
+}
+
+// rrtSchema returns the fixture with or without the table the migration drops.
+//
+// The dropped table carries one constraint of each kind the reverse has to
+// decide about: a primary key and a single-column foreign key, which its own
+// CREATE TABLE restores, and a CHECK, which nothing but an ALTER can restore.
+func rrtSchema(withGadgets bool) *goschema.Database {
+	schema := &goschema.Database{
+		Tables: []goschema.Table{{StructName: "RrtWidget", Name: rrtWidgets}},
+		Fields: []goschema.Field{
+			{StructName: "RrtWidget", Name: "id", Type: "BIGINT", Primary: true},
+		},
+	}
+	if withGadgets {
+		schema.Tables = append(schema.Tables, goschema.Table{StructName: "RrtGadget", Name: rrtGadgets})
+		schema.Fields = append(schema.Fields,
+			goschema.Field{StructName: "RrtGadget", Name: "id", Type: "BIGINT", Primary: true},
+			goschema.Field{StructName: "RrtGadget", Name: "qty", Type: "BIGINT"},
+			goschema.Field{
+				StructName: "RrtGadget", Name: "widget_id", Type: "BIGINT", Nullable: true,
+				Foreign: rrtWidgets + "(id)", ForeignKeyName: "ptah_rrt_gadget_widget_fk",
+			},
+		)
+		schema.Constraints = []goschema.Constraint{{
+			StructName:      "RrtGadget",
+			Table:           rrtGadgets,
+			Name:            "ptah_rrt_gadget_qty_ck",
+			Type:            "CHECK",
+			CheckExpression: "qty > 0",
+		}}
+	}
+	goschema.Finalize(schema)
+	return schema
+}
+
+// rrtHasTable reports whether the dropped table is present in the catalog.
+func rrtHasTable(db *dbschematypes.DBSchema) bool {
+	for _, table := range db.Tables {
+		if table.Name == rrtGadgets {
+			return true
+		}
+	}
+	return false
+}
+
+// rrtCatalog reduces the introspected schema to the constraints on the table
+// this test drops and restores, so a mismatch names the constraint rather than
+// dumping a whole schema. The constraint NAME is deliberately included: a
+// rollback that restores a constraint under a server-chosen name has not
+// restored the catalog it started from.
+//
+// PostgreSQL's own NOT NULL checks are left out. They are not constraints
+// anybody declared — the server synthesizes one per non-null column and names
+// it after the table's OID, so a table that is dropped and re-created gets a
+// new OID and new names for constraints whose meaning never changed.
+func rrtCatalog(db *dbschematypes.DBSchema) []string {
+	var lines []string
+	for _, constraint := range db.Constraints {
+		if constraint.TableName != rrtGadgets || rrtSyntheticNotNull(constraint) {
+			continue
+		}
+		lines = append(lines, fmt.Sprintf("%s %s (%s)",
+			constraint.Type, constraint.Name, strings.Join(constraint.ColumnNamesOrDefault(), ",")))
+	}
+	sort.Strings(lines)
+	return lines
+}
+
+// rrtSyntheticNotNull reports the server-generated per-column NOT NULL check,
+// under the same rule the schema converter applies to it.
+func rrtSyntheticNotNull(constraint dbschematypes.DBConstraint) bool {
+	if constraint.CheckClause == nil || !strings.HasSuffix(constraint.Name, "_not_null") {
+		return false
+	}
+	clause := strings.TrimSpace(strings.ToUpper(*constraint.CheckClause))
+	return strings.HasSuffix(clause, " IS NOT NULL") && strings.Count(clause, " IS NOT NULL") == 1
+}
+
+// rrtDropAll clears this test's tables, child first, so a rerun starts from an
+// empty catalog whatever the previous run left behind.
+func rrtDropAll(conn *dbschema.DatabaseConnection) {
+	for _, statement := range []string{
+		"DROP TABLE IF EXISTS " + rrtGadgets + " CASCADE",
+		"DROP TABLE IF EXISTS " + rrtWidgets + " CASCADE",
+	} {
+		_, _ = conn.Exec(statement)
+	}
+}


### PR DESCRIPTION
Closes the one cell #1013 was narrowed to, following the decision recorded on
the issue: **option A** — export a narrow reverse from `migration/generator`
and inject it as a hook — plus the plan-shape change that goes with it.
Options B (relocate ~700 lines into an internal package) and C (a second dev
round trip) are not taken, for the reasons the issue gives.

## What was open

`migrate diff` was the last verb that refused a migration directory laid out in
another tool's convention, under both spellings. Measured on `master` before
touching anything, on a golang-migrate directory hashed over that layout's
covered set, against the pinned community binary `v1.3.0` and a live PostgreSQL
dev database:

```
                                                community   ptah-compat (master)
diff --dir 'file://gm?format=golang-migrate'     0, WROTE    1, wrote nothing
diff --dir 'file://gm'            (CONTROL)      1           1
```

That refusal was the strict side and it stood for something real: the community
binary writes reverse SQL as well as forward SQL on every external layout, in
three shapes, and Ptah's `migrate diff` planned forward statements only.
Measured into an empty directory once per layout:

```
golang-migrate  20260808232952_demo.up.sql + …_demo.down.sql
flyway          V20260808233006__demo.sql  + U20260808233006__demo.sql
goose           one file: "-- +goose Up" … "-- +goose Down" …
dbmate          one file: "-- migrate:up" … "-- migrate:down" …
liquibase       one file: "--changeset atlas:-1" … "--rollback: …"
```

## Option A, as recorded

- `generator.ReverseSchemaDiff(diff, desired, current)` — one exported function
  in a package that already exports thirteen.
- `atlasmigrate.DiffOptions.PlanReverse` — the hook, on an internal type.
  `cmd/atlas/migrate_diff.go` supplies the function the same way it already
  supplies `VerifyDir` and `PreparePublication`.

The plan grows the second direction: `MigrationFileContent` carries `DownSQL`,
`Statements` and `ReverseStatements`, and `planDiffFileContents` produces both
halves. Four things then become layout-aware and nothing else does — the
existing directory is converted before it is replayed, the next version is
chosen from that converted view, the files are named and composed per layout,
and `atlas.sum` is computed over that layout's covered set.

The native Atlas layout takes the same path it always did.
`TestComposeMigrationArtifactsKeepsTheAtlasLayoutUnchanged` states that its file
name and bytes are unmoved.

## The rollback half is applied, not only rendered

The first revision of this branch wrote a rollback that **did not execute**
whenever the forward migration dropped a table. Reversing a diff swaps the
constraint lists, but the forward comparator deliberately never fills them for a
table it CREATES — so the reverse re-created the table AND listed its
constraints again, while the re-created body already carried the primary key
inline and had its field-level foreign key re-added by the planner's new-table
pass:

```sql
CREATE TABLE "gadgets" ("id" integer PRIMARY KEY NOT NULL, "widget_id" integer);
CREATE INDEX IF NOT EXISTS "gadgets_widget_idx" ON "gadgets" ("widget_id");
ALTER TABLE "gadgets" ADD PRIMARY KEY ("id");
ALTER TABLE "gadgets" ADD CONSTRAINT "gadgets_widget_fk" FOREIGN KEY …;
ALTER TABLE "gadgets" ADD CONSTRAINT "gadgets_widget_fk" FOREIGN KEY …;   -- again
```

```
$ psql -v ON_ERROR_STOP=1 -f …_dropgadgets.down.sql
CREATE TABLE / CREATE INDEX
ERROR:  multiple primary keys for table "gadgets" are not allowed
exit 3
```

**The same defect was already on `master`, on the native verb.** Measured with a
`master` build of `ptah migrations generate` against the same fixture: the
`.down.sql` it writes has the same shape and fails identically — PostgreSQL
17.10 exit 3, and MySQL 9.7 `ERROR 1068 (42000): Multiple primary key defined`,
exit 1. This branch did not introduce the rule; it made an already-broken
rollback reachable from a verb that used to exit 1 and write nothing. The fix
therefore lands where the rule is shared, in `reverseSchemaDiffWithSchema`, and
both writers of down files get it.

What is dropped from the reverse is only what the re-created table
demonstrably restores: its primary key (single-column and composite alike, both
rendered inline), and a field-level foreign key the new-table pass re-emits
under the same name. A **self-referencing** or **multi-column** foreign key is
kept, because that pass emits neither — measured on a fixture carrying both.
CHECK and UNIQUE additions are kept as well: the table body restores neither by
name, so dropping them would trade a rollback that fails loudly for one that
silently restores less than it should.

Measured after the fix, same fixture, on the compat verb:

```
$ psql -v ON_ERROR_STOP=1 -f …_dropgadgets.down.sql
CREATE TABLE / CREATE INDEX / ALTER TABLE
exit 0

postgres=# \d gadgets
Indexes:    "gadgets_pkey" PRIMARY KEY, btree (id)
            "gadgets_widget_idx" btree (widget_id)
Foreign-key constraints: "gadgets_widget_fk" FOREIGN KEY (widget_id) REFERENCES widgets(id)
```

MySQL 9.7, the same pair through `ptah migrations generate`: master exit 1, this
branch exit 0 with `PRIMARY KEY (id)` and the foreign key back.

## Red without the fix, green with it

Five mutations, each applied to the working tree, measured, and reverted.

| mutation | result |
| --- | --- |
| `ReverseSchemaDiff` returns an empty diff | all five layout rows of `…_ForeignLayoutComposesEachLayoutsFiles` RED, plus `…_GolangMigrateQueryWritesThatLayout` and the new rollback row. The container assertions alone stay green on goose and dbmate, which is why each row asserts the reverse SQL too |
| the foreign-layout refusal restored in `prepareAtlasMigrateDiffSource` | `…_GolangMigrateQueryWritesThatLayout`, `…_DirFormatFlagWritesTheSelectedLayout`, `…_ForeignLayoutComposesEachLayoutsFiles` (all five rows), the new rollback row, and three rows of `…_QueryFormatDecidesHowTheDirIsRead` RED |
| **the reverse rendered against `desired` instead of the pre-change state** — the cheaper wrong implementation the new doc comment warns about | every pre-existing `cmd/atlas` and `internal/atlasmigrate` test stayed GREEN (`go test ./internal/atlasmigrate` exit 0), because every other fixture is CREATE-only and its reverse is `DROP TABLE` against either schema. Only the new `TestCompatMigrateDiff_ForeignLayoutRollbackRebuildsTheDroppedTable` went RED, on a `.down.sql` written EMPTY |
| **the table-creation rule not applied** (deletion) | the unit rows RED on the duplicate; the live gate RED at execution, `ERROR: multiple primary keys for table "ptah_rrt_gadgets" are not allowed (SQLSTATE 42P16)` |
| **the table-creation rule applied to EVERY constraint type** — the cheaper wrong version of the fix, which also yields a rollback that applies | the unit rows RED on the missing CHECK and named UNIQUE; the live gate RED on the catalog compare, `CHECK ptah_rrt_gadget_qty_ck` absent after a rollback that exited 0 |

The last three are what the earlier evidence could not see, because no fixture
in this package had a forward half that DROPS anything. They are covered by:

- `migration/generator/reverse_recreated_tables_internal_test.go` — postgres and
  mysql rows over the real comparator, asserting both what the rollback stops
  repeating and what it must keep, plus the self-referencing and multi-column
  foreign keys it must not touch;
- `migration/generator/reverse_recreated_tables_live_internal_test.go`
  (`integration` tag, `POSTGRES_URL`) — seeds through Ptah, applies the up,
  **applies the down**, and compares the catalog. Wired into
  `.github/workflows/go-integration-tests.yml` behind the same
  `go test -list … | grep -q` existence guard the neighboring live gate uses, so
  a test that stops existing fails the step instead of silently not running;
- `cmd/atlas/migrate_diff_foreign_layout_rollback_test.go` — the first
  `migrate diff` fixture whose forward half DROPS something. It runs the verb,
  then executes both halves against a SQLite database and reads the catalog
  back, asserting the table returns with its foreign key.

## Measured against the binary

```
                                                community   ptah-compat
diff --dir 'file://gm?format=golang-migrate'     0, WROTE    0, WROTE
diff --dir 'file://gm' --dir-format golang-…     0, WROTE    0, WROTE
diff --dir 'file://gm'            (CONTROL)      1           1
```

`atlas.sum` afterwards covers the `.up.sql` halves and no `.down.sql`, and the
`.down.sql` carries real SQL rather than the empty file `migrate new` leaves.
The directory this writes was handed back to the pinned binary:
`migrate validate` exits 0, and `migrate apply` into a live PostgreSQL database
exits 0 and runs both migrations, the create and the drop.

The community binary's rollback for the drop fixture is one statement —
`CREATE TABLE "gadgets" (… PRIMARY KEY ("id"), CONSTRAINT "gadgets_widget_fk" …)`
— where Ptah's is a CREATE TABLE plus an ALTER for the foreign key. Both restore
the same catalog; the DDL text is Ptah's renderer's on every layout, including
`atlas`, and always was.

On a hashed NATIVE Atlas directory the layout decides how it is READ, so the
answer differs per row and each was measured:

```
?format=          community        ptah-compat
golang-migrate    1, mismatch      1, mismatch
flyway            1, mismatch      1, mismatch
goose             0, WROTE         0, WROTE
liquibase         0, WROTE         0, WROTE
dbmate            0, WROTE         1, refused     ← deliberate, below
atlas  (CONTROL)  0, WROTE         0, WROTE
```

## Deliberate divergences and residual differences

**liquibase granularity.** Ptah writes ONE changeset carrying the whole
migration and all of its `--rollback:` lines, where the community binary writes
one changeset per statement. Pairing forward statement *i* with reverse
statement *i* would be a guess: the reverse is planned for the run as a whole
and ordered by reverse dependency, so the two lists are neither index-aligned
nor necessarily the same length. Rolling the migration back is exact either way.

**dbmate reading a native Atlas file.** The community binary treats a file with
no `-- migrate:up` as having no up SQL, and then replans everything that file
already created — measured, it emitted `CREATE TABLE widgets` a second time.
Ptah's dbmate reader refuses instead. That refusal is older than this change and
is shared with `apply`, `lint` and `new`.

**Two differences survive a table's drop-and-rollback**, on this verb and on
`ptah migrations generate` alike, both present on `master` and unchanged here.
The restored primary key takes the server's default name rather than the name it
had, because the table body has nowhere to put one. A column that was UNIQUE
comes back both from the table body and from the named constraint, so the
restored table holds two unique constraints where it held one. Neither stops the
rollback from applying; both mean a `schema diff` right after a rollback can
report work to do. Written down in `reference/atlas-commands.md`.

`--edit` stays Atlas-only, matching the line `migrate new` already draws.

## Gates

Every one run from the worktree root on the REBASED tree (onto `master`
71a7d7f2), exit codes read directly:

```
go build ./...                        0
go vet ./...                          0
go vet -tags integration ./integration/...  0
go test ./... -count=1                0   (262 ok/no-test lines, 0 FAIL)
go tool qtlint ./...                  0
golangci-lint run ./...               0   (0 issues)
scripts/check-test-style.sh           0   (175 conditional groups, 42 white-box files)
scripts/check-public-api.sh           0
scripts/check-public-api-snapshot.sh  0
scripts/check-public-api-released.sh  0
docs/site: npm ci + all 14 check:* scripts   0   (check:responsive needs npm run build first)
```

Plus the live gate, against PostgreSQL 17.10 on a database of its own:

```
POSTGRES_URL=… go test -tags integration -count=1 \
  -run '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$' \
  ./migration/generator                0
```

The public-API surface grows exactly one line in `docs/public_api.snapshot`:

```
+func ReverseSchemaDiff(diff *types.SchemaDiff, desired *goschema.Database, ...) *types.SchemaDiff
```

## What remains open on #1013

Not claiming the issue closed. Two items survive.

**(c) — the conformance scenario, and it lives outside this repository.** The
definition of done asks for ce-gating scenarios pinning the golang-migrate
outcome flip. Everything in this PR is pinned in-process in `cmd/atlas`;
nothing in `ptah-atlas-conformance` runs both binaries on the `gm/` fixture
differentially. That is a separate change in a separate repository.

**The MySQL-family backing index.** `ReverseSchemaDiff` carries the exact
signature the issue recorded, which takes no dialect, so the two refinements
`migration/generator` applies to its own down direction are not included: the
backing index a dropped MySQL/MariaDB FOREIGN KEY leaves behind, and the
concurrent-index refs a down file inherits from the up file's policy. Neither
applies on PostgreSQL or SQLite. On MySQL and MariaDB a rollback of a migration
that ADDED a foreign key will leave that index behind. The exported doc comment
says so, and says what a caller that needs it has to add.

Refs #990, #1002, #1011, #1086, #1087, #1133, #1135, #1172, #1237.