### PR TITLE
Resolve an RLS policy's table by its identity, not by the string it was written as (#1311)

### DIFF
--- a/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
+++ b/cmd/atlas/schema_apply_rls_table_spelling_live_test.go
@@ -14,6 +14,8 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/cmd/atlas"
+	"go.5x5.cz/ptah/cmd/internal/schemaload"
+	"go.5x5.cz/ptah/core/renderer"
 	"go.5x5.cz/ptah/dbschema"
 )
 
@@ -84,6 +86,34 @@ func rlsPolicyRows(t *testing.T, dbURL string) []string {
 		   JOIN pg_class c ON c.oid = p.polrelid
 		   JOIN pg_namespace n ON n.oid = c.relnamespace
 		  WHERE n.nspname = 'public'
+		  ORDER BY 1`)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = rows.Close() }()
+	found := []string{}
+	for rows.Next() {
+		var row string
+		c.Assert(rows.Scan(&row), qt.IsNil)
+		found = append(found, row)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return found
+}
+
+// qualifiedRLSPolicyRows reports every user-schema row-level security policy as
+// a `nspname/relname/polname` triple, so a fixture whose relation lives outside
+// `public` can say which relation the policy actually landed on.
+func qualifiedRLSPolicyRows(t *testing.T, dbURL string) []string {
+	t.Helper()
+	c := qt.New(t)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	rows, err := conn.QueryContext(context.Background(),
+		`SELECT n.nspname || '/' || c.relname || '/' || p.polname
+		   FROM pg_policy p
+		   JOIN pg_class c ON c.oid = p.polrelid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		  WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
 		  ORDER BY 1`)
 	c.Assert(err, qt.IsNil)
 	defer func() { _ = rows.Close() }()
@@ -187,4 +217,128 @@ CREATE POLICY tenant_isolation ON shipments FOR ALL TO PUBLIC USING (tenant_id =
 		"orders/tenant_isolation",
 		"shipments/tenant_isolation",
 	})
+}
+
+// TestSchemaApplyRLSQuotedReferenceRefusedLivePostgres is the other side of the
+// quoting boundary, and the one the case fold got wrong.
+//
+// `CREATE POLICY p ON "ORDERS"` names the relation `ORDERS`, which this file
+// does not declare. Measured on PostgreSQL 17.10 with `-v ON_ERROR_STOP=1`,
+// psql exits 1 on this exact statement pair with `relation "ORDERS" does not
+// exist`.
+//
+// Ptah folded the reference down to the declaration and rendered
+// `CREATE POLICY "p" ON "orders"` instead, which the same server accepts: exit
+// 0, one pg_policy row on `public.orders`. The author asked for a policy on
+// `ORDERS` and got one on `orders` -- an access-control declaration moved to a
+// relation nobody named (stokaro/ptah#1311). Refusing is the only safe answer
+// when the alternative is guessing which relation was meant.
+func TestSchemaApplyRLSQuotedReferenceRefusedLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSSpelling(t)
+	targetURL, devURL := createRLSSpellingDatabases(t, adminURL)
+	schemaPath := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON "ORDERS" FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	out, err := runCompatSchemaApply(targetURL, devURL, schemaPath)
+
+	c.Assert(err, qt.ErrorMatches, `(?s)dev database simulation failed during plan: .*relation "ORDERS" does not exist.*the plan was not applied to the target database`)
+	c.Assert(out, qt.Not(qt.Contains), "Schema apply completed successfully.")
+	// Neither spelling is protected, and in particular `orders` did not quietly
+	// acquire the policy the file put on `ORDERS`.
+	c.Assert(qualifiedRLSPolicyRows(t, targetURL), qt.DeepEquals, []string{})
+}
+
+// executeRenderedSchema renders a schema file the way `ptah schema render` does
+// and executes every statement against dbURL in order, returning the first
+// execution error.
+//
+// Rendering is not applying, and for an access-control declaration the only
+// question worth answering is which relation the statement actually reached. So
+// these rows run the DDL and then read pg_policy.
+func executeRenderedSchema(t *testing.T, dbURL, schemaPath string) error {
+	t.Helper()
+	c := qt.New(t)
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{schemaPath}})
+	c.Assert(err, qt.IsNil)
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	for _, statement := range statements {
+		if _, execErr := conn.ExecContext(context.Background(), statement); execErr != nil {
+			return execErr
+		}
+	}
+	return nil
+}
+
+// TestRenderedRLSQualifiedMixedCaseReferenceLandsOnTheNamedRelationLivePostgres
+// is the form the whole-string fold could not reach at all.
+//
+// `"App".ORDERS` has one quoted component and one unquoted one, and PostgreSQL
+// answers them separately: the schema keeps its case, the table loses its own.
+// Measured on PostgreSQL 17.10, the source file's own policy statement lands on
+// `App.orders` with exit 0.
+//
+// Folding the complete identity asked whether `App.ORDERS` folds to itself. It
+// does not, because of the mixed-case schema, so the reference kept
+// `App.ORDERS` and the render was answered with `relation "App.ORDERS" does not
+// exist` (exit 1, measured) -- a schema file PostgreSQL accepts that Ptah could
+// not replay. The render is executed here, and pg_policy is asked which
+// relation carries the policy.
+//
+// This row goes through `schema render` rather than `schema apply` because the
+// apply planner emits its schema precondition as raw unquoted SQL
+// (`CREATE SCHEMA IF NOT EXISTS App`), which PostgreSQL folds to `app`, so
+// every following statement in `"App"` is refused with `schema "App" does not
+// exist`. That is a separate pre-existing defect about schema preconditions,
+// not about row-level security, and it is not this branch's subject; it is
+// recorded rather than worked around.
+func TestRenderedRLSQualifiedMixedCaseReferenceLandsOnTheNamedRelationLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSSpelling(t)
+	targetURL, _ := createRLSSpellingDatabases(t, adminURL)
+	schemaPath := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		`CREATE SCHEMA "App";
+CREATE TABLE "App".orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE "App".ORDERS ENABLE ROW LEVEL SECURITY;
+CREATE POLICY tenant_isolation ON "App".ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	c.Assert(executeRenderedSchema(t, targetURL, schemaPath), qt.IsNil)
+
+	c.Assert(qualifiedRLSPolicyRows(t, targetURL), qt.DeepEquals, []string{
+		"App/orders/tenant_isolation",
+	})
+}
+
+// TestRenderedRLSQuotedReferenceIsRefusedByPostgres is the executed half of the
+// blocker: the render of a file whose policy names `"ORDERS"` must be refused
+// by the server exactly as the file is, and must leave `orders` unprotected.
+//
+// The fold produced `CREATE POLICY "p" ON "orders"`, which the server accepts
+// with exit 0 and a pg_policy row on `public.orders` -- the relocation, seen in
+// the catalog rather than in a string comparison.
+func TestRenderedRLSQuotedReferenceIsRefusedByPostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSSpelling(t)
+	targetURL, _ := createRLSSpellingDatabases(t, adminURL)
+	schemaPath := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(schemaPath, []byte(
+		`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON "ORDERS" FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	err := executeRenderedSchema(t, targetURL, schemaPath)
+
+	c.Assert(err, qt.ErrorMatches, `(?s).*relation "ORDERS" does not exist.*`)
+	c.Assert(qualifiedRLSPolicyRows(t, targetURL), qt.DeepEquals, []string{})
 }

--- a/cmd/internal/schemaload/rls_policy_table_spelling_test.go
+++ b/cmd/internal/schemaload/rls_policy_table_spelling_test.go
@@ -195,6 +195,79 @@ CREATE POLICY p ON ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
 	})
 }
 
