### PR TITLE
Enable row security on the table a policy actually names (#1311, #1347)

### DIFF
--- a/cmd/internal/schemaload/rls_policy_table_spelling_test.go
+++ b/cmd/internal/schemaload/rls_policy_table_spelling_test.go
@@ -10,6 +10,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/cmd/internal/schemaload"
+	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/renderer"
 )
 
@@ -266,6 +267,61 @@ CREATE POLICY p ON "App".ORDERS FOR ALL TO PUBLIC USING (tenant_id = 1);
 	c.Assert(rowLevelSecurityStatements(statements), qt.DeepEquals, []string{
 		`ALTER TABLE "App"."orders" ENABLE ROW LEVEL SECURITY;`,
 	})
+}
+
+// TestLoad_SQLSchemaFileFoldsASCIIOnly pins which fold the reference resolver
+// uses, because the two candidates agree on every fixture that came before
+// this one.
+//
+// `catalogPostgresIdentifierPart` folds an unquoted component with
+// `identifier.ComparisonASCIIInsensitive`. Substituting
+// `identifier.ComparisonUnicodeInsensitive` -- `strings.ToLower`, which does
+// fold `Ä` to `ä` -- passed the entire suite. The two differ only outside
+// ASCII, and until this fixture nothing outside ASCII was ever loaded.
+//
+// PostgreSQL folds ASCII only. Measured on PostgreSQL 17.10 with
+// server_encoding UTF8, against a database holding both `Ä` and `ä`:
+// `CREATE POLICY p ON Ä` exits 0 with its pg_policy row on `public.Ä`, not on
+// `public.ä`. Both relations exist in this fixture for the same reason they did
+// in that measurement: under a Unicode fold the reference resolves to the OTHER
+// declared table rather than failing, so the declaration is silently relocated
+// and nothing reports an error -- the shape of stokaro/ptah#1311.
+//
+// This row stops at the loaded schema and does not assert the render. The
+// PostgreSQL renderer widens identifier bytes to runes when it splits a
+// qualified identifier (`core/renderer/internal/dialects/postgres/postgres.go`,
+// `splitQualifiedIdentifier`), so `Ä` is emitted as two mojibake characters;
+// `sqlite` and `mssql` carry the same line. That is a separate defect, and
+// asserting the render here would write it into a baseline instead of leaving
+// it to be fixed.
+func TestLoad_SQLSchemaFileFoldsASCIIOnly(t *testing.T) {
+	c := qt.New(t)
+
+	path := filepath.Join(t.TempDir(), "schema.sql")
+	c.Assert(os.WriteFile(path, []byte(`CREATE TABLE "Ä" (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+CREATE TABLE "ä" (id INTEGER PRIMARY KEY, tenant_id INTEGER);
+ALTER TABLE Ä ENABLE ROW LEVEL SECURITY;
+CREATE POLICY p ON Ä FOR ALL TO PUBLIC USING (tenant_id = 1);
+`), 0o600), qt.IsNil)
+
+	database, err := schemaload.Load(schemaload.Options{SchemaFiles: []string{path}})
+	c.Assert(err, qt.IsNil)
+
+	c.Assert(tableNames(database.Tables), qt.DeepEquals, []string{"Ä", "ä"})
+	c.Assert(database.RLSPolicies, qt.HasLen, 1)
+	c.Assert(database.RLSPolicies[0].Table, qt.Equals, "Ä")
+	c.Assert(database.RLSEnabledTables, qt.HasLen, 1)
+	c.Assert(database.RLSEnabledTables[0].Table, qt.Equals, "Ä")
+}
+
+// tableNames projects the loaded tables onto their declared names, so a
+// fixture can say which relations exist without asserting the whole schema.
+func tableNames(tables []goschema.Table) []string {
+	names := make([]string, 0, len(tables))
+	for _, table := range tables {
+		names = append(names, table.QualifiedName())
+	}
+	return names
 }
 
 // TestLoad_SQLSchemaFileKeepsTwoTablesDifferingOnlyInCase is the boundary the

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -198,6 +198,13 @@ declares a policy without declaring enablement is enabled with the table,
 because `CREATE POLICY` on a table whose row-level security is off protects
 nothing.
 
