### PR TITLE
Refuse a multi-schema HCL desired state a run cannot reach (#1231)

### DIFF
--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -470,9 +470,12 @@ func runAtlasSchemaApplyPlanFile(cmd *cobra.Command, opts atlasSchemaApplyOption
 	}
 	var desired *goschema.Database
 	if len(opts.toURLs) > 0 {
+		schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(opts.devURL, opts.url, "url")
 		desired, err = schemafile.LoadAll(opts.toURLs, schemafile.Options{
 			Dialect:               conn.Info().Dialect,
 			IgnoreUnknownHCLNames: true,
+			SchemaScope:           schemaScope,
+			SchemaScopeFlag:       schemaScopeFlag,
 			Vars:                  schemaVars,
 		})
 		if err != nil {

--- a/cmd/atlas/schema_plan_validate.go
+++ b/cmd/atlas/schema_plan_validate.go
@@ -155,9 +155,12 @@ func runAtlasSchemaPlanValidate(cmd *cobra.Command, opts atlasSchemaPlanValidate
 	if err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(opts.devURL, opts.fromURLs[0], "from")
 	desired, err := schemafile.LoadAll(opts.toURLs, schemafile.Options{
 		Dialect:               conn.Info().Dialect,
 		IgnoreUnknownHCLNames: true,
+		SchemaScope:           schemaScope,
+		SchemaScopeFlag:       schemaScopeFlag,
 		Vars:                  schemaVars,
 	})
 	if err != nil {

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -95,6 +95,38 @@ a column declared against a type in another schema is written against that
 schema's type. Applying such a document therefore rebuilds each object where it
 was, and applying it back to the database it describes plans nothing.
 
+#### A schema-limited run refuses a multi-schema HCL desired state
+
+An HCL desired state that declares more than one top-level `schema` block is
+refused when the run is limited to a single schema, and the message names the
+file and every block it counted:
+
+```text
+cannot use HCL with more than 1 schema when dev-url is limited to schema "main":
+2 top-level schema blocks are declared: "main" at schema.hcl:1, "other" at schema.hcl:4
+```
+
+A run is limited when the URL that decides its scope names one schema: any
+SQLite URL, a PostgreSQL-family URL carrying `search_path=<one name>`, or a
+MySQL-family URL naming a database. `--dev-url` is checked first and the target
+`--url` second, so the message names the flag that limited the run. A
+PostgreSQL-family URL with no `search_path` limits nothing, and the same
+document loads there with both schemas described.
+
+The refusal covers `schema inspect`, `schema apply`, `schema diff`,
+`schema plan validate` and `migrate diff`, because a desired state the run
+cannot reach in full is a desired state no plan can honor. Without it the extra
+schemas were dropped and the run reported success:
+`schema diff --from one.hcl --to two-schemas.hcl` answered
+`Schemas are synced, no changes to be made`, and `migrate diff` wrote a
+migration file covering half the document.
+
+The count is of BLOCKS, not of distinct names. A document that opens
+`schema "main"` twice — which is what a directory of per-table HCL files looks
+like when every file repeats the schema block — is two blocks, and is refused
+on a SQLite dev database for that reason. Declare the schema once, or give the
+run a realm-scoped URL.
+
 `--schema` / `-s` narrows inspection when the underlying database reader supports
 schema scoping, and outranks the URL's scope: naming a schema that does not
 exist renders an empty document rather than falling back to the connection's

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -54,6 +54,19 @@ table "users" {
 }
 ```
 
+### How many `schema` blocks a document may declare
+
+A document may declare as many schemas as the run can reach. A run whose URL
+names one schema — any SQLite URL, a PostgreSQL-family URL carrying
+`search_path=<one name>`, a MySQL-family URL naming a database — reaches one,
+and a document declaring more than one top-level `schema` block is refused
+there rather than narrowed. The count is of blocks: repeating
+`schema "main" {}` in two files of a schema directory is two.
+
+See
+[the Atlas-compatible schema commands](../../atlas/schema-commands/#a-schema-limited-run-refuses-a-multi-schema-hcl-desired-state)
+for the message and the flag it names.
+
 ## Supported object subset
 
 | Object | Supported shape |

--- a/docs/site/src/content/docs/reference/hcl-schema.md
+++ b/docs/site/src/content/docs/reference/hcl-schema.md
@@ -63,6 +63,13 @@ and a document declaring more than one top-level `schema` block is refused
 there rather than narrowed. The count is of blocks: repeating
 `schema "main" {}` in two files of a schema directory is two.
 
+This holds on the native commands, not only the compatibility binary:
+`ptah schema inspect --schema-file two-schemas.hcl --dev-url sqlite://dv?mode=memory`
+refuses, because narrowing a desired state to the scope and reporting success
+is a wrong answer wherever it happens. Give the run a realm-scoped URL to
+describe every schema the document declares. A desired state with no URL to be
+scoped by — Go annotation roots, `ptah schema test` — is unaffected.
+
 See
 [the Atlas-compatible schema commands](../../atlas/schema-commands/#a-schema-limited-run-refuses-a-multi-schema-hcl-desired-state)
 for the message and the flag it names.

--- a/internal/atlashcl/atlashcl.go
+++ b/internal/atlashcl/atlashcl.go
@@ -41,6 +41,21 @@ type Options struct {
 	// what the community binary does.
 	RecordIgnored func(IgnoredName)
 
+	// RecordSchemaBlock receives every TOP-LEVEL `schema` block the document
+	// declares, in file order, one call per block. Optional; nil discards them.
+	//
+	// It reports blocks rather than schemas because those are two different
+	// numbers and the caller needs the first: `goschema.Finalize` folds two
+	// `schema "main"` blocks into one schema, and the pinned Atlas community
+	// binary v1.3.0 counts that document as two. See [declaredSchemaBlocks].
+	//
+	// The recorder fires for a document that parses, whatever the caller then
+	// does with the count. Deciding what "too many" means needs facts this
+	// parser does not have -- which URL the run is limited to -- so the rule
+	// lives with the caller that knows them
+	// (go.5x5.cz/ptah/internal/schemafile.Options.SchemaScope).
+	RecordSchemaBlock func(SchemaBlock)
+
 	// Vars supplies values for the file's `variable` blocks, spelled the way
 	// `--var` spells them: one entry per flag occurrence, each entry a
 	// comma-separated list of name=value assignments.
@@ -88,6 +103,7 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 		return nil, fmt.Errorf("parse HCL schema: unsupported body type %T", file.Body)
 	}
 
+	schemaBlocks := declaredSchemaBlocks(body)
 	p := parser{
 		src:             data,
 		filename:        filename,
@@ -96,7 +112,7 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 		tolerant:        opts.IgnoreUnknownNames,
 		recordIgnored:   opts.RecordIgnored,
 		refContext:      columnRefContext(body),
-		declaredSchemas: declaredSchemaNames(body),
+		declaredSchemas: schemaBlockNames(schemaBlocks),
 	}
 	// Classify before validating the schema body. A file carrying a project-file
 	// marker is the wrong kind of file, and that verdict must not depend on
@@ -106,6 +122,13 @@ func ParseWithOptions(data []byte, filename string, opts Options) (*goschema.Dat
 	// block error, so the classification has to run ahead of the body walk.
 	if err := classifyProjectFile(body, filename); err != nil {
 		return nil, err
+	}
+	// After the project-file verdict, so a document that is not a schema file at
+	// all never contributes a schema block to a caller's count.
+	if opts.RecordSchemaBlock != nil {
+		for _, block := range schemaBlocks {
+			opts.RecordSchemaBlock(block)
+		}
 	}
 	// The evaluation context is built from the file's own variable and locals
 	// blocks, so it has to exist before any attribute is read -- including the

--- a/internal/atlashcl/evalreject.go
+++ b/internal/atlashcl/evalreject.go
@@ -102,10 +102,19 @@ func (p *parser) appendUnresolvedExpr(name string, attr *hclsyntax.Attribute, ou
 // root's own range, the way checkDroppedExpr reports one, because that is what
 // the community binary underlines -- `var.status` points at `var`. Everything
 // else is the HCL diagnostic, which already names the member or the operand.
+//
+// The one exception is a `schema.` reference the document itself declares: the
+// HCL diagnostic calls that name unknown, and it is not.
 func (p *parser) unresolvedExprError(expr hclsyntax.Expression) error {
 	for _, traversal := range hclsyntax.Variables(expr) {
 		root, ok := traversal[0].(hcl.TraverseRoot)
-		if !ok || !isEvalNamespace(root.Name) {
+		if !ok {
+			continue
+		}
+		if !isEvalNamespace(root.Name) {
+			if p.declaresSchemaRoot(root.Name) {
+				return p.schemaReferenceNotAValueError(root.Name, root.SrcRange)
+			}
 			continue
 		}
 		if _, bound := p.ctx.Variables[root.Name]; !bound {
@@ -116,6 +125,41 @@ func (p *parser) unresolvedExprError(expr hclsyntax.Expression) error {
 		return p.evaluationFailed(diags)
 	}
 	return nil
+}
+
+// declaresSchemaRoot reports whether name is the `schema.` reference root and
+// this document's own top-level `schema` blocks bind it.
+//
+// Both halves matter. A document with no `schema` block does not bind the root,
+// and "there is no variable named schema" is then the accurate thing to say.
+func (p *parser) declaresSchemaRoot(name string) bool {
+	return name == droppedSchemaNamespace && len(p.declaredSchemas) > 0
+}
+
+// schemaReferenceNotAValueError reports a `schema.` reference used where a value
+// was required.
+//
+// It replaces the HCL diagnostic for this one shape because that diagnostic is
+// wrong about the cause. Measured on a document declaring `schema "main"`:
+// `procedure "p" { names = jsonencode(schema.main) }` was refused with
+// `unknown variable: There is no variable named "schema"` -- for a name bound
+// two lines away, which `schema = schema.main` resolves on the same file, and
+// which a dropped body's own scope binds (see droppedSchemaRoot). A reader sent
+// after a missing block finds one already there.
+//
+// The refusal stays. Only a function call spelled as the whole value reaches
+// here (see mustEvaluate), every value helper in this package falls back to an
+// attribute's SOURCE TEXT when an expression will not evaluate, and a call let
+// through would reach the database as the literal `jsonencode(schema.main)`.
+// The pinned Atlas community binary v1.3.0 loads that document at exit 0, so
+// this is Ptah refusing what that binary accepts -- the same asymmetry the
+// closed dropped-body scope takes, and the one that costs a message rather than
+// a wrong schema.
+func (p *parser) schemaReferenceNotAValueError(name string, rng hcl.Range) error {
+	return fmt.Errorf(
+		"parse HCL schema at %s: schema reference %q has no value to pass to a function call: only var. and local. references are evaluated here",
+		rng.String(), name,
+	)
 }
 
 // sqlCallArgument unwraps `sql(X)` to X, reporting whether it unwrapped

--- a/internal/atlashcl/schema_blocks_test.go
+++ b/internal/atlashcl/schema_blocks_test.go
@@ -1,0 +1,96 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// TestRecordSchemaBlockReportsBlocksNotSchemas pins the one property the
+// schema-scope gate in internal/schemafile rests on: this recorder counts
+// BLOCKS, and the parse result counts SCHEMAS.
+//
+// The two differ exactly when a document declares one schema twice.
+// `goschema.Finalize` folds those into one entry in Database.Schemas, while the
+// pinned Atlas community binary v1.3.0 counts two: measured with
+// `schema inspect -u file://<schema "main" twice>.hcl --dev-url sqlite://dv?mode=memory`,
+// that binary exits 1 with `cannot use HCL with more than 1 schema when dev-url
+// is limited to schema "main"`, the same refusal it gives a document naming two
+// different schemas.
+//
+// A recorder that deduplicated by name would leave the gate exiting 0 on that
+// document, so the duplicate row asserts on both numbers rather than on the
+// two-name row alone.
+func TestRecordSchemaBlockReportsBlocksNotSchemas(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		assert func(c *qt.C, blocks []atlashcl.SchemaBlock, db *goschema.Database, err error)
+	}{
+		{
+			name: "two names are two blocks",
+			source: `schema "main" {}
+schema "other" {}
+`,
+			assert: func(c *qt.C, blocks []atlashcl.SchemaBlock, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(blocks, qt.DeepEquals, []atlashcl.SchemaBlock{
+					{Name: "main", Filename: "schema.hcl", Line: 1},
+					{Name: "other", Filename: "schema.hcl", Line: 2},
+				})
+				c.Assert(db.Schemas, qt.HasLen, 2)
+			},
+		},
+		{
+			name: "one name declared twice is two blocks and one schema",
+			source: `schema "main" {}
+schema "main" {}
+`,
+			assert: func(c *qt.C, blocks []atlashcl.SchemaBlock, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(blocks, qt.DeepEquals, []atlashcl.SchemaBlock{
+					{Name: "main", Filename: "schema.hcl", Line: 1},
+					{Name: "main", Filename: "schema.hcl", Line: 2},
+				})
+				c.Assert(db.Schemas, qt.HasLen, 1)
+			},
+		},
+		{
+			name:   "a document with no schema block records nothing",
+			source: "table \"users\" {\n  column \"id\" {\n    type = int\n  }\n}\n",
+			assert: func(c *qt.C, blocks []atlashcl.SchemaBlock, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(blocks, qt.HasLen, 0)
+				c.Assert(db.Schemas, qt.HasLen, 0)
+			},
+		},
+		{
+			name: "a project file records nothing, because it is not a schema file",
+			source: `schema "main" {}
+env "local" {
+  url = "postgres://localhost/x"
+}
+`,
+			assert: func(c *qt.C, blocks []atlashcl.SchemaBlock, _ *goschema.Database, err error) {
+				c.Assert(err, qt.ErrorMatches, `cannot parse project file "schema.hcl" as a schema file: .*`)
+				c.Assert(blocks, qt.HasLen, 0)
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			var recorded []atlashcl.SchemaBlock
+
+			db, err := atlashcl.ParseWithOptions([]byte(test.source), "schema.hcl", atlashcl.Options{
+				RecordSchemaBlock: func(block atlashcl.SchemaBlock) { recorded = append(recorded, block) },
+			})
+
+			test.assert(c, recorded, db, err)
+		})
+	}
+}

--- a/internal/atlashcl/schema_reference_value_test.go
+++ b/internal/atlashcl/schema_reference_value_test.go
@@ -1,0 +1,125 @@
+package atlashcl_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/atlashcl"
+)
+
+// TestSchemaReferenceInAFunctionCallNamesTheRealCause is the regression test for
+// a diagnostic that named the wrong cause.
+//
+// A function call spelled as a whole attribute value has to evaluate -- every
+// value helper in this package falls back to an attribute's SOURCE TEXT when an
+// expression will not, so a call let through would reach the database as the
+// literal `jsonencode(schema.main)` -- and the evaluation context binds only
+// `var.` and `local.`. The refusal is therefore correct. The MESSAGE was not:
+// it said `unknown variable: There is no variable named "schema"` for a root
+// that IS bound, both by the file's own `schema "main"` block two lines up and
+// by the scope a dropped body is evaluated in, where `schema = schema.main`
+// resolves. A reader sent looking for a missing block finds one already there.
+//
+// The tolerant row and the strict row both run because the tolerance policy is
+// irrelevant here: this check runs before the body walk decides which names to
+// drop, so both command trees saw the same wrong sentence.
+//
+// The undeclared row is the control that keeps the fix from becoming a blanket
+// rewrite: with no `schema` block in the file, nothing binds the root and
+// `unknown variable` is the accurate thing to say. So is `nonsense`, which no
+// document ever declares.
+func TestSchemaReferenceInAFunctionCallNamesTheRealCause(t *testing.T) {
+	const declared = `schema "main" {}
+procedure "p" {
+  names = jsonencode(schema.main)
+}
+`
+	const undeclared = `table "users" {
+  column "id" {
+    type = int
+  }
+}
+procedure "p" {
+  names = jsonencode(schema.main)
+}
+`
+	const unknownRoot = `schema "main" {}
+procedure "p" {
+  names = jsonencode(nonsense.thing)
+}
+`
+
+	tests := []struct {
+		name      string
+		source    string
+		tolerant  bool
+		errorLike string
+	}{
+		{
+			name:      "a declared schema reference names itself",
+			source:    declared,
+			tolerant:  true,
+			errorLike: `parse HCL schema at schema\.hcl:3,22-28: schema reference "schema" has no value to pass to a function call: only var\. and local\. references are evaluated here`,
+		},
+		{
+			name:      "the strict command tree reports the same cause",
+			source:    declared,
+			tolerant:  false,
+			errorLike: `parse HCL schema at schema\.hcl:3,22-28: schema reference "schema" has no value to pass to a function call: .*`,
+		},
+		{
+			name:      "an undeclared schema root is still an unknown variable",
+			source:    undeclared,
+			tolerant:  true,
+			errorLike: `parse HCL schema at schema\.hcl:7,22-28: unknown variable: There is no variable named "schema"\.`,
+		},
+		{
+			name:      "a root no document declares is still an unknown variable",
+			source:    unknownRoot,
+			tolerant:  true,
+			errorLike: `parse HCL schema at schema\.hcl:3,22-30: unknown variable: There is no variable named "nonsense"\.`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			_, err := atlashcl.ParseWithOptions([]byte(test.source), "schema.hcl", atlashcl.Options{
+				IgnoreUnknownNames: test.tolerant,
+			})
+
+			c.Assert(err, qt.ErrorMatches, test.errorLike)
+		})
+	}
+}
+
+// TestSchemaReferenceStillResolvesWhereItIsRead is the non-interference control
+// for the diagnostic above: the message changed and nothing else did.
+//
+// `schema = schema.main` on a modeled block is read from source text and never
+// reaches the evaluation check, and a dropped body naming a declared schema is
+// exit 0 on the pinned Atlas community binary v1.3.0 and here (stokaro/ptah#927).
+// A fix that reported the new message for every `schema.` traversal would take
+// both of these down.
+func TestSchemaReferenceStillResolvesWhereItIsRead(t *testing.T) {
+	const source = `schema "main" {}
+procedure "p" {
+  schema = schema.main
+}
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+	c := qt.New(t)
+
+	db, err := atlashcl.ParseWithOptions([]byte(source), "schema.hcl", atlashcl.Options{IgnoreUnknownNames: true})
+
+	c.Assert(err, qt.IsNil)
+	c.Assert(db.Tables, qt.HasLen, 1)
+	c.Assert(db.Tables[0].Schema, qt.Equals, "main")
+}

--- a/internal/atlashcl/unknown_names.go
+++ b/internal/atlashcl/unknown_names.go
@@ -38,6 +38,19 @@ type IgnoredName struct {
 	Line     int
 }
 
+// SchemaBlock is one top-level `schema` block a document declared.
+//
+// It carries the label and the position rather than a count, because the caller
+// that refuses a document has to name the blocks it counted: "more than one
+// schema" with no positions leaves an operator grepping a generated file.
+type SchemaBlock struct {
+	// Name is the block's single label.
+	Name string
+	// Filename and Line locate the block.
+	Filename string
+	Line     int
+}
+
 // typeKeyword is the Go type behind the opaque value a bare Atlas type keyword
 // evaluates to inside a dropped body. It carries nothing: the only thing the
 // keyword has to support is being written down.
@@ -206,23 +219,45 @@ func (p *parser) droppedSchemaRoot() (cty.Value, bool) {
 	return cty.ObjectVal(names), true
 }
 
-// declaredSchemaNames collects the labels of the file's top-level `schema`
-// blocks.
+// declaredSchemaBlocks collects the file's top-level `schema` blocks, ONE ENTRY
+// PER BLOCK and in file order.
 //
 // It reads the WHOLE body before the walk starts, because the community binary
 // evaluates the whole file before deciding what to decode: a `procedure` block
 // written above the `schema` block it names resolves there, so collecting these
 // as the walk reaches them would refuse a file over declaration order alone.
 //
+// Repeated labels are KEPT rather than folded, which is what makes the count
+// usable as a count. `goschema.Finalize` deduplicates schemas by name, so a
+// document declaring `schema "main"` twice has one schema in the IR and two
+// blocks here -- and two is the number the pinned Atlas community binary v1.3.0
+// counts: that document is refused against a schema-limited URL with
+// `cannot use HCL with more than 1 schema`, exactly as a document naming two
+// different schemas is.
+//
 // A block with anything other than one label is skipped rather than refused
 // here; parseSchema still reports it when the walk arrives.
-func declaredSchemaNames(body *hclsyntax.Body) []string {
-	names := make([]string, 0)
+func declaredSchemaBlocks(body *hclsyntax.Body) []SchemaBlock {
+	blocks := make([]SchemaBlock, 0)
 	for _, block := range body.Blocks {
 		if block.Type != droppedSchemaNamespace || len(block.Labels) != 1 {
 			continue
 		}
-		names = append(names, block.Labels[0])
+		blocks = append(blocks, SchemaBlock{
+			Name:     block.Labels[0],
+			Filename: block.TypeRange.Filename,
+			Line:     block.TypeRange.Start.Line,
+		})
+	}
+	return blocks
+}
+
+// schemaBlockNames projects [declaredSchemaBlocks] onto the labels the dropped
+// body scope binds.
+func schemaBlockNames(blocks []SchemaBlock) []string {
+	names := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		names = append(names, block.Name)
 	}
 	return names
 }

--- a/internal/atlasmigrate/diff.go
+++ b/internal/atlasmigrate/diff.go
@@ -22,6 +22,7 @@ import (
 	"go.5x5.cz/ptah/internal/migrationreplay"
 	"go.5x5.cz/ptah/internal/migrationsnapshot"
 	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/internal/schemafile"
 	"go.5x5.cz/ptah/internal/schemascope"
 	"go.5x5.cz/ptah/migration/migrator"
 	"go.5x5.cz/ptah/migration/planner"
@@ -403,12 +404,17 @@ func resolveDesiredState(
 	if err := opts.Desired.EnsureDevIsolation(devURL); err != nil {
 		return atlassource.State{}, err
 	}
+	// `migrate diff` has no target URL, so --dev-url is the only URL that can
+	// limit the run to one schema.
+	schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(devURL, "", "")
 	state, err := opts.Desired.Resolve(ctx, atlassource.ResolveOptions{
-		Dialect:        conn.Info().Dialect,
-		DialectFlag:    "--dev-url",
-		DevURL:         devURL,
-		ConnectTimeout: opts.SourceConnectTimeout,
-		DevLockHeld:    true,
+		Dialect:         conn.Info().Dialect,
+		DialectFlag:     "--dev-url",
+		DevURL:          devURL,
+		SchemaScope:     schemaScope,
+		SchemaScopeFlag: schemaScopeFlag,
+		ConnectTimeout:  opts.SourceConnectTimeout,
+		DevLockHeld:     true,
 		// `migrate diff` is registered on the Atlas-compatible command tree
 		// only, so this surface always reads files written for another tool.
 		IgnoreUnknownHCLNames: true,

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -316,10 +316,15 @@ func loadDesiredApplySchema(
 	if opts.Desired != nil {
 		return opts.Desired, nil
 	}
+	// Both the dev database and the target can limit an apply to one schema, and
+	// the target's URL is the one this connection was opened from.
+	schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(opts.DevURL, conn.Info().URL, "url")
 	if opts.LocalFilesOnly {
 		return schemafile.LoadAll(opts.ToURLs, schemafile.Options{
 			Dialect:               conn.Info().Dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			SchemaScope:           schemaScope,
+			SchemaScopeFlag:       schemaScopeFlag,
 			Vars:                  opts.Vars,
 		})
 	}
@@ -331,6 +336,8 @@ func loadDesiredApplySchema(
 		Dialect:               conn.Info().Dialect,
 		DialectFlag:           "--url",
 		DevURL:                opts.DevURL,
+		SchemaScope:           schemaScope,
+		SchemaScopeFlag:       schemaScopeFlag,
 		IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
 		Vars:                  opts.Vars,
 	})

--- a/internal/atlasschema/diff.go
+++ b/internal/atlasschema/diff.go
@@ -75,10 +75,15 @@ func Diff(ctx context.Context, opts DiffOptions) (atlasreport.SchemaDiff, error)
 		return atlasreport.SchemaDiff{}, fmt.Errorf("--dev-url is required for local schema file diffing")
 	}
 
+	// Both sides are desired states here, so --dev-url is the only URL that can
+	// limit the run to one schema.
+	schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(opts.DevURL, "", "")
 	resolveOpts := atlassource.ResolveOptions{
-		Dialect:     dialect,
-		DialectFlag: dialectFlag,
-		DevURL:      opts.DevURL,
+		Dialect:         dialect,
+		DialectFlag:     dialectFlag,
+		DevURL:          opts.DevURL,
+		SchemaScope:     schemaScope,
+		SchemaScopeFlag: schemaScopeFlag,
 		// Both sides introspect exactly the schemas --schema asked for. Without
 		// this the read is scoped to the connection default and the scope
 		// projection below filters a universe that never contained the

--- a/internal/atlasschema/inspect_source.go
+++ b/internal/atlasschema/inspect_source.go
@@ -133,9 +133,14 @@ func inspectOnDev(
 	var desired *goschema.Database
 	switch set.Kind {
 	case atlassource.KindLocalFile:
+		// The source URL is the file itself, so --dev-url is the only URL that
+		// can limit this run to a schema.
+		schemaScope, schemaScopeFlag := schemafile.ScopeFromURLs(devURL, "", "")
 		desired, err = schemafile.LoadAll(sourceRawURLs(set), schemafile.Options{
 			Dialect:               dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			SchemaScope:           schemaScope,
+			SchemaScopeFlag:       schemaScopeFlag,
 			Vars:                  opts.Vars,
 		})
 		if err != nil {

--- a/internal/atlassource/resolve.go
+++ b/internal/atlassource/resolve.go
@@ -43,6 +43,13 @@ type ResolveOptions struct {
 	// DevURL is the dev database URL used to replay migration-directory
 	// sources.
 	DevURL string
+	// SchemaScope and SchemaScopeFlag limit an HCL desired state to one schema;
+	// see [go.5x5.cz/ptah/internal/schemafile.Options]. They are passed in
+	// rather than derived from DevURL here because a verb with a target URL --
+	// `schema apply` -- is limited by either one, and the caller is the only
+	// layer that knows which flags it has.
+	SchemaScope     string
+	SchemaScopeFlag string
 	// ConnectTimeout bounds opening a database-backed source and reading its
 	// initial connection metadata. A zero value leaves the caller's context
 	// deadline unchanged.
@@ -99,6 +106,8 @@ func (s Set) Resolve(ctx context.Context, opts ResolveOptions) (State, error) {
 		schema, err := schemafile.LoadAll(s.rawURLs(), schemafile.Options{
 			Dialect:               opts.Dialect,
 			IgnoreUnknownHCLNames: opts.IgnoreUnknownHCLNames,
+			SchemaScope:           opts.SchemaScope,
+			SchemaScopeFlag:       opts.SchemaScopeFlag,
 			Vars:                  opts.Vars,
 		})
 		if err != nil {

--- a/internal/schemafile/schema_scope_test.go
+++ b/internal/schemafile/schema_scope_test.go
@@ -1,0 +1,249 @@
+package schemafile_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/core/goschema"
+	"go.5x5.cz/ptah/internal/schemafile"
+)
+
+const (
+	oneSchemaHCL = `schema "main" {}
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+	twoSchemasHCL = `schema "main" {}
+schema "other" {}
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+	sameSchemaTwiceHCL = `schema "main" {}
+schema "main" {}
+table "users" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+	postsHCL = `schema "main" {}
+table "posts" {
+  schema = schema.main
+  column "id" {
+    type = int
+  }
+}
+`
+)
+
+// TestLoadRefusesMoreSchemasThanTheRunCanReach is the regression test for a
+// document whose extra schemas were silently dropped.
+//
+// Every row is one measurement against the pinned Atlas community binary
+// v1.3.0, not a restatement of this implementation. The command was
+// `schema inspect -u file://<source> --dev-url <url>`, exit codes read from
+// unpiped invocations, with a throwaway PostgreSQL 17.10 database recreated
+// between runs:
+//
+//	two schema blocks, --dev-url sqlite://dv?mode=memory      exit 1
+//	two schema blocks, --dev-url postgres://…?search_path=…   exit 1
+//	two schema blocks, --dev-url postgres://…  (no search_path) exit 0
+//	`schema "main"` twice, --dev-url sqlite://dv?mode=memory   exit 1
+//	a directory of two files that each open with `schema "main"`,
+//	  --dev-url sqlite://dv?mode=memory                        exit 1
+//
+// Ptah exited 0 on all of the refusing ones, describing only the schema the URL
+// reached: `schema diff --from one.hcl --to two-schemas.hcl` answered "Schemas
+// are synced, no changes to be made" and `migrate diff` wrote a migration file
+// covering half the document.
+//
+// The last two rows carry the model. Counting DISTINCT SCHEMA NAMES instead of
+// BLOCKS passes every other row and exits 0 on both of them, where that binary
+// exits 1 -- and the directory row is the layout a per-file count also gets
+// wrong, since each file there declares exactly one.
+func TestLoadRefusesMoreSchemasThanTheRunCanReach(t *testing.T) {
+	tests := []struct {
+		name   string
+		files  map[string]string
+		opts   schemafile.Options
+		assert func(c *qt.C, db *goschema.Database, err error)
+	}{
+		{
+			name:  "two schemas under a limited run refuse and name both blocks",
+			files: map[string]string{"schema.hcl": twoSchemasHCL},
+			opts:  schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.ErrorMatches,
+					`cannot use HCL with more than 1 schema when dev-url is limited to schema "main": `+
+						`2 top-level schema blocks are declared: "main" at .*schema\.hcl:1, "other" at .*schema\.hcl:2`)
+				c.Assert(db, qt.IsNil)
+			},
+		},
+		{
+			name:  "the same schema declared twice is two blocks and refuses",
+			files: map[string]string{"schema.hcl": sameSchemaTwiceHCL},
+			opts:  schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.ErrorMatches,
+					`cannot use HCL with more than 1 schema when dev-url is limited to schema "main": `+
+						`2 top-level schema blocks are declared: "main" at .*, "main" at .*`)
+			},
+		},
+		{
+			name: "a directory whose files each open with a schema block refuses",
+			files: map[string]string{
+				"a.hcl": oneSchemaHCL,
+				"b.hcl": postsHCL,
+			},
+			opts: schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.ErrorMatches,
+					`cannot use HCL with more than 1 schema when dev-url is limited to schema "main": `+
+						`2 top-level schema blocks are declared: "main" at .*a\.hcl:1, "main" at .*b\.hcl:1`)
+			},
+		},
+		{
+			name:  "the flag the run was limited by is the one quoted",
+			files: map[string]string{"schema.hcl": twoSchemasHCL},
+			opts:  schemafile.Options{Dialect: "sqlite", SchemaScope: "public", SchemaScopeFlag: "url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.ErrorMatches,
+					`cannot use HCL with more than 1 schema when url is limited to schema "public": .*`)
+			},
+		},
+		{
+			name:  "two schemas on a realm-scoped run load both",
+			files: map[string]string{"schema.hcl": twoSchemasHCL},
+			opts:  schemafile.Options{Dialect: "sqlite"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(schemaNames(db), qt.DeepEquals, []string{"main", "other"})
+			},
+		},
+		{
+			name:  "one schema under a limited run loads",
+			files: map[string]string{"schema.hcl": oneSchemaHCL},
+			opts:  schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(tableNames(db), qt.DeepEquals, []string{"users"})
+			},
+		},
+		{
+			name:  "a document with no schema block at all loads under a limited run",
+			files: map[string]string{"schema.hcl": postsHCL[len("schema \"main\" {}\n"):]},
+			opts:  schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(tableNames(db), qt.DeepEquals, []string{"posts"})
+			},
+		},
+		{
+			name: "a SQL directory is unaffected by the gate",
+			files: map[string]string{
+				"1_a.sql": "CREATE TABLE users (id INTEGER PRIMARY KEY);\n",
+				"2_b.sql": "CREATE TABLE posts (id INTEGER PRIMARY KEY);\n",
+			},
+			opts: schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"},
+			assert: func(c *qt.C, db *goschema.Database, err error) {
+				c.Assert(err, qt.IsNil)
+				c.Assert(tableNames(db), qt.Contains, "users")
+				c.Assert(tableNames(db), qt.Contains, "posts")
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := writeSchemaDir(c, test.files)
+
+			db, err := schemafile.LoadPath(dir, test.opts)
+
+			test.assert(c, db, err)
+		})
+	}
+}
+
+// TestLoadAllCountsSchemaBlocksAcrossEveryURL pins that several --to files are
+// one desired state for the gate.
+//
+// It is a separate test because it goes through LoadAll rather than LoadPath:
+// `schema apply --to a.hcl --to b.hcl` reaches the loader once per URL, and a
+// gate that ran per URL would count one block twice instead of two blocks once.
+func TestLoadAllCountsSchemaBlocksAcrossEveryURL(t *testing.T) {
+	c := qt.New(t)
+	dir := writeSchemaDir(c, map[string]string{"a.hcl": oneSchemaHCL, "b.hcl": postsHCL})
+
+	limited := schemafile.Options{Dialect: "sqlite", SchemaScope: "main", SchemaScopeFlag: "dev-url"}
+	_, err := schemafile.LoadAll([]string{dir + "/a.hcl", dir + "/b.hcl"}, limited)
+	c.Assert(err, qt.ErrorMatches,
+		`cannot use HCL with more than 1 schema when dev-url is limited to schema "main": `+
+			`2 top-level schema blocks are declared: "main" at .*a\.hcl:1, "main" at .*b\.hcl:1`)
+
+	db, err := schemafile.LoadAll([]string{dir + "/a.hcl"}, limited)
+	c.Assert(err, qt.IsNil)
+	c.Assert(tableNames(db), qt.DeepEquals, []string{"users"})
+}
+
+// TestScopeFromURLsPrefersTheDevURL pins the precedence and the flag spelling
+// against the pinned community binary's own diagnostic. Measured on PostgreSQL
+// 17.10, `schema apply --to <two-schema file>` with one throwaway database per
+// side:
+//
+//	--url realm, --dev-url ?search_path=public   "…when dev-url is limited to schema \"public\""
+//	--url ?search_path=public, --dev-url realm   "…when url is limited to schema \"public\""
+//
+// A derivation that consulted the target first would report `url` for the first
+// row, which is a different sentence than the one a script may match on.
+func TestScopeFromURLsPrefersTheDevURL(t *testing.T) {
+	const (
+		realm  = "postgres://localhost:5432/db?sslmode=disable"
+		scoped = "postgres://localhost:5432/db?sslmode=disable&search_path=public"
+	)
+
+	tests := []struct {
+		name       string
+		devURL     string
+		targetURL  string
+		targetFlag string
+		scope      string
+		flag       string
+	}{
+		{name: "both limited reports the dev url", devURL: scoped, targetURL: scoped, targetFlag: "url", scope: "public", flag: "dev-url"},
+		{name: "only the dev url is limited", devURL: scoped, targetURL: realm, targetFlag: "url", scope: "public", flag: "dev-url"},
+		{name: "only the target is limited", devURL: realm, targetURL: scoped, targetFlag: "url", scope: "public", flag: "url"},
+		{name: "the target flag is the caller's", devURL: realm, targetURL: scoped, targetFlag: "from", scope: "public", flag: "from"},
+		{name: "neither is limited", devURL: realm, targetURL: realm, targetFlag: "url", scope: "", flag: ""},
+		{name: "no target url to consult", devURL: realm, targetURL: "", targetFlag: "", scope: "", flag: ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			scope, flag := schemafile.ScopeFromURLs(test.devURL, test.targetURL, test.targetFlag)
+
+			c.Assert(scope, qt.Equals, test.scope)
+			c.Assert(flag, qt.Equals, test.flag)
+		})
+	}
+}
+
+func schemaNames(db *goschema.Database) []string {
+	names := make([]string, 0, len(db.Schemas))
+	for _, schema := range db.Schemas {
+		names = append(names, schema.Name)
+	}
+	return names
+}

