### PR TITLE
feat(atlas): expand dynamic project environments

### DIFF
--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -1,6 +1,7 @@
 package atlas
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -15,6 +16,7 @@ import (
 
 	"go.5x5.cz/ptah/cmd/internal/cmdutil"
 	"go.5x5.cz/ptah/cmd/internal/dbcli"
+	"go.5x5.cz/ptah/cmd/internal/exitcode"
 	"go.5x5.cz/ptah/config/projectconfig"
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/internal/atlasargs"
@@ -40,6 +42,14 @@ type atlasMigrateApplyOptions struct {
 	lockTimeout     string
 	lock            atlasLockOptions
 	format          string
+}
+
+type atlasMigrateApplyRunOptions struct {
+	amount          uint64
+	baselineVersion int64
+	toVersion       int64
+	lockRequest     atlasLockRequest
+	skipChecks      bool
 }
 
 func newAtlasMigrateApplyCommand() *cobra.Command {
@@ -136,16 +146,75 @@ func runAtlasMigrateApply(
 	opts atlasMigrateApplyOptions,
 	args []string,
 ) (runErr error) {
-	formatOutput := cmd.Flags().Changed("format")
 	mode := ignoreMissingEnvSelection
 	if needsAtlasMigrateApplyConfig(cmd) {
 		mode = reportMissingEnvSelection
 	}
-	project, loaded, err := openAtlasProjectForCommand(cmd, mode)
+	projects, loaded, err := openAtlasProjectsForCommand(cmd, mode)
 	if err != nil {
 		return err
 	}
-	defer closeAtlasProject(&project, &runErr)
+	defer closeAtlasProjectSet(&projects, &runErr)
+
+	amount, err := atlasmigrate.ParseApplyAmount(args)
+	if err != nil {
+		return err
+	}
+	baselineVersion, err := atlasmigrate.ParseMigrationVersionFlag("baseline", opts.baseline)
+	if err != nil {
+		return err
+	}
+	toVersion, err := atlasmigrate.ParseMigrationVersionFlag("to-version", opts.toVersion)
+	if err != nil {
+		return err
+	}
+	lockRequest, err := resolveAtlasLockRequest(cmd, opts.lock)
+	if err != nil {
+		return err
+	}
+	skipChecks, err := resolveAtlasApplySkipChecks(cmd)
+	if err != nil {
+		return err
+	}
+	runOpts := atlasMigrateApplyRunOptions{
+		amount:          amount,
+		baselineVersion: baselineVersion,
+		toVersion:       toVersion,
+		lockRequest:     lockRequest,
+		skipChecks:      skipChecks,
+	}
+
+	targets := projects.projects
+	if !loaded {
+		targets = []atlasProject{{}}
+	}
+	out := cmd.OutOrStdout()
+	var targetOutput bytes.Buffer
+	cmd.SetOut(io.MultiWriter(out, &targetOutput))
+	defer cmd.SetOut(out)
+	for index, project := range targets {
+		formatted, err := runAtlasMigrateApplyTarget(cmd, project, opts, runOpts)
+		if err != nil {
+			return err
+		}
+		if formatted && index < len(targets)-1 && atlasMigrateApplyOutputNeedsSeparator(targetOutput.Bytes()) {
+			if _, err := fmt.Fprintln(out); err != nil {
+				return fmt.Errorf("write atlas migrate apply report separator: %w", err)
+			}
+		}
+		targetOutput.Reset()
+	}
+	return nil
+}
+
+func runAtlasMigrateApplyTarget(
+	cmd *cobra.Command,
+	project atlasProject,
+	opts atlasMigrateApplyOptions,
+	runOpts atlasMigrateApplyRunOptions,
+) (bool, error) {
+	formatOutput := cmd.Flags().Changed("format")
+	loaded := project.root != nil
 	projectCfg := project.Config
 	if loaded {
 		opts.url = dbcli.EffectiveString(
@@ -193,21 +262,24 @@ func runAtlasMigrateApply(
 		formatOutput = formatOutput || formatValue.Present
 	}
 	if formatOutput && strings.TrimSpace(opts.format) == "" {
-		return fmt.Errorf("--format must not be empty")
+		return formatOutput, fmt.Errorf("--format must not be empty")
 	}
 	if formatOutput {
 		if err := atlasreport.ValidateMigrateApplyTemplate(opts.format); err != nil {
-			return err
+			return formatOutput, err
 		}
 	}
 	if opts.url == "" {
-		return fmt.Errorf("database URL is required")
+		return formatOutput, fmt.Errorf("database URL is required")
 	}
 	if opts.dir == "" {
-		return fmt.Errorf("migrations directory is required")
+		return formatOutput, fmt.Errorf("migrations directory is required")
 	}
 
-	var localDir atlasargs.LocalDir
+	var (
+		localDir atlasargs.LocalDir
+		err      error
+	)
 	if loaded &&
 		!cmd.Flags().Changed("dir") &&
 		projectCfg.StringValue(projectconfig.StringMigrationDir).Present {
@@ -216,7 +288,7 @@ func runAtlasMigrateApply(
 		localDir, err = atlasargs.ParseLocalDir(opts.dir)
 	}
 	if err != nil {
-		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+		return formatOutput, fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
 	// An atlas.hcl `migration { format = "" }` selects the native Atlas layout
 	// rather than being refused. `migrate apply` registers no --dir-format flag,
@@ -226,59 +298,39 @@ func runAtlasMigrateApply(
 	// [resolveAtlasMigrateApplyDirFormat] below maps the empty value to the
 	// Atlas format, the same as the empty --dir-format the other verbs accept.
 
-	amount, err := atlasmigrate.ParseApplyAmount(args)
-	if err != nil {
-		return err
-	}
-	baselineVersion, err := atlasmigrate.ParseMigrationVersionFlag("baseline", opts.baseline)
-	if err != nil {
-		return err
-	}
-	toVersion, err := atlasmigrate.ParseMigrationVersionFlag("to-version", opts.toVersion)
-	if err != nil {
-		return err
-	}
 	txMode, err := migrator.ParseMigrationTxMode(opts.txMode)
 	if err != nil {
-		return err
+		return formatOutput, err
 	}
 	execOrder, err := migrator.ParseExecOrder(opts.execOrder)
 	if err != nil {
-		return err
+		return formatOutput, err
 	}
 	migrationLockTimeout, err := migrator.ParseMigrationLockTimeout(opts.lockTimeout)
 	if err != nil {
-		return err
-	}
-	lockRequest, err := resolveAtlasLockRequest(cmd, opts.lock)
-	if err != nil {
-		return err
-	}
-	skipChecks, err := resolveAtlasApplySkipChecks(cmd)
-	if err != nil {
-		return err
+		return formatOutput, err
 	}
 
 	resolvedDirFormat, err := resolveAtlasMigrateApplyDirFormat(cmd, opts.dirFormat, localDir.Query)
 	if err != nil {
-		return err
+		return formatOutput, err
 	}
 
 	source, err := project.openLocal(localDir)
 	if err != nil {
-		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+		return formatOutput, fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
 	dir := source.Display()
 	captured, err := atlasmigrate.CaptureApplySource(source.FS(), resolvedDirFormat)
 	closeErr := source.Close()
 	if err != nil {
-		return errors.Join(
+		return formatOutput, errors.Join(
 			fmt.Errorf("atlas migrate apply --dir: %w", err),
 			closeErr,
 		)
 	}
 	if closeErr != nil {
-		return fmt.Errorf("atlas migrate apply --dir: close migrations directory: %w", closeErr)
+		return formatOutput, fmt.Errorf("atlas migrate apply --dir: close migrations directory: %w", closeErr)
 	}
 
 	// Integrity gate (#955, #970, #973): the SOURCE directory must carry an
@@ -295,45 +347,46 @@ func runAtlasMigrateApply(
 	// unhashed directory can execute or create the target database — CE emits
 	// the checksum refusal even when --url is unreachable.
 	if err := verifyAtlasApplyChecksum(cmd, captured, resolvedDirFormat); err != nil {
-		return err
+		return formatOutput, err
 	}
 
 	migrationFS, err := atlasmigrate.ConvertApplySource(captured, dir, resolvedDirFormat)
 	if err != nil {
-		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+		return formatOutput, fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
 
 	conn, err := dbschema.ConnectToDatabase(cmd.Context(), opts.url)
 	if err != nil {
-		return fmt.Errorf("error connecting to database: %w", err)
+		return formatOutput, fmt.Errorf("error connecting to database: %w", err)
 	}
 	defer dbschema.CloseAndWarn(conn)
 
 	linearity, err := flywayLinearityOperands(captured, resolvedDirFormat)
 	if err != nil {
-		return fmt.Errorf("atlas migrate apply --dir: %w", err)
+		return formatOutput, fmt.Errorf("atlas migrate apply --dir: %w", err)
 	}
 
 	cleanScope, plan, err := inspectThenPrepareApply(cmd.Context(), conn, atlasmigrate.ApplyOptions{
-		Dir:                  dir,
-		FS:                   migrationFS,
-		DryRun:               opts.dryRun,
-		ExecOrder:            execOrder,
-		OutOfOrderExempt:     linearity.outOfOrderExempt,
-		SourceVersions:       linearity.sourceVersions,
-		TxMode:               txMode,
-		RevisionsSchema:      opts.revisionsSchema,
-		MigrationLockTimeout: migrationLockTimeout,
-		MigrationLockName:    lockRequest.Name,
-		SkipMigrationLock:    lockRequest.Skip,
-		Amount:               amount,
-		ToVersion:            toVersion,
-		AllowDirty:           opts.allowDirty,
-		BaselineVersion:      baselineVersion,
-		SkipChecks:           skipChecks,
+		Dir:                      dir,
+		FS:                       migrationFS,
+		DryRun:                   opts.dryRun,
+		ExecOrder:                execOrder,
+		OutOfOrderExempt:         linearity.outOfOrderExempt,
+		SourceVersions:           linearity.sourceVersions,
+		TxMode:                   txMode,
+		RevisionsSchema:          opts.revisionsSchema,
+		MigrationLockTimeout:     migrationLockTimeout,
+		MigrationLockName:        runOpts.lockRequest.Name,
+		SkipMigrationLock:        runOpts.lockRequest.Skip,
+		Amount:                   runOpts.amount,
+		ToVersion:                runOpts.toVersion,
+		AllowDirty:               opts.allowDirty,
+		DiscardRolledBackFailure: true,
+		BaselineVersion:          runOpts.baselineVersion,
+		SkipChecks:               runOpts.skipChecks,
 	})
 	if err != nil {
-		return err
+		return formatOutput, err
 	}
 	if err := runAtlasMigrateApplyRefusals(cmd.Context(), atlasMigrateApplyRefusalOperands{
 		conn:            conn,
@@ -344,10 +397,10 @@ func runAtlasMigrateApply(
 		execOrder:       execOrder,
 		revisionsSchema: opts.revisionsSchema,
 		allowDirty:      opts.allowDirty,
-		baselineVersion: baselineVersion,
+		baselineVersion: runOpts.baselineVersion,
 		cleanScope:      cleanScope,
 	}); err != nil {
-		return err
+		return formatOutput, err
 	}
 
 	noteAtlasMigrateApplyLockUnsupported(cmd, opts.lock, plan, conn.Info().Dialect)
@@ -356,7 +409,7 @@ func runAtlasMigrateApply(
 	emitApplyStart := func([]int64) {}
 	if !formatOutput {
 		emitApplyStart = func(selectedVersions []int64) {
-			emitAtlasMigrateApplyStart(out, opts, baselineVersion, selectedVersions)
+			emitAtlasMigrateApplyStart(out, opts, runOpts.baselineVersion, selectedVersions)
 		}
 	}
 	result, err := plan.ExecuteWithPreflight(
@@ -370,28 +423,37 @@ func runAtlasMigrateApply(
 		if formatOutput && result.ApplyError != nil {
 			writeErr := writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
 			if writeErr != nil {
-				return fmt.Errorf("%w; additionally failed to write --format output: %v", err, writeErr)
+				return formatOutput, fmt.Errorf("%w; additionally failed to write --format output: %v", err, writeErr)
 			}
+			// The structured report already carries the execution error. Atlas
+			// leaves stderr empty in this mode, so return a coded failure that
+			// bypasses the generic command diagnostic without losing exit status.
+			return formatOutput, exitcode.New(atlasErrorExitCode, err)
 		}
-		return err
+		return formatOutput, err
 	}
 	if handled, err := finishAtlasMigrateApplyFreshNoop(cmd, opts, migrationFS, conn, result); handled || err != nil {
-		return err
+		return formatOutput, err
 	}
 
 	if opts.dryRun {
 		emitAtlasMigrateApplyDeferredChecks(cmd, result.ChecksDeferred)
 		if formatOutput {
-			return writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
+			return formatOutput, writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
 		}
 		fmt.Fprintf(out, "Would have applied %d migrations.\n", len(result.SelectedVersions))
-		return nil
+		return formatOutput, nil
 	}
 	if formatOutput {
-		return writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
+		return formatOutput, writeAtlasMigrateApplyFormat(cmd, opts, migrationFS, conn, result)
 	}
 	fmt.Fprintf(out, "Migration complete. Current version: %d\n", result.FinalStatus.CurrentVersion)
-	return nil
+	return formatOutput, nil
+}
+
+func atlasMigrateApplyOutputNeedsSeparator(output []byte) bool {
+	trimmed := bytes.TrimLeft(output, " \t\r")
+	return len(trimmed) > 0 && !bytes.HasSuffix(trimmed, []byte{'\n'})
 }
 
 // noteAtlasMigrateApplyLockUnsupported surfaces the capability decision behind

--- a/cmd/atlas/migrate_apply_dynamic_env_test.go
+++ b/cmd/atlas/migrate_apply_dynamic_env_test.go
@@ -70,6 +70,7 @@ func TestCompatMigrateApplyDynamicEnvironments_HappyPath(t *testing.T) {
 	c.Assert(sqliteIndexCount(c, filepath.Join(root, "bar.db"), "c1_unique"), qt.Equals, 0)
 	c.Assert(sqliteIndexCount(c, filepath.Join(root, "foo.db"), "c1_unique"), qt.Equals, 0)
 	c.Assert(stdout, qt.Contains, "}\n{")
+	c.Assert(bytes.Count([]byte(stdout), []byte{'\n'}), qt.Equals, 1)
 
 	reports := decodeDynamicApplyReports(c, stdout)
 	c.Assert(reports[0].URL.Host, qt.Equals, "bar.db")
@@ -104,6 +105,7 @@ func TestCompatMigrateApplyDynamicEnvironments_PartialFailureAndRetry(t *testing
 	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "foo.db")), qt.DeepEquals, []string{"20240112070806"})
 	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "qux.db")), qt.DeepEquals, []string{"20240112070806"})
 	c.Assert(failureStdout, qt.Contains, "}\n{")
+	c.Assert(bytes.Count([]byte(failureStdout), []byte{'\n'}), qt.Equals, 1)
 	failureReports := decodeDynamicApplyReports(c, failureStdout)
 	c.Assert(failureReports[0].URL.Host, qt.Equals, "bar.db")
 	c.Assert(failureReports[0].Target, qt.Equals, "20240116003831")
@@ -119,6 +121,7 @@ func TestCompatMigrateApplyDynamicEnvironments_PartialFailureAndRetry(t *testing
 	c.Assert(retryErr, qt.ErrorMatches, `(?s).*UNIQUE constraint failed: t1.c1.*`)
 	c.Assert(retryStderr, qt.Equals, "")
 	c.Assert(retryStdout, qt.Contains, "}\n{")
+	c.Assert(bytes.Count([]byte(retryStdout), []byte{'\n'}), qt.Equals, 1)
 	retryReports := decodeDynamicApplyReports(c, retryStdout)
 	c.Assert(retryReports[0].URL.Host, qt.Equals, "bar.db")
 	c.Assert(retryReports[0].Applied, qt.HasLen, 0)

--- a/cmd/atlas/migrate_apply_dynamic_env_test.go
+++ b/cmd/atlas/migrate_apply_dynamic_env_test.go
@@ -1,0 +1,185 @@
+package atlas_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+const dynamicEnvironmentProject = `env {
+  for_each = toset([
+    "sqlite://bar.db?_fk=1",
+    "sqlite://foo.db?_fk=1",
+  ])
+  name = atlas.env
+  url  = each.value
+  migration {
+    dir = "file://migrations"
+  }
+}
+`
+
+const dynamicEnvironmentProjectWithThirdTarget = `env {
+  for_each = toset([
+    "sqlite://bar.db?_fk=1",
+    "sqlite://foo.db?_fk=1",
+    "sqlite://qux.db?_fk=1",
+  ])
+  name = atlas.env
+  url  = each.value
+  migration {
+    dir = "file://migrations"
+  }
+}
+`
+
+type dynamicApplyReport struct {
+	URL struct {
+		Host string
+	}
+	Applied []struct {
+		Version string
+	}
+	Target  string
+	Error   string
+	Message string
+}
+
+func TestCompatMigrateApplyDynamicEnvironments_HappyPath(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	writeDynamicEnvironmentProject(c)
+	writeDynamicEnvironmentMigrations(c)
+
+	stdout, stderr, err := executeDynamicEnvironmentApply("1")
+
+	c.Assert(err, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", stdout, stderr))
+	c.Assert(stderr, qt.Equals, "")
+	c.Assert(sqliteTableCount(c, filepath.Join(root, "bar.db"), "t1"), qt.Equals, 1)
+	c.Assert(sqliteTableCount(c, filepath.Join(root, "foo.db"), "t1"), qt.Equals, 1)
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "bar.db"), "c1_unique"), qt.Equals, 0)
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "foo.db"), "c1_unique"), qt.Equals, 0)
+	c.Assert(stdout, qt.Contains, "}\n{")
+
+	reports := decodeDynamicApplyReports(c, stdout)
+	c.Assert(reports[0].URL.Host, qt.Equals, "bar.db")
+	c.Assert(reports[0].Target, qt.Equals, "20240112070806")
+	c.Assert(reports[0].Applied, qt.HasLen, 1)
+	c.Assert(reports[1].URL.Host, qt.Equals, "foo.db")
+	c.Assert(reports[1].Target, qt.Equals, "20240112070806")
+	c.Assert(reports[1].Applied, qt.HasLen, 1)
+}
+
+func TestCompatMigrateApplyDynamicEnvironments_PartialFailureAndRetry(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	writeDynamicEnvironmentProjectWithThirdTarget(c)
+	writeDynamicEnvironmentMigrations(c)
+
+	initialStdout, initialStderr, initialErr := executeDynamicEnvironmentApply("1")
+	c.Assert(initialErr, qt.IsNil, qt.Commentf("stdout:\n%s\nstderr:\n%s", initialStdout, initialStderr))
+	c.Assert(initialStderr, qt.Equals, "")
+	c.Assert(sqliteTableCount(c, filepath.Join(root, "qux.db"), "t1"), qt.Equals, 1)
+	insertDuplicateDynamicEnvironmentRows(c, filepath.Join(root, "foo.db"))
+
+	failureStdout, failureStderr, failureErr := executeDynamicEnvironmentApply()
+
+	c.Assert(failureErr, qt.ErrorMatches, `(?s).*UNIQUE constraint failed: t1.c1.*`)
+	c.Assert(failureStderr, qt.Equals, "")
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "bar.db"), "c1_unique"), qt.Equals, 1)
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "foo.db"), "c1_unique"), qt.Equals, 0)
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "qux.db"), "c1_unique"), qt.Equals, 0)
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "bar.db")), qt.DeepEquals, []string{"20240112070806", "20240116003831"})
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "foo.db")), qt.DeepEquals, []string{"20240112070806"})
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "qux.db")), qt.DeepEquals, []string{"20240112070806"})
+	c.Assert(failureStdout, qt.Contains, "}\n{")
+	failureReports := decodeDynamicApplyReports(c, failureStdout)
+	c.Assert(failureReports[0].URL.Host, qt.Equals, "bar.db")
+	c.Assert(failureReports[0].Target, qt.Equals, "20240116003831")
+	c.Assert(failureReports[0].Applied, qt.HasLen, 1)
+	c.Assert(failureReports[0].Error, qt.Equals, "")
+	c.Assert(failureReports[1].URL.Host, qt.Equals, "foo.db")
+	c.Assert(failureReports[1].Target, qt.Equals, "20240116003831")
+	c.Assert(failureReports[1].Applied, qt.HasLen, 1)
+	c.Assert(failureReports[1].Error, qt.Contains, "UNIQUE constraint failed: t1.c1")
+
+	retryStdout, retryStderr, retryErr := executeDynamicEnvironmentApply()
+
+	c.Assert(retryErr, qt.ErrorMatches, `(?s).*UNIQUE constraint failed: t1.c1.*`)
+	c.Assert(retryStderr, qt.Equals, "")
+	c.Assert(retryStdout, qt.Contains, "}\n{")
+	retryReports := decodeDynamicApplyReports(c, retryStdout)
+	c.Assert(retryReports[0].URL.Host, qt.Equals, "bar.db")
+	c.Assert(retryReports[0].Applied, qt.HasLen, 0)
+	c.Assert(retryReports[0].Message, qt.Equals, "No migration files to execute")
+	c.Assert(retryReports[1].URL.Host, qt.Equals, "foo.db")
+	c.Assert(retryReports[1].Applied, qt.HasLen, 1, qt.Commentf("stdout:\n%s", retryStdout))
+	c.Assert(retryReports[1].Error, qt.Contains, "UNIQUE constraint failed: t1.c1")
+	c.Assert(sqliteIndexCount(c, filepath.Join(root, "qux.db"), "c1_unique"), qt.Equals, 0)
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "bar.db")), qt.DeepEquals, []string{"20240112070806", "20240116003831"})
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "foo.db")), qt.DeepEquals, []string{"20240112070806"})
+	c.Assert(sqliteAtlasRevisionVersions(c, filepath.Join(root, "qux.db")), qt.DeepEquals, []string{"20240112070806"})
+}
+
+func writeDynamicEnvironmentProject(c *qt.C) {
+	c.Helper()
+	c.Assert(os.WriteFile("atlas.hcl", []byte(dynamicEnvironmentProject), 0o600), qt.IsNil)
+}
+
+func writeDynamicEnvironmentProjectWithThirdTarget(c *qt.C) {
+	c.Helper()
+	c.Assert(os.WriteFile("atlas.hcl", []byte(dynamicEnvironmentProjectWithThirdTarget), 0o600), qt.IsNil)
+}
+
+func writeDynamicEnvironmentMigrations(c *qt.C) {
+	c.Helper()
+	writeAtlasApplyProjectMigration(c, "migrations", "20240112070806.sql", "CREATE TABLE t1(c1 int);\n")
+	writeAtlasApplyProjectMigration(c, "migrations", "20240116003831.sql", "CREATE UNIQUE INDEX c1_unique ON t1(c1);\n")
+	writeAtlasApplyProjectSum(c, "migrations")
+}
+
+func executeDynamicEnvironmentApply(amount ...string) (stdoutText, stderrText string, err error) {
+	args := []string{"migrate", "apply"}
+	args = append(args, amount...)
+	args = append(args, "--env", "local", "--format", "{{ json . }}")
+	cmd := atlas.NewCompatCommand("atlas")
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err = cmd.Execute()
+	return stdout.String(), stderr.String(), err
+}
+
+func decodeDynamicApplyReports(c *qt.C, output string) []dynamicApplyReport {
+	c.Helper()
+	decoder := json.NewDecoder(bytes.NewBufferString(output))
+	var first dynamicApplyReport
+	var second dynamicApplyReport
+	var excess dynamicApplyReport
+	c.Assert(decoder.Decode(&first), qt.IsNil, qt.Commentf("command output:\n%s", output))
+	c.Assert(decoder.Decode(&second), qt.IsNil, qt.Commentf("command output:\n%s", output))
+	c.Assert(decoder.Decode(&excess), qt.ErrorIs, io.EOF, qt.Commentf("command output:\n%s", output))
+	return []dynamicApplyReport{first, second}
+}
+
+func insertDuplicateDynamicEnvironmentRows(c *qt.C, dbPath string) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	_, err = conn.ExecContext(context.Background(), "INSERT INTO t1(c1) VALUES (1), (1)")
+	c.Assert(err, qt.IsNil)
+}