+Which table a policy belongs to is decided under the target's identifier rules
+rather than by spelling, so a policy declared on `orders` and a table created
+as `public.orders` are one table and the enablement is emitted once. Matching
+them as plain strings left the `CREATE POLICY` in the plan without its
+`ENABLE`, and the migration reported success while the policy sat inert on an
+unprotected table.
+
 A policy name is scoped to its table rather than to the schema, which is what
 PostgreSQL itself enforces: `CREATE POLICY tenant_isolation` succeeds on two
 tables in one schema and is refused only when repeated on the same table. Ptah

--- a/internal/planner/dialects/postgres/postgres.go
+++ b/internal/planner/dialects/postgres/postgres.go
@@ -10,6 +10,7 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/platform/capability"
+	"go.5x5.cz/ptah/core/platform/identifier"
 	"go.5x5.cz/ptah/internal/convert/fromschema"
 	"go.5x5.cz/ptah/internal/deporder"
 	"go.5x5.cz/ptah/internal/indexscope"
@@ -1365,9 +1366,14 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	if generated == nil {
 		generated = &goschema.Database{}
 	}
+	// One set of identifier rules for the whole plan. Every question of the form
+	// "do these two spellings name the same object" is answered with it, so the
+	// resolvers below and the statements that accompany what they resolve cannot
+	// disagree about which table a reference belongs to.
+	semantics := diff.EffectiveIdentifierSemantics(p.targetDialect())
 	indexes, err := indexscope.NewResolverWithSemantics(
 		p.targetDialect(),
-		diff.EffectiveIdentifierSemantics(p.targetDialect()),
+		semantics,
 		diff,
 		generated,
 	)
@@ -1383,7 +1389,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 	// would have removed it -- the diff is either coherent or it is not.
 	policies, err := rlsscope.NewResolverWithSemantics(
 		p.targetDialect(),
-		diff.EffectiveIdentifierSemantics(p.targetDialect()),
+		semantics,
 		diff,
 		generated,
 	)
