### PR TITLE
Stop generating concurrent index SQL PostgreSQL refuses, and stop dropping the copies it creates (#997)

### DIFF
--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -260,6 +260,37 @@ jobs:
           sh scripts/require-tests-ran.sh --package ./migration/generator --tags integration \
             --pattern '^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$' --timeout 5m
 
+      # The third ./migration/generator live-test step, alongside the two above.
+      # Every test in it decides something only a server can answer -- whether
+      # PostgreSQL refuses a concurrent index on a partitioned parent, which
+      # index a partition's copy makes undroppable, and whether a
+      # never-analyzed relation is empty or merely unmeasured. All six skip
+      # themselves when no DSN is set, and a skip reads as a pass, so two guards
+      # run and they fail on different things. The -list lines fail the step
+      # when a rename leaves the -run pattern matching nothing; the --- PASS
+      # greps over the captured log fail it when the tests were reached and
+      # skipped themselves. Neither alone is enough: -list answers from the
+      # source whether or not anything ran, and a PASS grep cannot tell a
+      # renamed test from one that never existed.
+      - name: Run partitioned and row-statistics concurrent-index tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$'
+          go test ./migration/generator -list '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$' | grep -q '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$' | grep -q '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'
+          go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres|TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres)$' -timeout 10m > partitioned-index.log || { cat partitioned-index.log; exit 1; }
+          cat partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres' partitioned-index.log
+
       - name: Run database-realm cleanup and replay tests
         env:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
@@ -364,36 +395,6 @@ jobs:
           POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
         run: |
           go test -v -count=1 ./cmd/migratebaseline -run 'TestVerifyBaselineShadowPostgres|TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL' -timeout 3m
-
-      # Every test in this step decides something only a server can answer --
-      # whether PostgreSQL refuses a concurrent index on a partitioned parent,
-      # which index a partition's copy makes undroppable, and whether a
-      # never-analyzed relation is empty or merely unmeasured. All six skip
-      # themselves when no DSN is set, and a skip reads as a pass, so two guards
-      # run and they fail on different things. The -list lines fail the step
-      # when a rename leaves the -run pattern matching nothing; the --- PASS
-      # greps over the captured log fail it when the tests were reached and
-      # skipped themselves. Neither alone is enough: -list answers from the
-      # source whether or not anything ran, and a PASS grep cannot tell a
-      # renamed test from one that never existed.
-      - name: Run partitioned and row-statistics concurrent-index tests
-        env:
-          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
-        run: |
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$'
-          go test ./migration/generator -list '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$' | grep -q '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$' | grep -q '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$'
-          go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'
-          go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres|TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres)$' -timeout 10m > partitioned-index.log || { cat partitioned-index.log; exit 1; }
-          cat partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' partitioned-index.log
-          grep -q -- '--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres' partitioned-index.log
 
       - name: Run all databases comprehensive test
         env:

--- a/.github/workflows/go-integration-tests.yml
+++ b/.github/workflows/go-integration-tests.yml
@@ -365,6 +365,36 @@ jobs:
         run: |
           go test -v -count=1 ./cmd/migratebaseline -run 'TestVerifyBaselineShadowPostgres|TestMigrateBaselineCommandPostgresWritesMetadataWithoutExecutingDDL' -timeout 3m
 
+      # Every test in this step decides something only a server can answer --
+      # whether PostgreSQL refuses a concurrent index on a partitioned parent,
+      # which index a partition's copy makes undroppable, and whether a
+      # never-analyzed relation is empty or merely unmeasured. All six skip
+      # themselves when no DSN is set, and a skip reads as a pass, so two guards
+      # run and they fail on different things. The -list lines fail the step
+      # when a rename leaves the -run pattern matching nothing; the --- PASS
+      # greps over the captured log fail it when the tests were reached and
+      # skipped themselves. Neither alone is enough: -list answers from the
+      # source whether or not anything ran, and a PASS grep cannot tell a
+      # renamed test from one that never existed.
+      - name: Run partitioned and row-statistics concurrent-index tests
+        env:
+          POSTGRES_TEST_DSN: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"
+        run: |
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$' | grep -q '^TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres$'
+          go test ./migration/generator -list '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$' | grep -q '^TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$' | grep -q '^TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres$'
+          go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'
+          go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres|TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres)$' -timeout 10m > partitioned-index.log || { cat partitioned-index.log; exit 1; }
+          cat partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' partitioned-index.log
+          grep -q -- '--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres' partitioned-index.log
+
       - name: Run all databases comprehensive test
         env:
           POSTGRES_URL: "postgres://ptah_user:ptah_password@localhost:5432/ptah_test?sslmode=disable"

--- a/cmd/lint/lint_test.go
+++ b/cmd/lint/lint_test.go
@@ -720,9 +720,17 @@ func TestRunLint_AtlasProjectConfigConcurrentIndexPolicyRaisesSeverity(t *testin
 		Findings []migrationlint.Finding `json:"findings"`
 	}
 	c.Assert(json.Unmarshal([]byte(stdout), &report), qt.IsNil)
-	c.Assert(report.Findings, qt.HasLen, 1)
-	c.Assert(report.Findings[0].Rule, qt.Equals, "PG101")
-	c.Assert(report.Findings[0].Severity, qt.Equals, migrationlint.SeverityError)
+	// The down file's blocking DROP INDEX is reported too (stokaro/ptah#997),
+	// and the concurrent_index policy family does not cover PG106, so its
+	// severity stays at the rule default while PG101 is raised.
+	severityByRule := make(map[string]migrationlint.Severity, len(report.Findings))
+	for _, finding := range report.Findings {
+		severityByRule[finding.Rule] = finding.Severity
+	}
+	c.Assert(severityByRule, qt.DeepEquals, map[string]migrationlint.Severity{
+		"PG101": migrationlint.SeverityError,
+		"PG106": migrationlint.SeverityWarning,
+	})
 }
 
 func TestRunLint_AtlasProjectConfigPolicyAffectsSARIFLevels(t *testing.T) {
@@ -766,8 +774,18 @@ ALTER TABLE users ADD COLUMN legacy TEXT;
 	}
 	c.Assert(rulesByID["DS102"].DefaultConfiguration.Level, qt.Equals, "warning")
 	c.Assert(rulesByID["PG101"].DefaultConfiguration.Level, qt.Equals, "error")
-	c.Assert(run.Results[0].Level, qt.Equals, "warning")
-	c.Assert(run.Results[1].Level, qt.Equals, "error")
+	// Keyed by rule rather than by position: the down file's blocking DROP
+	// INDEX is now a result too (stokaro/ptah#997), and it sorts ahead of the
+	// up file's results.
+	levelByRule := make(map[string]string, len(run.Results))
+	for _, result := range run.Results {
+		levelByRule[result.RuleID] = result.Level
+	}
+	c.Assert(levelByRule, qt.DeepEquals, map[string]string{
+		"DS102": "warning",
+		"PG101": "error",
+		"PG106": "warning",
+	})
 }
 
 func TestRunLint_ConfigRuleSeverityAndExclude(t *testing.T) {

--- a/cmd/migrate/generate_destructive_partition_test.go
+++ b/cmd/migrate/generate_destructive_partition_test.go
@@ -1,0 +1,180 @@
+package migrate_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/cmd/migrate"
+	"go.5x5.cz/ptah/dbschema"
+)
+
+// TestMigrateGenerateWritesTheUndeclaredPartitionDropUnlessAskedToCheck pins
+// which verb refuses the DROP TABLE that a desired state naming a partitioned
+// parent, but not its partitions, plans for those partitions.
+//
+// Two separate things are easy to conflate here, and #997's record conflated
+// them once already:
+//
+//   - `migrations generate` writes the statement. Its destructive gate is
+//     opt-in: --check-destructive turns it on, and --allow-destructive only
+//     means anything once it is on. With neither flag the command exits
+//     successfully and the file, its checksum and its commit exist.
+//   - The refusal that quotes DS101 belongs to `migrations up`, which reads
+//     the written directory and declines to apply it. That gate is pinned by
+//     TestMigrateUp_LintConfigWarningStillBlocksPostgresDropTable in
+//     cmd/migrateup, which also asserts the table survives the refusal.
+//
+// The fixture is a real partitioned parent rather than two ordinary tables,
+// because the neighboring over-reach this PR must not commit is to start
+// suppressing the partition the way it now suppresses the partition's copy of
+// a parent index. A partition is a table holding rows of its own; dropping it
+// is destructive and has to stay visible as such.
+func TestMigrateGenerateWritesTheUndeclaredPartitionDropUnlessAskedToCheck(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+
+	dbURL, conn := requireMigrateGeneratePostgresTestConnection(t, ctx)
+	defer dbschema.CloseAndWarn(conn)
+	releaseLock := acquireMigrateGenerateTestLock(c, ctx, conn)
+	defer releaseLock()
+	defer func() {
+		c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
+	}()
+
+	c.Assert(conn.SchemaWriter().DropAllTables(ctx), qt.IsNil)
+	_, err := conn.ExecContext(ctx, `
+		CREATE TABLE events (
+			id BIGINT NOT NULL,
+			tenant TEXT NOT NULL,
+			created_at DATE NOT NULL
+		) PARTITION BY RANGE (created_at)
+	`)
+	c.Assert(err, qt.IsNil)
+	_, err = conn.ExecContext(ctx, `
+		CREATE TABLE events_2026 PARTITION OF events
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01')
+	`)
+	c.Assert(err, qt.IsNil)
+
+	entitiesDir := writeMigrateGenerateParentOnlyEntities(c, c.TempDir())
+
+	c.Run("--check-destructive refuses before anything is written", func(c *qt.C) {
+		migrationsDir := filepath.Join(c.TempDir(), "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+		err := runMigrateGenerate(c, []string{
+			"--root-dir", entitiesDir,
+			"--db-url", dbURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "checked",
+			"--check-destructive",
+		})
+
+		c.Assert(err, qt.ErrorMatches, "destructive migration statements require AllowDestructive")
+		c.Assert(migrateGenerateSQLFiles(c, migrationsDir), qt.HasLen, 0)
+	})
+
+	c.Run("the default writes the DROP TABLE and reports success", func(c *qt.C) {
+		migrationsDir := filepath.Join(c.TempDir(), "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+		err := runMigrateGenerate(c, []string{
+			"--root-dir", entitiesDir,
+			"--db-url", dbURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "unchecked",
+		})
+
+		c.Assert(err, qt.IsNil)
+		upSQL := migrateGenerateUpSQL(c, migrationsDir)
+		c.Assert(upSQL, qt.Contains, `DROP TABLE IF EXISTS "events_2026" CASCADE;`)
+		// The declared half of the plan is here too, so the row above reports
+		// the destructive gate rather than a plan that came out empty.
+		c.Assert(upSQL, qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_events_tenant" ON "events" ("tenant");`)
+	})
+
+	c.Run("--check-destructive with --allow-destructive writes it too", func(c *qt.C) {
+		migrationsDir := filepath.Join(c.TempDir(), "migrations")
+		c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+		err := runMigrateGenerate(c, []string{
+			"--root-dir", entitiesDir,
+			"--db-url", dbURL,
+			"--migrations-dir", migrationsDir,
+			"--name", "allowed",
+			"--check-destructive",
+			"--allow-destructive",
+		})
+
+		c.Assert(err, qt.IsNil)
+		c.Assert(
+			migrateGenerateUpSQL(c, migrationsDir),
+			qt.Contains,
+			`DROP TABLE IF EXISTS "events_2026" CASCADE;`,
+		)
+	})
+}
+
+// runMigrateGenerate executes one `migrations generate` invocation and returns
+// its error, with stdout and stderr captured so a failure reports what the
+// command said.
+func runMigrateGenerate(c *qt.C, args []string) error {
+	c.Helper()
+	var stdout, stderr bytes.Buffer
+	cmd := migrate.NewMigrateGenerateCommand()
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	c.Logf("stdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+	return err
+}
+
+// migrateGenerateSQLFiles lists the .sql files a generate invocation left in a
+// directory, so "nothing was written" is measured against the directory.
+func migrateGenerateSQLFiles(c *qt.C, dir string) []string {
+	c.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.sql"))
+	c.Assert(err, qt.IsNil)
+	return matches
+}
+
+// migrateGenerateUpSQL reads the one generated up file in a directory. It
+// asserts there is exactly one, so a row that reads the wrong migration says so
+// rather than matching against whichever file the glob happened to order first.
+func migrateGenerateUpSQL(c *qt.C, dir string) string {
+	c.Helper()
+	matches, err := filepath.Glob(filepath.Join(dir, "*.up.sql"))
+	c.Assert(err, qt.IsNil)
+	c.Assert(matches, qt.HasLen, 1)
+	content, err := os.ReadFile(matches[0])
+	c.Assert(err, qt.IsNil)
+	return string(content)
+}
+
+func writeMigrateGenerateParentOnlyEntities(c *qt.C, dir string) string {
+	c.Helper()
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0o755), qt.IsNil)
+	content := `package entities
+
+//ptah:schema:table name="events"
+type Event struct {
+	//ptah:schema:field name="id" type="BIGINT" not_null="true"
+	ID int64
+
+	//ptah:schema:field name="tenant" type="TEXT" not_null="true"
+	//ptah:schema:index name="idx_events_tenant" fields="tenant"
+	Tenant string
+
+	//ptah:schema:field name="created_at" type="DATE" not_null="true"
+	CreatedAt string
+}
+`
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0o600), qt.IsNil)
+	return entitiesDir
+}

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -74,16 +74,32 @@ type DBSchemaInfo struct {
 }
 
 // DBTable represents a database table
+//
+// EstimatedRows and RowStatsUnknown are a pair, and reading EstimatedRows
+// alone is a mistake: PostgreSQL spells "nobody has ever counted this table"
+// as pg_class.reltuples = -1, which floors to the same 0 a genuinely empty
+// table reports. RowStatsUnknown carries that distinction so a caller choosing
+// between a blocking and a non-blocking index build can fail safe instead of
+// reading an absent statistic as an empty table. Readers that never collect
+// row statistics leave both fields zero, which claims nothing.
+//
+// Partitioned marks a PostgreSQL declaratively partitioned parent (relkind
+// 'p'). information_schema.tables reports it as an ordinary BASE TABLE, so
+// Type cannot carry it, and the distinction decides which statements are legal:
+// PostgreSQL rejects CREATE INDEX CONCURRENTLY and DROP INDEX CONCURRENTLY on
+// a partitioned relation with SQLSTATE 0A000.
 type DBTable struct {
-	Name          string     `json:"name"`
-	Schema        string     `json:"schema,omitempty"`
-	Type          string     `json:"type"` // TABLE, VIEW, etc.
-	Comment       string     `json:"comment"`
-	Columns       []DBColumn `json:"columns"`
-	EstimatedRows int64      `json:"estimated_rows,omitempty"` // Best-effort planner estimate from database statistics
-	RLSEnabled    bool       `json:"rls_enabled"`              // Whether RLS is enabled on this table (PostgreSQL)
-	Strict        bool       `json:"strict,omitempty"`         // SQLite STRICT table option
-	WithoutRowID  bool       `json:"without_rowid,omitempty"`  // SQLite WITHOUT ROWID table option
+	Name            string     `json:"name"`
+	Schema          string     `json:"schema,omitempty"`
+	Type            string     `json:"type"` // TABLE, VIEW, etc.
+	Comment         string     `json:"comment"`
+	Columns         []DBColumn `json:"columns"`
+	EstimatedRows   int64      `json:"estimated_rows,omitempty"`    // Best-effort planner estimate from database statistics
+	RowStatsUnknown bool       `json:"row_stats_unknown,omitempty"` // The database reports no usable row statistics; EstimatedRows is not a row count
+	Partitioned     bool       `json:"partitioned,omitempty"`       // PostgreSQL declaratively partitioned parent (pg_class.relkind = 'p')
+	RLSEnabled      bool       `json:"rls_enabled"`                 // Whether RLS is enabled on this table (PostgreSQL)
+	Strict          bool       `json:"strict,omitempty"`            // SQLite STRICT table option
+	WithoutRowID    bool       `json:"without_rowid,omitempty"`     // SQLite WITHOUT ROWID table option
 }
 
 // QualifiedName returns schema.table when Schema is set, or Name otherwise.

--- a/dbschema/types/types.go
+++ b/dbschema/types/types.go
@@ -415,6 +415,26 @@ type DBIndex struct {
 	// Granularity is the GRANULARITY value the index was declared with.
 	// Non-zero only on ClickHouse skipping indexes.
 	Granularity int `json:"granularity,omitempty"`
+
+	// PartitionAttached reports that this index is a partition's copy of an
+	// index on its partitioned parent, attached to that parent index rather
+	// than standing on its own.
+	//
+	// PostgreSQL creates one such index per partition whenever an index is
+	// created on a partitioned parent, names it itself
+	// (events_2026_tenant_idx), and refuses to drop it alone:
+	// DROP INDEX "events_2026_tenant_idx" answers `cannot drop index
+	// events_2026_tenant_idx because index idx_events_tenant requires it`
+	// (SQLSTATE 2BP01). It is the index equivalent of a constraint's backing
+	// index -- a real catalog row that no standalone statement addresses --
+	// and a comparison that reads it as an ordinary index plans a DROP the
+	// server refuses.
+	//
+	// The parent index is not marked: it is the object the DDL names, and on
+	// PostgreSQL it is relkind 'I' while a partition's copy is relkind 'i'.
+	// Only readers that can ask the catalog (pg_inherits over index
+	// relations) set this; everything else leaves it false.
+	PartitionAttached bool `json:"partition_attached,omitempty"`
 }
 
 // QualifiedTableName returns schema.table when Schema is set, or TableName otherwise.

--- a/docs/atlas_project_config.md
+++ b/docs/atlas_project_config.md
@@ -242,6 +242,11 @@ build avoided. A non-dry-run PostgreSQL `schema apply` plan that emits
 `DROP INDEX CONCURRENTLY` requires `--tx-mode none` for the same reason the
 create side does.
 
+Either setting fails `migrate diff` before it writes anything when the index it
+names belongs to a PostgreSQL declaratively partitioned parent: PostgreSQL has
+no concurrent form of either statement for `relkind = 'p'` and answers with
+SQLSTATE `0A000` at execution time. The error names the index and the table.
+
 `lint.latest` and `lint.git` configure the migration changeset selected by
 `migrations lint` and `ptah-compat migrate lint`. These selectors are mutually
 exclusive. `lint.git.dir` matches Atlas's working-directory option for Git

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -249,6 +249,15 @@ build is always emitted as `DROP INDEX CONCURRENTLY` where the target supports
 it, whatever this setting says: a blocking drop on rollback would take the very
 write lock the build was written to avoid.
 
+Both settings **fail generation** when the index they name belongs to a
+PostgreSQL declaratively partitioned parent. PostgreSQL has no concurrent form
+of either statement for `relkind = 'p'` and refuses it with SQLSTATE `0A000` at
+execution time, so honoring the request is impossible and downgrading it
+silently would give a project that asked for a non-blocking statement a
+blocking one. The error names the index and the table; unset the setting to get
+the plain statement, or manage the index per partition. The built-in heuristic,
+which nobody asked for, downgrades instead of failing.
+
 ## Precedence
 
 Runtime values resolve in this order:

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -5873,6 +5873,26 @@ type DBIndex struct {
     // Granularity is the GRANULARITY value the index was declared with.
     // Non-zero only on ClickHouse skipping indexes.
     Granularity int `json:"granularity,omitempty"`
+
+    // PartitionAttached reports that this index is a partition's copy of an
+    // index on its partitioned parent, attached to that parent index rather
+    // than standing on its own.
+    //
+    // PostgreSQL creates one such index per partition whenever an index is
+    // created on a partitioned parent, names it itself
+    // (events_2026_tenant_idx), and refuses to drop it alone:
+    // DROP INDEX "events_2026_tenant_idx" answers `cannot drop index
+    // events_2026_tenant_idx because index idx_events_tenant requires it`
+    // (SQLSTATE 2BP01). It is the index equivalent of a constraint's backing
+    // index -- a real catalog row that no standalone statement addresses --
+    // and a comparison that reads it as an ordinary index plans a DROP the
+    // server refuses.
+    //
+    // The parent index is not marked: it is the object the DDL names, and on
+    // PostgreSQL it is relkind 'I' while a partition's copy is relkind 'i'.
+    // Only readers that can ask the catalog (pg_inherits over index
+    // relations) set this; everything else leaves it false.
+    PartitionAttached bool `json:"partition_attached,omitempty"`
 }
     DBIndex represents a database index.
 

--- a/docs/public_api.snapshot
+++ b/docs/public_api.snapshot
@@ -6111,17 +6111,33 @@ func (s DBSequence) QualifiedName() string
 package types // import "go.5x5.cz/ptah/dbschema/types"
 
 type DBTable struct {
-    Name          string     `json:"name"`
-    Schema        string     `json:"schema,omitempty"`
-    Type          string     `json:"type"` // TABLE, VIEW, etc.
-    Comment       string     `json:"comment"`
-    Columns       []DBColumn `json:"columns"`
-    EstimatedRows int64      `json:"estimated_rows,omitempty"` // Best-effort planner estimate from database statistics
-    RLSEnabled    bool       `json:"rls_enabled"`              // Whether RLS is enabled on this table (PostgreSQL)
-    Strict        bool       `json:"strict,omitempty"`         // SQLite STRICT table option
-    WithoutRowID  bool       `json:"without_rowid,omitempty"`  // SQLite WITHOUT ROWID table option
+    Name            string     `json:"name"`
+    Schema          string     `json:"schema,omitempty"`
+    Type            string     `json:"type"` // TABLE, VIEW, etc.
+    Comment         string     `json:"comment"`
+    Columns         []DBColumn `json:"columns"`
+    EstimatedRows   int64      `json:"estimated_rows,omitempty"`    // Best-effort planner estimate from database statistics
+    RowStatsUnknown bool       `json:"row_stats_unknown,omitempty"` // The database reports no usable row statistics; EstimatedRows is not a row count
+    Partitioned     bool       `json:"partitioned,omitempty"`       // PostgreSQL declaratively partitioned parent (pg_class.relkind = 'p')
+    RLSEnabled      bool       `json:"rls_enabled"`                 // Whether RLS is enabled on this table (PostgreSQL)
+    Strict          bool       `json:"strict,omitempty"`            // SQLite STRICT table option
+    WithoutRowID    bool       `json:"without_rowid,omitempty"`     // SQLite WITHOUT ROWID table option
 }
     DBTable represents a database table
+
+    EstimatedRows and RowStatsUnknown are a pair, and reading EstimatedRows
+    alone is a mistake: PostgreSQL spells "nobody has ever counted this table"
+    as pg_class.reltuples = -1, which floors to the same 0 a genuinely empty
+    table reports. RowStatsUnknown carries that distinction so a caller choosing
+    between a blocking and a non-blocking index build can fail safe instead of
+    reading an absent statistic as an empty table. Readers that never collect
+    row statistics leave both fields zero, which claims nothing.
+
+    Partitioned marks a PostgreSQL declaratively partitioned parent (relkind
+    'p'). information_schema.tables reports it as an ordinary BASE TABLE,
+    so Type cannot carry it, and the distinction decides which statements
+    are legal: PostgreSQL rejects CREATE INDEX CONCURRENTLY and DROP INDEX
+    CONCURRENTLY on a partitioned relation with SQLSTATE 0A000.
 
 func (t DBTable) QualifiedName() string
 