+// TestLoad_SQLSchemaFileKeepsAQuotedReferenceOffAnUnquotedTable is the
+// direction the case fold must not run, seen from the side the fold could not
+// tell apart.
+//
+// `CREATE POLICY p ON "ORDERS"` names the relation `ORDERS`. A table declared
+// `orders` is a different relation, and PostgreSQL says so: measured on
+// PostgreSQL 17.10 with `-v ON_ERROR_STOP=1`, this file exits 1 with
+// `relation "ORDERS" does not exist`. Folding the reference down to the
+// declaration instead rendered `CREATE POLICY "p" ON "orders"`, which the same
+// server accepts with exit 0 and a pg_policy row on `public.orders` -- an
+// access-control declaration moved onto a relation the author did not name
+// (stokaro/ptah#1311).
+//
+// The reference therefore keeps `ORDERS` and the render reproduces the
+// database's own answer.
+func TestLoad_SQLSchemaFileKeepsAQuotedReferenceOffAnUnquotedTable(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE orders ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON "ORDERS" FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "ORDERS")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"ORDERS\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+}
+
+// TestLoad_SQLSchemaFileFoldsOnlyTheUnquotedHalfOfAQualifiedReference is the
+// half the whole-string fold could not reach.
+//
+// `"App".ORDERS` is two components with two different answers: the quoted
+// schema keeps its case, the unquoted table loses its own. PostgreSQL 17.10
+// resolves it to `App.orders` and accepts the policy with exit 0 against a
+// table created as `"App".orders`. Folding the complete identity instead asked
+// whether `App.ORDERS` folds to itself, which it does not because of the
+// schema, so the reference kept `App.ORDERS` and the render was answered with
+// `relation "App.ORDERS" does not exist` (exit 1, measured).
+func TestLoad_SQLSchemaFileFoldsOnlyTheUnquotedHalfOfAQualifiedReference(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE SCHEMA "App";
+CREATE TABLE "App".orders (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE "App".ORDERS ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON "App".ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "App.orders")
+	c.Assert(database.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(database.RLSEnabledTables[0].Table, qt.Equals, "App.orders")
+
+	statements, err := renderer.GetOrderedCreateStatements(database, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Assert(createPolicyStatements(statements), qt.DeepEquals, []string{
+		"CREATE POLICY \"p\" ON \"App\".\"orders\" FOR ALL TO PUBLIC\n    USING (tenant_id = 1)\n;",
+	})
+	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
+		`ALTER TABLE "App"."orders" ENABLE ROW LEVEL SECURITY;`,
+	})
+}
+
 // TestLoad_SQLSchemaFileKeepsTwoTablesDifferingOnlyInCase is the boundary the
 // case fold must not cross. A quoted identifier keeps its case, so `orders`
 // and `"ORDERS"` are two tables; PostgreSQL 17.10 accepts a policy called `p`