@@ -1465,7 +1471,7 @@ func (p *Planner) GenerateMigrationASTChecked(diff *types.SchemaDiff, generated 
 
 	// 8. Enable RLS on tables (must be done after table creation and modification)
 	if p.capabilities().Has(capability.RowLevelSecurity) {
-		result = p.enableRLSOnTables(result, diff, generated)
+		result = p.enableRLSOnTables(result, diff, generated, semantics)
 	}
 
 	// 9. Add RLS policies (must be done after RLS is enabled and columns exist)
@@ -2230,19 +2236,57 @@ func findTrigger(triggers []goschema.Trigger, tableName, triggerName string) *go
 // declare a policy without a separate enablement annotation, and CREATE POLICY
 // on a table whose row-level security is off protects nothing, so the
 // enablement is emitted with the table rather than left to the operator.
-func (p *Planner) enableRLSOnTables(result []ast.Node, diff *types.SchemaDiff, generated *goschema.Database) []ast.Node {
-	tablesNeedingRLS := make(map[string]bool)
+//
+// Which table a policy belongs to is decided under the target's identifier
+// semantics, the same rules [addNewRLSPolicies] resolves the policy itself
+// with. `orders` and `public.orders` are one relation and two strings, so
+// asking `slices.Contains(diff.TablesAdded, policy.Table)` answered no whenever
+// the desired table and the policy's declaration were spelled differently: the
+// plan emitted CREATE POLICY and no ENABLE ROW LEVEL SECURITY, applied cleanly,
+// and left a pg_policy row on a relation whose pg_class.relrowsecurity was
+// still false. The policy was inert and the plan reported success. Measured on
+// PostgreSQL 17.10 -- the fourth appearance of one mistake, after
+// stokaro/ptah#1276, stokaro/ptah#1311 and stokaro/ptah#1347.
+//
+// The map is keyed by identity and carries the spelling to render, so a table
+// named by both sources is enabled once. The rendered spelling comes from the
+// diff -- the comparator's own verdict, or the name the plan creates the table
+// under -- rather than from the declaration, so the statement always names an
+// object this plan is known to have produced.
+func (p *Planner) enableRLSOnTables(
+	result []ast.Node,
+	diff *types.SchemaDiff,
+	generated *goschema.Database,
+	semantics identifier.Semantics,
+) []ast.Node {
+	tablesNeedingRLS := make(map[string]string)
+	rememberTable := func(tableName string) {
+		key := semantics.QualifiedTableIdentityKey(tableName)
+		if _, seen := tablesNeedingRLS[key]; !seen {
+			tablesNeedingRLS[key] = tableName
+		}
+	}
 	for _, tableName := range diff.RLSEnabledTablesAdded {
-		tablesNeedingRLS[tableName] = true
+		rememberTable(tableName)
+	}
+
+	addedTables := make(map[string]string, len(diff.TablesAdded))
+	for _, tableName := range diff.TablesAdded {
+		key := semantics.QualifiedTableIdentityKey(tableName)
+		if _, seen := addedTables[key]; !seen {
+			addedTables[key] = tableName
+		}
 	}
 	for _, policy := range generated.RLSPolicies {
-		if slices.Contains(diff.TablesAdded, policy.Table) {
-			tablesNeedingRLS[policy.Table] = true
+		addedTable, isNew := addedTables[semantics.QualifiedTableIdentityKey(policy.Table)]
+		if !isNew {
+			continue
 		}
+		rememberTable(addedTable)
 	}
 
 	// Iterate in sorted order so migration output is deterministic (issue #59).
-	for _, tableName := range slices.Sorted(maps.Keys(tablesNeedingRLS)) {
+	for _, tableName := range slices.Sorted(maps.Values(tablesNeedingRLS)) {
 		enableRLSNode := ast.NewAlterTableEnableRLS(tableName).
 			SetComment(fmt.Sprintf("Enable RLS for %s table", tableName))
 		result = append(result, enableRLSNode)

--- a/internal/planner/dialects/postgres/rls_enable_table_identity_live_test.go
+++ b/internal/planner/dialects/postgres/rls_enable_table_identity_live_test.go
@@ -1,0 +1,267 @@
+package postgres_test
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/planner"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// livePostgresURLForRLSEnable gates these rows on the same environment
+// variables as the other live PostgreSQL tests.
+func livePostgresURLForRLSEnable(t *testing.T) string {
+	t.Helper()
+	dbURL := os.Getenv("POSTGRES_TEST_DSN")
+	if dbURL == "" {
+		dbURL = os.Getenv("TEST_DATABASE_URL")
+	}
+	if dbURL == "" {
+		t.Skip("POSTGRES_TEST_DSN or TEST_DATABASE_URL not set")
+	}
+	if !strings.HasPrefix(dbURL, "postgres://") && !strings.HasPrefix(dbURL, "postgresql://") {
+		t.Skip("PostgreSQL URL required for RLS enablement live tests")
+	}
+	return dbURL
+}
+
+// createRLSEnableDatabase provisions one empty database per row and registers
+// its removal. The shared development server is dirty, and a row that asks
+// pg_class whether row-level security is on needs a relation nothing else
+// touched.
+func createRLSEnableDatabase(c *qt.C, adminURL string) string {
+	c.Helper()
+	name := fmt.Sprintf("ptah_rlsenable_%d_%d", os.Getpid(), time.Now().UnixNano()%1_000_000)
+	conn, err := dbschema.ConnectToDatabase(context.Background(), adminURL)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() {
+		_, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+name+" WITH (FORCE)")
+		dbschema.CloseAndWarn(conn)
+	})
+	_, err = conn.ExecContext(context.Background(), "CREATE DATABASE "+name)
+	c.Assert(err, qt.IsNil)
+	parsed, err := url.Parse(adminURL)
+	c.Assert(err, qt.IsNil)
+	parsed.Path = "/" + name
+	return parsed.String()
+}
+
+// executeSQL runs every statement in order and fails on the first error.
+func executeSQL(c *qt.C, dbURL string, statements []string) {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	for _, statement := range statements {
+		_, execErr := conn.ExecContext(context.Background(), statement)
+		c.Assert(execErr, qt.IsNil, qt.Commentf("statement: %s", statement))
+	}
+}
+
+// planAndApply plans the diff for PostgreSQL, executes the plan against dbURL
+// and returns the statements it ran.
+//
+// Rendering is not applying. The claim these rows make is about what the
+// database enforces afterwards, so the plan is executed and the catalog is
+// asked; a string assertion on the SQL cannot distinguish a policy that
+// protects rows from one that is inert.
+func planAndApply(c *qt.C, dbURL string, diff *types.SchemaDiff, generated *goschema.Database) []string {
+	c.Helper()
+	statements, err := planner.GenerateSchemaDiffSQLStatements(diff, generated, "postgres")
+	c.Assert(err, qt.IsNil)
+	c.Logf("planned SQL:\n%s", strings.Join(statements, "\n"))
+	executeSQL(c, dbURL, statements)
+	return statements
+}
+
+// rowSecurityRelations reports every user-schema relation whose
+// pg_class.relrowsecurity is true, as `nspname/relname` pairs.
+func rowSecurityRelations(c *qt.C, dbURL string) []string {
+	c.Helper()
+	return queryStrings(c, dbURL,
+		`SELECT n.nspname || '/' || c.relname
+		   FROM pg_class c
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		  WHERE c.relrowsecurity
+		    AND n.nspname NOT IN ('pg_catalog', 'information_schema')
+		  ORDER BY 1`)
+}
+
+// rlsPolicyRelations reports every user-schema row-level security policy as an
+// `nspname/relname/polname` triple.
+func rlsPolicyRelations(c *qt.C, dbURL string) []string {
+	c.Helper()
+	return queryStrings(c, dbURL,
+		`SELECT n.nspname || '/' || c.relname || '/' || p.polname
+		   FROM pg_policy p
+		   JOIN pg_class c ON c.oid = p.polrelid
+		   JOIN pg_namespace n ON n.oid = c.relnamespace
+		  WHERE n.nspname NOT IN ('pg_catalog', 'information_schema')
+		  ORDER BY 1`)
+}
+
+func queryStrings(c *qt.C, dbURL, query string) []string {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), dbURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+	rows, err := conn.QueryContext(context.Background(), query)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = rows.Close() }()
+	found := []string{}
+	for rows.Next() {
+		var row string
+		c.Assert(rows.Scan(&row), qt.IsNil)
+		found = append(found, row)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return found
+}
+
+// ordersSchema returns the target schema for a single `orders` table whose
+// policy names the owning table with policyTable.
+func ordersSchema(tableSchema, policyTable string) *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{{Name: "orders", Schema: tableSchema, StructName: "Order"}},
+		Fields: []goschema.Field{
+			{Name: "id", StructName: "Order", Type: "INTEGER", Primary: true},
+			{Name: "tenant_id", StructName: "Order", Type: "INTEGER"},
+		},
+		RLSPolicies: []goschema.RLSPolicy{{
+			Name:            "tenant_isolation",
+			Table:           policyTable,
+			PolicyFor:       "ALL",
+			ToRoles:         "PUBLIC",
+			UsingExpression: "tenant_id = 1",
+		}},
+	}
+}
+
+// TestPlannerEnablesRowSecurityForANewTableWhoseSpellingDiffersLivePostgres is
+// the fourth instance of one mistake, asserted where it is observable.
+//
+// `enableRLSOnTables` decided whether a policy's owning table is new by asking
+// `slices.Contains(diff.TablesAdded, policy.Table)` -- a raw string comparison
+// -- while `addNewRLSPolicies` resolves the same table through the target's
+// identifier semantics (stokaro/ptah#1311, stokaro/ptah#1347). `orders` and
+// `public.orders` are one relation under PostgreSQL's rules and two different
+// strings, so the plan emitted `CREATE POLICY` and no
+// `ALTER TABLE ... ENABLE ROW LEVEL SECURITY`.
+//
+// Measured on PostgreSQL 17.10: the plan applies cleanly, pg_policy carries the
+// policy, and pg_class.relrowsecurity for the relation is false. The policy is
+// inert -- row-level security is not enforced on a table the author asked to
+// protect -- and the plan reported success. That is why these rows read the
+// catalog rather than the SQL: "the plan lacks a statement" and "the database
+// does not enforce the policy" are different claims and only the second one
+// matters.
+func TestPlannerEnablesRowSecurityForANewTableWhoseSpellingDiffersLivePostgres(t *testing.T) {
+	c := qt.New(t)
+	adminURL := livePostgresURLForRLSEnable(t)
+
+	tests := []struct {
+		name string
+		// seed runs against the fresh database before the plan, for rows whose
+		// subject is a table the diff does not create.
+		seed      []string
+		diff      *types.SchemaDiff
+		generated *goschema.Database
+		assert    func(c *qt.C, dbURL string)
+	}{
+		{
+			name: "the diff creates orders and the policy names public.orders",
+			diff: &types.SchemaDiff{
+				TablesAdded: []string{"orders"},
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "public.orders"},
+				},
+			},
+			generated: ordersSchema("", "public.orders"),
+			assert: func(c *qt.C, dbURL string) {
+				c.Assert(rlsPolicyRelations(c, dbURL), qt.DeepEquals, []string{"public/orders/tenant_isolation"})
+				c.Assert(rowSecurityRelations(c, dbURL), qt.DeepEquals, []string{"public/orders"})
+			},
+		},
+		{
+			name: "the diff creates public.orders and the policy names orders",
+			diff: &types.SchemaDiff{
+				TablesAdded: []string{"public.orders"},
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "orders"},
+				},
+			},
+			generated: ordersSchema("public", "orders"),
+			assert: func(c *qt.C, dbURL string) {
+				c.Assert(rlsPolicyRelations(c, dbURL), qt.DeepEquals, []string{"public/orders/tenant_isolation"})
+				c.Assert(rowSecurityRelations(c, dbURL), qt.DeepEquals, []string{"public/orders"})
+			},
+		},
+		{
+			name: "both sides spell the table the same way",
+			diff: &types.SchemaDiff{
+				TablesAdded: []string{"orders"},
+				RLSPoliciesAdded: []types.RLSPolicyRef{
+					{PolicyName: "tenant_isolation", TableName: "orders"},
+				},
+			},
+			generated: ordersSchema("", "orders"),
+			assert: func(c *qt.C, dbURL string) {
+				c.Assert(rlsPolicyRelations(c, dbURL), qt.DeepEquals, []string{"public/orders/tenant_isolation"})
+				c.Assert(rowSecurityRelations(c, dbURL), qt.DeepEquals, []string{"public/orders"})
+			},
+		},
+		{
+			// The control the widened match must not swallow. `legacy` already
+			// exists, keeps its declared policy, and is in no diff collection;
+			// enabling row-level security on it would deny by default on a table
+			// nothing in this plan touches. A fix that enabled every declared
+			// policy's table instead of the ones the diff creates fails here.
+			name: "a policy on a table the diff does not create leaves it alone",
+			seed: []string{
+				`CREATE TABLE legacy (id INTEGER PRIMARY KEY, tenant_id INTEGER)`,
+			},
+			diff: &types.SchemaDiff{
+				TablesAdded: []string{"shipments"},
+			},
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "shipments", StructName: "Shipment"},
+					{Name: "legacy", StructName: "Legacy"},
+				},
+				Fields: []goschema.Field{
+					{Name: "id", StructName: "Shipment", Type: "INTEGER", Primary: true},
+					{Name: "id", StructName: "Legacy", Type: "INTEGER", Primary: true},
+				},
+				RLSPolicies: []goschema.RLSPolicy{{
+					Name:            "tenant_isolation",
+					Table:           "legacy",
+					PolicyFor:       "ALL",
+					ToRoles:         "PUBLIC",
+					UsingExpression: "tenant_id = 1",
+				}},
+			},
+			assert: func(c *qt.C, dbURL string) {
+				c.Assert(rlsPolicyRelations(c, dbURL), qt.DeepEquals, []string{})
+				c.Assert(rowSecurityRelations(c, dbURL), qt.DeepEquals, []string{})
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			dbURL := createRLSEnableDatabase(c, adminURL)
+			executeSQL(c, dbURL, test.seed)
+			planAndApply(c, dbURL, test.diff, test.generated)
+			test.assert(c, dbURL)
+		})
+	}
+}