@@ -7119,6 +7135,15 @@ type File struct {
     // IsUp reports whether statement rules treat this as an up migration:
     // the migrator parses it as up, or its name carries the .up.sql suffix.
     IsUp bool
+    // IsDown reports whether this is the rollback half of a migration: the
+    // migrator parses it as down, or its name carries the .down.sql suffix.
+    //
+    // A down file is executed against a production database exactly like an up
+    // file, so a hazard in one is a hazard in the other. Rules stay up-only by
+    // default because most of them describe a forward change, and the ones that
+    // describe a statement's cost or its executability opt in with
+    // [Rule.AppliesToDown].
+    IsDown bool
     // HasPair reports whether the matching counterpart file (down for up,
     // up for down) exists in the same directory.
     HasPair bool
@@ -7130,8 +7155,9 @@ type File struct {
     // NoTransaction reports whether file-scoped directives opt this migration
     // out of the migrator's transaction wrapper.
     NoTransaction bool
-    // Statements holds the parsed statements of up migrations. Empty for
-    // down migrations (statement rules do not run there).
+    // Statements holds the parsed statements of up and down migrations. Empty
+    // for any other file. A rule that reads them without checking direction
+    // gets both, which is why every direction-sensitive rule tests IsUp.
     Statements []Statement
     // Changes holds the semantic schema changes this up migration expresses,
     // recovered from Ptah's dialect-aware SQL parser. Empty for down migrations
@@ -7245,9 +7271,21 @@ type Rule struct {
     // Dialects restricts the rule to specific target dialects; empty means
     // every dialect.
     Dialects []string
-    // CheckStatement inspects one statement of an up migration and reports
-    // whether the rule fires, with a specific message.
+    // CheckStatement inspects one statement of a migration and reports whether
+    // the rule fires, with a specific message. It sees up migrations only
+    // unless AppliesToDown is set.
     CheckStatement func(stmt *Statement) (bool, string)
+    // AppliesToDown extends a CheckStatement rule to the down half of a
+    // migration. It is off by default because most statement rules describe a
+    // forward schema change, where the rollback is the remedy rather than the
+    // hazard. Set it for a rule that describes the cost or the executability of
+    // a statement, which the database charges identically in either direction:
+    // a blocking DROP INDEX holds the same lock whether a migration is being
+    // applied or rolled back.
+    //
+    // It has no effect on a CheckFile rule, which receives every file already
+    // and decides for itself; those read [File.IsUp] and [File.IsDown].
+    AppliesToDown bool
     // CheckFile inspects file-level form and returns full findings.
     CheckFile func(file *File) []Finding
 }

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -328,14 +328,24 @@ which happens on a crash-recovery restart, on `pg_stat_reset()`, and for a
 table restored into a fresh cluster. A table holding millions of rows reports
 exactly what an empty one reports.
 
-A table Ptah cannot get statistics for counts as **populated**, so it gets the
-non-blocking build. The alternative failed closed in the wrong direction: a
-blocking `CREATE INDEX` immediately after a bulk load or a restore held writes
-for the length of the scan. Running `ANALYZE` on the table before generating
-gives the decision a real number and restores the transactional build for a
-table that is genuinely empty. A table that does not exist in the database yet
-is a separate case and stays transactional — the migration creates it, so it
-starts empty.
+Missing statistics alone would be a poor test, because `reltuples = -1` is also
+the state of every table that has never had a row inserted — so reading it as
+"row count unknown" would put every freshly created table into a
+non-transactional migration of its own. Ptah asks the file system instead:
+`pg_relation_size` reports the table's main fork, which is not reset by an
+analyze, by a counter reset, or by a restore.
+
+- **No statistics and no storage** is an empty table. It gets the plain,
+  transactional `CREATE INDEX`.
+- **No statistics but storage in use** is a row count Ptah genuinely does not
+  know, and it counts as **populated** — the non-blocking build. Failing the
+  other way was the wrong direction: a blocking `CREATE INDEX` immediately after
+  a bulk load or a restore held writes for the length of the scan.
+
+Running `ANALYZE` on the table before generating gives the decision a real
+number in either case. A table that does not exist in the database yet is a
+separate case and stays transactional — the migration creates it, so it starts
+empty.
 
 ### Partitioned parents
 

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -364,6 +364,29 @@ PARTITION`. The parent index stays `indisvalid = false` until every partition is
 attached, and Ptah's migration guards recognize that shape rather than treating
 it as failed-build residue.
 
+### The index copies a partitioned parent creates
+
+Creating an index on a partitioned parent makes PostgreSQL create one copy of it
+on every partition, under a name the server chooses (`events_2026_tenant_idx`).
+Those copies are attached to the parent index and cannot be dropped on their own:
+
+```
+DROP INDEX "events_2026_tenant_idx";
+ERROR:  cannot drop index events_2026_tenant_idx because index idx_events_tenant requires it
+```
+
+A desired state written against the parent never names them, so a comparison
+that reads them as ordinary indexes plans exactly that refused statement — and
+only on the *second* generate, because the copies do not exist until the first
+migration has been applied. Ptah reads the attachment from `pg_inherits` and
+plans neither a create nor a drop for an attached copy; the parent index is
+where the plan acts.
+
+The attachment is the test, not the name and not the table. An index created on
+a partition directly is still managed, including one that happens to carry the
+name PostgreSQL would have generated for a copy, and a copy attached under a
+name of your own choosing is still left alone.
+
 ## Concurrent index removal
 
 `DROP INDEX CONCURRENTLY` is the matching non-blocking removal, and it carries

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -370,9 +370,9 @@ Creating an index on a partitioned parent makes PostgreSQL create one copy of it
 on every partition, under a name the server chooses (`events_2026_tenant_idx`).
 Those copies are attached to the parent index and cannot be dropped on their own:
 
-```
+```sql
 DROP INDEX "events_2026_tenant_idx";
-ERROR:  cannot drop index events_2026_tenant_idx because index idx_events_tenant requires it
+-- ERROR:  cannot drop index events_2026_tenant_idx because index idx_events_tenant requires it
 ```
 
 A desired state written against the parent never names them, so a comparison

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -318,6 +318,52 @@ in `atlas.hcl` tags such files with the Atlas `-- atlas:txmode none` directive
 instead ([Atlas migrate commands](../../atlas/migrate-commands/)); the
 migrator honors both directives.
 
+### What "populated" means when the database cannot say
+
+The decision reads `pg_class.reltuples` and `pg_stat_all_tables.n_live_tup`,
+and PostgreSQL reports **no row statistics at all** in more situations than it
+reports zero rows: `reltuples` is `-1` until something vacuums or analyzes the
+relation, and `n_live_tup` reads `0` after the cumulative counters are reset —
+which happens on a crash-recovery restart, on `pg_stat_reset()`, and for a
+table restored into a fresh cluster. A table holding millions of rows reports
+exactly what an empty one reports.
+
+A table Ptah cannot get statistics for counts as **populated**, so it gets the
+non-blocking build. The alternative failed closed in the wrong direction: a
+blocking `CREATE INDEX` immediately after a bulk load or a restore held writes
+for the length of the scan. Running `ANALYZE` on the table before generating
+gives the decision a real number and restores the transactional build for a
+table that is genuinely empty. A table that does not exist in the database yet
+is a separate case and stays transactional — the migration creates it, so it
+starts empty.
+
+### Partitioned parents
+
+PostgreSQL has no concurrent index statement for a declaratively partitioned
+parent: both `CREATE INDEX CONCURRENTLY` and `DROP INDEX CONCURRENTLY` are
+refused on `relkind = 'p'` with SQLSTATE `0A000`, and they are refused at
+execution time — after the migration file, its checksum and its commit exist.
+
+Ptah reads the partitioned flag from the catalog (`information_schema` reports
+a partitioned parent as an ordinary `BASE TABLE`, so it cannot carry this) and
+handles the two cases differently:
+
+- **The populated-table heuristic** excludes a partitioned parent and generates
+  the plain, transactional statement. Nothing asked for a concurrent build, and
+  the plain form is legal SQL that `ptah migrations lint` still reports as
+  `PG101`.
+- **An explicit `diff.concurrent_index.create` / `diff.concurrent_index.drop`**
+  fails generation before any file is written, naming the index and the
+  partitioned table. Silently downgrading an explicit request would hand a
+  project that asked for a non-blocking build a blocking one without saying so.
+
+To build a partitioned index without locking every partition at once, use the
+documented sequence by hand: `CREATE INDEX ... ON ONLY` the parent, then
+`CREATE INDEX CONCURRENTLY` on each partition, then `ALTER INDEX ... ATTACH
+PARTITION`. The parent index stays `indisvalid = false` until every partition is
+attached, and Ptah's migration guards recognize that shape rather than treating
+it as failed-build residue.
+
 ## Concurrent index removal
 
 `DROP INDEX CONCURRENTLY` is the matching non-blocking removal, and it carries

--- a/docs/site/src/content/docs/versioned/integrity-and-safety.md
+++ b/docs/site/src/content/docs/versioned/integrity-and-safety.md
@@ -544,6 +544,24 @@ migrations/0000000003_drop_users.up.sql:1 [error] DS101: DROP TABLE permanently 
 
 A clean run prints `No lint findings.` and exits `0`.
 
+### Which direction each rule reads
+
+Most rules describe a forward schema change, so they read the `.up.sql` half
+only: a down file dropping what its up created is the expected shape, not a
+hazard.
+
+Rules whose subject is the **cost or the executability** of a statement read
+both halves, because PostgreSQL charges the same lock and enforces the same
+transaction restriction whichever direction asked for it:
+
+- `PG106` — `DROP INDEX` without `CONCURRENTLY` blocks writes. This is the
+  statement a rollback file is normally made of, including the one Ptah
+  generates whenever the forward statement was not a concurrent build.
+- `PG103` — a `CONCURRENTLY` statement in a file with no `no_transaction`
+  marker cannot execute at all. A rollback that cannot run is only discovered
+  when someone needs it.
+- `TX101` — a file mixing autocommit-only statements with transactional DDL.
+
 Useful controls, all designed for CI:
 
 - `--latest N` lints only the newest N versions — the changeset of a pull

--- a/integration/gonative/retry_invalid_index_integration_test.go
+++ b/integration/gonative/retry_invalid_index_integration_test.go
@@ -263,12 +263,14 @@ func TestPostgreSQLFirstAttemptRefusesOverPreexistingInvalidIndexIntegration(t *
 // The probe runs before the body, so the index it asks about does not exist yet
 // and the migration applies.
 //
-// The limit is honest, and this test does not pin it: a migration in this shape
-// that failed on a later statement and was run again WOULD be refused, because
-// by then the parent index exists and is invalid. The operator would have to
-// finish or drop it first. Telling a partitioned parent apart from residue is
-// stokaro/ptah#997's partitioned-parent awareness, which is measured there
-// rather than guessed at here.
+// Re-measured for stokaro/ptah#997: this test does pin the distinction now,
+// through the post-execution probe added afterwards -- with the partitioned
+// shape treated as ordinary residue it fails with "cannot be applied ...
+// (indisvalid=false, indisready=true)" from the completion check. It still only
+// covers the first attempt, where the preflight has nothing to look at because
+// the parent index does not exist yet;
+// [TestPostgreSQLSecondAttemptOverPartitionedParentIndexStillAppliesIntegration]
+// covers the retry, which is the path the false positive was reported on.
 func TestPostgreSQLFirstAttemptOverPartitionedParentIndexStillAppliesIntegration(t *testing.T) {
 	dsn := skipIfNoPostgreSQL(t)
 	c := qt.New(t)
@@ -286,6 +288,67 @@ func TestPostgreSQLFirstAttemptOverPartitionedParentIndexStillAppliesIntegration
 	valid, ready := retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
 	c.Assert(valid, qt.IsFalse)
 	c.Assert(ready, qt.IsTrue)
+
+	status, err := mig.GetMigrationStatus(ctx)
+	c.Assert(err, qt.IsNil)
+	c.Assert(status.DirtyRevision, qt.IsNil)
+	c.Assert(status.AppliedMigrations, qt.DeepEquals, []int64{retryInvalidIndexVersion})
+}
+
+// TestPostgreSQLSecondAttemptOverPartitionedParentIndexStillAppliesIntegration
+// pins the case the up-path refusal can get wrong in the other direction: a
+// false positive over an index PostgreSQL is perfectly happy with.
+//
+// A partitioned parent built with CREATE INDEX ... ON ONLY reports
+// relkind='I', indisvalid=false, indisready=true -- deliberately incomplete
+// until an index is attached for every partition. Failed concurrent-build
+// residue reports indisvalid=false as well, and refusing on that flag alone
+// makes a migration in this shape unrepeatable: the first attempt applies, and
+// any second attempt is refused over an object that is exactly what its own
+// migration asked for.
+//
+// The fixture separates the two: the same run leaves BOTH shapes behind, and
+// after the genuine residue is cleared the retry has to succeed over the parent
+// that is still invalid. This is the retry path specifically -- a resumed
+// migration whose earlier statements are excluded from the preflight, so the
+// parent index is judged by the completion probe over the whole up SQL.
+func TestPostgreSQLSecondAttemptOverPartitionedParentIndexStillAppliesIntegration(t *testing.T) {
+	dsn := skipIfNoPostgreSQL(t)
+	c := qt.New(t)
+	ctx := t.Context()
+
+	db := openRetryInvalidIndexDB(c, dsn)
+	seedRetryPartitionedTable(c, db)
+	seedRetryPartitionedDuplicateRows(c, db)
+
+	conn, err := dbschema.ConnectToDatabase(ctx, dsn)
+	c.Assert(err, qt.IsNil)
+	c.Cleanup(func() { c.Check(conn.Close(), qt.IsNil) })
+	mig := retryPartitionedParentThenFailingIndexMigrator(conn)
+
+	// First attempt: the parent index is created invalid by design, then the
+	// concurrent unique build fails on the duplicates and leaves its own
+	// invalid index behind.
+	c.Assert(mig.MigrateUp(ctx), qt.ErrorMatches, "(?s).*could not create unique index.*")
+	parentValid, parentReady := retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
+	c.Assert(parentValid, qt.IsFalse)
+	c.Assert(parentReady, qt.IsTrue)
+	residueValid, residueReady := retryInvalidIndexFlags(c, db, retryInvalidUniqueIndex)
+	c.Assert(residueValid, qt.IsFalse)
+	c.Assert(residueReady, qt.IsFalse)
+
+	// The operator fixes the data and clears the residue the refusal names.
+	_, err = db.ExecContext(ctx, "DELETE FROM "+retryPartitionedTable+" WHERE id > 1")
+	c.Assert(err, qt.IsNil)
+	_, err = db.ExecContext(ctx, fmt.Sprintf("DROP INDEX %q", retryInvalidUniqueIndex))
+	c.Assert(err, qt.IsNil)
+
+	// The only invalid index left is the partitioned parent, and it must not be
+	// mistaken for residue.
+	c.Assert(mig.MigrateUpWithOptions(ctx, migrator.MigrateUpOptions{AllowDirty: true}), qt.IsNil)
+	parentValid, parentReady = retryInvalidIndexFlags(c, db, retryInvalidPlainIndex)
+	c.Assert(parentValid, qt.IsFalse)
+	c.Assert(parentReady, qt.IsTrue)
 
 	status, err := mig.GetMigrationStatus(ctx)
 	c.Assert(err, qt.IsNil)
@@ -332,6 +395,24 @@ func retryPartitionedParentIndexMigrator(conn *dbschema.DatabaseConnection) *mig
 		retryInvalidPlainIndex, retryPartitionedTable, "email",
 	)
 	down := fmt.Sprintf("DROP INDEX IF EXISTS %q;", retryInvalidPlainIndex)
+	return retryInvalidIndexMigrator(conn, up, down)
+}
+
+// retryPartitionedParentThenFailingIndexMigrator builds the two-statement shape
+// the second-attempt case needs: a partitioned parent index that is invalid by
+// design, followed by a concurrent unique build that fails on the seeded
+// duplicates. The failure is what forces a second attempt over the parent.
+func retryPartitionedParentThenFailingIndexMigrator(conn *dbschema.DatabaseConnection) *migrator.Migrator {
+	up := fmt.Sprintf(
+		"-- +ptah no_transaction\nCREATE INDEX IF NOT EXISTS %q ON ONLY %q (%q);\n"+
+			"CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS %q ON %q (%q);",
+		retryInvalidPlainIndex, retryPartitionedTable, "email",
+		retryInvalidUniqueIndex, retryPartitionedTable+"_p1", "email",
+	)
+	down := fmt.Sprintf(
+		"-- +ptah no_transaction\nDROP INDEX IF EXISTS %q;\nDROP INDEX IF EXISTS %q;",
+		retryInvalidUniqueIndex, retryInvalidPlainIndex,
+	)
 	return retryInvalidIndexMigrator(conn, up, down)
 }
 
@@ -399,6 +480,20 @@ func seedRetryPartitionedTable(c *qt.C, db *sql.DB) {
 		"CREATE TABLE %s_p1 PARTITION OF %s FOR VALUES FROM (1) TO (100)",
 		retryPartitionedTable, retryPartitionedTable,
 	))
+	c.Assert(err, qt.IsNil)
+}
+
+// seedRetryPartitionedDuplicateRows fills the single partition with rows that
+// all share one email, so a concurrent UNIQUE build on the partition fails and
+// leaves the migration to be attempted again.
+func seedRetryPartitionedDuplicateRows(c *qt.C, db *sql.DB) {
+	c.Helper()
+	_, err := db.Exec(fmt.Sprintf(
+		"INSERT INTO %s SELECT g, 'shared@example.com' FROM generate_series(1, 99) g",
+		retryPartitionedTable,
+	))
+	c.Assert(err, qt.IsNil)
+	_, err = db.Exec("ANALYZE " + retryPartitionedTable)
 	c.Assert(err, qt.IsNil)
 }
 

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -209,6 +209,11 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 
 	db := dbtest.Open(t, func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
 		switch {
+		case strings.Contains(query, "p.proname = 'pg_relation_size'"):
+			return dbtest.QueryResult{
+				Columns: []string{"exists"},
+				Rows:    [][]driver.Value{{true}},
+			}, nil
 		case strings.Contains(query, "FROM information_schema.columns"):
 			return dbtest.QueryResult{
 				Columns: []string{
@@ -255,7 +260,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 	tables, err := reader.readTablesForSchema("public")
 
 	c.Assert(err, qt.IsNil)
-	c.Assert(db.QueryCount(), qt.Equals, 2)
+	c.Assert(db.QueryCount(), qt.Equals, 3)
 	c.Assert(tables, qt.HasLen, 50)
 	c.Assert(tables[0].Name, qt.Equals, "table_00")
 	c.Assert(tables[0].Columns, qt.HasLen, 2)

--- a/internal/dbschema/postgres/postgres_test.go
+++ b/internal/dbschema/postgres/postgres_test.go
@@ -200,7 +200,7 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 	columnRows := make([][]driver.Value, 0, 100)
 	for i := range 50 {
 		tableName := fmt.Sprintf("table_%02d", i)
-		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false})
+		tableRows = append(tableRows, []driver.Value{"public", tableName, "BASE TABLE", "", int64(0), false, false, false})
 		columnRows = append(columnRows,
 			[]driver.Value{tableName, "id", "integer", "int4", "", "", "", "NO", nil, nil, nil, nil, int64(1), "", "", "", ""},
 			[]driver.Value{tableName, "name", "character varying", "varchar", "", "", "", "NO", nil, int64(255), nil, nil, int64(2), "", "", "", ""},
@@ -240,6 +240,8 @@ func TestPostgreSQLReaderReadTablesUsesBulkColumnQuery(t *testing.T) {
 					"table_type",
 					"table_comment",
 					"estimated_rows",
+					"row_stats_unknown",
+					"partitioned",
 					"rls_enabled",
 				},
 				Rows: tableRows,

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -266,11 +266,27 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 		return nil, fmt.Errorf("failed to read columns for schema %s: %w", schemaName, err)
 	}
 
-	// Read tables, excluding system tables like schema_migrations
+	// Read tables, excluding system tables like schema_migrations.
+	//
+	// row_stats_unknown is the tri-state EstimatedRows cannot carry on its own.
+	// PostgreSQL 14 and later store pg_class.reltuples = -1 for a relation that
+	// has never been vacuumed or analyzed, and the cumulative statistics view
+	// reports n_live_tup = 0 both for an empty table and for one whose counters
+	// were reset -- after a crash-recovery restart, a pg_stat_reset(), or a
+	// restored dump. GREATEST floors all of that to 0, which reads as "empty"
+	// and is how a populated table silently earned a blocking index build.
+	//
+	// relkind = 'p' is the declaratively partitioned parent.
+	// information_schema.tables reports it as an ordinary BASE TABLE, so the
+	// catalog is the only place the distinction survives, and PostgreSQL
+	// rejects both CREATE INDEX CONCURRENTLY and DROP INDEX CONCURRENTLY on
+	// such a relation.
 	tablesQuery := `
 		SELECT table_schema, table_name, table_type,
 		       COALESCE(obj_description(c.oid), '') as table_comment,
 		       COALESCE(GREATEST(c.reltuples::bigint, st.n_live_tup, 0), 0) AS estimated_rows,
+		       NOT COALESCE(c.reltuples >= 0 OR COALESCE(st.n_live_tup, 0) > 0, false) AS row_stats_unknown,
+		       COALESCE(c.relkind = 'p', false) AS partitioned,
 		       COALESCE(c.relrowsecurity, false) AS rls_enabled
 			FROM information_schema.tables t
 			LEFT JOIN pg_namespace n ON n.nspname = t.table_schema
@@ -290,7 +306,16 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	var tables []types.DBTable
 	for rows.Next() {
 		var table types.DBTable
-		err := rows.Scan(&table.Schema, &table.Name, &table.Type, &table.Comment, &table.EstimatedRows, &table.RLSEnabled)
+		err := rows.Scan(
+			&table.Schema,
+			&table.Name,
+			&table.Type,
+			&table.Comment,
+			&table.EstimatedRows,
+			&table.RowStatsUnknown,
+			&table.Partitioned,
+			&table.RLSEnabled,
+		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan table: %w", err)
 		}

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -276,6 +276,23 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	// restored dump. GREATEST floors all of that to 0, which reads as "empty"
 	// and is how a populated table silently earned a blocking index build.
 	//
+	// The second conjunct is what keeps that tri-state from swallowing every
+	// ordinary empty table. reltuples = -1 is the state of ANY never-analyzed
+	// relation, which includes every table that has never had a row inserted,
+	// so "no usable statistics" alone marks a freshly created table as one
+	// whose row count is unknown -- and a caller resolving the unknown toward a
+	// concurrent build then emits CREATE INDEX CONCURRENTLY, in its own
+	// non-transactional migration, for a table with nothing in it.
+	// pg_relation_size reads the main fork's size from the file system rather
+	// than from statistics, so it is not reset by any of the events above:
+	// measured on PostgreSQL 17.10, a never-analyzed table holding 5000 rows
+	// reports 188416 and a never-analyzed empty one reports 0, while both
+	// report reltuples = -1 and n_live_tup = 0. It is the table's own main fork
+	// on purpose -- pg_table_size adds the TOAST relation and its index, and an
+	// empty table with one text column already carries an 8192-byte TOAST
+	// index. A relation with no statistics and no storage is empty; only a
+	// relation with no statistics and storage is genuinely unknown.
+	//
 	// relkind = 'p' is the declaratively partitioned parent.
 	// information_schema.tables reports it as an ordinary BASE TABLE, so the
 	// catalog is the only place the distinction survives, and PostgreSQL
@@ -285,7 +302,8 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 		SELECT table_schema, table_name, table_type,
 		       COALESCE(obj_description(c.oid), '') as table_comment,
 		       COALESCE(GREATEST(c.reltuples::bigint, st.n_live_tup, 0), 0) AS estimated_rows,
-		       NOT COALESCE(c.reltuples >= 0 OR COALESCE(st.n_live_tup, 0) > 0, false) AS row_stats_unknown,
+		       (NOT COALESCE(c.reltuples >= 0 OR COALESCE(st.n_live_tup, 0) > 0, false))
+		           AND COALESCE(pg_relation_size(c.oid), 0) > 0 AS row_stats_unknown,
 		       COALESCE(c.relkind = 'p', false) AS partitioned,
 		       COALESCE(c.relrowsecurity, false) AS rls_enabled
 			FROM information_schema.tables t

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -1076,11 +1076,11 @@ type postgresIndexRow struct {
 // model. It does not set Schema, which needs the reader's output-schema policy.
 func buildPostgresIndex(row postgresIndexRow) (types.DBIndex, error) {
 	index := types.DBIndex{
-		Name:          row.indexName,
-		TableName:     row.tableName,
-		Definition:    row.indexDef,
-		Condition:     row.predicate,
-		Comment:       row.comment,
+		Name:              row.indexName,
+		TableName:         row.tableName,
+		Definition:        row.indexDef,
+		Condition:         row.predicate,
+		Comment:           row.comment,
 		IsUnique:          row.isUnique,
 		IsPrimary:         row.isPrimary,
 		Method:            row.method,

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -976,7 +976,24 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 			COALESCE(obj_description(i.oid, 'pg_class'), '') as index_comment,
 			COALESCE(pg_get_expr(ix.indpred, ix.indrelid), '') as predicate,
 			ix.indisprimary,
-			ix.indisunique
+			ix.indisunique,
+			-- Whether this index is a partition's copy of an index on its
+			-- partitioned parent. PostgreSQL records the attachment in
+			-- pg_inherits over index relations, the same catalog that records
+			-- a partition's attachment to its parent table, and an index row
+			-- there exists only for that reason.
+			--
+			-- The distinction matters because the copy is not separately
+			-- droppable: PostgreSQL 17.10 answers
+			-- DROP INDEX "events_2026_tenant_idx" with the message
+			-- "cannot drop index events_2026_tenant_idx because index
+			-- idx_events_tenant requires it" (SQLSTATE 2BP01). Reading relkind
+			-- instead would answer a different question: the parent is 'I' and
+			-- the copy is 'i', so a relkind test marks the object that IS
+			-- addressable and leaves the one that is not.
+			EXISTS (
+				SELECT 1 FROM pg_inherits inh WHERE inh.inhrelid = i.oid
+			) as partition_attached
 		FROM pg_index ix
 		JOIN pg_class i ON i.oid = ix.indexrelid
 		JOIN pg_class t ON t.oid = ix.indrelid
@@ -999,7 +1016,8 @@ func (r *Reader) readIndexesForSchema(schemaName string) ([]types.DBIndex, error
 			&row.schemaName, &row.tableName, &row.indexName, &row.indexDef,
 			&row.keyTexts, &row.keyAttnums, &row.keyOpclasses, &row.keyOptions,
 			&row.includeColumns, &row.method, &row.storageParams, &row.requiredExtensions,
-			&row.comment, &row.predicate, &row.isPrimary, &row.isUnique,
+			&row.comment,
+			&row.predicate, &row.isPrimary, &row.isUnique, &row.partitionAttached,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan index: %w", err)
@@ -1049,6 +1067,9 @@ type postgresIndexRow struct {
 	predicate string
 	isPrimary bool
 	isUnique  bool
+	// partitionAttached is the pg_inherits attachment of this index relation
+	// to an index on the partitioned parent.
+	partitionAttached bool
 }
 
 // buildPostgresIndex maps one introspection row onto the dialect-neutral index
@@ -1060,10 +1081,11 @@ func buildPostgresIndex(row postgresIndexRow) (types.DBIndex, error) {
 		Definition:    row.indexDef,
 		Condition:     row.predicate,
 		Comment:       row.comment,
-		IsUnique:      row.isUnique,
-		IsPrimary:     row.isPrimary,
-		Method:        row.method,
-		NullsDistinct: postgresNullsDistinctFromDefinition(row.indexDef),
+		IsUnique:          row.isUnique,
+		IsPrimary:         row.isPrimary,
+		Method:            row.method,
+		NullsDistinct:     postgresNullsDistinctFromDefinition(row.indexDef),
+		PartitionAttached: row.partitionAttached,
 	}
 
 	columns, err := parsePostgresIndexColumns(row.keyTexts, row.indexDef)

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -22,6 +22,12 @@ type Reader struct {
 	schemas []string
 	scoped  bool
 	caps    capability.Capabilities
+
+	// relationSize records whether pg_catalog.pg_relation_size exists on the
+	// connected server, and relationSizeProbed whether that has been asked yet.
+	// The pair is a cache, not configuration: see supportsRelationSize.
+	relationSize       bool
+	relationSizeProbed bool
 }
 
 // NewPostgreSQLReader creates a new PostgreSQL schema reader
@@ -260,6 +266,73 @@ func (r *Reader) readTables() ([]types.DBTable, error) {
 	return tables, nil
 }
 
+// rowStatsUnknownStatisticsOnly is the part of the tri-state every
+// PostgreSQL-family server can answer: the statistics carry no usable row
+// count.
+const rowStatsUnknownStatisticsOnly = `NOT COALESCE(c.reltuples >= 0 OR COALESCE(st.n_live_tup, 0) > 0, false)`
+
+// rowStatsUnknownProjection builds the row_stats_unknown projection for the
+// server at hand.
+//
+// Statistics alone are not enough to call a row count unknown. reltuples = -1
+// is the state of ANY never-analyzed relation, which includes every table that
+// has never had a row inserted, so the statistics-only test marks a freshly
+// created empty table as one whose row count nobody knows -- and a caller
+// resolving the unknown toward a concurrent build then emits CREATE INDEX
+// CONCURRENTLY, in its own non-transactional migration, for a table with
+// nothing in it.
+//
+// pg_relation_size separates the two, because it reads the main fork's size
+// from the file system rather than from statistics, so no analyze, counter
+// reset, crash-recovery restart or restore moves it. Measured on PostgreSQL
+// 17.10: a never-analyzed table holding 5000 rows reports 188416 and a
+// never-analyzed empty one reports 0, while both report reltuples = -1 and
+// n_live_tup = 0. It is the table's own main fork on purpose -- pg_table_size
+// adds the TOAST relation and its index, and an empty table with one text
+// column already carries an 8192-byte TOAST index.
+//
+// The function is asked for rather than assumed. CockroachDB does not
+// implement it: on CCL v26.2.5, pg_relation_size('t'::regclass) is
+// "unknown function: pg_relation_size()" (SQLSTATE 42883), and because that is
+// a planning error it takes the whole table read down with it rather than one
+// column -- which is what the integration suite reported. pg_catalog.pg_proc
+// answers the question there (`f`) and on PostgreSQL 17.10 (`t`), so the
+// projection degrades to the statistics-only test on a server without the
+// function instead of failing the read.
+func (r *Reader) rowStatsUnknownProjection() (string, error) {
+	hasRelationSize, err := r.supportsRelationSize()
+	if err != nil {
+		return "", err
+	}
+	if !hasRelationSize {
+		return rowStatsUnknownStatisticsOnly, nil
+	}
+	return `(` + rowStatsUnknownStatisticsOnly + `)
+		           AND COALESCE(pg_relation_size(c.oid), 0) > 0`, nil
+}
+
+// supportsRelationSize reports whether pg_catalog.pg_relation_size exists on
+// the connected server, asking once per reader.
+func (r *Reader) supportsRelationSize() (bool, error) {
+	if r.relationSizeProbed {
+		return r.relationSize, nil
+	}
+	const probe = `
+		SELECT EXISTS (
+			SELECT 1
+			FROM pg_catalog.pg_proc p
+			JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
+			WHERE n.nspname = 'pg_catalog' AND p.proname = 'pg_relation_size'
+		)`
+	var supported bool
+	if err := r.db.QueryRow(probe).Scan(&supported); err != nil {
+		return false, fmt.Errorf("failed to probe pg_relation_size availability: %w", err)
+	}
+	r.relationSize = supported
+	r.relationSizeProbed = true
+	return supported, nil
+}
+
 func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error) {
 	columnsByTable, err := r.readColumnsForSchema(schemaName)
 	if err != nil {
@@ -276,34 +349,24 @@ func (r *Reader) readTablesForSchema(schemaName string) ([]types.DBTable, error)
 	// restored dump. GREATEST floors all of that to 0, which reads as "empty"
 	// and is how a populated table silently earned a blocking index build.
 	//
-	// The second conjunct is what keeps that tri-state from swallowing every
-	// ordinary empty table. reltuples = -1 is the state of ANY never-analyzed
-	// relation, which includes every table that has never had a row inserted,
-	// so "no usable statistics" alone marks a freshly created table as one
-	// whose row count is unknown -- and a caller resolving the unknown toward a
-	// concurrent build then emits CREATE INDEX CONCURRENTLY, in its own
-	// non-transactional migration, for a table with nothing in it.
-	// pg_relation_size reads the main fork's size from the file system rather
-	// than from statistics, so it is not reset by any of the events above:
-	// measured on PostgreSQL 17.10, a never-analyzed table holding 5000 rows
-	// reports 188416 and a never-analyzed empty one reports 0, while both
-	// report reltuples = -1 and n_live_tup = 0. It is the table's own main fork
-	// on purpose -- pg_table_size adds the TOAST relation and its index, and an
-	// empty table with one text column already carries an 8192-byte TOAST
-	// index. A relation with no statistics and no storage is empty; only a
-	// relation with no statistics and storage is genuinely unknown.
+	// The storage conjunct rowStatsUnknownProjection adds when the server has
+	// pg_relation_size is what keeps that tri-state from swallowing every
+	// ordinary empty table -- see that method.
 	//
 	// relkind = 'p' is the declaratively partitioned parent.
 	// information_schema.tables reports it as an ordinary BASE TABLE, so the
 	// catalog is the only place the distinction survives, and PostgreSQL
 	// rejects both CREATE INDEX CONCURRENTLY and DROP INDEX CONCURRENTLY on
 	// such a relation.
+	rowStatsUnknown, err := r.rowStatsUnknownProjection()
+	if err != nil {
+		return nil, err
+	}
 	tablesQuery := `
 		SELECT table_schema, table_name, table_type,
 		       COALESCE(obj_description(c.oid), '') as table_comment,
 		       COALESCE(GREATEST(c.reltuples::bigint, st.n_live_tup, 0), 0) AS estimated_rows,
-		       (NOT COALESCE(c.reltuples >= 0 OR COALESCE(st.n_live_tup, 0) > 0, false))
-		           AND COALESCE(pg_relation_size(c.oid), 0) > 0 AS row_stats_unknown,
+		       ` + rowStatsUnknown + ` AS row_stats_unknown,
 		       COALESCE(c.relkind = 'p', false) AS partitioned,
 		       COALESCE(c.relrowsecurity, false) AS rls_enabled
 			FROM information_schema.tables t

--- a/internal/dbschema/postgres/reader_indexes_internal_test.go
+++ b/internal/dbschema/postgres/reader_indexes_internal_test.go
@@ -97,6 +97,9 @@ type pgIndexCatalog struct {
 	predicate    string
 	isPrimary    bool
 	isUnique     bool
+	// partitionAttached is whether pg_inherits records this index relation as
+	// attached to an index on a partitioned parent.
+	partitionAttached bool
 }
 
 // pgIndexKeyOpclass is one key's operator class as three separate catalog
@@ -380,6 +383,19 @@ func extensionAccessMethodCatalog() pgIndexCatalog {
 	return catalog
 }
 
+// partitionAttachedCatalog is the copy PostgreSQL creates on a partition when
+// an index is created on its partitioned parent: an ordinary relkind 'i' index
+// that pg_inherits records as attached to the parent's index.
+func partitionAttachedCatalog() pgIndexCatalog {
+	catalog := plainCatalog()
+	catalog.tableName = "events_2026"
+	catalog.indexName = "events_2026_tenant_idx"
+	catalog.indexDef = "CREATE INDEX events_2026_tenant_idx ON public.events_2026 USING btree (tenant)"
+	catalog.keyTexts = `["tenant"]`
+	catalog.partitionAttached = true
+	return catalog
+}
+
 // sortOrderCatalog builds a one-key fixture with the given pg_index.indoption
 // bitmask. The four values were read off PostgreSQL 17.10: (a DESC) reports 3,
 // (c DESC NULLS LAST) reports 1, (b NULLS FIRST) reports 2, plain ascending
@@ -435,10 +451,32 @@ func serveIndexQuery(catalog pgIndexCatalog, query string) (dbtest.QueryResult, 
 		columns = append(columns, answer.alias)
 		values = append(values, value)
 	}
-	columns = append(columns, "predicate", "indisprimary", "indisunique")
-	values = append(values, catalog.predicate, catalog.isPrimary, catalog.isUnique)
+	attached, err := answerPartitionAttached(query, catalog.partitionAttached)
+	if err != nil {
+		return dbtest.QueryResult{}, err
+	}
+	columns = append(columns, "predicate", "indisprimary", "indisunique", "partition_attached")
+	values = append(values, catalog.predicate, catalog.isPrimary, catalog.isUnique, attached)
 
 	return dbtest.QueryResult{Columns: columns, Rows: [][]driver.Value{values}}, nil
+}
+
+// answerPartitionAttached answers the partition_attached projection the way a
+// server would: with the catalog's answer when the projection reads
+// pg_inherits, and with false when it reads something else.
+//
+// pg_inherits is where the attachment of a partition's index copy to its parent
+// index is recorded, and it is the only place. A projection reading relkind
+// instead is not a weaker version of this question, it is a different one --
+// relkind marks the parent, which is the one index of the pair a DROP INDEX may
+// name -- so a mutant that swaps them gets the answer a server would give it,
+// false, rather than the catalog's.
+func answerPartitionAttached(query string, attached bool) (driver.Value, error) {
+	projection, ok := selectListItem(query, "partition_attached", "FROM pg_index")
+	if !ok {
+		return nil, fmt.Errorf("query has no projection aliased %q:\n%s", "partition_attached", query)
+	}
+	return attached && strings.Contains(projection, "pg_inherits"), nil
 }
 
 // answerProjection returns what a PostgreSQL server would hand back for the
@@ -973,6 +1011,23 @@ func TestReadIndexesForSchema_AsksTheCatalogForEveryKeyAttribute(t *testing.T) {
 				c.Assert(index.Parts, qt.DeepEquals, []types.DBIndexPart{
 					{Name: "name"},
 				})
+			},
+		},
+		{
+			// The attachment of a partition's index copy to its parent index
+			// lives in pg_inherits and nowhere else, so a projection that reads
+			// anything else answers false here exactly as a server would.
+			name:    "a partition's copy of a parent index is reported as attached",
+			catalog: partitionAttachedCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.PartitionAttached, qt.IsTrue)
+			},
+		},
+		{
+			name:    "an ordinary index is not reported as attached",
+			catalog: plainCatalog,
+			assert: func(c *qt.C, index types.DBIndex) {
+				c.Assert(index.PartitionAttached, qt.IsFalse)
 			},
 		},
 	}