--- a/core/goschema/rls_policy_identity_test.go
+++ b/core/goschema/rls_policy_identity_test.go
@@ -145,13 +145,22 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			},
 		},
 		{
-			// The schema is not the only part of a table that has more than
-			// one spelling. An unquoted PostgreSQL identifier folds to lower
-			// case, so `ORDERS` names the table declared as `orders`: measured
-			// on PostgreSQL 17.10, `CREATE POLICY p ON orders` followed by
-			// `CREATE POLICY p ON ORDERS` is refused with `policy "p" for
-			// table "orders" already exists`.
-			name:   "a case variant of one unqualified table collapses onto the first",
+			// A [Database] built in memory carries no quoting: this is what an
+			// annotation, a YAML document or an HCL block produces, and Ptah
+			// quotes every identifier it renders, so `table="ORDERS"` renders
+			// `ON "ORDERS"` and names the relation `ORDERS`. That is a
+			// different relation from the declared `orders` -- measured on
+			// PostgreSQL 17.10, `CREATE POLICY p ON "ORDERS"` against a
+			// database holding only `orders` exits 1 with `relation "ORDERS"
+			// does not exist`.
+			//
+			// This row asserted the collapse until stokaro/ptah#1311 was
+			// reviewed. Collapsing meant the author wrote `ORDERS` and Ptah
+			// secured `orders`: a relocated access-control declaration, the
+			// same defect the SQL frontend had, on the surface where the
+			// quoting question has only one answer. Two spellings, two
+			// policies, and the render reproduces the database's own answer.
+			name:   "a case variant of one unqualified table is a second relation",
 			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
 			policies: []goschema.RLSPolicy{
 				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
@@ -159,22 +168,23 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 			},
 			want: []goschema.RLSPolicy{
 				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
 			},
 		},
 		{
-			// Collapsing onto the first declaration is only half an answer if
-			// the first declaration is the variant spelling. The survivor has
-			// to name the declared table, because the renderer quotes what it
-			// is given and `CREATE POLICY "p" ON "ORDERS"` is answered by
-			// `relation "ORDERS" does not exist`.
-			name:   "a case variant declared first still names the declared table",
+			// The same pair in the other order, which is the control on the
+			// rule being about the relations rather than about which
+			// declaration came first. Neither spelling is rewritten into the
+			// other, so order changes nothing.
+			name:   "a case variant declared first keeps its own spelling",
 			tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
 			policies: []goschema.RLSPolicy{
 				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
 				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
 			},
 			want: []goschema.RLSPolicy{
-				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 2"},
+				{Name: "p", Table: "ORDERS", UsingExpression: "tenant_id = 2"},
+				{Name: "p", Table: "orders", UsingExpression: "tenant_id = 1"},
 			},
 		},
 		{
@@ -213,16 +223,24 @@ func TestDeduplicate_KeepsOnePolicyNamePerTable(t *testing.T) {
 		},
 		{
 			// The pair to the row above, differing only in the case of the
-			// declared schema. `CREATE SCHEMA app` is its own folded form, so
-			// PostgreSQL 17.10 accepts `CREATE POLICY row_guard ON APP.LEDGER`
-			// against `app.ledger` with exit 0, and the fold runs.
-			name:   "a folded reference reaches a schema declared in lower case",
+			// declared schema, and the answer is the same for the same reason:
+			// nothing here was ever written unquoted. `table="APP.ORDERS"`
+			// renders `ON "APP"."ORDERS"`, which PostgreSQL 17.10 answers with
+			// `relation "APP.ORDERS" does not exist`, and quietly rewriting it
+			// to `app.orders` would secure a relation the author did not name.
+			//
+			// Case folding belongs where quoting still exists. The SQL frontend
+			// folds `APP.ORDERS` written without quotes into `app.orders`
+			// before it ever reaches this resolver, per component, so a schema
+			// file gets PostgreSQL's answer and a schema built in memory gets
+			// the one its own renderer will produce.
+			name:   "a case variant of a qualified reference keeps its spelling",
 			tables: []goschema.Table{{Name: "orders", Schema: "app", StructName: "Order"}},
 			policies: []goschema.RLSPolicy{
 				{Name: "p", Table: "APP.ORDERS", UsingExpression: "tenant_id = 1"},
 			},
 			want: []goschema.RLSPolicy{
-				{Name: "p", Table: "app.orders", UsingExpression: "tenant_id = 1"},
+				{Name: "p", Table: "APP.ORDERS", UsingExpression: "tenant_id = 1"},
 			},
 		},
 		{

--- a/core/goschema/utils.go
+++ b/core/goschema/utils.go
@@ -1224,80 +1224,52 @@ var rlsTableSemantics = identifier.ForDialect(platform.Postgres)
 //
 //   - the exact spelling wins, through [tableScopeResolver.resolve];
 //   - failing that, the table identity wins, which is what folds
-//     `public.orders` onto a table declared without a schema;
-//   - failing that, an ASCII case fold wins, and only downwards, onto a table
-//     whose declared name is already its own folded form ([foldTarget]), and
-//     only when exactly one declared table matches. Two tables declared as
-//     `orders` and `"ORDERS"` are two tables -- PostgreSQL keeps a policy
-//     called `p` on each -- so an ambiguous fold resolves to nothing and the
-//     reference keeps its spelling.
+//     `public.orders` onto a table declared without a schema.
 //
-// The fold is one-directional because Ptah does not retain whether an
-// identifier was quoted. `CREATE TABLE ORDERS` and `CREATE TABLE "ORDERS"` are
-// two different instructions to PostgreSQL -- the first creates `orders`, the
-// second creates `ORDERS` -- and both reach this resolver as the string
-// `ORDERS`. Folding in both directions therefore has to be wrong for one of
-// two indistinguishable inputs, and being wrong for the quoted one relocates an
-// access-control declaration onto a relation the author did not name.
+// There is deliberately no case fold here, and that is the whole point of this
+// comment. `ORDERS` and `"ORDERS"` are two different instructions to
+// PostgreSQL -- the first names `orders`, the second names `ORDERS` -- and by
+// the time a declaration reaches this resolver the two are the same string.
+// Folding here therefore had to be wrong for one of two inputs it cannot tell
+// apart, and being wrong for the quoted one relocated an access-control
+// declaration onto a relation the author did not name (stokaro/ptah#1311).
+// Measured on PostgreSQL 17.10 against a database holding only `orders`,
+// `CREATE POLICY p ON "ORDERS"` exits 1 with `relation "ORDERS" does not
+// exist`, while the folded render `CREATE POLICY "p" ON "orders"` exits 0 and
+// leaves a pg_policy row on `public.orders`.
+//
+// Quoting is resolved where it still exists instead. The SQL frontend folds
+// each component of a row-level security table reference as PostgreSQL does --
+// unquoted components lose their case, quoted components keep it -- so a
+// reference arrives here already naming its relation. Sources with no quoting
+// syntax at all (Go annotations, YAML, HCL, a hand-built [Database]) are
+// case-preserving by construction, because Ptah quotes every identifier it
+// renders; for them the declaration is already the relation and there is
+// nothing to fold. A reference that matches no declared table keeps its own
+// spelling, so the render reproduces the database's own answer rather than
+// quietly succeeding somewhere else.
 type rlsTableResolver struct {
 	scopes     tableScopeResolver
 	byIdentity map[string]string
-	byFolded   map[string]string
 }
 
 func newRLSTableResolver(tables []Table, scopes tableScopeResolver) rlsTableResolver {
 	resolver := rlsTableResolver{
 		scopes:     scopes,
 		byIdentity: make(map[string]string, len(tables)),
-		byFolded:   make(map[string]string, len(tables)),
 	}
 	for _, table := range tables {
 		qualifiedName := table.QualifiedName()
 		identity := rlsTableSemantics.QualifiedTableIdentityKey(qualifiedName)
 		addTableScope(resolver.byIdentity, identity, qualifiedName)
-		if foldTarget(identity) {
-			addTableScope(resolver.byFolded, foldedRLSTableIdentity(identity), qualifiedName)
-		}
 	}
 	return resolver
-}
-
-// foldTarget reports whether a reference in some other case may be folded onto
-// a table declared under this identity.
-//
-// Only a table whose declared name is already its own folded form qualifies. A
-// table declared `orders` is indistinguishable from an unquoted lower-case
-// declaration, so folding `ORDERS` onto it is exactly what PostgreSQL does. A
-// table declared `ORDERS` or `Orders` may have been written `"ORDERS"` or
-// `"Orders"`, and Ptah cannot tell, so it is not a fold target: the reference
-// keeps its spelling and the render reproduces the database's own answer.
-//
-// Measured on PostgreSQL 17.10, on a file declaring `CREATE TABLE "ORDERS"` and
-// then writing `ALTER TABLE orders ENABLE ROW LEVEL SECURITY`, psql with
-// `-v ON_ERROR_STOP=1` exits 3 with `relation "orders" does not exist`, and the
-// pinned Atlas community v1.3.0 binary exits 1 on the same file. Folding the
-// declaration up instead bound both statements to `ORDERS`, applied cleanly,
-// and left the relation the file named with `relrowsecurity = f` and no policy.
-//
-// The schema half of the identity is an identifier too, and answers the same
-// question: `app` may be folded onto, `App` may not.
-func foldTarget(identity string) bool {
-	return identity == foldedRLSTableIdentity(identity)
-}
-
-// foldedRLSTableIdentity folds the ASCII case an unquoted PostgreSQL identifier
-// loses on its way into the catalog.
-func foldedRLSTableIdentity(identity string) string {
-	return identifier.ComparisonASCIIInsensitive.IdentityKey(identity)
 }
 
 func (r rlsTableResolver) resolve(structName, table string) string {
 	scoped := r.scopes.resolve(structName, table)
 	identity := rlsTableSemantics.QualifiedTableIdentityKey(scoped)
 	if declared := resolvedTableScope(r.byIdentity, identity, ""); declared != "" {
-		return declared
-	}
-	if declared := resolvedTableScope(r.byFolded, foldedRLSTableIdentity(identity), ""); declared != "" {
 		return declared
 	}
 	return scoped

--- a/docs/public_api.md
+++ b/docs/public_api.md
@@ -287,6 +287,20 @@ table. Live comparisons also snapshot catalog identifier semantics into the
 diff so comparison, destructive-change policy, forward planning, and reverse
 planning use one source of truth.
 
+Row-level security policies are carried the same way. `RLSPoliciesAdded` and
+`RLSPoliciesRemoved` are `[]RLSPolicyRef`, and `RLSPoliciesModified` is
+`[]RLSPolicyDiff`; all three name the owning table alongside the policy name.
+The pair is the identity, not decoration: a PostgreSQL policy name is scoped to
+its table, so two tables in one schema may each carry a policy called
+`tenant_isolation` and neither the comparator nor the planner can tell them
+apart from the name. The table half is matched under the diff's identifier
+semantics rather than as a raw string, which is what makes the desired
+spelling `public.orders` and the introspected spelling `orders` one table
+across the forward and reverse directions. Embedders that build these lists by
+hand must fill both fields; a reference the target schema cannot resolve is
+rejected with `ptaherr.ErrInvalidSchemaDiff` rather than silently omitted from
+the plan.
+
 `migration/schemadiff/types.ViewDiff` also records the view body that is in
 force before the diff is applied, and whether the entry is being planned as a
 rollback. Planners read the body to decide whether the target engine accepts an

--- a/docs/site/src/content/docs/direct/compare-and-drift.md
+++ b/docs/site/src/content/docs/direct/compare-and-drift.md
@@ -136,8 +136,16 @@ its table and two tables may each carry one called `tenant_isolation`. Both
 }
 ```
 
-`rls_policies_added` held bare policy-name strings before Ptah v0.2.0. A
-consumer reading that field reads `.policy_name` now; nothing was removed.
+`rls_policies_added` held bare policy-name strings in Ptah v0.2.0 and earlier —
+the v0.2.0 tag itself still declares `RLSPoliciesAdded []string`, so the object
+form has not appeared in a release yet. A consumer reading that field reads
+`.policy_name` now; nothing was removed.
+
+The same pair identifies a policy everywhere else it is named: the plan resolves
+`rls_policies_added`, `rls_policies_removed` and `rls_policies_modified` by the
+owning table together with the policy name, and the table is matched under the
+target's identifier rules, so `orders` and `public.orders` are one table. A
+reference the target schema cannot resolve is rejected rather than skipped.
 
 ## Plan-only runs
 

--- a/docs/site/src/content/docs/extend/public-api.md
+++ b/docs/site/src/content/docs/extend/public-api.md
@@ -225,6 +225,17 @@ table. Live comparisons snapshot catalog identifier semantics into the diff so
 comparison, policy, forward planning, and reverse planning share one source of
 truth.
 
+Row-level security policies use the same shape. `RLSPoliciesAdded` and
+`RLSPoliciesRemoved` are `[]RLSPolicyRef`, `RLSPoliciesModified` is
+`[]RLSPolicyDiff`, and every entry names the owning table next to the policy
+name. That pair is the policy's identity: a PostgreSQL policy name is scoped to
+its table, so two tables in one schema may each carry `tenant_isolation`. The
+table half is compared under the diff's identifier semantics, not as a raw
+string, so the desired spelling `public.orders` and the introspected spelling
+`orders` resolve to one table in both the forward and the reverse direction.
+A reference the target schema cannot resolve is rejected with
+`ptaherr.ErrInvalidSchemaDiff`; it is never dropped from the plan.
+
 Use `migration/generator.GenerateCheckpointWithDatabase` for a SQL Server
 schema whose live catalog semantics must survive checkpoint planning.
 `GenerateCheckpointWithDatabaseInfo` accepts a caller-supplied complete

--- a/internal/convert/toschema/identifiers.go
+++ b/internal/convert/toschema/identifiers.go
@@ -5,6 +5,7 @@ import (
 	"unicode"
 
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
 )
 
 func normalizeSQLIdentifier(value string) string {
@@ -30,6 +31,57 @@ func normalizeSQLTableIdentifier(value string) (schema, name string) {
 func normalizeSQLTableReference(value string) string {
 	schema, name := normalizeSQLTableIdentifier(value)
 	return goschema.QualifyTableName(schema, name)
+}
+
+// catalogPostgresTableReference answers which relation a PostgreSQL statement
+// names, one identifier component at a time.
+//
+// The two spellings `ORDERS` and `"ORDERS"` reach this package as different
+// strings, and PostgreSQL reads them as different relations: the unquoted one
+// is folded to `orders` on its way into the catalog, the quoted one keeps its
+// case. Measured on PostgreSQL 17.10 against a database holding only `orders`,
+// `CREATE POLICY p ON ORDERS` exits 0 with a pg_policy row on `public.orders`
+// while `CREATE POLICY p ON "ORDERS"` exits 1 with `relation "ORDERS" does not
+// exist`.
+//
+// [normalizeSQLTableReference] unquotes every component and therefore erases
+// that difference, which is why the reference has to be folded HERE, at the one
+// point in the pipeline that still holds the quoting. Everything downstream
+// sees the relation, so nothing downstream has to guess -- and a guess is what
+// relocated an access-control declaration onto a relation the author did not
+// name (stokaro/ptah#1311).
+//
+// The fold is per component because the components are independent:
+// `"App".ORDERS` names the relation `orders` inside the schema `App`, and
+// PostgreSQL 17.10 resolves it against a table created as `"App".orders`
+// with exit 0.
+//
+// This is deliberately not applied to identifiers in general. Only PostgreSQL
+// folds unquoted identifiers down, and only the RLS statements this package
+// routes here are PostgreSQL-only syntax; the MySQL, MariaDB and SQL Server
+// frontends share the reader and must keep their own case rules.
+func catalogPostgresTableReference(value string) string {
+	parts := splitSQLIdentifier(value)
+	for index, part := range parts {
+		parts[index] = catalogPostgresIdentifierPart(strings.TrimSpace(part))
+	}
+	if len(parts) == 1 {
+		return goschema.QualifyTableName("", parts[0])
+	}
+	return goschema.QualifyTableName(
+		strings.Join(parts[:len(parts)-1], "."),
+		parts[len(parts)-1],
+	)
+}
+
+// catalogPostgresIdentifierPart folds one component the way PostgreSQL does:
+// an unquoted component loses its ASCII case, a quoted one keeps every
+// character it was written with.
+func catalogPostgresIdentifierPart(part string) string {
+	if isQuotedSQLIdentifierPart(part) {
+		return unquoteSQLIdentifierPart(part)
+	}
+	return identifier.ComparisonASCIIInsensitive.IdentityKey(part)
 }
 
 func tableStructName(value string) string {

--- a/internal/convert/toschema/postgres_objects.go
+++ b/internal/convert/toschema/postgres_objects.go
@@ -63,10 +63,19 @@ func toGrant(node *ast.GrantPrivilegeNode) goschema.Grant {
 	return grant
 }
 
+// toRLSPolicy resolves the policy's table through
+// [catalogPostgresTableReference] rather than the plain unquoting every other
+// object uses.
+//
+// A policy is an access-control declaration, and the relation it lands on is
+// the whole question. `CREATE POLICY p ON "ORDERS"` and `CREATE POLICY p ON
+// ORDERS` name different relations, so keeping the raw spelling left the rest
+// of the pipeline to guess -- and the guess secured a relation the author did
+// not name (stokaro/ptah#1311).
 func toRLSPolicy(node *ast.CreatePolicyNode) goschema.RLSPolicy {
 	return goschema.RLSPolicy{
 		Name:                normalizeSQLIdentifier(node.Name),
-		Table:               normalizeSQLTableReference(node.Table),
+		Table:               catalogPostgresTableReference(node.Table),
 		PolicyFor:           node.PolicyFor,
 		ToRoles:             normalizeRoleList(node.ToRoles),
 		UsingExpression:     node.UsingExpression,
@@ -88,9 +97,12 @@ func normalizeRoleList(roles string) string {
 	return strings.Join(parts, ", ")
 }
 
+// toRLSEnabledTable resolves its table the same way [toRLSPolicy] does. The
+// enablement and the policies on it have to name one relation, or the render
+// turns row-level security on for one table and protects another.
 func toRLSEnabledTable(node *ast.AlterTableEnableRLSNode) goschema.RLSEnabledTable {
 	return goschema.RLSEnabledTable{
-		Table:   normalizeSQLTableReference(node.Table),
+		Table:   catalogPostgresTableReference(node.Table),
 		Comment: node.Comment,
 	}
 }

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -15,6 +15,7 @@ import (
 	"go.5x5.cz/ptah/internal/indexscope"
 	"go.5x5.cz/ptah/internal/planner/objectlookup"
 	"go.5x5.cz/ptah/internal/planner/tablelookup"
+	"go.5x5.cz/ptah/internal/rlsscope"
 	"go.5x5.cz/ptah/internal/tableref"
 	"go.5x5.cz/ptah/migration/diffpolicy"
 	"go.5x5.cz/ptah/migration/schemadiff/types"
@@ -1373,6 +1374,22 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	if err != nil {
 		return nil, err
 	}
+	// Row-level security references are validated with the indexes, before any
+	// node is emitted, for the reason the index resolver is: a reference the
+	// target schema cannot resolve used to be skipped, so the plan came back
+	// successful with an access-control operation missing from it
+	// (stokaro/ptah#1311). Validating the diff as it arrived, ahead of the skip
+	// policy below, means a malformed reference is refused even when the policy
+	// would have removed it -- the diff is either coherent or it is not.
+	policies, err := rlsscope.NewResolverWithSemantics(
+		p.targetDialect(),
+		diff.EffectiveIdentifierSemantics(p.targetDialect()),
+		diff,
+		generated,
+	)
+	if err != nil {
+		return nil, err
+	}
 
 	// Apply the diff policy first so skipped destructive changes never reach the
 	// per-object emission below (and so a skipped DROP never trips the coarse
@@ -1453,8 +1470,14 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 
 	// 9. Add RLS policies (must be done after RLS is enabled and columns exist)
 	if p.capabilities().Has(capability.RowLevelSecurity) {
-		result = p.addNewRLSPolicies(result, diff, generated)
-		result = p.modifyExistingRLSPolicies(result, diff, generated)
+		result, err = p.addNewRLSPolicies(result, diff, policies)
+		if err != nil {
+			return nil, err
+		}
+		result, err = p.modifyExistingRLSPolicies(result, diff, policies)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	// 9.5. Add role privilege grants after roles and target objects exist.
@@ -2192,15 +2215,6 @@ func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *go
 	return objectlookup.Trigger(triggers, tableName, triggerName)
 }
 
-func findRLSPolicy(policies []goschema.RLSPolicy, tableName, policyName string) *goschema.RLSPolicy {
-	for i := range policies {
-		if policies[i].Table == tableName && policies[i].Name == policyName {
-			return &policies[i]
-		}
-	}
-	return nil
-}
-
 // enableRLSOnTables emits ALTER TABLE ... ENABLE ROW LEVEL SECURITY.
 //
 // Two sources feed it, and both are needed.
@@ -2285,36 +2299,71 @@ func (p *Planner) disableRLSOnTables(result []ast.Node, diff *types.SchemaDiff) 
 	return result
 }
 
-func (p *Planner) addNewRLSPolicies(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+// addNewRLSPolicies emits one CREATE POLICY per added reference.
+//
+// The reference is resolved through [rlsscope.Resolver], which keys by the
+// owning table under the target's identifier semantics and by the policy's own
+// name. Two things follow, and both are the point of the resolver existing.
+//
+// The name alone does not identify a policy: two tables may each carry a
+// policy called "tenant_isolation", and matching on the name picked whichever
+// was declared first. And the table alone is not a string comparison either:
+// `orders` and `public.orders` are one table, which is exactly the pair the
+// comparator normalizes and a raw-string lookup missed.
+//
+// An unresolved reference is an error rather than a skip. A plan that omits a
+// CREATE POLICY and still reports success leaves the database without the
+// protection the migration was generated to add (stokaro/ptah#1311).
+func (p *Planner) addNewRLSPolicies(
+	result []ast.Node,
+	diff *types.SchemaDiff,
+	policies *rlsscope.Resolver,
+) ([]ast.Node, error) {
 	for _, policyRef := range diff.RLSPoliciesAdded {
-		// Find the policy definition. The name alone does not identify it:
-		// two tables may each carry a policy called "tenant_isolation", and
-		// matching on the name picked whichever was declared first.
-		policy := findRLSPolicy(generated.RLSPolicies, policyRef.TableName, policyRef.PolicyName)
-		if policy == nil {
-			continue
+		policy, err := policies.Resolve(policyRef)
+		if err != nil {
+			return nil, err
 		}
-		policyNode := fromschema.FromRLSPolicy(*policy)
+		policyNode := fromschema.FromRLSPolicy(policy)
 		// Set Replace flag to handle conflicts gracefully during migrations
 		policyNode.Replace = true
 		result = append(result, policyNode)
 	}
-	return result
+	return result, nil
 }
 
-func (p *Planner) modifyExistingRLSPolicies(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
+// modifyExistingRLSPolicies re-renders each modified policy from the schema the
+// plan is targeting, through the same resolver [addNewRLSPolicies] uses.
+//
+// The two sides of a modification do not spell the owning table the same way.
+// The comparator normalizes `orders` and `public.orders` to one table and then
+// reports the DESIRED side's spelling, while a rollback plans against the
+// INTROSPECTED schema, whose policy carries the database's spelling. A
+// raw-string lookup therefore found nothing on the down direction and the
+// generated rollback was `-- No rollback operations needed`: a policy body
+// changed on the way up and nothing put it back (stokaro/ptah#1311).
+func (p *Planner) modifyExistingRLSPolicies(
+	result []ast.Node,
+	diff *types.SchemaDiff,
+	policies *rlsscope.Resolver,
+) ([]ast.Node, error) {
 	for _, policyDiff := range diff.RLSPoliciesModified {
-		if policy := findRLSPolicy(generated.RLSPolicies, policyDiff.TableName, policyDiff.PolicyName); policy != nil {
-			policyNode := fromschema.FromRLSPolicy(*policy).SetReplace()
-			policyNode.SetComment(fmt.Sprintf("Modify RLS policy %s on table %s: %s",
-				policyDiff.PolicyName,
-				policyDiff.TableName,
-				summarizeRLSChanges(policyDiff),
-			))
-			result = append(result, policyNode)
+		policy, err := policies.Resolve(types.RLSPolicyRef{
+			PolicyName: policyDiff.PolicyName,
+			TableName:  policyDiff.TableName,
+		})
+		if err != nil {
+			return nil, err
 		}
+		policyNode := fromschema.FromRLSPolicy(policy).SetReplace()
+		policyNode.SetComment(fmt.Sprintf("Modify RLS policy %s on table %s: %s",
+			policyDiff.PolicyName,
+			policyDiff.TableName,
+			summarizeRLSChanges(policyDiff),
+		))
+		result = append(result, policyNode)
 	}
-	return result
+	return result, nil
 }
 
 func summarizeRLSChanges(policyDiff types.RLSPolicyDiff) string {

--- a/internal/planner/dialects/postgres/rls_policy_ref_test.go
+++ b/internal/planner/dialects/postgres/rls_policy_ref_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.5x5.cz/ptah/core/ast"
 	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/ptaherr"
 	"go.5x5.cz/ptah/internal/planner/dialects/postgres"
 	"go.5x5.cz/ptah/migration/schemadiff/types"
 )
@@ -81,20 +82,157 @@ func TestPlanner_RLSPolicyRefs_CreatesThePolicyOnTheNamedTable(t *testing.T) {
 	}
 }
 
-// TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold is the
+// TestPlanner_RLSPolicyRefs_RefusesAPolicyTheDesiredSchemaDoesNotHold is the
 // control for the lookup becoming exact: a reference the desired schema cannot
-// resolve must produce nothing rather than fall back to a same-named policy on
-// some other table, which is what the name-only lookup did on a down
-// migration.
-func TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold(t *testing.T) {
-	c := qt.New(t)
-	diff := &types.SchemaDiff{
-		RLSPoliciesAdded: []types.RLSPolicyRef{
-			{PolicyName: "tenant_isolation", TableName: "omega_orders"},
+// resolve must not fall back to a same-named policy on some other table, which
+// is what the name-only lookup did on a down migration.
+//
+// It must also not fall back to SILENCE, which is what this test asserted until
+// stokaro/ptah#1311 was reviewed. The checked planner returned a successful
+// plan with the CREATE POLICY simply absent from it, so a stale or hand-built
+// diff produced valid-looking SQL that left the database without an
+// access-control protection the migration claimed to add -- while the public
+// planning contract promises an invalid schema diff is rejected with
+// ptaherr.ErrInvalidSchemaDiff. The refusal is the assertion now.
+//
+// Every reference category is covered because they fail differently: an
+// addition and a modification both build their CREATE POLICY from a
+// declaration and so need one, while a removal renders `DROP POLICY name ON
+// table` out of the reference itself and needs no declaration at all -- so it
+// must still be planned, and only its shape can be checked.
+func TestPlanner_RLSPolicyRefs_RefusesAPolicyTheDesiredSchemaDoesNotHold(t *testing.T) {
+	tests := []struct {
+		name   string
+		diff   *types.SchemaDiff
+		assert func(c *qt.C, nodes []ast.Node, err error)
+	}{
+		{
+			name: "an addition naming an undeclared table is refused",
+			diff: &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "omega_orders"},
+				},
+			},
+			assert: func(c *qt.C, nodes []ast.Node, err error) {
+				c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+				c.Assert(err, qt.ErrorMatches, `.*added RLS policy tenant_isolation on table omega_orders at position 0 is missing from the target schema`)
+				c.Assert(nodes, qt.IsNil)
+			},
+		},
+		{
+			name: "a modification naming an undeclared policy is refused",
+			diff: &types.SchemaDiff{
+				RLSPoliciesModified: []types.RLSPolicyDiff{{
+					PolicyName: "tenant_isolation",
+					TableName:  "omega_orders",
+					Changes:    map[string]string{"using_expression": "a -> b"},
+				}},
+			},
+			assert: func(c *qt.C, nodes []ast.Node, err error) {
+				c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+				c.Assert(err, qt.ErrorMatches, `.*modified RLS policy tenant_isolation on table omega_orders at position 0 is missing from the target schema`)
+				c.Assert(nodes, qt.IsNil)
+			},
+		},
+		{
+			name: "a reference with no owning table is refused",
+			diff: &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{{PolicyName: "tenant_isolation"}},
+			},
+			assert: func(c *qt.C, nodes []ast.Node, err error) {
+				c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+				c.Assert(err, qt.ErrorMatches, `.*added RLS policy reference at position 0 requires a policy name and owning table`)
+				c.Assert(nodes, qt.IsNil)
+			},
+		},
+		{
+			name: "a removal needs no declaration and is still planned",
+			diff: &types.SchemaDiff{
+				RLSPoliciesRemoved: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "omega_orders"},
+				},
+			},
+			assert: func(c *qt.C, nodes []ast.Node, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(nodes, qt.HasLen, 2)
+				drop, ok := nodes[0].(*ast.DropPolicyNode)
+				c.Assert(ok, qt.IsTrue)
+				c.Assert(drop.Name, qt.Equals, "tenant_isolation")
+				c.Assert(drop.Table, qt.Equals, "omega_orders")
+			},
+		},
+		{
+			name: "a removal with no owning table is refused",
+			diff: &types.SchemaDiff{
+				RLSPoliciesRemoved: []types.RLSPolicyRef{{PolicyName: "tenant_isolation"}},
+			},
+			assert: func(c *qt.C, nodes []ast.Node, err error) {
+				c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+				c.Assert(err, qt.ErrorMatches, `.*removed RLS policy reference at position 0 requires a policy name and owning table`)
+				c.Assert(nodes, qt.IsNil)
+			},
 		},
 	}
 
-	nodes, err := postgres.New().GenerateMigrationASTChecked(diff, generatedSharedPolicyName())
-	c.Assert(err, qt.IsNil)
-	c.Assert(nodes, qt.HasLen, 0)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			nodes, err := postgres.New().GenerateMigrationASTChecked(test.diff, generatedSharedPolicyName())
+
+			test.assert(c, nodes, err)
+		})
+	}
+}
+
+// TestPlanner_RLSPolicyRefs_ResolvesTheDefaultSchemaSpelling is the pair to the
+// refusal: a reference the target schema DOES hold under the dialect's
+// identifier rules must resolve, not be refused for spelling its table
+// differently.
+//
+// `orders` and `public.orders` are one table on PostgreSQL, which is why the
+// comparator normalizes them -- and why the planner has to as well, in both
+// directions, or a diff the comparator produced would be rejected by the
+// planner that consumes it.
+func TestPlanner_RLSPolicyRefs_ResolvesTheDefaultSchemaSpelling(t *testing.T) {
+	tests := []struct {
+		name      string
+		declared  string
+		reference string
+	}{
+		{name: "declared bare, referenced qualified", declared: "orders", reference: "public.orders"},
+		{name: "declared qualified, referenced bare", declared: "public.orders", reference: "orders"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				Tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+				RLSPolicies: []goschema.RLSPolicy{{
+					Name:            "tenant_isolation",
+					Table:           test.declared,
+					PolicyFor:       "ALL",
+					ToRoles:         "PUBLIC",
+					UsingExpression: "tenant_id = 1",
+				}},
+			}
+			diff := &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: test.reference},
+				},
+			}
+
+			nodes, err := postgres.New().GenerateMigrationASTChecked(diff, generated)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(nodes, qt.HasLen, 1)
+			policy, ok := nodes[0].(*ast.CreatePolicyNode)
+			c.Assert(ok, qt.IsTrue)
+			// The declared spelling is what is rendered: only the matching is
+			// normalized.
+			c.Assert(policy.Table, qt.Equals, test.declared)
+			c.Assert(policy.UsingExpression, qt.Equals, "tenant_id = 1")
+		})
+	}
 }

