### PR TITLE
Hand identifier splitting its bytes back unchanged (#1352)

### DIFF
--- a/core/renderer/identifier_bytes_test.go
+++ b/core/renderer/identifier_bytes_test.go
@@ -1,0 +1,122 @@
+package renderer_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/ast"
+	"go.5x5.cz/ptah/core/renderer"
+)
+
+// The identifiers this file renders, named by code point rather than typed
+// literally so the bytes each one stands for are stated and not inferred from
+// how an editor happened to normalize the file. TestIdentifierFixtureBytes pins
+// the encoding of each, so a change to these constants reddens there rather
+// than quietly weakening every assertion below.
+const (
+	// asciiIdentifier is the CONTROL. Every dialect renders it byte for byte
+	// both before and after the fix for stokaro/ptah#1352, so a suite that
+	// only ever compares output to input would pass on it alone.
+	asciiIdentifier = "orders"
+
+	// multiByteIdentifier is U+00C4 LATIN CAPITAL LETTER A WITH DIAERESIS,
+	// UTF-8 C3 84. Rendering it through a byte-wise accumulator produced
+	// C3 83 C2 84 -- `Ã` followed by U+0084 -- which is a different relation
+	// name, not a rejected one.
+	multiByteIdentifier = "Ä"
+
+	// multiByteSchema is U+00D6 LATIN CAPITAL LETTER O WITH DIAERESIS followed
+	// by ASCII, UTF-8 C3 96 6E 74. It qualifies the table name so the dot
+	// scanning path -- the one that owns the defect -- is actually entered.
+	multiByteSchema = "Önt"
+
+	// undecodableIdentifier is the single byte C4, which is `Ä` in Latin-1 and
+	// not valid UTF-8 at all. It separates the two candidate fixes: slicing
+	// the input hands this byte back untouched, while decoding to runes turns
+	// it into U+FFFD (EF BF BD) and renames the object just as silently as the
+	// defect being fixed here did.
+	undecodableIdentifier = "\xc4"
+)
+
+// TestIdentifierFixtureBytes pins the encoding of each fixture identifier. The
+// rendering assertions below compare Go strings, which is a byte comparison, so
+// they are only claims about bytes as long as these constants hold the bytes
+// their comments name.
+func TestIdentifierFixtureBytes(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert([]byte(asciiIdentifier), qt.DeepEquals, []byte{'o', 'r', 'd', 'e', 'r', 's'})
+	c.Assert([]byte(multiByteIdentifier), qt.DeepEquals, []byte{0xc3, 0x84})
+	c.Assert([]byte(multiByteSchema), qt.DeepEquals, []byte{0xc3, 0x96, 'n', 't'})
+	c.Assert([]byte(undecodableIdentifier), qt.DeepEquals, []byte{0xc4})
+}
+
+// TestRenderSQL_IdentifierKeepsSourceBytes renders a table whose name carries
+// bytes above 0x7f and requires the rendered identifier to be those same bytes.
+//
+// Every dialect here quotes identifiers, so none of these names is refused or
+// folded: whatever comes out names a relation, and if the bytes differ it names
+// the WRONG one. Before stokaro/ptah#1352 was fixed, all three dialects widened
+// each byte of the name as its own code point.
+//
+// One row per dialect. The only thing that varies between them is the quoting
+// syntax, which each row carries as a func rather than as a branch in the body.
+//
+// The four name assertions are Checks, not Asserts, so restoring the defect
+// reports all four verdicts for every dialect in one run. That is what makes
+// the ASCII control readable: it stays green under the mutation that reddens
+// the other three, which is the difference between this suite testing the
+// encoding and merely testing that output echoes input.
+func TestRenderSQL_IdentifierKeepsSourceBytes(t *testing.T) {
+	tests := []struct {
+		name    string
+		dialect string
+		quote   func(part string) string
+	}{
+		{name: "postgres", dialect: "postgres", quote: quoteWithDoubleQuotes},
+		{name: "sqlite", dialect: "sqlite", quote: quoteWithDoubleQuotes},
+		{name: "sqlserver", dialect: "sqlserver", quote: quoteWithBrackets},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			ascii, err := renderTableNamed(tt.dialect, asciiIdentifier)
+			c.Assert(err, qt.IsNil)
+			c.Check(ascii, qt.Contains, "CREATE TABLE "+tt.quote(asciiIdentifier),
+				qt.Commentf("ASCII control"))
+
+			multiByte, err := renderTableNamed(tt.dialect, multiByteIdentifier)
+			c.Assert(err, qt.IsNil)
+			c.Check(multiByte, qt.Contains, "CREATE TABLE "+tt.quote(multiByteIdentifier),
+				qt.Commentf("multi-byte name, rendered % x", multiByte))
+
+			qualified, err := renderTableNamed(tt.dialect, multiByteSchema+"."+multiByteIdentifier)
+			c.Assert(err, qt.IsNil)
+			c.Check(qualified, qt.Contains,
+				"CREATE TABLE "+tt.quote(multiByteSchema)+"."+tt.quote(multiByteIdentifier),
+				qt.Commentf("schema-qualified multi-byte name, rendered % x", qualified))
+
+			undecodable, err := renderTableNamed(tt.dialect, undecodableIdentifier)
+			c.Assert(err, qt.IsNil)
+			c.Check(undecodable, qt.Contains, "CREATE TABLE "+tt.quote(undecodableIdentifier),
+				qt.Commentf("name that is not valid UTF-8, rendered % x", undecodable))
+		})
+	}
+}
+
+func renderTableNamed(dialect, name string) (string, error) {
+	table := ast.NewCreateTable(name).
+		AddColumn(ast.NewColumn("id", "INT").SetPrimary())
+	return renderer.RenderSQL(dialect, table)
+}
+
+func quoteWithDoubleQuotes(part string) string {
+	return `"` + part + `"`
+}
+
+func quoteWithBrackets(part string) string {
+	return "[" + part + "]"
+}