--- a/internal/schemafile/schemafile.go
+++ b/internal/schemafile/schemafile.go
@@ -19,6 +19,7 @@ import (
 	"go.5x5.cz/ptah/internal/convert/toschema"
 	"go.5x5.cz/ptah/internal/parser"
 	"go.5x5.cz/ptah/internal/pathguard"
+	"go.5x5.cz/ptah/internal/schemaselection"
 	"go.5x5.cz/ptah/internal/tableref"
 	"go.5x5.cz/ptah/internal/yamlschema"
 )
@@ -55,6 +56,129 @@ type Options struct {
 	// Other schema file formats ignore it: YAML and SQL have no variables, and
 	// silently accepting a value for one there would suggest they do.
 	Vars []string
+
+	// SchemaScope names the one schema this run is limited to. Empty means the
+	// run is realm-scoped and every schema the source declares is reachable.
+	//
+	// When it is set, an HCL desired state declaring more than one top-level
+	// `schema` block is REFUSED. Ptah otherwise loaded such a document, narrowed
+	// it to the scope and reported success, so `schema diff --from one.hcl --to
+	// two-schemas.hcl` answered "Schemas are synced" and `migrate diff` wrote a
+	// migration covering half the document -- silently, at exit 0. The pinned
+	// Atlas community binary v1.3.0 refuses the same run with `cannot use HCL
+	// with more than 1 schema when <flag> is limited to schema %q`.
+	//
+	// Like [Options.IgnoreUnknownHCLNames] the split is by COMMAND TREE: it is
+	// set only by cmd/atlas and the Atlas-compatible packages beneath it, where
+	// the behavior was measured against that binary. The native `ptah schema`
+	// commands leave it empty and keep narrowing, which is a separate defect
+	// with its own issue rather than something this loader may decide for them.
+	//
+	// Use [ScopeFromURLs] to derive it, so every caller picks the same flag.
+	SchemaScope string
+
+	// SchemaScopeFlag names the flag that limited the run, spelled the way the
+	// community binary's own message spells it -- `dev-url`, `url`, with no
+	// leading dashes -- so the leading sentence stays byte-identical to the one
+	// a script may be matching on. Ignored when SchemaScope is empty.
+	SchemaScopeFlag string
+
+	// collect gathers the top-level `schema` blocks of every HCL file one load
+	// reached, so the [Options.SchemaScope] gate counts the whole desired state
+	// -- a directory of HCL files, or several --to files -- rather than one file
+	// at a time. It is unexported because only the entry points below may own
+	// it: a caller-supplied collector would make the gate run twice for a
+	// directory, once per entry and once for the whole.
+	collect *schemaBlockCollector
+}
+
+// schemaBlockCollector accumulates the top-level `schema` blocks of one load.
+type schemaBlockCollector struct {
+	blocks []atlashcl.SchemaBlock
+}
+
+func (c *schemaBlockCollector) record(block atlashcl.SchemaBlock) {
+	c.blocks = append(c.blocks, block)
+}
+
+// recordSchemaBlock is the recorder handed to the HCL parser, nil when no entry
+// point owns a collector (which is every caller that left SchemaScope empty as
+// well as the nested loads of a directory's entries).
+func (o Options) recordSchemaBlock() func(atlashcl.SchemaBlock) {
+	if o.collect == nil {
+		return nil
+	}
+	return o.collect.record
+}
+
+// ScopeFromURLs picks the schema an Atlas-compatible run is limited to, and
+// names the flag that limited it.
+//
+// The dev URL is consulted before the target because that is the order the
+// pinned Atlas community binary v1.3.0 reports. Measured on PostgreSQL 17.10
+// with a two-schema HCL desired state, one throwaway database per side:
+//
+//	--url realm  --dev-url ?search_path=public  ->  "…when dev-url is limited to schema \"public\""
+//	--url ?search_path=public  --dev-url realm  ->  "…when url is limited to schema \"public\""
+//
+// so a run with both limited reports dev-url, which is what `schema apply` on
+// two SQLite URLs prints.
+//
+// An empty targetURL is the shape `schema inspect` and `migrate diff` have:
+// there is no second URL to consult. targetFlag is the flag that URL came from,
+// spelled without leading dashes to match the binary's message, so
+// `schema plan validate` reports `from` rather than a flag it does not have.
+func ScopeFromURLs(devURL, targetURL, targetFlag string) (scope, flag string) {
+	if selected, limited := schemaselection.URLScope(devURL); limited {
+		return selected, "dev-url"
+	}
+	if selected, limited := schemaselection.URLScope(targetURL); limited {
+		return selected, targetFlag
+	}
+	return "", ""
+}
+
+// gateSchemaScope runs one load with a collector attached and applies the
+// [Options.SchemaScope] gate to everything it reached.
+//
+// A nested load -- a directory entry, or one of several --to files -- finds the
+// collector already set and just contributes to it, so the count is the desired
+// state's and the refusal is reported once.
+func gateSchemaScope(opts Options, load func(Options) (*goschema.Database, error)) (*goschema.Database, error) {
+	if opts.collect != nil {
+		return load(opts)
+	}
+	inner := opts
+	inner.collect = &schemaBlockCollector{}
+	db, err := load(inner)
+	if err != nil {
+		return nil, err
+	}
+	if err := opts.checkSchemaScope(inner.collect.blocks); err != nil {
+		return nil, err
+	}
+	return db, nil
+}
+
+// checkSchemaScope refuses a desired state that declares more schemas than the
+// run can reach.
+//
+// The leading sentence is the community binary's, kept so a script matching on
+// it keeps working. What follows is Ptah going past it: that binary names
+// neither the file nor the blocks, which leaves an operator holding a generated
+// document with nothing to grep for.
+func (o Options) checkSchemaScope(blocks []atlashcl.SchemaBlock) error {
+	if o.SchemaScope == "" || len(blocks) <= 1 {
+		return nil
+	}
+	declared := make([]string, 0, len(blocks))
+	for _, block := range blocks {
+		declared = append(declared, fmt.Sprintf("%q at %s:%d", block.Name, block.Filename, block.Line))
+	}
+	return fmt.Errorf(
+		"cannot use HCL with more than 1 schema when %s is limited to schema %q: %d top-level schema blocks are declared: %s",
+		o.SchemaScopeFlag, o.SchemaScope, len(blocks), strings.Join(declared, ", "),
+	)
 }
 
 // Load reads one local schema file from either a plain path or file:// URL.