--- a/internal/rlsscope/rlsscope.go
+++ b/internal/rlsscope/rlsscope.go
@@ -1,0 +1,224 @@
+// Package rlsscope resolves row-level security policy references against the
+// schema a migration plan is built from, using the identifier semantics the
+// diff was produced with.
+package rlsscope
+
+import (
+	"fmt"
+	"strings"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// identity is what makes two policy references the same policy: the table that
+// owns it, under the target's table semantics, and the policy's own name.
+//
+// It is a struct rather than a joined string because both components are
+// database identifiers and either may contain a dot when quoted, so no
+// separator encoding is injective: table `a` with policy `"b.c"` and table
+// `a.b` with policy `c` would share one joined key and one of two distinct
+// policies would be dropped (stokaro/ptah#1276).
+//
+// The policy name is compared as written, which is what
+// `compare.RLSPoliciesWithSemantics` keys on. A resolver that normalized the
+// name differently from the comparator that produced the reference would miss
+// exactly the references the comparator meant to hand it.
+type identity struct {
+	table  string
+	policy string
+}
+
+// Resolver holds the target row-level security policies one migration plan may
+// need, indexed by the identity the diff refers to them with.
+type Resolver struct {
+	semantics identifier.Semantics
+	policies  map[identity]goschema.RLSPolicy
+}
+
+// Resolve returns the target policy identified by ref.
+//
+// A reference that resolves to nothing is an error rather than a skip. The
+// planner's only alternative is to emit no statement for it, and a plan that
+// silently drops an access-control operation reports success while leaving the
+// database unprotected -- the failure stokaro/ptah#1311 was reviewed for. The
+// public planning contract already promises that an invalid schema diff is
+// rejected with [ptaherr.ErrInvalidSchemaDiff].
+func (r *Resolver) Resolve(ref types.RLSPolicyRef) (goschema.RLSPolicy, error) {
+	if r == nil {
+		return goschema.RLSPolicy{}, fmt.Errorf(
+			"%w: no validated target RLS policies are available",
+			ptaherr.ErrInvalidSchemaDiff,
+		)
+	}
+	policy, ok := r.policies[identityKey(r.semantics, ref)]
+	if !ok {
+		return goschema.RLSPolicy{}, fmt.Errorf(
+			"%w: target RLS policy %s on table %s was not part of the validated plan",
+			ptaherr.ErrInvalidSchemaDiff,
+			ref.PolicyName,
+			ref.TableName,
+		)
+	}
+	return policy, nil
+}
+
+// NewResolver validates every policy identity needed to plan diff and indexes
+// the target schema, using conservative offline rules for dialect.
+func NewResolver(
+	dialect string,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+) (*Resolver, error) {
+	return NewResolverWithSemantics(dialect, identifier.ForDialect(dialect), diff, generated)
+}
+
+// NewResolverWithSemantics validates and indexes target policies using explicit
+// live or offline identifier semantics.
+//
+// Validation covers every reference in the diff, in all three categories:
+//
+//   - a reference missing either half of its identity is refused outright,
+//     because a policy name alone does not identify a policy;
+//   - every ADDED and every MODIFIED reference must resolve to a declared
+//     policy, since both emit a CREATE POLICY built from that declaration;
+//   - a REMOVED reference needs no declaration -- `DROP POLICY name ON table`
+//     is built from the reference itself -- so it is checked for shape only.
+//
+// The target schema is refused when two declarations collapse onto one
+// identity, since the plan would then depend on which one the map happened to
+// keep.
+func NewResolverWithSemantics(
+	dialect string,
+	semantics identifier.Semantics,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+) (*Resolver, error) {
+	if diff == nil {
+		return nil, fmt.Errorf("%w: schema diff is nil", ptaherr.ErrInvalidSchemaDiff)
+	}
+	if err := validateRefs("added", diff.RLSPoliciesAdded); err != nil {
+		return nil, err
+	}
+	if err := validateRefs("removed", diff.RLSPoliciesRemoved); err != nil {
+		return nil, err
+	}
+	if err := validateRefs("modified", modifiedRefs(diff)); err != nil {
+		return nil, err
+	}
+	resolver, err := newTargetResolver(dialect, semantics, generated)
+	if err != nil {
+		return nil, err
+	}
+	if err := resolver.requireResolvable("added", diff.RLSPoliciesAdded); err != nil {
+		return nil, err
+	}
+	return resolver, resolver.requireResolvable("modified", modifiedRefs(diff))
+}
+
+// modifiedRefs projects the modified policy diffs onto the same reference shape
+// the added and removed lists carry, so one validation path covers all three.
+func modifiedRefs(diff *types.SchemaDiff) []types.RLSPolicyRef {
+	refs := make([]types.RLSPolicyRef, 0, len(diff.RLSPoliciesModified))
+	for _, policyDiff := range diff.RLSPoliciesModified {
+		refs = append(refs, types.RLSPolicyRef{
+			PolicyName: policyDiff.PolicyName,
+			TableName:  policyDiff.TableName,
+		})
+	}
+	return refs
+}
+
+func newTargetResolver(
+	dialect string,
+	semantics identifier.Semantics,
+	generated *goschema.Database,
+) (*Resolver, error) {
+	resolver := &Resolver{
+		semantics: semantics,
+		policies:  make(map[identity]goschema.RLSPolicy),
+	}
+	if generated == nil {
+		return resolver, nil
+	}
+	for position, policy := range generated.RLSPolicies {
+		ref := types.RLSPolicyRef{PolicyName: policy.Name, TableName: policy.Table}
+		if err := validateRef("target", position, ref); err != nil {
+			return nil, err
+		}
+		key := identityKey(semantics, ref)
+		if previous, conflict := resolver.policies[key]; conflict {
+			return nil, conflictError(dialect, previous, policy)
+		}
+		resolver.policies[key] = policy
+	}
+	return resolver, nil
+}
+
+func (r *Resolver) requireResolvable(operation string, refs []types.RLSPolicyRef) error {
+	for position, ref := range refs {
+		if _, exists := r.policies[identityKey(r.semantics, ref)]; exists {
+			continue
+		}
+		return fmt.Errorf(
+			"%w: %s RLS policy %s on table %s at position %d is missing from the target schema",
+			ptaherr.ErrInvalidSchemaDiff,
+			operation,
+			ref.PolicyName,
+			ref.TableName,
+			position,
+		)
+	}
+	return nil
+}
+
+// identityKey returns the comparison identity for ref under semantics. It is
+// intended only for map keys; callers must keep the original reference when
+// rendering SQL so the supplied identifier spelling is preserved.
+//
+// The table goes through the target's qualified-table rules, which is what
+// makes `orders` and `public.orders` one table -- the difference between the
+// desired spelling a comparator reports and the introspected spelling a
+// rollback plans against (stokaro/ptah#1311).
+func identityKey(semantics identifier.Semantics, ref types.RLSPolicyRef) identity {
+	return identity{
+		table:  semantics.QualifiedTableIdentityKey(ref.TableName),
+		policy: ref.PolicyName,
+	}
+}
+
+func validateRefs(operation string, refs []types.RLSPolicyRef) error {
+	for position, ref := range refs {
+		if err := validateRef(operation, position, ref); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func validateRef(operation string, position int, ref types.RLSPolicyRef) error {
+	if strings.TrimSpace(ref.PolicyName) == "" || strings.TrimSpace(ref.TableName) == "" {
+		return fmt.Errorf(
+			"%w: %s RLS policy reference at position %d requires a policy name and owning table",
+			ptaherr.ErrInvalidSchemaDiff,
+			operation,
+			position,
+		)
+	}
+	return nil
+}
+
+func conflictError(dialect string, previous, policy goschema.RLSPolicy) error {
+	return fmt.Errorf(
+		"%w: target RLS policies %s on %s and %s on %s share one identity in %s",
+		ptaherr.ErrInvalidSchemaDiff,
+		previous.Name,
+		previous.Table,
+		policy.Name,
+		policy.Table,
+		platform.NormalizeDialect(dialect),
+	)
+}

--- a/internal/rlsscope/rlsscope_test.go
+++ b/internal/rlsscope/rlsscope_test.go
@@ -1,0 +1,184 @@
+package rlsscope_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform/identifier"
+	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/internal/rlsscope"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestNewResolver_RefusesADiffItCannotPlan covers the refusals the PostgreSQL
+// planner delegates here, including the two a planner cannot reach on its own:
+// a nil diff, and a target schema whose declarations collapse onto one identity.
+func TestNewResolver_RefusesADiffItCannotPlan(t *testing.T) {
+	declared := func(policies ...goschema.RLSPolicy) *goschema.Database {
+		return &goschema.Database{RLSPolicies: policies}
+	}
+
+	tests := []struct {
+		name      string
+		diff      *types.SchemaDiff
+		generated *goschema.Database
+		wantError string
+	}{
+		{
+			name:      "a nil diff",
+			diff:      nil,
+			generated: declared(),
+			wantError: `invalid schema diff: schema diff is nil`,
+		},
+		{
+			name: "an addition with no owning table",
+			diff: &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{{PolicyName: "p"}},
+			},
+			generated: declared(),
+			wantError: `invalid schema diff: added RLS policy reference at position 0 requires a policy name and owning table`,
+		},
+		{
+			name: "an addition with no policy name",
+			diff: &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{{TableName: "orders"}},
+			},
+			generated: declared(),
+			wantError: `invalid schema diff: added RLS policy reference at position 0 requires a policy name and owning table`,
+		},
+		{
+			name: "an addition the target schema does not hold",
+			diff: &types.SchemaDiff{
+				RLSPoliciesAdded: []types.RLSPolicyRef{{PolicyName: "p", TableName: "orders"}},
+			},
+			generated: declared(),
+			wantError: `invalid schema diff: added RLS policy p on table orders at position 0 is missing from the target schema`,
+		},
+		{
+			// Two spellings of one table carrying one policy name are one
+			// policy under PostgreSQL's rules, so the map would keep whichever
+			// came last and the plan would depend on declaration order.
+			name: "a target schema with two declarations of one policy",
+			diff: &types.SchemaDiff{},
+			generated: declared(
+				goschema.RLSPolicy{Name: "p", Table: "orders"},
+				goschema.RLSPolicy{Name: "p", Table: "public.orders"},
+			),
+			wantError: `invalid schema diff: target RLS policies p on orders and p on public.orders share one identity in postgres`,
+		},
+		{
+			name:      "a target declaration with no owning table",
+			diff:      &types.SchemaDiff{},
+			generated: declared(goschema.RLSPolicy{Name: "p"}),
+			wantError: `invalid schema diff: target RLS policy reference at position 0 requires a policy name and owning table`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			resolver, err := rlsscope.NewResolver("postgres", test.diff, test.generated)
+
+			c.Assert(resolver, qt.IsNil)
+			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+			c.Assert(err, qt.ErrorMatches, test.wantError)
+		})
+	}
+}
+
+// TestResolver_ResolveOnANilResolver is the guard for a caller that ignored a
+// construction error. Returning a zero policy without saying so would put an
+// empty CREATE POLICY into a plan.
+func TestResolver_ResolveOnANilResolver(t *testing.T) {
+	c := qt.New(t)
+	var resolver *rlsscope.Resolver
+
+	policy, err := resolver.Resolve(types.RLSPolicyRef{PolicyName: "p", TableName: "orders"})
+
+	c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+	c.Assert(err, qt.ErrorMatches, `invalid schema diff: no validated target RLS policies are available`)
+	c.Assert(policy, qt.DeepEquals, goschema.RLSPolicy{})
+}
+
+// TestResolver_ResolvesEitherDefaultSchemaSpelling pins the matching rule the
+// comparator already uses: `orders` and `public.orders` are one table on
+// PostgreSQL, in whichever direction the two sides happen to spell it.
+func TestResolver_ResolvesEitherDefaultSchemaSpelling(t *testing.T) {
+	tests := []struct {
+		name      string
+		declared  string
+		reference string
+	}{
+		{name: "declared bare, referenced qualified", declared: "orders", reference: "public.orders"},
+		{name: "declared qualified, referenced bare", declared: "public.orders", reference: "orders"},
+		{name: "both bare", declared: "orders", reference: "orders"},
+		{name: "both qualified", declared: "public.orders", reference: "public.orders"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			generated := &goschema.Database{
+				RLSPolicies: []goschema.RLSPolicy{
+					{Name: "p", Table: test.declared, UsingExpression: "tenant_id = 1"},
+				},
+			}
+			ref := types.RLSPolicyRef{PolicyName: "p", TableName: test.reference}
+
+			resolver, err := rlsscope.NewResolverWithSemantics(
+				"postgres",
+				identifier.ForDialect("postgres"),
+				&types.SchemaDiff{RLSPoliciesAdded: []types.RLSPolicyRef{ref}},
+				generated,
+			)
+			c.Assert(err, qt.IsNil)
+
+			policy, err := resolver.Resolve(ref)
+
+			c.Assert(err, qt.IsNil)
+			// The declared spelling survives: only the matching is normalized,
+			// because the planner renders whatever it is handed.
+			c.Assert(policy.Table, qt.Equals, test.declared)
+			c.Assert(policy.UsingExpression, qt.Equals, "tenant_id = 1")
+		})
+	}
+}
+
+// TestResolver_KeepsOnePolicyNamePerTable is the control the identity must not
+// swallow: two tables in one schema may each carry a policy called
+// tenant_isolation, and each reference must reach its own.
+func TestResolver_KeepsOnePolicyNamePerTable(t *testing.T) {
+	tests := []struct {
+		name      string
+		table     string
+		wantUsing string
+	}{
+		{name: "alpha", table: "alpha_orders", wantUsing: "tenant_id = 1"},
+		{name: "zeta", table: "zeta_orders", wantUsing: "tenant_id = 2"},
+	}
+
+	generated := &goschema.Database{
+		RLSPolicies: []goschema.RLSPolicy{
+			{Name: "tenant_isolation", Table: "alpha_orders", UsingExpression: "tenant_id = 1"},
+			{Name: "tenant_isolation", Table: "zeta_orders", UsingExpression: "tenant_id = 2"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ref := types.RLSPolicyRef{PolicyName: "tenant_isolation", TableName: test.table}
+
+			resolver, err := rlsscope.NewResolver("postgres", &types.SchemaDiff{}, generated)
+			c.Assert(err, qt.IsNil)
+
+			policy, err := resolver.Resolve(ref)
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(policy.UsingExpression, qt.Equals, test.wantUsing)
+		})
+	}
+}

