### PR TITLE
Use transaction witnesses for MySQL file progress

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -324,6 +324,14 @@ jobs:
         run: |
           go test -v -count=1 ./migration/migrator -run 'TestMigrateUp_PostgresLockTimeoutIntegration|TestOutOfOrderMigrationsPostgresIntegration|TestMigrationAdvisoryLock_PostgresConcurrentRunners|TestMigrationAdvisoryLock_PostgresTimeoutIntegration|TestMigrationAdvisoryLock_MySQLDefaultTimeoutIntegration|TestMigrationAdvisoryLock_MariaDBDefaultTimeoutIntegration|TestDirtyMigrationState_PostgresFailureRollsBackAndBlocksRetry|TestDirtyMigrationState_MySQLRepairReachesHead|TestDirtyMigrationState_MariaDBRepairReachesHead|TestMigrationChecksumMismatch_PostgresIntegration|TestBaseline_|TestAtlasRevisionMetadata_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouseRejectsSet)Integration|TestAtlasDotMetadata_(Postgres|MySQL)Integration|TestAtlasTxtarChecks_((Postgres|MySQL|MariaDB)(SessionLockReleased|CommentSemantics|EscapeString|ExecutableCommentEscape|ShortNumericPrefixRejectsNonSelect)?|ClickHouse|CockroachDB|YugabyteDB)Integration|TestAtlasRevisionTable_(Postgres|CockroachDB|YugabyteDB)UsesTimestamptzIntegration|TestAtlasSetSerializable_PostgresConcurrentInsertIntegration|TestDryRunRevisionState_(Postgres|MySQL|MariaDB|CockroachDB|YugabyteDB|ClickHouse)Integration' -timeout 3m
 
+      - name: Run MySQL-family rolled-back progress tests
+        env:
+          MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+        run: |
+          go test ./migration/migrator -list '^TestRolledBackProgress_' | grep -q '^TestRolledBackProgress_'
+          go test -v -count=1 ./migration/migrator -run '^TestRolledBackProgress_' -timeout 3m
+
       - name: Run no-transaction and shadow generator integration tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -327,7 +327,9 @@ jobs:
       - name: Run MySQL-family rolled-back progress tests
         env:
           MYSQL_TEST_URL: "mysql://ptah_user:ptah_password@tcp(127.0.0.1:3306)/ptah_test"
+          MYSQL_ADMIN_TEST_URL: "mysql://root:root_password@tcp(127.0.0.1:3306)/ptah_test"
           MARIADB_TEST_URL: "mariadb://ptah_user:ptah_password@tcp(127.0.0.1:3307)/ptah_test"
+          MARIADB_ADMIN_TEST_URL: "mariadb://root:root_password@tcp(127.0.0.1:3307)/ptah_test"
         run: |
           go test ./migration/migrator -list '^TestRolledBackProgress_' | grep -q '^TestRolledBackProgress_'
           go test -v -count=1 ./migration/migrator -run '^TestRolledBackProgress_' -timeout 3m

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -164,16 +164,30 @@ the zero-progress revision row. The next apply retries the whole file without
 `--allow-dirty`, matching Atlas. Native `ptah migrations up` keeps its durable
 failure record instead.
 
-On MySQL and MariaDB a rollback does not always reach zero progress. The server
-commits the open transaction on its own before a DDL statement, and that commit
-*ends* the transaction rather than flushing it: every statement after the DDL
-runs with no transaction open and commits itself, so the rollback reaches none
-of them either. `ptah-compat` records that whole committed prefix — and its
-`partial_hashes` — and the row stays, because retrying the file whole would
-repeat SQL the server has already committed. A body that reached no such
-statement leaves nothing behind and its row is removed like any other
-rolled-back failure. A statement Ptah cannot classify counts as rolled back, so
-a retry repeats it rather than skipping it on a guess.
+On MySQL and MariaDB a `file` rollback does not always reach zero progress: the
+server may commit around DDL. `ptah-compat` does not guess the boundary from SQL
+keywords. The Atlas revision row is an InnoDB witness updated on the same
+physical transaction before and after each statement. An implicit server commit
+makes the matching `applied` count and `partial_hashes` durable with the body;
+an ordinary rollback removes both the user DML and its witness. A plain-DML body
+that rolls back leaves no committed prefix and is retried whole. A witnessed
+DDL/DML prefix stays dirty because retrying it would repeat committed SQL.
+
+This recovery mode requires InnoDB for the Atlas revision table, the session's
+default storage engine, and every existing base table in the selected database.
+An explicit non-InnoDB `CREATE`, `ALTER`, or storage-engine setting is refused
+before the migration runs. `CREATE TABLE ... LIKE` is also refused because the
+new table inherits an engine that the session default does not prove.
+
+MySQL-family `file` bodies cannot contain transaction-control SQL such as
+`BEGIN`, `COMMIT`, or `SET autocommit`; Ptah owns the file transaction. Durable
+server-state operations such as `SET GLOBAL`, `SET PERSIST`, and `RESET` are
+refused because their effects are not tied to the InnoDB witness. `USE` is also
+refused; the connection URL must name the database whose engines Ptah validates.
+MySQL and MariaDB do not support `--tx-mode all`. Ordinary session settings
+remain valid. Ptah runs the body on one pinned session, discards it afterward,
+and replays safe settings such as `SET SESSION sql_mode` from a verified
+committed prefix before an automatic retry.
 
 When a statement committed under `--tx-mode none`, or its outcome is unknown,
 `ptah-compat` preserves the revision row. `migrate status` reports that row as

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -179,15 +179,30 @@ An explicit non-InnoDB `CREATE`, `ALTER`, or storage-engine setting is refused
 before the migration runs. `CREATE TABLE ... LIKE` is also refused because the
 new table inherits an engine that the session default does not prove.
 
-MySQL-family `file` bodies cannot contain transaction-control SQL such as
-`BEGIN`, `COMMIT`, or `SET autocommit`; Ptah owns the file transaction. Durable
-server-state operations such as `SET GLOBAL`, `SET PERSIST`, and `RESET` are
-refused because their effects are not tied to the InnoDB witness. `USE` is also
-refused; the connection URL must name the database whose engines Ptah validates.
+MySQL-family `file` bodies fail closed on SQL whose effects Ptah cannot tie to
+the InnoDB witness:
+
+- Transaction controls such as `BEGIN`, `COMMIT`, and `SET autocommit`.
+- Durable server-state operations such as `SET GLOBAL`, `SET PERSIST`, `RESET`,
+  and `CREATE`, `ALTER`, or `DROP DATABASE` or `SCHEMA`.
+- `USE` and qualified references to another database. The connection URL must
+  name the database whose engines Ptah validates.
+- Executable comments, nested or dynamic SQL, and table locks.
+- Definitions of indirect database objects, references to existing views or
+  trigger-bearing tables, and stored-routine calls.
+- Custom migration functions, whose inner statements are opaque to Ptah.
+- Statement interceptors, which can replace inspected SQL with another
+  execution path.
+
+Rejection errors identify the statement number and safety class without echoing
+the SQL.
+
 MySQL and MariaDB do not support `--tx-mode all`. Ordinary session settings
 remain valid. Ptah runs the body on one pinned session, discards it afterward,
 and replays safe settings such as `SET SESSION sql_mode` from a verified
-committed prefix before an automatic retry.
+committed prefix before an automatic retry. A durable unknown-outcome witness
+blocks automatic retry until the database is inspected and the revision is
+repaired.
 
 When a statement committed under `--tx-mode none`, or its outcome is unknown,
 `ptah-compat` preserves the revision row. `migrate status` reports that row as

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -164,6 +164,17 @@ the zero-progress revision row. The next apply retries the whole file without
 `--allow-dirty`, matching Atlas. Native `ptah migrations up` keeps its durable
 failure record instead.
 
+On MySQL and MariaDB a rollback does not always reach zero progress. The server
+commits the open transaction on its own before a DDL statement, and that commit
+*ends* the transaction rather than flushing it: every statement after the DDL
+runs with no transaction open and commits itself, so the rollback reaches none
+of them either. `ptah-compat` records that whole committed prefix — and its
+`partial_hashes` — and the row stays, because retrying the file whole would
+repeat SQL the server has already committed. A body that reached no such
+statement leaves nothing behind and its row is removed like any other
+rolled-back failure. A statement Ptah cannot classify counts as rolled back, so
+a retry repeats it rather than skipping it on a guess.
+
 When a statement committed under `--tx-mode none`, or its outcome is unknown,
 `ptah-compat` preserves the revision row. `migrate status` reports that row as
 a half-applied file, because `Current Version` counts it:

--- a/docs/site/src/content/docs/atlas/migrate-commands.md
+++ b/docs/site/src/content/docs/atlas/migrate-commands.md
@@ -179,6 +179,14 @@ An explicit non-InnoDB `CREATE`, `ALTER`, or storage-engine setting is refused
 before the migration runs. `CREATE TABLE ... LIKE` is also refused because the
 new table inherits an engine that the session default does not prove.
 
+The migration account must also hold `TRIGGER` at database or global scope.
+MySQL and MariaDB hide trigger metadata from an account without it while those
+triggers still fire during ordinary DML, so without the privilege `ptah-compat`
+cannot prove a target table has no hidden indirect writer and refuses `file`
+mode. A privilege on a database whose name contains an underscore escapes it,
+so a grant covering `ptah_test` is stored and printed as `ptah\_test`, and
+`ptah-compat` reads that database the way the server does.
+
 MySQL-family `file` bodies fail closed on SQL whose effects Ptah cannot tie to
 the InnoDB witness:
 
@@ -194,8 +202,11 @@ the InnoDB witness:
 - Statement interceptors, which can replace inspected SQL with another
   execution path.
 
-Rejection errors identify the statement number and safety class without echoing
-the SQL.
+The first five entries are statement-level: the error names the statement number
+and its safety class. Custom migration functions and statement interceptors have
+no statement to point at, so those two are refused for the whole migration and
+the error names the direction instead. None of these errors repeats the SQL, so
+a credential inside a refused statement stays out of the message.
 
 MySQL and MariaDB do not support `--tx-mode all`. Ordinary session settings
 remain valid. Ptah runs the body on one pinned session, discards it afterward,

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -204,6 +204,17 @@ people and pipelines share a directory:
   the complete body and pins its physical session before changing revision
   metadata, so either failure leaves a new version absent and preserves an
   existing dirty row unchanged.
+  MySQL and MariaDB also reject transaction-control statements in `file` mode:
+  Ptah owns that file transaction, and changing `autocommit` inside the body
+  would make a post-DDL checkpoint ambiguous. Their revision metadata, default
+  storage engine, and every existing base table in the selected database must
+  use InnoDB. A migration that explicitly selects another storage engine or
+  inherits one through `CREATE TABLE ... LIKE` is refused before its first
+  statement. Durable server-state operations such as `SET GLOBAL`, `SET
+  PERSIST`, and `RESET` are refused for the same reason: their effects do not
+  share the InnoDB transaction containing the witness. `USE` is rejected as
+  well; select the target database in `--db-url` so Ptah can validate the
+  database it will modify.
   Pre-migration checks are not rerun after committed progress because they
   describe the original pre-migration state. Automatic continuation is
   up-direction only: a row left dirty by an interrupted rollback is refused so
@@ -336,27 +347,19 @@ skips is only ever the prefix that really survived:
   Nothing is recorded as committed, and the retry runs the body from its first
   statement. An Atlas-format row written for such a failure is removed rather
   than left claiming progress that no longer exists.
-- Under `file` or `all` on MySQL and MariaDB, the server commits the open
-  transaction on its own before a DDL statement, so part of a rolled-back body
-  can survive it. That commit ends the transaction rather than flushing it, so
-  every statement after the DDL runs with no transaction open, commits itself,
-  and survives the rollback too. The committed prefix therefore runs to the last
-  statement that executed, not to the last statement that forced the commit —
-  and the failing statement forces its own commit before it runs, so the
-  statements ahead of a failing DDL are committed as well. A body of plain DML
-  that fails leaves nothing behind and is retried whole; a body that reached a
-  DDL statement keeps everything up to the failure and is resumed after it.
-  A statement Ptah cannot classify is treated as rolled back, so a retry repeats
-  it rather than skipping it on a guess.
-- A body that rolls back its own transaction part-way is the one shape a single
-  counter cannot describe: the statements after the `ROLLBACK` are durable and
-  the ones before it are not. Ptah records no committed prefix for it, which
-  never claims a statement committed that was not, at the cost of repeating the
-  statements after the in-body `ROLLBACK` on a retry.
+- Under `file` on MySQL and MariaDB, the server may commit the open transaction
+  around DDL, so part of a failed body can survive its final rollback. Ptah does
+  not infer that prefix from SQL keywords. Before and after each statement it
+  updates the InnoDB revision row on the same physical transaction as the body.
+  A server-side implicit commit therefore makes the matching witness durable;
+  an ordinary rollback removes both user DML and its witness. Plain DML that
+  rolls back retries from the first statement, while a durable DDL/DML prefix
+  resumes at the first statement not witnessed as complete. Ptah pins and then
+  discards the physical session; a retry replays safe session settings from the
+  verified prefix before it continues. MySQL and MariaDB do not support `all`.
 
-Transactional modes therefore never expose partial progress that a rollback
-undid, and non-transactional mode never hides progress that a rollback could
-not undo.
+Recorded progress therefore excludes transactional work that a rollback undid,
+while non-transactional mode retains work that no rollback could undo.
 
 **A non-transactional statement was interrupted.** If the process exits, the
 context is canceled, or its deadline expires while an autocommit statement is

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -324,6 +324,40 @@ the same recoverable state in both revision-table formats;
 Atlas's hidden failed-down state. [Roll back migrations](../rollback/) shows
 how to resume it through the native repair command.
 
