### PR TITLE
Refuse an invalid value for every boolean PTAH_* variable (#1334)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,6 +50,39 @@ The shape that satisfies both:
 "CE refuses it, so we stopped emitting it" is an incomplete answer. The complete
 one names where the capability still lives.
 
+### Boolean `PTAH_*` environment variables are strict
+
+Absence selects the documented default; a present value must parse as a boolean
+or the owning command refuses before doing work. **Never convert a boolean
+environment parse error into the default value.**
+
+The four states are distinguishable and stay that way. `os.Getenv` answers the
+empty string for an absent variable and for `PTAH_X=` alike, which is how a typo
+in a CI environment file, a container manifest or a systemd unit became a silent
+default; use `os.LookupEnv`, and treat an exported empty value as the
+configuration error it is.
+
+In practice that means: declare the variable once with
+`envbool.New(name, defaultValue)` in the package that owns it, resolve it through
+`Var.Resolve`, and never write `strconv.ParseBool(os.Getenv(...))` at a feature
+call site. `internal/envbool` holds the one grammar (exactly
+`strconv.ParseBool`'s spellings, nothing trimmed) and the one error shape
+(`invalid boolean value %q for %s`); `cmd/internal/envboolguard` refuses a new
+tree that reintroduces the pattern.
+
+Resolve the variables a command owns **before** its early returns. A malformed
+value must not stay dormant because this invocation did not reach the branch
+where the value would have mattered -- that branch is the one the operator
+already knows they changed, and the runs that never reach it are the whole of a
+healthy pipeline. Validate on every invocation of the command or subsystem that
+recognizes the variable, and on no others: an invalid PostgreSQL-inspection
+variable must not break an unrelated SQLite command.
+
+Every boolean `PTAH_*` variable today opts IN to the more permissive side, so a
+typo lands on the strict default and fails closed. If one ever defaults to the
+permissive side, a typo on it fails OPEN and this stops being a usability rule.
+Do not add one.
+
 ### Compatibility with older Ptah is a different axis, and it is not owed
 
 Everything above is about the community binary. Compatibility with **Ptah's own

--- a/cmd/atlas/compat_overstrict_test.go
+++ b/cmd/atlas/compat_overstrict_test.go
@@ -601,10 +601,15 @@ func TestCompatMigrateLintScopeOptIn(t *testing.T) {
 	c.Assert(out.String(), qt.Contains, "-- 1 version ok")
 }
 
-// TestCompatMigrateLintScopeOptInIgnoresNonBoolean keeps the opt-in from being
-// a check that anything at all disables. Unset, empty, false and unparsable
-// values all keep the default refusal.
-func TestCompatMigrateLintScopeOptInIgnoresNonBoolean(t *testing.T) {
+// TestCompatMigrateLintScopeOptInRefusesANonBoolean keeps the opt-in from being
+// a check that anything at all disables, and from being one a typo disables in
+// silence.
+//
+// Before stokaro/ptah#1334 `yes please` produced `--latest or --git-base is
+// required`, which reads to the operator as "the opt-in does not cover this
+// run" rather than "the opt-in was never read". The refusal now names the
+// variable and the value the operator typed.
+func TestCompatMigrateLintScopeOptInRefusesANonBoolean(t *testing.T) {
 	c := qt.New(t)
 	root := t.TempDir()
 	t.Chdir(root)
@@ -623,7 +628,72 @@ func TestCompatMigrateLintScopeOptInIgnoresNonBoolean(t *testing.T) {
 
 	err := cmd.Execute()
 
-	c.Assert(err, qt.ErrorMatches, "--latest or --git-base is required", qt.Commentf("%s", out.String()))
+	c.Assert(err, qt.ErrorMatches,
+		`invalid boolean value "yes please" for PTAH_ATLAS_LINT_ALL_VERSIONS`,
+		qt.Commentf("%s", out.String()))
+}
+
+// TestCompatMigrateLintScopeOptInRefusesEvenWhenTheScopeIsNamed is the
+// discriminating case for "validate before control-flow shortcuts".
+//
+// `--latest 1` names a scope, so the opt-in's value cannot change what this run
+// does. That is precisely the run a pipeline makes every day, and resolving the
+// variable at its use site left the typo dormant on all of them.
+func TestCompatMigrateLintScopeOptInRefusesEvenWhenTheScopeIsNamed(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("PTAH_ATLAS_LINT_ALL_VERSIONS", "yes please")
+	writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_init.sql", "CREATE TABLE t (id INTEGER);\n")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "lint",
+		"--dir", "file://migrations",
+		"--dev-url", "sqlite://file?mode=memory",
+		"--latest", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches,
+		`invalid boolean value "yes please" for PTAH_ATLAS_LINT_ALL_VERSIONS`,
+		qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Not(qt.Contains), "1 version ok",
+		qt.Commentf("the refusal has to land before the report is produced"))
+}
+
+// TestCompatMigrateLintDevURLOptInRefusesEvenWhenADevURLIsGiven is the same
+// discriminating case for the other lint variable. A run carrying --dev-url
+// never consults PTAH_ATLAS_LINT_WITHOUT_DEV_URL, and that is every healthy run.
+func TestCompatMigrateLintDevURLOptInRefusesEvenWhenADevURLIsGiven(t *testing.T) {
+	c := qt.New(t)
+	root := t.TempDir()
+	t.Chdir(root)
+	t.Setenv("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", "tru")
+	writeHashedAtlasDir(c, filepath.Join(root, "migrations"), "20240101000000_init.sql", "CREATE TABLE t (id INTEGER);\n")
+
+	cmd := atlas.NewCompatCommand("atlas")
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+	cmd.SetErr(&out)
+	cmd.SetArgs([]string{
+		"migrate", "lint",
+		"--dir", "file://migrations",
+		"--dev-url", "sqlite://file?mode=memory",
+		"--latest", "1",
+	})
+
+	err := cmd.Execute()
+
+	c.Assert(err, qt.ErrorMatches,
+		`invalid boolean value "tru" for PTAH_ATLAS_LINT_WITHOUT_DEV_URL`,
+		qt.Commentf("%s", out.String()))
+	c.Assert(out.String(), qt.Not(qt.Contains), "1 version ok",
+		qt.Commentf("the refusal has to land before the report is produced"))
 }
 
 // writeAtlasProjectFile writes an atlas.hcl whose migration directory is chosen

--- a/cmd/atlas/external_schema_source_test.go
+++ b/cmd/atlas/external_schema_source_test.go
@@ -13,6 +13,7 @@ import (
 
 	"go.5x5.cz/ptah/cmd/atlas"
 	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // seedSQLiteDBAt creates a SQLite database with the given DDL at path.
@@ -115,7 +116,7 @@ func TestSchemaDiffExternalSchemaSource(t *testing.T) {
 
 func TestSchemaDiffExternalSchemaGate_FailurePath(t *testing.T) {
 	c := qt.New(t)
-	t.Setenv("PTAH_ALLOW_EXTERNAL_SCHEMA", "")
+	envbooltest.Unset("PTAH_ALLOW_EXTERNAL_SCHEMA")(t)
 	configPath := writeExternalSchemaAtlasHCL(t, "sql")
 	targetPath := filepath.Join(t.TempDir(), "target.db")
 	seedSQLiteDBAt(t, targetPath, "CREATE TABLE existing (id INTEGER PRIMARY KEY)")

--- a/cmd/atlas/migrate_apply.go
+++ b/cmd/atlas/migrate_apply.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"io/fs"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
@@ -25,6 +24,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasmigratereport"
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/dblock"
+	"go.5x5.cz/ptah/internal/envbool"
 	"go.5x5.cz/ptah/migration/migrator"
 )
 
@@ -639,16 +639,18 @@ const applySkipChecksEnvVar = "PTAH_SKIP_CHECKS"
 // believes they are bypassed; the same choice is already made for the
 // PTAH_<FLAG> fallbacks on `migrate down`.
 func atlasApplySkipChecksFromEnv() (bool, error) {
-	value, ok := os.LookupEnv(applySkipChecksEnvVar)
-	if !ok || value == "" {
-		return false, nil
-	}
-	skip, err := strconv.ParseBool(value)
-	if err != nil {
-		return false, fmt.Errorf("invalid boolean value %q for %s", value, applySkipChecksEnvVar)
-	}
-	return skip, nil
+	return applySkipChecks.Resolve()
 }
+
+// applySkipChecks is the declaration of the variable, made once, on the verb
+// that owns it. See [go.5x5.cz/ptah/internal/envbool].
+//
+// It carries the one change stokaro/ptah#1334 makes to this reader: an
+// explicitly EMPTY value used to read as unset here, which folded a
+// `PTAH_SKIP_CHECKS=` left behind by a broken shell expansion into "checks
+// enforced" without a word. Absence still selects the default; a present value
+// has to parse.
+var applySkipChecks = envbool.New(applySkipChecksEnvVar, false)
 
 // resolveAtlasApplySkipChecks resolves the bypass and announces an active one.
 //

--- a/cmd/atlas/migrate_apply_skip_checks_env_test.go
+++ b/cmd/atlas/migrate_apply_skip_checks_env_test.go
@@ -111,9 +111,13 @@ func setSkipChecksEnv(value string) func(t *testing.T) {
 const txtarCheckRefusal = "pre-migration check checks.sql#1 for migration 20260801000002 was not satisfied"
 
 // TestMigrateApplySkipChecksEnvEnforcesChecks separates "the variable is set"
-// from "the variable parses as true". An absent variable, an empty one and the
-// two false spellings must all leave checks enforcing, and a value that is not
-// a boolean must be refused outright rather than read as false.
+// from "the variable parses as true". An absent variable and the false
+// spellings leave checks enforcing; a value that is not a boolean -- including
+// an exported empty one, since stokaro/ptah#1334 -- is refused outright rather
+// than read as false.
+//
+// Every row also asserts the column count, so each one is a no-mutation guard:
+// the refusal has to land with the migration unapplied, not after it.
 //
 // Each case builds its own directory and database. A shared fixture would let a
 // case pass on another case's state instead of on its own input.
@@ -126,7 +130,11 @@ func TestMigrateApplySkipChecksEnvEnforcesChecks(t *testing.T) {
 		wantErr string
 	}{
 		{name: "absent enforces checks", setEnv: unsetSkipChecksEnv, wantErr: txtarCheckRefusal},
-		{name: "empty enforces checks", setEnv: setSkipChecksEnv(""), wantErr: txtarCheckRefusal},
+		{
+			name:    "an exported empty value is refused, not read as unset",
+			setEnv:  setSkipChecksEnv(""),
+			wantErr: `invalid boolean value "" for PTAH_SKIP_CHECKS`,
+		},
 		{name: "zero enforces checks", setEnv: setSkipChecksEnv("0"), wantErr: txtarCheckRefusal},
 		{name: "false enforces checks", setEnv: setSkipChecksEnv("false"), wantErr: txtarCheckRefusal},
 		{name: "f enforces checks", setEnv: setSkipChecksEnv("f"), wantErr: txtarCheckRefusal},

--- a/cmd/atlas/migrate_checkpoint_flags_test.go
+++ b/cmd/atlas/migrate_checkpoint_flags_test.go
@@ -8,6 +8,7 @@ import (
 
 	qt "github.com/frankban/quicktest"
 
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/migration/migrator"
 )
@@ -98,7 +99,7 @@ func TestCompatCommand_MigrateCheckpointEditRefusesWhatItCannotFinish(t *testing
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			c.Setenv("PTAH_ALLOW_NONINTERACTIVE_EDIT", "")
+			envbooltest.Unset("PTAH_ALLOW_NONINTERACTIVE_EDIT")(c)
 			test.env(c)
 			migrationsDir, devURL := checkpointFlagFixture(c)
 

--- a/cmd/atlas/migrate_dir_query.go
+++ b/cmd/atlas/migrate_dir_query.go
@@ -4,12 +4,12 @@ import (
 	"fmt"
 	"io"
 	"net/url"
-	"os"
 	"strconv"
 	"strings"
 
 	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/atlasmigrateimport"
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // resolveWritingVerbDirFormat resolves the migration directory layout the one
@@ -131,16 +131,14 @@ const dirQueryStrictEnvVar = "PTAH_STRICT_DIR_QUERY"
 // atlasDirQueryStrictFromEnv resolves whether an ignored `--dir` query key is
 // refused rather than reported.
 func atlasDirQueryStrictFromEnv() (bool, error) {
-	value, ok := os.LookupEnv(dirQueryStrictEnvVar)
-	if !ok || value == "" {
-		return false, nil
-	}
-	strict, err := strconv.ParseBool(value)
-	if err != nil {
-		return false, fmt.Errorf("invalid boolean value %q for %s", value, dirQueryStrictEnvVar)
-	}
-	return strict, nil
+	return dirQueryStrict.Resolve()
 }
+
+// dirQueryStrict is the declaration of the variable, made once, on the surface
+// that owns it. See [go.5x5.cz/ptah/internal/envbool]. An explicitly empty value
+// is now refused here too, which is stokaro/ptah#1334's one change to this
+// reader.
+var dirQueryStrict = envbool.New(dirQueryStrictEnvVar, false)
 
 // reportIgnoredDirQuery names the `--dir` URL query keys the run took no
 // meaning from, on every verb that reads that query.

--- a/cmd/atlas/migrate_down.go
+++ b/cmd/atlas/migrate_down.go
@@ -18,6 +18,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasmigrate"
 	"go.5x5.cz/ptah/internal/atlasreport"
+	"go.5x5.cz/ptah/internal/envbool"
 	"go.5x5.cz/ptah/migration/generator"
 	"go.5x5.cz/ptah/migration/migrator"
 )
@@ -308,18 +309,24 @@ func applyAtlasMigrateDownEnvFallback(flagSet *pflag.FlagSet) error {
 			return
 		}
 		value, ok := os.LookupEnv(atlasFlagEnvName(flag.Name))
-		if !ok || value == "" {
+		if !ok {
 			return
 		}
 		if flag.Value.Type() == "bool" {
-			parsed, err := strconv.ParseBool(value)
+			// One grammar and one error for every boolean PTAH_* variable, and an
+			// explicitly empty one is a configuration error rather than a silent
+			// "unset". See [go.5x5.cz/ptah/internal/envbool] and
+			// stokaro/ptah#1334.
+			parsed, err := envbool.Parse(atlasFlagEnvName(flag.Name), value)
 			if err != nil {
-				envErr = fmt.Errorf("atlas migrate down: invalid boolean value %q for %s", value, atlasFlagEnvName(flag.Name))
+				envErr = fmt.Errorf("atlas migrate down: %w", err)
 				return
 			}
 			if !parsed {
 				return
 			}
+		} else if value == "" {
+			return
 		}
 		if err := flag.Value.Set(value); err != nil {
 			envErr = fmt.Errorf("atlas migrate down: invalid value %q for %s: %w", value, atlasFlagEnvName(flag.Name), err)

--- a/cmd/atlas/migrate_lint.go
+++ b/cmd/atlas/migrate_lint.go
@@ -3,8 +3,6 @@ package atlas
 import (
 	"errors"
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -16,6 +14,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasargs"
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/internal/envbool"
 	"go.5x5.cz/ptah/internal/migrationlintreport"
 	migrationlint "go.5x5.cz/ptah/migration/lint"
 )
@@ -96,6 +95,21 @@ func runAtlasMigrateLint(
 	cmd *cobra.Command,
 	opts atlasMigrateLintOptions,
 ) (runErr error) {
+	// Both variables this verb owns are resolved first, before the project file
+	// is opened and before any directory or dev database is touched. Resolving
+	// them at their use sites left each one dormant on the runs that did not need
+	// it -- a lint that named a scope never read PTAH_ATLAS_LINT_ALL_VERSIONS,
+	// and a lint carrying --dev-url never read PTAH_ATLAS_LINT_WITHOUT_DEV_URL --
+	// so a typo in either survived every healthy run of the pipeline that
+	// exported it. See stokaro/ptah#1334.
+	lintAllVersions, err := atlasMigrateLintAllVersions()
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
+	withoutDevURL, err := lintWithoutDevURL()
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	formatOutput := cmd.Flags().Changed("format")
 	project, loaded, err := openAtlasProjectForCommand(cmd, ignoreMissingEnvSelection)
 	if err != nil {
@@ -154,8 +168,10 @@ func runAtlasMigrateLint(
 	// the same invocation carrying a tampered atlas.sum answers it too. An
 	// atlas.hcl env that supplies `dev` satisfies it there and here, which is why
 	// this reads the merged value rather than the flag.
-	if err := requireAtlasMigrateLintDevURL(opts.devURL); err != nil {
-		return cmdutil.Fail(cmd, err)
+	if !withoutDevURL {
+		if err := requireAtlasMigrateLintDevURL(opts.devURL); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 	if err := validateAtlasMigrateLintOptions(opts); err != nil {
 		return cmdutil.Fail(cmd, err)
@@ -169,8 +185,10 @@ func runAtlasMigrateLint(
 	if _, err := resolveAtlasVerbDirFormat(cmd.ErrOrStderr(), "lint", opts.dirFormat, nil); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
-	if err := requireAtlasMigrateLintScope(cmd, opts, projectCfg); err != nil {
-		return cmdutil.Fail(cmd, err)
+	if !lintAllVersions {
+		if err := requireAtlasMigrateLintScope(cmd, opts, projectCfg); err != nil {
+			return cmdutil.Fail(cmd, err)
+		}
 	}
 	if formatOutput {
 		if err := validateAtlasMigrateLintFormat(opts.format); err != nil {
@@ -368,11 +386,15 @@ func validateAtlasMigrateLintOptions(opts atlasMigrateLintOptions) error {
 // [go.5x5.cz/ptah/internal/atlashclrender.KeepAtlasRefusedBlocksEnvVar].
 const atlasMigrateLintAllVersionsEnvVar = "PTAH_ATLAS_LINT_ALL_VERSIONS"
 
-// atlasMigrateLintAllVersions reports whether the opt-in is set to a true
-// boolean. Unset, empty, false and unparsable values all keep the default.
-func atlasMigrateLintAllVersions() bool {
-	all, err := strconv.ParseBool(os.Getenv(atlasMigrateLintAllVersionsEnvVar))
-	return err == nil && all
+// atlasLintAllVersions is the declaration of the variable, made once, on the
+// verb that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var atlasLintAllVersions = envbool.New(atlasMigrateLintAllVersionsEnvVar, false)
+
+// atlasMigrateLintAllVersions reports whether the opt-in lints the whole
+// directory. Unset keeps the default and a valid false spelling keeps it too; an
+// empty or unparsable value is a configuration error (stokaro/ptah#1334).
+func atlasMigrateLintAllVersions() (bool, error) {
+	return atlasLintAllVersions.Resolve()
 }
 
 // atlasMigrateLintScopeGiven reports whether anything named the set of versions
@@ -437,7 +459,7 @@ func requireAtlasMigrateLintScope(
 	opts atlasMigrateLintOptions,
 	projectCfg projectconfig.Config,
 ) error {
-	if atlasMigrateLintScopeGiven(cmd, opts, projectCfg) || atlasMigrateLintAllVersions() {
+	if atlasMigrateLintScopeGiven(cmd, opts, projectCfg) {
 		return nil
 	}
 	return errors.New("--latest or --git-base is required")
@@ -459,22 +481,25 @@ func requireAtlasMigrateLintScope(
 // is stokaro/ptah#1231 case 2, which #1307 explicitly left open rather than
 // widening into itself.
 func requireAtlasMigrateLintDevURL(devURL string) error {
-	if strings.TrimSpace(devURL) != "" || lintWithoutDevURL() {
+	if strings.TrimSpace(devURL) != "" {
 		return nil
 	}
 	return errors.New(`required flag(s) "dev-url" not set`)
 }
 
-// lintWithoutDevURL reports whether the opt-in variable is set to a true
-// boolean value. Unset, empty, false and unparsable values all keep the
-// default, mirroring how the other PTAH_* opt-ins on this surface read theirs.
+// atlasLintWithoutDevURL is the declaration of the variable, made once, on the
+// verb that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var atlasLintWithoutDevURL = envbool.New(atlasLintWithoutDevURLEnvVar, false)
+
+// lintWithoutDevURL reports whether the opt-in asks for Ptah's database-free
+// analysis. Unset keeps the requirement and a valid false spelling keeps it too;
+// an empty or unparsable value is a configuration error (stokaro/ptah#1334).
 //
 // It relaxes ONLY the dev-database requirement. A run with no scope is still
 // refused; [atlasMigrateLintAllVersions] is the separate opt-in for that, and
 // neither variable implies the other.
-func lintWithoutDevURL() bool {
-	allow, err := strconv.ParseBool(os.Getenv(atlasLintWithoutDevURLEnvVar))
-	return err == nil && allow
+func lintWithoutDevURL() (bool, error) {
+	return atlasLintWithoutDevURL.Resolve()
 }
 
 func validateAtlasMigrateLintFormat(format string) error {

--- a/cmd/atlas/migrate_preconditions_test.go
+++ b/cmd/atlas/migrate_preconditions_test.go
@@ -11,6 +11,7 @@ import (
 
 	"go.5x5.cz/ptah/cmd/atlas"
 	"go.5x5.cz/ptah/cmd/internal/exitcode"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // Every test in this file drives the whole compatibility CLI, argv in and exit
@@ -83,30 +84,60 @@ func TestCompatCommand_MigrateLintWithoutDevURLOptIn(t *testing.T) {
 	c.Assert(out, qt.Contains, "-- 1 version ok")
 }
 
-// TestCompatCommand_MigrateLintOptInIgnoresNonBooleanValues pins that the
-// opt-in is a boolean, so an operator who exported it as a word does not get a
-// silently looser CLI.
-func TestCompatCommand_MigrateLintOptInIgnoresNonBooleanValues(t *testing.T) {
+// TestCompatCommand_MigrateLintOptInIsABoolean pins that the opt-in is a
+// boolean, so an operator who exported it as a word does not get a silently
+// looser CLI -- and, since stokaro/ptah#1334, does not get a silently STRICTER
+// one either.
+//
+// The two answers are different on purpose. A valid false keeps the community
+// binary's own refusal, word for word, because that is the compatibility
+// default. A value that is not a boolean at all is a configuration error naming
+// the variable, because `required flag(s) "dev-url" not set` would send an
+// operator who did set the opt-in looking at their command line instead of at
+// their environment file.
+func TestCompatCommand_MigrateLintOptInIsABoolean(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
+		name    string
+		env     func(testing.TB)
+		wantErr string
 	}{
-		{name: "empty", value: ""},
-		{name: "false", value: "false"},
-		{name: "zero", value: "0"},
-		{name: "word", value: "yes please"},
+		{
+			name:    "unset",
+			env:     envbooltest.Unset("PTAH_ATLAS_LINT_WITHOUT_DEV_URL"),
+			wantErr: `Error: required flag(s) "dev-url" not set`,
+		},
+		{
+			name:    "false",
+			env:     envbooltest.Set("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", "false"),
+			wantErr: `Error: required flag(s) "dev-url" not set`,
+		},
+		{
+			name:    "zero",
+			env:     envbooltest.Set("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", "0"),
+			wantErr: `Error: required flag(s) "dev-url" not set`,
+		},
+		{
+			name:    "empty",
+			env:     envbooltest.Set("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", ""),
+			wantErr: `Error: invalid boolean value "" for PTAH_ATLAS_LINT_WITHOUT_DEV_URL`,
+		},
+		{
+			name:    "word",
+			env:     envbooltest.Set("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", "yes please"),
+			wantErr: `Error: invalid boolean value "yes please" for PTAH_ATLAS_LINT_WITHOUT_DEV_URL`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
 			dir := seedAtlasPreconditionDir(c, t.TempDir())
-			t.Setenv("PTAH_ATLAS_LINT_WITHOUT_DEV_URL", test.value)
+			test.env(t)
 
 			out, err := runAtlasPrecondition(c, "migrate", "lint", "--dir", "file://"+dir, "--latest", "1")
 
 			c.Assert(exitcode.Code(err, 0), qt.Equals, 1)
-			c.Assert(out, qt.Contains, `Error: required flag(s) "dev-url" not set`)
+			c.Assert(out, qt.Contains, test.wantErr)
 		})
 	}
 }

--- a/cmd/atlas/schema_apply.go
+++ b/cmd/atlas/schema_apply.go
@@ -6,9 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"slices"
-	"strconv"
 	"strings"
 	"time"
 
@@ -25,6 +23,7 @@ import (
 	"go.5x5.cz/ptah/internal/atlasreport"
 	"go.5x5.cz/ptah/internal/atlasschema"
 	"go.5x5.cz/ptah/internal/atlassource"
+	"go.5x5.cz/ptah/internal/envbool"
 	"go.5x5.cz/ptah/internal/schemafile"
 	migrationlint "go.5x5.cz/ptah/migration/lint"
 	"go.5x5.cz/ptah/migration/migrator"
@@ -944,6 +943,15 @@ func ensureAtlasSchemaApplyDevURL(
 	opts atlasSchemaApplyOptions,
 	projectEnv atlassource.ProjectEnv,
 ) error {
+	// Resolved before the --dev-url shortcut, so a run that supplies a dev
+	// database still refuses a malformed value. That is the whole of a healthy
+	// pipeline: the variable exists for the runs that have no dev database, and
+	// validating it only there would let a typo survive every other run.
+	// See stokaro/ptah#1334.
+	allowed, err := atlasApplyWithoutDevURLAllowed()
+	if err != nil {
+		return err
+	}
 	if strings.TrimSpace(opts.devURL) != "" {
 		return nil
 	}
@@ -954,15 +962,22 @@ func ensureAtlasSchemaApplyDevURL(
 		// can improve on it.
 		return nil //nolint:nilerr // the caller already refused on this error
 	}
-	if atlasApplyWithoutDevURLAllowed() {
+	if allowed {
 		return nil
 	}
 	return errors.New("--dev-url cannot be empty")
 }
 
-func atlasApplyWithoutDevURLAllowed() bool {
-	allowed, err := strconv.ParseBool(os.Getenv(applyWithoutDevURLEnvVar))
-	return err == nil && allowed
+// atlasApplyWithoutDevURL is the declaration of the variable, made once, on the
+// verb that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var atlasApplyWithoutDevURL = envbool.New(applyWithoutDevURLEnvVar, false)
+
+// atlasApplyWithoutDevURLAllowed reports whether a non-database desired state
+// may be applied with no dev database. Unset keeps the refusal and a valid false
+// spelling keeps it too; an empty or unparsable value is a configuration error
+// (stokaro/ptah#1334).
+func atlasApplyWithoutDevURLAllowed() (bool, error) {
+	return atlasApplyWithoutDevURL.Resolve()
 }
 
 func printAtlasSchemaApplyPlan(out io.Writer, sqlText string) {

--- a/cmd/atlas/schema_apply_unmatched_exclude_env_test.go
+++ b/cmd/atlas/schema_apply_unmatched_exclude_env_test.go
@@ -1,0 +1,124 @@
+package atlas_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/dbschema"
+	"go.5x5.cz/ptah/internal/atlasfilter"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
+)
+
+// TestSchemaApplyUnmatchedExcludeOptInIsResolvedBeforeAnyWork is the
+// early-return control for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE, and the
+// no-mutation guard for it.
+//
+// The selector NAMES AN OBJECT THAT EXISTS, so there is no unmatched selector on
+// this run and the opt-in's value cannot change what the command does. That is
+// the shape of every healthy run of a pipeline that exports the variable, and
+// before stokaro/ptah#1334 it was the shape on which a typo was invisible: the
+// value was read beside the refusal, and the refusal never fired.
+//
+// The row assertions are not the exit code alone. `applied` reads the target
+// back through the real reader afterwards, so a refusal that landed after the
+// plan was carried out would fail here even though the exit code was 1.
+func TestSchemaApplyUnmatchedExcludeOptInIsResolvedBeforeAnyWork(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         func(testing.TB)
+		wantErr     string
+		wantApplied bool
+	}{
+		{
+			name:        "an unparsable value refuses with every selector matched",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "maybe"),
+			wantErr:     `invalid boolean value "maybe" for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE`,
+			wantApplied: false,
+		},
+		{
+			name:        "an exported empty value refuses too",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, ""),
+			wantErr:     `invalid boolean value "" for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE`,
+			wantApplied: false,
+		},
+		{
+			name:        "unset applies, which is the control the refusal has to leave alone",
+			env:         envbooltest.Unset(atlasfilter.AllowUnmatchedExcludeEnvVar),
+			wantApplied: true,
+		},
+		{
+			name:        "a valid false applies, because no selector went unmatched",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "false"),
+			wantApplied: true,
+		},
+		{
+			name:        "a valid true applies",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "1"),
+			wantApplied: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			allowSchemaApplyWithoutDevURL(t)
+			test.env(t)
+			dir := t.TempDir()
+			targetPath := filepath.Join(dir, "target.db")
+			seedSQLiteDBAt(t, targetPath, "CREATE TABLE users (id INTEGER PRIMARY KEY); CREATE TABLE legacy (id INTEGER PRIMARY KEY)")
+			schemaPath := writeUnmatchedExcludeSchemaFile(c, dir)
+
+			out, err := runCompatCommand(t,
+				"schema", "apply",
+				"--auto-approve",
+				"--url", "sqlite://"+targetPath,
+				"--to", "file://"+schemaPath,
+				"--exclude", "legacy",
+			)
+
+			c.Assert(errMessageOrEmpty(err), qt.Equals, test.wantErr, qt.Commentf("%s", out))
+			c.Assert(sqliteHasUsersEmailColumn(c, targetPath), qt.Equals, test.wantApplied,
+				qt.Commentf("command output:\n%s", out))
+		})
+	}
+}
+
+// writeUnmatchedExcludeSchemaFile writes a desired state that adds one column to
+// `users` and leaves `legacy` as it is, so an applied run is visible as exactly
+// one catalog change.
+func writeUnmatchedExcludeSchemaFile(c *qt.C, dir string) string {
+	c.Helper()
+	path := filepath.Join(dir, "schema.sql")
+	body := "CREATE TABLE users (id INTEGER PRIMARY KEY, email TEXT);\n" +
+		"CREATE TABLE legacy (id INTEGER PRIMARY KEY);\n"
+	c.Assert(os.WriteFile(path, []byte(body), 0o600), qt.IsNil)
+	return path
+}
+
+// sqliteHasUsersEmailColumn reads the target back through the real reader, so
+// the assertion is about the database rather than about what was printed.
+func sqliteHasUsersEmailColumn(c *qt.C, path string) bool {
+	c.Helper()
+	conn, err := dbschema.ConnectToDatabase(context.Background(), "sqlite://"+path)
+	c.Assert(err, qt.IsNil)
+	defer dbschema.CloseAndWarn(conn)
+
+	var count int
+	row := conn.QueryRowContext(context.Background(),
+		"SELECT COUNT(*) FROM pragma_table_info('users') WHERE name = 'email'")
+	c.Assert(row.Scan(&count), qt.IsNil)
+	return count == 1
+}
+
+// errMessageOrEmpty renders an error for comparison against a table row without
+// a branch in the test body.
+func errMessageOrEmpty(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/cmd/atlas/schema_inspect.go
+++ b/cmd/atlas/schema_inspect.go
@@ -112,6 +112,14 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 	if err := refuseAtlasUIFlag(cmd, "schema", "inspect", atlasSchemaWebFlag()); err != nil {
 		return cmdutil.Fail(cmd, err)
 	}
+	// The variable this verb owns is resolved here, before the project file is
+	// read and before anything is connected to, so a malformed value is refused
+	// on every inspect rather than on the ones whose schema happens to contain a
+	// block the default would omit. See stokaro/ptah#1334.
+	omitRefusedBlocks, err := atlasInspectOmitsRefusedBlocks()
+	if err != nil {
+		return cmdutil.Fail(cmd, err)
+	}
 	formatConfigured := cmd.Flags().Changed("format")
 	mode := ignoreMissingEnvSelection
 	if needsAtlasSchemaInspectConfig(cmd) {
@@ -171,7 +179,7 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 
 		// Atlas-compatible surface; see cmd/atlas/schema_apply.go.
 		IgnoreUnknownHCLNames:  true,
-		OmitAtlasRefusedBlocks: atlasInspectOmitsRefusedBlocks(),
+		OmitAtlasRefusedBlocks: omitRefusedBlocks,
 		Vars:                   schemaVars,
 	})
 	if err != nil {
@@ -202,8 +210,12 @@ func runAtlasSchemaInspect(cmd *cobra.Command, opts atlasSchemaInspectOptions) e
 //
 // Native `ptah schema inspect` never calls this and always describes every
 // construct Ptah models.
-func atlasInspectOmitsRefusedBlocks() bool {
-	return !atlashclrender.KeepAtlasRefusedBlocks()
+func atlasInspectOmitsRefusedBlocks() (bool, error) {
+	keep, err := atlashclrender.KeepAtlasRefusedBlocks()
+	if err != nil {
+		return false, err
+	}
+	return !keep, nil
 }
 
 func needsAtlasSchemaInspectConfig(cmd *cobra.Command) bool {

--- a/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
+++ b/cmd/atlas/schema_inspect_refused_blocks_internal_test.go
@@ -18,6 +18,7 @@ import (
 	"go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlashclrender"
 	"go.5x5.cz/ptah/internal/atlasreport"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // TestAtlasInspectRefusedBlockGate pins both states of the capability gate, and
@@ -34,12 +35,12 @@ import (
 func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 	tests := []struct {
 		name   string
-		value  string
+		env    func(testing.TB)
 		assert func(c *qt.C, hcl, diagnostics string)
 	}{
 		{
-			name:  "unset omits the blocks the pinned binary refuses",
-			value: "",
+			name: "unset omits the blocks the pinned binary refuses",
+			env:  envbooltest.Unset(atlashclrender.KeepAtlasRefusedBlocksEnvVar),
 			assert: func(c *qt.C, hcl, diagnostics string) {
 				c.Assert(hcl, qt.Not(qt.Contains), "extension \"pgcrypto\"")
 				c.Assert(hcl, qt.Not(qt.Contains), "sequence \"lonely_seq\"")
@@ -50,8 +51,8 @@ func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 			},
 		},
 		{
-			name:  "the opt-in puts every block back",
-			value: "1",
+			name: "the opt-in puts every block back",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "1"),
 			assert: func(c *qt.C, hcl, diagnostics string) {
 				c.Assert(hcl, qt.Contains, "extension \"pgcrypto\"")
 				c.Assert(hcl, qt.Contains, "sequence \"lonely_seq\"")
@@ -60,8 +61,8 @@ func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 			},
 		},
 		{
-			name:  "a false value keeps the compatible default",
-			value: "false",
+			name: "a false value keeps the compatible default",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "false"),
 			assert: func(c *qt.C, hcl, diagnostics string) {
 				c.Assert(hcl, qt.Not(qt.Contains), "extension \"pgcrypto\"")
 				c.Assert(diagnostics, qt.Contains, "omitted from Atlas-compatible")
@@ -72,15 +73,17 @@ func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, test.value)
+			test.env(t)
 
+			omit, gateErr := atlasInspectOmitsRefusedBlocks()
+			c.Assert(gateErr, qt.IsNil)
 			var diagnostics bytes.Buffer
 			report := atlasreport.NewSchemaInspectReport(
 				refusedBlockGateDatabase(),
 				&types.DBSchema{},
 				types.DBInfo{Dialect: "postgres", Schema: "public"},
 				&diagnostics,
-				atlasInspectOmitsRefusedBlocks(),
+				omit,
 				true,
 			)
 
@@ -101,11 +104,20 @@ func TestAtlasInspectRefusedBlockGate(t *testing.T) {
 // `pq: relation "order_seq" does not exist`. Reproducing it would be copying a
 // defect, so the sequence stays whichever way the gate is set.
 func TestAtlasInspectKeepsAReferencedBlockInEitherState(t *testing.T) {
-	for _, value := range []string{"", "1"} {
-		t.Run("PTAH_ATLAS_INSPECT_ALL_BLOCKS="+value, func(t *testing.T) {
+	states := []struct {
+		name string
+		env  func(testing.TB)
+	}{
+		{name: "unset", env: envbooltest.Unset(atlashclrender.KeepAtlasRefusedBlocksEnvVar)},
+		{name: "1", env: envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "1")},
+	}
+	for _, state := range states {
+		t.Run("PTAH_ATLAS_INSPECT_ALL_BLOCKS="+state.name, func(t *testing.T) {
 			c := qt.New(t)
-			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, value)
+			state.env(t)
 
+			omit, gateErr := atlasInspectOmitsRefusedBlocks()
+			c.Assert(gateErr, qt.IsNil)
 			var diagnostics bytes.Buffer
 			db := refusedBlockGateDatabase()
 			db.Fields = append(db.Fields, goschema.Field{
@@ -119,7 +131,7 @@ func TestAtlasInspectKeepsAReferencedBlockInEitherState(t *testing.T) {
 				&types.DBSchema{},
 				types.DBInfo{Dialect: "postgres", Schema: "public"},
 				&diagnostics,
-				atlasInspectOmitsRefusedBlocks(),
+				omit,
 				true,
 			)
 

--- a/cmd/internal/cmdflags/env.go
+++ b/cmd/internal/cmdflags/env.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 const (
@@ -127,7 +129,15 @@ func applyEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet)
 		}
 		envName := EnvName(prefix, flag.Name)
 		value, ok := os.LookupEnv(envName)
-		if !ok || value == "" {
+		if !ok {
+			return
+		}
+		// An empty value keeps meaning "unset" for every flag type EXCEPT bool,
+		// where stokaro/ptah#1334 makes it a configuration error: for a string or
+		// a uint an empty environment value is a plausible way to spell "no
+		// value", while `PTAH_DRY_RUN=` is a boolean with nothing in it and there
+		// is no reading of it that is not a mistake.
+		if value == "" && flag.Value.Type() != "bool" {
 			return
 		}
 		applyErr = setEnvValue(flags, flag, envName, value)
@@ -138,8 +148,11 @@ func applyEnv(prefix string, visited map[*pflag.Flag]bool, flags *pflag.FlagSet)
 func setEnvValue(flags *pflag.FlagSet, flag *pflag.Flag, envName, value string) error {
 	switch flag.Value.Type() {
 	case "bool":
-		if _, err := strconv.ParseBool(value); err != nil {
-			return fmt.Errorf("invalid boolean value %q for %s", value, envName)
+		// One grammar and one error shape for every boolean PTAH_* variable,
+		// whether it reaches a feature through a flag or is read directly by the
+		// package that owns it. See [go.5x5.cz/ptah/internal/envbool].
+		if _, err := envbool.Parse(envName, value); err != nil {
+			return err
 		}
 	case "uint", "uint64":
 		if _, err := strconv.ParseUint(value, 0, 64); err != nil {

--- a/cmd/internal/cmdflags/env_test.go
+++ b/cmd/internal/cmdflags/env_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"go.5x5.cz/ptah/cmd/internal/cmdflags"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 func TestEnvNameNormalizesFlagName(t *testing.T) {
@@ -68,6 +69,69 @@ func TestInitializeEnvIgnoresEmptyEnvironmentValues(t *testing.T) {
 
 	c.Assert(err, qt.IsNil)
 	c.Assert(dbURL, qt.Equals, "postgres://default")
+}
+
+// TestInitializeEnvSplitsEmptyByFlagType is where the boolean rule departs from
+// the general one, and the two halves are asserted together so neither can be
+// changed without meeting the other.
+//
+// An empty value keeps meaning "unset" for a string or a uint: those are types
+// where "no value" is a thing an operator can plausibly want to spell. For a
+// boolean it is a configuration error (stokaro/ptah#1334) -- `PTAH_DRY_RUN=` is
+// a boolean with nothing in it, and reading it as `false` is how a broken shell
+// expansion turned into a silent default.
+func TestInitializeEnvSplitsEmptyByFlagType(t *testing.T) {
+	tests := []struct {
+		name        string
+		envName     string
+		register    func(*cobra.Command)
+		wantMessage string
+	}{
+		{
+			name:    "a string flag keeps ignoring an empty value",
+			envName: "PTAH_DB_URL",
+			register: func(cmd *cobra.Command) {
+				cmd.Flags().String("db-url", "", "Database URL")
+			},
+		},
+		{
+			name:    "a uint flag keeps ignoring an empty value",
+			envName: "PTAH_LATEST",
+			register: func(cmd *cobra.Command) {
+				cmd.Flags().Uint("latest", 0, "Latest versions")
+			},
+		},
+		{
+			name:    "a bool flag refuses an empty value",
+			envName: "PTAH_DRY_RUN",
+			register: func(cmd *cobra.Command) {
+				cmd.Flags().Bool("dry-run", false, "Preview changes")
+			},
+			wantMessage: `invalid boolean value "" for PTAH_DRY_RUN`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			t.Setenv(test.envName, "")
+			cmd := &cobra.Command{Use: "ptah"}
+			test.register(cmd)
+
+			err := cmdflags.InitializeEnv("PTAH", cmd)
+
+			c.Assert(errMessage(err), qt.Equals, test.wantMessage)
+		})
+	}
+}
+
+// errMessage renders an error for comparison against a table row without a
+// branch in the test body.
+func errMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 func TestInitializeEnvSkipsDisabledEnvironmentBinding(t *testing.T) {
@@ -284,7 +348,7 @@ func TestSetOnCommandLineForgetsAPreviousExecution(t *testing.T) {
 	c.Assert(cmdflags.InitializeEnv("PTAH", cmd), qt.IsNil)
 	c.Assert(cmdflags.SetOnCommandLine(cmd.Flags(), "dry-run"), qt.IsFalse)
 
-	t.Setenv("PTAH_DRY_RUN", "")
+	envbooltest.Unset("PTAH_DRY_RUN")(t)
 	c.Assert(cmdflags.InitializeEnv("PTAH", cmd), qt.IsNil)
 
 	c.Assert(cmdflags.SetOnCommandLine(cmd.Flags(), "dry-run"), qt.IsTrue)

--- a/cmd/internal/editor/editor.go
+++ b/cmd/internal/editor/editor.go
@@ -11,11 +11,12 @@ import (
 	"io"
 	"os"
 	"os/exec"
-	"strconv"
 	"strings"
 
 	"github.com/google/shlex"
 	"github.com/mattn/go-isatty"
+
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // ErrNoEditor reports that no editor command could be resolved. Callers may
@@ -72,20 +73,18 @@ func RequireInteractive(in io.Reader) error {
 	return fmt.Errorf("%w; set %s=1 when the configured editor edits non-interactively", ErrNotInteractive, AllowNonInteractiveEnvVar)
 }
 
+// allowNonInteractive is the declaration of the variable, made once, in the
+// package that owns it. See [go.5x5.cz/ptah/internal/envbool]. An explicitly
+// empty value is refused here too, which is stokaro/ptah#1334's one change to
+// this reader.
+var allowNonInteractive = envbool.New(AllowNonInteractiveEnvVar, false)
+
 // nonInteractiveAllowed reads the opt-out. An unparsable value is an error
 // rather than a silent false: an operator who believes the gate is lifted must
 // not get a refusal from a typo, and one who believes it is closed must not get
 // an editor launched by one.
 func nonInteractiveAllowed() (bool, error) {
-	value, ok := os.LookupEnv(AllowNonInteractiveEnvVar)
-	if !ok || value == "" {
-		return false, nil
-	}
-	allowed, err := strconv.ParseBool(value)
-	if err != nil {
-		return false, fmt.Errorf("invalid boolean value %q for %s", value, AllowNonInteractiveEnvVar)
-	}
-	return allowed, nil
+	return allowNonInteractive.Resolve()
 }
 
 // isTerminal reports whether in is an open terminal device. A stream that is

--- a/cmd/internal/envboolguard/doc.go
+++ b/cmd/internal/envboolguard/doc.go
@@ -1,0 +1,41 @@
+// Package envboolguard hosts the repository guard for the boolean `PTAH_*`
+// environment-variable contract.
+//
+// The contract itself lives in [go.5x5.cz/ptah/internal/envbool]: absence
+// selects the documented default, a present value must parse as a boolean, and
+// anything else refuses the command before it does work. A contract that only
+// exists in the packages that happen to follow it today is not a contract; the
+// pattern it replaced
+//
+//	value, err := strconv.ParseBool(os.Getenv(name))
+//	return err == nil && value
+//
+// was copied from one package to the next five times precisely because nothing
+// refused the sixth copy.
+//
+// Two guards, and they fail for different reasons on purpose:
+//
+//   - a SOURCE scan refuses a new direct boolean environment parse anywhere
+//     outside the shared package. It works on the shape of the code, so it
+//     catches the pattern before any variable is named;
+//   - an ENUMERATION check derives every `PTAH_*` name that appears in the
+//     tree's non-test Go source and requires each one to be either declared
+//     through the shared package or listed here as non-boolean. It works on the
+//     names, so it catches a boolean variable that was added with a hand-rolled
+//     reader the source scan's shape rules happened not to match.
+//
+// Neither list is hand-maintained on the boolean side. The boolean set is read
+// back from [envbool.Registered] at run time, which is why the test imports the
+// packages that own the variables: the registration happens in their package
+// initialization, and an owner nobody imports contributes nothing. Only the
+// NON-boolean classification is written down, because a new name there is a
+// deliberate statement that the variable is not a boolean and deserves the
+// friction of saying so.
+//
+// It lives under cmd/internal rather than beside the shared package because
+// `cmd/internal/editor` owns one of the variables, and Go's internal-import rule
+// lets only packages under `cmd/` import it. A guard that could not see one
+// owner's registrations would report that owner's variables as unclassified.
+//
+// The package carries no runtime code of its own.
+package envboolguard

--- a/cmd/internal/envboolguard/envboolguard_test.go
+++ b/cmd/internal/envboolguard/envboolguard_test.go
@@ -1,0 +1,589 @@
+package envboolguard_test
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	// Importing the owners is what populates the registry the enumeration check
+	// reads back. A package left out here contributes no declarations, so its
+	// variables would look unclassified rather than boolean -- which is the
+	// direction that fails loudly instead of passing quietly.
+	_ "go.5x5.cz/ptah/cmd/atlas"
+	_ "go.5x5.cz/ptah/cmd/internal/editor"
+	_ "go.5x5.cz/ptah/internal/atlasfilter"
+	_ "go.5x5.cz/ptah/internal/atlashclrender"
+	_ "go.5x5.cz/ptah/internal/atlassource"
+	"go.5x5.cz/ptah/internal/envbool"
+	_ "go.5x5.cz/ptah/internal/reservedrole"
+	_ "go.5x5.cz/ptah/internal/rolescope"
+)
+
+// nonBooleanPtahVars is the ONLY hand-written list in this file: the `PTAH_*`
+// names that carry something other than a boolean.
+//
+// A new entry here is a deliberate statement, which is the point. A boolean
+// variable added without going through the shared package appears in neither
+// this list nor the registry and fails TestEveryPtahVariableIsClassified with
+// its own name in the message.
+//
+// Only names the scan can actually see belong here. Test-only probe names do
+// not, because the scan skips `_test.go` files: an entry for one would be a
+// claim about the tree that nothing checks.
+var nonBooleanPtahVars = []string{
+	"PTAH_CURRENT_VERSION", // migration version, passed to preflight hooks
+	"PTAH_DB_URL",          // database URL
+	"PTAH_DIALECT",         // dialect name
+	"PTAH_DIR",             // migration directory URL
+	"PTAH_FORMAT",          // Go template
+	"PTAH_LOG_FORMAT",      // log format name
+	"PTAH_MIGRATIONS_DIR",  // native migration directory path
+	"PTAH_PLAN",            // plan name, an Atlas capability Ptah refuses
+	"PTAH_TARGET_VERSION",  // migration version, passed to preflight hooks
+	"PTAH_TO_TAG",          // tag name, an Atlas capability Ptah refuses
+	"PTAH_VAR",             // repeatable name=value assignment
+}
+
+// ptahVarPattern finds a variable name anywhere inside a string literal, so
+// `"PTAH_DB_URL="` and "`PTAH_ATLAS_LINT_ALL_VERSIONS=1`" are both recognized
+// as naming their variable. A bare `"PTAH_"` prefix used for name construction
+// matches nothing, which is correct: it names no variable.
+var ptahVarPattern = regexp.MustCompile(`PTAH_[A-Z0-9]+[A-Z0-9_]*`)
+
+// booleanLiterals are the values a hand-rolled truthiness test compares against.
+// `""` is deliberately absent: comparing an environment value with the empty
+// string is a presence test, not a boolean parse, and several non-boolean
+// variables legitimately do it.
+var booleanLiterals = []string{
+	"0", "1", "f", "F", "false", "False", "FALSE", "t", "T", "true", "True", "TRUE",
+}
+
+// TestNoDirectBooleanEnvironmentParsing is the shape guard.
+//
+// A function that reads the environment AND parses a boolean is the pattern
+// this change removed, whichever way the two are spelled -- nested in one
+// expression, or split across a `LookupEnv` and a later `ParseBool` the way the
+// three already-strict readers spelled it. Both forms are one function, so one
+// rule catches both.
+func TestNoDirectBooleanEnvironmentParsing(t *testing.T) {
+	c := qt.New(t)
+	root := repositoryRoot(c)
+
+	var violations []string
+	for _, path := range goSourceFiles(c, root) {
+		violations = append(violations, scanFile(c, root, path)...)
+	}
+
+	c.Assert(violations, qt.HasLen, 0, qt.Commentf(
+		"route the read through go.5x5.cz/ptah/internal/envbool instead:\n%s",
+		strings.Join(violations, "\n")))
+}
+
+// TestGuardCatchesTheShapesItClaimsTo is the guard's own control.
+//
+// A scanner that selected nothing would pass TestNoDirectBooleanEnvironmentParsing
+// on any tree at all, including the one this change started from. Each fixture
+// is a shape the guard has to reject, and the last one is a shape it must NOT
+// reject -- a non-boolean variable compared with the empty string, which is how
+// several string variables legitimately test for presence.
+func TestGuardCatchesTheShapesItClaimsTo(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   int
+	}{
+		{
+			name: "the nested form",
+			source: `package p
+
+import (
+	"os"
+	"strconv"
+)
+
+func Allowed() bool {
+	v, err := strconv.ParseBool(os.Getenv("PTAH_ENVBOOLGUARD_PROBE"))
+	return err == nil && v
+}
+`,
+			want: 1,
+		},
+		{
+			name: "the split form",
+			source: `package p
+
+import (
+	"os"
+	"strconv"
+)
+
+func Allowed() (bool, error) {
+	value, ok := os.LookupEnv("PTAH_ENVBOOLGUARD_PROBE")
+	if !ok {
+		return false, nil
+	}
+	return strconv.ParseBool(value)
+}
+`,
+			want: 1,
+		},
+		{
+			name: "a manual truthiness test",
+			source: `package p
+
+import "os"
+
+func Allowed() bool {
+	return os.Getenv("PTAH_ENVBOOLGUARD_PROBE") == "1"
+}
+`,
+			want: 1,
+		},
+		{
+			// Two comparisons, two reports: the guard names every offending
+			// expression rather than the first one, so a partial fix stays red.
+			name: "a manual truthiness test through a local",
+			source: `package p
+
+import "os"
+
+func Allowed() bool {
+	value := os.Getenv("PTAH_ENVBOOLGUARD_PROBE")
+	return value == "true" || value == "TRUE"
+}
+`,
+			want: 2,
+		},
+		{
+			// The shape the function-level rule alone would have missed, and the
+			// one cmd/internal/cmdflags actually had: the read and the parse are
+			// two functions apart.
+			name: "the read and the parse in separate functions",
+			source: `package p
+
+import (
+	"os"
+	"strconv"
+)
+
+func value() (string, bool) {
+	return os.LookupEnv("PTAH_ENVBOOLGUARD_PROBE")
+}
+
+func parse(raw string) (bool, error) {
+	return strconv.ParseBool(raw)
+}
+`,
+			want: 1,
+		},
+		{
+			name: "a read of a variable this contract does not govern is left alone",
+			source: `package p
+
+import (
+	"os"
+	"strconv"
+)
+
+func Verbose() bool {
+	v, err := strconv.ParseBool(os.Getenv("SHOW_DETAILS"))
+	return err == nil && v
+}
+`,
+			want: 0,
+		},
+		{
+			name: "a presence test against the empty string is left alone",
+			source: `package p
+
+import "os"
+
+func Configured() bool {
+	return os.Getenv("PTAH_ENVBOOLGUARD_PROBE") != ""
+}
+`,
+			want: 0,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			dir := t.TempDir()
+			path := filepath.Join(dir, "probe.go")
+			writeFile(c, path, test.source)
+
+			got := scanFile(c, dir, path)
+
+			c.Assert(got, qt.HasLen, test.want, qt.Commentf("%v", got))
+		})
+	}
+}
+
+// TestEveryPtahVariableIsClassified is the enumeration guard.
+//
+// It derives the names from the source rather than trusting a list, because a
+// list is exactly what goes stale the next time a variable is added. Every name
+// the tree mentions has to be either a declared boolean or a written-down
+// non-boolean; a name that is neither is a variable nobody decided about.
+func TestEveryPtahVariableIsClassified(t *testing.T) {
+	c := qt.New(t)
+
+	mentioned := ptahVarNames(c, repositoryRoot(c))
+
+	c.Assert(len(mentioned) > 10, qt.IsTrue, qt.Commentf(
+		"found %d names; a scan that finds nothing is also green", len(mentioned)))
+	unclassified := namesOutsideBothClassifications(mentioned)
+	c.Assert(unclassified, qt.HasLen, 0, qt.Commentf(
+		"declare each through go.5x5.cz/ptah/internal/envbool, or record it in"+
+			" nonBooleanPtahVars: %v", unclassified))
+}
+
+// TestNoVariableIsClassifiedTwice keeps the two classifications from disagreeing.
+// A name in both lists would make the enumeration guard pass whichever way the
+// variable is actually read.
+func TestNoVariableIsClassifiedTwice(t *testing.T) {
+	c := qt.New(t)
+
+	both := namesInBothClassifications()
+
+	c.Assert(both, qt.HasLen, 0)
+}
+
+// TestEveryDeclaredVariableIsNamedAndDefaultedSafely pins two properties of the
+// registry at once.
+//
+// The prefix is the namespace this contract governs. The default is the more
+// interesting half: every boolean toggle in this tree opts IN to the more
+// permissive side, so a typo lands on the strict default and fails CLOSED. The
+// first variable to default true would invert that, and a typo on it would open
+// the gate it guards. Reading the defaults back from the registry is what turns
+// "we checked once" into a standing assertion.
+func TestEveryDeclaredVariableIsNamedAndDefaultedSafely(t *testing.T) {
+	c := qt.New(t)
+
+	registered := envbool.Registered()
+
+	c.Assert(len(registered) > 0, qt.IsTrue, qt.Commentf(
+		"the registry is empty, so every assertion over it is vacuous"))
+	for _, variable := range registered {
+		c.Run(variable.Name(), func(c *qt.C) {
+			c.Assert(strings.HasPrefix(variable.Name(), envbool.Prefix), qt.IsTrue)
+			c.Assert(variable.Default(), qt.IsFalse, qt.Commentf(
+				"a boolean PTAH_* variable defaulting to the permissive side turns a typo"+
+					" into an open gate; see the reasoning in internal/envbool"))
+		})
+	}
+}
+
+// TestNoVariableIsDeclaredTwice keeps one name from being declared with two
+// defaults in two packages, which would make the answer depend on which reader
+// ran.
+func TestNoVariableIsDeclaredTwice(t *testing.T) {
+	c := qt.New(t)
+
+	duplicated := duplicateRegisteredNames()
+
+	c.Assert(duplicated, qt.HasLen, 0)
+}
+
+// registeredNames returns the declared variable names, sorted and deduplicated.
+func registeredNames() []string {
+	var names []string
+	for _, variable := range envbool.Registered() {
+		names = append(names, variable.Name())
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// duplicateRegisteredNames returns the names declared more than once.
+func duplicateRegisteredNames() []string {
+	seen := map[string]int{}
+	for _, variable := range envbool.Registered() {
+		seen[variable.Name()]++
+	}
+	var duplicated []string
+	for name, count := range seen {
+		if count > 1 {
+			duplicated = append(duplicated, name)
+		}
+	}
+	slices.Sort(duplicated)
+	return duplicated
+}
+
+// namesOutsideBothClassifications returns the mentioned names that are neither
+// declared through the shared package nor recorded as non-boolean.
+func namesOutsideBothClassifications(mentioned []string) []string {
+	declared := registeredNames()
+	var unclassified []string
+	for _, name := range mentioned {
+		if slices.Contains(declared, name) || slices.Contains(nonBooleanPtahVars, name) {
+			continue
+		}
+		unclassified = append(unclassified, name)
+	}
+	return unclassified
+}
+
+// namesInBothClassifications returns the names claimed by both classifications.
+func namesInBothClassifications() []string {
+	var both []string
+	for _, name := range registeredNames() {
+		if slices.Contains(nonBooleanPtahVars, name) {
+			both = append(both, name)
+		}
+	}
+	return both
+}
+
+// scanFile reports the guard violations in one Go source file, as
+// "path:line: reason" strings.
+func scanFile(c *qt.C, root, path string) []string {
+	c.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	c.Assert(err, qt.IsNil)
+
+	relative, err := filepath.Rel(root, path)
+	c.Assert(err, qt.IsNil)
+
+	var violations []string
+	parsedInAFunction := false
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Body == nil {
+			continue
+		}
+		found := scanFunc(fset, relative, fn)
+		parsedInAFunction = parsedInAFunction || slices.ContainsFunc(found, func(v string) bool {
+			return strings.Contains(v, "parses a boolean itself")
+		})
+		violations = append(violations, found...)
+	}
+
+	// The file-level fallback exists because one shape survived the
+	// function-level rule: cmd/internal/cmdflags read the value in `applyEnv`
+	// and parsed it in `setEnvValue`, two functions apart. That is the same
+	// defect split across a call, and a rule that stopped at the function
+	// boundary would have let the next copy of it in.
+	if !parsedInAFunction && fileReadsPtahEnv(file) && fileParsesBool(file) {
+		violations = append(violations, fmt.Sprintf(
+			"%s: reads a PTAH_ environment value and parses a boolean in the same file", relative))
+	}
+	return violations
+}
+
+// fileReadsPtahEnv reports whether anything in the file reads an environment
+// variable this contract governs.
+func fileReadsPtahEnv(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		call, ok := node.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		name := selectorName(call.Fun)
+		if (name == "os.Getenv" || name == "os.LookupEnv") && readsPtahVariable(call) {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// fileParsesBool reports whether anything in the file calls strconv.ParseBool.
+func fileParsesBool(file *ast.File) bool {
+	found := false
+	ast.Inspect(file, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok && selectorName(call.Fun) == "strconv.ParseBool" {
+			found = true
+		}
+		return true
+	})
+	return found
+}
+
+// scanFunc applies both shape rules to one function body.
+//
+// The unit is the function rather than the expression because the split form --
+// `LookupEnv` here, `ParseBool` three lines down -- is the same defect as the
+// nested one and has to fail the same way.
+func scanFunc(fset *token.FileSet, path string, fn *ast.FuncDecl) []string {
+	var (
+		readsEnv     bool
+		parsesBool   bool
+		comparisons  []ast.Node
+		envPositions []token.Pos
+	)
+	ast.Inspect(fn.Body, func(node ast.Node) bool {
+		if call, ok := node.(*ast.CallExpr); ok {
+			name := selectorName(call.Fun)
+			if (name == "os.Getenv" || name == "os.LookupEnv") && readsPtahVariable(call) {
+				readsEnv = true
+				envPositions = append(envPositions, call.Pos())
+			}
+			if name == "strconv.ParseBool" {
+				parsesBool = true
+			}
+		}
+		if binary, ok := node.(*ast.BinaryExpr); ok &&
+			(binary.Op == token.EQL || binary.Op == token.NEQ) &&
+			(isBooleanLiteral(binary.X) || isBooleanLiteral(binary.Y)) {
+			comparisons = append(comparisons, binary)
+		}
+		return true
+	})
+
+	var violations []string
+	if readsEnv && parsesBool {
+		violations = append(violations, fmt.Sprintf(
+			"%s:%d: %s reads the environment and parses a boolean itself",
+			path, fset.Position(envPositions[0]).Line, fn.Name.Name))
+	}
+	if readsEnv {
+		for _, comparison := range comparisons {
+			violations = append(violations, fmt.Sprintf(
+				"%s:%d: %s compares an environment value with a boolean literal",
+				path, fset.Position(comparison.Pos()).Line, fn.Name.Name))
+		}
+	}
+	return violations
+}
+
+// readsPtahVariable reports whether an environment read is one this contract
+// governs.
+//
+// A read whose argument is a string literal is judged by the name in it, which
+// keeps `os.Getenv("VISUAL")` and `os.Getenv("CLICKHOUSE_URL")` out of a rule
+// that has nothing to say about them. A read whose argument is anything else --
+// a constant, a computed name -- is IN scope, because that is how every reader
+// this change touched spells its own variable, and a rule that needed a literal
+// would have matched none of them.
+func readsPtahVariable(call *ast.CallExpr) bool {
+	if len(call.Args) != 1 {
+		return true
+	}
+	literal, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return true
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return true
+	}
+	return strings.HasPrefix(value, envbool.Prefix)
+}
+
+// isBooleanLiteral reports whether expression is one of the string spellings a
+// hand-rolled truthiness test compares against.
+func isBooleanLiteral(expression ast.Expr) bool {
+	literal, ok := expression.(*ast.BasicLit)
+	if !ok || literal.Kind != token.STRING {
+		return false
+	}
+	value, err := strconv.Unquote(literal.Value)
+	if err != nil {
+		return false
+	}
+	return slices.Contains(booleanLiterals, value)
+}
+
+// selectorName renders a package-qualified call target, or "" for anything else.
+func selectorName(expression ast.Expr) string {
+	selector, ok := expression.(*ast.SelectorExpr)
+	if !ok {
+		return ""
+	}
+	pkg, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return ""
+	}
+	return pkg.Name + "." + selector.Sel.Name
+}
+
+// ptahVarNames returns every PTAH_* name mentioned in a string literal in the
+// tree's non-test Go source, sorted and deduplicated.
+//
+// Only string literals count. A name in a comment is prose; a name in a literal
+// is the program naming a variable.
+func ptahVarNames(c *qt.C, root string) []string {
+	c.Helper()
+	var names []string
+	for _, path := range goSourceFiles(c, root) {
+		fset := token.NewFileSet()
+		file, err := parser.ParseFile(fset, path, nil, 0)
+		c.Assert(err, qt.IsNil)
+		ast.Inspect(file, func(node ast.Node) bool {
+			literal, ok := node.(*ast.BasicLit)
+			if !ok || literal.Kind != token.STRING {
+				return true
+			}
+			value, err := strconv.Unquote(literal.Value)
+			if err != nil {
+				return true
+			}
+			names = append(names, ptahVarPattern.FindAllString(value, -1)...)
+			return true
+		})
+	}
+	slices.Sort(names)
+	return slices.Compact(names)
+}
+
+// goSourceFiles lists the repository's non-test Go files, excluding the shared
+// package itself and this guard's own fixtures.
+//
+// git is the path source for the reason scripts/check-test-style.sh gives: a
+// filesystem walk descends into every linked worktree parked under the
+// repository, and judges code that is not in this working tree at all.
+func goSourceFiles(c *qt.C, root string) []string {
+	c.Helper()
+	cmd := exec.Command("git", "-c", "core.quotePath=false",
+		"ls-files", "--cached", "--others", "--exclude-standard", "--", "*.go")
+	cmd.Dir = root
+	var out bytes.Buffer
+	cmd.Stdout = &out
+	c.Assert(cmd.Run(), qt.IsNil)
+
+	var paths []string
+	for line := range strings.SplitSeq(strings.TrimSpace(out.String()), "\n") {
+		if line == "" || strings.HasSuffix(line, "_test.go") {
+			continue
+		}
+		if strings.HasPrefix(line, "internal/envbool/") || strings.HasPrefix(line, "cmd/internal/envboolguard/") {
+			continue
+		}
+		paths = append(paths, filepath.Join(root, line))
+	}
+	c.Assert(len(paths) > 100, qt.IsTrue, qt.Commentf(
+		"selected %d files; a guard that scans nothing is also green", len(paths)))
+	return paths
+}
+
+// repositoryRoot resolves the checkout this test belongs to.
+func repositoryRoot(c *qt.C) string {
+	c.Helper()
+	root, err := filepath.Abs(filepath.Join("..", "..", ".."))
+	c.Assert(err, qt.IsNil)
+	return root
+}
+
+// writeFile writes a fixture, failing the test rather than the scanner.
+func writeFile(c *qt.C, path, content string) {
+	c.Helper()
+	c.Assert(os.WriteFile(path, []byte(content), 0o600), qt.IsNil)
+}

--- a/docs/POSTGRESQL_ROLES.md
+++ b/docs/POSTGRESQL_ROLES.md
@@ -171,6 +171,14 @@ accepts `CREATE ROLE "postgres"` and the role appears in `pg_roles`. The
 variable decides only whether Ptah refuses first or the server does; it changes
 neither read, so a `pg_` name still fails at the server whatever it is set to.
 
+Both variables on this page are booleans and read the same way: leaving one
+unset selects the default described here, a valid boolean is honored, and
+anything else — an exported empty value included — fails the command before it
+reads or compares anything, naming the variable and the value. A malformed value
+is refused even on a run that declares no reserved role at all. The accepted
+spellings are documented once, in
+[Configuration](site/src/content/docs/reference/configuration.md).
+
 ### Role Modifications
 
 When role attributes change between migrations, Ptah generates ALTER ROLE statements:

--- a/docs/pre-migration-checks.md
+++ b/docs/pre-migration-checks.md
@@ -191,18 +191,25 @@ PTAH_SKIP_CHECKS=1 ptah-compat migrate apply --url "$DB" --dir file://migrations
 The name is not a second convention. Ptah binds every native flag to a
 `PTAH_<FLAG>` environment twin, so `ptah migrations up --skip-checks` already
 answers to `PTAH_SKIP_CHECKS`; `ptah-compat migrate apply` reads the same
-variable. Values are parsed as booleans (`1`, `true`, `t`, and their negations),
-and an unset or empty value enforces checks. A run with the bypass active prints
-a warning on stderr, because unlike a flag it leaves no trace in the command
-line.
+variable. A run with the bypass active prints a warning on stderr, because
+unlike a flag it leaves no trace in the command line.
 
-The two binaries agree on the name and on every valid boolean. They differ on an
-**invalid** one: `ptah-compat migrate apply` refuses it outright, before opening
-the database, so a typo in a CI environment file cannot read as a bypass that
-silently was not one, while native `ptah migrations up` discards the parse error
-and enforces checks. Both fail safe — a value neither of them understands never
-bypasses anything — but only the compat surface says so. Values with surrounding
-whitespace (`" 1"`) are not booleans and follow the same split.
+The two binaries agree on the name, on every valid boolean, and on every invalid
+one. An unset variable enforces checks and so does a valid false spelling; any
+other value — a typo, surrounding whitespace as in `" 1"`, or an exported empty
+value — is a configuration error that stops the run before the database is
+opened, on both binaries:
+
+```console
+$ PTAH_SKIP_CHECKS=notabool ptah migrations up --db-url "$DB" --migrations-dir migrations
+error: invalid boolean value "notabool" for PTAH_SKIP_CHECKS
+$ PTAH_SKIP_CHECKS=notabool ptah-compat migrate apply --url "$DB" --dir file://migrations
+Error: invalid boolean value "notabool" for PTAH_SKIP_CHECKS
+```
+
+A typo in a CI environment file therefore cannot read as a bypass that silently
+was not one. See
+[Boolean environment variables](site/src/content/docs/reference/configuration.md).
 
 It is an environment variable rather than a flag because Atlas registers no
 `--skip-checks` on `migrate apply` and `ptah-compat` does not add flags Atlas

--- a/docs/project_config.md
+++ b/docs/project_config.md
@@ -259,13 +259,19 @@ Runtime values resolve in this order:
 4. `ptah.yaml`
 5. Built-in command defaults
 
-A non-empty `PTAH_<FLAG>` value must parse as the corresponding flag type.
-Ptah rejects a malformed value before argument validation, command hooks, or
-database work begins. For example, `PTAH_DRY_RUN=notabool` fails with
+A `PTAH_<FLAG>` value must parse as the corresponding flag type. Ptah rejects a
+malformed value before argument validation, command hooks, or database work
+begins. For example, `PTAH_DRY_RUN=notabool` fails with
 `invalid boolean value "notabool" for PTAH_DRY_RUN` instead of running with
 the default `false` value. An explicit CLI flag wins without reading its
-environment twin, including when that environment value is malformed. Empty
-environment values remain unset.
+environment twin, including when that environment value is malformed. An empty
+value remains unset for every flag type except boolean, where it is rejected.
+
+Boolean `PTAH_*` variables — flag twins and direct feature toggles alike —
+follow one rule: absence selects the documented default, a present value must
+parse as a boolean, and anything else fails the command before it does work.
+The accepted spellings and the error shape are documented once, in the
+[Configuration reference](site/src/content/docs/reference/configuration.md).
 
 Project-file merging preserves source presence. For a supported field, an
 explicitly present value replaces the lower-precedence value instead of being

--- a/docs/site/src/content/docs/atlas/overview.md
+++ b/docs/site/src/content/docs/atlas/overview.md
@@ -153,6 +153,18 @@ schemas or migrations, native `ptah` reaches it under native names.
 
 ### The variables
 
+Every variable below is a boolean, and they all read the same way: leaving it
+unset selects the default described here, a valid boolean is honored, and
+anything else — including an exported empty value — fails the command before it
+does any work, naming the variable and the value you typed. The accepted
+spellings and the error shape are documented once, in
+[Boolean environment variables](../../reference/configuration/#boolean-environment-variables).
+
+The value is read on every run of the command that owns it, not only on the runs
+that would have used the enabled behavior, so `PTAH_ATLAS_LINT_ALL_VERSIONS=yes`
+in a CI environment file fails the next run rather than the next run that
+happens to omit `--latest`.
+
 **`PTAH_ATLAS_INSPECT_ALL_BLOCKS`** — by default, `ptah-compat schema inspect`
 leaves an `extension`, `sequence` or `policy` block out of PostgreSQL HCL
 output when nothing else in the document depends on it, and reports each
@@ -200,12 +212,12 @@ no opt-in.
 `format` is ignored, exactly as the community CLI ignores it, and named on
 standard error so a misspelled `?fromat=goose` does not quietly read the
 directory in the wrong layout. Set it to `1` and such a key is a refusal
-instead, for a pipeline that wants a typo to stop the run. An invalid value is
-an error rather than a silent "off": the value is read on every run of the eight
-verbs that accept a `--dir` query — `apply`, `diff`, `hash`, `lint`, `new`,
-`set`, `status` and `validate` — whether or not the URL carries a query at all,
-so `PTAH_STRICT_DIR_QUERY=nope` in a CI environment file fails the next run
-rather than the next typo. `migrate checkpoint`, `down`, `edit`, `rebase`, `rm`
+instead, for a pipeline that wants a typo to stop the run. The value is read on
+every run of the eight verbs that accept a `--dir` query — `apply`, `diff`,
+`hash`, `lint`, `new`, `set`, `status` and `validate` — whether or not the URL
+carries a query at all, so `PTAH_STRICT_DIR_QUERY=nope` in a CI environment file
+fails the next run rather than the next typo.
+`migrate checkpoint`, `down`, `edit`, `rebase`, `rm`
 and `test` refuse a `--dir` query outright, so neither the note nor this
 variable applies there.
 

--- a/docs/site/src/content/docs/atlas/schema-commands.md
+++ b/docs/site/src/content/docs/atlas/schema-commands.md
@@ -284,6 +284,13 @@ It is an environment variable and not a flag because the conformance
 `cli-surface` tier asserts that `ptah-compat` registers exactly the flags the
 pinned binary registers.
 
+It reads like every other boolean `PTAH_*` variable: unset keeps the refusal, a
+valid boolean is honored, and anything else fails `schema apply` before it reads
+the database — including on a run whose selectors all match, so a typo in a
+shared environment file stops the next run rather than the next unmatched
+selector. See
+[Boolean environment variables](../../reference/configuration/#boolean-environment-variables).
+
 Accepting both spellings is looser than the pinned Atlas community binary,
 deliberately. That binary reads a pattern relative to the URL scope: on a
 database URL only `public.users` matches, and on a schema-bound URL

--- a/docs/site/src/content/docs/databases/postgresql.md
+++ b/docs/site/src/content/docs/databases/postgresql.md
@@ -169,6 +169,13 @@ reads are untouched, so a `pg_` name still fails at the server whatever you set
 it to. It is an environment variable rather than a flag because `ptah-compat`
 registers exactly the flags the Atlas community CLI registers.
 
+Both variables on this page are booleans and read the same way: unset selects
+the default described above, a valid boolean is honored, and anything else fails
+the command before it reads or compares anything — including on a run that
+declares no reserved role and leaves no role out, which is what makes a typo
+visible before the day it would have mattered. See
+[Boolean environment variables](../../reference/configuration/#boolean-environment-variables).
+
 :::caution
 Ptah never drops a role automatically. A role that disappears from the desired
 schema stays in the database, because roles may be shared with DBAs,

--- a/docs/site/src/content/docs/direct/inspect.md
+++ b/docs/site/src/content/docs/direct/inspect.md
@@ -84,6 +84,11 @@ comparison already treats those roles as present either way. Reserved `pg_`
 names and the bootstrap `postgres` superuser stay out of both. See
 [PostgreSQL roles and grants](../../databases/postgresql/#roles-and-grants).
 
+Leaving the variable unset keeps the scoped read; a valid boolean is honored;
+anything else fails the read before the database is queried, naming the variable
+and the value. See
+[Boolean environment variables](../../reference/configuration/#boolean-environment-variables).
+
 Role creation statements in PostgreSQL output are intended for
 a clean target. If a role already exists, running the SQL by hand
 fails before its description or grants are changed; this prevents privileges

--- a/docs/site/src/content/docs/reference/atlas-commands.md
+++ b/docs/site/src/content/docs/reference/atlas-commands.md
@@ -110,10 +110,13 @@ environment variable rather than a flag this surface must not grow:
 PTAH_SKIP_CHECKS=1 ptah-compat migrate apply --url "$DB" --dir file://migrations
 ```
 
-It parses as a boolean, rejects a non-boolean value outright, warns on stderr
-while active, and bypasses checks only — `atlas.sum` verification and revision
-bookkeeping are unaffected. See
-[Pre-migration checks](../../versioned/integrity-and-safety/).
+It reads like every other boolean `PTAH_*` variable — unset enforces the checks,
+a valid boolean is honored, and anything else, an exported empty value included,
+fails the run before a migration is applied. It warns on stderr while active and
+bypasses checks only: `atlas.sum` verification and revision bookkeeping are
+unaffected. See
+[Pre-migration checks](../../versioned/integrity-and-safety/) and
+[Boolean environment variables](../configuration/#boolean-environment-variables).
 
 Native twin: [`ptah migrations up`](../native-commands/).
 

--- a/docs/site/src/content/docs/reference/configuration.md
+++ b/docs/site/src/content/docs/reference/configuration.md
@@ -13,13 +13,56 @@ Configuration precedence is:
 | 4 | `ptah.yaml` selected environment |
 | 5 | Built-in defaults |
 
-A non-empty `PTAH_<FLAG>` value must parse as the corresponding flag type.
-Ptah rejects a malformed value before argument validation, command hooks, or
-database work begins. For example, `PTAH_DRY_RUN=notabool` fails with
+A `PTAH_<FLAG>` value must parse as the corresponding flag type. Ptah rejects a
+malformed value before argument validation, command hooks, or database work
+begins. For example, `PTAH_DRY_RUN=notabool` fails with
 `invalid boolean value "notabool" for PTAH_DRY_RUN` instead of running with
 the default `false` value. An explicit CLI flag wins without reading its
-environment twin, including when that environment value is malformed. Empty
-environment values remain unset.
+environment twin, including when that environment value is malformed. An empty
+value remains unset for every flag type except boolean, where it is rejected;
+see [Boolean environment variables](#boolean-environment-variables).
+
+## Boolean environment variables
+
+Every boolean `PTAH_*` variable follows one rule, whether it is a flag's
+environment twin or a feature toggle read directly:
+
+| State | Result |
+| --- | --- |
+| Not set | The documented default |
+| Set to a valid boolean | Parsed and honored |
+| Set to anything else | The command fails before doing any work |
+
+The accepted spellings are Go's `strconv.ParseBool` spellings:
+
+```text
+true:  1  t  T  true  True  TRUE
+false: 0  f  F  false  False  FALSE
+```
+
+Nothing is trimmed before parsing. `" true"`, `"true "` and an exported empty
+value are all rejected, because a quoting or expansion mistake in a YAML
+manifest, a CI environment file or a systemd unit is exactly the configuration
+error this rule exists to surface. The refusal names the variable and the raw
+value:
+
+```text
+Error: invalid boolean value "maybe" for PTAH_POSTGRES_INSPECT_ALL_ROLES
+```
+
+The refusal comes before the command connects to a database, writes a migration
+file, applies schema changes, touches revision state, or produces a
+machine-readable result on standard output. It also comes before the command's
+own early returns: an invalid value is rejected even on a run that would never
+have consulted it, such as a `migrate lint` that already names `--latest`, or a
+`schema apply` whose `--exclude` selectors all match.
+
+A command only validates the variables it owns. A malformed PostgreSQL
+inspection variable does not break an unrelated SQLite command or
+`ptah version`.
+
+Non-boolean `PTAH_*` variables are unchanged: an empty value still reads as
+unset for them.
 
 Project-file merging preserves source presence. For a supported field, an
 explicitly present value replaces the lower-precedence value instead of being

--- a/internal/atlasargs/args.go
+++ b/internal/atlasargs/args.go
@@ -9,6 +9,8 @@ import (
 	"slices"
 	"strconv"
 	"strings"
+
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // LocalDir describes a parsed local Atlas migration directory URL.
@@ -521,17 +523,23 @@ func appendEnvArgs(flags []Flag, args []string) ([]string, error) {
 			continue
 		}
 		value, ok := os.LookupEnv(envName("PTAH", flag.Name))
-		if !ok || value == "" {
+		if !ok {
 			continue
 		}
 		if flag.Kind == BoolFlag {
-			parsed, err := strconv.ParseBool(value)
+			// One grammar and one error for every boolean PTAH_* variable, and an
+			// explicitly empty one is a configuration error rather than a silent
+			// "unset". See [go.5x5.cz/ptah/internal/envbool] and
+			// stokaro/ptah#1334.
+			parsed, err := envbool.Parse(envName("PTAH", flag.Name), value)
 			if err != nil {
-				return nil, fmt.Errorf("invalid boolean value %q for %s", value, envName("PTAH", flag.Name))
+				return nil, err
 			}
 			if !parsed {
 				continue
 			}
+		} else if value == "" {
+			continue
 		}
 		if flag.Kind == UintFlag {
 			if _, err := strconv.ParseUint(value, 0, 64); err != nil {

--- a/internal/atlasfilter/filter_unmatched_exclude_test.go
+++ b/internal/atlasfilter/filter_unmatched_exclude_test.go
@@ -8,6 +8,7 @@ import (
 	"go.5x5.cz/ptah/core/goschema"
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/atlasfilter"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // TestExcludeDatabaseReport_NamesSelectorsThatMatchedNothing is the emptiness
@@ -181,25 +182,61 @@ func TestUnmatchedAcrossStates_IntersectsSides(t *testing.T) {
 // binary.
 func TestAllowUnmatchedExclude_ReadsTheOptIn(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
-		want  bool
+		name        string
+		env         func(testing.TB)
+		want        bool
+		wantMessage string
 	}{
-		{name: "unset keeps the safe default", value: "", want: false},
-		{name: "false keeps the safe default", value: "false", want: false},
-		{name: "unparsable keeps the safe default", value: "maybe", want: false},
-		{name: "1 opts in", value: "1", want: true},
-		{name: "true opts in", value: "true", want: true},
+		{
+			name: "unset keeps the safe default",
+			env:  envbooltest.Unset(atlasfilter.AllowUnmatchedExcludeEnvVar),
+		},
+		{
+			name: "false keeps the safe default",
+			env:  envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "false"),
+		},
+		{
+			name:        "unparsable is refused",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "maybe"),
+			wantMessage: `invalid boolean value "maybe" for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE`,
+		},
+		{
+			name:        "an exported empty value is refused",
+			env:         envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, ""),
+			wantMessage: `invalid boolean value "" for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE`,
+		},
+		{
+			name: "1 opts in",
+			env:  envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "1"),
+			want: true,
+		},
+		{
+			name: "true opts in",
+			env:  envbooltest.Set(atlasfilter.AllowUnmatchedExcludeEnvVar, "true"),
+			want: true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			t.Setenv(atlasfilter.AllowUnmatchedExcludeEnvVar, test.value)
+			test.env(t)
 
-			c.Assert(atlasfilter.AllowUnmatchedExclude(), qt.Equals, test.want)
+			got, err := atlasfilter.AllowUnmatchedExclude()
+
+			c.Assert(got, qt.Equals, test.want)
+			c.Assert(errMessage(err), qt.Equals, test.wantMessage)
 		})
 	}
+}
+
+// errMessage renders an error for comparison against a table row without a
+// branch in the test body.
+func errMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // TestUnmatchedExcludeError_NamesEverySelector keeps the diagnostic quoting the

--- a/internal/atlasfilter/unmatched.go
+++ b/internal/atlasfilter/unmatched.go
@@ -1,9 +1,9 @@
 package atlasfilter
 
 import (
-	"os"
 	"slices"
-	"strconv"
+
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // AllowUnmatchedExcludeEnvVar restores the permissive treatment of an
@@ -22,12 +22,20 @@ import (
 // keeps working on this same surface rather than being told to rewrite.
 const AllowUnmatchedExcludeEnvVar = "PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE"
 
-// AllowUnmatchedExclude reports whether the opt-in variable is set to a true
-// boolean value. Unset, empty, false and unparsable values all keep the
-// default.
-func AllowUnmatchedExclude() bool {
-	allow, err := strconv.ParseBool(os.Getenv(AllowUnmatchedExcludeEnvVar))
-	return err == nil && allow
+// allowUnmatchedExclude is the declaration of the variable, made once, in the
+// package that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var allowUnmatchedExclude = envbool.New(AllowUnmatchedExcludeEnvVar, false)
+
+// AllowUnmatchedExclude reports whether the opt-in restores the permissive
+// treatment of an --exclude selector that named no object.
+//
+// Unset keeps the refusal and a valid false spelling keeps it too; an empty or
+// unparsable value is a configuration error. A shared exclude list is exactly
+// the setting where the variable is exported once and read on every run, so a
+// typo in it must not read as "refusal still on" while the operator believes
+// they turned it off (stokaro/ptah#1334).
+func AllowUnmatchedExclude() (bool, error) {
+	return allowUnmatchedExclude.Resolve()
 }
 
 // UnmatchedAcrossStates intersects per-state [ExcludeReport]s into the

--- a/internal/atlashclrender/atlas_refused_blocks.go
+++ b/internal/atlashclrender/atlas_refused_blocks.go
@@ -2,14 +2,13 @@ package atlashclrender
 
 import (
 	"fmt"
-	"os"
 	"slices"
-	"strconv"
 	"strings"
 
 	"go.5x5.cz/ptah/core/coverage"
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // Top-level HCL block spellings an inspected render can emit. Only the ones a
@@ -44,13 +43,19 @@ const (
 // surface rather than being told to rewrite against native `ptah`.
 const KeepAtlasRefusedBlocksEnvVar = "PTAH_ATLAS_INSPECT_ALL_BLOCKS"
 
-// KeepAtlasRefusedBlocks reports whether the opt-in variable is set to a true
-// boolean value. Unset, empty, false and unparsable values all keep the
-// default, mirroring how [go.5x5.cz/ptah/internal/atlassource] reads its own
-// opt-in.
-func KeepAtlasRefusedBlocks() bool {
-	keep, err := strconv.ParseBool(os.Getenv(KeepAtlasRefusedBlocksEnvVar))
-	return err == nil && keep
+// keepAtlasRefusedBlocks is the declaration of the variable, made once, in the
+// package that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var keepAtlasRefusedBlocks = envbool.New(KeepAtlasRefusedBlocksEnvVar, false)
+
+// KeepAtlasRefusedBlocks reports whether the opt-in restores every block Ptah
+// models.
+//
+// Unset keeps the default and a valid false spelling keeps it too; an empty or
+// unparsable value is a configuration error, because a render that silently
+// omitted an extension after an operator believed they had asked for it is the
+// one answer this must never give (stokaro/ptah#1334).
+func KeepAtlasRefusedBlocks() (bool, error) {
+	return keepAtlasRefusedBlocks.Resolve()
 }
 
 // atlasRefusedBlockTypes lists, per dialect, the top-level block types the

--- a/internal/atlashclrender/atlas_refused_blocks_env_test.go
+++ b/internal/atlashclrender/atlas_refused_blocks_env_test.go
@@ -6,6 +6,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	"go.5x5.cz/ptah/internal/atlashclrender"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // TestKeepAtlasRefusedBlocksReadsTheOptIn pins how the opt-in is parsed.
@@ -14,31 +15,75 @@ import (
 // narrower document at all: a capability that cannot be reached is a capability
 // that was removed (AGENTS.md, "Compatibility never removes a capability"). The
 // rows mirror [go.5x5.cz/ptah/internal/atlassource]'s own opt-in, so an
-// operator who learned one spelling is not surprised by the other -- unset,
-// empty, false and unparsable all keep the default.
+// operator who learned one spelling is not surprised by the other -- absence
+// and a valid false keep the default, and anything else is refused by name and
+// by value (stokaro/ptah#1334).
 func TestKeepAtlasRefusedBlocksReadsTheOptIn(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
-		want  bool
+		name        string
+		env         func(testing.TB)
+		want        bool
+		wantMessage string
 	}{
-		{name: "unset keeps the compatible default", value: "", want: false},
-		{name: "1 restores the superset", value: "1", want: true},
-		{name: "true restores the superset", value: "true", want: true},
-		{name: "TRUE restores the superset", value: "TRUE", want: true},
-		{name: "0 keeps the compatible default", value: "0", want: false},
-		{name: "false keeps the compatible default", value: "false", want: false},
-		{name: "an unparsable value keeps the compatible default", value: "yes please", want: false},
+		{
+			name: "unset keeps the compatible default",
+			env:  envbooltest.Unset(atlashclrender.KeepAtlasRefusedBlocksEnvVar),
+		},
+		{
+			name: "1 restores the superset",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "1"),
+			want: true,
+		},
+		{
+			name: "true restores the superset",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "true"),
+			want: true,
+		},
+		{
+			name: "TRUE restores the superset",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "TRUE"),
+			want: true,
+		},
+		{
+			name: "0 keeps the compatible default",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "0"),
+		},
+		{
+			name: "false keeps the compatible default",
+			env:  envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "false"),
+		},
+		{
+			name:        "an unparsable value is refused",
+			env:         envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, "yes please"),
+			wantMessage: `invalid boolean value "yes please" for PTAH_ATLAS_INSPECT_ALL_BLOCKS`,
+		},
+		{
+			name:        "an exported empty value is refused",
+			env:         envbooltest.Set(atlashclrender.KeepAtlasRefusedBlocksEnvVar, ""),
+			wantMessage: `invalid boolean value "" for PTAH_ATLAS_INSPECT_ALL_BLOCKS`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			t.Setenv(atlashclrender.KeepAtlasRefusedBlocksEnvVar, test.value)
+			test.env(t)
 
-			c.Assert(atlashclrender.KeepAtlasRefusedBlocks(), qt.Equals, test.want)
+			got, err := atlashclrender.KeepAtlasRefusedBlocks()
+
+			c.Assert(got, qt.Equals, test.want)
+			c.Assert(errMessage(err), qt.Equals, test.wantMessage)
 		})
 	}
+}
+
+// errMessage renders an error for comparison against a table row without a
+// branch in the test body.
+func errMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // TestKeepAtlasRefusedBlocksEnvVarIsSpelledLikeItsPrecedent pins the name the

--- a/internal/atlasschema/apply.go
+++ b/internal/atlasschema/apply.go
@@ -156,6 +156,20 @@ func computeApplyPlan(
 	if len(opts.ToURLs) == 0 && opts.Desired == nil {
 		return applyComputation{}, errors.New("schema apply planning requires desired schema URLs")
 	}
+	// Resolved here, before the desired state is loaded and before the target is
+	// read, so a malformed value refuses the run with nothing planned, nothing
+	// executed and nothing written. Resolving it beside the refusal below would
+	// hide the typo on every run whose --exclude selectors all matched -- the
+	// healthy pipeline -- and surface it only on the run it was set to govern.
+	// See stokaro/ptah#1334.
+	allowUnmatched := false
+	if opts.RefuseUnmatchedExclude {
+		allowed, err := atlasfilter.AllowUnmatchedExclude()
+		if err != nil {
+			return applyComputation{}, err
+		}
+		allowUnmatched = allowed
+	}
 
 	scope := atlasfilter.Scope{
 		Schemas:       opts.Schemas,
@@ -186,8 +200,8 @@ func computeApplyPlan(
 	// message restores the permissive one. Callers that only compute a plan
 	// say so instead.
 	unmatched := atlasfilter.UnmatchedAcrossStates(currentReport, desiredReport)
-	if opts.RefuseUnmatchedExclude {
-		if err := refuseUnmatchedExclude(opts.Diagnostics, unmatched); err != nil {
+	if opts.RefuseUnmatchedExclude && !allowUnmatched {
+		if err := refuseUnmatchedExclude(unmatched); err != nil {
 			return applyComputation{}, err
 		}
 	} else {

--- a/internal/atlasschema/scope.go
+++ b/internal/atlasschema/scope.go
@@ -97,19 +97,19 @@ func reportUnmatchedExclude(diagnostics io.Writer, selectors []string) {
 }
 
 // refuseUnmatchedExclude turns unmatched --exclude selectors into the error
-// `schema apply` fails with, or into nil when the caller opted back into the
-// permissive behavior.
+// `schema apply` fails with.
+//
+// Whether the run refuses at all is the caller's decision, resolved from
+// [atlasfilter.AllowUnmatchedExcludeEnvVar] before any state is read; a caller
+// that opted back into the permissive behavior calls
+// [reportUnmatchedExclude] instead.
 //
 // Apply is the verb that executes, so it is the one that refuses: a user
 // writes --exclude to keep an object out of the plan, and a selector that
 // named nothing means the plan is free to change it. Diff and inspect warn
 // instead, which is the split #1113 recorded for the --include side.
-func refuseUnmatchedExclude(diagnostics io.Writer, selectors []string) error {
+func refuseUnmatchedExclude(selectors []string) error {
 	if len(selectors) == 0 {
-		return nil
-	}
-	if atlasfilter.AllowUnmatchedExclude() {
-		reportUnmatchedExclude(diagnostics, selectors)
 		return nil
 	}
 	return fmt.Errorf(

--- a/internal/atlassource/atlassource.go
+++ b/internal/atlassource/atlassource.go
@@ -29,7 +29,6 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
-	"strconv"
 	"strings"
 
 	"go.5x5.cz/ptah/config/projectconfig"
@@ -37,6 +36,7 @@ import (
 	"go.5x5.cz/ptah/core/schemasource"
 	"go.5x5.cz/ptah/internal/atlasprojectpath"
 	"go.5x5.cz/ptah/internal/atlasurl"
+	"go.5x5.cz/ptah/internal/envbool"
 	"go.5x5.cz/ptah/internal/migratesum"
 	"go.5x5.cz/ptah/internal/pathguard"
 	"go.5x5.cz/ptah/internal/schemafile"
@@ -333,8 +333,23 @@ func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 	if err := ValidateEnvAttr(source.EnvAttr); err != nil {
 		return nil, err
 	}
+	// Env expansion is the subsystem that recognizes the external-schema opt-in,
+	// so the value is resolved on every expansion -- including the ones that
+	// reference `url` or `migration`, and the ones whose selected env declares no
+	// external schema program at all. Resolving it only inside
+	// [expandEnvExternalSchema] would let PTAH_ALLOW_EXTERNAL_SCHEMA=tru pass in
+	// silence on every configuration that does not use the feature, which is
+	// exactly the pipeline that exports it and never sees it work.
+	// See stokaro/ptah#1334.
+	allowExternal, err := externalSchemaAllowed()
+	if err != nil {
+		return nil, err
+	}
 	switch source.EnvAttr {
 	case "src", "schema.src":
+		if !allowExternal && envSelectsExternalSchema(env) {
+			return nil, errExternalSchemaDisabled()
+		}
 		return expandEnvSchemaSources(source, env)
 	case "url":
 		return expandEnvDatabaseURL(source.EnvAttr, env.Config.DatabaseURL)
@@ -352,7 +367,7 @@ func expandEnv(source Source, env ProjectEnv) ([]Source, error) {
 
 func expandEnvSchemaSources(source Source, env ProjectEnv) ([]Source, error) {
 	if len(env.Config.SchemaSources) == 0 {
-		if len(env.Config.ExternalSchema.Program) > 0 {
+		if envSelectsExternalSchema(env) {
 			return expandEnvExternalSchema(source, env)
 		}
 		return nil, errors.New("the selected atlas.hcl env does not define schema sources (env.src or env.schema.src)")
@@ -374,12 +389,6 @@ func expandEnvSchemaSources(source Source, env ProjectEnv) ([]Source, error) {
 // explicit environment opt-in; the gate fails during classification, before
 // any database is contacted and before the program could run.
 func expandEnvExternalSchema(source Source, env ProjectEnv) ([]Source, error) {
-	if !externalSchemaAllowed() {
-		return nil, fmt.Errorf(
-			"atlas.hcl data.external_schema executes a repository-controlled program and is disabled by default; set %s=1 to allow it",
-			AllowExternalSchemaEnvVar,
-		)
-	}
 	external := env.Config.ExternalSchema
 	return []Source{{
 		Raw:  source.Raw,
@@ -393,13 +402,45 @@ func expandEnvExternalSchema(source Source, env ProjectEnv) ([]Source, error) {
 	}}, nil
 }
 
-// externalSchemaAllowed reports whether the external schema opt-in variable is
-// set to a true boolean value. Unset, empty, false, and unparsable values all
-// deny, mirroring how the native env twin feeds the --allow-external-schema
-// bool flag.
-func externalSchemaAllowed() bool {
-	allowed, err := strconv.ParseBool(os.Getenv(AllowExternalSchemaEnvVar))
-	return err == nil && allowed
+// envSelectsExternalSchema reports whether the selected env's desired state is
+// the declared external schema program rather than ordinary schema sources.
+//
+// The gate above and the expansion below both ask this, and they have to agree:
+// a gate testing a different condition would either refuse an env that runs no
+// program or let one run unguarded.
+func envSelectsExternalSchema(env ProjectEnv) bool {
+	return len(env.Config.SchemaSources) == 0 && len(env.Config.ExternalSchema.Program) > 0
+}
+
+// errExternalSchemaDisabled is the refusal an env expansion returns when the
+// selected env's desired state is a repository-controlled program and the
+// opt-in was not given. It names the way back, because a refusal that does not
+// is a dead end.
+func errExternalSchemaDisabled() error {
+	return fmt.Errorf(
+		"atlas.hcl data.external_schema executes a repository-controlled program and is disabled by default; set %s=1 to allow it",
+		AllowExternalSchemaEnvVar,
+	)
+}
+
+// allowExternalSchema is the declaration of the variable, made once, in the
+// package that owns it. See [go.5x5.cz/ptah/internal/envbool].
+//
+// The same name reaches the native surface as the --allow-external-schema
+// flag's environment twin, which cmd/internal/cmdflags already parses under the
+// same grammar and the same error, so one name means one thing on both
+// binaries.
+var allowExternalSchema = envbool.New(AllowExternalSchemaEnvVar, false)
+
+// externalSchemaAllowed reports whether executing an atlas.hcl
+// data.external_schema program is allowed.
+//
+// Unset denies and a valid false spelling denies too; an empty or unparsable
+// value is a configuration error. Denying on a typo is the safe direction, but
+// silence is not: an operator who exported the opt-in and is refused anyway has
+// to be told why (stokaro/ptah#1334).
+func externalSchemaAllowed() (bool, error) {
+	return allowExternalSchema.Resolve()
 }
 
 // classifyEnvValue classifies one env-provided source value. Relative local

--- a/internal/atlassource/external_schema_test.go
+++ b/internal/atlassource/external_schema_test.go
@@ -11,6 +11,7 @@ import (
 	"go.5x5.cz/ptah/config/projectconfig"
 	"go.5x5.cz/ptah/core/schemasource"
 	"go.5x5.cz/ptah/internal/atlassource"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 )
 
 // externalHelperModes maps a mode name to the behavior the re-executed test
@@ -99,29 +100,89 @@ func TestClassifySetExternalSchema_GateFailurePath(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
-		name  string
-		value string
+		name    string
+		env     func(testing.TB)
+		wantErr string
 	}{
-		{name: "empty", value: ""},
-		{name: "zero", value: "0"},
-		{name: "false", value: "false"},
-		{name: "garbage", value: "yes-please"},
+		{
+			name: "unset",
+			env:  envbooltest.Unset(atlassource.AllowExternalSchemaEnvVar),
+			wantErr: `--to "env://src": atlas\.hcl data\.external_schema executes a repository-controlled` +
+				` program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`,
+		},
+		{
+			name: "zero",
+			env:  envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, "0"),
+			wantErr: `--to "env://src": atlas\.hcl data\.external_schema executes a repository-controlled` +
+				` program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`,
+		},
+		{
+			name: "false",
+			env:  envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, "false"),
+			wantErr: `--to "env://src": atlas\.hcl data\.external_schema executes a repository-controlled` +
+				` program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`,
+		},
+		{
+			// The refusal changes shape here since stokaro/ptah#1334: a value
+			// that is not a boolean is a configuration error, not a denial, and
+			// telling the operator "disabled by default" when they had in fact
+			// enabled it sends them looking in the wrong place.
+			name:    "garbage",
+			env:     envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, "yes-please"),
+			wantErr: `--to "env://src": invalid boolean value "yes-please" for PTAH_ALLOW_EXTERNAL_SCHEMA`,
+		},
+		{
+			name:    "an exported empty value",
+			env:     envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, ""),
+			wantErr: `--to "env://src": invalid boolean value "" for PTAH_ALLOW_EXTERNAL_SCHEMA`,
+		},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			t.Setenv(atlassource.AllowExternalSchemaEnvVar, test.value)
+			test.env(c)
 
 			_, err := atlassource.ClassifySet("--to", []string{"env://src"}, externalSchemaProjectEnv("sql"))
 
-			c.Assert(err, qt.ErrorMatches, `--to "env://src": atlas\.hcl data\.external_schema executes a repository-controlled program and is disabled by default; set PTAH_ALLOW_EXTERNAL_SCHEMA=1 to allow it`)
+			c.Assert(err, qt.ErrorMatches, test.wantErr)
 		})
 	}
 }
 
+// TestClassifySetExternalSchemaGateRefusesAMalformedValueWithNoProgram is the
+// discriminating case: the selected env declares ordinary schema sources, so
+// nothing on this run could ever execute a program. Resolving the opt-in only
+// inside the external-schema branch left the typo dormant on every such
+// configuration, which is most of them.
+func TestClassifySetExternalSchemaGateRefusesAMalformedValueWithNoProgram(t *testing.T) {
+	c := qt.New(t)
+	envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, "yes-please")(t)
+	env := externalSchemaProjectEnv("sql")
+	env.Config.SchemaSources = []string{"file://schema.hcl"}
+
+	_, err := atlassource.ClassifySet("--to", []string{"env://src"}, env)
+
+	c.Assert(err, qt.ErrorMatches, `--to "env://src": invalid boolean value "yes-please" for PTAH_ALLOW_EXTERNAL_SCHEMA`)
+}
+
+// TestClassifySetRefusesAMalformedValueOnAnUnrelatedEnvAttribute widens the same
+// point one step: `env://url` expands a database URL and has no relationship to
+// external schema programs at all, and it still refuses. Env expansion is the
+// subsystem that owns the variable, so every expansion reads it.
+func TestClassifySetRefusesAMalformedValueOnAnUnrelatedEnvAttribute(t *testing.T) {
+	c := qt.New(t)
+	envbooltest.Set(atlassource.AllowExternalSchemaEnvVar, "yes-please")(t)
+	env := externalSchemaProjectEnv("sql")
+	env.Config.DatabaseURL = "sqlite://target.db"
+
+	_, err := atlassource.ClassifySet("--to", []string{"env://url"}, env)
+
+	c.Assert(err, qt.ErrorMatches, `--to "env://url": invalid boolean value "yes-please" for PTAH_ALLOW_EXTERNAL_SCHEMA`)
+}
+
 func TestClassifySetExternalSchemaGateDoesNotExecuteProgram(t *testing.T) {
 	c := qt.New(t)
-	t.Setenv(atlassource.AllowExternalSchemaEnvVar, "")
+	envbooltest.Unset(atlassource.AllowExternalSchemaEnvVar)(t)
 	dir := t.TempDir()
 	sentinel := filepath.Join(dir, "executed.sentinel")
 	script := filepath.Join(dir, "gen.sh")

--- a/internal/dbschema/postgres/reader.go
+++ b/internal/dbschema/postgres/reader.go
@@ -2535,6 +2535,19 @@ func (r *Reader) readRoles() ([]types.DBRole, error) {
 // The union is re-sorted by name rather than concatenated, so the fuller
 // description is ordered exactly as the single unscoped query ordered it.
 func (r *Reader) readRolesInto(schema *types.DBSchema) error {
+	// Resolved FIRST, before either query, so a malformed value is refused on
+	// every role read and not only on the runs that would have widened the
+	// description. A server whose scoped and unscoped reads happen to agree
+	// leaves nothing out, and resolving below would let
+	// PTAH_POSTGRES_INSPECT_ALL_ROLES=maybe pass in silence there --
+	// the healthy half of a pipeline, and the only runs a CI environment file
+	// is read on until the schema grows the role that makes the two differ.
+	// See stokaro/ptah#1334.
+	describeAll, err := rolescope.DescribeAll()
+	if err != nil {
+		return err
+	}
+
 	described, err := r.readRoles()
 	if err != nil {
 		return fmt.Errorf("failed to read roles: %w", err)
@@ -2549,7 +2562,7 @@ func (r *Reader) readRolesInto(schema *types.DBSchema) error {
 		return fmt.Errorf("failed to read roles outside the inspected scope: %w", err)
 	}
 
-	if rolescope.DescribeAll() {
+	if describeAll {
 		everyManagedRole := slices.Concat(described, outOfScope)
 		slices.SortFunc(everyManagedRole, func(a, b types.DBRole) int {
 			return strings.Compare(a.Name, b.Name)

--- a/internal/dbschema/postgres/reader_roles_internal_test.go
+++ b/internal/dbschema/postgres/reader_roles_internal_test.go
@@ -43,6 +43,7 @@ import (
 	"go.5x5.cz/ptah/core/platform/capability"
 	"go.5x5.cz/ptah/dbschema/types"
 	"go.5x5.cz/ptah/internal/dbschema/dbtest"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 	"go.5x5.cz/ptah/internal/rolescope"
 )
 
@@ -945,7 +946,7 @@ func TestReadRolesIntoScopesTheDescriptionByDefault(t *testing.T) {
 	// The default: the description is the scoped read, and the roles it leaves
 	// out are carried separately for the comparator alone. This is the shape
 	// every surface produces unless an operator asks for the other one.
-	c.Setenv(rolescope.DescribeAllEnvVar, "")
+	envbooltest.Unset(rolescope.DescribeAllEnvVar)(c)
 	reader := newRolesServer(c.TB, fullCluster(), []string{"public"}, capability.Postgres16())
 	schema := &types.DBSchema{}
 
@@ -957,6 +958,63 @@ func TestReadRolesIntoScopesTheDescriptionByDefault(t *testing.T) {
 	c.Assert(roleNames(schema.RolesOutOfScope), qt.DeepEquals, []string{
 		"app_schema_grantee", "pgbouncer", "someone_elses", "third_party", "unrelated_tenant",
 	})
+}
+
+// TestReadRolesIntoRefusesAMalformedOptIn pins the state split stokaro/ptah#1334
+// introduced, and pins it on the run that used to hide it.
+//
+// The `--schemas empty` row is the discriminating one: the scoped read and the
+// complement partition the same cluster either way, so on a schema nothing uses
+// the opt-in changes which list the roles land in but never which roles exist.
+// A read resolved beside the branch would pass there in silence. Resolving it
+// before the two queries makes the typo answer on every read.
+//
+// The schema is asserted untouched in both rows: a refusal that had already
+// written half a description would be a worse answer than the silence it
+// replaces.
+func TestReadRolesIntoRefusesAMalformedOptIn(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		env         func(testing.TB)
+		schemas     []string
+		wantMessage string
+	}{
+		{
+			name:        "an unparsable value",
+			env:         envbooltest.Set(rolescope.DescribeAllEnvVar, "all of them"),
+			schemas:     []string{"public"},
+			wantMessage: `invalid boolean value "all of them" for PTAH_POSTGRES_INSPECT_ALL_ROLES`,
+		},
+		{
+			name:        "an exported empty value",
+			env:         envbooltest.Set(rolescope.DescribeAllEnvVar, ""),
+			schemas:     []string{"public"},
+			wantMessage: `invalid boolean value "" for PTAH_POSTGRES_INSPECT_ALL_ROLES`,
+		},
+		{
+			name:        "a scope where the opt-in would change nothing",
+			env:         envbooltest.Set(rolescope.DescribeAllEnvVar, "maybe"),
+			schemas:     []string{"empty"},
+			wantMessage: `invalid boolean value "maybe" for PTAH_POSTGRES_INSPECT_ALL_ROLES`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			test.env(c)
+			reader := newRolesServer(c.TB, fullCluster(), test.schemas, capability.Postgres16())
+			schema := &types.DBSchema{}
+
+			err := reader.readRolesInto(schema)
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.wantMessage)
+			c.Assert(schema.Roles, qt.HasLen, 0)
+			c.Assert(schema.RolesOutOfScope, qt.HasLen, 0)
+		})
+	}
 }
 
 func TestReadRolesIntoDescribesEveryManagedRoleUnderTheOptIn(t *testing.T) {
@@ -999,18 +1057,34 @@ func TestReadRolesIntoLeavesTheComparatorsAnswerAlone(t *testing.T) {
 	// already there, which is the failure stokaro/ptah#1276 is about.
 	tests := []struct {
 		name    string
-		optIn   string
+		env     func(testing.TB)
 		schemas []string
 	}{
-		{name: "default, public", optIn: "", schemas: []string{"public"}},
-		{name: "opt-in, public", optIn: "1", schemas: []string{"public"}},
-		{name: "default, a schema nothing uses", optIn: "", schemas: []string{"empty"}},
-		{name: "opt-in, a schema nothing uses", optIn: "1", schemas: []string{"empty"}},
+		{
+			name:    "default, public",
+			env:     envbooltest.Unset(rolescope.DescribeAllEnvVar),
+			schemas: []string{"public"},
+		},
+		{
+			name:    "opt-in, public",
+			env:     envbooltest.Set(rolescope.DescribeAllEnvVar, "1"),
+			schemas: []string{"public"},
+		},
+		{
+			name:    "default, a schema nothing uses",
+			env:     envbooltest.Unset(rolescope.DescribeAllEnvVar),
+			schemas: []string{"empty"},
+		},
+		{
+			name:    "opt-in, a schema nothing uses",
+			env:     envbooltest.Set(rolescope.DescribeAllEnvVar, "1"),
+			schemas: []string{"empty"},
+		},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			c.Setenv(rolescope.DescribeAllEnvVar, test.optIn)
+			test.env(c)
 			reader := newRolesServer(c.TB, fullCluster(), test.schemas, capability.Postgres16())
 			schema := &types.DBSchema{}
 

--- a/internal/envbool/envbool.go
+++ b/internal/envbool/envbool.go
@@ -1,0 +1,138 @@
+// Package envbool owns the one grammar Ptah accepts for a boolean `PTAH_*`
+// environment variable, and the one error it reports for anything else.
+//
+// The rule this package exists to make unavoidable:
+//
+//	unset                 the documented default
+//	a valid boolean       parsed and honored
+//	anything else         a configuration error naming the variable and the value
+//
+// Before stokaro/ptah#1334 the direct feature toggles each spelled their own
+// read as
+//
+//	value, err := strconv.ParseBool(os.Getenv(name))
+//	return err == nil && value
+//
+// which answers the same `false` for four distinguishable states: the variable
+// is absent, it is set to a false spelling, it is set to the empty string, and
+// it holds a typo. An operator who wrote `PTAH_ALLOW_RESERVED_ROLE_NAMES=yes`
+// in a CI environment file, a container manifest or a systemd unit believes
+// they changed the behavior, and nothing tells them otherwise. Every boolean
+// toggle in this tree opts IN to the more permissive side, so the typo lands on
+// the strict default and fails closed -- which is why this is a usability
+// defect today and would be a security one the first time a boolean `PTAH_*`
+// variable defaults to the permissive side. The guard test over [Registered]
+// asserts every declared default is false, so that flip cannot happen quietly.
+//
+// The accepted spellings are exactly [strconv.ParseBool]'s, deliberately not a
+// narrower or wider set: `1 t T TRUE true True` and `0 f F FALSE false False`.
+// Nothing is trimmed before parsing, so `" true"`, `"true "` and `""` are
+// configuration errors rather than accidents that happen to work -- a quoting
+// mistake in a YAML manifest is precisely the class this rule exists to
+// surface.
+//
+// Variables are DECLARED, not read ad hoc: a package-level [New] call names the
+// variable and its default once, and [Registered] is the derived list a guard
+// test measures the tree against. A hand-maintained list is what goes stale the
+// next time a variable is added, which is the failure mode this package is
+// shaped to prevent.
+package envbool
+
+import (
+	"fmt"
+	"os"
+	"slices"
+	"strconv"
+	"strings"
+	"sync"
+)
+
+// Prefix is the namespace every variable this package governs lives in.
+const Prefix = "PTAH_"
+
+// Parse validates one raw environment value already read from name.
+//
+// It is the seam for the flag/environment binding paths, which read the value
+// themselves because they must decide what to do with it by flag type; every
+// other caller should hold a [Var] and call [Var.Resolve] instead.
+//
+// The error names both the variable and the raw value, because either alone
+// leaves the operator guessing: the name without the value does not say which
+// of several exported variables is the bad one when the shell that exported it
+// is not in front of them, and the value without the name does not say where to
+// look.
+func Parse(name, value string) (bool, error) {
+	parsed, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("invalid boolean value %q for %s", value, name)
+	}
+	return parsed, nil
+}
+
+// Var is one declared boolean `PTAH_*` environment variable.
+//
+// The zero Var is not usable; construct one with [New] at package level so the
+// declaration is a fact about the program rather than something a call site
+// decides.
+type Var struct {
+	name         string
+	defaultValue bool
+}
+
+var (
+	registryMu sync.Mutex
+	registry   []Var
+)
+
+// New declares a boolean `PTAH_*` environment variable and records it in the
+// registry [Registered] reports.
+//
+// defaultValue is what an ABSENT variable selects. It is stated here rather
+// than at the call site so the default and the name travel together and a guard
+// test can read both.
+func New(name string, defaultValue bool) Var {
+	variable := Var{name: name, defaultValue: defaultValue}
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	registry = append(registry, variable)
+	return variable
+}
+
+// Name returns the environment variable name.
+func (v Var) Name() string {
+	return v.name
+}
+
+// Default returns the value an absent variable selects.
+func (v Var) Default() bool {
+	return v.defaultValue
+}
+
+// Resolve reads the variable and reports what it selects.
+//
+// It is [os.LookupEnv] and not [os.Getenv] on purpose: `os.Getenv` answers the
+// empty string for an absent variable and for `PTAH_X=` alike, which folds the
+// one state that must keep the default into the one state that must be
+// refused.
+func (v Var) Resolve() (bool, error) {
+	value, ok := os.LookupEnv(v.name)
+	if !ok {
+		return v.defaultValue, nil
+	}
+	return Parse(v.name, value)
+}
+
+// Registered returns every variable declared through [New], sorted by name.
+//
+// It is the derived enumeration a guard test measures the tree against, so it
+// reports the registrations as they were made -- duplicates included -- rather
+// than quietly collapsing two declarations of one name into one entry.
+func Registered() []Var {
+	registryMu.Lock()
+	defer registryMu.Unlock()
+	out := slices.Clone(registry)
+	slices.SortFunc(out, func(a, b Var) int {
+		return strings.Compare(a.name, b.name)
+	})
+	return out
+}

--- a/internal/envbool/envbool_test.go
+++ b/internal/envbool/envbool_test.go
@@ -1,0 +1,177 @@
+package envbool_test
+
+import (
+	"testing"
+
+	qt "github.com/frankban/quicktest"
+
+	"go.5x5.cz/ptah/internal/envbool"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
+)
+
+// probeEnvVar is a name no production code declares, so these rows measure the
+// grammar and nothing else.
+const probeEnvVar = "PTAH_ENVBOOL_PROBE"
+
+// TestResolveAcceptsEveryParseBoolSpelling pins the accepted grammar, which is
+// exactly [strconv.ParseBool]'s and deliberately no narrower.
+//
+// Narrowing it would be a capability removal: `PTAH_ATLAS_INSPECT_ALL_BLOCKS=t`
+// works today and has to keep working, and an operator who learned one spelling
+// on one variable must not find it refused on the next.
+func TestResolveAcceptsEveryParseBoolSpelling(t *testing.T) {
+	tests := []struct {
+		name string
+		env  func(testing.TB)
+		want bool
+	}{
+		{name: "1", env: envbooltest.Set(probeEnvVar, "1"), want: true},
+		{name: "t", env: envbooltest.Set(probeEnvVar, "t"), want: true},
+		{name: "T", env: envbooltest.Set(probeEnvVar, "T"), want: true},
+		{name: "true", env: envbooltest.Set(probeEnvVar, "true"), want: true},
+		{name: "True", env: envbooltest.Set(probeEnvVar, "True"), want: true},
+		{name: "TRUE", env: envbooltest.Set(probeEnvVar, "TRUE"), want: true},
+		{name: "0", env: envbooltest.Set(probeEnvVar, "0"), want: false},
+		{name: "f", env: envbooltest.Set(probeEnvVar, "f"), want: false},
+		{name: "F", env: envbooltest.Set(probeEnvVar, "F"), want: false},
+		{name: "false", env: envbooltest.Set(probeEnvVar, "false"), want: false},
+		{name: "False", env: envbooltest.Set(probeEnvVar, "False"), want: false},
+		{name: "FALSE", env: envbooltest.Set(probeEnvVar, "FALSE"), want: false},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			test.env(t)
+			variable := envbool.New(probeEnvVar, false)
+
+			got, err := variable.Resolve()
+
+			c.Assert(err, qt.IsNil)
+			c.Assert(got, qt.Equals, test.want)
+		})
+	}
+}
+
+// TestResolveDistinguishesAbsentFromEmpty is the state split this whole change
+// exists for.
+//
+// `os.Getenv` answers "" for both, which is how a typo became a default. Absence
+// selects the declared default -- both of them, so a future variable defaulting
+// to true is covered by the same rows -- while an exported empty value is a
+// configuration error.
+func TestResolveDistinguishesAbsentFromEmpty(t *testing.T) {
+	tests := []struct {
+		name        string
+		env         func(testing.TB)
+		defaultVal  bool
+		want        bool
+		wantErr     bool
+		wantMessage string
+	}{
+		{
+			name:       "absent selects a false default",
+			env:        envbooltest.Unset(probeEnvVar),
+			defaultVal: false,
+			want:       false,
+		},
+		{
+			name:       "absent selects a true default",
+			env:        envbooltest.Unset(probeEnvVar),
+			defaultVal: true,
+			want:       true,
+		},
+		{
+			name:        "an exported empty value is refused",
+			env:         envbooltest.Set(probeEnvVar, ""),
+			defaultVal:  false,
+			wantErr:     true,
+			wantMessage: `invalid boolean value "" for PTAH_ENVBOOL_PROBE`,
+		},
+		{
+			name:        "an exported empty value is refused against a true default too",
+			env:         envbooltest.Set(probeEnvVar, ""),
+			defaultVal:  true,
+			wantErr:     true,
+			wantMessage: `invalid boolean value "" for PTAH_ENVBOOL_PROBE`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			test.env(t)
+			variable := envbool.New(probeEnvVar, test.defaultVal)
+
+			got, err := variable.Resolve()
+
+			c.Assert(err != nil, qt.Equals, test.wantErr)
+			c.Assert(got, qt.Equals, test.want)
+			c.Assert(errMessage(err), qt.Equals, test.wantMessage)
+		})
+	}
+}
+
+// TestResolveRefusesEveryInvalidValue covers the spellings an operator actually
+// types, including the whitespace and quoting mistakes.
+//
+// Nothing is trimmed on purpose. `PTAH_X=" true"` in a YAML manifest is a
+// quoting mistake, and accepting it would hide the mistake on every OTHER
+// variable in the same file that the quoting also broke.
+func TestResolveRefusesEveryInvalidValue(t *testing.T) {
+	tests := []struct {
+		name        string
+		value       string
+		wantMessage string
+	}{
+		{name: "yes", value: "yes", wantMessage: `invalid boolean value "yes" for PTAH_ENVBOOL_PROBE`},
+		{name: "no", value: "no", wantMessage: `invalid boolean value "no" for PTAH_ENVBOOL_PROBE`},
+		{name: "on", value: "on", wantMessage: `invalid boolean value "on" for PTAH_ENVBOOL_PROBE`},
+		{name: "maybe", value: "maybe", wantMessage: `invalid boolean value "maybe" for PTAH_ENVBOOL_PROBE`},
+		{name: "tru", value: "tru", wantMessage: `invalid boolean value "tru" for PTAH_ENVBOOL_PROBE`},
+		{name: "2", value: "2", wantMessage: `invalid boolean value "2" for PTAH_ENVBOOL_PROBE`},
+		{name: "leading space", value: " true", wantMessage: `invalid boolean value " true" for PTAH_ENVBOOL_PROBE`},
+		{name: "trailing space", value: "false ", wantMessage: `invalid boolean value "false " for PTAH_ENVBOOL_PROBE`},
+		{name: "quoted", value: `"true"`, wantMessage: `invalid boolean value "\"true\"" for PTAH_ENVBOOL_PROBE`},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			c := qt.New(t)
+			t.Setenv(probeEnvVar, test.value)
+			variable := envbool.New(probeEnvVar, false)
+
+			got, err := variable.Resolve()
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.wantMessage)
+			c.Assert(got, qt.Equals, false)
+		})
+	}
+}
+
+// TestErrorNamesBothTheVariableAndTheRawValue keeps the diagnostic answerable.
+//
+// The name alone does not tell an operator which of several exported values is
+// the bad one when the shell that exported it is not in front of them, and the
+// value alone does not tell them where to look. Both halves are asserted
+// separately so dropping either one reddens this test on its own.
+func TestErrorNamesBothTheVariableAndTheRawValue(t *testing.T) {
+	c := qt.New(t)
+
+	_, err := envbool.Parse("PTAH_POSTGRES_INSPECT_ALL_ROLES", "maybe")
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Contains, "PTAH_POSTGRES_INSPECT_ALL_ROLES")
+	c.Assert(err.Error(), qt.Contains, `"maybe"`)
+	c.Assert(err.Error(), qt.Equals, `invalid boolean value "maybe" for PTAH_POSTGRES_INSPECT_ALL_ROLES`)
+}
+
+// errMessage renders an error for comparison against a table row without a
+// branch in the test body.
+func errMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/envbool/envbooltest/envbooltest.go
+++ b/internal/envbool/envbooltest/envbooltest.go
@@ -1,0 +1,40 @@
+// Package envbooltest carries the environment manipulation that every boolean
+// `PTAH_*` contract test needs, so the four states the contract distinguishes
+// are spelled the same way wherever they are exercised.
+//
+// It exists because the states are not symmetric and the asymmetry is the whole
+// point. `t.Setenv(name, "")` EXPORTS an empty value, which the contract refuses;
+// "absent" is a different state that a table row cannot reach by passing an
+// empty string. Writing that difference out per package invited exactly the row
+// that means to test "unset" and tests "" instead.
+//
+// The steps are values a table row carries, which is what keeps the test bodies
+// free of the branching the repository's test-style gate rejects.
+package envbooltest
+
+import (
+	"os"
+	"testing"
+)
+
+// Set exports name with value for the duration of the test.
+func Set(name, value string) func(testing.TB) {
+	return func(t testing.TB) {
+		t.Helper()
+		t.Setenv(name, value)
+	}
+}
+
+// Unset removes name for the duration of the test.
+//
+// The Setenv call before the Unsetenv call is load-bearing twice over: it is
+// what registers the restore of whatever the ambient environment held, and it is
+// what makes the test fail loudly rather than silently skip when it is run in
+// parallel with another test.
+func Unset(name string) func(testing.TB) {
+	return func(t testing.TB) {
+		t.Helper()
+		t.Setenv(name, "")
+		os.Unsetenv(name)
+	}
+}

--- a/internal/reservedrole/reservedrole.go
+++ b/internal/reservedrole/reservedrole.go
@@ -8,13 +8,12 @@ package reservedrole
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/platform"
 	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 const (
@@ -116,13 +115,17 @@ func likePattern() string {
 	return pattern.String()
 }
 
-// Allowed reports whether the opt-in variable is set to a true boolean value.
-// Unset, empty, false and unparsable values all keep the refusal, mirroring how
-// [go.5x5.cz/ptah/internal/rolescope] and
-// [go.5x5.cz/ptah/internal/atlassource] read their own opt-ins.
-func Allowed() bool {
-	allow, err := strconv.ParseBool(os.Getenv(AllowEnvVar))
-	return err == nil && allow
+// allow is the declaration of the variable, made once, in the package that owns
+// it. See [go.5x5.cz/ptah/internal/envbool].
+var allow = envbool.New(AllowEnvVar, false)
+
+// Allowed reports whether the opt-in lifts the refusal.
+//
+// Unset keeps the refusal and a valid false spelling keeps it too; an empty or
+// unparsable value is a configuration error rather than a silent refusal
+// (stokaro/ptah#1334).
+func Allowed() (bool, error) {
+	return allow.Resolve()
 }
 
 // ValidateDeclared refuses a desired schema that declares a reserved role,
@@ -140,7 +143,22 @@ func Allowed() bool {
 // normalized or raw target dialect; an empty or non-PostgreSQL dialect declares
 // nothing about PostgreSQL role names and is left alone.
 func ValidateDeclared(dialect string, roles []goschema.Role) error {
-	if !platform.IsPostgresFamily(dialect) || Allowed() {
+	if !platform.IsPostgresFamily(dialect) {
+		// A non-PostgreSQL target declares nothing about PostgreSQL role names,
+		// so this subsystem does not recognize the variable on that run and must
+		// not fail a MySQL render for it. That boundary is stokaro/ptah#1334's:
+		// validate on every invocation of the subsystem that owns the variable,
+		// and on no others.
+		return nil
+	}
+	// Resolved before the roles are scanned, so a desired schema that declares
+	// no reserved role at all -- the whole of a healthy pipeline -- still
+	// refuses a malformed value instead of passing in silence.
+	allowed, err := Allowed()
+	if err != nil {
+		return err
+	}
+	if allowed {
 		return nil
 	}
 	var refused []string

--- a/internal/reservedrole/reservedrole_test.go
+++ b/internal/reservedrole/reservedrole_test.go
@@ -7,6 +7,7 @@ import (
 
 	"go.5x5.cz/ptah/core/goschema"
 	"go.5x5.cz/ptah/core/ptaherr"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 	"go.5x5.cz/ptah/internal/reservedrole"
 )
 
@@ -207,29 +208,115 @@ func TestValidateDeclaredOptInRestoresTheOlderBehavior(t *testing.T) {
 	}
 }
 
-// TestValidateDeclaredOptInKeepsTheRefusalForEveryOtherValue mirrors how the
-// other PTAH_ opt-ins read themselves: unset, empty, false and unparsable all
-// keep the default.
-func TestValidateDeclaredOptInKeepsTheRefusalForEveryOtherValue(t *testing.T) {
+// TestValidateDeclaredOptInKeepsTheRefusalForAValidFalse mirrors how the other
+// PTAH_ opt-ins read themselves: absence and a valid false keep the default.
+func TestValidateDeclaredOptInKeepsTheRefusalForAValidFalse(t *testing.T) {
 	c := qt.New(t)
 
 	tests := []struct {
-		name  string
-		value string
+		name string
+		env  func(testing.TB)
 	}{
-		{name: "empty", value: ""},
-		{name: "zero", value: "0"},
-		{name: "false", value: "false"},
-		{name: "unparsable", value: "yes please"},
+		{name: "unset", env: envbooltest.Unset(reservedrole.AllowEnvVar)},
+		{name: "zero", env: envbooltest.Set(reservedrole.AllowEnvVar, "0")},
+		{name: "false", env: envbooltest.Set(reservedrole.AllowEnvVar, "false")},
+		{name: "FALSE", env: envbooltest.Set(reservedrole.AllowEnvVar, "FALSE")},
 	}
 
 	for _, test := range tests {
 		c.Run(test.name, func(c *qt.C) {
-			c.Setenv(reservedrole.AllowEnvVar, test.value)
+			test.env(c)
 
 			err := reservedrole.ValidateDeclared("postgres", []goschema.Role{{Name: "postgres"}})
 
 			c.Assert(err, qt.ErrorIs, ptaherr.ErrInvalidSchemaDiff)
+		})
+	}
+}
+
+// TestValidateDeclaredRefusesAMalformedOptIn is the state split stokaro/ptah#1334
+// introduced: a value that is neither absent nor a boolean is a configuration
+// error, and the refusal it produces is NOT the schema-diff refusal.
+//
+// The two are asserted apart on purpose. Before this, `yes please` produced the
+// reserved-role refusal, which reads to the operator as "the opt-in did not
+// apply to this role" rather than "the opt-in was never read".
+func TestValidateDeclaredRefusesAMalformedOptIn(t *testing.T) {
+	c := qt.New(t)
+
+	tests := []struct {
+		name        string
+		env         func(testing.TB)
+		wantMessage string
+	}{
+		{
+			name:        "unparsable",
+			env:         envbooltest.Set(reservedrole.AllowEnvVar, "yes please"),
+			wantMessage: `invalid boolean value "yes please" for PTAH_ALLOW_RESERVED_ROLE_NAMES`,
+		},
+		{
+			name:        "an exported empty value",
+			env:         envbooltest.Set(reservedrole.AllowEnvVar, ""),
+			wantMessage: `invalid boolean value "" for PTAH_ALLOW_RESERVED_ROLE_NAMES`,
+		},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			test.env(c)
+
+			err := reservedrole.ValidateDeclared("postgres", []goschema.Role{{Name: "postgres"}})
+
+			c.Assert(err, qt.IsNotNil)
+			c.Assert(err.Error(), qt.Equals, test.wantMessage)
+			c.Assert(err, qt.Not(qt.ErrorIs), ptaherr.ErrInvalidSchemaDiff)
+		})
+	}
+}
+
+// TestValidateDeclaredRefusesAMalformedOptInWithNoReservedRole is the
+// discriminating case for "validate before control-flow shortcuts".
+//
+// A desired schema declaring no reserved role at all is the whole of a healthy
+// pipeline, and it is the only shape most runs ever have. Resolving the variable
+// beside the refusal left a typo dormant on every one of them and surfaced it
+// only on the run the operator had already set the variable to change, which is
+// the run they would have noticed anyway.
+func TestValidateDeclaredRefusesAMalformedOptInWithNoReservedRole(t *testing.T) {
+	c := qt.New(t)
+	envbooltest.Set(reservedrole.AllowEnvVar, "yes please")(t)
+
+	err := reservedrole.ValidateDeclared("postgres", []goschema.Role{{Name: "app_user"}})
+
+	c.Assert(err, qt.IsNotNil)
+	c.Assert(err.Error(), qt.Equals, `invalid boolean value "yes please" for PTAH_ALLOW_RESERVED_ROLE_NAMES`)
+}
+
+// TestValidateDeclaredLeavesAnUnrelatedDialectAlone is the other side of the
+// same boundary, and it is the half that keeps the rule from becoming a global
+// environment validation.
+//
+// A MySQL render declares nothing about PostgreSQL role names, so this subsystem
+// does not recognize the variable on that invocation and must not fail for it.
+func TestValidateDeclaredLeavesAnUnrelatedDialectAlone(t *testing.T) {
+	c := qt.New(t)
+	envbooltest.Set(reservedrole.AllowEnvVar, "yes please")(t)
+
+	tests := []struct {
+		name    string
+		dialect string
+	}{
+		{name: "mysql", dialect: "mysql"},
+		{name: "mariadb", dialect: "mariadb"},
+		{name: "sqlite", dialect: "sqlite"},
+		{name: "an empty dialect", dialect: ""},
+	}
+
+	for _, test := range tests {
+		c.Run(test.name, func(c *qt.C) {
+			err := reservedrole.ValidateDeclared(test.dialect, []goschema.Role{{Name: "postgres"}})
+
+			c.Assert(err, qt.IsNil)
 		})
 	}
 }

--- a/internal/rolescope/rolescope.go
+++ b/internal/rolescope/rolescope.go
@@ -8,10 +8,9 @@ package rolescope
 import (
 	"fmt"
 	"io"
-	"os"
-	"strconv"
 
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/envbool"
 )
 
 // DescribeAllEnvVar restores the pre-scoping read: every role Ptah manages on
@@ -40,13 +39,18 @@ import (
 // this on can never make Ptah plan a CREATE ROLE it would otherwise skip.
 const DescribeAllEnvVar = "PTAH_POSTGRES_INSPECT_ALL_ROLES"
 
-// DescribeAll reports whether the opt-in variable is set to a true boolean
-// value. Unset, empty, false and unparsable values all keep the default,
-// mirroring how [go.5x5.cz/ptah/internal/atlassource] and
-// [go.5x5.cz/ptah/internal/atlashclrender] read their own opt-ins.
-func DescribeAll() bool {
-	all, err := strconv.ParseBool(os.Getenv(DescribeAllEnvVar))
-	return err == nil && all
+// describeAll is the declaration of the variable, made once, in the package
+// that owns it. See [go.5x5.cz/ptah/internal/envbool].
+var describeAll = envbool.New(DescribeAllEnvVar, false)
+
+// DescribeAll reports whether the opt-in restores the full cluster read.
+//
+// Unset keeps the default and a valid false spelling keeps it too; an empty or
+// unparsable value is a configuration error, because a description that
+// silently stayed scoped after an operator believed they widened it is the one
+// answer this must never give (stokaro/ptah#1334).
+func DescribeAll() (bool, error) {
+	return describeAll.Resolve()
 }
 
 // ReportUndescribed writes a note naming how many roles the description left

--- a/internal/rolescope/rolescope_test.go
+++ b/internal/rolescope/rolescope_test.go
@@ -7,6 +7,7 @@ import (
 	qt "github.com/frankban/quicktest"
 
 	dbschematypes "go.5x5.cz/ptah/dbschema/types"
+	"go.5x5.cz/ptah/internal/envbool/envbooltest"
 	"go.5x5.cz/ptah/internal/rolescope"
 )
 
@@ -14,31 +15,75 @@ import (
 //
 // The rows mirror [go.5x5.cz/ptah/internal/atlashclrender]'s and
 // [go.5x5.cz/ptah/internal/atlassource]'s opt-ins, so an operator who learned
-// one spelling is not surprised by this one: unset, empty, false and
-// unparsable all keep the scoped default.
+// one spelling is not surprised by this one: absence keeps the scoped default, a
+// valid false keeps it too, and anything else is refused by name and by value
+// (stokaro/ptah#1334).
 func TestDescribeAllReadsTheOptIn(t *testing.T) {
 	tests := []struct {
-		name  string
-		value string
-		want  bool
+		name        string
+		env         func(testing.TB)
+		want        bool
+		wantMessage string
 	}{
-		{name: "unset keeps the scoped description", value: "", want: false},
-		{name: "1 restores the full cluster read", value: "1", want: true},
-		{name: "true restores the full cluster read", value: "true", want: true},
-		{name: "TRUE restores the full cluster read", value: "TRUE", want: true},
-		{name: "0 keeps the scoped description", value: "0", want: false},
-		{name: "false keeps the scoped description", value: "false", want: false},
-		{name: "an unparsable value keeps the scoped description", value: "all of them", want: false},
+		{
+			name: "unset keeps the scoped description",
+			env:  envbooltest.Unset(rolescope.DescribeAllEnvVar),
+		},
+		{
+			name: "1 restores the full cluster read",
+			env:  envbooltest.Set(rolescope.DescribeAllEnvVar, "1"),
+			want: true,
+		},
+		{
+			name: "true restores the full cluster read",
+			env:  envbooltest.Set(rolescope.DescribeAllEnvVar, "true"),
+			want: true,
+		},
+		{
+			name: "TRUE restores the full cluster read",
+			env:  envbooltest.Set(rolescope.DescribeAllEnvVar, "TRUE"),
+			want: true,
+		},
+		{
+			name: "0 keeps the scoped description",
+			env:  envbooltest.Set(rolescope.DescribeAllEnvVar, "0"),
+		},
+		{
+			name: "false keeps the scoped description",
+			env:  envbooltest.Set(rolescope.DescribeAllEnvVar, "false"),
+		},
+		{
+			name:        "an unparsable value is refused",
+			env:         envbooltest.Set(rolescope.DescribeAllEnvVar, "all of them"),
+			wantMessage: `invalid boolean value "all of them" for PTAH_POSTGRES_INSPECT_ALL_ROLES`,
+		},
+		{
+			name:        "an exported empty value is refused",
+			env:         envbooltest.Set(rolescope.DescribeAllEnvVar, ""),
+			wantMessage: `invalid boolean value "" for PTAH_POSTGRES_INSPECT_ALL_ROLES`,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			c := qt.New(t)
-			t.Setenv(rolescope.DescribeAllEnvVar, test.value)
+			test.env(t)
 
-			c.Assert(rolescope.DescribeAll(), qt.Equals, test.want)
+			got, err := rolescope.DescribeAll()
+
+			c.Assert(got, qt.Equals, test.want)
+			c.Assert(errMessage(err), qt.Equals, test.wantMessage)
 		})
 	}
+}
+
+// errMessage renders an error for comparison against a table row without a
+// branch in the test body.
+func errMessage(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
 }
 
 // TestDescribeAllEnvVarIsSpelledLikeTheDocumentationQuotesIt pins the name the


### PR DESCRIPTION
Closes #1334.

## The audit, derived rather than listed

Searched the tree for `PTAH_` string literals, `strconv.ParseBool`, `os.Getenv`,
`os.LookupEnv`, and boolean Cobra flags reached through environment binding.

**14 readers of a boolean `PTAH_*` value: 11 named variables + 3 generic
flag/environment binding paths.**

| variable | owner | default | invalid value before | validation point now |
|---|---|---|---|---|
| `PTAH_POSTGRES_INSPECT_ALL_ROLES` | `internal/rolescope`, consumed by the PostgreSQL reader | scoped read | silent default | top of `readRolesInto`, before either query |
| `PTAH_ALLOW_RESERVED_ROLE_NAMES` | `internal/reservedrole` | refuse | silent default | in `ValidateDeclared`, after the dialect gate, before the role scan |
| `PTAH_ALLOW_EXTERNAL_SCHEMA` | `internal/atlassource` | deny | silent default | top of `expandEnv`, on every `env://` expansion |
| `PTAH_ATLAS_INSPECT_ALL_BLOCKS` | `internal/atlashclrender` | omit refused blocks | silent default | first statement of `runAtlasSchemaInspect` |
| `PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE` | `internal/atlasfilter` | refuse | silent default | top of `computeApplyPlan`, before the desired state is loaded |
| `PTAH_ATLAS_LINT_ALL_VERSIONS` | `cmd/atlas` migrate lint | require a scope | silent default | first statement of `runAtlasMigrateLint` |
| `PTAH_ATLAS_LINT_WITHOUT_DEV_URL` | `cmd/atlas` migrate lint | require `--dev-url` | silent default | first statement of `runAtlasMigrateLint` |
| `PTAH_ATLAS_APPLY_WITHOUT_DEV_URL` | `cmd/atlas` schema apply | require `--dev-url` | silent default | top of `ensureAtlasSchemaApplyDevURL`, before the `--dev-url` shortcut |
| `PTAH_SKIP_CHECKS` | `cmd/atlas` migrate apply | enforce checks | already an error; **empty** read as unset | unchanged point, empty now refused |
| `PTAH_STRICT_DIR_QUERY` | `cmd/atlas` migrate dir query | report, do not refuse | already an error; **empty** read as unset | unchanged point, empty now refused |
| `PTAH_ALLOW_NONINTERACTIVE_EDIT` | `cmd/internal/editor` | require a terminal | already an error; **empty** read as unset | unchanged point, empty now refused |
| every `bool` flag on the native tree | `cmd/internal/cmdflags` | per flag | already an error; **empty** read as unset | unchanged point, empty now refused for `bool` only |
| every `BoolFlag` on the compat arg mapper | `internal/atlasargs` | per flag | already an error; **empty** read as unset | same |
| every `bool` flag on `migrate down` | `cmd/atlas/migrate_down.go` | per flag | already an error; **empty** read as unset | same |

The 11 non-boolean `PTAH_*` names found and classified: `PTAH_CURRENT_VERSION`,
`PTAH_DB_URL`, `PTAH_DIALECT`, `PTAH_DIR`, `PTAH_FORMAT`, `PTAH_LOG_FORMAT`,
`PTAH_MIGRATIONS_DIR`, `PTAH_PLAN`, `PTAH_TARGET_VERSION`, `PTAH_TO_TAG`,
`PTAH_VAR`. Their behavior is unchanged, empty-means-unset included.

## The shared parse

`internal/envbool` holds one grammar (exactly `strconv.ParseBool`'s spellings,
nothing trimmed) and one error shape (`invalid boolean value %q for %s`). A
variable is declared once, in the package that owns it:

```go
var describeAll = envbool.New(DescribeAllEnvVar, false)

func DescribeAll() (bool, error) { return describeAll.Resolve() }
```

`Var.Resolve` uses `os.LookupEnv`, so absent and `PTAH_X=` stay different
answers. `envbool.Parse` is the seam for the three flag-binding paths, which
read the value themselves because they dispatch on flag type.

## The guard

`cmd/internal/envboolguard` (under `cmd/` because `cmd/internal/editor` owns one
of the variables and only packages under `cmd/` may import it):

* a **source scan** refuses a new direct boolean environment parse outside the
  shared package — the nested form, the split-across-functions form, and manual
  truthiness tests against `"1"`/`"true"`/`"false"`. Its own five fixtures pin
  that it catches each shape and leaves a presence test against `""` alone;
* an **enumeration check** derives every `PTAH_*` name from the tree's non-test
  Go source and requires each to be either declared through `envbool` (read back
  from the registry at run time, not from a list) or recorded as non-boolean.
  Only the non-boolean side is hand-written;
* `TestEveryDeclaredVariableIsNamedAndDefaultedSafely` asserts every declared
  default is `false`. Every boolean toggle today opts in to the more permissive
  side, so a typo fails **closed**; the first variable to default permissive
  would make a typo fail open, and this keeps that from happening quietly.

Pointed at a checkout of `origin/master` (extracted with `git archive` into the
worktree, then deleted), the scan named **all fourteen** readers:

```
.agentbin/master-probe/cmd/atlas/migrate_apply.go:642: atlasApplySkipChecksFromEnv reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/atlas/migrate_dir_query.go:134: atlasDirQueryStrictFromEnv reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/atlas/migrate_down.go:310: applyAtlasMigrateDownEnvFallback reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/atlas/migrate_lint.go:374: atlasMigrateLintAllVersions reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/atlas/migrate_lint.go:476: lintWithoutDevURL reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/atlas/schema_apply.go:964: atlasApplyWithoutDevURLAllowed reads the environment and parses a boolean itself
.agentbin/master-probe/cmd/internal/cmdflags/env.go: reads a PTAH_ environment value and parses a boolean in the same file
.agentbin/master-probe/cmd/internal/editor/editor.go:80: nonInteractiveAllowed reads the environment and parses a boolean itself
.agentbin/master-probe/internal/atlasargs/args.go:523: appendEnvArgs reads the environment and parses a boolean itself
.agentbin/master-probe/internal/atlasfilter/unmatched.go:29: AllowUnmatchedExclude reads the environment and parses a boolean itself
.agentbin/master-probe/internal/atlashclrender/atlas_refused_blocks.go:52: KeepAtlasRefusedBlocks reads the environment and parses a boolean itself
.agentbin/master-probe/internal/atlassource/atlassource.go:401: externalSchemaAllowed reads the environment and parses a boolean itself
.agentbin/master-probe/internal/reservedrole/reservedrole.go:124: Allowed reads the environment and parses a boolean itself
.agentbin/master-probe/internal/rolescope/rolescope.go:48: DescribeAll reads the environment and parses a boolean itself
```

`cmd/internal/cmdflags/env.go` is the row that motivated the file-level rule:
its read was in `applyEnv` and its parse in `setEnvValue`, two functions apart,
which a function-scoped rule alone would have missed.

## No-mutation guard, measured live

PostgreSQL 17.10 in a container started for this branch and removed afterwards
(`postgres:17.10`, port 15334). `t1334` seeded with `users(id)` and
`legacy(id)`; the desired state adds `users.email`. The selector **matches**, so
the opt-in cannot change what this run does — which is exactly the run that used
to hide the typo.

```console
$ PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE=maybe ptah-compat schema apply --auto-approve \
    --url 'postgres://…/t1334?…' --to file://schema.hcl --dev-url 'postgres://…/d1334?…' \
    --exclude legacy; echo "exit=$?"
Error: invalid boolean value "maybe" for PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE
exit=1
```

Catalog read back, not stdout:

```
 table_name | column_name
------------+-------------
 legacy     | id
 users      | id
(2 rows)
```

Control, same command with the variable unset:

```console
exit=0
```

```
 table_name | column_name
------------+-------------
 legacy     | id
 users      | id
 users      | email
(3 rows)
```

## Valid values still behave, on several variables

```console
$ PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE=0 … --exclude nosuchobject_zzz   # exit 1, the refusal
$ PTAH_ATLAS_ALLOW_UNMATCHED_EXCLUDE=true … --exclude nosuchobject_zzz # exit 0, "Warning: the --exclude selection matched no objects"
$ PTAH_POSTGRES_INSPECT_ALL_ROLES=0 ptah-compat schema inspect …       # exit 0, 1 CREATE ROLE + the omission note
$ PTAH_POSTGRES_INSPECT_ALL_ROLES=T ptah-compat schema inspect …       # exit 0, 2 CREATE ROLE, no note
$ PTAH_ATLAS_INSPECT_ALL_BLOCKS=0 ptah-compat schema inspect …         # exit 0, no extension/sequence block
$ PTAH_ATLAS_INSPECT_ALL_BLOCKS=True ptah-compat schema inspect …      # exit 0, extension "plpgsql" + sequence "lonely_seq"
$ PTAH_ATLAS_APPLY_WITHOUT_DEV_URL=f ptah-compat schema apply --dry-run … # exit 1, --dev-url cannot be empty
$ PTAH_ATLAS_APPLY_WITHOUT_DEV_URL=1 ptah-compat schema apply --dry-run … # exit 0, plan printed
```

Invalid values, each refused before the work:

```console
$ PTAH_POSTGRES_INSPECT_ALL_ROLES=maybe ptah-compat schema inspect …
Error: read database schema: invalid boolean value "maybe" for PTAH_POSTGRES_INSPECT_ALL_ROLES   # exit 1
$ PTAH_ATLAS_INSPECT_ALL_BLOCKS=tru ptah-compat schema inspect …
Error: invalid boolean value "tru" for PTAH_ATLAS_INSPECT_ALL_BLOCKS                             # exit 1, before the note and the warnings
$ PTAH_ATLAS_APPLY_WITHOUT_DEV_URL=yes ptah-compat schema apply --dry-run … --dev-url …
Error: invalid boolean value "yes" for PTAH_ATLAS_APPLY_WITHOUT_DEV_URL                          # exit 1, with --dev-url given
$ PTAH_ATLAS_LINT_ALL_VERSIONS='yes please' ptah-compat migrate lint … --latest 1
Error: invalid boolean value "yes please" for PTAH_ATLAS_LINT_ALL_VERSIONS                       # exit 1, with a scope named
$ PTAH_ATLAS_LINT_WITHOUT_DEV_URL=tru ptah-compat migrate lint … --dev-url … --latest 1
Error: invalid boolean value "tru" for PTAH_ATLAS_LINT_WITHOUT_DEV_URL                           # exit 1, with --dev-url given
```

The same `migrate lint` invocation with nothing exported exits 0 and prints
`-- 1 version ok`.

Unrelated commands are untouched:

```console
$ PTAH_POSTGRES_INSPECT_ALL_ROLES=maybe PTAH_ALLOW_RESERVED_ROLE_NAMES=yes ptah version   # exit 0
$ PTAH_POSTGRES_INSPECT_ALL_ROLES=maybe ptah-compat schema inspect --url sqlite://probe.db # exit 0
```

And both binaries now agree on a malformed value, which the documentation
claimed they did not:

```console
$ PTAH_SKIP_CHECKS=notabool ptah migrations up …
error: invalid boolean value "notabool" for PTAH_SKIP_CHECKS      # exit 2
$ PTAH_SKIP_CHECKS=notabool ptah-compat migrate apply …
Error: invalid boolean value "notabool" for PTAH_SKIP_CHECKS      # exit 1
```

`docs/pre-migration-checks.md` said native `ptah migrations up` "discards the
parse error and enforces checks". That has been false since #1006; corrected.

## Mutants: each cheaper wrong implementation, red then green

| mutant | red | restored |
|---|---|---|
| parse error becomes the default (`Var.Resolve` swallows `Parse`'s error) | `envbool` 11 subtests, `rolescope` 2, `reservedrole` 3, `atlasfilter` 2 | green |
| `os.Getenv` + `value == ""` replaces `os.LookupEnv` | `TestResolveDistinguishesAbsentFromEmpty` (2), `TestDescribeAllReadsTheOptIn/an exported empty value is refused` | green |
| flag binding drops the bool exception (`if value == ""` for every type) | `TestInitializeEnvSplitsEmptyByFlagType/a bool flag refuses an empty value` | green |
| validation moves below the early return (`ValidateDeclared` resolves after the role scan) | `TestValidateDeclaredRefusesAMalformedOptInWithNoReservedRole` | green |
| validation moves below the early return (`computeApplyPlan` resolves beside the refusal) | `TestSchemaApplyUnmatchedExcludeOptInIsResolvedBeforeAnyWork` (2 rows) | green |
| one call site bypasses the shared parser (`AllowUnmatchedExclude` restored verbatim) | `atlasfilter` 2 subtests **and** `TestNoDirectBooleanEnvironmentParsing` | green |
| the error omits the variable name | `TestErrorNamesBothTheVariableAndTheRawValue` + 11 subtests | green |
| a valid `false` reads as true | `envbool` 6, `rolescope` 2, `reservedrole` 3 | green |
| a valid `true` is ignored | `envbool` 6, `rolescope` 3, `reservedrole` 3 | green |

## Gates

`go build ./...`, `go vet ./...`, `go vet -tags integration ./integration/...`,
`go test ./... -count=1` (exit 0, 189 packages), `go tool qtlint ./...`,
`golangci-lint run ./...`, `scripts/check-test-style.sh`,
`scripts/check-public-api.sh`, `scripts/check-public-api-snapshot.sh`,
`scripts/check-public-api-released.sh`, and every `check:*` script in
`docs/site/package.json` including `check:responsive` after `npm run build`.
Exit codes read directly, never through a pipe.

`cmd/viz`'s `TestSVGReportsGraphvizStderrOnFailure` fails under heavy machine
load (`signal: killed` on the fake `dot` script). Reproduced identically on a
clean checkout of `origin/master` d6a3c81b, and green in the two unloaded
`go test ./...` runs. Pre-existing and load-dependent, not a regression here.

## Not done

`ptah-compat migrate hash` is refused by this environment's command guard, so I
could not build a hashed migration directory at the CLI. The two `migrate lint`
variables are therefore measured at the CLI on an unhashed directory (where the
refusal still lands first, which is the ordering claim) and through the
command-level Go tests, which build hashed directories in-process.

## Documentation

* `AGENTS.md` gains "Boolean `PTAH_*` environment variables are strict",
  including the ordering rule and the fails-closed invariant;
* `docs/site/.../reference/configuration.md` gains "Boolean environment
  variables" — the single place the accepted spellings and the error shape are
  written down. Every other page links to it rather than repeating the list;
* `docs/site/.../atlas/overview.md`, `atlas/schema-commands.md`,
  `databases/postgresql.md`, `direct/inspect.md`, `reference/atlas-commands.md`,
  `docs/POSTGRESQL_ROLES.md`, `docs/project_config.md` updated;
* the comments claiming "unset, empty, false and unparsable values all keep the
  default" are gone from all six packages that carried them.

## Non-goals honored

No default changed, no capability moved, no flag added, no Atlas-compatible
behavior changed when no malformed Ptah-specific variable is present, and no
non-boolean `PTAH_*` variable touched.