--- a/migration/generator/rls_policy_rollback_internal_test.go
+++ b/migration/generator/rls_policy_rollback_internal_test.go
@@ -1,0 +1,129 @@
+package generator
+
+// White-box testing required: the down direction is reached through
+// generateDownMigrationSQL, which is unexported, and the defect these tests pin
+// lives between the reversed diff and the introspected schema the rollback is
+// planned against. No exported entry point reaches that pair without a live
+// database and a migration directory.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+)
+
+// desiredPolicyOnOrders is the desired state for the rollback tests: one policy
+// on one table, spelled however the caller writes it, with the USING expression
+// the migration is changing to.
+func desiredPolicyOnOrders(spelling string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{Name: "orders", StructName: "Order"}},
+		RLSEnabledTables: []goschema.RLSEnabledTable{
+			{Table: spelling, StructName: "Order"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "tenant_isolation",
+			Table:           spelling,
+			StructName:      "Order",
+			PolicyFor:       "ALL",
+			ToRoles:         "PUBLIC",
+			UsingExpression: "tenant_id = 2",
+		}},
+	}
+}
+
+// introspectedPolicyOnOrders is the database side, carrying the spelling the
+// PostgreSQL reader reports and the USING expression a rollback has to restore.
+func introspectedPolicyOnOrders(spelling string) *dbschematypes.DBSchema {
+	return &dbschematypes.DBSchema{
+		Tables: []dbschematypes.DBTable{
+			{Name: "orders", Schema: "public", RLSEnabled: true},
+		},
+		RLSPolicies: []dbschematypes.DBRLSPolicy{{
+			Name:            "tenant_isolation",
+			Table:           spelling,
+			PolicyFor:       "ALL",
+			ToRoles:         "PUBLIC",
+			UsingExpression: "tenant_id = 1",
+		}},
+	}
+}
+
+// TestGenerateDownMigrationSQL_RestoresAModifiedRLSPolicyAcrossSpellings pins
+// the rollback of a changed row-level security policy.
+//
+// The comparator deliberately treats `orders` and `public.orders` as one table
+// and then reports the DESIRED side's spelling in RLSPolicyDiff.TableName. The
+// down direction plans against the INTROSPECTED schema, whose policy carries
+// the database's spelling, so a raw-string lookup found nothing and the
+// generated rollback was exactly `-- No rollback operations needed` -- a policy
+// body changed on the way up and nothing put it back (stokaro/ptah#1311).
+//
+// The diff is produced by the real comparator rather than written out by hand:
+// which spelling lands in TableName is the comparator's decision, and a
+// hand-built diff would be asserting this test's own assumption instead of the
+// pipeline's behavior.
+//
+// Every combination of the two default-schema spellings is covered, because the
+// pair that fails is the pair that differs and either side may be the qualified
+// one.
+func TestGenerateDownMigrationSQL_RestoresAModifiedRLSPolicyAcrossSpellings(t *testing.T) {
+	tests := []struct {
+		name      string
+		desired   string
+		database  string
+		wantTable string
+	}{
+		{
+			name:      "desired qualified, database bare",
+			desired:   "public.orders",
+			database:  "orders",
+			wantTable: "orders",
+		},
+		{
+			name:      "desired bare, database qualified",
+			desired:   "orders",
+			database:  "public.orders",
+			wantTable: "public.orders",
+		},
+		{
+			name:      "both bare",
+			desired:   "orders",
+			database:  "orders",
+			wantTable: "orders",
+		},
+		{
+			name:      "both qualified",
+			desired:   "public.orders",
+			database:  "public.orders",
+			wantTable: "public.orders",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			desired := desiredPolicyOnOrders(test.desired)
+			database := introspectedPolicyOnOrders(test.database)
+
+			diff := schemadiff.CompareWithDialect(desired, database, "postgres")
+			c.Assert(diff.RLSPoliciesModified, qt.HasLen, 1)
+
+			downSQL, err := generateDownMigrationSQL(diff, desired, database, "postgres")
+			c.Assert(err, qt.IsNil)
+
+			// The rollback drops the changed policy and recreates it from the
+			// pre-change database definition, on the table the database itself
+			// reports.
+			c.Assert(downSQL, qt.Not(qt.Contains), "No rollback operations needed")
+			c.Assert(legacyRenderedSQL(downSQL), qt.Contains,
+				"DROP POLICY IF EXISTS tenant_isolation ON "+test.wantTable+";")
+			c.Assert(legacyRenderedSQL(downSQL), qt.Contains, "USING (tenant_id = 1)")
+			c.Assert(downSQL, qt.Not(qt.Contains), "tenant_id = 2")
+		})
+	}
+}