--- a/internal/dbschema/postgres/reader_row_stats_internal_test.go
+++ b/internal/dbschema/postgres/reader_row_stats_internal_test.go
@@ -1,0 +1,176 @@
+package postgres
+
+// White-box testing required: the projection under test is a fragment of the
+// SQL readTablesForSchema builds, and both answers produce the same
+// []types.DBTable for the rows a fake server hands back. Only the text of the
+// query the reader issued says which projection it chose, and
+// readTablesForSchema is unexported.
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+)
+
+// relationSizeProbeMarker is the fragment that identifies the reader's
+// capability probe among the queries a fake server is asked.
+const relationSizeProbeMarker = "p.proname = 'pg_relation_size'"
+
+// rowStatsFakeServer answers the three queries readTablesForSchema issues.
+// The probe is answered with hasRelationSize; the tables query is recorded in
+// tablesQuery so a test can read the projection the reader chose.
+func rowStatsFakeServer(
+	hasRelationSize bool,
+	tablesQuery *string,
+) func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+	return func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		switch {
+		case strings.Contains(query, relationSizeProbeMarker):
+			return dbtest.QueryResult{
+				Columns: []string{"exists"},
+				Rows:    [][]driver.Value{{hasRelationSize}},
+			}, nil
+		case strings.Contains(query, "FROM information_schema.columns"):
+			return dbtest.QueryResult{Columns: []string{"table_name"}}, nil
+		case strings.Contains(query, "FROM information_schema.tables"):
+			*tablesQuery = query
+			return dbtest.QueryResult{
+				Columns: []string{
+					"table_schema",
+					"table_name",
+					"table_type",
+					"table_comment",
+					"estimated_rows",
+					"row_stats_unknown",
+					"partitioned",
+					"rls_enabled",
+				},
+				Rows: [][]driver.Value{
+					{"public", "members", "BASE TABLE", "", int64(0), false, false, false},
+				},
+			}, nil
+		default:
+			return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+		}
+	}
+}
+
+// rowStatsReadResult is everything one fake-server table read produced.
+type rowStatsReadResult struct {
+	tables      []types.DBTable
+	tablesQuery string
+	queries     int
+	err         error
+}
+
+func readTablesThroughRowStatsFakeServer(t *testing.T, hasRelationSize bool) rowStatsReadResult {
+	t.Helper()
+	var out rowStatsReadResult
+	db := dbtest.Open(t, rowStatsFakeServer(hasRelationSize, &out.tablesQuery))
+	reader := NewPostgreSQLReader(db.SQL, "public")
+	out.tables, out.err = reader.readTablesForSchema("public")
+	out.queries = db.QueryCount()
+	return out
+}
+
+// TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize pins the probe
+// that keeps the table read working on a PostgreSQL-family server without
+// pg_relation_size.
+//
+// The storage half of row_stats_unknown cannot be written unconditionally.
+// CockroachDB does not implement pg_relation_size -- CCL v26.2.5 answers
+// pg_relation_size('t'::regclass) with "unknown function: pg_relation_size()"
+// (SQLSTATE 42883) -- and because an unknown function is a planning error, the
+// whole table read fails rather than one column. A runtime CASE cannot rescue
+// that; the reader has to know before it writes the query, so it asks
+// pg_catalog.pg_proc, which both servers answer.
+//
+// The two rows below are the two answers. Each asserts what the tables query
+// must contain AND what it must not, because an implementation that always
+// emits the conjunct passes the first row on its content assertion alone, and
+// one that never emits it passes the second.
+func TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize(t *testing.T) {
+	tests := []struct {
+		name            string
+		serverHasProbe  bool
+		wantInTables    []string
+		wantNotInTables []string
+	}{
+		{
+			name:           "a server with pg_relation_size measures storage",
+			serverHasProbe: true,
+			wantInTables: []string{
+				"pg_relation_size(c.oid)",
+				"NOT COALESCE(c.reltuples >= 0",
+			},
+			wantNotInTables: nil,
+		},
+		{
+			name:           "a server without pg_relation_size falls back to statistics",
+			serverHasProbe: false,
+			wantInTables: []string{
+				"NOT COALESCE(c.reltuples >= 0",
+			},
+			wantNotInTables: []string{"pg_relation_size(c.oid)"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got := readTablesThroughRowStatsFakeServer(t, tt.serverHasProbe)
+
+			c.Assert(got.err, qt.IsNil)
+			c.Assert(got.tables, qt.HasLen, 1)
+			c.Assert(got.queries, qt.Equals, 3)
+			for _, want := range tt.wantInTables {
+				c.Assert(got.tablesQuery, qt.Contains, want)
+			}
+			for _, unwanted := range tt.wantNotInTables {
+				c.Assert(got.tablesQuery, qt.Not(qt.Contains), unwanted)
+			}
+		})
+	}
+}
+
+// probeCountingServer answers only the capability probe and counts how often it
+// is asked.
+func probeCountingServer(probes *int) func(string, []driver.NamedValue) (dbtest.QueryResult, error) {
+	return func(query string, _ []driver.NamedValue) (dbtest.QueryResult, error) {
+		switch {
+		case strings.Contains(query, relationSizeProbeMarker):
+			*probes++
+			return dbtest.QueryResult{
+				Columns: []string{"exists"},
+				Rows:    [][]driver.Value{{true}},
+			}, nil
+		default:
+			return dbtest.QueryResult{}, fmt.Errorf("unexpected query: %s", query)
+		}
+	}
+}
+
+// TestSupportsRelationSize_AsksOncePerReader pins the caching, which is what
+// keeps the probe from adding one round trip per schema read.
+func TestSupportsRelationSize_AsksOncePerReader(t *testing.T) {
+	c := qt.New(t)
+	probes := 0
+	db := dbtest.Open(t, probeCountingServer(&probes))
+	reader := NewPostgreSQLReader(db.SQL, "public")
+
+	first, firstErr := reader.supportsRelationSize()
+	second, secondErr := reader.supportsRelationSize()
+
+	c.Assert(firstErr, qt.IsNil)
+	c.Assert(secondErr, qt.IsNil)
+	c.Assert(first, qt.IsTrue)
+	c.Assert(second, qt.IsTrue)
+	c.Assert(probes, qt.Equals, 1)
+}

--- a/internal/migrationlintreport/report_test.go
+++ b/internal/migrationlintreport/report_test.go
@@ -29,6 +29,17 @@ func writeWarningMigration(c *qt.C, dir string) {
 	writeLintTestFile(c, dir, "0000000001_index.down.sql", "DROP INDEX idx_users_id;\n")
 }
 