+**What a failed body records depends on the transaction mode — and, on the
+MySQL family, on the statements themselves.** The committed prefix a resume
+skips is only ever the prefix that really survived:
+
+- Under `none`, every statement commits on its own. The revision row is
+  checkpointed after each one, so `applied` and the cumulative digests name
+  exactly the statements that ran, and the retry continues at the next one.
+- Under `file` or `all` on PostgreSQL, CockroachDB, YugabyteDB, SQLite and
+  SQL Server, DDL is transactional and the failure rolls the whole body back.
+  Nothing is recorded as committed, and the retry runs the body from its first
+  statement. An Atlas-format row written for such a failure is removed rather
+  than left claiming progress that no longer exists.
+- Under `file` or `all` on MySQL and MariaDB, the server commits the open
+  transaction on its own before a DDL statement, so part of a rolled-back body
+  can survive it. That commit ends the transaction rather than flushing it, so
+  every statement after the DDL runs with no transaction open, commits itself,
+  and survives the rollback too. The committed prefix therefore runs to the last
+  statement that executed, not to the last statement that forced the commit —
+  and the failing statement forces its own commit before it runs, so the
+  statements ahead of a failing DDL are committed as well. A body of plain DML
+  that fails leaves nothing behind and is retried whole; a body that reached a
+  DDL statement keeps everything up to the failure and is resumed after it.
+  A statement Ptah cannot classify is treated as rolled back, so a retry repeats
+  it rather than skipping it on a guess.
+- A body that rolls back its own transaction part-way is the one shape a single
+  counter cannot describe: the statements after the `ROLLBACK` are durable and
+  the ones before it are not. Ptah records no committed prefix for it, which
+  never claims a statement committed that was not, at the cost of repeating the
+  statements after the in-body `ROLLBACK` on a retry.
+
+Transactional modes therefore never expose partial progress that a rollback
+undid, and non-transactional mode never hides progress that a rollback could
+not undo.
+
 **A non-transactional statement was interrupted.** If the process exits, the
 context is canceled, or its deadline expires while an autocommit statement is
 in flight, the revision row preserves the last known completed statement and

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -211,10 +211,21 @@ people and pipelines share a directory:
   use InnoDB. A migration that explicitly selects another storage engine or
   inherits one through `CREATE TABLE ... LIKE` is refused before its first
   statement. Durable server-state operations such as `SET GLOBAL`, `SET
-  PERSIST`, and `RESET` are refused for the same reason: their effects do not
-  share the InnoDB transaction containing the witness. `USE` is rejected as
+  PERSIST`, `RESET`, and `CREATE`, `ALTER`, or `DROP DATABASE` are refused for
+  the same reason: their effects do not share the InnoDB transaction containing
+  the witness. The equivalent `SCHEMA` statements and `USE` are rejected as
   well; select the target database in `--db-url` so Ptah can validate the
-  database it will modify.
+  database it will modify. References to another database are rejected even
+  when qualified directly. Ptah also refuses executable comments, `CALL`,
+  prepared or dynamic SQL, table locks, definitions of views, triggers,
+  routines, and events, references to existing views or trigger-bearing tables,
+  and calls to stored routines. Those forms can hide work that does not share
+  the witness transaction. A custom `MigrationFunc` is opaque for the same
+  reason and must use `none`; a `StatementInterceptor` is also opaque because
+  it can replace the inspected statement with different SQL. MySQL-family
+  `file` mode accepts directly executed SQL-backed migrations only. Rejected
+  diagnostics identify the statement number and safety class without echoing
+  the SQL, which may contain credentials.
   Pre-migration checks are not rerun after committed progress because they
   describe the original pre-migration state. Automatic continuation is
   up-direction only: a row left dirty by an interrupted rollback is refused so
@@ -356,7 +367,10 @@ skips is only ever the prefix that really survived:
   rolls back retries from the first statement, while a durable DDL/DML prefix
   resumes at the first statement not witnessed as complete. Ptah pins and then
   discards the physical session; a retry replays safe session settings from the
-  verified prefix before it continues. MySQL and MariaDB do not support `all`.
+  verified prefix before it continues. If a witness committed before a failing
+  statement whose lack of side effects cannot be proven, the row remains marked
+  unknown and automatic retry stops for manual inspection. MySQL and MariaDB do
+  not support `all`.
 
 Recorded progress therefore excludes transactional work that a rollback undid,
 while non-transactional mode retains work that no rollback could undo.

--- a/docs/site/src/content/docs/versioned/apply.md
+++ b/docs/site/src/content/docs/versioned/apply.md
@@ -223,8 +223,13 @@ people and pipelines share a directory:
   the witness transaction. A custom `MigrationFunc` is opaque for the same
   reason and must use `none`; a `StatementInterceptor` is also opaque because
   it can replace the inspected statement with different SQL. MySQL-family
-  `file` mode accepts directly executed SQL-backed migrations only. Rejected
-  diagnostics identify the statement number and safety class without echoing
+  `file` mode accepts directly executed SQL-backed migrations only. The
+  migration account must hold `TRIGGER` at database or global scope, because
+  MySQL and MariaDB hide trigger metadata from an account without it while
+  those triggers still fire during ordinary DML. A refused statement is
+  reported by its number and safety class; a `MigrationFunc` or
+  `StatementInterceptor` is refused for the whole migration and reported by
+  direction, because neither has a statement to point at. Neither form repeats
   the SQL, which may contain credentials.
   Pre-migration checks are not rerun after committed progress because they
   describe the original pre-migration state. Automatic continuation is

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -663,6 +663,30 @@ before the affected migration body or revision row changes. Global `all`
 validates the complete selected batch before opening its transaction; global
 `file` and `none` validate each selected file when execution reaches it.
 
+MySQL and MariaDB support `file` and `none`, but not `all`. Their DDL may commit
+the server transaction even though Ptah did not request a commit. In `file`
+mode, Ptah therefore updates the revision row before and after each statement
+on the same physical transaction as the migration body. A server-side implicit
+commit makes the matching progress witness durable; an ordinary rollback
+removes both transactional DML and its witness. A retry skips only the verified
+durable prefix and replays safe session settings from that prefix on a newly
+pinned session before continuing.
+
+The witness requires InnoDB for revision metadata, the session default, and
+every existing base table in the selected database. Ptah-created native and
+Atlas revision tables declare `ENGINE=InnoDB`; an existing revision table using
+a different engine is rejected before Ptah upgrades its layout. A `file`
+migration that selects a non-InnoDB engine or inherits an unverified engine
+through `CREATE TABLE ... LIKE` is rejected before its body starts.
+
+Top-level transaction-control statements, including `SET autocommit`, are also
+rejected because Ptah owns the file transaction and cannot prove a checkpoint
+boundary after the body changes that state. Durable server-state operations
+such as `SET GLOBAL`, `SET PERSIST`, and `RESET` are refused because their
+effects do not share the witness transaction. `USE` is rejected so the
+connection URL, the engine preflight, the migration target, and the qualified
+metadata table all refer to the same database.
+
 ### Non-Transactional Migrations
 
 Most migrations should stay transactional. When the database rejects

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -679,6 +679,11 @@ a different engine is rejected before Ptah upgrades its layout. A `file`
 migration that selects a non-InnoDB engine or inherits an unverified engine
 through `CREATE TABLE ... LIKE` is rejected before its body starts.
 
+The migration account must hold `TRIGGER` at database or global scope. MySQL
+and MariaDB hide trigger metadata from accounts without that privilege, while
+those hidden triggers can still run during ordinary DML. Ptah therefore refuses
+`file` mode when it cannot prove that its trigger catalog view is complete.
+
 MySQL-family `file` mode rejects SQL whose effective writes cannot be proven
 from the outer statement:
 

--- a/migration/migrator/README.md
+++ b/migration/migrator/README.md
@@ -679,13 +679,23 @@ a different engine is rejected before Ptah upgrades its layout. A `file`
 migration that selects a non-InnoDB engine or inherits an unverified engine
 through `CREATE TABLE ... LIKE` is rejected before its body starts.
 
-Top-level transaction-control statements, including `SET autocommit`, are also
-rejected because Ptah owns the file transaction and cannot prove a checkpoint
-boundary after the body changes that state. Durable server-state operations
-such as `SET GLOBAL`, `SET PERSIST`, and `RESET` are refused because their
-effects do not share the witness transaction. `USE` is rejected so the
-connection URL, the engine preflight, the migration target, and the qualified
-metadata table all refer to the same database.
+MySQL-family `file` mode rejects SQL whose effective writes cannot be proven
+from the outer statement:
+
+- Top-level transaction controls, including `SET autocommit`.
+- Durable server-state operations such as `SET GLOBAL`, `SET PERSIST`, `RESET`,
+  and `CREATE`, `ALTER`, or `DROP DATABASE` or `SCHEMA`.
+- `USE` and qualified references to another database. The connection URL,
+  engine preflight, migration target, and metadata table must refer to one
+  database.
+- Executable comments, `CALL`, prepared or dynamic SQL, and table locks.
+- Definitions of views, triggers, routines, and events; references to existing
+  views or trigger-bearing tables; and stored-routine calls.
+- Statement interceptors, which can replace inspected SQL with another
+  execution path.
+
+Rejection diagnostics omit the SQL text so credentials in a refused statement
+are not disclosed.
 
 ### Non-Transactional Migrations
 
@@ -769,8 +779,10 @@ suffix or a direction-suffixed applied state, is rejected before migration work
 continues. Completed rollbacks are represented by deleting the row.
 
 A custom `MigrationFunc` is opaque to Ptah and can only be recorded at function
-completion; use SQL-backed migrations when statement-level crash progress is
-required.
+completion. MySQL-family `file` mode rejects it because an implicit commit may
+make only part of the function durable without a statement witness. Use a
+SQL-backed migration for `file` mode or select `none` when the function owns its
+recovery behavior.
 
 On PostgreSQL, `RepairMigration` also refuses to finish while an index a
 conditional create in the selected direction expects is still unusable. A

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -152,6 +152,12 @@
 // revision-table mode intentionally keeps its own documented bookkeeping
 // semantics.
 //
+// MySQL and MariaDB file transactions use an InnoDB revision-row witness on the
+// same physical transaction as the migration body because their DDL can commit
+// independently. These dialects reject transaction-control SQL, durable server
+// settings outside that transaction, and unverified storage engines in file
+// mode; batch mode is unsupported.
+//
 // # SQL File Support
 //
 // The package provides utilities for SQL file-based migrations:

--- a/migration/migrator/doc.go
+++ b/migration/migrator/doc.go
@@ -155,8 +155,10 @@
 // MySQL and MariaDB file transactions use an InnoDB revision-row witness on the
 // same physical transaction as the migration body because their DDL can commit
 // independently. These dialects reject transaction-control SQL, durable server
-// settings outside that transaction, and unverified storage engines in file
-// mode; batch mode is unsupported.
+// settings outside that transaction, database-catalog changes, unverified
+// storage engines, cross-database references, executable comments, nested SQL,
+// indirect database objects, opaque migration functions, and statement
+// interceptors in file mode; batch mode is unsupported.
 //
 // # SQL File Support
 //

--- a/migration/migrator/implicit_commit.go
+++ b/migration/migrator/implicit_commit.go
@@ -43,7 +43,7 @@ func (m *Migrator) validateTransactionalProgressSQL(
 	}
 	if migration.hasStatementInterceptor(direction) {
 		return fmt.Errorf(
-			"migration %d cannot run a %s statement interceptor in tx-mode file on a MySQL-family database; "+
+			"migration %d cannot run a statement interceptor for the %s direction in tx-mode file on a MySQL-family database; "+
 				"an interceptor can execute SQL outside Ptah's transaction witness, so use tx-mode none",
 			migration.Version,
 			direction,

--- a/migration/migrator/implicit_commit.go
+++ b/migration/migrator/implicit_commit.go
@@ -1,6 +1,9 @@
 package migrator
 
 import (
+	"fmt"
+	"strings"
+
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/internal/lexer"
 )
@@ -23,280 +26,289 @@ func implicitCommitDialect(dialect string) bool {
 	}
 }
 
-// implicitCommitEffect is what a MySQL-family server does to the transaction
-// that is open when a statement starts.
-//
-// Two bits matter, not one. Whether the statement makes the work before it
-// durable is the obvious bit. Whether it leaves a transaction open afterwards
-// is the bit the first version of this file missed, and it is the one that
-// decides the fate of every statement that follows: after a DDL statement no
-// transaction is open, so the statements after it commit themselves and a later
-// ROLLBACK cannot reach them.
-type implicitCommitEffect int
-
-const (
-	// implicitCommitNone leaves the transaction state alone. The statement is
-	// durable exactly when no transaction was open.
-	implicitCommitNone implicitCommitEffect = iota
-	// implicitCommitEnds commits the open transaction and leaves none open, so
-	// every statement after it commits on its own.
-	implicitCommitEnds
-	// implicitCommitRestarts commits the open transaction and immediately opens
-	// a new one, so the statements after it are pending again.
-	implicitCommitRestarts
-	// implicitCommitDiscards throws the open transaction away. The work before
-	// it is gone, which no prefix counter can describe.
-	implicitCommitDiscards
-)
-
-// commitsBeforeItRuns reports whether the server has already committed whatever
-// was pending by the time the statement itself executes — including when the
-// statement then fails. Measured on both servers: an INSERT before a
-// `CREATE TABLE` that fails with "table already exists" still survives the
-// ROLLBACK that follows.
-func (e implicitCommitEffect) commitsBeforeItRuns() bool {
-	return e == implicitCommitEnds || e == implicitCommitRestarts
-}
-
-// implicitCommitEffectOf classifies one statement of a MySQL-family migration
-// body.
-//
-// Every row below was measured on MySQL 9.7.1 and MariaDB 11.4.12 with the same
-// probe, one statement at a time:
-//
-//	START TRANSACTION;
-//	INSERT INTO led VALUES (1,'a_pre');
-//	<the statement under test>
-//	INSERT INTO led VALUES (2,'b_post');
-//	ROLLBACK;
-//	SELECT note FROM led;
-//
-// Both rows surviving means the statement committed the prefix and left no
-// transaction open (implicitCommitEnds). Only `a_pre` surviving means it
-// committed the prefix and opened a new transaction (implicitCommitRestarts).
-// Neither surviving means it committed nothing (implicitCommitNone). Only
-// `b_post` surviving means the prefix was thrown away (implicitCommitDiscards).
-// [TestImplicitCommitEffectOf] carries the measured result of every probe.
-//
-// Two rows differ between the servers, which is why the dialect reaches this
-// far down: `CACHE INDEX` and `LOAD INDEX INTO CACHE` end the transaction on
-// MySQL and do nothing at all on MariaDB.
-//
-// An unclassified statement is reported as implicitCommitNone. That direction
-// is the one a resume can survive: the statement is treated as undone and run
-// again, instead of being skipped forever on the strength of a guess.
-func implicitCommitEffectOf(statement, dialect string) implicitCommitEffect {
-	tokens := significantSQLTokens(statement, dialect)
-	if len(tokens) == 0 {
-		return implicitCommitNone
+func (m *Migrator) validateTransactionalProgressSQL(
+	migration *Migration,
+	direction MigrationDirection,
+) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return nil
 	}
-	head := tokens[0]
-	switch {
-	case matchesAnyKeyword(head, "CREATE", "DROP"):
-		// Measured: every CREATE and DROP ends the transaction — table, index,
-		// view, database, user — except the TEMPORARY forms, which commit
-		// nothing.
-		if hasTemporaryQualifier(tokens) {
-			return implicitCommitNone
+	statements := splitSQLStatementsForConnection(m.conn, migrationSQLForDirection(migration, direction))
+	for i, statement := range statements {
+		tokens := significantSQLTokens(statement, m.connectionDialect())
+		if len(tokens) > 0 && tokens[0].MatchIdentifierValue("USE") {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because %q changes the target database; "+
+					"select the database in the connection URL so Ptah can verify its storage engines",
+				migration.Version,
+				i+1,
+				strings.TrimSpace(statement),
+			)
 		}
-		return implicitCommitEnds
-	case head.MatchIdentifierValue("SET"):
-		return setStatementEffect(tokens)
-	case head.MatchIdentifierValue("LOAD"):
-		return loadStatementEffect(tokens, dialect)
-	case head.MatchIdentifierValue("CACHE"):
-		// Measured: `CACHE INDEX mi IN default` ends the transaction on MySQL
-		// and commits nothing on MariaDB.
-		return keyCacheEffect(dialect)
-	case matchesAnyKeyword(head, "BEGIN", "START"):
-		// Measured: both commit the prefix and open a new transaction, so the
-		// statement after them is pending again. `START` reaches here only as
-		// `START TRANSACTION`; no other START form was measured, and treating
-		// one as opening a transaction costs nothing a resume can notice.
-		return implicitCommitRestarts
-	case head.MatchIdentifierValue("COMMIT"):
-		// Measured: `COMMIT` ends the transaction, `COMMIT AND CHAIN` opens a
-		// new one straight away.
-		if hasChainClause(tokens) {
-			return implicitCommitRestarts
+		if mysqlUnwitnessedStateChange(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because %q changes state outside "+
+					"Ptah's migration transaction; use a session-scoped setting or tx-mode none",
+				migration.Version,
+				i+1,
+				strings.TrimSpace(statement),
+			)
 		}
-		return implicitCommitEnds
-	case head.MatchIdentifierValue("ROLLBACK"):
-		// Measured: `ROLLBACK TO SAVEPOINT` keeps the transaction and commits
-		// nothing; a whole-transaction ROLLBACK destroys the prefix.
-		if isSavepointRollback(tokens) {
-			return implicitCommitNone
+		if isTransactionControlStatement(statement, m.connectionDialect()) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because %q controls transaction state; "+
+					"remove the transaction control and let Ptah manage the file transaction",
+				migration.Version,
+				i+1,
+				strings.TrimSpace(statement),
+			)
 		}
-		return implicitCommitDiscards
-	case matchesAnyKeyword(head,
-		// Measured, identical on both servers: each of these ends the
-		// transaction. The representative statement measured for each keyword
-		// is the one [TestImplicitCommitEffectOf] carries.
-		"ALTER", "ANALYZE", "CHECK", "FLUSH", "GRANT", "INSTALL", "LOCK",
-		"OPTIMIZE", "RENAME", "REPAIR", "RESET", "REVOKE", "TRUNCATE",
-		"UNINSTALL",
-	):
-		return implicitCommitEnds
-	}
-	return implicitCommitNone
-}
-
-// setStatementEffect classifies the SET forms.
-//
-// Measured: `SET PASSWORD` and `SET DEFAULT ROLE` end the transaction. Every
-// other SET commits nothing — including `SET autocommit = 1`, which the first
-// version of this file listed as committing. It does not, because the session
-// autocommit value is already 1: Ptah opens the migration transaction with
-// START TRANSACTION and never turns session autocommit off, so the assignment
-// has nothing to change and commits nothing. `SET autocommit = 0` was measured
-// in the same session shape and also commits nothing.
-func setStatementEffect(tokens []lexer.Token) implicitCommitEffect {
-	rest := tokens[1:]
-	if len(rest) == 0 {
-		return implicitCommitNone
-	}
-	if rest[0].MatchIdentifierValue("PASSWORD") {
-		return implicitCommitEnds
-	}
-	if len(rest) > 1 && rest[0].MatchIdentifierValue("DEFAULT") && rest[1].MatchIdentifierValue("ROLE") {
-		return implicitCommitEnds
-	}
-	return implicitCommitNone
-}
-
-// loadStatementEffect classifies the LOAD forms.
-//
-// Measured: `LOAD DATA INFILE` commits nothing on either server — a ROLLBACK
-// takes the INSERT before it and the loaded rows with it. `LOAD INDEX INTO
-// CACHE` ends the transaction on MySQL and commits nothing on MariaDB.
-func loadStatementEffect(tokens []lexer.Token, dialect string) implicitCommitEffect {
-	if len(tokens) > 1 && tokens[1].MatchIdentifierValue("INDEX") {
-		return keyCacheEffect(dialect)
-	}
-	return implicitCommitNone
-}
-
-// keyCacheEffect answers for the two MyISAM key-cache statements, the only
-// place the two servers disagree.
-func keyCacheEffect(dialect string) implicitCommitEffect {
-	if platform.NormalizeDialect(dialect) == platform.MySQL {
-		return implicitCommitEnds
-	}
-	return implicitCommitNone
-}
-
-// hasTemporaryQualifier reports whether TEMP or TEMPORARY qualifies the object
-// a leading CREATE or DROP names.
-//
-// The qualifier can only appear before the TABLE keyword, so the scan stops
-// there. Scanning a fixed number of leading tokens instead reads a column named
-// `temp` in `CREATE TABLE hastemp (temp INT)` as the qualifier — measured, that
-// statement ends the transaction like any other CREATE TABLE.
-func hasTemporaryQualifier(tokens []lexer.Token) bool {
-	for i := range tokens[1:] {
-		token := tokens[1+i]
-		if token.MatchIdentifierValue("TEMP") || token.MatchIdentifierValue("TEMPORARY") {
-			return true
+		if mysqlCreateTableLike(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because CREATE TABLE LIKE inherits "+
+					"a storage engine that Ptah cannot prove is InnoDB; declare the table explicitly or use tx-mode none",
+				migration.Version,
+				i+1,
+			)
 		}
-		if token.MatchIdentifierValue("TABLE") {
-			return false
-		}
-	}
-	return false
-}
-
-// hasChainClause reports whether a COMMIT carries AND CHAIN rather than
-// AND NO CHAIN.
-func hasChainClause(tokens []lexer.Token) bool {
-	for i := range tokens {
-		if !tokens[i].MatchIdentifierValue("CHAIN") {
+		engine, selected := mysqlStorageEngineSelection(statement, m.connectionDialect())
+		if !selected || strings.EqualFold(engine, "InnoDB") || strings.EqualFold(engine, "DEFAULT") {
 			continue
 		}
-		return i == 0 || !tokens[i-1].MatchIdentifierValue("NO")
+		return fmt.Errorf(
+			"migration %d statement %d selects non-transactional storage engine %s; "+
+				"tx-mode file requires InnoDB on MySQL-family databases",
+			migration.Version,
+			i+1,
+			engine,
+		)
 	}
-	return false
+	return nil
 }
 
-// isSavepointRollback reports whether a ROLLBACK names a savepoint instead of
-// discarding the whole transaction.
-func isSavepointRollback(tokens []lexer.Token) bool {
-	return containsAnyKeyword(tokens[1:], "TO")
-}
+// mysqlUnwitnessedStateChange identifies MySQL-family statements whose effects
+// are not session-local and are not tied to the InnoDB transaction containing
+// the revision witness. Replaying one after the witness rolls back can repeat a
+// durable server change, while skipping it can lose a change that never took
+// effect. File mode therefore refuses these statements before any body SQL.
+func mysqlUnwitnessedStateChange(tokens []lexer.Token) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	if tokens[0].MatchIdentifierValue("RESET") {
+		return true
+	}
+	if !tokens[0].MatchIdentifierValue("SET") {
+		return false
+	}
 
-func containsAnyKeyword(tokens []lexer.Token, keywords ...string) bool {
-	for i := range tokens {
-		if matchesAnyKeyword(tokens[i], keywords...) {
+	assignmentStart := true
+	for _, token := range tokens[1:] {
+		if token.Value == "," {
+			assignmentStart = true
+			continue
+		}
+		if !assignmentStart || token.Type != lexer.TokenIdentifier {
+			continue
+		}
+		assignmentStart = false
+		if matchesAnyKeyword(
+			token,
+			"GLOBAL",
+			"PERSIST",
+			"PERSIST_ONLY",
+			"PASSWORD",
+			"DEFAULT",
+			"RESOURCE",
+			"STATEMENT",
+		) {
 			return true
 		}
 	}
 	return false
 }
 
-// committedPrefixAfterRollback returns how many leading statements of sqlText a
-// MySQL-family server has already committed when the transaction wrapping the
-// body rolls back, given that executed statements ran and that the statement at
-// failedIndex (1-based, 0 when no statement itself failed) is the one that
-// stopped the run.
-//
-// The rule is not "the prefix ends at the last statement that forced a commit".
-// An implicit commit ENDS the transaction; it does not merely flush it. Every
-// statement after one therefore runs with no transaction open and commits
-// itself, and the ROLLBACK the failure triggers reaches none of them. Measured
-// on MySQL 9.7.1 and MariaDB 11.4.12:
-//
-//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
-//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
-//	-> rows 1 and 3 both survive
-//
-// So the walk below tracks whether a transaction is open at all, and counts a
-// statement as committed either because it forced the commit itself or because
-// nothing was open to hold it. The failing statement counts the same way: the
-// server commits before it runs, and it does so even when the statement then
-// fails.
-//
-// A body that rolls back a transaction it is itself inside is the one shape no
-// counter can describe — the statements after the ROLLBACK are durable and the
-// ones before it are not, so the durable set is not a prefix. Zero is the only
-// prefix that never claims a statement committed which did not, so that is what
-// it reports, at the cost of re-running the statements after the in-body
-// ROLLBACK. A ROLLBACK that arrives with no transaction open is a no-op and
-// costs nothing.
-func committedPrefixAfterRollback(sqlText, dialect string, executed, failedIndex int) int {
-	if executed <= 0 {
-		return 0
+func mysqlCreateTableLike(tokens []lexer.Token) bool {
+	if len(tokens) < 3 || !tokens[0].MatchIdentifierValue("CREATE") {
+		return false
 	}
-	statements := splitSQLStatementsForDialect(sqlText, dialect)
-	if len(statements) < executed {
-		// The executor counted more statements than the split finds, so the
-		// prefix cannot be classified statement by statement. Reporting nothing
-		// committed is the conservative answer: a retry re-runs the body from
-		// the top instead of skipping a statement that may never have run.
-		return 0
+	tableKeyword := mysqlTableKeyword(tokens)
+	if tableKeyword < 0 {
+		return false
 	}
-	inTransaction := true
-	committed := 0
-	for i, statement := range statements[:executed] {
-		switch implicitCommitEffectOf(statement, dialect) {
-		case implicitCommitEnds:
-			committed, inTransaction = i+1, false
-		case implicitCommitRestarts:
-			committed, inTransaction = i+1, true
-		case implicitCommitDiscards:
-			// With no transaction open there is nothing to throw away and the
-			// statement is a no-op; the prefix ahead of it is already durable.
-			if inTransaction {
-				return 0
-			}
-			committed = i + 1
-		case implicitCommitNone:
-			if !inTransaction {
-				committed = i + 1
-			}
+
+	depth := 0
+	for _, token := range tokens[tableKeyword+1:] {
+		switch token.Value {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth = max(depth-1, 0)
+			continue
+		}
+		if depth == 0 && token.MatchIdentifierValue("LIKE") {
+			return true
 		}
 	}
-	if failedIndex > executed && failedIndex <= len(statements) &&
-		implicitCommitEffectOf(statements[failedIndex-1], dialect).commitsBeforeItRuns() {
-		return executed
+	return false
+}
+
+func mysqlStorageEngineSelection(statement, dialect string) (string, bool) {
+	tokens := significantSQLTokens(statement, dialect)
+	if len(tokens) == 0 {
+		return "", false
 	}
-	return committed
+	if tokens[0].MatchIdentifierValue("SET") {
+		return mysqlStorageEngineSetting(tokens)
+	}
+	if tokens[0].MatchIdentifierValue("CREATE") {
+		return mysqlCreateTableStorageEngine(tokens)
+	}
+	if tokens[0].MatchIdentifierValue("ALTER") {
+		return mysqlAlterTableStorageEngine(tokens)
+	}
+	return "", false
+}
+
+func mysqlStorageEngineSetting(tokens []lexer.Token) (string, bool) {
+	assignmentStart := 1
+	for assignmentStart < len(tokens) {
+		assignmentEnd := len(tokens)
+		for i := assignmentStart; i < len(tokens); i++ {
+			if tokens[i].Value == "," {
+				assignmentEnd = i
+				break
+			}
+		}
+		if engine, selected := mysqlStorageEngineAssignment(tokens[assignmentStart:assignmentEnd]); selected {
+			return engine, true
+		}
+		assignmentStart = assignmentEnd + 1
+	}
+	return "", false
+}
+
+func mysqlStorageEngineAssignment(tokens []lexer.Token) (string, bool) {
+	equals := -1
+	storageEngineTarget := false
+	for i, token := range tokens {
+		if token.Value == "=" {
+			equals = i
+			break
+		}
+		if matchesAnyKeyword(token, "STORAGE_ENGINE", "DEFAULT_STORAGE_ENGINE") {
+			storageEngineTarget = true
+		}
+	}
+	if !storageEngineTarget || equals < 0 {
+		return "", false
+	}
+	return mysqlStorageEngineValue(tokens, equals+1)
+}
+
+func mysqlCreateTableStorageEngine(tokens []lexer.Token) (string, bool) {
+	tableKeyword := mysqlTableKeyword(tokens)
+	if tableKeyword < 0 {
+		return "", false
+	}
+	optionStart := mysqlTableNameEnd(tokens, tableKeyword+1)
+	if optionStart < 0 {
+		return "", false
+	}
+	depth := 0
+	for i := optionStart; i < len(tokens); i++ {
+		token := tokens[i]
+		switch token.Value {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth = max(depth-1, 0)
+			continue
+		}
+		if depth != 0 {
+			continue
+		}
+		if matchesAnyKeyword(token, "AS", "SELECT") {
+			return "", false
+		}
+		if token.MatchIdentifierValue("ENGINE") {
+			return mysqlStorageEngineValue(tokens, i+1)
+		}
+	}
+	return "", false
+}
+
+func mysqlAlterTableStorageEngine(tokens []lexer.Token) (string, bool) {
+	tableKeyword := mysqlTableKeyword(tokens)
+	if tableKeyword < 0 {
+		return "", false
+	}
+	optionStart := mysqlTableNameEnd(tokens, tableKeyword+1)
+	if optionStart < 0 {
+		return "", false
+	}
+	depth := 0
+	atOptionStart := true
+	for i := optionStart; i < len(tokens); i++ {
+		token := tokens[i]
+		switch token.Value {
+		case "(":
+			depth++
+			continue
+		case ")":
+			depth = max(depth-1, 0)
+			continue
+		case ",":
+			if depth == 0 {
+				atOptionStart = true
+			}
+			continue
+		}
+		if depth != 0 || !atOptionStart {
+			continue
+		}
+		if token.MatchIdentifierValue("ENGINE") {
+			return mysqlStorageEngineValue(tokens, i+1)
+		}
+		atOptionStart = false
+	}
+	return "", false
+}
+
+func mysqlTableKeyword(tokens []lexer.Token) int {
+	for i, token := range tokens[1:min(len(tokens), 6)] {
+		if token.MatchIdentifierValue("TABLE") {
+			return i + 1
+		}
+	}
+	return -1
+}
+
+func mysqlTableNameEnd(tokens []lexer.Token, start int) int {
+	for start < len(tokens) && matchesAnyKeyword(tokens[start], "IF", "NOT", "EXISTS") {
+		start++
+	}
+	if start >= len(tokens) || tokens[start].Type != lexer.TokenIdentifier {
+		return -1
+	}
+	start++
+	if start+1 < len(tokens) && tokens[start].Value == "." && tokens[start+1].Type == lexer.TokenIdentifier {
+		start += 2
+	}
+	return start
+}
+
+func mysqlStorageEngineValue(tokens []lexer.Token, start int) (string, bool) {
+	for _, token := range tokens[start:] {
+		if token.Value == "=" {
+			continue
+		}
+		if token.Value == "," || token.Type == lexer.TokenSemicolon {
+			return "", false
+		}
+		return strings.Trim(token.Value, "`\"'"), true
+	}
+	return "", false
 }

--- a/migration/migrator/implicit_commit.go
+++ b/migration/migrator/implicit_commit.go
@@ -1,0 +1,302 @@
+package migrator
+
+import (
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/lexer"
+)
+
+// implicitCommitDialect reports whether the server commits an open transaction
+// on its own, without the client asking, before certain statements run.
+//
+// Only the MySQL family does. Everywhere else a migration body that ran inside
+// one transaction either survives whole or leaves nothing behind, so "did the
+// rollback undo this statement?" has a single answer for the whole file. On
+// MySQL and MariaDB the answer differs statement by statement, and a resume
+// that assumes otherwise either repeats committed SQL or skips SQL that never
+// ran.
+func implicitCommitDialect(dialect string) bool {
+	switch platform.NormalizeDialect(dialect) {
+	case platform.MySQL, platform.MariaDB:
+		return true
+	default:
+		return false
+	}
+}
+
+// implicitCommitEffect is what a MySQL-family server does to the transaction
+// that is open when a statement starts.
+//
+// Two bits matter, not one. Whether the statement makes the work before it
+// durable is the obvious bit. Whether it leaves a transaction open afterwards
+// is the bit the first version of this file missed, and it is the one that
+// decides the fate of every statement that follows: after a DDL statement no
+// transaction is open, so the statements after it commit themselves and a later
+// ROLLBACK cannot reach them.
+type implicitCommitEffect int
+
+const (
+	// implicitCommitNone leaves the transaction state alone. The statement is
+	// durable exactly when no transaction was open.
+	implicitCommitNone implicitCommitEffect = iota
+	// implicitCommitEnds commits the open transaction and leaves none open, so
+	// every statement after it commits on its own.
+	implicitCommitEnds
+	// implicitCommitRestarts commits the open transaction and immediately opens
+	// a new one, so the statements after it are pending again.
+	implicitCommitRestarts
+	// implicitCommitDiscards throws the open transaction away. The work before
+	// it is gone, which no prefix counter can describe.
+	implicitCommitDiscards
+)
+
+// commitsBeforeItRuns reports whether the server has already committed whatever
+// was pending by the time the statement itself executes — including when the
+// statement then fails. Measured on both servers: an INSERT before a
+// `CREATE TABLE` that fails with "table already exists" still survives the
+// ROLLBACK that follows.
+func (e implicitCommitEffect) commitsBeforeItRuns() bool {
+	return e == implicitCommitEnds || e == implicitCommitRestarts
+}
+
+// implicitCommitEffectOf classifies one statement of a MySQL-family migration
+// body.
+//
+// Every row below was measured on MySQL 9.7.1 and MariaDB 11.4.12 with the same
+// probe, one statement at a time:
+//
+//	START TRANSACTION;
+//	INSERT INTO led VALUES (1,'a_pre');
+//	<the statement under test>
+//	INSERT INTO led VALUES (2,'b_post');
+//	ROLLBACK;
+//	SELECT note FROM led;
+//
+// Both rows surviving means the statement committed the prefix and left no
+// transaction open (implicitCommitEnds). Only `a_pre` surviving means it
+// committed the prefix and opened a new transaction (implicitCommitRestarts).
+// Neither surviving means it committed nothing (implicitCommitNone). Only
+// `b_post` surviving means the prefix was thrown away (implicitCommitDiscards).
+// [TestImplicitCommitEffectOf] carries the measured result of every probe.
+//
+// Two rows differ between the servers, which is why the dialect reaches this
+// far down: `CACHE INDEX` and `LOAD INDEX INTO CACHE` end the transaction on
+// MySQL and do nothing at all on MariaDB.
+//
+// An unclassified statement is reported as implicitCommitNone. That direction
+// is the one a resume can survive: the statement is treated as undone and run
+// again, instead of being skipped forever on the strength of a guess.
+func implicitCommitEffectOf(statement, dialect string) implicitCommitEffect {
+	tokens := significantSQLTokens(statement, dialect)
+	if len(tokens) == 0 {
+		return implicitCommitNone
+	}
+	head := tokens[0]
+	switch {
+	case matchesAnyKeyword(head, "CREATE", "DROP"):
+		// Measured: every CREATE and DROP ends the transaction — table, index,
+		// view, database, user — except the TEMPORARY forms, which commit
+		// nothing.
+		if hasTemporaryQualifier(tokens) {
+			return implicitCommitNone
+		}
+		return implicitCommitEnds
+	case head.MatchIdentifierValue("SET"):
+		return setStatementEffect(tokens)
+	case head.MatchIdentifierValue("LOAD"):
+		return loadStatementEffect(tokens, dialect)
+	case head.MatchIdentifierValue("CACHE"):
+		// Measured: `CACHE INDEX mi IN default` ends the transaction on MySQL
+		// and commits nothing on MariaDB.
+		return keyCacheEffect(dialect)
+	case matchesAnyKeyword(head, "BEGIN", "START"):
+		// Measured: both commit the prefix and open a new transaction, so the
+		// statement after them is pending again. `START` reaches here only as
+		// `START TRANSACTION`; no other START form was measured, and treating
+		// one as opening a transaction costs nothing a resume can notice.
+		return implicitCommitRestarts
+	case head.MatchIdentifierValue("COMMIT"):
+		// Measured: `COMMIT` ends the transaction, `COMMIT AND CHAIN` opens a
+		// new one straight away.
+		if hasChainClause(tokens) {
+			return implicitCommitRestarts
+		}
+		return implicitCommitEnds
+	case head.MatchIdentifierValue("ROLLBACK"):
+		// Measured: `ROLLBACK TO SAVEPOINT` keeps the transaction and commits
+		// nothing; a whole-transaction ROLLBACK destroys the prefix.
+		if isSavepointRollback(tokens) {
+			return implicitCommitNone
+		}
+		return implicitCommitDiscards
+	case matchesAnyKeyword(head,
+		// Measured, identical on both servers: each of these ends the
+		// transaction. The representative statement measured for each keyword
+		// is the one [TestImplicitCommitEffectOf] carries.
+		"ALTER", "ANALYZE", "CHECK", "FLUSH", "GRANT", "INSTALL", "LOCK",
+		"OPTIMIZE", "RENAME", "REPAIR", "RESET", "REVOKE", "TRUNCATE",
+		"UNINSTALL",
+	):
+		return implicitCommitEnds
+	}
+	return implicitCommitNone
+}
+
+// setStatementEffect classifies the SET forms.
+//
+// Measured: `SET PASSWORD` and `SET DEFAULT ROLE` end the transaction. Every
+// other SET commits nothing — including `SET autocommit = 1`, which the first
+// version of this file listed as committing. It does not, because the session
+// autocommit value is already 1: Ptah opens the migration transaction with
+// START TRANSACTION and never turns session autocommit off, so the assignment
+// has nothing to change and commits nothing. `SET autocommit = 0` was measured
+// in the same session shape and also commits nothing.
+func setStatementEffect(tokens []lexer.Token) implicitCommitEffect {
+	rest := tokens[1:]
+	if len(rest) == 0 {
+		return implicitCommitNone
+	}
+	if rest[0].MatchIdentifierValue("PASSWORD") {
+		return implicitCommitEnds
+	}
+	if len(rest) > 1 && rest[0].MatchIdentifierValue("DEFAULT") && rest[1].MatchIdentifierValue("ROLE") {
+		return implicitCommitEnds
+	}
+	return implicitCommitNone
+}
+
+// loadStatementEffect classifies the LOAD forms.
+//
+// Measured: `LOAD DATA INFILE` commits nothing on either server — a ROLLBACK
+// takes the INSERT before it and the loaded rows with it. `LOAD INDEX INTO
+// CACHE` ends the transaction on MySQL and commits nothing on MariaDB.
+func loadStatementEffect(tokens []lexer.Token, dialect string) implicitCommitEffect {
+	if len(tokens) > 1 && tokens[1].MatchIdentifierValue("INDEX") {
+		return keyCacheEffect(dialect)
+	}
+	return implicitCommitNone
+}
+
+// keyCacheEffect answers for the two MyISAM key-cache statements, the only
+// place the two servers disagree.
+func keyCacheEffect(dialect string) implicitCommitEffect {
+	if platform.NormalizeDialect(dialect) == platform.MySQL {
+		return implicitCommitEnds
+	}
+	return implicitCommitNone
+}
+
+// hasTemporaryQualifier reports whether TEMP or TEMPORARY qualifies the object
+// a leading CREATE or DROP names.
+//
+// The qualifier can only appear before the TABLE keyword, so the scan stops
+// there. Scanning a fixed number of leading tokens instead reads a column named
+// `temp` in `CREATE TABLE hastemp (temp INT)` as the qualifier — measured, that
+// statement ends the transaction like any other CREATE TABLE.
+func hasTemporaryQualifier(tokens []lexer.Token) bool {
+	for i := range tokens[1:] {
+		token := tokens[1+i]
+		if token.MatchIdentifierValue("TEMP") || token.MatchIdentifierValue("TEMPORARY") {
+			return true
+		}
+		if token.MatchIdentifierValue("TABLE") {
+			return false
+		}
+	}
+	return false
+}
+
+// hasChainClause reports whether a COMMIT carries AND CHAIN rather than
+// AND NO CHAIN.
+func hasChainClause(tokens []lexer.Token) bool {
+	for i := range tokens {
+		if !tokens[i].MatchIdentifierValue("CHAIN") {
+			continue
+		}
+		return i == 0 || !tokens[i-1].MatchIdentifierValue("NO")
+	}
+	return false
+}
+
+// isSavepointRollback reports whether a ROLLBACK names a savepoint instead of
+// discarding the whole transaction.
+func isSavepointRollback(tokens []lexer.Token) bool {
+	return containsAnyKeyword(tokens[1:], "TO")
+}
+
+func containsAnyKeyword(tokens []lexer.Token, keywords ...string) bool {
+	for i := range tokens {
+		if matchesAnyKeyword(tokens[i], keywords...) {
+			return true
+		}
+	}
+	return false
+}
+
+// committedPrefixAfterRollback returns how many leading statements of sqlText a
+// MySQL-family server has already committed when the transaction wrapping the
+// body rolls back, given that executed statements ran and that the statement at
+// failedIndex (1-based, 0 when no statement itself failed) is the one that
+// stopped the run.
+//
+// The rule is not "the prefix ends at the last statement that forced a commit".
+// An implicit commit ENDS the transaction; it does not merely flush it. Every
+// statement after one therefore runs with no transaction open and commits
+// itself, and the ROLLBACK the failure triggers reaches none of them. Measured
+// on MySQL 9.7.1 and MariaDB 11.4.12:
+//
+//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
+//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
+//	-> rows 1 and 3 both survive
+//
+// So the walk below tracks whether a transaction is open at all, and counts a
+// statement as committed either because it forced the commit itself or because
+// nothing was open to hold it. The failing statement counts the same way: the
+// server commits before it runs, and it does so even when the statement then
+// fails.
+//
+// A body that rolls back a transaction it is itself inside is the one shape no
+// counter can describe — the statements after the ROLLBACK are durable and the
+// ones before it are not, so the durable set is not a prefix. Zero is the only
+// prefix that never claims a statement committed which did not, so that is what
+// it reports, at the cost of re-running the statements after the in-body
+// ROLLBACK. A ROLLBACK that arrives with no transaction open is a no-op and
+// costs nothing.
+func committedPrefixAfterRollback(sqlText, dialect string, executed, failedIndex int) int {
+	if executed <= 0 {
+		return 0
+	}
+	statements := splitSQLStatementsForDialect(sqlText, dialect)
+	if len(statements) < executed {
+		// The executor counted more statements than the split finds, so the
+		// prefix cannot be classified statement by statement. Reporting nothing
+		// committed is the conservative answer: a retry re-runs the body from
+		// the top instead of skipping a statement that may never have run.
+		return 0
+	}
+	inTransaction := true
+	committed := 0
+	for i, statement := range statements[:executed] {
+		switch implicitCommitEffectOf(statement, dialect) {
+		case implicitCommitEnds:
+			committed, inTransaction = i+1, false
+		case implicitCommitRestarts:
+			committed, inTransaction = i+1, true
+		case implicitCommitDiscards:
+			// With no transaction open there is nothing to throw away and the
+			// statement is a no-op; the prefix ahead of it is already durable.
+			if inTransaction {
+				return 0
+			}
+			committed = i + 1
+		case implicitCommitNone:
+			if !inTransaction {
+				committed = i + 1
+			}
+		}
+	}
+	if failedIndex > executed && failedIndex <= len(statements) &&
+		implicitCommitEffectOf(statements[failedIndex-1], dialect).commitsBeforeItRuns() {
+		return executed
+	}
+	return committed
+}

--- a/migration/migrator/implicit_commit.go
+++ b/migration/migrator/implicit_commit.go
@@ -33,34 +33,71 @@ func (m *Migrator) validateTransactionalProgressSQL(
 	if !implicitCommitDialect(m.connectionDialect()) {
 		return nil
 	}
+	if !migration.hasSQLExecutor(direction) {
+		return fmt.Errorf(
+			"migration %d cannot run an opaque %s function in tx-mode file on a MySQL-family database; "+
+				"use a SQL-backed migration or tx-mode none",
+			migration.Version,
+			direction,
+		)
+	}
+	if migration.hasStatementInterceptor(direction) {
+		return fmt.Errorf(
+			"migration %d cannot run a %s statement interceptor in tx-mode file on a MySQL-family database; "+
+				"an interceptor can execute SQL outside Ptah's transaction witness, so use tx-mode none",
+			migration.Version,
+			direction,
+		)
+	}
 	statements := splitSQLStatementsForConnection(m.conn, migrationSQLForDirection(migration, direction))
 	for i, statement := range statements {
 		tokens := significantSQLTokens(statement, m.connectionDialect())
+		if mysqlExecutableComment(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because MySQL-family executable comments "+
+					"can bypass transaction-witness validation; use ordinary SQL or tx-mode none",
+				migration.Version,
+				i+1,
+			)
+		}
 		if len(tokens) > 0 && tokens[0].MatchIdentifierValue("USE") {
 			return fmt.Errorf(
-				"migration %d cannot run tx-mode file statement %d because %q changes the target database; "+
+				"migration %d cannot run tx-mode file statement %d because it changes the target database; "+
 					"select the database in the connection URL so Ptah can verify its storage engines",
 				migration.Version,
 				i+1,
-				strings.TrimSpace(statement),
 			)
 		}
 		if mysqlUnwitnessedStateChange(tokens) {
 			return fmt.Errorf(
-				"migration %d cannot run tx-mode file statement %d because %q changes state outside "+
+				"migration %d cannot run tx-mode file statement %d because it changes state outside "+
 					"Ptah's migration transaction; use a session-scoped setting or tx-mode none",
 				migration.Version,
 				i+1,
-				strings.TrimSpace(statement),
+			)
+		}
+		if mysqlOpaqueExecution(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because nested or dynamic SQL cannot be "+
+					"tied to Ptah's transaction witness; use direct SQL or tx-mode none",
+				migration.Version,
+				i+1,
+			)
+		}
+		if mysqlDefinesIndirectWriter(tokens) {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because it defines an indirect database "+
+					"writer that Ptah cannot validate before execution; use tx-mode none",
+				migration.Version,
+				i+1,
 			)
 		}
 		if isTransactionControlStatement(statement, m.connectionDialect()) {
 			return fmt.Errorf(
-				"migration %d cannot run tx-mode file statement %d because %q controls transaction state; "+
+				"migration %d cannot run tx-mode file statement %d because it controls transaction state; "+
 					"remove the transaction control and let Ptah manage the file transaction",
 				migration.Version,
 				i+1,
-				strings.TrimSpace(statement),
 			)
 		}
 		if mysqlCreateTableLike(tokens) {
@@ -86,6 +123,55 @@ func (m *Migrator) validateTransactionalProgressSQL(
 	return nil
 }
 
+func (m *Migration) hasSQLExecutor(direction MigrationDirection) bool {
+	if direction == MigrationDirectionDown {
+		return m.downSQLFunc != nil
+	}
+	return m.upSQLFunc != nil
+}
+
+func (m *Migration) hasStatementInterceptor(direction MigrationDirection) bool {
+	if direction == MigrationDirectionDown {
+		return m.downHasStatementInterceptor
+	}
+	return m.upHasStatementInterceptor
+}
+
+func mysqlExecutableComment(tokens []lexer.Token) bool {
+	for _, token := range tokens {
+		if token.Type != lexer.TokenUnknown {
+			continue
+		}
+		value := strings.TrimSpace(token.Value)
+		if strings.HasPrefix(value, "/*!") || strings.HasPrefix(value, "/*M!") {
+			return true
+		}
+	}
+	return false
+}
+
+func mysqlOpaqueExecution(tokens []lexer.Token) bool {
+	if len(tokens) == 0 {
+		return false
+	}
+	return matchesAnyKeyword(tokens[0], "CALL", "PREPARE", "EXECUTE", "DEALLOCATE", "LOCK", "UNLOCK")
+}
+
+func mysqlDefinesIndirectWriter(tokens []lexer.Token) bool {
+	if len(tokens) == 0 || !matchesAnyKeyword(tokens[0], "CREATE", "ALTER") {
+		return false
+	}
+	for _, token := range tokens[1:] {
+		if token.Value == "(" {
+			return false
+		}
+		if matchesAnyKeyword(token, "VIEW", "TRIGGER", "PROCEDURE", "FUNCTION", "EVENT") {
+			return true
+		}
+	}
+	return false
+}
+
 // mysqlUnwitnessedStateChange identifies MySQL-family statements whose effects
 // are not session-local and are not tied to the InnoDB transaction containing
 // the revision witness. Replaying one after the witness rolls back can repeat a
@@ -94,6 +180,9 @@ func (m *Migrator) validateTransactionalProgressSQL(
 func mysqlUnwitnessedStateChange(tokens []lexer.Token) bool {
 	if len(tokens) == 0 {
 		return false
+	}
+	if mysqlDatabaseCatalogChange(tokens) {
+		return true
 	}
 	if tokens[0].MatchIdentifierValue("RESET") {
 		return true
@@ -124,6 +213,22 @@ func mysqlUnwitnessedStateChange(tokens []lexer.Token) bool {
 		) {
 			return true
 		}
+	}
+	return false
+}
+
+func mysqlDatabaseCatalogChange(tokens []lexer.Token) bool {
+	if len(tokens) == 0 || !matchesAnyKeyword(tokens[0], "CREATE", "ALTER", "DROP") {
+		return false
+	}
+	for _, token := range tokens[1:] {
+		if token.Type != lexer.TokenIdentifier {
+			continue
+		}
+		if matchesAnyKeyword(token, "OR", "REPLACE", "IF", "NOT", "EXISTS") {
+			continue
+		}
+		return matchesAnyKeyword(token, "DATABASE", "SCHEMA")
 	}
 	return false
 }

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -1,9 +1,8 @@
 package migrator
 
-// White-box testing required: the rollback accounting these tests pin is
-// unexported and has no public surface. Reaching it through MigrateUp would
-// need a live MySQL server per row, and the point of the table is to separate
-// the dialect axis from the statement axis, which only a direct call can do.
+// White-box testing required: the error-only rollback fallback is unexported.
+// Live MySQL and MariaDB tests cover the transactional progress witness that
+// replaces this fallback when implicit commits are possible.
 
 import (
 	"testing"
@@ -11,488 +10,213 @@ import (
 	qt "github.com/frankban/quicktest"
 )
 
-// effectOfSurvivors maps what survived the probe's ROLLBACK to the transaction
-// effect that explains it. The probe is always the same six lines:
-//
-//	START TRANSACTION;
-//	INSERT INTO led VALUES (1,'a_pre');
-//	<the statement under test>
-//	INSERT INTO led VALUES (2,'b_post');
-//	ROLLBACK;
-//	SELECT note FROM led;
-//
-// so the surviving rows are a direct reading of what the server did:
-//
-//	none          nothing was committed and the transaction was still open
-//	a_pre+b_post  the prefix was committed and no transaction was left open, so
-//	              the statement after it committed itself
-//	a_pre         the prefix was committed and a new transaction was opened, so
-//	              the statement after it was rolled back
-//	b_post        the prefix was thrown away and the statement after it
-//	              committed itself
-var effectOfSurvivors = map[string]implicitCommitEffect{
-	"none":         implicitCommitNone,
-	"a_pre+b_post": implicitCommitEnds,
-	"a_pre":        implicitCommitRestarts,
-	"b_post":       implicitCommitDiscards,
-}
-
-// TestImplicitCommitEffectOf pins the classifier against a measurement, one row
-// per statement, on both servers.
-//
-// Every mysql/mariadb value below is the literal output of running that row's
-// statement through the probe described on [effectOfSurvivors] against MySQL
-// 9.7.1 and MariaDB 11.4.12. Nothing here is derived from documentation, and
-// the two servers are listed separately because they do not agree: CACHE INDEX
-// and LOAD INDEX INTO CACHE end the transaction on MySQL and do nothing on
-// MariaDB.
-//
-// Getting a row wrong is not cosmetic. A statement wrongly reported as
-// committing marks a rolled-back statement applied and a resume skips it
-// forever; a statement wrongly reported as committing nothing makes a resume
-// re-run SQL the server already committed and duplicate its effect.
-func TestImplicitCommitEffectOf(t *testing.T) {
+func TestMySQLStorageEngineSelection_Selected(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
 		name      string
 		statement string
-		mysql     string
-		mariadb   string
+		want      string
 	}{
-		// Data statements and session settings: the transaction survives them.
-		{name: "INSERT", statement: "INSERT INTO tgt VALUES (1)", mysql: "none", mariadb: "none"},
-		{name: "UPDATE", statement: "UPDATE tgt SET i = i", mysql: "none", mariadb: "none"},
-		{name: "DELETE", statement: "DELETE FROM tgt", mysql: "none", mariadb: "none"},
-		{name: "REPLACE", statement: "REPLACE INTO tgt VALUES (1)", mysql: "none", mariadb: "none"},
-		{name: "SELECT", statement: "SELECT COUNT(*) INTO @discard FROM tgt", mysql: "none", mariadb: "none"},
-		{name: "SET SESSION", statement: "SET SESSION sql_mode = ''", mysql: "none", mariadb: "none"},
-		{name: "SET user variable", statement: "SET @user_var = 1", mysql: "none", mariadb: "none"},
-		// The first version of this file listed SET autocommit as committing.
-		// It does not: Ptah opens the migration transaction with START
-		// TRANSACTION and leaves session autocommit at 1, so the assignment has
-		// nothing to change.
-		{name: "SET autocommit = 1", statement: "SET autocommit = 1", mysql: "none", mariadb: "none"},
-		{name: "SET autocommit = 0", statement: "SET autocommit = 0", mysql: "none", mariadb: "none"},
-
-		// Account management.
-		{
-			name:      "SET PASSWORD",
-			statement: "SET PASSWORD FOR 'probeu'@'%' = 'Pw234567!'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "SET DEFAULT ROLE",
-			statement: "SET DEFAULT ROLE NONE TO 'probeu'@'%'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "CREATE USER",
-			statement: "CREATE USER 'probeu2'@'%' IDENTIFIED BY 'Pw123456!'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "ALTER USER",
-			statement: "ALTER USER 'probeu2'@'%' IDENTIFIED BY 'Pw234567!'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "RENAME USER",
-			statement: "RENAME USER 'probeu2'@'%' TO 'probeu3'@'%'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{name: "DROP USER", statement: "DROP USER 'probeu3'@'%'", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{
-			name:      "GRANT",
-			statement: "GRANT SELECT ON icprobe.* TO 'probeu'@'%'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "REVOKE",
-			statement: "REVOKE SELECT ON icprobe.* FROM 'probeu'@'%'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-
-		// Schema DDL.
-		{name: "CREATE TABLE", statement: "CREATE TABLE ct1 (i INT)", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{
-			name:      "CREATE INDEX",
-			statement: "CREATE INDEX ix1 ON ixt (i)",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "CREATE VIEW",
-			statement: "CREATE VIEW v1 AS SELECT 1 AS one",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "CREATE DATABASE",
-			statement: "CREATE DATABASE icprobe_scratch",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		// A column named `temp` is not the TEMPORARY qualifier. Scanning a fixed
-		// number of leading tokens for it read this row as a temporary table.
-		{
-			name:      "CREATE TABLE with a temp column",
-			statement: "CREATE TABLE hastemp (temp INT)",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{name: "DROP TABLE", statement: "DROP TABLE dropme", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "DROP INDEX", statement: "DROP INDEX ix1 ON ixt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{
-			name:      "DROP DATABASE",
-			statement: "DROP DATABASE icprobe_scratch",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "ALTER TABLE",
-			statement: "ALTER TABLE alt ADD COLUMN c1 INT",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "RENAME TABLE",
-			statement: "RENAME TABLE ren_a TO ren_b",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{name: "TRUNCATE TABLE", statement: "TRUNCATE TABLE trunct", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-
-		// The documented TEMPORARY exceptions.
-		{
-			name:      "CREATE TEMPORARY TABLE",
-			statement: "CREATE TEMPORARY TABLE tt1 (i INT)",
-			mysql:     "none", mariadb: "none",
-		},
-		{
-			name:      "CREATE TEMPORARY TABLE AS SELECT",
-			statement: "CREATE TEMPORARY TABLE tt3 AS SELECT 1 AS one",
-			mysql:     "none", mariadb: "none",
-		},
-		{name: "DROP TEMPORARY TABLE", statement: "DROP TEMPORARY TABLE tt2", mysql: "none", mariadb: "none"},
-
-		// Table administration.
-		{name: "ANALYZE TABLE", statement: "ANALYZE TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "OPTIMIZE TABLE", statement: "OPTIMIZE TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "CHECK TABLE", statement: "CHECK TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "REPAIR TABLE", statement: "REPAIR TABLE mi", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-
-		// Server administration.
-		{name: "FLUSH TABLES", statement: "FLUSH TABLES", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "FLUSH PRIVILEGES", statement: "FLUSH PRIVILEGES", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "RESET REPLICA", statement: "RESET REPLICA", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{
-			name:      "INSTALL PLUGIN",
-			statement: "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so'",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-		{
-			name:      "UNINSTALL PLUGIN",
-			statement: "UNINSTALL PLUGIN mysql_no_login",
-			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
-		},
-
-		// Locking. UNLOCK TABLES was measured with no table locked, which is the
-		// only state it can meet inside a migration transaction: a LOCK TABLES
-		// earlier in the body would already have ended that transaction.
-		{name: "LOCK TABLES", statement: "LOCK TABLES led WRITE", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "UNLOCK TABLES", statement: "UNLOCK TABLES", mysql: "none", mariadb: "none"},
-
-		// The two rows where the servers disagree.
-		{name: "CACHE INDEX", statement: "CACHE INDEX mi IN default", mysql: "a_pre+b_post", mariadb: "none"},
-		{name: "LOAD INDEX INTO CACHE", statement: "LOAD INDEX INTO CACHE mi", mysql: "a_pre+b_post", mariadb: "none"},
-
-		// LOAD DATA is in neither server's implicit-commit set. Reporting it as
-		// committing marks rows applied that the rollback took, and the resume
-		// then skips the statement that would have loaded them.
-		{
-			name:      "LOAD DATA",
-			statement: "LOAD DATA INFILE '/var/lib/mysql-files/probe.txt' INTO TABLE ld",
-			mysql:     "none", mariadb: "none",
-		},
-
-		// Transaction control.
-		{name: "BEGIN", statement: "BEGIN", mysql: "a_pre", mariadb: "a_pre"},
-		{name: "START TRANSACTION", statement: "START TRANSACTION", mysql: "a_pre", mariadb: "a_pre"},
-		{name: "COMMIT", statement: "COMMIT", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
-		{name: "COMMIT AND CHAIN", statement: "COMMIT AND CHAIN", mysql: "a_pre", mariadb: "a_pre"},
-		{name: "ROLLBACK", statement: "ROLLBACK", mysql: "b_post", mariadb: "b_post"},
-		{name: "SAVEPOINT", statement: "SAVEPOINT sp1", mysql: "none", mariadb: "none"},
-		{name: "RELEASE SAVEPOINT", statement: "RELEASE SAVEPOINT sp2", mysql: "none", mariadb: "none"},
-		// ROLLBACK TO SAVEPOINT undoes work back to the savepoint, but it
-		// neither commits the prefix nor ends the transaction, and work that is
-		// still pending is work this accounting already reports as uncommitted.
-		{name: "ROLLBACK TO SAVEPOINT", statement: "ROLLBACK TO SAVEPOINT sp4", mysql: "none", mariadb: "none"},
-
-		// A statement with nothing in it cannot be reached by any of the above.
-		{name: "a comment alone", statement: "-- nothing here", mysql: "none", mariadb: "none"},
+		{name: "create table", statement: "CREATE TABLE jobs (id BIGINT) ENGINE=MyISAM", want: "MyISAM"},
+		{name: "alter table", statement: "ALTER TABLE jobs ENGINE = InnoDB", want: "InnoDB"},
+		{name: "alter table without equals", statement: "ALTER TABLE jobs ENGINE MyISAM", want: "MyISAM"},
+		{name: "qualified create table", statement: "CREATE TABLE archive.jobs (id BIGINT) ENGINE=MyISAM", want: "MyISAM"},
+		{name: "MariaDB replace table", statement: "CREATE OR REPLACE TABLE jobs (id BIGINT) ENGINE=MyISAM", want: "MyISAM"},
+		{name: "session default", statement: "SET SESSION default_storage_engine = 'MyISAM'", want: "MyISAM"},
+		{name: "qualified session default", statement: "SET @@SESSION.default_storage_engine = MyISAM", want: "MyISAM"},
+		{name: "legacy default", statement: "SET storage_engine=DEFAULT", want: "DEFAULT"},
 	}
 
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			c.Assert(implicitCommitEffectOf(tt.statement, "mysql"), qt.Equals, effectOfSurvivors[tt.mysql])
-			c.Assert(implicitCommitEffectOf(tt.statement, "mariadb"), qt.Equals, effectOfSurvivors[tt.mariadb])
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, selected := mysqlStorageEngineSelection(test.statement, "mysql")
+			c.Assert(selected, qt.IsTrue)
+			c.Assert(got, qt.Equals, test.want)
 		})
 	}
 }
 
-// TestImplicitCommitEffectOf_DiscardingForms separates the statements that
-// throw the open transaction away from the statements that do nothing. The
-// probe on [effectOfSurvivors] cannot tell them apart, because both leave
-// nothing behind, so these rows were measured with a DDL statement appended:
-//
-//	START TRANSACTION;
-//	INSERT INTO led VALUES (1,'a_pre');
-//	<the statement under test>
-//	INSERT INTO led VALUES (2,'b_post');
-//	CREATE TABLE disc_x (i INT);
-//	ROLLBACK;
-//	SELECT note FROM led;
-//
-// The trailing DDL commits whatever is still pending, so `a_pre+b_post` means
-// nothing was discarded and `b_post` means the prefix was.
-func TestImplicitCommitEffectOf_DiscardingForms(t *testing.T) {
+func TestMySQLUnwitnessedStateChange_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"RESET PERSIST",
+		"RESET CONNECTION",
+		"SET GLOBAL sql_mode = 'ANSI_QUOTES'",
+		"SET @@GLOBAL.sql_mode = 'ANSI_QUOTES'",
+		"SET PERSIST max_connections = 200",
+		"SET PASSWORD = 'secret'",
+		"SET DEFAULT ROLE ALL TO app",
+		"SET RESOURCE GROUP batch",
+		"SET STATEMENT max_statement_time=1 FOR SELECT 1",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlUnwitnessedStateChange(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLUnwitnessedStateChange_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"SET SESSION sql_mode = 'ANSI_QUOTES'",
+		"SET @@SESSION.sql_mode = 'ANSI_QUOTES'",
+		"SET @migration_tenant = 7",
+		"SET NAMES utf8mb4",
+		"SET NAMES DEFAULT",
+		"SET CHARACTER SET utf8mb4",
+		"SET CHARACTER SET DEFAULT",
+		"SET SESSION sql_mode = 'GLOBAL'",
+		"SET ROLE app_writer",
+		"INSERT INTO jobs (id) VALUES (1)",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlUnwitnessedStateChange(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLCreateTableLike_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TABLE jobs_archive LIKE archive.jobs",
+		"CREATE TEMPORARY TABLE jobs_copy LIKE jobs",
+		"CREATE OR REPLACE TABLE jobs_copy LIKE jobs",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlCreateTableLike(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLCreateTableLike_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TABLE jobs (id BIGINT) ENGINE=InnoDB",
+		"CREATE TABLE jobs (note VARCHAR(32) CHECK (note LIKE 'ok%'))",
+		"CREATE VIEW jobs_like AS SELECT * FROM jobs",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlCreateTableLike(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLStorageEngineSelection_Absent(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
 		name      string
 		statement string
-		survivors string
-		want      implicitCommitEffect
 	}{
-		{
-			name:      "a plain INSERT discards nothing",
-			statement: "INSERT INTO tgt VALUES (1)",
-			survivors: "a_pre+b_post",
-			want:      implicitCommitNone,
-		},
-		{
-			name:      "ROLLBACK discards the prefix",
-			statement: "ROLLBACK",
-			survivors: "b_post",
-			want:      implicitCommitDiscards,
-		},
-		{
-			name:      "ROLLBACK AND CHAIN discards the prefix too",
-			statement: "ROLLBACK AND CHAIN",
-			survivors: "b_post",
-			want:      implicitCommitDiscards,
-		},
+		{name: "column name", statement: "CREATE TABLE jobs (engine VARCHAR(32), id BIGINT)"},
+		{name: "alter column name", statement: "ALTER TABLE jobs ADD COLUMN engine VARCHAR(32)"},
+		{name: "select alias", statement: "CREATE TABLE jobs AS SELECT engine FROM source_jobs"},
+		{name: "setting value", statement: "SET SESSION note = default_storage_engine"},
+		{name: "unrelated variable name", statement: "SET SESSION ptah_storage_engine_note = 'MyISAM'"},
+		{name: "unrelated setting", statement: "SET SESSION sql_mode = 'ANSI_QUOTES'"},
+		{name: "insert", statement: "INSERT INTO jobs (id) VALUES (1)"},
 	}
 
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			c.Assert(implicitCommitEffectOf(tt.statement, "mysql"), qt.Equals, tt.want)
-			c.Assert(implicitCommitEffectOf(tt.statement, "mariadb"), qt.Equals, tt.want)
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			got, selected := mysqlStorageEngineSelection(test.statement, "mysql")
+			c.Assert(selected, qt.IsFalse)
+			c.Assert(got, qt.Equals, "")
 		})
 	}
 }
 
-// TestCommittedPrefixAfterRollback pins how much of a rolled-back MySQL-family
-// body is still committed.
-//
-// The row that matters most is "a DDL statement commits everything after it
-// too". Measured on MySQL 9.7.1 and MariaDB 11.4.12:
-//
-//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
-//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
-//	-> rows 1 and 3 both survive
-//
-// An implicit commit ends the transaction rather than flushing it, so the
-// statements after it commit themselves and the ROLLBACK reaches none of them.
-// Counting only up to the last committing statement understates the prefix, and
-// the retry then re-executes a statement that is already committed.
-func TestCommittedPrefixAfterRollback(t *testing.T) {
-	c := qt.New(t)
-
-	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n" +
-		"INSERT INTO ledger (id) VALUES (3);\n"
-	const ddlThenDML = "CREATE TABLE ledger (id INT);\n" +
-		"INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n"
-	const dmlThenDDL = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n" +
-		"CREATE TABLE audit (id INT);\n"
-	const dmlThenBegin = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"BEGIN;\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n" +
-		"INSERT INTO ledger (id) VALUES (3);\n"
-	const ddlThenRollback = "CREATE TABLE ledger (id INT);\n" +
-		"ROLLBACK;\n" +
-		"INSERT INTO ledger (id) VALUES (1);\n"
-	const dmlThenRollbackThenDDL = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"ROLLBACK;\n" +
-		"CREATE TABLE audit (id INT);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n"
-	const ddlThenLoadIndex = "CREATE TABLE ledger (id INT);\n" +
-		"LOAD INDEX INTO CACHE ledger;\n" +
-		"INSERT INTO ledger (id) VALUES (1);\n"
-
-	tests := []struct {
-		name        string
-		sqlText     string
-		dialect     string
-		executed    int
-		failedIndex int
-		want        int
-	}{
-		{
-			name:    "DML only loses everything the rollback took",
-			sqlText: dmlOnly, dialect: "mysql",
-			executed: 1, failedIndex: 2, want: 0,
-		},
-		{
-			name:    "DML only loses a longer prefix too",
-			sqlText: dmlOnly, dialect: "mysql",
-			executed: 2, failedIndex: 3, want: 0,
-		},
-		{
-			name:    "a DDL statement commits everything after it too",
-			sqlText: ddlThenDML, dialect: "mysql",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			name:    "a DDL statement commits everything after it on MariaDB too",
-			sqlText: ddlThenDML, dialect: "mariadb",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			name:    "a failing DDL statement commits the DML before it",
-			sqlText: dmlThenDDL, dialect: "mysql",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			name:    "BEGIN commits the prefix and puts the rest back at risk",
-			sqlText: dmlThenBegin, dialect: "mysql",
-			executed: 3, failedIndex: 4, want: 2,
-		},
-		{
-			// The CREATE already ended the transaction, so this ROLLBACK has
-			// nothing to throw away and the DDL before it stays committed.
-			name:    "a ROLLBACK with no open transaction takes nothing back",
-			sqlText: ddlThenRollback, dialect: "mysql",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			// Here the ROLLBACK does undo statement one, while the CREATE after
-			// it is durable. The durable set is not a prefix, and zero is the
-			// only prefix that claims nothing false.
-			name:    "a body that rolls back its own transaction can claim no prefix",
-			sqlText: dmlThenRollbackThenDDL, dialect: "mysql",
-			executed: 3, failedIndex: 4, want: 0,
-		},
-		{
-			name:    "LOAD INDEX keeps the MySQL prefix committed",
-			sqlText: ddlThenLoadIndex, dialect: "mysql",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			// The CREATE ahead of it already ended the transaction, so the
-			// answer is the same on MariaDB even though LOAD INDEX commits
-			// nothing there.
-			name:    "LOAD INDEX keeps the MariaDB prefix committed by the DDL before it",
-			sqlText: ddlThenLoadIndex, dialect: "mariadb",
-			executed: 2, failedIndex: 3, want: 2,
-		},
-		{
-			name:    "nothing executed keeps nothing",
-			sqlText: dmlOnly, dialect: "mysql",
-			executed: 0, failedIndex: 1, want: 0,
-		},
-		{
-			name:    "an unsplittable body keeps nothing",
-			sqlText: "INSERT INTO ledger (id) VALUES (1);", dialect: "mysql",
-			executed: 3, failedIndex: 4, want: 0,
-		},
-		{
-			name:    "no failing statement judges only what ran",
-			sqlText: dmlThenDDL, dialect: "mysql",
-			executed: 2, failedIndex: 0, want: 0,
-		},
-	}
-
-	for _, tt := range tests {
-		c.Run(tt.name, func(c *qt.C) {
-			got := committedPrefixAfterRollback(tt.sqlText, tt.dialect, tt.executed, tt.failedIndex)
-			c.Assert(got, qt.Equals, tt.want)
-		})
-	}
-}
-
-// TestRolledBackApplied is the regression guard for stokaro/ptah#887: a
-// MySQL-family body that ran under tx-mode file and rolled back used to keep
-// the failing statement's predecessors in `applied`, so the next attempt
-// resumed past statements the rollback had undone. The PostgreSQL and
-// no-transaction rows are the non-interference controls -- correcting MySQL
-// must not move either of them.
+// TestRolledBackApplied pins the error-only fallback. Transactional failures
+// report zero without database evidence; the MySQL-family integration path
+// replaces that value with the committed revision-row witness.
 func TestRolledBackApplied(t *testing.T) {
 	c := qt.New(t)
 
-	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n" +
-		"INSERT INTO ledger (id) VALUES (3);\n"
-	const ddlThenDML = "CREATE TABLE ledger (id INT);\n" +
-		"INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) VALUES (2);\n"
-
 	tests := []struct {
-		name        string
-		sqlText     string
-		dialect     string
-		txMode      MigrationTxMode
-		executed    int
-		failedIndex int
-		want        int
+		name     string
+		dialect  string
+		txMode   MigrationTxMode
+		executed int
+		want     int
 	}{
 		{
-			name:    "MySQL file mode drops a rolled-back DML prefix",
-			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeFile,
-			executed: 1, failedIndex: 2, want: 0,
+			name:     "MySQL file mode drops a rolled-back DML prefix",
+			dialect:  "mysql",
+			txMode:   MigrationTxModeFile,
+			executed: 1,
+			want:     0,
 		},
 		{
-			name:    "MariaDB file mode drops a rolled-back DML prefix",
-			sqlText: dmlOnly, dialect: "mariadb", txMode: MigrationTxModeFile,
-			executed: 1, failedIndex: 2, want: 0,
+			name:     "MariaDB file mode drops a rolled-back DML prefix",
+			dialect:  "mariadb",
+			txMode:   MigrationTxModeFile,
+			executed: 1,
+			want:     0,
 		},
 		{
-			name:    "MySQL file mode keeps everything a committed DDL statement carried",
-			sqlText: ddlThenDML, dialect: "mysql", txMode: MigrationTxModeFile,
-			executed: 2, failedIndex: 3, want: 2,
+			name:     "MySQL file mode does not infer a DDL prefix",
+			dialect:  "mysql",
+			txMode:   MigrationTxModeFile,
+			executed: 2,
+			want:     0,
 		},
 		{
-			name:    "MariaDB file mode keeps everything a committed DDL statement carried",
-			sqlText: ddlThenDML, dialect: "mariadb", txMode: MigrationTxModeFile,
-			executed: 2, failedIndex: 3, want: 2,
+			name:     "MySQL all mode drops a rolled-back DML prefix",
+			dialect:  "mysql",
+			txMode:   MigrationTxModeAll,
+			executed: 2,
+			want:     0,
 		},
 		{
-			name:    "MySQL all mode drops a rolled-back DML prefix",
-			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeAll,
-			executed: 2, failedIndex: 3, want: 0,
+			name:     "MySQL no-transaction mode keeps every committed statement",
+			dialect:  "mysql",
+			txMode:   MigrationTxModeNone,
+			executed: 2,
+			want:     2,
 		},
 		{
-			name:    "MySQL no-transaction mode keeps every committed statement",
-			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeNone,
-			executed: 2, failedIndex: 3, want: 2,
+			name:     "PostgreSQL file mode still drops the whole body",
+			dialect:  "postgres",
+			txMode:   MigrationTxModeFile,
+			executed: 2,
+			want:     0,
 		},
 		{
-			name:    "PostgreSQL file mode still drops the whole body",
-			sqlText: ddlThenDML, dialect: "postgres", txMode: MigrationTxModeFile,
-			executed: 2, failedIndex: 3, want: 0,
+			name:     "SQLite file mode still drops the whole body",
+			dialect:  "sqlite",
+			txMode:   MigrationTxModeFile,
+			executed: 2,
+			want:     0,
 		},
 		{
-			name:    "SQLite file mode still drops the whole body",
-			sqlText: ddlThenDML, dialect: "sqlite", txMode: MigrationTxModeFile,
-			executed: 2, failedIndex: 3, want: 0,
-		},
-		{
-			name:    "PostgreSQL no-transaction mode keeps every committed statement",
-			sqlText: ddlThenDML, dialect: "postgres", txMode: MigrationTxModeNone,
-			executed: 2, failedIndex: 3, want: 2,
+			name:     "PostgreSQL no-transaction mode keeps every committed statement",
+			dialect:  "postgres",
+			txMode:   MigrationTxModeNone,
+			executed: 2,
+			want:     2,
 		},
 	}
 
 	for _, tt := range tests {
 		c.Run(tt.name, func(c *qt.C) {
-			got := rolledBackApplied(tt.sqlText, tt.dialect, tt.txMode, tt.executed, tt.failedIndex)
+			got := rolledBackApplied(tt.dialect, tt.txMode, tt.executed)
 			c.Assert(got, qt.Equals, tt.want)
 		})
 	}
@@ -504,43 +228,15 @@ func TestRolledBackApplied(t *testing.T) {
 func TestMigrationExecutionProgress_RolledBackMySQLBody(t *testing.T) {
 	c := qt.New(t)
 
-	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
-		"INSERT INTO ledger (id) SELECT 2 FROM blocker;\n" +
-		"INSERT INTO ledger (id) VALUES (3);\n"
-
 	failure := &MigrationExecutionError{
 		Statement:      "INSERT INTO ledger (id) SELECT 2 FROM blocker",
 		StatementIndex: 2,
 		Total:          3,
 	}
 
-	progress := migrationExecutionProgress(failure, dmlOnly, "mysql", MigrationTxModeFile)
+	progress := migrationExecutionProgress(failure, "mysql", MigrationTxModeFile)
 
 	c.Assert(progress.Applied, qt.Equals, 0)
 	c.Assert(progress.Total, qt.Equals, 3)
 	c.Assert(progress.FailedIndex, qt.Equals, 2)
-}
-
-// TestMigrationExecutionProgress_CommittedDDLPrefix is the other half of the
-// wiring: the body from stokaro/ptah#1356's first blocker, where the DDL at
-// statement one committed itself and statement two along with it. Recording 1
-// here made the retry re-execute the committed INSERT and duplicate its row.
-func TestMigrationExecutionProgress_CommittedDDLPrefix(t *testing.T) {
-	c := qt.New(t)
-
-	const ddlThenDML = "CREATE TABLE created (id INT);\n" +
-		"INSERT INTO ledger (id, note) VALUES (1, 'one');\n" +
-		"INSERT INTO ledger (id, note) SELECT 2, 'two' FROM blocker;\n"
-
-	failure := &MigrationExecutionError{
-		Statement:      "INSERT INTO ledger (id, note) SELECT 2, 'two' FROM blocker",
-		StatementIndex: 3,
-		Total:          3,
-	}
-
-	progress := migrationExecutionProgress(failure, ddlThenDML, "mysql", MigrationTxModeFile)
-
-	c.Assert(progress.Applied, qt.Equals, 2)
-	c.Assert(progress.Total, qt.Equals, 3)
-	c.Assert(progress.FailedIndex, qt.Equals, 3)
 }

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -312,6 +312,77 @@ func TestMySQLGrantsProvideTriggerCatalogVisibility_FailurePath(t *testing.T) {
 	}
 }
 
+// TestMySQLGrantsProvideTriggerCatalogVisibility_SchemaPattern pins the
+// database of a schema-level privilege as the pattern the server stores rather
+// than as a name. Every schema here contains an underscore, which the cases
+// above never do, and that is the whole point: `SHOW GRANTS` prints the
+// escaped `ptah\_test` for the privilege the official MySQL and MariaDB images
+// create for MYSQL_USER on `ptah_test`, and a name comparison both refuses a
+// user who holds TRIGGER and misses the REVOKE that took it away.
+func TestMySQLGrantsProvideTriggerCatalogVisibility_SchemaPattern(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		schema string
+		grants []string
+		want   bool
+	}{
+		{
+			name:   "escaped underscore covers the database",
+			schema: "ptah_test",
+			grants: []string{"GRANT ALL PRIVILEGES ON `ptah\\_test`.* TO `ptah`@`%`"},
+			want:   true,
+		},
+		{
+			name:   "literal underscore covers the database",
+			schema: "ptah_test",
+			grants: []string{"GRANT ALL PRIVILEGES ON `ptah_test`.* TO `ptah`@`%`"},
+			want:   true,
+		},
+		{
+			name:   "trailing wildcard covers the database",
+			schema: "ptah_test",
+			grants: []string{"GRANT TRIGGER ON `ptah%`.* TO `ptah`@`%`"},
+			want:   true,
+		},
+		{
+			name:   "unescaped underscore matches any single character",
+			schema: "ptahXtest",
+			grants: []string{"GRANT TRIGGER ON `ptah_test`.* TO `ptah`@`%`"},
+			want:   true,
+		},
+		{
+			name:   "escaped percent is not a wildcard",
+			schema: "ptah_test",
+			grants: []string{"GRANT TRIGGER ON `ptah\\%test`.* TO `ptah`@`%`"},
+			want:   false,
+		},
+		{
+			name:   "escaped underscore does not reach another database",
+			schema: "ptah_test",
+			grants: []string{"GRANT TRIGGER ON `archive\\_test`.* TO `ptah`@`%`"},
+			want:   false,
+		},
+		{
+			name:   "escaped revoke takes the privilege away",
+			schema: "ptah_test",
+			grants: []string{
+				"GRANT ALL PRIVILEGES ON *.* TO `ptah`@`%`",
+				"REVOKE TRIGGER ON `ptah\\_test`.* FROM `ptah`@`%`",
+			},
+			want: false,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			visible := mysqlGrantsProvideTriggerCatalogVisibility(test.grants, test.schema, "mysql")
+			c.Assert(visible, qt.Equals, test.want)
+		})
+	}
+}
+
 func TestMySQLReferencedCatalogName(t *testing.T) {
 	c := qt.New(t)
 	names := map[string]struct{}{"active_jobs": {}}

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -1,0 +1,546 @@
+package migrator
+
+// White-box testing required: the rollback accounting these tests pin is
+// unexported and has no public surface. Reaching it through MigrateUp would
+// need a live MySQL server per row, and the point of the table is to separate
+// the dialect axis from the statement axis, which only a direct call can do.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+)
+
+// effectOfSurvivors maps what survived the probe's ROLLBACK to the transaction
+// effect that explains it. The probe is always the same six lines:
+//
+//	START TRANSACTION;
+//	INSERT INTO led VALUES (1,'a_pre');
+//	<the statement under test>
+//	INSERT INTO led VALUES (2,'b_post');
+//	ROLLBACK;
+//	SELECT note FROM led;
+//
+// so the surviving rows are a direct reading of what the server did:
+//
+//	none          nothing was committed and the transaction was still open
+//	a_pre+b_post  the prefix was committed and no transaction was left open, so
+//	              the statement after it committed itself
+//	a_pre         the prefix was committed and a new transaction was opened, so
+//	              the statement after it was rolled back
+//	b_post        the prefix was thrown away and the statement after it
+//	              committed itself
+var effectOfSurvivors = map[string]implicitCommitEffect{
+	"none":         implicitCommitNone,
+	"a_pre+b_post": implicitCommitEnds,
+	"a_pre":        implicitCommitRestarts,
+	"b_post":       implicitCommitDiscards,
+}
+
+// TestImplicitCommitEffectOf pins the classifier against a measurement, one row
+// per statement, on both servers.
+//
+// Every mysql/mariadb value below is the literal output of running that row's
+// statement through the probe described on [effectOfSurvivors] against MySQL
+// 9.7.1 and MariaDB 11.4.12. Nothing here is derived from documentation, and
+// the two servers are listed separately because they do not agree: CACHE INDEX
+// and LOAD INDEX INTO CACHE end the transaction on MySQL and do nothing on
+// MariaDB.
+//
+// Getting a row wrong is not cosmetic. A statement wrongly reported as
+// committing marks a rolled-back statement applied and a resume skips it
+// forever; a statement wrongly reported as committing nothing makes a resume
+// re-run SQL the server already committed and duplicate its effect.
+func TestImplicitCommitEffectOf(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		statement string
+		mysql     string
+		mariadb   string
+	}{
+		// Data statements and session settings: the transaction survives them.
+		{name: "INSERT", statement: "INSERT INTO tgt VALUES (1)", mysql: "none", mariadb: "none"},
+		{name: "UPDATE", statement: "UPDATE tgt SET i = i", mysql: "none", mariadb: "none"},
+		{name: "DELETE", statement: "DELETE FROM tgt", mysql: "none", mariadb: "none"},
+		{name: "REPLACE", statement: "REPLACE INTO tgt VALUES (1)", mysql: "none", mariadb: "none"},
+		{name: "SELECT", statement: "SELECT COUNT(*) INTO @discard FROM tgt", mysql: "none", mariadb: "none"},
+		{name: "SET SESSION", statement: "SET SESSION sql_mode = ''", mysql: "none", mariadb: "none"},
+		{name: "SET user variable", statement: "SET @user_var = 1", mysql: "none", mariadb: "none"},
+		// The first version of this file listed SET autocommit as committing.
+		// It does not: Ptah opens the migration transaction with START
+		// TRANSACTION and leaves session autocommit at 1, so the assignment has
+		// nothing to change.
+		{name: "SET autocommit = 1", statement: "SET autocommit = 1", mysql: "none", mariadb: "none"},
+		{name: "SET autocommit = 0", statement: "SET autocommit = 0", mysql: "none", mariadb: "none"},
+
+		// Account management.
+		{
+			name:      "SET PASSWORD",
+			statement: "SET PASSWORD FOR 'probeu'@'%' = 'Pw234567!'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "SET DEFAULT ROLE",
+			statement: "SET DEFAULT ROLE NONE TO 'probeu'@'%'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "CREATE USER",
+			statement: "CREATE USER 'probeu2'@'%' IDENTIFIED BY 'Pw123456!'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "ALTER USER",
+			statement: "ALTER USER 'probeu2'@'%' IDENTIFIED BY 'Pw234567!'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "RENAME USER",
+			statement: "RENAME USER 'probeu2'@'%' TO 'probeu3'@'%'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{name: "DROP USER", statement: "DROP USER 'probeu3'@'%'", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{
+			name:      "GRANT",
+			statement: "GRANT SELECT ON icprobe.* TO 'probeu'@'%'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "REVOKE",
+			statement: "REVOKE SELECT ON icprobe.* FROM 'probeu'@'%'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+
+		// Schema DDL.
+		{name: "CREATE TABLE", statement: "CREATE TABLE ct1 (i INT)", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{
+			name:      "CREATE INDEX",
+			statement: "CREATE INDEX ix1 ON ixt (i)",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "CREATE VIEW",
+			statement: "CREATE VIEW v1 AS SELECT 1 AS one",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "CREATE DATABASE",
+			statement: "CREATE DATABASE icprobe_scratch",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		// A column named `temp` is not the TEMPORARY qualifier. Scanning a fixed
+		// number of leading tokens for it read this row as a temporary table.
+		{
+			name:      "CREATE TABLE with a temp column",
+			statement: "CREATE TABLE hastemp (temp INT)",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{name: "DROP TABLE", statement: "DROP TABLE dropme", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "DROP INDEX", statement: "DROP INDEX ix1 ON ixt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{
+			name:      "DROP DATABASE",
+			statement: "DROP DATABASE icprobe_scratch",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "ALTER TABLE",
+			statement: "ALTER TABLE alt ADD COLUMN c1 INT",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "RENAME TABLE",
+			statement: "RENAME TABLE ren_a TO ren_b",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{name: "TRUNCATE TABLE", statement: "TRUNCATE TABLE trunct", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+
+		// The documented TEMPORARY exceptions.
+		{
+			name:      "CREATE TEMPORARY TABLE",
+			statement: "CREATE TEMPORARY TABLE tt1 (i INT)",
+			mysql:     "none", mariadb: "none",
+		},
+		{
+			name:      "CREATE TEMPORARY TABLE AS SELECT",
+			statement: "CREATE TEMPORARY TABLE tt3 AS SELECT 1 AS one",
+			mysql:     "none", mariadb: "none",
+		},
+		{name: "DROP TEMPORARY TABLE", statement: "DROP TEMPORARY TABLE tt2", mysql: "none", mariadb: "none"},
+
+		// Table administration.
+		{name: "ANALYZE TABLE", statement: "ANALYZE TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "OPTIMIZE TABLE", statement: "OPTIMIZE TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "CHECK TABLE", statement: "CHECK TABLE tgt", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "REPAIR TABLE", statement: "REPAIR TABLE mi", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+
+		// Server administration.
+		{name: "FLUSH TABLES", statement: "FLUSH TABLES", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "FLUSH PRIVILEGES", statement: "FLUSH PRIVILEGES", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "RESET REPLICA", statement: "RESET REPLICA", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{
+			name:      "INSTALL PLUGIN",
+			statement: "INSTALL PLUGIN mysql_no_login SONAME 'mysql_no_login.so'",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+		{
+			name:      "UNINSTALL PLUGIN",
+			statement: "UNINSTALL PLUGIN mysql_no_login",
+			mysql:     "a_pre+b_post", mariadb: "a_pre+b_post",
+		},
+
+		// Locking. UNLOCK TABLES was measured with no table locked, which is the
+		// only state it can meet inside a migration transaction: a LOCK TABLES
+		// earlier in the body would already have ended that transaction.
+		{name: "LOCK TABLES", statement: "LOCK TABLES led WRITE", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "UNLOCK TABLES", statement: "UNLOCK TABLES", mysql: "none", mariadb: "none"},
+
+		// The two rows where the servers disagree.
+		{name: "CACHE INDEX", statement: "CACHE INDEX mi IN default", mysql: "a_pre+b_post", mariadb: "none"},
+		{name: "LOAD INDEX INTO CACHE", statement: "LOAD INDEX INTO CACHE mi", mysql: "a_pre+b_post", mariadb: "none"},
+
+		// LOAD DATA is in neither server's implicit-commit set. Reporting it as
+		// committing marks rows applied that the rollback took, and the resume
+		// then skips the statement that would have loaded them.
+		{
+			name:      "LOAD DATA",
+			statement: "LOAD DATA INFILE '/var/lib/mysql-files/probe.txt' INTO TABLE ld",
+			mysql:     "none", mariadb: "none",
+		},
+
+		// Transaction control.
+		{name: "BEGIN", statement: "BEGIN", mysql: "a_pre", mariadb: "a_pre"},
+		{name: "START TRANSACTION", statement: "START TRANSACTION", mysql: "a_pre", mariadb: "a_pre"},
+		{name: "COMMIT", statement: "COMMIT", mysql: "a_pre+b_post", mariadb: "a_pre+b_post"},
+		{name: "COMMIT AND CHAIN", statement: "COMMIT AND CHAIN", mysql: "a_pre", mariadb: "a_pre"},
+		{name: "ROLLBACK", statement: "ROLLBACK", mysql: "b_post", mariadb: "b_post"},
+		{name: "SAVEPOINT", statement: "SAVEPOINT sp1", mysql: "none", mariadb: "none"},
+		{name: "RELEASE SAVEPOINT", statement: "RELEASE SAVEPOINT sp2", mysql: "none", mariadb: "none"},
+		// ROLLBACK TO SAVEPOINT undoes work back to the savepoint, but it
+		// neither commits the prefix nor ends the transaction, and work that is
+		// still pending is work this accounting already reports as uncommitted.
+		{name: "ROLLBACK TO SAVEPOINT", statement: "ROLLBACK TO SAVEPOINT sp4", mysql: "none", mariadb: "none"},
+
+		// A statement with nothing in it cannot be reached by any of the above.
+		{name: "a comment alone", statement: "-- nothing here", mysql: "none", mariadb: "none"},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(implicitCommitEffectOf(tt.statement, "mysql"), qt.Equals, effectOfSurvivors[tt.mysql])
+			c.Assert(implicitCommitEffectOf(tt.statement, "mariadb"), qt.Equals, effectOfSurvivors[tt.mariadb])
+		})
+	}
+}
+
+// TestImplicitCommitEffectOf_DiscardingForms separates the statements that
+// throw the open transaction away from the statements that do nothing. The
+// probe on [effectOfSurvivors] cannot tell them apart, because both leave
+// nothing behind, so these rows were measured with a DDL statement appended:
+//
+//	START TRANSACTION;
+//	INSERT INTO led VALUES (1,'a_pre');
+//	<the statement under test>
+//	INSERT INTO led VALUES (2,'b_post');
+//	CREATE TABLE disc_x (i INT);
+//	ROLLBACK;
+//	SELECT note FROM led;
+//
+// The trailing DDL commits whatever is still pending, so `a_pre+b_post` means
+// nothing was discarded and `b_post` means the prefix was.
+func TestImplicitCommitEffectOf_DiscardingForms(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name      string
+		statement string
+		survivors string
+		want      implicitCommitEffect
+	}{
+		{
+			name:      "a plain INSERT discards nothing",
+			statement: "INSERT INTO tgt VALUES (1)",
+			survivors: "a_pre+b_post",
+			want:      implicitCommitNone,
+		},
+		{
+			name:      "ROLLBACK discards the prefix",
+			statement: "ROLLBACK",
+			survivors: "b_post",
+			want:      implicitCommitDiscards,
+		},
+		{
+			name:      "ROLLBACK AND CHAIN discards the prefix too",
+			statement: "ROLLBACK AND CHAIN",
+			survivors: "b_post",
+			want:      implicitCommitDiscards,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			c.Assert(implicitCommitEffectOf(tt.statement, "mysql"), qt.Equals, tt.want)
+			c.Assert(implicitCommitEffectOf(tt.statement, "mariadb"), qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestCommittedPrefixAfterRollback pins how much of a rolled-back MySQL-family
+// body is still committed.
+//
+// The row that matters most is "a DDL statement commits everything after it
+// too". Measured on MySQL 9.7.1 and MariaDB 11.4.12:
+//
+//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
+//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
+//	-> rows 1 and 3 both survive
+//
+// An implicit commit ends the transaction rather than flushing it, so the
+// statements after it commit themselves and the ROLLBACK reaches none of them.
+// Counting only up to the last committing statement understates the prefix, and
+// the retry then re-executes a statement that is already committed.
+func TestCommittedPrefixAfterRollback(t *testing.T) {
+	c := qt.New(t)
+
+	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n" +
+		"INSERT INTO ledger (id) VALUES (3);\n"
+	const ddlThenDML = "CREATE TABLE ledger (id INT);\n" +
+		"INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n"
+	const dmlThenDDL = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n" +
+		"CREATE TABLE audit (id INT);\n"
+	const dmlThenBegin = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"BEGIN;\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n" +
+		"INSERT INTO ledger (id) VALUES (3);\n"
+	const ddlThenRollback = "CREATE TABLE ledger (id INT);\n" +
+		"ROLLBACK;\n" +
+		"INSERT INTO ledger (id) VALUES (1);\n"
+	const dmlThenRollbackThenDDL = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"ROLLBACK;\n" +
+		"CREATE TABLE audit (id INT);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n"
+	const ddlThenLoadIndex = "CREATE TABLE ledger (id INT);\n" +
+		"LOAD INDEX INTO CACHE ledger;\n" +
+		"INSERT INTO ledger (id) VALUES (1);\n"
+
+	tests := []struct {
+		name        string
+		sqlText     string
+		dialect     string
+		executed    int
+		failedIndex int
+		want        int
+	}{
+		{
+			name:    "DML only loses everything the rollback took",
+			sqlText: dmlOnly, dialect: "mysql",
+			executed: 1, failedIndex: 2, want: 0,
+		},
+		{
+			name:    "DML only loses a longer prefix too",
+			sqlText: dmlOnly, dialect: "mysql",
+			executed: 2, failedIndex: 3, want: 0,
+		},
+		{
+			name:    "a DDL statement commits everything after it too",
+			sqlText: ddlThenDML, dialect: "mysql",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "a DDL statement commits everything after it on MariaDB too",
+			sqlText: ddlThenDML, dialect: "mariadb",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "a failing DDL statement commits the DML before it",
+			sqlText: dmlThenDDL, dialect: "mysql",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "BEGIN commits the prefix and puts the rest back at risk",
+			sqlText: dmlThenBegin, dialect: "mysql",
+			executed: 3, failedIndex: 4, want: 2,
+		},
+		{
+			// The CREATE already ended the transaction, so this ROLLBACK has
+			// nothing to throw away and the DDL before it stays committed.
+			name:    "a ROLLBACK with no open transaction takes nothing back",
+			sqlText: ddlThenRollback, dialect: "mysql",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			// Here the ROLLBACK does undo statement one, while the CREATE after
+			// it is durable. The durable set is not a prefix, and zero is the
+			// only prefix that claims nothing false.
+			name:    "a body that rolls back its own transaction can claim no prefix",
+			sqlText: dmlThenRollbackThenDDL, dialect: "mysql",
+			executed: 3, failedIndex: 4, want: 0,
+		},
+		{
+			name:    "LOAD INDEX keeps the MySQL prefix committed",
+			sqlText: ddlThenLoadIndex, dialect: "mysql",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			// The CREATE ahead of it already ended the transaction, so the
+			// answer is the same on MariaDB even though LOAD INDEX commits
+			// nothing there.
+			name:    "LOAD INDEX keeps the MariaDB prefix committed by the DDL before it",
+			sqlText: ddlThenLoadIndex, dialect: "mariadb",
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "nothing executed keeps nothing",
+			sqlText: dmlOnly, dialect: "mysql",
+			executed: 0, failedIndex: 1, want: 0,
+		},
+		{
+			name:    "an unsplittable body keeps nothing",
+			sqlText: "INSERT INTO ledger (id) VALUES (1);", dialect: "mysql",
+			executed: 3, failedIndex: 4, want: 0,
+		},
+		{
+			name:    "no failing statement judges only what ran",
+			sqlText: dmlThenDDL, dialect: "mysql",
+			executed: 2, failedIndex: 0, want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got := committedPrefixAfterRollback(tt.sqlText, tt.dialect, tt.executed, tt.failedIndex)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestRolledBackApplied is the regression guard for stokaro/ptah#887: a
+// MySQL-family body that ran under tx-mode file and rolled back used to keep
+// the failing statement's predecessors in `applied`, so the next attempt
+// resumed past statements the rollback had undone. The PostgreSQL and
+// no-transaction rows are the non-interference controls -- correcting MySQL
+// must not move either of them.
+func TestRolledBackApplied(t *testing.T) {
+	c := qt.New(t)
+
+	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n" +
+		"INSERT INTO ledger (id) VALUES (3);\n"
+	const ddlThenDML = "CREATE TABLE ledger (id INT);\n" +
+		"INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) VALUES (2);\n"
+
+	tests := []struct {
+		name        string
+		sqlText     string
+		dialect     string
+		txMode      MigrationTxMode
+		executed    int
+		failedIndex int
+		want        int
+	}{
+		{
+			name:    "MySQL file mode drops a rolled-back DML prefix",
+			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeFile,
+			executed: 1, failedIndex: 2, want: 0,
+		},
+		{
+			name:    "MariaDB file mode drops a rolled-back DML prefix",
+			sqlText: dmlOnly, dialect: "mariadb", txMode: MigrationTxModeFile,
+			executed: 1, failedIndex: 2, want: 0,
+		},
+		{
+			name:    "MySQL file mode keeps everything a committed DDL statement carried",
+			sqlText: ddlThenDML, dialect: "mysql", txMode: MigrationTxModeFile,
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "MariaDB file mode keeps everything a committed DDL statement carried",
+			sqlText: ddlThenDML, dialect: "mariadb", txMode: MigrationTxModeFile,
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "MySQL all mode drops a rolled-back DML prefix",
+			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeAll,
+			executed: 2, failedIndex: 3, want: 0,
+		},
+		{
+			name:    "MySQL no-transaction mode keeps every committed statement",
+			sqlText: dmlOnly, dialect: "mysql", txMode: MigrationTxModeNone,
+			executed: 2, failedIndex: 3, want: 2,
+		},
+		{
+			name:    "PostgreSQL file mode still drops the whole body",
+			sqlText: ddlThenDML, dialect: "postgres", txMode: MigrationTxModeFile,
+			executed: 2, failedIndex: 3, want: 0,
+		},
+		{
+			name:    "SQLite file mode still drops the whole body",
+			sqlText: ddlThenDML, dialect: "sqlite", txMode: MigrationTxModeFile,
+			executed: 2, failedIndex: 3, want: 0,
+		},
+		{
+			name:    "PostgreSQL no-transaction mode keeps every committed statement",
+			sqlText: ddlThenDML, dialect: "postgres", txMode: MigrationTxModeNone,
+			executed: 2, failedIndex: 3, want: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		c.Run(tt.name, func(c *qt.C) {
+			got := rolledBackApplied(tt.sqlText, tt.dialect, tt.txMode, tt.executed, tt.failedIndex)
+			c.Assert(got, qt.Equals, tt.want)
+		})
+	}
+}
+
+// TestMigrationExecutionProgress_RolledBackMySQLBody walks the same correction
+// through the error the executor actually raises, so the wiring between the
+// failure and the recorded counter is covered and not only the helper.
+func TestMigrationExecutionProgress_RolledBackMySQLBody(t *testing.T) {
+	c := qt.New(t)
+
+	const dmlOnly = "INSERT INTO ledger (id) VALUES (1);\n" +
+		"INSERT INTO ledger (id) SELECT 2 FROM blocker;\n" +
+		"INSERT INTO ledger (id) VALUES (3);\n"
+
+	failure := &MigrationExecutionError{
+		Statement:      "INSERT INTO ledger (id) SELECT 2 FROM blocker",
+		StatementIndex: 2,
+		Total:          3,
+	}
+
+	progress := migrationExecutionProgress(failure, dmlOnly, "mysql", MigrationTxModeFile)
+
+	c.Assert(progress.Applied, qt.Equals, 0)
+	c.Assert(progress.Total, qt.Equals, 3)
+	c.Assert(progress.FailedIndex, qt.Equals, 2)
+}
+
+// TestMigrationExecutionProgress_CommittedDDLPrefix is the other half of the
+// wiring: the body from stokaro/ptah#1356's first blocker, where the DDL at
+// statement one committed itself and statement two along with it. Recording 1
+// here made the retry re-execute the committed INSERT and duplicate its row.
+func TestMigrationExecutionProgress_CommittedDDLPrefix(t *testing.T) {
+	c := qt.New(t)
+
+	const ddlThenDML = "CREATE TABLE created (id INT);\n" +
+		"INSERT INTO ledger (id, note) VALUES (1, 'one');\n" +
+		"INSERT INTO ledger (id, note) SELECT 2, 'two' FROM blocker;\n"
+
+	failure := &MigrationExecutionError{
+		Statement:      "INSERT INTO ledger (id, note) SELECT 2, 'two' FROM blocker",
+		StatementIndex: 3,
+		Total:          3,
+	}
+
+	progress := migrationExecutionProgress(failure, ddlThenDML, "mysql", MigrationTxModeFile)
+
+	c.Assert(progress.Applied, qt.Equals, 2)
+	c.Assert(progress.Total, qt.Equals, 3)
+	c.Assert(progress.FailedIndex, qt.Equals, 3)
+}

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -1,8 +1,8 @@
 package migrator
 
-// White-box testing required: the error-only rollback fallback is unexported.
-// Live MySQL and MariaDB tests cover the transactional progress witness that
-// replaces this fallback when implicit commits are possible.
+// White-box testing required: this file verifies unexported MySQL-family safety
+// classifiers, catalog-reference scans, and rollback-progress invariants that
+// cannot be observed independently through the exported migration API.
 
 import (
 	"testing"
@@ -41,6 +41,10 @@ func TestMySQLUnwitnessedStateChange_Present(t *testing.T) {
 	c := qt.New(t)
 
 	statements := []string{
+		"CREATE DATABASE archive",
+		"CREATE OR REPLACE SCHEMA archive",
+		"ALTER DATABASE archive READ ONLY = 1",
+		"DROP SCHEMA IF EXISTS archive",
 		"RESET PERSIST",
 		"RESET CONNECTION",
 		"SET GLOBAL sql_mode = 'ANSI_QUOTES'",
@@ -82,6 +86,228 @@ func TestMySQLUnwitnessedStateChange_Absent(t *testing.T) {
 			c.Assert(got, qt.IsFalse)
 		})
 	}
+}
+
+func TestMySQLExecutableComment_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"/*! SET autocommit = 0 */",
+		"/*!50699 SET autocommit = 0 */",
+		"/*M! SET autocommit = 0 */",
+		"SELECT 1 /*! + 1 */",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlExecutableComment(significantSQLTokens(statement, "mariadb"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLExecutableComment_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"/* ordinary comment */ SELECT 1",
+		"SELECT '/*! SET autocommit = 0 */'",
+		"SELECT 1 /*+ MAX_EXECUTION_TIME(10) */",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlExecutableComment(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLOpaqueExecution_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CALL apply_changes()",
+		"PREPARE stmt FROM @sql",
+		"EXECUTE stmt",
+		"EXECUTE IMMEDIATE @sql",
+		"DEALLOCATE PREPARE stmt",
+		"LOCK TABLES jobs WRITE",
+		"UNLOCK TABLES",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlOpaqueExecution(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLOpaqueExecution_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"INSERT INTO jobs (id) VALUES (1)",
+		"SET SESSION sql_mode = 'ANSI_QUOTES'",
+		"CREATE TABLE jobs (id BIGINT) ENGINE=InnoDB",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlOpaqueExecution(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLDefinesIndirectWriter_Present(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE VIEW active_jobs AS SELECT * FROM jobs",
+		"CREATE TRIGGER jobs_audit AFTER INSERT ON jobs FOR EACH ROW INSERT INTO audit VALUES (NEW.id)",
+		"CREATE DEFINER = app PROCEDURE apply_jobs() INSERT INTO jobs VALUES (1)",
+		"ALTER FUNCTION next_job_id COMMENT 'changed'",
+		"CREATE EVENT cleanup_jobs DO DELETE FROM jobs",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlDefinesIndirectWriter(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLDefinesIndirectWriter_Absent(t *testing.T) {
+	c := qt.New(t)
+
+	statements := []string{
+		"CREATE TABLE jobs (function_name VARCHAR(32)) ENGINE=InnoDB",
+		"ALTER TABLE jobs ADD COLUMN event_id BIGINT",
+		"DROP VIEW active_jobs",
+	}
+
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			got := mysqlDefinesIndirectWriter(significantSQLTokens(statement, "mysql"))
+			c.Assert(got, qt.IsFalse)
+		})
+	}
+}
+
+func TestMySQLReferencedSchema(t *testing.T) {
+	c := qt.New(t)
+	names := map[string]struct{}{"archive": {}}
+
+	qualified, referenced := mysqlReferencedSchema(
+		significantSQLTokens("INSERT INTO `archive`.jobs VALUES (1)", "mysql"),
+		names,
+	)
+	c.Assert(referenced, qt.IsTrue)
+	c.Assert(qualified, qt.Equals, "archive")
+
+	routine, referenced := mysqlReferencedSchema(
+		significantSQLTokens("INSERT INTO jobs VALUES (archive.next_job_id())", "mysql"),
+		names,
+	)
+	c.Assert(referenced, qt.IsTrue)
+	c.Assert(routine, qt.Equals, "archive")
+
+	unqualified, referenced := mysqlReferencedSchema(
+		significantSQLTokens("SELECT archive FROM jobs", "mysql"),
+		names,
+	)
+	c.Assert(referenced, qt.IsFalse)
+	c.Assert(unqualified, qt.Equals, "")
+
+	alias, referenced := mysqlReferencedSchema(
+		significantSQLTokens("SELECT archive.id FROM jobs AS archive", "mysql"),
+		names,
+	)
+	c.Assert(referenced, qt.IsFalse)
+	c.Assert(alias, qt.Equals, "")
+}
+
+func TestMySQLReferencedCatalogName(t *testing.T) {
+	c := qt.New(t)
+	names := map[string]struct{}{"active_jobs": {}}
+
+	statements := []string{
+		"INSERT INTO active_jobs VALUES (1)",
+		"INSERT LOW_PRIORITY active_jobs VALUES (1)",
+		"UPDATE IGNORE active_jobs SET id = 1",
+		"WITH pending AS (SELECT 1) UPDATE IGNORE active_jobs SET id = 1",
+		"SELECT * FROM active_jobs",
+		"SELECT * FROM jobs JOIN active_jobs ON active_jobs.id = jobs.id",
+		"SELECT * FROM jobs, active_jobs",
+		"SELECT * FROM ptahtest.active_jobs",
+	}
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			relation, referenced := mysqlReferencedCatalogName(significantSQLTokens(statement, "mysql"), names)
+			c.Assert(referenced, qt.IsTrue)
+			c.Assert(relation, qt.Equals, "active_jobs")
+		})
+	}
+}
+
+func TestMySQLReferencedCatalogName_IgnoresNonRelationIdentifiers(t *testing.T) {
+	c := qt.New(t)
+	names := map[string]struct{}{"active_jobs": {}}
+
+	statements := []string{
+		"SELECT active_jobs FROM jobs",
+		"INSERT INTO jobs (active_jobs) VALUES (1)",
+		"UPDATE jobs SET active_jobs = 1",
+		"CREATE TABLE jobs (active_jobs INT)",
+	}
+	for _, statement := range statements {
+		c.Run(statement, func(c *qt.C) {
+			relation, referenced := mysqlReferencedCatalogName(significantSQLTokens(statement, "mysql"), names)
+			c.Assert(referenced, qt.IsFalse)
+			c.Assert(relation, qt.Equals, "")
+		})
+	}
+}
+
+func TestMySQLInvokedRoutine(t *testing.T) {
+	c := qt.New(t)
+	routines := map[string]struct{}{"next_job_id": {}}
+
+	invoked, found := mysqlInvokedRoutine(
+		significantSQLTokens("INSERT INTO jobs VALUES (next_job_id())", "mysql"),
+		routines,
+	)
+	c.Assert(found, qt.IsTrue)
+	c.Assert(invoked, qt.Equals, "next_job_id")
+
+	identifier, found := mysqlInvokedRoutine(
+		significantSQLTokens("SELECT next_job_id FROM jobs", "mysql"),
+		routines,
+	)
+	c.Assert(found, qt.IsFalse)
+	c.Assert(identifier, qt.Equals, "")
+}
+
+func TestMigrationHasSQLExecutor(t *testing.T) {
+	c := qt.New(t)
+	sqlMigration := CreateMigrationFromSQL(1, "sql", "SELECT 1", "SELECT 1")
+	opaqueMigration := &Migration{Up: NoopMigrationFunc, Down: NoopMigrationFunc}
+
+	c.Assert(sqlMigration.hasSQLExecutor(MigrationDirectionUp), qt.IsTrue)
+	c.Assert(sqlMigration.hasSQLExecutor(MigrationDirectionDown), qt.IsTrue)
+	c.Assert(opaqueMigration.hasSQLExecutor(MigrationDirectionUp), qt.IsFalse)
+	c.Assert(opaqueMigration.hasSQLExecutor(MigrationDirectionDown), qt.IsFalse)
+}
+
+func TestMigrationHasStatementInterceptor(t *testing.T) {
+	c := qt.New(t)
+	migration := &Migration{upHasStatementInterceptor: true}
+
+	c.Assert(migration.hasStatementInterceptor(MigrationDirectionUp), qt.IsTrue)
+	c.Assert(migration.hasStatementInterceptor(MigrationDirectionDown), qt.IsFalse)
 }
 
 func TestMySQLCreateTableLike_Present(t *testing.T) {
@@ -220,6 +446,35 @@ func TestRolledBackApplied(t *testing.T) {
 			c.Assert(got, qt.Equals, tt.want)
 		})
 	}
+}
+
+func TestPreservesProgressWitnessUnknownOutcome(t *testing.T) {
+	c := qt.New(t)
+
+	c.Assert(
+		preservesProgressWitnessUnknownOutcome(
+			&MigrationExecutionError{Statement: "CALL apply_changes()"},
+			&MigrationRevision{Error: unknownStatementOutcomeError},
+			"mysql",
+		),
+		qt.IsTrue,
+	)
+	c.Assert(
+		preservesProgressWitnessUnknownOutcome(
+			&MigrationExecutionError{Statement: "INSERT INTO jobs VALUES (1)"},
+			&MigrationRevision{Error: unknownStatementOutcomeError},
+			"mysql",
+		),
+		qt.IsFalse,
+	)
+	c.Assert(
+		preservesProgressWitnessUnknownOutcome(
+			&MigrationExecutionError{Statement: "INSERT INTO jobs VALUES (1)"},
+			&MigrationRevision{Error: "statement failed"},
+			"mysql",
+		),
+		qt.IsFalse,
+	)
 }
 
 // TestMigrationExecutionProgress_RolledBackMySQLBody walks the same correction

--- a/migration/migrator/implicit_commit_internal_test.go
+++ b/migration/migrator/implicit_commit_internal_test.go
@@ -197,37 +197,119 @@ func TestMySQLDefinesIndirectWriter_Absent(t *testing.T) {
 	}
 }
 
-func TestMySQLReferencedSchema(t *testing.T) {
+func TestMySQLReferencedExternalSchema(t *testing.T) {
 	c := qt.New(t)
-	names := map[string]struct{}{"archive": {}}
 
-	qualified, referenced := mysqlReferencedSchema(
+	qualified, referenced := mysqlReferencedExternalSchema(
 		significantSQLTokens("INSERT INTO `archive`.jobs VALUES (1)", "mysql"),
-		names,
+		"ptahtest",
 	)
 	c.Assert(referenced, qt.IsTrue)
 	c.Assert(qualified, qt.Equals, "archive")
 
-	routine, referenced := mysqlReferencedSchema(
+	routine, referenced := mysqlReferencedExternalSchema(
 		significantSQLTokens("INSERT INTO jobs VALUES (archive.next_job_id())", "mysql"),
-		names,
+		"ptahtest",
 	)
 	c.Assert(referenced, qt.IsTrue)
 	c.Assert(routine, qt.Equals, "archive")
 
-	unqualified, referenced := mysqlReferencedSchema(
+	selected, referenced := mysqlReferencedExternalSchema(
+		significantSQLTokens("INSERT INTO ptahtest.jobs VALUES (1)", "mysql"),
+		"ptahtest",
+	)
+	c.Assert(referenced, qt.IsFalse)
+	c.Assert(selected, qt.Equals, "")
+
+	caseVariant, referenced := mysqlReferencedExternalSchema(
+		significantSQLTokens("INSERT INTO PTAHTEST.jobs VALUES (1)", "mysql"),
+		"ptahtest",
+	)
+	c.Assert(referenced, qt.IsTrue)
+	c.Assert(caseVariant, qt.Equals, "PTAHTEST")
+
+	unqualified, referenced := mysqlReferencedExternalSchema(
 		significantSQLTokens("SELECT archive FROM jobs", "mysql"),
-		names,
+		"ptahtest",
 	)
 	c.Assert(referenced, qt.IsFalse)
 	c.Assert(unqualified, qt.Equals, "")
 
-	alias, referenced := mysqlReferencedSchema(
+	alias, referenced := mysqlReferencedExternalSchema(
 		significantSQLTokens("SELECT archive.id FROM jobs AS archive", "mysql"),
-		names,
+		"ptahtest",
 	)
 	c.Assert(referenced, qt.IsFalse)
 	c.Assert(alias, qt.Equals, "")
+}
+
+func TestMySQLGrantsProvideTriggerCatalogVisibility_HappyPath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		grants []string
+	}{
+		{
+			name:   "database trigger",
+			grants: []string{"GRANT SELECT, INSERT, TRIGGER ON `ptahtest`.* TO `ptah`@`%`"},
+		},
+		{
+			name:   "global all privileges",
+			grants: []string{"GRANT ALL PRIVILEGES ON *.* TO `ptah`@`%`"},
+		},
+		{
+			name:   "active role expanded by server",
+			grants: []string{"GRANT TRIGGER ON `ptahtest`.* TO `ptah_trigger_role`"},
+		},
+		{
+			name:   "ANSI quotes session",
+			grants: []string{`GRANT ALL PRIVILEGES ON "ptahtest".* TO "ptah"@"%"`},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			visible := mysqlGrantsProvideTriggerCatalogVisibility(test.grants, "ptahtest", "mysql")
+			c.Assert(visible, qt.IsTrue)
+		})
+	}
+}
+
+func TestMySQLGrantsProvideTriggerCatalogVisibility_FailurePath(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name   string
+		grants []string
+	}{
+		{
+			name:   "no trigger privilege",
+			grants: []string{"GRANT SELECT, INSERT ON `ptahtest`.* TO `ptah`@`%`"},
+		},
+		{
+			name:   "different database",
+			grants: []string{"GRANT TRIGGER ON `archive`.* TO `ptah`@`%`"},
+		},
+		{
+			name:   "table scope is incomplete",
+			grants: []string{"GRANT TRIGGER ON `ptahtest`.`jobs` TO `ptah`@`%`"},
+		},
+		{
+			name: "partial revoke",
+			grants: []string{
+				"GRANT ALL PRIVILEGES ON *.* TO `ptah`@`%`",
+				"REVOKE TRIGGER ON `ptahtest`.* FROM `ptah`@`%`",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			visible := mysqlGrantsProvideTriggerCatalogVisibility(test.grants, "ptahtest", "mysql")
+			c.Assert(visible, qt.IsFalse)
+		})
+	}
 }
 
 func TestMySQLReferencedCatalogName(t *testing.T) {

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -2,6 +2,8 @@ package migrator
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -60,6 +62,64 @@ func (m *Migrator) migrationsTableUsesLegacyRevisionLayout(ctx context.Context) 
 		return false, fmt.Errorf("incomplete migrations metadata layout: missing columns %s", strings.Join(missing, ", "))
 	}
 	return false, nil
+}
+
+func (m *Migrator) requireTransactionalMetadataEngine(ctx context.Context) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return nil
+	}
+	schema := configuredOrConnectionSchema(m.metadataTableSchemaName(), m.connectionSchemaName())
+	var engine string
+	err := m.conn.QueryRowContext(ctx, `SELECT engine
+FROM information_schema.tables
+WHERE table_schema = ? AND table_name = ? AND table_type = 'BASE TABLE'`, schema, m.migrationsTableName()).Scan(&engine)
+	if err != nil {
+		return fmt.Errorf("failed to inspect migrations metadata storage engine: %w", err)
+	}
+	if !strings.EqualFold(engine, "InnoDB") {
+		return fmt.Errorf(
+			"migrations metadata table %s must use InnoDB to track MySQL-family implicit commits; found %s",
+			m.qualifiedMigrationsTable(),
+			engine,
+		)
+	}
+	return nil
+}
+
+func (m *Migrator) requireTransactionalTargetEngines(ctx context.Context) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return nil
+	}
+	var defaultEngine string
+	if err := m.conn.QueryRowContext(ctx, "SELECT @@SESSION.default_storage_engine").Scan(&defaultEngine); err != nil {
+		return fmt.Errorf("failed to inspect MySQL-family default storage engine: %w", err)
+	}
+	if !strings.EqualFold(defaultEngine, "InnoDB") {
+		return fmt.Errorf(
+			"tx-mode file requires InnoDB on MySQL-family databases; default storage engine is %s",
+			defaultEngine,
+		)
+	}
+	schema := m.connectionSchemaName()
+	var table, engine string
+	err := m.conn.QueryRowContext(ctx, `SELECT table_name, engine
+FROM information_schema.tables
+WHERE table_schema = ? AND table_type = 'BASE TABLE'
+  AND UPPER(COALESCE(engine, '')) <> 'INNODB'
+ORDER BY table_name
+LIMIT 1`, schema).Scan(&table, &engine)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("failed to inspect MySQL-family target table storage engines: %w", err)
+	}
+	return fmt.Errorf(
+		"tx-mode file requires InnoDB target tables on MySQL-family databases; table %s.%s uses %s",
+		schema,
+		table,
+		engine,
+	)
 }
 
 func missingMetadataColumns(present map[string]struct{}, required []string) []string {

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -125,7 +125,6 @@ LIMIT 1`, schema).Scan(&table, &engine)
 }
 
 type mysqlTransactionalCatalog struct {
-	otherSchemas    map[string]struct{}
 	unsafeRelations map[string]struct{}
 	routines        map[string]struct{}
 }
@@ -145,7 +144,7 @@ func (m *Migrator) requireTransactionalTargetIsolation(
 	statements := splitSQLStatementsForConnection(m.conn, migrationSQLForDirection(migration, direction))
 	for i, statement := range statements {
 		tokens := significantSQLTokens(statement, m.connectionDialect())
-		if schema, referenced := mysqlReferencedSchema(tokens, catalog.otherSchemas); referenced {
+		if schema, referenced := mysqlReferencedExternalSchema(tokens, m.connectionSchemaName()); referenced {
 			return fmt.Errorf(
 				"migration %d cannot run tx-mode file statement %d because it references database %s outside "+
 					"the selected database; use a connection scoped to that database or tx-mode none",
@@ -179,21 +178,15 @@ func (m *Migrator) requireTransactionalTargetIsolation(
 func (m *Migrator) loadMySQLTransactionalCatalog(ctx context.Context) (mysqlTransactionalCatalog, error) {
 	schema := m.connectionSchemaName()
 	catalog := mysqlTransactionalCatalog{
-		otherSchemas:    make(map[string]struct{}),
 		unsafeRelations: make(map[string]struct{}),
 		routines:        make(map[string]struct{}),
 	}
-	if err := m.collectMySQLCatalogNames(
-		ctx,
-		"SELECT schema_name FROM information_schema.schemata WHERE LOWER(schema_name) <> LOWER(?)",
-		[]any{schema},
-		func(name string) { catalog.otherSchemas[strings.ToLower(name)] = struct{}{} },
-	); err != nil {
-		return mysqlTransactionalCatalog{}, fmt.Errorf("failed to inspect MySQL-family database boundaries: %w", err)
+	if err := m.requireMySQLTriggerCatalogVisibility(ctx, schema); err != nil {
+		return mysqlTransactionalCatalog{}, err
 	}
 	if err := m.collectMySQLCatalogNames(
 		ctx,
-		"SELECT table_name FROM information_schema.views WHERE table_schema = ?",
+		"SELECT table_name FROM information_schema.tables WHERE table_schema = ? AND table_type = 'VIEW'",
 		[]any{schema},
 		func(name string) { catalog.unsafeRelations[strings.ToLower(name)] = struct{}{} },
 	); err != nil {
@@ -218,6 +211,88 @@ func (m *Migrator) loadMySQLTransactionalCatalog(ctx context.Context) (mysqlTran
 	return catalog, nil
 }
 
+func (m *Migrator) requireMySQLTriggerCatalogVisibility(ctx context.Context, schema string) error {
+	rows, err := m.conn.QueryContext(ctx, "SHOW GRANTS")
+	if err != nil {
+		return fmt.Errorf("failed to prove MySQL-family trigger catalog visibility: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	grants := []string{}
+	for rows.Next() {
+		var grant string
+		if err := rows.Scan(&grant); err != nil {
+			return fmt.Errorf("failed to scan MySQL-family grants: %w", err)
+		}
+		grants = append(grants, grant)
+	}
+	if err := rows.Err(); err != nil {
+		return fmt.Errorf("failed to inspect MySQL-family grants: %w", err)
+	}
+	if !mysqlGrantsProvideTriggerCatalogVisibility(grants, schema, m.connectionDialect()) {
+		return fmt.Errorf(
+			"tx-mode file requires the TRIGGER privilege at database or global scope on MySQL-family databases " +
+				"so Ptah can prove that target tables have no hidden indirect writers",
+		)
+	}
+	return nil
+}
+
+func mysqlGrantsProvideTriggerCatalogVisibility(grants []string, schema, dialect string) bool {
+	provided := false
+	revoked := false
+	for _, grant := range grants {
+		tokens := significantSQLTokens(grant, dialect)
+		if mysqlPrivilegeStatementCoversSchema(tokens, "GRANT", schema) {
+			provided = true
+		}
+		if mysqlPrivilegeStatementCoversSchema(tokens, "REVOKE", schema) {
+			revoked = true
+		}
+	}
+	return provided && !revoked
+}
+
+func mysqlPrivilegeStatementCoversSchema(tokens []lexer.Token, verb, schema string) bool {
+	if len(tokens) == 0 || !tokens[0].MatchIdentifierValue(verb) {
+		return false
+	}
+	on := -1
+	hasTrigger := false
+	for i, token := range tokens[1:] {
+		if token.MatchIdentifierValue("ON") {
+			on = i + 1
+			break
+		}
+		if matchesAnyKeyword(token, "ALL", "TRIGGER") {
+			hasTrigger = true
+		}
+	}
+	if !hasTrigger || on < 0 || on+3 >= len(tokens) || tokens[on+2].Value != "." || tokens[on+3].Value != "*" {
+		return false
+	}
+	if tokens[on+1].Value == "*" {
+		return true
+	}
+	grantedSchema, identifier := mysqlGrantSchemaValue(tokens[on+1])
+	return identifier && grantedSchema == schema
+}
+
+// mysqlGrantSchemaValue accepts ANSI_QUOTES output because SHOW GRANTS uses
+// the session SQL mode when it renders identifiers. This decoder is deliberately
+// local to server-generated grants; double quotes remain string delimiters in
+// ordinary MySQL migration SQL unless the session explicitly changes that mode.
+func mysqlGrantSchemaValue(token lexer.Token) (string, bool) {
+	if value, identifier := mysqlIdentifierValue(token); identifier {
+		return value, true
+	}
+	if token.Type != lexer.TokenString || len(token.Value) < 2 ||
+		token.Value[0] != '"' || token.Value[len(token.Value)-1] != '"' {
+		return "", false
+	}
+	return strings.ReplaceAll(token.Value[1:len(token.Value)-1], `""`, `"`), true
+}
+
 func (m *Migrator) collectMySQLCatalogNames(
 	ctx context.Context,
 	query string,
@@ -239,7 +314,7 @@ func (m *Migrator) collectMySQLCatalogNames(
 	return rows.Err()
 }
 
-func mysqlReferencedSchema(tokens []lexer.Token, names map[string]struct{}) (string, bool) {
+func mysqlReferencedExternalSchema(tokens []lexer.Token, selectedSchema string) (string, bool) {
 	for i, token := range tokens {
 		name, identifier := mysqlIdentifierValue(token)
 		if !identifier || i+2 >= len(tokens) || tokens[i+1].Value != "." {
@@ -253,7 +328,7 @@ func mysqlReferencedSchema(tokens []lexer.Token, names map[string]struct{}) (str
 		if !relationReference && !routineReference {
 			continue
 		}
-		if _, known := names[strings.ToLower(name)]; known {
+		if name != selectedSchema {
 			return name, true
 		}
 	}

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -275,7 +275,70 @@ func mysqlPrivilegeStatementCoversSchema(tokens []lexer.Token, verb, schema stri
 		return true
 	}
 	grantedSchema, identifier := mysqlGrantSchemaValue(tokens[on+1])
-	return identifier && grantedSchema == schema
+	return identifier && mysqlGrantSchemaPatternMatches(grantedSchema, schema)
+}
+
+// mysqlGrantSchemaPatternMatches reports whether the database of a schema-level
+// GRANT or REVOKE covers schema.
+//
+// A schema-level privilege stores its database as a pattern, not as a name:
+// `_` matches one character, `%` matches any run, and a backslash escapes
+// either. Comparing the two as plain strings therefore answers a different
+// question than the server does, and it answers it wrongly in the ordinary
+// case. Granting on a database whose name contains an underscore is documented
+// to require escaping it, the official MySQL and MariaDB container images do
+// exactly that when they provision MYSQL_USER, and `SHOW GRANTS` then prints
+// `ptah\_test` for a privilege that covers `ptah_test`. Reading that as a name
+// makes Ptah refuse tx-mode file for a user who does hold TRIGGER.
+func mysqlGrantSchemaPatternMatches(pattern, schema string) bool {
+	patternRunes := []rune(pattern)
+	schemaRunes := []rune(schema)
+	patternIndex, schemaIndex := 0, 0
+	wildcard, wildcardMatch := -1, 0
+	for schemaIndex < len(schemaRunes) {
+		if consumed, matched := mysqlGrantPatternStep(patternRunes, patternIndex, schemaRunes[schemaIndex]); matched {
+			patternIndex += consumed
+			schemaIndex++
+			continue
+		}
+		if patternIndex < len(patternRunes) && patternRunes[patternIndex] == '%' {
+			wildcard = patternIndex
+			wildcardMatch = schemaIndex
+			patternIndex++
+			continue
+		}
+		if wildcard < 0 {
+			return false
+		}
+		// The last `%` matched too little: give it one more character and retry
+		// the rest of the pattern from there.
+		patternIndex = wildcard + 1
+		wildcardMatch++
+		schemaIndex = wildcardMatch
+	}
+	for patternIndex < len(patternRunes) && patternRunes[patternIndex] == '%' {
+		patternIndex++
+	}
+	return patternIndex == len(patternRunes)
+}
+
+// mysqlGrantPatternStep reports how many pattern runes a single schema rune
+// consumes, and whether it matches at all. A `%` never matches here: it is the
+// backtracking point and belongs to the caller.
+func mysqlGrantPatternStep(pattern []rune, index int, schemaRune rune) (consumed int, matched bool) {
+	if index >= len(pattern) {
+		return 0, false
+	}
+	if pattern[index] == '\\' && index+1 < len(pattern) {
+		return 2, pattern[index+1] == schemaRune
+	}
+	if pattern[index] == '_' {
+		return 1, true
+	}
+	if pattern[index] == '%' {
+		return 0, false
+	}
+	return 1, pattern[index] == schemaRune
 }
 
 // mysqlGrantSchemaValue accepts ANSI_QUOTES output because SHOW GRANTS uses

--- a/migration/migrator/metadata_presence.go
+++ b/migration/migrator/metadata_presence.go
@@ -5,10 +5,12 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"slices"
 	"strings"
 
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/sqlutil"
+	"go.5x5.cz/ptah/internal/lexer"
 )
 
 func (m *Migrator) migrationsTableExists(ctx context.Context) (bool, error) {
@@ -120,6 +122,234 @@ LIMIT 1`, schema).Scan(&table, &engine)
 		table,
 		engine,
 	)
+}
+
+type mysqlTransactionalCatalog struct {
+	otherSchemas    map[string]struct{}
+	unsafeRelations map[string]struct{}
+	routines        map[string]struct{}
+}
+
+func (m *Migrator) requireTransactionalTargetIsolation(
+	ctx context.Context,
+	migration *Migration,
+	direction MigrationDirection,
+) error {
+	if !implicitCommitDialect(m.connectionDialect()) {
+		return nil
+	}
+	catalog, err := m.loadMySQLTransactionalCatalog(ctx)
+	if err != nil {
+		return err
+	}
+	statements := splitSQLStatementsForConnection(m.conn, migrationSQLForDirection(migration, direction))
+	for i, statement := range statements {
+		tokens := significantSQLTokens(statement, m.connectionDialect())
+		if schema, referenced := mysqlReferencedSchema(tokens, catalog.otherSchemas); referenced {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because it references database %s outside "+
+					"the selected database; use a connection scoped to that database or tx-mode none",
+				migration.Version,
+				i+1,
+				schema,
+			)
+		}
+		if relation, referenced := mysqlReferencedCatalogName(tokens, catalog.unsafeRelations); referenced {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because relation %s has indirect behavior "+
+					"that Ptah cannot tie to the transaction witness; use direct InnoDB tables or tx-mode none",
+				migration.Version,
+				i+1,
+				relation,
+			)
+		}
+		if routine, invoked := mysqlInvokedRoutine(tokens, catalog.routines); invoked {
+			return fmt.Errorf(
+				"migration %d cannot run tx-mode file statement %d because routine %s can execute SQL outside "+
+					"Ptah's transaction witness; use direct SQL or tx-mode none",
+				migration.Version,
+				i+1,
+				routine,
+			)
+		}
+	}
+	return nil
+}
+
+func (m *Migrator) loadMySQLTransactionalCatalog(ctx context.Context) (mysqlTransactionalCatalog, error) {
+	schema := m.connectionSchemaName()
+	catalog := mysqlTransactionalCatalog{
+		otherSchemas:    make(map[string]struct{}),
+		unsafeRelations: make(map[string]struct{}),
+		routines:        make(map[string]struct{}),
+	}
+	if err := m.collectMySQLCatalogNames(
+		ctx,
+		"SELECT schema_name FROM information_schema.schemata WHERE LOWER(schema_name) <> LOWER(?)",
+		[]any{schema},
+		func(name string) { catalog.otherSchemas[strings.ToLower(name)] = struct{}{} },
+	); err != nil {
+		return mysqlTransactionalCatalog{}, fmt.Errorf("failed to inspect MySQL-family database boundaries: %w", err)
+	}
+	if err := m.collectMySQLCatalogNames(
+		ctx,
+		"SELECT table_name FROM information_schema.views WHERE table_schema = ?",
+		[]any{schema},
+		func(name string) { catalog.unsafeRelations[strings.ToLower(name)] = struct{}{} },
+	); err != nil {
+		return mysqlTransactionalCatalog{}, fmt.Errorf("failed to inspect MySQL-family views: %w", err)
+	}
+	if err := m.collectMySQLCatalogNames(
+		ctx,
+		"SELECT event_object_table FROM information_schema.triggers WHERE trigger_schema = ?",
+		[]any{schema},
+		func(name string) { catalog.unsafeRelations[strings.ToLower(name)] = struct{}{} },
+	); err != nil {
+		return mysqlTransactionalCatalog{}, fmt.Errorf("failed to inspect MySQL-family triggers: %w", err)
+	}
+	if err := m.collectMySQLCatalogNames(
+		ctx,
+		"SELECT routine_name FROM information_schema.routines WHERE routine_schema = ?",
+		[]any{schema},
+		func(name string) { catalog.routines[strings.ToLower(name)] = struct{}{} },
+	); err != nil {
+		return mysqlTransactionalCatalog{}, fmt.Errorf("failed to inspect MySQL-family routines: %w", err)
+	}
+	return catalog, nil
+}
+
+func (m *Migrator) collectMySQLCatalogNames(
+	ctx context.Context,
+	query string,
+	args []any,
+	collect func(string),
+) error {
+	rows, err := m.conn.QueryContext(ctx, query, args...)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = rows.Close() }()
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return err
+		}
+		collect(name)
+	}
+	return rows.Err()
+}
+
+func mysqlReferencedSchema(tokens []lexer.Token, names map[string]struct{}) (string, bool) {
+	for i, token := range tokens {
+		name, identifier := mysqlIdentifierValue(token)
+		if !identifier || i+2 >= len(tokens) || tokens[i+1].Value != "." {
+			continue
+		}
+		if _, referenced := mysqlIdentifierValue(tokens[i+2]); !referenced {
+			continue
+		}
+		relationReference := mysqlDirectRelationReference(tokens, i)
+		routineReference := i+3 < len(tokens) && tokens[i+3].Value == "("
+		if !relationReference && !routineReference {
+			continue
+		}
+		if _, known := names[strings.ToLower(name)]; known {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func mysqlReferencedCatalogName(tokens []lexer.Token, names map[string]struct{}) (string, bool) {
+	for i, token := range tokens {
+		name, identifier := mysqlIdentifierValue(token)
+		if !identifier {
+			continue
+		}
+		_, known := names[strings.ToLower(name)]
+		if !known || !mysqlRelationReference(tokens, i) {
+			continue
+		}
+		return name, true
+	}
+	return "", false
+}
+
+func mysqlRelationReference(tokens []lexer.Token, index int) bool {
+	if index >= 2 && tokens[index-1].Value == "." {
+		return mysqlDirectRelationReference(tokens, index-2)
+	}
+	return mysqlDirectRelationReference(tokens, index)
+}
+
+func mysqlDirectRelationReference(tokens []lexer.Token, index int) bool {
+	if index > 0 && matchesAnyKeyword(tokens[index-1], "FROM", "JOIN", "INTO", "UPDATE", "TABLE", "USING") {
+		return true
+	}
+	if index > 0 && tokens[index-1].Value == "," && mysqlCommaContinuesRelationList(tokens[:index-1]) {
+		return true
+	}
+	return mysqlFollowsDMLTargetPrefix(tokens[:index])
+}
+
+func mysqlCommaContinuesRelationList(tokens []lexer.Token) bool {
+	depth := 0
+	for _, v := range slices.Backward(tokens) {
+		switch v.Value {
+		case ")":
+			depth++
+		case "(":
+			if depth == 0 {
+				return false
+			}
+			depth--
+		}
+		if depth != 0 || v.Type != lexer.TokenIdentifier {
+			continue
+		}
+		if matchesAnyKeyword(v, "FROM", "UPDATE", "USING") {
+			return true
+		}
+		if matchesAnyKeyword(v, "SELECT", "SET", "VALUES", "WHERE", "GROUP", "HAVING", "ORDER", "LIMIT") {
+			return false
+		}
+	}
+	return false
+}
+
+func mysqlFollowsDMLTargetPrefix(tokens []lexer.Token) bool {
+	for _, v := range slices.Backward(tokens) {
+		token := v
+		if matchesAnyKeyword(token, "LOW_PRIORITY", "DELAYED", "HIGH_PRIORITY", "IGNORE", "INTO") {
+			continue
+		}
+		return matchesAnyKeyword(token, "INSERT", "REPLACE", "UPDATE")
+	}
+	return false
+}
+
+func mysqlInvokedRoutine(tokens []lexer.Token, routines map[string]struct{}) (string, bool) {
+	for i, token := range tokens {
+		name, identifier := mysqlIdentifierValue(token)
+		if !identifier || i+1 >= len(tokens) || tokens[i+1].Value != "(" {
+			continue
+		}
+		if _, known := routines[strings.ToLower(name)]; known {
+			return name, true
+		}
+	}
+	return "", false
+}
+
+func mysqlIdentifierValue(token lexer.Token) (string, bool) {
+	if token.Type != lexer.TokenIdentifier {
+		return "", false
+	}
+	value := token.Value
+	if len(value) >= 2 && value[0] == '`' && value[len(value)-1] == '`' {
+		return strings.ReplaceAll(value[1:len(value)-1], "``", "`"), true
+	}
+	return value, true
 }
 
 func missingMetadataColumns(present map[string]struct{}, required []string) []string {

--- a/migration/migrator/migration_provider.go
+++ b/migration/migrator/migration_provider.go
@@ -395,6 +395,7 @@ func setMigrationUp(migration *Migration, up sqlMigrationFile) {
 		return up.fn(ctx, conn, migration.upExecutionMode())
 	}
 	migration.upSQLFunc = up.fn
+	migration.upHasStatementInterceptor = up.statementIntercepted
 	migration.UpSQL = up.sql
 	migration.atlasCheckFiles = up.checkFiles
 	migration.UpTimeouts = up.timeouts
@@ -417,6 +418,7 @@ func setMigrationDown(migration *Migration, down sqlMigrationFile) {
 		return down.fn(ctx, conn, migration.downExecutionMode())
 	}
 	migration.downSQLFunc = down.fn
+	migration.downHasStatementInterceptor = down.statementIntercepted
 	migration.DownSQL = down.sql
 	migration.DownTimeouts = down.timeouts
 	migration.DownTxMode = down.txMode

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -275,13 +275,14 @@ const (
 type sqlMigrationFunc func(context.Context, *dbschema.DatabaseConnection, migrationExecutionMode) error
 
 type sqlMigrationFile struct {
-	fn           sqlMigrationFunc
-	sql          string
-	sourcePath   string
-	timeouts     MigrationTimeouts
-	txMode       MigrationFileTxMode
-	txModeSource migrationFileTxModeSource
-	txModeErr    error
+	fn                   sqlMigrationFunc
+	sql                  string
+	sourcePath           string
+	timeouts             MigrationTimeouts
+	txMode               MigrationFileTxMode
+	txModeSource         migrationFileTxModeSource
+	txModeErr            error
+	statementIntercepted bool
 	// checkFiles are the raw Atlas txtar checks.sql and checks/*.sql sections.
 	// They remain unsplit until execution, when the target dialect is known.
 	checkFiles []atlasTxtarCheckFile
@@ -501,12 +502,13 @@ func migrationFuncFromSQLStringWithMetadata(filename, sql string, hooks statemen
 		fn: func(ctx context.Context, conn *dbschema.DatabaseConnection, mode migrationExecutionMode) error {
 			return executeMigrationFileSQL(ctx, conn, filename, sql, hooks, mode)
 		},
-		sql:          sql,
-		sourcePath:   filename,
-		timeouts:     timeouts,
-		txMode:       txMode.mode,
-		txModeSource: txMode.source,
-		txModeErr:    txMode.err,
+		sql:                  sql,
+		sourcePath:           filename,
+		timeouts:             timeouts,
+		txMode:               txMode.mode,
+		txModeSource:         txMode.source,
+		txModeErr:            txMode.err,
+		statementIntercepted: hooks.interceptor != nil,
 	}, nil
 }
 
@@ -700,15 +702,17 @@ type Migration struct {
 	UpTxMode MigrationFileTxMode
 	// DownTxMode is the down-direction counterpart to UpTxMode. Rollback has no
 	// global transaction-mode flag, so the zero value behaves like file.
-	DownTxMode       MigrationFileTxMode
-	upTxModeSource   migrationFileTxModeSource
-	downTxModeSource migrationFileTxModeSource
-	upTxModeErr      error
-	downTxModeErr    error
-	upSourcePath     string
-	downSourcePath   string
-	upSQLFunc        sqlMigrationFunc
-	downSQLFunc      sqlMigrationFunc
+	DownTxMode                  MigrationFileTxMode
+	upTxModeSource              migrationFileTxModeSource
+	downTxModeSource            migrationFileTxModeSource
+	upTxModeErr                 error
+	downTxModeErr               error
+	upSourcePath                string
+	downSourcePath              string
+	upSQLFunc                   sqlMigrationFunc
+	downSQLFunc                 sqlMigrationFunc
+	upHasStatementInterceptor   bool
+	downHasStatementInterceptor bool
 	// atlasCheckFiles are raw Atlas txtar checks.sql and checks/*.sql sections.
 	// They are parsed with the live connection dialect before `-- +ptah check`
 	// directives in UpSQL, preventing dialect-blind boundary decisions.

--- a/migration/migrator/migrations.go
+++ b/migration/migrator/migrations.go
@@ -174,8 +174,12 @@ func migrationStatementAlreadyApplied(ctx context.Context, index int) bool {
 }
 
 func migrationAppliedFloor(ctx context.Context) int {
+	return migrationResumeFrom(ctx) - 1
+}
+
+func migrationResumeFrom(ctx context.Context) int {
 	resumeFrom, _ := ctx.Value(migrationResumeContextKey{}).(int)
-	return max(resumeFrom-1, 0)
+	return max(resumeFrom, 1)
 }
 
 type statementProgressError struct {

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -1827,6 +1827,9 @@ func (m *Migrator) applyUpMigrationObserved(
 		if err := m.requireTransactionalTargetEngines(ctx); err != nil {
 			return false, err
 		}
+		if err := m.requireTransactionalTargetIsolation(ctx, migration, MigrationDirectionUp); err != nil {
+			return false, err
+		}
 	}
 	plan, err := m.planUpRetry(ctx, migration)
 	if err != nil {
@@ -2136,6 +2139,9 @@ func (m *Migrator) withTransactionalMigrationSession(
 		if err := scoped.requireTransactionalTargetEngines(ctx); err != nil {
 			return err
 		}
+		if err := scoped.requireTransactionalTargetIsolation(ctx, migration, direction); err != nil {
+			return err
+		}
 		return use(&scoped)
 	})
 }
@@ -2280,16 +2286,22 @@ func (m *Migrator) rollbackMigrationObserved(ctx context.Context, migration *Mig
 		}
 		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
 	}
-	if usesTransactionalProgressWitness(m.connectionDialect(), txMode) {
+	usesWitness := usesTransactionalProgressWitness(m.connectionDialect(), txMode)
+	if usesWitness {
 		if err := m.validateTransactionalProgressSQL(migration, MigrationDirectionDown); err != nil {
 			return err
 		}
 		if err := m.requireTransactionalTargetEngines(ctx); err != nil {
 			return err
 		}
+		if err := m.requireTransactionalTargetIsolation(ctx, migration, MigrationDirectionDown); err != nil {
+			return err
+		}
 	}
-	if err := m.beginRollbackRevision(ctx, migration, startedAt); err != nil {
-		return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
+	if !usesWitness || m.conn.Writer().IsDryRun() {
+		if err := m.beginRollbackRevision(ctx, migration, startedAt); err != nil {
+			return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
+		}
 	}
 	return m.rollbackMigrationTransactional(ctx, migration, startedAt, deleteSQL)
 }
@@ -2333,6 +2345,9 @@ func (m *Migrator) rollbackMigrationTransactional(
 			migration,
 			MigrationDirectionDown,
 			func(scoped *Migrator) error {
+				if err := scoped.beginRollbackRevision(ctx, migration, startedAt); err != nil {
+					return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
+				}
 				return scoped.rollbackMigrationTransactionalOnSession(ctx, migration, startedAt, deleteSQL)
 			},
 		)

--- a/migration/migrator/migrator.go
+++ b/migration/migrator/migrator.go
@@ -544,6 +544,10 @@ BEGIN
     )
 END`, sqlStringLiteral(m.sqlServerObjectName()), m.qualifiedMigrationsTable())
 	}
+	engineClause := ""
+	if implicitCommitDialect(m.connectionDialect()) {
+		engineClause = " ENGINE=InnoDB"
+	}
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
     version BIGINT PRIMARY KEY,
     description TEXT NOT NULL,
@@ -555,7 +559,7 @@ END`, sqlStringLiteral(m.sqlServerObjectName()), m.qualifiedMigrationsTable())
     error_stmt TEXT NULL,
     execution_time_ms BIGINT NOT NULL DEFAULT 0,
     checksum VARCHAR(64) NOT NULL DEFAULT ''
-)`, m.qualifiedMigrationsTable())
+)%s`, m.qualifiedMigrationsTable(), engineClause)
 }
 
 func (m *Migrator) getVersionSQL() string {
@@ -623,6 +627,12 @@ func (m *Migrator) Initialize(ctx context.Context) error {
 	if _, err := m.conn.ExecContext(ctx, m.createMigrationsTableSQL()); err != nil {
 		return fmt.Errorf("failed to create migrations table: %w", err)
 	}
+	// Check the engine before upgrading an existing table. ALTER TABLE itself
+	// commits on the MySQL family, so validating afterward could mutate metadata
+	// that Ptah has already decided is unsafe to use as a transaction witness.
+	if err := m.requireTransactionalMetadataEngine(ctx); err != nil {
+		return err
+	}
 	if !m.revisionTableFormat.isAtlas() {
 		if err := m.ensureMigrationsVersionColumn(ctx); err != nil {
 			return fmt.Errorf("failed to prepare migrations version column: %w", err)
@@ -670,6 +680,9 @@ func (m *Migrator) inspectDryRunMetadata(ctx context.Context) (available, legacy
 	}
 	if !exists {
 		return false, false, nil
+	}
+	if err := m.requireTransactionalMetadataEngine(ctx); err != nil {
+		return false, false, err
 	}
 	if m.revisionTableFormat.isAtlas() {
 		return true, false, nil
@@ -1807,6 +1820,14 @@ func (m *Migrator) applyUpMigrationObserved(
 			return false, err
 		}
 	}
+	if usesTransactionalProgressWitness(m.connectionDialect(), txMode) {
+		if err := m.validateTransactionalProgressSQL(migration, MigrationDirectionUp); err != nil {
+			return false, err
+		}
+		if err := m.requireTransactionalTargetEngines(ctx); err != nil {
+			return false, err
+		}
+	}
 	plan, err := m.planUpRetry(ctx, migration)
 	if err != nil {
 		return false, err
@@ -1831,6 +1852,10 @@ func (m *Migrator) applyUpMigrationObserved(
 	}
 	if txMode == MigrationTxModeNone {
 		return checksDeferred, m.applyUpMigrationNoTransaction(ctx, migration, startedAt, plan)
+	}
+	if usesTransactionalProgressWitness(m.connectionDialect(), txMode) && !m.conn.Writer().IsDryRun() {
+		ctx = withMigrationResume(ctx, plan.resumeFrom)
+		return checksDeferred, m.applyUpMigrationTransactionalWithPlan(ctx, migration, startedAt, plan)
 	}
 	if err := m.recordPendingMigrationRevisionOn(ctx, m.conn, migration, startedAt, plan); err != nil {
 		return false, fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
@@ -1960,6 +1985,40 @@ func (m *Migrator) recordAppliedMigrationOn(
 }
 
 func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration *Migration, startedAt time.Time) error {
+	return m.applyUpMigrationTransactionalOnSession(ctx, migration, startedAt)
+}
+
+func (m *Migrator) applyUpMigrationTransactionalWithPlan(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	plan upRetryPlan,
+) error {
+	return m.withTransactionalMigrationSession(
+		ctx,
+		migration,
+		MigrationDirectionUp,
+		func(scoped *Migrator) error {
+			if err := scoped.recordPendingMigrationRevisionOn(ctx, scoped.conn, migration, startedAt, plan); err != nil {
+				return fmt.Errorf("failed to record pending migration %d: %w", migration.Version, err)
+			}
+			if plan.resumeFrom > 1 {
+				scoped.logger.Info(
+					"Resuming migration after a partially applied attempt",
+					"version", migration.Version,
+					"resumeFromStatement", plan.resumeFrom,
+				)
+			}
+			return scoped.applyUpMigrationTransactionalOnSession(ctx, migration, startedAt)
+		},
+	)
+}
+
+func (m *Migrator) applyUpMigrationTransactionalOnSession(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+) error {
 	scoped := *m
 	// Pre-migration checks already ran in runPreMigrationChecks, before this
 	// migration had any revision row: they read committed state on the pool, so
@@ -1992,7 +2051,14 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 		)
 	}
 
-	executionCtx := scoped.withPostgresIndexObservation(ctx, txConn)
+	executionCtx := scoped.withTransactionalProgressRecorder(
+		ctx,
+		txConn,
+		migration,
+		startedAt,
+		MigrationDirectionUp,
+	)
+	executionCtx = scoped.withPostgresIndexObservation(executionCtx, txConn)
 	if err := migration.executeUp(executionCtx, txConn, migrationExecutionTransactional); err != nil {
 		err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
 		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
@@ -2045,6 +2111,33 @@ func (m *Migrator) applyUpMigrationTransactional(ctx context.Context, migration 
 	}
 	m.logger.Info("Applied migration", "version", migration.Version, "description", migration.Description)
 	return nil
+}
+
+func (m *Migrator) withTransactionalMigrationSession(
+	ctx context.Context,
+	migration *Migration,
+	direction MigrationDirection,
+	use func(*Migrator) error,
+) error {
+	return m.conn.WithSession(ctx, func(conn *dbschema.DatabaseConnection) error {
+		scoped := *m
+		scoped.conn = conn
+		if scoped.migrationsSchema == "" {
+			scoped.migrationsSchema = scoped.connectionSchemaName()
+		}
+		if err := scoped.restoreNoTransactionSessionPrefix(
+			ctx,
+			migration,
+			direction,
+			migrationResumeFrom(ctx),
+		); err != nil {
+			return fmt.Errorf("failed to restore session state for migration %d: %w", migration.Version, err)
+		}
+		if err := scoped.requireTransactionalTargetEngines(ctx); err != nil {
+			return err
+		}
+		return use(&scoped)
+	})
 }
 
 type migrationTransactionRolledBackError struct {
@@ -2187,6 +2280,14 @@ func (m *Migrator) rollbackMigrationObserved(ctx context.Context, migration *Mig
 		}
 		return m.rollbackMigrationNoTransaction(ctx, migration, startedAt, deleteSQL)
 	}
+	if usesTransactionalProgressWitness(m.connectionDialect(), txMode) {
+		if err := m.validateTransactionalProgressSQL(migration, MigrationDirectionDown); err != nil {
+			return err
+		}
+		if err := m.requireTransactionalTargetEngines(ctx); err != nil {
+			return err
+		}
+	}
 	if err := m.beginRollbackRevision(ctx, migration, startedAt); err != nil {
 		return fmt.Errorf("failed to record pending rollback %d: %w", migration.Version, err)
 	}
@@ -2226,6 +2327,25 @@ func (m *Migrator) rollbackMigrationTransactional(
 	startedAt time.Time,
 	deleteSQL string,
 ) error {
+	if usesTransactionalProgressWitness(m.connectionDialect(), MigrationTxModeFile) && !m.conn.Writer().IsDryRun() {
+		return m.withTransactionalMigrationSession(
+			ctx,
+			migration,
+			MigrationDirectionDown,
+			func(scoped *Migrator) error {
+				return scoped.rollbackMigrationTransactionalOnSession(ctx, migration, startedAt, deleteSQL)
+			},
+		)
+	}
+	return m.rollbackMigrationTransactionalOnSession(ctx, migration, startedAt, deleteSQL)
+}
+
+func (m *Migrator) rollbackMigrationTransactionalOnSession(
+	ctx context.Context,
+	migration *Migration,
+	startedAt time.Time,
+	deleteSQL string,
+) error {
 	scoped := *m
 	tx, err := m.conn.SchemaWriter().BeginTransaction(ctx)
 	if err != nil {
@@ -2242,7 +2362,7 @@ func (m *Migrator) rollbackMigrationTransactional(
 
 	restoreTimeouts, err := m.applyTimeoutsWithRestore(ctx, txConn, mergeMigrationTimeouts(m.defaultTimeouts, migration.DownTimeouts))
 	if err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failRollbackWithDirtyState(
 			ctx,
 			migration,
@@ -2253,10 +2373,17 @@ func (m *Migrator) rollbackMigrationTransactional(
 		)
 	}
 
-	executionCtx := scoped.withPostgresIndexObservation(ctx, txConn)
+	executionCtx := scoped.withTransactionalProgressRecorder(
+		ctx,
+		txConn,
+		migration,
+		startedAt,
+		MigrationDirectionDown,
+	)
+	executionCtx = scoped.withPostgresIndexObservation(executionCtx, txConn)
 	if err := migration.executeDown(executionCtx, txConn, migrationExecutionTransactional); err != nil {
 		err = m.restoreTimeoutsAfterFailure(ctx, migration.Version, restoreTimeouts, err)
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failRollbackWithDirtyState(
 			ctx,
 			migration,
@@ -2268,11 +2395,11 @@ func (m *Migrator) rollbackMigrationTransactional(
 	}
 
 	if err := m.restoreTimeouts(ctx, migration.Version, restoreTimeouts); err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failRollbackWithDirtyState(ctx, migration, startedAt, err, migration.DownSQL, "")
 	}
 	if err := scoped.refuseRollbackCompletionOverUnsafeIndexOn(ctx, txConn, migration); err != nil {
-		_ = tx.Rollback()
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
 		return m.failRollbackWithDirtyState(
 			ctx,
 			migration,
@@ -2284,8 +2411,15 @@ func (m *Migrator) rollbackMigrationTransactional(
 	}
 
 	if err := txConn.Writer().ExecuteSQL(ctx, deleteSQL, m.revisionVersionArg(migration.Version)); err != nil {
-		_ = tx.Rollback()
-		return fmt.Errorf("failed to record migration reversion %d: %w", migration.Version, err)
+		err = migrationFailureAfterRollback(migration.Version, err, tx.Rollback())
+		return m.failRollbackWithDirtyState(
+			ctx,
+			migration,
+			startedAt,
+			err,
+			migration.DownSQL,
+			fmt.Sprintf("failed to record migration reversion %d", migration.Version),
+		)
 	}
 
 	if err := tx.Commit(); err != nil {

--- a/migration/migrator/no_transaction_crash_test.go
+++ b/migration/migrator/no_transaction_crash_test.go
@@ -1,6 +1,8 @@
 package migrator_test
 
 import (
+	"crypto/sha256"
+	"encoding/base64"
 	"os/exec"
 	"path/filepath"
 	"testing"
@@ -47,14 +49,26 @@ func TestNoTransactionCrash_PersistsProgressBeforeObserver(t *testing.T) {
 		c.Assert(noTransactionTableExists(c, conn, "posts"), qt.IsFalse)
 
 		var applied, total int
-		var failure string
+		var failure, partialHashes string
 		c.Assert(
-			conn.QueryRow("SELECT applied, total, COALESCE(error, '') FROM atlas_schema_revisions WHERE version = '1'").Scan(&applied, &total, &failure),
+			conn.QueryRow(`
+				SELECT applied, total, COALESCE(error, ''), COALESCE(partial_hashes, '')
+				FROM atlas_schema_revisions WHERE version = '1'
+			`).Scan(&applied, &total, &failure, &partialHashes),
 			qt.IsNil,
 		)
 		c.Assert(applied, qt.Equals, 1)
 		c.Assert(total, qt.Equals, 2)
 		c.Assert(failure, qt.Equals, "")
+		// The counter alone cannot be resumed from: a resume verifies the
+		// committed prefix against the digest chain, so the durable checkpoint
+		// has to carry it too. A `null` here would leave the interrupted run
+		// unresumable by anything that checks (#887).
+		c.Assert(
+			partialHashes,
+			qt.Equals,
+			`["h1:`+crashCheckpointDigest("CREATE TABLE users (id INTEGER PRIMARY KEY);")+`"]`,
+		)
 	})
 
 	// The down crash records the same progress numbers as the up crash above --
@@ -203,6 +217,15 @@ func TestNoTransactionCrash_PersistsProgressBeforeObserver(t *testing.T) {
 		c.Assert(status.DirtyRevision, qt.IsNotNil)
 		c.Assert(status.DirtyRevision.Direction, qt.Equals, migrator.MigrationDirectionDown)
 	})
+}
+
+// crashCheckpointDigest is the digest Atlas records for a one-statement
+// committed prefix: base64 of the SHA-256 of that statement's source text.
+// Spelling it out here rather than reusing the production helper keeps the
+// expectation independent of the code that writes the column.
+func crashCheckpointDigest(statement string) string {
+	sum := sha256.Sum256([]byte(statement))
+	return base64.StdEncoding.EncodeToString(sum[:])
 }
 
 func runNoTransactionCrashHelper(

--- a/migration/migrator/no_transaction_session_internal_test.go
+++ b/migration/migrator/no_transaction_session_internal_test.go
@@ -67,6 +67,21 @@ func TestIsTransactionControlStatement(t *testing.T) {
 	}{
 		{name: "PostgreSQL begin", statement: "BEGIN", dialect: "postgres", want: true},
 		{name: "PostgreSQL set transaction", statement: "SET TRANSACTION ISOLATION LEVEL SERIALIZABLE", dialect: "postgres", want: true},
+		// A chained commit or rollback ends the migration transaction and opens
+		// another one on the same session, so the connection still reports a
+		// transaction while the body before it has already been made durable or
+		// discarded. Reading "is this bare COMMIT or ROLLBACK?" instead of "does
+		// this end the transaction?" lets exactly these two through.
+		{name: "MySQL commit", statement: "COMMIT", dialect: "mysql", want: true},
+		{name: "MySQL rollback", statement: "ROLLBACK", dialect: "mysql", want: true},
+		{name: "MySQL commit and chain", statement: "COMMIT AND CHAIN", dialect: "mysql", want: true},
+		{name: "MariaDB rollback and chain", statement: "ROLLBACK AND CHAIN", dialect: "mariadb", want: true},
+		{name: "MySQL commit and no chain release", statement: "COMMIT AND NO CHAIN RELEASE", dialect: "mysql", want: true},
+		{name: "MySQL start transaction", statement: "START TRANSACTION", dialect: "mysql", want: true},
+		{name: "MySQL savepoint", statement: "SAVEPOINT ptah_save", dialect: "mysql", want: true},
+		{name: "MySQL release savepoint", statement: "RELEASE SAVEPOINT ptah_save", dialect: "mysql", want: true},
+		{name: "MySQL rollback to savepoint", statement: "ROLLBACK TO SAVEPOINT ptah_save", dialect: "mysql", want: true},
+		{name: "PostgreSQL abort", statement: "ABORT", dialect: "postgres", want: true},
 		{name: "MySQL autocommit zero", statement: "SET autocommit = 0", dialect: "mysql", want: true},
 		{name: "MariaDB session autocommit", statement: "SET @@session.autocommit = 1", dialect: "mariadb", want: true},
 		{name: "SQL Server implicit transactions", statement: "SET IMPLICIT_TRANSACTIONS ON", dialect: "sqlserver", want: true},

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -1622,7 +1622,7 @@ func (m *Migrator) failMigrationRevisionWithMode(
 			return fmt.Errorf("failed to read migration %d progress witness: %w", migration.Version, err)
 		}
 		if revision != nil {
-			if preservesProgressWitnessUnknownOutcome(ctx, failure, revision) {
+			if preservesProgressWitnessUnknownOutcome(failure, revision, m.connectionDialect()) {
 				return nil
 			}
 			applied = revision.Applied
@@ -1674,9 +1674,9 @@ func (m *Migrator) restoreTransactionalRecoverySession(
 }
 
 func preservesProgressWitnessUnknownOutcome(
-	ctx context.Context,
 	failure error,
 	revision *MigrationRevision,
+	dialect string,
 ) bool {
 	if revision.Error != unknownStatementOutcomeError {
 		return false
@@ -1687,9 +1687,20 @@ func preservesProgressWitnessUnknownOutcome(
 	}
 	var execErr *MigrationExecutionError
 	if !errors.As(failure, &execErr) {
+		return true
+	}
+	if errors.Is(execErr.Err, context.Canceled) || errors.Is(execErr.Err, context.DeadlineExceeded) {
+		return true
+	}
+	return !mysqlAtomicFailureStatement(execErr.Statement, dialect)
+}
+
+func mysqlAtomicFailureStatement(statement, dialect string) bool {
+	tokens := significantSQLTokens(statement, dialect)
+	if len(tokens) == 0 {
 		return false
 	}
-	return ctx.Err() != nil || errors.Is(execErr.Err, context.Canceled) || errors.Is(execErr.Err, context.DeadlineExceeded)
+	return matchesAnyKeyword(tokens[0], "INSERT", "UPDATE", "DELETE", "REPLACE")
 }
 
 func preservesUnknownStatementOutcome(ctx context.Context, failure error, txMode MigrationTxMode) bool {

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -170,7 +170,6 @@ type migrationProgress struct {
 
 func migrationExecutionProgress(
 	err error,
-	sqlText string,
 	dialect string,
 	txMode MigrationTxMode,
 ) migrationProgress {
@@ -189,7 +188,7 @@ func migrationExecutionProgress(
 		// The observed statement executed and only the observation that follows
 		// it failed, so no statement of the body is itself the failure: pass 0
 		// as the failing index rather than the statement that succeeded.
-		applied := rolledBackApplied(sqlText, dialect, txMode, event.Index, 0)
+		applied := rolledBackApplied(dialect, txMode, event.Index)
 		return migrationProgress{
 			Applied: applied, Total: event.Total,
 			Statement: event.Statement, FailedIndex: event.Index,
@@ -210,7 +209,7 @@ func migrationExecutionProgress(
 	// unnormalized list that omitted SQLite and SQL Server and so recorded
 	// applied=1 for a file whose transaction had rolled the whole body back
 	// (#966).
-	applied = rolledBackApplied(sqlText, dialect, txMode, applied, execErr.StatementIndex)
+	applied = rolledBackApplied(dialect, txMode, applied)
 	return migrationProgress{
 		Applied: applied, Total: execErr.Total,
 		Statement: execErr.Statement, FailedIndex: execErr.StatementIndex,
@@ -218,24 +217,18 @@ func migrationExecutionProgress(
 }
 
 // rolledBackApplied corrects how many statements a failed migration body left
-// committed, given that executed of them ran before the statement at
-// failedIndex (1-based, 0 when no statement itself failed) stopped it.
+// committed, given that executed of them ran before it stopped.
 //
 // A body that did not run inside a transaction keeps its own count. A body that
-// did, on a dialect whose DDL is transactional, committed nothing. On the MySQL
-// family neither answer holds: the server commits on its own before every DDL
-// statement, so part of the body can survive a rollback and the rest cannot.
-// Recording the whole prefix there marks statements applied that the rollback
-// undid, and a resume then skips them permanently (#887); recording zero
-// re-runs DDL the server already committed.
-func rolledBackApplied(sqlText, dialect string, txMode MigrationTxMode, executed, failedIndex int) int {
+// did reports zero from this error-only fallback because SQL text cannot prove
+// what a stateful database session committed. MySQL and MariaDB replace this
+// fallback with the revision-row witness installed by
+// [Migrator.withTransactionalProgressRecorder].
+func rolledBackApplied(dialect string, txMode MigrationTxMode, executed int) int {
 	if !migrationProgressRolledBack(dialect, txMode) {
 		return executed
 	}
-	if !implicitCommitDialect(dialect) {
-		return 0
-	}
-	return committedPrefixAfterRollback(sqlText, dialect, executed, failedIndex)
+	return 0
 }
 
 // migrationProgressRolledBack reports whether the migration body ran inside a
@@ -689,6 +682,10 @@ END`, sqlServerObjectLiteral, qualifiedTable)
     operator_version VARCHAR(255) NOT NULL
 )`, qualifiedTable)
 	}
+	engineClause := ""
+	if implicitCommitDialect(dialect) {
+		engineClause = " ENGINE=InnoDB"
+	}
 	return fmt.Sprintf(`CREATE TABLE IF NOT EXISTS %s (
     version VARCHAR(255) PRIMARY KEY,
     description TEXT NOT NULL,
@@ -702,7 +699,7 @@ END`, sqlServerObjectLiteral, qualifiedTable)
     hash VARCHAR(255) NOT NULL,
     partial_hashes JSON NULL,
     operator_version VARCHAR(255) NOT NULL
-)`, qualifiedTable)
+)%s`, qualifiedTable, engineClause)
 }
 
 func (m *Migrator) isClickHouse() bool {
@@ -1413,12 +1410,23 @@ func (m *Migrator) checkpointMigrationRevision(
 	}
 	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
 	defer cancelRecord()
+	return m.checkpointMigrationRevisionOn(recordCtx, m.conn, migration, startedAt, event, direction)
+}
+
+func (m *Migrator) checkpointMigrationRevisionOn(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migration *Migration,
+	startedAt time.Time,
+	event StatementEvent,
+	direction MigrationDirection,
+) error {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.checkpointMigrationSQL())
 	if m.revisionTableFormat.isAtlas() {
 		sqlText := migrationSQLForDirection(migration, direction)
-		return executeSQLOutsideTransaction(
-			recordCtx,
-			m.conn,
+		return executeSQLOn(
+			ctx,
+			conn,
 			query,
 			event.Index,
 			event.Total,
@@ -1428,9 +1436,9 @@ func (m *Migrator) checkpointMigrationRevision(
 			strconv.FormatInt(migration.Version, 10),
 		)
 	}
-	return executeSQLOutsideTransaction(
-		recordCtx,
-		m.conn,
+	return executeSQLOn(
+		ctx,
+		conn,
 		query,
 		encodeRevisionState(migrationStatePending, direction),
 		event.Index,
@@ -1453,12 +1461,23 @@ func (m *Migrator) markMigrationStatementInFlight(
 	}
 	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
 	defer cancelRecord()
+	return m.markMigrationStatementInFlightOn(recordCtx, m.conn, migration, startedAt, event, direction)
+}
+
+func (m *Migrator) markMigrationStatementInFlightOn(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migration *Migration,
+	startedAt time.Time,
+	event StatementEvent,
+	direction MigrationDirection,
+) error {
 	query := sqlutil.Rebind(m.conn.Info().Dialect, m.failMigrationSQL())
 	if m.revisionTableFormat.isAtlas() {
 		sqlText := migrationSQLForDirection(migration, direction)
-		return executeSQLOutsideTransaction(
-			recordCtx,
-			m.conn,
+		return executeSQLOn(
+			ctx,
+			conn,
 			query,
 			event.Index-1,
 			event.Total,
@@ -1470,9 +1489,9 @@ func (m *Migrator) markMigrationStatementInFlight(
 			strconv.FormatInt(migration.Version, 10),
 		)
 	}
-	return executeSQLOutsideTransaction(
-		recordCtx,
-		m.conn,
+	return executeSQLOn(
+		ctx,
+		conn,
 		query,
 		encodeRevisionState(migrationStatePending, direction),
 		event.Index-1,
@@ -1482,6 +1501,32 @@ func (m *Migrator) markMigrationStatementInFlight(
 		time.Since(startedAt).Milliseconds(),
 		m.dirtyRevisionChecksum(migration, direction, event.Index-1),
 		migration.Version,
+	)
+}
+
+// withTransactionalProgressRecorder stores the MySQL-family progress witness
+// on the same physical transaction as the migration body. An implicit server
+// commit therefore makes the witness durable with the user SQL, while a normal
+// rollback removes both. This avoids guessing transaction boundaries from SQL
+// keywords, whose effects depend on session state and storage engine details.
+func (m *Migrator) withTransactionalProgressRecorder(
+	ctx context.Context,
+	conn *dbschema.DatabaseConnection,
+	migration *Migration,
+	startedAt time.Time,
+	direction MigrationDirection,
+) context.Context {
+	if !implicitCommitDialect(m.connectionDialect()) || conn.Writer().IsDryRun() {
+		return ctx
+	}
+	return withStatementProgressRecorder(
+		ctx,
+		func(ctx context.Context, event StatementEvent) error {
+			return m.markMigrationStatementInFlightOn(ctx, conn, migration, startedAt, event, direction)
+		},
+		func(ctx context.Context, event StatementEvent) error {
+			return m.checkpointMigrationRevisionOn(ctx, conn, migration, startedAt, event, direction)
+		},
 	)
 }
 
@@ -1554,7 +1599,10 @@ func (m *Migrator) failMigrationRevisionWithMode(
 	}
 	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
 	defer cancelRecord()
-	progress := migrationExecutionProgress(failure, sqlText, m.conn.Info().Dialect, txMode)
+	if err := m.restoreTransactionalRecoverySession(recordCtx, failure, txMode); err != nil {
+		return err
+	}
+	progress := migrationExecutionProgress(failure, m.conn.Info().Dialect, txMode)
 	applied, total, stmt, failedIndex := progress.Applied, progress.Total, progress.Statement, progress.FailedIndex
 	if total == 0 {
 		total = m.migrationStatementCount(sqlText)
@@ -1566,7 +1614,19 @@ func (m *Migrator) failMigrationRevisionWithMode(
 	// The up direction is left alone deliberately: it is the number the
 	// Atlas-shaped surface reports.
 	if direction == MigrationDirectionDown {
-		applied = rolledBackApplied(sqlText, m.conn.Info().Dialect, txMode, applied, failedIndex)
+		applied = rolledBackApplied(m.conn.Info().Dialect, txMode, applied)
+	}
+	if usesTransactionalProgressWitness(m.conn.Info().Dialect, txMode) {
+		revision, err := m.getRevision(recordCtx, migration.Version)
+		if err != nil {
+			return fmt.Errorf("failed to read migration %d progress witness: %w", migration.Version, err)
+		}
+		if revision != nil {
+			if preservesProgressWitnessUnknownOutcome(ctx, failure, revision) {
+				return nil
+			}
+			applied = revision.Applied
+		}
 	}
 	if direction == MigrationDirectionUp {
 		applied = max(applied, migrationAppliedFloor(ctx))
@@ -1590,6 +1650,46 @@ func (m *Migrator) failMigrationRevisionWithMode(
 		m.dirtyRevisionChecksum(migration, direction, applied),
 		migration.Version,
 	)
+}
+
+func usesTransactionalProgressWitness(dialect string, txMode MigrationTxMode) bool {
+	return txMode == MigrationTxModeFile && implicitCommitDialect(dialect)
+}
+
+func (m *Migrator) restoreTransactionalRecoverySession(
+	ctx context.Context,
+	failure error,
+	txMode MigrationTxMode,
+) error {
+	if !usesTransactionalProgressWitness(m.connectionDialect(), txMode) {
+		return nil
+	}
+	if _, rolledBack := migrationTransactionRollbackVersion(failure); !rolledBack {
+		return nil
+	}
+	if _, err := m.conn.ExecContext(ctx, "SET autocommit = 1"); err != nil {
+		return fmt.Errorf("failed to restore MySQL-family autocommit before recording migration recovery state: %w", err)
+	}
+	return nil
+}
+
+func preservesProgressWitnessUnknownOutcome(
+	ctx context.Context,
+	failure error,
+	revision *MigrationRevision,
+) bool {
+	if revision.Error != unknownStatementOutcomeError {
+		return false
+	}
+	var progressErr *statementProgressError
+	if errors.As(failure, &progressErr) {
+		return true
+	}
+	var execErr *MigrationExecutionError
+	if !errors.As(failure, &execErr) {
+		return false
+	}
+	return ctx.Err() != nil || errors.Is(execErr.Err, context.Canceled) || errors.Is(execErr.Err, context.DeadlineExceeded)
 }
 
 func preservesUnknownStatementOutcome(ctx context.Context, failure error, txMode MigrationTxMode) bool {

--- a/migration/migrator/revisions.go
+++ b/migration/migrator/revisions.go
@@ -170,6 +170,7 @@ type migrationProgress struct {
 
 func migrationExecutionProgress(
 	err error,
+	sqlText string,
 	dialect string,
 	txMode MigrationTxMode,
 ) migrationProgress {
@@ -185,10 +186,10 @@ func migrationExecutionProgress(
 	var observationErr *StatementObservationError
 	if errors.As(err, &observationErr) {
 		event := observationErr.Event
-		applied := event.Index
-		if migrationProgressRolledBack(dialect, txMode) {
-			applied = 0
-		}
+		// The observed statement executed and only the observation that follows
+		// it failed, so no statement of the body is itself the failure: pass 0
+		// as the failing index rather than the statement that succeeded.
+		applied := rolledBackApplied(sqlText, dialect, txMode, event.Index, 0)
 		return migrationProgress{
 			Applied: applied, Total: event.Total,
 			Statement: event.Statement, FailedIndex: event.Index,
@@ -200,26 +201,47 @@ func migrationExecutionProgress(
 		return migrationProgress{}
 	}
 
-	applied := execErr.StatementIndex - 1
+	applied := max(execErr.StatementIndex-1, 0)
 	// The recorded counter is not decoration: a retry resumes at applied+1, so
 	// overstating it skips a statement that never ran. Whether the earlier
-	// statements survived the failure is a property of the transaction mode and
-	// the dialect, which is what migrationProgressRolledBack answers — this
-	// branch used to carry its own shorter, unnormalized list that omitted SQLite
-	// and SQL Server and so recorded applied=1 for a file whose transaction had
-	// rolled the whole body back (#966).
-	if migrationProgressRolledBack(dialect, txMode) {
-		applied = 0
-	}
-	if applied < 0 {
-		applied = 0
-	}
+	// statements survived the failure is a property of the transaction mode, the
+	// dialect and — on the MySQL family — the statements themselves, which is
+	// what rolledBackApplied answers. This branch used to carry its own shorter,
+	// unnormalized list that omitted SQLite and SQL Server and so recorded
+	// applied=1 for a file whose transaction had rolled the whole body back
+	// (#966).
+	applied = rolledBackApplied(sqlText, dialect, txMode, applied, execErr.StatementIndex)
 	return migrationProgress{
 		Applied: applied, Total: execErr.Total,
 		Statement: execErr.Statement, FailedIndex: execErr.StatementIndex,
 	}
 }
 
+// rolledBackApplied corrects how many statements a failed migration body left
+// committed, given that executed of them ran before the statement at
+// failedIndex (1-based, 0 when no statement itself failed) stopped it.
+//
+// A body that did not run inside a transaction keeps its own count. A body that
+// did, on a dialect whose DDL is transactional, committed nothing. On the MySQL
+// family neither answer holds: the server commits on its own before every DDL
+// statement, so part of the body can survive a rollback and the rest cannot.
+// Recording the whole prefix there marks statements applied that the rollback
+// undid, and a resume then skips them permanently (#887); recording zero
+// re-runs DDL the server already committed.
+func rolledBackApplied(sqlText, dialect string, txMode MigrationTxMode, executed, failedIndex int) int {
+	if !migrationProgressRolledBack(dialect, txMode) {
+		return executed
+	}
+	if !implicitCommitDialect(dialect) {
+		return 0
+	}
+	return committedPrefixAfterRollback(sqlText, dialect, executed, failedIndex)
+}
+
+// migrationProgressRolledBack reports whether the migration body ran inside a
+// transaction that the failure rolled back. It says nothing about which
+// statements survived that rollback — on the MySQL family, where the server
+// commits DDL on its own, some of them do. See [rolledBackApplied].
 func migrationProgressRolledBack(dialect string, txMode MigrationTxMode) bool {
 	if txMode == MigrationTxModeAll {
 		return true
@@ -228,7 +250,8 @@ func migrationProgressRolledBack(dialect string, txMode MigrationTxMode) bool {
 		return false
 	}
 	switch platform.NormalizeDialect(dialect) {
-	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.SQLite, platform.SQLServer:
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.SQLite, platform.SQLServer,
+		platform.MySQL, platform.MariaDB:
 		return true
 	default:
 		return false
@@ -1531,22 +1554,19 @@ func (m *Migrator) failMigrationRevisionWithMode(
 	}
 	recordCtx, cancelRecord := durableRevisionWriteContext(ctx)
 	defer cancelRecord()
-	progress := migrationExecutionProgress(failure, m.conn.Info().Dialect, txMode)
+	progress := migrationExecutionProgress(failure, sqlText, m.conn.Info().Dialect, txMode)
 	applied, total, stmt, failedIndex := progress.Applied, progress.Total, progress.Statement, progress.FailedIndex
 	if total == 0 {
 		total = m.migrationStatementCount(sqlText)
 	}
-	// migrationExecutionProgress reports a plain execution error as
-	// StatementIndex-1 statements applied, and only zeroes that for tx-mode all
-	// and the PostgreSQL family -- so on SQLite and SQL Server, whose DDL is
-	// transactional too, a rolled-back body still counts its failing statement's
-	// predecessors as committed. Recovery from a rollback reads that number to
-	// decide whether the schema was changed at all, so the down direction
-	// corrects it here, using the same rule the observation path already uses.
+	// The per-statement progress recorder reports its own count, which the
+	// rollback correction inside migrationExecutionProgress never sees.
+	// Recovery from a rollback reads that number to decide whether the schema
+	// was changed at all, so the down direction runs the same correction here.
 	// The up direction is left alone deliberately: it is the number the
 	// Atlas-shaped surface reports.
-	if direction == MigrationDirectionDown && migrationProgressRolledBack(m.conn.Info().Dialect, txMode) {
-		applied = 0
+	if direction == MigrationDirectionDown {
+		applied = rolledBackApplied(sqlText, m.conn.Info().Dialect, txMode, applied, failedIndex)
 	}
 	if direction == MigrationDirectionUp {
 		applied = max(applied, migrationAppliedFloor(ctx))

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -97,6 +97,16 @@ func TestRolledBackProgress_MariaDBRejectsAutocommitControl(t *testing.T) {
 	runRejectsAutocommitControl(t, dbURL, "mariadb")
 }
 
+func TestRolledBackProgress_MySQLRejectsTransactionControl(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsTransactionControl(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBRejectsTransactionControl(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsTransactionControl(t, dbURL, "mariadb")
+}
+
 func TestRolledBackProgress_MySQLRejectsChangingTargetDatabase(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
 	runRejectsChangingTargetDatabase(t, dbURL, "mysql")
@@ -321,6 +331,46 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, adminURL, dia
 		c.Assert(err, qt.ErrorMatches, `.*cannot run a statement interceptor for the up direction in tx-mode file.*`)
 		c.Assert(interceptor.called, qt.IsFalse)
 		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	// An interceptor is refused in both directions, and the message names the
+	// direction rather than leaning on a stray article. A rollback body reaches
+	// the same execution path as an apply body, so an interceptor can run SQL
+	// outside the witness on the way down exactly as it can on the way up.
+	t.Run("statement interceptor down", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_interceptor_down")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		upSQL := fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.createdTable)
+		downSQL := fmt.Sprintf("DROP TABLE %s", names.createdTable)
+		initial := migrator.CreateMigrationFromSQL(1, "interceptor down", upSQL, downSQL)
+		c.Assert(issue887Migrator(conn, names, initial).MigrateUp(ctx), qt.IsNil)
+
+		interceptor := &issue887StatementInterceptor{}
+		intercepted, err := migrator.NewMigrationFromSQLFilesWithInterceptor(
+			1,
+			"interceptor down",
+			"migration.up.sql",
+			"migration.down.sql",
+			fstest.MapFS{
+				"migration.up.sql":   &fstest.MapFile{Data: []byte(upSQL)},
+				"migration.down.sql": &fstest.MapFile{Data: []byte(downSQL)},
+			},
+			interceptor,
+		)
+		c.Assert(err, qt.IsNil)
+
+		err = issue887Migrator(conn, names, intercepted).MigrateDown(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*cannot run a statement interceptor for the down direction in tx-mode file.*`)
+		c.Assert(interceptor.called, qt.IsFalse)
+		c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(1))
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(1))
 	})
 
 	t.Run("nested SQL", func(t *testing.T) {
@@ -775,6 +825,73 @@ func runRejectsAutocommitControl(t *testing.T, dbURL, dialect string) {
 	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
 	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
 	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+// runRejectsTransactionControl drives the primary transaction-control arm of
+// the tx-mode file preflight through MigrateUp on a live server.
+//
+// The witness contract holds only while one InnoDB transaction covers both the
+// body and the revision row, so a body statement that ends that transaction
+// breaks it. `COMMIT AND CHAIN` and `ROLLBACK AND CHAIN` are the cases worth
+// naming: they end the transaction and immediately open another one, so the
+// session still looks like it is inside a transaction even though everything
+// before them has already been made durable or thrown away. A classifier that
+// asks "is this a bare COMMIT or ROLLBACK?" instead of "does this control the
+// transaction?" lets both through, MigrateUp then returns nil for a run that
+// applied only the tail of the body, and the revision row calls the migration
+// complete. The counted notes are what separate that from a correct run: the
+// returned error alone cannot, because the broken version returns none.
+func runRejectsTransactionControl(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	tests := []struct {
+		name    string
+		control string
+	}{
+		{name: "commit", control: "COMMIT"},
+		{name: "rollback", control: "ROLLBACK"},
+		{name: "commit and chain", control: "COMMIT AND CHAIN"},
+		{name: "rollback and chain", control: "ROLLBACK AND CHAIN"},
+		{name: "start transaction", control: "START TRANSACTION"},
+		{name: "savepoint", control: "SAVEPOINT ptah_887_control"},
+		{name: "release savepoint", control: "RELEASE SAVEPOINT ptah_887_control"},
+	}
+
+	for index, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			ctx := context.Background()
+			conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+			c.Assert(err, qt.IsNil)
+			defer func() { _ = conn.Close() }()
+
+			names := issue887Names(fmt.Sprintf("%s_txcontrol%d", dialect, index))
+			cleanupIssue887(t, conn, names)
+			defer cleanupIssue887(t, conn, names)
+			_, err = conn.ExecContext(ctx, fmt.Sprintf(
+				"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+			))
+			c.Assert(err, qt.IsNil)
+
+			body := fmt.Sprintf(
+				"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
+					"%[2]s;\n"+
+					"INSERT INTO %[1]s (id, note) VALUES (2, 'two');\n",
+				names.ledgerTable, test.control,
+			)
+			migration := migrator.CreateMigrationFromSQL(1, "transaction control", body,
+				fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+
+			err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+			// Checks, not assertions: a classifier that misses this control
+			// reports success and loses the first note, and both symptoms are
+			// worth seeing in the same failure.
+			c.Check(err, qt.ErrorMatches,
+				`.*migration 1 cannot run tx-mode file statement 2 because it controls transaction state.*`)
+			c.Check(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{})
+			c.Check(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+		})
+	}
 }
 
 func runRejectsChangingTargetDatabase(t *testing.T, dbURL, dialect string) {

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -3,6 +3,7 @@ package migrator_test
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 	"testing/fstest"
 	"time"
@@ -10,6 +11,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/sqlident"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -187,15 +189,17 @@ func TestRolledBackProgress_MariaDBRejectsInheritedStorageEngine(t *testing.T) {
 
 func TestRolledBackProgress_MySQLRejectsUnwitnessedExecutionBoundaries(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
-	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, "mysql")
+	adminURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_ADMIN_TEST_URL", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, adminURL, "mysql")
 }
 
 func TestRolledBackProgress_MariaDBRejectsUnwitnessedExecutionBoundaries(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
-	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, "mariadb")
+	adminURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_ADMIN_TEST_URL", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, adminURL, "mariadb")
 }
 
-func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect string) {
+func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, adminURL, dialect string) {
 	t.Helper()
 
 	t.Run("executable comment", func(t *testing.T) {
@@ -314,7 +318,7 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 		c.Assert(err, qt.IsNil)
 
 		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
-		c.Assert(err, qt.ErrorMatches, `.*cannot run an up statement interceptor in tx-mode file.*`)
+		c.Assert(err, qt.ErrorMatches, `.*cannot run a statement interceptor for the up direction in tx-mode file.*`)
 		c.Assert(interceptor.called, qt.IsFalse)
 		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
 	})
@@ -342,15 +346,20 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 		c.Assert(err, qt.IsNil)
 		defer func() { _ = conn.Close() }()
+		adminConn, err := dbschema.ConnectToDatabase(ctx, adminURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = adminConn.Close() }()
 
 		names := issue887Names(dialect + "_cross_db")
 		cleanupIssue887(t, conn, names)
 		defer cleanupIssue887(t, conn, names)
 		externalDatabase := fmt.Sprintf("ptah887external%d", time.Now().UnixNano())
-		_, err = conn.ExecContext(ctx, "CREATE DATABASE "+externalDatabase)
+		_, err = adminConn.ExecContext(ctx, "CREATE DATABASE "+externalDatabase)
 		c.Assert(err, qt.IsNil)
-		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+externalDatabase) }()
-		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		defer func() {
+			_, _ = adminConn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+externalDatabase)
+		}()
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
 			"CREATE TABLE %s.external_jobs (id INTEGER PRIMARY KEY) ENGINE=MyISAM", externalDatabase,
 		))
 		c.Assert(err, qt.IsNil)
@@ -364,7 +373,7 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
 		c.Assert(err, qt.ErrorMatches, `.*references database .* outside the selected database.*`)
 		c.Assert(
-			issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s.external_jobs", externalDatabase)),
+			issue887ScalarCount(t, adminConn, fmt.Sprintf("SELECT COUNT(*) FROM %s.external_jobs", externalDatabase)),
 			qt.Equals,
 			int64(0),
 		)
@@ -410,6 +419,9 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 		c.Assert(err, qt.IsNil)
 		defer func() { _ = conn.Close() }()
+		adminConn, err := dbschema.ConnectToDatabase(ctx, adminURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = adminConn.Close() }()
 
 		names := issue887Names(dialect + "_trigger")
 		cleanupIssue887(t, conn, names)
@@ -423,14 +435,16 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 			"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
 		))
 		c.Assert(err, qt.IsNil)
-		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
 			"CREATE TRIGGER %s AFTER INSERT ON %s FOR EACH ROW INSERT INTO %s (id) VALUES (NEW.id)",
 			triggerName,
 			names.ledgerTable,
 			names.blockerTable,
 		))
 		c.Assert(err, qt.IsNil)
-		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP TRIGGER IF EXISTS "+triggerName) }()
+		defer func() {
+			_, _ = adminConn.ExecContext(context.Background(), "DROP TRIGGER IF EXISTS "+triggerName)
+		}()
 		migration := migrator.CreateMigrationFromSQL(
 			1,
 			"triggered relation",
@@ -445,12 +459,73 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
 	})
 
+	t.Run("hidden trigger catalog", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		adminConn, err := dbschema.ConnectToDatabase(ctx, adminURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = adminConn.Close() }()
+
+		username := fmt.Sprintf("p887_%d", time.Now().UnixNano())
+		password := username + "_password"
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE USER '%s'@'%%' IDENTIFIED BY '%s'", username, password,
+		))
+		c.Assert(err, qt.IsNil)
+		defer func() {
+			_, _ = adminConn.ExecContext(context.Background(), fmt.Sprintf("DROP USER IF EXISTS '%s'@'%%'", username))
+		}()
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
+			"GRANT SELECT, INSERT, UPDATE, DELETE, CREATE, DROP, ALTER, INDEX ON %s.* TO '%s'@'%%'",
+			sqlident.Quote(dialect, adminConn.Info().Schema),
+			username,
+		))
+		c.Assert(err, qt.IsNil)
+
+		limitedURL := issue887ReplaceMySQLCredentials(t, adminURL, username, password)
+		conn, err := dbschema.ConnectToDatabase(ctx, limitedURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_hidden_trigger")
+		cleanupIssue887(t, adminConn, names)
+		defer cleanupIssue887(t, adminConn, names)
+		triggerName := fmt.Sprintf("ptah887trigger%d", time.Now().UnixNano())
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TRIGGER %s BEFORE INSERT ON %s FOR EACH ROW SET NEW.note = 'triggered'",
+			triggerName,
+			names.ledgerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		defer func() {
+			_, _ = adminConn.ExecContext(context.Background(), "DROP TRIGGER IF EXISTS "+triggerName)
+		}()
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"hidden trigger catalog",
+			fmt.Sprintf("INSERT INTO %s VALUES (1, 'one')", names.ledgerTable),
+			fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*tx-mode file requires the TRIGGER privilege at database or global scope.*`)
+		c.Assert(issue887LedgerCount(t, adminConn, names), qt.Equals, int64(0))
+		c.Assert(issue887RevisionCount(t, adminConn, names), qt.Equals, int64(0))
+	})
+
 	t.Run("stored function", func(t *testing.T) {
 		c := qt.New(t)
 		ctx := context.Background()
 		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
 		c.Assert(err, qt.IsNil)
 		defer func() { _ = conn.Close() }()
+		adminConn, err := dbschema.ConnectToDatabase(ctx, adminURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = adminConn.Close() }()
 
 		names := issue887Names(dialect + "_routine")
 		cleanupIssue887(t, conn, names)
@@ -460,11 +535,13 @@ func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect strin
 			"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
 		))
 		c.Assert(err, qt.IsNil)
-		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		_, err = adminConn.ExecContext(ctx, fmt.Sprintf(
 			"CREATE FUNCTION %s() RETURNS INT DETERMINISTIC RETURN 7", routineName,
 		))
 		c.Assert(err, qt.IsNil)
-		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP FUNCTION IF EXISTS "+routineName) }()
+		defer func() {
+			_, _ = adminConn.ExecContext(context.Background(), "DROP FUNCTION IF EXISTS "+routineName)
+		}()
 		migration := migrator.CreateMigrationFromSQL(
 			1,
 			"stored function",
@@ -980,6 +1057,16 @@ func issue887Names(prefix string) issue887TestNames {
 		blockerTable:   "ptah_887_blocker_" + suffix,
 		createdTable:   "ptah_887_created_" + suffix,
 	}
+}
+
+func issue887ReplaceMySQLCredentials(t *testing.T, rawURL, username, password string) string {
+	t.Helper()
+
+	scheme, remainder, found := strings.Cut(rawURL, "://")
+	qt.Assert(t, found, qt.IsTrue)
+	_, endpoint, found := strings.Cut(remainder, "@")
+	qt.Assert(t, found, qt.IsTrue)
+	return fmt.Sprintf("%s://%s:%s@%s", scheme, username, password, endpoint)
 }
 
 func issue887Migrator(

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"testing/fstest"
 	"time"
 
 	qt "github.com/frankban/quicktest"
@@ -11,6 +12,24 @@ import (
 	"go.5x5.cz/ptah/dbschema"
 	"go.5x5.cz/ptah/migration/migrator"
 )
+
+type issue887StatementInterceptor struct {
+	called bool
+}
+
+func (*issue887StatementInterceptor) ValidateDirectives(map[string]string) error {
+	return nil
+}
+
+func (i *issue887StatementInterceptor) ExecuteStatement(
+	context.Context,
+	*dbschema.DatabaseConnection,
+	string,
+	map[string]string,
+) (bool, error) {
+	i.called = true
+	return true, nil
+}
 
 // TestRolledBackProgress_MySQLDataOnlyBodyResumesFromTheTop is the end-to-end
 // guard for stokaro/ptah#887 on a server whose DDL commits itself.
@@ -32,13 +51,18 @@ func TestRolledBackProgress_MariaDBDataOnlyBodyResumesFromTheTop(t *testing.T) {
 	runRolledBackDataOnlyBody(t, dbURL, "mariadb")
 }
 
-// TestRolledBackProgress_MySQLCommittedDDLPrefixIsKept is the non-interference
-// control for the test above. MySQL commits the transaction before it runs a
-// DDL statement, so the statements ahead of a failing CREATE TABLE really are
-// durable; forgetting that would make the retry repeat them.
-func TestRolledBackProgress_MySQLCommittedDDLPrefixIsKept(t *testing.T) {
+// TestRolledBackProgress_MySQLFailingDDLKeepsUnknownOutcome verifies that a
+// witness committed before a failing DDL statement is not downgraded to an
+// ordinary failure. The prefix is durable, but the statement outcome remains
+// unknown and automatic retry must stop before it can repeat user SQL.
+func TestRolledBackProgress_MySQLFailingDDLKeepsUnknownOutcome(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
 	runRolledBackCommittedDDLPrefix(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBFailingDDLKeepsUnknownOutcome(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackCommittedDDLPrefix(t, dbURL, "mariadb")
 }
 
 func TestRolledBackProgress_MySQLDDLThenDMLKeepsTheWholeDurablePrefix(t *testing.T) {
@@ -161,6 +185,324 @@ func TestRolledBackProgress_MariaDBRejectsInheritedStorageEngine(t *testing.T) {
 	runRejectsInheritedStorageEngine(t, dbURL, "mariadb_create_like")
 }
 
+func TestRolledBackProgress_MySQLRejectsUnwitnessedExecutionBoundaries(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBRejectsUnwitnessedExecutionBoundaries(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsUnwitnessedExecutionBoundaries(t, dbURL, "mariadb")
+}
+
+func runRejectsUnwitnessedExecutionBoundaries(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	t.Run("executable comment", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_exec_comment")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"executable comment",
+			fmt.Sprintf("/*! SET autocommit = 0 */; INSERT INTO %s VALUES (1, 'one')", names.ledgerTable),
+			fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*MySQL-family executable comments can bypass transaction-witness validation.*`)
+		c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("opaque up function", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_opaque_up")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		called := false
+		migration := &migrator.Migration{
+			Version:     1,
+			Description: "opaque up",
+			Up: func(context.Context, *dbschema.DatabaseConnection) error {
+				called = true
+				return nil
+			},
+			Down: migrator.NoopMigrationFunc,
+		}
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*cannot run an opaque up function in tx-mode file.*`)
+		c.Assert(called, qt.IsFalse)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("opaque down function", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_opaque_down")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		upSQL := fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.createdTable)
+		initial := migrator.CreateMigrationFromSQL(
+			1,
+			"opaque down",
+			upSQL,
+			fmt.Sprintf("DROP TABLE %s", names.createdTable),
+		)
+		c.Assert(issue887Migrator(conn, names, initial).MigrateUp(ctx), qt.IsNil)
+		called := false
+		opaque := &migrator.Migration{
+			Version:     1,
+			Description: "opaque down",
+			UpSQL:       upSQL,
+			Up:          migrator.NoopMigrationFunc,
+			Down: func(context.Context, *dbschema.DatabaseConnection) error {
+				called = true
+				return nil
+			},
+		}
+
+		err = issue887Migrator(conn, names, opaque).MigrateDown(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*cannot run an opaque down function in tx-mode file.*`)
+		c.Assert(called, qt.IsFalse)
+		c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(1))
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(1))
+	})
+
+	t.Run("statement interceptor", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_interceptor")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		interceptor := &issue887StatementInterceptor{}
+		migration, err := migrator.NewMigrationFromSQLFilesWithInterceptor(
+			1,
+			"interceptor",
+			"migration.up.sql",
+			"migration.down.sql",
+			fstest.MapFS{
+				"migration.up.sql":   &fstest.MapFile{Data: []byte("SELECT 1")},
+				"migration.down.sql": &fstest.MapFile{Data: []byte("SELECT 1")},
+			},
+			interceptor,
+		)
+		c.Assert(err, qt.IsNil)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*cannot run an up statement interceptor in tx-mode file.*`)
+		c.Assert(interceptor.called, qt.IsFalse)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("nested SQL", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_call")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		migration := migrator.CreateMigrationFromSQL(1, "nested SQL", "CALL missing_procedure()", "SELECT 1")
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*nested or dynamic SQL cannot be tied to Ptah's transaction witness.*`)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("cross-database table", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_cross_db")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		externalDatabase := fmt.Sprintf("ptah887external%d", time.Now().UnixNano())
+		_, err = conn.ExecContext(ctx, "CREATE DATABASE "+externalDatabase)
+		c.Assert(err, qt.IsNil)
+		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+externalDatabase) }()
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s.external_jobs (id INTEGER PRIMARY KEY) ENGINE=MyISAM", externalDatabase,
+		))
+		c.Assert(err, qt.IsNil)
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"cross database",
+			fmt.Sprintf("INSERT INTO %s.external_jobs VALUES (1)", externalDatabase),
+			fmt.Sprintf("DELETE FROM %s.external_jobs", externalDatabase),
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*references database .* outside the selected database.*`)
+		c.Assert(
+			issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s.external_jobs", externalDatabase)),
+			qt.Equals,
+			int64(0),
+		)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("database creation", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_create_db")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		databaseName := fmt.Sprintf("ptah887created%d", time.Now().UnixNano())
+		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP DATABASE IF EXISTS "+databaseName) }()
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"database creation",
+			"CREATE DATABASE "+databaseName,
+			"DROP DATABASE "+databaseName,
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*changes state outside Ptah's migration transaction.*`)
+		c.Assert(
+			issue887ScalarCount(
+				t,
+				conn,
+				fmt.Sprintf("SELECT COUNT(*) FROM information_schema.schemata WHERE schema_name = '%s'", databaseName),
+			),
+			qt.Equals,
+			int64(0),
+		)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("triggered relation", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_trigger")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		triggerName := fmt.Sprintf("ptah887trigger%d", time.Now().UnixNano())
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TRIGGER %s AFTER INSERT ON %s FOR EACH ROW INSERT INTO %s (id) VALUES (NEW.id)",
+			triggerName,
+			names.ledgerTable,
+			names.blockerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP TRIGGER IF EXISTS "+triggerName) }()
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"triggered relation",
+			fmt.Sprintf("INSERT INTO %s VALUES (1, 'one')", names.ledgerTable),
+			fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*relation .* has indirect behavior that Ptah cannot tie to the transaction witness.*`)
+		c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+		c.Assert(issue887ScalarCount(t, conn, "SELECT COUNT(*) FROM "+names.blockerTable), qt.Equals, int64(0))
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("stored function", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_routine")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		routineName := fmt.Sprintf("ptah887routine%d", time.Now().UnixNano())
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+		))
+		c.Assert(err, qt.IsNil)
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE FUNCTION %s() RETURNS INT DETERMINISTIC RETURN 7", routineName,
+		))
+		c.Assert(err, qt.IsNil)
+		defer func() { _, _ = conn.ExecContext(context.Background(), "DROP FUNCTION IF EXISTS "+routineName) }()
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"stored function",
+			fmt.Sprintf("INSERT INTO %s VALUES (%s(), 'one')", names.ledgerTable, routineName),
+			fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.ErrorMatches, `.*routine .* can execute SQL outside Ptah's transaction witness.*`)
+		c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+
+	t.Run("secret redaction", func(t *testing.T) {
+		c := qt.New(t)
+		ctx := context.Background()
+		conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+		c.Assert(err, qt.IsNil)
+		defer func() { _ = conn.Close() }()
+
+		names := issue887Names(dialect + "_secret")
+		cleanupIssue887(t, conn, names)
+		defer cleanupIssue887(t, conn, names)
+		secret := fmt.Sprintf("ptah-%s-%d", dialect, time.Now().UnixNano())
+		migration := migrator.CreateMigrationFromSQL(
+			1,
+			"secret",
+			"SET PASSWORD = '"+secret+"'",
+			"SELECT 1",
+		)
+
+		err = issue887Migrator(conn, names, migration).MigrateUp(ctx)
+		c.Assert(err, qt.IsNotNil)
+		c.Assert(err.Error(), qt.Not(qt.Contains), secret)
+		c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+	})
+}
+
 func runRolledBackDataOnlyBody(t *testing.T, dbURL, dialect string) {
 	t.Helper()
 
@@ -253,6 +595,7 @@ func runRolledBackCommittedDDLPrefix(t *testing.T, dbURL, dialect string) {
 	// there and the revision has to say so.
 	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
 	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887RevisionError(t, conn, names), qt.Equals, "statement execution outcome is unknown after process interruption")
 
 	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s", names.blockerTable))
 	c.Assert(err, qt.IsNil)
@@ -262,10 +605,11 @@ func runRolledBackCommittedDDLPrefix(t *testing.T, dbURL, dialect string) {
 		AllowDirty:               true,
 		DiscardRolledBackFailure: true,
 	})
-	c.Assert(err, qt.IsNil)
-	// Two rows, not three: the committed INSERT must not have run twice.
-	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
-	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "three"})
+	c.Assert(err, qt.ErrorMatches, `migration 1 cannot resume automatically: the outcome of statement 2 is unknown.*`)
+	// The retry did not enter the body and therefore did not repeat the committed
+	// INSERT or run the statement after the failed DDL.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one"})
 }
 
 func runRolledBackDDLThenDML(
@@ -350,7 +694,7 @@ func runRejectsAutocommitControl(t *testing.T, dbURL, dialect string) {
 
 	mig := issue887Migrator(conn, names, migration)
 	err = mig.MigrateUp(ctx)
-	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because "SET autocommit = 0" controls transaction state; remove the transaction control and let Ptah manage the file transaction`)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because it controls transaction state; remove the transaction control and let Ptah manage the file transaction`)
 	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
 	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
 	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
@@ -380,7 +724,7 @@ func runRejectsChangingTargetDatabase(t *testing.T, dbURL, dialect string) {
 
 	mig := issue887Migrator(conn, names, migration)
 	err = mig.MigrateUp(ctx)
-	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because "USE .*" changes the target database; select the database in the connection URL so Ptah can verify its storage engines`)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because it changes the target database; select the database in the connection URL so Ptah can verify its storage engines`)
 	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
 	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
 }
@@ -677,6 +1021,18 @@ func issue887AppliedCount(t *testing.T, conn *dbschema.DatabaseConnection, names
 	return issue887ScalarCount(t, conn, fmt.Sprintf(
 		"SELECT applied FROM %s WHERE version = '1'", names.revisionsTable,
 	))
+}
+
+func issue887RevisionError(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) string {
+	t.Helper()
+
+	var failure string
+	err := conn.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT error FROM %s WHERE version = '1'", names.revisionsTable),
+	).Scan(&failure)
+	qt.Assert(t, err, qt.IsNil)
+	return failure
 }
 
 func issue887MetadataEngine(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) string {

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -1,0 +1,412 @@
+package migrator_test
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestRolledBackProgress_MySQLDataOnlyBodyResumesFromTheTop is the end-to-end
+// guard for stokaro/ptah#887 on a server whose DDL commits itself.
+//
+// A tx-mode file body of plain DML that fails part way is rolled back whole,
+// but the failure used to be recorded as `applied = 1`. The revision then
+// claimed a committed prefix that no longer existed, the retry resumed at
+// statement two, and the first statement was never applied by any run while the
+// migration reported itself complete. The assertion that matters is the row
+// count after the retry, not the counter: a resume that skips a statement is
+// indistinguishable from a correct one until the data is counted.
+func TestRolledBackProgress_MySQLDataOnlyBodyResumesFromTheTop(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackDataOnlyBody(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBDataOnlyBodyResumesFromTheTop(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackDataOnlyBody(t, dbURL, "mariadb")
+}
+
+// TestRolledBackProgress_MySQLCommittedDDLPrefixIsKept is the non-interference
+// control for the test above. MySQL commits the transaction before it runs a
+// DDL statement, so the statements ahead of a failing CREATE TABLE really are
+// durable; forgetting that would make the retry repeat them.
+func TestRolledBackProgress_MySQLCommittedDDLPrefixIsKept(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackCommittedDDLPrefix(t, dbURL, "mysql")
+}
+
+// TestRolledBackProgress_MySQLDDLCarriesTheStatementsAfterIt is the guard for
+// the first blocker on stokaro/ptah#1356.
+//
+// An implicit commit does not flush the open transaction, it ENDS it. Every
+// statement after a DDL statement therefore runs with no transaction open and
+// commits itself, and the ROLLBACK the failure triggers reaches none of them.
+// Measured directly on both servers:
+//
+//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
+//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
+//	-> rows 1 and 3 both survive
+//
+// Counting the prefix only up to the DDL statement recorded applied=1 for the
+// body below, where two statements had committed. The retry then resumed at
+// statement two and inserted its row a second time, and the migration reported
+// success. The ledger has no primary key on purpose: a repeat has to show up as
+// a duplicated row rather than as an error, because that is how it shows up in
+// production.
+func TestRolledBackProgress_MySQLDDLCarriesTheStatementsAfterIt(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackDDLCarriesTheRest(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBDDLCarriesTheStatementsAfterIt(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackDDLCarriesTheRest(t, dbURL, "mariadb")
+}
+
+// TestRolledBackProgress_MySQLNonCommittingStatementKeepsNothing is the guard
+// for the second blocker on stokaro/ptah#1356: a statement the classifier
+// wrongly reports as committing.
+//
+// `UNLOCK TABLES` with no table locked was measured to commit nothing on both
+// servers, and no table can be locked inside a migration transaction because a
+// LOCK TABLES would already have ended it. Reporting it as committing recorded
+// applied=2 for the body below, and the resume then skipped the INSERT that
+// really had been rolled back — permanently, while reporting success. That is
+// the same shape as `LOAD DATA`, which was also measured to commit nothing on
+// both servers and is pinned in TestImplicitCommitEffectOf; this body uses
+// UNLOCK TABLES because it needs no server-side data file to run.
+func TestRolledBackProgress_MySQLNonCommittingStatementKeepsNothing(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackNonCommittingStatement(t, dbURL, "mysql")
+}
+
+func TestRolledBackProgress_MariaDBNonCommittingStatementKeepsNothing(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackNonCommittingStatement(t, dbURL, "mariadb")
+}
+
+func runRolledBackDDLCarriesTheRest(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_carry")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"CREATE TABLE %[3]s (id INTEGER PRIMARY KEY);\n"+
+			"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
+			"INSERT INTO %[1]s (id, note) SELECT 2, 'two' FROM %[2]s;\n",
+		names.ledgerTable, names.blockerTable, names.createdTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "ddl carries the rest", body,
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+
+	failing := issue887Migrator(conn, names, migration)
+	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+	// The CREATE ended the transaction, so the INSERT after it committed on its
+	// own and the ROLLBACK could not reach it.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887TableExists(t, conn, names.createdTable), qt.IsTrue)
+	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(2))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (7)", names.blockerTable))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887Migrator(conn, names, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
+		AllowDirty:               true,
+		DiscardRolledBackFailure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	// Two rows, not three. Recording applied=1 resumed at the INSERT that had
+	// already committed and left the ledger reading one, one, two.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
+	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "two"})
+	c.Assert(issue887TableExists(t, conn, names.createdTable), qt.IsTrue)
+}
+
+func runRolledBackNonCommittingStatement(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_nocommit")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
+			"UNLOCK TABLES;\n"+
+			"INSERT INTO %[1]s (id, note) SELECT 2, 'two' FROM %[2]s;\n",
+		names.ledgerTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "non committing statement", body,
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+
+	failing := issue887Migrator(conn, names, migration)
+	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+	// UNLOCK TABLES committed nothing, so the rollback took the INSERT with it
+	// and no revision row may claim otherwise.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (7)", names.blockerTable))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887Migrator(conn, names, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
+		AllowDirty:               true,
+		DiscardRolledBackFailure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	// Both rows. Recording applied=2 resumed past the INSERT the rollback had
+	// undone, and no run ever applied it.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
+	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "two"})
+}
+
+func runRolledBackDataOnlyBody(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_dml")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
+			"INSERT INTO %[1]s (id, note) SELECT 2, 'two' FROM %[2]s;\n"+
+			"INSERT INTO %[1]s (id, note) VALUES (3, 'three');\n",
+		names.ledgerTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "data only", body,
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+
+	failing := issue887Migrator(conn, names, migration)
+	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+	// Nothing survived the rollback, so nothing may be recorded as committed:
+	// the Atlas-shaped surface expresses that by leaving no revision at all.
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (7)", names.blockerTable))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887Migrator(conn, names, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
+		AllowDirty:               true,
+		DiscardRolledBackFailure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(3))
+	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "three", "two"})
+}
+
+func runRolledBackCommittedDDLPrefix(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_ddl")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
+			"CREATE TABLE %[2]s (id INTEGER PRIMARY KEY);\n"+
+			"INSERT INTO %[1]s (id, note) VALUES (3, 'three');\n",
+		names.ledgerTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "ddl prefix", body,
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+
+	failing := issue887Migrator(conn, names, migration)
+	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
+	c.Assert(err, qt.IsNotNil)
+	// MySQL committed the INSERT when it reached the CREATE TABLE, so the row is
+	// there and the revision has to say so.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(1))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf("DROP TABLE %s", names.blockerTable))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887Migrator(conn, names, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
+		AllowDirty:               true,
+		DiscardRolledBackFailure: true,
+	})
+	c.Assert(err, qt.IsNil)
+	// Two rows, not three: the committed INSERT must not have run twice.
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
+	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "three"})
+}
+
+type issue887TestNames struct {
+	revisionsTable string
+	ledgerTable    string
+	blockerTable   string
+	createdTable   string
+}
+
+func issue887Names(prefix string) issue887TestNames {
+	suffix := fmt.Sprintf("%s_%d", prefix, time.Now().UnixNano())
+	return issue887TestNames{
+		revisionsTable: "atlas_revisions_887_" + suffix,
+		ledgerTable:    "ptah_887_ledger_" + suffix,
+		blockerTable:   "ptah_887_blocker_" + suffix,
+		createdTable:   "ptah_887_created_" + suffix,
+	}
+}
+
+func issue887Migrator(
+	conn *dbschema.DatabaseConnection,
+	names issue887TestNames,
+	migrations ...*migrator.Migration,
+) *migrator.Migrator {
+	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
+		WithMigrationsTable("", names.revisionsTable).
+		WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithTransactionMode(migrator.MigrationTxModeFile).
+		WithMigrationLockTimeout(10 * time.Second)
+}
+
+func issue887LedgerCount(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) int64 {
+	t.Helper()
+
+	return issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.ledgerTable))
+}
+
+func issue887RevisionCount(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) int64 {
+	t.Helper()
+
+	return issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.revisionsTable))
+}
+
+func issue887AppliedCount(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) int64 {
+	t.Helper()
+
+	return issue887ScalarCount(t, conn, fmt.Sprintf(
+		"SELECT applied FROM %s WHERE version = '1'", names.revisionsTable,
+	))
+}
+
+// issue887TableExists asserts against the catalog rather than the revision row.
+// A committed prefix that the accounting claims and the schema does not have is
+// exactly the failure these tests exist to catch.
+func issue887TableExists(t *testing.T, conn *dbschema.DatabaseConnection, table string) bool {
+	t.Helper()
+
+	count := issue887ScalarCount(t, conn, fmt.Sprintf(
+		"SELECT COUNT(*) FROM information_schema.tables "+
+			"WHERE table_schema = DATABASE() AND table_name = '%s'", table,
+	))
+	return count == 1
+}
+
+func issue887ScalarCount(t *testing.T, conn *dbschema.DatabaseConnection, query string) int64 {
+	t.Helper()
+
+	var count int64
+	err := conn.QueryRowContext(context.Background(), query).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func issue887LedgerNotes(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) []string {
+	t.Helper()
+
+	rows, err := conn.QueryContext(
+		context.Background(),
+		fmt.Sprintf("SELECT note FROM %s ORDER BY note", names.ledgerTable),
+	)
+	qt.Assert(t, err, qt.IsNil)
+	defer func() { _ = rows.Close() }()
+
+	notes := []string{}
+	for rows.Next() {
+		var note string
+		qt.Assert(t, rows.Scan(&note), qt.IsNil)
+		notes = append(notes, note)
+	}
+	qt.Assert(t, rows.Err(), qt.IsNil)
+	return notes
+}
+
+func cleanupIssue887(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) {
+	t.Helper()
+
+	for _, table := range []string{
+		names.revisionsTable, names.blockerTable, names.ledgerTable, names.createdTable,
+	} {
+		_, _ = conn.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
+	}
+}

--- a/migration/migrator/rolled_back_progress_integration_test.go
+++ b/migration/migrator/rolled_back_progress_integration_test.go
@@ -41,166 +41,124 @@ func TestRolledBackProgress_MySQLCommittedDDLPrefixIsKept(t *testing.T) {
 	runRolledBackCommittedDDLPrefix(t, dbURL, "mysql")
 }
 
-// TestRolledBackProgress_MySQLDDLCarriesTheStatementsAfterIt is the guard for
-// the first blocker on stokaro/ptah#1356.
-//
-// An implicit commit does not flush the open transaction, it ENDS it. Every
-// statement after a DDL statement therefore runs with no transaction open and
-// commits itself, and the ROLLBACK the failure triggers reaches none of them.
-// Measured directly on both servers:
-//
-//	START TRANSACTION; INSERT INTO led VALUES (1,'one'); CREATE TABLE ddl1 (i INT);
-//	INSERT INTO led VALUES (3,'three'); ROLLBACK; SELECT id,note FROM led ORDER BY id;
-//	-> rows 1 and 3 both survive
-//
-// Counting the prefix only up to the DDL statement recorded applied=1 for the
-// body below, where two statements had committed. The retry then resumed at
-// statement two and inserted its row a second time, and the migration reported
-// success. The ledger has no primary key on purpose: a repeat has to show up as
-// a duplicated row rather than as an error, because that is how it shows up in
-// production.
-func TestRolledBackProgress_MySQLDDLCarriesTheStatementsAfterIt(t *testing.T) {
+func TestRolledBackProgress_MySQLDDLThenDMLKeepsTheWholeDurablePrefix(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
-	runRolledBackDDLCarriesTheRest(t, dbURL, "mysql")
+	runRolledBackDDLThenDML(t, dbURL, "mysql", migrator.RevisionTableFormatAtlas)
 }
 
-func TestRolledBackProgress_MariaDBDDLCarriesTheStatementsAfterIt(t *testing.T) {
+func TestRolledBackProgress_MariaDBDDLThenDMLKeepsTheWholeDurablePrefix(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
-	runRolledBackDDLCarriesTheRest(t, dbURL, "mariadb")
+	runRolledBackDDLThenDML(t, dbURL, "mariadb", migrator.RevisionTableFormatAtlas)
 }
 
-// TestRolledBackProgress_MySQLNonCommittingStatementKeepsNothing is the guard
-// for the second blocker on stokaro/ptah#1356: a statement the classifier
-// wrongly reports as committing.
-//
-// `UNLOCK TABLES` with no table locked was measured to commit nothing on both
-// servers, and no table can be locked inside a migration transaction because a
-// LOCK TABLES would already have ended it. Reporting it as committing recorded
-// applied=2 for the body below, and the resume then skipped the INSERT that
-// really had been rolled back — permanently, while reporting success. That is
-// the same shape as `LOAD DATA`, which was also measured to commit nothing on
-// both servers and is pinned in TestImplicitCommitEffectOf; this body uses
-// UNLOCK TABLES because it needs no server-side data file to run.
-func TestRolledBackProgress_MySQLNonCommittingStatementKeepsNothing(t *testing.T) {
+func TestRolledBackProgress_MySQLNativeRevisionKeepsTheWholeDurablePrefix(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
-	runRolledBackNonCommittingStatement(t, dbURL, "mysql")
+	runRolledBackDDLThenDML(t, dbURL, "mysql_native", migrator.RevisionTableFormatPtah)
 }
 
-func TestRolledBackProgress_MariaDBNonCommittingStatementKeepsNothing(t *testing.T) {
+func TestRolledBackProgress_MariaDBNativeRevisionKeepsTheWholeDurablePrefix(t *testing.T) {
 	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
-	runRolledBackNonCommittingStatement(t, dbURL, "mariadb")
+	runRolledBackDDLThenDML(t, dbURL, "mariadb_native", migrator.RevisionTableFormatPtah)
 }
 
-func runRolledBackDDLCarriesTheRest(t *testing.T, dbURL, dialect string) {
-	t.Helper()
-
-	c := qt.New(t)
-	ctx := context.Background()
-
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	c.Assert(err, qt.IsNil)
-	defer func() { _ = conn.Close() }()
-
-	names := issue887Names(dialect + "_carry")
-	cleanupIssue887(t, conn, names)
-	defer cleanupIssue887(t, conn, names)
-
-	_, err = conn.ExecContext(ctx, fmt.Sprintf(
-		"CREATE TABLE %s (id INTEGER, note VARCHAR(64))", names.ledgerTable,
-	))
-	c.Assert(err, qt.IsNil)
-
-	body := fmt.Sprintf(
-		"CREATE TABLE %[3]s (id INTEGER PRIMARY KEY);\n"+
-			"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
-			"INSERT INTO %[1]s (id, note) SELECT 2, 'two' FROM %[2]s;\n",
-		names.ledgerTable, names.blockerTable, names.createdTable,
-	)
-	migration := migrator.CreateMigrationFromSQL(1, "ddl carries the rest", body,
-		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
-
-	failing := issue887Migrator(conn, names, migration)
-	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
-	c.Assert(err, qt.IsNotNil)
-	// The CREATE ended the transaction, so the INSERT after it committed on its
-	// own and the ROLLBACK could not reach it.
-	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
-	c.Assert(issue887TableExists(t, conn, names.createdTable), qt.IsTrue)
-	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(2))
-
-	_, err = conn.ExecContext(ctx, fmt.Sprintf(
-		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
-	))
-	c.Assert(err, qt.IsNil)
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (7)", names.blockerTable))
-	c.Assert(err, qt.IsNil)
-
-	retried := issue887Migrator(conn, names, migration)
-	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
-		AllowDirty:               true,
-		DiscardRolledBackFailure: true,
-	})
-	c.Assert(err, qt.IsNil)
-	// Two rows, not three. Recording applied=1 resumed at the INSERT that had
-	// already committed and left the ledger reading one, one, two.
-	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
-	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "two"})
-	c.Assert(issue887TableExists(t, conn, names.createdTable), qt.IsTrue)
+func TestRolledBackProgress_MySQLRejectsAutocommitControl(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsAutocommitControl(t, dbURL, "mysql")
 }
 
-func runRolledBackNonCommittingStatement(t *testing.T, dbURL, dialect string) {
-	t.Helper()
+func TestRolledBackProgress_MariaDBRejectsAutocommitControl(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsAutocommitControl(t, dbURL, "mariadb")
+}
 
-	c := qt.New(t)
-	ctx := context.Background()
+func TestRolledBackProgress_MySQLRejectsChangingTargetDatabase(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsChangingTargetDatabase(t, dbURL, "mysql")
+}
 
-	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
-	c.Assert(err, qt.IsNil)
-	defer func() { _ = conn.Close() }()
+func TestRolledBackProgress_MariaDBRejectsChangingTargetDatabase(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsChangingTargetDatabase(t, dbURL, "mariadb")
+}
 
-	names := issue887Names(dialect + "_nocommit")
-	cleanupIssue887(t, conn, names)
-	defer cleanupIssue887(t, conn, names)
+func TestRolledBackProgress_MySQLReplaysCommittedSessionState(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackSessionStateReplay(t, dbURL, "mysql")
+}
 
-	_, err = conn.ExecContext(ctx, fmt.Sprintf(
-		"CREATE TABLE %s (id INTEGER, note VARCHAR(64))", names.ledgerTable,
-	))
-	c.Assert(err, qt.IsNil)
+func TestRolledBackProgress_MariaDBReplaysCommittedSessionState(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackSessionStateReplay(t, dbURL, "mariadb")
+}
 
-	body := fmt.Sprintf(
-		"INSERT INTO %[1]s (id, note) VALUES (1, 'one');\n"+
-			"UNLOCK TABLES;\n"+
-			"INSERT INTO %[1]s (id, note) SELECT 2, 'two' FROM %[2]s;\n",
-		names.ledgerTable, names.blockerTable,
-	)
-	migration := migrator.CreateMigrationFromSQL(1, "non committing statement", body,
-		fmt.Sprintf("DELETE FROM %s", names.ledgerTable))
+func TestRolledBackProgress_MySQLAtlasDownRecordsTheDurablePrefix(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackDownProgress(t, dbURL, "mysql_down_atlas", migrator.RevisionTableFormatAtlas)
+}
 
-	failing := issue887Migrator(conn, names, migration)
-	err = failing.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{DiscardRolledBackFailure: true})
-	c.Assert(err, qt.IsNotNil)
-	// UNLOCK TABLES committed nothing, so the rollback took the INSERT with it
-	// and no revision row may claim otherwise.
-	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
-	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+func TestRolledBackProgress_MariaDBAtlasDownRecordsTheDurablePrefix(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackDownProgress(t, dbURL, "mariadb_down_atlas", migrator.RevisionTableFormatAtlas)
+}
 
-	_, err = conn.ExecContext(ctx, fmt.Sprintf(
-		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
-	))
-	c.Assert(err, qt.IsNil)
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("INSERT INTO %s (id) VALUES (7)", names.blockerTable))
-	c.Assert(err, qt.IsNil)
+func TestRolledBackProgress_MySQLNativeDownRecordsTheDurablePrefix(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRolledBackDownProgress(t, dbURL, "mysql_down_native", migrator.RevisionTableFormatPtah)
+}
 
-	retried := issue887Migrator(conn, names, migration)
-	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{
-		AllowDirty:               true,
-		DiscardRolledBackFailure: true,
-	})
-	c.Assert(err, qt.IsNil)
-	// Both rows. Recording applied=2 resumed past the INSERT the rollback had
-	// undone, and no run ever applied it.
-	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(2))
-	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "two"})
+func TestRolledBackProgress_MariaDBNativeDownRecordsTheDurablePrefix(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRolledBackDownProgress(t, dbURL, "mariadb_down_native", migrator.RevisionTableFormatPtah)
+}
+
+func TestRolledBackProgress_MySQLRejectsNonTransactionalMetadata(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsNonTransactionalMetadata(t, dbURL, "mysql_myisam")
+}
+
+func TestRolledBackProgress_MariaDBRejectsNonTransactionalMetadata(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsNonTransactionalMetadata(t, dbURL, "mariadb_myisam")
+}
+
+func TestRolledBackProgress_MySQLRejectsNonTransactionalNativeMetadataBeforeUpgrade(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsNonTransactionalNativeMetadataBeforeUpgrade(t, dbURL, "mysql_native_myisam")
+}
+
+func TestRolledBackProgress_MariaDBRejectsNonTransactionalNativeMetadataBeforeUpgrade(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsNonTransactionalNativeMetadataBeforeUpgrade(t, dbURL, "mariadb_native_myisam")
+}
+
+func TestRolledBackProgress_MySQLRejectsNonTransactionalTargetTable(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsNonTransactionalTargetTable(t, dbURL, "mysql_target_myisam")
+}
+
+func TestRolledBackProgress_MariaDBRejectsNonTransactionalTargetTable(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsNonTransactionalTargetTable(t, dbURL, "mariadb_target_myisam")
+}
+
+func TestRolledBackProgress_MySQLRejectsCreatingNonTransactionalTargetTable(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsCreatingNonTransactionalTargetTable(t, dbURL, "mysql_create_myisam")
+}
+
+func TestRolledBackProgress_MariaDBRejectsCreatingNonTransactionalTargetTable(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsCreatingNonTransactionalTargetTable(t, dbURL, "mariadb_create_myisam")
+}
+
+func TestRolledBackProgress_MySQLRejectsInheritedStorageEngine(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mysql", "MYSQL_TEST_URL", "MYSQL_URL")
+	runRejectsInheritedStorageEngine(t, dbURL, "mysql_create_like")
+}
+
+func TestRolledBackProgress_MariaDBRejectsInheritedStorageEngine(t *testing.T) {
+	dbURL := mySQLFamilyTestURL(t, "mariadb", "MARIADB_TEST_URL", "MARIADB_URL")
+	runRejectsInheritedStorageEngine(t, dbURL, "mariadb_create_like")
 }
 
 func runRolledBackDataOnlyBody(t *testing.T, dbURL, dialect string) {
@@ -310,6 +268,359 @@ func runRolledBackCommittedDDLPrefix(t *testing.T, dbURL, dialect string) {
 	c.Assert(issue887LedgerNotes(t, conn, names), qt.DeepEquals, []string{"one", "three"})
 }
 
+func runRolledBackDDLThenDML(
+	t *testing.T,
+	dbURL,
+	dialect string,
+	revisionFormat migrator.RevisionTableFormat,
+) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_ddl_dml")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"CREATE TABLE %[1]s (id INTEGER PRIMARY KEY);\n"+
+			"INSERT INTO %[2]s (id, note) VALUES (1, 'one');\n"+
+			"INSERT INTO %[3]s (id) VALUES (7);\n",
+		names.createdTable, names.ledgerTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "ddl then dml", body,
+		fmt.Sprintf("DROP TABLE %s", names.createdTable))
+
+	failing := issue887MigratorWithFormat(conn, names, revisionFormat, migration)
+	err = failing.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(issue887MetadataEngine(t, conn, names), qt.Equals, "InnoDB")
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(2))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887MigratorWithFormat(conn, names, revisionFormat, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true})
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+	c.Assert(issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.blockerTable)), qt.Equals, int64(1))
+}
+
+func runRejectsAutocommitControl(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_autocommit_zero")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	body := fmt.Sprintf(
+		"CREATE TABLE %[1]s (id INTEGER PRIMARY KEY);\n"+
+			"SET autocommit = 0;\n"+
+			"INSERT INTO %[2]s (id, note) VALUES (1, 'one');\n",
+		names.createdTable, names.ledgerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "autocommit zero", body,
+		fmt.Sprintf("DROP TABLE %s", names.createdTable))
+
+	mig := issue887Migrator(conn, names, migration)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because "SET autocommit = 0" controls transaction state; remove the transaction control and let Ptah manage the file transaction`)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(0))
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runRejectsChangingTargetDatabase(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_use")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	body := fmt.Sprintf(
+		"CREATE TABLE %[1]s (id INTEGER PRIMARY KEY);\n"+
+			"USE %[2]s;\n",
+		names.createdTable, conn.Info().Schema,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "change database", body,
+		fmt.Sprintf("DROP TABLE %s", names.createdTable))
+
+	mig := issue887Migrator(conn, names, migration)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 2 because "USE .*" changes the target database; select the database in the connection URL so Ptah can verify its storage engines`)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runRolledBackSessionStateReplay(t *testing.T, dbURL, dialect string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(dialect + "_session_replay")
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	body := fmt.Sprintf(
+		"SET SESSION sql_mode = 'ANSI_QUOTES';\n"+
+			"CREATE TABLE %[1]s (id INTEGER PRIMARY KEY);\n"+
+			"INSERT INTO \"%[1]s\" (id) VALUES (1);\n"+
+			"INSERT INTO \"%[2]s\" (id) VALUES (7);\n",
+		names.createdTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "session replay", body,
+		fmt.Sprintf("DROP TABLE %s", names.createdTable))
+
+	failing := issue887Migrator(conn, names, migration)
+	err = failing.MigrateUp(ctx)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(issue887AppliedCount(t, conn, names), qt.Equals, int64(3))
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.blockerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	retried := issue887Migrator(conn, names, migration)
+	err = retried.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true})
+	c.Assert(err, qt.IsNil)
+	c.Assert(issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.createdTable)), qt.Equals, int64(1))
+}
+
+func runRolledBackDownProgress(
+	t *testing.T,
+	dbURL,
+	prefix string,
+	revisionFormat migrator.RevisionTableFormat,
+) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY, note VARCHAR(64))", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	upSQL := fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY)", names.createdTable)
+	downSQL := fmt.Sprintf(
+		"DROP TABLE %[1]s;\n"+
+			"INSERT INTO %[2]s (id, note) VALUES (1, 'one');\n"+
+			"INSERT INTO %[3]s (id) VALUES (7);\n",
+		names.createdTable, names.ledgerTable, names.blockerTable,
+	)
+	migration := migrator.CreateMigrationFromSQL(1, "down progress", upSQL, downSQL)
+	mig := issue887MigratorWithFormat(conn, names, revisionFormat, migration)
+
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.IsNil)
+	err = mig.MigrateDown(ctx)
+	c.Assert(err, qt.IsNotNil)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNotNil)
+	c.Assert(status.DirtyRevision.Direction, qt.Equals, migrator.MigrationDirectionDown)
+	c.Assert(status.DirtyRevision.Applied, qt.Equals, 2)
+	c.Assert(issue887LedgerCount(t, conn, names), qt.Equals, int64(1))
+}
+
+func runRejectsNonTransactionalMetadata(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (version VARCHAR(191) PRIMARY KEY) ENGINE=MyISAM", names.revisionsTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	migration := migrator.CreateMigrationFromSQL(1, "metadata engine", "SELECT 1", "SELECT 1")
+	mig := issue887Migrator(conn, names, migration)
+	conn.SchemaWriter().SetDryRun(true)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migrations metadata table .* must use InnoDB to track MySQL-family implicit commits; found MyISAM`)
+	conn.SchemaWriter().SetDryRun(false)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migrations metadata table .* must use InnoDB to track MySQL-family implicit commits; found MyISAM`)
+}
+
+func runRejectsNonTransactionalNativeMetadataBeforeUpgrade(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(`CREATE TABLE %s (
+version BIGINT PRIMARY KEY,
+description TEXT NOT NULL,
+applied_at TIMESTAMP NOT NULL
+) ENGINE=MyISAM`, names.revisionsTable))
+	c.Assert(err, qt.IsNil)
+
+	migration := migrator.CreateMigrationFromSQL(1, "native metadata engine", "SELECT 1", "SELECT 1")
+	mig := issue887MigratorWithFormat(conn, names, migrator.RevisionTableFormatPtah, migration)
+	conn.SchemaWriter().SetDryRun(true)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migrations metadata table .* must use InnoDB to track MySQL-family implicit commits; found MyISAM`)
+	c.Assert(issue887ColumnCount(t, conn, names.revisionsTable, "state"), qt.Equals, int64(0))
+
+	conn.SchemaWriter().SetDryRun(false)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migrations metadata table .* must use InnoDB to track MySQL-family implicit commits; found MyISAM`)
+	c.Assert(issue887ColumnCount(t, conn, names.revisionsTable, "state"), qt.Equals, int64(0))
+}
+
+func runRejectsNonTransactionalTargetTable(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	_, err = conn.ExecContext(ctx, fmt.Sprintf(
+		"CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=MyISAM", names.ledgerTable,
+	))
+	c.Assert(err, qt.IsNil)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"target engine",
+		fmt.Sprintf("INSERT INTO %s (id) VALUES (1)", names.ledgerTable),
+		fmt.Sprintf("DELETE FROM %s", names.ledgerTable),
+	)
+	mig := issue887Migrator(conn, names, migration)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*tx-mode file requires InnoDB target tables on MySQL-family databases; table .* uses MyISAM`)
+	c.Assert(issue887ScalarCount(t, conn, fmt.Sprintf("SELECT COUNT(*) FROM %s", names.ledgerTable)), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runRejectsCreatingNonTransactionalTargetTable(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"create target engine",
+		fmt.Sprintf("CREATE TABLE %s (id INTEGER PRIMARY KEY) ENGINE=MyISAM", names.createdTable),
+		fmt.Sprintf("DROP TABLE %s", names.createdTable),
+	)
+	mig := issue887Migrator(conn, names, migration)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 statement 1 selects non-transactional storage engine MyISAM; tx-mode file requires InnoDB on MySQL-family databases`)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
+func runRejectsInheritedStorageEngine(t *testing.T, dbURL, prefix string) {
+	t.Helper()
+
+	c := qt.New(t)
+	ctx := context.Background()
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dbURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { _ = conn.Close() }()
+
+	names := issue887Names(prefix)
+	cleanupIssue887(t, conn, names)
+	defer cleanupIssue887(t, conn, names)
+
+	migration := migrator.CreateMigrationFromSQL(
+		1,
+		"inherited target engine",
+		fmt.Sprintf("CREATE TABLE %s LIKE %s", names.createdTable, names.blockerTable),
+		fmt.Sprintf("DROP TABLE %s", names.createdTable),
+	)
+	mig := issue887Migrator(conn, names, migration)
+	err = mig.MigrateUp(ctx)
+	c.Assert(err, qt.ErrorMatches, `.*migration 1 cannot run tx-mode file statement 1 because CREATE TABLE LIKE inherits a storage engine that Ptah cannot prove is InnoDB; declare the table explicitly or use tx-mode none`)
+	c.Assert(issue887TableCount(t, conn, names.createdTable), qt.Equals, int64(0))
+	c.Assert(issue887RevisionCount(t, conn, names), qt.Equals, int64(0))
+}
+
 type issue887TestNames struct {
 	revisionsTable string
 	ledgerTable    string
@@ -332,9 +643,18 @@ func issue887Migrator(
 	names issue887TestNames,
 	migrations ...*migrator.Migration,
 ) *migrator.Migrator {
+	return issue887MigratorWithFormat(conn, names, migrator.RevisionTableFormatAtlas, migrations...)
+}
+
+func issue887MigratorWithFormat(
+	conn *dbschema.DatabaseConnection,
+	names issue887TestNames,
+	format migrator.RevisionTableFormat,
+	migrations ...*migrator.Migration,
+) *migrator.Migrator {
 	return migrator.NewMigrator(conn, migrator.NewRegisteredMigrationProvider(migrations...)).
 		WithMigrationsTable("", names.revisionsTable).
-		WithRevisionTableFormat(migrator.RevisionTableFormatAtlas).
+		WithRevisionTableFormat(format).
 		WithTransactionMode(migrator.MigrationTxModeFile).
 		WithMigrationLockTimeout(10 * time.Second)
 }
@@ -359,17 +679,53 @@ func issue887AppliedCount(t *testing.T, conn *dbschema.DatabaseConnection, names
 	))
 }
 
-// issue887TableExists asserts against the catalog rather than the revision row.
-// A committed prefix that the accounting claims and the schema does not have is
-// exactly the failure these tests exist to catch.
-func issue887TableExists(t *testing.T, conn *dbschema.DatabaseConnection, table string) bool {
+func issue887MetadataEngine(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) string {
 	t.Helper()
 
-	count := issue887ScalarCount(t, conn, fmt.Sprintf(
-		"SELECT COUNT(*) FROM information_schema.tables "+
-			"WHERE table_schema = DATABASE() AND table_name = '%s'", table,
-	))
-	return count == 1
+	var engine string
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT engine FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+		conn.Info().Schema,
+		names.revisionsTable,
+	).Scan(&engine)
+	qt.Assert(t, err, qt.IsNil)
+	return engine
+}
+
+func issue887TableCount(t *testing.T, conn *dbschema.DatabaseConnection, table string) int64 {
+	t.Helper()
+
+	var count int64
+	err := conn.QueryRowContext(
+		context.Background(),
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
+		conn.Info().Schema,
+		table,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
+}
+
+func issue887ColumnCount(
+	t *testing.T,
+	conn *dbschema.DatabaseConnection,
+	table,
+	column string,
+) int64 {
+	t.Helper()
+
+	var count int64
+	err := conn.QueryRowContext(
+		context.Background(),
+		`SELECT COUNT(*) FROM information_schema.columns
+WHERE table_schema = ? AND table_name = ? AND column_name = ?`,
+		conn.Info().Schema,
+		table,
+		column,
+	).Scan(&count)
+	qt.Assert(t, err, qt.IsNil)
+	return count
 }
 
 func issue887ScalarCount(t *testing.T, conn *dbschema.DatabaseConnection, query string) int64 {
@@ -404,9 +760,7 @@ func issue887LedgerNotes(t *testing.T, conn *dbschema.DatabaseConnection, names 
 func cleanupIssue887(t *testing.T, conn *dbschema.DatabaseConnection, names issue887TestNames) {
 	t.Helper()
 
-	for _, table := range []string{
-		names.revisionsTable, names.blockerTable, names.ledgerTable, names.createdTable,
-	} {
+	for _, table := range []string{names.revisionsTable, names.blockerTable, names.createdTable, names.ledgerTable} {
 		_, _ = conn.ExecContext(context.Background(), fmt.Sprintf("DROP TABLE IF EXISTS %s", table))
 	}
 }


### PR DESCRIPTION
Refs #887.

## Problem

MySQL and MariaDB can commit an open transaction before DDL and then execute
later statements in autocommit mode. A static SQL keyword classifier cannot
prove the durable contiguous prefix after a failure. Understating that prefix
replays committed SQL; overstating it skips rolled-back SQL.

## Design

This change removes durable-prefix inference from SQL classification. In
MySQL-family `tx-mode file`, Ptah pins one physical session and records a
revision witness in the same InnoDB transaction as the migration body:

1. Before each statement, the revision records an unknown outcome.
2. After success, the same transaction records the applied count and partial
   hashes.
3. An implicit commit makes the witness and the preceding user SQL durable
   together.
4. An ordinary rollback removes the uncommitted tail together.
5. Recovery reads the durable witness and resumes only after a proven prefix.

The mechanism applies to up and down execution and to native and Atlas-shaped
revision tables. Down validation and session preflight complete before Ptah
marks the revision dirty. A failed statement whose lack of effects cannot be
proved leaves an unknown outcome and blocks automatic retry instead of
guessing.

## Safety boundaries

The witness contract is enabled only when Ptah can prove its durability model:

- Revision metadata, the session default, and every existing base table in the
  selected database must use InnoDB.
- Explicit non-InnoDB engines and `CREATE TABLE ... LIKE` are rejected.
- The migration account must hold `TRIGGER` at database or global scope, since
  MySQL and MariaDB hide trigger metadata from an account without it while
  those triggers still fire during ordinary DML.
- Transaction controls, `USE`, durable server-state changes, and database
  catalog changes are rejected.
- Cross-database relation and routine references are rejected.
- Executable comments, nested or dynamic SQL, table locks, indirect database
  objects, trigger-bearing relations, and stored-routine calls are rejected.
- Opaque `MigrationFunc` callbacks and statement interceptors must use
  `tx-mode none`, in both directions.

Checks run before body SQL and again on the pinned session. A statement-level
rejection names the statement number and its safety class; a `MigrationFunc`
or a statement interceptor is refused for the whole migration and named by
direction, because neither has a statement to point at. Neither form echoes
the SQL, which may contain credentials. Safe session settings are replayed
when a proven durable prefix resumes on a new session.

## Reading a granted database the way the server does

A schema-level privilege stores its database as a pattern, not as a name: `_`
and `%` are wildcards unless a backslash escapes them. A grant on a literal
database name therefore escapes the underscores in it, and the official MySQL
and MariaDB container images do exactly that when they provision `MYSQL_USER`,
so `SHOW GRANTS` prints `` `ptah\_test` `` for a privilege that covers
`ptah_test`. The trigger-privilege preflight compared that to the schema as a
string, which refused `tx-mode file` for an account that does hold `TRIGGER`
and, in the other direction, failed to see a `REVOKE` written the same way.
The granted database is now matched with the server's pattern semantics.

Every existing row for that classifier used a schema name with no underscore,
which is why nothing caught it. The new rows all use one, and they separate
the pattern from both a name comparison and a plain unescape.

## Tests

The live suite runs against MySQL 9.7 and MariaDB, and covers:

- pure-DML rollback and retry from the top;
- DDL followed by durable DML, with retry beginning at statement 3 and no
  duplicate insert;
- fail-closed recovery from a failed DDL with an unknown outcome;
- up and down progress with native and Atlas-shaped revision layouts;
- session-state replay;
- revision metadata, default-engine, target-table, explicit-engine, and
  `CREATE TABLE ... LIKE` rejection paths;
- transaction control in the body, including `COMMIT AND CHAIN` and
  `ROLLBACK AND CHAIN`, which end the file transaction and open another one on
  the same session. A classifier that only recognizes a bare `COMMIT` or
  `ROLLBACK` lets those through, and `MigrateUp` then returns nil for a body
  whose leading statements were discarded and whose trailing statements
  committed. The live cases count the surviving rows, because the returned
  error cannot separate that outcome from a correct run: there is none;
- executable comments, opaque callbacks, statement interceptors in both
  directions, nested SQL, cross-database writes and database creation,
  trigger-bearing relations, stored functions, and secret redaction.

The `integration-tests` job runs a dedicated `TestRolledBackProgress_` step for
MySQL and MariaDB, with a test-list guard so the live cases cannot silently
disappear.

## Documentation

The versioned apply guide, Atlas-compatible migrate guide, package README, and
package documentation describe the witness behavior, fail-closed boundaries,
unknown-outcome recovery, the `TRIGGER` privilege requirement, and the lack of
MySQL-family `tx-mode all` support.

## Local validation

Run on this branch after rebasing onto master, each exit code read directly:

- `go build ./...`, `go vet ./...`, `go vet -tags integration ./integration/...`
- `go test ./... -count=1`
- `go tool qtlint ./...`, `golangci-lint run ./...`
- `scripts/check-test-style.sh`, `scripts/check-public-api.sh`,
  `scripts/check-public-api-snapshot.sh`, `scripts/check-public-api-released.sh`
- every `check:*` script in `docs/site/package.json`
- `go test -v -count=1 ./migration/migrator -run '^TestRolledBackProgress_'`
  against MySQL 9.7.1 with MariaDB 11.4.12, and again against MySQL 9.7.1 with
  MariaDB 10.11.18, the tag CI pins: 32 tests, 32 PASS, no FAIL and no SKIP in
  either run
- `go test -v -count=1 ./migration/migrator -run '(MySQL|MariaDB)'` against the
  same servers: 76 PASS, no FAIL and no SKIP

GitHub CI on the final commit remains the merge gate.