### PR DESCRIPTION
## The defect

`enableRLSOnTables` decided whether a policy's owning table is new by asking
`slices.Contains(diff.TablesAdded, policy.Table)` — a raw string match — while
`addNewRLSPolicies`, three functions away in the same file, resolves the same
table through the target's identifier semantics (#1347).

`orders` and `public.orders` are one relation under PostgreSQL's rules and two
different strings. Where the comparator's spelling and the declaration's spelling
disagreed, the plan emitted `CREATE POLICY` and no `ALTER TABLE ... ENABLE ROW
LEVEL SECURITY`. This predates #1347 — the line is unchanged on master and was
unchanged on that PR's branch — so it is not a regression that PR introduced. It
is the fourth appearance of one mistake, after #1276, #1311 and #1347.

## Reproduced in the catalog, not in the SQL

Measured on PostgreSQL 17.10. Applying the plan master produces for a diff whose
`TablesAdded` carries `orders` while the policy names `public.orders`:

```
 nspname | relname | relrowsecurity | relforcerowsecurity
---------+---------+----------------+---------------------
 public  | orders  | f              | f

 nspname | relname |     polname      | polcmd
---------+---------+------------------+--------
 public  | orders  | tenant_isolation | *
```

The policy row is present and row security is off, so the policy is inert. The
plan applied cleanly and reported success. A role granted `SELECT` on that table
sees every tenant's rows:

```
SET ROLE repro_reader; SELECT id, tenant_id FROM orders ORDER BY id;
 id | tenant_id            -- after ALTER TABLE orders ENABLE ROW LEVEL SECURITY:
----+-----------            id | tenant_id
  1 |         1            ----+-----------
  2 |         2              1 |         1
```

"The plan lacks a statement" and "the database does not enforce the policy" are
different claims, and only the second one matters — so the regression rows apply
the plan to a live database and read `pg_class.relrowsecurity` and `pg_policy`.

## The fix

Both sources of `enableRLSOnTables` are now keyed by identity under
`diff.EffectiveIdentifierSemantics(dialect)` — the semantics the RLS and index
resolvers in the same function already use, now computed once and shared. A table
named by both the comparator's verdict and a declaration is enabled once, and the
rendered statement takes the diff's spelling, so it always names an object the
plan is known to have produced.

## Red/green

Mutating only the identity keying back to a raw match, keeping the rest of the
new code, reddens exactly the two spelling-mismatch rows on the catalog
assertion, and leaves both controls green:

```
--- FAIL: .../the_diff_creates_orders_and_the_policy_names_public.orders
    got:  []string{}          want: []string{"public/orders"}   (relrowsecurity)
--- FAIL: .../the_diff_creates_public.orders_and_the_policy_names_orders
    got:  []string{}          want: []string{"public/orders"}
--- PASS: .../both_sides_spell_the_table_the_same_way
--- PASS: .../a_policy_on_a_table_the_diff_does_not_create_leaves_it_alone
```