### PR DESCRIPTION
Refs #1311, which is merged. A post-merge adversarial review found three
access-control defects in it. They are one problem seen from three sides: a
row-level security policy reference is resolved by raw string in places that
need the identifier semantics the comparator already computes. Each was
reproduced with the reviewer's own reproduction before anything changed.

None of these were visible to CI, and the review says why: the boundary forms
were missing from every fixture. Green checks are not offered as evidence about
behavior anywhere below; every claim is a measurement.

## Finding 1 (BLOCKER) — quote loss relocated an RLS policy

**Reproduction, through `schemaload.Load` as the review specifies.** Input:

```sql
CREATE TABLE orders (id integer);
CREATE POLICY p ON "ORDERS" USING (true);
```

Literal output on master:

```
table: name="orders"
policy: name="p" table="ORDERS"   <-- wanted; master printed table="orders"
stmt: CREATE POLICY "p" ON "orders"
    USING (true)
;
```

`schemaload.Load` returned `orders`, exactly as reported.

**What that costs, executed against live PostgreSQL 17.10** (container
`ptah1074-dev`, `psql -v ON_ERROR_STOP=1`, exit codes read directly):

| statement | exit | `pg_policy` |
| --- | --- | --- |
| the source: `CREATE POLICY p ON "ORDERS"` | 1 | `relation "ORDERS" does not exist` |
| master's render: `CREATE POLICY "p" ON "orders"` | 0 | `p / orders / public` |