--- a/core/renderer/internal/dialects/mssql/mssql.go
+++ b/core/renderer/internal/dialects/mssql/mssql.go
@@ -728,21 +728,37 @@ func unquoteIdentifier(identifier string) string {
 	return identifier
 }
 
+// splitQualifiedIdentifier splits on the dots that separate name parts while
+// leaving dots inside a bracketed, double-quoted or backtick-quoted part alone.
+// A doubled closing bracket is SQL Server's escape for a literal bracket and
+// does not end the bracketed part.
+//
+// Each part is a SLICE of the input, never a character-by-character copy. The
+// delimiters this scan recognizes are ASCII, and UTF-8 is self synchronizing --
+// no byte of a multi-byte sequence is ever below 0x80 -- so a byte scan can
+// find them without decoding, and slicing hands every other byte back exactly
+// as it arrived. The previous form accumulated `string(character)` from a byte,
+// which re-encodes each byte as its own code point: `Ä` (C3 84) came back out
+// as `Ã` plus U+0084, renaming every non-ASCII object. See stokaro/ptah#1352.
+//
+// Decoding to runes would fix that case and introduce another: text that is not
+// valid UTF-8 -- a Latin-1 schema file, say -- decodes to U+FFFD per bad byte
+// and would be rewritten just as silently. A splitter owes its caller the bytes
+// it was given.
 func splitQualifiedIdentifier(identifier string) []string {
-	parts := []string{""}
+	var parts []string
+	start := 0
 	inBrackets := false
 	inQuotes := false
 	inBackticks := false
 	for i := 0; i < len(identifier); i++ {
-		character := identifier[i]
-		switch character {
+		switch identifier[i] {
 		case '[':
 			if !inQuotes && !inBackticks {
 				inBrackets = true
 			}
 		case ']':
 			if inBrackets && i+1 < len(identifier) && identifier[i+1] == ']' {
-				parts[len(parts)-1] += "]]"
 				i++
 				continue
 			}
@@ -757,13 +773,12 @@ func splitQualifiedIdentifier(identifier string) []string {
 			}
 		case '.':
 			if !inBrackets && !inQuotes && !inBackticks {
-				parts = append(parts, "")
-				continue
+				parts = append(parts, identifier[start:i])
+				start = i + 1
 			}
 		}
-		parts[len(parts)-1] += string(character)
 	}
-	return parts
+	return append(parts, identifier[start:])
 }
 
 func unsupportedFeaturef(format string, args ...any) error {

--- a/core/renderer/internal/dialects/postgres/postgres.go
+++ b/core/renderer/internal/dialects/postgres/postgres.go
@@ -333,26 +333,39 @@ func unquoteIdentifier(identifier string) string {
 	return identifier
 }
 
+// splitQualifiedIdentifier splits on the dots that separate name parts while
+// leaving dots inside a double-quoted part alone. A doubled quote is SQL's
+// escape for a literal quote and does not end the quoted part.
+//
+// Each part is a SLICE of the input, never a character-by-character copy. The
+// two delimiters this scan recognizes are ASCII, and UTF-8 is self
+// synchronizing -- no byte of a multi-byte sequence is ever below 0x80 -- so a
+// byte scan can find them without decoding, and slicing hands every other byte
+// back exactly as it arrived. The previous form accumulated `string(character)`
+// from a byte, which re-encodes each byte as its own code point: `Ä` (C3 84)
+// came back out as `Ã` plus U+0084, renaming every non-ASCII object. See
+// stokaro/ptah#1352.
+//
+// Decoding to runes would fix that case and introduce another: text that is not
+// valid UTF-8 -- a Latin-1 schema file, say -- decodes to U+FFFD per bad byte
+// and would be rewritten just as silently. A splitter owes its caller the bytes
+// it was given.
 func splitQualifiedIdentifier(identifier string) []string {
-	parts := []string{""}
+	var parts []string
+	start := 0
 	inQuotes := false
 	for i := 0; i < len(identifier); i++ {
-		character := identifier[i]
-		if character == '"' {
-			if inQuotes && i+1 < len(identifier) && identifier[i+1] == '"' {
-				parts[len(parts)-1] += `""`
-				i++
-				continue
-			}
+		switch {
+		case identifier[i] == '"' && inQuotes && i+1 < len(identifier) && identifier[i+1] == '"':
+			i++
+		case identifier[i] == '"':
 			inQuotes = !inQuotes
+		case identifier[i] == '.' && !inQuotes:
+			parts = append(parts, identifier[start:i])
+			start = i + 1
 		}
-		if character == '.' && !inQuotes {
-			parts = append(parts, "")
-			continue
-		}
-		parts[len(parts)-1] += string(character)
 	}
-	return parts
+	return append(parts, identifier[start:])
 }
 
 // GetDialect returns the database dialect (alias for Dialect for compatibility)

--- a/core/renderer/internal/dialects/sqlite/sqlite.go
+++ b/core/renderer/internal/dialects/sqlite/sqlite.go
@@ -646,26 +646,41 @@ func unquoteIdentifier(identifier string) string {
 	return identifier
 }
 
+// splitQualifiedIdentifier splits on the dots that separate name parts while
+// leaving dots inside a double-quoted or backtick-quoted part alone.
+//
+// Each part is a SLICE of the input, never a character-by-character copy. The
+// three delimiters this scan recognizes are ASCII, and UTF-8 is self
+// synchronizing -- no byte of a multi-byte sequence is ever below 0x80 -- so a
+// byte scan can find them without decoding, and slicing hands every other byte
+// back exactly as it arrived. The previous form accumulated `string(character)`
+// from a byte, which re-encodes each byte as its own code point: `Ä` (C3 84)
+// came back out as `Ã` plus U+0084, renaming every non-ASCII object. See
+// stokaro/ptah#1352.
+//
+// Decoding to runes would fix that case and introduce another: text that is not
+// valid UTF-8 -- a Latin-1 schema file, say -- decodes to U+FFFD per bad byte
+// and would be rewritten just as silently. A splitter owes its caller the bytes
+// it was given.
 func splitQualifiedIdentifier(identifier string) []string {
-	parts := []string{""}
+	var parts []string
+	start := 0
 	inQuotes := false
 	inBackticks := false
 	for i := range len(identifier) {
-		character := identifier[i]
-		switch character {
+		switch identifier[i] {
 		case '"':
 			inQuotes = !inQuotes
 		case '`':
 			inBackticks = !inBackticks
 		case '.':
 			if !inQuotes && !inBackticks {
-				parts = append(parts, "")
-				continue
+				parts = append(parts, identifier[start:i])
+				start = i + 1
 			}
 		}
-		parts[len(parts)-1] += string(character)
 	}
-	return parts
+	return append(parts, identifier[start:])
 }
 
 func unsupportedFeaturef(format string, args ...any) error {


### PR DESCRIPTION
`splitQualifiedIdentifier` accumulated `string(character)`, where `character` was `identifier[i]` — a byte. Converting a byte to a string re-encodes it as a code point, so every byte of a multi-byte UTF-8 sequence became its own character. The identical line stood in the PostgreSQL, SQLite and SQL Server renderers.

## Reproduced first, black-box, through the built binary

Source fixture, `CREATE TABLE "Ä" (...)`, whose name is the two bytes `c3 84`:

```
$ xxd schema.sql | head -1
00000000: 4352 4541 5445 2054 4142 4c45 2022 c384  CREATE TABLE "..
```

Rendered on `master` (`ptah schema render --schema-file schema.sql --dialect ...`), piped through `xxd` so the bytes are visible rather than a terminal's rendering of them:

| dialect | rendered `CREATE TABLE` name | bytes |
| --- | --- | --- |
| postgres | `"Ã` + U+0084 + `"` | `22 c383 c284 22` |
| sqlite | `"Ã` + U+0084 + `"` | `22 c383 c284 22` |
| sqlserver | `[Ã` + U+0084 + `]` | `5b c383 c284 5d` |

`c3 84` in, `c3 83 c2 84` out — `Ã` followed by U+0084. Also reached through the PostgreSQL renderer: cockroachdb, yugabytedb, spanner. The MySQL family and ClickHouse rendered `c3 84` correctly.

## Why nothing caught it

`go vet` has a check for exactly this class, `stringintconv`, and it **exempts `string(byte)`** because that conversion is legal Go and usually deliberate. The one spelling that is always wrong for accumulating text is the one spelling nothing warns about.

## The fix

Each part is now a **slice** of the input rather than a character-by-character copy. The delimiters these scans recognize are ASCII and UTF-8 is self synchronizing — no byte of a multi-byte sequence is ever below `0x80` — so a byte scan still finds them without decoding, and slicing returns every other byte exactly as it arrived. This is the shape `internal/parser/postgres_objects.go` and `internal/convert/toschema/identifiers.go` already use for the same job.

**This is deliberately not "iterate runes".** Decoding would fix the reported case and open another: text that is not valid UTF-8 — a Latin-1 schema file, say — decodes to U+FFFD per bad byte and would be rewritten just as silently as the defect being fixed. A splitter owes its caller the bytes it was given. The regression test pins that too: a lone `c4` renders as `c4`, so the two candidate fixes are told apart by a measurement rather than by argument.

## Sweep for the same shape

`string(x[i])` over a string is the pattern and `go vet` will not find it, so the sweep was not a grep — the operand is usually a named variable, as it was here (`character := identifier[i]`). A `go/types` pass over every package in the module — tests included, and again under `-tags integration` — enumerated every conversion `string(x)` whose operand has an integer type. Twenty-two sites before the fix, nineteen after: two `byte`, six `rune`, eleven untyped-rune constants.

| site | operand | verdict |
| --- | --- | --- |
| `core/renderer/internal/dialects/postgres/postgres.go:353` | `byte` | **DEFECT — fixed** |
| `core/renderer/internal/dialects/sqlite/sqlite.go:666` | `byte` | **DEFECT — fixed** |
| `core/renderer/internal/dialects/mssql/mssql.go:764` | `byte` | **DEFECT — fixed** |
| `internal/atlasschema/planguard.go:443` | `byte` `quote` | correct — the function returns early unless `quote` is a single or double quote, and its accumulator is `WriteByte` |
| `internal/parser/postgres_objects.go:643` | `byte` `quote` | correct — same guard, same reason |
| `cmd/internal/cmdadapter/cmdadapter.go:442` | `rune` | correct — `range` over a string yields runes; `string(rune)` is the exact round trip |
| `internal/atlashclrender/objects.go:601` | `rune` | correct — `len(string(r))` is `utf8.RuneLen` spelled longhand, used to advance a byte index |
| `internal/parser/parser.go:1700` | `rune` | correct — same |
| `internal/graphqlrender/render.go:234` | `rune` (`runes[0]`) | correct — element of a `[]rune` |
| `internal/schemaexport/schemaexport.go:223` | `rune` (`runes[0]`) | correct — same |
| `internal/lexer/lexer_test.go:760` | `rune` | correct — an ASCII digit built as `rune('0'+i%10)` |
| 11 sites across `cmd/atlas` (3), `internal/atlasschema` (2), `internal/migrationlintreport` (2), `config/projectconfig`, `cmd/migrateup`, `internal/ociartifact`, `internal/pathguard` | untyped rune constant | correct — `filepath.Separator`, `os.PathSeparator`, `os.PathListSeparator`, all ASCII |

Two adjacent shapes that produce the same corruption were swept separately and are absent: there is no `%c` verb anywhere in the tree, and every `WriteRune` call takes a rune from `range`, never `rune(b)`.

The MySQL family renderer was never affected: its `splitQualifiedIdentifier` delegates to `internal/tableref`, which accumulates with `strings.Builder.WriteByte`.

The `rune(s[i])` sites in `internal/protobufrender/naming.go`, `internal/deporder/deporder.go`, `migration/lint/lint.go` and `migration/schemadiff/internal/compare/check_constraints.go` widen a byte the same way, but every one of them feeds a **predicate** (`unicode.IsLower`, `isSQLIdentifierRune`, `isCheckIdentChar`, …) and none appends to output, so they cannot corrupt text. They are worth a look for classification accuracy on non-ASCII input; that is a different question from this one and is left alone here.

## Regression test, red then green

`core/renderer/identifier_bytes_test.go`, black-box against `renderer.RenderSQL`. One row per dialect; the only thing that varies is the quoting syntax, which each row carries as a `func` rather than as a branch in the body. `TestIdentifierFixtureBytes` pins the encoding of every fixture constant, so the rendering assertions are claims about bytes and not about whatever an editor normalized the file to.

The four name assertions are `Check`s, not `Assert`s, so one mutation run reports all four verdicts per dialect.

Reverting all three functions to the `identifier[i]` form:

```
--- PASS: TestIdentifierFixtureBytes
--- FAIL: TestRenderSQL_IdentifierKeepsSourceBytes
    --- FAIL: TestRenderSQL_IdentifierKeepsSourceBytes/postgres
    --- FAIL: TestRenderSQL_IdentifierKeepsSourceBytes/sqlite
    --- FAIL: TestRenderSQL_IdentifierKeepsSourceBytes/sqlserver
```

with, per dialect, the multi-byte, schema-qualified and non-UTF-8 rows failing and reporting the rendered bytes — for example `43 52 45 41 54 45 20 54 41 42 4c 45 20 22 c3 83 c2 84 22` against a wanted `CREATE TABLE "Ä"`. The **ASCII control row never appears in the failure list**: it passes under the mutation that reddens the other three, which is what separates this suite from one that merely asserts output echoes input. Restoring the fix returns all three rows to PASS.

## Executed, not only rendered

Rendered is not applied, so the fix is checked against catalogs.

**PostgreSQL 17.10** (`PostgreSQL 17.10 (Debian 17.10-1.pgdg13+1)`), both renderings of the one authored name `Ä` applied to the same database, each at exit 0:

```
relname | encode(convert_to(relname::text,'UTF8'),'hex') | length
Ã       | c383c284                                      | 2
Ä       | c384                                          | 1
```

Two relations from one authored name. Not a refusal — a rename. The schema-qualified form reads back as `"Önt"."Ä"`, and an RLS policy on `"Ärger"` lands with `pg_policy.polname` = `70 5f c3 84 72 67 65 72` on `pg_class.relname` = `c3 84 72 67 65 72`.

**SQLite 3.51**, same two renderings into one database:

```
name | hex(CAST(name AS BLOB)) | length
Ã    | C383C284                | 2
Ä    | C384                    | 1
```

**SQL Server: not executed.** No instance is reachable here — no container, running or stopped, and nothing listening on 1433. That dialect is covered by rendering and the unit test only, and is stated as such rather than implied.

The consequence reaches further than creation. A database created by the previous renderer now diffs against its own source as an unrelated object. Pointing `--from` at such a database and `--to` at the schema file that produced it:

```
$ ptah schema diff --from postgres://.../created_by_the_previous_renderer --to schema.sql --dev-url ...
CREATE TABLE "Ä" ( "id" INTEGER PRIMARY KEY NOT NULL );
-- ALTER statements: --
ALTER TABLE "Ã" DROP CONSTRAINT IF EXISTS "Ã_pkey";
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "Ã" CASCADE;
```

Against a database created by the fixed renderer the same diff reports `Schemas are synced, no changes to be made.`

## Interaction with #1347

#1347 is correct and unaffected. Its fold, `foldASCII`, compares bytes against the range `A` to `Z`, and a UTF-8 continuation byte is never in that range, so it is already ASCII-only by construction and byte-exact; this defect sat before it and handed it the wrong bytes.

With the bytes right, confirmed on the live server: `"Ä"` and `"ä"` reach `pg_class` as `c384` and `c3a4` — distinct relations — and a mixed-case non-ASCII name reaches the catalog whole.

One observation, recorded and **not** changed here: Ptah's SQL frontend does not case-fold an unquoted `CREATE TABLE` name at all. `CREATE TABLE ÄRGER` renders `"ÄRGER"` where PostgreSQL's own answer for the same source is `Ärger`. That is not non-ASCII-specific — `CREATE TABLE ORDERS` likewise renders `"ORDERS"` — so it is a separate question about table-name folding on the create path, distinct from the reference-resolution folding #1347 governs, and out of scope for this fix.

## Gates

Run from the worktree root, exit codes read directly. `origin/master` was fetched immediately before and had not moved from `39ad9b93`, so this commit sits on the current tip with no rebase required and no conflict markers in the tree.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1` | 0 (262 packages, 0 `FAIL` lines) |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (175 conditional groups, 42 white-box files) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 (pre-existing approved pre-v1 incompatibilities only) |
| `docs/site`: `npm ci` | 0 |
| `docs/site`: `check:exit-codes`, `:selftest` | 0, 0 |
| `docs/site`: `check:core-doc-links` | 0 |
| `docs/site`: `check:page-health` | 0 |
| `docs/site`: `check:links`, `:selftest` | 0, 0 |
| `docs/site`: `check:redirects`, `:selftest` | 0, 0 |
| `docs/site`: `check:style`, `:selftest` | 0, 0 |
| `docs/site`: `check:limitations`, `:selftest` | 0, 0 |
| `docs/site`: `check:responsive`, `:selftest` | 0, 0 |

`check:responsive` exits 1 on a tree with no `dist`; the 0 above is after `npm run build` (exit 0).

## Documentation

Nothing in `docs/` described the previous behavior, so there is no stale section to correct. The three functions are unexported and carry the explanation in their doc comments. `docs/site/.../extend/components.md` says "All three retain the declared spelling in `IndexRef` values and rendered SQL" — that sentence was silently false for non-ASCII spellings and is now true, so it needs no edit.

## Residual risk

- **SQL Server is not executed.** Rendering and the unit test agree, and the code path is the same shape as the two that were executed, but no `sys.tables` row was read back.
- **The predicate-only `rune(s[i])` sites are untouched.** They cannot corrupt output, but a UTF-8 continuation byte reaching `unicode.IsLower` is answered as a Latin-1 code point. Worth its own look.
- **Nothing prevents a fifth recurrence.** `go vet` is structurally silent here by design. A repo-local check that rejects `string(x)` over a `byte` operand outside a guarded-ASCII context would close it; that is a new gate and is proposed rather than added.
- **The commit message splits the nineteen remaining sweep sites as "twelve constants, five `string(rune)`".** The correct split is eleven and six; the total, and every verdict, is right. The table above is authoritative. Amending would need a force-push, so it is recorded here instead.

Closes #1352