--- a/cmd/atlas/migrate_dirty_retry_test.go
+++ b/cmd/atlas/migrate_dirty_retry_test.go
@@ -75,10 +75,11 @@ func TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure(t *testing
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 	)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "failed to apply migration "+dirtyRetryVersionTwo)
-	c.Assert(compatTableNames(c, dbPath), qt.Not(qt.Contains), "dr_two")
+	c.Assert(compatTableNames(c, dbPath), qt.Contains, "dr_two")
 
 	// Without the flag the dirty guard still refuses, so --allow-dirty is doing
 	// the work rather than the guard having quietly disappeared.
@@ -87,6 +88,7 @@ func TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure(t *testing
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 	)
 	c.Assert(guardErr, qt.IsNotNil)
 	c.Assert(guardErr.Error(), qt.Contains, "is dirty")
@@ -95,6 +97,7 @@ func TestCompatCommand_MigrateApplyAllowDirtyRecoversAfterBodyFailure(t *testing
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 		"--allow-dirty",
 	)
 	c.Assert(retryErr, qt.IsNil)
@@ -135,6 +138,7 @@ func TestCompatCommand_DirtyGuardRefusalLeavesTheDatabaseWritable(t *testing.T) 
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 	)
 	c.Assert(err, qt.IsNotNil)
 
@@ -143,6 +147,7 @@ func TestCompatCommand_DirtyGuardRefusalLeavesTheDatabaseWritable(t *testing.T) 
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 	)
 	c.Assert(guardErr, qt.IsNotNil)
 	c.Assert(guardErr.Error(), qt.Contains, "is dirty")
@@ -175,6 +180,7 @@ func TestCompatCommand_MigrateStatusReportsTheDirtyMigration(t *testing.T) {
 		"migrate", "apply",
 		"--url", "sqlite://"+dbPath,
 		"--dir", "file://"+migrationsDir,
+		"--tx-mode", "none",
 	)
 	c.Assert(err, qt.IsNotNil)
 