@@ -69,14 +193,16 @@ func Load(rawURL string, opts Options) (*goschema.Database, error) {
 // LoadPath reads one local schema source from a resolved filesystem path: a
 // single schema file, or a directory of schema files (see [loadSchemaDir]).
 func LoadPath(path string, opts Options) (*goschema.Database, error) {
-	resolved, isDir, err := statSchemaPath(path)
-	if err != nil {
-		return nil, err
-	}
-	if isDir {
-		return loadSchemaDir(resolved, opts)
-	}
-	return loadSchemaFile(resolved, opts)
+	return gateSchemaScope(opts, func(opts Options) (*goschema.Database, error) {
+		resolved, isDir, err := statSchemaPath(path)
+		if err != nil {
+			return nil, err
+		}
+		if isDir {
+			return loadSchemaDir(resolved, opts)
+		}
+		return loadSchemaFile(resolved, opts)
+	})
 }
 
 // loadSchemaDirEntry reads one entry of a schema directory, together with the
@@ -131,6 +257,7 @@ func loadSchemaFile(resolved string, opts Options) (*goschema.Database, error) {
 	case ".hcl":
 		return atlashcl.ParseFileWithOptions(resolved, atlashcl.Options{
 			IgnoreUnknownNames: opts.IgnoreUnknownHCLNames,
+			RecordSchemaBlock:  opts.recordSchemaBlock(),
 			Vars:               opts.Vars,
 		})
 	case ".yaml", ".yml":
@@ -254,16 +381,18 @@ func LoadAll(rawURLs []string, opts Options) (*goschema.Database, error) {
 		return nil, fmt.Errorf("at least one schema file URL is required")
 	}
 
-	merged := &goschema.Database{}
-	for _, rawURL := range rawURLs {
-		db, err := Load(rawURL, opts)
-		if err != nil {
-			return nil, err
+	return gateSchemaScope(opts, func(opts Options) (*goschema.Database, error) {
+		merged := &goschema.Database{}
+		for _, rawURL := range rawURLs {
+			db, err := Load(rawURL, opts)
+			if err != nil {
+				return nil, err
+			}
+			appendDatabase(merged, db)
 		}
-		appendDatabase(merged, db)
-	}
-	goschema.Finalize(merged)
-	return merged, nil
+		goschema.Finalize(merged)
+		return merged, nil
+	})
 }
 
 // ToDBSchema converts Ptah's desired-schema IR into the DB schema shape used by

--- a/internal/schemafile/schemafile.go
+++ b/internal/schemafile/schemafile.go
@@ -68,11 +68,20 @@ type Options struct {
 	// Atlas community binary v1.3.0 refuses the same run with `cannot use HCL
 	// with more than 1 schema when <flag> is limited to schema %q`.
 	//
-	// Like [Options.IgnoreUnknownHCLNames] the split is by COMMAND TREE: it is
-	// set only by cmd/atlas and the Atlas-compatible packages beneath it, where
-	// the behavior was measured against that binary. The native `ptah schema`
-	// commands leave it empty and keep narrowing, which is a separate defect
-	// with its own issue rather than something this loader may decide for them.
+	// Unlike [Options.IgnoreUnknownHCLNames] this is NOT split by command tree.
+	// Every caller that knows the URLs its run is scoped by sets it, and the
+	// native `ptah schema inspect` and `ptah schema diff` reach this loader
+	// through the same shared packages, so they gate too. Measured with the
+	// derivation removed and put back, `ptah schema inspect --schema-file
+	// two-schemas.hcl --dev-url sqlite://dv?mode=memory` went from exit 0
+	// describing one schema to exit 2 naming both blocks.
+	//
+	// That is deliberate rather than an accident of sharing. Narrowing a desired
+	// state to the scope and reporting success is a wrong answer on any surface,
+	// and the escape hatch is the run's own URL: a realm-scoped one describes
+	// every schema the document declares. Callers with no URL to derive from --
+	// a Go-annotation desired state, cmd/internal/schemaload, `ptah schema
+	// test` -- leave it empty and are unaffected.
 	//
 	// Use [ScopeFromURLs] to derive it, so every caller picks the same flag.
 	SchemaScope string

--- a/internal/schemaselection/schemaselection.go
+++ b/internal/schemaselection/schemaselection.go
@@ -169,6 +169,76 @@ func Realm(dialect, rawURL, connectedSchema string) bool {
 	}
 }
 
+// sqliteDefaultSchema is the only schema a SQLite connection has. It is spelled
+// here rather than imported from the identifier semantics because this package
+// needs the NAME a diagnostic prints, not the comparison rules that type
+// carries, and importing those would pull the identifier layer under every
+// caller of a URL question.
+const sqliteDefaultSchema = "main"
+
+// URLScope reports the one schema a database URL limits a run to, and whether it
+// limits it at all.
+//
+// It answers [Realm]'s question from the URL ALONE, which is the point: the
+// caller that needs it has not connected yet. The pinned Atlas community binary
+// v1.3.0 refuses an HCL desired state that declares more than one schema against
+// a schema-limited URL, and Ptah has to refuse it before the dev database is
+// reset -- destroying that database over a document the run was never going to
+// read is worse than the divergence being fixed. Measured with
+// `schema inspect -u file://two-schema-blocks.hcl`:
+//
+//	--dev-url sqlite://dv?mode=memory              exit 1, limited to "main"
+//	--dev-url postgres://…/db?search_path=public   exit 1, limited to "public"
+//	--dev-url mysql://…/wf823_dev                  exit 1, limited to "wf823_dev"
+//	--dev-url postgres://…/db                      exit 0, not limited
+//
+// PostgreSQL-family URLs defer to [FromURL], so this and [Realm] cannot disagree
+// there. A dialect whose boundary nobody has measured limits nothing, which
+// keeps this from refusing a run the comparison tool accepts.
+func URLScope(rawURL string) (scope string, limited bool) {
+	rawURL = strings.TrimSpace(rawURL)
+	if rawURL == "" {
+		return "", false
+	}
+	dialect, err := atlasurl.DialectFromURL(rawURL)
+	if err != nil {
+		return "", false
+	}
+	switch platform.NormalizeDialect(dialect) {
+	case platform.SQLite:
+		// SQLite has one namespace, so every SQLite URL is limited to it.
+		return sqliteDefaultSchema, true
+	case platform.Postgres, platform.CockroachDB, platform.YugabyteDB, platform.Spanner:
+		selected := FromURL(rawURL).Scope
+		return selected, selected != ""
+	case platform.MySQL, platform.MariaDB:
+		named := urlDatabaseName(rawURL)
+		return named, named != ""
+	default:
+		return "", false
+	}
+}
+
+// urlDatabaseName reads the database a MySQL-family URL names, which is the same
+// thing as its schema there.
+//
+// It cuts the string rather than going through [net/url.Parse] because the
+// driver's own `tcp(host:port)` spelling is not a parseable URL host, and a
+// parse failure would answer "no database" for a URL that names one -- the
+// looser direction.
+func urlDatabaseName(rawURL string) string {
+	_, afterScheme, ok := strings.Cut(rawURL, "://")
+	if !ok {
+		return ""
+	}
+	_, path, ok := strings.Cut(afterScheme, "/")
+	if !ok {
+		return ""
+	}
+	path, _, _ = strings.Cut(path, "?")
+	return strings.TrimSpace(path)
+}
+
 // RowsQuerier is the part of *sql.DB and dbschema.DatabaseConnection
 // [RealmSchemas] needs.
 type RowsQuerier interface {

--- a/internal/schemaselection/url_scope_test.go
+++ b/internal/schemaselection/url_scope_test.go
@@ -1,0 +1,76 @@
+package schemaselection_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/schemaselection"
+)
+
+// TestURLScopeAnswersFromTheURLAlone pins which URLs limit a run to one schema.
+//
+// Each row that matters is a measurement against the pinned Atlas community
+// binary v1.3.0 with `schema inspect -u file://<two schema blocks>.hcl`, exit
+// codes read from unpiped invocations and a throwaway database per run:
+//
+//	--dev-url sqlite://dv?mode=memory                   exit 1, limited to "main"
+//	--dev-url postgres://…/db?search_path=public        exit 1, limited to "public"
+//	--dev-url mysql://…/wf823_dev                       exit 1, limited to "wf823_dev"
+//	--dev-url postgres://…/db (no search_path)          exit 0
+//
+// The PostgreSQL realm row is the one that decides whether the gate above is
+// usable at all: an implementation that read the DATABASE name there -- which
+// is what the MySQL row does -- would call every PostgreSQL URL limited and
+// refuse the realm-scoped multi-schema document that binary loads at exit 0.
+//
+// The comma row is not a search-path list to that binary but one schema NAME,
+// which it refuses outright (`schema "public,app" was not found`), so nothing
+// is limited here and the whole document stays under review.
+func TestURLScopeAnswersFromTheURLAlone(t *testing.T) {
+	tests := []struct {
+		name    string
+		url     string
+		scope   string
+		limited bool
+	}{
+		{name: "sqlite is always one namespace", url: "sqlite://dv?mode=memory", scope: "main", limited: true},
+		{name: "sqlite file", url: "sqlite://app.db", scope: "main", limited: true},
+		{
+			name:    "postgres with a single search_path",
+			url:     "postgres://localhost:5432/db?sslmode=disable&search_path=public",
+			scope:   "public",
+			limited: true,
+		},
+		{name: "postgres without a search_path", url: "postgres://localhost:5432/db?sslmode=disable", scope: "", limited: false},
+		{
+			name:    "postgres with a comma-carrying search_path limits nothing",
+			url:     "postgres://localhost:5432/db?sslmode=disable&search_path=public,app",
+			scope:   "",
+			limited: false,
+		},
+		{name: "mysql names its database", url: "mysql://localhost:3306/appdb", scope: "appdb", limited: true},
+		{name: "mysql with query parameters", url: "mysql://localhost:3306/appdb?parseTime=true", scope: "appdb", limited: true},
+		{name: "mysql with no database", url: "mysql://localhost:3306/", scope: "", limited: false},
+		{name: "mariadb names its database", url: "mariadb://localhost:3306/appdb", scope: "appdb", limited: true},
+		{
+			name:    "the mysql driver's tcp() host spelling still names its database",
+			url:     "mysql://root@tcp(localhost:3306)/appdb",
+			scope:   "appdb",
+			limited: true,
+		},
+		{name: "an empty url limits nothing", url: "", scope: "", limited: false},
+		{name: "an unparseable url limits nothing", url: "not a url", scope: "", limited: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+
+			scope, limited := schemaselection.URLScope(test.url)
+
+			c.Assert(scope, qt.Equals, test.scope)
+			c.Assert(limited, qt.Equals, test.limited)
+		})
+	}
+}


### PR DESCRIPTION
Closes one more cell of #1231 (`ptah-compat` exits 0 where the pinned Atlas community binary v1.3.0 exits 1), found while verifying #927 / #1355 and pre-existing on master.

## The defect, reproduced on master before anything was changed

`ptah-compat` built from `master` `7189e79e` into this worktree's own `bin/`. Exit codes read from unpiped invocations. Fixture: one `.hcl` file declaring `schema "main"`, `schema "other"` and a table.

```
$ ptah-compat schema inspect -u file://two_distinct.hcl --dev-url "sqlite://dv?mode=memory"
… renders schema "main" and table users; schema "other" is absent
PTAH_EXIT=0

$ atlas schema inspect -u file://two_distinct.hcl --dev-url "sqlite://dv?mode=memory"
Error: cannot use HCL with more than 1 schema when dev-url is limited to schema "main"
ATLAS_EXIT=1
```

The same divergence on the other three verbs, same fixture:

```
$ ptah-compat schema apply -u sqlite://app.db --to file://two_distinct.hcl \
      --dev-url "sqlite://dv?mode=memory" --auto-approve
Planned schema changes:
CREATE TABLE "main"."users" (…);
Schema apply completed successfully.
PTAH_EXIT=0                       ATLAS_EXIT=1, same message

$ ptah-compat schema diff --from file://one.hcl --to file://two_distinct.hcl \
      --dev-url "sqlite://dv?mode=memory"
Schemas are synced, no changes to be made
PTAH_EXIT=0                       ATLAS_EXIT=1, same message

$ ptah-compat migrate diff init --dir file://mig2 --to file://two_distinct.hcl \
      --dev-url "sqlite://dv?mode=memory"
Created migration file: …/mig2/20260809072535_init.sql
Updated migration checksum: …/mig2/atlas.sum
PTAH_EXIT=0                       ATLAS_EXIT=1, same message
```

`schema diff` reported "Schemas are synced" for a document declaring a schema the other side never had, and `migrate diff` wrote a durable migration file covering half the document. Both silent, both exit 0.

Same on PostgreSQL 17.10 with `?search_path=public` on `--dev-url` (throwaway database dropped and recreated per run): `atlas` exit 1, `ptah-compat` exit 0 rendering only `public`, with `other` and its table gone and no diagnostic.

## Why that binary refuses, and whether Ptah should

Its message names the cause: the run is *limited to one schema*, and the document describes more than one. A plan computed from a desired state the run cannot represent is a plan for a schema nobody asked for. Ptah's behavior was strictly worse than the refusal — it narrowed the document and called it success.

So this is rule (a) and rule (b) pointing the same way, and the refusal is adopted rather than reproduced grudgingly. What Ptah adds past the binary: the message names the file and every block counted.

```
Error: cannot use HCL with more than 1 schema when dev-url is limited to schema "main":
2 top-level schema blocks are declared: "main" at …/two_distinct.hcl:1, "other" at …/two_distinct.hcl:4
```

The leading sentence up to the first colon is byte-identical to the binary's, so a script matching on it keeps working.

## When a run is limited, measured

`schema inspect -u file://<two schema blocks>.hcl`, one throwaway database per run:

| `--dev-url` | pinned binary |
| --- | --- |
| `sqlite://dv?mode=memory` | exit 1, limited to `main` |
| `postgres://…/db?sslmode=disable&search_path=public` | exit 1, limited to `public` |
| `mysql://…/wf823_dev` | exit 1, limited to `wf823_dev` |
| `postgres://…/db` (no `search_path`) | **exit 0** |

Both the dev URL and the target `--url` limit a run, and the binary names which. Measured on PostgreSQL 17.10, `schema apply --to <two-schema file>`, one throwaway database per side:

```
--url realm,           --dev-url ?search_path=public  ->  "…when dev-url is limited to schema \"public\""
--url ?search_path=public, --dev-url realm           ->  "…when url is limited to schema \"public\""
```

`--dev-url` is therefore consulted first, which is also what a two-SQLite-URL apply prints. `schemafile.ScopeFromURLs` implements exactly that order, and a unit row pins each of the four combinations.

## The count is of BLOCKS

`goschema.Finalize` deduplicates schemas by name, so `schema "main" {}` twice is one schema in the IR. That binary counts two and refuses it identically:

```
$ atlas schema inspect -u file://two_same_label.hcl --dev-url "sqlite://dv?mode=memory"
Error: cannot use HCL with more than 1 schema when dev-url is limited to schema "main"
ATLAS_EXIT=1
```

A directory whose files each open with the schema block is the same shape, and it is the layout that matters in practice — one HCL file per table, every file repeating `schema "main" {}`:

```
$ atlas      schema inspect -u file://dir --dev-url "sqlite://dv?mode=memory"   -> exit 1
$ ptah-compat schema inspect -u file://dir --dev-url "sqlite://dv?mode=memory"  -> exit 1 (this branch),
    naming "main" at dir/a.hcl:1 and "main" at dir/b.hcl:1
```

That is why `atlashcl` gained `Options.RecordSchemaBlock` rather than the loader reading `len(db.Schemas)`: an implementation counting distinct names passes every other case and exits 0 on both of these.

## Which surfaces this reaches

Not compat-only. `internal/atlasschema` is shared with `cmd/schema`, so the native `ptah schema inspect` and `ptah schema diff` gate too, and that is deliberate: narrowing a desired state and reporting success is a wrong answer on any surface, and the escape hatch is the run's own URL. Measured by removing the derivation in `inspect_source.go` and putting it back:

```
$ ptah schema inspect --schema-file two_distinct.hcl --dev-url "sqlite://dv?mode=memory"
without the gate:  exit 0, renders schema "main" only
with the gate:     exit 2, names both blocks
```

Callers with no URL to be scoped by — a Go-annotation desired state, `cmd/internal/schemaload`, `ptah schema test` — leave the scope empty and are unaffected. Native `ptah schema apply` supplies a pre-loaded desired state and does not reach the loader here.

## Second, smaller: the diagnostic named the wrong cause

A function call spelled as a whole attribute value must evaluate, because every value helper in `atlashcl` falls back to the attribute's source text otherwise — a call let through reaches the database as the literal `jsonencode(schema.main)`. So the refusal is right. The message was not:

```
$ ptah-compat schema inspect -u file://iter5.hcl --dev-url "sqlite://dv?mode=memory"
Error: parse HCL schema at …:5,22-28: unknown variable: There is no variable named "schema".
PTAH_EXIT=1
```

for a document whose second line is `schema "main" {}`, in a scope that binds `schema` (that is what #1355 added). It now says what happened:

```
Error: parse HCL schema at …:5,22-28: schema reference "schema" has no value to pass to
a function call: only var. and local. references are evaluated here
```

The exit code is unchanged in both directions. `jsonencode(schema.main)` is exit 0 on the pinned binary and exit 1 here — Ptah refusing what that binary accepts, the same asymmetry the closed dropped-body scope already takes. A control row keeps `schema.` resolving where it is read from source text, and an undeclared-root row keeps `unknown variable` for a name nothing binds.

## Sweep: is the hole open for other repeated top-level blocks

Every top-level block kind `parseTopLevelBlock` accepts, one fixture each declaring the object TWICE with identical bodies, `schema inspect -u file://<fixture>.hcl --dev-url <realm PostgreSQL 17.10>`, database dropped and recreated between every run.

| top-level block | pinned binary v1.3.0 | ptah-compat | reading |
| --- | --- | --- | --- |
| `schema`, realm-scoped run | 0 | 0 | agree |
| `schema`, schema-limited run | 1 | 0 → **1** | the cell this PR closes |
| `table` | 1 `create "users" table: pq: relation "users" already exists (42P07)` | 0, merged | **open**, filed as #1360 |
| `enum` | 1 `duplicate enum "mood"` | 0, merged | **open**, filed as #1360 |
| `sequence` | 1 `postgres: sequences are not supported by this version` | 1 `relation "order_seq" already exists (42P07)` | both refuse |
| `domain` | 1 `Unknown variable; … "text"` | 1 `type "email" already exists (42710)` | both refuse |
| `composite` | 1 `Unknown variable; … "text"` | 1 | both refuse |
| `range` | 1 `Unknown variable; … "float8"` | 1 | both refuse |
| `extension` | 1 `postgres: extensions are not supported by this version` | 0 | binary refuses the construct, not the repeat |
| `function` | 1 `Unknown variable; … "SQL"` | 0 | same |
| `trigger` | 1 `Unknown variable; … "ROW"` | 0 | same |
| `policy` | 1 `Unknown variable; … "SELECT"` | 0 | same |
| `permission` | 1 `Unknown variable; … "PUBLIC"` | 0 | same |
| `data` | 1 `data block "data" must have exactly 2 labels` | 0 | same |
| `view` | 0, block dropped from its own output | 0 | agree |
| `materialized` | 0, dropped | 0 | agree |
| `role` | 0, dropped | 0 | agree |
| `variable` | 0 | 0 | agree |
| `locals` | 0 | 0 | agree |
| `env` | 1 `cannot parse project file "env.hcl" as a schema file` | 1, same sentence | agree |
| an unmodeled block (`procedure`) | 0 | 0 | agree |

The shape is not "some kinds are checked". `goschema.Deduplicate` folds a redeclaration for exactly the kinds it covers — `schema`, `table`, `enum`, `extension`, `function` and the index/RLS families — and the kinds it does not cover (`sequence`, `domain`, `composite`, `range`, deduplicated only by `deduplicateComposite`, which `Finalize` does not call) render twice and are refused by the dev database. Two cells are therefore still open, both filed as #1360, together with a third from the same sweep recorded as a comment there: `--schema public` against a realm dev URL is exit 1 on that binary (`schema "other" … is not requested`) and exit 0 here — a membership rule rather than this count rule, and untouched by this PR.

Not fixed here because refusing a within-file redeclaration changes what merging means for every format and every source, including the directory ledger in `internal/schemafile/schemadir_order.go` that already refuses redeclaration across files but not within one.

## Live PostgreSQL 17.10

Rendered is not applied, so the legitimate path was executed and the catalog read back.

```
realm-scoped apply of the two-schema document          exit 0
  information_schema.tables  ->  other.audit, public.users
re-apply                                               exit 0, "Schema is synced, no changes to be made"

schema-limited apply (--url ?search_path=public) of the same document   exit 1
  user tables in the target                            0
  schemata named 'other'                               0
```

The refused apply left the target untouched.

## Red/green with a cheaper-wrong mutant

Five mutants, each a plausible cheaper implementation rather than a deletion, each observed red and restored green.

| mutant | test that went red |
| --- | --- |
| `declaredSchemaBlocks` deduplicates by name | `RecordSchemaBlockReportsBlocksNotSchemas/one_name_declared_twice…` and `LoadRefusesMoreSchemasThanTheRunCanReach/the_same_schema_declared_twice…` |
| `gateSchemaScope` gates per file instead of per load | `LoadAllCountsSchemaBlocksAcrossEveryURL` |
| `ScopeFromURLs` consults the target before the dev URL | `ScopeFromURLsPrefersTheDevURL/both_limited_reports_the_dev_url` |
| `URLScope` reads the database name for PostgreSQL when no `search_path` is set (which is exactly right for MySQL) | `URLScopeAnswersFromTheURLAlone/postgres_without_a_search_path` plus 5 more rows |
| `declaresSchemaRoot` drops the "and the document declares one" half | `SchemaReferenceInAFunctionCallNamesTheRealCause/an_undeclared_schema_root…` |

## Gates

Run from the worktree root, exit codes read directly from unpiped commands, all `0`:

`go build ./...`, `go vet ./...`, `go vet -tags integration ./integration/...`, `go test ./... -count=1`, `go tool qtlint ./...`, `golangci-lint run ./...`, `scripts/check-test-style.sh`, `scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`, `scripts/check-public-api-released.sh`, and in `docs/site` after `npm ci`: `check:exit-codes`, `check:exit-codes:selftest`, `check:core-doc-links`, `check:page-health`, `check:links`, `check:links:selftest`, `check:redirects`, `check:redirects:selftest`, `check:style`, `check:style:selftest`, `check:limitations`, `check:limitations:selftest`, `check:responsive`, `check:responsive:selftest`, plus `npm run build`.

No package failed and none needed a rerun. The branch was created from `origin/master` `7189e79e` and `origin/master` had not moved when the gates were run, so no rebase was performed.

## What is not measured here

- MySQL: the `--dev-url mysql://…/<db>` cell is measured on the pinned binary only. The shared MySQL server this session had available refuses cleaning (`external trigger \`i931\`.\`row_trg\` may reference the cleanup realm`), so `ptah-compat` could not complete a run there; the MySQL half of `URLScope` is covered by unit rows, not by an end-to-end run.
- ClickHouse and Spanner limit nothing in `URLScope`, because their boundary was not measured against the pinned binary. Those runs keep the pre-existing behavior.
- MariaDB was not exercised.

## One uncommitted correction, and why

While writing this body I found that the `SchemaScope` doc comment on the pushed commit claims the gate is split by command tree the way `IgnoreUnknownHCLNames` is. That is wrong — the "Which surfaces this reaches" measurement above is the correction, and the corrected comment plus a matching paragraph in `docs/site/src/content/docs/reference/hcl-schema.md` is staged in the working tree. It could not be committed: commit signing needs a passphrase prompt and this session has no terminal (`gpg: signing failed: Inappropriate ioctl for device`), and the earlier commit only succeeded because the agent still had the passphrase cached. Both files pass every gate with the correction applied. It needs one signed commit from a session that can sign.