The file PostgreSQL refuses became a file it accepts, protecting a relation the
author did not name.

The second half of the finding, same server:

| statement | exit | `pg_policy` |
| --- | --- | --- |
| the source: `CREATE POLICY p ON "App".ORDERS` | 0 | `p / orders / App` |
| master's render: `CREATE POLICY "p" ON "App"."ORDERS"` | 1 | `relation "App.ORDERS" does not exist` |

**What closes it.** The fold lived in `core/goschema`, where `ORDERS` and
`"ORDERS"` are already the same string — so it had to be wrong for one of two
inputs it cannot tell apart, and being wrong for the quoted one moves an
access-control declaration. Quote provenance is now resolved at the one point
in the pipeline that still holds it: `internal/convert/toschema` folds each
**component** of a row-level security table reference the way PostgreSQL does —
unquoted components lose their ASCII case, quoted components keep it — so the
reference reaches the rest of the pipeline already naming its relation.
`core/goschema`'s resolver has no case fold left at all.

Per component is also what closes the `"App".ORDERS` half: the quoted schema
keeps its case, the unquoted table loses its own, and the pair resolves to a
declared `"App".orders`.

**Where the representation cannot distinguish, it fails closed.** Go
annotations, YAML, HCL and a hand-built `goschema.Database` carry no quoting
syntax, and Ptah quotes every identifier it renders — so `table="ORDERS"`
renders `ON "ORDERS"` and means the relation `ORDERS`. Nothing folds there. A
reference matching no declaration keeps its own spelling, so the render
reproduces the database's own answer instead of quietly succeeding elsewhere.