Restored: all four pass. The control is not merely non-interfering — a fix that
enabled every declared policy's table rather than the ones the diff creates would
redden it.

## Also: the ASCII-only fold is now pinned

Substituting `identifier.ComparisonUnicodeInsensitive` for
`ComparisonASCIIInsensitive` in `catalogPostgresIdentifierPart` passed the entire
suite, because nothing outside ASCII was ever loaded — the two folds agree on
every existing fixture.

PostgreSQL folds ASCII only. Measured on PostgreSQL 17.10, `server_encoding`
UTF8, against a database holding both `Ä` and `ä`: `CREATE POLICY p ON Ä` exits 0
with its `pg_policy` row on `public.Ä`. Under a Unicode fold the reference
resolves to the *other declared table* rather than failing, so the declaration is
relocated silently — the shape of #1311. Under the mutant the new row is the only
failure in the whole suite, and it fails with `got: "ä" want: "Ä"`.

That row stops at the loaded schema and deliberately does not assert the render,
because the render cannot currently carry a non-ASCII identifier at all — see the
first follow-up below.

## Follow-ups found, not taken here

1. **The PostgreSQL renderer corrupts non-ASCII identifiers.**
   `core/renderer/internal/dialects/postgres/postgres.go`, in
   `splitQualifiedIdentifier`, accumulates `parts[len(parts)-1] += string(character)`
   where `character := identifier[i]` is a **byte**. `string(byte)` widens it as a
   rune, so every byte ≥ 0x80 is re-encoded: `Ä` (C3 84) renders as `Ã`.
   `ptah schema render` on a table declared `"Ä"` emits `CREATE TABLE "Ã<84>"`.
   `sqlite.go:666` and `mssql.go:764` carry the identical line. `go vet` does not
   flag it — `string(byte)` is exempt from `stringintconv`. This blocks the
   executed form of the fold test and is a correctness bug in its own right.