@@ -186,8 +192,8 @@ func TestCompatCommand_MigrateStatusReportsTheDirtyMigration(t *testing.T) {
 
 	c.Assert(statusErr, qt.IsNil)
 	c.Assert(statusOut, qt.Contains, "Migration Status: PENDING\n")
-	c.Assert(statusOut, qt.Contains, "  -- Current Version: "+dirtyRetryVersionTwo+" (0 statements applied)\n")
-	c.Assert(statusOut, qt.Contains, "  -- Next Version:    "+dirtyRetryVersionTwo+" (2 statements left)\n")
+	c.Assert(statusOut, qt.Contains, "  -- Current Version: "+dirtyRetryVersionTwo+" (1 statements applied)\n")
+	c.Assert(statusOut, qt.Contains, "  -- Next Version:    "+dirtyRetryVersionTwo+" (1 statements left)\n")
 	c.Assert(statusOut, qt.Contains, "  -- Executed Files:  2 (last one partially)\n")
 	c.Assert(statusOut, qt.Contains, "  -- Pending Files:   1\n")
 	c.Assert(statusOut, qt.Contains, "\nLast migration attempt had errors:\n")

--- a/cmd/atlas/project_config.go
+++ b/cmd/atlas/project_config.go
@@ -57,6 +57,39 @@ type atlasProject struct {
 	migrationDirResolved bool
 }
 
+// atlasProjectSet owns one rooted project directory and exposes one non-owning
+// project view per selected Atlas environment instance. The root is shared so
+// dynamic expansion cannot reopen or resolve the same project through a
+// different filesystem boundary for each target.
+type atlasProjectSet struct {
+	projects []atlasProject
+	root     *pathguard.OpenedDirectory
+}
+
+func (s *atlasProjectSet) Close() error {
+	if s == nil || s.root == nil {
+		return nil
+	}
+	err := s.root.Close()
+	s.root = nil
+	return err
+}
+
+type atlasProjectSource struct {
+	path string
+	raw  []byte
+	root *pathguard.OpenedDirectory
+}
+
+func (s *atlasProjectSource) Close() error {
+	if s == nil || s.root == nil {
+		return nil
+	}
+	err := s.root.Close()
+	s.root = nil
+	return err
+}
+
 func (p *atlasProject) Close() error {
 	if p == nil || p.root == nil {
 		return nil
@@ -74,6 +107,10 @@ func closeAtlasProjectOnError(project *atlasProject, runErr *error) {
 	if *runErr != nil {
 		closeAtlasProject(project, runErr)
 	}
+}
+
+func closeAtlasProjectSet(projects *atlasProjectSet, runErr *error) {
+	*runErr = errors.Join(*runErr, projects.Close())
 }
 
 func (p atlasProject) localDirWithQuery(raw string) (atlasargs.LocalDir, error) {
@@ -159,42 +196,79 @@ func openAtlasProject(
 	flags atlasProjectFlagValues,
 	requirement atlasProjectRequirement,
 ) (atlasProject, bool, error) {
+	source, loaded, err := openAtlasProjectSource(flags, requirement)
+	if err != nil || !loaded {
+		return atlasProject{}, loaded, err
+	}
+	cfg, err := projectconfig.ParseAtlasFSWithOptions(
+		source.raw,
+		source.path,
+		source.root.FS(),
+		projectconfig.AtlasLoadOptions{EnvName: flags.envName, Vars: flags.vars},
+	)
+	if err != nil {
+		return atlasProject{}, false, errors.Join(err, source.Close())
+	}
+	root := source.root
+	source.root = nil
+	return atlasProject{Config: cfg, root: root}, true, nil
+}
+
+func openAtlasProjects(
+	flags atlasProjectFlagValues,
+	requirement atlasProjectRequirement,
+) (atlasProjectSet, bool, error) {
+	source, loaded, err := openAtlasProjectSource(flags, requirement)
+	if err != nil || !loaded {
+		return atlasProjectSet{}, loaded, err
+	}
+	configs, err := projectconfig.ParseAtlasFSCollectionWithOptions(
+		source.raw,
+		source.path,
+		source.root.FS(),
+		projectconfig.AtlasLoadOptions{EnvName: flags.envName, Vars: flags.vars},
+	)
+	if err != nil {
+		return atlasProjectSet{}, false, errors.Join(err, source.Close())
+	}
+	projects := make([]atlasProject, 0, len(configs))
+	for _, cfg := range configs {
+		projects = append(projects, atlasProject{Config: cfg, root: source.root})
+	}
+	root := source.root
+	source.root = nil
+	return atlasProjectSet{projects: projects, root: root}, true, nil
+}
+
+func openAtlasProjectSource(
+	flags atlasProjectFlagValues,
+	requirement atlasProjectRequirement,
+) (atlasProjectSource, bool, error) {
 	path, err := atlasConfigPathValue(flags.configPath)
 	if err != nil {
-		return atlasProject{}, false, err
+		return atlasProjectSource{}, false, err
 	}
 	absolute, err := filepath.Abs(path)
 	if err != nil {
-		return atlasProject{}, false, fmt.Errorf("resolve atlas config path %s: %w", path, err)
+		return atlasProjectSource{}, false, fmt.Errorf("resolve atlas config path %s: %w", path, err)
 	}
 	root, err := pathguard.OpenDirectory(filepath.Dir(absolute))
 	if err != nil {
-		return atlasProject{}, false, fmt.Errorf("open atlas config directory %s: %w", filepath.Dir(path), err)
+		return atlasProjectSource{}, false, fmt.Errorf("open atlas config directory %s: %w", filepath.Dir(path), err)
 	}
 	raw, err := fs.ReadFile(root.FS(), filepath.Base(absolute))
 	if errors.Is(err, fs.ErrNotExist) && requirement == optionalAtlasProject {
 		closeErr := root.Close()
-		return atlasProject{}, false, closeErr
+		return atlasProjectSource{}, false, closeErr
 	}
 	if err != nil {
 		closeErr := root.Close()
-		return atlasProject{}, false, errors.Join(
+		return atlasProjectSource{}, false, errors.Join(
 			fmt.Errorf("failed to read atlas config %s: %w", path, err),
 			closeErr,
 		)
 	}
-	cfg, err := projectconfig.ParseAtlasFSWithOptions(raw, path, root.FS(), projectconfig.AtlasLoadOptions{
-		EnvName: flags.envName,
-		Vars:    flags.vars,
-	})
-	if err != nil {
-		closeErr := root.Close()
-		return atlasProject{}, false, errors.Join(err, closeErr)
-	}
-	return atlasProject{
-		Config: cfg,
-		root:   root,
-	}, true, nil
+	return atlasProjectSource{path: path, raw: raw, root: root}, true, nil
 }
 
 func openRequiredMergedProjectConfig(
@@ -332,6 +406,33 @@ func openAtlasProjectForCommand(
 		}
 	}
 	return project, loaded, nil
+}
+
+func openAtlasProjectsForCommand(
+	cmd *cobra.Command,
+	mode missingAtlasEnvSelectionMode,
+) (atlasProjectSet, bool, error) {
+	flags, changed, err := atlasProjectFlagsFromCommand(cmd)
+	if err != nil {
+		return atlasProjectSet{}, false, err
+	}
+	requirement := optionalAtlasProject
+	if changed {
+		requirement = requiredAtlasProject
+	}
+	projects, loaded, err := openAtlasProjects(flags, requirement)
+	if err != nil {
+		if isAtlasEnvSelectionRequired(err) && mode == ignoreMissingEnvSelection {
+			return atlasProjectSet{}, false, nil
+		}
+		return atlasProjectSet{}, false, err
+	}
+	if loaded && len(projects.projects) > 0 {
+		if err := dbcli.ReportIgnoredAtlasConstructs(cmd.ErrOrStderr(), projects.projects[0].Config); err != nil {
+			return atlasProjectSet{}, false, errors.Join(err, projects.Close())
+		}
+	}
+	return projects, loaded, nil
 }
 
 func atlasProjectFlagsFromCommand(cmd *cobra.Command) (atlasProjectFlagValues, bool, error) {

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -37,38 +37,43 @@ func LoadAtlasFile(path, envName string) (Config, error) {
 // config file with Atlas-compatible evaluation options. A missing file returns
 // an empty config.
 func LoadAtlasFileWithOptions(path string, opts AtlasLoadOptions) (Config, error) {
-	return loadAtlasFileWithOptions(path, opts)
+	configs, err := LoadAtlasFileCollectionWithOptions(path, opts)
+	if err != nil {
+		return Config{}, err
+	}
+	return singularAtlasConfig(configs, opts.EnvName)
 }
 
-func loadAtlasFileWithOptions(
+// LoadAtlasFileCollectionWithOptions loads every selected instance from an
+// Atlas project config file with Atlas-compatible evaluation options. A
+// missing file returns a collection containing one empty config.
+func LoadAtlasFileCollectionWithOptions(
 	path string,
 	opts AtlasLoadOptions,
-) (
-	cfg Config,
-	returnErr error,
-) {
+) ([]Config, error) {
 	absolute, err := filepath.Abs(path)
 	if err != nil {
-		return Config{}, fmt.Errorf("resolve atlas config path %s: %w", path, err)
+		return nil, fmt.Errorf("resolve atlas config path %s: %w", path, err)
 	}
 	root, err := os.OpenRoot(filepath.Dir(absolute))
 	if errors.Is(err, fs.ErrNotExist) {
-		return Config{}, nil
+		return []Config{{}}, nil
 	}
 	if err != nil {
-		return Config{}, fmt.Errorf("open atlas config directory %s: %w", filepath.Dir(path), err)
+		return nil, fmt.Errorf("open atlas config directory %s: %w", filepath.Dir(path), err)
 	}
-	defer func() {
-		returnErr = errors.Join(returnErr, root.Close())
-	}()
 	raw, err := fs.ReadFile(root.FS(), filepath.Base(absolute))
 	switch {
 	case errors.Is(err, fs.ErrNotExist):
-		return Config{}, nil
+		return []Config{{}}, root.Close()
 	case err != nil:
-		return Config{}, fmt.Errorf("failed to read atlas config %s: %w", path, err)
+		return nil, errors.Join(
+			fmt.Errorf("failed to read atlas config %s: %w", path, err),
+			root.Close(),
+		)
 	}
-	return ParseAtlasFSWithOptions(raw, path, root.FS(), opts)
+	configs, parseErr := ParseAtlasFSCollectionWithOptions(raw, path, root.FS(), opts)
+	return configs, errors.Join(parseErr, root.Close())
 }
 
 // ParseAtlas parses the supported subset of an Atlas project config file.
@@ -84,6 +89,19 @@ func ParseAtlas(data []byte, filename, envName string) (Config, error) {
 // read a file outside it. os.DirFS is deliberately not used here: it follows
 // such a link out of the directory and hands back the target's contents.
 func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error) {
+	configs, err := ParseAtlasCollectionWithOptions(data, filename, opts)
+	if err != nil {
+		return Config{}, err
+	}
+	return singularAtlasConfig(configs, opts.EnvName)
+}
+
+// ParseAtlasCollectionWithOptions parses every selected instance from an
+// Atlas project config file with Atlas-compatible evaluation options.
+//
+// file() and fileset() use the same rooted filesystem for every instance, so
+// expansion does not weaken the project directory confinement.
+func ParseAtlasCollectionWithOptions(data []byte, filename string, opts AtlasLoadOptions) ([]Config, error) {
 	if filename == "" {
 		filename = AtlasFileName
 	}
@@ -93,12 +111,10 @@ func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) 
 		// calls neither parses from an unreadable directory exactly as it did
 		// before the sandbox was rooted, so the failure is reported by the
 		// first read instead of by the parse.
-		return ParseAtlasFSWithOptions(data, filename, unreadableFS{err: err}, opts)
+		return ParseAtlasFSCollectionWithOptions(data, filename, unreadableFS{err: err}, opts)
 	}
-	// Closed here rather than in a defer, so the exported signature keeps its
-	// unnamed results and the public API snapshot stays byte-identical.
-	cfg, parseErr := ParseAtlasFSWithOptions(data, filename, root.FS(), opts)
-	return cfg, errors.Join(parseErr, root.Close())
+	configs, parseErr := ParseAtlasFSCollectionWithOptions(data, filename, root.FS(), opts)
+	return configs, errors.Join(parseErr, root.Close())
 }
 
 // unreadableFS reports the same error from every open. It stands in for a
@@ -127,23 +143,54 @@ func ParseAtlasFSWithOptions(
 	fsys fs.FS,
 	opts AtlasLoadOptions,
 ) (Config, error) {
+	configs, err := ParseAtlasFSCollectionWithOptions(data, filename, fsys, opts)
+	if err != nil {
+		return Config{}, err
+	}
+	return singularAtlasConfig(configs, opts.EnvName)
+}
+
+// ParseAtlasFSCollectionWithOptions parses every selected Atlas project config
+// instance while resolving file() and fileset() through fsys. fsys must be
+// rooted at the directory that contains filename.
+func ParseAtlasFSCollectionWithOptions(
+	data []byte,
+	filename string,
+	fsys fs.FS,
+	opts AtlasLoadOptions,
+) ([]Config, error) {
 	if filename == "" {
 		filename = AtlasFileName
 	}
 	file, diags := hclsyntax.ParseConfig(data, filename, hcl.Pos{Line: 1, Column: 1})
 	if diags.HasErrors() {
-		return Config{}, fmt.Errorf("parse atlas project config: %s", diags.Error())
+		return nil, fmt.Errorf("parse atlas project config: %s", diags.Error())
 	}
 	body, ok := file.Body.(*hclsyntax.Body)
 	if !ok {
-		return Config{}, fmt.Errorf("parse atlas project config: unsupported body type %T", file.Body)
+		return nil, fmt.Errorf("parse atlas project config: unsupported body type %T", file.Body)
 	}
 
 	p, err := newAtlasParser(fsys, opts.Vars, filename)
 	if err != nil {
-		return Config{}, err
+		return nil, err
 	}
-	return p.parse(body, opts.EnvName)
+	return p.parseCollection(body, opts.EnvName)
+}
+
+func singularAtlasConfig(configs []Config, envName string) (Config, error) {
+	switch len(configs) {
+	case 1:
+		return configs[0], nil
+	case 0:
+		return Config{}, fmt.Errorf("atlas env %q selected no project config instances", envName)
+	default:
+		return Config{}, fmt.Errorf(
+			"atlas env %q selected %d project config instances; use the corresponding collection-valued API",
+			envName,
+			len(configs),
+		)
+	}
 }
 
 type atlasParser struct {
@@ -216,6 +263,7 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 				"format":     stdlib.FormatFunc,
 				"getenv":     atlasGetenvFunc(),
 				"jsonencode": stdlib.JSONEncodeFunc,
+				"toset":      stdlib.MakeToFunc(cty.Set(cty.DynamicPseudoType)),
 			},
 		},
 		varOverride:     overrides,
@@ -224,14 +272,18 @@ func newAtlasParser(fsys fs.FS, rawVars []string, filename string) (atlasParser,
 	}, nil
 }
 
-func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error) {
+func (p atlasParser) parseCollection(body *hclsyntax.Body, envName string) ([]Config, error) {
+	p.ctx.Variables["atlas"] = cty.ObjectVal(map[string]cty.Value{
+		"env": cty.StringVal(envName),
+	})
+
 	// CE's tolerance covers unknown ATTRIBUTES as well as blocks -- measured,
 	// and the point stokaro/ptah#1014 left open. The expression is still
 	// evaluated, so a bad reference in one is still fatal.
 	for _, name := range sortedAttributeNames(body.Attributes) {
 		attr := body.Attributes[name]
 		if _, diags := attr.Expr.Value(p.ctx); diags.HasErrors() {
-			return Config{}, p.evaluationFailed(name, attr, diags)
+			return nil, p.evaluationFailed(name, attr, diags)
 		}
 		p.noteIgnored("attribute", name, attr.NameRange)
 	}
@@ -239,42 +291,52 @@ func (p atlasParser) parse(body *hclsyntax.Body, envName string) (Config, error)
 	base := Config{}
 	blocks, err := p.collectAtlasTopBlocks(body.Blocks)
 	if err != nil {
-		return Config{}, err
+		return nil, err
 	}
 	if err := p.validateAtlasEnvStructures(blocks.envs); err != nil {
-		return Config{}, err
+		return nil, err
 	}
 
 	if err := p.configureEvalContext(blocks.variables, blocks.locals, blocks.data); err != nil {
-		return Config{}, err
+		return nil, err
 	}
 	if err := p.parseSingleAtlasBlock(blocks.globalDiff, &base, p.parseDiff); err != nil {
-		return Config{}, err
+		return nil, err
 	}
 	if err := p.parseSingleAtlasBlock(blocks.globalLint, &base, p.parseLint); err != nil {
-		return Config{}, err
+		return nil, err
 	}
 	if len(blocks.envs) == 0 {
 		base.IgnoredConstructs = p.ignoredConstructs()
-		return base, nil
+		return []Config{base}, nil
 	}
 
-	selected, err := selectAtlasEnvBlock(blocks.envs, envName)
+	selected, err := selectAtlasEnvBlocks(blocks.envs, envName)
 	if err != nil {
-		return Config{}, err
+		return nil, err
 	}
-	cfg, err := p.parseEnv(selected)
-	if err != nil {
-		return Config{}, err
+	configs := make([]Config, 0, len(selected))
+	for _, env := range selected {
+		instances, err := p.parseAtlasEnvInstances(env, envName)
+		if err != nil {
+			return nil, err
+		}
+		for _, instance := range instances {
+			merged := Merge(base, instance)
+			if err := p.resolveExternalSchemaMarkers(&merged); err != nil {
+				return nil, err
+			}
+			configs = append(configs, merged)
+		}
 	}
-	merged := Merge(base, cfg)
-	if err := p.resolveExternalSchemaMarkers(&merged); err != nil {
-		return Config{}, err
+	if len(configs) == 0 {
+		return nil, fmt.Errorf("atlas env %q not found", envName)
 	}
-	// Set after Merge, not inside parseEnv: Merge carries only the fields it
-	// knows about, so an assignment made before it is silently dropped.
-	merged.IgnoredConstructs = p.ignoredConstructs()
-	return merged, nil
+	ignored := p.ignoredConstructs()
+	for i := range configs {
+		configs[i].IgnoredConstructs = slices.Clone(ignored)
+	}
+	return configs, nil
 }
 
 type atlasTopBlocks struct {
@@ -527,6 +589,10 @@ type atlasEnvBlock struct {
 	block *hclsyntax.Block
 }
 
+func (e atlasEnvBlock) labeled() bool {
+	return len(e.block.Labels) == 1
+}
+
 func atlasEnvBlockFromHCL(block *hclsyntax.Block) (atlasEnvBlock, error) {
 	if len(block.Labels) > 1 {
 		return atlasEnvBlock{}, unsupportedBlock(block)
@@ -541,9 +607,95 @@ func atlasEnvBlockFromHCL(block *hclsyntax.Block) (atlasEnvBlock, error) {
 	}, nil
 }
 
-func (p atlasParser) parseEnv(env atlasEnvBlock) (Config, error) {
+func (p atlasParser) parseAtlasEnvInstances(env atlasEnvBlock, selectedName string) ([]Config, error) {
+	nameAttr := env.block.Body.Attributes["name"]
+	forEachAttr, ok := env.block.Body.Attributes["for_each"]
+	if !ok {
+		instance, selected, err := p.parseAtlasEnvInstance(env, nameAttr, selectedName)
+		if err != nil {
+			return nil, err
+		}
+		if !selected {
+			return nil, nil
+		}
+		return []Config{instance}, nil
+	}
+	forEach, diags := forEachAttr.Expr.Value(p.ctx)
+	if diags.HasErrors() {
+		return nil, p.evaluationFailed("for_each", forEachAttr, diags)
+	}
+	if forEach.IsNull() {
+		return nil, fmt.Errorf("schemahcl: for_each cannot be null")
+	}
+	if !forEach.IsWhollyKnown() {
+		return nil, fmt.Errorf("schemahcl: for_each must be wholly known")
+	}
+	forEachType := forEach.Type()
+	if !forEachType.IsListType() &&
+		!forEachType.IsTupleType() &&
+		!forEachType.IsMapType() &&
+		!forEachType.IsObjectType() &&
+		!forEachType.IsSetType() {
+		return nil, fmt.Errorf("schemahcl: for_each does not support %s type", forEachType.FriendlyName())
+	}
+
+	configs := make([]Config, 0, forEach.LengthInt())
+	// cty preserves list/tuple order and gives map/object/set iterators a stable
+	// key order, so one iterator defines the public expansion order.
+	iterator := forEach.ElementIterator()
+	instanceNumber := 0
+	for iterator.Next() {
+		instanceNumber++
+		key, value := iterator.Element()
+		child := p.ctx.NewChild()
+		child.Variables = map[string]cty.Value{
+			"each": cty.ObjectVal(map[string]cty.Value{
+				"key":   key,
+				"value": value,
+			}),
+		}
+		instanceParser := p
+		instanceParser.ctx = child
+		instance, selected, err := instanceParser.parseAtlasEnvInstance(env, nameAttr, selectedName)
+		if err != nil {
+			// Values commonly contain database URLs and may originate in a
+			// sensitive variable. The ordinal identifies the failing expansion
+			// without publishing credentials through the error path.
+			return nil, fmt.Errorf("schemahcl: evaluate env block instance %d: %w", instanceNumber, err)
+		}
+		if selected {
+			configs = append(configs, instance)
+		}
+	}
+	return configs, nil
+}
+
+func (p atlasParser) parseAtlasEnvInstance(
+	env atlasEnvBlock,
+	nameAttr *hclsyntax.Attribute,
+	selectedName string,
+) (Config, bool, error) {
+	name := env.name
+	if nameAttr != nil {
+		var err error
+		name, err = p.nonEmptyStringAttr("name", nameAttr)
+		if err != nil {
+			return Config{}, false, err
+		}
+	}
+	if selectedName != "" && name != selectedName {
+		return Config{}, false, nil
+	}
+	cfg, err := p.parseEnv(env, name)
+	if err != nil {
+		return Config{}, false, err
+	}
+	return cfg, true, nil
+}
+
+func (p atlasParser) parseEnv(env atlasEnvBlock, name string) (Config, error) {
 	cfg := Config{
-		EnvName: env.name,
+		EnvName: name,
 	}
 	cfg.presence.mark(fieldEnvName)
 
@@ -713,6 +865,9 @@ func (p atlasParser) parseSchemaMode(block *hclsyntax.Block, cfg *Config) error 
 
 func (p atlasParser) parseEnvAttr(attrName string, attr *hclsyntax.Attribute, cfg *Config) error {
 	switch attrName {
+	case "for_each", "name":
+		// Meta attributes are evaluated before the instance body.
+		return nil
 	case "url":
 		value, err := p.stringAttr(attrName, attr)
 		if err != nil {
@@ -1257,11 +1412,8 @@ func (p atlasParser) configureVariables(blocks []*hclsyntax.Block) error {
 		if err != nil {
 			return err
 		}
-		if variable.sensitive && p.sensitiveValues != nil &&
-			value.Type() == cty.String && !value.IsNull() {
-			if raw := value.AsString(); raw != "" {
-				*p.sensitiveValues = append(*p.sensitiveValues, raw)
-			}
+		if variable.sensitive && p.sensitiveValues != nil {
+			appendSensitiveStrings(p.sensitiveValues, value)
 		}
 		vars[name] = value
 	}
@@ -1308,6 +1460,27 @@ func appendAtlasVarValue(existing cty.Value, value cty.Value) cty.Value {
 	return cty.ListVal([]cty.Value{existing, value})
 }
 
+func appendSensitiveStrings(target *[]string, value cty.Value) {
+	if value.IsNull() || !value.IsWhollyKnown() {
+		return
+	}
+	if value.Type() == cty.String {
+		if raw := value.AsString(); raw != "" {
+			*target = append(*target, raw)
+		}
+		return
+	}
+	if !value.CanIterateElements() {
+		return
+	}
+	iterator := value.ElementIterator()
+	for iterator.Next() {
+		key, element := iterator.Element()
+		appendSensitiveStrings(target, key)
+		appendSensitiveStrings(target, element)
+	}
+}
+
 // atlasVariable is one parsed atlas.hcl variable block.
 type atlasVariable struct {
 	name       string
@@ -1325,7 +1498,7 @@ func (v atlasVariable) typed() bool {
 // atlasSupportedVariableTypes names the variable type constraints Ptah
 // implements, for error messages. Anything else fails loudly so a config never
 // silently drops a constraint Atlas enforces.
-const atlasSupportedVariableTypes = "string, number, bool, and list(string)"
+const atlasSupportedVariableTypes = "string, number, bool, list(string), and map(string)"
 
 func (p atlasParser) parseVariableBlock(block *hclsyntax.Block) (atlasVariable, error) {
 	variable := atlasVariable{name: block.Labels[0]}
@@ -1460,8 +1633,8 @@ func atlasVariableTypeAttr(name string, attr *hclsyntax.Attribute) (cty.Type, er
 }
 
 // atlasVariableType maps the accepted atlas.hcl type expressions to cty types.
-// Exotic constraints (object, tuple, map, set, ...) report not-ok so the
-// caller rejects them with an error naming the supported set.
+// Other constraints (object, tuple, set, ...) report not-ok so the caller
+// rejects them with an error naming the supported set.
 func atlasVariableType(expr hclsyntax.Expression) (cty.Type, bool) {
 	switch expr := expr.(type) {
 	case *hclsyntax.ScopeTraversalExpr:
@@ -1474,9 +1647,14 @@ func atlasVariableType(expr hclsyntax.Expression) (cty.Type, bool) {
 			return cty.Bool, true
 		}
 	case *hclsyntax.FunctionCallExpr:
-		if expr.Name == "list" && len(expr.Args) == 1 {
+		if len(expr.Args) == 1 {
 			if arg, ok := expr.Args[0].(*hclsyntax.ScopeTraversalExpr); ok && atlasTypeKeyword(arg) == "string" {
-				return cty.List(cty.String), true
+				switch expr.Name {
+				case "list":
+					return cty.List(cty.String), true
+				case "map":
+					return cty.Map(cty.String), true
+				}
 			}
 		}
 	}
@@ -1504,6 +1682,8 @@ func atlasVariableTypeName(typ cty.Type) string {
 		return "bool"
 	case typ.IsListType():
 		return "list(string)"
+	case typ.IsMapType():
+		return "map(string)"
 	default:
 		return typ.FriendlyName()
 	}
@@ -1880,19 +2060,33 @@ func (p atlasParser) hclSchemaDataSource(block *hclsyntax.Block) (cty.Value, err
 	}
 }
 
-func selectAtlasEnvBlock(envs []atlasEnvBlock, envName string) (atlasEnvBlock, error) {
+func selectAtlasEnvBlocks(envs []atlasEnvBlock, envName string) ([]atlasEnvBlock, error) {
 	if envName != "" {
+		labeled := make([]atlasEnvBlock, 0, 1)
 		for _, env := range envs {
-			if env.name == envName {
-				return env, nil
+			if env.labeled() && env.name == envName {
+				labeled = append(labeled, env)
 			}
 		}
-		return atlasEnvBlock{}, fmt.Errorf("atlas env %q not found", envName)
+		if len(labeled) > 0 {
+			return labeled, nil
+		}
+
+		dynamic := make([]atlasEnvBlock, 0, 1)
+		for _, env := range envs {
+			if !env.labeled() {
+				dynamic = append(dynamic, env)
+			}
+		}
+		if len(dynamic) > 0 {
+			return dynamic, nil
+		}
+		return nil, fmt.Errorf("atlas env %q not found", envName)
 	}
 	if len(envs) == 1 {
-		return envs[0], nil
+		return envs, nil
 	}
-	return atlasEnvBlock{}, fmt.Errorf("atlas.hcl contains multiple env blocks; pass --env")
+	return nil, fmt.Errorf("atlas.hcl contains multiple env blocks; pass --env")
 }
 
 func (p atlasParser) stringAttr(name string, attr *hclsyntax.Attribute) (string, error) {

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -631,17 +631,15 @@ func (p atlasParser) parseAtlasEnvInstances(env atlasEnvBlock, selectedName stri
 		return nil, fmt.Errorf("schemahcl: for_each must be wholly known")
 	}
 	forEachType := forEach.Type()
-	if !forEachType.IsListType() &&
-		!forEachType.IsTupleType() &&
-		!forEachType.IsMapType() &&
+	if !forEachType.IsTupleType() &&
 		!forEachType.IsObjectType() &&
 		!forEachType.IsSetType() {
 		return nil, fmt.Errorf("schemahcl: for_each does not support %s type", forEachType.FriendlyName())
 	}
 
 	configs := make([]Config, 0, forEach.LengthInt())
-	// cty preserves list/tuple order and gives map/object/set iterators a stable
-	// key order, so one iterator defines the public expansion order.
+	// cty preserves tuple order and gives object/set iterators a stable key
+	// order, so one iterator defines the public expansion order.
 	iterator := forEach.ElementIterator()
 	instanceNumber := 0
 	for iterator.Next() {

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -683,12 +683,12 @@ func (p atlasParser) parseAtlasEnvInstance(
 			return Config{}, false, err
 		}
 	}
-	if selectedName != "" && name != selectedName {
-		return Config{}, false, nil
-	}
 	cfg, err := p.parseEnv(env, name)
 	if err != nil {
 		return Config{}, false, err
+	}
+	if selectedName != "" && name != selectedName {
+		return Config{}, false, nil
 	}
 	return cfg, true, nil
 }
@@ -2074,7 +2074,7 @@ func selectAtlasEnvBlocks(envs []atlasEnvBlock, envName string) ([]atlasEnvBlock
 
 		dynamic := make([]atlasEnvBlock, 0, 1)
 		for _, env := range envs {
-			if !env.labeled() {
+			if !env.labeled() && atlasEnvNameUsesSelection(env) {
 				dynamic = append(dynamic, env)
 			}
 		}
@@ -2087,6 +2087,23 @@ func selectAtlasEnvBlocks(envs []atlasEnvBlock, envName string) ([]atlasEnvBlock
 		return envs, nil
 	}
 	return nil, fmt.Errorf("atlas.hcl contains multiple env blocks; pass --env")
+}
+
+func atlasEnvNameUsesSelection(env atlasEnvBlock) bool {
+	name, ok := env.block.Body.Attributes["name"]
+	if !ok {
+		return false
+	}
+	for _, traversal := range name.Expr.Variables() {
+		if len(traversal) < 2 || traversal.RootName() != "atlas" {
+			continue
+		}
+		attribute, ok := traversal[1].(hcl.TraverseAttr)
+		if ok && attribute.Name == "env" {
+			return true
+		}
+	}
+	return false
 }
 
 func (p atlasParser) stringAttr(name string, attr *hclsyntax.Attribute) (string, error) {

--- a/config/projectconfig/atlas.go
+++ b/config/projectconfig/atlas.go
@@ -631,15 +631,17 @@ func (p atlasParser) parseAtlasEnvInstances(env atlasEnvBlock, selectedName stri
 		return nil, fmt.Errorf("schemahcl: for_each must be wholly known")
 	}
 	forEachType := forEach.Type()
-	if !forEachType.IsTupleType() &&
+	if !forEachType.IsListType() &&
+		!forEachType.IsTupleType() &&
+		!forEachType.IsMapType() &&
 		!forEachType.IsObjectType() &&
 		!forEachType.IsSetType() {
 		return nil, fmt.Errorf("schemahcl: for_each does not support %s type", forEachType.FriendlyName())
 	}
 
 	configs := make([]Config, 0, forEach.LengthInt())
-	// cty preserves tuple order and gives object/set iterators a stable key
-	// order, so one iterator defines the public expansion order.
+	// cty preserves list/tuple order and gives map/object/set iterators a stable
+	// key order, so one iterator defines the public expansion order.
 	iterator := forEach.ElementIterator()
 	instanceNumber := 0
 	for iterator.Next() {

--- a/config/projectconfig/atlas_dynamic_env_test.go
+++ b/config/projectconfig/atlas_dynamic_env_test.go
@@ -49,6 +49,7 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
+		prefix  string
 		forEach string
 		want    []dynamicEnvSummary
 	}{
@@ -61,8 +62,37 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 			},
 		},
 		{
+			name: "typed list keeps source order",
+			prefix: `variable "targets" {
+  type    = list(string)
+  default = ["second", "first"]
+}
+`,
+			forEach: `var.targets`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "second", Key: "0"},
+				{Name: "local", URL: "first", Key: "1"},
+			},
+		},
+		{
 			name:    "object sorts keys",
 			forEach: `{ z = "last", a = "first" }`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "first", Key: `"a"`},
+				{Name: "local", URL: "last", Key: `"z"`},
+			},
+		},
+		{
+			name: "typed map sorts keys",
+			prefix: `variable "targets" {
+  type = map(string)
+  default = {
+    z = "last"
+    a = "first"
+  }
+}
+`,
+			forEach: `var.targets`,
 			want: []dynamicEnvSummary{
 				{Name: "local", URL: "first", Key: `"a"`},
 				{Name: "local", URL: "last", Key: `"z"`},
@@ -80,7 +110,7 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			raw := []byte(`env {
+			raw := []byte(test.prefix + `env {
   for_each = ` + test.forEach + `
   name     = atlas.env
   url      = each.value
@@ -321,40 +351,17 @@ func TestParseAtlasCollectionRejectsInvalidForEach(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
-		prefix  string
 		value   string
 		wantErr string
 	}{
 		{name: "number", value: `42`, wantErr: `schemahcl: for_each does not support number type`},
 		{name: "string", value: `"target"`, wantErr: `schemahcl: for_each does not support string type`},
 		{name: "null", value: `null`, wantErr: `schemahcl: for_each cannot be null`},
-		{
-			name: "typed list",
-			prefix: `variable "targets" {
-  type    = list(string)
-  default = ["first", "second"]
-}
-`,
-			value:   `var.targets`,
-			wantErr: `schemahcl: for_each does not support list of string type`,
-		},
-		{
-			name: "typed map",
-			prefix: `variable "targets" {
-  type = map(string)
-  default = {
-    first = "one"
-  }
-}
-`,
-			value:   `var.targets`,
-			wantErr: `schemahcl: for_each does not support map of string type`,
-		},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			raw := []byte(test.prefix + `env {
+			raw := []byte(`env {
   for_each = ` + test.value + `
   name     = atlas.env
   url      = each.value

--- a/config/projectconfig/atlas_dynamic_env_test.go
+++ b/config/projectconfig/atlas_dynamic_env_test.go
@@ -186,7 +186,7 @@ func TestParseAtlasCollectionFiltersLabeledEnvByEvaluatedName(t *testing.T) {
 	c.Assert(err, qt.ErrorMatches, `atlas env "local" not found`)
 }
 
-func TestParseAtlasCollectionSelectsUnlabeledStaticEnvByName(t *testing.T) {
+func TestParseAtlasCollectionRejectsUnlabeledStaticEnvSelection(t *testing.T) {
 	c := qt.New(t)
 	raw := []byte(`env {
   name = "local"
@@ -199,17 +199,14 @@ env {
 }
 `)
 
-	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+	_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
 		EnvName: "local",
 	})
 
-	c.Assert(err, qt.IsNil)
-	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
-		{Name: "local", URL: "sqlite://local.db"},
-	})
+	c.Assert(err, qt.ErrorMatches, `atlas env "local" not found`)
 }
 
-func TestParseAtlasCollectionSelectsForEachInstanceByEvaluatedName(t *testing.T) {
+func TestParseAtlasCollectionRejectsUnlabeledEachKeySelection(t *testing.T) {
 	c := qt.New(t)
 	raw := []byte(`env {
   for_each = {
@@ -221,6 +218,21 @@ func TestParseAtlasCollectionSelectsForEachInstanceByEvaluatedName(t *testing.T)
 }
 `)
 
+	_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `atlas env "local" not found`)
+}
+
+func TestParseAtlasCollectionSelectsComputedAtlasEnvName(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  name = format("%s", atlas.env)
+  url  = "sqlite://local.db"
+}
+`)
+
 	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
 		EnvName: "local",
 	})
@@ -229,6 +241,27 @@ func TestParseAtlasCollectionSelectsForEachInstanceByEvaluatedName(t *testing.T)
 	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
 		{Name: "local", URL: "sqlite://local.db"},
 	})
+}
+
+func TestParseAtlasCollectionEvaluatesRejectedLabeledInstance(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  for_each = {
+    local = "sqlite://local.db"
+    prod  = "sqlite://prod.db"
+  }
+  name = each.key
+  url  = each.key == "prod" ? var.missing : each.value
+}
+`)
+
+	_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "schemahcl: evaluate env block instance 2")
+	c.Assert(err.Error(), qt.Contains, `no variable named "var"`)
 }
 
 func TestParseAtlasCollectionMergesGlobalPolicyIntoEveryInstance(t *testing.T) {

--- a/config/projectconfig/atlas_dynamic_env_test.go
+++ b/config/projectconfig/atlas_dynamic_env_test.go
@@ -49,7 +49,6 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
-		prefix  string
 		forEach string
 		want    []dynamicEnvSummary
 	}{
@@ -59,35 +58,6 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 			want: []dynamicEnvSummary{
 				{Name: "local", URL: "second", Key: "0"},
 				{Name: "local", URL: "first", Key: "1"},
-			},
-		},
-		{
-			name: "list keeps source order",
-			prefix: `variable "targets" {
-  type    = list(string)
-  default = ["second", "first"]
-}
-`,
-			forEach: `var.targets`,
-			want: []dynamicEnvSummary{
-				{Name: "local", URL: "second", Key: "0"},
-				{Name: "local", URL: "first", Key: "1"},
-			},
-		},
-		{
-			name: "map sorts keys",
-			prefix: `variable "targets" {
-  type = map(string)
-  default = {
-    z = "last"
-    a = "first"
-  }
-}
-`,
-			forEach: `var.targets`,
-			want: []dynamicEnvSummary{
-				{Name: "local", URL: "first", Key: `"a"`},
-				{Name: "local", URL: "last", Key: `"z"`},
 			},
 		},
 		{
@@ -110,7 +80,7 @@ func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			raw := []byte(test.prefix + `env {
+			raw := []byte(`env {
   for_each = ` + test.forEach + `
   name     = atlas.env
   url      = each.value
@@ -351,17 +321,40 @@ func TestParseAtlasCollectionRejectsInvalidForEach(t *testing.T) {
 	c := qt.New(t)
 	tests := []struct {
 		name    string
+		prefix  string
 		value   string
 		wantErr string
 	}{
 		{name: "number", value: `42`, wantErr: `schemahcl: for_each does not support number type`},
 		{name: "string", value: `"target"`, wantErr: `schemahcl: for_each does not support string type`},
 		{name: "null", value: `null`, wantErr: `schemahcl: for_each cannot be null`},
+		{
+			name: "typed list",
+			prefix: `variable "targets" {
+  type    = list(string)
+  default = ["first", "second"]
+}
+`,
+			value:   `var.targets`,
+			wantErr: `schemahcl: for_each does not support list of string type`,
+		},
+		{
+			name: "typed map",
+			prefix: `variable "targets" {
+  type = map(string)
+  default = {
+    first = "one"
+  }
+}
+`,
+			value:   `var.targets`,
+			wantErr: `schemahcl: for_each does not support map of string type`,
+		},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			raw := []byte(`env {
+			raw := []byte(test.prefix + `env {
   for_each = ` + test.value + `
   name     = atlas.env
   url      = each.value
@@ -380,14 +373,14 @@ func TestParseAtlasCollectionRejectsInvalidForEach(t *testing.T) {
 func TestParseAtlasCollectionDoesNotExposeForEachValueInBodyError(t *testing.T) {
 	c := qt.New(t)
 	const secret = "SUPERSECRET_DYNAMIC_TARGET_12345"
-	raw := []byte(`variable "targets" {
-  type      = list(string)
-  sensitive = true
-  default   = ["` + secret + `"]
+	raw := []byte(`variable "target" {
+	  type      = string
+	  sensitive = true
+	  default   = "` + secret + `"
 }
 
 env {
-  for_each = var.targets
+	  for_each = toset([var.target])
   name     = atlas.env
   url      = true
 }
@@ -405,14 +398,14 @@ env {
 func TestParseAtlasCollectionScrubsSensitiveForEachValueFromHCLDiagnostic(t *testing.T) {
 	c := qt.New(t)
 	const secret = "SUPERSECRET_DYNAMIC_FILE_12345"
-	raw := []byte(`variable "targets" {
-  type      = list(string)
-  sensitive = true
-  default   = ["` + secret + `"]
+	raw := []byte(`variable "target" {
+	  type      = string
+	  sensitive = true
+	  default   = "` + secret + `"
 }
 
 env {
-  for_each = var.targets
+	  for_each = toset([var.target])
   name     = atlas.env
   url      = file(each.value)
 }
@@ -433,16 +426,16 @@ env {
 func TestParseAtlasCollectionScrubsSensitiveForEachKeyFromHCLDiagnostic(t *testing.T) {
 	c := qt.New(t)
 	const secret = "SUPERSECRET_DYNAMIC_KEY_12345"
-	raw := []byte(`variable "targets" {
-  type      = map(string)
-  sensitive = true
-  default = {
-    "` + secret + `" = "sqlite://target.db"
-  }
+	raw := []byte(`variable "target" {
+	  type      = string
+	  sensitive = true
+	  default   = "` + secret + `"
 }
 
 env {
-  for_each = var.targets
+	  for_each = {
+	    (var.target) = "sqlite://target.db"
+	  }
   name     = atlas.env
   url      = file(each.key)
 }

--- a/config/projectconfig/atlas_dynamic_env_test.go
+++ b/config/projectconfig/atlas_dynamic_env_test.go
@@ -1,0 +1,469 @@
+package projectconfig_test
+
+import (
+	"testing"
+	"testing/fstest"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/config/projectconfig"
+)
+
+type dynamicEnvSummary struct {
+	Name string
+	URL  string
+	Key  string
+}
+
+func TestParseAtlasCollectionExpandsUpstreamMultiTenantFixture(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  for_each = toset([
+    "sqlite://bar.db?_fk=1",
+    "sqlite://foo.db?_fk=1",
+  ])
+  name = atlas.env
+  url  = each.value
+
+  migration {
+    dir = "file://migrations"
+  }
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(configs, qt.HasLen, 2)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "sqlite://bar.db?_fk=1"},
+		{Name: "local", URL: "sqlite://foo.db?_fk=1"},
+	})
+	c.Assert(configs[0].Migration.Dir, qt.Equals, "migrations")
+	c.Assert(configs[1].Migration.Dir, qt.Equals, "migrations")
+}
+
+func TestParseAtlasCollectionOrdersEachBindingsDeterministically(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		prefix  string
+		forEach string
+		want    []dynamicEnvSummary
+	}{
+		{
+			name:    "tuple keeps source order",
+			forEach: `["second", "first"]`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "second", Key: "0"},
+				{Name: "local", URL: "first", Key: "1"},
+			},
+		},
+		{
+			name: "list keeps source order",
+			prefix: `variable "targets" {
+  type    = list(string)
+  default = ["second", "first"]
+}
+`,
+			forEach: `var.targets`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "second", Key: "0"},
+				{Name: "local", URL: "first", Key: "1"},
+			},
+		},
+		{
+			name: "map sorts keys",
+			prefix: `variable "targets" {
+  type = map(string)
+  default = {
+    z = "last"
+    a = "first"
+  }
+}
+`,
+			forEach: `var.targets`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "first", Key: `"a"`},
+				{Name: "local", URL: "last", Key: `"z"`},
+			},
+		},
+		{
+			name:    "object sorts keys",
+			forEach: `{ z = "last", a = "first" }`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "first", Key: `"a"`},
+				{Name: "local", URL: "last", Key: `"z"`},
+			},
+		},
+		{
+			name:    "set sorts and removes duplicates",
+			forEach: `toset(["second", "first", "second"])`,
+			want: []dynamicEnvSummary{
+				{Name: "local", URL: "first", Key: `"first"`},
+				{Name: "local", URL: "second", Key: `"second"`},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(test.prefix + `env {
+  for_each = ` + test.forEach + `
+  name     = atlas.env
+  url      = each.value
+  dev      = jsonencode(each.key)
+}
+`)
+
+			configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+				EnvName: "local",
+			})
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, test.want)
+		})
+	}
+}
+
+func TestParseAtlasCollectionPreservesLabeledEnvPrecedence(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  url = "labeled"
+  dev = atlas.env
+}
+
+env {
+  for_each = var.not_evaluated
+  name     = atlas.env
+  url      = each.value
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "labeled", Key: "local"},
+	})
+}
+
+func TestParseAtlasCollectionExpandsLabeledEnv(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  for_each = toset(["sqlite://foo.db", "sqlite://bar.db"])
+  url      = each.value
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "sqlite://bar.db"},
+		{Name: "local", URL: "sqlite://foo.db"},
+	})
+}
+
+func TestParseAtlasCollectionFiltersLabeledEnvByEvaluatedName(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env "local" {
+  name = "other"
+  url  = "sqlite://other.db"
+}
+`)
+
+	_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.ErrorMatches, `atlas env "local" not found`)
+}
+
+func TestParseAtlasCollectionSelectsUnlabeledStaticEnvByName(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  name = "local"
+  url  = "sqlite://local.db"
+}
+
+env {
+  name = "prod"
+  url  = var.not_evaluated
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "sqlite://local.db"},
+	})
+}
+
+func TestParseAtlasCollectionSelectsForEachInstanceByEvaluatedName(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  for_each = {
+    prod  = "sqlite://prod.db"
+    local = "sqlite://local.db"
+  }
+  name = each.key
+  url  = each.value
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "sqlite://local.db"},
+	})
+}
+
+func TestParseAtlasCollectionMergesGlobalPolicyIntoEveryInstance(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`lint {
+  latest = 3
+}
+
+diff {
+  skip {
+    drop_table = true
+  }
+}
+
+env {
+  for_each = ["first", "second"]
+  name     = atlas.env
+  url      = each.value
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(configs, qt.HasLen, 2)
+	c.Assert(configs[0].Lint.Latest, qt.IsNotNil)
+	c.Assert(configs[1].Lint.Latest, qt.IsNotNil)
+	c.Assert(*configs[0].Lint.Latest, qt.Equals, 3)
+	c.Assert(*configs[1].Lint.Latest, qt.Equals, 3)
+	c.Assert(configs[0].Diff.Skip.DropTable, qt.DeepEquals, projectconfig.ConfigBool{Value: true, Set: true})
+	c.Assert(configs[1].Diff.Skip.DropTable, qt.DeepEquals, projectconfig.ConfigBool{Value: true, Set: true})
+}
+
+func TestParseAtlasCollectionSharesIgnoredConstructsAcrossInstances(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  for_each = ["first", "second"]
+  name     = atlas.env
+  url      = each.value
+  custom   = each.key
+}
+`)
+
+	configs, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(configs, qt.HasLen, 2)
+	want := []projectconfig.IgnoredAtlasConstruct{
+		{Name: "custom", Kind: "attribute", Filename: "atlas.hcl", Line: 5},
+	}
+	c.Assert(configs[0].IgnoredConstructs, qt.DeepEquals, want)
+	c.Assert(configs[1].IgnoredConstructs, qt.DeepEquals, want)
+}
+
+func TestParseAtlasCollectionReusesRootedFileEvaluation(t *testing.T) {
+	c := qt.New(t)
+	raw := []byte(`env {
+  for_each = toset(["first.txt", "second.txt"])
+  name     = atlas.env
+  url      = file(each.value)
+}
+`)
+	fsys := fstest.MapFS{
+		"first.txt":  {Data: []byte("first")},
+		"second.txt": {Data: []byte("second")},
+	}
+
+	configs, err := projectconfig.ParseAtlasFSCollectionWithOptions(
+		raw,
+		"atlas.hcl",
+		fsys,
+		projectconfig.AtlasLoadOptions{EnvName: "local"},
+	)
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(dynamicEnvSummaries(configs), qt.DeepEquals, []dynamicEnvSummary{
+		{Name: "local", URL: "first"},
+		{Name: "local", URL: "second"},
+	})
+}
+
+func TestParseAtlasCollectionRejectsInvalidForEach(t *testing.T) {
+	c := qt.New(t)
+	tests := []struct {
+		name    string
+		value   string
+		wantErr string
+	}{
+		{name: "number", value: `42`, wantErr: `schemahcl: for_each does not support number type`},
+		{name: "string", value: `"target"`, wantErr: `schemahcl: for_each does not support string type`},
+		{name: "null", value: `null`, wantErr: `schemahcl: for_each cannot be null`},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			raw := []byte(`env {
+  for_each = ` + test.value + `
+  name     = atlas.env
+  url      = each.value
+}
+`)
+
+			_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+				EnvName: "local",
+			})
+
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
+		})
+	}
+}
+
+func TestParseAtlasCollectionDoesNotExposeForEachValueInBodyError(t *testing.T) {
+	c := qt.New(t)
+	const secret = "SUPERSECRET_DYNAMIC_TARGET_12345"
+	raw := []byte(`variable "targets" {
+  type      = list(string)
+  sensitive = true
+  default   = ["` + secret + `"]
+}
+
+env {
+  for_each = var.targets
+  name     = atlas.env
+  url      = true
+}
+`)
+
+	_, err := projectconfig.ParseAtlasCollectionWithOptions(raw, "atlas.hcl", projectconfig.AtlasLoadOptions{
+		EnvName: "local",
+	})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "evaluate env block instance 1")
+	c.Assert(err.Error(), qt.Not(qt.Contains), secret)
+}
+
+func TestParseAtlasCollectionScrubsSensitiveForEachValueFromHCLDiagnostic(t *testing.T) {
+	c := qt.New(t)
+	const secret = "SUPERSECRET_DYNAMIC_FILE_12345"
+	raw := []byte(`variable "targets" {
+  type      = list(string)
+  sensitive = true
+  default   = ["` + secret + `"]
+}
+
+env {
+  for_each = var.targets
+  name     = atlas.env
+  url      = file(each.value)
+}
+`)
+
+	_, err := projectconfig.ParseAtlasFSCollectionWithOptions(
+		raw,
+		"atlas.hcl",
+		fstest.MapFS{},
+		projectconfig.AtlasLoadOptions{EnvName: "local"},
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "(sensitive value)")
+	c.Assert(err.Error(), qt.Not(qt.Contains), secret)
+}
+
+func TestParseAtlasCollectionScrubsSensitiveForEachKeyFromHCLDiagnostic(t *testing.T) {
+	c := qt.New(t)
+	const secret = "SUPERSECRET_DYNAMIC_KEY_12345"
+	raw := []byte(`variable "targets" {
+  type      = map(string)
+  sensitive = true
+  default = {
+    "` + secret + `" = "sqlite://target.db"
+  }
+}
+
+env {
+  for_each = var.targets
+  name     = atlas.env
+  url      = file(each.key)
+}
+`)
+
+	_, err := projectconfig.ParseAtlasFSCollectionWithOptions(
+		raw,
+		"atlas.hcl",
+		fstest.MapFS{},
+		projectconfig.AtlasLoadOptions{EnvName: "local"},
+	)
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "(sensitive value)")
+	c.Assert(err.Error(), qt.Not(qt.Contains), secret)
+}
+
+func TestSingularProjectConfigAdaptersRejectMultipleSelectedInstances(t *testing.T) {
+	c := qt.New(t)
+	raw := `env {
+  for_each = toset(["first", "second"])
+  name     = atlas.env
+  url      = each.value
+}
+`
+
+	_, err := projectconfig.ParseAtlas([]byte(raw), "atlas.hcl", "local")
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`atlas env "local" selected 2 project config instances; use the corresponding collection-valued API`,
+	)
+
+	chdirWith(c, map[string]string{"atlas.hcl": raw})
+	configs, err := projectconfig.LoadCollection(projectconfig.LoadOptions{EnvName: "local"})
+	c.Assert(err, qt.IsNil)
+	c.Assert(configs, qt.HasLen, 2)
+
+	_, err = projectconfig.Load(projectconfig.LoadOptions{EnvName: "local"})
+	c.Assert(
+		err,
+		qt.ErrorMatches,
+		`atlas env "local" selected 2 project config instances; use the corresponding collection-valued API`,
+	)
+}
+
+func dynamicEnvSummaries(configs []projectconfig.Config) []dynamicEnvSummary {
+	summaries := make([]dynamicEnvSummary, len(configs))
+	for i, cfg := range configs {
+		summaries[i] = dynamicEnvSummary{
+			Name: cfg.EnvName,
+			URL:  cfg.DatabaseURL,
+			Key:  cfg.DevURL,
+		}
+	}
+	return summaries
+}

--- a/config/projectconfig/atlas_structure.go
+++ b/config/projectconfig/atlas_structure.go
@@ -20,7 +20,7 @@ type atlasBlockStructure struct {
 
 func atlasEnvBodyStructure() atlasBodyStructure {
 	return atlasBodyStructure{
-		attributes:             []string{"dev", "exclude", "src", "url"},
+		attributes:             []string{"dev", "exclude", "for_each", "name", "src", "url"},
 		allowUnknownAttributes: true,
 		allowUnknownBlocks:     true,
 		blocks: map[string]atlasBlockStructure{

--- a/config/projectconfig/atlas_test.go
+++ b/config/projectconfig/atlas_test.go
@@ -1689,15 +1689,15 @@ env "local" {
   type = object({ url = string })
 }
 `,
-			err: `atlas\.hcl variable "conn" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, and list\(string\)`,
+			err: `atlas\.hcl variable "conn" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, list\(string\), and map\(string\)`,
 		},
 		{
-			name: "variable map type is unsupported",
+			name: "variable map element type is unsupported",
 			raw: `variable "labels" {
-  type = map(string)
+  type = map(number)
 }
 `,
-			err: `atlas\.hcl variable "labels" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, and list\(string\)`,
+			err: `atlas\.hcl variable "labels" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, list\(string\), and map\(string\)`,
 		},
 		{
 			name: "variable tuple type is unsupported",
@@ -1705,7 +1705,7 @@ env "local" {
   type = tuple([string, number])
 }
 `,
-			err: `atlas\.hcl variable "pair" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, and list\(string\)`,
+			err: `atlas\.hcl variable "pair" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, list\(string\), and map\(string\)`,
 		},
 		{
 			name: "variable list of number type is unsupported",
@@ -1713,7 +1713,7 @@ env "local" {
   type = list(number)
 }
 `,
-			err: `atlas\.hcl variable "ports" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, and list\(string\)`,
+			err: `atlas\.hcl variable "ports" type at atlas\.hcl:2 is not supported: supported types are string, number, bool, list\(string\), and map\(string\)`,
 		},
 		{
 			name: "variable default does not match type",

--- a/config/projectconfig/load.go
+++ b/config/projectconfig/load.go
@@ -13,6 +13,16 @@ type LoadOptions struct {
 // required to exist; an empty PtahPath uses the optional conventional
 // ./ptah.yaml path.
 func Load(opts LoadOptions) (Config, error) {
+	configs, err := LoadCollection(opts)
+	if err != nil {
+		return Config{}, err
+	}
+	return singularAtlasConfig(configs, opts.EnvName)
+}
+
+// LoadCollection reads Ptah and Atlas project config files and returns every
+// selected Atlas instance merged over the Ptah config.
+func LoadCollection(opts LoadOptions) ([]Config, error) {
 	ptahPath := opts.PtahPath
 	if ptahPath == "" {
 		ptahPath = PtahFileName
@@ -29,14 +39,18 @@ func Load(opts LoadOptions) (Config, error) {
 
 	ptah, err := loadPtahFile(ptahPath, opts.EnvName, ptahSource)
 	if err != nil {
-		return Config{}, err
+		return nil, err
 	}
-	atlas, err := LoadAtlasFileWithOptions(atlasPath, AtlasLoadOptions{
+	atlas, err := LoadAtlasFileCollectionWithOptions(atlasPath, AtlasLoadOptions{
 		EnvName: opts.EnvName,
 		Vars:    opts.AtlasVars,
 	})
 	if err != nil {
-		return Config{}, err
+		return nil, err
 	}
-	return Merge(ptah, atlas), nil
+	configs := make([]Config, len(atlas))
+	for i := range atlas {
+		configs[i] = Merge(ptah, atlas[i])
+	}
+	return configs, nil
 }

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -503,9 +503,10 @@ For an unlabeled block selected with `--env`, `name` must depend on `atlas.env`;
 a static name or a name based only on `each.key` does not define that selected
 environment. Labeled blocks use their label as the initial candidate. Every
 expanded instance of an admitted block is evaluated before its resulting name
-is filtered, so an invalid nonmatching instance still fails the command. List
-and tuple instances keep source order; map, object, and set instances use stable
-key order.
+is filtered, so an invalid nonmatching instance still fails the command. Tuple
+instances keep source order; object and set instances use stable key order.
+Typed list and map values are rejected for env `for_each`, even though those
+types remain valid for variables used elsewhere.
 
 `ptah-compat migrate apply --env local` runs every selected instance in that
 order and stops at the first failure. With `--format '{{ json . }}'`, each

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -499,9 +499,13 @@ env {
 }
 ```
 
-`name` selects instances after `for_each` evaluation. A block without `name`
-uses its label, if present. List and tuple instances keep source order; map,
-object, and set instances use stable key order.
+For an unlabeled block selected with `--env`, `name` must depend on `atlas.env`;
+a static name or a name based only on `each.key` does not define that selected
+environment. Labeled blocks use their label as the initial candidate. Every
+expanded instance of an admitted block is evaluated before its resulting name
+is filtered, so an invalid nonmatching instance still fails the command. List
+and tuple instances keep source order; map, object, and set instances use stable
+key order.
 
 `ptah-compat migrate apply --env local` runs every selected instance in that
 order and stops at the first failure. With `--format '{{ json . }}'`, each

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -313,6 +313,9 @@ config workflows:
 - `getenv("NAME")` for environment-provided URLs and settings.
 - `file("path")` for local file contents, relative to the `atlas.hcl` file.
 - `fileset("glob")` for local file lists, relative to the `atlas.hcl` file.
+- `toset(value)` for deterministic environment-instance expansion.
+- `atlas.env`, plus `each.key` and `each.value` inside an env expanded with
+  `for_each`.
 - `data "hcl_schema" "name"` blocks with either `path` or `paths`, exposed as
   `data.hcl_schema.<name>.url`.
 - `format(format_string, values...)` and `jsonencode(value)` for Atlas-style
@@ -445,17 +448,18 @@ migration directory, no migration file and no `atlas.sum`, and
 
 A `variable` block without a `default` is valid when the invocation provides a
 matching `--var name=value`. Variable blocks accept the `type` constraints
-`string`, `number`, `bool`, and `list(string)` — the attribute the official
-Atlas binary requires:
+`string`, `number`, `bool`, `list(string)`, and `map(string)`:
 
 - `--var` overrides convert to the declared type: `--var latest=3` becomes a
   number and `--var concurrent=true` becomes a bool. Bool conversion follows
   cty's rules: `1` and `0` convert, while `True` and `yes` fail with the
   wrong-shape error. Repeated `--var name=value` flags build a `list(string)`
   value.
+- `map(string)` is available to defaults and HCL expressions. The string/list
+  `--var` flag syntax does not encode map values.
 - A `default` that does not convert to the declared type, an override of the
   wrong shape, and any other type constraint (for example `object(...)`,
-  `map(...)`, or `tuple(...)`) fail with named errors.
+  `set(...)`, or `tuple(...)`) fail with named errors.
 - `sensitive = true` is accepted. Parse-time conversion errors print
   `(sensitive value)` instead of the variable's value; a sensitive value
   interpolated into a URL or path can still appear in downstream errors that
@@ -476,6 +480,34 @@ values are required and multiple envs remain ambiguous, Ptah returns:
 ```text
 atlas.hcl contains multiple env blocks; pass --env
 ```
+
+An env block can expand into several instances with `for_each`. Labeled and
+unlabeled blocks both support the meta-attributes:
+
+```hcl
+env {
+  for_each = toset([
+    "sqlite://bar.db?_fk=1",
+    "sqlite://foo.db?_fk=1",
+  ])
+  name = atlas.env
+  url  = each.value
+
+  migration {
+    dir = "file://migrations"
+  }
+}
+```
+
+`name` selects instances after `for_each` evaluation. A block without `name`
+uses its label, if present. List and tuple instances keep source order; map,
+object, and set instances use stable key order.
+
+`ptah-compat migrate apply --env local` runs every selected instance in that
+order and stops at the first failure. With `--format '{{ json . }}'`, each
+attempt writes one JSON document and adjacent documents are separated by one
+newline. Other commands and the singular project-config Go APIs reject a
+selection that produces more than one instance instead of choosing one.
 
 ## Precedence
 

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -504,9 +504,9 @@ a static name or a name based only on `each.key` does not define that selected
 environment. Labeled blocks use their label as the initial candidate. Every
 expanded instance of an admitted block is evaluated before its resulting name
 is filtered, so an invalid nonmatching instance still fails the command. Tuple
-instances keep source order; object and set instances use stable key order.
-Typed list and map values are rejected for env `for_each`, even though those
-types remain valid for variables used elsewhere.
+and list instances keep source order; object, map, and set instances use stable
+key order. As a Ptah extension, typed list and map values are accepted for env
+`for_each` in addition to tuple, object, and set values.
 
 `ptah-compat migrate apply --env local` runs every selected instance in that
 order and stops at the first failure. With `--format '{{ json . }}'`, each

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -51,7 +51,11 @@ online-DDL policy is parsed, merged, validated, and then passed to migration
 execution without a second configuration-file read.
 `ParseAtlasFSWithOptions` lets embedders evaluate `atlas.hcl` against an
 already anchored or immutable `fs.FS`; `file()` and `fileset()` resolve only
-through that filesystem. `Config.IgnoredConstructs` identifies names that
+through that filesystem. Use `ParseAtlasFSCollectionWithOptions`,
+`ParseAtlasCollectionWithOptions`, or `LoadCollection` when an env `for_each`
+can select several independent configs. The singular functions require exactly
+one selected instance and return an error rather than discarding the others.
+`Config.IgnoredConstructs` identifies names that
 Atlas CE accepts without acting on, with kind and source location. `Merge`
 preserves this diagnostic metadata from both inputs. Ptah's command layer warns
 for each entry; embedders can choose their own reporting policy.
@@ -163,6 +167,14 @@ migration lock before transaction-mode validation, including empty plans. It
 is a metadata-only observer and cannot abort execution. `Preflight` remains the
 abort-capable hook after validation, so user-facing start output is not emitted
 for a statically invalid migration.
+
+`MigrateUpOptions.DiscardRolledBackFailure` models the Atlas revision-table
+compatibility surface, which treats a confirmed transactional rollback as no
+recorded attempt. It has no effect with the native Ptah revision-table format.
+With the Atlas format, it removes only the failed revision written by the
+current invocation and only after `Rollback` succeeds. Existing dirty rows,
+partial progress, rollback failure, commit failure, and unknown statement
+outcomes remain dirty and block automatic retry.
 
 `migration/migrator.WithStatementValidator` installs a pre-execution safety
 gate on a filesystem provider. Ptah splits and validates every statement in one

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -149,10 +149,14 @@ type AtlasLoadOptions struct{ ... }
 type Config struct{ ... }
     func Load(opts LoadOptions) (Config, error)
     func LoadAtlasFile(path, envName string) (Config, error)
+    func LoadAtlasFileCollectionWithOptions(path string, opts AtlasLoadOptions) ([]Config, error)
     func LoadAtlasFileWithOptions(path string, opts AtlasLoadOptions) (Config, error)
+    func LoadCollection(opts LoadOptions) ([]Config, error)
     func LoadPtahFile(path, envName string) (Config, error)
     func Merge(base, override Config) Config
     func ParseAtlas(data []byte, filename, envName string) (Config, error)
+    func ParseAtlasCollectionWithOptions(data []byte, filename string, opts AtlasLoadOptions) ([]Config, error)
+    func ParseAtlasFSCollectionWithOptions(data []byte, filename string, fsys fs.FS, opts AtlasLoadOptions) ([]Config, error)
     func ParseAtlasFSWithOptions(data []byte, filename string, fsys fs.FS, opts AtlasLoadOptions) (Config, error)
     func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error)
     func ParsePtah(data []byte, filename, envName string) (Config, error)
@@ -236,10 +240,14 @@ type Config struct {
 
 func Load(opts LoadOptions) (Config, error)
 func LoadAtlasFile(path, envName string) (Config, error)
+func LoadAtlasFileCollectionWithOptions(path string, opts AtlasLoadOptions) ([]Config, error)
 func LoadAtlasFileWithOptions(path string, opts AtlasLoadOptions) (Config, error)
+func LoadCollection(opts LoadOptions) ([]Config, error)
 func LoadPtahFile(path, envName string) (Config, error)
 func Merge(base, override Config) Config
 func ParseAtlas(data []byte, filename, envName string) (Config, error)
+func ParseAtlasCollectionWithOptions(data []byte, filename string, opts AtlasLoadOptions) ([]Config, error)
+func ParseAtlasFSCollectionWithOptions(data []byte, filename string, fsys fs.FS, opts AtlasLoadOptions) ([]Config, error)
 func ParseAtlasFSWithOptions(data []byte, filename string, fsys fs.FS, opts AtlasLoadOptions) (Config, error)
 func ParseAtlasWithOptions(data []byte, filename string, opts AtlasLoadOptions) (Config, error)
 func ParsePtah(data []byte, filename, envName string) (Config, error)
@@ -7708,6 +7716,11 @@ type MigrateUpOptions struct {
     // a pending dirty migration. It does not bypass committed-prefix verification;
     // callers should expose it only as an explicit recovery action.
     AllowDirty bool
+    // DiscardRolledBackFailure removes the Atlas revision row written for a
+    // failed up migration only when this invocation observed a successful
+    // transaction rollback. Existing dirty revisions and uncertain commit or
+    // rollback outcomes remain recorded and block automatic retry.
+    DiscardRolledBackFailure bool
     // AssumedAppliedVersions are treated as applied for plan selection without
     // reading or writing revision metadata. This is intended for dry-run paths
     // that need to model metadata-only operations such as baseline.

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -86,7 +86,7 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Whole-document validation covers every env. `migrate apply` expands labeled or unlabeled env `for_each` instances in stable order; other commands still require one selected instance.",
+    "note": "Validates every env. `migrate apply` expands labeled or unlabeled env `for_each` in stable order; typed list/map are Ptah extensions. Other commands require one instance.",
     "evidence": "config/projectconfig/atlas.go and atlas_dynamic_env_test.go (collection expansion, selection, ordering, rooted evaluation); cmd/atlas/migrate_apply_dynamic_env_test.go (sequential live SQLite apply, partial failure, retry, and exact revision state)"
   },
   {

--- a/docs/site/scripts/data/feature-matrix-rows.json
+++ b/docs/site/scripts/data/feature-matrix-rows.json
@@ -86,8 +86,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "Whole-document structural validation rejects unsupported shapes in every env. Names Atlas CE accepts as no-ops are preserved and warned once per source location.",
-    "evidence": "config/projectconfig/atlas_structure.go (open/closed body contract), config/projectconfig/atlas.go (selected-env evaluation and IgnoredConstructs), config/projectconfig/atlas_structure_test.go, cmd/atlas/project_config_ignored_test.go"
+    "note": "Whole-document validation covers every env. `migrate apply` expands labeled or unlabeled env `for_each` instances in stable order; other commands still require one selected instance.",
+    "evidence": "config/projectconfig/atlas.go and atlas_dynamic_env_test.go (collection expansion, selection, ordering, rooted evaluation); cmd/atlas/migrate_apply_dynamic_env_test.go (sequential live SQLite apply, partial failure, retry, and exact revision state)"
   },
   {
     "area": "Project config",
@@ -104,8 +104,8 @@
     "ptah": "partial",
     "atlas_oss": "yes",
     "atlas_pro": "yes",
-    "note": "file, fileset, format, getenv, and jsonencode evaluate. Variables support string, number, bool, list(string), and sensitive; validation blocks fail. `for_each` is accepted and warned.",
-    "evidence": "config/projectconfig/atlas.go newAtlasParser, parseVariableBlock, convertAtlasVariableOverride, tolerateUnknownAttr; config/projectconfig/atlas_structure_test.go selected-only evaluation cases"
+    "note": "file, fileset, format, getenv, jsonencode, and toset evaluate. Variables add map(string). Env `for_each` exposes atlas.env, each.key, and each.value.",
+    "evidence": "config/projectconfig/atlas.go newAtlasParser, parseVariableBlock, appendSensitiveStrings, and parseAtlasEnvInstances; config/projectconfig/atlas_dynamic_env_test.go ordering, collection-sensitive redaction, and selection cases"
   },
   {
     "area": "Project config",

--- a/docs/site/src/content/docs/atlas/comparison.md
+++ b/docs/site/src/content/docs/atlas/comparison.md
@@ -527,7 +527,12 @@ Native lint and plan commands can attach canonical reports to exact migration or
 
 **Ptah.** Ptah parses strict HCL schema and Atlas project config subsets.
 
-Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff` policy, and supported lint analyzer severity policy feed Atlas-compatible commands, including local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`), repeated string/list `--var name=value` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, `data.external_schema.<name>.url` (gated behind `--allow-external-schema` / `PTAH_ALLOW_EXTERNAL_SCHEMA`), and `lint.latest` / `lint.git` changeset defaults for migration linting.
+Evaluated local env, schema, format, diff, and lint settings feed
+Atlas-compatible commands. The evaluator supports typed variables (`string`,
+`number`, `bool`, `list(string)`, `map(string)`), string/list `--var` overrides,
+locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `toset`, local and
+external schema data sources, and migration-lint changeset defaults. Env
+`for_each` expansion is supported by `migrate apply`.
 
 Ptah also composes a desired-schema schema from multiple sources — several Go roots, or a mix of Go annotations, YAML, HCL, and SQL — via repeatable `--root-dir` and `--schema-file` flags on `ptah schema render`, `ptah schema compare`, `ptah migrations plan`, and `ptah migrations generate`, an open, local, no-account counterpart to Atlas's Pro `composite_schema` data source.
 
@@ -668,7 +673,10 @@ Each area below states the current status and links the evidence behind it.
 
 **Ptah status.** Strict supported subset.
 
-Evaluated local `env.src`, `env.schema.src`, `env.exclude`, `env.schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff` policy, and supported lint analyzer severity policy can feed `ptah-compat ... --env` commands, including local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`), repeated string/list `--var name=value` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, and `data.hcl_schema.<name>.url`.
+Evaluated local env, schema, format, diff, and lint settings can feed
+`ptah-compat ... --env` commands. Typed variables include `map(string)` for HCL
+defaults and expressions; `toset`, `atlas.env`, `each.key`, and `each.value`
+support ordered multi-target `migrate apply` expansion.
 
 Structurally unsupported constructs fail explicitly. Names that Atlas CE
 accepts without acting on are accepted and reported once per source location
@@ -870,44 +878,30 @@ Revisit when the conformance Atlas pin advances past v1.2.0.
 
 ### Revision row for a migration whose body failed
 
-**Type.** Deliberate divergence
+**Type.** Compatibility behavior with a native safety difference
 
-**Current boundary.** When a migration body fails inside a transaction, the
-pinned community binary v1.3.0 writes no revision row — its insert rolls back
-with the body. Ptah writes one, durably, outside that transaction. Measured
-across the transaction-mode matrix:
+**Current boundary.** When a migration body fails inside a transaction and
+rollback succeeds, the pinned community binary v1.3.0 writes no revision row.
+`ptah-compat` now reaches the same end state and retries the whole file on the
+next apply. Native `ptah migrations up` keeps a durable failed row for status
+and repair workflows.
 
-```text
---tx-mode file, no file directive     binary 0 rows   ptah 1 row
---tx-mode file, -- atlas:txmode file  binary 0 rows   ptah 1 row
---tx-mode all,  no file directive     binary 0 rows   ptah 1 row
---tx-mode none, -- atlas:txmode file  binary 0 rows   ptah 1 row
---tx-mode none, -- atlas:txmode none  binary 1 row    ptah 1 row
-```
-
-The boundary is the transaction, not the directive spelling: the four that
-differ are the ones where the body ran transactionally, and the row that has
-nothing to roll back agrees. The reason for the divergence is that the failure
-should survive the run that caused it — `migrate status` reports the dirty
-version, `ptah migrations repair` has a row to act on, and a retry resumes
-rather than stacking work on an unfinished migration.
-
-It costs nothing on the interop path, which is the part worth measuring rather
-than assuming. Handed a database Ptah left in that state, the community binary
-re-runs the whole migration and reports clean:
+Measured across the effective transaction-mode matrix:
 
 ```text
-ptah-compat migrate apply --tx-mode file   leaves 1 row, applied=0
-atlas migrate apply   on that database     exit 0, "1 migration, 2 sql statements"
-atlas migrate status  on that database     Migration Status: OK
+effective file transaction   binary 0 rows   ptah-compat 0 rows   native 1 row
+effective all transaction    binary 0 rows   ptah-compat 0 rows   native 1 row
+effective no transaction     binary 1 row    ptah-compat 1 row    native 1 row
 ```
 
-It does not refuse, does not skip the statements the row might have implied
-were already done, and does not need `--allow-dirty`. `applied=0` is honest —
-the transaction rolled everything back — and it reads as a pending version
-rather than as damage.
+The compatibility cleanup is fail-closed. It removes a zero-progress row only
+after `Rollback` returns success. A rollback error, commit error, unknown
+statement outcome, or any committed statement keeps the row. Those states
+still require explicit recovery, so parity does not erase evidence when the
+database outcome is uncertain.
 
-**Tracking.** [`stokaro/ptah#1196`](https://github.com/stokaro/ptah/issues/1196)
+**Evidence.** [`stokaro/ptah#1196`](https://github.com/stokaro/ptah/issues/1196),
+[`stokaro/ptah#1333`](https://github.com/stokaro/ptah/issues/1333)
 
 ### Dirty retry verifies committed statements
 

--- a/docs/site/src/content/docs/atlas/docs-coverage.md
+++ b/docs/site/src/content/docs/atlas/docs-coverage.md
@@ -245,10 +245,11 @@ expressions are evaluated.
 
 Cloud, registry, data sources beyond the local subset, variable `validation` blocks, other variable type constraints such as `object(...)`, Atlas check-level lint policy, custom lint rules, unsupported lint analyzer options, unsupported format blocks, unsupported diff policy fields, and remote directory behavior are not implemented.
 
-**Conformance status.** Partially measured. As of 2026-08-08, parser, merge,
-direct-command, adapter, and live SQLite tests cover the supported local subset,
-whole-document structural decisions, selected-environment evaluation,
-multi-target apply with partial failure and retry, and ignored-name warnings.
+**Conformance status.** The committed companion reports do not yet measure
+dynamic env expansion. Main-repository parser, adapter, command, and live SQLite
+tests cover the supported local subset, whole-document structural decisions,
+selected-environment evaluation, multi-target apply with partial failure and
+retry, and ignored-name warnings.
 
 **Follow-up.** [`stokaro/ptah#582`](https://github.com/stokaro/ptah/issues/582), [`stokaro/ptah#583`](https://github.com/stokaro/ptah/issues/583), [`stokaro/ptah#581`](https://github.com/stokaro/ptah/issues/581), [`stokaro/ptah#619`](https://github.com/stokaro/ptah/issues/619).
 

--- a/docs/site/src/content/docs/atlas/docs-coverage.md
+++ b/docs/site/src/content/docs/atlas/docs-coverage.md
@@ -235,7 +235,7 @@ The native OCI source is available to `schema compare` and `drift` through `--sc
 
 **Implementation status.** Partial.
 
-Ptah reads a documented subset into project config IR, including local env settings, `schema.src`, `schema.mode`, `format.schema.inspect/apply/diff`, `format.migrate.apply/diff/lint/status`, supported `diff.skip.drop_table` and `diff.concurrent_index.create` policy, supported migration-lint analyzer severity policy for `destructive`, `concurrent_index`, `data_depend`, `incompatible`, and `nestedtx`, local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`) with `sensitive` support, string/list variable overrides through repeated `--var name=value` with conversion to the declared type, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `data.hcl_schema.<name>.url`, and migration-lint changeset selectors such as `lint.latest` and `lint.git`.
+Ptah reads a documented subset into project config IR, including local env settings, `schema.src`, `schema.mode`, output formats, supported diff and lint policy, local variable defaults, typed variables (`string`, `number`, `bool`, `list(string)`, `map(string)`) with `sensitive` support, string/list `--var` overrides, locals, `getenv`, `file`, `fileset`, `format`, `jsonencode`, `toset`, `atlas.env`, `each.key`, `each.value`, `data.hcl_schema.<name>.url`, and migration-lint changeset selectors. Atlas-compatible `migrate apply` expands labeled or unlabeled env `for_each` collections into ordered database targets.
 
 Whole-document structural validation classifies every environment before one is
 selected. Unsupported shapes fail in selected and unselected environments.
@@ -247,8 +247,8 @@ Cloud, registry, data sources beyond the local subset, variable `validation` blo
 
 **Conformance status.** Partially measured. As of 2026-08-08, parser, merge,
 direct-command, adapter, and live SQLite tests cover the supported local subset,
-whole-document structural decisions, selected-environment evaluation, and
-ignored-name warnings.
+whole-document structural decisions, selected-environment evaluation,
+multi-target apply with partial failure and retry, and ignored-name warnings.
 
 **Follow-up.** [`stokaro/ptah#582`](https://github.com/stokaro/ptah/issues/582), [`stokaro/ptah#583`](https://github.com/stokaro/ptah/issues/583), [`stokaro/ptah#581`](https://github.com/stokaro/ptah/issues/581), [`stokaro/ptah#619`](https://github.com/stokaro/ptah/issues/619).
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -252,7 +252,7 @@ seven of them as open capabilities regardless.
 | Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. An unknown key fails, naming the key, its line, and the accepted keys. |
 | PTAH_* environment-variable flag equivalents | ✅ | ❌ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
-| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | file, fileset, format, getenv, jsonencode, and toset evaluate. Variables support string, number, bool, list(string), map(string), and sensitive. Env `for_each` exposes atlas.env, each.key, and each.value. |
+| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | file, fileset, format, getenv, jsonencode, and toset evaluate. Variables add map(string). Env `for_each` exposes atlas.env, each.key, and each.value. |
 
 ## Databases and schema objects
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -243,7 +243,7 @@ seven of them as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | `--var` does not require an `atlas.hcl` | ✅ | ✅ | ✅ | `-c` and `--env` select a project file and still require one. `--var` only supplies values to one, on every verb. Its syntax is still checked with no `atlas.hcl` present. |
 | A malformed `--var` is refused wherever it is spelled | ✅ | ✅ | ✅ | CE parses `--var` while parsing flags, so a value with no `=` is refused before any project file is sought. Ptah checks it on every command under `schema` and `migrate`, even ones that never read it. |
-| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Whole-document structural validation rejects unsupported shapes in every env. Names Atlas CE accepts as no-ops are preserved and warned once per source location. |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Whole-document validation covers every env. `migrate apply` expands labeled or unlabeled env `for_each` instances in stable order; other commands still require one selected instance. |
 | atlas.hcl file() and fileset() path confinement | ✅ | ❌ | ❌ | Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today. |
 | atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl in the working directory; `--var name=value` supplies a variable with no default on every env-aware verb; `--config` still takes ptah.yaml only. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input is rejected by name, and an absolute path or a non-file:// scheme is rejected by its rule rather than as an unsupported construct. |
@@ -252,7 +252,7 @@ seven of them as open capabilities regardless.
 | Native project config (ptah.yaml) | ✅ | ➖ | ➖ | Keys url, dev, schemas, exclude, external_schema, migration, lint, migrate, diff, online_ddl. No variables or functions. An unknown key fails, naming the key, its line, and the accepted keys. |
 | PTAH_* environment-variable flag equivalents | ✅ | ❌ | ❌ | Every flag on every native verb has a documented PTAH_* environment variable ([env: PTAH_X] in help) that substitutes for the flag. CE annotates no flag with an environment variable. |
 | Remote and template directory sources | ❌ | ✅ | ✅ | An atlas.hcl data-source question, not a registry one: ptah-compat migration.dir takes file:// only. Native oci:// distribution is a separate ptah path. |
-| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | file, fileset, format, getenv, and jsonencode evaluate. Variables support string, number, bool, list(string), and sensitive; validation blocks fail. `for_each` is accepted and warned. |
+| Variables, locals, and HCL functions | 🟡 | ✅ | ✅ | file, fileset, format, getenv, jsonencode, and toset evaluate. Variables support string, number, bool, list(string), map(string), and sensitive. Env `for_each` exposes atlas.env, each.key, and each.value. |
 
 ## Databases and schema objects
 

--- a/docs/site/src/content/docs/atlas/feature-matrix.md
+++ b/docs/site/src/content/docs/atlas/feature-matrix.md
@@ -243,7 +243,7 @@ seven of them as open capabilities regardless.
 | --- | :-: | :-: | :-: | --- |
 | `--var` does not require an `atlas.hcl` | ✅ | ✅ | ✅ | `-c` and `--env` select a project file and still require one. `--var` only supplies values to one, on every verb. Its syntax is still checked with no `atlas.hcl` present. |
 | A malformed `--var` is refused wherever it is spelled | ✅ | ✅ | ✅ | CE parses `--var` while parsing flags, so a value with no `=` is refused before any project file is sought. Ptah checks it on every command under `schema` and `migrate`, even ones that never read it. |
-| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Whole-document validation covers every env. `migrate apply` expands labeled or unlabeled env `for_each` instances in stable order; other commands still require one selected instance. |
+| Atlas project config (atlas.hcl) | 🟡 | ✅ | ✅ | Validates every env. `migrate apply` expands labeled or unlabeled env `for_each` in stable order; typed list/map are Ptah extensions. Other commands require one instance. |
 | atlas.hcl file() and fileset() path confinement | ✅ | ❌ | ❌ | Ptah confines file() and fileset() to the atlas.hcl directory: absolute, parent-traversal and symlink escapes are refused by name. Atlas reads them. Deliberate divergence; exit 1 either way today. |
 | atlas.hcl from the native ptah binary | 🟡 | ➖ | ➖ | ptah `--env` reads ./atlas.hcl in the working directory; `--var name=value` supplies a variable with no default on every env-aware verb; `--config` still takes ptah.yaml only. |
 | data "hcl_schema" reference | 🟡 | ✅ | ✅ | Takes path or paths and exports .url; the Atlas vars input is rejected by name, and an absolute path or a non-file:// scheme is rejected by its rule rather than as an unsupported construct. |

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -159,9 +159,14 @@ surfaces are allowed to differ and only the compatibility one is a contract.
 
 ## Recovering from a migration body that failed part-way
 
-Unlike Atlas, Ptah records a revision row for a migration whose body failed, so
-the failure survives the run that caused it. `migrate status` reports that row
-as a half-applied file, because `Current Version` counts it:
+When a transactional body fails and `Rollback` succeeds, `ptah-compat` removes
+the zero-progress revision row. The next apply retries the whole file without
+`--allow-dirty`, matching Atlas. Native `ptah migrations up` keeps its durable
+failure record instead.
+
+When a statement committed under `--tx-mode none`, or its outcome is unknown,
+`ptah-compat` preserves the revision row. `migrate status` reports that row as
+a half-applied file, because `Current Version` counts it:
 
 ```text
 Migration Status: PENDING
@@ -390,6 +395,12 @@ redacted. With `--env`, Ptah can read `env.url`, `migration`, and
 revision rows and include only migrations that a real apply would select. They
 also run the same dirty-state, checksum, execution-order, and transaction-mode
 validations as a real apply.
+
+An env `for_each` can select several database targets. `migrate apply` runs
+them sequentially in stable expansion order and stops at the first failure.
+Formatted output contains one document per attempted target with one newline
+between adjacent documents. A structured execution failure stays in that
+target's report; stderr remains empty and the process exits `1`.
 
 `--lock-name` replaces the name of the session advisory lock that serializes
 migration runs (`ptah_migrate` by default). Two runs serialize only when they

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -422,14 +422,15 @@ env {
 ```
 
 `atlas.env` is the requested `--env` value. `each.key` and `each.value` expose
-the current tuple, object, or set entry. For an unlabeled block,
+the current collection entry. For an unlabeled block,
 `name` must depend on `atlas.env`; a static name or a name based only on
 `each.key` does not define the requested environment. A labeled block uses its
 label as the initial candidate when `name` is absent. Every expanded instance
 of an admitted block is evaluated before its resulting name is filtered, so an
-invalid nonmatching instance still fails. Tuples keep source order; objects and
-sets use stable key order. Typed list and map values are rejected for env
-`for_each`, even though those types remain valid for variables used elsewhere.
+invalid nonmatching instance still fails. Tuples and lists keep source order;
+objects, maps, and sets use stable key order. As a Ptah extension, typed list
+and map values are accepted for env `for_each` in addition to tuple, object,
+and set values.
 
 `ptah-compat migrate apply --env local` runs every selected target sequentially
 and stops at the first failure. A formatted run emits one document per attempted

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -422,9 +422,13 @@ env {
 ```
 
 `atlas.env` is the requested `--env` value. `each.key` and `each.value` expose
-the current list, tuple, map, object, or set entry. A labeled block uses its
-label when `name` is absent. List and tuple instances keep source order; the
-other collection types use stable key order.
+the current list, tuple, map, object, or set entry. For an unlabeled block,
+`name` must depend on `atlas.env`; a static name or a name based only on
+`each.key` does not define the requested environment. A labeled block uses its
+label as the initial candidate when `name` is absent. Every expanded instance
+of an admitted block is evaluated before its resulting name is filtered, so an
+invalid nonmatching instance still fails. List and tuple instances keep source
+order; the other collection types use stable key order.
 
 `ptah-compat migrate apply --env local` runs every selected target sequentially
 and stops at the first failure. A formatted run emits one document per attempted

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -422,13 +422,14 @@ env {
 ```
 
 `atlas.env` is the requested `--env` value. `each.key` and `each.value` expose
-the current list, tuple, map, object, or set entry. For an unlabeled block,
+the current tuple, object, or set entry. For an unlabeled block,
 `name` must depend on `atlas.env`; a static name or a name based only on
 `each.key` does not define the requested environment. A labeled block uses its
 label as the initial candidate when `name` is absent. Every expanded instance
 of an admitted block is evaluated before its resulting name is filtered, so an
-invalid nonmatching instance still fails. List and tuple instances keep source
-order; the other collection types use stable key order.
+invalid nonmatching instance still fails. Tuples keep source order; objects and
+sets use stable key order. Typed list and map values are rejected for env
+`for_each`, even though those types remain valid for variables used elsewhere.
 
 `ptah-compat migrate apply --env local` runs every selected target sequentially
 and stops at the first failure. A formatted run emits one document per attempted

--- a/docs/site/src/content/docs/atlas/project-config.md
+++ b/docs/site/src/content/docs/atlas/project-config.md
@@ -384,12 +384,12 @@ the same check:
 Error: invalid argument "novalue" for "--var" flag: variables must be format as key=value, got: "novalue"
 ```
 
-Variable blocks accept the `type` constraints `string`, `number`, `bool`, and
-`list(string)` — the attribute Atlas requires — so one
-`atlas.hcl` with typed variables works with both binaries. `--var` overrides
-convert to the declared type, and repeated `--var` flags fill a `list(string)`
-variable. Overrides of the wrong shape, defaults that do not match the declared
-type, and other type constraints such as `object(...)` fail with named errors.
+Variable blocks accept the `type` constraints `string`, `number`, `bool`,
+`list(string)`, and `map(string)`. `--var` overrides convert to scalar types,
+and repeated flags fill a `list(string)` variable. `map(string)` values come
+from defaults or HCL expressions because the string/list flag syntax does not
+encode maps. Overrides of the wrong shape, defaults that do not match the
+declared type, and other constraints such as `object(...)` fail with named errors.
 `sensitive = true` is accepted; parse-time conversion errors print
 `(sensitive value)` instead of the variable's value, though a sensitive value
 interpolated into a URL or path can still appear in downstream errors that
@@ -400,6 +400,36 @@ If an `atlas.hcl` file has exactly one `env` block, named or unnamed, Ptah can
 use it as the default. Atlas-compatible `migrate apply` does not need to select
 an environment when both `--url` and `--dir` are explicit. Other ambiguous or
 unsupported environment layouts fail instead of guessing.
+
+### Expand one environment into several targets
+
+Use `for_each` when one Atlas environment applies the same migration directory
+to several databases:
+
+```hcl
+env {
+  for_each = toset([
+    "sqlite://bar.db?_fk=1",
+    "sqlite://foo.db?_fk=1",
+  ])
+  name = atlas.env
+  url  = each.value
+
+  migration {
+    dir = "file://migrations"
+  }
+}
+```
+
+`atlas.env` is the requested `--env` value. `each.key` and `each.value` expose
+the current list, tuple, map, object, or set entry. A labeled block uses its
+label when `name` is absent. List and tuple instances keep source order; the
+other collection types use stable key order.
+
+`ptah-compat migrate apply --env local` runs every selected target sequentially
+and stops at the first failure. A formatted run emits one document per attempted
+target with one newline between adjacent documents. Commands that require one
+project instance reject a multi-instance selection instead of choosing one.
 
 ## Structural validation and ignored names
 

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -56,6 +56,8 @@ bypass the gate.
 `projectconfig.ParseAtlasFSWithOptions` evaluates `atlas.hcl` against a
 caller-provided `fs.FS`. Use it when project config and its `file()` or
 `fileset()` inputs must come from one anchored or immutable filesystem view.
+Use the collection-valued parse or load functions for an env `for_each` that
+selects several configs; singular functions reject that cardinality.
 `projectconfig.Config.IgnoredConstructs` carries every Atlas CE-compatible
 no-op name with its kind and source location, and `projectconfig.Merge`
 preserves the collection. Ptah's CLI reports each entry; embedders decide how
@@ -168,6 +170,13 @@ migration lock before transaction-mode validation, including an empty plan. It
 captures metadata but cannot abort execution. Use the abort-capable `Preflight`
 hook for work that must run after static validation and before any schema or
 revision change.
+
+`MigrateUpOptions.DiscardRolledBackFailure` applies only to the Atlas
+revision-table format; it has no effect with native Ptah metadata. It removes
+only the failed revision written by the current invocation, and only after
+transaction rollback succeeds. Existing dirty revisions and commit, rollback,
+partial-progress, and unknown-outcome failures remain recorded and block
+automatic retry.
 
 ## Pinned database sessions
 

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -38,6 +38,8 @@ local `variable` defaults and Atlas-style `--var name=value` overrides,
 references for local schema-file workflows.
 Supported Atlas env blocks can also set `schema.src`, `schema.mode`, `format`,
 and local `diff` policy defaults for the `ptah-compat` binary's commands.
+`ptah-compat migrate apply` expands env `for_each` collections and applies each
+selected database target sequentially.
 
 Ptah reads each selected project config once per command and converts it to a
 typed configuration value. Migration database settings and online-DDL policy

--- a/internal/atlasmigrate/apply.go
+++ b/internal/atlasmigrate/apply.go
@@ -52,9 +52,12 @@ type ApplyOptions struct {
 	// it is enforced by the migrator inside the migration lock rather than by
 	// the preview below, so a run that races another writer applies the
 	// versions the bound names rather than a count computed before the lock.
-	ToVersion       int64
-	AllowDirty      bool
-	BaselineVersion int64
+	ToVersion  int64
+	AllowDirty bool
+	// DiscardRolledBackFailure mirrors Atlas's handling of a failed
+	// transactional migration whose body was fully rolled back.
+	DiscardRolledBackFailure bool
+	BaselineVersion          int64
 	// SkipChecks bypasses pre-migration check evaluation. Atlas registers no
 	// flag for this on `migrate apply` (measured on CE v1.2.0 and on
 	// Atlas's own help surface), so the compat command resolves it from
@@ -238,10 +241,11 @@ func (p ApplyPlan) execute(ctx context.Context, hook migrator.PreMigrationHook) 
 	executionStarted := false
 	lockedPlanObserved := false
 	err := p.mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
-		Amount:                 p.opts.Amount,
-		TargetVersion:          p.opts.ToVersion,
-		AllowDirty:             p.opts.AllowDirty,
-		AssumedAppliedVersions: p.assumedAppliedVersions,
+		Amount:                   p.opts.Amount,
+		TargetVersion:            p.opts.ToVersion,
+		AllowDirty:               p.opts.AllowDirty,
+		DiscardRolledBackFailure: p.opts.DiscardRolledBackFailure,
+		AssumedAppliedVersions:   p.assumedAppliedVersions,
 		PlanObserver: func(_ context.Context, plan migrator.MigrationPlan) {
 			lockedPlanObserved = true
 			result.SelectedVersions = slices.Clone(plan.Versions)

--- a/migration/migrator/dirty_retry_test.go
+++ b/migration/migrator/dirty_retry_test.go
@@ -131,6 +131,151 @@ func TestMigrateUp_AllowDirtyRetryReusesTheDirtyRevisionRow(t *testing.T) {
 	c.Assert(status.CurrentVersion, qt.Equals, int64(2))
 }
 
+func TestMigrateUp_DiscardRolledBackFailureRefusesExistingZeroProgressDirty(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "zero-progress-retry.db")
+
+	_, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	c.Assert(initial.MigrateUp(c.Context()), qt.IsNotNil)
+
+	conn, retried := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	err := retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+	revisions, err := retried.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[1].Dirty, qt.IsTrue)
+	c.Assert(revisions[1].Applied, qt.Equals, 0)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 0)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureDiscardsCurrentFailure(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "zero-progress-discard.db")
+
+	conn, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	err := initial.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+
+	revisions, err := initial.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 1)
+	c.Assert(revisions[0].Version, qt.Equals, int64(1))
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 0)
+
+	_, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true}), qt.IsNil)
+
+	revisions, err = fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[1].Version, qt.Equals, int64(2))
+	c.Assert(revisions[1].Dirty, qt.IsFalse)
+	c.Assert(revisions[1].Applied, qt.Equals, 2)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureDiscardsCurrentBatchFailure(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "zero-progress-batch-discard.db")
+
+	_, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeAll, migrator.RevisionTableFormatAtlas)
+	err := initial.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+
+	revisions, err := initial.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 0)
+
+	conn, fixed := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeAll, migrator.RevisionTableFormatAtlas)
+	c.Assert(fixed.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true}), qt.IsNil)
+
+	revisions, err = fixed.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 2)
+	c.Assert(revisions[0].Version, qt.Equals, int64(1))
+	c.Assert(revisions[1].Version, qt.Equals, int64(2))
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsTrue)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureTargetsCurrentVersion(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "target-current-failure.db")
+
+	_, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeAll, migrator.RevisionTableFormatAtlas)
+	c.Assert(initial.MigrateUp(c.Context()), qt.IsNotNil)
+
+	conn, err := dbschema.ConnectToDatabase(c.Context(), "sqlite://"+dbPath)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { _ = conn.Close() })
+	retried, err := migrator.NewFSMigrator(conn, fstest.MapFS{
+		"0000000001_users.up.sql":   &fstest.MapFile{Data: []byte(dirtyRetryFirstUp)},
+		"0000000001_users.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE users;\n")},
+		"0000000002_seed.up.sql":    &fstest.MapFile{Data: []byte(dirtyRetryFixedUp)},
+		"0000000002_seed.down.sql":  &fstest.MapFile{Data: []byte("DROP TABLE pets;\n")},
+		"0000000003_fail.up.sql": &fstest.MapFile{Data: []byte(`CREATE TABLE toys (id INTEGER PRIMARY KEY);
+THIS IS A FAILING STATEMENT;
+`)},
+		"0000000003_fail.down.sql": &fstest.MapFile{Data: []byte("DROP TABLE toys;\n")},
+	})
+	c.Assert(err, qt.IsNil)
+	retried = retried.WithTransactionMode(migrator.MigrationTxModeAll).
+		WithRevisionTableFormat(migrator.RevisionTableFormatAtlas)
+
+	err = retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{
+		AllowDirty:               true,
+		DiscardRolledBackFailure: true,
+	})
+	c.Assert(err, qt.IsNotNil)
+
+	revisions, err := retried.GetRevisions(c.Context())
+	c.Assert(err, qt.IsNil)
+	c.Assert(revisions, qt.HasLen, 1)
+	c.Assert(revisions[0].Version, qt.Equals, int64(2))
+	c.Assert(revisions[0].Dirty, qt.IsTrue)
+	c.Assert(revisions[0].Applied, qt.Equals, 0)
+	c.Assert(dirtyRetryTableExists(c, conn, "users"), qt.IsFalse)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+	c.Assert(dirtyRetryTableExists(c, conn, "toys"), qt.IsFalse)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureRefusesCommittedProgress(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "committed-progress-retry.db")
+
+	_, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatAtlas)
+	c.Assert(initial.MigrateUp(c.Context()), qt.IsNotNil)
+
+	conn, retried := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeNone, migrator.RevisionTableFormatAtlas)
+	err := retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 1)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureDoesNotChangeNativePolicy(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "native-zero-progress.db")
+
+	_, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	c.Assert(initial.MigrateUp(c.Context()), qt.IsNotNil)
+
+	conn, retried := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatPtah)
+	err := retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
+	c.Assert(dirtyRetryUserCount(c, conn), qt.Equals, 0)
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
 // TestMigrateUp_AllowDirtyRetryResumesAfterCommittedStatements covers the
 // no-transaction case, where the earlier attempt's first statement is already
 // committed when the retry starts.
@@ -649,6 +794,27 @@ func TestMigrateUp_AllowDirtyRefusesToResumeAnUnknownStatementOutcome(t *testing
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "migration 2 cannot resume automatically")
 	c.Assert(err.Error(), qt.Contains, "the outcome of statement 2 is unknown")
+	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
+}
+
+func TestMigrateUp_DiscardRolledBackFailureRefusesExistingAtlasUnknownOutcome(t *testing.T) {
+	c := qt.New(t)
+	dbPath := filepath.Join(t.TempDir(), "unknown-zero-progress.db")
+
+	conn, initial := newDirtyRetryMigrator(c, dbPath, dirtyRetryFailingUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	c.Assert(initial.MigrateUp(c.Context()), qt.IsNotNil)
+	_, err := conn.ExecContext(
+		c.Context(),
+		"UPDATE atlas_schema_revisions SET error = ? WHERE version = '2'",
+		"statement execution outcome is unknown after process interruption",
+	)
+	c.Assert(err, qt.IsNil)
+
+	_, retried := newDirtyRetryMigrator(c, dbPath, dirtyRetryFixedUp, migrator.MigrationTxModeFile, migrator.RevisionTableFormatAtlas)
+	err = retried.MigrateUpWithOptions(c.Context(), migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(migrator.IsDirtyMigration(err), qt.IsTrue)
 	c.Assert(dirtyRetryTableExists(c, conn, "pets"), qt.IsFalse)
 }
 

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -3,6 +3,7 @@ package migrator
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"io/fs"
 	"log/slog"
@@ -77,6 +78,11 @@ type MigrateUpOptions struct {
 	// a pending dirty migration. It does not bypass committed-prefix verification;
 	// callers should expose it only as an explicit recovery action.
 	AllowDirty bool
+	// DiscardRolledBackFailure removes the Atlas revision row written for a
+	// failed up migration only when this invocation observed a successful
+	// transaction rollback. Existing dirty revisions and uncertain commit or
+	// rollback outcomes remain recorded and block automatic retry.
+	DiscardRolledBackFailure bool
 	// AssumedAppliedVersions are treated as applied for plan selection without
 	// reading or writing revision metadata. This is intended for dry-run paths
 	// that need to model metadata-only operations such as baseline.
@@ -1262,6 +1268,9 @@ func (m *Migrator) migrateUpLocked(ctx context.Context, opts MigrateUpOptions) e
 	m.logger.Info("Migrating up", "currentVersion", currentVersion, "totalMigrations", len(migrations))
 	checksDeferred, err := m.applyUpMigrations(ctx, migrationsToApply)
 	if err != nil {
+		if opts.DiscardRolledBackFailure {
+			return errors.Join(err, m.discardRolledBackFailure(ctx, err))
+		}
 		return err
 	}
 	notifyChecksDeferredObserver(ctx, opts.ChecksDeferredObserver, checksDeferred)
@@ -1679,7 +1688,7 @@ func (m *Migrator) applyUpMigrationsInSingleTransaction(ctx context.Context, mig
 		plan := plans[migration.Version]
 		migrationCtx := withMigrationResume(ctx, plan.resumeFrom)
 		if err := m.applyUpMigrationInExistingTransaction(migrationCtx, txConn, migration, startedAt[migration.Version]); err != nil {
-			_ = tx.Rollback()
+			err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 			return nil, m.recordRolledBackBatchFailure(ctx, migration, startedAt[migration.Version], err, plan)
 		}
 		if err := m.recordAppliedMigrationOn(ctx, txConn, migration, startedAt[migration.Version], plan); err != nil {
@@ -1972,7 +1981,7 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 
 	restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, txConn, mergeMigrationTimeouts(m.defaultTimeouts, migration.UpTimeouts))
 	if err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failMigrationWithDirtyState(
 			ctx,
 			migration,
@@ -1986,7 +1995,7 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 	executionCtx := scoped.withPostgresIndexObservation(ctx, txConn)
 	if err := migration.executeUp(executionCtx, txConn, migrationExecutionTransactional); err != nil {
 		err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failMigrationWithDirtyState(
 			ctx,
 			migration,
@@ -1998,11 +2007,11 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 	}
 
 	if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failMigrationWithDirtyState(ctx, migration, startedAt, err, migration.UpSQL, "")
 	}
 	if err := scoped.refuseUpCompletionOverUnsafeIndex(ctx, txConn, migration); err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failMigrationWithDirtyState(
 			ctx,
 			migration,
@@ -2013,7 +2022,7 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 		)
 	}
 	if err := m.completeMigrationRevisionOn(ctx, txConn, migration, startedAt); err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failMigrationWithDirtyState(
 			ctx,
 			migration,
@@ -2036,6 +2045,34 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 	}
 	m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
 	return nil
+}
+
+type migrationTransactionRolledBackError struct {
+	version int64
+	cause   error
+}
+
+func (e *migrationTransactionRolledBackError) Error() string {
+	return e.cause.Error()
+}
+
+func (e *migrationTransactionRolledBackError) Unwrap() error {
+	return e.cause
+}
+
+func migrationFailureAfterRollback(version int64, failure, rollbackErr error) error {
+	if rollbackErr != nil {
+		return fmt.Errorf("%w; additionally failed to roll back migration transaction: %v", failure, rollbackErr)
+	}
+	return &migrationTransactionRolledBackError{version: version, cause: failure}
+}
+
+func migrationTransactionRollbackVersion(err error) (int64, bool) {
+	var target *migrationTransactionRolledBackError
+	if !errors.As(err, &target) {
+		return 0, false
+	}
+	return target.version, true
 }
 
 func (m *Migrator) applyUpMigrationNoTransaction(

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -947,6 +947,34 @@ func (m *Migrator) failIfDirty(ctx context.Context) error {
 	return nil
 }
 
+func isZeroProgressUpFailure(revision MigrationRevision) bool {
+	return revision.Direction == MigrationDirectionUp &&
+		revision.Applied == 0 &&
+		revision.Total > 0 &&
+		revision.Error != unknownStatementOutcomeError
+}
+
+func (m *Migrator) discardRolledBackFailure(ctx context.Context, failure error) error {
+	version, confirmed := migrationTransactionRollbackVersion(failure)
+	if !m.revisionTableFormat.isAtlas() || !confirmed {
+		return nil
+	}
+	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
+	defer cancelRecord()
+	revision, err := m.getRevision(recordCtx, version)
+	if err != nil {
+		return fmt.Errorf("inspect rolled-back migration failure %d: %w", version, err)
+	}
+	if revision == nil || !revision.Dirty || !isZeroProgressUpFailure(*revision) {
+		return nil
+	}
+	query := sqlutil.Rebind(m.conn.Info().Dialect, m.deleteMigrationSQL())
+	if err := executeSQLOutsideTransaction(recordCtx, m.conn, query, m.revisionVersionArg(version)); err != nil {
+		return fmt.Errorf("discard rolled-back migration failure %d: %w", version, err)
+	}
+	return nil
+}
+
 // upRetryPlan says how an up attempt relates to an earlier attempt at the same
 // version. The zero value is not usable: build it with [Migrator.planUpRetry],
 // which always sets resumeFrom to at least 1.

--- a/migration/migrator/transaction_rollback_internal_test.go
+++ b/migration/migrator/transaction_rollback_internal_test.go
@@ -1,0 +1,40 @@
+package migrator
+
+// White-box testing required: these tests verify the private rollback-outcome
+// marker that gates deletion of failed revision metadata. Commit and rollback
+// failure injection is not exposed by the public DatabaseConnection API.
+
+import (
+	"errors"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+func TestMigrationFailureAfterRollback_Confirmed(t *testing.T) {
+	c := qt.New(t)
+	const version int64 = 42
+	cause := errors.New("migration execution failed")
+
+	err := migrationFailureAfterRollback(version, cause, nil)
+	gotVersion, confirmed := migrationTransactionRollbackVersion(err)
+
+	c.Assert(err, qt.ErrorIs, cause)
+	c.Assert(err.Error(), qt.Equals, cause.Error())
+	c.Assert(confirmed, qt.IsTrue)
+	c.Assert(gotVersion, qt.Equals, version)
+}
+
+func TestMigrationFailureAfterRollback_Unconfirmed(t *testing.T) {
+	c := qt.New(t)
+	cause := errors.New("migration execution failed")
+	rollbackErr := errors.New("rollback failed")
+
+	err := migrationFailureAfterRollback(42, cause, rollbackErr)
+	gotVersion, confirmed := migrationTransactionRollbackVersion(err)
+
+	c.Assert(err, qt.ErrorIs, cause)
+	c.Assert(err.Error(), qt.Contains, rollbackErr.Error())
+	c.Assert(confirmed, qt.IsFalse)
+	c.Assert(gotVersion, qt.Equals, int64(0))
+}


### PR DESCRIPTION
## Summary

- expand Atlas project `env` blocks with `for_each`, `atlas.env`, `each.key`, and `each.value`
- support deterministic list, tuple, map, object, and set expansion; typed list/map values are documented Ptah extensions
- run `ptah-compat migrate apply` sequentially across selected targets with Atlas-shaped structured output and stop-on-first-failure behavior
- clean up only the exact rollback-confirmed Atlas revision written by the current invocation while keeping persisted, uncertain, and native Ptah revision states fail-closed
- document collection APIs, CLI behavior, safety semantics, and current conformance evidence

## Validation completed

- full repository tests and affected Go package tests
- race tests for project config, Atlas migration helpers, the migrator, and the standalone `testkit` module
- focused default-transaction and multi-target SQLite CLI tests
- exact one-newline formatted-report separator assertions for success, partial failure, and retry
- `go vet ./...`
- `golangci-lint run --fix ./...` and `golangci-lint run ./...`
- `go tool qtlint ./...`
- `scripts/check-test-style.sh`
- documentation links, redirects, style, limitations, versions, page health, responsive checks, Astro build, and npm audit
- public API source, snapshot, and released-baseline guards

## Review status

Three independent review passes and a final local self-review covered collection semantics, deterministic ordering, command fan-out, partial-result retention, revision safety, security-sensitive diagnostics, documentation, and test completeness. Findings were addressed, and every GitHub check passed on the final head.

Closes #1333
Parent: #843