Both forms are added to the live PostgreSQL round-trip matrix in
`cmd/atlas/schema_apply_rls_table_spelling_live_test.go`, and both **execute**
DDL and read `pg_policy` rather than comparing strings.

## Finding 2 (MAJOR) — DOWN silently omitted a modified RLS policy

**Reproduction, through the real `schemadiff.CompareWithDialect` path, not a
hand-written diff.** A desired policy on `public.orders` changes its USING
expression; the database reports the same policy on `orders`. Literal output on
master:

```
RLSPoliciesModified=[{PolicyName:tenant_isolation TableName:public.orders Changes:map[using_expression:tenant_id = 1 -> tenant_id = 2]}]

UP SQL:
-- Modify RLS policy tenant_isolation on table public.orders: using_expression
DROP POLICY IF EXISTS "tenant_isolation" ON "public"."orders";
CREATE POLICY "tenant_isolation" ON "public"."orders" FOR ALL TO PUBLIC
    USING (tenant_id = 2);

DOWN SQL:
-- No rollback operations needed
```

The comparator normalizes `orders` and `public.orders` to one table but reports
the DESIRED spelling, while DOWN planning runs against `dbAsGoSchema`, whose
policy carries the INTROSPECTED spelling. The raw-string lookup missed.

**What closes it.** References resolve through
`diff.EffectiveIdentifierSemantics("postgres")`, so the two spellings are one
table in both directions. Same input on this branch:

```
DOWN SQL:
-- Modify RLS policy tenant_isolation on table public.orders: using_expression
DROP POLICY IF EXISTS "tenant_isolation" ON "orders";
CREATE POLICY "tenant_isolation" ON "orders" FOR ALL TO PUBLIC
    USING (tenant_id = 1);
```

## Finding 3 (MAJOR) — unresolved additions failed open

**Reproduction.** `TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold`
passed on master: `GenerateMigrationASTChecked` returned a nil error and zero
nodes for a reference the target schema does not hold. The checked planner
reported success with an access-control operation dropped from the plan, while
the public planning documentation promises invalid schema diffs are rejected
with `ptaherr.ErrInvalidSchemaDiff`.

**What closes it.** A new `internal/rlsscope`, built the way
`internal/indexscope` is: every reference in all three categories is validated
before a node is emitted, the owning table is keyed through the diff's
identifier semantics, and a missing or ambiguous reference is an error.
Additions and modifications must resolve, because both build their CREATE
POLICY from a declaration; a removal renders `DROP POLICY name ON table` out of
the reference itself, so it needs no declaration and only its shape is checked.
A stale or malformed serialized diff can no longer produce valid-looking SQL
with an RLS policy omitted.

**The test that enshrined the silent behavior was rewritten, not deleted.**
`TestPlanner_RLSPolicyRefs_SkipsAPolicyTheDesiredSchemaDoesNotHold` is now
`TestPlanner_RLSPolicyRefs_RefusesAPolicyTheDesiredSchemaDoesNotHold` and
asserts the refusal, with the reason recorded in its doc comment. It covers all
three categories plus the shape checks. A companion test asserts the pair to it
— a reference the target *does* hold under the dialect's rules must resolve, so
the planner cannot start rejecting diffs its own comparator produces.

## One more test file changed, and why

Three rows of `TestDeduplicate_KeepsOnePolicyNamePerTable` in
`core/goschema/rls_policy_identity_test.go` asserted that a hand-built
`Database` folds `ORDERS` onto a declared `orders`. They now assert that it
does not. On that surface the collapse was the same relocation as Finding 1:
the author writes `table="ORDERS"`, Ptah renders `ON "ORDERS"`, and folding it
to `orders` secures a relation nobody named. Fail-closed is the required answer
where the representation cannot distinguish quoted from unquoted.

## Red–green, per finding

Every new assertion was seen fail with the fix mutated, then restored.

| mutation | tests that went RED |
| --- | --- |
| **A** — `catalogPostgresIdentifierPart` folds every component regardless of quoting (the master defect) | both new `schemaload` tests; all three live rows, including `got nil error` where the server must refuse |
| **B** — `identityKey` keys the table by raw string | all four rows of the DOWN regression (`missing from the target schema`); both rows of the default-schema spelling test |
| **C** — `requireResolvable` returns nil and the planner skips on error (the fail-open master behavior) | the addition and modification refusal rows (`got nil error but want non-nil`) |

`grep -rn MUTATION` over the tree is empty on the pushed commit.

## Adjacent pre-existing defect, recorded not fixed

The mixed-case live row could not go through `ptah-compat schema apply`:
`addSchemaPreconditions` in the PostgreSQL planner emits its precondition as
raw **unquoted** SQL, `ast.NewRawSQL("CREATE SCHEMA IF NOT EXISTS "+schema)`.
PostgreSQL folds that to `app`, and every following statement in `"App"` is
refused with `schema "App" does not exist`. Confirmed independently of this
branch:

```
CREATE SCHEMA IF NOT EXISTS App;   -- exit 0, creates: app
CREATE TABLE "App"."orders" (...); -- exit 1, ERROR: schema "App" does not exist
```

That is about schema preconditions, not row-level security, and it would ripple
through five test files including an integration test, so it is not fixed here.
The row goes through `schema render` and executes the rendered DDL instead, and
the reason is written into the test.

## Gates

All run from the worktree root, exit codes read directly (never through a pipe).

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1` | 0 (187 packages ok, no FAIL lines) |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 |
| `docs/site`: `npm ci` + all 13 `check:*` scripts | 0 each |

No package needed an isolated rerun; nothing failed on a timeout.

Live PostgreSQL 17.10, five rows, exit 0:
`TestSchemaApplyRLSReferenceToUndeclaredRelationRefusedLivePostgres`,
`TestSchemaApplyRLSDeclaredRelationAcceptedLivePostgres`,
`TestSchemaApplyRLSQuotedReferenceRefusedLivePostgres`,
`TestRenderedRLSQualifiedMixedCaseReferenceLandsOnTheNamedRelationLivePostgres`,
`TestRenderedRLSQuotedReferenceIsRefusedByPostgres`.

## Documentation

- `docs/site/.../direct/compare-and-drift.md` said `rls_policies_added` held
  bare strings "before Ptah v0.2.0". The tag was checked before the sentence
  was written: v0.2.0 still declares `RLSPoliciesAdded []string`, and
  `scripts/check-public-api-released.sh` reports exactly
  `SchemaDiff.RLSPoliciesAdded: changed from []string to []RLSPolicyRef`
  against it. It now reads "in Ptah v0.2.0 and earlier", noting no release
  carries the object form yet.
- `docs/public_api.md` and `docs/site/.../extend/public-api.md` described only
  table-qualified index refs. Both now document the `[]RLSPolicyRef` fields,
  the table-plus-policy identity, that the table half is matched under the
  diff's identifier semantics, and that an unresolvable reference is rejected
  with `ptaherr.ErrInvalidSchemaDiff` rather than omitted.