2. **`rlsscope` validates the whole target schema for every plan.** Measured: a
   diff containing no row-level security references at all — one added column — is
   refused when the target schema carries an unrelated colliding or malformed
   policy declaration:

   ```
   colliding: invalid schema diff: target RLS policies p on orders and p on public.orders share one identity in postgres
   malformed: invalid schema diff: target RLS policy reference at position 0 requires a policy name and owning table
   ```

   Both messages say "target", the class says "diff", and the diff is valid. A
   minimal narrowing is available — skip indexing when the diff has no added or
   modified references, since `Resolve` is then never called, while keeping the
   whole-map conflict check whenever anything *is* resolved. Left out on purpose:
   it changes when `ptah migrate` refuses, and the error class is part of the
   documented planning contract, so it wants its own PR with its own control
   (a collision the plan *does* touch must still be refused).

## Sweep

The full per-site inventory of "schema-object reference matched against a diff
collection" across all five dialect planners is in the task report accompanying
this branch. Headline: `objectlookup.resolve` is the single best conversion
candidate — giving it `identifier.Semantics` would turn eight call sites across
four dialects from structural (`tableref`-based, no folding, no `DefaultSchema`)
into identity at once. `sqlite.go:190/196` are the two remaining direct instances
of this exact `slices.Contains(diff.Tables*, …)` shape.

## Gates

`go build`, `go vet`, `go vet -tags integration ./integration/...`,
`go test ./... -count=1`, `go tool qtlint`, `golangci-lint run` (0 issues),
`check-test-style.sh`, `check-public-api.sh`, `check-public-api-snapshot.sh`,
`check-public-api-released.sh`, and every `docs/site` `check:*` script — all exit
0. No exported symbol added or changed.