+// findingRules lists the reported rule codes in report order. The pair above
+// produces one warning per direction: PG101 for the blocking build and PG106
+// for the blocking drop the rollback performs (stokaro/ptah#997).
+func findingRules(findings []migrationlint.Finding) []string {
+	rules := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		rules = append(rules, finding.Rule)
+	}
+	return rules
+}
+
 func TestBuild_UsesProjectConfigWithoutCobra(t *testing.T) {
 	c := qt.New(t)
 	dir := t.TempDir()
@@ -238,8 +249,7 @@ func TestBuild_FailOnErrorDoesNotFailWarnings(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(report.Failed, qt.IsFalse)
-	c.Assert(report.Findings, qt.HasLen, 1)
-	c.Assert(report.Findings[0].Rule, qt.Equals, "PG101")
+	c.Assert(findingRules(report.Findings), qt.DeepEquals, []string{"PG106", "PG101"})
 }
 
 func TestBuild_FailOnAnyFailsWarnings(t *testing.T) {
@@ -257,8 +267,7 @@ func TestBuild_FailOnAnyFailsWarnings(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(report.Failed, qt.IsTrue)
-	c.Assert(report.Findings, qt.HasLen, 1)
-	c.Assert(report.Findings[0].Rule, qt.Equals, "PG101")
+	c.Assert(findingRules(report.Findings), qt.DeepEquals, []string{"PG106", "PG101"})
 }
 
 func TestWrite_GitHubActionsEscapesWorkflowCommandCharacters(t *testing.T) {

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -927,8 +927,14 @@ func planGeneratedMigrationSpecs(
 		diff, skipped = diffpolicy.ApplyForDialect(diff, skipSet, info.Dialect)
 	}
 
-	concurrentIndexRefs := concurrentIndexRefsForPolicy(diff, dbSchema, info, policy)
-	concurrentIndexDropRefs := concurrentIndexDropRefsForPolicy(diff, info, policy)
+	concurrentIndexRefs, err := concurrentIndexRefsForPolicy(diff, dbSchema, info, policy)
+	if err != nil {
+		return nil, nil, err
+	}
+	concurrentIndexDropRefs, err := concurrentIndexDropRefsForPolicy(diff, dbSchema, info, policy)
+	if err != nil {
+		return nil, nil, err
+	}
 	plannerOpts := planner.Options{
 		Capabilities:            info.Capabilities,
 		ConcurrentIndexRefs:     concurrentIndexRefs,
@@ -1190,19 +1196,86 @@ func isConcurrentIndexNode(node ast.Node) bool {
 // concurrently. When the diff policy requests it, every newly added index is
 // concurrent (still gated on dialect and the CreateIndexConcurrently
 // capability); otherwise the populated-table heuristic applies.
+//
+// A partitioned parent is refused rather than published: PostgreSQL rejects
+// CREATE INDEX CONCURRENTLY on relkind 'p' with SQLSTATE 0A000, so the request
+// cannot be honored and silently downgrading it would give a project that asked
+// for a non-blocking build a blocking one without saying so. The heuristic path
+// downgrades instead -- see [concurrentIndexRefsForPopulatedTables].
 func concurrentIndexRefsForPolicy(
 	diff *types.SchemaDiff,
 	dbSchema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	policy DiffPolicy,
-) []types.IndexRef {
+) ([]types.IndexRef, error) {
 	if !policy.ConcurrentIndex {
-		return concurrentIndexRefsForPopulatedTables(diff, dbSchema, info)
+		return concurrentIndexRefsForPopulatedTables(diff, dbSchema, info), nil
 	}
 	if !platform.IsPostgresFamily(info.Dialect) || !info.Capabilities.Has(capability.CreateIndexConcurrently) {
+		return nil, nil
+	}
+	refs := diff.IndexAdditions()
+	if err := refusePartitionedConcurrentIndexRefs(refs, dbSchema, concurrentIndexCreatePolicy); err != nil {
+		return nil, err
+	}
+	return refs, nil
+}
+
+// concurrentIndexPolicyKind names the half of the concurrent-index policy a
+// refusal came from, so the diagnostic can quote the configuration key the
+// operator would change.
+type concurrentIndexPolicyKind struct {
+	statement string
+	configKey string
+}
+
+var (
+	concurrentIndexCreatePolicy = concurrentIndexPolicyKind{
+		statement: "CREATE INDEX CONCURRENTLY",
+		configKey: "diff.concurrent_index.create",
+	}
+	concurrentIndexDropPolicy = concurrentIndexPolicyKind{
+		statement: "DROP INDEX CONCURRENTLY",
+		configKey: "diff.concurrent_index.drop",
+	}
+)
+
+// refusePartitionedConcurrentIndexRefs fails generation before any migration
+// file is written when an explicitly requested concurrent index statement names
+// a PostgreSQL partitioned parent.
+//
+// PostgreSQL answers both statements with SQLSTATE 0A000 on relkind 'p'
+// ("cannot create index on partitioned table ... concurrently", "cannot drop
+// partitioned index ... concurrently"), and it answers at execution time -- so
+// without this the plan is written, hashed, and committed, and the failure
+// arrives against a production database instead of against the developer who
+// generated it.
+func refusePartitionedConcurrentIndexRefs(
+	refs []types.IndexRef,
+	dbSchema *dbschematypes.DBSchema,
+	kind concurrentIndexPolicyKind,
+) error {
+	partitioned := partitionedTableSet(dbSchema)
+	var offending []string
+	for _, ref := range refs {
+		if _, ok := partitioned[ref.TableName]; !ok {
+			continue
+		}
+		offending = append(offending, fmt.Sprintf("%q on %q", ref.Name, ref.TableName))
+	}
+	if len(offending) == 0 {
 		return nil
 	}
-	return diff.IndexAdditions()
+	return fmt.Errorf(
+		"%s requested by %s cannot be generated for partitioned table(s): %s; "+
+			"PostgreSQL refuses a concurrent index statement on a partitioned parent (SQLSTATE 0A000). "+
+			"Unset %s to generate the plain, transactional statement, or manage the index per partition "+
+			"(CREATE INDEX ... ON ONLY the parent, CREATE INDEX CONCURRENTLY on each partition, then ALTER INDEX ... ATTACH PARTITION)",
+		kind.statement,
+		kind.configKey,
+		strings.Join(offending, ", "),
+		kind.configKey,
+	)
 }
 
 // concurrentIndexDropRefsForPolicy resolves which index removals are dropped
@@ -1221,14 +1294,15 @@ func concurrentIndexRefsForPolicy(
 // marker, which the no-transaction diff does not carry.
 func concurrentIndexDropRefsForPolicy(
 	diff *types.SchemaDiff,
+	dbSchema *dbschematypes.DBSchema,
 	info dbschematypes.DBInfo,
 	policy DiffPolicy,
-) []types.IndexRef {
+) ([]types.IndexRef, error) {
 	if !policy.ConcurrentIndexDrop {
-		return nil
+		return nil, nil
 	}
 	if !platform.IsPostgresFamily(info.Dialect) || !info.Capabilities.Has(capability.DropIndexConcurrently) {
-		return nil
+		return nil, nil
 	}
 	// Match the planner's own redefinition test (indexscope conflict semantics),
 	// not plain struct equality: two refs differing only in identifier case are
@@ -1249,9 +1323,21 @@ func concurrentIndexDropRefsForPolicy(
 		}
 		refs = append(refs, ref)
 	}
-	return refs
+	if err := refusePartitionedConcurrentIndexRefs(refs, dbSchema, concurrentIndexDropPolicy); err != nil {
+		return nil, err
+	}
+	return refs, nil
 }
 
+// concurrentIndexRefsForPopulatedTables is the default heuristic: build an
+// index concurrently when the table it targets already holds rows.
+//
+// A partitioned parent is excluded rather than refused. Nothing asked for a
+// concurrent build here, PostgreSQL supports no concurrent form for relkind
+// 'p', and the plain CREATE INDEX the exclusion selects is legal SQL that says
+// what it does -- lint reports it as PG101 exactly like any other blocking
+// build. Refusing instead would leave a project with a partitioned table unable
+// to generate an index migration at all.
 func concurrentIndexRefsForPopulatedTables(
 	diff *types.SchemaDiff,
 	dbSchema *dbschematypes.DBSchema,
@@ -1261,8 +1347,12 @@ func concurrentIndexRefsForPopulatedTables(
 		return nil
 	}
 	populatedTables := populatedTableSet(dbSchema)
+	partitioned := partitionedTableSet(dbSchema)
 	var refs []types.IndexRef
 	for _, ref := range diff.IndexAdditions() {
+		if _, ok := partitioned[ref.TableName]; ok {
+			continue
+		}
 		if _, ok := populatedTables[ref.TableName]; ok {
 			refs = append(refs, ref)
 		}
@@ -1270,13 +1360,48 @@ func concurrentIndexRefsForPopulatedTables(
 	return refs
 }
 
+// populatedTableSet indexes the tables a concurrent build should be preferred
+// for, under every spelling an index ref can use for its table.
+//
+// A table whose row statistics the database could not report counts as
+// populated. PostgreSQL reports a never-analyzed relation as reltuples = -1 and
+// a relation whose cumulative counters were reset as n_live_tup = 0, and both
+// floor to the same 0 an empty table reports; reading that 0 as "empty" is how
+// a table holding millions of rows earned a blocking CREATE INDEX immediately
+// after a bulk load, a restored dump, or a crash-recovery restart. Choosing the
+// concurrent build when nothing is known costs a non-transactional migration
+// file on a table that may turn out to be empty; choosing the blocking build
+// costs writes for the length of the scan. Only the first is recoverable, so
+// the unknown is resolved toward it.
+//
+// A table absent from dbSchema entirely is a different case and stays
+// transactional: the migration creates it, so it starts empty.
 func populatedTableSet(dbSchema *dbschematypes.DBSchema) map[string]struct{} {
+	return tableSetMatching(dbSchema, func(table dbschematypes.DBTable) bool {
+		return table.RowStatsUnknown || table.EstimatedRows > 0
+	})
+}
+
+// partitionedTableSet indexes the PostgreSQL declaratively partitioned parents.
+func partitionedTableSet(dbSchema *dbschematypes.DBSchema) map[string]struct{} {
+	return tableSetMatching(dbSchema, func(table dbschematypes.DBTable) bool {
+		return table.Partitioned
+	})
+}
+
+// tableSetMatching collects the selected tables under both the qualified and
+// the bare spelling, because an index ref carries whichever one the diff was
+// built from.
+func tableSetMatching(
+	dbSchema *dbschematypes.DBSchema,
+	selected func(dbschematypes.DBTable) bool,
+) map[string]struct{} {
 	out := make(map[string]struct{})
 	if dbSchema == nil {
 		return out
 	}
 	for _, table := range dbSchema.Tables {
-		if table.EstimatedRows <= 0 {
+		if !selected(table) {
 			continue
 		}
 		out[table.QualifiedName()] = struct{}{}

--- a/migration/generator/generator.go
+++ b/migration/generator/generator.go
@@ -1255,10 +1255,11 @@ func refusePartitionedConcurrentIndexRefs(
 	dbSchema *dbschematypes.DBSchema,
 	kind concurrentIndexPolicyKind,
 ) error {
-	partitioned := partitionedTableSet(dbSchema)
+	tables := indexTableFacts(dbSchema)
 	var offending []string
 	for _, ref := range refs {
-		if _, ok := partitioned[ref.TableName]; !ok {
+		facts, known := tables.lookup(ref.TableName)
+		if !known || !facts.partitioned {
 			continue
 		}
 		offending = append(offending, fmt.Sprintf("%q on %q", ref.Name, ref.TableName))
@@ -1346,70 +1347,111 @@ func concurrentIndexRefsForPopulatedTables(
 	if !platform.IsPostgresFamily(info.Dialect) || !info.Capabilities.Has(capability.CreateIndexConcurrently) {
 		return nil
 	}
-	populatedTables := populatedTableSet(dbSchema)
-	partitioned := partitionedTableSet(dbSchema)
+	tables := indexTableFacts(dbSchema)
 	var refs []types.IndexRef
 	for _, ref := range diff.IndexAdditions() {
-		if _, ok := partitioned[ref.TableName]; ok {
+		facts, known := tables.lookup(ref.TableName)
+		if !known || facts.partitioned || !facts.populated {
 			continue
 		}
-		if _, ok := populatedTables[ref.TableName]; ok {
-			refs = append(refs, ref)
-		}
+		refs = append(refs, ref)
 	}
 	return refs
 }
 
-// populatedTableSet indexes the tables a concurrent build should be preferred
-// for, under every spelling an index ref can use for its table.
+// tableConcurrencyFacts is what the concurrent-index decision needs to know
+// about the table an index ref names.
 //
-// A table whose row statistics the database could not report counts as
-// populated. PostgreSQL reports a never-analyzed relation as reltuples = -1 and
-// a relation whose cumulative counters were reset as n_live_tup = 0, and both
-// floor to the same 0 an empty table reports; reading that 0 as "empty" is how
-// a table holding millions of rows earned a blocking CREATE INDEX immediately
-// after a bulk load, a restored dump, or a crash-recovery restart. Choosing the
-// concurrent build when nothing is known costs a non-transactional migration
-// file on a table that may turn out to be empty; choosing the blocking build
-// costs writes for the length of the scan. Only the first is recoverable, so
-// the unknown is resolved toward it.
-//
-// A table absent from dbSchema entirely is a different case and stays
-// transactional: the migration creates it, so it starts empty.
-func populatedTableSet(dbSchema *dbschematypes.DBSchema) map[string]struct{} {
-	return tableSetMatching(dbSchema, func(table dbschematypes.DBTable) bool {
-		return table.RowStatsUnknown || table.EstimatedRows > 0
-	})
+// populated is true for a table that holds rows, and for one whose row
+// statistics the database could not compute. PostgreSQL reports a relation
+// whose cumulative counters were reset as n_live_tup = 0, which floors to the
+// same 0 an empty table reports; reading that 0 as "empty" is how a table
+// holding millions of rows earned a blocking CREATE INDEX immediately after a
+// restored dump or a crash-recovery restart. Choosing the concurrent build when
+// nothing is known costs a non-transactional migration file on a table that may
+// turn out to be empty; choosing the blocking build costs writes for the length
+// of the scan. Only the first is recoverable, so the unknown resolves toward it.
+type tableConcurrencyFacts struct {
+	partitioned bool
+	populated   bool
 }
 
-// partitionedTableSet indexes the PostgreSQL declaratively partitioned parents.
-func partitionedTableSet(dbSchema *dbschematypes.DBSchema) map[string]struct{} {
-	return tableSetMatching(dbSchema, func(table dbschematypes.DBTable) bool {
-		return table.Partitioned
-	})
+// tableFactsIndex answers, for the table spelling an index ref carries, what
+// the catalog reported about the table that spelling names.
+//
+// Two spellings reach this lookup because the two sides of a diff qualify a
+// table differently: the PostgreSQL reader blanks the schema of the
+// connection's own schema, so a database-side ref is bare, while a Go entity
+// declared with an explicit schema produces "schema.table". A bare spelling
+// therefore has to be able to reach a schema-qualified table -- but only when
+// no table answers to it exactly, and never by pooling every schema's tables
+// into one set.
+//
+// That pooling is the wrong implementation this type exists to prevent. One
+// flat set keyed under both spellings makes a partitioned "app"."events" and an
+// ordinary "public"."events" indistinguishable, so a bare ref is answered by
+// whichever fact any table with that name carries: the ordinary table loses its
+// concurrent build, and an explicit diff.concurrent_index request is refused
+// with a diagnostic naming a table that is not partitioned. The two facts also
+// have to aggregate in opposite directions when the bare spelling really is
+// ambiguous -- partitioned only when every candidate is partitioned, populated
+// when any candidate is -- because both refusing and downgrading on a guess
+// costs a capability, while the concurrent build is the recoverable side of
+// each choice.
+type tableFactsIndex struct {
+	qualified map[string]tableConcurrencyFacts
+	bare      map[string]tableConcurrencyFacts
 }
 
-// tableSetMatching collects the selected tables under both the qualified and
-// the bare spelling, because an index ref carries whichever one the diff was
-// built from.
-func tableSetMatching(
-	dbSchema *dbschematypes.DBSchema,
-	selected func(dbschematypes.DBTable) bool,
-) map[string]struct{} {
-	out := make(map[string]struct{})
+// lookup resolves an index ref's table spelling. The second result is false
+// when no table in the schema answers to it at all -- the migration is creating
+// that table, so it starts empty and stays transactional.
+func (idx tableFactsIndex) lookup(tableName string) (tableConcurrencyFacts, bool) {
+	if facts, ok := idx.qualified[tableName]; ok {
+		return facts, true
+	}
+	facts, ok := idx.bare[tableName]
+	return facts, ok
+}
+
+// indexTableFacts indexes a read schema by both spellings an index ref can use.
+func indexTableFacts(dbSchema *dbschematypes.DBSchema) tableFactsIndex {
+	index := tableFactsIndex{
+		qualified: make(map[string]tableConcurrencyFacts),
+		bare:      make(map[string]tableConcurrencyFacts),
+	}
 	if dbSchema == nil {
-		return out
+		return index
 	}
 	for _, table := range dbSchema.Tables {
-		if !selected(table) {
-			continue
+		facts := tableConcurrencyFacts{
+			partitioned: table.Partitioned,
+			populated:   table.RowStatsUnknown || table.EstimatedRows > 0,
 		}
-		out[table.QualifiedName()] = struct{}{}
+		mergeTableConcurrencyFacts(index.qualified, table.QualifiedName(), facts)
 		if table.Schema != "" {
-			out[table.Name] = struct{}{}
+			mergeTableConcurrencyFacts(index.bare, table.Name, facts)
 		}
 	}
-	return out
+	return index
+}
+
+// mergeTableConcurrencyFacts folds one more candidate into a spelling that
+// several tables answer to.
+func mergeTableConcurrencyFacts(
+	into map[string]tableConcurrencyFacts,
+	key string,
+	facts tableConcurrencyFacts,
+) {
+	previous, seen := into[key]
+	if !seen {
+		into[key] = facts
+		return
+	}
+	into[key] = tableConcurrencyFacts{
+		partitioned: previous.partitioned && facts.partitioned,
+		populated:   previous.populated || facts.populated,
+	}
 }
 
 type splitSchemaDiffs struct {

--- a/migration/generator/partitioned_index_cycle_postgres_live_test.go
+++ b/migration/generator/partitioned_index_cycle_postgres_live_test.go
@@ -3,6 +3,7 @@ package generator_test
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"testing"
 
 	qt "github.com/frankban/quicktest"
@@ -158,9 +159,23 @@ func TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres
 // A copy attached under a name of the operator's own choosing
 // (my_local_created) is not droppable; a standalone index carrying the name
 // PostgreSQL would have generated for a copy (events_2026_id_idx) is. Neither
-// the name nor the table separates them -- pg_inherits does. relkind does not
-// either: it marks the parent, which is the one object of the three that a
-// DROP INDEX may name.
+// the name nor the table separates them -- pg_inherits over the INDEX relation
+// does. Three things this fixture is built to refuse:
+//
+//   - The naming convention. events_2026_id_idx carries the name a copy would
+//     have and is droppable; my_local_created is a copy and is not.
+//   - relkind. It marks the parent ('I') and leaves the copy ('i'), and two of
+//     the three droppable indexes here are 'I' while the third is 'i'.
+//   - The partition's own attachment. pg_inherits over the TABLE relation is
+//     true for every index on events_2026, which is three of these five.
+//
+// The fixture is read TWICE, before and after the ATTACH, because the two
+// halves of it are the same object in different states and a single reading
+// cannot tell a rule that answers the state from one that answers the name. It
+// also records what the catalog cannot hold at once: attaching the only
+// partition's index to idx_events_created is exactly what makes that parent
+// indisvalid, so "my_local_created is attached" and "idx_events_created is not
+// yet valid" are states of two different moments, never of one.
 func TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres(t *testing.T) {
 	c := qt.New(t)
 	ctx := t.Context()
@@ -187,17 +202,51 @@ func TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres(t *testing.T)
 		CREATE INDEX events_2026_id_idx ON events_2026 (id);
 		CREATE INDEX my_local_created ON events_2026 (created_at);
 		CREATE INDEX idx_events_created ON ONLY events (created_at);
-		ALTER INDEX idx_events_created ATTACH PARTITION my_local_created;
 	`)
 	c.Assert(err, qt.IsNil)
 
-	schema, err := target.Reader().ReadSchema()
+	// Before the ATTACH. my_local_created is an ordinary index that happens to
+	// live on a partition, and idx_events_created is a parent with no child
+	// yet, so it is not valid. A rule keyed on the partition's own attachment
+	// marks my_local_created here, and this is where it is wrong.
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_id_idx", RelKind: "i", Valid: true, Ready: true, Attached: false},
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_created", RelKind: "I", Valid: false, Ready: true, Attached: false},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+			{Name: "my_local_created", RelKind: "i", Valid: true, Ready: true, Attached: false},
+		},
+	)
+	c.Assert(readPartitionAttachedMarks(c, target), qt.DeepEquals, map[string]bool{
+		"idx_events_tenant":      false,
+		"idx_events_created":     false,
+		"events_2026_tenant_idx": true,
+		"events_2026_id_idx":     false,
+		"my_local_created":       false,
+	})
+
+	_, err = target.ExecContext(ctx, `ALTER INDEX idx_events_created ATTACH PARTITION my_local_created`)
 	c.Assert(err, qt.IsNil)
 
-	attached := make(map[string]bool, len(schema.Indexes))
-	for _, index := range schema.Indexes {
-		attached[index.Name] = index.PartitionAttached
-	}
+	// After the ATTACH. my_local_created became a copy without being touched,
+	// and idx_events_created became valid without being touched: the single
+	// partition now has an attached index, which is the condition PostgreSQL
+	// validates the parent on.
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_id_idx", RelKind: "i", Valid: true, Ready: true, Attached: false},
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_created", RelKind: "I", Valid: true, Ready: true, Attached: false},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+			{Name: "my_local_created", RelKind: "i", Valid: true, Ready: true, Attached: true},
+		},
+	)
+	attached := readPartitionAttachedMarks(c, target)
 	c.Assert(attached, qt.DeepEquals, map[string]bool{
 		"idx_events_tenant":      false,
 		"idx_events_created":     false,
@@ -206,12 +255,67 @@ func TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres(t *testing.T)
 		"my_local_created":       true,
 	})
 
-	// The reader's mark and the server's refusal name the same objects.
+	// The reader's mark and the server's refusal name the same objects, over
+	// the WHOLE fixture rather than over a chosen pair. Three of these five
+	// indexes accept a DROP INDEX and two refuse it, and the two that refuse
+	// are exactly the two the reader marks.
+	c.Assert(refusedDropIndex(c, target, indexNames(attached)), qt.DeepEquals, attached)
+
+	// The refusal is the one #997 is about, quoted rather than counted.
 	_, err = target.ExecContext(ctx, `DROP INDEX "events_2026_id_idx"`)
 	c.Assert(err, qt.IsNil)
 	_, err = target.ExecContext(ctx, `DROP INDEX "my_local_created"`)
 	c.Assert(err, qt.IsNotNil)
 	c.Assert(err.Error(), qt.Contains, "cannot drop index my_local_created")
+}
+
+// readPartitionAttachedMarks reports PartitionAttached per index name, as the
+// reader under test describes the live database.
+func readPartitionAttachedMarks(c *qt.C, conn *dbschema.DatabaseConnection) map[string]bool {
+	c.Helper()
+	schema, err := conn.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+	marks := make(map[string]bool, len(schema.Indexes))
+	for _, index := range schema.Indexes {
+		marks[index.Name] = index.PartitionAttached
+	}
+	return marks
+}
+
+// indexNames lists the keys of a per-index map in sorted order, so the set the
+// server is asked about is the set the reader described rather than a list
+// written out by hand beside it.
+func indexNames(marks map[string]bool) []string {
+	names := make([]string, 0, len(marks))
+	for name := range marks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// refusedDropIndex reports, per index name, whether PostgreSQL refuses a
+// DROP INDEX that names it.
+//
+// Each attempt runs in a transaction of its own and is rolled back, so every
+// name is measured against the same catalog the reader was asked about --
+// dropping one index for real would change what the next attempt means, and
+// dropping a parent takes its copies with it.
+func refusedDropIndex(c *qt.C, conn *dbschema.DatabaseConnection, names []string) map[string]bool {
+	c.Helper()
+	session, err := conn.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(session.Close(), qt.IsNil) }()
+
+	refused := make(map[string]bool, len(names))
+	for _, name := range names {
+		transaction, beginErr := session.BeginTx(c.Context(), nil)
+		c.Assert(beginErr, qt.IsNil)
+		_, dropErr := transaction.ExecContext(c.Context(), `DROP INDEX "`+name+`"`)
+		refused[name] = dropErr != nil
+		c.Assert(transaction.Rollback(), qt.IsNil)
+	}
+	return refused
 }
 
 // partitionedIndexRow is one pg_index observation, named so a failure reads as

--- a/migration/generator/partitioned_index_cycle_postgres_live_test.go
+++ b/migration/generator/partitioned_index_cycle_postgres_live_test.go
@@ -1,0 +1,276 @@
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/generator"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres
+// runs the loop a single round trip cannot see: generate, apply, and generate
+// again against the state the first cycle produced.
+//
+// Creating an index on a partitioned parent makes PostgreSQL create one copy of
+// it per partition, named by the server (events_2026_tenant_idx). Those copies
+// do not exist when the first migration is generated, so the first cycle is
+// clean; they exist by the time the next generate introspects, and a desired
+// state written against the parent never names them. Read as ordinary indexes
+// they are removals, and PostgreSQL 17.10 answers the DROP with
+// `cannot drop index events_2026_tenant_idx because index idx_events_tenant
+// requires it (SQLSTATE 2BP01)` -- at execution time, after the file, its
+// checksum and its commit exist. See #997.
+//
+// Every cycle asserts pg_index rather than the generated text: the parent index
+// is relkind 'I' and the copy is relkind 'i', and both are indisvalid and
+// indisready here, which is what separates them from the failed concurrent
+// build #1101 is about.
+func TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_partition_cycle")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	_, err = target.ExecContext(ctx, `
+		CREATE TABLE events (
+			id BIGINT NOT NULL,
+			tenant TEXT NOT NULL,
+			created_at DATE NOT NULL
+		) PARTITION BY RANGE (created_at);
+		CREATE TABLE events_2026 PARTITION OF events
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+		INSERT INTO events
+			SELECT g, 'tenant-' || (g % 7), DATE '2026-01-01' + (g % 300)
+			FROM generate_series(1, 5000) AS g;
+		ANALYZE;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	dir := t.TempDir()
+	entitiesDir := writePartitionedIndexEntities(c, dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+	// Cycle 1: the parent index is planned and applied.
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "add_events_tenant_index",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	migrations := migrator.NewMigrator(target, provider)
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+
+	// The state the second cycle has to survive: the parent index and the copy
+	// the server created for the partition, both usable.
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+		},
+	)
+
+	// Cycle 2: nothing is left to plan. Before #997 this published
+	// DROP INDEX IF EXISTS "events_2026_tenant_idx", which the server refuses.
+	second, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "second_cycle",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(second, qt.IsNil)
+	c.Assert(readGeneratedMigrationFilenames(c, migrationsDir), qt.HasLen, 2)
+
+	// Whatever the second cycle decided, the directory still applies: a no-op
+	// run is only worth something if the run itself succeeds.
+	replayProvider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrator.NewMigrator(target, replayProvider).MigrateUp(ctx), qt.IsNil)
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+		},
+	)
+
+	// The copy is skipped because the catalog says it is attached, not because
+	// indexes on partitions stopped being managed. An index created on the
+	// partition directly is still planned for removal, and the server accepts
+	// that drop -- these two indexes are the pair that separates the fact from
+	// every cheaper guess about it.
+	_, err = target.ExecContext(ctx, `CREATE INDEX events_2026_id_idx ON events_2026 (id)`)
+	c.Assert(err, qt.IsNil)
+	third, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "third_cycle",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(third, qt.IsNotNil)
+	c.Assert(third.Files, qt.HasLen, 1)
+	thirdUp, err := os.ReadFile(third.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(thirdUp), qt.Contains, `DROP INDEX IF EXISTS "events_2026_id_idx";`)
+	c.Assert(string(thirdUp), qt.Not(qt.Contains), "events_2026_tenant_idx")
+
+	thirdProvider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrator.NewMigrator(target, thirdProvider).MigrateUp(ctx), qt.IsNil)
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+		},
+	)
+}
+
+// TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres pins what the
+// reader reports, on the one fixture pair where a cheaper rule and the catalog
+// fact disagree in both directions.
+//
+// A copy attached under a name of the operator's own choosing
+// (my_local_created) is not droppable; a standalone index carrying the name
+// PostgreSQL would have generated for a copy (events_2026_id_idx) is. Neither
+// the name nor the table separates them -- pg_inherits does. relkind does not
+// either: it marks the parent, which is the one object of the three that a
+// DROP INDEX may name.
+func TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_reader_partition_index")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	_, err = target.ExecContext(ctx, `
+		CREATE TABLE events (
+			id BIGINT NOT NULL,
+			tenant TEXT NOT NULL,
+			created_at DATE NOT NULL
+		) PARTITION BY RANGE (created_at);
+		CREATE TABLE events_2026 PARTITION OF events
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+		CREATE INDEX idx_events_tenant ON events (tenant);
+		CREATE INDEX events_2026_id_idx ON events_2026 (id);
+		CREATE INDEX my_local_created ON events_2026 (created_at);
+		CREATE INDEX idx_events_created ON ONLY events (created_at);
+		ALTER INDEX idx_events_created ATTACH PARTITION my_local_created;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	schema, err := target.Reader().ReadSchema()
+	c.Assert(err, qt.IsNil)
+
+	attached := make(map[string]bool, len(schema.Indexes))
+	for _, index := range schema.Indexes {
+		attached[index.Name] = index.PartitionAttached
+	}
+	c.Assert(attached, qt.DeepEquals, map[string]bool{
+		"idx_events_tenant":      false,
+		"idx_events_created":     false,
+		"events_2026_tenant_idx": true,
+		"events_2026_id_idx":     false,
+		"my_local_created":       true,
+	})
+
+	// The reader's mark and the server's refusal name the same objects.
+	_, err = target.ExecContext(ctx, `DROP INDEX "events_2026_id_idx"`)
+	c.Assert(err, qt.IsNil)
+	_, err = target.ExecContext(ctx, `DROP INDEX "my_local_created"`)
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "cannot drop index my_local_created")
+}
+
+// partitionedIndexRow is one pg_index observation, named so a failure reads as
+// the catalog state it is rather than as a tuple of booleans.
+type partitionedIndexRow struct {
+	Name     string
+	RelKind  string
+	Valid    bool
+	Ready    bool
+	Attached bool
+}
+
+// readPartitionedIndexCatalog reports every index on the partitioned parent and
+// its partition, in name order.
+//
+// indisvalid and indisready are read alongside relkind because they are what
+// separates the shapes a probe must not confuse: a partition's copy is 'i', a
+// parent index is 'I', a parent built with CREATE INDEX ... ON ONLY is 'I' with
+// indisvalid false and indisready true, and a failed concurrent build is 'i'
+// with both false.
+func readPartitionedIndexCatalog(c *qt.C, conn *dbschema.DatabaseConnection) []partitionedIndexRow {
+	c.Helper()
+	rows, err := conn.QueryContext(c.Context(), `
+		SELECT class.relname,
+		       class.relkind::text,
+		       index.indisvalid,
+		       index.indisready,
+		       EXISTS (SELECT 1 FROM pg_inherits inh WHERE inh.inhrelid = class.oid)
+		FROM pg_index AS index
+		JOIN pg_class AS class ON class.oid = index.indexrelid
+		JOIN pg_class AS parent ON parent.oid = index.indrelid
+		JOIN pg_namespace AS namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = current_schema()
+		  AND parent.relname IN ('events', 'events_2026')
+		ORDER BY class.relname
+	`)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(rows.Close(), qt.IsNil) }()
+
+	var observed []partitionedIndexRow
+	for rows.Next() {
+		var row partitionedIndexRow
+		c.Assert(rows.Scan(&row.Name, &row.RelKind, &row.Valid, &row.Ready, &row.Attached), qt.IsNil)
+		observed = append(observed, row)
+	}
+	c.Assert(rows.Err(), qt.IsNil)
+	return observed
+}
+
+// readGeneratedMigrationFilenames lists the migration directory so a "nothing
+// was generated" claim is measured against the directory rather than against
+// the return value alone.
+func readGeneratedMigrationFilenames(c *qt.C, dir string) []string {
+	c.Helper()
+	entries, err := os.ReadDir(dir)
+	c.Assert(err, qt.IsNil)
+	names := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		names = append(names, entry.Name())
+	}
+	return names
+}

--- a/migration/generator/partitioned_index_schema_scope_internal_test.go
+++ b/migration/generator/partitioned_index_schema_scope_internal_test.go
@@ -1,0 +1,227 @@
+package generator
+
+// White-box testing required: which table an index ref names is resolved by
+// unexported selectors before any SQL exists, and the fixture this file is
+// built around -- two tables with the same bare name in different schemas --
+// produces a rendered migration that looks identical whichever table the
+// selector picked. Only the ref lists say which one it read.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// concurrentIndexOutcome is what the three concurrent-index selectors made of
+// one index ref against one read schema.
+type concurrentIndexOutcome struct {
+	heuristic []types.IndexRef
+	policy    []types.IndexRef
+	policyErr error
+	dropRefs  []types.IndexRef
+	dropErr   error
+}
+
+// TestConcurrentIndexSelectors_ResolveTheTableTheRefNames pins the identity the
+// partitioned rule is keyed on.
+//
+// A read schema can hold two different tables with the same bare name, one per
+// schema, and an index ref carries whichever spelling the side of the diff it
+// came from produced -- bare from the PostgreSQL reader for the connection's
+// own schema, "schema.table" from a Go entity that declares one. Keying the
+// partitioned rule on a set that pools both spellings makes one partitioned
+// parent answer for every ordinary table sharing its bare name: the ordinary
+// table silently loses its concurrent build, and an explicit
+// diff.concurrent_index request is refused with a diagnostic naming a table
+// that is not partitioned at all.
+//
+// The rows below separate that pooling from the rule in four directions: a
+// qualified ref must still find its own partitioned parent, a bare ref must
+// prefer the table that answers to it exactly, a bare ref every candidate
+// answers as partitioned must still be refused, and a bare ref reaching a
+// single schema-qualified parent must still be refused.
+func TestConcurrentIndexSelectors_ResolveTheTableTheRefNames(t *testing.T) {
+	tests := []struct {
+		name   string
+		tables []dbschematypes.DBTable
+		ref    types.IndexRef
+		assert func(c *qt.C, got concurrentIndexOutcome)
+	}{
+		{
+			// One partitioned table must not poison every ordinary table that
+			// shares its bare name. A pooled set fails this row three times.
+			name: "a partitioned parent in another schema does not answer for a bare ref",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", Schema: "app", Partitioned: true, EstimatedRows: 5000},
+				{Name: "events", Schema: "public", EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.policyErr, qt.IsNil)
+				c.Assert(got.dropErr, qt.IsNil)
+				c.Assert(got.heuristic, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+				c.Assert(got.policy, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+				c.Assert(got.dropRefs, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+		{
+			// The shape the PostgreSQL reader actually produces: it blanks the
+			// schema of the connection's own schema, so the ordinary table is
+			// the one the bare spelling names exactly.
+			name: "a bare ref prefers the table whose own spelling is bare",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", EstimatedRows: 5000},
+				{Name: "events", Schema: "app", Partitioned: true, EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.policyErr, qt.IsNil)
+				c.Assert(got.dropErr, qt.IsNil)
+				c.Assert(got.heuristic, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+				c.Assert(got.policy, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+		{
+			// The other direction: resolving by bare name only would lose the
+			// parent this ref names exactly, and publish a statement the server
+			// answers with SQLSTATE 0A000.
+			name: "a qualified ref finds its own partitioned parent",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", EstimatedRows: 5000},
+				{Name: "events", Schema: "app", Partitioned: true, EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "app.events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.heuristic, qt.IsNil)
+				c.Assert(got.policy, qt.IsNil)
+				c.Assert(got.policyErr, qt.IsNotNil)
+				c.Assert(got.policyErr.Error(), qt.Contains, `"idx_events_tenant" on "app.events"`)
+				c.Assert(got.dropRefs, qt.IsNil)
+				c.Assert(got.dropErr, qt.IsNotNil)
+				c.Assert(got.dropErr.Error(), qt.Contains, `"idx_events_tenant" on "app.events"`)
+			},
+		},
+		{
+			// Ambiguity is not a licence to publish. When every table the bare
+			// spelling can name is a partitioned parent, the statement is
+			// unexecutable whichever one it meant.
+			name: "a bare ref every candidate answers as partitioned is still refused",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", Schema: "app", Partitioned: true, EstimatedRows: 5000},
+				{Name: "events", Schema: "reporting", Partitioned: true, EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.heuristic, qt.IsNil)
+				c.Assert(got.policy, qt.IsNil)
+				c.Assert(got.policyErr, qt.IsNotNil)
+				c.Assert(got.dropRefs, qt.IsNil)
+				c.Assert(got.dropErr, qt.IsNotNil)
+			},
+		},
+		{
+			// The bare fallback still has to reach a schema-qualified table --
+			// the two sides of a diff do not have to agree on the spelling.
+			name: "a bare ref reaching one schema-qualified parent is refused",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", Schema: "app", Partitioned: true, EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.heuristic, qt.IsNil)
+				c.Assert(got.policy, qt.IsNil)
+				c.Assert(got.policyErr, qt.IsNotNil)
+				c.Assert(got.dropRefs, qt.IsNil)
+				c.Assert(got.dropErr, qt.IsNotNil)
+			},
+		},
+		{
+			name: "a bare ref reaching one ordinary schema-qualified table builds concurrently",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", Schema: "app", EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.policyErr, qt.IsNil)
+				c.Assert(got.heuristic, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+		{
+			// One populated candidate is enough to prefer the concurrent build:
+			// a blocking build on a table that turns out to hold rows is the
+			// unrecoverable side of the guess.
+			name: "a bare ref with one populated candidate builds concurrently",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", Schema: "app", EstimatedRows: 0},
+				{Name: "events", Schema: "reporting", EstimatedRows: 5000},
+			},
+			ref: types.IndexRef{Name: "idx_events_tenant", TableName: "events"},
+			assert: func(c *qt.C, got concurrentIndexOutcome) {
+				c.Assert(got.heuristic, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			tt.assert(c, runConcurrentIndexSelectors(tt.tables, tt.ref))
+		})
+	}
+}
+
+// runConcurrentIndexSelectors puts one ref through all three selectors against
+// one read schema. Each selector gets its own diff because they read different
+// halves of it.
+func runConcurrentIndexSelectors(
+	tables []dbschematypes.DBTable,
+	ref types.IndexRef,
+) concurrentIndexOutcome {
+	dbSchema := func() *dbschematypes.DBSchema {
+		return &dbschematypes.DBSchema{Tables: tables}
+	}
+	additions := func() *types.SchemaDiff {
+		diff := &types.SchemaDiff{}
+		diff.SetIndexAdditions([]types.IndexRef{ref})
+		return diff
+	}
+	removals := &types.SchemaDiff{}
+	removals.SetIndexRemovals([]types.IndexRef{ref})
+
+	var out concurrentIndexOutcome
+	out.heuristic = concurrentIndexRefsForPopulatedTables(
+		additions(),
+		dbSchema(),
+		postgresIndexDBInfo(),
+	)
+	out.policy, out.policyErr = concurrentIndexRefsForPolicy(
+		additions(),
+		dbSchema(),
+		postgresIndexDBInfo(),
+		DiffPolicy{ConcurrentIndex: true},
+	)
+	out.dropRefs, out.dropErr = concurrentIndexDropRefsForPolicy(
+		removals,
+		dbSchema(),
+		postgresIndexDBInfo(),
+		DiffPolicy{ConcurrentIndexDrop: true},
+	)
+	return out
+}

--- a/migration/generator/partitioned_index_shadow_postgres_live_test.go
+++ b/migration/generator/partitioned_index_shadow_postgres_live_test.go
@@ -1,0 +1,147 @@
+package generator_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/generator"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres runs
+// the same generate/apply/generate loop through the surface a user reaches with
+// --shadow-db, on a partitioned parent whose history the migration directory
+// carries.
+//
+// The shadow database is dropped and the directory replayed onto it before
+// anything is written, so the parent is created there by the plan itself. That
+// is the only arrangement in which the shadow can say anything about a
+// partitioned parent at all: the shadow starts empty, and a migration that only
+// adds an index to a table the directory never created fails there with
+// `relation "events" does not exist` whether or not the table is partitioned.
+//
+// The partition is attached between the cycles rather than created with the
+// parent, because attaching an existing table is what makes PostgreSQL build
+// the copy of the parent's index -- the object the second cycle used to plan a
+// DROP for. See #997.
+func TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_partition_shadow_target")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	shadowURL, shadowDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_partition_shadow_db")
+	defer dropGeneratorTestPostgres(c, admin, shadowDatabase)
+
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	migrationsDir := filepath.Join(t.TempDir(), "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+	desired := partitionedParentDesiredSchema()
+
+	// Cycle 1: the parent, the table that becomes its partition, and the index
+	// on the parent -- verified on the shadow before a byte is written.
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		Generated:         desired,
+		DatabaseURL:       targetURL,
+		ShadowDatabaseURL: shadowURL,
+		MigrationName:     "create_partitioned_events",
+		OutputDir:         migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	upSQL, err := os.ReadFile(files.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upSQL), qt.Contains, `PARTITION BY RANGE ("created_at")`)
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrator.NewMigrator(target, provider).MigrateUp(ctx), qt.IsNil)
+
+	_, err = target.ExecContext(ctx, `
+		ALTER TABLE events ATTACH PARTITION events_2026
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+		INSERT INTO events
+			SELECT g, 'tenant-' || (g % 7), DATE '2026-01-01' + (g % 300)
+			FROM generate_series(1, 5000) AS g;
+		ANALYZE;
+	`)
+	c.Assert(err, qt.IsNil)
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+		},
+	)
+
+	// Cycle 2 over the same surface: nothing left to plan, and the shadow is
+	// never asked to judge a statement that would have failed on the target.
+	second, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		Generated:         desired,
+		DatabaseURL:       targetURL,
+		ShadowDatabaseURL: shadowURL,
+		MigrationName:     "second_cycle",
+		OutputDir:         migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(second, qt.IsNil)
+	c.Assert(readGeneratedMigrationFilenames(c, migrationsDir), qt.HasLen, 2)
+
+	replay, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	c.Assert(migrator.NewMigrator(target, replay).MigrateUp(ctx), qt.IsNil)
+	c.Assert(
+		readPartitionedIndexCatalog(c, target),
+		qt.DeepEquals,
+		[]partitionedIndexRow{
+			{Name: "events_2026_tenant_idx", RelKind: "i", Valid: true, Ready: true, Attached: true},
+			{Name: "idx_events_tenant", RelKind: "I", Valid: true, Ready: true, Attached: false},
+		},
+	)
+}
+
+// partitionedParentDesiredSchema is the desired state both shadow cycles
+// compare against: a partitioned parent, a plain table an operator attaches to
+// it as a partition, and one index declared on the parent.
+func partitionedParentDesiredSchema() *goschema.Database {
+	return &goschema.Database{
+		Tables: []goschema.Table{
+			{
+				Name:       "events",
+				StructName: "Event",
+				Partition: &goschema.PartitionSpec{
+					Type:  "RANGE",
+					Parts: []goschema.PartitionPart{{Name: "created_at"}},
+				},
+			},
+			{Name: "events_2026", StructName: "Event2026"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Event", Name: "id", Type: "BIGINT"},
+			{StructName: "Event", Name: "tenant", Type: "TEXT"},
+			{StructName: "Event", Name: "created_at", Type: "DATE"},
+			{StructName: "Event2026", Name: "id", Type: "BIGINT"},
+			{StructName: "Event2026", Name: "tenant", Type: "TEXT"},
+			{StructName: "Event2026", Name: "created_at", Type: "DATE"},
+		},
+		Indexes: []goschema.Index{
+			{Name: "idx_events_tenant", StructName: "Event", Fields: []string{"tenant"}},
+		},
+	}
+}

--- a/migration/generator/partitioned_index_stats_internal_test.go
+++ b/migration/generator/partitioned_index_stats_internal_test.go
@@ -1,0 +1,244 @@
+package generator
+
+// White-box testing required: the concurrent-index decision is taken by
+// unexported ref selectors before any SQL exists, and the distinctions under
+// test -- a partitioned parent, and row statistics the database could not
+// report -- are erased by the time the public API returns rendered migration
+// files.
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/core/platform/capability"
+	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+func postgresIndexDBInfo() dbschematypes.DBInfo {
+	return dbschematypes.DBInfo{
+		Dialect:      platform.Postgres,
+		Capabilities: capability.Postgres17(),
+	}
+}
+
+// TestConcurrentIndexRefsForPopulatedTables_PartitionedAndUnknownStats pins the
+// two catalog facts the heuristic must read beyond "estimated rows".
+//
+// A partitioned parent has no concurrent index build at all: PostgreSQL answers
+// CREATE INDEX CONCURRENTLY on relkind 'p' with SQLSTATE 0A000, measured on
+// 17.10. Row statistics that the database could not report are not a row count
+// of zero: pg_class.reltuples is -1 until something analyzes the relation, and
+// n_live_tup is 0 after the cumulative counters are reset, so a table holding
+// five thousand rows reports the same numbers an empty one does.
+func TestConcurrentIndexRefsForPopulatedTables_PartitionedAndUnknownStats(t *testing.T) {
+	tests := []struct {
+		name   string
+		tables []dbschematypes.DBTable
+		want   []types.IndexRef
+	}{
+		{
+			name:   "populated ordinary table builds concurrently",
+			tables: []dbschematypes.DBTable{{Name: "events", EstimatedRows: 5000}},
+			want:   []types.IndexRef{{Name: "idx_events_tenant", TableName: "events"}},
+		},
+		{
+			// The discriminating row: an exclusion keyed on "the schema contains
+			// a partitioned table" rather than on "this index names one" passes
+			// every other row and fails here.
+			name: "an unrelated partitioned table does not downgrade the build",
+			tables: []dbschematypes.DBTable{
+				{Name: "events", EstimatedRows: 5000},
+				{Name: "measurements", EstimatedRows: 5000, Partitioned: true},
+			},
+			want: []types.IndexRef{{Name: "idx_events_tenant", TableName: "events"}},
+		},
+		{
+			name:   "reported empty table stays transactional",
+			tables: []dbschematypes.DBTable{{Name: "events", EstimatedRows: 0}},
+			want:   nil,
+		},
+		{
+			name:   "unreported row statistics build concurrently",
+			tables: []dbschematypes.DBTable{{Name: "events", EstimatedRows: 0, RowStatsUnknown: true}},
+			want:   []types.IndexRef{{Name: "idx_events_tenant", TableName: "events"}},
+		},
+		{
+			name:   "populated partitioned parent stays transactional",
+			tables: []dbschematypes.DBTable{{Name: "events", EstimatedRows: 5000, Partitioned: true}},
+			want:   nil,
+		},
+		{
+			name: "partitioned parent with unreported statistics stays transactional",
+			tables: []dbschematypes.DBTable{{
+				Name:            "events",
+				EstimatedRows:   0,
+				RowStatsUnknown: true,
+				Partitioned:     true,
+			}},
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &types.SchemaDiff{}
+			diff.SetIndexAdditions([]types.IndexRef{
+				{Name: "idx_events_tenant", TableName: "events"},
+			})
+
+			got := concurrentIndexRefsForPopulatedTables(
+				diff,
+				&dbschematypes.DBSchema{Tables: tt.tables},
+				postgresIndexDBInfo(),
+			)
+
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}
+
+// TestConcurrentIndexPolicy_RefusesPartitionedParent covers the explicitly
+// requested half. The heuristic downgrades because nothing asked for a
+// concurrent statement; a project that set diff.concurrent_index is asking, and
+// the answer PostgreSQL gives cannot be honored -- so generation fails here,
+// before a migration file, its checksum, and its commit exist.
+func TestConcurrentIndexPolicy_RefusesPartitionedParent(t *testing.T) {
+	tests := []struct {
+		name   string
+		policy DiffPolicy
+		tables []dbschematypes.DBTable
+		assert func(c *qt.C, refs []types.IndexRef, err error)
+	}{
+		{
+			name:   "create over a partitioned parent is refused",
+			policy: DiffPolicy{ConcurrentIndex: true},
+			tables: []dbschematypes.DBTable{{Name: "events", Partitioned: true}},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, "CREATE INDEX CONCURRENTLY")
+				c.Assert(err.Error(), qt.Contains, "diff.concurrent_index.create")
+				c.Assert(err.Error(), qt.Contains, `"idx_events_tenant" on "events"`)
+				c.Assert(err.Error(), qt.Contains, "0A000")
+				c.Assert(refs, qt.IsNil)
+			},
+		},
+		{
+			name:   "create over an ordinary table is honored",
+			policy: DiffPolicy{ConcurrentIndex: true},
+			tables: []dbschematypes.DBTable{{Name: "events"}},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(refs, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+		{
+			// The discriminating row: a refusal keyed on "the schema contains a
+			// partitioned table" rather than on "this index names one" passes
+			// every row above and fails here.
+			name:   "an unrelated partitioned table does not refuse the run",
+			policy: DiffPolicy{ConcurrentIndex: true},
+			tables: []dbschematypes.DBTable{
+				{Name: "events"},
+				{Name: "measurements", Partitioned: true},
+			},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(refs, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &types.SchemaDiff{}
+			diff.SetIndexAdditions([]types.IndexRef{
+				{Name: "idx_events_tenant", TableName: "events"},
+			})
+
+			refs, err := concurrentIndexRefsForPolicy(
+				diff,
+				&dbschematypes.DBSchema{Tables: tt.tables},
+				postgresIndexDBInfo(),
+				tt.policy,
+			)
+
+			tt.assert(c, refs, err)
+		})
+	}
+}
+
+// TestConcurrentIndexDropPolicy_RefusesPartitionedParent is the drop half.
+// PostgreSQL refuses DROP INDEX CONCURRENTLY on a partitioned index with its
+// own message ("cannot drop partitioned index ... concurrently"), so the
+// rollback of a partitioned build is unexecutable in exactly the same way the
+// build is -- and a rollback nobody ran is where that goes unnoticed.
+func TestConcurrentIndexDropPolicy_RefusesPartitionedParent(t *testing.T) {
+	tests := []struct {
+		name   string
+		tables []dbschematypes.DBTable
+		assert func(c *qt.C, refs []types.IndexRef, err error)
+	}{
+		{
+			name:   "drop over a partitioned parent is refused",
+			tables: []dbschematypes.DBTable{{Name: "events", Partitioned: true}},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNotNil)
+				c.Assert(err.Error(), qt.Contains, "DROP INDEX CONCURRENTLY")
+				c.Assert(err.Error(), qt.Contains, "diff.concurrent_index.drop")
+				c.Assert(err.Error(), qt.Contains, `"idx_events_tenant" on "events"`)
+				c.Assert(refs, qt.IsNil)
+			},
+		},
+		{
+			name:   "drop over an ordinary table is honored",
+			tables: []dbschematypes.DBTable{{Name: "events"}},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(refs, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+		{
+			name: "an unrelated partitioned table does not refuse the run",
+			tables: []dbschematypes.DBTable{
+				{Name: "events"},
+				{Name: "measurements", Partitioned: true},
+			},
+			assert: func(c *qt.C, refs []types.IndexRef, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(refs, qt.DeepEquals, []types.IndexRef{
+					{Name: "idx_events_tenant", TableName: "events"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+			diff := &types.SchemaDiff{}
+			diff.SetIndexRemovals([]types.IndexRef{
+				{Name: "idx_events_tenant", TableName: "events"},
+			})
+
+			refs, err := concurrentIndexDropRefsForPolicy(
+				diff,
+				&dbschematypes.DBSchema{Tables: tt.tables},
+				postgresIndexDBInfo(),
+				DiffPolicy{ConcurrentIndexDrop: true},
+			)
+
+			tt.assert(c, refs, err)
+		})
+	}
+}

--- a/migration/generator/partitioned_stats_postgres_live_test.go
+++ b/migration/generator/partitioned_stats_postgres_live_test.go
@@ -1,0 +1,267 @@
+package generator_test
+
+import (
+	"database/sql"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/migration/generator"
+	"go.5x5.cz/ptah/migration/migrator"
+)
+
+// TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres
+// pins the whole round trip for a declaratively partitioned parent.
+//
+// The parent reports pg_class.reltuples for every row in every partition, so
+// the populated-table heuristic selected it and emitted CREATE INDEX
+// CONCURRENTLY -- which PostgreSQL answers with SQLSTATE 0A000 at execution
+// time, after the migration file, its checksum and its commit already exist.
+// The rollback half is refused the same way ("cannot drop partitioned index
+// ... concurrently"), so both directions are executed here rather than
+// inspected.
+func TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_partitioned")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	_, err = target.ExecContext(ctx, `
+		CREATE TABLE events (
+			id BIGINT NOT NULL,
+			tenant TEXT NOT NULL,
+			created_at DATE NOT NULL
+		) PARTITION BY RANGE (created_at);
+		CREATE TABLE events_2026 PARTITION OF events
+			FOR VALUES FROM ('2026-01-01') TO ('2027-01-01');
+		INSERT INTO events
+			SELECT g, 'tenant-' || (g % 7), DATE '2026-01-01' + (g % 300)
+			FROM generate_series(1, 5000) AS g;
+		ANALYZE;
+	`)
+	c.Assert(err, qt.IsNil)
+
+	// The precondition the whole test rests on: the parent is relkind 'p' and
+	// reports the partitions' rows as its own, so the heuristic sees a
+	// populated table.
+	var relkind string
+	var estimatedRows int64
+	c.Assert(target.QueryRowContext(ctx, `
+		SELECT relkind::text, reltuples::bigint FROM pg_class WHERE relname = 'events'
+	`).Scan(&relkind, &estimatedRows), qt.IsNil)
+	c.Assert(relkind, qt.Equals, "p")
+	c.Assert(estimatedRows, qt.Equals, int64(5000))
+
+	dir := t.TempDir()
+	entitiesDir := writePartitionedIndexEntities(c, dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "add_events_tenant_index",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(files.Files[0].NoTransaction, qt.IsFalse)
+
+	upSQL, err := os.ReadFile(files.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upSQL), qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_events_tenant" ON "events" ("tenant");`)
+	c.Assert(string(upSQL), qt.Not(qt.Contains), "CONCURRENTLY")
+	downSQL, err := os.ReadFile(files.Files[0].DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downSQL), qt.Contains, `DROP INDEX IF EXISTS "idx_events_tenant";`)
+	c.Assert(string(downSQL), qt.Not(qt.Contains), "CONCURRENTLY")
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	migrations := migrator.NewMigrator(target, provider)
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid := readGeneratorPostgresIndexState(c, target, "idx_events_tenant")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
+
+	c.Assert(migrations.MigrateDown(ctx), qt.IsNil)
+	exists, _ = readGeneratorPostgresIndexState(c, target, "idx_events_tenant")
+	c.Assert(exists, qt.IsFalse)
+}
+
+// TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres
+// pins the other half of the same decision: a populated table whose statistics
+// PostgreSQL cannot report.
+//
+// pg_class.reltuples is -1 until something analyzes a relation, and the
+// cumulative counters read 0 after they are reset -- which happens on a
+// crash-recovery restart, on an explicit reset, and for a table restored into a
+// fresh cluster. GREATEST floored both to 0, so five thousand rows were
+// indistinguishable from an empty table and earned a blocking CREATE INDEX.
+func TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_unknown_stats")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	setupUnknownRowStatistics(c, targetURL)
+
+	// The precondition: the table holds 5000 rows and the catalog reports the
+	// same numbers an empty table reports.
+	var reltuples, liveTuples, actualRows int64
+	c.Assert(target.QueryRowContext(ctx, `
+		SELECT c.reltuples::bigint,
+		       COALESCE(st.n_live_tup, 0),
+		       (SELECT COUNT(*) FROM members)
+		FROM pg_class c
+		LEFT JOIN pg_stat_all_tables st ON st.relid = c.oid
+		WHERE c.relname = 'members'
+	`).Scan(&reltuples, &liveTuples, &actualRows), qt.IsNil)
+	c.Assert(reltuples, qt.Equals, int64(-1))
+	c.Assert(liveTuples, qt.Equals, int64(0))
+	c.Assert(actualRows, qt.Equals, int64(5000))
+
+	dir := t.TempDir()
+	entitiesDir := writeUnknownStatsIndexEntities(c, dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "add_members_email_index",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(files.Files[0].NoTransaction, qt.IsTrue)
+
+	upSQL, err := os.ReadFile(files.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upSQL), qt.Contains, "-- +ptah no_transaction")
+	c.Assert(string(upSQL), qt.Contains, `CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");`)
+	downSQL, err := os.ReadFile(files.Files[0].DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downSQL), qt.Contains, `DROP INDEX CONCURRENTLY IF EXISTS "idx_members_email";`)
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	migrations := migrator.NewMigrator(target, provider)
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid := readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
+
+	c.Assert(migrations.MigrateDown(ctx), qt.IsNil)
+	exists, _ = readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsFalse)
+}
+
+// setupUnknownRowStatistics populates a table and then leaves PostgreSQL with
+// no usable statistics for it, deterministically.
+//
+// Everything runs on one pinned connection because the order matters:
+// pg_stat_force_next_flush pushes the INSERT's counters out of this backend's
+// local memory, and only then does pg_stat_reset have anything to clear that
+// will stay cleared. Without the forced flush the pending counters are written
+// back after the reset and the table reports 5000 live tuples again. Autovacuum
+// is disabled on the table so nothing analyzes it behind the test's back.
+func setupUnknownRowStatistics(c *qt.C, targetURL string) {
+	c.Helper()
+	raw, err := sql.Open("pgx", targetURL)
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(raw.Close(), qt.IsNil) }()
+	conn, err := raw.Conn(c.Context())
+	c.Assert(err, qt.IsNil)
+	defer func() { c.Assert(conn.Close(), qt.IsNil) }()
+
+	for _, statement := range []string{
+		`CREATE TABLE members (
+			id BIGINT NOT NULL,
+			email TEXT NOT NULL
+		) WITH (autovacuum_enabled = false)`,
+		`INSERT INTO members SELECT g, 'user-' || g || '@example.com' FROM generate_series(1, 5000) AS g`,
+		`SELECT pg_stat_force_next_flush()`,
+		`SELECT pg_stat_reset()`,
+	} {
+		_, err = conn.ExecContext(c.Context(), statement)
+		c.Assert(err, qt.IsNil, qt.Commentf("statement failed: %s", statement))
+	}
+}
+
+func writePartitionedIndexEntities(c *qt.C, dir string) string {
+	c.Helper()
+	return writeGeneratorEntities(c, dir, `package entities
+
+//ptah:schema:table name="events"
+type Event struct {
+	//ptah:schema:field name="id" type="BIGINT" not_null="true"
+	ID int64
+
+	//ptah:schema:field name="tenant" type="TEXT" not_null="true"
+	//ptah:schema:index name="idx_events_tenant" fields="tenant"
+	Tenant string
+
+	//ptah:schema:field name="created_at" type="DATE" not_null="true"
+	CreatedAt string
+}
+
+//ptah:schema:table name="events_2026"
+type Event2026 struct {
+	//ptah:schema:field name="id" type="BIGINT" not_null="true"
+	ID int64
+
+	//ptah:schema:field name="tenant" type="TEXT" not_null="true"
+	Tenant string
+
+	//ptah:schema:field name="created_at" type="DATE" not_null="true"
+	CreatedAt string
+}
+`)
+}
+
+func writeUnknownStatsIndexEntities(c *qt.C, dir string) string {
+	c.Helper()
+	return writeGeneratorEntities(c, dir, `package entities
+
+//ptah:schema:table name="members"
+type Member struct {
+	//ptah:schema:field name="id" type="BIGINT" not_null="true"
+	ID int64
+
+	//ptah:schema:field name="email" type="TEXT" not_null="true"
+	//ptah:schema:index name="idx_members_email" fields="email"
+	Email string
+}
+`)
+}
+
+func writeGeneratorEntities(c *qt.C, dir, content string) string {
+	c.Helper()
+	entitiesDir := filepath.Join(dir, "entities")
+	c.Assert(os.MkdirAll(entitiesDir, 0o755), qt.IsNil)
+	c.Assert(os.WriteFile(filepath.Join(entitiesDir, "schema.go"), []byte(content), 0o600), qt.IsNil)
+	return entitiesDir
+}

--- a/migration/generator/partitioned_stats_postgres_live_test.go
+++ b/migration/generator/partitioned_stats_postgres_live_test.go
@@ -193,6 +193,109 @@ func TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres
 	c.Assert(valid, qt.IsTrue)
 }
 
+// TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres
+// is the other side of the tri-state, and it is the common case rather than the
+// exotic one.
+//
+// pg_class.reltuples is -1 for ANY relation nothing has analyzed, which
+// includes every table that has never had a row inserted -- so "statistics are
+// unusable" on its own marks a freshly created empty table as populated, and
+// the concurrent build it then selects arrives as CREATE INDEX CONCURRENTLY in
+// its own non-transactional migration file for a table with nothing in it. The
+// storage the relation occupies is the fact that separates the two, because it
+// is read from the file system rather than from statistics.
+//
+// The table carries a text column on purpose. That gives it a TOAST relation
+// whose index occupies a page while the table itself occupies none, so
+// pg_table_size -- the size function this reads as the obvious one -- reports
+// 8192 for an empty table and cannot be the probe. The assertions below pin
+// both numbers so the distinction cannot be quietly re-collapsed.
+func TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres(t *testing.T) {
+	c := qt.New(t)
+	ctx := t.Context()
+	adminURL := requireGeneratorPostgresURL(t)
+	admin, err := dbschema.ConnectToDatabase(ctx, adminURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(admin)
+	c.Assert(platform.NormalizeDialect(admin.Info().Dialect), qt.Equals, platform.Postgres)
+	targetURL, targetDatabase := createGeneratorTestPostgres(c, admin, adminURL, "ptah_generator_empty_stats")
+	defer dropGeneratorTestPostgres(c, admin, targetDatabase)
+	target, err := dbschema.ConnectToDatabase(ctx, targetURL)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(target)
+
+	_, err = target.ExecContext(ctx, `
+		CREATE TABLE members (
+			id BIGINT NOT NULL,
+			email TEXT NOT NULL
+		) WITH (autovacuum_enabled = false)
+	`)
+	c.Assert(err, qt.IsNil)
+
+	// The precondition: the table is empty and nothing has analyzed it, so it
+	// reports exactly the statistics a bulk-loaded table reports before its
+	// first ANALYZE -- and its main fork, unlike pg_table_size, is empty too.
+	var reltuples, liveTuples, mainFork, tableSize, actualRows int64
+	c.Assert(target.QueryRowContext(ctx, `
+		SELECT c.reltuples::bigint,
+		       COALESCE(st.n_live_tup, 0),
+		       pg_relation_size(c.oid),
+		       pg_table_size(c.oid),
+		       (SELECT COUNT(*) FROM members)
+		FROM pg_class c
+		LEFT JOIN pg_stat_all_tables st ON st.relid = c.oid
+		WHERE c.relname = 'members'
+	`).Scan(&reltuples, &liveTuples, &mainFork, &tableSize, &actualRows), qt.IsNil)
+	c.Assert(reltuples, qt.Equals, int64(-1))
+	c.Assert(liveTuples, qt.Equals, int64(0))
+	c.Assert(actualRows, qt.Equals, int64(0))
+	c.Assert(mainFork, qt.Equals, int64(0))
+	c.Assert(tableSize > 0, qt.IsTrue, qt.Commentf("pg_table_size was %d", tableSize))
+
+	dir := t.TempDir()
+	entitiesDir := writeUnknownStatsIndexEntities(c, dir)
+	migrationsDir := filepath.Join(dir, "migrations")
+	c.Assert(os.MkdirAll(migrationsDir, 0o755), qt.IsNil)
+
+	files, err := generator.GenerateMigration(ctx, generator.GenerateMigrationOptions{
+		GoEntitiesDir: entitiesDir,
+		DatabaseURL:   targetURL,
+		MigrationName: "add_members_email_index",
+		OutputDir:     migrationsDir,
+	})
+	c.Assert(err, qt.IsNil)
+	c.Assert(files, qt.IsNotNil)
+	c.Assert(files.Files, qt.HasLen, 1)
+	c.Assert(files.Files[0].NoTransaction, qt.IsFalse)
+
+	upSQL, err := os.ReadFile(files.Files[0].UpFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(upSQL), qt.Contains, `CREATE INDEX IF NOT EXISTS "idx_members_email" ON "members" ("email");`)
+	c.Assert(string(upSQL), qt.Not(qt.Contains), "CONCURRENTLY")
+	c.Assert(string(upSQL), qt.Not(qt.Contains), "no_transaction")
+	downSQL, err := os.ReadFile(files.Files[0].DownFile)
+	c.Assert(err, qt.IsNil)
+	c.Assert(string(downSQL), qt.Contains, `DROP INDEX IF EXISTS "idx_members_email";`)
+	c.Assert(string(downSQL), qt.Not(qt.Contains), "CONCURRENTLY")
+
+	provider, err := migrator.NewFSMigrationProvider(os.DirFS(migrationsDir))
+	c.Assert(err, qt.IsNil)
+	migrations := migrator.NewMigrator(target, provider)
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid := readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
+
+	c.Assert(migrations.MigrateDown(ctx), qt.IsNil)
+	exists, _ = readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsFalse)
+
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid = readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
+}
+
 // setupUnknownRowStatistics populates a table and then leaves PostgreSQL with
 // no usable statistics for it, deterministically.
 //

--- a/migration/generator/partitioned_stats_postgres_live_test.go
+++ b/migration/generator/partitioned_stats_postgres_live_test.go
@@ -100,6 +100,12 @@ func TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgre
 	c.Assert(migrations.MigrateDown(ctx), qt.IsNil)
 	exists, _ = readGeneratorPostgresIndexState(c, target, "idx_events_tenant")
 	c.Assert(exists, qt.IsFalse)
+
+	// up/down/up: the pair has to be replayable, not merely runnable once.
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid = readGeneratorPostgresIndexState(c, target, "idx_events_tenant")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
 }
 
 // TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres
@@ -177,6 +183,14 @@ func TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres
 	c.Assert(migrations.MigrateDown(ctx), qt.IsNil)
 	exists, _ = readGeneratorPostgresIndexState(c, target, "idx_members_email")
 	c.Assert(exists, qt.IsFalse)
+
+	// up/down/up over a non-transactional pair: both halves have to be
+	// replayable, and a concurrent build that resumes onto its own leftovers is
+	// exactly where that stops being true.
+	c.Assert(migrations.MigrateUp(ctx), qt.IsNil)
+	exists, valid = readGeneratorPostgresIndexState(c, target, "idx_members_email")
+	c.Assert(exists, qt.IsTrue)
+	c.Assert(valid, qt.IsTrue)
 }
 
 // setupUnknownRowStatistics populates a table and then leaves PostgreSQL with

--- a/migration/lint/analysis.go
+++ b/migration/lint/analysis.go
@@ -170,6 +170,15 @@ type File struct {
 	// IsUp reports whether statement rules treat this as an up migration:
 	// the migrator parses it as up, or its name carries the .up.sql suffix.
 	IsUp bool
+	// IsDown reports whether this is the rollback half of a migration: the
+	// migrator parses it as down, or its name carries the .down.sql suffix.
+	//
+	// A down file is executed against a production database exactly like an up
+	// file, so a hazard in one is a hazard in the other. Rules stay up-only by
+	// default because most of them describe a forward change, and the ones that
+	// describe a statement's cost or its executability opt in with
+	// [Rule.AppliesToDown].
+	IsDown bool
 	// HasPair reports whether the matching counterpart file (down for up,
 	// up for down) exists in the same directory.
 	HasPair bool
@@ -181,8 +190,9 @@ type File struct {
 	// NoTransaction reports whether file-scoped directives opt this migration
 	// out of the migrator's transaction wrapper.
 	NoTransaction bool
-	// Statements holds the parsed statements of up migrations. Empty for
-	// down migrations (statement rules do not run there).
+	// Statements holds the parsed statements of up and down migrations. Empty
+	// for any other file. A rule that reads them without checking direction
+	// gets both, which is why every direction-sensitive rule tests IsUp.
 	Statements []Statement
 	// Changes holds the semantic schema changes this up migration expresses,
 	// recovered from Ptah's dialect-aware SQL parser. Empty for down migrations
@@ -565,6 +575,7 @@ func prepareFile(
 		// lint must follow it; the suffix check keeps hazard scanning for
 		// .up.sql files whose version prefix is malformed.
 		IsUp:           direction == "up" || strings.HasSuffix(base, ".up.sql"),
+		IsDown:         direction == "down" || strings.HasSuffix(base, ".down.sql"),
 		WellFormedName: strictNameRe.MatchString(base) || atlasFormat,
 		compatibility:  compatibility,
 		baseline:       baseline[version],
@@ -589,8 +600,11 @@ func prepareFile(
 		_, file.HasPair = present[strings.TrimSuffix(name, ".down.sql")+".up.sql"]
 	}
 
-	// Statement rules apply to up migrations only.
-	if file.IsUp {
+	// Both halves of a migration are executed against the database, so both are
+	// parsed into statements. Which rules read them is decided per rule; see
+	// [Rule.AppliesToDown]. Schema changes stay up-only: a change set is the
+	// forward delta this version applies, and the rollback is not a second one.
+	if file.IsUp || file.IsDown {
 		sql := raw
 		if atlasFormat && migrator.LooksAtlasTemplateSQL(sql) {
 			rendered, _, err := migrator.RenderAtlasTemplateSQL(snapshot, name, atlasTemplateData)
@@ -617,7 +631,9 @@ func prepareFile(
 				suppressedRules: rawStmt.suppressedRules,
 			})
 		}
-		file.Changes, file.scopeExcluded = extractSchemaChanges(&file, dialect, scope)
+		if file.IsUp {
+			file.Changes, file.scopeExcluded = extractSchemaChanges(&file, dialect, scope)
+		}
 	}
 	return file, nil
 }

--- a/migration/lint/down_direction_test.go
+++ b/migration/lint/down_direction_test.go
@@ -1,0 +1,98 @@
+package lint_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/migration/lint"
+)
+
+// lintPair lints one up/down pair and returns the rule code and file basename
+// of every finding, so a row can say which direction a hazard was reported in.
+func lintPair(c *qt.C, upSQL, downSQL string) []string {
+	c.Helper()
+	fsys := fixture(map[string]string{
+		"0000000001_x.up.sql":   upSQL,
+		"0000000001_x.down.sql": downSQL,
+	})
+	findings, err := lint.LintFS(fsys, lint.Options{Dialect: "postgres"})
+	c.Assert(err, qt.IsNil)
+	located := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		located = append(located, finding.Rule+" "+finding.File)
+	}
+	return located
+}
+
+// TestLintFS_DownDirectionHazards pins which rules read the rollback half.
+//
+// Statement rules were confined to up files, so the blocking DROP INDEX that a
+// rollback is normally made of -- including the one Ptah generates itself
+// whenever the forward statement was not a concurrent build -- was reported as
+// clean (stokaro/ptah#997). PG106 now opts in, and the opt-in is what is under
+// test: the second and third rows are the discriminating controls. An
+// implementation that simply ran every statement rule on every file would
+// report PG101 for the down file's CREATE INDEX and TX201 for its BEGIN, and
+// both rows would fail.
+func TestLintFS_DownDirectionHazards(t *testing.T) {
+	tests := []struct {
+		name string
+		up   string
+		down string
+		want []string
+	}{
+		{
+			name: "blocking drop is reported in either direction",
+			up:   "CREATE INDEX CONCURRENTLY idx ON t (id);\n",
+			down: "DROP INDEX idx;\n",
+			want: []string{
+				"PG106 0000000001_x.down.sql",
+				"PG103 0000000001_x.up.sql",
+			},
+		},
+		{
+			name: "a rule that did not opt in stays silent on the down file",
+			up:   "ALTER TABLE t ADD COLUMN c INT;\n",
+			down: "CREATE INDEX idx ON t (id);\n",
+			want: []string{},
+		},
+		{
+			name: "a second rule that did not opt in stays silent on the down file",
+			up:   "ALTER TABLE t ADD COLUMN c INT;\n",
+			down: "BEGIN;\nALTER TABLE t DROP COLUMN c;\nCOMMIT;\n",
+			want: []string{},
+		},
+		{
+			name: "a concurrent rollback without the marker cannot execute",
+			up:   "-- +ptah no_transaction\nCREATE INDEX CONCURRENTLY idx ON t (id);\n",
+			down: "DROP INDEX CONCURRENTLY idx;\n",
+			want: []string{"PG103 0000000001_x.down.sql"},
+		},
+		{
+			name: "the marker exempts the rollback Ptah generates",
+			up:   "-- +ptah no_transaction\nCREATE INDEX CONCURRENTLY idx ON t (id);\n",
+			down: "-- +ptah no_transaction\nDROP INDEX CONCURRENTLY idx;\n",
+			want: []string{},
+		},
+		{
+			name: "a rollback mixing autocommit and transactional DDL is reported",
+			up:   "ALTER TABLE t ADD COLUMN c INT;\n",
+			down: "DROP INDEX CONCURRENTLY idx;\nALTER TABLE t DROP COLUMN c;\n",
+			want: []string{
+				"PG103 0000000001_x.down.sql",
+				"TX101 0000000001_x.down.sql",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			got := lintPair(c, tt.up, tt.down)
+
+			c.Assert(got, qt.DeepEquals, tt.want)
+		})
+	}
+}

--- a/migration/lint/lint.go
+++ b/migration/lint/lint.go
@@ -24,9 +24,13 @@
 //     identifiers stay opaque single words, so data or a column named like a
 //     keyword can neither trigger nor mask a rule.
 //
-// Statement-level rules run on up migrations only: a down migration dropping
-// what its up created is the expected shape, not a hazard. File-level form
-// rules (naming, pairing) look at every *.sql file.
+// Statement-level rules run on up migrations by default: a down migration
+// dropping what its up created is the expected shape, not a hazard. A rule
+// whose subject is the cost or the executability of a statement rather than the
+// schema change it expresses sets [Rule.AppliesToDown] and is checked in both
+// directions -- PostgreSQL charges the same lock for a blocking DROP INDEX
+// whether a migration is being applied or rolled back. File-level form rules
+// (naming, pairing) look at every *.sql file.
 package lint
 
 import (
@@ -63,9 +67,21 @@ type Rule struct {
 	// Dialects restricts the rule to specific target dialects; empty means
 	// every dialect.
 	Dialects []string
-	// CheckStatement inspects one statement of an up migration and reports
-	// whether the rule fires, with a specific message.
+	// CheckStatement inspects one statement of a migration and reports whether
+	// the rule fires, with a specific message. It sees up migrations only
+	// unless AppliesToDown is set.
 	CheckStatement func(stmt *Statement) (bool, string)
+	// AppliesToDown extends a CheckStatement rule to the down half of a
+	// migration. It is off by default because most statement rules describe a
+	// forward schema change, where the rollback is the remedy rather than the
+	// hazard. Set it for a rule that describes the cost or the executability of
+	// a statement, which the database charges identically in either direction:
+	// a blocking DROP INDEX holds the same lock whether a migration is being
+	// applied or rolled back.
+	//
+	// It has no effect on a CheckFile rule, which receives every file already
+	// and decides for itself; those read [File.IsUp] and [File.IsDown].
+	AppliesToDown bool
 	// CheckFile inspects file-level form and returns full findings.
 	CheckFile func(file *File) []Finding
 }
@@ -157,6 +173,9 @@ func runRules(file *File, opts Options, rules []Rule) []Finding {
 				attachUniqueStatementContext(file, &finding)
 				findings = append(findings, finding)
 			}
+			continue
+		}
+		if !file.IsUp && !rule.AppliesToDown {
 			continue
 		}
 		for i := range file.Statements {

--- a/migration/lint/rules.go
+++ b/migration/lint/rules.go
@@ -862,8 +862,11 @@ func postgresConcurrentIndexRule() Rule {
 		Title:    "concurrent index operation in a transactional migration",
 		Severity: SeverityWarning,
 		Dialects: []string{"postgres"},
+		// Either direction: a down file carrying DROP INDEX CONCURRENTLY without
+		// the no_transaction marker cannot execute at all, and the rollback half
+		// of a concurrent build is exactly where that statement appears.
 		CheckFile: func(file *File) []Finding {
-			if !file.IsUp || file.NoTransaction {
+			if (!file.IsUp && !file.IsDown) || file.NoTransaction {
 				return nil
 			}
 			var findings []Finding
@@ -897,13 +900,23 @@ func postgresAddUniqueConstraintRule() Rule {
 		"adding a unique constraint takes an ACCESS EXCLUSIVE lock and validates existing rows; build a unique index concurrently first when the table is populated")
 }
 
+// postgresDropIndexRule reports a blocking index drop in either direction.
+//
+// The down half is where this rule earns its keep: the statement that removes
+// an index is what a rollback file is normally made of, and PostgreSQL takes
+// the same ACCESS EXCLUSIVE lock whichever direction asked for it. Confining
+// statement rules to up files left a rollback that blocks writes on a populated
+// table reported as clean -- including one Ptah generates itself, whenever the
+// forward statement was not a concurrent build.
 func postgresDropIndexRule() Rule {
-	return postgresStatementRule("PG106", "index dropped with a table lock", func(stmt *Statement) (bool, string) {
+	rule := postgresStatementRule("PG106", "index dropped with a table lock", func(stmt *Statement) (bool, string) {
 		if !hasWordPrefix(stmt.Words, "DROP", "INDEX") || slices.Contains(stmt.Words, "CONCURRENTLY") {
 			return false, ""
 		}
 		return true, "DROP INDEX without CONCURRENTLY blocks writes while PostgreSQL removes the index; use DROP INDEX CONCURRENTLY outside a transaction for populated tables"
 	})
+	rule.AppliesToDown = true
+	return rule
 }
 
 func postgresColumnAlignmentRule() Rule {
@@ -1092,8 +1105,12 @@ func transactionRules() []Rule {
 			Title:    "transactional and non-transactional statements mixed",
 			Severity: SeverityWarning,
 			Dialects: []string{"postgres"},
+			// Either direction: the migrator wraps a down file in the same
+			// transaction it wraps an up file in, so a rollback that mixes
+			// CREATE INDEX CONCURRENTLY with transactional DDL is refused by
+			// PostgreSQL exactly the same way.
 			CheckFile: func(file *File) []Finding {
-				if !file.IsUp || file.NoTransaction {
+				if (!file.IsUp && !file.IsDown) || file.NoTransaction {
 					return nil
 				}
 				var nonTransactional *Statement

--- a/migration/schemadiff/internal/compare/indexes.go
+++ b/migration/schemadiff/internal/compare/indexes.go
@@ -192,6 +192,10 @@ type databaseIndexEntry struct {
 	// enforces the index, so the object is the constraint's and both directions
 	// of a plan have to say so. See [uniqueConstraintEnforcesTheIndex].
 	constraintBacked bool
+	// partitionAttached reports that the index is a partition's copy of an
+	// index on its partitioned parent, so no statement of its own creates or
+	// drops it. See [partitionAttachedIndexIsNotPlannable].
+	partitionAttached bool
 }
 
 func IndexesWithDialect(generated *goschema.Database, database *types.DBSchema, diff *difftypes.SchemaDiff, dialect string) {
@@ -375,9 +379,10 @@ func collectDatabaseIndexes(
 			continue
 		}
 		indexes[identity] = databaseIndexEntry{
-			ref:              ref,
-			index:            index,
-			constraintBacked: uniqueConstraintEnforcesTheIndex(identity, uniqueConstraints),
+			ref:               ref,
+			index:             index,
+			constraintBacked:  uniqueConstraintEnforcesTheIndex(identity, uniqueConstraints),
+			partitionAttached: index.PartitionAttached,
 		}
 	}
 	return indexes
@@ -492,6 +497,8 @@ func appendIndexDifferences(
 		switch {
 		case !exists:
 			appendIndexAddition(diff, generatedEntry.ref)
+		case partitionAttachedIndexIsNotPlannable(databaseEntry):
+			continue
 		case indexReplacementRequired(
 			generatedEntry,
 			databaseEntry,
@@ -507,10 +514,39 @@ func appendIndexDifferences(
 		if _, ambiguous := ambiguousGenerated[identity]; ambiguous {
 			continue
 		}
+		if partitionAttachedIndexIsNotPlannable(entry) {
+			continue
+		}
 		if _, exists := generated[identity]; !exists {
 			appendIndexRemoval(diff, entry)
 		}
 	}
+}
+
+// partitionAttachedIndexIsNotPlannable reports whether a database index is a
+// partition's copy of an index on its partitioned parent, which no statement of
+// its own creates or drops.
+//
+// PostgreSQL builds one copy per partition when an index is created on a
+// partitioned parent, and names it itself. A desired state written against the
+// parent never mentions those names, so the ordinary "in the database, not in
+// the desired state" arm below reads every one of them as an index to remove --
+// and PostgreSQL 17.10 answers the drop with `cannot drop index
+// events_2026_tenant_idx because index idx_events_tenant requires it
+// (SQLSTATE 2BP01)`. Because the copies appear only after the parent index is
+// applied, the first generate/apply cycle is clean and the next generate is the
+// one that publishes the unexecutable file, by which point it has a checksum and
+// a commit. See #997.
+//
+// The replacement arm is suppressed for the same reason and not only the
+// removal: a copy carries the parent's definition, so the only way a desired
+// state disagrees with it is by disagreeing with the parent, and neither half of
+// a replacement addresses the copy -- the DROP is refused and the CREATE
+// collides with a name the server owns. The parent index is what a plan
+// changes, and the parent is a separate entry here, compared and planned on its
+// own.
+func partitionAttachedIndexIsNotPlannable(entry databaseIndexEntry) bool {
+	return entry.partitionAttached
 }
 
 func appendIndexAddition(diff *difftypes.SchemaDiff, ref difftypes.IndexRef) {

--- a/migration/schemadiff/partition_attached_index_test.go
+++ b/migration/schemadiff/partition_attached_index_test.go
@@ -1,0 +1,246 @@
+package schemadiff_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/migration/schemadiff"
+	difftypes "go.5x5.cz/ptah/migration/schemadiff/types"
+)
+
+// TestCompareWithDialect_PartitionAttachedIndexIsNeverPlanned pins the object a
+// plan must leave alone: a partition's copy of an index on its partitioned
+// parent.
+//
+// PostgreSQL builds one copy per partition when an index is created on a
+// partitioned parent and names it itself, so a desired state written against
+// the parent never mentions those names. Read as ordinary indexes they are
+// "in the database, not in the desired state" and the plan drops them, which
+// PostgreSQL 17.10 refuses with SQLSTATE 2BP01: `cannot drop index
+// events_2026_tenant_idx because index idx_events_tenant requires it`. The copy
+// exists only after the parent index has been applied, so the defect is
+// invisible to a single generate/apply cycle and surfaces on the next generate,
+// by which point the file has a checksum and a commit. See #997.
+//
+// Two rows are discriminating fixtures rather than cases of their own, and both
+// were confirmed against PostgreSQL 17.10 before being written down:
+//
+//   - `events_2026_id_idx` is a standalone index on the partition that carries
+//     the same name PostgreSQL would have given a copy. `DROP INDEX
+//     "events_2026_id_idx"` succeeds, so an implementation keyed on the naming
+//     convention -- or on "this table is a partition, leave its indexes alone"
+//     -- silently stops managing an index the server drops on request.
+//   - `my_local_created` is a copy that carries a name the convention would
+//     never produce, built as CREATE INDEX on the partition and then
+//     ALTER INDEX ... ATTACH PARTITION. `DROP INDEX "my_local_created"` is
+//     refused with `cannot drop index my_local_created because index
+//     idx_events_created requires it`, so the same naming implementation plans
+//     a statement the server rejects.
+//
+// The attachment is the fact; the name is a coincidence in both directions.
+func TestCompareWithDialect_PartitionAttachedIndexIsNeverPlanned(t *testing.T) {
+	partitionTables := []types.DBTable{
+		{Name: "events", Type: "TABLE", Partitioned: true},
+		{Name: "events_2026", Type: "TABLE"},
+	}
+	parentDeclaration := &goschema.Database{
+		Tables: []goschema.Table{
+			{Name: "events", StructName: "Event"},
+			{Name: "events_2026", StructName: "Event2026"},
+		},
+		Fields: []goschema.Field{
+			{StructName: "Event", Name: "tenant", Type: "TEXT"},
+			{StructName: "Event2026", Name: "tenant", Type: "TEXT"},
+		},
+		Indexes: []goschema.Index{
+			{Name: "idx_events_tenant", StructName: "Event", Fields: []string{"tenant"}},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		generated *goschema.Database
+		database  *types.DBSchema
+		assert    func(c *qt.C, diff *difftypes.SchemaDiff)
+	}{
+		{
+			name:      "the partition copy of a declared parent index is not dropped",
+			generated: parentDeclaration,
+			database: &types.DBSchema{
+				Tables: partitionTables,
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:              "events_2026_tenant_idx",
+						TableName:         "events_2026",
+						Columns:           []string{"tenant"},
+						PartitionAttached: true,
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+				c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			},
+		},
+		{
+			name:      "an index created on the partition itself is still dropped",
+			generated: parentDeclaration,
+			database: &types.DBSchema{
+				Tables: partitionTables,
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:              "events_2026_tenant_idx",
+						TableName:         "events_2026",
+						Columns:           []string{"tenant"},
+						PartitionAttached: true,
+					},
+					{
+						Name:      "idx_events_2026_local",
+						TableName: "events_2026",
+						Columns:   []string{"id"},
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{
+					{Name: "idx_events_2026_local", TableName: "events_2026"},
+				})
+			},
+		},
+		{
+			name:      "a standalone partition index named like a copy is still dropped",
+			generated: parentDeclaration,
+			database: &types.DBSchema{
+				Tables: partitionTables,
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:      "events_2026_id_idx",
+						TableName: "events_2026",
+						Columns:   []string{"id"},
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{
+					{Name: "events_2026_id_idx", TableName: "events_2026"},
+				})
+			},
+		},
+		{
+			name:      "a copy attached under a name of its own is not dropped",
+			generated: parentDeclaration,
+			database: &types.DBSchema{
+				Tables: partitionTables,
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:              "my_local_created",
+						TableName:         "events_2026",
+						Columns:           []string{"created_at"},
+						PartitionAttached: true,
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+			},
+		},
+		{
+			name: "a declared index that the database reports as a partition copy is not replaced",
+			generated: &goschema.Database{
+				Tables: []goschema.Table{
+					{Name: "events", StructName: "Event"},
+					{Name: "events_2026", StructName: "Event2026"},
+				},
+				Fields: []goschema.Field{
+					{StructName: "Event", Name: "tenant", Type: "TEXT"},
+					{StructName: "Event2026", Name: "tenant", Type: "TEXT"},
+					{StructName: "Event2026", Name: "id", Type: "BIGINT"},
+				},
+				Indexes: []goschema.Index{
+					{Name: "idx_events_tenant", StructName: "Event", Fields: []string{"tenant"}},
+					{Name: "events_2026_tenant_idx", StructName: "Event2026", Fields: []string{"id"}},
+				},
+			},
+			database: &types.DBSchema{
+				Tables: partitionTables,
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:              "events_2026_tenant_idx",
+						TableName:         "events_2026",
+						Columns:           []string{"tenant"},
+						PartitionAttached: true,
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.HasLen, 0)
+				c.Assert(diff.IndexAdditions(), qt.HasLen, 0)
+			},
+		},
+		{
+			name:      "control: an ordinary undeclared index on an ordinary table is dropped",
+			generated: parentDeclaration,
+			database: &types.DBSchema{
+				Tables: append(
+					[]types.DBTable{{Name: "members", Type: "TABLE"}},
+					partitionTables...,
+				),
+				Indexes: []types.DBIndex{
+					{
+						Name:      "idx_events_tenant",
+						TableName: "events",
+						Columns:   []string{"tenant"},
+					},
+					{
+						Name:      "idx_members_email",
+						TableName: "members",
+						Columns:   []string{"email"},
+					},
+				},
+			},
+			assert: func(c *qt.C, diff *difftypes.SchemaDiff) {
+				c.Assert(diff.IndexRemovals(), qt.DeepEquals, []difftypes.IndexRef{
+					{Name: "idx_members_email", TableName: "members"},
+				})
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			diff := schemadiff.CompareWithDialect(tt.generated, tt.database, "postgres")
+
+			tt.assert(c, diff)
+		})
+	}
+}

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -499,10 +499,14 @@ func normalizeSchema(schema *dbtypes.DBSchema) {
 	})
 
 	for idx := range schema.Tables {
-		// Both statistics fields depend on whether autovacuum happened to have
-		// analyzed the table before the read, which no test controls.
+		// EstimatedRows depends on whether autovacuum happened to have analyzed
+		// the table before the read, which no test controls.
+		//
+		// DBTable.RowStatsUnknown (stokaro/ptah#997) is nondeterministic for the
+		// same reason and belongs here too, but this module compiles against the
+		// PUBLISHED go.5x5.cz/ptah, so the field cannot be named until a release
+		// carries it. Add it when this module's ptah requirement is bumped.
 		schema.Tables[idx].EstimatedRows = 0
-		schema.Tables[idx].RowStatsUnknown = false
 		slices.SortFunc(schema.Tables[idx].Columns, compareColumns)
 	}
 

--- a/testkit/testkit.go
+++ b/testkit/testkit.go
@@ -499,7 +499,10 @@ func normalizeSchema(schema *dbtypes.DBSchema) {
 	})
 
 	for idx := range schema.Tables {
+		// Both statistics fields depend on whether autovacuum happened to have
+		// analyzed the table before the read, which no test controls.
 		schema.Tables[idx].EstimatedRows = 0
+		schema.Tables[idx].RowStatsUnknown = false
 		slices.SortFunc(schema.Tables[idx].Columns, compareColumns)
 	}
 


### PR DESCRIPTION
Four of the workstreams the triage comment retained for #997, plus the two
defects the previous review round found in this branch's own work.

**This description was rewritten from scratch for head `f7741d31`. Every block
below is the output of the command shown directly above it, run in this session.
Nothing was carried forward from an earlier revision of this description, and no
claim from an earlier revision is repeated here unless I re-ran it.** The parts
of the earlier record I did *not* re-run are listed at the end, under
"Not re-measured this round".

Three token substitutions, in command lines **and** in output blocks, and
nothing else is elided anywhere in this document:

1. `PSQL` stands for exactly these bytes, with `DBNAME` replaced by the database
   named in the surrounding text:

   ```
   docker exec -e PGPASSWORD=pw ptah1074-dev psql -v ON_ERROR_STOP=1 -U postgres -h 127.0.0.1 -d DBNAME
   ```

2. `WORK` stands for the absolute path of the git worktree this session used.
   Every command below ran with that directory as the working directory; the
   `cd` that gets there prints nothing and is the only line the listings drop.

3. `SIX` stands for exactly this `-run` argument, one line, no wrapping:

   ```
   '^(TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres|TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres)$'
   ```

Several generated files end without a trailing newline, so `CAT_EXIT=0` visibly
joins the last line of the file — that is the file's own missing newline, not a
trim. Every exit code below is read from the command that produced the output,
never through a pipe; the two places where a pipeline's status is read on
purpose say so.

The server is PostgreSQL 17.10 in container `ptah1074-dev` on port 15975, shared
with other work, so every probe below created its own database and the ones
still in use are dropped at the end.

Which tree each block ran on is stated where it is not the head. Two blocks in
section 2 — the `grep -rn` over `.github/` and the five-test no-DSN run — were
measured on `8915a365`, the head this branch had before this round. One block in
section 1 was measured on `d6a3c81b`, the base, in a second worktree. Section 3a
opens with the CI log of `52d9b4fd`, the first head this round pushed. Sections
1 to 3 were measured on `52d9b4fd`, whose generator and migration-file output
neither later commit changes; the gates in section 4 were re-run on `43c946f7`,
which is `f7741d31` minus a move of one workflow step. Every "before" side is a
binary built from the tree at hand with the named mutant applied and then
reverted.

This round pushed three heads. `52d9b4fd` carried the two blocker fixes and the
follow-up; `43c946f7` added the CockroachDB capability probe its CI run
demanded; `f7741d31` moved the new workflow step next to the two other
`./migration/generator` live-test steps, which also moved it ahead of a step
that fails for every pull request right now for a reason belonging to master
(section 2, "The one red left in that job").

---

## 1. Defect this branch introduced: one partitioned table poisoned every table sharing its bare name

`tableSetMatching` indexed a selected table under **both** its qualified name and
its bare name, and `refusePartitionedConcurrentIndexRefs` then tested
`partitioned[ref.TableName]`. Membership in a pooled set is an OR, so a single
partitioned parent answered for every ordinary table with the same bare name in
another schema.

The fixture, in `wf47089_two`: a partitioned `app.events` with one partition and
5000 rows, and an ordinary, populated `public.events`.

```
$ PSQL -c "CREATE SCHEMA app; CREATE TABLE app.events (id BIGINT NOT NULL, tenant TEXT NOT NULL, created_at DATE NOT NULL) PARTITION BY RANGE (created_at); CREATE TABLE app.events_2026 PARTITION OF app.events FOR VALUES FROM ('2026-01-01') TO ('2027-01-01'); INSERT INTO app.events SELECT g, 'tenant-' || (g % 7), DATE '2026-01-01' + (g % 300) FROM generate_series(1,5000) AS g; CREATE TABLE public.events (id BIGINT NOT NULL, tenant TEXT NOT NULL, created_at DATE NOT NULL); INSERT INTO public.events SELECT g, 'tenant-' || (g % 7), DATE '2026-01-01' + (g % 300) FROM generate_series(1,5000) AS g; ANALYZE;" -c "SELECT n.nspname, c.relname, c.relkind, c.reltuples::bigint FROM pg_class c JOIN pg_namespace n ON n.oid=c.relnamespace WHERE c.relname IN ('events','events_2026') ORDER BY 1,2;"
$ echo "SETUP_TWO_EXIT=$?"
CREATE SCHEMA
CREATE TABLE
CREATE TABLE
INSERT 0 5000
CREATE TABLE
INSERT 0 5000
ANALYZE
 nspname |   relname   | relkind | reltuples 
---------+-------------+---------+-----------
 app     | events      | p       |      5000
 app     | events_2026 | r       |      5000
 public  | events      | r       |      5000
(3 rows)

SETUP_TWO_EXIT=0
```

What the server says about each of those two tables. This is the whole point:
one of these statements is refused and the other is accepted.

```
$ PSQL -c '\set VERBOSITY verbose' -c 'CREATE INDEX CONCURRENTLY idx_app_events_tenant ON app.events (tenant);'
$ echo "CIC_ON_PARENT_EXIT=$?"
ERROR:  0A000: cannot create index on partitioned table "events" concurrently
LOCATION:  DefineIndex, indexcmds.c:727
CIC_ON_PARENT_EXIT=1
```

```
$ PSQL -c '\set VERBOSITY verbose' -c 'CREATE INDEX CONCURRENTLY idx_public_events_tenant ON public.events (tenant);'
$ echo "CIC_ON_ORDINARY_EXIT=$?"
CREATE INDEX
CIC_ON_ORDINARY_EXIT=0
```

`WORK/.probe/ent-two/schema.go` declares one table, `events`, with
`idx_events_tenant` on `tenant`. `WORK/.probe/ptah-concurrent.yaml` is

```
diff:
  concurrent_index: true
```

`WORK/.probe/bin/ptah-pooled` is `go build -o .probe/bin/ptah-pooled ./cmd/ptah`
with the pooled-set implementation in place; `WORK/.probe/bin/ptah` is the same
build of `52d9b4fd`. Explicit policy, pooled set:

```
$ .probe/bin/ptah-pooled migrations generate --config .probe/ptah-concurrent.yaml --root-dir .probe/ent-two --db-url 'postgres://postgres:pw@localhost:15975/wf47089_two?sslmode=disable' --schemas public,app --migrations-dir .probe/mig-two-prefix --name twoschema
$ echo "GEN_TWO_POOLED_EXIT=$?"
error: CREATE INDEX CONCURRENTLY requested by diff.concurrent_index.create cannot be generated for partitioned table(s): "idx_events_tenant" on "events"; PostgreSQL refuses a concurrent index statement on a partitioned parent (SQLSTATE 0A000). Unset diff.concurrent_index.create to generate the plain, transactional statement, or manage the index per partition (CREATE INDEX ... ON ONLY the parent, CREATE INDEX CONCURRENTLY on each partition, then ALTER INDEX ... ATTACH PARTITION)
GEN_TWO_POOLED_EXIT=2
```

```
$ ls -A .probe/mig-two-prefix | wc -l
$ echo "WC_EXIT=$?"
       0
WC_EXIT=0
```

The run is refused, nothing is written, and the table the diagnostic names —
`events`, the ordinary `public.events` the server had just accepted a concurrent
build on — is not partitioned. Same command on `52d9b4fd`:

```
$ .probe/bin/ptah migrations generate --config .probe/ptah-concurrent.yaml --root-dir .probe/ent-two --db-url 'postgres://postgres:pw@localhost:15975/wf47089_two?sslmode=disable' --schemas public,app --migrations-dir .probe/mig-two-fixed --name twoschema
$ echo "GEN_TWO_FIXED_EXIT=$?"
Generated migration files for postgres://postgres:***@localhost:15975/wf47089_two?sslmode=disable:
UP:   WORK/.probe/mig-two-fixed/1786278683_twoschema_transactional.up.sql
DOWN: WORK/.probe/mig-two-fixed/1786278683_twoschema_transactional.down.sql
UP:   WORK/.probe/mig-two-fixed/1786278684_twoschema_concurrent_indexes.up.sql
DOWN: WORK/.probe/mig-two-fixed/1786278684_twoschema_concurrent_indexes.down.sql
GEN_TWO_FIXED_EXIT=0
```

```
$ cat .probe/mig-two-fixed/1786278684_twoschema_concurrent_indexes.up.sql; echo "CAT_EXIT=$?"
-- +ptah no_transaction
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:31:23+02:00
-- Direction: UP

CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_events_tenant" ON "events" ("tenant");CAT_EXIT=0
```

The default heuristic path costs the same table its concurrent build without
saying anything. Pooled set, no config:

```
$ .probe/bin/ptah-pooled migrations generate --root-dir .probe/ent-two --db-url 'postgres://postgres:pw@localhost:15975/wf47089_two?sslmode=disable' --schemas public,app --migrations-dir .probe/mig-two-heur-pooled --name heur
$ echo "GEN_HEUR_POOLED_EXIT=$?"
Generated migration files for postgres://postgres:***@localhost:15975/wf47089_two?sslmode=disable:
UP:   WORK/.probe/mig-two-heur-pooled/1786278740_heur.up.sql
DOWN: WORK/.probe/mig-two-heur-pooled/1786278740_heur.down.sql
GEN_HEUR_POOLED_EXIT=0
```

```
$ cat .probe/mig-two-heur-pooled/1786278740_heur.up.sql; echo "CAT_EXIT=$?"
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:32:20+02:00
-- Direction: UP

CREATE INDEX IF NOT EXISTS "idx_events_tenant" ON "events" ("tenant");
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "app"."events" CASCADE;
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "app"."events_2026" CASCADE;CAT_EXIT=0
```

One file, no `CONCURRENTLY`, no `no_transaction` marker. On `52d9b4fd` the same
command splits the plan and keeps the build non-blocking:

```
$ .probe/bin/ptah migrations generate --root-dir .probe/ent-two --db-url 'postgres://postgres:pw@localhost:15975/wf47089_two?sslmode=disable' --schemas public,app --migrations-dir .probe/mig-two-heur-fixed --name heur
$ echo "GEN_HEUR_FIXED_EXIT=$?"
Generated migration files for postgres://postgres:***@localhost:15975/wf47089_two?sslmode=disable:
UP:   WORK/.probe/mig-two-heur-fixed/1786278733_heur_transactional.up.sql
DOWN: WORK/.probe/mig-two-heur-fixed/1786278733_heur_transactional.down.sql
UP:   WORK/.probe/mig-two-heur-fixed/1786278734_heur_concurrent_indexes.up.sql
DOWN: WORK/.probe/mig-two-heur-fixed/1786278734_heur_concurrent_indexes.down.sql
GEN_HEUR_FIXED_EXIT=0
```

```
$ cat .probe/mig-two-heur-fixed/1786278734_heur_concurrent_indexes.up.sql; echo "CAT_EXIT=$?"
-- +ptah no_transaction
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:32:13+02:00
-- Direction: UP

CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_events_tenant" ON "events" ("tenant");CAT_EXIT=0
```

```
$ cat .probe/mig-two-heur-fixed/1786278733_heur_transactional.up.sql; echo "CAT_EXIT=$?"
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:32:13+02:00
-- Direction: UP

-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "app"."events" CASCADE;
-- WARNING: This will delete all data!
DROP TABLE IF EXISTS "app"."events_2026" CASCADE;CAT_EXIT=0
```

The `DROP TABLE`s are the same on both sides: the desired state declares one
`events` and the read covers two schemas, so the `app` tables are undeclared.
That is not what changed; the `CREATE INDEX` is.

**The base of this branch does neither.** `d6a3c81b` has no partitioned
filtering at all, and its `populatedTableSet` double-keys purely as a "prefer
concurrent" hint. Measured by checking out `d6a3c81b` into a second worktree and
calling the three selectors directly on the two-schema shape:

```
PROBE base explicit-policy refs=[{idx_events_tenant events}]
PROBE base heuristic refs=[{idx_events_tenant events}]
PROBE base drop-policy refs=[{idx_events_tenant events}]
```

That block is the `fmt.Printf` output of a throwaway `_test.go` in the base
worktree, run with `go test ./migration/generator -run TestZZProbeBlocker1Base -v`;
the file and the worktree were both deleted afterwards, so it is the one block
here that is not reproducible from a command on this branch. The same shape is
pinned as a committed test below.

### What replaced it

An index ref now resolves to the table it names. `tableFactsIndex` keeps the
qualified spellings and the bare fallback in separate maps: an exact qualified
match wins, and only when nothing answers exactly does the bare name reach a
schema-qualified table. When the bare fallback really is ambiguous the two facts
aggregate in opposite directions — `partitioned` only when **every** candidate is
partitioned, `populated` when **any** candidate is — because refusing and
downgrading both cost a capability on a guess, while the concurrent build is the
recoverable side of each choice.

The branch's own table test already contained a row named "an unrelated
partitioned table does not downgrade the build". It uses a different bare name
(`measurements`), so it never separated the rule from the pooled alternative.
The new test, `TestConcurrentIndexSelectors_ResolveTheTableTheRefNames` in
`migration/generator/partitioned_index_schema_scope_internal_test.go`, puts one
ref through all three selectors and pins four directions: a bare ref must not be
answered by a partitioned parent in another schema, a bare ref must prefer the
table whose own spelling is bare, a qualified ref must still find its own
partitioned parent, and a bare ref whose every candidate is partitioned must
still be refused.

### Mutants for it

Each was applied alone, measured red, reverted, measured green. `MUT*` runs the
whole `./migration/generator` package so the same block shows which other tests
the mutant does *not* redden.

**Mutant D — the pooled single set this branch shipped.** `indexTableFacts` keys
the bare spelling into the qualified map instead of the bare map, and
`mergeTableConcurrencyFacts` aggregates `partitioned` with `||`. Two lines, and
for these fixtures it is exactly the shipped `map[string]struct{}` membership
test.

```
$ go test ./migration/generator -count=1 > .probe/mutD-pkg.log 2>&1; echo "MUTD_PKG_EXIT=$?"
$ grep -E '^(---|    ---|FAIL|ok)' .probe/mutD-pkg.log
MUTD_PKG_EXIT=1
--- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames (0.00s)
    --- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames/a_partitioned_parent_in_another_schema_does_not_answer_for_a_bare_ref (0.00s)
    --- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames/a_bare_ref_prefers_the_table_whose_own_spelling_is_bare (0.00s)
FAIL
FAIL	go.5x5.cz/ptah/migration/generator	2.749s
```

```
$ go test ./migration/generator -count=1 > .probe/revD-pkg.log 2>&1; echo "REVD_PKG_EXIT=$?"
$ tail -2 .probe/revD-pkg.log
REVD_PKG_EXIT=0
ok  	go.5x5.cz/ptah/migration/generator	3.067s
```

**Mutant E — the aggregation direction alone.** One line:
`partitioned: previous.partitioned && facts.partitioned` becomes `||`.

```
$ go test ./migration/generator -count=1 > .probe/mutE-pkg.log 2>&1; echo "MUTE_PKG_EXIT=$?"
$ grep -E '^(---|    ---|FAIL|ok)' .probe/mutE-pkg.log
MUTE_PKG_EXIT=1
--- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames (0.00s)
    --- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames/a_partitioned_parent_in_another_schema_does_not_answer_for_a_bare_ref (0.00s)
FAIL
FAIL	go.5x5.cz/ptah/migration/generator	2.516s
```

```
$ go test ./migration/generator -count=1 > .probe/revE-pkg.log 2>&1; echo "REVE_PKG_EXIT=$?"
$ tail -2 .probe/revE-pkg.log
REVE_PKG_EXIT=0
ok  	go.5x5.cz/ptah/migration/generator	2.472s
```

**Mutant F — the precedence alone.** One line: `lookup` consults `bare` before
`qualified`.

```
$ go test ./migration/generator -count=1 > .probe/mutF-pkg.log 2>&1; echo "MUTF_PKG_EXIT=$?"
$ grep -E '^(---|    ---|FAIL|ok)' .probe/mutF-pkg.log
MUTF_PKG_EXIT=1
--- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames (0.00s)
    --- FAIL: TestConcurrentIndexSelectors_ResolveTheTableTheRefNames/a_bare_ref_prefers_the_table_whose_own_spelling_is_bare (0.00s)
FAIL
FAIL	go.5x5.cz/ptah/migration/generator	2.535s
```

```
$ go test ./migration/generator -count=1 > .probe/revF-pkg.log 2>&1; echo "REVF_PKG_EXIT=$?"
$ tail -2 .probe/revF-pkg.log
REVF_PKG_EXIT=0
ok  	go.5x5.cz/ptah/migration/generator	2.437s
```

E and F are the two halves of D, and each reddens exactly one row. Nothing else
in the package holds either direction.

---

## 2. Defect this branch introduced: the new PostgreSQL tests never ran in CI

Five live tests were added to `./migration/generator` and named in no workflow
file. Measured on `8915a365`:

```
$ grep -rn -E "TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres" .github/ ; echo "GREP_GITHUB_EXIT=$?"
GREP_GITHUB_EXIT=1
```

They skip themselves without a DSN and the command exits 0, which is what "a
skip reads as a pass" means concretely:

```
$ go test ./migration/generator -count=1 -v -run 'TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres|TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres|TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres|TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' ; echo "NODSN_EXIT=$?"
=== RUN   TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres
    partitioned_index_cycle_postgres_live_test.go:38: POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set
--- SKIP: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres (0.00s)
=== RUN   TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres
    partitioned_index_cycle_postgres_live_test.go:182: POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set
--- SKIP: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres (0.00s)
=== RUN   TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres
    partitioned_index_shadow_postgres_live_test.go:36: POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set
--- SKIP: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres (0.00s)
=== RUN   TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres
    partitioned_stats_postgres_live_test.go:30: POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set
--- SKIP: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres (0.00s)
=== RUN   TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres
    partitioned_stats_postgres_live_test.go:123: POSTGRES_TEST_DSN, POSTGRES_URL, TEST_DATABASE_URL, or TEST_DB_URL is not set
--- SKIP: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres (0.00s)
PASS
ok  	go.5x5.cz/ptah/migration/generator	0.417s
NODSN_EXIT=0
```

**So the green CI the previous revision of this description presented as
evidence never executed any of these five, and the description did not say so.**
The two jobs that could have:

```
$ grep -n "go test" .github/workflows/go-unit-tests.yml; echo "GREP_EXIT=$?"
$ grep -cn "POSTGRES\|MYSQL\|MARIADB\|CLICKHOUSE\|SQLSERVER" .github/workflows/go-unit-tests.yml; echo "GREP_ENV_EXIT=$?"
35:          go test -v -race ./... -timeout 10m
55:        run: go test -v -count=1 ./internal/fsdurable ./internal/pathguard -timeout 5m
58:        run: go test -v -count=1 ./internal/migratesum ./internal/devlock -timeout 5m
61:        run: go test -v -count=1 ./internal/goannotationcleanup ./internal/goannotationexport -timeout 5m
64:        run: go test -v -count=1 ./internal/atlasmigrate -run '^(TestPublishArtifactsLocked_|TestGenerateDiff_PreparedContentsArePublishedWithMatchingChecksum)' -timeout 5m
67:        run: go test -v -count=1 ./migration/generator -run '^TestMigrationPlanWriteFiles_' -timeout 5m
70:        run: go test -v -count=1 ./internal/atlasurl ./internal/atlasschema ./cmd/atlas -run '^(TestSameDatabaseEndpoint_|TestMayAddressSameDatabase_|TestSimulateOnDev_|TestSchemaPlanValidate)' -timeout 5m
GREP_EXIT=0
0
GREP_ENV_EXIT=1
```

`go test -v -race ./...` reaches all five and sets no database variable, so they
skip; the only `./migration/generator` selection in that file is
`^TestMigrationPlanWriteFiles_`. In `go-integration-tests.yml` the
`./migration/generator` selections at `8915a365` were
`TestGenerateMigration_SQLServerIndexDirectionRoundTrip|TestShadowIdentifierSemanticsMatch_SQLServerLive`,
`^TestReverseViewLikeObjects_DownRoundTrip_Integration$`,
`^TestReverseRecreatedTable_DropTableRollbackApplies_Integration$`,
`^TestVerifyRollbackFromShadow_FailurePathRejects(DriverOverrideAliasLive|LiveDialectMismatch)$`
and `^TestGenerateMigration(ShadowVerificationWithRealDB|_ConcurrentIndexApplyAndRollbackWithRealPostgres)$`.
All five are anchored or SQL Server-specific; none matches any of the five test
names, which is the same fact the `grep -rn` above reports.

### What replaced it

A step of its own in `.github/workflows/go-integration-tests.yml`, carrying the
six tests (the five plus the one added in section 3) and **both** guards the
repository already uses, because they fail on different things.

The `-list` guard fails the step when a rename leaves the `-run` pattern matching
nothing. Renaming
`TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres`
to `...RENAMED` in the source and running the guard line — the exit code read
here is deliberately the pipeline's, that is `grep`'s, which is what
`bash -e` acts on in a workflow step:

```
$ go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'; echo "RENAME_MUTANT_GUARD_EXIT=$?"
RENAME_MUTANT_GUARD_EXIT=1
```

```
$ go test ./migration/generator -list '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$' | grep -q '^TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres$'; echo "RENAME_REVERTED_GUARD_EXIT=$?"
RENAME_REVERTED_GUARD_EXIT=0
```

The `--- PASS` greps fail the step when the tests were reached and skipped. The
`go test` line of the new step, with no DSN, on `52d9b4fd`:

```
$ go test -v -count=1 ./migration/generator -run SIX -timeout 10m > .probe/partitioned-index-nodsn.log 2>&1; echo "STEP_NODSN_GOTEST_EXIT=$?"
STEP_NODSN_GOTEST_EXIT=0
```

```
$ grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' .probe/partitioned-index-nodsn.log; echo "GUARD_NODSN_GREP1_EXIT=$?"
GUARD_NODSN_GREP1_EXIT=1
```

```
$ grep -c -- '--- SKIP:' .probe/partitioned-index-nodsn.log; echo "SKIP_COUNT_EXIT=$?"
$ grep -c -- '--- PASS:' .probe/partitioned-index-nodsn.log; echo "PASS_COUNT_EXIT=$?"
6
SKIP_COUNT_EXIT=0
0
PASS_COUNT_EXIT=1
```

`go test` exits 0 with six skips and zero passes, and the first `--- PASS` grep
exits 1. Under `bash -e` that fails the step. The same command with the DSN the
step sets:

```
$ POSTGRES_TEST_DSN='postgres://postgres:pw@localhost:15975/postgres?sslmode=disable' go test -v -count=1 ./migration/generator -run SIX -timeout 10m > .probe/partitioned-index-dsn.log 2>&1; echo "STEP_WITH_DSN_GOTEST_EXIT=$?"
STEP_WITH_DSN_GOTEST_EXIT=0
```

```
$ grep -E '^(--- PASS|--- SKIP|--- FAIL|PASS|FAIL|ok)' .probe/partitioned-index-dsn.log; echo "GREP_SUMMARY_EXIT=$?"
--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres (1.74s)
--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres (0.17s)
--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres (1.03s)
--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres (0.37s)
--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres (0.35s)
--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres (0.27s)
PASS
ok  	go.5x5.cz/ptah/migration/generator	4.369s
GREP_SUMMARY_EXIT=0
```

Six `--- PASS` lines, zero `--- SKIP`. The step's six `grep -q` lines all match
that log.

### The step in CI

The local server is PostgreSQL 17.10 and the workflow's service container is
`postgres:18`, so the local runs above are evidence the tests execute against a
live PostgreSQL, not evidence about the CI image. Run 31316238049 on `f7741d31`
is. Step 11 of that job is the new step and it reports `success`:

```
$ gh api repos/stokaro/ptah/actions/runs/31316238049/jobs --jq '.jobs[0].steps[] | "\(.number) \(.conclusion) \(.name)"'
$ echo "STEPS_EXIT=$?"
1 success Set up job
2 success Initialize containers
3 success Run actions/checkout@v7
4 success Set up Go
5 success Install dependencies
6 success Start distributed SQL databases
7 success Wait for databases to be ready
8 success Run executor integration tests with live databases
9 success Run reverse view-like rollback round trip
10 success Run dropped-table rollback round trip
11 success Run partitioned and row-statistics concurrent-index tests
12 success Run database-realm cleanup and replay tests
13 success Run compatibility apply table-spelling tests
14 success Build integration test binary
15 success Test integration binary help
16 success Run basic smoke test
17 failure Run migrator safety integration tests
18 skipped Run MySQL-family rolled-back progress tests
19 skipped Run no-transaction and shadow generator integration tests
20 skipped Run migrate-baseline integration tests
21 skipped Run all databases comprehensive test
22 skipped Run distributed SQL live smoke tests
23 skipped Run SQL Server live smoke tests
24 success Upload integration test reports
25 skipped Run dynamic integration tests
48 skipped Post Set up Go
49 success Post Run actions/checkout@v7
50 success Stop containers
51 success Complete job
STEPS_EXIT=0
```

and the six tests ran rather than skipped inside it. `.probe/ci-run3.log` is the
whole run log of 31316238049, downloaded with `gh run view --log`; the first
column of each line is the job name and the second the step name, which is how
these lines are selected:

```
$ grep "Run partitioned and row-statistics concurrent-index tests" .probe/ci-run3.log | grep -E "(--- PASS|--- SKIP|--- FAIL|ok  )" 
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2926259Z grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2927269Z grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2928137Z grep -q -- '--- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2929190Z grep -q -- '--- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2930011Z grep -q -- '--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:24.2930906Z grep -q -- '--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres' partitioned-index.log
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5429405Z --- PASS: TestGenerateMigration_PartitionedParentSurvivesASecondCycleWithRealPostgres (0.42s)
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5430990Z --- PASS: TestReadSchema_PartitionAttachedIndexIsMarkedWithRealPostgres (0.16s)
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5442793Z --- PASS: TestGenerateMigration_PartitionedParentShadowRoundTripWithRealPostgres (0.57s)
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5451493Z --- PASS: TestGenerateMigration_PartitionedParentAvoidsConcurrentIndexWithRealPostgres (0.27s)
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5459935Z --- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres (0.25s)
integration-tests	Run partitioned and row-statistics concurrent-index tests	2026-08-09T13:41:33.5468215Z ok  	go.5x5.cz/ptah/migration/generator	1.858s
```

The first six lines are the guard commands the runner echoes; the last seven are
the run. Terminal escape sequences around the echoed commands are the only bytes
removed from that block. Zero skips inside the step:

```
$ grep "Run partitioned and row-statistics concurrent-index tests" .probe/ci-run3.log | grep -c -- "--- SKIP"; echo "SKIP_GREP_EXIT=$?"
0
SKIP_GREP_EXIT=1
```

So the six tests execute in CI against `postgres:18`, including the empty-table
one that rests on `pg_relation_size`.

### The one red left in that job, and whose it is

Step 17, `Run migrator safety integration tests`, fails with

```
--- FAIL: TestAtlasTxtarChecks_MySQLCommentSemanticsIntegration
```

and

```
pre-migration check failed for migration 3: pre-migration check checks/future.sql#1 for migration 3 could not run: check assertion must be a read-only SELECT statement (assert: /*!99999 DELETE FROM users */ SELECT 1)
```

That is not this branch's. Master merged `Update mysql Docker tag to v26 (#791)`
at 13:22Z:

```
$ gh api repos/stokaro/ptah/compare/d47f417f...90281329 --jq '.commits[] | "\(.sha[0:8]) \(.commit.message | split("\n")[0])"'
$ echo "COMPARE_EXIT=$?"
90281329 Update mysql Docker tag to v26 (#791)
COMPARE_EXIT=0
```

Master's own Integration Tests run for `90281329` fails on the same test name,
while `d47f417f` — the commit before it — succeeded. This branch still pins
`mysql:9.7`:

```
$ grep -n "image: mysql" .github/workflows/go-integration-tests.yml; echo "GREP_EXIT=$?"
34:        image: mysql:9.7
GREP_EXIT=0
```

but the `pull_request` event runs the merge of head and master, and that run
used the bumped image:

```
$ grep -o -E "mysql:[0-9.]+" .probe/ci-run-full.log | sort | uniq -c; echo "GREP_EXIT=$?"
   4 mysql:26.7
GREP_EXIT=0
```

(`.probe/ci-run-full.log` is the whole log of run 31315645374.) A server at 26.7
executes a `/*!99999 ... */` guard instead of ignoring it, so Ptah's read-only
assertion check refuses the fixture — correctly. That fixture needs a version
above the new image; fixing it belongs to #791, not here. This branch touches no
file on that path.

---

## 3. Follow-up: `reltuples = -1` marked every empty table as populated

`reltuples` is `-1` for **any** never-analyzed relation, and that includes every
table that has never had a row inserted. Reading "statistics unusable" as "row
count unknown" therefore put ordinary empty tables on the concurrent path, in a
non-transactional migration of their own.

`wf47089_e3`, one freshly created empty table with a text column:

```
$ PSQL -c "CREATE TABLE members (id BIGINT NOT NULL, email TEXT NOT NULL);" -c "SELECT c.relname, c.reltuples::bigint AS reltuples, COALESCE(st.n_live_tup,0) AS n_live_tup, pg_relation_size(c.oid) AS main_fork, pg_table_size(c.oid) AS table_size, (SELECT COUNT(*) FROM members) AS actual_rows FROM pg_class c LEFT JOIN pg_stat_all_tables st ON st.relid=c.oid WHERE c.relname='members';"
$ echo "SETUP_E3_EXIT=$?"
CREATE TABLE
 relname | reltuples | n_live_tup | main_fork | table_size | actual_rows 
---------+-----------+------------+-----------+------------+-------------
 members |        -1 |          0 |         0 |       8192 |           0
(1 row)

SETUP_E3_EXIT=0
```

`WORK/.probe/bin/ptah-nostorage` is `go build -o .probe/bin/ptah-nostorage
./cmd/ptah` with the storage conjunct removed from the reader — the
implementation this branch shipped:

```
$ .probe/bin/ptah-nostorage migrations generate --root-dir .probe/ent-empty --db-url 'postgres://postgres:pw@localhost:15975/wf47089_e3?sslmode=disable' --migrations-dir .probe/mig-e3-nostorage --name addindex
$ echo "GEN_E3_NOSTORAGE_EXIT=$?"
Generated migration files for postgres://postgres:***@localhost:15975/wf47089_e3?sslmode=disable:
UP:   WORK/.probe/mig-e3-nostorage/1786278847_addindex.up.sql
DOWN: WORK/.probe/mig-e3-nostorage/1786278847_addindex.down.sql
GEN_E3_NOSTORAGE_EXIT=0
```

```
$ cat .probe/mig-e3-nostorage/1786278847_addindex.up.sql; echo "CAT_EXIT=$?"
-- +ptah no_transaction
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:34:07+02:00
-- Direction: UP

CREATE INDEX CONCURRENTLY IF NOT EXISTS "idx_members_email" ON "members" ("email");CAT_EXIT=0
```

Same database, same entities, `52d9b4fd`:

```
$ .probe/bin/ptah migrations generate --root-dir .probe/ent-empty --db-url 'postgres://postgres:pw@localhost:15975/wf47089_e3?sslmode=disable' --migrations-dir .probe/mig-e3-branch --name addindex
$ echo "GEN_E3_BRANCH_EXIT=$?"
Generated migration files for postgres://postgres:***@localhost:15975/wf47089_e3?sslmode=disable:
UP:   WORK/.probe/mig-e3-branch/1786278817_addindex.up.sql
DOWN: WORK/.probe/mig-e3-branch/1786278817_addindex.down.sql
GEN_E3_BRANCH_EXIT=0
```

```
$ cat .probe/mig-e3-branch/1786278817_addindex.up.sql; echo "CAT_EXIT=$?"
-- Migration generated from schema differences
-- Generated on: 2026-08-09T14:33:37+02:00
-- Direction: UP

CREATE INDEX IF NOT EXISTS "idx_members_email" ON "members" ("email");CAT_EXIT=0
```

### The decision, and why the storage probe is the right one

Keeping the current behavior was not defensible: it puts every table created by
an earlier migration into a non-transactional file the first time an index is
added to it, and a failed `CREATE INDEX CONCURRENTLY` leaves an invalid index
behind rather than rolling back. Reverting the tri-state was not defensible
either: it restores the hazard #997 is about. The two states are separable, so
neither compromise is necessary.

The separating fact is storage, because it is read from the file system rather
than from statistics — no analyze, counter reset, crash-recovery restart or
restore moves it. In `wf47089_probe`, one never-analyzed empty table and one
never-analyzed table holding 5000 rows:

```
$ PSQL -c "CREATE TABLE never_touched (id BIGINT NOT NULL); CREATE TABLE bulk_loaded (id BIGINT NOT NULL); INSERT INTO bulk_loaded SELECT g FROM generate_series(1,5000) AS g;" -c "SELECT c.relname, c.reltuples::bigint AS reltuples, c.relpages, pg_table_size(c.oid) AS table_size, pg_relation_size(c.oid) AS rel_size, COALESCE(st.n_live_tup,0) AS n_live_tup FROM pg_class c LEFT JOIN pg_stat_all_tables st ON st.relid=c.oid WHERE c.relname IN ('never_touched','bulk_loaded') ORDER BY 1;"
$ echo "PROBE_STATS_EXIT=$?"
CREATE TABLE
CREATE TABLE
INSERT 0 5000
    relname    | reltuples | relpages | table_size | rel_size | n_live_tup 
---------------+-----------+----------+------------+----------+------------
 bulk_loaded   |        -1 |        0 |     212992 |   188416 |          0
 never_touched |        -1 |        0 |          0 |        0 |          0
(2 rows)

PROBE_STATS_EXIT=0
```

`reltuples`, `relpages` and `n_live_tup` are identical for both; the size
columns are not. It is `pg_relation_size` — the table's own main fork — and not
`pg_table_size`, because `pg_table_size` adds the TOAST relation and its index:
the empty `members` above, which has one `text` column, reports `main_fork = 0`
and `table_size = 8192`.

`pg_relation_size` also does not need `SELECT` on the table. A role with only
`CONNECT` and `USAGE ON SCHEMA public`:

```
$ docker exec -e PGPASSWORD=x ptah1074-dev psql -v ON_ERROR_STOP=1 -U wf47089_limited -h 127.0.0.1 -d wf47089_probe -c "SELECT relname, pg_relation_size(oid) AS main_fork FROM pg_class WHERE relname IN ('bulk_loaded','never_touched') ORDER BY 1;"
$ echo "LIMITED_SIZE_EXIT=$?"
    relname    | main_fork 
---------------+-----------
 bulk_loaded   |    188416
 never_touched |         0
(2 rows)

LIMITED_SIZE_EXIT=0
```

So `row_stats_unknown` is now "no usable statistics **and** storage in use". A
relation with no statistics and no storage is empty; only a relation with no
statistics and storage is genuinely unknown, and that one still gets the
non-blocking build.

### The test and its mutant

`TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres`
builds the empty-with-text-column fixture, asserts `reltuples = -1`,
`n_live_tup = 0`, `COUNT(*) = 0`, `pg_relation_size = 0` and
`pg_table_size > 0`, then asserts the generated pair is transactional and
carries no `CONCURRENTLY`, and applies it up/down/up.

**Mutant G — `pg_table_size` instead of `pg_relation_size`.** The size function
this reads as the obvious one, and the one a rewrite would reach for. Run
together with the populated-statistics test, which is its non-interference
control:

```
$ POSTGRES_TEST_DSN='postgres://postgres:pw@localhost:15975/postgres?sslmode=disable' go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres)$' -timeout 5m > .probe/mutG-live.log 2>&1; echo "MUTG_LIVE_EXIT=$?"
$ grep -E '^(--- PASS|--- SKIP|--- FAIL|PASS|FAIL|ok)' .probe/mutG-live.log
MUTG_LIVE_EXIT=1
--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres (0.52s)
--- FAIL: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres (0.26s)
FAIL
FAIL	go.5x5.cz/ptah/migration/generator	1.292s
```

What it fails on, from the same log:

```
$ sed -n '15,26p' .probe/mutG-live.log; echo "SED_EXIT=$?"
=== RUN   TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres
    partitioned_stats_postgres_live_test.go:269: 
        error:
          value is not false
        got:
          bool(true)
        stack:
          WORK/migration/generator/partitioned_stats_postgres_live_test.go:269
            c.Assert(files.Files[0].NoTransaction, qt.IsFalse)
        
--- FAIL: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres (0.26s)
FAIL
SED_EXIT=0
```

```
$ POSTGRES_TEST_DSN='postgres://postgres:pw@localhost:15975/postgres?sslmode=disable' go test -v -count=1 ./migration/generator -run '^(TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres|TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres)$' -timeout 5m > .probe/revG-live.log 2>&1; echo "REVG_LIVE_EXIT=$?"
$ grep -E '^(--- PASS|--- SKIP|--- FAIL|PASS|FAIL|ok)' .probe/revG-live.log
REVG_LIVE_EXIT=0
--- PASS: TestGenerateMigration_UnknownRowStatisticsBuildConcurrentlyWithRealPostgres (0.40s)
--- PASS: TestGenerateMigration_EmptyNeverAnalyzedTableStaysTransactionalWithRealPostgres (0.25s)
PASS
ok  	go.5x5.cz/ptah/migration/generator	1.054s
```

The populated-but-unmeasurable table keeps its concurrent build under the mutant
and after the revert. Only the empty one moves.

`docs/site/src/content/docs/databases/postgresql.md` is updated in the same
commit: the paragraph this branch added said a table Ptah cannot get statistics
for counts as populated, full stop, which is no longer what the code does.

---

## 3a. What the first CI run on this head caught: CockroachDB has no `pg_relation_size`

The storage probe above was pushed unconditionally at `52d9b4fd`, and the
PostgreSQL reader serves the whole PostgreSQL family. The `integration-tests`
job failed on that head in step 8:

```
$ grep -n -E "^.*(--- FAIL|^FAIL|##\[error\])" .probe/ci-job.log | head -40; echo "GREP_EXIT=$?"
1440:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:06.7029446Z --- FAIL: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E (9.87s)
1441:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:06.7030732Z     --- FAIL: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/cockroachdb (0.48s)
1941:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:35.8733980Z FAIL
1942:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:35.8755670Z FAIL	go.5x5.cz/ptah/integration	58.584s
1943:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:35.8813460Z FAIL
1944:integration-tests	Run executor integration tests with live databases	2026-08-09T12:51:36.0411514Z ##[error]Process completed with exit code 1.
GREP_EXIT=0
```

with

```
Error: load --to schema: read --to database schema: failed to read tables: failed to query tables: ERROR: unknown function: pg_relation_size() (SQLSTATE 42883)
```

That line is `.probe/ci-job.log:1430`, the log of job 93246591308 downloaded
whole. The `yugabytedb` subtest of the same test passed, so this is CockroachDB
specifically, not the family.

Reproduced on a CockroachDB CCL v26.2.5 container started for this session
(`wf47089-crdb`, host port 26289):

```
$ docker exec wf47089-crdb /cockroach/cockroach sql --insecure --host=127.0.0.1:26257 --execute="CREATE TABLE probe_t (id INT8 PRIMARY KEY);" --execute="SELECT pg_relation_size('probe_t'::regclass);"
$ echo "CRDB_CALL_EXIT=$?"
CREATE TABLE
ERROR: unknown function: pg_relation_size()
SQLSTATE: 42883
Failed running "sql"
CRDB_CALL_EXIT=1
```

An unknown function is a **planning** error, so it takes the whole table read
down rather than one column, and no runtime `CASE` can rescue it. The reader
has to know before it writes the query. `pg_catalog.pg_proc` answers on both
servers:

```
$ docker exec wf47089-crdb /cockroach/cockroach sql --insecure --host=127.0.0.1:26257 --execute="SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'pg_catalog' AND p.proname = 'pg_relation_size') AS has_relation_size;"
$ echo "CRDB_PROBE_EXIT=$?"
has_relation_size
f
CRDB_PROBE_EXIT=0
```

```
$ PSQL -c "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_proc p JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace WHERE n.nspname = 'pg_catalog' AND p.proname = 'pg_relation_size') AS has_relation_size;"
$ echo "PG_PROBE_EXIT=$?"
 has_relation_size 
-------------------
 t
(1 row)

PG_PROBE_EXIT=0
```

(that `PSQL` ran against `-d postgres`.) So the reader asks once per reader and
degrades to the statistics-only tri-state where the function is absent, rather
than failing the read. That is the previously shipped behavior on CockroachDB
and the new behavior everywhere the function exists — a capability grade, not a
removal.

**Mutant H — assume every PostgreSQL-family server has it.** The projection is
made unconditional again, which is the cheaper implementation (no probe query),
and is what `52d9b4fd` did. Against the live CockroachDB:

```
$ COCKROACHDB_URL='cockroachdb://root@localhost:26289/defaultdb?sslmode=disable' go test -tags=integration ./integration -count=1 -run '^TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E$' -v > .probe/crdb-mutH.log 2>&1; echo "CRDB_MUTH_EXIT=$?"
$ grep -E '^(=== RUN|--- PASS|--- SKIP|--- FAIL|    ---|PASS|FAIL|ok)' .probe/crdb-mutH.log
CRDB_MUTH_EXIT=1
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/cockroachdb
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/yugabytedb
--- FAIL: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E (10.93s)
    --- FAIL: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/cockroachdb (8.10s)
    --- SKIP: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/yugabytedb (0.00s)
FAIL
FAIL	go.5x5.cz/ptah/integration	15.507s
```

```
$ grep -n "pg_relation_size" .probe/crdb-mutH.log | head -5; echo "GREP_EXIT=$?"
8:          Error: load --to schema: read --to database schema: failed to read tables: failed to query tables: ERROR: unknown function: pg_relation_size() (SQLSTATE 42883)
GREP_EXIT=0
```

Offline, the same mutant reddens the fake-server tests:

```
$ go test ./internal/dbschema/postgres/... -count=1 -run 'TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize|TestSupportsRelationSize_AsksOncePerReader|TestPostgreSQLReaderReadTablesUsesBulkColumnQuery' > .probe/pgprobe-mutH.log 2>&1; echo "PGPROBE_MUTH_EXIT=$?"
$ grep -E '^(---|    ---|FAIL|ok)' .probe/pgprobe-mutH.log
PGPROBE_MUTH_EXIT=1
--- FAIL: TestPostgreSQLReaderReadTablesUsesBulkColumnQuery (0.00s)
--- FAIL: TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize (0.00s)
    --- FAIL: TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize/a_server_with_pg_relation_size_measures_storage (0.00s)
    --- FAIL: TestReadTablesForSchema_AsksWhetherTheServerHasRelationSize/a_server_without_pg_relation_size_falls_back_to_statistics (0.00s)
FAIL
FAIL	go.5x5.cz/ptah/internal/dbschema/postgres	3.037s
```

Reverted:

```
$ COCKROACHDB_URL='cockroachdb://root@localhost:26289/defaultdb?sslmode=disable' go test -tags=integration ./integration -count=1 -run '^TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E$' -v > .probe/crdb-revH.log 2>&1; echo "CRDB_REVH_EXIT=$?"
$ grep -E '^(=== RUN|--- PASS|--- SKIP|--- FAIL|    ---|PASS|FAIL|ok)' .probe/crdb-revH.log
CRDB_REVH_EXIT=0
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/cockroachdb
=== RUN   TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/yugabytedb
--- PASS: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E (12.42s)
    --- PASS: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/cockroachdb (10.21s)
    --- SKIP: TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E/yugabytedb (0.00s)
PASS
ok  	go.5x5.cz/ptah/integration	15.722s
```

```
$ go test ./internal/dbschema/postgres/... -count=1 > .probe/pgprobe-revH.log 2>&1; echo "PGPROBE_REVH_EXIT=$?"
$ tail -2 .probe/pgprobe-revH.log
PGPROBE_REVH_EXIT=0
ok  	go.5x5.cz/ptah/internal/dbschema/postgres	3.352s
```

The `yugabytedb` subtest skips locally because no YugabyteDB was started for
this session; it is the CI run that measured that half, and it passed there
under the unconditional projection, which is what says YugabyteDB has the
function.

---

## 4. Gates

All run from `WORK` on `43c946f7`, each as its own command, each exit code read
directly from that command.

| gate | exit |
| --- | --- |
| `go build ./...` | 0 |
| `go vet ./...` | 0 |
| `go vet -tags integration ./integration/...` | 0 |
| `go test ./... -count=1` | 0 (187 `ok` lines, `grep -cE '^FAIL'` prints 0 and exits 1) |
| `go tool qtlint ./...` | 0 |
| `golangci-lint run ./...` | 0 (`0 issues.`) |
| `scripts/check-test-style.sh` | 0 (`teststyle: OK (175 conditional groups, 42 white-box files)`) |
| `scripts/check-public-api.sh` | 0 |
| `scripts/check-public-api-snapshot.sh` | 0 |
| `scripts/check-public-api-released.sh` | 0 (five `approved pre-v1 public API incompatibility` lines; I did not check when each was approved) |
| `cd testkit && go build ./...` | 0 |
| `POSTGRES_TEST_DSN=... go test -tags integration ./integration/gonative -count=1` | 0 (`ok go.5x5.cz/ptah/integration/gonative 27.502s`) |
| `POSTGRES_TEST_DSN=... go test ./internal/dbschema/postgres/... -tags integration -count=1` | 0 (`ok go.5x5.cz/ptah/internal/dbschema/postgres 0.457s`) |
| `COCKROACHDB_URL=... go test -tags=integration ./integration -count=1 -run '^TestAtlasMigrateDiffPostgresFamilyDevCleanupE2E$'` | 0 (cockroachdb PASS, yugabytedb SKIP — no YugabyteDB here) |
| `POSTGRES_TEST_DSN=... go test -v -count=1 ./migration/generator -run SIX -timeout 10m` | 0 (six `--- PASS`, zero `--- SKIP`) |

`docs/site` has fourteen `check:*` scripts, all run on `52d9b4fd` after `npm ci`
(exit 0) and `npm run build` (exit 0, `61 page(s) built`). Each was run as its
own command and each exit code read directly: `check:exit-codes` 0,
`check:exit-codes:selftest` 0, `check:core-doc-links` 0, `check:page-health` 0,
`check:links` 0, `check:links:selftest` 0, `check:redirects` 0,
`check:redirects:selftest` 0, `check:style` 0
(`check-style.mjs: OK (100 documentation files)`), `check:style:selftest` 0,
`check:limitations` 0, `check:limitations:selftest` 0, `check:responsive` 0
(`OK (60 routes x 2 viewports, cells within 8 lines)`),
`check:responsive:selftest` 0. `43c946f7` changes three files, all Go, none
under `docs/site`, so those runs still describe this tree's documentation — but
they were not re-run on it.

The test-style gate judges the new white-box file rather than skipping it.
Deleting its justification comment:

```
$ scripts/check-test-style.sh ; echo "TESTSTYLE_WITHOUT_JUSTIFICATION_EXIT=$?"
teststyle: teststyle baseline mismatch
new white-box test violations:
  - migration/generator/partitioned_index_schema_scope_internal_test.go	generator	missing white-box justification comment after package clause


Run go tool teststyle -write-baseline after intentional cleanup.
TESTSTYLE_WITHOUT_JUSTIFICATION_EXIT=1
```

---

## 5. Cleanup

The probe databases (`wf47089_probe`, `wf47089_empty`, `wf47089_empty2`,
`wf47089_e3`, `wf47089_two`) and the probe role `wf47089_limited` were created
for this session on a shared PostgreSQL server and are dropped at the end of it;
`SELECT datname FROM pg_database WHERE datname LIKE 'wf47089%'` and the matching
`pg_roles` query both return `(0 rows)`. The `wf47089-crdb` CockroachDB
container is removed. The six live tests each create and drop their own
database.

---

## Not re-measured this round

These were measured by earlier rounds and are recorded in the commit messages of
`76242535`, `1af7c746`, `9d350e35`, `3e0ea113`, `cb73291e`, `faf8cb8f` and
`8915a365`. I did not re-run them in this session, so they are cited as prior
record rather than as evidence produced here:

- The five-index partition-attachment fixture and the drop-refusal split it
  rests on (`3e0ea113`, `faf8cb8f`, `8915a365`).
- The lint down-direction opt-in and its mutant (`76242535`).
- The `--check-destructive` / `--allow-destructive` behavior of
  `migrations generate` and the `DS101` refusal belonging to `migrations up`
  and `migrations lint` (`faf8cb8f`).
- `TestPostgreSQLSecondAttemptOverPartitionedParentIndexStillAppliesIntegration`
  in `./integration/gonative` ran as part of the whole-package integration run
  in the gates table above, but I did not run it by name.

## What this does NOT close

Not `Closes #997`.

- **The live matrix is still missing the concurrent-writer case.** A writer
  holding the table while the concurrent build runs is not covered; the
  assertion that would matter is a race on a build that finishes in
  milliseconds.
- **"Generated artifacts pass Ptah lint" is asserted by none of the gates.** The
  downgraded partitioned build is a plain `CREATE INDEX`, which `PG101` reports.
- **`testkit` does not normalize `PartitionAttached` or `RowStatsUnknown`.** It
  is a separate module requiring the published `go.5x5.cz/ptah v0.2.0`, so it
  cannot name a field this branch adds.
- **Only PostgreSQL 17.10 and CockroachDB CCL v26.2.5 were measured locally.**
  The `reltuples = -1` and `pg_relation_size` readings the tri-state rests on
  were observed on 17.10 only. CI runs `postgres:18`, and the new step is the
  first thing that will say whether they hold there. YugabyteDB's side of the
  probe rests on the CI run of `52d9b4fd`, not on a local server.
- **`PartitionAttached` and `RowStatsUnknown` are set by the PostgreSQL reader
  only.** No other dialect was measured.

## Residual risk

- **A bare index ref that is ambiguous between a partitioned and an ordinary
  table now resolves to "not partitioned".** If the ref really meant the
  partitioned one, an explicit `diff.concurrent_index` request produces a
  statement PostgreSQL answers with `0A000` at apply time. That is the base
  branch's behavior, restored; the alternative refuses a legitimate run and
  names the wrong table, which is what this round fixed.
- **A table that was analyzed while empty, then bulk-loaded, still reports
  `reltuples = 0`** and reads as empty. Storage does not help there, because the
  statistics are present and wrong rather than absent.
- **`pg_relation_size` is one more catalog function per table read, plus one
  probe query per reader.** The function stats the relation's files; on a schema
  with thousands of tables that cost was not measured.
- **On a PostgreSQL-family server without `pg_relation_size`, the empty-table
  behavior of section 3 does not apply.** The tri-state degrades to the
  statistics-only test there, which is what `8915a365` shipped everywhere. On
  CockroachDB that is inert, because its capability preset disables
  `CreateIndexConcurrently` and the concurrent-build selector returns nothing
  before it reads a row count — but that is a property of the preset, not of the
  reader, and no test ties the two together.
- **A desired state that declares a partition's index copy is silently
  unmanaged**, unchanged from the previous rounds.

Refs #997
